### PR TITLE
Fixes External/Internel GTEST Configurations for Unit Testing

### DIFF
--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -1,6 +1,7 @@
 KOKKOS_PATH = ../..
 
-GTEST_PATH = ../../TPL/gtest
+GTEST_PATH     = ../../TPL/gtest
+GTEST_ALL_PATH = $(GTEST_PATH)/gtest/gtest-all.cc
 
 vpath %.cpp ${KOKKOS_PATH}/core/unit_test
 TEST_HEADERS = $(wildcard $(KOKKOS_PATH)/core/unit_test/*.hpp)
@@ -149,6 +150,6 @@ clean: kokkos-clean
 %.o:%.cpp $(KOKKOS_CPP_DEPENDS) $(TEST_HEADERS)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<
 
-gtest-all.o:$(GTEST_PATH)/gtest/gtest-all.cc
-	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $(GTEST_PATH)/gtest/gtest-all.cc
+gtest-all.o: $(GTEST_ALL_PATH)
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $(GTEST_ALL_PATH)
 

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -1,7 +1,19 @@
 KOKKOS_PATH = ../..
 
+# Google Test Import for Trilinos
 GTEST_PATH     = ../../TPL/gtest
 GTEST_ALL_PATH = $(GTEST_PATH)/gtest/gtest-all.cc
+GTEST_INC      = -I$(GTEST_PATH)
+
+# Use Kokkos Internal Copy of Google Test
+#GTEST_PATH      = ../../tpls/gtest
+#GTEST_ALL_PATH  = $(GTEST_PATH)/gtest/gtest-all.cc
+#GTEST_INC       = -I$(GTEST_PATH)
+
+# Google Test Import for GoogleTest Github Code Checkout Locally
+#GTEST_PATH      = $(HOME)/git/googletest/googletest
+#GTEST_INC       = -I$(GTEST_PATH)/include -I$(GTEST_PATH)
+#GTEST_ALL_PATH  = $(GTEST_PATH)/src/gtest-all.cc
 
 vpath %.cpp ${KOKKOS_PATH}/core/unit_test
 TEST_HEADERS = $(wildcard $(KOKKOS_PATH)/core/unit_test/*.hpp)
@@ -23,7 +35,7 @@ else
 	LDFLAGS ?= -lpthread
 endif
 
-KOKKOS_CXXFLAGS += -I$(GTEST_PATH) -I${KOKKOS_PATH}/core/unit_test
+KOKKOS_CXXFLAGS += $(GTEST_INC) -I${KOKKOS_PATH}/core/unit_test
 
 TEST_TARGETS =
 TARGETS =
@@ -152,4 +164,3 @@ clean: kokkos-clean
 
 gtest-all.o: $(GTEST_ALL_PATH)
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $(GTEST_ALL_PATH)
-


### PR DESCRIPTION
GTEST seems to be configured only for Trillinos integration. This has come up several times with users/developers at the lab. This fix extracts the needed parameters for external GoogleTest checkouts to the top of the Makefile for easy editing.