### PR TITLE
Fix issue where if KokkosP is enabled and a library is not specified

### DIFF
--- a/core/src/impl/Kokkos_Profiling_Interface.cpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.cpp
@@ -98,6 +98,13 @@ namespace Kokkos {
         void* firstProfileLibrary;
 
         char* envProfileLibrary  = getenv("KOKKOS_PROFILE_LIBRARY");
+
+	// If we do not find a profiling library in the environment then exit
+	// early.
+	if( NULL == envProfileLibrary ) {
+		return ;
+	}
+
 	char* profileLibraryName = strtok(envProfileLibrary, ";");
 
         if( (NULL != profileLibraryName) && (strcmp(profileLibraryName, "") != 0) ) {
@@ -107,7 +114,7 @@ namespace Kokkos {
                 std::cerr << "Error: Unable to load KokkosP library: " <<
                 profileLibraryName << std::endl;
             } else {
-                std::cout << "KOKKOSP: Library Loaded: " << profileLibraryName << std::endl;
+                std::cout << "KokkosP: Library Loaded: " << profileLibraryName << std::endl;
 
                 beginForCallee = (beginFunction) dlsym(firstProfileLibrary, "kokkosp_begin_parallel_for");
                 beginScanCallee = (beginFunction) dlsym(firstProfileLibrary, "kokkosp_begin_parallel_scan");


### PR DESCRIPTION
KokkosP loader may have an issue where profiling interface is enabled but a library is not specified in the environment. In this case it may be possible to seg-fault with the call to the library string tokenizer. Was seen during initial LULESH profiling work.
