### PR TITLE
Fixes KokkosP Profiling Library loading when Stacking Tools

### DIFF
--- a/core/src/impl/Kokkos_Profiling_Interface.cpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.cpp
@@ -105,7 +105,10 @@ namespace Kokkos {
 		return ;
 	}
 
-	char* profileLibraryName = strtok(envProfileLibrary, ";");
+		char* envProfileCopy = (char*) malloc(sizeof(char) * (strlen(envProfileLibrary) + 1));
+		sprintf(envProfileCopy, "%s", envProfileLibrary);
+
+		char* profileLibraryName = strtok(envProfileCopy, ";");
 
         if( (NULL != profileLibraryName) && (strcmp(profileLibraryName, "") != 0) ) {
             firstProfileLibrary = dlopen(profileLibraryName, RTLD_NOW | RTLD_GLOBAL);

--- a/core/src/impl/Kokkos_Profiling_Interface.cpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.cpp
@@ -134,10 +134,12 @@ namespace Kokkos {
 
         if(NULL != initProfileLibrary) {
             (*initProfileLibrary)(0,
-		(uint64_t) KOKKOSP_INTERFACE_VERSION,
-		(uint32_t) 0,
-		NULL);
+			(uint64_t) KOKKOSP_INTERFACE_VERSION,
+			(uint32_t) 0,
+			NULL);
         }
+
+		free(envProfileCopy);
     };
 
     void finalize() {


### PR DESCRIPTION
Tokenization code trashes the environment variables being provided for profile library loading. This code produces a copy of the buffer for tokenization.