### PR TITLE
Removed tests from DynRankView deep_copy

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -573,9 +573,7 @@ inline
 void deep_copy
   ( const DynRankView<DT,DP...> & dst
   , typename ViewTraits<DT,DP...>::const_value_type & value
-  , typename std::enable_if<
-    std::is_same< typename ViewTraits<DT,DP...>::specialize , void >::value
-    >::type * = 0 )
+  )
 {
   deep_copy( dst.ConstDownCast() , value );
 }
@@ -586,9 +584,7 @@ inline
 void deep_copy
   ( typename ViewTraits<ST,SP...>::non_const_value_type & dst
   , const DynRankView<ST,SP...> & src
-  , typename std::enable_if<
-    std::is_same< typename ViewTraits<ST,SP...>::specialize , void >::value
-    >::type * = 0 )
+  )
 {
   deep_copy( dst , src.ConstDownCast() );
 }
@@ -601,10 +597,7 @@ inline
 void deep_copy
   ( const DynRankView<DT,DP...> & dst
   , const DynRankView<ST,SP...> & src
-  , typename std::enable_if<(
-    std::is_same< typename ViewTraits<DT,DP...>::specialize , void >::value &&
-    std::is_same< typename ViewTraits<ST,SP...>::specialize , void >::value // &&
-  )>::type * = 0 )
+  )
 {
   deep_copy( dst.ConstDownCast() , src.ConstDownCast() );
 }


### PR DESCRIPTION
Caused compiler errors with Stacado; tests run by Kokkos::View