### PR TITLE
Fixed race condition in team_broadcast

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -122,6 +122,7 @@ public:
     }
     team_barrier();
     value = sh_val;
+    team_barrier();
   }
 
 #ifdef KOKKOS_HAVE_CXX11


### PR DESCRIPTION
Fixed race condition in team_broadcast when multiple broadcasts are done one after another. In that case the shared memory location of sh_val variable gets reused. This may result in overwriting it by thread thread_id before other threads read the value from the previous call.