### PR TITLE
Issue 110 - converted unsigned long casts to uintptr_t, snprintf

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -745,10 +745,17 @@ print_records( std::ostream & s , const Kokkos::CudaSpace & space , bool detail 
       }
 
       //Formatting dependent on sizeof(uintptr_t)
+      const char * format_string;
+
+      if (sizeof(uintptr_t) == sizeof(unsigned long)) { 
+        format_string = "Cuda addr( 0x%.12lx ) list( 0x%.12lx 0x%.12lx ) extent[ 0x%.12lx + %.8ld ] count(%d) dealloc(0x%.12lx) %s\n";
+      }
+      else if (sizeof(uintptr_t) == sizeof(unsigned long long)) { 
+        format_string = "Cuda addr( 0x%.12llx ) list( 0x%.12llx 0x%.12llx ) extent[ 0x%.12llx + %.8ld ] count(%d) dealloc(0x%.12llx) %s\n";
+      }
+
       snprintf( buffer , 256 
-              , ( (sizeof(uintptr_t) == sizeof(unsigned long)) 
-                  ? ("Cuda addr( 0x%.12lx ) list( 0x%.12lx 0x%.12lx ) extent[ 0x%.12lx + %.8ld ] count(%d) dealloc(0x%.12lx) %s\n")
-                  : ("Cuda addr( 0x%.12llx ) list( 0x%.12llx 0x%.12llx ) extent[ 0x%.12llx + %.8ld ] count(%d) dealloc(0x%.12llx) %s\n") )
+              , format_string
               , reinterpret_cast<uintptr_t>( r )
               , reinterpret_cast<uintptr_t>( r->m_prev )
               , reinterpret_cast<uintptr_t>( r->m_next )
@@ -769,10 +776,17 @@ print_records( std::ostream & s , const Kokkos::CudaSpace & space , bool detail 
         Kokkos::Impl::DeepCopy<HostSpace,CudaSpace>::DeepCopy( & head , r->m_alloc_ptr , sizeof(SharedAllocationHeader) );
 
         //Formatting dependent on sizeof(uintptr_t)
+        const char * format_string;
+
+        if (sizeof(uintptr_t) == sizeof(unsigned long)) { 
+          format_string = "Cuda [ 0x%.12lx + %ld ] %s\n";
+        }
+        else if (sizeof(uintptr_t) == sizeof(unsigned long long)) { 
+          format_string = "Cuda [ 0x%.12llx + %ld ] %s\n";
+        }
+
         snprintf( buffer , 256 
-                , ( (sizeof(uintptr_t) == sizeof(unsigned long)) 
-                  ? ("Cuda [ 0x%.12lx + %ld ] %s\n")
-                  : ("Cuda [ 0x%.12llx + %ld ] %s\n") )
+                , format_string
                 , reinterpret_cast< uintptr_t >( r->data() )
                 , r->size()
                 , head.m_label

--- a/core/src/impl/KokkosExp_SharedAlloc.cpp
+++ b/core/src/impl/KokkosExp_SharedAlloc.cpp
@@ -95,10 +95,17 @@ is_sane( SharedAllocationRecord< void , void > * arg_record )
 
 if ( ! ok ) {
   //Formatting dependent on sizeof(uintptr_t) 
+  const char * format_string;
+  
+  if (sizeof(uintptr_t) == sizeof(unsigned long)) {
+     format_string = "Kokkos::Experimental::Impl::SharedAllocationRecord failed is_sane: rec(0x%.12lx){ m_count(%d) m_root(0x%.12lx) m_next(0x%.12lx) m_prev(0x%.12lx) m_next->m_prev(0x%.12lx) m_prev->m_next(0x%.12lx) }\n";
+  }
+  else if (sizeof(uintptr_t) == sizeof(unsigned long long)) {
+     format_string = "Kokkos::Experimental::Impl::SharedAllocationRecord failed is_sane: rec(0x%.12llx){ m_count(%d) m_root(0x%.12llx) m_next(0x%.12llx) m_prev(0x%.12llx) m_next->m_prev(0x%.12llx) m_prev->m_next(0x%.12llx) }\n";
+  }
+
   fprintf(stderr
-        , ( (sizeof(uintptr_t) == sizeof(unsigned long))
-            ? ("Kokkos::Experimental::Impl::SharedAllocationRecord failed is_sane: rec(0x%.12lx){ m_count(%d) m_root(0x%.12lx) m_next(0x%.12lx) m_prev(0x%.12lx) m_next->m_prev(0x%.12lx) m_prev->m_next(0x%.12lx) }\n")
-            : ("Kokkos::Experimental::Impl::SharedAllocationRecord failed is_sane: rec(0x%.12llx){ m_count(%d) m_root(0x%.12llx) m_next(0x%.12llx) m_prev(0x%.12llx) m_next->m_prev(0x%.12llx) m_prev->m_next(0x%.12llx) }\n") )
+        , format_string 
         , reinterpret_cast< uintptr_t >( rec )
         , rec->m_count
         , reinterpret_cast< uintptr_t >( rec->m_root )
@@ -258,10 +265,17 @@ print_host_accessible_records( std::ostream & s
   if ( detail ) {
     do {
       //Formatting dependent on sizeof(uintptr_t) 
+      const char * format_string;
+
+      if (sizeof(uintptr_t) == sizeof(unsigned long)) {
+        format_string = "%s addr( 0x%.12lx ) list( 0x%.12lx 0x%.12lx ) extent[ 0x%.12lx + %.8ld ] count(%d) dealloc(0x%.12lx) %s\n";
+      }
+      else if (sizeof(uintptr_t) == sizeof(unsigned long long)) {
+        format_string = "%s addr( 0x%.12llx ) list( 0x%.12llx 0x%.12llx ) extent[ 0x%.12llx + %.8ld ] count(%d) dealloc(0x%.12llx) %s\n";
+      }
+
       snprintf( buffer , 256
-              , ( (sizeof(uintptr_t) == sizeof(unsigned long))
-                  ? ("%s addr( 0x%.12lx ) list( 0x%.12lx 0x%.12lx ) extent[ 0x%.12lx + %.8ld ] count(%d) dealloc(0x%.12lx) %s\n")
-                  : ("%s addr( 0x%.12llx ) list( 0x%.12llx 0x%.12llx ) extent[ 0x%.12llx + %.8ld ] count(%d) dealloc(0x%.12llx) %s\n") )
+              , format_string
               , space_name
               , reinterpret_cast<uintptr_t>( r )
               , reinterpret_cast<uintptr_t>( r->m_prev )
@@ -279,11 +293,18 @@ print_host_accessible_records( std::ostream & s
   else {
     do {
       if ( r->m_alloc_ptr ) {
-      //Formatting dependent on sizeof(uintptr_t) 
+        //Formatting dependent on sizeof(uintptr_t) 
+        const char * format_string;
+
+        if (sizeof(uintptr_t) == sizeof(unsigned long)) { 
+          format_string = "%s [ 0x%.12lx + %ld ] %s\n";
+        }
+        else if (sizeof(uintptr_t) == sizeof(unsigned long long)) { 
+          format_string = "%s [ 0x%.12llx + %ld ] %s\n";
+        }
+
         snprintf( buffer , 256
-                , ( (sizeof(uintptr_t) == sizeof(unsigned long))
-                    ? ("%s [ 0x%.12lx + %ld ] %s\n")
-                    : ("%s [ 0x%.12llx + %ld ] %s\n") )
+                , format_string
                 , space_name
                 , reinterpret_cast< uintptr_t >( r->data() )
                 , r->size()


### PR DESCRIPTION
Fixes for clang/3.6.1 compiler warnings with char * ternary operator formatting in Kokkos_CudaSpaces.cpp and KokkosExp_SharedAlloc.cpp