### PR TITLE
Switch test_all_sandia to use new smart modules from SEMS NFS TPLs

### DIFF
--- a/config/test_all_sandia
+++ b/config/test_all_sandia
@@ -52,11 +52,10 @@ ARCH_FLAG=""
 #
 
 if [ "$MACHINE" = "sems" ]; then
-    source /projects/modulefiles/utils/sems-modules-init.sh
-    source /projects/modulefiles/utils/kokkos-modules-init.sh
+    source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
-    BASE_MODULE_LIST="<COMPILER_NAME>/<COMPILER_VERSION>/base,hwloc/1.10.1/<COMPILER_NAME>/<COMPILER_VERSION>/base"
-    CUDA_MODULE_LIST="<COMPILER_NAME>/<COMPILER_VERSION>,gcc/4.7.2/base"
+    BASE_MODULE_LIST="sems-env,kokkos-env,sems-<COMPILER_NAME>/<COMPILER_VERSION>,kokkos-hwloc/1.10.1/base"
+    CUDA_MODULE_LIST="sems-env,kokkos-env,kokkos-<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/4.7.2"
 
     # Format: (compiler module-list build-list exe-name warning-flag)
     COMPILERS=("gcc/4.7.2 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"


### PR DESCRIPTION
Verified that these changes work on kokkos-dev. Going to self-integrate.