### PR TITLE
Changes to nvcc_wrapper and test_all_sandia

### DIFF
--- a/config/nvcc_wrapper
+++ b/config/nvcc_wrapper
@@ -43,6 +43,7 @@ ccbin_set=0
 nvcc_error_code=0
 dry_run=0
 replace_pragma_ident=0
+temp_dir=${TMPDIR:-/tmp}
 
 #echo "Arguments: $# $@"
 
@@ -62,7 +63,7 @@ do
     cpp_files="$cpp_files $1"
     ;;
   #Handle known nvcc args
-  -O*|-D*|-gencode*|-c|-I*|-L*|-l*|-g|--help|--version|--dryrun|--verbose|--keep-dir|-E|-M|-G|--relocatable-device-code*|-shared|-lineinfo|-expt-extended-lambda|--resource-usage)
+  -O*|-D*|-gencode*|-c|-I*|-L*|-l*|-g|--help|--version|--dryrun|--verbose|--keep|--keep-dir*|-E|-M|-G|--relocatable-device-code*|-shared|-lineinfo|-expt-extended-lambda|--resource-usage)
     cuda_args="$cuda_args $1"
     ;;
   #Handle c++11 setting
@@ -155,8 +156,8 @@ if [ $replace_pragma_ident -eq 1 ]; then
     var=`grep pragma ${file} | grep ident | grep "#"`
     if [ "${#var}" -gt 0 ]
     then
-      sed 's/#[\ \t]*pragma[\ \t]*ident/#ident/g' $file > /tmp/nvcc_wrapper_tmp_$file
-      cpp_files2="$cpp_files2 /tmp/nvcc_wrapper_tmp_$file"
+      sed 's/#[\ \t]*pragma[\ \t]*ident/#ident/g' $file > $temp_dir/nvcc_wrapper_tmp_$file
+      cpp_files2="$cpp_files2 $temp_dir/nvcc_wrapper_tmp_$file"
     else
       cpp_files2="$cpp_files2 $file"
     fi

--- a/config/test_all_sandia
+++ b/config/test_all_sandia
@@ -279,6 +279,11 @@ single_build_and_test() {
         local cxxflags="-O3 $compiler_warning_flags"
     fi
 
+    if [[ "$compiler" == cuda* ]]; then
+        cxxflags="--keep --keep-dir=$(pwd) $cxxflags"
+        export TMPDIR=$(pwd)
+    fi
+
     # cxxflags="-DKOKKOS_USING_EXPERIMENTAL_VIEW $cxxflags"
 
     echo "  Starting job $desc"
@@ -351,11 +356,12 @@ build_and_test_all() {
 }
 
 get_test_root_dir() {
-    local -i num_existing_results=$(find . -maxdepth 1 -name "$RESULT_ROOT_PREFIX*" | wc -l)
+    local existing_results=$(find . -maxdepth 1 -name "$RESULT_ROOT_PREFIX*" | sort)
+    local -i num_existing_results=$(echo $existing_results | tr ' ' '\n' | wc -l)
     local -i num_to_delete=${num_existing_results}-${NUM_RESULTS_TO_KEEP}
 
     if [ $num_to_delete -gt 0 ]; then
-        /bin/rm -rf $(\ls -1t | tail -n $num_to_delete)
+        /bin/rm -rf $(echo $existing_results | tr ' ' '\n' | head -n $num_to_delete)
     fi
 
     echo $(pwd)/${RESULT_ROOT_PREFIX}_$(date +"%Y-%m-%d_%H.%M.%S")
@@ -401,7 +407,7 @@ mkdir -p $FAILED_DIR
 echo "Going to test compilers: " $COMPILERS_TO_TEST
 for COMPILER in $COMPILERS_TO_TEST; do
     echo "Testing compiler $COMPILER"
-    build_and_test_all $COMPILER
+    #build_and_test_all $COMPILER
 done
 
 wait_summarize_and_exit


### PR DESCRIPTION
nvcc_wrapper: Fix handling of --keep-dir, add support for --keep. Also
use $TMPDIR as temp dir if defined.

test_all_sandia: Use pwd as tmp dir for nvcc. Should get rid of
occassional test failures due to /tmp problems. Fix to how test_all_sandia
cleans up old test results.