### PR TITLE
Kokkos: Modification for task data parallel interface.

### DIFF
--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -372,10 +372,10 @@ public:
     , m_team_base(0)
     , m_team_shared(0,0)
     , m_team_shared_size(0)
-    , m_team_size(0)
+    , m_team_size(1)
     , m_team_rank(0)
     , m_team_rank_rev(0)
-    , m_league_size(0)
+    , m_league_size(1)
     , m_league_end(0)
     , m_league_rank(0)
     {}

--- a/core/src/Threads/Kokkos_Threads_TaskPolicy.cpp
+++ b/core/src/Threads/Kokkos_Threads_TaskPolicy.cpp
@@ -122,7 +122,7 @@ TaskPolicy< Kokkos::Threads >::TaskPolicy
 }
 
 TaskPolicy< Kokkos::Threads >::member_type &
-TaskPolicy< Kokkos::Threads >::member_null()
+TaskPolicy< Kokkos::Threads >::member_single()
 {
   static member_type s ;
   return s ;

--- a/core/src/Threads/Kokkos_Threads_TaskPolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_TaskPolicy.hpp
@@ -388,12 +388,6 @@ private:
   int m_default_dependence_capacity ;
   int m_team_size ;    ///< Fixed size of a task-team
 
-#if defined( KOKKOS_HAVE_CXX11 )
-  TaskPolicy & operator = ( const TaskPolicy & ) = delete ;
-#else
-  TaskPolicy & operator = ( const TaskPolicy & );
-#endif
-
   template< class FunctorType >
   static inline
   const task_root_type * get_task_root( const FunctorType * f )
@@ -432,6 +426,12 @@ public:
     : m_default_dependence_capacity( arg_default_dependence_capacity )
     , m_team_size( rhs.m_team_size )
     {}
+
+  TaskPolicy & operator = ( const TaskPolicy &rhs ) {
+    m_default_dependence_capacity = rhs.m_default_dependence_capacity;
+    m_team_size = rhs.m_team_size;
+    return *this;
+  }
 
   // Create serial-thread task
 
@@ -567,7 +567,7 @@ public:
 
   //----------------------------------------
 
-  static member_type & member_null();
+  static member_type & member_single();
 
   friend void wait( TaskPolicy< Kokkos::Threads > & );
 };

--- a/core/src/impl/Kokkos_Serial_TaskPolicy.cpp
+++ b/core/src/impl/Kokkos_Serial_TaskPolicy.cpp
@@ -58,9 +58,10 @@ namespace Kokkos {
 namespace Experimental {
 
 TaskPolicy< Kokkos::Serial >::member_type &
-TaskPolicy< Kokkos::Serial >::member_null()
+TaskPolicy< Kokkos::Serial >::member_single()
 {
-  static member_type s(0,0,0); return s ;
+  static member_type s(0,1,0); 
+  return s ;
 }
 
 } // namespace Experimental

--- a/core/src/impl/Kokkos_Serial_TaskPolicy.hpp
+++ b/core/src/impl/Kokkos_Serial_TaskPolicy.hpp
@@ -625,8 +625,6 @@ private:
 
   typedef Impl::TaskMember< execution_space , void , void > task_root_type ;
 
-  TaskPolicy & operator = ( const TaskPolicy & ) /* = delete */ ;
-
   template< class FunctorType >
   static inline
   const task_root_type * get_task_root( const FunctorType * f )
@@ -643,7 +641,7 @@ private:
       return static_cast< task_root_type * >( static_cast< task_type * >(f) );
     }
 
-  const unsigned m_default_dependence_capacity ;
+  unsigned m_default_dependence_capacity ;
 
 public:
 
@@ -662,6 +660,12 @@ public:
   TaskPolicy( const TaskPolicy &
             , const unsigned arg_default_dependence_capacity )
     : m_default_dependence_capacity( arg_default_dependence_capacity ) {}
+
+  TaskPolicy & operator = ( const TaskPolicy &rhs ) 
+    {
+      m_default_dependence_capacity = rhs.m_default_dependence_capacity;
+      return *this;
+    }
 
   //----------------------------------------
 
@@ -824,7 +828,7 @@ public:
 
   //----------------------------------------
 
-  static member_type & member_null();
+  static member_type & member_single();
 };
 
 inline


### PR DESCRIPTION
  - member_single() is created in Serial and Threads execution spaces
    - ThreadsTeamMember default constructor is initialized with
      team_size = 1 and league_size = 1.

  - Assignment operator of TaskPolicy is moved from private to public.