### PR TITLE
CudaUVMSpace: Make counter incr/decr atomically

### DIFF
--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -156,7 +156,13 @@ public:
   /** \brief  If UVM capability is available */
   static bool available();
 
-  static int get_num_allocs();
+
+  /*--------------------------------*/
+  /** \brief  CudaUVMSpace specific routine */
+  static int number_of_allocations();
+
+  /*--------------------------------*/
+
 
   /*--------------------------------*/
 

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -156,6 +156,8 @@ public:
   /** \brief  If UVM capability is available */
   static bool available();
 
+  static int get_num_allocs();
+
   /*--------------------------------*/
 
   CudaUVMSpace();

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -60,8 +60,6 @@ void test_cuda_spaces_int_value( int * ptr )
 
 TEST_F( cuda , space_access )
 {
-        int num_allocs = Kokkos::CudaUVMSpace::get_num_allocs() ;
-        printf(" num of uvm allocs at tests begin: %d\n",num_allocs);
 
   static_assert(
     Kokkos::Impl::MemorySpaceAccess< Kokkos::HostSpace , Kokkos::HostSpace >::assignable , "" );


### PR DESCRIPTION
This fixes a race condition that was exposed during unit testing on
apollo.
Unit test was also revised to remove possible leaked memory.
A static member function to return the number of uvm allocation was
added.

	modified:   src/Cuda/Kokkos_CudaSpace.cpp
	modified:   src/Kokkos_CudaSpace.hpp
	modified:   unit_test/cuda/TestCuda_Spaces.cpp