### PR TITLE
Fix clang build warnings and allow macs to use hwloc

### DIFF
--- a/core/perf_test/test_atomic.cpp
+++ b/core/perf_test/test_atomic.cpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -167,7 +167,7 @@ T AddLoopSerial(int loop) {
   *data+=(T)1;
 
   T val = *data;
-  delete data;
+  delete [] data;
   return val;
 }
 
@@ -272,7 +272,7 @@ T CASLoopSerial(int loop) {
   }
 
   T val = *data;
-  delete data;
+  delete [] data;
   return val;
 }
 
@@ -373,8 +373,8 @@ T ExchLoopSerial(int loop) {
   }
 
   T val = *data2 + *data;
-  delete data;
-  delete data2;
+  delete [] data;
+  delete [] data2;
   return val;
 }
 

--- a/core/src/Kokkos_hwloc.hpp
+++ b/core/src/Kokkos_hwloc.hpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -109,7 +109,7 @@ unsigned thread_mapping( const char * const label ,
 /** \brief  Query core-coordinate of the current thread
  *          with respect to the core_topology.
  *
- *  As long as the thread is running within the 
+ *  As long as the thread is running within the
  *  process binding the following condition holds.
  *
  *  core_coordinate.first  < core_topology.first
@@ -119,6 +119,10 @@ std::pair<unsigned,unsigned> get_this_thread_coordinate();
 
 /** \brief  Bind the current thread to a core. */
 bool bind_this_thread( const std::pair<unsigned,unsigned> );
+
+
+/** \brief Can hwloc bind threads? */
+bool can_bind_threads();
 
 /** \brief  Bind the current thread to one of the cores in the list.
  *          Set that entry to (~0,~0) and return the index.

--- a/core/src/OpenMP/Kokkos_OpenMPexec.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMPexec.cpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -282,7 +282,9 @@ void OpenMP::initialize( unsigned thread_count ,
         // Reverse the rank for threads so that the scan operation reduces to the highest rank thread.
 
         const unsigned omp_rank    = omp_get_thread_num();
-        const unsigned thread_r    = Impl::s_using_hwloc ? Kokkos::hwloc::bind_this_thread( thread_count , threads_coord ) : omp_rank ;
+        const unsigned thread_r    = Impl::s_using_hwloc && Kokkos::hwloc::can_bind_threads()
+                                   ? Kokkos::hwloc::bind_this_thread( thread_count , threads_coord )
+                                   : omp_rank ;
 
         Impl::OpenMPexec::m_map_rank[ omp_rank ] = thread_r ;
       }
@@ -327,7 +329,7 @@ void OpenMP::finalize()
 
   omp_set_num_threads(1);
 
-  if ( Impl::s_using_hwloc ) {
+  if ( Impl::s_using_hwloc && Kokkos::hwloc::can_bind_threads() ) {
     hwloc::unbind_this_thread();
   }
 }

--- a/core/src/impl/Kokkos_hwloc.cpp
+++ b/core/src/impl/Kokkos_hwloc.cpp
@@ -697,6 +697,7 @@ namespace Kokkos {
 namespace hwloc {
 
 bool available() { return false ; }
+bool can_bind_threads() { return false ; }
 
 unsigned get_available_numa_count() { return 1 ; }
 unsigned get_available_cores_per_numa() { return 1 ; }

--- a/core/src/impl/Kokkos_hwloc.cpp
+++ b/core/src/impl/Kokkos_hwloc.cpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -254,6 +254,7 @@ hwloc_topology_t             s_hwloc_topology(0);
 hwloc_bitmap_t               s_hwloc_location(0);
 hwloc_bitmap_t               s_process_binding(0);
 hwloc_bitmap_t               s_core[ MAX_CORE ];
+bool                         s_can_bind_threads(true);
 
 struct Sentinel {
   ~Sentinel();
@@ -309,6 +310,22 @@ Sentinel::Sentinel()
   s_process_binding = hwloc_bitmap_alloc();
 
   hwloc_get_cpubind( s_hwloc_topology , s_process_binding ,  HWLOC_CPUBIND_PROCESS );
+
+  if ( hwloc_bitmap_iszero( s_process_binding ) ) {
+    std::cerr << "WARNING: Cannot detect process binding -- ASSUMING ALL processing units" << std::endl;
+    const int pu_depth = hwloc_get_type_depth( s_hwloc_topology, HWLOC_OBJ_PU );
+    int num_pu = 1;
+    if ( pu_depth != HWLOC_TYPE_DEPTH_UNKNOWN ) {
+      num_pu = hwloc_get_nbobjs_by_depth( s_hwloc_topology, pu_depth );
+    }
+    else {
+      std::cerr << "WARNING: Cannot detect number of processing units -- ASSUMING 1 (serial)." << std::endl;
+      num_pu = 1;
+    }
+    hwloc_bitmap_set_range( s_process_binding, 0, num_pu-1);
+    s_can_bind_threads = false;
+  }
+
 
   if ( remove_core_0 ) {
 
@@ -509,6 +526,9 @@ unsigned get_available_cores_per_numa()
 
 unsigned get_available_threads_per_core()
 { sentinel(); return s_core_capacity ; }
+
+bool can_bind_threads()
+{ sentinel(); return s_can_bind_threads; }
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/unit_test/TestAtomic.hpp
+++ b/core/unit_test/TestAtomic.hpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -204,7 +204,7 @@ T AddLoopSerial(int loop) {
   *data+=(T)1;
 
   T val = *data;
-  delete data;
+  delete [] data;
   return val;
 }
 
@@ -266,7 +266,7 @@ T CASLoopSerial(int loop) {
   }
 
   T val = *data;
-  delete data;
+  delete [] data;
   return val;
 }
 
@@ -324,8 +324,8 @@ T ExchLoopSerial(int loop) {
   }
 
   T val = *data2 + *data;
-  delete data;
-  delete data2;
+  delete [] data;
+  delete [] data2;
   return val;
 }
 


### PR DESCRIPTION
Fix clang build warnings and allow macs to use hwloc to size thread pools.