### PR TITLE
Tutorial: Makefiles: Don't require separate CUDA=yes flag

### DIFF
--- a/example/tutorial/01_hello_world/Makefile
+++ b/example/tutorial/01_hello_world/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/01_hello_world_lambda/Makefile
+++ b/example/tutorial/01_hello_world_lambda/Makefile
@@ -3,11 +3,11 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
-LINK = nvcc_wrapper
+LINK = ${CXX}
 LINKFLAGS = 
 EXE = $(SRC:.cpp=.cuda)
 KOKKOS_DEVICES = "Cuda,OpenMP"
@@ -15,7 +15,7 @@ KOKKOS_ARCH = "SNB,Kepler35"
 else
 CXX = g++
 CXXFLAGS = -O3
-LINK = g++
+LINK = ${CXX}
 LINKFLAGS =  
 EXE = $(SRC:.cpp=.host)
 KOKKOS_DEVICES = "OpenMP"
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/02_simple_reduce/Makefile
+++ b/example/tutorial/02_simple_reduce/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/02_simple_reduce_lambda/Makefile
+++ b/example/tutorial/02_simple_reduce_lambda/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/03_simple_view/Makefile
+++ b/example/tutorial/03_simple_view/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/03_simple_view_lambda/Makefile
+++ b/example/tutorial/03_simple_view_lambda/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/04_simple_memoryspaces/Makefile
+++ b/example/tutorial/04_simple_memoryspaces/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/05_simple_atomics/Makefile
+++ b/example/tutorial/05_simple_atomics/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Advanced_Views/01_data_layouts/Makefile
+++ b/example/tutorial/Advanced_Views/01_data_layouts/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Advanced_Views/02_memory_traits/Makefile
+++ b/example/tutorial/Advanced_Views/02_memory_traits/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Advanced_Views/03_subviews/Makefile
+++ b/example/tutorial/Advanced_Views/03_subviews/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Advanced_Views/04_dualviews/Makefile
+++ b/example/tutorial/Advanced_Views/04_dualviews/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Advanced_Views/05_NVIDIA_UVM/Makefile
+++ b/example/tutorial/Advanced_Views/05_NVIDIA_UVM/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Advanced_Views/06_AtomicViews/Makefile
+++ b/example/tutorial/Advanced_Views/06_AtomicViews/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Algorithms/01_random_numbers/Makefile
+++ b/example/tutorial/Algorithms/01_random_numbers/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Hierarchical_Parallelism/01_thread_teams/Makefile
+++ b/example/tutorial/Hierarchical_Parallelism/01_thread_teams/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Hierarchical_Parallelism/01_thread_teams_lambda/Makefile
+++ b/example/tutorial/Hierarchical_Parallelism/01_thread_teams_lambda/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Hierarchical_Parallelism/02_nested_parallel_for/Makefile
+++ b/example/tutorial/Hierarchical_Parallelism/02_nested_parallel_for/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Hierarchical_Parallelism/03_vectorization/Makefile
+++ b/example/tutorial/Hierarchical_Parallelism/03_vectorization/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/Hierarchical_Parallelism/04_team_scan/Makefile
+++ b/example/tutorial/Hierarchical_Parallelism/04_team_scan/Makefile
@@ -3,8 +3,8 @@ SRC = $(wildcard *.cpp)
 
 default: build
 	echo "Start Build"
-	
-ifeq ($(CUDA), yes)
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = nvcc_wrapper
 CXXFLAGS = -O3
 LINK = ${CXX}
@@ -41,6 +41,3 @@ clean: kokkos-clean
 
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
-
-
-

--- a/example/tutorial/README
+++ b/example/tutorial/README
@@ -1,6 +1,11 @@
 Build the examples by typing in each directory: 
-make all -j 16
-make all -j 16 CUDA=yes
+make -j 16
+
+To specify a target device:
+make openmp -j 16
+make pthreads -j 16
+make serial -j 16
+make cuda -j 16
 
 The lambda variants can not be build with CUDA=yes at the moment, since
 CUDA does not support lambdas from the host. 


### PR DESCRIPTION
Rather than requiring a separate CUDA=yes flag to build the tutorial samples for CUDA,
determine this from the KOKKOS_DEVICES variable that is already passed in. Also make
README a little more clear about how to build for different targets (and remove the bit
saying "make all," since there is no "all" target)