### PR TITLE
CudaSpace: Add tracking for num of UVM allocs

### DIFF
--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -175,7 +175,6 @@ public:
   /*--------------------------------*/
 
 private:
-
   int  m_device ; ///< Which Cuda device
 };
 

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -120,6 +120,31 @@ TEST_F( cuda, uvm )
   }
 }
 
+TEST_F( cuda, uvm_num_allocs )
+{
+  if ( Kokkos::CudaUVMSpace::available() ) {
+
+    struct TestMaxUVMAllocs {
+      using view_type         = Kokkos::View< double* , Kokkos::CudaUVMSpace >;
+      using view_of_view_type = Kokkos::View< view_type[ 65537 ] , Kokkos::CudaUVMSpace >;
+
+      TestMaxUVMAllocs()
+      : view_allocs_test("view_allocs_test")
+      {
+        for ( auto i = 0; i < max_num_allocs_plus_one; ++i ) {
+          view_allocs_test(i) = view_type("inner_view",1);
+        } //end for
+      }
+
+      const int max_num_allocs_plus_one = 65537;
+      view_of_view_type view_allocs_test ;
+    } ;
+
+    // The constructor should throw runtime error once 65536 uvm allocations exceeded
+    EXPECT_ANY_THROW( TestMaxUVMAllocs() );
+  }
+}
+
 template< class MemSpace , class ExecSpace >
 struct TestViewCudaAccessible {
 


### PR DESCRIPTION
This refers to Kokkos Github issue #300.
There is a limit of 64k i.e. 65536 Cuda UVM allocations after which an
"out of memory" error is issue.
This commit adds tracking of the number of allocations to CudaUVM space
and throws a runtime error when the max number of UVM allocations is
reached, along with a message for users.

	modified:   core/src/Cuda/Kokkos_CudaSpace.cpp
	modified:   core/src/Kokkos_CudaSpace.hpp
	modified:   core/unit_test/cuda/TestCuda_Spaces.cpp