### PR TITLE
Experimental::View progress

### DIFF
--- a/core/src/Cuda/Kokkos_CudaExec.hpp
+++ b/core/src/Cuda/Kokkos_CudaExec.hpp
@@ -208,9 +208,9 @@ struct CudaParallelLaunch< DriverType , true > {
         Kokkos::Impl::throw_runtime_exception( std::string("CudaParallelLaunch FAILED: shared memory request is too large") );
       }
       else if ( shmem ) {
-        cudaFuncSetCacheConfig( cuda_parallel_launch_constant_memory< DriverType > , cudaFuncCachePreferShared );
+        CUDA_SAFE_CALL( cudaFuncSetCacheConfig( cuda_parallel_launch_constant_memory< DriverType > , cudaFuncCachePreferShared ) );
       } else {
-        cudaFuncSetCacheConfig( cuda_parallel_launch_constant_memory< DriverType > , cudaFuncCachePreferL1 );
+        CUDA_SAFE_CALL( cudaFuncSetCacheConfig( cuda_parallel_launch_constant_memory< DriverType > , cudaFuncCachePreferL1 ) );
       }
 
       // Copy functor to constant memory on the device
@@ -246,9 +246,9 @@ struct CudaParallelLaunch< DriverType , false > {
         Kokkos::Impl::throw_runtime_exception( std::string("CudaParallelLaunch FAILED: shared memory request is too large") );
       }
       else if ( shmem ) {
-        cudaFuncSetCacheConfig( cuda_parallel_launch_local_memory< DriverType > , cudaFuncCachePreferShared );
+        CUDA_SAFE_CALL( cudaFuncSetCacheConfig( cuda_parallel_launch_local_memory< DriverType > , cudaFuncCachePreferShared ) );
       } else {
-        cudaFuncSetCacheConfig( cuda_parallel_launch_local_memory< DriverType > , cudaFuncCachePreferL1 );
+        CUDA_SAFE_CALL( cudaFuncSetCacheConfig( cuda_parallel_launch_local_memory< DriverType > , cudaFuncCachePreferL1 ) );
       }
 
       int* lock_array_ptr = lock_array_cuda_space_ptr();

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -536,15 +536,17 @@ SharedAllocationRecord< Kokkos::CudaSpace , void >::get_record( void * alloc_ptr
 
 #if 0
   // Copy the header from the allocation
-  SharedAllocationHeader head ;
+  Header head ;
 
-  SharedAllocationHeader const * const head_cuda = Header::get_header( alloc_ptr );
+  Header const * const head_cuda = alloc_ptr ? Header::get_header( alloc_ptr ) : (Header*) 0 ;
 
-  Kokkos::Impl::DeepCopy<HostSpace,CudaSpace>::DeepCopy( & head , head_cuda , sizeof(SharedAllocationHeader) );
+  if ( alloc_ptr ) {
+    Kokkos::Impl::DeepCopy<HostSpace,CudaSpace>::DeepCopy( & head , head_cuda , sizeof(SharedAllocationHeader) );
+  }
 
-  RecordCuda * const record = static_cast< RecordCuda * >( head.m_record );
+  RecordCuda * const record = alloc_ptr ? static_cast< RecordCuda * >( head.m_record ) : (RecordCuda *) 0 ;
 
-  if ( record->m_alloc_ptr != head_cuda ) {
+  if ( ! alloc_ptr || record->m_alloc_ptr != head_cuda ) {
     Kokkos::Impl::throw_runtime_exception( std::string("Kokkos::Experimental::Impl::SharedAllocationRecord< Kokkos::CudaSpace , void >::get_record ERROR" ) );
   }
 
@@ -570,9 +572,9 @@ SharedAllocationRecord< Kokkos::CudaUVMSpace , void >::get_record( void * alloc_
   using Header     = SharedAllocationHeader ;
   using RecordCuda = SharedAllocationRecord< Kokkos::CudaUVMSpace , void > ;
 
-  Header * const h = reinterpret_cast< Header * >( alloc_ptr ) - 1 ;
+  Header * const h = alloc_ptr ? reinterpret_cast< Header * >( alloc_ptr ) - 1 : (Header *) 0 ;
 
-  if ( h->m_record->m_alloc_ptr != h ) {
+  if ( ! alloc_ptr || h->m_record->m_alloc_ptr != h ) {
     Kokkos::Impl::throw_runtime_exception( std::string("Kokkos::Experimental::Impl::SharedAllocationRecord< Kokkos::CudaUVMSpace , void >::get_record ERROR" ) );
   }
 
@@ -585,9 +587,9 @@ SharedAllocationRecord< Kokkos::CudaHostPinnedSpace , void >::get_record( void *
   using Header     = SharedAllocationHeader ;
   using RecordCuda = SharedAllocationRecord< Kokkos::CudaHostPinnedSpace , void > ;
 
-  Header * const h = reinterpret_cast< Header * >( alloc_ptr ) - 1 ;
+  Header * const h = alloc_ptr ? reinterpret_cast< Header * >( alloc_ptr ) - 1 : (Header *) 0 ;
 
-  if ( h->m_record->m_alloc_ptr != h ) {
+  if ( ! alloc_ptr || h->m_record->m_alloc_ptr != h ) {
     Kokkos::Impl::throw_runtime_exception( std::string("Kokkos::Experimental::Impl::SharedAllocationRecord< Kokkos::CudaHostPinnedSpace , void >::get_record ERROR" ) );
   }
 

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -106,6 +106,8 @@ void DeepCopyAsyncCuda( void * dst , const void * src , size_t n) {
 
 namespace Kokkos {
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
 namespace {
 
 void texture_object_attach_impl(  Impl::AllocationTracker const & tracker
@@ -164,6 +166,8 @@ void CudaSpace::texture_object_attach(  Impl::AllocationTracker const & tracker
   texture_object_attach_impl( tracker, type_size, desc );
 }
 
+#endif /* #if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW ) */
+
 void CudaSpace::access_error()
 {
   const std::string msg("Kokkos::CudaSpace::access_error attempt to execute Cuda function from non-Cuda space" );
@@ -178,6 +182,8 @@ void CudaSpace::access_error( const void * const )
 
 /*--------------------------------------------------------------------------*/
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
 Impl::AllocationTracker CudaUVMSpace::allocate_and_track( const std::string & label, const size_t size )
 {
   return Impl::AllocationTracker( allocator(), size, label);
@@ -191,6 +197,8 @@ void CudaUVMSpace::texture_object_attach(  Impl::AllocationTracker const & track
   texture_object_attach_impl( tracker, type_size, desc );
 }
 
+#endif /* #if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW ) */
+
 bool CudaUVMSpace::available()
 {
 #if defined( CUDA_VERSION ) && ( 6000 <= CUDA_VERSION ) && !defined(__APPLE__)
@@ -203,10 +211,14 @@ bool CudaUVMSpace::available()
 
 /*--------------------------------------------------------------------------*/
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
 Impl::AllocationTracker CudaHostPinnedSpace::allocate_and_track( const std::string & label, const size_t size )
 {
   return Impl::AllocationTracker( allocator(), size, label);
 }
+
+#endif /* #if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW ) */
 
 } // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -289,6 +289,132 @@ void CudaHostPinnedSpace::deallocate( void * const arg_alloc_ptr , const size_t 
   } catch(...) {}
 }
 
+void * CudaSpace::allocate_tracked( const size_t arg_alloc_size
+                                  , const std::string & arg_alloc_label ) const
+{
+  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< CudaSpace , void >  Record ;
+
+  if ( ! arg_alloc_size ) return (void *) 0 ;
+
+  Record * const r = Record::allocate( *this , arg_alloc_label , arg_alloc_size );
+
+  Record::increment( r );
+
+  return r->data();
+}
+
+void * CudaUVMSpace::allocate_tracked( const size_t arg_alloc_size
+                                  , const std::string & arg_alloc_label ) const
+{
+  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< CudaUVMSpace , void >  Record ;
+
+  if ( ! arg_alloc_size ) return (void *) 0 ;
+
+  Record * const r = Record::allocate( *this , arg_alloc_label , arg_alloc_size );
+
+  Record::increment( r );
+
+  return r->data();
+}
+
+void * CudaHostPinnedSpace::allocate_tracked( const size_t arg_alloc_size
+                                  , const std::string & arg_alloc_label ) const
+{
+  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< CudaHostPinnedSpace , void >  Record ;
+
+  if ( ! arg_alloc_size ) return (void *) 0 ;
+
+  Record * const r = Record::allocate( *this , arg_alloc_label , arg_alloc_size );
+
+  Record::increment( r );
+
+  return r->data();
+}
+
+void CudaSpace::deallocate_tracked( void * const arg_alloc_ptr ) const
+{
+  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< CudaSpace , void >  Record ;
+
+  if ( arg_alloc_ptr != 0 ) {
+    Record * const r = Record::get_record( arg_alloc_ptr );
+
+    Record::decrement( r );
+  }
+}
+
+void CudaUVMSpace::deallocate_tracked( void * const arg_alloc_ptr ) const
+{
+  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< CudaUVMSpace , void >  Record ;
+
+  if ( arg_alloc_ptr != 0 ) {
+    Record * const r = Record::get_record( arg_alloc_ptr );
+
+    Record::decrement( r );
+  }
+}
+
+void CudaHostPinnedSpace::deallocate_tracked( void * const arg_alloc_ptr ) const
+{
+  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< CudaHostPinnedSpace , void >  Record ;
+
+  if ( arg_alloc_ptr != 0 ) {
+    Record * const r = Record::get_record( arg_alloc_ptr );
+
+    Record::decrement( r );
+  }
+}
+
+void * CudaSpace::reallocate_tracked( void * const arg_alloc_ptr
+                                    , const size_t arg_alloc_size ) const
+{
+  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< CudaSpace , void >  Record ;
+
+  Record * const r_old = Record::get_record( arg_alloc_ptr );
+  Record * const r_new = Record::allocate( *this , r_old->get_label() , arg_alloc_size );
+
+  Kokkos::Impl::DeepCopy<CudaSpace,CudaSpace>( r_new->data() , r_old->data()
+                                             , std::min( r_old->size() , r_new->size() ) );
+
+  Record::increment( r_new );
+  Record::decrement( r_old );
+
+  return r_new->data();
+}
+
+void * CudaUVMSpace::reallocate_tracked( void * const arg_alloc_ptr
+                                       , const size_t arg_alloc_size ) const
+{
+  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< CudaUVMSpace , void >  Record ;
+
+  Record * const r_old = Record::get_record( arg_alloc_ptr );
+  Record * const r_new = Record::allocate( *this , r_old->get_label() , arg_alloc_size );
+
+  Kokkos::Impl::DeepCopy<CudaUVMSpace,CudaUVMSpace>( r_new->data() , r_old->data()
+                                                   , std::min( r_old->size() , r_new->size() ) );
+
+  Record::increment( r_new );
+  Record::decrement( r_old );
+
+  return r_new->data();
+}
+
+void * CudaHostPinnedSpace::reallocate_tracked( void * const arg_alloc_ptr
+                                              , const size_t arg_alloc_size ) const
+{
+  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< CudaHostPinnedSpace , void >  Record ;
+
+  Record * const r_old = Record::get_record( arg_alloc_ptr );
+  Record * const r_new = Record::allocate( *this , r_old->get_label() , arg_alloc_size );
+
+  Kokkos::Impl::DeepCopy<CudaHostPinnedSpace,CudaHostPinnedSpace>( r_new->data() , r_old->data()
+                                                   , std::min( r_old->size() , r_new->size() ) );
+
+  Record::increment( r_new );
+  Record::decrement( r_old );
+
+  return r_new->data();
+}
+
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda_Impl.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Impl.cpp
@@ -222,9 +222,13 @@ private:
   CudaInternal( const CudaInternal & );
   CudaInternal & operator = ( const CudaInternal & );
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
   AllocationTracker m_scratchFlagsTracker;
   AllocationTracker m_scratchSpaceTracker;
   AllocationTracker m_scratchUnifiedTracker;
+
+#endif
 
 
 public:
@@ -501,8 +505,21 @@ CudaInternal::scratch_flags( const Cuda::size_type size )
 
     m_scratchFlagsCount = ( size + sizeScratchGrain - 1 ) / sizeScratchGrain ;
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
     m_scratchFlagsTracker = CudaSpace::allocate_and_track( std::string("InternalScratchFlags") , sizeof( ScratchGrain ) * m_scratchFlagsCount );
+
     m_scratchFlags = reinterpret_cast<size_type *>(m_scratchFlagsTracker.alloc_ptr());
+
+#else
+
+    m_scratchFlags = reinterpret_cast<size_type *>(
+      Kokkos::Experimental::kokkos_malloc< CudaSpace >
+        ( sizeof( ScratchGrain ) * m_scratchFlagsCount
+        , "InternalScratchFlags" ) );
+
+#endif
+
 
     CUDA_SAFE_CALL( cudaMemset( m_scratchFlags , 0 , m_scratchFlagsCount * sizeScratchGrain ) );
   }
@@ -517,8 +534,20 @@ CudaInternal::scratch_space( const Cuda::size_type size )
 
     m_scratchSpaceCount = ( size + sizeScratchGrain - 1 ) / sizeScratchGrain ;
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
     m_scratchSpaceTracker = CudaSpace::allocate_and_track( std::string("InternalScratchSpace") , sizeof( ScratchGrain ) * m_scratchSpaceCount );
+
     m_scratchSpace = reinterpret_cast<size_type *>(m_scratchSpaceTracker.alloc_ptr());
+
+#else
+
+    m_scratchSpace = reinterpret_cast< size_type *>(
+      Kokkos::Experimental::kokkos_malloc< CudaSpace >
+        ( sizeof( ScratchGrain ) * m_scratchSpaceCount
+        , "InternalScratchSpace" ));
+
+#endif
 
   }
 
@@ -533,8 +562,22 @@ CudaInternal::scratch_unified( const Cuda::size_type size )
 
     m_scratchUnifiedCount = ( size + sizeScratchGrain - 1 ) / sizeScratchGrain ;
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
     m_scratchUnifiedTracker = CudaHostPinnedSpace::allocate_and_track( std::string("InternalScratchUnified") , sizeof( ScratchGrain ) * m_scratchUnifiedCount );
+
     m_scratchUnified = reinterpret_cast<size_type *>( m_scratchUnifiedTracker.alloc_ptr() );
+
+#else
+
+    m_scratchUnified = reinterpret_cast<size_type *>(
+      Kokkos::Experimental::kokkos_malloc< CudaHostPinnedSpace >
+        ( sizeof( ScratchGrain ) * m_scratchUnifiedCount
+        , "InternalScratchUnified" ));
+
+
+#endif
+
   }
 
   return m_scratchUnified ;
@@ -555,9 +598,19 @@ void CudaInternal::finalize()
       ::free( m_stream );
     }
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
     m_scratchSpaceTracker.clear();
     m_scratchFlagsTracker.clear();
     m_scratchUnifiedTracker.clear();
+
+#else
+
+    Kokkos::Experimental::kokkos_free< CudaSpace >( m_scratchFlags );
+    Kokkos::Experimental::kokkos_free< CudaSpace >( m_scratchSpace );
+    Kokkos::Experimental::kokkos_free< CudaHostPinnedSpace >( m_scratchUnified );
+
+#endif
 
     m_cudaDev             = -1 ;
     m_maxWarpCount        = 0 ;

--- a/core/src/KokkosExp_View.hpp
+++ b/core/src/KokkosExp_View.hpp
@@ -851,7 +851,6 @@ private:
     map_type  m_map ;
     ExecSpace m_space ;
 
-    KOKKOS_INLINE_FUNCTION
     void destroy_shared_allocation() { m_map.destroy( m_space ); }
   };
 
@@ -907,15 +906,17 @@ public:
                       , arg_N0 , arg_N1 , arg_N2 , arg_N3
                       , arg_N4 , arg_N5 , arg_N6 , arg_N7 );
 
-      // Copy the destroy functor into the allocation record before initiating tracking.
-      record->m_destroy.m_map   = m_map ;
-      record->m_destroy.m_space = prop.execution ;
-
+      // If constructing the plan for destructing as well
+      // Copy the destroy functor into the allocation record
+      // before initiating tracking.
       if ( prop.initialize.value ) {
         m_map.construct( prop.execution );
+
+        record->m_destroy.m_map   = m_map ;
+        record->m_destroy.m_space = prop.execution ;
       }
 
-      // Destroy functor assigned and initialization complete, start tracking
+      // Setup and initialization complete, start tracking
       m_track = track_type( record );
     }
 
@@ -955,14 +956,15 @@ public:
       m_map = map_type( record->data() , prop.allow_padding , arg_layout );
 
       // Copy the destroy functor into the allocation record before initiating tracking.
-      record->m_destroy.m_map   = m_map ;
-      record->m_destroy.m_space = prop.execution ;
 
       if ( prop.initialize.value ) {
         m_map.construct( prop.execution );
+
+        record->m_destroy.m_map   = m_map ;
+        record->m_destroy.m_space = prop.execution ;
       }
 
-      // Destroy functor assigned and initialization complete, start tracking
+      // Setup and initialization complete, start tracking
       m_track = track_type( record );
     }
 

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -113,28 +113,45 @@ void fence();
 namespace Kokkos {
 namespace Experimental {
 
+/* Allocate memory from a memory space.
+ * The allocation is tracked in Kokkos memory tracking system, so
+ * leaked memory can be identified.
+ */
+template< class Space = typename Kokkos::DefaultExecutionSpace::memory_space >
+inline
+void * kokkos_malloc( const std::string & arg_alloc_label
+                    , const size_t arg_alloc_size )
+{
+  typedef typename Space::memory_space MemorySpace ;
+  return Impl::SharedAllocationRecord< MemorySpace >::
+    allocate_tracked( MemorySpace() , arg_alloc_label , arg_alloc_size );
+}
+
 template< class Space = typename Kokkos::DefaultExecutionSpace::memory_space >
 inline
 void * kokkos_malloc( const size_t arg_alloc_size )
 {
-  typename Space::memory_space s ;
-  return s.allocate_tracked( arg_alloc_size );
+  typedef typename Space::memory_space MemorySpace ;
+  return Impl::SharedAllocationRecord< MemorySpace >::
+    allocate_tracked( MemorySpace() , "no-label" , arg_alloc_size );
 }
 
 template< class Space = typename Kokkos::DefaultExecutionSpace::memory_space >
 inline
 void kokkos_free( void * arg_alloc )
 {
-  typename Space::memory_space s ;
-  return s.deallocate_tracked( arg_alloc );
+  typedef typename Space::memory_space MemorySpace ;
+  return Impl::SharedAllocationRecord< MemorySpace >::
+    deallocate_tracked( arg_alloc );
 }
 
 template< class Space = typename Kokkos::DefaultExecutionSpace::memory_space >
 inline
 void * kokkos_realloc( void * arg_alloc , const size_t arg_alloc_size )
 {
-  typename Space::memory_space s ;
-  return s.reallocate_tracked( arg_alloc , arg_alloc_size );
+  typedef typename Space::memory_space MemorySpace ;
+  return Impl::SharedAllocationRecord< MemorySpace >::
+    reallocate_tracked( arg_alloc , arg_alloc_size );
 }
 
 } // namespace Experimental

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -115,50 +115,26 @@ namespace Experimental {
 
 template< class Space = typename Kokkos::DefaultExecutionSpace::memory_space >
 inline
-void * kokkos_malloc( const size_t arg_alloc_size
-                    , const std::string & arg_label = std::string("kokkos_malloc") )
+void * kokkos_malloc( const size_t arg_alloc_size )
 {
-  typedef typename Space::memory_space  MemorySpace ;
-  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< MemorySpace , void >  RecordSpace ;
-
-  RecordSpace * const r = RecordSpace::allocate( MemorySpace() , arg_label , arg_alloc_size );
-
-  RecordSpace::increment( r );
-
-  return r->data();
+  typename Space::memory_space s ;
+  return s.allocate_tracked( arg_alloc_size );
 }
 
 template< class Space = typename Kokkos::DefaultExecutionSpace::memory_space >
 inline
 void kokkos_free( void * arg_alloc )
 {
-  typedef typename Space::memory_space  MemorySpace ;
-  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< MemorySpace , void >  RecordSpace ;
-
-  if ( arg_alloc ) {
-    RecordSpace * const r = RecordSpace::get_record( arg_alloc );
-
-    RecordSpace::decrement( r );
-  }
+  typename Space::memory_space s ;
+  return s.deallocate_tracked( arg_alloc );
 }
 
 template< class Space = typename Kokkos::DefaultExecutionSpace::memory_space >
 inline
 void * kokkos_realloc( void * arg_alloc , const size_t arg_alloc_size )
 {
-  typedef typename Space::memory_space  MemorySpace ;
-  typedef Kokkos::Experimental::Impl::SharedAllocationRecord< MemorySpace , void >  RecordSpace ;
-
-  RecordSpace * const r_old = RecordSpace::get_record( arg_alloc );
-  RecordSpace * const r_new = RecordSpace::allocate( MemorySpace() , r_old->get_label() , arg_alloc_size );
-
-  Kokkos::Impl::DeepCopy<MemorySpace,MemorySpace>( r_new->data() , r_old->data()
-                                                 , std::min( r_old->size() , r_new->size() ) );
-
-  RecordSpace::increment( r_new );
-  RecordSpace::decrement( r_old );
-
-  return r_new->data();
+  typename Space::memory_space s ;
+  return s.reallocate_tracked( arg_alloc , arg_alloc_size );
 }
 
 } // namespace Experimental

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -109,12 +109,23 @@ public:
   CudaSpace & operator = ( const CudaSpace & rhs ) = default ;
   ~CudaSpace() = default ;
 
-  /**\brief  Allocate memory in the cuda space */
+  /**\brief  Allocate untracked memory in the cuda space */
   void * allocate( const size_t arg_alloc_size ) const ;
 
-  /**\brief  Deallocate memory in the cuda space */
+  /**\brief  Deallocate untracked memory in the cuda space */
   void deallocate( void * const arg_alloc_ptr
                  , const size_t arg_alloc_size ) const ;
+
+  /**\brief  Allocate tracked memory in the space */
+  void * allocate_tracked( const size_t arg_alloc_size
+                         , const std::string & arg_label = "no_label" ) const ;
+
+  /**\brief  Reallocate tracked memory in the space */
+  void * reallocate_tracked( void * const arg_alloc_ptr
+                           , const size_t arg_alloc_size ) const ;
+
+  /**\brief  Deallocate tracked memory in the space */
+  void deallocate_tracked( void * const arg_alloc_ptr ) const ;
 
   /*--------------------------------*/
   /** \brief  Error reporting for HostSpace attempt to access CudaSpace */
@@ -202,12 +213,23 @@ public:
   CudaUVMSpace & operator = ( const CudaUVMSpace & rhs ) = default ;
   ~CudaUVMSpace() = default ;
 
-  /**\brief  Allocate memory in the cuda space */
+  /**\brief  Allocate untracked memory in the cuda space */
   void * allocate( const size_t arg_alloc_size ) const ;
 
-  /**\brief  Deallocate memory in the cuda space */
+  /**\brief  Deallocate untracked memory in the cuda space */
   void deallocate( void * const arg_alloc_ptr
                  , const size_t arg_alloc_size ) const ;
+
+  /**\brief  Allocate tracked memory in the space */
+  void * allocate_tracked( const size_t arg_alloc_size
+                         , const std::string & arg_label = "no_label" ) const ;
+
+  /**\brief  Reallocate tracked memory in the space */
+  void * reallocate_tracked( void * const arg_alloc_ptr
+                           , const size_t arg_alloc_size ) const ;
+
+  /**\brief  Deallocate tracked memory in the space */
+  void deallocate_tracked( void * const arg_alloc_ptr ) const ;
 
   /*--------------------------------*/
 
@@ -259,12 +281,23 @@ public:
   CudaHostPinnedSpace & operator = ( const CudaHostPinnedSpace & rhs ) = default ;
   ~CudaHostPinnedSpace() = default ;
 
-  /**\brief  Allocate memory in the cuda space */
+  /**\brief  Allocate untracked memory in the space */
   void * allocate( const size_t arg_alloc_size ) const ;
 
-  /**\brief  Deallocate memory in the cuda space */
+  /**\brief  Deallocate untracked memory in the space */
   void deallocate( void * const arg_alloc_ptr
                  , const size_t arg_alloc_size ) const ;
+
+  /**\brief  Allocate tracked memory in the space */
+  void * allocate_tracked( const size_t arg_alloc_size
+                         , const std::string & arg_label = "no_label" ) const ;
+
+  /**\brief  Reallocate tracked memory in the space */
+  void * reallocate_tracked( void * const arg_alloc_ptr
+                           , const size_t arg_alloc_size ) const ;
+
+  /**\brief  Deallocate tracked memory in the space */
+  void deallocate_tracked( void * const arg_alloc_ptr ) const ;
 
   /*--------------------------------*/
 };

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -116,17 +116,6 @@ public:
   void deallocate( void * const arg_alloc_ptr
                  , const size_t arg_alloc_size ) const ;
 
-  /**\brief  Allocate tracked memory in the space */
-  void * allocate_tracked( const size_t arg_alloc_size
-                         , const std::string & arg_label = "no_label" ) const ;
-
-  /**\brief  Reallocate tracked memory in the space */
-  void * reallocate_tracked( void * const arg_alloc_ptr
-                           , const size_t arg_alloc_size ) const ;
-
-  /**\brief  Deallocate tracked memory in the space */
-  void deallocate_tracked( void * const arg_alloc_ptr ) const ;
-
   /*--------------------------------*/
   /** \brief  Error reporting for HostSpace attempt to access CudaSpace */
   static void access_error();
@@ -220,17 +209,6 @@ public:
   void deallocate( void * const arg_alloc_ptr
                  , const size_t arg_alloc_size ) const ;
 
-  /**\brief  Allocate tracked memory in the space */
-  void * allocate_tracked( const size_t arg_alloc_size
-                         , const std::string & arg_label = "no_label" ) const ;
-
-  /**\brief  Reallocate tracked memory in the space */
-  void * reallocate_tracked( void * const arg_alloc_ptr
-                           , const size_t arg_alloc_size ) const ;
-
-  /**\brief  Deallocate tracked memory in the space */
-  void deallocate_tracked( void * const arg_alloc_ptr ) const ;
-
   /*--------------------------------*/
 
 private:
@@ -287,17 +265,6 @@ public:
   /**\brief  Deallocate untracked memory in the space */
   void deallocate( void * const arg_alloc_ptr
                  , const size_t arg_alloc_size ) const ;
-
-  /**\brief  Allocate tracked memory in the space */
-  void * allocate_tracked( const size_t arg_alloc_size
-                         , const std::string & arg_label = "no_label" ) const ;
-
-  /**\brief  Reallocate tracked memory in the space */
-  void * reallocate_tracked( void * const arg_alloc_ptr
-                           , const size_t arg_alloc_size ) const ;
-
-  /**\brief  Deallocate tracked memory in the space */
-  void deallocate_tracked( void * const arg_alloc_ptr ) const ;
 
   /*--------------------------------*/
 };
@@ -682,8 +649,24 @@ public:
 
   static SharedAllocationRecord * allocate( const Kokkos::CudaSpace &  arg_space
                                           , const std::string       &  arg_label
-                                          , const size_t               arg_alloc_size
-                                          );
+                                          , const size_t               arg_alloc_size );
+
+  /**\brief  Allocate tracked memory in the space */
+  static
+  void * allocate_tracked( const Kokkos::CudaSpace & arg_space
+                         , const std::string & arg_label
+                         , const size_t arg_alloc_size );
+
+  /**\brief  Reallocate tracked memory in the space */
+  static
+  void * reallocate_tracked( void * const arg_alloc_ptr
+                           , const size_t arg_alloc_size );
+
+  /**\brief  Deallocate tracked memory in the space */
+  static
+  void deallocate_tracked( void * const arg_alloc_ptr );
+
+  static SharedAllocationRecord * get_record( void * arg_alloc_ptr );
 
   template< typename AliasType >
   inline
@@ -710,8 +693,6 @@ public:
       // Texture object is attached to the entire allocation range
       return ptr - reinterpret_cast<AliasType*>( RecordBase::m_alloc_ptr );
     }
-
-  static SharedAllocationRecord * get_record( void * arg_alloc_ptr );
 
   static void print_records( std::ostream & , const Kokkos::CudaSpace & , bool detail = false );
 };
@@ -755,6 +736,24 @@ public:
                                           , const size_t                  arg_alloc_size
                                           );
 
+  /**\brief  Allocate tracked memory in the space */
+  static
+  void * allocate_tracked( const Kokkos::CudaUVMSpace & arg_space
+                         , const std::string & arg_label
+                         , const size_t arg_alloc_size );
+
+  /**\brief  Reallocate tracked memory in the space */
+  static
+  void * reallocate_tracked( void * const arg_alloc_ptr
+                           , const size_t arg_alloc_size );
+
+  /**\brief  Deallocate tracked memory in the space */
+  static
+  void deallocate_tracked( void * const arg_alloc_ptr );
+
+  static SharedAllocationRecord * get_record( void * arg_alloc_ptr );
+
+
   template< typename AliasType >
   inline
   ::cudaTextureObject_t attach_texture_object()
@@ -781,8 +780,6 @@ public:
       // Texture object is attached to the entire allocation range
       return ptr - reinterpret_cast<AliasType*>( RecordBase::m_alloc_ptr );
     }
-
-  static SharedAllocationRecord * get_record( void * arg_alloc_ptr );
 
   static void print_records( std::ostream & , const Kokkos::CudaUVMSpace & , bool detail = false );
 };
@@ -823,6 +820,21 @@ public:
                                           , const std::string          &  arg_label
                                           , const size_t                  arg_alloc_size
                                           );
+  /**\brief  Allocate tracked memory in the space */
+  static
+  void * allocate_tracked( const Kokkos::CudaHostPinnedSpace & arg_space
+                         , const std::string & arg_label
+                         , const size_t arg_alloc_size );
+
+  /**\brief  Reallocate tracked memory in the space */
+  static
+  void * reallocate_tracked( void * const arg_alloc_ptr
+                           , const size_t arg_alloc_size );
+
+  /**\brief  Deallocate tracked memory in the space */
+  static
+  void deallocate_tracked( void * const arg_alloc_ptr );
+
 
   static SharedAllocationRecord * get_record( void * arg_alloc_ptr );
 

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -75,6 +75,10 @@ public:
 
   typedef unsigned int          size_type ;
 
+  /*--------------------------------*/
+
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
   typedef Impl::CudaMallocAllocator allocator;
 
   /** \brief  Allocate a contiguous block of memory.
@@ -95,6 +99,8 @@ public:
                                     , ::cudaChannelFormatDesc const & desc
                                    );
 #endif
+
+#endif /* #if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW ) */
 
   /*--------------------------------*/
 
@@ -162,6 +168,10 @@ public:
   /** \brief  If UVM capability is available */
   static bool available();
 
+  /*--------------------------------*/
+
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
   typedef Impl::CudaUVMAllocator allocator;
 
   /** \brief  Allocate a contiguous block of memory.
@@ -182,6 +192,9 @@ public:
                                     , ::cudaChannelFormatDesc const & desc
                                    );
 #endif
+
+#endif /* #if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW ) */
+
   /*--------------------------------*/
 
   CudaUVMSpace();
@@ -223,6 +236,9 @@ public:
   typedef Kokkos::Device<execution_space,memory_space> device_type;
   typedef unsigned int                size_type ;
 
+  /*--------------------------------*/
+
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
 
   typedef Impl::CudaHostAllocator allocator ;
 
@@ -233,6 +249,8 @@ public:
    *  allocation gives it a reference count of one.
    */
   static Impl::AllocationTracker allocate_and_track( const std::string & label, const size_t size );
+
+#endif /* #if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW ) */
 
   /*--------------------------------*/
 

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -128,6 +128,8 @@ public:
   //! This memory space preferred device_type
   typedef Kokkos::Device<execution_space,memory_space> device_type;
 
+  /*--------------------------------*/
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
 
 #if defined( KOKKOS_USE_PAGE_ALIGNED_HOST_MEMORY )
   typedef Impl::PageAlignedAllocator allocator ;
@@ -142,6 +144,8 @@ public:
    *  allocation gives it a reference count of one.
    */
   static Impl::AllocationTracker allocate_and_track( const std::string & label, const size_t size );
+
+#endif /* #if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW ) */
 
   /*--------------------------------*/
   /* Functions unique to the HostSpace */

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -168,12 +168,23 @@ public:
   explicit
   HostSpace( const AllocationMechanism & );
 
-  /**\brief  Allocate memory in the host space */
+  /**\brief  Allocate untracked memory in the space */
   void * allocate( const size_t arg_alloc_size ) const ;
 
-  /**\brief  Deallocate memory in the host space */
+  /**\brief  Deallocate untracked memory in the space */
   void deallocate( void * const arg_alloc_ptr 
                  , const size_t arg_alloc_size ) const ;
+
+  /**\brief  Allocate tracked memory in the space */
+  void * allocate_tracked( const size_t arg_alloc_size
+                         , const std::string & arg_label = "no_label" ) const ;
+
+  /**\brief  Reallocate tracked memory in the space */
+  void * reallocate_tracked( void * const arg_alloc_ptr
+                           , const size_t arg_alloc_size ) const ;
+
+  /**\brief  Deallocate tracked memory in the space */
+  void deallocate_tracked( void * const arg_alloc_ptr ) const ;
 
 private:
 

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -175,17 +175,6 @@ public:
   void deallocate( void * const arg_alloc_ptr 
                  , const size_t arg_alloc_size ) const ;
 
-  /**\brief  Allocate tracked memory in the space */
-  void * allocate_tracked( const size_t arg_alloc_size
-                         , const std::string & arg_label = "no_label" ) const ;
-
-  /**\brief  Reallocate tracked memory in the space */
-  void * reallocate_tracked( void * const arg_alloc_ptr
-                           , const size_t arg_alloc_size ) const ;
-
-  /**\brief  Deallocate tracked memory in the space */
-  void deallocate_tracked( void * const arg_alloc_ptr ) const ;
-
 private:
 
   AllocationMechanism  m_alloc_mech ;
@@ -253,6 +242,21 @@ public:
       return (SharedAllocationRecord *) 0 ;
 #endif
     }
+
+  /**\brief  Allocate tracked memory in the space */
+  static
+  void * allocate_tracked( const Kokkos::HostSpace & arg_space
+                         , const std::string & arg_label
+                         , const size_t arg_alloc_size );
+
+  /**\brief  Reallocate tracked memory in the space */
+  static
+  void * reallocate_tracked( void * const arg_alloc_ptr
+                           , const size_t arg_alloc_size );
+
+  /**\brief  Deallocate tracked memory in the space */
+  static
+  void deallocate_tracked( void * const arg_alloc_ptr );
 
 
   static SharedAllocationRecord * get_record( void * arg_alloc_ptr );

--- a/core/src/OpenMP/Kokkos_OpenMPexec.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMPexec.cpp
@@ -84,7 +84,15 @@ int OpenMPexec::m_map_rank[ OpenMPexec::MAX_THREAD_COUNT ] = { 0 };
 
 int OpenMPexec::m_pool_topo[ 4 ] = { 0 };
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
 OpenMPexec::Pool OpenMPexec::m_pool;
+
+#else
+
+OpenMPexec * OpenMPexec::m_pool[ OpenMPexec::MAX_THREAD_COUNT ] = { 0 };
+
+#endif
 
 void OpenMPexec::verify_is_process( const char * const label )
 {
@@ -109,7 +117,12 @@ void OpenMPexec::clear_scratch()
 #pragma omp parallel
   {
     const int rank_rev = m_map_rank[ omp_get_thread_num() ];
+#if defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+    Kokkos::kokkos_free< Kokkos::HostSpace >( m_pool[ rank_rev ] );
+    m_pool[ rank_rev ] = 0 ;
+#else
     m_pool.at(rank_rev).clear();
+#endif
   }
 /* END #pragma omp parallel */
 }
@@ -147,7 +160,18 @@ void OpenMPexec::resize_scratch( size_t reduce_size , size_t thread_size )
       const int rank_rev = m_map_rank[ omp_get_thread_num() ];
       const int rank     = pool_size - ( rank_rev + 1 );
 
+#if defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
+      m_pool[ rank_rev ] = reinterpret_cast<OpenMPexec*>(
+        Kokkos::kokkos_malloc< Kokkos::HostSpace >( alloc_size , "openmp_scratch" )
+        );
+
+#else
+
       m_pool.at(rank_rev) = HostSpace::allocate_and_track( "openmp_scratch", alloc_size );
+
+#endif
+
       new ( m_pool[ rank_rev ] ) OpenMPexec( rank , ALLOC_EXEC , reduce_size , thread_size );
     }
 /* END #pragma omp parallel */

--- a/core/src/OpenMP/Kokkos_OpenMPexec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMPexec.hpp
@@ -61,6 +61,8 @@ public:
 
   enum { MAX_THREAD_COUNT = 4096 };
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
   struct Pool
   {
     Pool() : m_trackers() {}
@@ -78,11 +80,21 @@ public:
     }
   };
 
+
 private:
+
+  static Pool         m_pool; // Indexed by: m_pool_rank_rev
+
+#else
+
+private:
+
+  static OpenMPexec * m_pool[ MAX_THREAD_COUNT ]; // Indexed by: m_pool_rank_rev
+
+#endif
 
   static int          m_pool_topo[ 4 ];
   static int          m_map_rank[ MAX_THREAD_COUNT ];
-  static Pool         m_pool; // Indexed by: m_pool_rank_rev
 
   friend class Kokkos::OpenMP ;
 

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -89,7 +89,11 @@ private:
 
   ThreadsExec * const * m_pool_base ; ///< Base for pool fan-in
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
   Impl::AllocationTracker m_scratch ;
+#else
+  void *        m_scratch ;
+#endif
   int           m_scratch_reduce_end ;
   int           m_scratch_thread_end ;
   int           m_numa_rank ;
@@ -122,8 +126,18 @@ public:
   static int get_thread_count();
   static ThreadsExec * get_thread( const int init_thread_rank );
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
   inline void * reduce_memory() const { return reinterpret_cast<unsigned char *>(m_scratch.alloc_ptr()); }
   KOKKOS_INLINE_FUNCTION  void * scratch_memory() const { return reinterpret_cast<unsigned char *>(m_scratch.alloc_ptr()) + m_scratch_reduce_end ; }
+
+#else
+
+  inline void * reduce_memory() const { return m_scratch ; }
+  KOKKOS_INLINE_FUNCTION  void * scratch_memory() const
+    { return reinterpret_cast<unsigned char *>(m_scratch) + m_scratch_reduce_end ; }
+
+#endif
 
   KOKKOS_INLINE_FUNCTION  int volatile & state() { return m_pool_state ; }
   KOKKOS_INLINE_FUNCTION  ThreadsExec * const * pool_base() const { return m_pool_base ; }

--- a/core/src/impl/KokkosExp_SharedAlloc.cpp
+++ b/core/src/impl/KokkosExp_SharedAlloc.cpp
@@ -47,6 +47,8 @@ namespace Kokkos {
 namespace Experimental {
 namespace Impl {
 
+int SharedAllocationRecord< void , void >::s_tracking_enabled = 1 ;
+
 bool
 SharedAllocationRecord< void , void >::
 is_sane( SharedAllocationRecord< void , void > * arg_record )

--- a/core/src/impl/KokkosExp_SharedAlloc.hpp
+++ b/core/src/impl/KokkosExp_SharedAlloc.hpp
@@ -78,6 +78,8 @@ protected:
 
   typedef void (* function_type )( SharedAllocationRecord<void,void> * );
 
+  static int s_tracking_enabled ;
+
   SharedAllocationHeader * const m_alloc_ptr ;
   size_t                   const m_alloc_size ;
   function_type            const m_dealloc ;
@@ -99,6 +101,8 @@ protected:
                         );
 
 public:
+
+  static int tracking_enabled() { return s_tracking_enabled ; }
 
   ~SharedAllocationRecord() = default ;
 
@@ -226,8 +230,8 @@ private:
   };
 
   // The allocation record resides in Host memory space
-  Record * m_record ;
-  unsigned long m_record_bits;
+  Record      * m_record ;
+  unsigned long m_record_bits ;
 
   KOKKOS_INLINE_FUNCTION
   static Record * disable( Record * rec )
@@ -237,7 +241,10 @@ private:
   void increment() const
     {
 #if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
-      if ( ! ( m_record_bits & DO_NOT_DEREF_FLAG ) ) Record::increment( m_record );
+      if ( Record::tracking_enabled() &&
+           ! ( m_record_bits & DO_NOT_DEREF_FLAG ) ) {
+        Record::increment( m_record );
+      }
 #endif
     }
 
@@ -245,7 +252,10 @@ private:
   void decrement() const
     {
 #if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
-       if ( ! ( m_record_bits & DO_NOT_DEREF_FLAG ) ) Record::decrement( m_record );
+      if ( Record::tracking_enabled() &&
+           ! ( m_record_bits & DO_NOT_DEREF_FLAG ) ) {
+        Record::decrement( m_record );
+      }
 #endif
     }
 

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -159,6 +159,8 @@ int HostSpace::in_parallel()
 
 /*--------------------------------------------------------------------------*/
 
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
 namespace Kokkos {
 
 Impl::AllocationTracker HostSpace::allocate_and_track( const std::string & label, const size_t size )
@@ -167,6 +169,8 @@ Impl::AllocationTracker HostSpace::allocate_and_track( const std::string & label
 }
 
 } // namespace Kokkos
+
+#endif /* #if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW ) */
 
 /*--------------------------------------------------------------------------*/
 

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -407,10 +407,10 @@ SharedAllocationRecord< Kokkos::HostSpace , void >::get_record( void * alloc_ptr
   typedef SharedAllocationHeader  Header ;
   typedef SharedAllocationRecord< Kokkos::HostSpace , void >  RecordHost ;
 
-  SharedAllocationHeader const * const head   = Header::get_header( alloc_ptr );
-  RecordHost                   * const record = static_cast< RecordHost * >( head->m_record );
+  SharedAllocationHeader const * const head   = alloc_ptr ? Header::get_header( alloc_ptr ) : (SharedAllocationHeader *)0 ;
+  RecordHost                   * const record = head ? static_cast< RecordHost * >( head->m_record ) : (RecordHost *) 0 ;
 
-  if ( record->m_alloc_ptr != head ) {
+  if ( ! alloc_ptr || record->m_alloc_ptr != head ) {
     Kokkos::Impl::throw_runtime_exception( std::string("Kokkos::Experimental::Impl::SharedAllocationRecord< Kokkos::HostSpace , void >::get_record ERROR" ) );
   }
 

--- a/core/unit_test/TestCuda.cpp
+++ b/core/unit_test/TestCuda.cpp
@@ -134,7 +134,9 @@ TEST_F( cuda, uvm )
 
 #else
 
-    int * uvm_ptr = (int*) Kokkos::kokkos_malloc<Kokkos::CudaUVMSpace>(sizeof(int),"uvm_ptr");
+    Kokkos::CudaUVMSpace space ;
+
+    int * uvm_ptr = (int*) space.allocate_tracked(sizeof(int),"uvm_ptr");
 
 #endif
 
@@ -148,7 +150,7 @@ TEST_F( cuda, uvm )
 
 #if defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
 
-    Kokkos::kokkos_free<Kokkos::CudaUVMSpace>(uvm_ptr);
+    space.deallocate_tracked(uvm_ptr);
 
 #endif
 

--- a/core/unit_test/TestCuda.cpp
+++ b/core/unit_test/TestCuda.cpp
@@ -62,6 +62,7 @@
 
 #include <TestViewAPI.hpp>
 #include <TestViewSubview.hpp>
+#include <TestViewOfClass.hpp>
 
 #include <TestReduce.hpp>
 #include <TestScan.hpp>
@@ -155,6 +156,11 @@ TEST_F( cuda , impl_view_mapping )
   test_view_mapping_subview< Kokkos::Cuda >();
   test_view_mapping_operator< Kokkos::Cuda >();
   TestViewMappingAtomic< Kokkos::Cuda >::run();
+}
+
+TEST_F( cuda , view_of_class )
+{
+  TestViewMappingClassValue< Kokkos::Cuda >::run();
 }
 
 template< class MemSpace >
@@ -282,6 +288,12 @@ TEST_F( cuda, view_api )
   // y[0] = 10 ;
   // y(0) = 10 ;
 #endif
+}
+
+
+TEST_F( cuda , view_nested_view )
+{
+  ::Test::view_nested_view< Kokkos::Cuda >();
 }
 
 TEST_F( cuda, view_subview_auto_1d_left ) {

--- a/core/unit_test/TestCuda.cpp
+++ b/core/unit_test/TestCuda.cpp
@@ -126,19 +126,7 @@ TEST_F( cuda, uvm )
 {
   if ( Kokkos::CudaUVMSpace::available() ) {
 
-#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
-
-    Kokkos::Impl::AllocationTracker tracker = Kokkos::CudaUVMSpace::allocate_and_track("uvm_ptr",sizeof(int));
-
-    int * uvm_ptr = (int*) tracker.alloc_ptr();
-
-#else
-
-    Kokkos::CudaUVMSpace space ;
-
-    int * uvm_ptr = (int*) space.allocate_tracked(sizeof(int),"uvm_ptr");
-
-#endif
+    int * uvm_ptr = (int*) Kokkos::kokkos_malloc< Kokkos::CudaUVMSpace >("uvm_ptr",sizeof(int));
 
     *uvm_ptr = 42 ;
 
@@ -148,12 +136,7 @@ TEST_F( cuda, uvm )
 
     EXPECT_EQ( *uvm_ptr, int(2*42) );
 
-#if defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
-
-    space.deallocate_tracked(uvm_ptr);
-
-#endif
-
+    Kokkos::kokkos_free< Kokkos::CudaUVMSpace >(uvm_ptr );
   }
 }
 

--- a/core/unit_test/TestCuda.cpp
+++ b/core/unit_test/TestCuda.cpp
@@ -122,13 +122,21 @@ TEST_F( cuda , memory_space )
   TestMemorySpace< Kokkos::Cuda >();
 }
 
-TEST_F( cuda, spaces )
+TEST_F( cuda, uvm )
 {
   if ( Kokkos::CudaUVMSpace::available() ) {
+
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
 
     Kokkos::Impl::AllocationTracker tracker = Kokkos::CudaUVMSpace::allocate_and_track("uvm_ptr",sizeof(int));
 
     int * uvm_ptr = (int*) tracker.alloc_ptr();
+
+#else
+
+    int * uvm_ptr = (int*) Kokkos::kokkos_malloc<Kokkos::CudaUVMSpace>(sizeof(int),"uvm_ptr");
+
+#endif
 
     *uvm_ptr = 42 ;
 
@@ -137,6 +145,12 @@ TEST_F( cuda, spaces )
     Kokkos::Cuda::fence();
 
     EXPECT_EQ( *uvm_ptr, int(2*42) );
+
+#if defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+
+    Kokkos::kokkos_free<Kokkos::CudaUVMSpace>(uvm_ptr);
+
+#endif
 
   }
 }

--- a/core/unit_test/TestDefaultDeviceType.cpp
+++ b/core/unit_test/TestDefaultDeviceType.cpp
@@ -240,7 +240,7 @@ TEST_F( defaultdevicetype , malloc )
 
   int* data2 = (int*) Kokkos::kokkos_malloc(0);
   ASSERT_TRUE(data2==NULL);
-  Kokkos::kokkos_free(data);
+  Kokkos::kokkos_free(data2);
 }
 
 } // namespace test

--- a/core/unit_test/TestOpenMP.cpp
+++ b/core/unit_test/TestOpenMP.cpp
@@ -52,6 +52,7 @@
 
 #include <TestViewAPI.hpp>
 #include <TestViewSubview.hpp>
+#include <TestViewOfClass.hpp>
 
 #include <TestSharedAlloc.hpp>
 #include <TestViewMapping.hpp>
@@ -116,6 +117,10 @@ TEST_F( openmp, view_api) {
   TestViewAPI< double , Kokkos::OpenMP >();
 }
 
+TEST_F( openmp , view_nested_view )
+{
+  ::Test::view_nested_view< Kokkos::OpenMP >();
+}
 
 TEST_F( openmp, view_subview_auto_1d_left ) {
   TestViewSubview::test_auto_1d< Kokkos::LayoutLeft,Kokkos::OpenMP >();

--- a/core/unit_test/TestQthread.cpp
+++ b/core/unit_test/TestQthread.cpp
@@ -54,6 +54,7 @@
 #include <TestAtomic.hpp>
 
 #include <TestViewAPI.hpp>
+#include <TestViewOfClass.hpp>
 
 #include <TestTeam.hpp>
 #include <TestRange.hpp>
@@ -97,6 +98,11 @@ TEST_F( qthread, view_impl) {
 
 TEST_F( qthread, view_api) {
   TestViewAPI< double , Kokkos::Qthread >();
+}
+
+TEST_F( qthread , view_nested_view )
+{
+  ::Test::view_nested_view< Kokkos::Qthread >();
 }
 
 TEST_F( qthread , range_tag )

--- a/core/unit_test/TestSynchronic.hpp
+++ b/core/unit_test/TestSynchronic.hpp
@@ -186,7 +186,7 @@ struct unique_lock<Test::mcs_mutex> : Test::mcs_mutex::unique_lock {
 
 }
 
-#include <cmath>
+/* #include <cmath> */
 #include <stdlib.h>
 
 namespace Test {

--- a/core/unit_test/TestThreads.cpp
+++ b/core/unit_test/TestThreads.cpp
@@ -60,6 +60,7 @@
 
 #include <TestViewAPI.hpp>
 #include <TestViewSubview.hpp>
+#include <TestViewOfClass.hpp>
 #include <TestAtomic.hpp>
 
 #include <TestReduce.hpp>
@@ -151,6 +152,11 @@ TEST_F( threads, view_impl) {
 
 TEST_F( threads, view_api) {
   TestViewAPI< double , Kokkos::Threads >();
+}
+
+TEST_F( threads , view_nested_view )
+{
+  ::Test::view_nested_view< Kokkos::Threads >();
 }
 
 TEST_F( threads, view_subview_auto_1d_left ) {

--- a/core/unit_test/TestViewMapping.hpp
+++ b/core/unit_test/TestViewMapping.hpp
@@ -1073,6 +1073,51 @@ struct TestViewMappingAtomic {
     }
 };
 
+/*--------------------------------------------------------------------------*/
+
+template< class ExecSpace >
+struct TestViewMappingClassValue {
+
+  struct ValueType {
+    KOKKOS_INLINE_FUNCTION
+    ValueType()
+    {
+#if 0
+#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA )
+      printf("TestViewMappingClassValue construct on Cuda\n");
+#elif defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+      printf("TestViewMappingClassValue construct on Host\n");
+#else
+      printf("TestViewMappingClassValue construct unknown\n");
+#endif
+#endif
+    }
+    KOKKOS_INLINE_FUNCTION
+    ~ValueType()
+    {
+#if 0
+#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA )
+      printf("TestViewMappingClassValue destruct on Cuda\n");
+#elif defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+      printf("TestViewMappingClassValue destruct on Host\n");
+#else
+      printf("TestViewMappingClassValue destruct unknown\n");
+#endif
+#endif
+    }
+  };
+
+  static void run()
+  {
+    using namespace Kokkos::Experimental ;
+    ExecSpace::fence();
+    {
+      View< ValueType , ExecSpace > a("a");
+      ExecSpace::fence();
+    }
+    ExecSpace::fence();
+  }
+};
 
 } /* namespace Test */
 

--- a/core/unit_test/TestViewOfClass.hpp
+++ b/core/unit_test/TestViewOfClass.hpp
@@ -52,50 +52,82 @@
 
 namespace Test {
 
-namespace {
-volatile int nested_view_count ;
-}
-
 template< class Space >
-class NestedView {
-private:
+struct NestedView {
+
   Kokkos::View<int*,Space> member ;
 
 public:
 
   KOKKOS_INLINE_FUNCTION
-  NestedView()
-#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
-    : member("member",2)
-    { Kokkos::atomic_increment( & nested_view_count ); }
-#else
-    : member(){}
-#endif
-
-  ~NestedView()
-#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
-    { Kokkos::atomic_decrement( & nested_view_count ); }
-#else
+  NestedView() : member()
     {}
-#endif
 
+  KOKKOS_INLINE_FUNCTION
+  NestedView & operator = ( const Kokkos::View<int*,Space> & lhs )
+    {
+      member = lhs ;
+      if ( member.dimension_0() ) Kokkos::atomic_add( & member(0) , 1 );
+      return *this ;
+    }
+
+  KOKKOS_INLINE_FUNCTION
+  ~NestedView()
+  { 
+    if ( member.dimension_0() ) {
+      Kokkos::atomic_add( & member(0) , -1 );
+    }
+  }
+};
+
+template< class Space >
+struct NestedViewFunctor {
+
+  Kokkos::View< NestedView<Space> * , Space > nested ;
+  Kokkos::View<int*,Space>                    array ;
+
+  NestedViewFunctor( 
+    const Kokkos::View< NestedView<Space> * , Space > & arg_nested ,
+    const Kokkos::View<int*,Space>                    & arg_array )
+  : nested( arg_nested )
+  , array(  arg_array )
+  {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()( int i ) const
+    { nested[i] = array ; }
 };
 
 
 template< class Space >
 void view_nested_view()
 {
-  ASSERT_EQ( 0 , nested_view_count );
+  Kokkos::View<int*,Space> tracking("tracking",1);
+
+  typename Kokkos::View<int*,Space>::HostMirror
+     host_tracking = Kokkos::create_mirror( tracking );
+
   {
     Kokkos::View< NestedView<Space> * , Space > a("a_nested_view",2);
-    ASSERT_EQ( 2 , nested_view_count );
+    a = Kokkos::View< NestedView<Space> * , Space >();
+
+    Kokkos::parallel_for( Kokkos::RangePolicy<Space>(0,2) , NestedViewFunctor<Space>( a , tracking ) );
+    Kokkos::deep_copy( host_tracking , tracking );
+    ASSERT_EQ( 2 , host_tracking(0) );
+
     Kokkos::View< NestedView<Space> * , Space > b("b_nested_view",2);
-    ASSERT_EQ( 4 , nested_view_count );
+    Kokkos::parallel_for( Kokkos::RangePolicy<Space>(0,2) , NestedViewFunctor<Space>( b , tracking ) );
+    Kokkos::deep_copy( host_tracking , tracking );
+    ASSERT_EQ( 4 , host_tracking(0) );
+
   }
-  // ASSERT_EQ( 0 , nested_view_count );
+  Kokkos::deep_copy( host_tracking , tracking );
+  // ASSERT_EQ( 0 , host_tracking(0) );
 }
 
 }
+
+#if ! defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
 
 namespace Kokkos {
 namespace Impl {
@@ -121,6 +153,8 @@ struct ViewDefaultConstruct< ExecSpace , Test::NestedView<S> , true >
 
 } // namespace Impl
 } // namespace Kokkos
+
+#endif
 
 /*--------------------------------------------------------------------------*/
 

--- a/core/unit_test/TestViewOfClass.hpp
+++ b/core/unit_test/TestViewOfClass.hpp
@@ -109,7 +109,6 @@ void view_nested_view()
 
   {
     Kokkos::View< NestedView<Space> * , Space > a("a_nested_view",2);
-    a = Kokkos::View< NestedView<Space> * , Space >();
 
     Kokkos::parallel_for( Kokkos::RangePolicy<Space>(0,2) , NestedViewFunctor<Space>( a , tracking ) );
     Kokkos::deep_copy( host_tracking , tracking );
@@ -122,7 +121,11 @@ void view_nested_view()
 
   }
   Kokkos::deep_copy( host_tracking , tracking );
-  // ASSERT_EQ( 0 , host_tracking(0) );
+
+#if defined( KOKKOS_USING_EXPERIMENTAL_VIEW )
+  ASSERT_EQ( 0 , host_tracking(0) );
+#endif
+
 }
 
 }


### PR DESCRIPTION
View containing views unit testing
More replacements of AllocationTracker
Continue requiring -DKOKKOS_USING_EXPERIMENTAL_VIEW to swap out Kokkos::View
