### PR TITLE
Replace "Trilinos_ENABLE_XXX" with "${PROJECT_NAME}_ENABLE_XXX" (Kokkos #17)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   Kokkos_ENABLE_OpenMP
   KOKKOS_HAVE_OPENMP
   "Enable OpenMP support in Kokkos."
-  "${Trilinos_ENABLE_OpenMP}"
+  "${${PROJECT_NAME}_ENABLE_OpenMP}"
   )
 
 TRIBITS_ADD_OPTION_AND_DEFINE(
@@ -60,7 +60,7 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   Kokkos_ENABLE_CXX11
   KOKKOS_HAVE_CXX11
   "Enable C++11 support in Kokkos."
-  "${Trilinos_ENABLE_CXX11}"
+  "${${PROJECT_NAME}_ENABLE_CXX11}"
   )
   
 TRIBITS_ADD_OPTION_AND_DEFINE(


### PR DESCRIPTION
This makes Kokkos behave correctly when the project is not "Trilinos", like
when it is "VERA" or "SCALE".

See Github Kokkos issue #17.
