### PR TITLE
Fixes Illegal Instruction and Segmentation Faults in Intel 17.0 compiling for Knights Landing AVX512

### DIFF
--- a/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
@@ -156,9 +156,26 @@ T atomic_fetch_add( volatile T * const dest ,
 
 #elif defined(KOKKOS_ATOMICS_USE_GCC) || defined(KOKKOS_ATOMICS_USE_INTEL)
 
+#if defined( KOKKOS_ENABLE_ASM ) && defined ( KOKKOS_USE_ISA_X86_64 )
+KOKKOS_INLINE_FUNCTION
+int atomic_fetch_add( volatile int * dest , const int val )
+{
+	int original = val;
+
+	__asm__ __volatile__(
+      		"lock xadd %1, %0"
+      		: "+m" (*dest), "+r" (original)
+      		: "m" (*dest), "r" (original)
+      		: "memory"
+    	);
+
+	return original;
+}
+#else
 KOKKOS_INLINE_FUNCTION
 int atomic_fetch_add( volatile int * const dest , const int val )
-{ return __sync_fetch_and_add(dest,val); }
+{ return __sync_fetch_and_add(dest, val); }
+#endif
 
 KOKKOS_INLINE_FUNCTION
 long int atomic_fetch_add( volatile long int * const dest , const long int val )


### PR DESCRIPTION
Addresses an issue with internal intrinsics on Intel 17.0 for Knights Landing AVX512 by replacing intrinsics with specific `asm voltatile` sequence. This passes on `ARCH={KNL, HSW}` with Intel and GCC compilers.