### PR TITLE
ErrorReporter

### DIFF
--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -1,0 +1,177 @@
+/*
+//@HEADER
+// ************************************************************************
+// 
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+// 
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
+// 
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_EXPERIMENTAL_ERROR_REPORTER_HPP
+#define KOKKOS_EXPERIMENTAL_ERROR_REPORTER_HPP
+
+#include <vector>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_View.hpp>
+#include <Kokkos_DualView.hpp>
+
+namespace kokkos {
+namespace Experimental {
+
+template <typename ReportType, typename DeviceType>
+class ErrorReporter
+{
+public:
+
+  typedef ReportType                                      report_type;
+  typedef DeviceType                                      device_type;
+  typedef typename device_type::execution_space           execution_space;
+
+  ErrorReporter(int max_results)
+    : m_numReportsAttempted(""),
+      m_reports("", max_results),
+      m_reporters("", max_results)
+  {
+    clear();
+  }
+
+  int getCapacity() const { return m_reports.h_view.dimension_0(); }
+
+  int getNumReports();
+
+  int getNumReportAttempts();
+
+  void getReports(std::vector<int> &reporters_out, std::vector<report_type> &reports_out);
+
+  void clear();
+
+  void resize(const size_t new_size);
+
+  bool full() {return (getNumReportAttempts() >= getCapacity()); }
+
+  KOKKOS_INLINE_FUNCTION
+  bool add_report(int reporter_id, report_type report) const
+  {
+    int idx = Kokkos::atomic_fetch_add(&m_numReportsAttempted.d_view(), 1);
+
+    if (idx >= 0 && (idx < static_cast<int>(m_reports.d_view.dimension_0()))) {
+      m_reporters.d_view(idx) = reporter_id;
+      m_reports.d_view(idx)   = report;
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+
+private:
+
+  typedef Kokkos::View<report_type *, device_type>        reports_view_t;
+  typedef Kokkos::DualView<report_type *, device_type>    reports_dualview_t;
+
+  typedef typename reports_dualview_t::host_mirror_space  host_mirror_space;
+  Kokkos::DualView<int, device_type>   m_numReportsAttempted;
+  reports_dualview_t                   m_reports;
+  Kokkos::DualView<int *, device_type> m_reporters;
+
+};
+
+
+template <typename ReportType, typename DeviceType>
+inline int ErrorReporter<ReportType, DeviceType>::getNumReports() 
+{
+  m_numReportsAttempted.template sync<host_mirror_space>();
+
+  int num_reports = m_numReportsAttempted.h_view();
+  if (num_reports > static_cast<int>(m_reports.h_view.dimension_0())) {
+    num_reports = m_reports.h_view.dimension_0();
+  }
+  return num_reports;
+}
+
+template <typename ReportType, typename DeviceType>
+inline int ErrorReporter<ReportType, DeviceType>::getNumReportAttempts()
+{
+  m_numReportsAttempted.template sync<host_mirror_space>();
+  return m_numReportsAttempted.h_view();
+}
+
+template <typename ReportType, typename DeviceType>
+void ErrorReporter<ReportType, DeviceType>::getReports(std::vector<int> &reporters_out, std::vector<report_type> &reports_out)
+{
+  int num_reports = getNumReports();
+  reporters_out.clear();
+  reporters_out.reserve(num_reports);
+  reports_out.clear();
+  reports_out.reserve(num_reports);
+
+  if (num_reports > 0) {
+    m_reports.template sync<host_mirror_space>();
+    m_reporters.template sync<host_mirror_space>();
+
+    for (int i = 0; i < num_reports; ++i) {
+      reporters_out.push_back(m_reporters.h_view(i));
+      reports_out.push_back(m_reports.h_view(i));
+    }
+  }
+}
+
+template <typename ReportType, typename DeviceType>
+void ErrorReporter<ReportType, DeviceType>::clear()
+{
+  m_numReportsAttempted.template modify<host_mirror_space>();
+  m_numReportsAttempted.h_view() = 0;
+  m_numReportsAttempted.template sync<execution_space>();
+
+  m_numReportsAttempted.template modify<execution_space>();
+  m_reports.template modify<execution_space>();
+  m_reporters.template modify<execution_space>();
+}
+
+template <typename ReportType, typename DeviceType>
+void ErrorReporter<ReportType, DeviceType>::resize(const size_t new_size)
+{
+  m_reports.resize(new_size);
+  m_reporters.resize(new_size);
+  Kokkos::fence();
+}
+
+
+} // namespace Experimental
+} // namespace kokkos
+
+#endif

--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -100,13 +100,13 @@ public:
 
 private:
 
-  typedef Kokkos::View<report_type *, device_type>        reports_view_t;
-  typedef Kokkos::DualView<report_type *, device_type>    reports_dualview_t;
+  typedef Kokkos::View<report_type *, execution_space>        reports_view_t;
+  typedef Kokkos::DualView<report_type *, execution_space>    reports_dualview_t;
 
   typedef typename reports_dualview_t::host_mirror_space  host_mirror_space;
-  Kokkos::DualView<int, device_type>   m_numReportsAttempted;
+  Kokkos::DualView<int, execution_space>   m_numReportsAttempted;
   reports_dualview_t                   m_reports;
-  Kokkos::DualView<int *, device_type> m_reporters;
+  Kokkos::DualView<int *, execution_space> m_reporters;
 
 };
 

--- a/containers/unit_tests/TestCuda.cpp
+++ b/containers/unit_tests/TestCuda.cpp
@@ -63,6 +63,9 @@
 #include <Kokkos_DynRankView.hpp>
 #include <TestDynViewAPI.hpp>
 
+#include <Kokkos_ErrorReporter.hpp>
+#include <TestErrorReporter.hpp>
+
 //----------------------------------------------------------------------------
 
 
@@ -207,6 +210,11 @@ TEST_F( cuda , dynamic_view )
   }
 }
 
+
+TEST_F(cuda, ErrorReporter)
+{
+  TestErrorReporter<ErrorReporterDriver<Kokkos::Cuda>>();
+}
 
 }
 

--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -1,0 +1,209 @@
+/*
+//@HEADER
+// ************************************************************************
+// 
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+// 
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
+// 
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_TEST_EXPERIMENTAL_ERROR_REPORTER_HPP
+#define KOKKOS_TEST_EXPERIMENTAL_ERROR_REPORTER_HPP
+
+#include <gtest/gtest.h>
+#include <iostream>
+
+namespace Test {
+
+// Just save the data in the report.  Informative text goies in the operator<<(..).
+template <typename DataType1, typename DataType2, typename DataType3>
+struct ThreeValReport
+{
+  DataType1 m_data1;
+  DataType2 m_data2;
+  DataType3 m_data3;
+
+};
+
+template <typename DataType1, typename DataType2, typename DataType3>
+std::ostream &operator<<(std::ostream & os, const ThreeValReport<DataType1, DataType2, DataType3> &val)
+{
+  return os << "{" << val.m_data1 << " " << val.m_data2 << " " << val.m_data3 << "}";
+}
+
+template<typename ReportType>
+void checkReportersAndReportsAgree(const std::vector<int> &reporters,
+                                   const std::vector<ReportType> &reports)
+{
+  for (size_t i = 0; i < reports.size(); ++i) {
+    EXPECT_EQ(1, reporters[i] % 2);
+    EXPECT_EQ(reporters[i], reports[i].m_data1);
+  }
+}
+
+
+template <typename DeviceType>
+struct ErrorReporterDriverBase {
+
+  typedef ThreeValReport<int, int, double>                                      report_type;
+  typedef kokkos::Experimental::ErrorReporter<report_type, DeviceType>  error_reporter_type;
+  error_reporter_type m_errorReporter;
+
+  ErrorReporterDriverBase(int reporter_capacity, int test_size)
+    : m_errorReporter(reporter_capacity)  {  }
+
+  KOKKOS_INLINE_FUNCTION bool error_condition(const int work_idx) const { return (work_idx % 2 != 0); }
+
+  void check_expectations(int reporter_capacity, int test_size)
+  {
+    int num_reported = m_errorReporter.getNumReports();
+    int num_attempts = m_errorReporter.getNumReportAttempts();
+
+    int expected_num_reports = std::min(reporter_capacity, test_size / 2);
+    EXPECT_EQ(expected_num_reports, num_reported);
+    EXPECT_EQ(test_size / 2, num_attempts);
+
+    bool expect_full = (reporter_capacity <= (test_size / 2));
+    bool reported_full = m_errorReporter.full();
+    EXPECT_EQ(expect_full, reported_full);
+  }
+};
+
+
+template <typename DeviceType>
+struct ErrorReporterDriver : public ErrorReporterDriverBase<DeviceType>
+{
+  typedef ErrorReporterDriverBase<DeviceType>                             driver_base;
+  typedef typename driver_base::error_reporter_type::execution_space  execution_space;
+
+  ErrorReporterDriver(int reporter_capacity, int test_size)
+    : driver_base(reporter_capacity, test_size)
+  {
+    execute(reporter_capacity, test_size);
+
+    // Test that clear() and resize() work across memory spaces.
+    if (reporter_capacity < test_size) {
+      driver_base::m_errorReporter.clear();
+      driver_base::m_errorReporter.resize(test_size);
+      execute(test_size, test_size);
+    }
+  }
+
+  void execute(int reporter_capacity, int test_size)
+  {
+    Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(0,test_size), *this);
+    driver_base::check_expectations(reporter_capacity, test_size);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int work_idx) const
+  {
+    if (driver_base::error_condition(work_idx)) {
+      double val = M_PI * static_cast<double>(work_idx);
+      typename driver_base::report_type report = {work_idx, -2*work_idx, val};
+      driver_base::m_errorReporter.add_report(work_idx, report);
+    }
+  }
+};
+
+
+template <typename ErrorReporterDriverType>
+void TestErrorReporter()
+{
+  typedef ErrorReporterDriverType tester_type;
+  std::vector<int> reporters;
+  std::vector<typename tester_type::report_type> reports;
+
+  tester_type test1(100, 10);
+  test1.m_errorReporter.getReports(reporters, reports);
+  checkReportersAndReportsAgree(reporters, reports);
+
+  tester_type test2(10, 100);
+  test2.m_errorReporter.getReports(reporters, reports);
+  checkReportersAndReportsAgree(reporters, reports);
+}
+
+
+#ifndef KOKKOS_HAVE_CUDA
+template <typename DeviceType>
+struct ErrorReporterDriverUseLambda : public ErrorReporterDriverBase<DeviceType>
+{
+  typedef ErrorReporterDriverBase<DeviceType>                             driver_base;
+  typedef typename driver_base::error_reporter_type::execution_space  execution_space;
+
+  ErrorReporterDriverUseLambda(int reporter_capacity, int test_size)
+    : driver_base(reporter_capacity, test_size)
+  {
+    Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(0,test_size),
+                         KOKKOS_LAMBDA(const int work_idx)
+    {
+      if (driver_base::error_condition(work_idx)) {
+        double val = M_PI * static_cast<double>(work_idx);
+        typename driver_base::report_type report = {work_idx, -2*work_idx, val};
+        driver_base::m_errorReporter.add_report(work_idx, report);
+      }
+    });
+    driver_base::check_expectations(reporter_capacity, test_size);
+  }
+};
+#endif
+
+
+#ifdef _OPENMP
+struct ErrorReporterDriverNativeOpenMP : public ErrorReporterDriverBase<Kokkos::OpenMP>
+{
+  typedef ErrorReporterDriverBase<Kokkos::OpenMP>  driver_base;
+
+  ErrorReporterDriverNativeOpenMP(int reporter_capacity, int test_size)
+    : driver_base(reporter_capacity, test_size)
+  {
+#pragma omp parallel for
+    for(int work_idx = 0; work_idx < test_size; ++work_idx)
+    {
+      if (driver_base::error_condition(work_idx)) {
+        double val = M_PI * static_cast<double>(work_idx);
+        typename driver_base::report_type report = {work_idx, -2*work_idx, val};
+        driver_base::m_errorReporter.add_report(work_idx, report);
+      }
+    };
+    driver_base::check_expectations(reporter_capacity, test_size);
+  }
+};
+#endif
+
+} // namespace Test
+#endif // #ifndef KOKKOS_TEST_ERROR_REPORTING_HPP

--- a/containers/unit_tests/TestOpenMP.cpp
+++ b/containers/unit_tests/TestOpenMP.cpp
@@ -61,6 +61,9 @@
 #include <Kokkos_DynRankView.hpp>
 #include <TestDynViewAPI.hpp>
 
+#include <Kokkos_ErrorReporter.hpp>
+#include <TestErrorReporter.hpp>
+
 #include <iomanip>
 
 namespace Test {
@@ -168,6 +171,31 @@ TEST_F( openmp , dynamic_view )
   for ( int i = 0 ; i < 10 ; ++i ) {
     TestDynView::run( 100000 + 100 * i );
   }
+}
+
+#ifndef __INTEL_COMPILER
+#ifdef __GNUG__
+#if ((__GNUC__ == 4) && (__GNUC_MINOR__ < 8))
+#define COMPILER_HAS_FLAKY_LAMBDA_CAPTURE
+#endif
+#endif
+#endif
+
+#ifndef COMPILER_HAS_FLAKY_LAMBDA_CAPTURE
+TEST_F(openmp, ErrorReporterViaLambda)
+{
+  TestErrorReporter<ErrorReporterDriverUseLambda<Kokkos::OpenMP>>();
+}
+#endif
+
+TEST_F(openmp, ErrorReporter)
+{
+  TestErrorReporter<ErrorReporterDriver<Kokkos::OpenMP>>();
+}
+
+TEST_F(openmp, ErrorReporterNativeOpenMP)
+{
+  TestErrorReporter<ErrorReporterDriverNativeOpenMP>();
 }
 
 } // namespace test

--- a/containers/unit_tests/TestSerial.cpp
+++ b/containers/unit_tests/TestSerial.cpp
@@ -66,6 +66,9 @@
 #include <Kokkos_DynRankView.hpp>
 #include <TestDynViewAPI.hpp>
 
+#include <Kokkos_ErrorReporter.hpp>
+#include <TestErrorReporter.hpp>
+
 namespace Test {
 
 class serial : public ::testing::Test {
@@ -159,6 +162,26 @@ TEST_F( serial , dynamic_view )
     TestDynView::run( 100000 + 100 * i );
   }
 }
+
+#ifndef __INTEL_COMPILER
+#ifdef __GNUG__
+#if ((__GNUC__ == 4) && (__GNUC_MINOR__ < 8))
+#define COMPILER_HAS_FLAKY_LAMBDA_CAPTURE
+#endif
+#endif
+#endif
+
+TEST_F(serial, ErrorReporter)
+{
+  TestErrorReporter<ErrorReporterDriver<Kokkos::Serial>>();
+}
+
+#ifndef COMPILER_HAS_FLAKY_LAMBDA_CAPTURE
+TEST_F(serial, ErrorReporterViaLambda)
+{
+  TestErrorReporter<ErrorReporterDriverUseLambda<Kokkos::Serial>>();
+}
+#endif
 
 } // namespace Test
 

--- a/containers/unit_tests/TestThreads.cpp
+++ b/containers/unit_tests/TestThreads.cpp
@@ -66,6 +66,9 @@
 #include <Kokkos_DynRankView.hpp>
 #include <TestDynViewAPI.hpp>
 
+#include <Kokkos_ErrorReporter.hpp>
+#include <TestErrorReporter.hpp>
+
 namespace Test {
 
 class threads : public ::testing::Test {
@@ -161,7 +164,6 @@ THREADS_DUALVIEW_COMBINE_TEST( 10 )
 #undef THREADS_DUALVIEW_COMBINE_TEST
 
 
-
 TEST_F( threads , dynamic_view )
 {
   typedef TestDynamicView< double , Kokkos::Threads >
@@ -170,6 +172,27 @@ TEST_F( threads , dynamic_view )
   for ( int i = 0 ; i < 10 ; ++i ) {
     TestDynView::run( 100000 + 100 * i );
   }
+}
+
+
+#ifndef __INTEL_COMPILER
+#ifdef __GNUG__
+#if ((__GNUC__ == 4) && (__GNUC_MINOR__ < 8))
+#define COMPILER_HAS_FLAKY_LAMBDA_CAPTURE
+#endif
+#endif
+#endif
+
+#ifndef COMPILER_HAS_FLAKY_LAMBDA_CAPTURE
+TEST_F(threads, ErrorReporterViaLambda)
+{
+  TestErrorReporter<ErrorReporterDriverUseLambda<Kokkos::Threads>>();
+}
+#endif
+
+TEST_F(threads, ErrorReporter)
+{
+  TestErrorReporter<ErrorReporterDriver<Kokkos::Threads>>();
 }
 
 } // namespace Test


### PR DESCRIPTION
This is the ErrorReporter class whose implementation I have discussed with some of you over the summer.

As I discussed with Christian more recently:

- The ErrorReporter (template class) belongs in kokkos/containers.  I have tried to follow kokkos conventions in locating the class and unit test code.
- I have put the class in the kokkos::Experimental namespace.

There is only one device-side function, and the test code shows how to use the class.  However, I expect there might be some follow-up about adding documentation consistent with the level provided by Kokkos in general.

Cheers,
Patrick