### PR TITLE
Fix for issue 188: copying const view back to host

### DIFF
--- a/core/src/KokkosExp_View.hpp
+++ b/core/src/KokkosExp_View.hpp
@@ -1695,7 +1695,7 @@ void deep_copy
 template< class ST , class ... SP >
 inline
 void deep_copy
-  ( ST & dst
+  ( typename ViewTraits<ST,SP...>::non_const_value_type & dst
   , const View<ST,SP...> & src
   , typename std::enable_if<
     std::is_same< typename ViewTraits<ST,SP...>::specialize , void >::value


### PR DESCRIPTION
Modified destination type dst in deep_copy (into a value in Host memory
for a view) in /core/src/KokkosExp_View.hpp