### PR TITLE
Add Synchronic to Kokkos

### DIFF
--- a/config/test_all_sandia
+++ b/config/test_all_sandia
@@ -33,9 +33,7 @@ COMPILERS=("gcc/4.7.2 gcc/4.7.2/base,hwloc/1.10.0/host/gnu/4.7.2 $GCC_BUILD_LIST
 
 export OMP_NUM_THREADS=4
 
-export SEMS_MODULE_ROOT=/projects/modulefiles
-module use /home/projects/modulefiles
-module use /projects/modulefiles/rhel6-x86_64/sems/compiler
+source /projects/modulefiles/utils/sems-modules-rhel6-x86_64.sh
 
 SCRIPT_KOKKOS_ROOT=$( cd "$( dirname "$0" )" && cd .. && pwd )
 

--- a/core/src/impl/Kokkos_Synchronic.hpp
+++ b/core/src/impl/Kokkos_Synchronic.hpp
@@ -1,0 +1,693 @@
+/*
+
+Copyright (c) 2014, NVIDIA Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef KOKKOS_SYNCHRONIC_HPP
+#define KOKKOS_SYNCHRONIC_HPP
+
+#include <impl/Kokkos_Synchronic_Config.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <functional>
+#include <algorithm>
+
+namespace Kokkos {
+namespace Impl {
+
+enum notify_hint {
+  notify_all,
+  notify_one,
+  notify_none
+};
+enum expect_hint {
+  expect_urgent,
+  expect_delay
+};
+
+namespace Details {
+
+template <class S, class T>
+bool __synchronic_spin_wait_for_update(S const& arg, T const& nval, int attempts) noexcept {
+  int i = 0;
+  for(;i < __SYNCHRONIC_SPIN_RELAX(attempts); ++i)
+    if(__builtin_expect(arg.load(std::memory_order_relaxed) != nval,1))
+      return true;
+    else
+      __synchronic_relax();
+  for(;i < attempts; ++i)
+    if(__builtin_expect(arg.load(std::memory_order_relaxed) != nval,1))
+      return true;
+    else
+      __synchronic_yield();
+  return false;
+}
+
+struct __exponential_backoff {
+  __exponential_backoff(int arg_maximum=512) : maximum(arg_maximum), microseconds(8), x(123456789), y(362436069), z(521288629) {
+  }
+  static inline void sleep_for(std::chrono::microseconds const& time) {
+    auto t = time.count();
+    if(__builtin_expect(t > 75,0)) {
+      portable_sleep(time);
+    }
+    else if(__builtin_expect(t > 25,0))
+      __synchronic_yield();
+    else
+      __synchronic_relax();
+  }
+  void sleep_for_step() {
+    sleep_for(step());
+  }
+  std::chrono::microseconds step() {
+    float const f = ranfu();
+    int const t = int(microseconds * f);
+    if(__builtin_expect(f >= 0.95f,0))
+      microseconds = 8;
+    else
+      microseconds = (std::min)(microseconds>>1,maximum);
+    return std::chrono::microseconds(t);
+  }
+private :
+  int maximum, microseconds, x, y, z;
+  int xorshf96() {
+    int t;
+    x ^= x << 16; x ^= x >> 5; x ^= x << 1;
+    t = x; x = y; y = z; z = t ^ x ^ y;
+    return z;
+  }
+  float ranfu() {
+    return (float)(xorshf96()&(~0UL>>1)) / (float)(~0UL>>1);
+  }
+};
+
+template <class T, class Enable = void>
+struct __synchronic_base {
+
+protected:
+  std::atomic<T> atom;
+
+  void notify(notify_hint = notify_all) noexcept {
+  }
+  void notify(notify_hint = notify_all) volatile noexcept {
+  }
+
+public :
+  __synchronic_base() noexcept = default;
+  constexpr __synchronic_base(T v) noexcept : atom(v) { }
+  __synchronic_base(const __synchronic_base&) = delete;
+  ~__synchronic_base() { }
+  __synchronic_base& operator=(const __synchronic_base&) = delete;
+  __synchronic_base& operator=(const __synchronic_base&) volatile = delete;
+
+  void expect_update(T val, expect_hint = expect_urgent) const noexcept {
+    if(__synchronic_spin_wait_for_update(atom, val, __SYNCHRONIC_SPIN_COUNT_A))
+      return;
+    __exponential_backoff b;
+    while(atom.load(std::memory_order_relaxed) == val) {
+      __do_backoff(b);
+      if(__synchronic_spin_wait_for_update(atom, val, __SYNCHRONIC_SPIN_COUNT_B))
+        return;
+    }
+  }
+  void expect_update(T val, expect_hint = expect_urgent) const volatile noexcept {
+    if(__synchronic_spin_wait_for_update(atom, val, __SYNCHRONIC_SPIN_COUNT_A))
+      return;
+    __exponential_backoff b;
+    while(atom.load(std::memory_order_relaxed) == val) {
+      __do_backoff(b);
+      if(__synchronic_spin_wait_for_update(atom, val, __SYNCHRONIC_SPIN_COUNT_B))
+        return;
+    }
+  }
+
+  template <class Clock, class Duration>
+  void expect_update_until(T val, std::chrono::time_point<Clock,Duration> const& then, expect_hint = expect_urgent) const {
+    if(__synchronic_spin_wait_for_update(atom, val, __SYNCHRONIC_SPIN_COUNT_A))
+      return;
+    __exponential_backoff b;
+    std::chrono::milliseconds remains = then - std::chrono::high_resolution_clock::now();
+    while(remains > std::chrono::milliseconds::zero() && atom.load(std::memory_order_relaxed) == val) {
+      __do_backoff(b);
+      if(__synchronic_spin_wait_for_update(atom, val, __SYNCHRONIC_SPIN_COUNT_B))
+        return;
+      remains = then - std::chrono::high_resolution_clock::now();
+    }
+  }
+  template <class Clock, class Duration>
+  void expect_update_until(T val, std::chrono::time_point<Clock,Duration> const& then, expect_hint = expect_urgent) const volatile {
+    if(__synchronic_spin_wait_for_update(atom, val, __SYNCHRONIC_SPIN_COUNT_A))
+      return;
+    __exponential_backoff b;
+    std::chrono::milliseconds remains = then - std::chrono::high_resolution_clock::now();
+    while(remains > std::chrono::milliseconds::zero() && atom.load(std::memory_order_relaxed) == val) {
+      __do_backoff(b);
+      if(__synchronic_spin_wait_for_update(atom, val, __SYNCHRONIC_SPIN_COUNT_B))
+        return;
+      remains = then - std::chrono::high_resolution_clock::now();
+    }
+  }
+};
+
+#ifdef __SYNCHRONIC_COMPATIBLE
+template <class T>
+struct __synchronic_base<T, typename std::enable_if<__SYNCHRONIC_COMPATIBLE(T)>::type> {
+
+public:
+  std::atomic<T> atom;
+
+  void notify(notify_hint hint = notify_all) noexcept {
+    if(__builtin_expect(hint == notify_none,1))
+      return;
+    auto const x = count.fetch_add(0,std::memory_order_acq_rel);
+    if(__builtin_expect(x,0)) {
+      if(__builtin_expect(hint == notify_all,1))
+        __synchronic_wake_all(&atom);
+      else
+        __synchronic_wake_one(&atom);
+    }
+  }
+  void notify(notify_hint hint = notify_all) volatile noexcept {
+    if(__builtin_expect(hint == notify_none,1))
+      return;
+    auto const x = count.fetch_add(0,std::memory_order_acq_rel);
+    if(__builtin_expect(x,0)) {
+      if(__builtin_expect(hint == notify_all,1))
+        __synchronic_wake_all_volatile(&atom);
+      else
+        __synchronic_wake_one_volatile(&atom);
+    }
+  }
+
+public :
+  __synchronic_base() noexcept : count(0) { }
+  constexpr __synchronic_base(T v) noexcept : atom(v), count(0) { }
+  __synchronic_base(const __synchronic_base&) = delete;
+  ~__synchronic_base() { }
+  __synchronic_base& operator=(const __synchronic_base&) = delete;
+  __synchronic_base& operator=(const __synchronic_base&) volatile = delete;
+
+  void expect_update(T val, expect_hint = expect_urgent) const noexcept {
+    if(__builtin_expect(__synchronic_spin_wait_for_update(atom, val,__SYNCHRONIC_SPIN_COUNT_A),1))
+      return;
+    while(__builtin_expect(atom.load(std::memory_order_relaxed) == val,1)) {
+      count.fetch_add(1,std::memory_order_release);
+      __synchronic_wait(&atom,val);
+      count.fetch_add(-1,std::memory_order_acquire);
+    }
+  }
+  void expect_update(T val, expect_hint = expect_urgent) const volatile noexcept {
+    if(__builtin_expect(__synchronic_spin_wait_for_update(atom, val,__SYNCHRONIC_SPIN_COUNT_A),1))
+      return;
+    while(__builtin_expect(atom.load(std::memory_order_relaxed) == val,1)) {
+      count.fetch_add(1,std::memory_order_release);
+      __synchronic_wait_volatile(&atom,val);
+      count.fetch_add(-1,std::memory_order_acquire);
+    }
+  }
+
+  template <class Clock, class Duration>
+  void expect_update_until(T val, std::chrono::time_point<Clock,Duration> const& then, expect_hint = expect_urgent) const {
+    if(__builtin_expect(__synchronic_spin_wait_for_update(atom, val,__SYNCHRONIC_SPIN_COUNT_A),1))
+      return;
+    std::chrono::milliseconds remains = then - std::chrono::high_resolution_clock::now();
+    while(__builtin_expect(remains > std::chrono::milliseconds::zero() && atom.load(std::memory_order_relaxed) == val,1)) {
+      count.fetch_add(1,std::memory_order_release);
+      __synchronic_wait_timed(&atom,val,remains);
+      count.fetch_add(-1,std::memory_order_acquire);
+      remains = then - std::chrono::high_resolution_clock::now();
+    }
+  }
+  template <class Clock, class Duration>
+  void expect_update_until(T val, std::chrono::time_point<Clock,Duration> const& then, expect_hint = expect_urgent) const volatile {
+    if(__builtin_expect(__synchronic_spin_wait_for_update(atom, val,__SYNCHRONIC_SPIN_COUNT_A),1))
+      return;
+    std::chrono::milliseconds remains = then - std::chrono::high_resolution_clock::now();
+    while(__builtin_expect(remains > std::chrono::milliseconds::zero() && atom.load(std::memory_order_relaxed) == val,1)) {
+      count.fetch_add(1,std::memory_order_release);
+      __synchronic_wait_timed_volatile(&atom,val,remains);
+      count.fetch_add(-1,std::memory_order_acquire);
+      remains = then - std::chrono::high_resolution_clock::now();
+    }
+  }
+private:
+  mutable std::atomic<int> count;
+};
+#endif
+
+template <class T, class Enable = void>
+struct __synchronic : public __synchronic_base<T> {
+
+  __synchronic() noexcept = default;
+  constexpr __synchronic(T v) noexcept : __synchronic_base<T>(v) { }
+  __synchronic(const __synchronic&) = delete;
+  __synchronic& operator=(const __synchronic&) = delete;
+  __synchronic& operator=(const __synchronic&) volatile = delete;
+};
+
+template <class T>
+struct __synchronic<T,typename std::enable_if<std::is_integral<T>::value>::type> : public __synchronic_base<T> {
+
+  T fetch_add(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.fetch_add(v,m);
+    this->notify(n);
+    return t;
+  }
+  T fetch_add(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.fetch_add(v,m);
+    this->notify(n);
+    return t;
+  }
+  T fetch_sub(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.fetch_sub(v,m);
+    this->notify(n);
+    return t;
+  }
+  T fetch_sub(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.fetch_sub(v,m);
+    this->notify(n);
+    return t;
+  }
+  T fetch_and(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.fetch_and(v,m);
+    this->notify(n);
+    return t;
+  }
+  T fetch_and(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.fetch_and(v,m);
+    this->notify(n);
+    return t;
+  }
+  T fetch_or(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.fetch_or(v,m);
+    this->notify(n);
+    return t;
+  }
+  T fetch_or(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.fetch_or(v,m);
+    this->notify(n);
+    return t;
+  }
+  T fetch_xor(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.fetch_xor(v,m);
+    this->notify(n);
+    return t;
+  }
+  T fetch_xor(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.fetch_xor(v,m);
+    this->notify(n);
+    return t;
+  }
+
+  __synchronic() noexcept = default;
+  constexpr __synchronic(T v) noexcept : __synchronic_base<T>(v) { }
+  __synchronic(const __synchronic&) = delete;
+  __synchronic& operator=(const __synchronic&) = delete;
+  __synchronic& operator=(const __synchronic&) volatile = delete;
+
+  T operator=(T v) volatile noexcept {
+    auto const t = this->atom = v;
+    this->notify();
+    return t;
+  }
+  T operator=(T v) noexcept {
+    auto const t = this->atom = v;
+    this->notify();
+    return t;
+  }
+  T operator++(int) volatile noexcept {
+    auto const t = ++this->atom;
+    this->notify();
+    return t;
+  }
+  T operator++(int) noexcept {
+    auto const t = ++this->atom;
+    this->notify();
+    return t;
+  }
+  T operator--(int) volatile noexcept {
+    auto const t = --this->atom;
+    this->notify();
+    return t;
+  }
+  T operator--(int) noexcept {
+    auto const t = --this->atom;
+    this->notify();
+    return t;
+  }
+  T operator++() volatile noexcept {
+    auto const t = this->atom++;
+    this->notify();
+    return t;
+  }
+  T operator++() noexcept {
+    auto const t = this->atom++;
+    this->notify();
+    return t;
+  }
+  T operator--() volatile noexcept {
+    auto const t = this->atom--;
+    this->notify();
+    return t;
+  }
+  T operator--() noexcept {
+    auto const t = this->atom--;
+    this->notify();
+    return t;
+  }
+  T operator+=(T v) volatile noexcept {
+    auto const t = this->atom += v;
+    this->notify();
+    return t;
+  }
+  T operator+=(T v) noexcept {
+    auto const t = this->atom += v;
+    this->notify();
+    return t;
+  }
+  T operator-=(T v) volatile noexcept {
+    auto const t = this->atom -= v;
+    this->notify();
+    return t;
+  }
+  T operator-=(T v) noexcept {
+    auto const t = this->atom -= v;
+    this->notify();
+    return t;
+  }
+  T operator&=(T v) volatile noexcept {
+    auto const t = this->atom &= v;
+    this->notify();
+    return t;
+  }
+  T operator&=(T v) noexcept {
+    auto const t = this->atom &= v;
+    this->notify();
+    return t;
+  }
+  T operator|=(T v) volatile noexcept {
+    auto const t = this->atom |= v;
+    this->notify();
+    return t;
+  }
+  T operator|=(T v) noexcept {
+    auto const t = this->atom |= v;
+    this->notify();
+    return t;
+  }
+  T operator^=(T v) volatile noexcept {
+    auto const t = this->atom ^= v;
+    this->notify();
+    return t;
+  }
+  T operator^=(T v) noexcept {
+    auto const t = this->atom ^= v;
+    this->notify();
+    return t;
+  }
+};
+
+template <class T>
+struct __synchronic<T*> : public __synchronic_base<T*> {
+
+  T* fetch_add(ptrdiff_t v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.fetch_add(v,m);
+    this->notify(n);
+    return t;
+  }
+  T* fetch_add(ptrdiff_t v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.fetch_add(v,m);
+    this->notify(n);
+    return t;
+  }
+  T* fetch_sub(ptrdiff_t v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.fetch_sub(v,m);
+    this->notify(n);
+    return t;
+  }
+  T* fetch_sub(ptrdiff_t v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.fetch_sub(v,m);
+    this->notify(n);
+    return t;
+  }
+
+  __synchronic() noexcept = default;
+  constexpr __synchronic(T* v) noexcept : __synchronic_base<T*>(v) { }
+  __synchronic(const __synchronic&) = delete;
+  __synchronic& operator=(const __synchronic&) = delete;
+  __synchronic& operator=(const __synchronic&) volatile = delete;
+
+  T* operator=(T* v) volatile noexcept {
+    auto const t = this->atom = v;
+    this->notify();
+    return t;
+  }
+  T* operator=(T* v) noexcept {
+    auto const t = this->atom = v;
+    this->notify();
+    return t;
+  }
+  T* operator++(int) volatile noexcept {
+    auto const t = ++this->atom;
+    this->notify();
+    return t;
+  }
+  T* operator++(int) noexcept {
+    auto const t = ++this->atom;
+    this->notify();
+    return t;
+  }
+  T* operator--(int) volatile noexcept {
+    auto const t = --this->atom;
+    this->notify();
+    return t;
+  }
+  T* operator--(int) noexcept {
+    auto const t = --this->atom;
+    this->notify();
+    return t;
+  }
+  T* operator++() volatile noexcept {
+    auto const t = this->atom++;
+    this->notify();
+    return t;
+  }
+  T* operator++() noexcept {
+    auto const t = this->atom++;
+    this->notify();
+    return t;
+  }
+  T* operator--() volatile noexcept {
+    auto const t = this->atom--;
+    this->notify();
+    return t;
+  }
+  T* operator--() noexcept {
+    auto const t = this->atom--;
+    this->notify();
+    return t;
+  }
+  T* operator+=(ptrdiff_t v) volatile noexcept {
+    auto const t = this->atom += v;
+    this->notify();
+    return t;
+  }
+  T* operator+=(ptrdiff_t v) noexcept {
+    auto const t = this->atom += v;
+    this->notify();
+    return t;
+  }
+  T* operator-=(ptrdiff_t v) volatile noexcept {
+    auto const t = this->atom -= v;
+    this->notify();
+    return t;
+  }
+  T* operator-=(ptrdiff_t v) noexcept {
+    auto const t = this->atom -= v;
+    this->notify();
+    return t;
+  }
+};
+
+} //namespace Details
+
+template <class T>
+struct synchronic : public Details::__synchronic<T> {
+
+  bool is_lock_free() const volatile noexcept { return this->atom.is_lock_free(); }
+  bool is_lock_free() const noexcept { return this->atom.is_lock_free(); }
+  void store(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) volatile noexcept {
+    this->atom.store(v,m);
+    this->notify(n);
+  }
+  void store(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) noexcept {
+    this->atom.store(v,m);
+    this->notify(n);
+  }
+  T load(std::memory_order m = std::memory_order_seq_cst) const volatile noexcept { return this->atom.load(m); }
+  T load(std::memory_order m = std::memory_order_seq_cst) const noexcept { return this->atom.load(m); }
+
+  operator T() const volatile noexcept { return (T)this->atom; }
+  operator T() const noexcept { return (T)this->atom; }
+
+  T exchange(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.exchange(v,m);
+    this->notify(n);
+    return t;
+  }
+  T exchange(T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.exchange(v,m);
+    this->notify(n);
+    return t;
+  }
+  bool compare_exchange_weak(T& r, T v, std::memory_order m1, std::memory_order m2, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.compare_exchange_weak(r,v,m1,m2);
+    this->notify(n);
+    return t;
+  }
+  bool compare_exchange_weak(T& r, T v, std::memory_order m1, std::memory_order m2, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.compare_exchange_weak(r,v,m1, m2);
+    this->notify(n);
+    return t;
+  }
+  bool compare_exchange_strong(T& r, T v, std::memory_order m1, std::memory_order m2, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.compare_exchange_strong(r,v,m1,m2);
+    this->notify(n);
+    return t;
+  }
+  bool compare_exchange_strong(T& r, T v, std::memory_order m1, std::memory_order m2, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.compare_exchange_strong(r,v,m1,m2);
+    this->notify(n);
+    return t;
+  }
+  bool compare_exchange_weak(T& r, T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.compare_exchange_weak(r,v,m);
+    this->notify(n);
+    return t;
+  }
+  bool compare_exchange_weak(T& r, T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.compare_exchange_weak(r,v,m);
+    this->notify(n);
+    return t;
+  }
+  bool compare_exchange_strong(T& r, T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) volatile noexcept {
+    auto const t = this->atom.compare_exchange_strong(r,v,m);
+    this->notify(n);
+    return t;
+  }
+  bool compare_exchange_strong(T& r, T v, std::memory_order m = std::memory_order_seq_cst, notify_hint n = notify_all) noexcept {
+    auto const t = this->atom.compare_exchange_strong(r,v,m);
+    this->notify(n);
+    return t;
+  }
+
+  synchronic() noexcept = default;
+  constexpr synchronic(T val) noexcept : Details::__synchronic<T>(val) { }
+  synchronic(const synchronic&) = delete;
+  ~synchronic() { }
+  synchronic& operator=(const synchronic&) = delete;
+  synchronic& operator=(const synchronic&) volatile = delete;
+  T operator=(T val) noexcept {
+    return Details::__synchronic<T>::operator=(val);
+  }
+  T operator=(T val) volatile noexcept {
+    return Details::__synchronic<T>::operator=(val);
+  }
+
+  T load_when_not_equal(T val, std::memory_order order = std::memory_order_seq_cst, expect_hint h = expect_urgent) const noexcept {
+    Details::__synchronic<T>::expect_update(val,h);
+    return load(order);
+  }
+  T load_when_not_equal(T val, std::memory_order order = std::memory_order_seq_cst, expect_hint h = expect_urgent) const volatile noexcept {
+    Details::__synchronic<T>::expect_update(val,h);
+    return load(order);
+  }
+  T load_when_equal(T val, std::memory_order order = std::memory_order_seq_cst, expect_hint h = expect_urgent) const noexcept {
+    for(T nval = load(std::memory_order_relaxed); nval != val; nval = load(std::memory_order_relaxed))
+      Details::__synchronic<T>::expect_update(nval,h);
+    return load(order);
+  }
+  T load_when_equal(T val, std::memory_order order = std::memory_order_seq_cst, expect_hint h = expect_urgent) const volatile noexcept {
+    for(T nval = load(std::memory_order_relaxed); nval != val; nval = load(std::memory_order_relaxed))
+      expect_update(nval,h);
+    return load(order);
+  }
+  template <class Rep, class Period>
+  void expect_update_for(T val, std::chrono::duration<Rep,Period> const& delta, expect_hint h = expect_urgent) const {
+    Details::__synchronic<T>::expect_update_until(val, std::chrono::high_resolution_clock::now() + delta,h);
+  }
+  template < class Rep, class Period>
+  void expect_update_for(T val, std::chrono::duration<Rep,Period> const& delta, expect_hint h = expect_urgent) const volatile {
+    Details::__synchronic<T>::expect_update_until(val, std::chrono::high_resolution_clock::now() + delta,h);
+  }
+};
+
+#include <inttypes.h>
+
+typedef synchronic<char> synchronic_char;
+typedef synchronic<char> synchronic_schar;
+typedef synchronic<unsigned char> synchronic_uchar;
+typedef synchronic<short> synchronic_short;
+typedef synchronic<unsigned short> synchronic_ushort;
+typedef synchronic<int> synchronic_int;
+typedef synchronic<unsigned int> synchronic_uint;
+typedef synchronic<long> synchronic_long;
+typedef synchronic<unsigned long> synchronic_ulong;
+typedef synchronic<long long> synchronic_llong;
+typedef synchronic<unsigned long long> synchronic_ullong;
+//typedef synchronic<char16_t> synchronic_char16_t;
+//typedef synchronic<char32_t> synchronic_char32_t;
+typedef synchronic<wchar_t> synchronic_wchar_t;
+
+typedef synchronic<int_least8_t> synchronic_int_least8_t;
+typedef synchronic<uint_least8_t> synchronic_uint_least8_t;
+typedef synchronic<int_least16_t> synchronic_int_least16_t;
+typedef synchronic<uint_least16_t> synchronic_uint_least16_t;
+typedef synchronic<int_least32_t> synchronic_int_least32_t;
+typedef synchronic<uint_least32_t> synchronic_uint_least32_t;
+//typedef synchronic<int_least_64_t> synchronic_int_least_64_t;
+typedef synchronic<uint_least64_t> synchronic_uint_least64_t;
+typedef synchronic<int_fast8_t> synchronic_int_fast8_t;
+typedef synchronic<uint_fast8_t> synchronic_uint_fast8_t;
+typedef synchronic<int_fast16_t> synchronic_int_fast16_t;
+typedef synchronic<uint_fast16_t> synchronic_uint_fast16_t;
+typedef synchronic<int_fast32_t> synchronic_int_fast32_t;
+typedef synchronic<uint_fast32_t> synchronic_uint_fast32_t;
+typedef synchronic<int_fast64_t> synchronic_int_fast64_t;
+typedef synchronic<uint_fast64_t> synchronic_uint_fast64_t;
+typedef synchronic<intptr_t> synchronic_intptr_t;
+typedef synchronic<uintptr_t> synchronic_uintptr_t;
+typedef synchronic<size_t> synchronic_size_t;
+typedef synchronic<ptrdiff_t> synchronic_ptrdiff_t;
+typedef synchronic<intmax_t> synchronic_intmax_t;
+typedef synchronic<uintmax_t> synchronic_uintmax_t;
+
+}
+}
+
+#endif //__SYNCHRONIC_H

--- a/core/src/impl/Kokkos_Synchronic_Config.hpp
+++ b/core/src/impl/Kokkos_Synchronic_Config.hpp
@@ -1,0 +1,168 @@
+/*
+
+Copyright (c) 2014, NVIDIA Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef KOKKOS_SYNCHRONIC_CONFIG_H
+#define KOKKOS_SYNCHRONIC_CONFIG_H
+
+#include <thread>
+#include <chrono>
+
+namespace Kokkos {
+namespace Impl {
+
+//the default yield function used inside the implementation is the Standard one
+#define __synchronic_yield std::this_thread::yield
+#define __synchronic_relax __synchronic_yield
+
+#if defined(_MSC_VER)
+    //this is a handy GCC optimization that I use inside the implementation
+    #define __builtin_expect(condition,common) condition
+    #if _MSC_VER <= 1800
+        //using certain keywords that VC++ temporarily doesn't support
+        #define _ALLOW_KEYWORD_MACROS
+        #define noexcept
+        #define constexpr
+    #endif
+    //yes, I define multiple assignment operators
+    #pragma warning(disable:4522)
+    //I don't understand how Windows is so bad at timing functions, but is OK
+    //with straight-up yield loops
+    #define __do_backoff(b) __synchronic_yield()
+#else
+#define __do_backoff(b) b.sleep_for_step()
+#endif
+
+//certain platforms have efficient support for spin-waiting built into the operating system
+#if defined(__linux__) || (defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602)
+#if defined(_WIN32_WINNT)
+    #include <Windows.h>
+    //the combination of WaitOnAddress and WakeByAddressAll is supported on Windows 8.1+
+    #define __synchronic_wait(x,v) WaitOnAddress((PVOID)x,(PVOID)&v,sizeof(v),-1)
+    #define __synchronic_wait_timed(x,v,t) WaitOnAddress((PVOID)x,(PVOID)&v,sizeof(v),std::chrono::duration_cast<std::chrono::milliseconds>(t).count())
+    #define __synchronic_wake_one(x) WakeByAddressSingle((PVOID)x)
+    #define __synchronic_wake_all(x) WakeByAddressAll((PVOID)x)
+    #define __synchronic_wait_volatile(x,v) WaitOnAddress((PVOID)x,(PVOID)&v,sizeof(v),-1)
+    #define __synchronic_wait_timed_volatile(x,v,t) WaitOnAddress((PVOID)x,(PVOID)&v,sizeof(v),std::chrono::duration_cast<std::chrono::milliseconds>(t).count())
+    #define __synchronic_wake_one_volatile(x) WakeByAddressSingle((PVOID)x)
+    #define __synchronic_wake_all_volatile(x) WakeByAddressAll((PVOID)x)
+    #define __SYNCHRONIC_COMPATIBLE(x) (std::is_pod<x>::value && (sizeof(x) <= 8))
+
+    inline void native_sleep(unsigned long microseconds)
+    {
+      // What to do if microseconds is < 1000?
+      Sleep(microseconds / 1000);
+    }
+
+    inline void native_yield()
+    {
+      SwitchToThread();
+    }
+#elif defined(__linux__)
+    #include <chrono>
+    #include <time.h>
+    #include <unistd.h>
+    #include <pthread.h>
+    #include <linux/futex.h>
+    #include <sys/syscall.h>
+    #include <climits>
+    #include <cassert>
+    template < class Rep, class Period>
+    inline timespec to_timespec(std::chrono::duration<Rep,Period> const& delta) {
+      struct timespec ts;
+      ts.tv_sec = static_cast<long>(std::chrono::duration_cast<std::chrono::seconds>(delta).count());
+      assert(!ts.tv_sec);
+      ts.tv_nsec = static_cast<long>(std::chrono::duration_cast<std::chrono::nanoseconds>(delta).count());
+      return ts;
+    }
+    inline long futex(void const* addr1, int op, int val1) {
+        return syscall(SYS_futex, addr1, op, val1, 0, 0, 0);
+    }
+    inline long futex(void const* addr1, int op, int val1, struct timespec timeout) {
+        return syscall(SYS_futex, addr1, op, val1, &timeout, 0, 0);
+    }
+    inline void native_sleep(unsigned long microseconds)
+    {
+      usleep(microseconds);
+    }
+    inline void native_yield()
+    {
+      pthread_yield();
+    }
+
+    //the combination of SYS_futex(WAIT) and SYS_futex(WAKE) is supported on all recent Linux distributions
+    #define __synchronic_wait(x,v) futex(x, FUTEX_WAIT_PRIVATE, v)
+    #define __synchronic_wait_timed(x,v,t) futex(x, FUTEX_WAIT_PRIVATE, v, to_timespec(t))
+    #define __synchronic_wake_one(x) futex(x, FUTEX_WAKE_PRIVATE, 1)
+    #define __synchronic_wake_all(x) futex(x, FUTEX_WAKE_PRIVATE, INT_MAX)
+    #define __synchronic_wait_volatile(x,v) futex(x, FUTEX_WAIT, v)
+    #define __synchronic_wait_volatile_timed(x,v,t) futex(x, FUTEX_WAIT, v, to_timespec(t))
+    #define __synchronic_wake_one_volatile(x) futex(x, FUTEX_WAKE, 1)
+    #define __synchronic_wake_all_volatile(x) futex(x, FUTEX_WAKE, INT_MAX)
+    #define __SYNCHRONIC_COMPATIBLE(x) (std::is_integral<x>::value && (sizeof(x) <= 4))
+
+    //the yield function on Linux is better replaced by sched_yield, which is tuned for spin-waiting
+    #undef __synchronic_yield
+    #define __synchronic_yield sched_yield
+
+    //for extremely short wait times, just let another hyper-thread run
+    #undef __synchronic_relax
+    #define __synchronic_relax() asm volatile("rep; nop" ::: "memory")
+
+#endif
+#endif
+
+#ifdef _GLIBCXX_USE_NANOSLEEP
+inline void portable_sleep(std::chrono::microseconds const& time)
+{ std::this_thread::sleep_for(time); }
+#else
+inline void portable_sleep(std::chrono::microseconds const& time)
+{ native_sleep(time.count()); }
+#endif
+
+#ifdef _GLIBCXX_USE_SCHED_YIELD
+inline void portable_yield()
+{ std::this_thread::yield(); }
+#else
+inline void portable_yield()
+{ native_yield(); }
+#endif
+
+//this is the number of times we initially spin, on the first wait attempt
+#define __SYNCHRONIC_SPIN_COUNT_A 16
+
+//this is how decide to yield instead of just spinning, 'c' is the current trip count
+//#define __SYNCHRONIC_SPIN_YIELD(c) true
+#define __SYNCHRONIC_SPIN_RELAX(c) (c>>3)
+
+//this is the number of times we normally spin, on every subsequent wait attempt
+#define __SYNCHRONIC_SPIN_COUNT_B 8
+
+}
+}
+
+#endif //__SYNCHRONIC_CONFIG_H

--- a/core/src/impl/Kokkos_Synchronic_n3998.hpp
+++ b/core/src/impl/Kokkos_Synchronic_n3998.hpp
@@ -1,0 +1,162 @@
+/*
+
+Copyright (c) 2014, NVIDIA Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef KOKKOS_SYNCHRONIC_N3998_HPP
+#define KOKKOS_SYNCHRONIC_N3998_HPP
+
+#include <impl/Kokkos_Synchronic.hpp>
+#include <functional>
+
+/*
+In the section below, a synchronization point represents a point at which a
+thread may block until a given synchronization condition has been reached or
+at which it may notify other threads that a synchronization condition has
+been achieved.
+*/
+namespace Kokkos { namespace Impl {
+
+    /*
+    A latch maintains an internal counter that is initialized when the latch
+    is created. The synchronization condition is reached when the counter is
+    decremented to 0. Threads may block at a synchronization point waiting
+    for the condition to be reached. When the condition is reached, any such
+    blocked threads will be released.
+    */
+    struct latch {
+        latch(int val) : count(val), released(false) { }
+        latch(const latch&) = delete;
+        latch& operator=(const latch&) = delete;
+        ~latch( ) { }
+        void arrive( ) {
+            __arrive( );
+        }
+        void arrive_and_wait( ) {
+            if(!__arrive( ))
+                wait( );
+        }
+        void wait( ) {
+            while(!released.load_when_not_equal(false,std::memory_order_acquire))
+                ;
+        }
+        bool try_wait( ) {
+            return released.load(std::memory_order_acquire);
+        }
+    private:
+        bool __arrive( ) {
+            if(count.fetch_add(-1,std::memory_order_release)!=1)
+                return false;
+            released.store(true,std::memory_order_release);
+            return true;
+        }
+        std::atomic<int> count;
+        synchronic<bool> released;
+    };
+
+    /*
+    A barrier is created with an initial value representing the number of threads
+    that can arrive at the synchronization point. When that many threads have
+    arrived, the  synchronization condition is reached and the threads are
+    released. The barrier will then reset, and may be reused for a new cycle, in
+    which the same set of threads may arrive again at the synchronization point.
+    The same set of threads shall arrive at the barrier in each cycle, otherwise
+    the behaviour is undefined.
+    */
+    struct barrier {
+        barrier(int val) : expected(val), arrived(0), nexpected(val), epoch(0) { }
+        barrier(const barrier&) = delete;
+        barrier& operator=(const barrier&) = delete;
+        ~barrier() { }
+        void arrive_and_wait() {
+            int const myepoch = epoch.load(std::memory_order_relaxed);
+            if(!__arrive(myepoch))
+                while(epoch.load_when_not_equal(myepoch,std::memory_order_acquire) == myepoch)
+                    ;
+        }
+        void arrive_and_drop() {
+            nexpected.fetch_add(-1,std::memory_order_relaxed);
+            __arrive(epoch.load(std::memory_order_relaxed));
+        }
+    private:
+        bool __arrive(int const myepoch) {
+            int const myresult = arrived.fetch_add(1,std::memory_order_acq_rel) + 1;
+            if(__builtin_expect(myresult == expected,0)) {
+                expected = nexpected.load(std::memory_order_relaxed);
+                arrived.store(0,std::memory_order_relaxed);
+                epoch.store(myepoch+1,std::memory_order_release);
+                return true;
+            }
+            return false;
+        }
+        int expected;
+        std::atomic<int> arrived, nexpected;
+        synchronic<int> epoch;
+    };
+
+    /*
+    A notifying barrier behaves as a barrier, but is constructed with a callable
+    completion function that is invoked after all threads have arrived at the
+    synchronization point, and before the synchronization condition is reached.
+    The completion may modify the set of threads that arrives at the barrier in
+    each cycle.
+    */
+    struct notifying_barrier {
+        template <typename T>
+        notifying_barrier(int val, T && f) : expected(val), arrived(0), nexpected(val), epoch(0), completion(std::forward<T>(f)) { }
+        notifying_barrier(const notifying_barrier&) = delete;
+        notifying_barrier& operator=(const notifying_barrier&) = delete;
+        ~notifying_barrier( ) { }
+        void arrive_and_wait() {
+            int const myepoch = epoch.load(std::memory_order_relaxed);
+            if(!__arrive(myepoch))
+                while(epoch.load_when_not_equal(myepoch,std::memory_order_acquire) == myepoch)
+                    ;
+        }
+        void arrive_and_drop() {
+            nexpected.fetch_add(-1,std::memory_order_relaxed);
+            __arrive(epoch.load(std::memory_order_relaxed));
+        }
+    private:
+        bool __arrive(int const myepoch) {
+            int const myresult = arrived.fetch_add(1,std::memory_order_acq_rel) + 1;
+            if(__builtin_expect(myresult == expected,0)) {
+                int const newexpected = completion();
+                expected = newexpected ? newexpected : nexpected.load(std::memory_order_relaxed);
+                arrived.store(0,std::memory_order_relaxed);
+                epoch.store(myepoch+1,std::memory_order_release);
+                return true;
+            }
+            return false;
+        }
+        int expected;
+        std::atomic<int> arrived, nexpected;
+        synchronic<int> epoch;
+        std::function<int()> completion;
+    };
+}}
+
+#endif //__N3998_H

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -7,7 +7,6 @@ TEST_HEADERS = $(wildcard $(KOKKOS_PATH)/core/unit_test/*.hpp)
 
 default: build_all
 	echo "End Build"
-	
 
 include $(KOKKOS_PATH)/Makefile.kokkos
 
@@ -25,8 +24,8 @@ endif
 
 KOKKOS_CXXFLAGS += -I$(GTEST_PATH) -I${KOKKOS_PATH}/core/unit_test
 
-TEST_TARGETS = 
-TARGETS = 
+TEST_TARGETS =
+TARGETS =
 
 ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
 	OBJ_CUDA = TestCuda.o UnitTestMain.o gtest-all.o
@@ -74,13 +73,16 @@ OBJ_DEFAULTINIT = TestDefaultDeviceTypeInit.o UnitTestMain.o gtest-all.o
 TARGETS += KokkosCore_UnitTest_DefaultInit
 TEST_TARGETS += test-default-init
 
+OBJ_SYNCHRONIC = TestSynchronic.o UnitTestMain.o gtest-all.o
+TARGETS += KokkosCore_UnitTest_Synchronic
+TEST_TARGETS += test-synchronic
 
 KokkosCore_UnitTest_Cuda: $(OBJ_CUDA) $(KOKKOS_LINK_DEPENDS)
 	$(LINK) $(KOKKOS_LDFLAGS) $(LDFLAGS) $(EXTRA_PATH) $(OBJ_CUDA) $(KOKKOS_LIBS) $(LIB) -o KokkosCore_UnitTest_Cuda
 
 KokkosCore_UnitTest_Threads: $(OBJ_THREADS) $(KOKKOS_LINK_DEPENDS)
 	$(LINK) $(KOKKOS_LDFLAGS) $(LDFLAGS) $(EXTRA_PATH) $(OBJ_THREADS) $(KOKKOS_LIBS) $(LIB) -o KokkosCore_UnitTest_Threads
-	
+
 KokkosCore_UnitTest_OpenMP: $(OBJ_OPENMP) $(KOKKOS_LINK_DEPENDS)
 	$(LINK) $(KOKKOS_LDFLAGS) $(LDFLAGS) $(EXTRA_PATH) $(OBJ_OPENMP) $(KOKKOS_LIBS) $(LIB) -o KokkosCore_UnitTest_OpenMP
 
@@ -102,6 +104,9 @@ KokkosCore_UnitTest_Default: $(OBJ_DEFAULT) $(KOKKOS_LINK_DEPENDS)
 KokkosCore_UnitTest_DefaultInit: $(OBJ_DEFAULTINIT) $(KOKKOS_LINK_DEPENDS)
 	$(LINK) $(KOKKOS_LDFLAGS) $(LDFLAGS) $(EXTRA_PATH) $(OBJ_DEFAULTINIT) $(KOKKOS_LIBS) $(LIB) -o KokkosCore_UnitTest_DefaultInit
 
+KokkosCore_UnitTest_Synchronic: $(OBJ_SYNCHRONIC) $(KOKKOS_LINK_DEPENDS)
+	$(LINK) $(KOKKOS_LDFLAGS) $(LDFLAGS) $(EXTRA_PATH) $(OBJ_SYNCHRONIC) $(KOKKOS_LIBS) $(LIB) -o KokkosCore_UnitTest_Synchronic
+
 test-cuda: KokkosCore_UnitTest_Cuda
 	./KokkosCore_UnitTest_Cuda
 
@@ -113,27 +118,30 @@ test-openmp: KokkosCore_UnitTest_OpenMP
 
 test-serial: KokkosCore_UnitTest_Serial
 	./KokkosCore_UnitTest_Serial
-	
+
 test-qthread: KokkosCore_UnitTest_Qthread
 	./KokkosCore_UnitTest_Qthread
 
 test-hwloc: KokkosCore_UnitTest_HWLOC
 	./KokkosCore_UnitTest_HWLOC
-	
+
 test-allocationtracker: KokkosCore_UnitTest_AllocationTracker
 	./KokkosCore_UnitTest_AllocationTracker
-	
+
 test-default: KokkosCore_UnitTest_Default
 	./KokkosCore_UnitTest_Default
-	
+
 test-default-init: KokkosCore_UnitTest_DefaultInit
 	./KokkosCore_UnitTest_DefaultInit
+
+test-synchronic: KokkosCore_UnitTest_Synchronic
+	./KokkosCore_UnitTest_Synchronic
 
 build_all: $(TARGETS)
 
 test: $(TEST_TARGETS)
-	
-clean: kokkos-clean 
+
+clean: kokkos-clean
 	rm -f *.o $(TARGETS)
 
 # Compilation rules
@@ -141,6 +149,6 @@ clean: kokkos-clean
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS) $(TEST_HEADERS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
 
-gtest-all.o:$(GTEST_PATH)/gtest/gtest-all.cc 
+gtest-all.o:$(GTEST_PATH)/gtest/gtest-all.cc
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $(GTEST_PATH)/gtest/gtest-all.cc
 

--- a/core/unit_test/TestSynchronic.cpp
+++ b/core/unit_test/TestSynchronic.cpp
@@ -1,0 +1,440 @@
+/*
+
+Copyright (c) 2014, NVIDIA Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+//#undef _WIN32_WINNT
+//#define _WIN32_WINNT 0x0602
+
+#include <gtest/gtest.h>
+
+#ifdef USEOMP
+#include <omp.h>
+#endif
+
+#include <iostream>
+#include <sstream>
+#include <algorithm>
+#include <string>
+#include <vector>
+#include <map>
+#include <cstring>
+#include <ctime>
+
+//#include <details/config>
+//#undef __SYNCHRONIC_COMPATIBLE
+
+#include <impl/Kokkos_Synchronic.hpp>
+#include <impl/Kokkos_Synchronic_n3998.hpp>
+
+#include "TestSynchronic.hpp"
+
+// Uncomment to allow test to dump output
+//#define VERBOSE_TEST
+
+namespace Test {
+
+unsigned next_table[] =
+    {
+        0, 1, 2, 3,         //0-3
+        4, 4, 6, 6,         //4-7
+        8, 8, 8, 8,         //8-11
+        12, 12, 12, 12,     //12-15
+        16, 16, 16, 16,     //16-19
+        16, 16, 16, 16,     //20-23
+        24, 24, 24, 24,     //24-27
+        24, 24, 24, 24,     //28-31
+        32, 32, 32, 32,     //32-35
+        32, 32, 32, 32,     //36-39
+        40, 40, 40, 40,     //40-43
+        40, 40, 40, 40,     //44-47
+        48, 48, 48, 48,     //48-51
+        48, 48, 48, 48,     //52-55
+        56, 56, 56, 56,     //56-59
+        56, 56, 56, 56,     //60-63
+    };
+
+//change this if you want to allow oversubscription of the system, by default only the range {1-(system size)} is tested
+#define FOR_GAUNTLET(x) for(unsigned x = (std::min)(std::thread::hardware_concurrency()*8,unsigned(sizeof(next_table)/sizeof(unsigned))); x; x = next_table[x-1])
+
+//set this to override the benchmark of barriers to use OMP barriers instead of n3998 std::barrier
+//#define USEOMP
+
+#if defined(__SYNCHRONIC_COMPATIBLE)
+    #define PREFIX "futex-"
+#else
+    #define PREFIX "backoff-"
+#endif
+
+//this test uses a custom Mersenne twister to eliminate implementation variation
+MersenneTwister mt;
+
+int dummya = 1, dummyb =1;
+
+int dummy1 = 1;
+std::atomic<int> dummy2(1);
+std::atomic<int> dummy3(1);
+
+double time_item(int const count = (int)1E8)  {
+
+    clock_t const start = clock();
+
+    for(int i = 0;i < count; ++i)
+        mt.integer();
+
+    clock_t const end = clock();
+    double elapsed_seconds = (end - start) / double(CLOCKS_PER_SEC);
+
+    return elapsed_seconds / count;
+}
+double time_nil(int const count = (int)1E08)  {
+
+    clock_t const start = clock();
+
+    dummy3 = count;
+    for(int i = 0;i < (int)1E6; ++i) {
+        if(dummy1) {
+            // Do some work while holding the lock
+            int workunits = dummy3;//(int) (mtc.poissonInterval((float)num_items_critical) + 0.5f);
+            for (int j = 1; j < workunits; j++)
+                dummy1 &= j;       // Do one work unit
+            dummy2.fetch_add(dummy1,std::memory_order_relaxed);
+        }
+    }
+
+    clock_t const end = clock();
+    double elapsed_seconds = (end - start) / double(CLOCKS_PER_SEC);
+
+    return elapsed_seconds / count;
+}
+
+
+template <class mutex_type>
+void testmutex_inner(mutex_type& m, std::atomic<int>& t,std::atomic<int>& wc,std::atomic<int>& wnc, int const num_iterations,
+                     int const num_items_critical, int const num_items_noncritical, MersenneTwister& mtc, MersenneTwister& mtnc, bool skip) {
+
+    for(int k = 0; k < num_iterations; ++k) {
+
+        if(num_items_noncritical) {
+            // Do some work without holding the lock
+            int workunits = num_items_noncritical;//(int) (mtnc.poissonInterval((float)num_items_noncritical) + 0.5f);
+            for (int i = 1; i < workunits; i++)
+                mtnc.integer();       // Do one work unit
+            wnc.fetch_add(workunits,std::memory_order_relaxed);
+        }
+
+        t.fetch_add(1,std::memory_order_relaxed);
+
+        if(!skip) {
+            std::unique_lock<mutex_type> l(m);
+            if(num_items_critical) {
+                // Do some work while holding the lock
+                int workunits = num_items_critical;//(int) (mtc.poissonInterval((float)num_items_critical) + 0.5f);
+                for (int i = 1; i < workunits; i++)
+                    mtc.integer();       // Do one work unit
+                wc.fetch_add(workunits,std::memory_order_relaxed);
+            }
+        }
+    }
+}
+template <class mutex_type>
+void testmutex_outer(std::map<std::string,std::vector<double>>& results, std::string const& name, double critical_fraction, double critical_duration) {
+
+    std::ostringstream truename;
+    truename << name << " (f=" << critical_fraction << ",d=" << critical_duration << ")";
+
+    std::vector<double>& data = results[truename.str()];
+
+    double const workItemTime = time_item() ,
+                 nilTime = time_nil();
+
+    int const num_items_critical = (critical_duration <= 0 ? 0 : (std::max)( int(critical_duration / workItemTime + 0.5), int(100 * nilTime / workItemTime + 0.5))),
+              num_items_noncritical = (num_items_critical <= 0 ? 0 : int( ( 1 - critical_fraction ) * num_items_critical / critical_fraction + 0.5 ));
+
+    FOR_GAUNTLET(num_threads) {
+
+        Kokkos::Impl::portable_sleep(std::chrono::microseconds(2000000));
+
+        int const num_iterations = (num_items_critical + num_items_noncritical != 0) ?
+#ifdef __SYNCHRONIC_JUST_YIELD
+                                        int( 1 / ( 8 * workItemTime ) / (num_items_critical + num_items_noncritical) / num_threads + 0.5 ) :
+#else
+                                        int( 1 / ( 8 * workItemTime ) / (num_items_critical + num_items_noncritical) / num_threads + 0.5 ) :
+#endif
+#ifdef WIN32
+                                        int( 1 / workItemTime / (20 * num_threads * num_threads) );
+#else
+                                        int( 1 / workItemTime / (200 * num_threads * num_threads) );
+#endif
+
+#ifdef VERBOSE_TEST
+        std::cerr << "running " << truename.str() << " #" << num_threads << ", " << num_iterations << " * " << num_items_noncritical << "\n" << std::flush;
+#endif
+
+
+        std::atomic<int> t[2], wc[2], wnc[2];
+
+        clock_t start[2], end[2];
+        for(int pass = 0; pass < 2; ++pass) {
+
+            t[pass] = 0;
+            wc[pass] = 0;
+            wnc[pass] = 0;
+
+            srand(num_threads);
+            std::vector<MersenneTwister> randomsnc(num_threads),
+                                         randomsc(num_threads);
+
+            mutex_type m;
+
+            start[pass] = clock();
+#ifdef USEOMP
+            omp_set_num_threads(num_threads);
+            std::atomic<int> _j(0);
+            #pragma omp parallel
+            {
+                int const j = _j.fetch_add(1,std::memory_order_relaxed);
+                testmutex_inner(m, t[pass], wc[pass], wnc[pass], num_iterations, num_items_critical, num_items_noncritical, randomsc[j], randomsnc[j], pass==0);
+                num_threads = omp_get_num_threads();
+            }
+#else
+            std::vector<std::thread*> threads(num_threads);
+            for(unsigned j = 0; j < num_threads; ++j)
+                threads[j] = new std::thread([&,j](){
+                        testmutex_inner(m, t[pass], wc[pass], wnc[pass], num_iterations, num_items_critical, num_items_noncritical, randomsc[j], randomsnc[j], pass==0);
+                    }
+                );
+            for(unsigned j = 0; j < num_threads; ++j) {
+                threads[j]->join();
+                delete threads[j];
+            }
+#endif
+            end[pass] = clock();
+        }
+        if(t[0] != t[1]) throw std::string("mismatched iteration counts");
+        if(wnc[0] != wnc[1]) throw std::string("mismatched work item counts");
+
+        double elapsed_seconds_0 = (end[0] - start[0]) / double(CLOCKS_PER_SEC),
+               elapsed_seconds_1 = (end[1] - start[1]) / double(CLOCKS_PER_SEC);
+        double time = (elapsed_seconds_1 - elapsed_seconds_0 - wc[1]*workItemTime) / num_iterations;
+
+        data.push_back(time);
+#ifdef VERBOSE_TEST
+        std::cerr << truename.str() << " : " << num_threads << "," << elapsed_seconds_1 / num_iterations << " - " << elapsed_seconds_0 / num_iterations << " - " << wc[1]*workItemTime/num_iterations << " = " << time << "                                                 \n";
+#endif
+    }
+}
+
+template <class barrier_type>
+void testbarrier_inner(barrier_type& b, int const num_threads, int const j, std::atomic<int>& t,std::atomic<int>& w,
+                       int const num_iterations_odd, int const num_iterations_even,
+                       int const num_items_noncritical, MersenneTwister& arg_mt, bool skip) {
+
+    for(int k = 0; k < (std::max)(num_iterations_even,num_iterations_odd); ++k) {
+
+        if(k >= (~j & 0x1 ? num_iterations_odd : num_iterations_even )) {
+            if(!skip)
+                b.arrive_and_drop();
+            break;
+        }
+
+        if(num_items_noncritical) {
+            // Do some work without holding the lock
+            int workunits = (int) (arg_mt.poissonInterval((float)num_items_noncritical) + 0.5f);
+            for (int i = 1; i < workunits; i++)
+                arg_mt.integer();       // Do one work unit
+            w.fetch_add(workunits,std::memory_order_relaxed);
+        }
+
+        t.fetch_add(1,std::memory_order_relaxed);
+
+        if(!skip) {
+            int const thiscount = (std::min)(k+1,num_iterations_odd)*((num_threads>>1)+(num_threads&1)) + (std::min)(k+1,num_iterations_even)*(num_threads>>1);
+            if(t.load(std::memory_order_relaxed) > thiscount) {
+                std::cerr << "FAILURE: some threads have run ahead of the barrier (" << t.load(std::memory_order_relaxed) << ">" <<  thiscount << ").\n";
+                EXPECT_TRUE(false);
+            }
+#ifdef USEOMP
+            #pragma omp barrier
+#else
+            b.arrive_and_wait();
+#endif
+            if(t.load(std::memory_order_relaxed) < thiscount) {
+                std::cerr << "FAILURE: some threads have fallen behind the barrier (" << t.load(std::memory_order_relaxed) << "<" << thiscount << ").\n";
+                EXPECT_TRUE(false);
+            }
+        }
+    }
+}
+template <class barrier_type>
+void testbarrier_outer(std::map<std::string,std::vector<double>>& results, std::string const& name, double barrier_frequency, double phase_duration, bool randomIterations = false) {
+
+    std::vector<double>& data = results[name];
+
+    double const workItemTime = time_item();
+    int const num_items_noncritical = int( phase_duration / workItemTime + 0.5 );
+
+    FOR_GAUNTLET(num_threads) {
+
+        int const num_iterations = int( barrier_frequency );
+#ifdef VERBOSE_TEST
+        std::cerr << "running " << name << " #" << num_threads << ", " << num_iterations << " * " << num_items_noncritical << "\r" << std::flush;
+#endif
+
+        srand(num_threads);
+
+        MersenneTwister local_mt;
+        int const num_iterations_odd = randomIterations ? int(local_mt.poissonInterval((float)num_iterations)+0.5f) : num_iterations,
+                  num_iterations_even = randomIterations ? int(local_mt.poissonInterval((float)num_iterations)+0.5f) : num_iterations;
+
+        std::atomic<int> t[2], w[2];
+        std::chrono::time_point<std::chrono::high_resolution_clock> start[2], end[2];
+        for(int pass = 0; pass < 2; ++pass) {
+
+            t[pass] = 0;
+            w[pass] = 0;
+
+            srand(num_threads);
+            std::vector<MersenneTwister> randoms(num_threads);
+
+            barrier_type b(num_threads);
+
+            start[pass] = std::chrono::high_resolution_clock::now();
+#ifdef USEOMP
+            omp_set_num_threads(num_threads);
+            std::atomic<int> _j(0);
+            #pragma omp parallel
+            {
+                int const j = _j.fetch_add(1,std::memory_order_relaxed);
+                testbarrier_inner(b, num_threads, j, t[pass], w[pass], num_iterations_odd, num_iterations_even, num_items_noncritical, randoms[j], pass==0);
+                num_threads = omp_get_num_threads();
+            }
+#else
+            std::vector<std::thread*> threads(num_threads);
+            for(unsigned j = 0; j < num_threads; ++j)
+                threads[j] = new std::thread([&,j](){
+                    testbarrier_inner(b, num_threads, j, t[pass], w[pass], num_iterations_odd, num_iterations_even, num_items_noncritical, randoms[j], pass==0);
+                });
+            for(unsigned j = 0; j < num_threads; ++j) {
+                threads[j]->join();
+                delete threads[j];
+            }
+#endif
+            end[pass] = std::chrono::high_resolution_clock::now();
+        }
+
+        if(t[0] != t[1]) throw std::string("mismatched iteration counts");
+        if(w[0] != w[1]) throw std::string("mismatched work item counts");
+
+        int const phases = (std::max)(num_iterations_odd, num_iterations_even);
+
+        std::chrono::duration<double> elapsed_seconds_0 = end[0]-start[0],
+                                      elapsed_seconds_1 = end[1]-start[1];
+        double const time = (elapsed_seconds_1.count() - elapsed_seconds_0.count()) / phases;
+
+        data.push_back(time);
+#ifdef VERBOSE_TEST
+        std::cerr << name << " : " << num_threads << "," << elapsed_seconds_1.count() / phases << " - " << elapsed_seconds_0.count() / phases << " = " << time << "                                                 \n";
+#endif
+    }
+}
+
+template <class... T>
+struct mutex_tester;
+template <class F>
+struct mutex_tester<F> {
+    static void run(std::map<std::string,std::vector<double>>& results, std::string const name[], double critical_fraction, double critical_duration) {
+        testmutex_outer<F>(results, *name, critical_fraction, critical_duration);
+    }
+};
+template <class F, class... T>
+struct mutex_tester<F,T...> {
+    static void run(std::map<std::string,std::vector<double>>& results, std::string const name[], double critical_fraction, double critical_duration) {
+        mutex_tester<F>::run(results, name, critical_fraction, critical_duration);
+        mutex_tester<T...>::run(results, ++name, critical_fraction, critical_duration);
+    }
+};
+
+TEST( synchronic, main )
+{
+    //warm up
+    time_item();
+
+    //measure up
+#ifdef VERBOSE_TEST
+    std::cerr << "measuring work item speed...\r";
+    std::cerr << "work item speed is " << time_item() << " per item, nil is " << time_nil() << "\n";
+#endif
+    try {
+
+        std::pair<double,double> testpoints[] = { /*{1E-1, 10E-6}, {5E-1, 2E-6},  {1, 0},*/ {3E-1, 50E-9}, };
+        for(auto x : testpoints ) {
+
+            std::map<std::string,std::vector<double>> results;
+
+            //testbarrier_outer<std::barrier>(results, PREFIX"bar 1khz 100us", 1E3, x.second);
+
+            std::string const names[] = {
+                PREFIX"tkt", PREFIX"mcs", PREFIX"ttas", PREFIX"std"
+#ifdef WIN32
+                ,PREFIX"srw"
+#endif
+            };
+
+            //run -->
+
+            mutex_tester<
+                ticket_mutex, mcs_mutex, ttas_mutex, std::mutex
+#ifdef WIN32
+                ,srw_mutex
+#endif
+            >::run(results, names, x.first, x.second);
+
+            //<-- run
+
+#ifdef VERBOSE_TEST
+            std::cout << "threads";
+            for(auto & i : results)
+                std::cout << ",\"" << i.first << '\"';
+            std::cout << std::endl;
+            int j = 0;
+            FOR_GAUNTLET(num_threads) {
+                std::cout << num_threads;
+                for(auto & i : results)
+                    std::cout << ',' << i.second[j];
+                std::cout << std::endl;
+                ++j;
+            }
+#endif
+        }
+    }
+    catch(std::string & e) {
+        std::cerr << "EXCEPTION : " << e << std::endl;
+        EXPECT_TRUE( false );
+    }
+}
+
+} // namespace Test

--- a/core/unit_test/TestSynchronic.hpp
+++ b/core/unit_test/TestSynchronic.hpp
@@ -1,0 +1,239 @@
+/*
+
+Copyright (c) 2014, NVIDIA Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TEST_SYNCHRONIC_HPP
+#define TEST_SYNCHRONIC_HPP
+
+#include <impl/Kokkos_Synchronic.hpp>
+#include <mutex>
+
+namespace Test {
+
+template <bool truly>
+struct dumb_mutex {
+
+    dumb_mutex () : locked(0) {
+    }
+
+    void lock() {
+        while(1) {
+            bool state = false;
+            if (locked.compare_exchange_weak(state,true,std::memory_order_acquire)) {
+                break;
+            }
+            while (locked.load(std::memory_order_relaxed)) {
+              if (!truly) {
+                Kokkos::Impl::portable_yield();
+              }
+            }
+        }
+    }
+
+    void unlock() {
+        locked.store(false,std::memory_order_release);
+    }
+
+private :
+    std::atomic<bool> locked;
+};
+
+#ifdef WIN32
+#include <windows.h>
+#include <synchapi.h>
+struct srw_mutex {
+
+    srw_mutex () {
+        InitializeSRWLock(&_lock);
+    }
+
+    void lock() {
+        AcquireSRWLockExclusive(&_lock);
+    }
+    void unlock() {
+        ReleaseSRWLockExclusive(&_lock);
+    }
+
+private :
+    SRWLOCK _lock;
+};
+#endif
+
+struct ttas_mutex {
+
+    ttas_mutex() : locked(false) {
+    }
+
+	ttas_mutex(const ttas_mutex&) = delete;
+	ttas_mutex& operator=(const ttas_mutex&) = delete;
+
+    void lock() {
+        for(int i = 0;; ++i) {
+            bool state = false;
+            if(locked.compare_exchange_weak(state,true,std::memory_order_relaxed,Kokkos::Impl::notify_none))
+                break;
+            locked.expect_update(true);
+        }
+        std::atomic_thread_fence(std::memory_order_acquire);
+    }
+    void unlock() {
+        locked.store(false,std::memory_order_release);
+    }
+
+private :
+    Kokkos::Impl::synchronic<bool> locked;
+};
+
+struct ticket_mutex {
+
+    ticket_mutex() : active(0), queue(0) {
+    }
+
+	ticket_mutex(const ticket_mutex&) = delete;
+	ticket_mutex& operator=(const ticket_mutex&) = delete;
+
+    void lock() {
+        int const me = queue.fetch_add(1, std::memory_order_relaxed);
+        while(me != active.load_when_equal(me, std::memory_order_acquire))
+            ;
+    }
+
+    void unlock() {
+        active.fetch_add(1,std::memory_order_release);
+    }
+private :
+    Kokkos::Impl::synchronic<int> active;
+    std::atomic<int> queue;
+};
+
+struct mcs_mutex {
+
+    mcs_mutex() : head(nullptr) {
+    }
+
+	mcs_mutex(const mcs_mutex&) = delete;
+	mcs_mutex& operator=(const mcs_mutex&) = delete;
+
+    struct unique_lock {
+
+        unique_lock(mcs_mutex & arg_m) : m(arg_m), next(nullptr), ready(false) {
+
+            unique_lock * const head = m.head.exchange(this,std::memory_order_acquire);
+            if(__builtin_expect(head != nullptr,0)) {
+                head->next.store(this,std::memory_order_seq_cst,Kokkos::Impl::notify_one);
+                while(!ready.load_when_not_equal(false,std::memory_order_acquire))
+                    ;
+            }
+        }
+
+	    unique_lock(const unique_lock&) = delete;
+	    unique_lock& operator=(const unique_lock&) = delete;
+
+        ~unique_lock() {
+            unique_lock * head = this;
+            if(__builtin_expect(!m.head.compare_exchange_strong(head,nullptr,std::memory_order_release, std::memory_order_relaxed),0)) {
+                unique_lock * n = next.load(std::memory_order_relaxed);
+                while(!n)
+                    n = next.load_when_not_equal(n,std::memory_order_relaxed);
+                n->ready.store(true,std::memory_order_release,Kokkos::Impl::notify_one);
+            }
+        }
+
+    private:
+        mcs_mutex & m;
+        Kokkos::Impl::synchronic<unique_lock*> next;
+        Kokkos::Impl::synchronic<bool> ready;
+    };
+
+private :
+    std::atomic<unique_lock*> head;
+};
+
+}
+
+namespace std {
+template<>
+struct unique_lock<Test::mcs_mutex> : Test::mcs_mutex::unique_lock {
+  unique_lock(Test::mcs_mutex & arg_m) : Test::mcs_mutex::unique_lock(arg_m) {
+  }
+  unique_lock(const unique_lock&) = delete;
+  unique_lock& operator=(const unique_lock&) = delete;
+};
+
+}
+
+#include <cmath>
+#include <stdlib.h>
+
+namespace Test {
+
+//-------------------------------------
+//  MersenneTwister
+//-------------------------------------
+#define MT_IA  397
+#define MT_LEN 624
+
+class MersenneTwister
+{
+    volatile unsigned long m_buffer[MT_LEN][64/sizeof(unsigned long)];
+    volatile int m_index;
+
+public:
+    MersenneTwister() {
+        for (int i = 0; i < MT_LEN; i++)
+            m_buffer[i][0] = rand();
+        m_index = 0;
+        for (int i = 0; i < MT_LEN * 100; i++)
+            integer();
+    }
+    unsigned long integer() {
+        // Indices
+        int i = m_index;
+        int i2 = m_index + 1; if (i2 >= MT_LEN) i2 = 0; // wrap-around
+        int j = m_index + MT_IA; if (j >= MT_LEN) j -= MT_LEN; // wrap-around
+
+        // Twist
+        unsigned long s = (m_buffer[i][0] & 0x80000000) | (m_buffer[i2][0] & 0x7fffffff);
+        unsigned long r = m_buffer[j][0] ^ (s >> 1) ^ ((s & 1) * 0x9908B0DF);
+        m_buffer[m_index][0] = r;
+        m_index = i2;
+
+        // Swizzle
+        r ^= (r >> 11);
+        r ^= (r << 7) & 0x9d2c5680UL;
+        r ^= (r << 15) & 0xefc60000UL;
+        r ^= (r >> 18);
+        return r;
+    }
+    float poissonInterval(float ooLambda) {
+        return -logf(1.0f - integer() * 2.3283e-10f) * ooLambda;
+    }
+};
+
+} // namespace Test
+
+#endif //TEST_HPP


### PR DESCRIPTION
The paper describing synchronic is here: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4195.pdf

The code was obtained from here: https://code.google.com/p/synchronic

The code was modified in the following ways:
* Namespace changes (they were injecting into std, we want Kokkos::Impl)
* Remove trailing whitespace
* Remove windows-style ^M line terminations
* Use standard indentation, 2-space, no indent for namespaces
* Convert test to be compatible with GTest
* Remove shadow warnings
* Change test to not produce output unless user asks for it
* Add portable_sleep and portable_yield: our GCC-4.7.2 and 4.8.4 could not handle use of this_thread::sleep_for or this_thread::yield