### PR TITLE
KokkosCore: Update the core makefile to use sed in a portable way

### DIFF
--- a/core/src/Makefile
+++ b/core/src/Makefile
@@ -71,11 +71,14 @@ build-makefile-kokkos:
 	echo "KOKKOS_LINK_DEPENDS  = $(KOKKOS_LINK_DEPENDS)" >> Makefile.kokkos
 	echo "KOKKOS_LIBS = $(KOKKOS_LIBS)" >> Makefile.kokkos
 	echo "KOKKOS_LD_FLAGS = $(KOKKOS_LDFLAGS)" >> Makefile.kokkos
-	sed -i 's|\.\./\.\./core/src|$(PREFIX)/include|g' Makefile.kokkos
-	sed -i 's|\.\./\.\./containers/src|$(PREFIX)/include|g' Makefile.kokkos
-	sed -i 's|\.\./\.\./algorithms/src|$(PREFIX)/include|g' Makefile.kokkos
-	sed -i 's|-L$(PWD)|-L$(PREFIX)/lib|g' Makefile.kokkos
-	sed -i 's|= KokkosCore_config.h|= $(PREFIX)/include/KokkosCore_config.h|g' Makefile.kokkos
+	sed \
+		-e 's|\.\./\.\./core/src|$(PREFIX)/include|g' \
+		-e 's|\.\./\.\./containers/src|$(PREFIX)/include|g' \
+		-e 's|\.\./\.\./algorithms/src|$(PREFIX)/include|g' \
+		-e 's|-L$(PWD)|-L$(PREFIX)/lib|g' \
+		-e 's|= KokkosCore_config.h|= $(PREFIX)/include/KokkosCore_config.h|g' Makefile.kokkos \
+		> Makefile.kokkos.tmp
+	mv -f Makefile.kokkos.tmp Makefile.kokkos
 
 build-lib: build-makefile-kokkos $(KOKKOS_LINK_DEPENDS)
 


### PR DESCRIPTION
sed -i expects an extension for the backup file on OS X 