### PR TITLE
replace long with long long for 32-bit-compatibility

### DIFF
--- a/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
+++ b/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
@@ -173,22 +173,22 @@ template < typename T >
 inline
 T atomic_compare_exchange( volatile T * const dest, const T & compare,
   typename Kokkos::Impl::enable_if< sizeof(T) != sizeof(int) &&
-                                    sizeof(T) == sizeof(long) , const T & >::type val )
+                                    sizeof(T) == sizeof(long long) , const T & >::type val )
 {
 #ifdef KOKKOS_HAVE_CXX11
   union U {
-    long i ;
+    long long i ;
     T t ;
     KOKKOS_INLINE_FUNCTION U() {};
   } tmp ;
 #else
   union U {
-    long i ;
+    long long i ;
     T t ;
   } tmp ;
 #endif
 
-  tmp.i = __sync_val_compare_and_swap( (long*) dest , *((long*)&compare) , *((long*)&val) );
+  tmp.i = __sync_val_compare_and_swap( (long long*) dest , *((long long*)&compare) , *((long long*)&val) );
   return tmp.t ;
 }
 

--- a/core/src/impl/Kokkos_Atomic_Exchange.hpp
+++ b/core/src/impl/Kokkos_Atomic_Exchange.hpp
@@ -168,10 +168,10 @@ void atomic_assign(
 template< typename T >
 inline
 T atomic_exchange( volatile T * const dest ,
-  typename Kokkos::Impl::enable_if< sizeof(T) == sizeof(int) || sizeof(T) == sizeof(long)
+  typename Kokkos::Impl::enable_if< sizeof(T) == sizeof(int) || sizeof(T) == sizeof(long long)
                                   , const T & >::type val )
 {
-  typedef typename Kokkos::Impl::if_c< sizeof(T) == sizeof(int) , int , long >::type type ;
+  typedef typename Kokkos::Impl::if_c< sizeof(T) == sizeof(int) , int , long long >::type type ;
 
   const type v = *((type*)&val); // Extract to be sure the value doesn't change
 
@@ -258,10 +258,10 @@ T atomic_exchange( volatile T * const dest ,
 template< typename T >
 inline
 void atomic_assign( volatile T * const dest ,
-  typename Kokkos::Impl::enable_if< sizeof(T) == sizeof(int) || sizeof(T) == sizeof(long)
+  typename Kokkos::Impl::enable_if< sizeof(T) == sizeof(int) || sizeof(T) == sizeof(long long)
                                   , const T & >::type val )
 {
-  typedef typename Kokkos::Impl::if_c< sizeof(T) == sizeof(int) , int , long >::type type ;
+  typedef typename Kokkos::Impl::if_c< sizeof(T) == sizeof(int) , int , long long >::type type ;
 
   const type v = *((type*)&val); // Extract to be sure the value doesn't change
 

--- a/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
@@ -234,17 +234,17 @@ template < typename T >
 inline
 T atomic_fetch_add( volatile T * const dest ,
   typename Kokkos::Impl::enable_if< sizeof(T) != sizeof(int) &&
-                                    sizeof(T) == sizeof(long) , const T >::type val )
+                                    sizeof(T) == sizeof(long long) , const T >::type val )
 {
 #ifdef KOKKOS_HAVE_CXX11
   union U {
-    long i ;
+    long long i ;
     T t ;
     inline U() {};
   } assume , oldval , newval ;
 #else
   union U {
-    long i ;
+    long long i ;
     T t ;
   } assume , oldval , newval ;
 #endif
@@ -254,7 +254,7 @@ T atomic_fetch_add( volatile T * const dest ,
   do {
     assume.i = oldval.i ;
     newval.t = assume.t + val ;
-    oldval.i = __sync_val_compare_and_swap( (long*) dest , assume.i , newval.i );
+    oldval.i = __sync_val_compare_and_swap( (long long*) dest , assume.i , newval.i );
   } while ( assume.i != oldval.i );
 
   return oldval.t ;

--- a/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
@@ -175,16 +175,16 @@ template < typename T >
 inline
 T atomic_fetch_sub( volatile T * const dest ,
   typename Kokkos::Impl::enable_if< sizeof(T) != sizeof(int) &&
-                                    sizeof(T) == sizeof(long) , const T >::type val )
+                                    sizeof(T) == sizeof(long long) , const T >::type val )
 {
-  union { long i ; T t ; } assume , oldval , newval ;
+  union { long long i ; T t ; } assume , oldval , newval ;
 
   oldval.t = *dest ;
 
   do {
     assume.i = oldval.i ;
     newval.t = assume.t - val ;
-    oldval.i = __sync_val_compare_and_swap( (long*) dest , assume.i , newval.i );
+    oldval.i = __sync_val_compare_and_swap( (long long*) dest , assume.i , newval.i );
   } while ( assume.i != oldval.i );
 
   return oldval.t ;


### PR DESCRIPTION
This patch changes nothing for 64-bit-builds, but improves compatibility for 32-bit-builds.

However, while the Kokkos-only build is successful, 1 out of the 21 unit tests, `KokkosCore_UnitTest_Serial_MPI_1`, fails. It includes 60 tests and of these only 4
fail with errors like:
```
Value of: result[i].value[j]
Actual: 5.00005e+09
Expected: (ScalarType) correct
Which is: 7.05083e+08
```
@kokkos-devs, do you know what might be going wrong here?

Additionally, a build of all Trilinos packages fails with a few errors similar to
```
packages/tpetra/core/test/Distributor/createfromsendsandrecvs.cpp:315:61:
error: conversion from ‘Teuchos::ArrayView<const unsigned int>’ to
non-scalar type ‘Teuchos::ArrayView<const long unsigned int>’
requested
   ArrayView<const long unsigned int> c = dist.getLengthsFrom();
```
This failure might be related to the changes in this PR too. Any ideas?