### PR TITLE
SharedAllocationTracker refactor to be union

### DIFF
--- a/core/src/impl/KokkosExp_ViewMapping.hpp
+++ b/core/src/impl/KokkosExp_ViewMapping.hpp
@@ -2466,7 +2466,7 @@ public:
 
 /** \brief  View mapping for non-specialized data type and standard layout */
 template< class Traits , bool R0 , bool R1 , bool R2 , bool R3 , bool R4 , bool R5 , bool R6 , bool R7 >
-class SubviewMapping< Traits, R0, R1, R2, R3, R4, R5, R6, R7 ,
+struct SubviewMapping< Traits, R0, R1, R2, R3, R4, R5, R6, R7 ,
   typename std::enable_if<(
     std::is_same< typename Traits::specialize , void >::value
     &&

--- a/core/unit_test/TestSharedAlloc.hpp
+++ b/core/unit_test/TestSharedAlloc.hpp
@@ -78,6 +78,8 @@ void test_shared_alloc()
   typedef Kokkos::Experimental::Impl::SharedAllocationRecord< MemorySpace , void >                RecordMemS ;
   typedef Kokkos::Experimental::Impl::SharedAllocationRecord< MemorySpace , SharedAllocDestroy >  RecordFull ;
 
+  static_assert( sizeof(Tracker) == sizeof(int*), "SharedAllocationTracker has wrong size!" );
+
   MemorySpace s ;
 
   const size_t N = 1200 ;


### PR DESCRIPTION
Allows us to treat the pointer bits as an int without reinterpret casts.

Also, fix some other minor errors clang caught.