### PR TITLE
Add set_destroy method to the AllocationTracker

### DIFF
--- a/core/src/impl/Kokkos_AllocationTracker.cpp
+++ b/core/src/impl/Kokkos_AllocationTracker.cpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -76,6 +76,7 @@ struct AllocationRecord
             + sizeof(void*)                   // alloc_ptr
             + sizeof(uint64_t)                // alloc_size
             + sizeof(AllocatorAttributeBase*) // attribute
+            + sizeof(AllocatorDestroyBase*)   // destroy
             + sizeof(uint32_t)                // node_index
             + sizeof(uint32_t)                // ref_count
    , LABEL_LENGTH = 128 - OFFSET
@@ -85,6 +86,7 @@ struct AllocationRecord
   void * const                   alloc_ptr;
   const uint64_t                 alloc_size;
   AllocatorAttributeBase * const attribute;
+  AllocatorDestroyBase   * const destroy;
   const int32_t                  node_index;
   volatile uint32_t              ref_count;
   const char                     label[LABEL_LENGTH];
@@ -100,6 +102,7 @@ struct AllocationRecord
     , alloc_ptr(arg_alloc_ptr)
     , alloc_size(arg_alloc_size)
     , attribute(NULL)
+    , destroy(NULL)
     , node_index(arg_node_index)
     , ref_count(1)
     , label() // zero fill
@@ -110,6 +113,10 @@ struct AllocationRecord
 
   ~AllocationRecord()
   {
+    if (destroy) {
+      destroy->destroy(alloc_ptr, alloc_size );
+      delete destroy;
+    }
     if (attribute) {
       delete attribute;
     }
@@ -144,6 +151,18 @@ struct AllocationRecord
       result = NULL == atomic_compare_exchange(  const_cast<AllocatorAttributeBase **>(&attribute)
                                                , reinterpret_cast<AllocatorAttributeBase *>(NULL)
                                                , attr );
+    }
+
+    return result;
+  }
+
+  bool set_destroy( AllocatorDestroyBase * des )
+  {
+    bool result = false;
+    if (attribute == NULL) {
+      result = NULL == atomic_compare_exchange(  const_cast<AllocatorDestroyBase **>(&destroy)
+                                               , reinterpret_cast<AllocatorDestroyBase *>(NULL)
+                                               , des );
     }
 
     return result;
@@ -716,10 +735,27 @@ bool AllocationTracker::set_attribute( AllocatorAttributeBase * attr ) const
   return result;
 }
 
+bool AllocationTracker::set_destroy_impl( AllocatorDestroyBase * des ) const
+{
+  bool result = false;
+  if (m_alloc_rec & REF_COUNT_MASK) {
+    result = to_alloc_rec(m_alloc_rec)->set_destroy(des);
+  }
+  return result;
+}
+
 AllocatorAttributeBase * AllocationTracker::attribute() const
 {
   if (m_alloc_rec & REF_COUNT_MASK) {
     return to_alloc_rec(m_alloc_rec)->attribute;
+  }
+  return NULL;
+}
+
+AllocatorDestroyBase * AllocationTracker::destroy() const
+{
+  if (m_alloc_rec & REF_COUNT_MASK) {
+    return to_alloc_rec(m_alloc_rec)->destroy;
   }
   return NULL;
 }

--- a/core/src/impl/Kokkos_AllocationTracker.hpp
+++ b/core/src/impl/Kokkos_AllocationTracker.hpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -347,6 +347,40 @@ public:
 };
 
 //-----------------------------------------------------------------------------
+// AllocatorDestroy
+//-----------------------------------------------------------------------------
+
+
+/// class AllocatorDestroyBase
+class AllocatorDestroyBase
+{
+public:
+
+  virtual void destroy( void * alloc_ptr, uint64_t alloc_size ) = 0;
+
+  virtual ~AllocatorDestroyBase() {}
+};
+
+template <typename T>
+class AllocatorDestroy : public AllocatorDestroyBase
+{
+public:
+
+  AllocatorDestroy( const T & func )
+    : m_func( func )
+  {}
+
+  virtual void destroy( void * alloc_ptr, uint64_t alloc_size )
+  {
+    m_func(alloc_ptr, alloc_size );
+  }
+
+private:
+  T m_func;
+};
+
+
+//-----------------------------------------------------------------------------
 // AllocationTracker
 //-----------------------------------------------------------------------------
 
@@ -539,12 +573,28 @@ public:
   /// get the attribute ptr from the allocation record
   AllocatorAttributeBase * attribute() const;
 
+  /// set an destroy ptr on the allocation record
+  /// the arg_destroy apply method will be called with
+  /// the alloc_ptr and alloc_size and then deleted
+  /// when the record is destroyed
+  /// the dstroy ptr can only be set once
+  template <typename DestroyFunctor>
+  bool set_destroy( DestroyFunctor const & func ) const
+  {
+    AllocatorDestroy<DestroyFunctor> * destroy = new AllocatorDestroy<DestroyFunctor>(func);
+    return set_destroy_impl( destroy );
+  }
+
+  /// get the attribute ptr from the allocation record
+  AllocatorDestroyBase * destroy() const;
 
   /// reallocate the memory tracked by this allocation
   /// NOT thread-safe
   void reallocate( size_t size ) const;
 
 private:
+
+  bool set_destroy_impl( AllocatorDestroyBase * arg_destroy) const;
 
   static AllocationTracker find( void const * ptr, AllocatorBase const * arg_allocator );
 

--- a/core/src/impl/Kokkos_BasicAllocators.cpp
+++ b/core/src/impl/Kokkos_BasicAllocators.cpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -198,17 +198,6 @@ void * AlignedAllocator::reallocate(void * old_ptr, size_t old_size, size_t new_
   #define NO_MMAP
 #endif
 
-// huge page tables
-#if !defined( NO_MMAP )
-  #if defined( MAP_HUGETLB )
-    #define MMAP_FLAGS_HUGE (MMAP_FLAGS | MAP_HUGETLB )
-  #elif defined( MMAP_FLAGS )
-    #define MMAP_FLAGS_HUGE MMAP_FLAGS
-  #endif
-  // threshold to use huge pages
-  #define MMAP_USE_HUGE_PAGES (1u << 27)
-#endif
-
 // read write access to private memory
 #if !defined( NO_MMAP )
   #define MMAP_PROTECTION (PROT_READ | PROT_WRITE)
@@ -220,17 +209,12 @@ void* PageAlignedAllocator::allocate( size_t size )
   void *ptr = NULL;
   if (size) {
 #if !defined NO_MMAP
-    if ( size < MMAP_USE_HUGE_PAGES ) {
-      ptr = mmap( NULL, size, MMAP_PROTECTION, MMAP_FLAGS, -1 /*file descriptor*/, 0 /*offset*/);
-    } else {
-      ptr = mmap( NULL, size, MMAP_PROTECTION, MMAP_FLAGS_HUGE, -1 /*file descriptor*/, 0 /*offset*/);
-    }
+    ptr = mmap( NULL, size, MMAP_PROTECTION, MMAP_FLAGS, -1 /*file descriptor*/, 0 /*offset*/);
     if (ptr == MAP_FAILED) {
       ptr = NULL;
     }
 #else
     static const size_t page_size = 4096; // TODO: read in from sysconf( _SC_PAGE_SIZE )
-
     ptr = raw_aligned_allocate( size, page_size);
 #endif
     if (!ptr)


### PR DESCRIPTION
I found it necessary to run destructors before deallocating memory for non POD types. 
To use create a functor which takes the alloc_ptr and size to be called before the memory is
deallocated.  

i.e. 
struct  MyDestroy  {
void operator()( void * alloc_ptr, uint64_t alloc_size)  const
{ ... };
};

...
AllocationTracker tracker(...);
MyDestroy destroy_func;
tracker.set_destroy( destroy_func );