### PR TITLE
Fix parallel_reduce and parallel_scan with range length 0

### DIFF
--- a/core/unit_test/TestCuda.cpp
+++ b/core/unit_test/TestCuda.cpp
@@ -372,6 +372,7 @@ TEST_F( cuda, reduce )
 {
   TestReduce< long ,   Kokkos::Cuda >( 10000000 );
   TestReduce< double , Kokkos::Cuda >( 1000000 );
+  TestReduce< int , Kokkos::Cuda >( 0 );
 }
 
 TEST_F( cuda, reduce_team )
@@ -490,6 +491,10 @@ TEST_F( cuda , scan )
   TestScan< Kokkos::Cuda >::test_range( 1 , 1000 );
   TestScan< Kokkos::Cuda >( 1000000 );
   TestScan< Kokkos::Cuda >( 10000000 );
+
+  TestScan< Kokkos::Cuda >( 0 );
+  TestScan< Kokkos::Cuda >( 0 , 0 );
+
   Kokkos::Cuda::fence();
 }
 

--- a/core/unit_test/TestScan.hpp
+++ b/core/unit_test/TestScan.hpp
@@ -85,6 +85,12 @@ struct TestScan {
   TestScan( const WorkSpec & N )
     { parallel_scan( N , *this ); }
 
+  TestScan( const WorkSpec & Start , const WorkSpec & N )
+    {
+      typedef Kokkos::RangePolicy<execution_space> exec_policy ;
+      parallel_scan( exec_policy( Start , N ) , *this );
+    }
+
   static void test_range( const WorkSpec & begin , const WorkSpec & end )
     {
       for ( WorkSpec i = begin ; i < end ; ++i ) {


### PR DESCRIPTION
Fix ParallelReduce and ParallelScan in src/Cuda/Kokkos_Cuda_Parallel.hpp
in execute() methods to return proper values if range has length 0.
Added unit tests to check this.