### PR TITLE
Removes GNU Platform Options on POWER8 when Using PGI Compiler

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -403,8 +403,13 @@ endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_POWER8), 1)
     tmp := $(shell echo "\#define KOKKOS_ARCH_POWER8 1" >> KokkosCore_config.tmp )
-	KOKKOS_CXXFLAGS += -mcpu=power8 -mtune=power8
-	KOKKOS_LDFLAGS  += -mcpu=power8 -mtune=power8
+	ifeq ($(KOKKOS_INTERNAL_COMPILER_PGI), 1) 
+
+	else
+		# Assume that this is a really a GNU compiler or it could be XL on P8
+		KOKKOS_CXXFLAGS += -mcpu=power8 -mtune=power8
+		KOKKOS_LDFLAGS  += -mcpu=power8 -mtune=power8
+	endif
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AVX2), 1)


### PR DESCRIPTION
Removes GNU Platform Options on POWER8 when Using PGI Compiler.