### PR TITLE
Fix typo in comment: specififed -> specified.

### DIFF
--- a/example/md_skeleton/main.cpp
+++ b/example/md_skeleton/main.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
   int iter = 100;
 
   /* Default value for system size (4*nx*ny*nz atoms)
-   * nx, ny and nz are set to system_size if not specififed on commandline */
+   * nx, ny and nz are set to system_size if not specified on commandline */
 
   int system_size = 20;
   int nx = -1;


### PR DESCRIPTION
Small nit I noticed while perusing the sources.