### PR TITLE
Auto set profiling hook calls to NULL on finalize calls

### DIFF
--- a/core/src/impl/Kokkos_Profiling_Interface.cpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.cpp
@@ -140,6 +140,18 @@ namespace Kokkos {
     void finalize() {
         if(NULL != finalizeProfileLibrary) {
             (*finalizeProfileLibrary)();
+
+	    // Set all profile hooks to NULL to prevent
+	    // any additional calls. Once we are told to
+	    // finalize, we mean it
+	    beginForCallee = NULL;
+	    beginScanCallee = NULL;
+  	    beginReduceCallee = NULL;
+            endScanCallee = NULL;
+	    endForCallee = NULL;
+            endReduceCallee = NULL;
+            initProfileLibrary = NULL;
+            finalizeProfileLibrary = NULL;
         }
     };
   }


### PR DESCRIPTION
Set profiling hooks to NULL in the profiling interface once finalize is called, the tools are effectively stopped.