### PR TITLE
Change static const value in union to enum

### DIFF
--- a/core/src/impl/KokkosExp_SharedAlloc.hpp
+++ b/core/src/impl/KokkosExp_SharedAlloc.hpp
@@ -204,7 +204,9 @@ private:
 
   typedef SharedAllocationRecord<void,void>  Record ;
 
-  constexpr static unsigned long DO_NOT_DEREF_FLAG = 0x01ul;
+  enum : unsigned long {
+    DO_NOT_DEREF_FLAG = 0x01ul
+  };
 
   // The allocation record resides in Host memory space
   Record * m_record ;


### PR DESCRIPTION
Some compilers don't like mixing static and non-statics within
unions.