### PR TITLE
Dyn rank view

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -46,6 +46,13 @@
 ///
 /// This header file declares and defines Kokkos::Experimental::DynRankView and its
 /// related nonmember functions.
+/*
+ *   Changes from View
+ *   1. The rank of the DynRankView is returned by the method rank()
+ *   2. Max rank of a DynRankView is 7
+ *   3. subview name is subdynrankview
+ *   4. Every subdynrankview is returned with LayoutStride
+ */
 
 #ifndef KOKKOS_DYNRANKVIEW_HPP
 #define KOKKOS_DYNRANKVIEW_HPP
@@ -57,33 +64,113 @@
 namespace Kokkos {
 namespace Experimental {
 
+namespace Impl {
+
+template <typename Specialize>
+struct DynRankDimTraits {
+
+  // Compute the rank of the view from the nonzero dimension arguments.
+  KOKKOS_INLINE_FUNCTION
+  static size_t computeRank( const size_t N0
+                           , const size_t N1
+                           , const size_t N2
+                           , const size_t N3
+                           , const size_t N4
+                           , const size_t N5
+                           , const size_t N6
+                           , const size_t N7 )
+  {
+    return
+      (   (N6 == 0 && N5 == 0 && N4 == 0 && N3 == 0 && N2 == 0 && N1 == 0 && N0 == 0) ? 0
+      : ( (N6 == 0 && N5 == 0 && N4 == 0 && N3 == 0 && N2 == 0 && N1 == 0) ? 1
+      : ( (N6 == 0 && N5 == 0 && N4 == 0 && N3 == 0 && N2 == 0) ? 2
+      : ( (N6 == 0 && N5 == 0 && N4 == 0 && N3 == 0) ? 3
+      : ( (N6 == 0 && N5 == 0 && N4 == 0) ? 4
+      : ( (N6 == 0 && N5 == 0) ? 5
+      : ( (N6 == 0) ? 6
+      : 7 ) ) ) ) ) ) );
+  }
+
+  // Compute the rank of the view from the nonzero layout arguments.
+  template <typename Layout>
+  KOKKOS_INLINE_FUNCTION
+  static size_t computeRank( const Layout& layout )
+  {
+    return computeRank( layout.dimension[0]
+                      , layout.dimension[1]
+                      , layout.dimension[2]
+                      , layout.dimension[3]
+                      , layout.dimension[4]
+                      , layout.dimension[5]
+                      , layout.dimension[6]
+                      , layout.dimension[7] );
+  }
+
+  // Create the layout for the rank-7 view.
+  template <typename Layout>
+  KOKKOS_INLINE_FUNCTION
+  static Layout createLayout( const Layout& layout )
+  {
+    return Layout( layout.dimension[0] != 0 ? layout.dimension[0] : 1
+                 , layout.dimension[1] != 0 ? layout.dimension[1] : 1
+                 , layout.dimension[2] != 0 ? layout.dimension[2] : 1
+                 , layout.dimension[3] != 0 ? layout.dimension[3] : 1
+                 , layout.dimension[4] != 0 ? layout.dimension[4] : 1
+                 , layout.dimension[5] != 0 ? layout.dimension[5] : 1
+                 , layout.dimension[6] != 0 ? layout.dimension[6] : 1
+                 , layout.dimension[7] != 0 ? layout.dimension[7] : 1
+                 );
+  }
+
+  // Create a view from the given dimension arguments.
+  // This is only necessary because the shmem constructor doesn't take a layout.
+  template <typename ViewType, typename ViewArg>
+  static ViewType createView( const ViewArg& arg
+                            , const size_t N0
+                            , const size_t N1
+                            , const size_t N2
+                            , const size_t N3
+                            , const size_t N4
+                            , const size_t N5
+                            , const size_t N6
+                            , const size_t N7 )
+  {
+    return ViewType( arg
+                   , N0 != 0 ? N0 : 1
+                   , N1 != 0 ? N1 : 1
+                   , N2 != 0 ? N2 : 1
+                   , N3 != 0 ? N3 : 1
+                   , N4 != 0 ? N4 : 1
+                   , N5 != 0 ? N5 : 1
+                   , N6 != 0 ? N6 : 1
+                   , N7 != 0 ? N7 : 1 );
+  }
+
+};
+
+} //end Impl
+
 /* \class DynRankView
- * \brief Container that creates a Kokkos view with runtime rank. 
- *   Essentially this is a rank 8 view with that wraps the access operators
- *   to yield the functionality of a view with rank that varies. 
+ * \brief Container that creates a Kokkos view with rank determined at runtime. 
+ *   Essentially this is a rank 7 view that wraps the access operators
+ *   to yield the functionality of a view 
  *
  *   Changes from View
  *   1. The rank of the DynRankView is returned by the method rank()
  *   2. Max rank of a DynRankView is 7
  *   3. subview name is subdynrankview
  *   4. Every subdynrankview is returned with LayoutStride
+ *
  */
 
 template< typename DataType , class ... Properties >
-class DynRankView : private View< DataType********, Properties... >
+class DynRankView : private View< DataType*******, Properties... >
 {
   static_assert( !std::is_array<DataType>::value && !std::is_pointer<DataType>::value , "Cannot template DynRankView with array or pointer datatype - must be pod" );
 
 public: 
-  using view_type = View< DataType******** , Properties...>;
+  using view_type = View< DataType******* , Properties...>;
   using reference_type = typename view_type::reference_type; 
-
-  template< class D, class ... P , class ... Args >
-  friend
-  KOKKOS_INLINE_FUNCTION
-  DynRankView< D , P... >
-  subview( const DynRankView< D, P... > & src , Args ... args );
-
 
 private: 
   template < class , class ... > friend class DynRankView ;
@@ -99,7 +186,6 @@ public:
 
   typedef typename traits::execution_space execution_space;
   typedef typename traits::memory_space memory_space;
-
   typedef typename traits::size_type size_type;
 
   typedef typename traits::data_type data_type;
@@ -184,60 +270,62 @@ public:
   // Rank 0
   KOKKOS_INLINE_FUNCTION
   reference_type operator()() const
-    { return view_type::operator()(0,0,0,0,0,0,0,0); }
+    { return view_type::operator()(0,0,0,0,0,0,0); }
   
   // Rank 1
   template< typename iType >
   KOKKOS_INLINE_FUNCTION
   reference_type operator[](const iType & i0) const
-    { if ( m_rank != 1 )  Kokkos::Impl::throw_runtime_exception("Rank is not compatible");  return view_type::operator[](i0); }
+    { 
+#if !defined(KOKKOS_HAVE_CUDA)
+      if ( m_rank != 1 ) { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
+#endif
+#if defined(KOKKOS_HAVE_CUDA)
+      if ( m_rank != 1 ) { Kokkos::abort("Rank is not compatible"); }
+#endif
+      return view_type::operator[](i0); 
+    }
 
   template< typename iType >
   KOKKOS_INLINE_FUNCTION
   reference_type operator()(const iType & i0 ) const 
-    { return view_type::operator()(i0,0,0,0,0,0,0,0); }
+    { return view_type::operator()(i0,0,0,0,0,0,0); }
 
   // Rank 2
   template< typename iType0 , typename iType1 >
   KOKKOS_INLINE_FUNCTION
   reference_type operator()(const iType0 & i0 , const iType1 & i1 ) const 
-    { return view_type::operator()(i0,i1,0,0,0,0,0,0); }
+    { return view_type::operator()(i0,i1,0,0,0,0,0); }
 
   // Rank 3
   template< typename iType0 , typename iType1 , typename iType2 >
   KOKKOS_INLINE_FUNCTION
   reference_type operator()(const iType0 & i0 , const iType1 & i1 , const iType2 & i2 ) const 
-    { return view_type::operator()(i0,i1,i2,0,0,0,0,0); }
+    { return view_type::operator()(i0,i1,i2,0,0,0,0); }
 
   // Rank 4
   template< typename iType0 , typename iType1 , typename iType2 , typename iType3 >
   KOKKOS_INLINE_FUNCTION
   reference_type operator()(const iType0 & i0 , const iType1 & i1 , const iType2 & i2 , const iType3 & i3 ) const 
-    { return view_type::operator()(i0,i1,i2,i3,0,0,0,0); }
+    { return view_type::operator()(i0,i1,i2,i3,0,0,0); }
 
   // Rank 5
   template< typename iType0 , typename iType1 , typename iType2 , typename iType3, typename iType4 >
   KOKKOS_INLINE_FUNCTION
   reference_type operator()(const iType0 & i0 , const iType1 & i1 , const iType2 & i2 , const iType3 & i3 , const iType4 & i4 ) const 
-    { return view_type::operator()(i0,i1,i2,i3,i4,0,0,0); }
+    { return view_type::operator()(i0,i1,i2,i3,i4,0,0); }
 
   // Rank 6
   template< typename iType0 , typename iType1 , typename iType2 , typename iType3, typename iType4 , typename iType5 >
   KOKKOS_INLINE_FUNCTION
   reference_type operator()(const iType0 & i0 , const iType1 & i1 , const iType2 & i2 , const iType3 & i3 , const iType4 & i4 , const iType5 & i5 ) const 
-    { return view_type::operator()(i0,i1,i2,i3,i4,i5,0,0); }
+    { return view_type::operator()(i0,i1,i2,i3,i4,i5,0); }
 
   // Rank 7
   template< typename iType0 , typename iType1 , typename iType2 , typename iType3, typename iType4 , typename iType5 , typename iType6 >
   KOKKOS_INLINE_FUNCTION
   reference_type operator()(const iType0 & i0 , const iType1 & i1 , const iType2 & i2 , const iType3 & i3 , const iType4 & i4 , const iType5 & i5 , const iType6 & i6 ) const 
-    { return view_type::operator()(i0,i1,i2,i3,i4,i5,i6,0); }
-
-  // Rank 8
-  template< typename iType0 , typename iType1 , typename iType2 , typename iType3, typename iType4 , typename iType5 , typename iType6 , typename iType7 >
-  KOKKOS_INLINE_FUNCTION
-  reference_type operator()(const iType0 i0 , const iType1 i1 , const iType2 i2 , const iType3 i3 , const iType4 i4 , const iType5 i5 , const iType6 i6 , const iType7 i7 ) const 
-    { return view_type::operator()(i0,i1,i2,i3,i4,i5,i6,i7); }
+    { return view_type::operator()(i0,i1,i2,i3,i4,i5,i6); }
 
 
   //----------------------------------------
@@ -281,21 +369,13 @@ public:
   //----------------------------------------
   // Compatible subview constructor
   // may assign unmanaged from managed.
-  //
-  //Subview version of constructor accepting a rank 8 view
+  //Subview version of constructor accepting a rank 7 view
   template< class RT , class ... RP >
   KOKKOS_INLINE_FUNCTION
-  DynRankView( const Kokkos::Experimental::View<RT********,RP...> & rhs , unsigned RankVal )
+  DynRankView( const Kokkos::Experimental::View<RT*******,RP...> & rhs , unsigned RankVal )
     : view_type( rhs ) 
     , m_rank(RankVal)
     {}
-/*
-    { 
-      m_rank = RankVal; 
-      view_type::operator = (rhs); 
-      std::cout << "DRV ctor 1 and RankVal "<< RankVal << std::endl;
-    }
-*/
 
   //----------------------------------------
   // Allocation tracking properties
@@ -313,41 +393,10 @@ public:
                                , typename traits::array_layout
                                >::type const & arg_layout
       )
-      : view_type( arg_prop 
-                 , typename traits::array_layout
-                   ( arg_layout.dimension[0] != 0 ? arg_layout.dimension[0] : 1 
-                   , arg_layout.dimension[1] != 0 ? arg_layout.dimension[1] : 1 
-                   , arg_layout.dimension[2] != 0 ? arg_layout.dimension[2] : 1 
-                   , arg_layout.dimension[3] != 0 ? arg_layout.dimension[3] : 1 
-                   , arg_layout.dimension[4] != 0 ? arg_layout.dimension[4] : 1 
-                   , arg_layout.dimension[5] != 0 ? arg_layout.dimension[5] : 1 
-                   , arg_layout.dimension[6] != 0 ? arg_layout.dimension[6] : 1 
-                   , arg_layout.dimension[7] != 0 ? arg_layout.dimension[7] : 1 
-                   ) 
-                 )
-      , m_rank( ( arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0 && arg_layout.dimension[4] == 0 && arg_layout.dimension[3] == 0 && arg_layout.dimension[2] == 0 && arg_layout.dimension[1] == 0 && arg_layout.dimension[0] == 0) ? 0 
-            : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0 && arg_layout.dimension[4] == 0 && arg_layout.dimension[3] == 0 && arg_layout.dimension[2] == 0 && arg_layout.dimension[1] == 0) ? 1 
-            : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0 && arg_layout.dimension[4] == 0 && arg_layout.dimension[3] == 0 && arg_layout.dimension[2] == 0) ? 2 
-            : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0 && arg_layout.dimension[4] == 0 && arg_layout.dimension[3] == 0) ? 3 
-            : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0 && arg_layout.dimension[4] == 0) ? 4 
-            : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0) ? 5 
-            : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0) ? 6 
-            : ( arg_layout.dimension[7] == 0 ? 7 
-            : 8 ) ) ) ) ) ) )
-            )  
+      : view_type( arg_prop
+                 , Impl::DynRankDimTraits<typename traits::specialize>::createLayout(arg_layout) )
+      , m_rank( Impl::DynRankDimTraits<typename traits::specialize>::computeRank(arg_layout) )
     {}
-/*
-    {  std::cout << "DRV ctor 2"<<std::endl;
-       std::cout << "  arg_layout dims \n" << arg_layout.dimension[0] << " "
-                                           << arg_layout.dimension[1] << " "
-                                           << arg_layout.dimension[2] << " "
-                                           << arg_layout.dimension[3] << " "
-                                           << arg_layout.dimension[4] << " "
-                                           << arg_layout.dimension[5] << " "
-                                           << arg_layout.dimension[6] << " "
-                                           << arg_layout.dimension[7] << std::endl;
-    }
-*/
 
 //Wrappers
   template< class ... P >
@@ -357,31 +406,10 @@ public:
                                , typename traits::array_layout
                                >::type const & arg_layout
       )
-      : view_type( arg_prop 
-                , typename traits::array_layout
-                   ( arg_layout.dimension[0] != 0 ? arg_layout.dimension[0] : 1 
-                   , arg_layout.dimension[1] != 0 ? arg_layout.dimension[1] : 1 
-                   , arg_layout.dimension[2] != 0 ? arg_layout.dimension[2] : 1 
-                   , arg_layout.dimension[3] != 0 ? arg_layout.dimension[3] : 1 
-                   , arg_layout.dimension[4] != 0 ? arg_layout.dimension[4] : 1 
-                   , arg_layout.dimension[5] != 0 ? arg_layout.dimension[5] : 1 
-                   , arg_layout.dimension[6] != 0 ? arg_layout.dimension[6] : 1 
-                   , arg_layout.dimension[7] != 0 ? arg_layout.dimension[7] : 1 
-                   ) 
-               )
-      , m_rank( 
-               ( arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0 && arg_layout.dimension[4] == 0 && arg_layout.dimension[3] == 0 && arg_layout.dimension[2] == 0 && arg_layout.dimension[1] == 0 && arg_layout.dimension[0] == 0) ? 0 
-              : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0 && arg_layout.dimension[4] == 0 && arg_layout.dimension[3] == 0 && arg_layout.dimension[2] == 0 && arg_layout.dimension[1] == 0) ? 1 
-              : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0 && arg_layout.dimension[4] == 0 && arg_layout.dimension[3] == 0 && arg_layout.dimension[2] == 0) ? 2 
-              : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0 && arg_layout.dimension[4] == 0 && arg_layout.dimension[3] == 0) ? 3 
-              : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0 && arg_layout.dimension[4] == 0) ? 4 
-              : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0 && arg_layout.dimension[5] == 0) ? 5 
-              : ( (arg_layout.dimension[7] == 0 && arg_layout.dimension[6] == 0) ? 6 
-              : ( arg_layout.dimension[7] == 0 ? 7 
-              : 8 ) ) ) ) ) ) )
-            )  
+      : view_type( arg_prop
+                 , Impl::DynRankDimTraits<typename traits::specialize>::createLayout(arg_layout) )
+      , m_rank( Impl::DynRankDimTraits<typename traits::specialize>::computeRank(arg_layout) )
     {}
-//    {std::cout << "DRV ctor 3"<<std::endl;}
 
   //----------------------------------------
   //Constructor(s)
@@ -401,12 +429,11 @@ public:
       , const size_t arg_N6 = 0
       , const size_t arg_N7 = 0
       )
-    : DynRankView( arg_prop 
+    : DynRankView( arg_prop
     , typename traits::array_layout
           ( arg_N0 , arg_N1 , arg_N2 , arg_N3 , arg_N4 , arg_N5 , arg_N6 , arg_N7 )
       )
     {}
-//    {std::cout << "DRV ctor 4"<<std::endl;}
 
   template< class ... P >
   explicit KOKKOS_INLINE_FUNCTION
@@ -422,12 +449,11 @@ public:
       , const size_t arg_N6 = 0
       , const size_t arg_N7 = 0
       )
-    : DynRankView( arg_prop 
+    : DynRankView( arg_prop
     , typename traits::array_layout
           ( arg_N0 , arg_N1 , arg_N2 , arg_N3 , arg_N4 , arg_N5 , arg_N6 , arg_N7 )
       )
     {}
-//    {std::cout << "DRV ctor 5"<<std::endl;}
 
   // Allocate with label and layout
   template< typename Label >
@@ -439,9 +465,8 @@ public:
       )
     : DynRankView( Impl::ViewCtorProp< std::string >( arg_label ) , arg_layout )
     {}
-//    {std::cout << "DRV ctor 6"<<std::endl;}
 
-  // Allocate label and layout, must disambiguate from subview constructor.
+  // Allocate label and layout
   template< typename Label >
   explicit inline
   DynRankView( const Label & arg_label
@@ -461,7 +486,6 @@ public:
           ( arg_N0 , arg_N1 , arg_N2 , arg_N3 , arg_N4 , arg_N5 , arg_N6 , arg_N7 )
           )
     {}
-//    {std::cout << "DRV ctor 7 \n"<<std::endl;}
 
   // For backward compatibility
 /*
@@ -489,7 +513,6 @@ public:
       )
     : DynRankView(Impl::ViewCtorProp< std::string , Kokkos::Experimental::Impl::WithoutInitializing_t >( arg_prop.label , Kokkos::Experimental::WithoutInitializing ), arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7 ) 
     {}
-//    {std::cout << "DRV ctor 8"<<std::endl;}
 
   using view_type::memory_span;
 
@@ -506,7 +529,6 @@ public:
       )
     : DynRankView( Impl::ViewCtorProp<pointer_type>(arg_ptr) , arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7 )
     {}
-//    {std::cout << "DRV ctor 9"<<std::endl;}
 
   explicit KOKKOS_INLINE_FUNCTION
   DynRankView( pointer_type arg_ptr
@@ -514,7 +536,6 @@ public:
       )
     : DynRankView( Impl::ViewCtorProp<pointer_type>(arg_ptr) , arg_layout )
     {}
-//    {std::cout << "DRV ctor 10"<<std::endl;}
 
 
   //----------------------------------------
@@ -524,7 +545,7 @@ public:
 
   explicit KOKKOS_INLINE_FUNCTION
   DynRankView( const typename traits::execution_space::scratch_memory_space & arg_space
-      , const size_t arg_N0 = 0 //size_t to ptrdiff_t, default to -1
+      , const size_t arg_N0 = 0
       , const size_t arg_N1 = 0
       , const size_t arg_N2 = 0
       , const size_t arg_N3 = 0
@@ -532,56 +553,27 @@ public:
       , const size_t arg_N5 = 0
       , const size_t arg_N6 = 0
       , const size_t arg_N7 = 0 )
-    : view_type( arg_space
-                 , arg_N0 != 0 ? arg_N0 : 1 //if T > 0 ? T : 1
-                 , arg_N1 != 0 ? arg_N1 : 1 
-                 , arg_N2 != 0 ? arg_N2 : 1 
-                 , arg_N3 != 0 ? arg_N3 : 1 
-                 , arg_N4 != 0 ? arg_N4 : 1 
-                 , arg_N5 != 0 ? arg_N5 : 1 
-                 , arg_N6 != 0 ? arg_N6 : 1 
-                 , arg_N7 != 0 ? arg_N7 : 1 
-               )
-    , m_rank( //search for first argN < 0 to terminate / determine rank 
-             ( arg_N7 == 0 && arg_N6 == 0 && arg_N5 == 0 && arg_N4 == 0 && arg_N3 == 0 && arg_N2 == 0 && arg_N1 == 0 && arg_N0 == 0) ? 0 
-             : ( (arg_N7 == 0 && arg_N6 == 0 && arg_N5 == 0 && arg_N4 == 0 && arg_N3 == 0 && arg_N2 == 0 && arg_N1 == 0) ? 1 
-             : ( (arg_N7 == 0 && arg_N6 == 0 && arg_N5 == 0 && arg_N4 == 0 && arg_N3 == 0 && arg_N2 == 0) ? 2 
-             : ( (arg_N7 == 0 && arg_N6 == 0 && arg_N5 == 0 && arg_N4 == 0 && arg_N3 == 0) ? 3 
-             : ( (arg_N7 == 0 && arg_N6 == 0 && arg_N5 == 0 && arg_N4 == 0) ? 4 
-             : ( (arg_N7 == 0 && arg_N6 == 0 && arg_N5 == 0) ? 5 
-             : ( (arg_N7 == 0 && arg_N6 == 0) ? 6 
-             : ( arg_N7 == 0 ? 7 
-             : 8 ) ) ) ) ) ) ) 
-            ) 
+    : view_type( Impl::DynRankDimTraits<typename traits::specialize>::template createView<view_type>( arg_space
+                                                                                                    , arg_N0
+                                                                                                    , arg_N1
+                                                                                                    , arg_N2
+                                                                                                    , arg_N3
+                                                                                                    , arg_N4
+                                                                                                    , arg_N5
+                                                                                                    , arg_N6
+                                                                                                    , arg_N7 ) )
+    , m_rank( Impl::DynRankDimTraits<typename traits::specialize>::computeRank( arg_N0
+                                                                              , arg_N1
+                                                                              , arg_N2
+                                                                              , arg_N3
+                                                                              , arg_N4
+                                                                              , arg_N5
+                                                                              , arg_N6
+                                                                              , arg_N7 ) )
     {}
-//    {std::cout << "DRV ctor 11"<<std::endl;}
 
 };
 
-  //----------------------------------------
-  //using Subview...
-  //original from View
-
-// Carter's
-// EXTENT_ONE_t removed
-/*
-template< typename T >
-typename std::conditional< std::is_integral<T>::value
-                         , Kokkos::Experimental::Impl::EXTENT_ONE_t
-                         , const T & >::type
-KOKKOS_INLINE_FUNCTION
-variadic_sview_expansion( const T & i ) 
-{ 
-  return
-  typename std::conditional< std::is_integral<T>::value
-                         , Kokkos::Experimental::Impl::EXTENT_ONE_t
-                         , const T & >::type( i );
-}
-*/
-
-
-
-//----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 // Subview mapping.
 // Deduce destination view type from source view traits and subview arguments
@@ -609,9 +601,6 @@ struct ViewMapping
 {
 private:
 
-//  static_assert( SrcTraits::rank == sizeof...(Args) ,
-//    "Subview mapping requires one argument for each dimension of source View" );
-
   enum
     { RZ = false
     , R0 = bool(is_integral_extent<0,Args...>::value)
@@ -621,19 +610,17 @@ private:
     , R4 = bool(is_integral_extent<4,Args...>::value)
     , R5 = bool(is_integral_extent<5,Args...>::value)
     , R6 = bool(is_integral_extent<6,Args...>::value)
-    , R7 = bool(is_integral_extent<7,Args...>::value) //sacado
     };
-  //Query additional info
 
   enum { rank = unsigned(R0) + unsigned(R1) + unsigned(R2) + unsigned(R3)
-              + unsigned(R4) + unsigned(R5) + unsigned(R6) + unsigned(R7) }; //dyn rank, with correct use //sacado
+              + unsigned(R4) + unsigned(R5) + unsigned(R6) }; //dyn rank, with correct use 
 
   // Subview's layout
   typedef Kokkos::LayoutStride array_layout ;
 
   typedef typename SrcTraits::value_type  value_type ;
 
-  typedef value_type******** data_type ; //sacado
+  typedef value_type******* data_type ; 
 
 public:
 
@@ -648,6 +635,7 @@ public:
     , array_layout 
     , typename SrcTraits::device_type
     , typename SrcTraits::memory_traits > type ;
+
 
   template< class MemoryTraits >
   struct apply {
@@ -665,16 +653,17 @@ public:
       , array_layout
       , typename SrcTraits::device_type
       , MemoryTraits > type ;
-  };
+  }; //unnecessary function...
 
 
   typedef typename SrcTraits::dimension dimension ;
 
-  template < class Arg0 = int, class Arg1 = int, class Arg2 = int, class Arg3 = int, class Arg4 = int, class Arg5 = int, class Arg6 = int, class Arg7 = int > //sacado
+  template < class Arg0 = int, class Arg1 = int, class Arg2 = int, class Arg3 = int, class Arg4 = int, class Arg5 = int, class Arg6 = int >
   struct ExtentGenerator {
-    static SubviewExtents< 8 , rank > generator ( const dimension & dim , Arg0 arg0 = Arg0(), Arg1 arg1 = Arg1(), Arg2 arg2 = Arg2(), Arg3 arg3 = Arg3(), Arg4 arg4 = Arg4(), Arg5 arg5 = Arg5(), Arg6 arg6 = Arg6(), Arg7 arg7 = Arg7() ) //sacado - remove Arg7, 8 to 7
+    KOKKOS_INLINE_FUNCTION
+    static SubviewExtents< 7 , rank > generator ( const dimension & dim , Arg0 arg0 = Arg0(), Arg1 arg1 = Arg1(), Arg2 arg2 = Arg2(), Arg3 arg3 = Arg3(), Arg4 arg4 = Arg4(), Arg5 arg5 = Arg5(), Arg6 arg6 = Arg6() )
     {
-       return SubviewExtents< 8 , rank>( dim , arg0 , arg1 , arg2 , arg3 , arg4 , arg5 , arg6 , arg7 ); //sacado "
+       return SubviewExtents< 7 , rank>( dim , arg0 , arg1 , arg2 , arg3 , arg4 , arg5 , arg6 );
     }
   };
 
@@ -683,37 +672,29 @@ public:
 
   template < typename T , class ... P >
   KOKKOS_INLINE_FUNCTION
-  static ret_type subview( Kokkos::Experimental::View< T******** , P...> const & src  //sacado
+  static ret_type subview( Kokkos::Experimental::View< T******* , P...> const & src 
                     , Args ... args )
     {
-//      static_assert(
-//        ViewMapping< DstTraits , traits_type , void >::is_assignable ,
-//        "Subview destination type must be compatible with subview derived type" );
 
       typedef ViewMapping< traits_type, void >  DstType ;
 
-     typedef typename std::conditional< (rank==0) , ViewDimension<>
-                                                  , typename std::conditional< (rank==1) , ViewDimension<0>
-                                                  , typename std::conditional< (rank==2) , ViewDimension<0,0>
-                                                  , typename std::conditional< (rank==3) , ViewDimension<0,0,0>
-                                                  , typename std::conditional< (rank==4) , ViewDimension<0,0,0,0>
-                                                  , typename std::conditional< (rank==5) , ViewDimension<0,0,0,0,0>
-                                                  , typename std::conditional< (rank==6) , ViewDimension<0,0,0,0,0,0>
-                                                  , typename std::conditional< (rank==7) , ViewDimension<0,0,0,0,0,0,0> //sacado
-                                                                                         , ViewDimension<0,0,0,0,0,0,0,0>
-                                                  >::type >::type >::type >::type >::type >::type >::type >::type  DstDimType ;
+       typedef typename std::conditional< (rank==0) , ViewDimension<>
+                                                    , typename std::conditional< (rank==1) , ViewDimension<0>
+                                                    , typename std::conditional< (rank==2) , ViewDimension<0,0>
+                                                    , typename std::conditional< (rank==3) , ViewDimension<0,0,0>
+                                                    , typename std::conditional< (rank==4) , ViewDimension<0,0,0,0>
+                                                    , typename std::conditional< (rank==5) , ViewDimension<0,0,0,0,0>
+                                                    , typename std::conditional< (rank==6) , ViewDimension<0,0,0,0,0,0>
+                                                                                           , ViewDimension<0,0,0,0,0,0,0>
+                                                    >::type >::type >::type >::type >::type >::type >::type  DstDimType ;
 
       typedef ViewOffset< DstDimType , Kokkos::LayoutStride > dst_offset_type ;
-//      typedef typename DstType::offset_type  dst_offset_type ;
       typedef typename DstType::handle_type  dst_handle_type ;
 
-      Kokkos::Experimental::View< T******** , typename traits_type::array_layout , typename traits_type::device_type , typename traits_type::memory_traits > dst( src ) ; //sacado
+      Kokkos::Experimental::View< T******* , typename traits_type::array_layout , typename traits_type::device_type , typename traits_type::memory_traits > dst( src ) ;
 
-      const SubviewExtents< 8 , rank > extents = //sacado change 8 to 7
+      const SubviewExtents< 7 , rank > extents = 
         ExtentGenerator< Args ... >::generator( src.m_map.m_offset.m_dim , args... ); 
-
-//      const SubviewExtents< 8 , rank >
-//        extents( src.m_offset.m_dim , args... );
 
       dst_offset_type tempdst( src.m_map.m_offset , extents );
 
@@ -724,7 +705,6 @@ public:
       dst.m_map.m_offset.m_dim.N4 = tempdst.m_dim.N4 ;
       dst.m_map.m_offset.m_dim.N5 = tempdst.m_dim.N5 ;
       dst.m_map.m_offset.m_dim.N6 = tempdst.m_dim.N6 ;
-      dst.m_map.m_offset.m_dim.N7 = tempdst.m_dim.N7 ; //sacado
 
       dst.m_map.m_offset.m_stride.S0 = tempdst.m_stride.S0 ;
       dst.m_map.m_offset.m_stride.S1 = tempdst.m_stride.S1 ;
@@ -733,7 +713,6 @@ public:
       dst.m_map.m_offset.m_stride.S4 = tempdst.m_stride.S4 ;
       dst.m_map.m_offset.m_stride.S5 = tempdst.m_stride.S5 ;
       dst.m_map.m_offset.m_stride.S6 = tempdst.m_stride.S6 ;
-      dst.m_map.m_offset.m_stride.S7 = tempdst.m_stride.S7 ; //sacado
 
       dst.m_map.m_handle = dst_handle_type( src.m_map.m_handle +
                                       src.m_map.m_offset( extents.domain_offset(0)
@@ -743,105 +722,38 @@ public:
                                                   , extents.domain_offset(4)
                                                   , extents.domain_offset(5)
                                                   , extents.domain_offset(6)
-                                                  , extents.domain_offset(7) //sacado
                                                   ) );
       return ret_type( dst , rank );
     }
 };
-} //close Impl
 
+} // end Impl
 
-
-//Possible direction:
-// Remove EXTENT_ONE_t
-// Cleanup ViewMapping changes ...
-#if 0
-template < class Traits , class Arg0 = int, class Arg1 = int, class Arg2 = int, class Arg3 = int, class Arg4 = int, class Arg5 = int, class Arg6 = int, class Arg7 = int >
-struct Subdynrankview {
-
-  typedef typename Kokkos::Experimental::Impl::ViewMapping
-    < void
-    , Traits
-    , typename std::conditional<std::is_integral<Arg0>::value, Kokkos::pair<Arg0,Arg0> , Arg0>::type 
-    , typename std::conditional<std::is_integral<Arg1>::value, Kokkos::pair<Arg1,Arg1> , Arg1>::type 
-    , typename std::conditional<std::is_integral<Arg2>::value, Kokkos::pair<Arg2,Arg2> , Arg2>::type 
-    , typename std::conditional<std::is_integral<Arg3>::value, Kokkos::pair<Arg3,Arg3> , Arg3>::type 
-    , typename std::conditional<std::is_integral<Arg4>::value, Kokkos::pair<Arg4,Arg4> , Arg4>::type 
-    , typename std::conditional<std::is_integral<Arg5>::value, Kokkos::pair<Arg5,Arg5> , Arg5>::type 
-    , typename std::conditional<std::is_integral<Arg6>::value, Kokkos::pair<Arg6,Arg6> , Arg6>::type 
-    , typename std::conditional<std::is_integral<Arg7>::value, Kokkos::pair<Arg7,Arg7> , Arg7>::type 
-    >::type ViewType ;
-
-  //typedef DynRankView< typename ViewType::value_type , typename ViewType::array_layout , typename ViewType::device_type , typename ViewType::memory_traits >  type; //make array_layout Kokkos::LayoutStride to pass intel/14.0.4 compiler
-
-  typedef DynRankView< typename ViewType::value_type , Kokkos::LayoutStride , typename ViewType::device_type , typename ViewType::memory_traits >  type; //make array_layout Kokkos::LayoutStride to pass intel/14.0.4 compiler
-
-
-
-//Pass whole collection of args to a function with a rank number, 
-// scan through list for non-integer entry greater than or equal to rank
-// pass through; if no more remaining non-integer return the pair
-// Would be nice to have something like a stack to add args to, pop them off until non-integer reached
-
-/*
-  template< typename T >
-  static typename std::enable_if< std::is_integral<T>::value ,Kokkos::pair<T,T> >::type
-  KOKKOS_INLINE_FUNCTION
-  convert ( const T & i ) 
-  { 
-    return
-    Kokkos::pair<T,T>( i , i+1 );
-  }
-  
-  template< typename T >
-  static typename std::enable_if< !std::is_integral<T>::value , const T & >::type
-  KOKKOS_INLINE_FUNCTION
-  convert ( const T & i ) 
-  { 
-    return i;
-  }
-  
-
-  template < class T , class ... P >
-  static type subview( const Kokkos::Experimental::View<T******** , P... > & InputView , Arg0 arg0 = Arg0(), Arg1 arg1 = Arg1(), Arg2 arg2 = Arg2(), Arg3 arg3 = Arg3(), Arg4 arg4 = Arg4(), Arg5 arg5 = Arg5(), Arg6 arg6 = Arg6(), Arg7 arg7 = Arg7() )
-  {
-    const unsigned numArgs = unsigned(!std::is_integral<Arg0>::value) 
-                           + unsigned(!std::is_integral<Arg1>::value) 
-                           + unsigned(!std::is_integral<Arg2>::value) 
-                           + unsigned(!std::is_integral<Arg3>::value) 
-                           + unsigned(!std::is_integral<Arg4>::value) 
-                           + unsigned(!std::is_integral<Arg5>::value) 
-                           + unsigned(!std::is_integral<Arg6>::value) 
-                           + unsigned(!std::is_integral<Arg7>::value) ;
-
-    return type( Kokkos::Experimental::subview( InputView , convert(arg0) , convert(arg1) , convert(arg2) , convert(arg3) , convert(arg4) , convert(arg5) , convert(arg6) , convert(arg7) ) , numArgs );
-  }
-*/
-};
-#endif
-
-
-// Carter's idea
 
 template< class V , class ... Args >
 using Subdynrankview = typename Kokkos::Experimental::Impl::ViewMapping< Kokkos::Experimental::Impl::DynRankSubviewTag , V , Args... >::ret_type ;
 
 template< class D , class ... P , class ...Args >
 KOKKOS_INLINE_FUNCTION
-//typename Subdynrankview< Kokkos::Experimental::ViewTraits< D********, P... > , Args... >::type //original
-//typename Kokkos::Experimental::Impl::ViewMapping< Kokkos::Experimental::Impl::DynRankSubviewTag , Kokkos::Experimental::ViewTraits< D********, P... > , Args... >::ret_type //intel14 fix
-Subdynrankview< ViewTraits<D******** , P...> , Args... > //nicer looking return type //sacado
+  //typename Kokkos::Experimental::Impl::ViewMapping< Kokkos::Experimental::Impl::DynRankSubviewTag , Kokkos::Experimental::ViewTraits< D*******, P... > , Args... >::ret_type //intel14 fix
+Subdynrankview< ViewTraits<D******* , P...> , Args... > //nicer looking return type
 subdynrankview( const Kokkos::Experimental::DynRankView< D , P... > &src , Args...args)
-{
-  if ( src.rank() != sizeof...(Args) )
-    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
+  {
+//#if !defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA )
+#if !defined(KOKKOS_HAVE_CUDA)
+    if ( src.rank() != sizeof...(Args) )
+      { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
+#endif
+//#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA )
+#if defined(KOKKOS_HAVE_CUDA)
+    if ( src.rank() != sizeof...(Args) )
+      { Kokkos::abort("Rank is not compatible"); }
+#endif
+  
+    typedef Kokkos::Experimental::Impl::ViewMapping< Kokkos::Experimental::Impl::DynRankSubviewTag , Kokkos::Experimental::ViewTraits< D*******, P... > , Args... > metafcn ;
 
-  typedef Kokkos::Experimental::Impl::ViewMapping< Kokkos::Experimental::Impl::DynRankSubviewTag , Kokkos::Experimental::ViewTraits< D********, P... > , Args... > metafcn ; //sacado
-  return metafcn::subview( src.ConstDownCast() , args... );
-
-}
-
-// ************************************************** //
+    return metafcn::subview( src.ConstDownCast() , args... );
+  }
 
 } // namespace Experimental
 } // namespace Kokkos
@@ -902,8 +814,7 @@ template< class DT , class ... DP >
 inline
 void deep_copy
   ( const DynRankView<DT,DP...> & dst
-  , typename ViewTraits<DT,DP...>::const_value_type & value
-  )
+  , typename ViewTraits<DT,DP...>::const_value_type & value )
 {
   deep_copy( dst.ConstDownCast() , value );
 }
@@ -913,8 +824,7 @@ template< class ST , class ... SP >
 inline
 void deep_copy
   ( typename ViewTraits<ST,SP...>::non_const_value_type & dst
-  , const DynRankView<ST,SP...> & src
-  )
+  , const DynRankView<ST,SP...> & src )
 {
   deep_copy( dst , src.ConstDownCast() );
 }
@@ -926,8 +836,7 @@ template< class DT , class ... DP , class ST , class ... SP >
 inline
 void deep_copy
   ( const DynRankView<DT,DP...> & dst
-  , const DynRankView<ST,SP...> & src
-  )
+  , const DynRankView<ST,SP...> & src )
 {
   deep_copy( dst.ConstDownCast() , src.ConstDownCast() );
 }
@@ -1099,4 +1008,18 @@ void realloc( DynRankView<T,P...> & v ,
 } //end Experimental
 } //end Kokkos
 
+
+namespace Kokkos {
+
+template< typename D , class ... P >
+using DynRankView = Kokkos::Experimental::DynRankView< D , P... > ;
+
+using Kokkos::Experimental::deep_copy ;
+using Kokkos::Experimental::create_mirror ;
+using Kokkos::Experimental::create_mirror_view ;
+using Kokkos::Experimental::subdynrankview ;
+using Kokkos::Experimental::resize ;
+using Kokkos::Experimental::realloc ;
+
+} //end Kokkos
 #endif

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -61,6 +61,12 @@ namespace Experimental {
  * \brief Container that creates a Kokkos view with runtime rank. 
  *   Essentially this is a rank 8 view with that wraps the access operators
  *   to yield the functionality of a view with rank that varies. 
+ *
+ *   Changes from View
+ *   1. The rank of the DynRankView is returned by the method rank()
+ *   2. Max rank of a DynRankView is 7
+ *   3. subview name is subdynrankview
+ *   4. Every subdynrankview is returned with LayoutStride
  */
 
 template< typename DataType , class ... Properties >
@@ -72,18 +78,12 @@ public:
   using view_type = View< DataType******** , Properties...>;
   using reference_type = typename view_type::reference_type; 
 
-
   template< class D, class ... P , class ... Args >
   friend
   KOKKOS_INLINE_FUNCTION
   DynRankView< D , P... >
   subview( const DynRankView< D, P... > & src , Args ... args );
 
-  template< class D, class ... P , class ... Args >
-  friend
-  KOKKOS_INLINE_FUNCTION
-  DynRankView< D , P... >
-  dsubview( const DynRankView< D, P... > & src , Args ... args );
 
 private: 
   template < class , class ... > friend class DynRankView ;
@@ -189,48 +189,48 @@ public:
   // Rank 1
   template< typename iType >
   KOKKOS_INLINE_FUNCTION
-  reference_type operator[](const iType i0) const
-    { return view_type::operator[](i0,0,0,0,0,0,0,0); }
+  reference_type operator[](const iType & i0) const
+    { if ( m_rank != 1 )  Kokkos::Impl::throw_runtime_exception("Rank is not compatible");  return view_type::operator[](i0); }
 
   template< typename iType >
   KOKKOS_INLINE_FUNCTION
-  reference_type operator()(const iType i0 ) const 
+  reference_type operator()(const iType & i0 ) const 
     { return view_type::operator()(i0,0,0,0,0,0,0,0); }
 
   // Rank 2
   template< typename iType0 , typename iType1 >
   KOKKOS_INLINE_FUNCTION
-  reference_type operator()(const iType0 i0 , const iType1 i1 ) const 
+  reference_type operator()(const iType0 & i0 , const iType1 & i1 ) const 
     { return view_type::operator()(i0,i1,0,0,0,0,0,0); }
 
   // Rank 3
   template< typename iType0 , typename iType1 , typename iType2 >
   KOKKOS_INLINE_FUNCTION
-  reference_type operator()(const iType0 i0 , const iType1 i1 , const iType2 i2 ) const 
+  reference_type operator()(const iType0 & i0 , const iType1 & i1 , const iType2 & i2 ) const 
     { return view_type::operator()(i0,i1,i2,0,0,0,0,0); }
 
   // Rank 4
   template< typename iType0 , typename iType1 , typename iType2 , typename iType3 >
   KOKKOS_INLINE_FUNCTION
-  reference_type operator()(const iType0 i0 , const iType1 i1 , const iType2 i2 , const iType3 i3 ) const 
+  reference_type operator()(const iType0 & i0 , const iType1 & i1 , const iType2 & i2 , const iType3 & i3 ) const 
     { return view_type::operator()(i0,i1,i2,i3,0,0,0,0); }
 
   // Rank 5
   template< typename iType0 , typename iType1 , typename iType2 , typename iType3, typename iType4 >
   KOKKOS_INLINE_FUNCTION
-  reference_type operator()(const iType0 i0 , const iType1 i1 , const iType2 i2 , const iType3 i3 , const iType4 i4 ) const 
+  reference_type operator()(const iType0 & i0 , const iType1 & i1 , const iType2 & i2 , const iType3 & i3 , const iType4 & i4 ) const 
     { return view_type::operator()(i0,i1,i2,i3,i4,0,0,0); }
 
   // Rank 6
   template< typename iType0 , typename iType1 , typename iType2 , typename iType3, typename iType4 , typename iType5 >
   KOKKOS_INLINE_FUNCTION
-  reference_type operator()(const iType0 i0 , const iType1 i1 , const iType2 i2 , const iType3 i3 , const iType4 i4 , const iType5 i5 ) const 
+  reference_type operator()(const iType0 & i0 , const iType1 & i1 , const iType2 & i2 , const iType3 & i3 , const iType4 & i4 , const iType5 & i5 ) const 
     { return view_type::operator()(i0,i1,i2,i3,i4,i5,0,0); }
 
   // Rank 7
   template< typename iType0 , typename iType1 , typename iType2 , typename iType3, typename iType4 , typename iType5 , typename iType6 >
   KOKKOS_INLINE_FUNCTION
-  reference_type operator()(const iType0 i0 , const iType1 i1 , const iType2 i2 , const iType3 i3 , const iType4 i4 , const iType5 i5 , const iType6 i6 ) const 
+  reference_type operator()(const iType0 & i0 , const iType1 & i1 , const iType2 & i2 , const iType3 & i3 , const iType4 & i4 , const iType5 & i5 , const iType6 & i6 ) const 
     { return view_type::operator()(i0,i1,i2,i3,i4,i5,i6,0); }
 
   // Rank 8
@@ -621,19 +621,19 @@ private:
     , R4 = bool(is_integral_extent<4,Args...>::value)
     , R5 = bool(is_integral_extent<5,Args...>::value)
     , R6 = bool(is_integral_extent<6,Args...>::value)
-    , R7 = bool(is_integral_extent<7,Args...>::value)
+    , R7 = bool(is_integral_extent<7,Args...>::value) //sacado
     };
   //Query additional info
 
   enum { rank = unsigned(R0) + unsigned(R1) + unsigned(R2) + unsigned(R3)
-              + unsigned(R4) + unsigned(R5) + unsigned(R6) + unsigned(R7) }; //dyn rank, with correct use
+              + unsigned(R4) + unsigned(R5) + unsigned(R6) + unsigned(R7) }; //dyn rank, with correct use //sacado
 
   // Subview's layout
   typedef Kokkos::LayoutStride array_layout ;
 
   typedef typename SrcTraits::value_type  value_type ;
 
-  typedef value_type******** data_type ;
+  typedef value_type******** data_type ; //sacado
 
 public:
 
@@ -670,11 +670,11 @@ public:
 
   typedef typename SrcTraits::dimension dimension ;
 
-  template < class Arg0 = int, class Arg1 = int, class Arg2 = int, class Arg3 = int, class Arg4 = int, class Arg5 = int, class Arg6 = int, class Arg7 = int >
+  template < class Arg0 = int, class Arg1 = int, class Arg2 = int, class Arg3 = int, class Arg4 = int, class Arg5 = int, class Arg6 = int, class Arg7 = int > //sacado
   struct ExtentGenerator {
-    static SubviewExtents< 8 , rank > generator ( const dimension & dim , Arg0 arg0 = Arg0(), Arg1 arg1 = Arg1(), Arg2 arg2 = Arg2(), Arg3 arg3 = Arg3(), Arg4 arg4 = Arg4(), Arg5 arg5 = Arg5(), Arg6 arg6 = Arg6(), Arg7 arg7 = Arg7() )
+    static SubviewExtents< 8 , rank > generator ( const dimension & dim , Arg0 arg0 = Arg0(), Arg1 arg1 = Arg1(), Arg2 arg2 = Arg2(), Arg3 arg3 = Arg3(), Arg4 arg4 = Arg4(), Arg5 arg5 = Arg5(), Arg6 arg6 = Arg6(), Arg7 arg7 = Arg7() ) //sacado - remove Arg7, 8 to 7
     {
-       return SubviewExtents< 8 , rank>( dim , arg0 , arg1 , arg2 , arg3 , arg4 , arg5 , arg6 , arg7 );
+       return SubviewExtents< 8 , rank>( dim , arg0 , arg1 , arg2 , arg3 , arg4 , arg5 , arg6 , arg7 ); //sacado "
     }
   };
 
@@ -683,7 +683,7 @@ public:
 
   template < typename T , class ... P >
   KOKKOS_INLINE_FUNCTION
-  static ret_type subview( Kokkos::Experimental::View< T******** , P...> const & src 
+  static ret_type subview( Kokkos::Experimental::View< T******** , P...> const & src  //sacado
                     , Args ... args )
     {
 //      static_assert(
@@ -699,7 +699,7 @@ public:
                                                   , typename std::conditional< (rank==4) , ViewDimension<0,0,0,0>
                                                   , typename std::conditional< (rank==5) , ViewDimension<0,0,0,0,0>
                                                   , typename std::conditional< (rank==6) , ViewDimension<0,0,0,0,0,0>
-                                                  , typename std::conditional< (rank==7) , ViewDimension<0,0,0,0,0,0,0>
+                                                  , typename std::conditional< (rank==7) , ViewDimension<0,0,0,0,0,0,0> //sacado
                                                                                          , ViewDimension<0,0,0,0,0,0,0,0>
                                                   >::type >::type >::type >::type >::type >::type >::type >::type  DstDimType ;
 
@@ -707,9 +707,9 @@ public:
 //      typedef typename DstType::offset_type  dst_offset_type ;
       typedef typename DstType::handle_type  dst_handle_type ;
 
-      Kokkos::Experimental::View< T******** , typename traits_type::array_layout , typename traits_type::device_type , typename traits_type::memory_traits > dst( src ) ;
+      Kokkos::Experimental::View< T******** , typename traits_type::array_layout , typename traits_type::device_type , typename traits_type::memory_traits > dst( src ) ; //sacado
 
-      const SubviewExtents< 8 , rank > extents = 
+      const SubviewExtents< 8 , rank > extents = //sacado change 8 to 7
         ExtentGenerator< Args ... >::generator( src.m_map.m_offset.m_dim , args... ); 
 
 //      const SubviewExtents< 8 , rank >
@@ -724,7 +724,7 @@ public:
       dst.m_map.m_offset.m_dim.N4 = tempdst.m_dim.N4 ;
       dst.m_map.m_offset.m_dim.N5 = tempdst.m_dim.N5 ;
       dst.m_map.m_offset.m_dim.N6 = tempdst.m_dim.N6 ;
-      dst.m_map.m_offset.m_dim.N7 = tempdst.m_dim.N7 ;
+      dst.m_map.m_offset.m_dim.N7 = tempdst.m_dim.N7 ; //sacado
 
       dst.m_map.m_offset.m_stride.S0 = tempdst.m_stride.S0 ;
       dst.m_map.m_offset.m_stride.S1 = tempdst.m_stride.S1 ;
@@ -733,7 +733,7 @@ public:
       dst.m_map.m_offset.m_stride.S4 = tempdst.m_stride.S4 ;
       dst.m_map.m_offset.m_stride.S5 = tempdst.m_stride.S5 ;
       dst.m_map.m_offset.m_stride.S6 = tempdst.m_stride.S6 ;
-      dst.m_map.m_offset.m_stride.S7 = tempdst.m_stride.S7 ;
+      dst.m_map.m_offset.m_stride.S7 = tempdst.m_stride.S7 ; //sacado
 
       dst.m_map.m_handle = dst_handle_type( src.m_map.m_handle +
                                       src.m_map.m_offset( extents.domain_offset(0)
@@ -743,7 +743,7 @@ public:
                                                   , extents.domain_offset(4)
                                                   , extents.domain_offset(5)
                                                   , extents.domain_offset(6)
-                                                  , extents.domain_offset(7)
+                                                  , extents.domain_offset(7) //sacado
                                                   ) );
       return ret_type( dst , rank );
     }
@@ -755,6 +755,7 @@ public:
 //Possible direction:
 // Remove EXTENT_ONE_t
 // Cleanup ViewMapping changes ...
+#if 0
 template < class Traits , class Arg0 = int, class Arg1 = int, class Arg2 = int, class Arg3 = int, class Arg4 = int, class Arg5 = int, class Arg6 = int, class Arg7 = int >
 struct Subdynrankview {
 
@@ -771,16 +772,18 @@ struct Subdynrankview {
     , typename std::conditional<std::is_integral<Arg7>::value, Kokkos::pair<Arg7,Arg7> , Arg7>::type 
     >::type ViewType ;
 
-  //typedef typename Kokkos::Experimental::Impl::ViewMapping < void , Traits , Args... >::type ViewType ;
-//  typedef typename Kokkos::Experimental::Impl::ViewMapping < void , Traits , Arg0 , Arg1 , Arg2 , Arg3 , Arg4 , Arg5 , Arg6 , Arg7 >::type ViewType ;
+  //typedef DynRankView< typename ViewType::value_type , typename ViewType::array_layout , typename ViewType::device_type , typename ViewType::memory_traits >  type; //make array_layout Kokkos::LayoutStride to pass intel/14.0.4 compiler
 
-  typedef DynRankView< typename ViewType::value_type , typename ViewType::array_layout , typename ViewType::device_type , typename ViewType::memory_traits >  type;
+  typedef DynRankView< typename ViewType::value_type , Kokkos::LayoutStride , typename ViewType::device_type , typename ViewType::memory_traits >  type; //make array_layout Kokkos::LayoutStride to pass intel/14.0.4 compiler
+
+
 
 //Pass whole collection of args to a function with a rank number, 
 // scan through list for non-integer entry greater than or equal to rank
 // pass through; if no more remaining non-integer return the pair
 // Would be nice to have something like a stack to add args to, pop them off until non-integer reached
 
+/*
   template< typename T >
   static typename std::enable_if< std::is_integral<T>::value ,Kokkos::pair<T,T> >::type
   KOKKOS_INLINE_FUNCTION
@@ -813,20 +816,27 @@ struct Subdynrankview {
 
     return type( Kokkos::Experimental::subview( InputView , convert(arg0) , convert(arg1) , convert(arg2) , convert(arg3) , convert(arg4) , convert(arg5) , convert(arg6) , convert(arg7) ) , numArgs );
   }
-
+*/
 };
+#endif
 
 
 // Carter's idea
+
+template< class V , class ... Args >
+using Subdynrankview = typename Kokkos::Experimental::Impl::ViewMapping< Kokkos::Experimental::Impl::DynRankSubviewTag , V , Args... >::ret_type ;
+
 template< class D , class ... P , class ...Args >
 KOKKOS_INLINE_FUNCTION
-typename Subdynrankview< Kokkos::Experimental::ViewTraits< D********, P... > , Args... >::type
-subdynrankview( const DynRankView< D , P... > &src , Args...args)
+//typename Subdynrankview< Kokkos::Experimental::ViewTraits< D********, P... > , Args... >::type //original
+//typename Kokkos::Experimental::Impl::ViewMapping< Kokkos::Experimental::Impl::DynRankSubviewTag , Kokkos::Experimental::ViewTraits< D********, P... > , Args... >::ret_type //intel14 fix
+Subdynrankview< ViewTraits<D******** , P...> , Args... > //nicer looking return type //sacado
+subdynrankview( const Kokkos::Experimental::DynRankView< D , P... > &src , Args...args)
 {
   if ( src.rank() != sizeof...(Args) )
     { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
 
-  typedef Impl::ViewMapping< Impl::DynRankSubviewTag , Kokkos::Experimental::ViewTraits< D********, P... > , Args... > metafcn ;
+  typedef Kokkos::Experimental::Impl::ViewMapping< Kokkos::Experimental::Impl::DynRankSubviewTag , Kokkos::Experimental::ViewTraits< D********, P... > , Args... > metafcn ; //sacado
   return metafcn::subview( src.ConstDownCast() , args... );
 
 }

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -278,17 +278,6 @@ public:
     return *this;
   }
 
-/*
-  template< class RT , class ... RP >
-  KOKKOS_INLINE_FUNCTION
-  DynRankView & operator = (const View<RT********,RP...> & rhs )
-  {
-    view_type::operator = ( rhs );
-    m_rank = rhs.rank();
-    return *this;
-  }
-*/
-
   //----------------------------------------
   // Compatible subview constructor
   // may assign unmanaged from managed.
@@ -297,10 +286,16 @@ public:
   template< class RT , class ... RP >
   KOKKOS_INLINE_FUNCTION
   DynRankView( const Kokkos::Experimental::View<RT********,RP...> & rhs , unsigned RankVal )
-//    : view_type( rhs ) 
-//    , m_rank(RankVal)
-//    {}
-    { m_rank = RankVal; view_type::operator = (rhs); std::cout << "DRV ctor 1 and RankVal "<< RankVal << std::endl; }
+    : view_type( rhs ) 
+    , m_rank(RankVal)
+    {}
+/*
+    { 
+      m_rank = RankVal; 
+      view_type::operator = (rhs); 
+      std::cout << "DRV ctor 1 and RankVal "<< RankVal << std::endl;
+    }
+*/
 
   //----------------------------------------
   // Allocation tracking properties
@@ -340,6 +335,8 @@ public:
             : ( arg_layout.dimension[7] == 0 ? 7 
             : 8 ) ) ) ) ) ) )
             )  
+    {}
+/*
     {  std::cout << "DRV ctor 2"<<std::endl;
        std::cout << "  arg_layout dims \n" << arg_layout.dimension[0] << " "
                                            << arg_layout.dimension[1] << " "
@@ -350,6 +347,7 @@ public:
                                            << arg_layout.dimension[6] << " "
                                            << arg_layout.dimension[7] << std::endl;
     }
+*/
 
 //Wrappers
   template< class ... P >
@@ -382,7 +380,8 @@ public:
               : ( arg_layout.dimension[7] == 0 ? 7 
               : 8 ) ) ) ) ) ) )
             )  
-    {std::cout << "DRV ctor 3"<<std::endl;}
+    {}
+//    {std::cout << "DRV ctor 3"<<std::endl;}
 
   //----------------------------------------
   //Constructor(s)
@@ -406,7 +405,8 @@ public:
     , typename traits::array_layout
           ( arg_N0 , arg_N1 , arg_N2 , arg_N3 , arg_N4 , arg_N5 , arg_N6 , arg_N7 )
       )
-    {std::cout << "DRV ctor 4"<<std::endl;}
+    {}
+//    {std::cout << "DRV ctor 4"<<std::endl;}
 
   template< class ... P >
   explicit KOKKOS_INLINE_FUNCTION
@@ -426,7 +426,8 @@ public:
     , typename traits::array_layout
           ( arg_N0 , arg_N1 , arg_N2 , arg_N3 , arg_N4 , arg_N5 , arg_N6 , arg_N7 )
       )
-    {std::cout << "DRV ctor 5"<<std::endl;}
+    {}
+//    {std::cout << "DRV ctor 5"<<std::endl;}
 
   // Allocate with label and layout
   template< typename Label >
@@ -437,7 +438,8 @@ public:
           typename traits::array_layout >::type const & arg_layout
       )
     : DynRankView( Impl::ViewCtorProp< std::string >( arg_label ) , arg_layout )
-    {std::cout << "DRV ctor 6"<<std::endl;}
+    {}
+//    {std::cout << "DRV ctor 6"<<std::endl;}
 
   // Allocate label and layout, must disambiguate from subview constructor.
   template< typename Label >
@@ -458,7 +460,8 @@ public:
     , typename traits::array_layout
           ( arg_N0 , arg_N1 , arg_N2 , arg_N3 , arg_N4 , arg_N5 , arg_N6 , arg_N7 )
           )
-    {std::cout << "DRV ctor 7 \n"<<std::endl;}
+    {}
+//    {std::cout << "DRV ctor 7 \n"<<std::endl;}
 
   // For backward compatibility
 /*
@@ -485,7 +488,8 @@ public:
       , const size_t arg_N7 = 0
       )
     : DynRankView(Impl::ViewCtorProp< std::string , Kokkos::Experimental::Impl::WithoutInitializing_t >( arg_prop.label , Kokkos::Experimental::WithoutInitializing ), arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7 ) 
-    {std::cout << "DRV ctor 8"<<std::endl;}
+    {}
+//    {std::cout << "DRV ctor 8"<<std::endl;}
 
   using view_type::memory_span;
 
@@ -501,14 +505,16 @@ public:
       , const size_t arg_N7 = 0
       )
     : DynRankView( Impl::ViewCtorProp<pointer_type>(arg_ptr) , arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7 )
-    {std::cout << "DRV ctor 9"<<std::endl;}
+    {}
+//    {std::cout << "DRV ctor 9"<<std::endl;}
 
   explicit KOKKOS_INLINE_FUNCTION
   DynRankView( pointer_type arg_ptr
       , typename traits::array_layout & arg_layout
       )
     : DynRankView( Impl::ViewCtorProp<pointer_type>(arg_ptr) , arg_layout )
-    {std::cout << "DRV ctor 10"<<std::endl;}
+    {}
+//    {std::cout << "DRV ctor 10"<<std::endl;}
 
 
   //----------------------------------------
@@ -547,8 +553,8 @@ public:
              : ( arg_N7 == 0 ? 7 
              : 8 ) ) ) ) ) ) ) 
             ) 
-    {std::cout << "DRV ctor 11"<<std::endl;}
-
+    {}
+//    {std::cout << "DRV ctor 11"<<std::endl;}
 
 };
 
@@ -557,6 +563,8 @@ public:
   //original from View
 
 // Carter's
+// EXTENT_ONE_t removed
+/*
 template< typename T >
 typename std::conditional< std::is_integral<T>::value
                          , Kokkos::Experimental::Impl::EXTENT_ONE_t
@@ -569,446 +577,91 @@ variadic_sview_expansion( const T & i )
                          , Kokkos::Experimental::Impl::EXTENT_ONE_t
                          , const T & >::type( i );
 }
-
-
-// Attempt at expand function when numArgs < 8
-#if 0
-template< unsigned I , typename ... Args >
-Kokkos::Experimental::Impl::EXTENT_ONE_t 
-expand(Args ... args)
-{
-  return Kokkos::Experimental::Impl::EXTENT_ONE_t(0);
-}
-/*
-template< typename ... Args >
-Kokkos::Experimental::Impl::EXTENT_ONE_t 
-expand< 0 , Args... >(Args ... args)// void , Args ... args )
-{
-  return Kokkos::Experimental::Impl::EXTENT_ONE_t(0);
-}
 */
 
-template< typename T , typename ... Args >
-typename std::conditional< std::is_integral<T>::value
-                         , Kokkos::Experimental::Impl::EXTENT_ONE_t
-                         , const T & >::type
-expand< 0 , Args... >( const T & i , Args ... args)
-{
-  return 
-  typename std::conditional< std::is_integral<T>::value
-                         , Kokkos::Experimental::Impl::EXTENT_ONE_t
-                         , const T & >::type( i );
-}
 
-template< unsigned I , typename T , typename ... Args >
-typename std::conditional< std::is_integral<T>::value || std::is_same<T,void>::value
-                         , Kokkos::Experimental::Impl::EXTENT_ONE_t
-                         , const T & >::type
-expand( const T & i , Args ... args)
-{
-  return expand< I-1 , Args... > (args...);
-}
+//Possible direction:
+// Remove EXTENT_ONE_t
+// Cleanup ViewMapping changes ...
+template < class Traits , class Arg0 = int, class Arg1 = int, class Arg2 = int, class Arg3 = int, class Arg4 = int, class Arg5 = int, class Arg6 = int, class Arg7 = int >
+struct Subdynrankview {
 
-#endif
+  typedef typename Kokkos::Experimental::Impl::ViewMapping
+    < void
+    , Traits
+    , typename std::conditional<std::is_integral<Arg0>::value, Kokkos::pair<Arg0,Arg0> , Arg0>::type 
+    , typename std::conditional<std::is_integral<Arg1>::value, Kokkos::pair<Arg1,Arg1> , Arg1>::type 
+    , typename std::conditional<std::is_integral<Arg2>::value, Kokkos::pair<Arg2,Arg2> , Arg2>::type 
+    , typename std::conditional<std::is_integral<Arg3>::value, Kokkos::pair<Arg3,Arg3> , Arg3>::type 
+    , typename std::conditional<std::is_integral<Arg4>::value, Kokkos::pair<Arg4,Arg4> , Arg4>::type 
+    , typename std::conditional<std::is_integral<Arg5>::value, Kokkos::pair<Arg5,Arg5> , Arg5>::type 
+    , typename std::conditional<std::is_integral<Arg6>::value, Kokkos::pair<Arg6,Arg6> , Arg6>::type 
+    , typename std::conditional<std::is_integral<Arg7>::value, Kokkos::pair<Arg7,Arg7> , Arg7>::type 
+    >::type ViewType ;
 
+  //typedef typename Kokkos::Experimental::Impl::ViewMapping < void , Traits , Args... >::type ViewType ;
+//  typedef typename Kokkos::Experimental::Impl::ViewMapping < void , Traits , Arg0 , Arg1 , Arg2 , Arg3 , Arg4 , Arg5 , Arg6 , Arg7 >::type ViewType ;
 
+  typedef DynRankView< typename ViewType::value_type , typename ViewType::array_layout , typename ViewType::device_type , typename ViewType::memory_traits >  type;
 
-/*
-template <class C , class T>
-C variadic_sview_expansion(T i);
+//Pass whole collection of args to a function with a rank number, 
+// scan through list for non-integer entry greater than or equal to rank
+// pass through; if no more remaining non-integer return the pair
+// Would be nice to have something like a stack to add args to, pop them off until non-integer reached
 
-template <>
-Kokkos::Experimental::Impl::ALL_t variadic_sview_expansion<Kokkos::Experimental::Impl::ALL_t>
-( Kokkos::Experimental::Impl::ALL_t var_all ) { return var_all(); }
+  template< typename T >
+  static typename std::enable_if< std::is_integral<T>::value ,Kokkos::pair<T,T> >::type
+  KOKKOS_INLINE_FUNCTION
+  convert ( const T & i ) 
+  { 
+    return
+    Kokkos::pair<T,T>( i , i+1 );
+  }
+  
+  template< typename T >
+  static typename std::enable_if< !std::is_integral<T>::value , const T & >::type
+  KOKKOS_INLINE_FUNCTION
+  convert ( const T & i ) 
+  { 
+    return i;
+  }
+  
 
-template <>
-Kokkos::pair<size_t,size_t> variadic_sview_expansion( const Kokkos::pair<size_t,size_t> var_pair ) { return var_pair; }
-
-template <>
-typename Kokkos::Experimental::Impl::EXTENT_ONE_t variadic_sview_expansion< Kokkos::Experimental::Impl::EXTENT_ONE_t >( const size_t i ) { return Kokkos::Experimental::Impl::EXTENT_ONE_t(i); }
-
-*/
-
-#if 0
-template < unsigned I , class ... Args >
-struct VarArgs;
-
-//template < unsigned I , class Arg0 , class ... Args >
-template < class Arg0 , class ... Args >
-struct VarArgs< 0 , Arg0 , Args... > 
-{
-  std::conditional< !std::is_same<Arg0 , void>::value , Arg0 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
-
-  VarArgs( std::enable_if< !std::is_same<Arg0 , void>::value , Arg0>::type arg_ , Args ... args)
-    : arg(arg_) {}
-
-  VarArgs( std::enable_if< std::is_same<Arg0 , void>::value >::type arg_ , Args ... args)
-    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
-
-  std::conditional< !std::is_same<Arg0 , void>::value , Arg0 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
-  operator()()
+  template < class T , class ... P >
+  static type subview( const Kokkos::Experimental::View<T******** , P... > & InputView , Arg0 arg0 = Arg0(), Arg1 arg1 = Arg1(), Arg2 arg2 = Arg2(), Arg3 arg3 = Arg3(), Arg4 arg4 = Arg4(), Arg5 arg5 = Arg5(), Arg6 arg6 = Arg6(), Arg7 arg7 = Arg7() )
   {
-    return arg;
+    const unsigned numArgs = unsigned(!std::is_integral<Arg0>::value) 
+                           + unsigned(!std::is_integral<Arg1>::value) 
+                           + unsigned(!std::is_integral<Arg2>::value) 
+                           + unsigned(!std::is_integral<Arg3>::value) 
+                           + unsigned(!std::is_integral<Arg4>::value) 
+                           + unsigned(!std::is_integral<Arg5>::value) 
+                           + unsigned(!std::is_integral<Arg6>::value) 
+                           + unsigned(!std::is_integral<Arg7>::value) ;
+
+    return type( Kokkos::Experimental::subview( InputView , convert(arg0) , convert(arg1) , convert(arg2) , convert(arg3) , convert(arg4) , convert(arg5) , convert(arg6) , convert(arg7) ) , numArgs );
   }
 
-}
-
-//template < unsigned I , class Arg0 , class Arg1 , class ... Args >
-template < class Arg0 , class Arg1 , class ... Args >
-struct VarArgs< 1 > 
-{
-  std::conditional< !std::is_same<Arg1 , void>::value , Arg1 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
-
-  VarArgs( Arg0 arg0 , std::enable_if< !std::is_same<Arg1 , void>::value , Arg1>::type arg_ , Args ... args)
-    : arg(arg_) {}
-
-  VarArgs( Arg0 arg0 , std::enable_if< std::is_same<Arg1 , void>::value >::type arg_ , Args ... args)
-    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
-
-  std::conditional< !std::is_same<Arg1 , void>::value , Arg1 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
-  operator()()
-  {
-    return arg;
-  }
-}
-
-//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class ... Args >
-template < class Arg0 , class Arg1 , class Arg2 , class ... Args >
-struct VarArgs< 2 > 
-{
-  std::conditional< !std::is_same<Arg2 , void>::value , Arg2 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , std::enable_if< !std::is_same<Arg2 , void>::value , Arg2>::type arg_ , Args ... args)
-    : arg(arg_) {}
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , std::enable_if< std::is_same<Arg2 , void>::value >::type arg_ , Args ... args)
-    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
-
-  std::conditional< !std::is_same<Arg2 , void>::value , Arg2 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
-  operator()()
-  {
-    return arg;
-  }
-}
-
-//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class ... Args >
-template < class Arg0 , class Arg1 , class Arg2 , class Arg3 , class ... Args >
-struct VarArgs< 3 > 
-{
-  std::conditional< !std::is_same<Arg3 , void>::value , Arg3 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , std::enable_if< !std::is_same<Arg3 , void>::value , Arg3>::type arg_ , Args ... args)
-    : arg(arg_) {}
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , std::enable_if< std::is_same<Arg3 , void>::value >::type arg_ , Args ... args)
-    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
-
-  std::conditional< !std::is_same<Arg3 , void>::value , Arg3 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
-  operator()()
-  {
-    return arg;
-  }
-}
-
-//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class ... Args >
-template < class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class ... Args >
-struct VarArgs< 4 > 
-{
-  std::conditional< !std::is_same<Arg4 , void>::value , Arg4 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , std::enable_if< !std::is_same<Arg4 , void>::value , Arg4>::type arg_ , Args ... args)
-    : arg(arg_) {}
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , std::enable_if< std::is_same<Arg4 , void>::value >::type arg_ , Args ... args)
-    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
-
-  std::conditional< !std::is_same<Arg4 , void>::value , Arg4 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
-  operator()()
-  {
-    return arg;
-  }
-}
-
-//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class ... Args >
-template < class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class ... Args >
-struct VarArgs< 5 > 
-{
-  std::conditional< !std::is_same<Arg5 , void>::value , Arg5 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , std::enable_if< !std::is_same<Arg5 , void>::value , Arg5>::type arg_ , Args ... args)
-    : arg(arg_) {}
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , std::enable_if< std::is_same<Arg5 , void>::value >::type arg_ , Args ... args)
-    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
-
-  std::conditional< !std::is_same<Arg5 , void>::value , Arg5 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
-  operator()()
-  {
-    return arg;
-  }
-}
-
-//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 , class ... Args >
-template < class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 , class ... Args >
-struct VarArgs< 6 > 
-{
-  std::conditional< !std::is_same<Arg6 , void>::value , Arg6 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , std::enable_if< !std::is_same<Arg6 , void>::value , Arg6>::type arg_ , Args ... args)
-    : arg(arg_) {}
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , std::enable_if< std::is_same<Arg6 , void>::value >::type arg_ , Args ... args)
-    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
-
-  std::conditional< !std::is_same<Arg6 , void>::value , Arg6 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
-  operator()()
-  {
-    return arg;
-  }
-}
-
-//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 , class Arg7 , class ... Args >
-template < class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 , class Arg7 , class ... Args >
-struct VarArgs< 7 > 
-{
-  std::conditional< !std::is_same<Arg7 , void>::value , Arg7 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , Arg6 arg6 , std::enable_if< !std::is_same<Arg7 , void>::value , Arg7>::type arg_ , Args ... args)
-    : arg(arg_) {}
-
-  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , Arg6 arg6 , std::enable_if< std::is_same<Arg7 , void>::value >::type arg_ , Args ... args)
-    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
-
-  std::conditional< !std::is_same<Arg7 , void>::value , Arg7 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
-  operator()()
-  {
-    return arg;
-  }
-}
-
-#endif
+};
 
 
-template< class D, class ... P , typename iType >
+// Carter's idea
+template< class D , class ... P , class ...Args >
 KOKKOS_INLINE_FUNCTION
-DynRankView< D , P... >
-subdynrankview( const DynRankView< D, P... > & src , typename std::enable_if< std::is_integral<iType>::value, iType>::type arg0 )
+typename Subdynrankview< Kokkos::Experimental::ViewTraits< D********, P... > , Args... >::type
+subdynrankview( const DynRankView< D , P... > &src , Args...args)
 {
-  const unsigned numArgs = 0;
-  std::cout<< " 0 dyn rank rank "<<src.rank()<<std::endl;
-  if ( src.rank() != 0 )
+  if ( src.rank() != sizeof...(Args) )
     { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
 
-  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
+typedef Subdynrankview< Kokkos::Experimental::ViewTraits< D********, P... > , Args... > metafcn;
+return 
+//typename metafcn::subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... );
+metafcn::subview( src.ConstDownCast() , args... );
 
-  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<iType>(arg0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
-}
-
-template< class D, class ... P , class Arg0 >
-KOKKOS_INLINE_FUNCTION
-DynRankView< D , P... > 
-subdynrankview( const DynRankView< D, P... > & src , typename std::enable_if< !std::is_integral<Arg0>::value, Arg0>::type arg0 )
-{
-  const unsigned numArgs = 1;
-  std::cout<< " 1 dyn rank rank "<<src.rank()<<std::endl;
-  if ( src.rank() != 1 )
-    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
-
-  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
-
-  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
-}
-
-template< class D, class ... P , class Arg0 , class Arg1 >
-KOKKOS_INLINE_FUNCTION
-DynRankView< D , P... >
-subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 )
-{
-  const unsigned numArgs = 2;
-  std::cout<< " 2 dyn rank rank "<<src.rank()<<std::endl;
-  if ( src.rank() != 2 )
-    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
-
-  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
-
-  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
-}
-
-template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 >
-KOKKOS_INLINE_FUNCTION
-DynRankView< D , P... >
-subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 )
-{
-  const unsigned numArgs = 3;
-  std::cout<< " 3 dyn rank rank "<<src.rank()<<std::endl;
-  if ( src.rank() != 3 )
-    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
-
-  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
-
-  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
-}
-
-template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 , class Arg3 >
-KOKKOS_INLINE_FUNCTION
-DynRankView< D , P... >
-subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 )
-{
-  const unsigned numArgs = 4;
-  std::cout<< " 4 dyn rank rank "<<src.rank()<<std::endl;
-  if ( src.rank() != 4 )
-    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
-
-  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
-
-  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , variadic_sview_expansion<Arg3>(arg3) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
-}
-
-template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 >
-KOKKOS_INLINE_FUNCTION
-DynRankView< D , P... >
-subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 )
-{
-  const unsigned numArgs = 5;
-  std::cout<< " 5 dyn rank rank "<<src.rank()<<std::endl;
-  if ( src.rank() != 5 )
-    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
-
-  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
-
-  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , variadic_sview_expansion<Arg3>(arg3) , variadic_sview_expansion<Arg4>(arg4) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
-}
-
-template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 >
-KOKKOS_INLINE_FUNCTION
-DynRankView< D , P... >
-subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 )
-{
-  const unsigned numArgs = 6;
-  std::cout<< " 6 dyn rank rank "<<src.rank()<<std::endl;
-  static_assert( src.rank() == 6 , "Rank is not compatible");
-
-  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
-
-  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , variadic_sview_expansion<Arg3>(arg3) , variadic_sview_expansion<Arg4>(arg4) , variadic_sview_expansion<Arg5>(arg5) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
-}
-
-template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 >
-KOKKOS_INLINE_FUNCTION
-DynRankView< D , P... >
-subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , Arg6 arg6 )
-{
-  const unsigned numArgs = 7;
-  std::cout<< " 7 dyn rank rank "<<src.rank()<<std::endl;
-  if ( src.rank() != 7 )
-    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
-
-  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
-
-  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , variadic_sview_expansion<Arg3>(arg3) , variadic_sview_expansion<Arg4>(arg4) , variadic_sview_expansion<Arg5>(arg5) , variadic_sview_expansion<Arg6>(arg6) , EXTENT_ONE_t(0)) , numArgs ); 
-}
-
-template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 , class Arg7 >
-KOKKOS_INLINE_FUNCTION
-DynRankView< D , P... >
-subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , Arg6 arg6 , Arg7 arg7 )
-{
-  const unsigned numArgs = 8;
-  std::cout<< " 8 dyn rank rank "<<src.rank()<<std::endl;
-  if ( src.rank() != 8 )
-    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
-
-  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
-
-  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , variadic_sview_expansion<Arg3>(arg3) , variadic_sview_expansion<Arg4>(arg4) , variadic_sview_expansion<Arg5>(arg5) , variadic_sview_expansion<Arg6>(arg6) , variadic_sview_expansion<Arg7>(arg7)) , numArgs ); 
 }
 
 // ************************************************** //
-#define FIRSTVER 0
-#if FIRSTVER
-template< class D, class ... P , class ... Args >
-KOKKOS_INLINE_FUNCTION
-DynRankView< D , P... > //change the P... to match subview return type
-subview( const DynRankView< D, P... > & src , Args ... args )
-{
-  static const unsigned numArgs = sizeof...(Args);
-
-  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
-
-// API intended
-#define TESTONE 1
-#if TESTONE
-  std::cout << " numArgs in subview (dr) is " << numArgs <<std::endl;
-
-//may need some sort of 'std::enable_if' functionality, or suggested'expand<I>(args...)' routine
-#if 0
-  if ( numArgs == 7 )
-  { 
-//    static const unsigned totalArgs = sizeof...(Args , EXTENT_ONE_t);
-//    static_assert( totalArgs == 8 , "total concatenated args != 8 ");
-
-    typename Kokkos::Experimental::Impl::ViewMapping<void , Kokkos::Experimental::ViewTraits< D******** , P... > , Args ... , EXTENT_ONE_t >::type 
-  //sview = subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)...  ); 
-    sview = subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... , EXTENT_ONE_t(0) ); 
-
-//    static_assert( sview.rank == 8 , "subview rank did not return 8...");
-
-      return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... , EXTENT_ONE_t(0) ) , numArgs );
-  }
-#endif
-
-  if ( numArgs == 8 )
-  { 
-    typename Kokkos::Experimental::Impl::ViewMapping<void , Kokkos::Experimental::ViewTraits< D******** , P... > , Args ...>::type 
-    sview = subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... );
-//    static_assert( sview.rank == 8 , "subview rank did not return 8...");
-
-      return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... ) , numArgs ); 
-  }
-
-//     return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... ) , numArgs ); 
-
-/*
-  if ( numArgs == 0 )
-    { return DynRankView< D , P... >( subview( src.ConstDownCast() , EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0)  ) , numArgs ); }
-
-  else if ( numArgs == 1 )
-    { return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)..., EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0) ) , numArgs ); }
-
-  else if ( numArgs == 2 )
-    { return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)..., EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0) ) , numArgs ); }
-
-  else if ( numArgs == 3 )
-    { return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)..., EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0) ) , numArgs ); }
-
-  else if ( numArgs == 4 )
-    { return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)..., EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0) ) , numArgs ); }
-
-  else if ( numArgs == 5 )
-//    { std::cout << " in numArgs 5 " << std::endl; return DynRankView<D , P... >() ; }
-    { return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)..., EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0) ) , numArgs ); }
-
-  else if ( numArgs == 6 )
-    { return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)..., EXTENT_ONE_t(0),EXTENT_ONE_t(0) ) , numArgs ); }
-
-  else if ( numArgs == 7 )
-    { return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)..., EXTENT_ONE_t(0) ) , numArgs ); }
-
-  else if ( numArgs == 8 )
-    { return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... ) , numArgs ); }
-*/
-#else 
-// api second attempt - retrieve subview first to interrogate
-  typename Kokkos::Experimental::Impl::ViewMapping<void , Kokkos::Experimental::ViewTraits< D******** , P... > , Args ...>::type 
-  sview = subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)...); 
-  static_assert( sview.rank == 8 , "subview rank did not return 8...");
-  return DynRankView<D,P...>(sview , numArgs);
-#endif
-#undef TESTONE
-
-} //end subview
-#endif //end FIRSTVER
-#undef FIRSTVER
 
 } // namespace Experimental
 } // namespace Kokkos

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -300,7 +300,7 @@ public:
 //    : view_type( rhs ) 
 //    , m_rank(RankVal)
 //    {}
-    { m_rank = RankVal; view_type::operator = (rhs); }
+    { m_rank = RankVal; view_type::operator = (rhs); std::cout << "DRV ctor 1 and RankVal "<< RankVal << std::endl; }
 
   //----------------------------------------
   // Allocation tracking properties
@@ -340,7 +340,16 @@ public:
             : ( arg_layout.dimension[7] == 0 ? 7 
             : 8 ) ) ) ) ) ) )
             )  
-    {}
+    {  std::cout << "DRV ctor 2"<<std::endl;
+       std::cout << "  arg_layout dims \n" << arg_layout.dimension[0] << " "
+                                           << arg_layout.dimension[1] << " "
+                                           << arg_layout.dimension[2] << " "
+                                           << arg_layout.dimension[3] << " "
+                                           << arg_layout.dimension[4] << " "
+                                           << arg_layout.dimension[5] << " "
+                                           << arg_layout.dimension[6] << " "
+                                           << arg_layout.dimension[7] << std::endl;
+    }
 
 //Wrappers
   template< class ... P >
@@ -373,7 +382,7 @@ public:
               : ( arg_layout.dimension[7] == 0 ? 7 
               : 8 ) ) ) ) ) ) )
             )  
-    {}
+    {std::cout << "DRV ctor 3"<<std::endl;}
 
   //----------------------------------------
   //Constructor(s)
@@ -397,7 +406,7 @@ public:
     , typename traits::array_layout
           ( arg_N0 , arg_N1 , arg_N2 , arg_N3 , arg_N4 , arg_N5 , arg_N6 , arg_N7 )
       )
-    {}
+    {std::cout << "DRV ctor 4"<<std::endl;}
 
   template< class ... P >
   explicit KOKKOS_INLINE_FUNCTION
@@ -417,7 +426,7 @@ public:
     , typename traits::array_layout
           ( arg_N0 , arg_N1 , arg_N2 , arg_N3 , arg_N4 , arg_N5 , arg_N6 , arg_N7 )
       )
-    {}
+    {std::cout << "DRV ctor 5"<<std::endl;}
 
   // Allocate with label and layout
   template< typename Label >
@@ -428,7 +437,7 @@ public:
           typename traits::array_layout >::type const & arg_layout
       )
     : DynRankView( Impl::ViewCtorProp< std::string >( arg_label ) , arg_layout )
-    {}
+    {std::cout << "DRV ctor 6"<<std::endl;}
 
   // Allocate label and layout, must disambiguate from subview constructor.
   template< typename Label >
@@ -449,7 +458,7 @@ public:
     , typename traits::array_layout
           ( arg_N0 , arg_N1 , arg_N2 , arg_N3 , arg_N4 , arg_N5 , arg_N6 , arg_N7 )
           )
-    {}
+    {std::cout << "DRV ctor 7 \n"<<std::endl;}
 
   // For backward compatibility
 /*
@@ -476,7 +485,7 @@ public:
       , const size_t arg_N7 = 0
       )
     : DynRankView(Impl::ViewCtorProp< std::string , Kokkos::Experimental::Impl::WithoutInitializing_t >( arg_prop.label , Kokkos::Experimental::WithoutInitializing ), arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7 ) 
-    {}
+    {std::cout << "DRV ctor 8"<<std::endl;}
 
   using view_type::memory_span;
 
@@ -492,14 +501,14 @@ public:
       , const size_t arg_N7 = 0
       )
     : DynRankView( Impl::ViewCtorProp<pointer_type>(arg_ptr) , arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7 )
-    {}
+    {std::cout << "DRV ctor 9"<<std::endl;}
 
   explicit KOKKOS_INLINE_FUNCTION
   DynRankView( pointer_type arg_ptr
       , typename traits::array_layout & arg_layout
       )
     : DynRankView( Impl::ViewCtorProp<pointer_type>(arg_ptr) , arg_layout )
-    {}
+    {std::cout << "DRV ctor 10"<<std::endl;}
 
 
   //----------------------------------------
@@ -538,7 +547,7 @@ public:
              : ( arg_N7 == 0 ? 7 
              : 8 ) ) ) ) ) ) ) 
             ) 
-    {}
+    {std::cout << "DRV ctor 11"<<std::endl;}
 
 
 };
@@ -546,19 +555,6 @@ public:
   //----------------------------------------
   //using Subview...
   //original from View
-
-//Need to know the type that is coming in, create a base templated function before specializations
-//KOKKOS_INLINE_FUNCTION
-//constexpr const Kokkos::Experimental::Impl::ALL_t variadic_sview_expansion( const Kokkos::Experimental::Impl::ALL_t & var_all ) { return var_all; }
-//template < class tm >
-//constexpr tm variadic_sview_expansion()
-//{}
-
-//template <class C, class iType = void>
-
-//template <class C>
-//C variadic_sview_expansion( C i ) {return i;}
-
 
 // Carter's
 template< typename T >
@@ -573,6 +569,49 @@ variadic_sview_expansion( const T & i )
                          , Kokkos::Experimental::Impl::EXTENT_ONE_t
                          , const T & >::type( i );
 }
+
+
+// Attempt at expand function when numArgs < 8
+#if 0
+template< unsigned I , typename ... Args >
+Kokkos::Experimental::Impl::EXTENT_ONE_t 
+expand(Args ... args)
+{
+  return Kokkos::Experimental::Impl::EXTENT_ONE_t(0);
+}
+/*
+template< typename ... Args >
+Kokkos::Experimental::Impl::EXTENT_ONE_t 
+expand< 0 , Args... >(Args ... args)// void , Args ... args )
+{
+  return Kokkos::Experimental::Impl::EXTENT_ONE_t(0);
+}
+*/
+
+template< typename T , typename ... Args >
+typename std::conditional< std::is_integral<T>::value
+                         , Kokkos::Experimental::Impl::EXTENT_ONE_t
+                         , const T & >::type
+expand< 0 , Args... >( const T & i , Args ... args)
+{
+  return 
+  typename std::conditional< std::is_integral<T>::value
+                         , Kokkos::Experimental::Impl::EXTENT_ONE_t
+                         , const T & >::type( i );
+}
+
+template< unsigned I , typename T , typename ... Args >
+typename std::conditional< std::is_integral<T>::value || std::is_same<T,void>::value
+                         , Kokkos::Experimental::Impl::EXTENT_ONE_t
+                         , const T & >::type
+expand( const T & i , Args ... args)
+{
+  return expand< I-1 , Args... > (args...);
+}
+
+#endif
+
+
 
 /*
 template <class C , class T>
@@ -590,26 +629,309 @@ typename Kokkos::Experimental::Impl::EXTENT_ONE_t variadic_sview_expansion< Kokk
 
 */
 
+#if 0
+template < unsigned I , class ... Args >
+struct VarArgs;
 
+//template < unsigned I , class Arg0 , class ... Args >
+template < class Arg0 , class ... Args >
+struct VarArgs< 0 , Arg0 , Args... > 
+{
+  std::conditional< !std::is_same<Arg0 , void>::value , Arg0 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
+
+  VarArgs( std::enable_if< !std::is_same<Arg0 , void>::value , Arg0>::type arg_ , Args ... args)
+    : arg(arg_) {}
+
+  VarArgs( std::enable_if< std::is_same<Arg0 , void>::value >::type arg_ , Args ... args)
+    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
+
+  std::conditional< !std::is_same<Arg0 , void>::value , Arg0 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
+  operator()()
+  {
+    return arg;
+  }
+
+}
+
+//template < unsigned I , class Arg0 , class Arg1 , class ... Args >
+template < class Arg0 , class Arg1 , class ... Args >
+struct VarArgs< 1 > 
+{
+  std::conditional< !std::is_same<Arg1 , void>::value , Arg1 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
+
+  VarArgs( Arg0 arg0 , std::enable_if< !std::is_same<Arg1 , void>::value , Arg1>::type arg_ , Args ... args)
+    : arg(arg_) {}
+
+  VarArgs( Arg0 arg0 , std::enable_if< std::is_same<Arg1 , void>::value >::type arg_ , Args ... args)
+    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
+
+  std::conditional< !std::is_same<Arg1 , void>::value , Arg1 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
+  operator()()
+  {
+    return arg;
+  }
+}
+
+//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class ... Args >
+template < class Arg0 , class Arg1 , class Arg2 , class ... Args >
+struct VarArgs< 2 > 
+{
+  std::conditional< !std::is_same<Arg2 , void>::value , Arg2 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , std::enable_if< !std::is_same<Arg2 , void>::value , Arg2>::type arg_ , Args ... args)
+    : arg(arg_) {}
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , std::enable_if< std::is_same<Arg2 , void>::value >::type arg_ , Args ... args)
+    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
+
+  std::conditional< !std::is_same<Arg2 , void>::value , Arg2 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
+  operator()()
+  {
+    return arg;
+  }
+}
+
+//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class ... Args >
+template < class Arg0 , class Arg1 , class Arg2 , class Arg3 , class ... Args >
+struct VarArgs< 3 > 
+{
+  std::conditional< !std::is_same<Arg3 , void>::value , Arg3 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , std::enable_if< !std::is_same<Arg3 , void>::value , Arg3>::type arg_ , Args ... args)
+    : arg(arg_) {}
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , std::enable_if< std::is_same<Arg3 , void>::value >::type arg_ , Args ... args)
+    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
+
+  std::conditional< !std::is_same<Arg3 , void>::value , Arg3 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
+  operator()()
+  {
+    return arg;
+  }
+}
+
+//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class ... Args >
+template < class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class ... Args >
+struct VarArgs< 4 > 
+{
+  std::conditional< !std::is_same<Arg4 , void>::value , Arg4 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , std::enable_if< !std::is_same<Arg4 , void>::value , Arg4>::type arg_ , Args ... args)
+    : arg(arg_) {}
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , std::enable_if< std::is_same<Arg4 , void>::value >::type arg_ , Args ... args)
+    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
+
+  std::conditional< !std::is_same<Arg4 , void>::value , Arg4 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
+  operator()()
+  {
+    return arg;
+  }
+}
+
+//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class ... Args >
+template < class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class ... Args >
+struct VarArgs< 5 > 
+{
+  std::conditional< !std::is_same<Arg5 , void>::value , Arg5 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , std::enable_if< !std::is_same<Arg5 , void>::value , Arg5>::type arg_ , Args ... args)
+    : arg(arg_) {}
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , std::enable_if< std::is_same<Arg5 , void>::value >::type arg_ , Args ... args)
+    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
+
+  std::conditional< !std::is_same<Arg5 , void>::value , Arg5 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
+  operator()()
+  {
+    return arg;
+  }
+}
+
+//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 , class ... Args >
+template < class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 , class ... Args >
+struct VarArgs< 6 > 
+{
+  std::conditional< !std::is_same<Arg6 , void>::value , Arg6 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , std::enable_if< !std::is_same<Arg6 , void>::value , Arg6>::type arg_ , Args ... args)
+    : arg(arg_) {}
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , std::enable_if< std::is_same<Arg6 , void>::value >::type arg_ , Args ... args)
+    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
+
+  std::conditional< !std::is_same<Arg6 , void>::value , Arg6 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
+  operator()()
+  {
+    return arg;
+  }
+}
+
+//template < unsigned I , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 , class Arg7 , class ... Args >
+template < class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 , class Arg7 , class ... Args >
+struct VarArgs< 7 > 
+{
+  std::conditional< !std::is_same<Arg7 , void>::value , Arg7 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type arg;
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , Arg6 arg6 , std::enable_if< !std::is_same<Arg7 , void>::value , Arg7>::type arg_ , Args ... args)
+    : arg(arg_) {}
+
+  VarArgs( Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , Arg6 arg6 , std::enable_if< std::is_same<Arg7 , void>::value >::type arg_ , Args ... args)
+    : arg( Kokkos::Experimental::Impl::EXTENT_ONE_t(0) ) {}
+
+  std::conditional< !std::is_same<Arg7 , void>::value , Arg7 , Kokkos::Experimental::Impl::EXTENT_ONE_t >::type 
+  operator()()
+  {
+    return arg;
+  }
+}
+
+#endif
+
+
+template< class D, class ... P , typename iType >
+KOKKOS_INLINE_FUNCTION
+DynRankView< D , P... >
+subdynrankview( const DynRankView< D, P... > & src , typename std::enable_if< std::is_integral<iType>::value, iType>::type arg0 )
+{
+  const unsigned numArgs = 0;
+  std::cout<< " 0 dyn rank rank "<<src.rank()<<std::endl;
+  if ( src.rank() != 0 )
+    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
+
+  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
+
+  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<iType>(arg0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
+}
+
+template< class D, class ... P , class Arg0 >
+KOKKOS_INLINE_FUNCTION
+DynRankView< D , P... > 
+subdynrankview( const DynRankView< D, P... > & src , typename std::enable_if< !std::is_integral<Arg0>::value, Arg0>::type arg0 )
+{
+  const unsigned numArgs = 1;
+  std::cout<< " 1 dyn rank rank "<<src.rank()<<std::endl;
+  if ( src.rank() != 1 )
+    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
+
+  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
+
+  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
+}
+
+template< class D, class ... P , class Arg0 , class Arg1 >
+KOKKOS_INLINE_FUNCTION
+DynRankView< D , P... >
+subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 )
+{
+  const unsigned numArgs = 2;
+  std::cout<< " 2 dyn rank rank "<<src.rank()<<std::endl;
+  if ( src.rank() != 2 )
+    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
+
+  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
+
+  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
+}
+
+template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 >
+KOKKOS_INLINE_FUNCTION
+DynRankView< D , P... >
+subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 )
+{
+  const unsigned numArgs = 3;
+  std::cout<< " 3 dyn rank rank "<<src.rank()<<std::endl;
+  if ( src.rank() != 3 )
+    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
+
+  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
+
+  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
+}
+
+template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 , class Arg3 >
+KOKKOS_INLINE_FUNCTION
+DynRankView< D , P... >
+subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 )
+{
+  const unsigned numArgs = 4;
+  std::cout<< " 4 dyn rank rank "<<src.rank()<<std::endl;
+  if ( src.rank() != 4 )
+    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
+
+  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
+
+  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , variadic_sview_expansion<Arg3>(arg3) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
+}
+
+template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 >
+KOKKOS_INLINE_FUNCTION
+DynRankView< D , P... >
+subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 )
+{
+  const unsigned numArgs = 5;
+  std::cout<< " 5 dyn rank rank "<<src.rank()<<std::endl;
+  if ( src.rank() != 5 )
+    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
+
+  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
+
+  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , variadic_sview_expansion<Arg3>(arg3) , variadic_sview_expansion<Arg4>(arg4) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
+}
+
+template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 >
+KOKKOS_INLINE_FUNCTION
+DynRankView< D , P... >
+subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 )
+{
+  const unsigned numArgs = 6;
+  std::cout<< " 6 dyn rank rank "<<src.rank()<<std::endl;
+  static_assert( src.rank() == 6 , "Rank is not compatible");
+
+  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
+
+  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , variadic_sview_expansion<Arg3>(arg3) , variadic_sview_expansion<Arg4>(arg4) , variadic_sview_expansion<Arg5>(arg5) , EXTENT_ONE_t(0) , EXTENT_ONE_t(0)) , numArgs ); 
+}
+
+template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 >
+KOKKOS_INLINE_FUNCTION
+DynRankView< D , P... >
+subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , Arg6 arg6 )
+{
+  const unsigned numArgs = 7;
+  std::cout<< " 7 dyn rank rank "<<src.rank()<<std::endl;
+  if ( src.rank() != 7 )
+    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
+
+  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
+
+  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , variadic_sview_expansion<Arg3>(arg3) , variadic_sview_expansion<Arg4>(arg4) , variadic_sview_expansion<Arg5>(arg5) , variadic_sview_expansion<Arg6>(arg6) , EXTENT_ONE_t(0)) , numArgs ); 
+}
+
+template< class D, class ... P , class Arg0 , class Arg1 , class Arg2 , class Arg3 , class Arg4 , class Arg5 , class Arg6 , class Arg7 >
+KOKKOS_INLINE_FUNCTION
+DynRankView< D , P... >
+subdynrankview( const DynRankView< D, P... > & src , Arg0 arg0 , Arg1 arg1 , Arg2 arg2 , Arg3 arg3 , Arg4 arg4 , Arg5 arg5 , Arg6 arg6 , Arg7 arg7 )
+{
+  const unsigned numArgs = 8;
+  std::cout<< " 8 dyn rank rank "<<src.rank()<<std::endl;
+  if ( src.rank() != 8 )
+    { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
+
+  typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
+
+  return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Arg0>(arg0) , variadic_sview_expansion<Arg1>(arg1) , variadic_sview_expansion<Arg2>(arg2) , variadic_sview_expansion<Arg3>(arg3) , variadic_sview_expansion<Arg4>(arg4) , variadic_sview_expansion<Arg5>(arg5) , variadic_sview_expansion<Arg6>(arg6) , variadic_sview_expansion<Arg7>(arg7)) , numArgs ); 
+}
+
+// ************************************************** //
+#define FIRSTVER 0
+#if FIRSTVER
 template< class D, class ... P , class ... Args >
 KOKKOS_INLINE_FUNCTION
 DynRankView< D , P... > //change the P... to match subview return type
 subview( const DynRankView< D, P... > & src , Args ... args )
 {
-  unsigned numArgs = sizeof...(Args);
-
-//First attempt - works if 'receiving' DynRankView matches properties of the subview
-//  auto bview = src.ConstDownCast();
-    //  auto dsview = subview(bview , args...);
-//  return DynRankView< D , P... >( subview( bview , args...) , numArgs ); 
-//  return DynRankView< D , P... >( subview( src.ConstDownCast(), args...) , numArgs ); 
-//old
-    //return DynRankView< D , P... >( (const typename DynRankView<D,P...>::view_type)( subview( src.ConstDownCast(),args...) ) , numArgs ); 
-
-//Attempted fix - works, more verbose
-//  typename Kokkos::Experimental::Impl::ViewMapping<void , Kokkos::Experimental::ViewTraits< D******** , P... > , Args ...>::type 
-//  sview = subview( bview , args...); 
-//  return DynRankView< D , P... >(sview , numArgs);
+  static const unsigned numArgs = sizeof...(Args);
 
   typedef typename Kokkos::Experimental::Impl::EXTENT_ONE_t  EXTENT_ONE_t;
 
@@ -618,7 +940,34 @@ subview( const DynRankView< D, P... > & src , Args ... args )
 #if TESTONE
   std::cout << " numArgs in subview (dr) is " << numArgs <<std::endl;
 
-     return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... ) , numArgs ); 
+//may need some sort of 'std::enable_if' functionality, or suggested'expand<I>(args...)' routine
+#if 0
+  if ( numArgs == 7 )
+  { 
+//    static const unsigned totalArgs = sizeof...(Args , EXTENT_ONE_t);
+//    static_assert( totalArgs == 8 , "total concatenated args != 8 ");
+
+    typename Kokkos::Experimental::Impl::ViewMapping<void , Kokkos::Experimental::ViewTraits< D******** , P... > , Args ... , EXTENT_ONE_t >::type 
+  //sview = subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)...  ); 
+    sview = subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... , EXTENT_ONE_t(0) ); 
+
+//    static_assert( sview.rank == 8 , "subview rank did not return 8...");
+
+      return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... , EXTENT_ONE_t(0) ) , numArgs );
+  }
+#endif
+
+  if ( numArgs == 8 )
+  { 
+    typename Kokkos::Experimental::Impl::ViewMapping<void , Kokkos::Experimental::ViewTraits< D******** , P... > , Args ...>::type 
+    sview = subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... );
+//    static_assert( sview.rank == 8 , "subview rank did not return 8...");
+
+      return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... ) , numArgs ); 
+  }
+
+//     return DynRankView< D , P... >( subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... ) , numArgs ); 
+
 /*
   if ( numArgs == 0 )
     { return DynRankView< D , P... >( subview( src.ConstDownCast() , EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0),EXTENT_ONE_t(0)  ) , numArgs ); }
@@ -658,7 +1007,8 @@ subview( const DynRankView< D, P... > & src , Args ... args )
 #undef TESTONE
 
 } //end subview
-
+#endif //end FIRSTVER
+#undef FIRSTVER
 
 } // namespace Experimental
 } // namespace Kokkos

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -580,6 +580,178 @@ variadic_sview_expansion( const T & i )
 */
 
 
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+// Subview mapping.
+// Deduce destination view type from source view traits and subview arguments
+
+namespace Impl {
+
+struct DynRankSubviewTag {};
+
+template< class SrcTraits , class ... Args >
+struct ViewMapping
+  < typename std::enable_if<(
+      std::is_same< typename SrcTraits::specialize , void >::value
+      &&
+      (
+        std::is_same< typename SrcTraits::array_layout
+                    , Kokkos::LayoutLeft >::value ||
+        std::is_same< typename SrcTraits::array_layout
+                    , Kokkos::LayoutRight >::value ||
+        std::is_same< typename SrcTraits::array_layout
+                    , Kokkos::LayoutStride >::value
+      ) 
+    ), DynRankSubviewTag >::type
+  , SrcTraits
+  , Args ... >
+{
+private:
+
+//  static_assert( SrcTraits::rank == sizeof...(Args) ,
+//    "Subview mapping requires one argument for each dimension of source View" );
+
+  enum
+    { RZ = false
+    , R0 = bool(is_integral_extent<0,Args...>::value)
+    , R1 = bool(is_integral_extent<1,Args...>::value)
+    , R2 = bool(is_integral_extent<2,Args...>::value)
+    , R3 = bool(is_integral_extent<3,Args...>::value)
+    , R4 = bool(is_integral_extent<4,Args...>::value)
+    , R5 = bool(is_integral_extent<5,Args...>::value)
+    , R6 = bool(is_integral_extent<6,Args...>::value)
+    , R7 = bool(is_integral_extent<7,Args...>::value)
+    };
+  //Query additional info
+
+  enum { rank = unsigned(R0) + unsigned(R1) + unsigned(R2) + unsigned(R3)
+              + unsigned(R4) + unsigned(R5) + unsigned(R6) + unsigned(R7) }; //dyn rank, with correct use
+
+  // Subview's layout
+  typedef Kokkos::LayoutStride array_layout ;
+
+  typedef typename SrcTraits::value_type  value_type ;
+
+  typedef value_type******** data_type ;
+
+public:
+
+  typedef Kokkos::Experimental::ViewTraits
+    < data_type
+    , array_layout 
+    , typename SrcTraits::device_type
+    , typename SrcTraits::memory_traits > traits_type ;
+
+  typedef Kokkos::Experimental::View
+    < data_type
+    , array_layout 
+    , typename SrcTraits::device_type
+    , typename SrcTraits::memory_traits > type ;
+
+  template< class MemoryTraits >
+  struct apply {
+
+    static_assert( Kokkos::Impl::is_memory_traits< MemoryTraits >::value , "" );
+
+    typedef Kokkos::Experimental::ViewTraits
+      < data_type 
+      , array_layout
+      , typename SrcTraits::device_type
+      , MemoryTraits > traits_type ;
+
+    typedef Kokkos::Experimental::View
+      < data_type 
+      , array_layout
+      , typename SrcTraits::device_type
+      , MemoryTraits > type ;
+  };
+
+
+  typedef typename SrcTraits::dimension dimension ;
+
+  template < class Arg0 = int, class Arg1 = int, class Arg2 = int, class Arg3 = int, class Arg4 = int, class Arg5 = int, class Arg6 = int, class Arg7 = int >
+  struct ExtentGenerator {
+    static SubviewExtents< 8 , rank > generator ( const dimension & dim , Arg0 arg0 = Arg0(), Arg1 arg1 = Arg1(), Arg2 arg2 = Arg2(), Arg3 arg3 = Arg3(), Arg4 arg4 = Arg4(), Arg5 arg5 = Arg5(), Arg6 arg6 = Arg6(), Arg7 arg7 = Arg7() )
+    {
+       return SubviewExtents< 8 , rank>( dim , arg0 , arg1 , arg2 , arg3 , arg4 , arg5 , arg6 , arg7 );
+    }
+  };
+
+
+  typedef DynRankView< value_type , array_layout , typename SrcTraits::device_type , typename SrcTraits::memory_traits >  ret_type;
+
+  template < typename T , class ... P >
+  KOKKOS_INLINE_FUNCTION
+  static ret_type subview( Kokkos::Experimental::View< T******** , P...> const & src 
+                    , Args ... args )
+    {
+//      static_assert(
+//        ViewMapping< DstTraits , traits_type , void >::is_assignable ,
+//        "Subview destination type must be compatible with subview derived type" );
+
+      typedef ViewMapping< traits_type, void >  DstType ;
+
+     typedef typename std::conditional< (rank==0) , ViewDimension<>
+                                                  , typename std::conditional< (rank==1) , ViewDimension<0>
+                                                  , typename std::conditional< (rank==2) , ViewDimension<0,0>
+                                                  , typename std::conditional< (rank==3) , ViewDimension<0,0,0>
+                                                  , typename std::conditional< (rank==4) , ViewDimension<0,0,0,0>
+                                                  , typename std::conditional< (rank==5) , ViewDimension<0,0,0,0,0>
+                                                  , typename std::conditional< (rank==6) , ViewDimension<0,0,0,0,0,0>
+                                                  , typename std::conditional< (rank==7) , ViewDimension<0,0,0,0,0,0,0>
+                                                                                         , ViewDimension<0,0,0,0,0,0,0,0>
+                                                  >::type >::type >::type >::type >::type >::type >::type >::type  DstDimType ;
+
+      typedef ViewOffset< DstDimType , Kokkos::LayoutStride > dst_offset_type ;
+//      typedef typename DstType::offset_type  dst_offset_type ;
+      typedef typename DstType::handle_type  dst_handle_type ;
+
+      Kokkos::Experimental::View< T******** , typename traits_type::array_layout , typename traits_type::device_type , typename traits_type::memory_traits > dst( src ) ;
+
+      const SubviewExtents< 8 , rank > extents = 
+        ExtentGenerator< Args ... >::generator( src.m_map.m_offset.m_dim , args... ); 
+
+//      const SubviewExtents< 8 , rank >
+//        extents( src.m_offset.m_dim , args... );
+
+      dst_offset_type tempdst( src.m_map.m_offset , extents );
+
+      dst.m_map.m_offset.m_dim.N0 = tempdst.m_dim.N0 ;
+      dst.m_map.m_offset.m_dim.N1 = tempdst.m_dim.N1 ;
+      dst.m_map.m_offset.m_dim.N2 = tempdst.m_dim.N2 ;
+      dst.m_map.m_offset.m_dim.N3 = tempdst.m_dim.N3 ;
+      dst.m_map.m_offset.m_dim.N4 = tempdst.m_dim.N4 ;
+      dst.m_map.m_offset.m_dim.N5 = tempdst.m_dim.N5 ;
+      dst.m_map.m_offset.m_dim.N6 = tempdst.m_dim.N6 ;
+      dst.m_map.m_offset.m_dim.N7 = tempdst.m_dim.N7 ;
+
+      dst.m_map.m_offset.m_stride.S0 = tempdst.m_stride.S0 ;
+      dst.m_map.m_offset.m_stride.S1 = tempdst.m_stride.S1 ;
+      dst.m_map.m_offset.m_stride.S2 = tempdst.m_stride.S2 ;
+      dst.m_map.m_offset.m_stride.S3 = tempdst.m_stride.S3 ;
+      dst.m_map.m_offset.m_stride.S4 = tempdst.m_stride.S4 ;
+      dst.m_map.m_offset.m_stride.S5 = tempdst.m_stride.S5 ;
+      dst.m_map.m_offset.m_stride.S6 = tempdst.m_stride.S6 ;
+      dst.m_map.m_offset.m_stride.S7 = tempdst.m_stride.S7 ;
+
+      dst.m_map.m_handle = dst_handle_type( src.m_map.m_handle +
+                                      src.m_map.m_offset( extents.domain_offset(0)
+                                                  , extents.domain_offset(1)
+                                                  , extents.domain_offset(2)
+                                                  , extents.domain_offset(3)
+                                                  , extents.domain_offset(4)
+                                                  , extents.domain_offset(5)
+                                                  , extents.domain_offset(6)
+                                                  , extents.domain_offset(7)
+                                                  ) );
+      return ret_type( dst , rank );
+    }
+};
+} //close Impl
+
+
+
 //Possible direction:
 // Remove EXTENT_ONE_t
 // Cleanup ViewMapping changes ...
@@ -654,10 +826,8 @@ subdynrankview( const DynRankView< D , P... > &src , Args...args)
   if ( src.rank() != sizeof...(Args) )
     { Kokkos::Impl::throw_runtime_exception("Rank is not compatible"); }
 
-typedef Subdynrankview< Kokkos::Experimental::ViewTraits< D********, P... > , Args... > metafcn;
-return 
-//typename metafcn::subview( src.ConstDownCast() , variadic_sview_expansion<Args>(args)... );
-metafcn::subview( src.ConstDownCast() , args... );
+  typedef Impl::ViewMapping< Impl::DynRankSubviewTag , Kokkos::Experimental::ViewTraits< D********, P... > , Args... > metafcn ;
+  return metafcn::subview( src.ConstDownCast() , args... );
 
 }
 

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -814,13 +814,9 @@ public:
          N3 = 7 };
 
   typedef Kokkos::Experimental::DynRankView< T , device > dView0 ;
-  typedef Kokkos::Experimental::DynRankView< T , device > dView1 ;
-  typedef Kokkos::Experimental::DynRankView< T , device > dView2 ;
-  typedef Kokkos::Experimental::DynRankView< T , device > dView3 ;
-  typedef Kokkos::Experimental::DynRankView< T , device > dView4 ;
-  typedef Kokkos::Experimental::DynRankView< const T , device > const_dView4 ;
+  typedef Kokkos::Experimental::DynRankView< const T , device > const_dView0 ;
 
-  typedef Kokkos::Experimental::DynRankView< T, device, Kokkos::MemoryUnmanaged > dView4_unmanaged ;
+  typedef Kokkos::Experimental::DynRankView< T, device, Kokkos::MemoryUnmanaged > dView0_unmanaged ;
   typedef typename dView0::host_mirror_space host ;
 
   TestDynViewAPI()
@@ -830,7 +826,7 @@ public:
     run_test_scalar();
     run_test_const();
     run_test_subview();
-//    run_test_subview_strided();
+    run_test_subview_strided();
 //    run_test_vector();
 
     TestViewOperator< T , device >::testit();
@@ -885,34 +881,14 @@ public:
     // variables.
 
     typedef typename dView0::HostMirror  hView0 ;
-    typedef typename dView1::HostMirror  hView1 ;
-    typedef typename dView2::HostMirror  hView2 ;
-    typedef typename dView3::HostMirror  hView3 ;
-    typedef typename dView4::HostMirror  hView4 ;
 
     {
       hView0 thing;
       (void) thing;
     }
-    {
-      hView1 thing;
-      (void) thing;
-    }
-    {
-      hView2 thing;
-      (void) thing;
-    }
-    {
-      hView3 thing;
-      (void) thing;
-    }
-    {
-      hView4 thing;
-      (void) thing;
-    }
 
-    dView4 dx , dy , dz ;
-    hView4 hx , hy , hz ;
+    dView0 dx , dy , dz ;
+    hView0 hx , hy , hz ;
 
     ASSERT_TRUE( dx.ptr_on_device() == 0 );
     ASSERT_TRUE( dy.ptr_on_device() == 0 );
@@ -929,11 +905,11 @@ public:
     ASSERT_EQ( dx.rank() , 0u );
     ASSERT_EQ( hx.rank() , 0u );
 
-    dx = dView4( "dx" , N1 , N2 , N3 );
-    dy = dView4( "dy" , N1 , N2 , N3 );
+    dx = dView0( "dx" , N1 , N2 , N3 );
+    dy = dView0( "dy" , N1 , N2 , N3 );
 
-    hx = hView4( "hx" , N1 , N2 , N3 );
-    hy = hView4( "hy" , N1 , N2 , N3 );
+    hx = hView0( "hx" , N1 , N2 , N3 );
+    hy = hView0( "hy" , N1 , N2 , N3 );
 
     ASSERT_EQ( dx.dimension_0() , unsigned(N1) );
     ASSERT_EQ( dy.dimension_0() , unsigned(N1) );
@@ -942,10 +918,10 @@ public:
     ASSERT_EQ( dx.rank() , 3 );
     ASSERT_EQ( hx.rank() , 3 );
 
-    dx = dView4( "dx" , N0 , N1 , N2 , N3 );
-    dy = dView4( "dy" , N0 , N1 , N2 , N3 );
-    hx = hView4( "hx" , N0 , N1 , N2 , N3 );
-    hy = hView4( "hy" , N0 , N1 , N2 , N3 );
+    dx = dView0( "dx" , N0 , N1 , N2 , N3 );
+    dy = dView0( "dy" , N0 , N1 , N2 , N3 );
+    hx = hView0( "hx" , N0 , N1 , N2 , N3 );
+    hy = hView0( "hy" , N0 , N1 , N2 , N3 );
 
     ASSERT_EQ( dx.dimension_0() , unsigned(N0) );
     ASSERT_EQ( dy.dimension_0() , unsigned(N0) );
@@ -956,10 +932,10 @@ public:
 
     ASSERT_EQ( dx.use_count() , size_t(1) );
 
-    dView4_unmanaged unmanaged_dx = dx;
+    dView0_unmanaged unmanaged_dx = dx;
     ASSERT_EQ( dx.use_count() , size_t(1) );
 
-    dView4_unmanaged unmanaged_from_ptr_dx = dView4_unmanaged(dx.ptr_on_device(),
+    dView0_unmanaged unmanaged_from_ptr_dx = dView0_unmanaged(dx.ptr_on_device(),
                                                               dx.dimension_0(),
                                                               dx.dimension_1(),
                                                               dx.dimension_2(),
@@ -967,28 +943,28 @@ public:
 
     {
       // Destruction of this view should be harmless
-      const_dView4 unmanaged_from_ptr_const_dx( dx.ptr_on_device() ,
+      const_dView0 unmanaged_from_ptr_const_dx( dx.ptr_on_device() ,
                                                 dx.dimension_0() ,
                                                 dx.dimension_1() ,
                                                 dx.dimension_2() ,
                                                 dx.dimension_3() );
     }
 
-    const_dView4 const_dx = dx ;
+    const_dView0 const_dx = dx ;
     ASSERT_EQ( dx.use_count() , size_t(2) );
 
     {
-      const_dView4 const_dx2;
+      const_dView0 const_dx2;
       const_dx2 = const_dx;
       ASSERT_EQ( dx.use_count() , size_t(3) );
 
       const_dx2 = dy;
       ASSERT_EQ( dx.use_count() , size_t(2) );
 
-      const_dView4 const_dx3(dx);
+      const_dView0 const_dx3(dx);
       ASSERT_EQ( dx.use_count() , size_t(3) );
       
-      dView4_unmanaged dx4_unmanaged(dx);
+      dView0_unmanaged dx4_unmanaged(dx);
       ASSERT_EQ( dx.use_count() , size_t(3) );
     }
 
@@ -1033,9 +1009,9 @@ public:
       }}}}
 
 
-      Kokkos::deep_copy(typename hView4::execution_space(), dx , hx );
-      Kokkos::deep_copy(typename hView4::execution_space(), dy , dx );
-      Kokkos::deep_copy(typename hView4::execution_space(), hy , dy );
+      Kokkos::deep_copy(typename hView0::execution_space(), dx , hx );
+      Kokkos::deep_copy(typename hView0::execution_space(), dy , dx );
+      Kokkos::deep_copy(typename hView0::execution_space(), hy , dy );
 
       for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
       for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
@@ -1044,8 +1020,8 @@ public:
         { ASSERT_EQ( hx(ip,i1,i2,i3) , hy(ip,i1,i2,i3) ); }
       }}}}
 
-      Kokkos::deep_copy(typename hView4::execution_space(), dx , T(0) );
-      Kokkos::deep_copy(typename hView4::execution_space(), hx , dx );
+      Kokkos::deep_copy(typename hView0::execution_space(), dx , T(0) );
+      Kokkos::deep_copy(typename hView0::execution_space(), hx , dx );
 
       for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
       for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
@@ -1065,9 +1041,9 @@ public:
         hx(ip,i1,i2,i3) = ++count ;
       }}}}
 
-      Kokkos::deep_copy(typename dView4::execution_space(), dx , hx );
-      Kokkos::deep_copy(typename dView4::execution_space(), dy , dx );
-      Kokkos::deep_copy(typename dView4::execution_space(), hy , dy );
+      Kokkos::deep_copy(typename dView0::execution_space(), dx , hx );
+      Kokkos::deep_copy(typename dView0::execution_space(), dy , dx );
+      Kokkos::deep_copy(typename dView0::execution_space(), hy , dy );
 
       for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
       for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
@@ -1076,8 +1052,8 @@ public:
         { ASSERT_EQ( hx(ip,i1,i2,i3) , hy(ip,i1,i2,i3) ); }
       }}}}
 
-      Kokkos::deep_copy(typename dView4::execution_space(), dx , T(0) );
-      Kokkos::deep_copy(typename dView4::execution_space(), hx , dx );
+      Kokkos::deep_copy(typename dView0::execution_space(), dx , T(0) );
+      Kokkos::deep_copy(typename dView0::execution_space(), hx , dx );
 
       for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
       for ( size_t i1 = 0 ; i1 < N1 ; ++i1 ) {
@@ -1122,15 +1098,15 @@ public:
     dz = dx ; ASSERT_EQ( dx, dz); ASSERT_NE( dy, dz);
     dz = dy ; ASSERT_EQ( dy, dz); ASSERT_NE( dx, dz);
 
-    dx = dView4();
+    dx = dView0();
     ASSERT_TRUE( dx.ptr_on_device() == 0 );
     ASSERT_FALSE( dy.ptr_on_device() == 0 );
     ASSERT_FALSE( dz.ptr_on_device() == 0 );
-    dy = dView4();
+    dy = dView0();
     ASSERT_TRUE( dx.ptr_on_device() == 0 );
     ASSERT_TRUE( dy.ptr_on_device() == 0 );
     ASSERT_FALSE( dz.ptr_on_device() == 0 );
-    dz = dView4();
+    dz = dView0();
     ASSERT_TRUE( dx.ptr_on_device() == 0 );
     ASSERT_TRUE( dy.ptr_on_device() == 0 );
     ASSERT_TRUE( dz.ptr_on_device() == 0 );
@@ -1142,8 +1118,6 @@ public:
   check_auto_conversion_to_const(
      const Kokkos::Experimental::DynRankView< const DataType , device > & arg_const ,
      const Kokkos::Experimental::DynRankView< DataType , device > & arg )
-//     const Kokkos::View< const DataType , device > & arg_const ,
-//     const Kokkos::View< DataType , device > & arg )
   {
     ASSERT_TRUE( arg_const == arg );
   }
@@ -1181,13 +1155,10 @@ public:
 // LayoutStride may be causing issues with how it is declared...
 
     typedef Kokkos::Experimental::DynRankView< const T , device > sView ;
-  //typedef Kokkos::Experimental::DynRankView< T , device > dView8 ;
     typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , device > dView8 ; //this works
-    typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , device > dView9 ; //this works
-    //typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , Kokkos::Device<Kokkos::Serial , Kokkos::HostSpace > > dView8 ; //this works
-
 
     dView0 d0( "d0" );
+/*
     std::cout << " d0 rank " << d0.rank() <<std::endl;
     std::cout << " d0 dim0 "<< d0.dimension_0() <<std::endl;
     std::cout << " d0 dim1 "<< d0.dimension_1() <<std::endl;
@@ -1197,10 +1168,11 @@ public:
     std::cout << " d0 dim5 "<< d0.dimension_5() <<std::endl;
     std::cout << " d0 dim6 "<< d0.dimension_6() <<std::endl;
     std::cout << " d0 dim7 "<< d0.dimension_7() <<std::endl;
+*/
 
-//    dView8 d7( "d7" , unsigned(N0) , unsigned(N1) , unsigned(N2) , 2 , 2 , 2 , 2 ); //rank 7 dynrank view 
     unsigned order[] = { 6,5,4,3,2,1,0 }, dimen[] = { N0, N1, N2, 2, 2, 2, 2 };
     dView8 d7( "d7", Kokkos::LayoutStride::order_dimensions(7, order, dimen) );
+/*
     std::cout << " d7 rank " << d7.rank() <<std::endl;
     std::cout << " d7 dim0 "<< d7.dimension_0() <<std::endl;
     std::cout << " d7 dim1 "<< d7.dimension_1() <<std::endl;
@@ -1210,10 +1182,11 @@ public:
     std::cout << " d7 dim5 "<< d7.dimension_5() <<std::endl;
     std::cout << " d7 dim6 "<< d7.dimension_6() <<std::endl;
     std::cout << " d7 dim7 "<< d7.dimension_7() <<std::endl;
+*/
 
-    //dView8 d8( "d8" , unsigned(N0) , unsigned(N1) , unsigned(N2) , 2 , 2 , 2 , 2 , 2 );
     unsigned order2[] = { 7,6,5,4,3,2,1,0 }, dimen2[] = { N0, N1, N2, 2, 2, 2, 2, 2 };
     dView8 d8( "d8", Kokkos::LayoutStride::order_dimensions(8, order2, dimen2) );
+/*
     std::cout << " d8 rank " << d8.rank() <<std::endl;
     std::cout << " d8 dim0 "<< d8.dimension_0() <<std::endl;
     std::cout << " d8 dim1 "<< d8.dimension_1() <<std::endl;
@@ -1223,10 +1196,11 @@ public:
     std::cout << " d8 dim5 "<< d8.dimension_5() <<std::endl;
     std::cout << " d8 dim6 "<< d8.dimension_6() <<std::endl;
     std::cout << " d8 dim7 "<< d8.dimension_7() <<std::endl;
+*/
 
-//    dView8 d5( "d5" , unsigned(N0) , unsigned(N1) , unsigned(N2) , 2 , 2 );
     unsigned order3[] = { 4,3,2,1,0 }, dimen3[] = { N0, N1, N2, 2, 2 };
     dView8 d5( "d5", Kokkos::LayoutStride::order_dimensions(5, order3, dimen3) );
+/*
     std::cout << " d5 rank " << d5.rank() <<std::endl;
     std::cout << " d5 dim0 "<< d5.dimension_0() <<std::endl;
     std::cout << " d5 dim1 "<< d5.dimension_1() <<std::endl;
@@ -1236,22 +1210,22 @@ public:
     std::cout << " d5 dim5 "<< d5.dimension_5() <<std::endl;
     std::cout << " d5 dim6 "<< d5.dimension_6() <<std::endl;
     std::cout << " d5 dim7 "<< d5.dimension_7() <<std::endl;
+*/
 
     dView0 dtest("dtest" , N0 , N1 , N2 , 2 , 2 , 2 , 2 , 2);
 
     sView s0 = d0 ;
-//    sView s8 = Kokkos::Experimental::subview( d8 , 1,1,1,1,1,1,1,1); //Should be rank0 subview
+    dView8 ds0 = Kokkos::Experimental::subdynrankview( d8 , 1,1,1,1,1,1,1,1); //Should be rank0 subview
 
 //Basic test - ALL
-//    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() ); //compiles and runs
+    dView8 ds1 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() ); //compiles and runs
 //  Send a single value for one rank
-//    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , 1 );
+    dView8 ds2 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , 1 );
 //  Send a std::pair as a rank
-//    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , std::pair<unsigned,unsigned>(1,2) );
+    dView8 ds3 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , std::pair<unsigned,unsigned>(1,2) );
 //  Send a kokkos::pair as a rank
-//
-//    std::cout<<" dt8 rank 8 subview... "<<std::endl; //dView8 for layout stride or dView0 for lright? Neither compile...
-//    dView0 dt8 = Kokkos::Experimental::subdynrankview( dtest , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) ); //this causes error if not a strided layout, but if strided layout chose without proper initialization then issues with dimensions...
+    std::cout<<" dt8 rank 8 subview... "<<std::endl; 
+    dView8 dt8 = Kokkos::Experimental::subdynrankview( dtest , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
 
     std::cout<<" ds8 rank 8 subview... "<<std::endl;
     dView8 ds8 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
@@ -1262,23 +1236,85 @@ public:
 
     std::cout<<" ds5 rank 5 subview... "<<std::endl;
     dView8 ds5 = Kokkos::Experimental::subdynrankview( d5 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
-
-//
-/*
-    dView1 d1( "d1" , N0 );
-    dView2 d2( "d2" , N0 );
-    dView3 d3( "d3" , N0 );
-    dView4 d4( "d4" , N0 );
-    sView s1 = Kokkos::subview( d1 , 1 );
-    sView s2 = Kokkos::subview( d2 , 1 , 1 );
-    sView s3 = Kokkos::subview( d3 , 1 , 1 , 1 );
-    sView s4 = Kokkos::subview( d4 , 1 , 1 , 1 , 1 );
-*/
   }
 
-/*
   static void run_test_subview_strided()
   {
+    typedef Kokkos::Experimental::DynRankView < int , Kokkos::LayoutLeft , host > drview_left ;
+    typedef Kokkos::Experimental::DynRankView < int , Kokkos::LayoutRight , host > drview_right ;
+    typedef Kokkos::Experimental::DynRankView < int , Kokkos::LayoutStride , host > drview_stride ;
+
+    drview_left  xl2( "xl2", 100 , 200 );
+    drview_right xr2( "xr2", 100 , 200 );
+    drview_stride yl1 = Kokkos::Experimental::subdynrankview( xl2 , 0 , Kokkos::ALL() );
+    drview_stride yl2 = Kokkos::Experimental::subdynrankview( xl2 , 1 , Kokkos::ALL() );
+    drview_stride ys1 = Kokkos::Experimental::subdynrankview( xr2 , 0 , Kokkos::ALL() );
+    drview_stride ys2 = Kokkos::Experimental::subdynrankview( xr2 , 1 , Kokkos::ALL() );
+//    drview_right yr1 = Kokkos::Experimental::subdynrankview( xr2 , 0 , Kokkos::ALL() ); //errors out
+//    drview_right yr2 = Kokkos::Experimental::subdynrankview( xr2 , 1 , Kokkos::ALL() );
+
+// Original subview testing
+    typedef Kokkos::Experimental::View < int[100][200] , Kokkos::LayoutRight , host > view_right_2 ;
+    typedef Kokkos::Experimental::View < int[100][200] , Kokkos::LayoutLeft , host > view_left_2 ;
+
+    typedef Kokkos::Experimental::View < int* , host > sview_1 ;
+    typedef Kokkos::Experimental::View < int* , Kokkos::LayoutStride , host > strview_1 ;
+
+    view_left_2 vl2("vl2");
+//    sview_1 svl1 = Kokkos::Experimental::subview( vl2 , 0 , Kokkos::ALL() ); //breaks
+    strview_1 stvl1 = Kokkos::Experimental::subview( vl2 , 0 , Kokkos::ALL() );
+
+    std::cout << "  vl2.dim0 " << vl2.dimension_0() <<std::endl;
+    std::cout << "  vl2.dim1 " << vl2.dimension_1() <<std::endl;
+    std::cout << "  stvl1.dim0 " << stvl1.dimension_0() <<std::endl;//should be 200
+    std::cout << "  stvl1.dim1 " << stvl1.dimension_1() <<std::endl;//should be 1
+
+/*
+    typedef Kokkos::Experimental::View < int[20][5][3] , Kokkos::LayoutRight , host > view_right_3 ;
+    typedef Kokkos::Experimental::View < int** , host > view_right_2 ;
+
+    view_right_3 vr3("vr3");
+    for ( int i = 0 ; i < 20 ; ++i ) {
+    for ( int j = 0 ; j < 5 ; ++j ) {
+    for ( int k = 0 ; k < 3 ; ++k ) {
+      vr3(i,j,k) = k + j*3 + i *15;
+    }}}
+
+    view_right_2 sv2 = Kokkos::Experimental::subview(vr3 , Kokkos::ALL() , 1 , Kokkos::ALL() );
+
+    std::cout << "  vr3.dim0 " << vr3.dimension_0() <<std::endl;
+    std::cout << "  vr3.dim1 " << vr3.dimension_1() <<std::endl;
+    std::cout << "  vr3.dim2 " << vr3.dimension_2() <<std::endl;
+    std::cout << "  sv2.dim0 " << sv2.dimension_0() <<std::endl;
+    std::cout << "  sv2.dim1 " << sv2.dimension_1() <<std::endl;
+    std::cout << "  sv2.dim2 " << sv2.dimension_2() <<std::endl;
+    std::cout << "\n";
+*/
+
+// end subview testing
+
+    std::cout << "  xl2.dim0 " << xl2.dimension_0() <<std::endl;
+    std::cout << "  xl2.dim1 " << xl2.dimension_1() <<std::endl;
+    std::cout << "  yl1.dim0 " << yl1.dimension_0() <<std::endl; //should be 200
+    std::cout << "  yl1.dim1 " << yl1.dimension_1() <<std::endl; //should be 1
+    std::cout << "  xr2.dim0 " << xr2.dimension_0() <<std::endl;
+    std::cout << "  xr2.dim1 " << xr2.dimension_1() <<std::endl;
+//    std::cout << "  yr1.dim0 " << yr1.dimension_0() <<std::endl;
+//    std::cout << "  yr1.dim1 " << yr1.dimension_1() <<std::endl;
+//    std::cout << "  yr2.dim0 " << yr2.dimension_0() <<std::endl;
+//    std::cout << "  yr2.dim1 " << yr2.dimension_1() <<std::endl;
+    ASSERT_EQ( yl1.dimension_0() , xl2.dimension_1() );
+    ASSERT_EQ( yl2.dimension_0() , xl2.dimension_1() );
+/*
+    ASSERT_EQ( yr1.dimension_0() , xr2.dimension_1() );
+    ASSERT_EQ( yr2.dimension_0() , xr2.dimension_1() );
+
+    ASSERT_EQ( & yl1(0) - & xl2(0,0) , 0 );
+    ASSERT_EQ( & yl2(0) - & xl2(1,0) , 0 );
+    ASSERT_EQ( & yr1(0) - & xr2(0,0) , 0 );
+    ASSERT_EQ( & yr2(0) - & xr2(1,0) , 0 );
+
+//old
     typedef Kokkos::View< int **** , Kokkos::LayoutLeft  , host >  view_left_4 ;
     typedef Kokkos::View< int **** , Kokkos::LayoutRight , host >  view_right_4 ;
     typedef Kokkos::View< int **   , Kokkos::LayoutLeft  , host >  view_left_2 ;
@@ -1317,9 +1353,10 @@ public:
 
     ASSERT_EQ( & yl4(4,4) - & xl4(1,4,2,4) , 0 );
     ASSERT_EQ( & yr4(4,4) - & xr4(1,4,2,4) , 0 );
+*/
   }
 
-
+/*
   static void run_test_vector()
   {
     static const unsigned Length = 1000 , Count = 8 ;

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -110,110 +110,6 @@ template< class DataType ,
 struct TestViewOperator_LeftAndRight ;
 
 template< class DataType , class DeviceType >
-struct TestViewOperator_LeftAndRight< DataType , DeviceType , 8 >
-{
-  typedef DeviceType                          execution_space ;
-  typedef typename execution_space::memory_space  memory_space ;
-  typedef typename execution_space::size_type     size_type ;
-
-  typedef int value_type ;
-
-  KOKKOS_INLINE_FUNCTION
-  static void join( volatile value_type & update ,
-                    const volatile value_type & input )
-    { update |= input ; }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init( value_type & update )
-    { update = 0 ; }
-
-
-  typedef Kokkos::
-    Experimental::DynRankView< DataType, Kokkos::LayoutLeft, execution_space > left_view ;
-
-  typedef Kokkos::
-    Experimental::DynRankView< DataType, Kokkos::LayoutRight, execution_space > right_view ;
-
-  typedef Kokkos::
-    Experimental::DynRankView< DataType, Kokkos::LayoutStride, execution_space > stride_view ;
-
-  left_view    left ;
-  right_view   right ;
-  stride_view  left_stride ;
-  stride_view  right_stride ;
-  long         left_alloc ;
-  long         right_alloc ;
-
-  TestViewOperator_LeftAndRight(unsigned N0, unsigned N1, unsigned N2, unsigned N3, unsigned N4, unsigned N5, unsigned N6, unsigned N7)
-    : left(  "left", N0, N1, N2, N3, N4, N5, N6, N7 )
-    , right( "right" , N0, N1, N2, N3, N4, N5, N6, N7 )
-    , left_stride( left )
-    , right_stride( right )
-    , left_alloc( allocation_count( left ) )
-    , right_alloc( allocation_count( right ) )
-    {}
-
-  static void testit(unsigned N0, unsigned N1, unsigned N2, unsigned N3, unsigned N4, unsigned N5, unsigned N6, unsigned N7)
-  {
-    TestViewOperator_LeftAndRight driver (N0, N1, N2, N3, N4, N5, N6, N7);
-
-    int error_flag = 0 ;
-
-    Kokkos::parallel_reduce( 1 , driver , error_flag );
-
-    ASSERT_EQ( error_flag , 0 );
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()( const size_type , value_type & update ) const
-  {
-    long offset ;
-
-    offset = -1 ;
-    for ( unsigned i7 = 0 ; i7 < unsigned(left.dimension_7()) ; ++i7 )
-    for ( unsigned i6 = 0 ; i6 < unsigned(left.dimension_6()) ; ++i6 )
-    for ( unsigned i5 = 0 ; i5 < unsigned(left.dimension_5()) ; ++i5 )
-    for ( unsigned i4 = 0 ; i4 < unsigned(left.dimension_4()) ; ++i4 )
-    for ( unsigned i3 = 0 ; i3 < unsigned(left.dimension_3()) ; ++i3 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(left.dimension_2()) ; ++i2 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(left.dimension_1()) ; ++i1 )
-    for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
-    {
-      const long j = & left( i0, i1, i2, i3, i4, i5, i6, i7 ) -
-                     & left(  0,  0,  0,  0,  0,  0,  0,  0 );
-      if ( j <= offset || left_alloc <= j ) { update |= 1 ; }
-      offset = j ;
-
-      if ( & left(i0,i1,i2,i3,i4,i5,i6,i7) !=
-           & left_stride(i0,i1,i2,i3,i4,i5,i6,i7) ) {
-        update |= 4 ;
-      }
-    }
-
-    offset = -1 ;
-    for ( unsigned i0 = 0 ; i0 < unsigned(right.dimension_0()) ; ++i0 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(right.dimension_1()) ; ++i1 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(right.dimension_2()) ; ++i2 )
-    for ( unsigned i3 = 0 ; i3 < unsigned(right.dimension_3()) ; ++i3 )
-    for ( unsigned i4 = 0 ; i4 < unsigned(right.dimension_4()) ; ++i4 )
-    for ( unsigned i5 = 0 ; i5 < unsigned(right.dimension_5()) ; ++i5 )
-    for ( unsigned i6 = 0 ; i6 < unsigned(right.dimension_6()) ; ++i6 )
-    for ( unsigned i7 = 0 ; i7 < unsigned(right.dimension_7()) ; ++i7 )
-    {
-      const long j = & right( i0, i1, i2, i3, i4, i5, i6, i7 ) -
-                     & right(  0,  0,  0,  0,  0,  0,  0,  0 );
-      if ( j <= offset || right_alloc <= j ) { update |= 2 ; }
-      offset = j ;
-
-      if ( & right(i0,i1,i2,i3,i4,i5,i6,i7) !=
-           & right_stride(i0,i1,i2,i3,i4,i5,i6,i7) ) {
-        update |= 8 ;
-      }
-    }
-  }
-};
-
-template< class DataType , class DeviceType >
 struct TestViewOperator_LeftAndRight< DataType , DeviceType , 7 >
 {
   typedef DeviceType                          execution_space ;
@@ -644,8 +540,8 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 3 >
     for ( unsigned i1 = 0 ; i1 < unsigned(left.dimension_1()) ; ++i1 )
     for ( unsigned i2 = 0 ; i2 < unsigned(left.dimension_2()) ; ++i2 )
     {
-      if ( & left(i0,i1,i2)  != & left(i0,i1,i2,0,0,0,0,0) )  { update |= 3 ; }
-      if ( & right(i0,i1,i2) != & right(i0,i1,i2,0,0,0,0,0) ) { update |= 3 ; }
+      if ( & left(i0,i1,i2)  != & left(i0,i1,i2,0,0,0,0) )  { update |= 3 ; }
+      if ( & right(i0,i1,i2) != & right(i0,i1,i2,0,0,0,0) ) { update |= 3 ; }
     }
   }
 };
@@ -726,8 +622,8 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 2 >
     for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
     for ( unsigned i1 = 0 ; i1 < unsigned(left.dimension_1()) ; ++i1 )
     {
-      if ( & left(i0,i1)  != & left(i0,i1,0,0,0,0,0,0) )  { update |= 3 ; }
-      if ( & right(i0,i1) != & right(i0,i1,0,0,0,0,0,0) ) { update |= 3 ; }
+      if ( & left(i0,i1)  != & left(i0,i1,0,0,0,0,0) )  { update |= 3 ; }
+      if ( & right(i0,i1) != & right(i0,i1,0,0,0,0,0) ) { update |= 3 ; }
     }
   }
 };
@@ -792,8 +688,8 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 1 >
   {
     for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
     {
-      if ( & left(i0)  != & left(i0,0,0,0,0,0,0,0) )  { update |= 3 ; }
-      if ( & right(i0) != & right(i0,0,0,0,0,0,0,0) ) { update |= 3 ; }
+      if ( & left(i0)  != & left(i0,0,0,0,0,0,0) )  { update |= 3 ; }
+      if ( & right(i0) != & right(i0,0,0,0,0,0,0) ) { update |= 3 ; }
       if ( & left(i0)  != & left_stride(i0) ) { update |= 4 ; }
       if ( & right(i0) != & right_stride(i0) ) { update |= 8 ; }
     }
@@ -830,7 +726,6 @@ public:
     run_test_vector();
 
     TestViewOperator< T , device >::testit();
-    TestViewOperator_LeftAndRight< int , device , 8 >::testit(2,3,4,2,3,4,2,3); 
     TestViewOperator_LeftAndRight< int , device , 7 >::testit(2,3,4,2,3,4,2); 
     TestViewOperator_LeftAndRight< int , device , 6 >::testit(2,3,4,2,3,4); 
     TestViewOperator_LeftAndRight< int , device , 5 >::testit(2,3,4,2,3);
@@ -996,6 +891,7 @@ public:
     // T v1 = hx() ;    // Generates compile error as intended
     // T v2 = hx(0,0) ; // Generates compile error as intended
     // hx(0,0) = v2 ;   // Generates compile error as intended
+
 /*
 #if ! KOKKOS_USING_EXP_VIEW
     // Testing with asynchronous deep copy with respect to device
@@ -1152,90 +1048,42 @@ public:
 
   static void run_test_subview()
   {
-// LayoutStride may be causing issues with how it is declared...
-
+// LayoutStride required for all returned DynRankView subdynrankview's
     typedef Kokkos::Experimental::DynRankView< const T , device > sView ;
-    typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , device > sdView ; //this works
+    typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , device > sdView ; 
 
     dView0 d0( "d0" );
-/*
-    std::cout << " d0 rank " << d0.rank() <<std::endl;
-    std::cout << " d0 dim0 "<< d0.dimension_0() <<std::endl;
-    std::cout << " d0 dim1 "<< d0.dimension_1() <<std::endl;
-    std::cout << " d0 dim2 "<< d0.dimension_2() <<std::endl;
-    std::cout << " d0 dim3 "<< d0.dimension_3() <<std::endl;
-    std::cout << " d0 dim4 "<< d0.dimension_4() <<std::endl;
-    std::cout << " d0 dim5 "<< d0.dimension_5() <<std::endl;
-    std::cout << " d0 dim6 "<< d0.dimension_6() <<std::endl;
-    std::cout << " d0 dim7 "<< d0.dimension_7() <<std::endl;
-*/
 
-    unsigned order[] = { 6,5,4,3,2,1,0 }, dimen[] = { N0, N1, N2, 2, 2, 2, 2 };
-    sdView d7( "d7", Kokkos::LayoutStride::order_dimensions(7, order, dimen) );
-/*
-    std::cout << " d7 rank " << d7.rank() <<std::endl;
-    std::cout << " d7 dim0 "<< d7.dimension_0() <<std::endl;
-    std::cout << " d7 dim1 "<< d7.dimension_1() <<std::endl;
-    std::cout << " d7 dim2 "<< d7.dimension_2() <<std::endl;
-    std::cout << " d7 dim3 "<< d7.dimension_3() <<std::endl;
-    std::cout << " d7 dim4 "<< d7.dimension_4() <<std::endl;
-    std::cout << " d7 dim5 "<< d7.dimension_5() <<std::endl;
-    std::cout << " d7 dim6 "<< d7.dimension_6() <<std::endl;
-    std::cout << " d7 dim7 "<< d7.dimension_7() <<std::endl;
-*/
-
-    unsigned order2[] = { 7,6,5,4,3,2,1,0 }, dimen2[] = { N0, N1, N2, 2, 2, 2, 2, 2 };
-    sdView d8( "d8", Kokkos::LayoutStride::order_dimensions(8, order2, dimen2) );
-/*
-    std::cout << " d8 rank " << d8.rank() <<std::endl;
-    std::cout << " d8 dim0 "<< d8.dimension_0() <<std::endl;
-    std::cout << " d8 dim1 "<< d8.dimension_1() <<std::endl;
-    std::cout << " d8 dim2 "<< d8.dimension_2() <<std::endl;
-    std::cout << " d8 dim3 "<< d8.dimension_3() <<std::endl;
-    std::cout << " d8 dim4 "<< d8.dimension_4() <<std::endl;
-    std::cout << " d8 dim5 "<< d8.dimension_5() <<std::endl;
-    std::cout << " d8 dim6 "<< d8.dimension_6() <<std::endl;
-    std::cout << " d8 dim7 "<< d8.dimension_7() <<std::endl;
-*/
+    unsigned order[] = { 6,5,4,3,2,1,0 }, dimen[] = { N0, N1, N2, 2, 2, 2, 2 }; //LayoutRight equivalent
+    sdView d7( "d7" , Kokkos::LayoutStride::order_dimensions(7, order, dimen) );
 
     unsigned order3[] = { 4,3,2,1,0 }, dimen3[] = { N0, N1, N2, 2, 2 };
-    sdView d5( "d5", Kokkos::LayoutStride::order_dimensions(5, order3, dimen3) );
-/*
-    std::cout << " d5 rank " << d5.rank() <<std::endl;
-    std::cout << " d5 dim0 "<< d5.dimension_0() <<std::endl;
-    std::cout << " d5 dim1 "<< d5.dimension_1() <<std::endl;
-    std::cout << " d5 dim2 "<< d5.dimension_2() <<std::endl;
-    std::cout << " d5 dim3 "<< d5.dimension_3() <<std::endl;
-    std::cout << " d5 dim4 "<< d5.dimension_4() <<std::endl;
-    std::cout << " d5 dim5 "<< d5.dimension_5() <<std::endl;
-    std::cout << " d5 dim6 "<< d5.dimension_6() <<std::endl;
-    std::cout << " d5 dim7 "<< d5.dimension_7() <<std::endl;
-*/
-
-    dView0 dtest("dtest" , N0 , N1 , N2 , 2 , 2 , 2 , 2 , 2);
+    sdView d5( "d5" , Kokkos::LayoutStride::order_dimensions(5, order3, dimen3) );
 
     sView s0 = d0 ;
-    sdView ds0 = Kokkos::Experimental::subdynrankview( d8 , 1,1,1,1,1,1,1,1); //Should be rank0 subview
+//    sdView ds0 = Kokkos::Experimental::subdynrankview( d7 , 1 , 1 , 1 , 1 , 1 , 1 , 1 ); //Should be rank0 subview
+    sdView ds0 = Kokkos::subdynrankview( d7 , 1 , 1 , 1 , 1 , 1 , 1 , 1 ); //Should be rank0 subview
 
 //Basic test - ALL
-    sdView ds1 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() ); //compiles and runs
+    sdView dsALL = Kokkos::Experimental::subdynrankview( d7 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() ); //compiles and runs
+
 //  Send a single value for one rank
-    sdView ds2 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , 1 );
+    sdView dsm1 = Kokkos::Experimental::subdynrankview( d7 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , 1 );
+
 //  Send a std::pair as a rank
-    sdView ds3 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , std::pair<unsigned,unsigned>(1,2) );
-//  Send a kokkos::pair as a rank
-    std::cout<<" dt8 rank 8 subview... "<<std::endl; 
-    sdView dt8 = Kokkos::Experimental::subdynrankview( dtest , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+    sdView dssp = Kokkos::Experimental::subdynrankview( d7 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , std::pair<unsigned,unsigned>(1,2) );
 
-    std::cout<<" ds8 rank 8 subview... "<<std::endl;
-    sdView ds8 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+//  Send a kokkos::pair as a rank; take default layout as input
+    dView0 dd0("dd0" , N0 , N1 , N2 , 2 , 2 , 2 , 2 ); //default layout
+    sdView dtkp = Kokkos::Experimental::subdynrankview( dd0 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
 
-// Breaks...
-    std::cout<<" ds7 rank 7 subview... "<<std::endl;
+
+// Return rank 7 subview, taking a pair as one argument, layout stride input
     sdView ds7 = Kokkos::Experimental::subdynrankview( d7 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
 
-    std::cout<<" ds5 rank 5 subview... "<<std::endl;
+// Rank 5 subview of rank 5 dynamic rank view, layout stride input
     sdView ds5 = Kokkos::Experimental::subdynrankview( d5 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+
   }
 
   static void run_test_subview_strided()
@@ -1250,59 +1098,9 @@ public:
     drview_stride yl2 = Kokkos::Experimental::subdynrankview( xl2 , 1 , Kokkos::ALL() );
     drview_stride ys1 = Kokkos::Experimental::subdynrankview( xr2 , 0 , Kokkos::ALL() );
     drview_stride ys2 = Kokkos::Experimental::subdynrankview( xr2 , 1 , Kokkos::ALL() );
-    drview_stride yr1 = Kokkos::Experimental::subdynrankview( xr2 , 0 , Kokkos::ALL() ); //errors out
+    drview_stride yr1 = Kokkos::Experimental::subdynrankview( xr2 , 0 , Kokkos::ALL() );
     drview_stride yr2 = Kokkos::Experimental::subdynrankview( xr2 , 1 , Kokkos::ALL() );
 
-// Original subview testing
-/*
-//    typedef Kokkos::Experimental::View < int[100][200] , Kokkos::LayoutRight , host > view_right_2 ;
-    typedef Kokkos::Experimental::View < int[100][200] , Kokkos::LayoutLeft , host > view_left_2 ;
-
-//    typedef Kokkos::Experimental::View < int* , host > sview_1 ;
-    typedef Kokkos::Experimental::View < int* , Kokkos::LayoutStride , host > strview_1 ;
-
-    view_left_2 vl2("vl2");
-//    sview_1 svl1 = Kokkos::Experimental::subview( vl2 , 0 , Kokkos::ALL() ); //breaks
-    strview_1 stvl1 = Kokkos::Experimental::subview( vl2 , 0 , Kokkos::ALL() );
-
-    std::cout << "  vl2.dim0 " << vl2.dimension_0() <<std::endl;
-    std::cout << "  vl2.dim1 " << vl2.dimension_1() <<std::endl;
-    std::cout << "  stvl1.dim0 " << stvl1.dimension_0() <<std::endl;//should be 200
-    std::cout << "  stvl1.dim1 " << stvl1.dimension_1() <<std::endl;//should be 1
-
-    typedef Kokkos::Experimental::View < int[20][5][3] , Kokkos::LayoutRight , host > view_right_3 ;
-    typedef Kokkos::Experimental::View < int** , host > view_right_2 ;
-
-    view_right_3 vr3("vr3");
-    for ( int i = 0 ; i < 20 ; ++i ) {
-    for ( int j = 0 ; j < 5 ; ++j ) {
-    for ( int k = 0 ; k < 3 ; ++k ) {
-      vr3(i,j,k) = k + j*3 + i *15;
-    }}}
-
-    view_right_2 sv2 = Kokkos::Experimental::subview(vr3 , Kokkos::ALL() , 1 , Kokkos::ALL() );
-
-    std::cout << "  vr3.dim0 " << vr3.dimension_0() <<std::endl;
-    std::cout << "  vr3.dim1 " << vr3.dimension_1() <<std::endl;
-    std::cout << "  vr3.dim2 " << vr3.dimension_2() <<std::endl;
-    std::cout << "  sv2.dim0 " << sv2.dimension_0() <<std::endl;
-    std::cout << "  sv2.dim1 " << sv2.dimension_1() <<std::endl;
-    std::cout << "  sv2.dim2 " << sv2.dimension_2() <<std::endl;
-    std::cout << "\n";
-*/
-
-// end original subview testing
-
-    std::cout << "  xl2.dim0 " << xl2.dimension_0() <<std::endl;
-    std::cout << "  xl2.dim1 " << xl2.dimension_1() <<std::endl;
-    std::cout << "  yl1.dim0 " << yl1.dimension_0() <<std::endl; //should be 200
-    std::cout << "  yl1.dim1 " << yl1.dimension_1() <<std::endl; //should be 1
-    std::cout << "  xr2.dim0 " << xr2.dimension_0() <<std::endl;
-    std::cout << "  xr2.dim1 " << xr2.dimension_1() <<std::endl;
-//    std::cout << "  yr1.dim0 " << yr1.dimension_0() <<std::endl;
-//    std::cout << "  yr1.dim1 " << yr1.dimension_1() <<std::endl;
-//    std::cout << "  yr2.dim0 " << yr2.dimension_0() <<std::endl;
-//    std::cout << "  yr2.dim1 " << yr2.dimension_1() <<std::endl;
     ASSERT_EQ( yl1.dimension_0() , xl2.dimension_1() );
     ASSERT_EQ( yl2.dimension_0() , xl2.dimension_1() );
 
@@ -1335,23 +1133,18 @@ public:
   {
     static const unsigned Length = 1000 , Count = 8 ;
 
-    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutLeft , host > vector_type ; //rank 1
-    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutLeft , host > multivector_type ; //rank 2
+    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutLeft , host > multivector_type ; 
 
-    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutRight , host > vector_right_type ; //rank 1
-    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutRight , host > multivector_right_type ; //rank 2
-
-    typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutRight , host > const_vector_right_type ; //rank 1
-    typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutLeft , host > const_vector_type ; //rank 1
-    typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutLeft , host > const_multivector_type ; //rank 2
+    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutRight , host > multivector_right_type ;
 
     multivector_type mv = multivector_type( "mv" , Length , Count );
     multivector_right_type mv_right = multivector_right_type( "mv" , Length , Count );
 
     typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , host > svector_type ;
     typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , host > smultivector_type ;
-    typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutStride , host > const_svector_right_type ;
+    typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutStride , host > const_svector_right_type ; //LayoutStride, not right; setup to match original ViewAPI calls... update
     typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutStride , host > const_svector_type ;
+    typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutStride , host > const_smultivector_type ;
 
     svector_type v1 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL() , 0 );
     svector_type v2 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL() , 1 );
@@ -1406,81 +1199,16 @@ public:
     ASSERT_TRUE( & mvr1(0,0) == & mv_right( 1 , 2 ) );
     ASSERT_TRUE( & mvr1(1,1) == & mv_right( 2 , 3 ) );
     ASSERT_TRUE( & mvr1(3,2) == & mv_right( 4 , 4 ) );
-/*
 
-    typedef Kokkos::View< T* ,  Kokkos::LayoutLeft , host > vector_type ;
-    typedef Kokkos::View< T** , Kokkos::LayoutLeft , host > multivector_type ;
+    const_svector_type c_cv1( v1 );
+    typename svector_type::const_type c_cv2( v2 );
+    typename const_svector_type::const_type c_ccv2( v2 );
 
-    typedef Kokkos::View< T* ,  Kokkos::LayoutRight , host > vector_right_type ;
-    typedef Kokkos::View< T** , Kokkos::LayoutRight , host > multivector_right_type ;
 
-    typedef Kokkos::View< const T* , Kokkos::LayoutRight, host > const_vector_right_type ;
-    typedef Kokkos::View< const T* , Kokkos::LayoutLeft , host > const_vector_type ;
-    typedef Kokkos::View< const T** , Kokkos::LayoutLeft , host > const_multivector_type ;
+    const_smultivector_type cmv( mv );
+    typename smultivector_type::const_type cmvX( cmv );
+    typename const_smultivector_type::const_type ccmvX( cmv );
 
-    multivector_type mv = multivector_type( "mv" , Length , Count );
-    multivector_right_type mv_right = multivector_right_type( "mv" , Length , Count );
-
-    vector_type v1 = Kokkos::subview( mv , Kokkos::ALL() , 0 );
-    vector_type v2 = Kokkos::subview( mv , Kokkos::ALL() , 1 );
-    vector_type v3 = Kokkos::subview( mv , Kokkos::ALL() , 2 );
-
-    vector_type rv1 = Kokkos::subview( mv_right , 0 , Kokkos::ALL() );
-    vector_type rv2 = Kokkos::subview( mv_right , 1 , Kokkos::ALL() );
-    vector_type rv3 = Kokkos::subview( mv_right , 2 , Kokkos::ALL() );
-
-    multivector_type mv1 = Kokkos::subview( mv , std::make_pair( 1 , 998 ) ,
-                                                 std::make_pair( 2 , 5 ) );
-
-    multivector_right_type mvr1 =
-      Kokkos::subview( mv_right ,
-                       std::make_pair( 1 , 998 ) ,
-                       std::make_pair( 2 , 5 ) );
-
-    const_vector_type cv1 = Kokkos::subview( mv , Kokkos::ALL(), 0 );
-    const_vector_type cv2 = Kokkos::subview( mv , Kokkos::ALL(), 1 );
-    const_vector_type cv3 = Kokkos::subview( mv , Kokkos::ALL(), 2 );
-
-    vector_right_type vr1 = Kokkos::subview( mv , Kokkos::ALL() , 0 );
-    vector_right_type vr2 = Kokkos::subview( mv , Kokkos::ALL() , 1 );
-    vector_right_type vr3 = Kokkos::subview( mv , Kokkos::ALL() , 2 );
-
-    const_vector_right_type cvr1 = Kokkos::subview( mv , Kokkos::ALL() , 0 );
-    const_vector_right_type cvr2 = Kokkos::subview( mv , Kokkos::ALL() , 1 );
-    const_vector_right_type cvr3 = Kokkos::subview( mv , Kokkos::ALL() , 2 );
-
-    ASSERT_TRUE( & v1[0] == & v1(0) );
-    ASSERT_TRUE( & v1[0] == & mv(0,0) );
-    ASSERT_TRUE( & v2[0] == & mv(0,1) );
-    ASSERT_TRUE( & v3[0] == & mv(0,2) );
-
-    ASSERT_TRUE( & cv1[0] == & mv(0,0) );
-    ASSERT_TRUE( & cv2[0] == & mv(0,1) );
-    ASSERT_TRUE( & cv3[0] == & mv(0,2) );
-
-    ASSERT_TRUE( & vr1[0] == & mv(0,0) );
-    ASSERT_TRUE( & vr2[0] == & mv(0,1) );
-    ASSERT_TRUE( & vr3[0] == & mv(0,2) );
-
-    ASSERT_TRUE( & cvr1[0] == & mv(0,0) );
-    ASSERT_TRUE( & cvr2[0] == & mv(0,1) );
-    ASSERT_TRUE( & cvr3[0] == & mv(0,2) );
-
-    ASSERT_TRUE( & mv1(0,0) == & mv( 1 , 2 ) );
-    ASSERT_TRUE( & mv1(1,1) == & mv( 2 , 3 ) );
-    ASSERT_TRUE( & mv1(3,2) == & mv( 4 , 4 ) );
-    ASSERT_TRUE( & mvr1(0,0) == & mv_right( 1 , 2 ) );
-    ASSERT_TRUE( & mvr1(1,1) == & mv_right( 2 , 3 ) );
-    ASSERT_TRUE( & mvr1(3,2) == & mv_right( 4 , 4 ) );
-
-    const_vector_type c_cv1( v1 );
-    typename vector_type::const_type c_cv2( v2 );
-    typename const_vector_type::const_type c_ccv2( v2 );
-
-    const_multivector_type cmv( mv );
-    typename multivector_type::const_type cmvX( cmv );
-    typename const_multivector_type::const_type ccmvX( cmv );
-*/
   }
 };
 

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -1181,16 +1181,30 @@ public:
     typedef Kokkos::Experimental::DynRankView< const T , device > sView ;
   //typedef Kokkos::Experimental::DynRankView< T , device > dView8 ;
     typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , device > dView8 ; //this works
+    typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , device > dView9 ; //this works
     //typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , Kokkos::Device<Kokkos::Serial , Kokkos::HostSpace > > dView8 ; //this works
 
 
     dView0 d0( "d0" );
     dView8 d8( "d8" , N0 , N1 , N2 , 2 , 2 , 2 , 2 , 2 );
+    dView9 d9( "d9" , N0 , N1 , N2 , 2 , 2 , 2 , 2 , 2 );
 
     sView s0 = d0 ;
 //    sView s8 = Kokkos::Experimental::subview( d8 , 1,1,1,1,1,1,1,1); //Should be rank0 subview
-    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() );
-//    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , 1 );// Does not compile yet...
+
+//Basic test - ALL
+//    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() ); //compiles and runs
+//  Send a single value for one rank
+//    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , 1 );
+//  Send a std::pair as a rank
+//    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , std::pair<unsigned,unsigned>(1,2) );
+//  Send a kokkos::pair as a rank
+    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+
+// Breaks...
+//    dView9 ds5 = Kokkos::Experimental::subview( d9 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+
+//
 /*
     dView1 d1( "d1" , N0 );
     dView2 d2( "d2" , N0 );

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -818,7 +818,6 @@ public:
   typedef Kokkos::Experimental::DynRankView< T , device > dView2 ;
   typedef Kokkos::Experimental::DynRankView< T , device > dView3 ;
   typedef Kokkos::Experimental::DynRankView< T , device > dView4 ;
-  typedef Kokkos::Experimental::DynRankView< T , device > dView8 ;
   typedef Kokkos::Experimental::DynRankView< const T , device > const_dView4 ;
 
   typedef Kokkos::Experimental::DynRankView< T, device, Kokkos::MemoryUnmanaged > dView4_unmanaged ;
@@ -1180,7 +1179,10 @@ public:
   static void run_test_subview()
   {
     typedef Kokkos::Experimental::DynRankView< const T , device > sView ;
-//    typedef Kokkos::Experimental::View< const T******** , device > sView8 ;
+  //typedef Kokkos::Experimental::DynRankView< T , device > dView8 ;
+    typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , device > dView8 ; //this works
+    //typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , Kokkos::Device<Kokkos::Serial , Kokkos::HostSpace > > dView8 ; //this works
+
 
     dView0 d0( "d0" );
     dView8 d8( "d8" , N0 , N1 , N2 , 2 , 2 , 2 , 2 , 2 );
@@ -1188,6 +1190,7 @@ public:
     sView s0 = d0 ;
 //    sView s8 = Kokkos::Experimental::subview( d8 , 1,1,1,1,1,1,1,1); //Should be rank0 subview
     dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() );
+//    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , 1 );// Does not compile yet...
 /*
     dView1 d1( "d1" , N0 );
     dView2 d2( "d2" , N0 );

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -827,7 +827,7 @@ public:
     run_test_const();
     run_test_subview();
     run_test_subview_strided();
-//    run_test_vector();
+    run_test_vector();
 
     TestViewOperator< T , device >::testit();
     TestViewOperator_LeftAndRight< int , device , 8 >::testit(2,3,4,2,3,4,2,3); 
@@ -1155,7 +1155,7 @@ public:
 // LayoutStride may be causing issues with how it is declared...
 
     typedef Kokkos::Experimental::DynRankView< const T , device > sView ;
-    typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , device > dView8 ; //this works
+    typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , device > sdView ; //this works
 
     dView0 d0( "d0" );
 /*
@@ -1171,7 +1171,7 @@ public:
 */
 
     unsigned order[] = { 6,5,4,3,2,1,0 }, dimen[] = { N0, N1, N2, 2, 2, 2, 2 };
-    dView8 d7( "d7", Kokkos::LayoutStride::order_dimensions(7, order, dimen) );
+    sdView d7( "d7", Kokkos::LayoutStride::order_dimensions(7, order, dimen) );
 /*
     std::cout << " d7 rank " << d7.rank() <<std::endl;
     std::cout << " d7 dim0 "<< d7.dimension_0() <<std::endl;
@@ -1185,7 +1185,7 @@ public:
 */
 
     unsigned order2[] = { 7,6,5,4,3,2,1,0 }, dimen2[] = { N0, N1, N2, 2, 2, 2, 2, 2 };
-    dView8 d8( "d8", Kokkos::LayoutStride::order_dimensions(8, order2, dimen2) );
+    sdView d8( "d8", Kokkos::LayoutStride::order_dimensions(8, order2, dimen2) );
 /*
     std::cout << " d8 rank " << d8.rank() <<std::endl;
     std::cout << " d8 dim0 "<< d8.dimension_0() <<std::endl;
@@ -1199,7 +1199,7 @@ public:
 */
 
     unsigned order3[] = { 4,3,2,1,0 }, dimen3[] = { N0, N1, N2, 2, 2 };
-    dView8 d5( "d5", Kokkos::LayoutStride::order_dimensions(5, order3, dimen3) );
+    sdView d5( "d5", Kokkos::LayoutStride::order_dimensions(5, order3, dimen3) );
 /*
     std::cout << " d5 rank " << d5.rank() <<std::endl;
     std::cout << " d5 dim0 "<< d5.dimension_0() <<std::endl;
@@ -1215,27 +1215,27 @@ public:
     dView0 dtest("dtest" , N0 , N1 , N2 , 2 , 2 , 2 , 2 , 2);
 
     sView s0 = d0 ;
-    dView8 ds0 = Kokkos::Experimental::subdynrankview( d8 , 1,1,1,1,1,1,1,1); //Should be rank0 subview
+    sdView ds0 = Kokkos::Experimental::subdynrankview( d8 , 1,1,1,1,1,1,1,1); //Should be rank0 subview
 
 //Basic test - ALL
-    dView8 ds1 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() ); //compiles and runs
+    sdView ds1 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() ); //compiles and runs
 //  Send a single value for one rank
-    dView8 ds2 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , 1 );
+    sdView ds2 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , 1 );
 //  Send a std::pair as a rank
-    dView8 ds3 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , std::pair<unsigned,unsigned>(1,2) );
+    sdView ds3 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , std::pair<unsigned,unsigned>(1,2) );
 //  Send a kokkos::pair as a rank
     std::cout<<" dt8 rank 8 subview... "<<std::endl; 
-    dView8 dt8 = Kokkos::Experimental::subdynrankview( dtest , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+    sdView dt8 = Kokkos::Experimental::subdynrankview( dtest , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
 
     std::cout<<" ds8 rank 8 subview... "<<std::endl;
-    dView8 ds8 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+    sdView ds8 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
 
 // Breaks...
     std::cout<<" ds7 rank 7 subview... "<<std::endl;
-    dView8 ds7 = Kokkos::Experimental::subdynrankview( d7 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+    sdView ds7 = Kokkos::Experimental::subdynrankview( d7 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
 
     std::cout<<" ds5 rank 5 subview... "<<std::endl;
-    dView8 ds5 = Kokkos::Experimental::subdynrankview( d5 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+    sdView ds5 = Kokkos::Experimental::subdynrankview( d5 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
   }
 
   static void run_test_subview_strided()
@@ -1250,14 +1250,15 @@ public:
     drview_stride yl2 = Kokkos::Experimental::subdynrankview( xl2 , 1 , Kokkos::ALL() );
     drview_stride ys1 = Kokkos::Experimental::subdynrankview( xr2 , 0 , Kokkos::ALL() );
     drview_stride ys2 = Kokkos::Experimental::subdynrankview( xr2 , 1 , Kokkos::ALL() );
-//    drview_right yr1 = Kokkos::Experimental::subdynrankview( xr2 , 0 , Kokkos::ALL() ); //errors out
-//    drview_right yr2 = Kokkos::Experimental::subdynrankview( xr2 , 1 , Kokkos::ALL() );
+    drview_stride yr1 = Kokkos::Experimental::subdynrankview( xr2 , 0 , Kokkos::ALL() ); //errors out
+    drview_stride yr2 = Kokkos::Experimental::subdynrankview( xr2 , 1 , Kokkos::ALL() );
 
 // Original subview testing
-    typedef Kokkos::Experimental::View < int[100][200] , Kokkos::LayoutRight , host > view_right_2 ;
+/*
+//    typedef Kokkos::Experimental::View < int[100][200] , Kokkos::LayoutRight , host > view_right_2 ;
     typedef Kokkos::Experimental::View < int[100][200] , Kokkos::LayoutLeft , host > view_left_2 ;
 
-    typedef Kokkos::Experimental::View < int* , host > sview_1 ;
+//    typedef Kokkos::Experimental::View < int* , host > sview_1 ;
     typedef Kokkos::Experimental::View < int* , Kokkos::LayoutStride , host > strview_1 ;
 
     view_left_2 vl2("vl2");
@@ -1269,7 +1270,6 @@ public:
     std::cout << "  stvl1.dim0 " << stvl1.dimension_0() <<std::endl;//should be 200
     std::cout << "  stvl1.dim1 " << stvl1.dimension_1() <<std::endl;//should be 1
 
-/*
     typedef Kokkos::Experimental::View < int[20][5][3] , Kokkos::LayoutRight , host > view_right_3 ;
     typedef Kokkos::Experimental::View < int** , host > view_right_2 ;
 
@@ -1291,7 +1291,7 @@ public:
     std::cout << "\n";
 */
 
-// end subview testing
+// end original subview testing
 
     std::cout << "  xl2.dim0 " << xl2.dimension_0() <<std::endl;
     std::cout << "  xl2.dim1 " << xl2.dimension_1() <<std::endl;
@@ -1305,7 +1305,7 @@ public:
 //    std::cout << "  yr2.dim1 " << yr2.dimension_1() <<std::endl;
     ASSERT_EQ( yl1.dimension_0() , xl2.dimension_1() );
     ASSERT_EQ( yl2.dimension_0() , xl2.dimension_1() );
-/*
+
     ASSERT_EQ( yr1.dimension_0() , xr2.dimension_1() );
     ASSERT_EQ( yr2.dimension_0() , xr2.dimension_1() );
 
@@ -1314,37 +1314,12 @@ public:
     ASSERT_EQ( & yr1(0) - & xr2(0,0) , 0 );
     ASSERT_EQ( & yr2(0) - & xr2(1,0) , 0 );
 
-//old
-    typedef Kokkos::View< int **** , Kokkos::LayoutLeft  , host >  view_left_4 ;
-    typedef Kokkos::View< int **** , Kokkos::LayoutRight , host >  view_right_4 ;
-    typedef Kokkos::View< int **   , Kokkos::LayoutLeft  , host >  view_left_2 ;
-    typedef Kokkos::View< int **   , Kokkos::LayoutRight , host >  view_right_2 ;
 
-    typedef Kokkos::View< int * ,  Kokkos::LayoutStride , host >  view_stride_1 ;
-    typedef Kokkos::View< int ** ,  Kokkos::LayoutStride , host >  view_stride_2 ;
+    drview_left  xl4( "xl4", 10 , 20 , 30 , 40 );
+    drview_right xr4( "xr4", 10 , 20 , 30 , 40 );
 
-    view_left_2  xl2("xl2", 100 , 200 );
-    view_right_2 xr2("xr2", 100 , 200 );
-    view_stride_1  yl1 = Kokkos::subview( xl2 , 0 , Kokkos::ALL() );
-    view_stride_1  yl2 = Kokkos::subview( xl2 , 1 , Kokkos::ALL() );
-    view_stride_1  yr1 = Kokkos::subview( xr2 , 0 , Kokkos::ALL() );
-    view_stride_1  yr2 = Kokkos::subview( xr2 , 1 , Kokkos::ALL() );
-
-    ASSERT_EQ( yl1.dimension_0() , xl2.dimension_1() );
-    ASSERT_EQ( yl2.dimension_0() , xl2.dimension_1() );
-    ASSERT_EQ( yr1.dimension_0() , xr2.dimension_1() );
-    ASSERT_EQ( yr2.dimension_0() , xr2.dimension_1() );
-
-    ASSERT_EQ( & yl1(0) - & xl2(0,0) , 0 );
-    ASSERT_EQ( & yl2(0) - & xl2(1,0) , 0 );
-    ASSERT_EQ( & yr1(0) - & xr2(0,0) , 0 );
-    ASSERT_EQ( & yr2(0) - & xr2(1,0) , 0 );
-
-    view_left_4 xl4( "xl4" , 10 , 20 , 30 , 40 );
-    view_right_4 xr4( "xr4" , 10 , 20 , 30 , 40 );
-
-    view_stride_2 yl4 = Kokkos::subview( xl4 , 1 , Kokkos::ALL() , 2 , Kokkos::ALL() );
-    view_stride_2 yr4 = Kokkos::subview( xr4 , 1 , Kokkos::ALL() , 2 , Kokkos::ALL() );
+    drview_stride yl4 = Kokkos::Experimental::subdynrankview( xl4 , 1 , Kokkos::ALL() , 2 , Kokkos::ALL() );
+    drview_stride yr4 = Kokkos::Experimental::subdynrankview( xr4 , 1 , Kokkos::ALL() , 2 , Kokkos::ALL() );
 
     ASSERT_EQ( yl4.dimension_0() , xl4.dimension_1() );
     ASSERT_EQ( yl4.dimension_1() , xl4.dimension_3() );
@@ -1353,13 +1328,85 @@ public:
 
     ASSERT_EQ( & yl4(4,4) - & xl4(1,4,2,4) , 0 );
     ASSERT_EQ( & yr4(4,4) - & xr4(1,4,2,4) , 0 );
-*/
+
   }
 
-/*
   static void run_test_vector()
   {
     static const unsigned Length = 1000 , Count = 8 ;
+
+    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutLeft , host > vector_type ; //rank 1
+    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutLeft , host > multivector_type ; //rank 2
+
+    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutRight , host > vector_right_type ; //rank 1
+    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutRight , host > multivector_right_type ; //rank 2
+
+    typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutRight , host > const_vector_right_type ; //rank 1
+    typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutLeft , host > const_vector_type ; //rank 1
+    typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutLeft , host > const_multivector_type ; //rank 2
+
+    multivector_type mv = multivector_type( "mv" , Length , Count );
+    multivector_right_type mv_right = multivector_right_type( "mv" , Length , Count );
+
+    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , host > svector_type ;
+    typedef typename Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , host > smultivector_type ;
+    typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutStride , host > const_svector_right_type ;
+    typedef typename Kokkos::Experimental::DynRankView< const T , Kokkos::LayoutStride , host > const_svector_type ;
+
+    svector_type v1 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL() , 0 );
+    svector_type v2 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL() , 1 );
+    svector_type v3 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL() , 2 );
+
+    svector_type rv1 = Kokkos::Experimental::subdynrankview( mv_right , 0 , Kokkos::ALL() );
+    svector_type rv2 = Kokkos::Experimental::subdynrankview( mv_right , 1 , Kokkos::ALL() );
+    svector_type rv3 = Kokkos::Experimental::subdynrankview( mv_right , 2 , Kokkos::ALL() );
+
+    smultivector_type mv1 = Kokkos::Experimental::subdynrankview( mv , std::make_pair( 1 , 998 ) ,
+                                                 std::make_pair( 2 , 5 ) );
+
+    smultivector_type mvr1 =
+      Kokkos::Experimental::subdynrankview( mv_right ,
+                       std::make_pair( 1 , 998 ) ,
+                       std::make_pair( 2 , 5 ) );
+
+    const_svector_type cv1 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL(), 0 );
+    const_svector_type cv2 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL(), 1 );
+    const_svector_type cv3 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL(), 2 );
+
+    svector_type vr1 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL() , 0 );
+    svector_type vr2 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL() , 1 );
+    svector_type vr3 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL() , 2 );
+
+    const_svector_right_type cvr1 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL() , 0 );
+    const_svector_right_type cvr2 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL() , 1 );
+    const_svector_right_type cvr3 = Kokkos::Experimental::subdynrankview( mv , Kokkos::ALL() , 2 );
+
+
+    ASSERT_TRUE( & v1[0] == & v1(0) );
+    ASSERT_TRUE( & v1[0] == & mv(0,0) );
+    ASSERT_TRUE( & v2[0] == & mv(0,1) );
+    ASSERT_TRUE( & v3[0] == & mv(0,2) );
+
+    ASSERT_TRUE( & cv1[0] == & mv(0,0) );
+    ASSERT_TRUE( & cv2[0] == & mv(0,1) );
+    ASSERT_TRUE( & cv3[0] == & mv(0,2) );
+
+    ASSERT_TRUE( & vr1[0] == & mv(0,0) );
+    ASSERT_TRUE( & vr2[0] == & mv(0,1) );
+    ASSERT_TRUE( & vr3[0] == & mv(0,2) );
+
+    ASSERT_TRUE( & cvr1[0] == & mv(0,0) );
+    ASSERT_TRUE( & cvr2[0] == & mv(0,1) );
+    ASSERT_TRUE( & cvr3[0] == & mv(0,2) );
+
+
+    ASSERT_TRUE( & mv1(0,0) == & mv( 1 , 2 ) );
+    ASSERT_TRUE( & mv1(1,1) == & mv( 2 , 3 ) );
+    ASSERT_TRUE( & mv1(3,2) == & mv( 4 , 4 ) );
+    ASSERT_TRUE( & mvr1(0,0) == & mv_right( 1 , 2 ) );
+    ASSERT_TRUE( & mvr1(1,1) == & mv_right( 2 , 3 ) );
+    ASSERT_TRUE( & mvr1(3,2) == & mv_right( 4 , 4 ) );
+/*
 
     typedef Kokkos::View< T* ,  Kokkos::LayoutLeft , host > vector_type ;
     typedef Kokkos::View< T** , Kokkos::LayoutLeft , host > multivector_type ;
@@ -1433,8 +1480,8 @@ public:
     const_multivector_type cmv( mv );
     typename multivector_type::const_type cmvX( cmv );
     typename const_multivector_type::const_type ccmvX( cmv );
-  }
 */
+  }
 };
 
 } // namespace Test

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -1178,6 +1178,8 @@ public:
 
   static void run_test_subview()
   {
+// LayoutStride may be causing issues with how it is declared...
+
     typedef Kokkos::Experimental::DynRankView< const T , device > sView ;
   //typedef Kokkos::Experimental::DynRankView< T , device > dView8 ;
     typedef Kokkos::Experimental::DynRankView< T , Kokkos::LayoutStride , device > dView8 ; //this works
@@ -1186,8 +1188,56 @@ public:
 
 
     dView0 d0( "d0" );
-    dView8 d8( "d8" , N0 , N1 , N2 , 2 , 2 , 2 , 2 , 2 );
-    dView9 d9( "d9" , N0 , N1 , N2 , 2 , 2 , 2 , 2 , 2 );
+    std::cout << " d0 rank " << d0.rank() <<std::endl;
+    std::cout << " d0 dim0 "<< d0.dimension_0() <<std::endl;
+    std::cout << " d0 dim1 "<< d0.dimension_1() <<std::endl;
+    std::cout << " d0 dim2 "<< d0.dimension_2() <<std::endl;
+    std::cout << " d0 dim3 "<< d0.dimension_3() <<std::endl;
+    std::cout << " d0 dim4 "<< d0.dimension_4() <<std::endl;
+    std::cout << " d0 dim5 "<< d0.dimension_5() <<std::endl;
+    std::cout << " d0 dim6 "<< d0.dimension_6() <<std::endl;
+    std::cout << " d0 dim7 "<< d0.dimension_7() <<std::endl;
+
+//    dView8 d7( "d7" , unsigned(N0) , unsigned(N1) , unsigned(N2) , 2 , 2 , 2 , 2 ); //rank 7 dynrank view 
+    unsigned order[] = { 6,5,4,3,2,1,0 }, dimen[] = { N0, N1, N2, 2, 2, 2, 2 };
+    dView8 d7( "d7", Kokkos::LayoutStride::order_dimensions(7, order, dimen) );
+    std::cout << " d7 rank " << d7.rank() <<std::endl;
+    std::cout << " d7 dim0 "<< d7.dimension_0() <<std::endl;
+    std::cout << " d7 dim1 "<< d7.dimension_1() <<std::endl;
+    std::cout << " d7 dim2 "<< d7.dimension_2() <<std::endl;
+    std::cout << " d7 dim3 "<< d7.dimension_3() <<std::endl;
+    std::cout << " d7 dim4 "<< d7.dimension_4() <<std::endl;
+    std::cout << " d7 dim5 "<< d7.dimension_5() <<std::endl;
+    std::cout << " d7 dim6 "<< d7.dimension_6() <<std::endl;
+    std::cout << " d7 dim7 "<< d7.dimension_7() <<std::endl;
+
+    //dView8 d8( "d8" , unsigned(N0) , unsigned(N1) , unsigned(N2) , 2 , 2 , 2 , 2 , 2 );
+    unsigned order2[] = { 7,6,5,4,3,2,1,0 }, dimen2[] = { N0, N1, N2, 2, 2, 2, 2, 2 };
+    dView8 d8( "d8", Kokkos::LayoutStride::order_dimensions(8, order2, dimen2) );
+    std::cout << " d8 rank " << d8.rank() <<std::endl;
+    std::cout << " d8 dim0 "<< d8.dimension_0() <<std::endl;
+    std::cout << " d8 dim1 "<< d8.dimension_1() <<std::endl;
+    std::cout << " d8 dim2 "<< d8.dimension_2() <<std::endl;
+    std::cout << " d8 dim3 "<< d8.dimension_3() <<std::endl;
+    std::cout << " d8 dim4 "<< d8.dimension_4() <<std::endl;
+    std::cout << " d8 dim5 "<< d8.dimension_5() <<std::endl;
+    std::cout << " d8 dim6 "<< d8.dimension_6() <<std::endl;
+    std::cout << " d8 dim7 "<< d8.dimension_7() <<std::endl;
+
+//    dView8 d5( "d5" , unsigned(N0) , unsigned(N1) , unsigned(N2) , 2 , 2 );
+    unsigned order3[] = { 4,3,2,1,0 }, dimen3[] = { N0, N1, N2, 2, 2 };
+    dView8 d5( "d5", Kokkos::LayoutStride::order_dimensions(5, order3, dimen3) );
+    std::cout << " d5 rank " << d5.rank() <<std::endl;
+    std::cout << " d5 dim0 "<< d5.dimension_0() <<std::endl;
+    std::cout << " d5 dim1 "<< d5.dimension_1() <<std::endl;
+    std::cout << " d5 dim2 "<< d5.dimension_2() <<std::endl;
+    std::cout << " d5 dim3 "<< d5.dimension_3() <<std::endl;
+    std::cout << " d5 dim4 "<< d5.dimension_4() <<std::endl;
+    std::cout << " d5 dim5 "<< d5.dimension_5() <<std::endl;
+    std::cout << " d5 dim6 "<< d5.dimension_6() <<std::endl;
+    std::cout << " d5 dim7 "<< d5.dimension_7() <<std::endl;
+
+    dView0 dtest("dtest" , N0 , N1 , N2 , 2 , 2 , 2 , 2 , 2);
 
     sView s0 = d0 ;
 //    sView s8 = Kokkos::Experimental::subview( d8 , 1,1,1,1,1,1,1,1); //Should be rank0 subview
@@ -1199,10 +1249,19 @@ public:
 //  Send a std::pair as a rank
 //    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , std::pair<unsigned,unsigned>(1,2) );
 //  Send a kokkos::pair as a rank
-    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+//
+//    std::cout<<" dt8 rank 8 subview... "<<std::endl; //dView8 for layout stride or dView0 for lright? Neither compile...
+//    dView0 dt8 = Kokkos::Experimental::subdynrankview( dtest , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) ); //this causes error if not a strided layout, but if strided layout chose without proper initialization then issues with dimensions...
+
+    std::cout<<" ds8 rank 8 subview... "<<std::endl;
+    dView8 ds8 = Kokkos::Experimental::subdynrankview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
 
 // Breaks...
-//    dView9 ds5 = Kokkos::Experimental::subview( d9 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+    std::cout<<" ds7 rank 7 subview... "<<std::endl;
+    dView8 ds7 = Kokkos::Experimental::subdynrankview( d7 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
+
+    std::cout<<" ds5 rank 5 subview... "<<std::endl;
+    dView8 ds5 = Kokkos::Experimental::subdynrankview( d5 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) );
 
 //
 /*

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -818,6 +818,7 @@ public:
   typedef Kokkos::Experimental::DynRankView< T , device > dView2 ;
   typedef Kokkos::Experimental::DynRankView< T , device > dView3 ;
   typedef Kokkos::Experimental::DynRankView< T , device > dView4 ;
+  typedef Kokkos::Experimental::DynRankView< T , device > dView8 ;
   typedef Kokkos::Experimental::DynRankView< const T , device > const_dView4 ;
 
   typedef Kokkos::Experimental::DynRankView< T, device, Kokkos::MemoryUnmanaged > dView4_unmanaged ;
@@ -829,7 +830,7 @@ public:
     run_test();
     run_test_scalar();
     run_test_const();
-//    run_test_subview();
+    run_test_subview();
 //    run_test_subview_strided();
 //    run_test_vector();
 
@@ -1175,24 +1176,31 @@ public:
     check_auto_conversion_to_const( x , x );
   }
 
-/*
+
   static void run_test_subview()
   {
-    typedef Kokkos::View< const T , device > sView ;
+    typedef Kokkos::Experimental::DynRankView< const T , device > sView ;
+//    typedef Kokkos::Experimental::View< const T******** , device > sView8 ;
 
     dView0 d0( "d0" );
+    dView8 d8( "d8" , N0 , N1 , N2 , 2 , 2 , 2 , 2 , 2 );
+
+    sView s0 = d0 ;
+//    sView s8 = Kokkos::Experimental::subview( d8 , 1,1,1,1,1,1,1,1); //Should be rank0 subview
+    dView8 ds8 = Kokkos::Experimental::subview( d8 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() );
+/*
     dView1 d1( "d1" , N0 );
     dView2 d2( "d2" , N0 );
     dView3 d3( "d3" , N0 );
     dView4 d4( "d4" , N0 );
-
-    sView s0 = d0 ;
     sView s1 = Kokkos::subview( d1 , 1 );
     sView s2 = Kokkos::subview( d2 , 1 , 1 );
     sView s3 = Kokkos::subview( d3 , 1 , 1 , 1 );
     sView s4 = Kokkos::subview( d4 , 1 , 1 , 1 , 1 );
+*/
   }
 
+/*
   static void run_test_subview_strided()
   {
     typedef Kokkos::View< int **** , Kokkos::LayoutLeft  , host >  view_left_4 ;

--- a/core/src/KokkosExp_View.hpp
+++ b/core/src/KokkosExp_View.hpp
@@ -1083,6 +1083,24 @@ public:
       return m_map.reference(i0,i1,i2,i3,i4,i5,i6,i7);
     }
 
+// For DynRankView...
+  template< typename I0 >
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<
+    ( Kokkos::Impl::are_integral<I0>::value
+      && ( 8 == Rank )
+      && is_default_map
+      && is_layout_stride
+    ), reference_type >::type
+  operator[]( const I0 & i0 ) const
+    {
+//      KOKKOS_VIEW_OPERATOR_VERIFY( (m_map,i0) )
+      KOKKOS_VIEW_OPERATOR_VERIFY( (m_map,i0,0,0,0,0,0,0,0) )
+
+      return m_map.m_handle[ m_map.m_offset.m_stride.S0 * i0 ];
+    }
+
+
 #undef KOKKOS_VIEW_OPERATOR_VERIFY
 
   //----------------------------------------

--- a/core/src/KokkosExp_View.hpp
+++ b/core/src/KokkosExp_View.hpp
@@ -1044,25 +1044,6 @@ public:
       return m_map.reference(i0,i1,i2,i3,i4,i5,i6);
     }
 
-#if 1
-  // For DynRankView...
-  template< typename I0 >
-  KOKKOS_FORCEINLINE_FUNCTION
-  typename std::enable_if<
-    ( Kokkos::Impl::are_integral<I0>::value
-      && is_default_map
-      && is_layout_stride
-      && ( Rank == 7 )
-    ), reference_type >::type
-  operator[]( const I0 & i0 ) const
-    {
-      KOKKOS_VIEW_OPERATOR_VERIFY( (m_map,i0,0,0,0,0,0,0) )
-
-      return m_map.m_handle[ m_map.m_offset.m_stride.S0 * i0 ];
-    }
-  //End DynRankView
-#endif
-
   //------------------------------
   // Rank 8
 

--- a/core/src/KokkosExp_View.hpp
+++ b/core/src/KokkosExp_View.hpp
@@ -1044,6 +1044,25 @@ public:
       return m_map.reference(i0,i1,i2,i3,i4,i5,i6);
     }
 
+#if 1
+  // For DynRankView...
+  template< typename I0 >
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if<
+    ( Kokkos::Impl::are_integral<I0>::value
+      && is_default_map
+      && is_layout_stride
+      && ( Rank == 7 )
+    ), reference_type >::type
+  operator[]( const I0 & i0 ) const
+    {
+      KOKKOS_VIEW_OPERATOR_VERIFY( (m_map,i0,0,0,0,0,0,0) )
+
+      return m_map.m_handle[ m_map.m_offset.m_stride.S0 * i0 ];
+    }
+  //End DynRankView
+#endif
+
   //------------------------------
   // Rank 8
 
@@ -1082,24 +1101,6 @@ public:
 
       return m_map.reference(i0,i1,i2,i3,i4,i5,i6,i7);
     }
-
-// For DynRankView...
-  template< typename I0 >
-  KOKKOS_FORCEINLINE_FUNCTION
-  typename std::enable_if<
-    ( Kokkos::Impl::are_integral<I0>::value
-      && ( 8 == Rank )
-      && is_default_map
-      && is_layout_stride
-    ), reference_type >::type
-  operator[]( const I0 & i0 ) const
-    {
-//      KOKKOS_VIEW_OPERATOR_VERIFY( (m_map,i0) )
-      KOKKOS_VIEW_OPERATOR_VERIFY( (m_map,i0,0,0,0,0,0,0,0) )
-
-      return m_map.m_handle[ m_map.m_offset.m_stride.S0 * i0 ];
-    }
-
 
 #undef KOKKOS_VIEW_OPERATOR_VERIFY
 

--- a/core/src/impl/KokkosExp_ViewMapping.hpp
+++ b/core/src/impl/KokkosExp_ViewMapping.hpp
@@ -1221,14 +1221,7 @@ public:
       const SubviewExtents< DimRHS::rank , dimension_type::rank > & sub )
     : m_dim( sub.range_extent(0)
            , sub.range_extent(1)
-           , sub.range_extent(2)
-           , sub.range_extent(3)
-           , sub.range_extent(4)
-           , sub.range_extent(5)
-           , sub.range_extent(6)
-           , sub.range_extent(7)
-           )
-//           , 0, 0, 0, 0, 0, 0 )
+           , 0, 0, 0, 0, 0, 0 )
     , m_stride( ( 1 == sub.range_index(1) ? rhs.stride_1() :
                 ( 2 == sub.range_index(1) ? rhs.stride_2() :
                 ( 3 == sub.range_index(1) ? rhs.stride_3() :
@@ -1707,14 +1700,7 @@ public:
     )
     : m_dim( sub.range_extent(0)
            , sub.range_extent(1)
-           , sub.range_extent(2)
-           , sub.range_extent(3)
-           , sub.range_extent(4)
-           , sub.range_extent(5)
-           , sub.range_extent(6)
-           , sub.range_extent(7)
-           )
-//           , 0, 0, 0, 0, 0, 0 ) //should be unnecessary with correct guards in subview ViewMapping and static_assert below
+           , 0, 0, 0, 0, 0, 0 ) 
     , m_stride( 0 == sub.range_index(0) ? rhs.stride_0() : (
                 1 == sub.range_index(0) ? rhs.stride_1() : (
                 2 == sub.range_index(0) ? rhs.stride_2() : (
@@ -1740,6 +1726,20 @@ public:
 
 template< unsigned Rank >
 struct ViewStride ;
+
+template<>
+struct ViewStride<0> {
+  enum { S0 = 0 , S1 = 0 , S2 = 0 , S3 = 0 , S4 = 0 , S5 = 0 , S6 = 0 , S7 = 0 };
+
+  ViewStride() = default ;
+  ViewStride( const ViewStride & ) = default ;
+  ViewStride & operator = ( const ViewStride & ) = default ;
+
+  KOKKOS_INLINE_FUNCTION
+  constexpr ViewStride( size_t , size_t , size_t , size_t
+                      , size_t , size_t , size_t , size_t )
+    {}
+};
 
 template<>
 struct ViewStride<1> {
@@ -1874,7 +1874,8 @@ struct ViewStride<8> {
 
 template < class Dimension >
 struct ViewOffset< Dimension , Kokkos::LayoutStride
-                 , typename std::enable_if<( 0 < Dimension::rank )>::type >
+                 , void >
+//                 , typename std::enable_if<( 0 < Dimension::rank )>::type >
 {
 private:
   typedef ViewStride< Dimension::rank >  stride_type ;

--- a/core/src/impl/KokkosExp_ViewMapping.hpp
+++ b/core/src/impl/KokkosExp_ViewMapping.hpp
@@ -259,19 +259,9 @@ struct ALL_t {
   constexpr const ALL_t & operator()() const { return *this ; }
 };
 
-struct EXTENT_ONE_t {
-  size_t value;
-  EXTENT_ONE_t( const size_t i) : value(i) {}
-//  EXTENT_ONE_t() = default ; //causes error in dyn rank subview rank...
-//  EXTENT_ONE_t( const EXTENT_ONE_t & ) = default ;
-//  EXTENT_ONE_t & operator = ( const EXTENT_ONE_t & ) = default ;
-  //{ static_assert(false , "EXTENT_ONE_t called"); }
-};
-
 template< class T >
 struct is_integral_extent_type
-//{ enum { value = std::is_same<T,Kokkos::Experimental::Impl::ALL_t>::value ? 1 : 0 }; };
-{ enum { value = (std::is_same<T,Kokkos::Experimental::Impl::ALL_t>::value || std::is_same<T,Kokkos::Experimental::Impl::EXTENT_ONE_t>::value  ) ? 1 : 0 }; };
+{ enum { value = std::is_same<T,Kokkos::Experimental::Impl::ALL_t>::value ? 1 : 0 }; };
 
 template< class iType >
 struct is_integral_extent_type< std::pair<iType,iType> >
@@ -355,22 +345,6 @@ private:
     {
       m_begin[  domain_rank ] = 0 ;
       m_length[ range_rank  ] = dim.extent( domain_rank );
-      m_index[  range_rank  ] = domain_rank ;
-
-      return set( domain_rank + 1 , range_rank + 1 , dim , args... );
-    }
-
-  // EXTENT_ONE_t
-  template< size_t ... DimArgs , class ... Args >
-  KOKKOS_FORCEINLINE_FUNCTION
-  bool set( unsigned domain_rank
-          , unsigned range_rank
-          , const ViewDimension< DimArgs ... > & dim
-          , const Kokkos::Experimental::Impl::EXTENT_ONE_t ext
-          , Args ... args )
-    {
-      m_begin[  domain_rank ] = ext.value ;
-      m_length[ range_rank  ] = 1 ;
       m_index[  range_rank  ] = domain_rank ;
 
       return set( domain_rank + 1 , range_rank + 1 , dim , args... );
@@ -1247,7 +1221,14 @@ public:
       const SubviewExtents< DimRHS::rank , dimension_type::rank > & sub )
     : m_dim( sub.range_extent(0)
            , sub.range_extent(1)
-           , 0, 0, 0, 0, 0, 0 )
+           , sub.range_extent(2)
+           , sub.range_extent(3)
+           , sub.range_extent(4)
+           , sub.range_extent(5)
+           , sub.range_extent(6)
+           , sub.range_extent(7)
+           )
+//           , 0, 0, 0, 0, 0, 0 )
     , m_stride( ( 1 == sub.range_index(1) ? rhs.stride_1() :
                 ( 2 == sub.range_index(1) ? rhs.stride_2() :
                 ( 3 == sub.range_index(1) ? rhs.stride_3() :
@@ -1726,7 +1707,14 @@ public:
     )
     : m_dim( sub.range_extent(0)
            , sub.range_extent(1)
-           , 0, 0, 0, 0, 0, 0 )
+           , sub.range_extent(2)
+           , sub.range_extent(3)
+           , sub.range_extent(4)
+           , sub.range_extent(5)
+           , sub.range_extent(6)
+           , sub.range_extent(7)
+           )
+//           , 0, 0, 0, 0, 0, 0 ) //should be unnecessary with correct guards in subview ViewMapping and static_assert below
     , m_stride( 0 == sub.range_index(0) ? rhs.stride_0() : (
                 1 == sub.range_index(0) ? rhs.stride_1() : (
                 2 == sub.range_index(0) ? rhs.stride_2() : (

--- a/core/src/impl/KokkosExp_ViewMapping.hpp
+++ b/core/src/impl/KokkosExp_ViewMapping.hpp
@@ -286,10 +286,6 @@ struct is_integral_extent
           >::type >::type >::type type ;
 
   enum { value = is_integral_extent_type<type>::value };
-// is_all?
-// is_integer?
-// is_less_all?
-// is_void?
 
   static_assert( value ||
                  std::is_integral<type>::value ||
@@ -1723,6 +1719,7 @@ public:
 
 //----------------------------------------------------------------------------
 /* Strided array layout only makes sense for 0 < rank */
+/* rank = 0 included for DynRankView case */
 
 template< unsigned Rank >
 struct ViewStride ;
@@ -1875,7 +1872,6 @@ struct ViewStride<8> {
 template < class Dimension >
 struct ViewOffset< Dimension , Kokkos::LayoutStride
                  , void >
-//                 , typename std::enable_if<( 0 < Dimension::rank )>::type >
 {
 private:
   typedef ViewStride< Dimension::rank >  stride_type ;
@@ -2711,7 +2707,6 @@ private:
     , R6 = bool(is_integral_extent<6,Args...>::value)
     , R7 = bool(is_integral_extent<7,Args...>::value)
     };
-  //Query additional info
 
   enum { rank = unsigned(R0) + unsigned(R1) + unsigned(R2) + unsigned(R3)
               + unsigned(R4) + unsigned(R5) + unsigned(R6) + unsigned(R7) };
@@ -2738,11 +2733,6 @@ private:
         // OutputRank 1 or 2, InputLayout Right, Interval [InputRank-1]
         // because single stride one or second index has a stride.
         ( rank <= 2 && R0_rev && std::is_same< typename SrcTraits::array_layout , Kokkos::LayoutRight >::value ) //replace input rank
-        // Or case will help with DynRankView etc
-//        ||
-//        ( rank == 8 && SrcTraits::rank && R0 && std::is_same< typename SrcTraits::array_layout , Kokkos::LayoutLeft >::value )
-//        ||
-//        ( rank == 8 && SrcTraits::rank && R0_rev && std::is_same< typename SrcTraits::array_layout , Kokkos::LayoutRight >::value )
       ), typename SrcTraits::array_layout , Kokkos::LayoutStride
       >::type array_layout ;
 

--- a/core/src/impl/KokkosExp_ViewMapping.hpp
+++ b/core/src/impl/KokkosExp_ViewMapping.hpp
@@ -262,6 +262,10 @@ struct ALL_t {
 struct EXTENT_ONE_t {
   size_t value;
   EXTENT_ONE_t( const size_t i) : value(i) {}
+//  EXTENT_ONE_t() = default ; //causes error in dyn rank subview rank...
+//  EXTENT_ONE_t( const EXTENT_ONE_t & ) = default ;
+//  EXTENT_ONE_t & operator = ( const EXTENT_ONE_t & ) = default ;
+  //{ static_assert(false , "EXTENT_ONE_t called"); }
 };
 
 template< class T >


### PR DESCRIPTION
Updated DynRankView to include subview functionality and compatibility with Sacado

- DynRankView can have at most a rank of 7

- The method rank() is used to return the dynamic rank

- subdynrankview is the name for the dynamic rank subview function

Related to kokkos issue #189 and trilinos intrepid2 `https://github.com/trilinos/Trilinos/issues/152`