### PR TITLE
Kokkos::Serial: Fix build warning

### DIFF
--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -151,7 +151,11 @@ public:
   static void finalize() {}
 
   //! Print configuration information to the given output stream.
-  static void print_configuration( std::ostream & , const bool detail = false ) {}
+  static void print_configuration( std::ostream& /* out */ ) {}
+
+  /// \brief Print configuration information to the given output stream,
+  ///   with extra bool argument for whether to show details.
+  static void print_configuration (std::ostream& /* out */, const bool /* detail */ ) {}
 
   //--------------------------------------------------------------------------
 


### PR DESCRIPTION
Kokkos::Serial::print_configuration takes two arguments: an output stream, and a bool (presumably, for whether to print extra details).  The second argument was named, since it took a default value (of false).  Since it was named but not used, this caused build warnings.  Kokkos lives upstream of just about everything in Trilinos, so the build warnings were all over the place.

This commit fixes the build warning by splitting print_configuration into two overloads.  The first takes one argument, and the second takes two.  This avoids the default argument issue.