### PR TITLE
Make test_atomic.cpp print times in order consistent with results.

### DIFF
--- a/core/perf_test/test_atomic.cpp
+++ b/core/perf_test/test_atomic.cpp
@@ -414,24 +414,27 @@ void Loop(int loop, int test, const char* type_name) {
 
   Kokkos::Impl::Timer timer;
   T res = LoopVariant<T>(loop,test);
-  double time1 = timer.seconds();
+  double time = timer.seconds();
 
   timer.reset();
   T resNonAtomic = LoopVariantNonAtomic<T>(loop,test);
-  double time2 = timer.seconds();
+  double timeNonAtomic = timer.seconds();
 
   timer.reset();
   T resSerial = LoopVariantSerial<T>(loop,test);
-  double time3 = timer.seconds();
+  double timeSerial = timer.seconds();
 
-  time1*=1e6/loop;
-  time2*=1e6/loop;
-  time3*=1e6/loop;
+  time         *=1e6/loop;
+  timeNonAtomic*=1e6/loop;
+  timeSerial   *=1e6/loop;
   //textcolor_standard();
   bool passed = true;
   if(resSerial!=res) passed = false;
   //if(!passed) textcolor(RESET,BLACK,YELLOW);
-  printf("%s Test %i %s  --- Loop: %i Value (S,A,NA): %e %e %e Time: %7.4e %7.4e %7.4e Size of Type %i)",type_name,test,passed?"PASSED":"FAILED",loop,1.0*resSerial,1.0*res,1.0*resNonAtomic,time1,time2,time3,(int)sizeof(T));
+  printf("%s Test %i %s  --- Loop: %i Value (S,A,NA): %e %e %e Time: %7.4e %7.4e %7.4e Size of Type %i)",
+         type_name,test,passed?"PASSED":"FAILED",loop,
+         1.0*resSerial,1.0*res,1.0*resNonAtomic,
+         timeSerial,time,timeNonAtomic,(int)sizeof(T));
   //if(!passed) textcolor_standard();
   printf("\n");
 }


### PR DESCRIPTION
Patch for #373.  I renamed the `time` variables to be analogous to the `res` variables.  That undoes some typographic alignment, but made it much easier for me to keep track of what went with what.