### PR TITLE
Fix missing definitions of uint32_t and uint64_t for PGI Compilers

### DIFF
--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -48,6 +48,7 @@
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Macros.hpp>
 #include <string>
+#include <cinttypes>
 
 #if (KOKKOS_ENABLE_PROFILING)
 #include <impl/Kokkos_Profiling_DeviceInfo.hpp>


### PR DESCRIPTION
`uint32_t` and `uint64_t` are not found when using PGI compilers on X86. This adds include to ensure they are defined.