### PR TITLE
Fix a bug in Kokkos Profiling Interface where Library not Specified

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -220,8 +220,8 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AVX), 1)
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AVX2), 1)
-	KOKKOS_CXXFLAGS += -xcore-avx2
-	KOKKOS_LDFLAGS += -xcore-avx2
+	KOKKOS_CXXFLAGS += -march=core-avx2
+	KOKKOS_LDFLAGS += -march=core-avx2
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_KNC), 1)

--- a/config/nvcc_wrapper
+++ b/config/nvcc_wrapper
@@ -73,7 +73,7 @@ do
   -std=c++98|--std=c++98)
     ;;
   #Handle known nvcc args that have an argument
-  -o|-rdc|-maxrregcount)
+  -o|-rdc|-maxrregcount|--default-stream)
     cuda_args="$cuda_args $1 $2"
     shift
     ;;

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -259,109 +259,243 @@ public:
 namespace Kokkos {
 namespace Impl {
 
-template<> struct DeepCopy< CudaSpace , CudaSpace >
+void DeepCopyAsyncCuda( void * dst , const void * src , size_t n);
+
+template<> struct DeepCopy< CudaSpace , CudaSpace , Cuda>
 {
   DeepCopy( void * dst , const void * src , size_t );
   DeepCopy( const Cuda & , void * dst , const void * src , size_t );
 };
 
-template<> struct DeepCopy< CudaSpace , HostSpace >
+template<> struct DeepCopy< CudaSpace , HostSpace , Cuda >
 {
   DeepCopy( void * dst , const void * src , size_t );
   DeepCopy( const Cuda & , void * dst , const void * src , size_t );
 };
 
-template<> struct DeepCopy< HostSpace , CudaSpace >
+template<> struct DeepCopy< HostSpace , CudaSpace , Cuda >
 {
   DeepCopy( void * dst , const void * src , size_t );
   DeepCopy( const Cuda & , void * dst , const void * src , size_t );
 };
 
-template<> struct DeepCopy< CudaSpace , CudaUVMSpace >
+template<class ExecutionSpace> struct DeepCopy< CudaSpace , CudaSpace , ExecutionSpace >
 {
   inline
   DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< CudaSpace , CudaSpace >( dst , src , n ); }
+  { (void) DeepCopy< CudaSpace , CudaSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
 };
 
-template<> struct DeepCopy< CudaSpace , CudaHostPinnedSpace >
+template<class ExecutionSpace> struct DeepCopy< CudaSpace , HostSpace , ExecutionSpace >
 {
   inline
   DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< CudaSpace , HostSpace >( dst , src , n ); }
+  { (void) DeepCopy< CudaSpace , HostSpace , Cuda>( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
+};
+
+template<class ExecutionSpace>
+struct DeepCopy< HostSpace , CudaSpace , ExecutionSpace >
+{
+  inline
+  DeepCopy( void * dst , const void * src , size_t n )
+  { (void) DeepCopy< HostSpace , CudaSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
+};
+
+template<class ExecutionSpace>
+struct DeepCopy< CudaSpace , CudaUVMSpace , ExecutionSpace >
+{
+  inline
+  DeepCopy( void * dst , const void * src , size_t n )
+  { (void) DeepCopy< CudaSpace , CudaSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
+};
+
+template<class ExecutionSpace>
+struct DeepCopy< CudaSpace , CudaHostPinnedSpace , ExecutionSpace>
+{
+  inline
+  DeepCopy( void * dst , const void * src , size_t n )
+  { (void) DeepCopy< CudaSpace , HostSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
 };
 
 
-template<> struct DeepCopy< CudaUVMSpace , CudaSpace >
+template<class ExecutionSpace>
+struct DeepCopy< CudaUVMSpace , CudaSpace , ExecutionSpace>
 {
   inline
   DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< CudaSpace , CudaSpace >( dst , src , n ); }
+  { (void) DeepCopy< CudaSpace , CudaSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
 };
 
-template<> struct DeepCopy< CudaUVMSpace , CudaUVMSpace >
+template<class ExecutionSpace>
+struct DeepCopy< CudaUVMSpace , CudaUVMSpace , ExecutionSpace>
 {
   inline
   DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< CudaSpace , CudaSpace >( dst , src , n ); }
+  { (void) DeepCopy< CudaSpace , CudaSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
 };
 
-template<> struct DeepCopy< CudaUVMSpace , CudaHostPinnedSpace >
+template<class ExecutionSpace>
+struct DeepCopy< CudaUVMSpace , CudaHostPinnedSpace , ExecutionSpace>
 {
   inline
   DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< CudaSpace , HostSpace >( dst , src , n ); }
+  { (void) DeepCopy< CudaSpace , HostSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
 };
 
-template<> struct DeepCopy< CudaUVMSpace , HostSpace >
+template<class ExecutionSpace> struct DeepCopy< CudaUVMSpace , HostSpace , ExecutionSpace >
 {
   inline
   DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< CudaSpace , HostSpace >( dst , src , n ); }
-};
+  { (void) DeepCopy< CudaSpace , HostSpace , Cuda >( dst , src , n ); }
 
-
-template<> struct DeepCopy< CudaHostPinnedSpace , CudaSpace >
-{
   inline
-  DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< HostSpace , CudaSpace >( dst , src , n ); }
-};
-
-template<> struct DeepCopy< CudaHostPinnedSpace , CudaUVMSpace >
-{
-  inline
-  DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< HostSpace , CudaSpace >( dst , src , n ); }
-};
-
-template<> struct DeepCopy< CudaHostPinnedSpace , CudaHostPinnedSpace >
-{
-  inline
-  DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< HostSpace , HostSpace >( dst , src , n ); }
-};
-
-template<> struct DeepCopy< CudaHostPinnedSpace , HostSpace >
-{
-  inline
-  DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< HostSpace , HostSpace >( dst , src , n ); }
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
 };
 
 
-template<> struct DeepCopy< HostSpace , CudaUVMSpace >
+template<class ExecutionSpace> struct DeepCopy< CudaHostPinnedSpace , CudaSpace , ExecutionSpace >
 {
   inline
   DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< HostSpace , CudaSpace >( dst , src , n ); }
+  { (void) DeepCopy< HostSpace , CudaSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
 };
 
-template<> struct DeepCopy< HostSpace , CudaHostPinnedSpace >
+template<class ExecutionSpace> struct DeepCopy< CudaHostPinnedSpace , CudaUVMSpace , ExecutionSpace >
 {
   inline
   DeepCopy( void * dst , const void * src , size_t n )
-  { (void) DeepCopy< HostSpace , HostSpace >( dst , src , n ); }
+  { (void) DeepCopy< HostSpace , CudaSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
+};
+
+template<class ExecutionSpace> struct DeepCopy< CudaHostPinnedSpace , CudaHostPinnedSpace , ExecutionSpace >
+{
+  inline
+  DeepCopy( void * dst , const void * src , size_t n )
+  { (void) DeepCopy< HostSpace , HostSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
+};
+
+template<class ExecutionSpace> struct DeepCopy< CudaHostPinnedSpace , HostSpace , ExecutionSpace >
+{
+  inline
+  DeepCopy( void * dst , const void * src , size_t n )
+  { (void) DeepCopy< HostSpace , HostSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
+};
+
+
+template<class ExecutionSpace> struct DeepCopy< HostSpace , CudaUVMSpace , ExecutionSpace >
+{
+  inline
+  DeepCopy( void * dst , const void * src , size_t n )
+  { (void) DeepCopy< HostSpace , CudaSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
+};
+
+template<class ExecutionSpace> struct DeepCopy< HostSpace , CudaHostPinnedSpace , ExecutionSpace >
+{
+  inline
+  DeepCopy( void * dst , const void * src , size_t n )
+  { (void) DeepCopy< HostSpace , HostSpace , Cuda >( dst , src , n ); }
+
+  inline
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n )
+  {
+    exec.fence();
+    DeepCopyAsyncCuda (dst,src,n);
+  }
 };
 
 } // namespace Impl

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -255,11 +255,17 @@ public:
 namespace Kokkos {
 namespace Impl {
 
-template< class , class > struct DeepCopy ;
+template< class DstSpace, class SrcSpace, class ExecutionSpace = typename DstSpace::execution_space> struct DeepCopy ;
 
-template<>
-struct DeepCopy<HostSpace,HostSpace> {
-  DeepCopy( void * dst , const void * src , size_t n );
+template<class ExecutionSpace>
+struct DeepCopy<HostSpace,HostSpace,ExecutionSpace> {
+  DeepCopy( void * dst , const void * src , size_t n ) {
+    memcpy( dst , src , n );
+  }
+  DeepCopy( const ExecutionSpace& exec, void * dst , const void * src , size_t n ) {
+    exec.fence();
+    memcpy( dst , src , n );
+  }
 };
 
 } // namespace Impl

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -209,10 +209,16 @@
 
 #if ! defined( __clang__ ) && ! defined( KOKKOS_COMPILER_INTEL ) &&defined( __GNUC__ )
   #define KOKKOS_COMPILER_GNU __GNUC__*100+__GNUC_MINOR__*10+__GNUC_PATCHLEVEL__
+  #if ( 472 > KOKKOS_COMPILER_GNU )
+    #error "Compiling with GCC version earlier than 4.7.2 is not supported."
+  #endif
 #endif
 
 #if defined( __PGIC__ ) && ! defined( __GNUC__ )
   #define KOKKOS_COMPILER_PGI __PGIC__*100+__PGIC_MINOR__*10+__PGIC_PATCHLEVEL__
+  #if ( 1540 > KOKKOS_COMPILER_PGI )
+    #error "Compiling with PGI version earlier than 15.4 is not supported."
+  #endif
 #endif
 
 #endif /* #if ! defined( __CUDA_ARCH__ ) */
@@ -229,7 +235,14 @@
   #define KOKKOS_HAVE_PRAGMA_VECTOR 1
   #define KOKKOS_HAVE_PRAGMA_SIMD 1
 
-#if ( 1200 <= KOKKOS_COMPILER_INTEL ) && ! defined( KOKKOS_ENABLE_ASM ) && ! defined( _WIN32 )
+  #if ( 1400 > KOKKOS_COMPILER_INTEL )
+    #if ( 1300 > KOKKOS_COMPILER_INTEL )
+      #error "Compiling with Intel version earlier than 13.0 is not supported. Official minimal version is 14.0."
+    #else
+      #warning "Compiling with Intel version 13.x probably works but is not officially supported. Official minimal version is 14.0."
+    #endif
+  #endif
+  #if ( 1200 <= KOKKOS_COMPILER_INTEL ) && ! defined( KOKKOS_ENABLE_ASM ) && ! defined( _WIN32 )
     #define KOKKOS_ENABLE_ASM 1
   #endif
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -98,7 +98,7 @@ template< class DstViewSpecialize ,
           class Enable = void >
 struct ViewAssignment ;
 
-template< class DstMemorySpace , class SrcMemorySpace >
+template< class DstMemorySpace , class SrcMemorySpace , class ExecutionSpace>
 struct DeepCopy ;
 
 } /* namespace Impl */
@@ -1560,8 +1560,192 @@ void deep_copy( const View< DT, DL, DD, DM, DS > & dst ,
   Impl::ViewRemap< dst_type , src_type >( dst , src );
 }
 
+}
+
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
+
+namespace Kokkos {
+
+//----------------------------------------------------------------------------
+/** \brief  Deep copy a value into a view.
+ */
+template< class ExecSpace, class DT , class DL , class DD , class DM , class DS >
+inline
+void deep_copy( const ExecSpace&, const View<DT,DL,DD,DM,DS> & dst ,
+                typename Impl::enable_if<(
+                  Impl::is_same< typename ViewTraits<DT,DL,DD,DM>::non_const_value_type ,
+                                 typename ViewTraits<DT,DL,DD,DM>::value_type >::value
+                ), typename ViewTraits<DT,DL,DD,DM>::const_value_type >::type & value )
+{
+  Impl::ViewFill< View<DT,DL,DD,DM,DS> >( dst , value );
+}
+
+template< class ExecSpace, class ST , class SL , class SD , class SM , class SS >
+inline
+typename Impl::enable_if<( ViewTraits<ST,SL,SD,SM>::rank == 0 )>::type
+deep_copy( const ExecSpace& exec,  ST & dst , const View<ST,SL,SD,SM,SS> & src )
+{
+  typedef  ViewTraits<ST,SL,SD,SM>  src_traits ;
+  typedef typename src_traits::memory_space  src_memory_space ;
+  Impl::DeepCopy< HostSpace , src_memory_space , ExecSpace >( exec , & dst , src.ptr_on_device() , sizeof(ST) );
+}
+
+//----------------------------------------------------------------------------
+/** \brief  A deep copy between views of compatible type, and rank zero.
+ */
+template< class ExecSpace ,
+          class DT , class DL , class DD , class DM , class DS ,
+          class ST , class SL , class SD , class SM , class SS >
+inline
+void deep_copy( const ExecSpace& exec,
+                const View<DT,DL,DD,DM,DS> & dst ,
+                const View<ST,SL,SD,SM,SS> & src ,
+                typename Impl::enable_if<(
+                  // Same type and destination is not constant:
+                  Impl::is_same< typename View<DT,DL,DD,DM,DS>::value_type ,
+                                 typename View<ST,SL,SD,SM,SS>::non_const_value_type >::value
+                  &&
+                  // Rank zero:
+                  ( unsigned(View<DT,DL,DD,DM,DS>::rank) == unsigned(0) ) &&
+                  ( unsigned(View<ST,SL,SD,SM,SS>::rank) == unsigned(0) )
+                )>::type * = 0 )
+{
+  typedef  View<DT,DL,DD,DM,DS>  dst_type ;
+  typedef  View<ST,SL,SD,SM,SS>  src_type ;
+
+  typedef typename dst_type::memory_space  dst_memory_space ;
+  typedef typename src_type::memory_space  src_memory_space ;
+  typedef typename src_type::value_type    value_type ;
+
+  if ( dst.ptr_on_device() != src.ptr_on_device() ) {
+    Impl::DeepCopy< dst_memory_space , src_memory_space , ExecSpace >( exec , dst.ptr_on_device() , src.ptr_on_device() , sizeof(value_type) );
+  }
+}
+
+//----------------------------------------------------------------------------
+/** \brief  A deep copy between views of the default specialization, compatible type,
+ *          same non-zero rank, same contiguous layout.
+ */
+template< class ExecSpace ,
+          class DT , class DL , class DD , class DM ,
+          class ST , class SL , class SD , class SM >
+inline
+void deep_copy( const ExecSpace & exec,
+                const View<DT,DL,DD,DM,Impl::ViewDefault> & dst ,
+                const View<ST,SL,SD,SM,Impl::ViewDefault> & src ,
+                typename Impl::enable_if<(
+                  // Same type and destination is not constant:
+                  Impl::is_same< typename View<DT,DL,DD,DM,Impl::ViewDefault>::value_type ,
+                                 typename View<ST,SL,SD,SM,Impl::ViewDefault>::non_const_value_type >::value
+                  &&
+                  // Same non-zero rank:
+                  ( unsigned(View<DT,DL,DD,DM,Impl::ViewDefault>::rank) ==
+                    unsigned(View<ST,SL,SD,SM,Impl::ViewDefault>::rank) )
+                  &&
+                  ( 0 < unsigned(View<DT,DL,DD,DM,Impl::ViewDefault>::rank) )
+                  &&
+                  // Same layout:
+                  Impl::is_same< typename View<DT,DL,DD,DM,Impl::ViewDefault>::array_layout ,
+                                 typename View<ST,SL,SD,SM,Impl::ViewDefault>::array_layout >::value
+                )>::type * = 0 )
+{
+  typedef  View<DT,DL,DD,DM,Impl::ViewDefault>  dst_type ;
+  typedef  View<ST,SL,SD,SM,Impl::ViewDefault>  src_type ;
+
+  typedef typename dst_type::memory_space  dst_memory_space ;
+  typedef typename src_type::memory_space  src_memory_space ;
+
+  enum { is_contiguous = // Contiguous (e.g., non-strided, non-tiled) layout
+           Impl::is_same< typename View<DT,DL,DD,DM,Impl::ViewDefault>::array_layout , LayoutLeft >::value ||
+           Impl::is_same< typename View<DT,DL,DD,DM,Impl::ViewDefault>::array_layout , LayoutRight >::value };
+
+  if ( dst.ptr_on_device() != src.ptr_on_device() ) {
+
+    // Same shape (dimensions)
+
+    const bool shapes_are_equal = dst.shape() == src.shape();
+
+    if ( shapes_are_equal && is_contiguous && dst.capacity() == src.capacity() ) {
+
+      // Views span equal length contiguous range.
+      // Assuming can perform a straight memory copy over this range.
+
+      const size_t nbytes = sizeof(typename dst_type::value_type) * dst.capacity();
+
+      Impl::DeepCopy< dst_memory_space , src_memory_space , ExecSpace >( exec , dst.ptr_on_device() , src.ptr_on_device() , nbytes );
+    }
+    else {
+      // Destination view's execution space must be able to directly access source memory space
+      // in order for the ViewRemap functor run in the destination memory space's execution space.
+      size_t stride[8];
+      src.stride(stride);
+      size_t size_stride = stride[0]*src.dimension_0();
+      size_t size_dim = src.dimension_0();
+      for(int i = 1; i<src.rank; i++) {
+        if(stride[i]*src.dimension(i)>size_stride)
+          size_stride = stride[i]*src.dimension(i);
+        size_dim*=src.dimension(i);
+      }
+
+      if( shapes_are_equal && size_stride == size_dim) {
+        const size_t nbytes = sizeof(typename dst_type::value_type) * dst.capacity();
+
+        Impl::DeepCopy< dst_memory_space , src_memory_space , ExecSpace >( exec , dst.ptr_on_device() , src.ptr_on_device() , nbytes );
+      } else {
+        Impl::ViewRemap< dst_type , src_type >( dst , src );
+      }
+    }
+  }
+}
+
+
+/** \brief Deep copy equal dimension arrays in the same space which
+ *         have different layouts or specializations.
+ */
+template< class ExecSpace ,
+          class DT , class DL , class DD , class DM , class DS ,
+          class ST , class SL , class SD , class SM , class SS >
+inline
+void deep_copy( const ExecSpace& ,
+                const View< DT, DL, DD, DM, DS > & dst ,
+                const View< ST, SL, SD, SM, SS > & src ,
+                const typename Impl::enable_if<(
+                  // Same type and destination is not constant:
+                  Impl::is_same< typename View<DT,DL,DD,DM,DS>::value_type ,
+                                 typename View<DT,DL,DD,DM,DS>::non_const_value_type >::value
+                  &&
+                  // Source memory space is accessible to destination memory space
+                  Impl::VerifyExecutionCanAccessMemorySpace< typename View<DT,DL,DD,DM,DS>::memory_space
+                                                           , typename View<ST,SL,SD,SM,SS>::memory_space >::value
+                  &&
+                  // Same non-zero rank
+                  ( unsigned( View<DT,DL,DD,DM,DS>::rank ) ==
+                    unsigned( View<ST,SL,SD,SM,SS>::rank ) )
+                  &&
+                  ( 0 < unsigned( View<DT,DL,DD,DM,DS>::rank ) )
+                  &&
+                  // Different layout or different specialization:
+                  ( ( ! Impl::is_same< typename View<DT,DL,DD,DM,DS>::array_layout ,
+                                       typename View<ST,SL,SD,SM,SS>::array_layout >::value )
+                    ||
+                    ( ! Impl::is_same< DS , SS >::value )
+                  )
+                )>::type * = 0 )
+{
+  typedef View< DT, DL, DD, DM, DS > dst_type ;
+  typedef View< ST, SL, SD, SM, SS > src_type ;
+
+  assert_shapes_equal_dimension( dst.shape() , src.shape() );
+
+  Impl::ViewRemap< dst_type , src_type >( dst , src );
+}
+
+}
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace Kokkos {
 
 template< class T , class L , class D , class M , class S >
 typename Impl::enable_if<(

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -272,6 +272,29 @@ private:
   KOKKOS_INLINE_FUNCTION
   static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , T & , bool ) const ) {}
 
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , T & , const bool& ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , T & , const bool& ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , T & , const bool& ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , T & , const bool& ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , T & , const bool& ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , T & , const bool& ) const ) {}
   //----------------------------------------
   // parallel_scan operator with a tag:
 
@@ -291,6 +314,21 @@ private:
   KOKKOS_INLINE_FUNCTION
   static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember& , T & , bool ) const ) {}
 
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , T & , const bool& ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , T & , const bool& ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember& , T & , const bool& ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember& , T & , const bool& ) const ) {}
   //----------------------------------------
 
   typedef decltype( deduce_reduce_type( tag_type() , & FunctorType::operator() ) ) ValueType ;

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -99,20 +99,6 @@
 #include <impl/Kokkos_Error.hpp>
 #include <Kokkos_Atomic.hpp>
 
-/*--------------------------------------------------------------------------*/
-
-namespace Kokkos {
-namespace Impl {
-
-
-DeepCopy<HostSpace,HostSpace>::DeepCopy( void * dst , const void * src , size_t n )
-{
-  memcpy( dst , src , n );
-}
-
-}
-}
-
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 

--- a/core/src/impl/Kokkos_Profiling_Interface.cpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.cpp
@@ -98,6 +98,15 @@ namespace Kokkos {
         void* firstProfileLibrary;
 
         char* envProfileLibrary  = getenv("KOKKOS_PROFILE_LIBRARY");
+
+	// If the library is not set in the environment then exit early, no more
+	// processing to be done. Otherwise continue and attempt to resolve function
+	// call sites etc.
+	if(NULL == envProfileLibrary) {
+		// Exit, no library specified.
+		return ;
+	}
+
 	char* profileLibraryName = strtok(envProfileLibrary, ";");
 
         if( (NULL != profileLibraryName) && (strcmp(profileLibraryName, "") != 0) ) {

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1085,35 +1085,100 @@ public:
     // T v2 = hx(0,0) ; // Generates compile error as intended
     // hx(0,0) = v2 ;   // Generates compile error as intended
 
-    size_t count = 0 ;
-    for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
-    for ( size_t i1 = 0 ; i1 < hx.dimension_1() ; ++i1 ) {
-    for ( size_t i2 = 0 ; i2 < hx.dimension_2() ; ++i2 ) {
-    for ( size_t i3 = 0 ; i3 < hx.dimension_3() ; ++i3 ) {
-      hx(ip,i1,i2,i3) = ++count ;
-    }}}}
+    // Testing with asynchronous deep copy with respect to device
+    {
+      size_t count = 0 ;
+      for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
+      for ( size_t i1 = 0 ; i1 < hx.dimension_1() ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < hx.dimension_2() ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < hx.dimension_3() ; ++i3 ) {
+        hx(ip,i1,i2,i3) = ++count ;
+      }}}}
 
-    Kokkos::deep_copy( dx , hx );
-    Kokkos::deep_copy( dy , dx );
-    Kokkos::deep_copy( hy , dy );
+      Kokkos::deep_copy(typename hView4::execution_space(), dx , hx );
+      Kokkos::deep_copy(typename hView4::execution_space(), dy , dx );
+      Kokkos::deep_copy(typename hView4::execution_space(), hy , dy );
 
-    for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
-    for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
-    for ( size_t i2 = 0 ; i2 < N2 ; ++i2 ) {
-    for ( size_t i3 = 0 ; i3 < N3 ; ++i3 ) {
-      { ASSERT_EQ( hx(ip,i1,i2,i3) , hy(ip,i1,i2,i3) ); }
-    }}}}
+      for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
+      for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < N2 ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < N3 ; ++i3 ) {
+        { ASSERT_EQ( hx(ip,i1,i2,i3) , hy(ip,i1,i2,i3) ); }
+      }}}}
 
-    Kokkos::deep_copy( dx , T(0) );
-    Kokkos::deep_copy( hx , dx );
+      Kokkos::deep_copy(typename hView4::execution_space(), dx , T(0) );
+      Kokkos::deep_copy(typename hView4::execution_space(), hx , dx );
 
-    for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
-    for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
-    for ( size_t i2 = 0 ; i2 < N2 ; ++i2 ) {
-    for ( size_t i3 = 0 ; i3 < N3 ; ++i3 ) {
-      { ASSERT_EQ( hx(ip,i1,i2,i3) , T(0) ); }
-    }}}}
+      for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
+      for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < N2 ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < N3 ; ++i3 ) {
+        { ASSERT_EQ( hx(ip,i1,i2,i3) , T(0) ); }
+      }}}}
+    }
+    // Testing with asynchronous deep copy with respect to host
+    {
+      size_t count = 0 ;
+      for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
+      for ( size_t i1 = 0 ; i1 < hx.dimension_1() ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < hx.dimension_2() ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < hx.dimension_3() ; ++i3 ) {
+        hx(ip,i1,i2,i3) = ++count ;
+      }}}}
 
+      Kokkos::deep_copy(typename dView4::execution_space(), dx , hx );
+      Kokkos::deep_copy(typename dView4::execution_space(), dy , dx );
+      Kokkos::deep_copy(typename dView4::execution_space(), hy , dy );
+
+      for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
+      for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < N2 ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < N3 ; ++i3 ) {
+        { ASSERT_EQ( hx(ip,i1,i2,i3) , hy(ip,i1,i2,i3) ); }
+      }}}}
+
+      Kokkos::deep_copy(typename dView4::execution_space(), dx , T(0) );
+      Kokkos::deep_copy(typename dView4::execution_space(), hx , dx );
+
+      for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
+      for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < N2 ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < N3 ; ++i3 ) {
+        { ASSERT_EQ( hx(ip,i1,i2,i3) , T(0) ); }
+      }}}}
+    }
+
+    // Testing with synchronous deep copy
+    {
+      size_t count = 0 ;
+      for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
+      for ( size_t i1 = 0 ; i1 < hx.dimension_1() ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < hx.dimension_2() ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < hx.dimension_3() ; ++i3 ) {
+        hx(ip,i1,i2,i3) = ++count ;
+      }}}}
+
+      Kokkos::deep_copy( dx , hx );
+      Kokkos::deep_copy( dy , dx );
+      Kokkos::deep_copy( hy , dy );
+
+      for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
+      for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < N2 ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < N3 ; ++i3 ) {
+        { ASSERT_EQ( hx(ip,i1,i2,i3) , hy(ip,i1,i2,i3) ); }
+      }}}}
+
+      Kokkos::deep_copy( dx , T(0) );
+      Kokkos::deep_copy( hx , dx );
+
+      for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
+      for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < N2 ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < N3 ; ++i3 ) {
+        { ASSERT_EQ( hx(ip,i1,i2,i3) , T(0) ); }
+      }}}}
+    }
     dz = dx ; ASSERT_EQ( dx, dz); ASSERT_NE( dy, dz);
     dz = dy ; ASSERT_EQ( dy, dz); ASSERT_NE( dx, dz);
 

--- a/example/tutorial/Advanced_Views/07_Overlapping_DeepCopy/Makefile
+++ b/example/tutorial/Advanced_Views/07_Overlapping_DeepCopy/Makefile
@@ -1,0 +1,43 @@
+KOKKOS_PATH = ../../../..
+SRC = $(wildcard *.cpp)
+
+default: build
+	echo "Start Build"
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
+CXX = nvcc_wrapper
+CXXFLAGS = -O3 --default-stream per-thread 
+LINK = ${CXX}
+LINKFLAGS = 
+EXE = $(SRC:.cpp=.cuda)
+KOKKOS_DEVICES = "Cuda,OpenMP"
+KOKKOS_ARCH = "SNB,Kepler35"
+else
+CXX = g++
+CXXFLAGS = -O3
+LINK = ${CXX}
+LINKFLAGS =  
+EXE = $(SRC:.cpp=.host)
+KOKKOS_DEVICES = "OpenMP"
+KOKKOS_ARCH = "SNB"
+endif
+
+DEPFLAGS = -M
+
+OBJ = $(SRC:.cpp=.o)
+LIB =
+
+include $(KOKKOS_PATH)/Makefile.kokkos
+
+build: $(EXE)
+
+$(EXE): $(OBJ) $(KOKKOS_LINK_DEPENDS)
+	$(LINK) $(KOKKOS_LDFLAGS) $(LINKFLAGS) $(EXTRA_PATH) $(OBJ) $(KOKKOS_LIBS) $(LIB) -o $(EXE)
+
+clean: kokkos-clean 
+	rm -f *.o *.cuda *.host
+
+# Compilation rules
+
+%.o:%.cpp $(KOKKOS_CPP_DEPENDS)
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<

--- a/example/tutorial/Advanced_Views/07_Overlapping_DeepCopy/overlapping_deepcopy.cpp
+++ b/example/tutorial/Advanced_Views/07_Overlapping_DeepCopy/overlapping_deepcopy.cpp
@@ -122,7 +122,7 @@ int main(int argc, char * argv[]) {
   if(synch==1)
     Kokkos::deep_copy(Kokkos::OpenMP(),h_b,d_b);
   if(synch==2)
-    Kokkos::deep_copy(Kokkos::OpenMP(),h_b,d_b);
+    Kokkos::deep_copy(h_b,d_b);
 
 
   Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::OpenMP>(0,size),KOKKOS_LAMBDA (const int& i) {

--- a/example/tutorial/Advanced_Views/07_Overlapping_DeepCopy/overlapping_deepcopy.cpp
+++ b/example/tutorial/Advanced_Views/07_Overlapping_DeepCopy/overlapping_deepcopy.cpp
@@ -1,0 +1,148 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+#include <cstdio>
+#include <typeinfo>
+#include <cmath>
+#include <impl/Kokkos_Timer.hpp>
+
+struct FillDevice {
+  double value;
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace> a;
+  FillDevice(const double& val, const Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace>& d_a):
+     value(val),a(d_a){}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const int& i) const {
+    a(i) = value;
+  }
+};
+
+struct ComputeADevice {
+  int iter;
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace> a;
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace> b;
+  ComputeADevice(const int& iter_,
+                 const Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace>& d_a,
+                 const Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace>& d_b):
+     iter(iter_),a(d_a),b(d_b){}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const int& i) const {
+    for(int j=1;j<iter;j++) {
+      a(i) += std::pow(b(i),1.0+1.0/iter);
+    }
+  }
+};
+
+struct ComputeAHost {
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaHostPinnedSpace> a;
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaHostPinnedSpace> b;
+  ComputeAHost(  const Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaHostPinnedSpace>& d_a,
+                 const Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaHostPinnedSpace>& d_b):
+     a(d_a),b(d_b){}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const int& i) const {
+    a(i) += b(i);
+  }
+};
+
+struct MergeDevice {
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace> a;
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace> b;
+  MergeDevice(
+                 const Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace>& d_a,
+                 const Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace>& d_b):
+     a(d_a),b(d_b){}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const int& i) const {
+    a(i) += b(i);
+  }
+};
+
+int main(int argc, char * argv[]) {
+  int size = 100000000;
+  Kokkos::initialize();
+  int synch = atoi(argv[1]);
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace> d_a("Device A",size);
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace> d_b("Device B",size);
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaSpace> d_tmp("Device tmp",size);
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaHostPinnedSpace> h_a("Host A",size);
+  Kokkos::View<double*,Kokkos::LayoutLeft,Kokkos::CudaHostPinnedSpace> h_b("Host B",size);
+
+  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::Cuda>(0,size),FillDevice(0.0,d_a));
+  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::Cuda>(0,size),FillDevice(1.3513,d_b));
+  Kokkos::fence();
+  Kokkos::Impl::Timer timer;
+  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::Cuda>(0,size),ComputeADevice(20,d_a,d_b));
+
+  if(synch==1)
+    Kokkos::deep_copy(Kokkos::OpenMP(),h_b,d_b);
+  if(synch==2)
+    Kokkos::deep_copy(Kokkos::OpenMP(),h_b,d_b);
+
+
+  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::OpenMP>(0,size),KOKKOS_LAMBDA (const int& i) {
+    h_a(i) = 0.0;
+  });
+  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::OpenMP>(0,size),ComputeAHost(h_a,h_b));
+  Kokkos::OpenMP::fence();
+  if(synch==1)
+    Kokkos::deep_copy(Kokkos::OpenMP(), d_tmp,h_a);
+  if(synch==2)
+    Kokkos::deep_copy(d_tmp,h_a);
+  Kokkos::fence();
+
+  std::cout << "Time " << timer.seconds() << std::endl;
+  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::Cuda>(0,size),MergeDevice(d_a,d_tmp));
+
+  Kokkos::deep_copy(h_a,d_a);
+  std::cout << "h_a(0): " << h_a(0) << " ( Correct: 27.4154 )" << std::endl;
+  Kokkos::finalize();
+}
+
+
+


### PR DESCRIPTION
Fixes a bug in the Kokkos runtime when profiling is enabled but a library is not specified in the environment.
