### PR TITLE
test_all_sandia: Fix module problem

### DIFF
--- a/config/test_all_sandia
+++ b/config/test_all_sandia
@@ -34,6 +34,7 @@ COMPILERS=("gcc/4.7.2 gcc/4.7.2/base,hwloc/1.10.0/host/gnu/4.7.2 $GCC_BUILD_LIST
 export OMP_NUM_THREADS=4
 
 export SEMS_MODULE_ROOT=/projects/modulefiles
+module use /home/projects/modulefiles
 module use /projects/modulefiles/rhel6-x86_64/sems/compiler
 
 SCRIPT_KOKKOS_ROOT=$( cd "$( dirname "$0" )" && cd .. && pwd )


### PR DESCRIPTION
Need to explicitly use modules from /home/projects/modulefiles if
running under jenkins account.