### PR TITLE
attempt to address issue #226

### DIFF
--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -118,6 +118,9 @@ struct FunctorValueTraits< FunctorType , ArgTag , true /* == exists FunctorType:
   typedef typename Impl::if_c< ! StaticValueSize , value_type *
                                                  , value_type & >::type  reference_type ;
 
+  static_assert(StaticValueSize == 0 || StaticValueSize >= sizeof(int),
+      "Functor declared value_type must be at least word-sized");
+
   // Number of values if single value
   template< class F >
   KOKKOS_FORCEINLINE_FUNCTION static
@@ -341,6 +344,9 @@ public:
   typedef typename Impl::if_c< IS_VOID || IS_REJECT , void , ValueType & >::type  reference_type ;
 
   enum { StaticValueSize = IS_VOID || IS_REJECT ? 0 : sizeof(ValueType) };
+
+  static_assert(StaticValueSize == 0 || StaticValueSize >= sizeof(int),
+      "Functor deduced value_type must be at least word-sized");
 
   KOKKOS_FORCEINLINE_FUNCTION static
   unsigned value_size( const FunctorType & ) { return StaticValueSize ; }


### PR DESCRIPTION
(I know this makes two issues (#225, #226) and one pull request for a tiny thing, but I want to help out). This is either a real fix or a straw man for the real fix. FunctorValueTraits seemed the proper place to catch this issue. The current version ignores array types, I don't know what the rule ought to be in that case. I used plain "int" because that was @hcedwar 's description in #225, probably a better definition of word size is in order. To me word size usually means sizeof(void*).
