### PR TITLE
Fix OpenMP Atomic Test for Intel 15.X and 16.Y Compilers

### DIFF
--- a/core/unit_test/TestAtomic.hpp
+++ b/core/unit_test/TestAtomic.hpp
@@ -319,7 +319,7 @@ T ExchLoopSerial(int loop) {
   data2[0] = 0;
   for(int i=0;i<loop;i++) {
 	T old = *data;
-	*data=(T) i;
+	*data = i;
 	*data2+=old;
   }
 


### PR DESCRIPTION
Fixes the OpenMP Atomic test on Intel 15.5 and 16.{0, 1, 2} compilers. This test fails because the assignment to the 128-bit structure is a type cast from `int`. If this is not used, the assignment operator is called and the code generated functions the same as older compilers, GCC etc.