### PR TITLE
Bugfix for Kokkos random number generator normal function

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -670,8 +670,8 @@ namespace Kokkos {
       double S = 2.0;
       double U;
       while(S>=1.0) {
-        U = drand();
-        const double V = drand();
+        U = 2.0*drand() - 1.0;
+        const double V = 2.0*drand() - 1.0;
         S = U*U+V*V;
       }
       return U*sqrt(-2.0*log(S)/S);
@@ -910,8 +910,8 @@ namespace Kokkos {
       double S = 2.0;
       double U;
       while(S>=1.0) {
-        U = drand();
-        const double V = drand();
+        U = 2.0*drand() - 1.0;
+        const double V = 2.0*drand() - 1.0;
         S = U*U+V*V;
       }
       return U*sqrt(-2.0*log(S)/S);
@@ -1163,8 +1163,8 @@ namespace Kokkos {
       double S = 2.0;
       double U;
       while(S>=1.0) {
-        U = drand();
-        const double V = drand();
+        U = 2.0*drand() - 1.0;
+        const double V = 2.0*drand() - 1.0;
         S = U*U+V*V;
       }
       return U*sqrt(-2.0*log(S)/S);

--- a/config/master_history.txt
+++ b/config/master_history.txt
@@ -3,4 +3,4 @@ tag:  2.01.06    date: 09:02:2016    master: 9afaa87f    develop: 555f1a3a
 tag:  2.01.10    date: 09:27:2016    master: e4119325    develop: e6cda11e
 tag:  2.02.00    date: 10:30:2016    master: 6c90a581    develop: ca3dd56e
 tag:  2.02.01    date: 11:01:2016    master: 9c698c86    develop: b0072304
-
+tag:  2.02.07    date: 12:16:2016    master: 4b4cc4ba    develop: 382c0966


### PR DESCRIPTION
The normal() function in the Kokkos random number generator doesn't give the expected distribution of a gaussian centered at zero; the distribution is instead always positive. Comparing to the LAMMPS random number generator suggests this change.