### PR TITLE
Replacing Impl::VerifyExecutionCanAccessMemorySpace

### DIFF
--- a/config/test_all_sandia
+++ b/config/test_all_sandia
@@ -494,13 +494,14 @@ run_in_background() {
     local compiler=$1
 
     local -i num_jobs=$NUM_JOBS_TO_RUN_IN_PARALLEL
-    if [[ "$BUILD_ONLY" == True ]]; then
-        num_jobs=8
-    else
+    # don't override command line input
+    # if [[ "$BUILD_ONLY" == True ]]; then
+        # num_jobs=8
+    # else
         if [[ "$compiler" == cuda* ]]; then
             num_jobs=1
         fi
-    fi
+    # fi
     wait_for_jobs $num_jobs
 
     single_build_and_test $* &

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -75,6 +75,15 @@ private:
                  std::is_same< typename traits::specialize , void >::value
                , "DynamicView must have trivial data type" );
 
+
+  template< class Space , bool = Kokkos::Impl::MemorySpaceAccess< Space , typename traits::memory_space >::accessible > struct verify_space
+    { KOKKOS_FORCEINLINE_FUNCTION static void check() {} };
+
+  template< class Space > struct verify_space<Space,false>
+    { KOKKOS_FORCEINLINE_FUNCTION static void check()
+        { Kokkos::abort("Kokkos::DynamicView ERROR: attempt to access inaccessible memory space"); };
+    };
+
 public:
 
   typedef Kokkos::Experimental::MemoryPool< typename traits::device_type > memory_pool ;
@@ -117,10 +126,10 @@ public:
   KOKKOS_INLINE_FUNCTION constexpr size_t size() const
     {
       return
-        Kokkos::Impl::VerifyExecutionCanAccessMemorySpace
+        Kokkos::Impl::MemorySpaceAccess
           < Kokkos::Impl::ActiveExecutionMemorySpace
           , typename traits::memory_space
-          >::value 
+          >::accessible 
         ? // Runtime size is at the end of the chunk pointer array
           (*reinterpret_cast<const uintptr_t*>( m_chunks + m_chunk_max ))
           << m_chunk_shift
@@ -179,10 +188,7 @@ public:
       static_assert( Kokkos::Impl::are_integral<I0,Args...>::value
                    , "Indices must be integral type" );
 
-      Kokkos::Impl::VerifyExecutionCanAccessMemorySpace
-        < Kokkos::Impl::ActiveExecutionMemorySpace
-        , typename traits::memory_space
-        >::verify();
+      DynamicView::template verify_space< Kokkos::Impl::ActiveExecutionMemorySpace >::check();
 
       // Which chunk is being indexed.
       const uintptr_t ic = uintptr_t( i0 >> m_chunk_shift );
@@ -223,9 +229,7 @@ public:
     {
       typedef typename traits::value_type value_type ;
 
-      Kokkos::Impl::VerifyExecutionCanAccessMemorySpace
-        < Kokkos::Impl::ActiveExecutionMemorySpace
-        , typename traits::memory_space >::verify();
+      DynamicView::template verify_space< Kokkos::Impl::ActiveExecutionMemorySpace >::check();
 
       const uintptr_t NC = ( n + m_chunk_mask ) >> m_chunk_shift ;
 
@@ -269,9 +273,7 @@ public:
   inline
   void resize_serial( size_t n )
     {
-      Kokkos::Impl::VerifyExecutionCanAccessMemorySpace
-        < Kokkos::Impl::ActiveExecutionMemorySpace
-        , typename traits::memory_space >::verify();
+      DynamicView::template verify_space< Kokkos::Impl::ActiveExecutionMemorySpace >::check();
 
       const uintptr_t NC = ( n + m_chunk_mask ) >> m_chunk_shift ;
 
@@ -398,9 +400,7 @@ public:
     , m_chunk_mask( ( 1 << m_chunk_shift ) - 1 )
     , m_chunk_max( ( arg_size_max + m_chunk_mask ) >> m_chunk_shift )
     {
-      Kokkos::Impl::VerifyExecutionCanAccessMemorySpace
-        < Kokkos::Impl::ActiveExecutionMemorySpace
-        , typename traits::memory_space >::verify();
+      DynamicView::template verify_space< Kokkos::Impl::ActiveExecutionMemorySpace >::check();
 
       // A functor to deallocate all of the chunks upon final destruction
 
@@ -452,7 +452,7 @@ void deep_copy( const View<T,DP...> & dst
   typedef typename ViewTraits<T,SP...>::memory_space     src_memory_space ;
 
   enum { DstExecCanAccessSrc =
-   Kokkos::Impl::VerifyExecutionCanAccessMemorySpace< typename dst_execution_space::memory_space , src_memory_space >::value };
+   Kokkos::Impl::SpaceAccessibility< dst_execution_space , src_memory_space >::accessible };
 
   if ( DstExecCanAccessSrc ) {
     // Copying data between views in accessible memory spaces and either non-contiguous or incompatible shape.
@@ -476,7 +476,7 @@ void deep_copy( const DynamicView<T,DP...> & dst
   typedef typename ViewTraits<T,SP...>::memory_space     src_memory_space ;
 
   enum { DstExecCanAccessSrc =
-   Kokkos::Impl::VerifyExecutionCanAccessMemorySpace< typename dst_execution_space::memory_space , src_memory_space >::value };
+   Kokkos::Impl::SpaceAccessibility< dst_execution_space , src_memory_space >::accessible };
 
   if ( DstExecCanAccessSrc ) {
     // Copying data between views in accessible memory spaces and either non-contiguous or incompatible shape.

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -283,13 +283,16 @@ private:
   static_assert( Kokkos::is_space< AccessSpace >::value
                , "template argument #1 must be a Kokkos space" );
 
-  static_assert( Kokkos::Impl::MemorySpaceAccess
-                   < typename AccessSpace::execution_space::memory_space
-                   , typename AccessSpace::memory_space >::value
-               , "template argument #1 is an invalid space" );
-
   static_assert( Kokkos::is_memory_space< MemorySpace >::value
                , "template argument #2 must be a Kokkos memory space" );
+
+  // The input AccessSpace may be a Device<ExecSpace,MemSpace>
+  // verify that it is a valid combination of spaces.
+  static_assert( Kokkos::Impl::MemorySpaceAccess
+                   < typename AccessSpace::execution_space::memory_space
+                   , typename AccessSpace::memory_space
+                   >::accessible
+               , "template argument #1 is an invalid space" );
 
   typedef Kokkos::Impl::MemorySpaceAccess
     < typename AccessSpace::execution_space::memory_space , MemorySpace >

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -230,6 +230,17 @@ namespace Kokkos {
 namespace Impl {
 
 template<>
+struct MemorySpaceAccess
+  < Kokkos::Cuda::memory_space
+  , Kokkos::Cuda::scratch_memory_space
+  >
+{
+  enum { assignable = false };
+  enum { accessible = true };
+  enum { deepcopy   = false };
+};
+
+template<>
 struct VerifyExecutionCanAccessMemorySpace
   < Kokkos::CudaSpace
   , Kokkos::Cuda::scratch_memory_space

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -237,6 +237,8 @@ static_assert( Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaSpace , Kokkos::Cuda
 static_assert( Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaUVMSpace , Kokkos::CudaUVMSpace >::assignable , "" );
 static_assert( Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaHostPinnedSpace , Kokkos::CudaHostPinnedSpace >::assignable , "" );
 
+//----------------------------------------
+
 template<>
 struct MemorySpaceAccess< Kokkos::HostSpace , Kokkos::CudaSpace > {
   enum { assignable = false };
@@ -260,6 +262,7 @@ struct MemorySpaceAccess< Kokkos::HostSpace , Kokkos::CudaHostPinnedSpace > {
   enum { deepcopy   = true };
 };
 
+//----------------------------------------
 
 template<>
 struct MemorySpaceAccess< Kokkos::CudaSpace , Kokkos::HostSpace > {
@@ -270,6 +273,7 @@ struct MemorySpaceAccess< Kokkos::CudaSpace , Kokkos::HostSpace > {
 
 template<>
 struct MemorySpaceAccess< Kokkos::CudaSpace , Kokkos::CudaUVMSpace > {
+  // CudaSpace::execution_space == CudaUVMSpace::execution_space
   enum { assignable = true };
   enum { accessible = true };
   enum { deepcopy   = true };
@@ -283,13 +287,14 @@ struct MemorySpaceAccess< Kokkos::CudaSpace , Kokkos::CudaHostPinnedSpace > {
   enum { deepcopy   = true };
 };
 
+//----------------------------------------
+// CudaUVMSpace::execution_space == Cuda
+// CudaUVMSpace accessible to both Cuda and Host
 
 template<>
 struct MemorySpaceAccess< Kokkos::CudaUVMSpace , Kokkos::HostSpace > {
-  // CudaUVMSpace::execution_space == Cuda
-  // Cuda cannot access HostSpace
   enum { assignable = false };
-  enum { accessible = false };
+  enum { accessible = false }; // Cuda cannot access HostSpace
   enum { deepcopy   = true };
 };
 
@@ -313,12 +318,14 @@ struct MemorySpaceAccess< Kokkos::CudaUVMSpace , Kokkos::CudaHostPinnedSpace > {
 };
 
 
+//----------------------------------------
+// CudaHostPinnedSpace::execution_space == HostSpace::execution_space
+// CudaHostPinnedSpace accessible to both Cuda and Host
+
 template<>
 struct MemorySpaceAccess< Kokkos::CudaHostPinnedSpace , Kokkos::HostSpace > {
-  // Can access CudaHostPinnedSpace from Cuda
-  // Cannot access HostSpace from Cuda
   enum { assignable = false }; // Cannot access from Cuda
-  enum { accessible = false }; // CudaHostPinnedSpace::execution_space
+  enum { accessible = true };  // CudaHostPinnedSpace::execution_space
   enum { deepcopy   = true };
 };
 
@@ -335,6 +342,8 @@ struct MemorySpaceAccess< Kokkos::CudaHostPinnedSpace , Kokkos::CudaUVMSpace > {
   enum { accessible = true };  // same accessibility
   enum { deepcopy   = true };
 };
+
+//----------------------------------------
 
 }} // namespace Kokkos::Impl
 

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -161,6 +161,17 @@ namespace Kokkos {
 namespace Impl {
 
 template<>
+struct MemorySpaceAccess 
+  < Kokkos::OpenMP::memory_space
+  , Kokkos::OpenMP::scratch_memory_space
+  >
+{
+  enum { assignable = false };
+  enum { accessible = true };
+  enum { deepcopy   = false };
+};
+
+template<>
 struct VerifyExecutionCanAccessMemorySpace
   < Kokkos::OpenMP::memory_space
   , Kokkos::OpenMP::scratch_memory_space

--- a/core/src/Kokkos_Qthread.hpp
+++ b/core/src/Kokkos_Qthread.hpp
@@ -145,6 +145,17 @@ namespace Kokkos {
 namespace Impl {
 
 template<>
+struct MemorySpaceAccess 
+  < Kokkos::Qthread::memory_space
+  , Kokkos::Qthread::scratch_memory_space
+  >
+{
+  enum { assignable = false };
+  enum { accessible = true };
+  enum { deepcopy   = false };
+};
+
+template<>
 struct VerifyExecutionCanAccessMemorySpace
   < Kokkos::Qthread::memory_space
   , Kokkos::Qthread::scratch_memory_space

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -192,6 +192,17 @@ namespace Kokkos {
 namespace Impl {
 
 template<>
+struct MemorySpaceAccess 
+  < Kokkos::Serial::memory_space
+  , Kokkos::Serial::scratch_memory_space
+  >
+{
+  enum { assignable = false };
+  enum { accessible = true };
+  enum { deepcopy   = false };
+};
+
+template<>
 struct VerifyExecutionCanAccessMemorySpace
   < Kokkos::Serial::memory_space
   , Kokkos::Serial::scratch_memory_space

--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -190,6 +190,17 @@ namespace Kokkos {
 namespace Impl {
 
 template<>
+struct MemorySpaceAccess 
+  < Kokkos::Threads::memory_space
+  , Kokkos::Threads::scratch_memory_space
+  >
+{
+  enum { assignable = false };
+  enum { accessible = true };
+  enum { deepcopy   = false };
+};
+
+template<>
 struct VerifyExecutionCanAccessMemorySpace
   < Kokkos::Threads::memory_space
   , Kokkos::Threads::scratch_memory_space

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -630,7 +630,7 @@ private:
 #else
 
 #define KOKKOS_VIEW_OPERATOR_VERIFY( ARG ) \
-  View::template verify_space< Kokkos::Impl::ActiveExecutionMemorySpace >::check(); \
+  View::template verify_space< Kokkos::Impl::ActiveExecutionMemorySpace >::check();
 
 #endif
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -613,18 +613,24 @@ private:
       ( is_layout_left || is_layout_right || is_layout_stride )
   };
 
+  template< class Space , bool = Kokkos::Impl::MemorySpaceAccess< Space , typename traits::memory_space >::accessible > struct verify_space
+    { KOKKOS_FORCEINLINE_FUNCTION static void check() {} };
+
+  template< class Space > struct verify_space<Space,false>
+    { KOKKOS_FORCEINLINE_FUNCTION static void check()
+        { Kokkos::abort("Kokkos::View ERROR: attempt to access inaccessible memory space"); };
+    };
+
 #if defined( KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK )
 
 #define KOKKOS_VIEW_OPERATOR_VERIFY( ARG ) \
-  Kokkos::Impl::VerifyExecutionCanAccessMemorySpace \
-    < Kokkos::Impl::ActiveExecutionMemorySpace , typename traits::memory_space >::verify(); \
+  View::template verify_space< Kokkos::Impl::ActiveExecutionMemorySpace >::check(); \
   Kokkos::Impl::view_verify_operator_bounds ARG ;
 
 #else
 
 #define KOKKOS_VIEW_OPERATOR_VERIFY( ARG ) \
-  Kokkos::Impl::VerifyExecutionCanAccessMemorySpace \
-    < Kokkos::Impl::ActiveExecutionMemorySpace , typename traits::memory_space >::verify();
+  View::template verify_space< Kokkos::Impl::ActiveExecutionMemorySpace >::check(); \
 
 #endif
 
@@ -1907,10 +1913,10 @@ void deep_copy
   typedef typename src_type::memory_space     src_memory_space ;
 
   enum { DstExecCanAccessSrc =
-   Kokkos::Impl::VerifyExecutionCanAccessMemorySpace< typename dst_execution_space::memory_space , src_memory_space >::value };
+   Kokkos::Impl::SpaceAccessibility< dst_execution_space , src_memory_space >::accessible };
 
   enum { SrcExecCanAccessDst =
-   Kokkos::Impl::VerifyExecutionCanAccessMemorySpace< typename src_execution_space::memory_space , dst_memory_space >::value };
+   Kokkos::Impl::SpaceAccessibility< src_execution_space , dst_memory_space >::accessible };
 
 
   if ( (void *) dst.data() != (void*) src.data() ) {
@@ -2124,10 +2130,10 @@ void deep_copy
   typedef typename src_type::memory_space     src_memory_space ;
 
   enum { DstExecCanAccessSrc =
-   Kokkos::Impl::VerifyExecutionCanAccessMemorySpace< typename dst_execution_space::memory_space , src_memory_space >::value };
+   Kokkos::Impl::SpaceAccessibility< dst_execution_space , src_memory_space >::accessible };
 
   enum { SrcExecCanAccessDst =
-   Kokkos::Impl::VerifyExecutionCanAccessMemorySpace< typename src_execution_space::memory_space , dst_memory_space >::value };
+   Kokkos::Impl::SpaceAccessibility< src_execution_space , dst_memory_space >::accessible };
 
   if ( (void *) dst.data() != (void*) src.data() ) {
 

--- a/core/unit_test/TestDefaultDeviceType.cpp
+++ b/core/unit_test/TestDefaultDeviceType.cpp
@@ -76,6 +76,22 @@ protected:
   }
 };
 
+TEST_F( defaultdevicetype, host_space_access )
+{
+  typedef Kokkos::HostSpace::execution_space host_exec_space ;
+  typedef Kokkos::Device< host_exec_space , Kokkos::HostSpace > device_space ;
+  typedef Kokkos::Impl::HostMirror< Kokkos::DefaultExecutionSpace >::Space mirror_space ;
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility< host_exec_space , Kokkos::HostSpace >::accessible , "" );
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility< device_space , Kokkos::HostSpace >::accessible , "" );
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility< mirror_space , Kokkos::HostSpace >::accessible , "" );
+}
+
 TEST_F( defaultdevicetype, view_api) {
   TestViewAPI< double , Kokkos::DefaultExecutionSpace >();
 }

--- a/core/unit_test/TestViewMapping.hpp
+++ b/core/unit_test/TestViewMapping.hpp
@@ -702,7 +702,7 @@ void test_view_mapping()
 
     ASSERT_EQ( vr1.dimension_0() , N );
 
-    if ( Kokkos::Impl::VerifyExecutionCanAccessMemorySpace< typename Space::memory_space , Kokkos::HostSpace >::value ) {
+    if ( Kokkos::Impl::SpaceAccessibility< Kokkos::HostSpace , typename Space::memory_space >::accessible ) {
       for ( int i = 0 ; i < N ; ++i ) data[i] = i + 1 ;
       for ( int i = 0 ; i < N ; ++i ) ASSERT_EQ( vr1[i] , i + 1 );
       for ( int i = 0 ; i < N ; ++i ) ASSERT_EQ( cr1[i] , i + 1 );
@@ -745,7 +745,7 @@ void test_view_mapping()
  
     ASSERT_EQ( vr1.dimension_0() , N );
 
-    if ( Kokkos::Impl::VerifyExecutionCanAccessMemorySpace< typename Space::memory_space , Kokkos::HostSpace >::value ) {
+    if ( Kokkos::Impl::SpaceAccessibility< Kokkos::HostSpace , typename Space::memory_space >::accessible ) {
       for ( int i = 0 ; i < N ; ++i ) vr1(i) = i + 1 ;
       for ( int i = 0 ; i < N ; ++i ) ASSERT_EQ( vr1[i] , i + 1 );
       for ( int i = 0 ; i < N ; ++i ) ASSERT_EQ( cr1[i] , i + 1 );

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -144,7 +144,7 @@ void test_auto_1d ()
   }
 
   for (size_type j = 0; j < numCols; ++j) {
-    auto X_j = Kokkos::subview (X, Kokkos::ALL(), j);
+    auto X_j = Kokkos::subview (X, Kokkos::ALL, j);
 
     fill_1D<decltype(X_j),Space> f4(X_j, ZERO);
     Kokkos::parallel_for(X_j.dimension_0(),f4);
@@ -154,7 +154,7 @@ void test_auto_1d ()
     }
 
     for (size_type jj = 0; jj < numCols; ++jj) {
-      auto X_jj = Kokkos::subview (X, Kokkos::ALL(), jj);
+      auto X_jj = Kokkos::subview (X, Kokkos::ALL, jj);
       fill_1D<decltype(X_jj),Space> f5(X_jj, ONE);
       Kokkos::parallel_for(X_jj.dimension_0(),f5);
       Kokkos::deep_copy (X_h, X);
@@ -172,9 +172,9 @@ void test_1d_strided_assignment_impl(bool a, bool b, bool c, bool d, int n, int 
   int col = n>2?2:0;
   int row = m>2?2:0;
 
-  if(Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,Space>::value) {
+  if(Kokkos::Impl::SpaceAccessibility<Kokkos::HostSpace,typename Space::memory_space>::accessible) {
   if(a) {
-    Kokkos::View<double*,LD,Space> l1da = Kokkos::subview(l2d,Kokkos::ALL(),row);
+    Kokkos::View<double*,LD,Space> l1da = Kokkos::subview(l2d,Kokkos::ALL,row);
     ASSERT_TRUE( & l1da(0) == & l2d(0,row) );
     if(n>1)
       ASSERT_TRUE( & l1da(1) == & l2d(1,row) );
@@ -185,7 +185,7 @@ void test_1d_strided_assignment_impl(bool a, bool b, bool c, bool d, int n, int 
     ASSERT_TRUE( & l1db(1) == & l2d(3,row) );
   }
   if(c) {
-    Kokkos::View<double*,LD,Space> l1dc = Kokkos::subview(l2d,col,Kokkos::ALL());
+    Kokkos::View<double*,LD,Space> l1dc = Kokkos::subview(l2d,col,Kokkos::ALL);
     ASSERT_TRUE( & l1dc(0) == & l2d(col,0) );
     if(m>1)
       ASSERT_TRUE( & l1dc(1) == & l2d(col,1) );
@@ -226,7 +226,7 @@ void test_left_0()
   typedef Kokkos::View< int [2][3][4][5][2][3][4][5] , Kokkos::LayoutLeft , Space >
     view_static_8_type ;
 
-  if(Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,Space>::value) {
+  if(Kokkos::Impl::SpaceAccessibility<Kokkos::HostSpace,typename Space::memory_space>::accessible) {
 
   view_static_8_type  x_static_8("x_static_left_8");
 
@@ -290,7 +290,7 @@ void test_left_1()
   typedef Kokkos::View< int ****[2][3][4][5] , Kokkos::LayoutLeft , Space >
     view_type ;
 
-  if(Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,Space>::value) {
+  if(Kokkos::Impl::SpaceAccessibility<Kokkos::HostSpace,typename Space::memory_space>::accessible) {
 
   view_type  x8("x_left_8",2,3,4,5);
 
@@ -353,7 +353,7 @@ void test_left_2()
 {
   typedef Kokkos::View< int **** , Kokkos::LayoutLeft , Space > view_type ;
 
-  if(Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,Space>::value) {
+  if(Kokkos::Impl::SpaceAccessibility<Kokkos::HostSpace,typename Space::memory_space>::accessible) {
 
   view_type  x4("x4",2,3,4,5);
 
@@ -417,7 +417,7 @@ void test_left_3()
 {
   typedef Kokkos::View< int ** , Kokkos::LayoutLeft , Space > view_type ;
 
-  if(Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,Space>::value) {
+  if(Kokkos::Impl::SpaceAccessibility<Kokkos::HostSpace,typename Space::memory_space>::accessible) {
 
   view_type  xm("x4",10,5);
 
@@ -429,7 +429,7 @@ void test_left_3()
   ASSERT_TRUE( & x0() == & xm(5,3) );
 
   Kokkos::View<int*,Kokkos::LayoutLeft,Space> x1 =
-    Kokkos::subview( xm, Kokkos::ALL(), 3 );
+    Kokkos::subview( xm, Kokkos::ALL, 3 );
 
   ASSERT_TRUE( x1.is_contiguous() );
   for ( int i = 0 ; i < int(xm.dimension_0()) ; ++i ) {
@@ -437,7 +437,7 @@ void test_left_3()
   }
 
   Kokkos::View<int**,Kokkos::LayoutLeft,Space> x2 =
-    Kokkos::subview( xm, Kokkos::pair<int,int>(1,9), Kokkos::ALL() );
+    Kokkos::subview( xm, Kokkos::pair<int,int>(1,9), Kokkos::ALL );
 
   ASSERT_TRUE( ! x2.is_contiguous() );
   for ( int j = 0 ; j < int(x2.dimension_1()) ; ++j )
@@ -446,7 +446,7 @@ void test_left_3()
   }
 
   Kokkos::View<int**,Kokkos::LayoutLeft,Space> x2c =
-    Kokkos::subview( xm, Kokkos::ALL(), std::pair<int,int>(2,4) );
+    Kokkos::subview( xm, Kokkos::ALL, std::pair<int,int>(2,4) );
 
   ASSERT_TRUE( x2c.is_contiguous() );
   for ( int j = 0 ; j < int(x2c.dimension_1()) ; ++j )
@@ -455,13 +455,13 @@ void test_left_3()
   }
 
   Kokkos::View<int**,Kokkos::LayoutLeft,Space> x2_n1 =
-    Kokkos::subview( xm , std::pair<int,int>(1,1) , Kokkos::ALL() );
+    Kokkos::subview( xm , std::pair<int,int>(1,1) , Kokkos::ALL );
 
   ASSERT_TRUE( x2_n1.dimension_0() == 0 );
   ASSERT_TRUE( x2_n1.dimension_1() == xm.dimension_1() );
 
   Kokkos::View<int**,Kokkos::LayoutLeft,Space> x2_n2 =
-    Kokkos::subview( xm , Kokkos::ALL() , std::pair<int,int>(1,1) );
+    Kokkos::subview( xm , Kokkos::ALL , std::pair<int,int>(1,1) );
 
   ASSERT_TRUE( x2_n2.dimension_0() == xm.dimension_0() );
   ASSERT_TRUE( x2_n2.dimension_1() == 0 );
@@ -477,7 +477,7 @@ void test_right_0()
   typedef Kokkos::View< int [2][3][4][5][2][3][4][5] , Kokkos::LayoutRight , Space >
     view_static_8_type ;
 
-  if(Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,Space>::value) {
+  if(Kokkos::Impl::SpaceAccessibility<Kokkos::HostSpace,typename Space::memory_space>::accessible) {
 
   view_static_8_type  x_static_8("x_static_right_8");
 
@@ -542,7 +542,7 @@ void test_right_1()
   typedef Kokkos::View< int ****[2][3][4][5] , Kokkos::LayoutRight , Space >
     view_type ;
 
-  if(Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,Space>::value) {
+  if(Kokkos::Impl::SpaceAccessibility<Kokkos::HostSpace,typename Space::memory_space>::accessible) {
 
   view_type  x8("x_right_8",2,3,4,5);
 
@@ -597,7 +597,7 @@ void test_right_3()
 {
   typedef Kokkos::View< int ** , Kokkos::LayoutRight , Space > view_type ;
 
-  if(Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,Space>::value) {
+  if(Kokkos::Impl::SpaceAccessibility<Kokkos::HostSpace,typename Space::memory_space>::accessible) {
 
   view_type  xm("x4",10,5);
 
@@ -609,7 +609,7 @@ void test_right_3()
   ASSERT_TRUE( & x0() == & xm(5,3) );
 
   Kokkos::View<int*,Kokkos::LayoutRight,Space> x1 =
-    Kokkos::subview( xm, 3, Kokkos::ALL() );
+    Kokkos::subview( xm, 3, Kokkos::ALL );
 
   ASSERT_TRUE( x1.is_contiguous() );
   for ( int i = 0 ; i < int(xm.dimension_1()) ; ++i ) {
@@ -617,7 +617,7 @@ void test_right_3()
   }
 
   Kokkos::View<int**,Kokkos::LayoutRight,Space> x2c =
-    Kokkos::subview( xm, Kokkos::pair<int,int>(1,9), Kokkos::ALL() );
+    Kokkos::subview( xm, Kokkos::pair<int,int>(1,9), Kokkos::ALL );
 
   ASSERT_TRUE( x2c.is_contiguous() );
   for ( int j = 0 ; j < int(x2c.dimension_1()) ; ++j )
@@ -626,7 +626,7 @@ void test_right_3()
   }
 
   Kokkos::View<int**,Kokkos::LayoutRight,Space> x2 =
-    Kokkos::subview( xm, Kokkos::ALL(), std::pair<int,int>(2,4) );
+    Kokkos::subview( xm, Kokkos::ALL, std::pair<int,int>(2,4) );
 
   ASSERT_TRUE( ! x2.is_contiguous() );
   for ( int j = 0 ; j < int(x2.dimension_1()) ; ++j )
@@ -635,13 +635,13 @@ void test_right_3()
   }
 
   Kokkos::View<int**,Kokkos::LayoutRight,Space> x2_n1 =
-    Kokkos::subview( xm , std::pair<int,int>(1,1) , Kokkos::ALL() );
+    Kokkos::subview( xm , std::pair<int,int>(1,1) , Kokkos::ALL );
 
   ASSERT_TRUE( x2_n1.dimension_0() == 0 );
   ASSERT_TRUE( x2_n1.dimension_1() == xm.dimension_1() );
 
   Kokkos::View<int**,Kokkos::LayoutRight,Space> x2_n2 =
-    Kokkos::subview( xm , Kokkos::ALL() , std::pair<int,int>(1,1) );
+    Kokkos::subview( xm , Kokkos::ALL , std::pair<int,int>(1,1) );
 
   ASSERT_TRUE( x2_n2.dimension_0() == xm.dimension_0() );
   ASSERT_TRUE( x2_n2.dimension_1() == 0 );
@@ -758,11 +758,11 @@ void test_2d_subview_3d_impl_type() {
       for(int i2=0; i2<N2; i2++)
         a_org(i0,i1,i2) = i0*1000000+i1*1000+i2;
   Kokkos::View<TypeSub,LayoutSub,Space,MemTraits> a1;
-  a1 = Kokkos::subview(a,3,Kokkos::ALL(),Kokkos::ALL());
+  a1 = Kokkos::subview(a,3,Kokkos::ALL,Kokkos::ALL);
   Kokkos::fence();
   test_Check2D3D(a1,a,3,std::pair<int,int>(0,N1),std::pair<int,int>(0,N2));
 
-  Kokkos::View<TypeSub,LayoutSub,Space,MemTraits> a2(a,3,Kokkos::ALL(),Kokkos::ALL());
+  Kokkos::View<TypeSub,LayoutSub,Space,MemTraits> a2(a,3,Kokkos::ALL,Kokkos::ALL);
   Kokkos::fence();
   test_Check2D3D(a2,a,3,std::pair<int,int>(0,N1),std::pair<int,int>(0,N2));
 }
@@ -813,11 +813,11 @@ void test_3d_subview_5d_impl_type() {
           for(int i4=0; i4<N4; i4++)
             a_org(i0,i1,i2,i3,i4) = i0*1000000+i1*10000+i2*100+i3*10+i4;
   Kokkos::View<TypeSub,LayoutSub,Space,MemTraits> a1;
-  a1 = Kokkos::subview(a,3,5,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+  a1 = Kokkos::subview(a,3,5,Kokkos::ALL,Kokkos::ALL,Kokkos::ALL);
   Kokkos::fence();
   test_Check3D5D(a1,a,3,5,std::pair<int,int>(0,N2),std::pair<int,int>(0,N3),std::pair<int,int>(0,N4));
 
-  Kokkos::View<TypeSub,LayoutSub,Space,MemTraits> a2(a,3,5,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+  Kokkos::View<TypeSub,LayoutSub,Space,MemTraits> a2(a,3,5,Kokkos::ALL,Kokkos::ALL,Kokkos::ALL);
   Kokkos::fence();
   test_Check3D5D(a2,a,3,5,std::pair<int,int>(0,N2),std::pair<int,int>(0,N3),std::pair<int,int>(0,N4));
 }

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -47,9 +47,7 @@ namespace Test {
 __global__
 void test_abort()
 {
-  Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<
-    Kokkos::CudaSpace ,
-    Kokkos::HostSpace >::verify();
+  Kokkos::abort("test_abort");
 }
 
 __global__
@@ -60,9 +58,27 @@ void test_cuda_spaces_int_value( int * ptr )
 
 TEST_F( cuda , space_access )
 {
+  //--------------------------------------
 
   static_assert(
     Kokkos::Impl::MemorySpaceAccess< Kokkos::HostSpace , Kokkos::HostSpace >::assignable , "" );
+
+  static_assert(
+    Kokkos::Impl::MemorySpaceAccess< Kokkos::HostSpace , Kokkos::CudaHostPinnedSpace >::assignable , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::HostSpace , Kokkos::CudaSpace >::assignable , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::HostSpace , Kokkos::CudaSpace >::accessible , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::HostSpace , Kokkos::CudaUVMSpace >::assignable , "" );
+
+  static_assert(
+    Kokkos::Impl::MemorySpaceAccess< Kokkos::HostSpace , Kokkos::CudaUVMSpace >::accessible , "" );
+
+  //--------------------------------------
 
   static_assert(
     Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaSpace , Kokkos::CudaSpace >::assignable , "" );
@@ -71,13 +87,86 @@ TEST_F( cuda , space_access )
     Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaSpace , Kokkos::CudaUVMSpace >::assignable , "" );
 
   static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaSpace , Kokkos::CudaHostPinnedSpace >::assignable , "" );
+
+  static_assert(
+    Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaSpace , Kokkos::CudaHostPinnedSpace >::accessible , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaSpace , Kokkos::HostSpace >::assignable , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaSpace , Kokkos::HostSpace >::accessible , "" );
+
+  //--------------------------------------
+
+  static_assert(
     Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaUVMSpace , Kokkos::CudaUVMSpace >::assignable , "" );
 
   static_assert(
-    Kokkos::Impl::MemorySpaceAccess< Kokkos::HostSpace , Kokkos::CudaHostPinnedSpace >::assignable , "" );
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaUVMSpace , Kokkos::CudaSpace >::assignable , "" );
+
+  static_assert(
+    Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaUVMSpace , Kokkos::CudaSpace >::accessible , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaUVMSpace , Kokkos::HostSpace >::assignable , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaUVMSpace , Kokkos::HostSpace >::accessible , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaUVMSpace , Kokkos::CudaHostPinnedSpace >::assignable , "" );
+
+  static_assert(
+    Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaUVMSpace , Kokkos::CudaHostPinnedSpace >::accessible , "" );
+
+  //--------------------------------------
 
   static_assert(
     Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaHostPinnedSpace , Kokkos::CudaHostPinnedSpace >::assignable , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaHostPinnedSpace , Kokkos::HostSpace >::assignable , "" );
+
+  static_assert(
+    Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaHostPinnedSpace , Kokkos::HostSpace >::accessible , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaHostPinnedSpace , Kokkos::CudaSpace >::assignable , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaHostPinnedSpace , Kokkos::CudaSpace >::accessible , "" );
+
+  static_assert(
+    ! Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaHostPinnedSpace , Kokkos::CudaUVMSpace >::assignable , "" );
+
+  static_assert(
+    Kokkos::Impl::MemorySpaceAccess< Kokkos::CudaHostPinnedSpace , Kokkos::CudaUVMSpace >::accessible , "" );
+
+  //--------------------------------------
+
+  static_assert(
+    ! Kokkos::Impl::SpaceAccessibility< Kokkos::Cuda , Kokkos::HostSpace >::accessible , "" );
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility< Kokkos::Cuda , Kokkos::CudaSpace >::accessible , "" );
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility< Kokkos::Cuda , Kokkos::CudaUVMSpace >::accessible , "" );
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility< Kokkos::Cuda , Kokkos::CudaHostPinnedSpace >::accessible , "" );
+
+  static_assert(
+    ! Kokkos::Impl::SpaceAccessibility< Kokkos::HostSpace , Kokkos::CudaSpace >::accessible , "" );
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility< Kokkos::HostSpace , Kokkos::CudaUVMSpace >::accessible , "" );
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility< Kokkos::HostSpace , Kokkos::CudaHostPinnedSpace >::accessible , "" );
+
 
   static_assert(
     std::is_same< Kokkos::Impl::HostMirror< Kokkos::CudaSpace >::Space
@@ -97,6 +186,30 @@ TEST_F( cuda , space_access )
                                 , Kokkos::CudaUVMSpace >
                 , Kokkos::Device< Kokkos::HostSpace::execution_space
                                 , Kokkos::CudaUVMSpace > >::value , "" );
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility
+      < Kokkos::Impl::HostMirror< Kokkos::Cuda >::Space
+      , Kokkos::HostSpace
+      >::accessible , "" );
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility
+      < Kokkos::Impl::HostMirror< Kokkos::CudaSpace >::Space
+      , Kokkos::HostSpace
+      >::accessible , "" );
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility
+      < Kokkos::Impl::HostMirror< Kokkos::CudaUVMSpace >::Space
+      , Kokkos::HostSpace
+      >::accessible , "" );
+
+  static_assert(
+    Kokkos::Impl::SpaceAccessibility
+      < Kokkos::Impl::HostMirror< Kokkos::CudaHostPinnedSpace >::Space
+      , Kokkos::HostSpace
+      >::accessible , "" );
 }
 
 TEST_F( cuda, uvm )


### PR DESCRIPTION
Progress on issue #527 and #290 