### PR TITLE
Add multiple chunk size memory pool.

### DIFF
--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -260,7 +260,7 @@ private:
     }
     m_chunk_size[num_chunk_sizes] = 0;
 
-    size_t num_chunks[num_chunk_sizes];
+    size_t * num_chunks = new size_t[num_chunk_sizes];
 
     // Set the starting point in memory and get the number of chunks for each
     // freelist.  Start with the largest chunk size to ensure usage of all the
@@ -320,6 +320,8 @@ private:
 
       ExecutionSpace::fence();
     }
+
+    delete [] num_chunks;
 
 #ifdef KOKKOS_MEMPOOL_PRINT_INFO
     print_mempool < Link > pm( num_chunk_sizes, m_chunk_size, m_freelist, m_data );

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -335,17 +335,29 @@ private:
 #endif
   }
 
-  ///\brief  Inserts an already linked list of chunks into the pool.
+  /// \brief Inserts an already linked list of chunks into the pool.
   KOKKOS_FUNCTION
   void insert_list( Link * lp_head, Link * lp_tail, size_t list ) const;
 
-  ///\brief  Claim chunks of untracked memory from the pool.
+  /// \brief Claim chunks of untracked memory from the pool.
   KOKKOS_FUNCTION
   void * allocate( size_t alloc_size ) const;
 
-  ///\brief  Release claimed memory back into the pool.
+  /// \brief Release claimed memory back into the pool.
   KOKKOS_FUNCTION
   void deallocate( void * alloc_ptr, size_t alloc_size ) const;
+
+  /// \brief Tests if the memory pool is empty.
+  KOKKOS_INLINE_FUNCTION
+  bool is_empty() const
+  {
+    size_t l = 0;
+    while ( m_chunk_size[l] > 0 && m_freelist[l] == 0 ) {
+      ++l;
+    }
+
+    return m_chunk_size[l] == 0;
+  }
 
   // The following three functions are used for debugging.
   void print_status() const
@@ -419,7 +431,7 @@ public:
   MemoryPool & operator = ( const MemoryPool & ) = default;
   ~MemoryPool() = default;
 
-  /// \brief  Allocate memory pool
+  /// \brief Allocate memory pool
   /// \param memspace         From where to allocate the pool.
   /// \param base_chunk_size  Hand out memory in chunks of this size.
   /// \param total_size       Total size of the pool.
@@ -430,23 +442,20 @@ public:
                 num_chunk_sizes, chunk_spacing )
   {}
 
-  KOKKOS_INLINE_FUNCTION
-  bool is_empty() const { return 0 == *m_freelist.m_head_list ; }
-
-  KOKKOS_INLINE_FUNCTION
-  unsigned chunk_size() const { return m_freelist.m_chunk_size ; }
-
-  ///\brief  Claim chunks of untracked memory from the pool.
+  /// \brief Claim chunks of untracked memory from the pool.
   /// Can only be called from device.
   KOKKOS_INLINE_FUNCTION
   void * allocate( const size_t alloc_size ) const
   { return m_memory.allocate( alloc_size ); }
 
-  ///\brief  Release claimed memory back into the pool
+  /// \brief Release claimed memory back into the pool
   /// Can only be called from device.
   KOKKOS_INLINE_FUNCTION
   void deallocate( void * const alloc_ptr, const size_t alloc_size ) const
   { m_memory.deallocate( alloc_ptr, alloc_size ); }
+
+  KOKKOS_INLINE_FUNCTION
+  bool is_empty() const { return m_memory.is_empty(); }
 
   // The following three functions are used for debugging.
   void print_status() const { m_memory.print_status(); }

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -57,7 +57,7 @@
 // While experimental, code can abort instead.  If KOKKOS_MEMPOOL_PRINTERR is
 // defined, the code will abort with an error message.  Otherwise, the code will
 // return with a value indicating failure when possible, or do nothing instead.
-#define KOKKOS_MEMPOOL_PRINTERR
+//#define KOKKOS_MEMPOOL_PRINTERR
 
 //#define KOKKOS_MEMPOOL_PRINT_INFO
 

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -99,12 +99,16 @@ private:
 
   template< class > friend class Kokkos::Experimental::MemoryPool;
 
+public:
+
   /// \brief Structure used to create a linked list from the memory chunks.
   ///
   /// The chunks are cast to this type internally to create the lists.
   struct Link {
     Link * m_next;
   };
+
+private:
 
   Tracker   m_track;
 

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -152,7 +152,7 @@ private:
   size_t    m_chunk_spacing;
 
 #if defined(KOKKOS_MEMPOOL_PRINT_INFO) && defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-  mutable size_t m_count;
+  static long m_count;
 #endif
 
   ~MemPoolList() = default;
@@ -169,9 +169,6 @@ private:
                size_t num_chunk_sizes, size_t chunk_spacing )
     : m_track(), m_chunk_size(0), m_freelist(0), m_data(0), m_data_size(0),
       m_chunk_spacing(chunk_spacing)
-#if defined(KOKKOS_MEMPOOL_PRINT_INFO) && defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-    , m_count(0)
-#endif
   {
     typedef Impl::SharedAllocationRecord< MemorySpace, void >  SharedRecord;
     typedef Kokkos::RangePolicy< ExecutionSpace >              Range;

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -50,6 +50,15 @@
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_Atomic.hpp>
 
+// How should errors be handled?  In general, production code should return a
+// value indicating failure so the user can decide how the error is handled.
+// While experimental, code can abort instead.  If KOKKOS_MEMPOOL_PRINTERR is
+// defined, the code will abort with an error message.  Otherwise, the code will
+// return with a value indicating failure when possible, or do nothing instead.
+#define KOKKOS_MEMPOOL_PRINTERR
+
+//#define KOKKOS_MEMPOOL_PRINT_INFO
+
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
@@ -60,109 +69,239 @@ class MemoryPool ;
 
 namespace Impl {
 
+template < typename Link >
+struct initialize_mempool {
+  char *  m_data;
+  size_t  m_chunk_size;
+  size_t  m_last_chunk;
+
+  initialize_mempool( char * d, size_t cs, size_t lc )
+    : m_data(d), m_chunk_size(cs), m_last_chunk(lc)
+  {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()( size_t i ) const
+  {
+    Link * lp = reinterpret_cast< Link * >(m_data + i * m_chunk_size);
+
+    // All entries in the list point to the next entry except the last which
+    // is null.
+    lp->m_next = i < m_last_chunk ?
+                 reinterpret_cast< Link * >( m_data + (i + 1) * m_chunk_size ) :
+                 reinterpret_cast< Link * >(0);
+  }
+};
+
 class MemPoolList {
 private:
 
-  typedef Impl::SharedAllocationTracker  Tracker ;
+  typedef Impl::SharedAllocationTracker  Tracker;
 
-  template< class > friend class Kokkos::Experimental::MemoryPool ;
+  template< class > friend class Kokkos::Experimental::MemoryPool;
 
-  Tracker            m_track ;
-  void * volatile *  m_head_list ;
-  size_t             m_chunk_size ;
-  size_t             m_chunk_count ;
+  /// \brief Structure used to create a linked list from the memory chunks.
+  ///
+  /// The chunks are cast to this type internally to create the lists.
+  struct Link {
+    Link * m_next;
+  };
 
-public:
+  Tracker   m_track;
 
- // Public for the 'ParallelFor' to call for initialization.
+  // These three variables are pointers into device memory.
+  size_t *  m_chunk_size; // Array of chunk sizes of freelists.
+  Link **   m_freelist;   // Array of freelist heads.
+  char *    m_data;       // Beginning memory location used for chunks.
 
-  ~MemPoolList() = default ;
-  MemPoolList() = default ;
-  MemPoolList( MemPoolList && ) = default ;
-  MemPoolList( const MemPoolList & ) = default ;
-  MemPoolList & operator = ( MemPoolList && ) = default ;
-  MemPoolList & operator = ( const MemPoolList & ) = default ;
+  size_t    m_data_size;
+  size_t    m_chunk_spacing;
 
- KOKKOS_INLINE_FUNCTION
- void operator()( size_t i ) const
-   {
-     enum { S = Kokkos::Impl::power_of_two< sizeof(void*) >::value };
-     const size_t n = m_chunk_size >> S ;
-     const size_t j = i * n ;
-     // The last entry is null
-     m_head_list[j] =  i < m_chunk_count
-                    ? (void*) ( m_head_list + j + n )
-                    : (void*) 0 ; 
-   }
+#ifdef KOKKOS_MEMPOOL_PRINT_INFO
+  mutable size_t m_count;
+#endif
 
-private:
+  ~MemPoolList() = default;
+  MemPoolList() = default;
+  MemPoolList( MemPoolList && ) = default;
+  MemPoolList( const MemPoolList & ) = default;
+  MemPoolList & operator = ( MemPoolList && ) = default;
+  MemPoolList & operator = ( const MemPoolList & ) = default;
 
-  template< class MemorySpace , class ExecutionSpace>
+  template< class MemorySpace, class ExecutionSpace>
   inline
-  MemPoolList( const MemorySpace & arg_space 
-             , const ExecutionSpace & 
-             , size_t        arg_chunk
-             , size_t        arg_total
-             )
-    : m_track()
-    , m_head_list(0)
-    , m_chunk_size(0)
-    , m_chunk_count( arg_chunk * ( ( arg_total + arg_chunk - 1 ) / arg_chunk ) )
+  MemPoolList( const MemorySpace & memspace, const ExecutionSpace &,
+               size_t base_chunk_size, size_t total_size,
+               size_t num_chunk_sizes, size_t chunk_spacing )
+    : m_track(), m_chunk_size(0), m_freelist(0), m_data(0), m_data_size(0),
+      m_chunk_spacing(chunk_spacing)
+#ifdef KOKKOS_MEMPOOL_PRINT_INFO
+    , m_count(0)
+#endif
   {
-    typedef Impl::SharedAllocationRecord< MemorySpace, void >  SharedRecord ;
-    typedef Kokkos::RangePolicy< ExecutionSpace > Range ;
+    typedef Impl::SharedAllocationRecord< MemorySpace, void >  SharedRecord;
+    typedef Kokkos::RangePolicy< ExecutionSpace >              Range;
 
-    enum { host_can_access_memory =
-      Kokkos::Impl::VerifyExecutionCanAccessMemorySpace
-        < Kokkos::Impl::ActiveExecutionMemorySpace
-        , MemorySpace >::value };
+    // The base chunk size must be at least 128 bytes as this is the cache-line
+    // size for NVIDA GPUs.
+    if ( base_chunk_size < 128 ) {
+      printf( "** Chunk size must be at least 128 bytes.  Setting to 128. **\n" );
+      fflush( stdout );
 
-    // Force chunk size to be power of two,
-    // mininum of 32 (mininum of 4 x 8byte pointers),
-    // and at least arg_chunk size.
+      base_chunk_size = 128;
+    }
 
-    for ( m_chunk_size = 32 ; m_chunk_size < arg_chunk ; m_chunk_size <<= 1 );
+    // The base chunk size must also be a multiple of 128 bytes for correct
+    // memory alignment of the chunks.  If it isn't a multiple of 128, set it
+    // to the smallest multiple of 128 greater than the given chunk size.
+    if ( base_chunk_size % 128 != 0 ) {
+      size_t old_chunk_size = base_chunk_size;
+      base_chunk_size = ( ( old_chunk_size + 127 ) / 128 ) * 128;
 
-    // Force allocation to be a multiple of actual chunk_size.
-    // Allocate an extra chunk for the head(s) of the free list(s).
-    const size_t alloc_size = m_chunk_size * ( m_chunk_count + 1 );
+      printf( "** Chunk size must be a multiple of 128 bytes.  Given: %ld  Using: %ld. **\n",
+              old_chunk_size, base_chunk_size);
+      fflush( stdout );
+    }
+
+    // Force total_size to be a multiple of base_chunk_size.
+    total_size = ( ( total_size + base_chunk_size - 1 ) / base_chunk_size ) *
+                 base_chunk_size;
+
+    m_data_size = total_size;
+
+    // Get the chunk size for the largest possible chunk.
+    //   max_chunk_size =
+    //     base_chunk_size * (m_chunk_spacing ^ (num_chunk_sizes - 1))
+    size_t max_chunk_size = base_chunk_size;
+    for (size_t i = 1; i < num_chunk_sizes; ++i) {
+      max_chunk_size *= m_chunk_spacing;
+    }
+
+    // We want each chunk size to use total_size / num_chunk_sizes memory.  If
+    // the total size of the pool is not enough to accomodate this, keep making
+    // the next lower chunk size the max_chunk_size until it is.
+    while ( max_chunk_size > total_size / num_chunk_sizes ) {
+      max_chunk_size /= m_chunk_spacing;
+      --num_chunk_sizes;
+    }
+
+    // We put a header at the beginnig of the device memory and use extra
+    // chunks to store the header.  The header contains:
+    //   size_t  chunk_size[num_chunk_sizes+1]
+    //   Link *  freelist[num_chunk_sizes]
+
+    // Calculate the size of the header where the size is rounded up to the
+    // smallest multiple of base_chunk_size >= the needed size.
+    const size_t header_bytes = ( num_chunk_sizes + 1 ) * sizeof(size_t) +
+                                num_chunk_sizes * sizeof(void*);
+    const size_t header_size =
+      (header_bytes + base_chunk_size - 1 ) / base_chunk_size * base_chunk_size;
+
+    // Allocate the memory including the header.
+    const size_t alloc_size = total_size + header_size;
 
     SharedRecord * rec =
-      SharedRecord::allocate( arg_space, "mempool", alloc_size );
+      SharedRecord::allocate( memspace, "mempool", alloc_size );
 
     m_track.assign_allocated_record_to_uninitialized( rec );
 
-    m_head_list = reinterpret_cast< void ** >( rec->data() );
+    // TODO: I'm not sure that sizes of types are the same on host and device.
+    //       Will the pointer arithmetic hold on both host and device?  If
+    //       size_t is a different size on host and device, how do I handle
+    //       that?
 
-    // Initialize link list of free chunks
+    // Get the pointers into the allocated memory.
+    m_chunk_size = reinterpret_cast< size_t * >( rec->data() );
+    m_freelist = reinterpret_cast< Link ** >( m_chunk_size + num_chunk_sizes + 1 );
+    m_data = reinterpret_cast< char * >( m_freelist + num_chunk_sizes );
 
-    if ( host_can_access_memory ) {
-
-      const size_t n = m_chunk_size / sizeof(void*);
-
-      for ( size_t i = 0 ; i <= m_chunk_count ; ++i ) {
-        m_head_list[i*n] = i < m_chunk_count 
-                         ? (void*)( m_head_list + n * ( i + 1 ) )
-                         : (void*) 0 ;
-      }
+    // Initialize the chunk sizes array.  Create num_chunk_sizes different
+    // chunk sizes where each successive chunk size is
+    // m_chunk_spacing * previous chunk size.  The last entry in the array is
+    // 0 and is used for a stopping condition.
+    m_chunk_size[0] = base_chunk_size;
+    for ( size_t i = 1; i < num_chunk_sizes; ++i ) {
+      m_chunk_size[i] = m_chunk_size[i - 1] * m_chunk_spacing;
     }
-    else {
+    m_chunk_size[num_chunk_sizes] = 0;
 
-      Kokkos::Impl::ParallelFor< MemPoolList , Range >
-        closure( *this , Range( 0 , m_chunk_count + 1 ) );
+    size_t num_chunks[num_chunk_sizes];
+
+    // Set the starting point in memory and get the number of chunks for each
+    // freelist.  Start with the largest chunk size to ensure usage of all the
+    // memory.  If there is leftover memory for a chunk size, it will be used
+    // by a smaller chunk size.
+    size_t used_memory = 0;
+    for ( size_t i = num_chunk_sizes; i > 0; --i ) {
+      // Set the starting point in the memory for the current chunk sizes's
+      // freelist.
+      m_freelist[i - 1] = reinterpret_cast< Link * >( m_data + used_memory );
+
+      size_t mem_avail =
+        total_size - (i - 1) * ( total_size / num_chunk_sizes ) - used_memory;
+
+      // Set the number of chunks for the current chunk sizes's freelist.
+      num_chunks[i - 1] = mem_avail / m_chunk_size[i - 1];
+
+      used_memory += num_chunks[i - 1] * m_chunk_size[i - 1];
+    }
+
+#ifdef KOKKOS_MEMPOOL_PRINT_INFO
+    for ( size_t i = 0; i < num_chunk_sizes; ++i ) {
+      printf( "%2ld    freelist: 0x%lx    chunk_size: %6ld    num_chunks: %8ld\n",
+              i, (unsigned long) m_freelist[i], m_chunk_size[i], num_chunks[i] );
+    }
+#endif
+
+#ifdef KOKKOS_MEMPOOL_PRINTERR
+    if ( used_memory != total_size ) {
+      printf( "\n** MemoryPool::MemoryPool() USED_MEMORY(%ld) != TOTAL_SIZE(%ld) **\n",
+              used_memory, total_size );
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+      fflush( stdout );
+#endif
+      Kokkos::abort( "" );
+    }
+#endif
+
+    // Create the chunks for each freelist.
+    for ( size_t i = 0; i < num_chunk_sizes; ++i ) {
+      // Initialize the next pointers to point to the next chunk for all but the
+      // last chunk which has points to NULL.
+      initialize_mempool< Link >
+        im( (char *) m_freelist[i], m_chunk_size[i], num_chunks[i] - 1 );
+      Kokkos::Impl::ParallelFor< initialize_mempool< Link >, Range >
+        closure( im, Range( 0, num_chunks[i] ) );
 
       closure.execute();
-
-      ExecutionSpace::fence();
-      Kokkos::memory_fence();
     }
   }
 
+  ///\brief  Claim chunks of untracked memory from the pool.
   KOKKOS_FUNCTION
-  void * allocate( size_t arg_size ) const ;
+  void * allocate( size_t alloc_size ) const;
 
+  ///\brief  Release claimed memory back into the pool.
   KOKKOS_FUNCTION
-  void deallocate( void * arg_alloc , size_t arg_size ) const ;
+  void deallocate( void * alloc_ptr, size_t alloc_size ) const;
+
+  // The following three functions are used for debugging.
+  void print_status() const
+  {
+    for ( size_t l = 0; m_chunk_size[l] > 0; ++l ) {
+      size_t count = 0;
+      Link * chunk = m_freelist[l];
+
+      while ( chunk != NULL ) {
+        ++count;
+        chunk = chunk->m_next;
+      }
+
+      printf( "chunk_size: %6ld    num_chunks: %8ld\n", m_chunk_size[l], count );
+    }
+  }
+
+  size_t get_min_chunk_size() const { return m_chunk_size[0]; }
+  size_t get_mem_size() const { return m_data_size; }
 };
 
 } // namespace Impl
@@ -198,7 +337,7 @@ template < class Space >
 class MemoryPool {
 private:
 
-  Impl::MemPoolList  m_freelist ;
+  Impl::MemPoolList  m_memory;
 
   typedef typename Space::memory_space     backend_memory_space;
   typedef typename Space::execution_space  execution_space;
@@ -206,7 +345,7 @@ private:
 public:
 
   //! Tag this class as a kokkos memory space
-  typedef MemoryPool  memory_space ;
+  typedef MemoryPool  memory_space;
 
   //------------------------------------
 
@@ -217,13 +356,15 @@ public:
   MemoryPool & operator = ( const MemoryPool & ) = default;
   ~MemoryPool() = default;
 
-  /**\brief  Allocate memory pool */
-  MemoryPool
-    ( const backend_memory_space & arg_space /* From where to allocate the pool. */
-    , size_t arg_chunk_size   /* Hand out memory in chunks of this size. */
-    , size_t arg_total_size   /* Total size of the pool. */
-    )
-    : m_freelist( arg_space , execution_space(), arg_chunk_size , arg_total_size )
+  /// \brief  Allocate memory pool
+  /// \param memspace         From where to allocate the pool.
+  /// \param base_chunk_size  Hand out memory in chunks of this size.
+  /// \param total_size       Total size of the pool.
+  MemoryPool( const backend_memory_space & memspace,
+              size_t base_chunk_size, size_t total_size,
+              size_t num_chunk_sizes = 4, size_t chunk_spacing = 4 )
+    : m_memory( memspace, execution_space(), base_chunk_size, total_size,
+                num_chunk_sizes, chunk_spacing )
   {}
 
   KOKKOS_INLINE_FUNCTION
@@ -236,18 +377,29 @@ public:
   /// Can only be called from device.
   KOKKOS_INLINE_FUNCTION
   void * allocate( const size_t alloc_size ) const
-    { return m_freelist.allocate( alloc_size ); }
+  { return m_memory.allocate( alloc_size ); }
 
   ///\brief  Release claimed memory back into the pool
   /// Can only be called from device.
   KOKKOS_INLINE_FUNCTION
-  void deallocate( void * const alloc_ptr,
-                   const size_t alloc_size ) const
-    { m_freelist.deallocate( alloc_ptr , alloc_size ); }
+  void deallocate( void * const alloc_ptr, const size_t alloc_size ) const
+  { m_memory.deallocate( alloc_ptr, alloc_size ); }
+
+  // The following three functions are used for debugging.
+  void print_status() const { m_memory.print_status(); }
+  size_t get_min_chunk_size() const { return m_memory.get_min_chunk_size(); }
+  size_t get_mem_size() const { return m_memory.get_mem_size(); }
 };
 
 } // namespace Experimental
 } // namespace Kokkos
 
-#endif /* #define KOKKOS_MEMORYPOOL_HPP */
+#ifdef KOKKOS_MEMPOOL_PRINTERR
+#undef KOKKOS_MEMPOOL_PRINTERR
+#endif
 
+#ifdef KOKKOS_MEMPOOL_PRINT_INFO
+#undef KOKKOS_MEMPOOL_PRINT_INFO
+#endif
+
+#endif /* #define KOKKOS_MEMORYPOOL_HPP */

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -95,9 +95,9 @@ struct print_mempool {
       char padding[32];
       double ds = static_cast<double>( reinterpret_cast<unsigned long>( m_data ) );
       size_t padding_size = static_cast<size_t>( ceil( ceil( log2( ds ) ) / 4 ) + 2 );
-      for ( size_t j = 0; j < padding_size; ++j ) {
-        padding[j] = ' ';
-      }
+
+      // Create the padding string.
+      for ( size_t j = 0; j < padding_size; ++j ) padding[j] = ' ';
       padding[padding_size] = '\0';
 
       printf( "*** ON DEVICE ***\n");
@@ -176,7 +176,7 @@ private:
   MemPoolList & operator = ( MemPoolList && ) = default;
   MemPoolList & operator = ( const MemPoolList & ) = default;
 
-  template< class MemorySpace, class ExecutionSpace>
+  template< class MemorySpace, class ExecutionSpace >
   inline
   MemPoolList( const MemorySpace & memspace, const ExecutionSpace &,
                size_t base_chunk_size, size_t total_size,
@@ -301,9 +301,9 @@ private:
     char padding[32];
     double ds = static_cast<double>( reinterpret_cast<unsigned long>( m_data ) );
     size_t padding_size = static_cast<size_t>( ceil( ceil( log2( ds ) ) / 4 ) + 2 );
-    for ( size_t j = 0; j < padding_size; ++j ) {
-      padding[j] = ' ';
-    }
+
+    // Create the padding string.
+    for ( size_t j = 0; j < padding_size; ++j ) padding[j] = ' ';
     padding[padding_size] = '\0';
 
     printf( "\n" );
@@ -360,9 +360,14 @@ private:
 #endif
   }
 
-  /// \brief Inserts an already linked list of chunks into the pool.
+  /// \brief Releases a lock on a freelist.
   KOKKOS_FUNCTION
-  void insert_list( Link * lp_head, Link * lp_tail, size_t list ) const;
+  void acquire_lock( size_t pos, Link * volatile * & freelist,
+                     Link * & old_head ) const;
+
+  /// \brief Releases a lock on a freelist.
+  KOKKOS_FUNCTION
+  void release_lock( Link * volatile * freelist, Link * const new_head ) const;
 
   /// \brief Claim chunks of untracked memory from the pool.
   KOKKOS_FUNCTION
@@ -377,9 +382,7 @@ private:
   bool is_empty() const
   {
     size_t l = 0;
-    while ( m_chunk_size[l] > 0 && m_freelist[l] == 0 ) {
-      ++l;
-    }
+    while ( m_chunk_size[l] > 0 && m_freelist[l] == 0 ) ++l;
 
     return m_chunk_size[l] == 0;
   }

--- a/core/src/impl/Kokkos_MemoryPool_Inline.hpp
+++ b/core/src/impl/Kokkos_MemoryPool_Inline.hpp
@@ -132,7 +132,9 @@ void * MemPoolList::allocate( size_t alloc_size ) const
 
   // Find the first freelist whose chunk size is big enough for allocation.
   size_t l_exp = 0;
-  for ( ; m_chunk_size[l_exp] > 0 && alloc_size > m_chunk_size[l_exp]; ++l_exp );
+  while ( m_chunk_size[l_exp] > 0 && alloc_size > m_chunk_size[l_exp] ) {
+    ++l_exp;
+  }
 
 #ifdef KOKKOS_MEMPOOLLIST_PRINTERR
   if ( m_chunk_size[l_exp] == 0 ) {
@@ -147,7 +149,9 @@ void * MemPoolList::allocate( size_t alloc_size ) const
   while ( !removed ) {
     // Keep searching for a freelist until we find one with chunks available.
     l = l_exp;
-    for ( ; m_chunk_size[l] > 0 && m_freelist[l] == 0; ++l );
+    while ( m_chunk_size[l] > 0 && m_freelist[l] == 0 ) {
+      ++l;
+    }
 
     if ( m_chunk_size[l] > 0 )
     {
@@ -284,7 +288,9 @@ void MemPoolList::deallocate( void * alloc_ptr, size_t alloc_size ) const
 
   // Determine which freelist to place deallocated memory on.
   size_t l = 0;
-  for ( ; m_chunk_size[l] > 0 && alloc_size > m_chunk_size[l]; ++l );
+  while ( m_chunk_size[l] > 0 && alloc_size > m_chunk_size[l] ) {
+    ++l;
+  }
 
 #ifdef KOKKOS_MEMPOOLLIST_PRINTERR
     if ( m_chunk_size[l] == 0 ) {

--- a/core/unit_test/TestCuda.cpp
+++ b/core/unit_test/TestCuda.cpp
@@ -130,6 +130,8 @@ TEST_F( cuda , memory_pool )
   bool val = TestMemoryPool::test_mempool< Kokkos::Cuda, Kokkos::CudaUVMSpace >( 128, 128000 );
   ASSERT_TRUE( val );
 
+  Kokkos::Cuda::fence();
+
   TestMemoryPool::test_mempool2< Kokkos::Cuda, Kokkos::CudaUVMSpace >( 128, 1280000 );
 }
 

--- a/core/unit_test/TestCuda.cpp
+++ b/core/unit_test/TestCuda.cpp
@@ -132,7 +132,9 @@ TEST_F( cuda , memory_pool )
 
   Kokkos::Cuda::fence();
 
-  TestMemoryPool::test_mempool2< Kokkos::Cuda, Kokkos::CudaUVMSpace >( 128, 1280000 );
+  TestMemoryPool::test_mempool2< Kokkos::Cuda, Kokkos::CudaUVMSpace >( 128, 2560000 );
+
+  Kokkos::Cuda::fence();
 }
 
 TEST_F( cuda, uvm )

--- a/core/unit_test/TestCuda.cpp
+++ b/core/unit_test/TestCuda.cpp
@@ -127,10 +127,10 @@ TEST_F( cuda , memory_space )
 
 TEST_F( cuda , memory_pool )
 {
-  bool val = TestMemoryPool::test_mempool< Kokkos::Cuda, Kokkos::CudaUVMSpace >( 128, 12800000 );
+  bool val = TestMemoryPool::test_mempool< Kokkos::Cuda, Kokkos::CudaUVMSpace >( 128, 128000 );
   ASSERT_TRUE( val );
 
-  TestMemoryPool::test_mempool2< Kokkos::Cuda, Kokkos::CudaUVMSpace >( 128, 12800000 );
+  TestMemoryPool::test_mempool2< Kokkos::Cuda, Kokkos::CudaUVMSpace >( 128, 1280000 );
 }
 
 TEST_F( cuda, uvm )

--- a/core/unit_test/TestCuda.cpp
+++ b/core/unit_test/TestCuda.cpp
@@ -127,8 +127,10 @@ TEST_F( cuda , memory_space )
 
 TEST_F( cuda , memory_pool )
 {
-  bool val = TestMemoryPool::test_mempool< Kokkos::Cuda >( 32, 8000000 );
+  bool val = TestMemoryPool::test_mempool< Kokkos::Cuda >( 128, 1280000000 );
   ASSERT_TRUE( val );
+
+  TestMemoryPool::test_mempool2< Kokkos::Cuda >( 128, 1280000000 );
 }
 
 TEST_F( cuda, uvm )

--- a/core/unit_test/TestCuda.cpp
+++ b/core/unit_test/TestCuda.cpp
@@ -127,10 +127,10 @@ TEST_F( cuda , memory_space )
 
 TEST_F( cuda , memory_pool )
 {
-  bool val = TestMemoryPool::test_mempool< Kokkos::Cuda >( 128, 1280000000 );
+  bool val = TestMemoryPool::test_mempool< Kokkos::Cuda, Kokkos::CudaUVMSpace >( 128, 12800000 );
   ASSERT_TRUE( val );
 
-  TestMemoryPool::test_mempool2< Kokkos::Cuda >( 128, 1280000000 );
+  TestMemoryPool::test_mempool2< Kokkos::Cuda, Kokkos::CudaUVMSpace >( 128, 12800000 );
 }
 
 TEST_F( cuda, uvm )

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -84,9 +84,8 @@ struct allocate_memory {
   KOKKOS_INLINE_FUNCTION
   void operator()( size_type i ) const
   {
-    // Why do I need the first check?
-    if ( i / STRIDE < m_num_ptrs && i % STRIDE == 0 ) {
-      m_pointers[i/STRIDE].ptr =
+    if ( i % STRIDE == 0 ) {
+      m_pointers[i / STRIDE].ptr =
         static_cast< uint64_t * >( m_space.allocate( m_chunk_size ) );
     }
   }
@@ -112,8 +111,8 @@ struct fill_memory {
   KOKKOS_INLINE_FUNCTION
   void operator()( size_type i ) const
   {
-    if ( i / STRIDE < m_num_ptrs && i % STRIDE == 0 ) {
-      *m_pointers[i/STRIDE].ptr = i / STRIDE ;
+    if ( i % STRIDE == 0 ) {
+      *m_pointers[i / STRIDE].ptr = i / STRIDE ;
     }
   }
 };
@@ -148,8 +147,8 @@ struct sum_memory {
   KOKKOS_INLINE_FUNCTION
   void operator()( size_type i, value_type & r ) const
   {
-    if ( i / STRIDE < m_num_ptrs && i % STRIDE == 0 ) {
-      r += *m_pointers[i/STRIDE].ptr;
+    if ( i % STRIDE == 0 ) {
+      r += *m_pointers[i / STRIDE].ptr;
     }
   }
 };
@@ -177,8 +176,8 @@ struct deallocate_memory {
   KOKKOS_INLINE_FUNCTION
   void operator()( size_type i ) const
   {
-    if ( i / STRIDE < m_num_ptrs && i % STRIDE == 0 ) {
-      m_space.deallocate( m_pointers[i/STRIDE].ptr, m_chunk_size );
+    if ( i % STRIDE == 0 ) {
+      m_space.deallocate( m_pointers[i / STRIDE].ptr, m_chunk_size );
     }
   }
 };
@@ -207,7 +206,7 @@ struct allocate_deallocate_memory {
   KOKKOS_INLINE_FUNCTION
   void operator()( size_type i ) const
   {
-    if ( i / STRIDE < m_num_max_chunks && i % STRIDE == 0 ) {
+    if ( i % STRIDE == 0 ) {
       for ( size_t j = m_max_chunk_size; j >= m_min_chunk_size; j /= m_chunk_spacing ) {
         for ( size_t k = 0; k < 10; ++k ) {
           void * mem = m_space.allocate( j );

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -51,7 +51,7 @@
 
 #include <impl/Kokkos_Timer.hpp>
 
-#define TESTMEMORYPOOL_PRINT
+//#define TESTMEMORYPOOL_PRINT
 //#define TESTMEMORYPOOL_PRINT_STATUS
 
 namespace TestMemoryPool {
@@ -84,7 +84,8 @@ struct allocate_memory {
   KOKKOS_INLINE_FUNCTION
   void operator()( size_type i ) const
   {
-    if ( 0 == ( i % STRIDE ) ) {
+    // Why do I need the first check?
+    if ( i / STRIDE < m_num_ptrs && i % STRIDE == 0 ) {
       m_pointers[i/STRIDE].ptr =
         static_cast< uint64_t * >( m_space.allocate( m_chunk_size ) );
     }
@@ -111,7 +112,7 @@ struct fill_memory {
   KOKKOS_INLINE_FUNCTION
   void operator()( size_type i ) const
   {
-    if ( 0 == ( i % STRIDE ) ) {
+    if ( i / STRIDE < m_num_ptrs && i % STRIDE == 0 ) {
       *m_pointers[i/STRIDE].ptr = i / STRIDE ;
     }
   }
@@ -147,7 +148,7 @@ struct sum_memory {
   KOKKOS_INLINE_FUNCTION
   void operator()( size_type i, value_type & r ) const
   {
-    if ( 0 == ( i % STRIDE ) ) {
+    if ( i / STRIDE < m_num_ptrs && i % STRIDE == 0 ) {
       r += *m_pointers[i/STRIDE].ptr;
     }
   }
@@ -176,7 +177,7 @@ struct deallocate_memory {
   KOKKOS_INLINE_FUNCTION
   void operator()( size_type i ) const
   {
-    if ( 0 == ( i % STRIDE ) ) {
+    if ( i / STRIDE < m_num_ptrs && i % STRIDE == 0 ) {
       m_space.deallocate( m_pointers[i/STRIDE].ptr, m_chunk_size );
     }
   }
@@ -203,10 +204,10 @@ struct allocate_deallocate_memory {
   KOKKOS_INLINE_FUNCTION
   void operator()( size_type i ) const
   {
-    for ( size_t i = m_max_chunk_size; i >= m_min_chunk_size; i /= m_chunk_spacing ) {
-      for ( size_t j = 0; j < 10; ++j ) {
-        void * mem = m_space.allocate( i );
-        m_space.deallocate( mem, i );
+    for ( size_t j = m_max_chunk_size; j >= m_min_chunk_size; j /= m_chunk_spacing ) {
+      for ( size_t k = 0; k < 10; ++k ) {
+        void * mem = m_space.allocate( j );
+        m_space.deallocate( mem, j );
       }
     }
   }

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -418,7 +418,6 @@ bool test_mempool( size_t chunk_size, size_t total_size )
 template < class ExecSpace, class MemorySpace = typename ExecSpace::memory_space >
 void test_mempool2( size_t chunk_size, size_t total_size )
 {
-  typedef Kokkos::View<pointer_obj*, ExecSpace >           pointer_view;
   typedef Kokkos::Experimental::MemoryPool< MemorySpace >  pool_memory_space;
 
   size_t num_chunk_sizes = 4;

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -437,8 +437,6 @@ void test_mempool2( size_t chunk_size, size_t total_size )
   print_results( "initialize mempool: ", elapsed_time );
 #endif
 
-  uint64_t result;
-
   chunk_size = m_space.get_min_chunk_size();
   total_size = m_space.get_mem_size();
 

--- a/core/unit_test/TestOpenMP.cpp
+++ b/core/unit_test/TestOpenMP.cpp
@@ -379,8 +379,10 @@ TEST_F( openmp , memory_space )
 
 TEST_F( openmp , memory_pool )
 {
-  bool val = TestMemoryPool::test_mempool< Kokkos::OpenMP >( 32, 8000000 );
+  bool val = TestMemoryPool::test_mempool< Kokkos::OpenMP >( 128, 1280000000 );
   ASSERT_TRUE( val );
+
+  TestMemoryPool::test_mempool2< Kokkos::OpenMP >( 128, 1280000000 );
 }
 
 //----------------------------------------------------------------------------

--- a/core/unit_test/TestOpenMP.cpp
+++ b/core/unit_test/TestOpenMP.cpp
@@ -379,10 +379,10 @@ TEST_F( openmp , memory_space )
 
 TEST_F( openmp , memory_pool )
 {
-  bool val = TestMemoryPool::test_mempool< Kokkos::OpenMP >( 128, 1280000000 );
+  bool val = TestMemoryPool::test_mempool< Kokkos::OpenMP >( 128, 128000000 );
   ASSERT_TRUE( val );
 
-  TestMemoryPool::test_mempool2< Kokkos::OpenMP >( 128, 1280000000 );
+  TestMemoryPool::test_mempool2< Kokkos::OpenMP >( 128, 128000000 );
 }
 
 //----------------------------------------------------------------------------

--- a/core/unit_test/TestSerial.cpp
+++ b/core/unit_test/TestSerial.cpp
@@ -384,10 +384,10 @@ TEST_F( serial , memory_space )
 
 TEST_F( serial , memory_pool )
 {
-  bool val = TestMemoryPool::test_mempool< Kokkos::Serial >( 128, 1280000000 );
+  bool val = TestMemoryPool::test_mempool< Kokkos::Serial >( 128, 128000000 );
   ASSERT_TRUE( val );
 
-  TestMemoryPool::test_mempool2< Kokkos::Serial >( 128, 1280000000 );
+  TestMemoryPool::test_mempool2< Kokkos::Serial >( 128, 128000000 );
 }
 
 //----------------------------------------------------------------------------

--- a/core/unit_test/TestSerial.cpp
+++ b/core/unit_test/TestSerial.cpp
@@ -384,8 +384,10 @@ TEST_F( serial , memory_space )
 
 TEST_F( serial , memory_pool )
 {
-  bool val = TestMemoryPool::test_mempool< Kokkos::Serial >( 32, 8000000 );
+  bool val = TestMemoryPool::test_mempool< Kokkos::Serial >( 128, 1280000000 );
   ASSERT_TRUE( val );
+
+  TestMemoryPool::test_mempool2< Kokkos::Serial >( 128, 1280000000 );
 }
 
 //----------------------------------------------------------------------------

--- a/core/unit_test/TestTaskPolicy.hpp
+++ b/core/unit_test/TestTaskPolicy.hpp
@@ -222,7 +222,7 @@ long eval_fib( long n )
 template< class ExecSpace >
 void test_fib( long n )
 {
-  const unsigned task_max_count  = 1024 ;
+  const unsigned task_max_count  = 2048 ;
   const unsigned task_max_size   = 256 ;
   const unsigned task_dependence = 4 ;
 
@@ -246,7 +246,7 @@ void test_fib( long n )
 template< class ExecSpace >
 void test_fib2( long n )
 {
-  const unsigned task_max_count  = 1024 ;
+  const unsigned task_max_count  = 2048 ;
   const unsigned task_max_size   = 256 ;
   const unsigned task_dependence = 4 ;
 

--- a/core/unit_test/TestTaskPolicy.hpp
+++ b/core/unit_test/TestTaskPolicy.hpp
@@ -222,7 +222,7 @@ long eval_fib( long n )
 template< class ExecSpace >
 void test_fib( long n )
 {
-  const unsigned task_max_count  = 16 ; // 1024 ;
+  const unsigned task_max_count  = 1024 ;
   const unsigned task_max_size   = 256 ;
   const unsigned task_dependence = 4 ;
 

--- a/core/unit_test/TestThreads.cpp
+++ b/core/unit_test/TestThreads.cpp
@@ -432,8 +432,10 @@ TEST_F( threads , memory_space )
 
 TEST_F( threads , memory_pool )
 {
-  bool val = TestMemoryPool::test_mempool< Kokkos::Threads >( 32, 8000000 );
+  bool val = TestMemoryPool::test_mempool< Kokkos::Threads >( 128, 1280000000 );
   ASSERT_TRUE( val );
+
+  TestMemoryPool::test_mempool2< Kokkos::Threads >( 128, 1280000000 );
 }
 
 //----------------------------------------------------------------------------

--- a/core/unit_test/TestThreads.cpp
+++ b/core/unit_test/TestThreads.cpp
@@ -432,10 +432,10 @@ TEST_F( threads , memory_space )
 
 TEST_F( threads , memory_pool )
 {
-  bool val = TestMemoryPool::test_mempool< Kokkos::Threads >( 128, 1280000000 );
+  bool val = TestMemoryPool::test_mempool< Kokkos::Threads >( 128, 128000000 );
   ASSERT_TRUE( val );
 
-  TestMemoryPool::test_mempool2< Kokkos::Threads >( 128, 1280000000 );
+  TestMemoryPool::test_mempool2< Kokkos::Threads >( 128, 128000000 );
 }
 
 //----------------------------------------------------------------------------

--- a/core/unit_test/TestThreads.cpp
+++ b/core/unit_test/TestThreads.cpp
@@ -484,11 +484,11 @@ TEST_F( threads , task_policy )
   TestTaskPolicy::test_task_dep< Kokkos::Threads >( 10 );
 
   for ( long i = 0 ; i < 25 ; ++i ) {
-    // printf("TestTaskPolicy::test_fib< Kokkos::Threads >(%d);\n",i);
+//    printf( "test_fib():  %2ld\n", i );
     TestTaskPolicy::test_fib< Kokkos::Threads >(i);
   }
   for ( long i = 0 ; i < 35 ; ++i ) {
-    // printf("TestTaskPolicy::test_fib2< Kokkos::Threads >(%d);\n",i);
+//    printf( "test_fib2(): %2ld\n", i );
     TestTaskPolicy::test_fib2< Kokkos::Threads >(i);
   }
 }


### PR DESCRIPTION
This is an updated version from the earlier pull request (which I deleted) that has multiple locks instead of retires.  With a single chunk size, it performs basically the same as the version currently in the main repo.  It has passed all the compile and execution tests.