### PR TITLE
Enable aggregate initialization for Kokkos::Array

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -59,7 +59,13 @@ template< class T      = void
         , class Proxy  = void
         >
 struct Array {
-private:
+public:
+  /**
+   * The elements of this C array shall not be accessed directly. The data
+   * member has to be declared public to enable aggregate initialization as for
+   * std::array. We mark it as private in the documentation.
+   * @private
+   */
   T m_elem[N];
 public:
 

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -66,7 +66,7 @@ public:
    * std::array. We mark it as private in the documentation.
    * @private
    */
-  T m_elem[N];
+  T m_internal_implementation_private_member_data[N];
 public:
 
   typedef T &                                 reference ;
@@ -85,7 +85,7 @@ public:
   reference operator[]( const iType & i )
     {
       static_assert( std::is_integral<iType>::value , "Must be integral argument" );
-      return m_elem[i];
+      return m_internal_implementation_private_member_data[i];
     }
 
   template< typename iType >
@@ -93,11 +93,17 @@ public:
   const_reference operator[]( const iType & i ) const
     {
       static_assert( std::is_integral<iType>::value , "Must be integral argument" );
-      return m_elem[i];
+      return m_internal_implementation_private_member_data[i];
     }
 
-  KOKKOS_INLINE_FUNCTION pointer       data()       { return & m_elem[0] ; }
-  KOKKOS_INLINE_FUNCTION const_pointer data() const { return & m_elem[0] ; }
+  KOKKOS_INLINE_FUNCTION pointer       data()
+    {
+      return & m_internal_implementation_private_member_data[0];
+    }
+  KOKKOS_INLINE_FUNCTION const_pointer data() const
+    {
+      return & m_internal_implementation_private_member_data[0];
+    }
 
   ~Array() = default ;
   Array() = default ;

--- a/core/unit_test/TestAggregate.hpp
+++ b/core/unit_test/TestAggregate.hpp
@@ -99,6 +99,22 @@ void TestViewAggregate()
   ASSERT_EQ( y.extent(0) , 4 );
   ASSERT_EQ( y.extent(1) , 5 );
   ASSERT_EQ( y.extent(2) , 32 );
+
+
+  // Initialize arrays from brace-init-list as for std::array
+  Kokkos::Array<float, 2> aggregate_initialization_syntax_1 = { 1.41, 3.14 };
+  ASSERT_FLOAT_EQ( aggregate_initialization_syntax_1[0], 1.41 );
+  ASSERT_FLOAT_EQ( aggregate_initialization_syntax_1[1], 3.14 );
+  Kokkos::Array<int, 3> aggregate_initialization_syntax_2{ 0, 1, 2 }; // since C++11
+  for (int i = 0; i < 3; ++i)
+      ASSERT_EQ( aggregate_initialization_syntax_2[i], i );
+
+  // Note that this is a valid initialization
+  Kokkos::Array<double, 3> initialized_with_one_argument_missing = { 255, 255 };
+  for (int i = 0; i < 2; ++i)
+      ASSERT_DOUBLE_EQ( initialized_with_one_argument_missing[i], 255 );
+  // But the following line would not compile
+//  Kokkos::Array<double,3> initialized_with_too_many{1, 2, 3, 4};
 }
 
 }


### PR DESCRIPTION
Make underlying C-array public but mark it as private in the documentation.

Closes #611 