### PR TITLE
Issue 108: Disable tests for non-Cuda spaces if cuda enabled

### DIFF
--- a/core/unit_test/TestOpenMP.cpp
+++ b/core/unit_test/TestOpenMP.cpp
@@ -213,7 +213,7 @@ TEST_F( openmp, team_shared_request) {
   TestSharedTeam< Kokkos::OpenMP >();
 }
 
-#if defined (KOKKOS_HAVE_CXX11_DISPATCH_LAMBDA)
+#if defined(KOKKOS_HAVE_CXX11_DISPATCH_LAMBDA) && !defined(KOKKOS_HAVE_CUDA)
 TEST_F( openmp, team_lambda_shared_request) {
   TestLambdaSharedTeam< Kokkos::OpenMP >();
 }

--- a/core/unit_test/TestSerial.cpp
+++ b/core/unit_test/TestSerial.cpp
@@ -209,7 +209,7 @@ TEST_F( serial , team_shared_request) {
   TestSharedTeam< Kokkos::Serial >();
 }
 
-#if defined (KOKKOS_HAVE_CXX11_DISPATCH_LAMBDA)
+#if defined(KOKKOS_HAVE_CXX11_DISPATCH_LAMBDA) && !defined(KOKKOS_HAVE_CUDA)
 TEST_F( serial , team_lambda_shared_request) {
   TestLambdaSharedTeam< Kokkos::Serial >();
 }

--- a/core/unit_test/TestThreads.cpp
+++ b/core/unit_test/TestThreads.cpp
@@ -254,7 +254,7 @@ TEST_F( threads, team_shared_request) {
   TestSharedTeam< Kokkos::Threads >();
 }
 
-#if defined (KOKKOS_HAVE_CXX11_DISPATCH_LAMBDA)
+#if defined(KOKKOS_HAVE_CXX11_DISPATCH_LAMBDA) && !defined(KOKKOS_HAVE_CUDA)
 TEST_F( threads, team_lambda_shared_request) {
   TestLambdaSharedTeam< Kokkos::Threads >();
 }


### PR DESCRIPTION
This is done for tests that use experimental lambda