### PR TITLE
test_all_sandia: Add capability to run jobs in parallel

### DIFF
--- a/config/test_all_sandia
+++ b/config/test_all_sandia
@@ -35,6 +35,7 @@ COMPILERS=("gcc/4.7.2 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
 export OMP_NUM_THREADS=4
 
 declare -i NUM_RESULTS_TO_KEEP=7
+
 RESULT_ROOT_PREFIX=TestAll
 
 source /projects/modulefiles/utils/sems-modules-init.sh
@@ -50,6 +51,8 @@ DEBUG=False
 ARGS=""
 CUSTOM_BUILD_LIST=""
 DRYRUN=False
+declare -i NUM_JOBS_TO_RUN_IN_PARALLEL=8
+TEST_SCRIPT=False
 
 while [[ $# > 0 ]]
 do
@@ -64,6 +67,12 @@ CUSTOM_BUILD_LIST="${key#*=}"
 --debug*)
 DEBUG=True
 ;;
+--test-script*)
+TEST_SCRIPT=True
+;;
+--num*)
+NUM_JOBS_TO_RUN_IN_PARALLEL="${key#*=}"
+;;
 --dry-run*)
 DRYRUN=True
 ;;
@@ -72,6 +81,8 @@ echo "test_all_sandia <ARGS> <OPTIONS>:"
 echo "--kokkos-path=/Path/To/Kokkos: Path to the Kokkos root directory"
 echo "    Defaults to root repo containing this script"
 echo "--debug: Run tests in debug. Defaults to False"
+echo "--test-script: Test this script, not Kokkos"
+echo "--num=N: Number of jobs to run in parallel "
 echo "--dry-run: Just print what would be executed"
 echo "--build-list=BUILD,BUILD,BUILD..."
 echo "    Provide a comma-separated list of builds instead of running all builds"
@@ -96,6 +107,10 @@ echo "  % test_all_sandia --debug"
 echo ""
 echo "  Run gcc/4.7.2 and only do OpenMP and OpenMP_Serial builds"
 echo "  % test_all_sandia gcc/4.7.2 --build-list=OpenMP,OpenMP_Serial"
+echo ""
+echo "If you want to kill the tests, do:"
+echo "  hit ctrl-z"
+echo "  % kill -9 %1"
 echo
 exit 0
 ;;
@@ -106,7 +121,6 @@ ARGS="$ARGS $1"
 esac
 shift
 done
-
 
 # set kokkos path
 if [ -z "$KOKKOS_PATH" ]; then
@@ -132,8 +146,8 @@ fi
 COMPILERS_TO_TEST=""
 for ARG in $ARGS; do
     for COMPILER_DATA in "${COMPILERS[@]}"; do
-        arr=($COMPILER_DATA)
-        COMPILER=${arr[0]}
+        ARR=($COMPILER_DATA)
+        COMPILER=${ARR[0]}
         if [[ "$COMPILER" = $ARG* ]]; then
             if [[ "$COMPILERS_TO_TEST" != *${COMPILER}* ]]; then
                 COMPILERS_TO_TEST="$COMPILERS_TO_TEST $COMPILER"
@@ -165,6 +179,7 @@ get_compiler_data() {
     local compiler_name=$(get_compiler_name $compiler)
     local compiler_vers=$(get_compiler_version $compiler)
 
+    local compiler_data
     for compiler_data in "${COMPILERS[@]}" ; do
         local arr=($compiler_data)
         if [ "$compiler" = "${arr[0]}" ]; then
@@ -201,19 +216,41 @@ get_compiler_warning_flags() {
 run_cmd() {
     echo "RUNNING: $*"
     if [ "$DRYRUN" != "True" ]; then
-	eval "$*"
+	eval "$* 2>&1"
     fi
 }
 
+# report_and_log_test_results <SUCCESS> <DESC> <PHASE>
 report_and_log_test_result() {
-    if [ "$1" = "0" ]; then
-	echo "PASSED $2"
-	TEST_RESULTS="${TEST_RESULTS}\nPASSED $2"
+    # Use sane var names
+    local success=$1; local desc=$2; local phase=$3;
+
+    if [ "$success" = "0" ]; then
+	echo "  PASSED $desc"
+        touch $PASSED_DIR/$desc
     else
-	echo "FAILED $2" >&2
-	TEST_RESULTS="${TEST_RESULTS}\nFAILED $2 ($3)"
-	NUM_FAILED+=1
+	echo "  FAILED $desc" >&2
+        echo $phase > $FAILED_DIR/$desc
+        cat ${desc}.${phase}.log
     fi
+}
+
+setup_env() {
+    local compiler=$1
+    local compiler_modules=$(get_compiler_modules $compiler)
+
+    module purge
+
+    local mod
+    for mod in $compiler_modules; do
+	module load $mod 2>&1
+        # It is ridiculously hard to check for the success of a loaded
+        # module. Module does not return error codes and piping to grep
+        # causes module to run in a subshell.
+        module list 2>&1 | grep "$mod" >& /dev/null || return 1
+    done
+
+    return 0
 }
 
 # single_build_and_test <COMPILER> <BUILD> <BUILD_TYPE>
@@ -221,8 +258,13 @@ single_build_and_test() {
     # Use sane var names
     local compiler=$1; local build=$2; local build_type=$3;
 
-    cd $ROOT_DIR/$compiler
+    # set up env
+    mkdir -p $ROOT_DIR/$compiler/"${build}-$build_type"
+    cd $ROOT_DIR/$compiler/"${build}-$build_type"
+    local desc=$(echo "${compiler}-${build}-${build_type}" | sed 's:/:-:g')
+    setup_env $compiler >& ${desc}.configure.log || { report_and_log_test_result 1 ${desc} configure && return 0; }
 
+    # Set up flags
     local compiler_warning_flags=$(get_compiler_warning_flags $compiler)
     local compiler_exe=$(get_compiler_exe_name $compiler)
 
@@ -237,34 +279,50 @@ single_build_and_test() {
         local cxxflags="-O3 $compiler_warning_flags"
     fi
 
-    local desc=$(echo "${compiler}-${build}-${build_type}" | sed 's:/:-:g')
-    echo "  Doing build: $desc"
-
-    mkdir "${build}-$build_type"
-    cd "${build}-$build_type"
-
     # cxxflags="-DKOKKOS_USING_EXPERIMENTAL_VIEW $cxxflags"
 
-    run_cmd ${KOKKOS_PATH}/generate_makefile.bash --with-devices=$build --compiler=$(which $compiler_exe) --cxxflags=\"$cxxflags\" $extra_args 2>&1 | tee ${desc}.configure.log || { report_and_log_test_result 1 ${desc} configure && return 0; }
-    run_cmd make build-test 2>&1 | tee ${desc}.build.log || { report_and_log_test_result 1 ${desc} build && return 0; }
-    run_cmd make test 2>&1 | tee ${desc}.test.log || { report_and_log_test_result 1 ${desc} test && return 0; }
+    echo "  Starting job $desc"
+
+    if [ "$TEST_SCRIPT" = "True" ]; then
+        local rand=$[ 1 + $[ RANDOM % 10 ]]
+        sleep $rand
+        if [ $rand -gt 5 ]; then
+            run_cmd ls fake_problem >& ${desc}.configure.log || { report_and_log_test_result 1 $desc configure && return 0; }
+        fi
+    else
+        run_cmd ${KOKKOS_PATH}/generate_makefile.bash --with-devices=$build --compiler=$(which $compiler_exe) --cxxflags=\"$cxxflags\" $extra_args >& ${desc}.configure.log || { report_and_log_test_result 1 ${desc} configure && return 0; }
+        run_cmd make build-test >& ${desc}.build.log || { report_and_log_test_result 1 ${desc} build && return 0; }
+        run_cmd make test >& ${desc}.test.log || { report_and_log_test_result 1 ${desc} test && return 0; }
+    fi
+
     report_and_log_test_result 0 $desc
+
     return 0
 }
 
-setup_env() {
-    local compiler=$1
-    local compiler_modules=$(get_compiler_modules $compiler)
-
-    module purge
-
-    for mod in $compiler_modules; do
-	module load $mod
-        # It is ridiculously hard to check for the success of a loaded
-        # module. Module does not return error codes and piping to grep
-        # causes module to run in a subshell.
-        module list 2>&1 | grep "$mod"
+# wait_for_jobs <NUM-JOBS>
+wait_for_jobs() {
+    local -i max_jobs=$1
+    local -i num_active_jobs=$(jobs | wc -l)
+    while [ $num_active_jobs -ge $max_jobs ]
+    do
+        sleep 1
+        num_active_jobs=$(jobs | wc -l)
+        jobs >& /dev/null
     done
+}
+
+# run_in_background <COMPILER> <BUILD> <BUILD_TYPE>
+run_in_background() {
+    local compiler=$1
+
+    local -i num_jobs=$NUM_JOBS_TO_RUN_IN_PARALLEL
+    if [[ "$compiler" == cuda* ]]; then
+        num_jobs=1
+    fi
+    wait_for_jobs $num_jobs
+
+    single_build_and_test $* &
 }
 
 # build_and_test_all <COMPILER>
@@ -277,19 +335,15 @@ build_and_test_all() {
 	local compiler_build_list=$(echo "$CUSTOM_BUILD_LIST" | tr , ' ')
     fi
 
-    # set up env
-    cd $ROOT_DIR
-    mkdir -p $compiler
-    setup_env $compiler
-
     # do builds
+    local build
     for build in $compiler_build_list
     do
-	single_build_and_test $compiler $build $BUILD_TYPE
+	run_in_background $compiler $build $BUILD_TYPE
 
         # If not cuda, do a hwloc test too
         if [[ "$compiler" != cuda* ]]; then
-            single_build_and_test $compiler $build "hwloc-$BUILD_TYPE"
+            run_in_background $compiler $build "hwloc-$BUILD_TYPE"
         fi
     done
 
@@ -307,6 +361,30 @@ get_test_root_dir() {
     echo $(pwd)/${RESULT_ROOT_PREFIX}_$(date +"%Y-%m-%d_%H.%M.%S")
 }
 
+wait_summarize_and_exit() {
+    wait_for_jobs 1
+
+    echo "#######################################################"
+    echo "PASSED TESTS"
+    echo "#######################################################"
+
+    \ls -1 $PASSED_DIR | sort
+
+    echo "#######################################################"
+    echo "FAILED TESTS"
+    echo "#######################################################"
+
+    local failed_test
+    local -i rv=0
+    for failed_test in $(\ls -1 $FAILED_DIR)
+    do
+        echo $failed_test "("$(cat $FAILED_DIR/$failed_test)" failed)"
+        rv=$rv+1
+    done
+
+    exit $rv
+}
+
 #
 # Main
 #
@@ -315,16 +393,15 @@ ROOT_DIR=$(get_test_root_dir)
 mkdir -p $ROOT_DIR
 cd $ROOT_DIR
 
-TEST_RESULTS=""
-declare -i NUM_FAILED=0
+PASSED_DIR=$ROOT_DIR/results/passed
+FAILED_DIR=$ROOT_DIR/results/failed
+mkdir -p $PASSED_DIR
+mkdir -p $FAILED_DIR
+
+echo "Going to test compilers: " $COMPILERS_TO_TEST
 for COMPILER in $COMPILERS_TO_TEST; do
     echo "Testing compiler $COMPILER"
     build_and_test_all $COMPILER
 done
 
-echo "#######################################################"
-echo "RESULT SUMMARY"
-echo "#######################################################"
-echo -e $TEST_RESULTS
-
-exit $NUM_FAILED
+wait_summarize_and_exit


### PR DESCRIPTION
Instead of leveraging Jenkins to achieve parallelism, put parallelism
directly in the script. It's simpler that way and also allows people
to take advantge of this outside of Jenkins.

Default will be to run eight jobs at once. CUDA jobs will NOT be
run in parallel.

Also, adds a test mode for the script that sleeps instead of running
Kokkos.

Much more graceful handling of missing modules.