### PR TITLE
[WIP] Add variadic template constructor to Array

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -97,6 +97,17 @@ public:
   Array() = default ;
   Array( const Array & ) = default ;
   Array & operator = ( const Array & ) = default ;
+  // This constructor uses a variadic template rather than taking a
+  // std::initializer_list.
+  // Reasons for doing that are the constexpr version of
+  // std::initializer_list::size() is only available with C++14 and
+  // initialization of member C array with an initialization list is
+  // problematic.
+  template <typename... Args>
+  Array( Args&&... args ) : m_elem{args...} {
+      static_assert( sizeof...(Args) == N,
+                     "Invalid number of elements in the initializer_list");
+  }
 
   // Some supported compilers are not sufficiently C++11 compliant
   // for default move constructor and move assignment operator.


### PR DESCRIPTION
The goal is to allow the following code to initialize an Array
```
Kokkos::Array<double, 3> p = { 1.0, 2.0, 3.0 };
```
Closes #611