### PR TITLE
Make generate_makefile.bash issue warning for unrecognized option.

### DIFF
--- a/generate_makefile.bash
+++ b/generate_makefile.bash
@@ -107,7 +107,7 @@ case $key in
     exit 0
     ;;
     *)
-            # unknown option
+    echo "warning: ignoring unknown option $key"
     ;;
 esac
 shift


### PR DESCRIPTION
This PR makes `generate_makefile.bash` report unrecognized options.  The motivation is that I spent a while hunting down what turned out to be a misspelled (single '-') option.