### PR TITLE
Add option to enable device lambdas from cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,13 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   )
 
 TRIBITS_ADD_OPTION_AND_DEFINE(
+  Kokkos_ENABLE_Cuda_LAMBDA
+  KOKKOS_CUDA_USE_LAMBDA
+  "Enable CUDA lambda support in Kokkos."
+  OFF
+  )
+
+TRIBITS_ADD_OPTION_AND_DEFINE(
   Kokkos_ENABLE_Pthread
   KOKKOS_HAVE_PTHREAD
   "Enable Pthread support in Kokkos."

--- a/core/cmake/KokkosCore_config.h.in
+++ b/core/cmake/KokkosCore_config.h.in
@@ -39,6 +39,7 @@
 #cmakedefine KOKKOS_HAVE_CUSPARSE
 #cmakedefine KOKKOS_ENABLE_PROFILING_COLLECT_KERNEL_DATA
 #cmakedefine KOKKOS_ENABLE_PROFILING_AGGREGATE_MPI
+#cmakedefine KOKKOS_CUDA_USE_LAMBDA
 
 // Don't forbid users from defining this macro on the command line,
 // but still make sure that CMake logic can control its definition.


### PR DESCRIPTION
The symbol KOKKOS_CUDA_USE_LAMBDA is used to conditionally
define KOKKOS_LAMBDA to include the __device__ keyword. This
symbol is not settable when building from TriBits. Add a
build option to allow the user to set device lambda support.