### PR TITLE
Add optional destroy method to the AllocationTracker

### DIFF
--- a/core/src/impl/Kokkos_AllocationTracker.cpp
+++ b/core/src/impl/Kokkos_AllocationTracker.cpp
@@ -114,7 +114,7 @@ struct AllocationRecord
   ~AllocationRecord()
   {
     if (destroy) {
-      destroy->apply(alloc_ptr, alloc_size );
+      destroy->destroy(alloc_ptr, alloc_size );
       delete destroy;
     }
     if (attribute) {
@@ -735,7 +735,7 @@ bool AllocationTracker::set_attribute( AllocatorAttributeBase * attr ) const
   return result;
 }
 
-bool AllocationTracker::set_destroy( AllocatorDestroyBase * des ) const
+bool AllocationTracker::set_destroy_impl( AllocatorDestroyBase * des ) const
 {
   bool result = false;
   if (m_alloc_rec & REF_COUNT_MASK) {

--- a/core/src/impl/Kokkos_AllocationTracker.hpp
+++ b/core/src/impl/Kokkos_AllocationTracker.hpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -155,6 +155,16 @@ class AllocatorAttributeBase
 {
 public:
   virtual ~AllocatorAttributeBase() {}
+};
+
+/// class AllocatorDestroyBase
+class AllocatorDestroyBase
+{
+public:
+
+  virtual void apply( void * alloc_ptr, uint64_t alloc_size ) = 0;
+
+  virtual ~AllocatorDestroyBase() {}
 };
 
 //-----------------------------------------------------------------------------
@@ -539,6 +549,15 @@ public:
   /// get the attribute ptr from the allocation record
   AllocatorAttributeBase * attribute() const;
 
+  /// set an destroy ptr on the allocation record
+  /// the arg_destroy apply method will be called with
+  /// the alloc_ptr and alloc_size and then deleted
+  /// when the record is destroyed
+  /// the dstroy ptr can only be set once
+  bool set_destroy( AllocatorDestroyBase * arg_destroy) const;
+
+  /// get the attribute ptr from the allocation record
+  AllocatorDestroyBase * destroy() const;
 
   /// reallocate the memory tracked by this allocation
   /// NOT thread-safe

--- a/core/src/impl/Kokkos_BasicAllocators.cpp
+++ b/core/src/impl/Kokkos_BasicAllocators.cpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -198,17 +198,6 @@ void * AlignedAllocator::reallocate(void * old_ptr, size_t old_size, size_t new_
   #define NO_MMAP
 #endif
 
-// huge page tables
-#if !defined( NO_MMAP )
-  #if defined( MAP_HUGETLB )
-    #define MMAP_FLAGS_HUGE (MMAP_FLAGS | MAP_HUGETLB )
-  #elif defined( MMAP_FLAGS )
-    #define MMAP_FLAGS_HUGE MMAP_FLAGS
-  #endif
-  // threshold to use huge pages
-  #define MMAP_USE_HUGE_PAGES (1u << 27)
-#endif
-
 // read write access to private memory
 #if !defined( NO_MMAP )
   #define MMAP_PROTECTION (PROT_READ | PROT_WRITE)
@@ -220,17 +209,12 @@ void* PageAlignedAllocator::allocate( size_t size )
   void *ptr = NULL;
   if (size) {
 #if !defined NO_MMAP
-    if ( size < MMAP_USE_HUGE_PAGES ) {
-      ptr = mmap( NULL, size, MMAP_PROTECTION, MMAP_FLAGS, -1 /*file descriptor*/, 0 /*offset*/);
-    } else {
-      ptr = mmap( NULL, size, MMAP_PROTECTION, MMAP_FLAGS_HUGE, -1 /*file descriptor*/, 0 /*offset*/);
-    }
+    ptr = mmap( NULL, size, MMAP_PROTECTION, MMAP_FLAGS, -1 /*file descriptor*/, 0 /*offset*/);
     if (ptr == MAP_FAILED) {
       ptr = NULL;
     }
 #else
     static const size_t page_size = 4096; // TODO: read in from sysconf( _SC_PAGE_SIZE )
-
     ptr = raw_aligned_allocate( size, page_size);
 #endif
     if (!ptr)

--- a/core/unit_test/TestAllocationTracker.cpp
+++ b/core/unit_test/TestAllocationTracker.cpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -53,7 +53,7 @@
 
 namespace Test {
 
-class alocation_tracker : public ::testing::Test {
+class allocation_tracker : public ::testing::Test {
 protected:
   static void SetUpTestCase()
   {
@@ -66,7 +66,7 @@ protected:
   }
 };
 
-TEST_F( alocation_tracker, simple)
+TEST_F( allocation_tracker, simple)
 {
   using namespace Kokkos::Impl;
 
@@ -113,7 +113,7 @@ TEST_F( alocation_tracker, simple)
   }
 }
 
-TEST_F( alocation_tracker, force_leaks)
+TEST_F( allocation_tracker, force_leaks)
 {
 // uncomment to force memory leaks
 #if 0
@@ -123,7 +123,7 @@ TEST_F( alocation_tracker, force_leaks)
 #endif
 }
 
-TEST_F( alocation_tracker, disable_reference_counting)
+TEST_F( allocation_tracker, disable_reference_counting)
 {
   using namespace Kokkos::Impl;
   // test ref count and label
@@ -140,6 +140,63 @@ TEST_F( alocation_tracker, disable_reference_counting)
     EXPECT_EQ(1u, trackers[0].ref_count());
     EXPECT_EQ(std::string("Test"), std::string(trackers[0].label()));
   }
+}
+
+namespace {
+
+template <typename T>
+class Destroy
+  : public Kokkos::Impl::AllocatorDestroyBase
+{
+public:
+  virtual void apply( void * alloc_ptr, uint64_t alloc_size )
+  {
+    T * ptr = reinterpret_cast<T *>(alloc_ptr);
+    uint64_t size = alloc_size / sizeof(T);
+
+    for (uint64_t i=0; i < size; ++i) {
+      (ptr + i)->~T();
+    }
+  }
+};
+
+struct Foo {
+
+  int * destroy_count;
+
+  Foo( int  *count )
+    : destroy_count( count )
+  {}
+
+  ~Foo()
+  {
+    Kokkos::atomic_fetch_add( destroy_count, 1 );
+  }
+
+};
+
+}
+
+TEST_F( allocation_tracker, destroy)
+{
+  using namespace Kokkos::Impl;
+
+  const int size = 10;
+  int destroy_count = 0;
+
+  {
+    AllocationTracker tracker( MallocAllocator(), size * sizeof(Foo), "Test" );
+
+    Foo * f = reinterpret_cast<Foo *>(tracker.alloc_ptr());
+    // placement new
+    for (int i=0; i < size; ++i) {
+      new (f + i) Foo(&destroy_count);
+    }
+
+    tracker.set_destroy( new Destroy<Foo>() );
+  }
+
+  EXPECT_EQ( size, destroy_count );
 }
 
 } // namespace Test


### PR DESCRIPTION
I found it necessary to run destructors before deallocating memory for non pop types.  To use inherit from Impl::AllocatorDestroyBase and overload the virtual apply method.  Then set a pointer to the destroy object on the AllocationTracker.

i.e. 
class MyDestroy : public Kokkos::Impl::AllocatorDestroybase {
public:
  virtual void apply( void * alloc_ptr, uint64_t alloc_size) { ... };
};

...
AllocationTracker tracker(...);
tracker.set_destroy( new MyDestroy() );
