### PR TITLE
DynRankView: Add ops() specialized for perf

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -265,7 +265,6 @@ class ViewMapping< DstTraits , SrcTraits ,
   ) , ViewToDynRankViewTag >::type >
 {
 private:
-
   enum { is_assignable_value_type =
     std::is_same< typename DstTraits::value_type
                 , typename SrcTraits::value_type >::value ||
@@ -341,7 +340,7 @@ class DynRankView : public ViewTraits< DataType , Properties ... >
 
 private: 
   template < class , class ... > friend class DynRankView ;
-//  template < class , class ... > friend class Kokkos::Experimental::View ; //unnecessary now...
+//  template < class , class ... > friend class Kokkos::View ; //unnecessary now...
   template < class , class ... > friend class Impl::ViewMapping ;
 
 public: 
@@ -537,7 +536,7 @@ public:
       //return m_map.reference(0,0,0,0,0,0,0); 
     }
 
-  // Rank 1
+  // Rank 1 []
   // This assumes a contiguous underlying memory (i.e. no padding, no striding...)
   template< typename iType >
   KOKKOS_INLINE_FUNCTION
@@ -563,13 +562,34 @@ public:
       return rankone_view(i0);
     }
 
+
+  // Rank 1 ()
   template< typename iType >
-  KOKKOS_INLINE_FUNCTION
-  typename std::enable_if< (std::is_same<typename traits::specialize , void>::value && std::is_integral<iType>::value), reference_type>::type
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if< (std::is_same<typename traits::specialize , void>::value && std::is_integral<iType>::value && !is_default_map ), reference_type>::type
   operator()(const iType & i0 ) const 
     { 
       KOKKOS_VIEW_OPERATOR_VERIFY( 1 , ( m_map , i0 ) )
       return m_map.reference(i0); 
+    }
+
+  template< typename iType >
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if< (std::is_same<typename traits::specialize , void>::value && std::is_integral<iType>::value && is_default_map && !is_layout_stride ), reference_type>::type
+  operator()(const iType & i0 ) const 
+    { 
+      KOKKOS_VIEW_OPERATOR_VERIFY( 1 , ( m_map , i0 ) )
+      //return m_map.reference(i0); 
+      return m_map.m_handle[i0]; 
+    }
+
+  template< typename iType >
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if< (std::is_same<typename traits::specialize , void>::value && std::is_integral<iType>::value && is_default_map && is_layout_stride ), reference_type>::type
+  operator()(const iType & i0 ) const 
+    { 
+      KOKKOS_VIEW_OPERATOR_VERIFY( 1 , ( m_map , i0 ) )
+      return m_map.m_handle[ m_map.m_offset.m_stride.S0 * i0 ];
     }
 
   template< typename iType >
@@ -580,14 +600,42 @@ public:
       return m_map.reference(i0,0,0,0,0,0,0);
     }
 
-  // Rank 2
   template< typename iType0 , typename iType1 >
-  KOKKOS_INLINE_FUNCTION
-  typename std::enable_if< (std::is_same<typename traits::specialize , void>::value && std::is_integral<iType0>::value  && std::is_integral<iType1>::value), reference_type>::type
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if< (std::is_same<typename traits::specialize , void>::value && std::is_integral<iType0>::value  && std::is_integral<iType1>::value && !is_default_map), reference_type>::type
   operator()(const iType0 & i0 , const iType1 & i1 ) const 
     { 
       KOKKOS_VIEW_OPERATOR_VERIFY( 2 , ( m_map , i0 , i1 ) )
       return m_map.reference(i0,i1); 
+    }
+
+  template< typename iType0 , typename iType1 >
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if< (std::is_same<typename traits::specialize , void>::value && std::is_integral<iType0>::value  && std::is_integral<iType1>::value && is_default_map && is_layout_left), reference_type>::type
+  operator()(const iType0 & i0 , const iType1 & i1 ) const 
+    { 
+      KOKKOS_VIEW_OPERATOR_VERIFY( 2 , ( m_map , i0 , i1 ) )
+      return m_map.m_handle[ i0 + m_map.m_offset.m_stride * i1 ];
+      //return m_map.reference(i0,i1); 
+    }
+
+  template< typename iType0 , typename iType1 >
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if< (std::is_same<typename traits::specialize , void>::value && std::is_integral<iType0>::value  && std::is_integral<iType1>::value && is_default_map && is_layout_right), reference_type>::type
+  operator()(const iType0 & i0 , const iType1 & i1 ) const 
+    { 
+      KOKKOS_VIEW_OPERATOR_VERIFY( 2 , ( m_map , i0 , i1 ) )
+      return m_map.m_handle[ i1 + m_map.m_offset.m_stride * i0 ];
+    }
+
+  template< typename iType0 , typename iType1 >
+  KOKKOS_FORCEINLINE_FUNCTION
+  typename std::enable_if< (std::is_same<typename traits::specialize , void>::value && std::is_integral<iType0>::value  && std::is_integral<iType1>::value && is_default_map && is_layout_stride), reference_type>::type
+  operator()(const iType0 & i0 , const iType1 & i1 ) const 
+    { 
+      KOKKOS_VIEW_OPERATOR_VERIFY( 2 , ( m_map , i0 , i1 ) )
+      return m_map.m_handle[ i0 * m_map.m_offset.m_stride.S0 +
+                             i1 * m_map.m_offset.m_stride.S1 ];
     }
 
   template< typename iType0 , typename iType1 >

--- a/core/src/impl/KokkosExp_ViewMapping.hpp
+++ b/core/src/impl/KokkosExp_ViewMapping.hpp
@@ -2338,11 +2338,7 @@ class ViewMapping< Traits ,
               , void >::is_mapping_plugin::value
   )>::type >
 {
-private:
-
-  template< class , class ... > friend class ViewMapping ;
-  template< class , class ... > friend class Kokkos::Experimental::View ;
-
+public:
   typedef ViewOffset< typename Traits::dimension
                     , typename Traits::array_layout
                     , void
@@ -2358,8 +2354,6 @@ private:
     : m_handle( arg_handle )
     , m_offset( arg_offset )
     {}
-
-public:
 
   //----------------------------------------
   // Domain dimensions


### PR DESCRIPTION
Required moving private components of ViewMapping to public
accessibility; these components were already being accessed through
friendship by the View
	modified:   containers/src/Kokkos_DynRankView.hpp
	modified:   core/src/impl/KokkosExp_ViewMapping.hpp