### PR TITLE
Fix ARM64 compile error where pause is not allowed in assembly.

### DIFF
--- a/core/src/impl/Kokkos_spinwait.cpp
+++ b/core/src/impl/Kokkos_spinwait.cpp
@@ -47,7 +47,7 @@
 /*--------------------------------------------------------------------------*/
 
 #if ( KOKKOS_ENABLE_ASM )
-  #if defined( __arm__ )
+  #if defined( __arm__ ) || defined( __aarch64__ )
     /* No-operation instruction to idle the thread. */
     #define YIELD   asm volatile("nop")
   #else


### PR DESCRIPTION
Current checks are for 32-bit ARM only which results in compile errors. These checks extend support for 64-bit ARM as well.
