### PR TITLE
set KOKKOS_PATH before running make

### DIFF
--- a/README
+++ b/README
@@ -96,9 +96,10 @@ master branch, without -Werror and only for a select set of backends.
 
 In the 'example/tutorial' directory you will find step by step tutorial
 examples which explain many of the features of Kokkos. They work with
-simple Makefiles. To build with g++ and OpenMP simply type 'make openmp'
-in the 'example/tutorial' directory. This will build all examples in the
-subfolders.
+simple Makefiles. To build with g++ and OpenMP simply set the KOKKOS_PATH
+environment variable to the top-level Kokkos source directory (e.g. for bash
+'export KOKKOS_PATH=$HOME/kokkos/kokkos') and then type 'make' in the
+'example/tutorial' directory. This will build all examples in the subfolders.
 
 ============================================================================
 ====Running Unit Tests======================================================

--- a/example/tutorial/Makefile
+++ b/example/tutorial/Makefile
@@ -1,4 +1,3 @@
-KOKKOS_PATH=../../
 build:
 	mkdir -p 01_hello_world
 	cd ./01_hello_world; \

--- a/example/tutorial/README
+++ b/example/tutorial/README
@@ -1,3 +1,6 @@
+First set the KOKKOS_PATH environment variable to the top-level Kokkos
+source directory (e.g. for bash 'export KOKKOS_PATH=$HOME/kokkos/kokkos').
+
 Build the examples by typing in each directory: 
 make -j 16
 


### PR DESCRIPTION
Running ```make``` as instructed in the top-level README fails as the path to the kokkos source directory (```KOKKOS_PATH=../../``` in ```example/tutorial/Makefile```) is incorrect.

```
+cwsmith@pachisi: /lore/cwsmith/projects/kokkos/kokkos/example/tutorial ((224cb2d...))$ make
mkdir -p 01_hello_world
cd ./01_hello_world; \
make build -j 4 -f ../..//example/tutorial/01_hello_world/Makefile
make[1]: Entering directory '/lore/cwsmith/projects/kokkos/kokkos/example/tutorial/01_hello_world'
make[1]: ../..//example/tutorial/01_hello_world/Makefile: No such file or directory
make[1]: *** No rule to make target '../..//example/tutorial/01_hello_world/Makefile'.  Stop.
make[1]: Leaving directory '/lore/cwsmith/projects/kokkos/kokkos/example/tutorial/01_hello_world'
Makefile:3: recipe for target 'build' failed
make: *** [build] Error 2
```

Simply setting ```KOKKOS_PATH=/absolute/path/to/source/dir``` in ```example/tutorial/Makefile``` results in the following error when building the ```Advanced_Views``` examples:

```
make[1]: Leaving directory '/lore/cwsmith/projects/kokkos/kokkos/example/tutorial/05_simple_atomics'
mkdir -p Advanced_Views
cd ./Advanced_Views; \
make build -f /lore/cwsmith/projects/kokkos/kokkos//example/tutorial/Advanced_Views/Makefile KOKKOS_OPTIONS=''
make[1]: Entering directory '/lore/cwsmith/projects/kokkos/kokkos/example/tutorial/Advanced_Views'
mkdir -p 01_data_layouts
cd ./01_data_layouts; \
make build -j 4 -f /example/tutorial/Advanced_Views/01_data_layouts/Makefile
make[2]: Entering directory '/lore/cwsmith/projects/kokkos/kokkos/example/tutorial/Advanced_Views/01_data_layouts'
make[2]: /example/tutorial/Advanced_Views/01_data_layouts/Makefile: No such file or directory
make[2]: *** No rule to make target '/example/tutorial/Advanced_Views/01_data_layouts/Makefile'.  Stop.
make[2]: Leaving directory '/lore/cwsmith/projects/kokkos/kokkos/example/tutorial/Advanced_Views/01_data_layouts'
/lore/cwsmith/projects/kokkos/kokkos//example/tutorial/Advanced_Views/Makefile:2: recipe for target 'build' failed
make[1]: *** [build] Error 2
make[1]: Leaving directory '/lore/cwsmith/projects/kokkos/kokkos/example/tutorial/Advanced_Views'
Makefile:3: recipe for target 'build' failed
make: *** [build] Error 2
```

This patch uses an environment variable to fix the path problems.