### PR TITLE
Timer: Added Kokkos_Timer to core

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -72,6 +72,7 @@
 #include <Kokkos_Vectorization.hpp>
 #include <Kokkos_Atomic.hpp>
 #include <Kokkos_hwloc.hpp>
+#include <Kokkos_Timer.hpp>
 
 #ifdef KOKKOS_HAVE_CXX11
 #include <Kokkos_Complex.hpp>

--- a/core/src/Kokkos_Timer.hpp
+++ b/core/src/Kokkos_Timer.hpp
@@ -41,23 +41,72 @@
 //@HEADER
 */
 
-#ifndef KOKKOS_IMPLWALLTIME_HPP
-#define KOKKOS_IMPLWALLTIME_HPP
+#ifndef KOKKOS_TIMER_HPP
+#define KOKKOS_TIMER_HPP
 
-#include <Kokkos_Timer.hpp>
+#include <stddef.h>
+
+#ifdef _MSC_VER
+#undef KOKKOS_USE_LIBRT
+#include <gettimeofday.c>
+#else
+#ifdef KOKKOS_USE_LIBRT
+#include <ctime>
+#else
+#include <sys/time.h>
+#endif
+#endif
 
 namespace Kokkos {
-namespace Impl {
 
-/** \brief  Time since construction 
- *   Timer promoted from Impl to Kokkos ns
- *   This file included for backwards compatibility
- */
+/** \brief  Time since construction */
 
-  using Kokkos::Timer ;
+class Timer {
+private:
+  #ifdef KOKKOS_USE_LIBRT
+	struct timespec m_old;
+  #else
+	struct timeval m_old ;
+  #endif
+  Timer( const Timer & );
+  Timer & operator = ( const Timer & );
+public:
 
-} // namespace Impl
+  inline
+  void reset() {
+    #ifdef KOKKOS_USE_LIBRT
+	  clock_gettime(CLOCK_REALTIME, &m_old);
+    #else
+	  gettimeofday( & m_old , ((struct timezone *) NULL ) );
+    #endif
+  }
+
+  inline
+  ~Timer() {}
+
+  inline
+  Timer() { reset(); }
+
+  inline
+  double seconds() const
+  {
+    #ifdef KOKKOS_USE_LIBRT
+      struct timespec m_new;
+      clock_gettime(CLOCK_REALTIME, &m_new);
+
+      return ( (double) ( m_new.tv_sec  - m_old.tv_sec ) ) +
+             ( (double) ( m_new.tv_nsec - m_old.tv_nsec ) * 1.0e-9 );
+    #else
+      struct timeval m_new ;
+
+      ::gettimeofday( & m_new , ((struct timezone *) NULL ) );
+
+      return ( (double) ( m_new.tv_sec  - m_old.tv_sec ) ) +
+             ( (double) ( m_new.tv_usec - m_old.tv_usec ) * 1.0e-6 );
+    #endif
+  }
+};
+
 } // namespace Kokkos
 
-#endif /* #ifndef KOKKOS_IMPLWALLTIME_HPP */
-
+#endif /* #ifndef KOKKOS_TIMER_HPP */


### PR DESCRIPTION
Promotion of Timer from Impl to core was incomplete
* Moved Timer functionality to the file kokkos/core/src/Kokkos_Timer.hpp
* Included above file in Kokkos_Core
* impl/Kokkos_Timer.hpp still remains for backwards compatibility and now
only includes an alias for Kokkos::Impl::Timer (backwards compatibility)

	modified:   Kokkos_Core.hpp
	new file:   Kokkos_Timer.hpp
	modified:   impl/Kokkos_Timer.hpp