### PR TITLE
Fix for commenting warning/error detected by Jenkins

### DIFF
--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -1086,7 +1086,7 @@ public:
         { ASSERT_EQ( hx(ip,i1,i2,i3) , T(0) ); }
       }}}}
     }
-#endif /* #if ! KOKKOS_USING_EXP_VIEW */
+#endif */ // #if ! KOKKOS_USING_EXP_VIEW
 
     // Testing with synchronous deep copy
     {


### PR DESCRIPTION
Replaced comment on line 1089 between /* ... */ with //