### PR TITLE
Add KNL to the list of Supported Architectures in Makefile

### DIFF
--- a/generate_makefile.bash
+++ b/generate_makefile.bash
@@ -79,6 +79,7 @@ case $key in
     echo "                               SNB = Intel Sandy/Ivy Bridge CPUs"
     echo "                               HSW = Intel Haswell CPUs"
     echo "                               KNC = Intel Knights Corner Xeon Phi"
+    echo "                               KNL = Intel Knights Landing Xeon Phi"
     echo "                               Kepler30  = NVIDIA Kepler generation CC 3.0"
     echo "                               Kepler35  = NVIDIA Kepler generation CC 3.5"
     echo "                               Kepler37  = NVIDIA Kepler generation CC 3.7"


### PR DESCRIPTION
Very tiny change to add KNL to list of supported architectures with generate_makefile.sh
