### PR TITLE
Output a kokkos.cmake file

### DIFF
--- a/core/src/Makefile
+++ b/core/src/Makefile
@@ -124,8 +124,8 @@ build-cmake-kokkos:
 	echo "set(KOKKOS_CXX_STANDARD $(KOKKOS_CXX_STANDARD) CACHE STRING \"Kokkos C++ standard\")" >> kokkos.cmake
 	echo "set(KOKKOS_OPTIONS $(KOKKOS_OPTIONS) CACHE STRING \"Kokkos options\")" >> kokkos.cmake
 	echo "set(KOKKOS_CUDA_OPTIONS $(KOKKOS_CUDA_OPTIONS) CACHE STRING \"Kokkos Cuda options\")" >> kokkos.cmake
-	echo "if(NOT DEFINED ENV{CXX})" >> kokkos.cmake
-	echo "  set(CMAKE_CXX_COMPILER \"$(CXX)\")" >> kokkos.cmake
+	echo "if(NOT $ENV{CXX})" >> kokkos.cmake
+	echo '  message(WARNING "You are currently using compiler $${CMAKE_CXX_COMPILER} while Kokkos was built with $(CXX) ; make sure this is the behavior you intended to be.")' >> kokkos.cmake
 	echo "endif()" >> kokkos.cmake
 	echo "if(NOT DEFINED ENV{NVCC_WRAPPER})" >> kokkos.cmake
 	echo "  set(NVCC_WRAPPER \"$(NVCC_WRAPPER)\" CACHE FILEPATH \"Path to command nvcc_wrapper\")" >> kokkos.cmake

--- a/core/src/Makefile
+++ b/core/src/Makefile
@@ -60,6 +60,12 @@ ifeq ($(KOKKOS_OS),Darwin)
   COPY_FLAG =
 endif
 
+ifeq ($(KOKKOS_DEBUG),"no")
+  KOKKOS_DEBUG_CMAKE = OFF
+else
+  KOKKOS_DEBUG_CMAKE = ON
+endif
+
 messages: 
 	echo "Start Build"
 
@@ -107,7 +113,55 @@ build-makefile-kokkos:
 		> Makefile.kokkos.tmp
 	mv -f Makefile.kokkos.tmp Makefile.kokkos
 
-build-lib: build-makefile-kokkos $(KOKKOS_LINK_DEPENDS)
+build-cmake-kokkos:
+	rm -f kokkos.cmake
+	echo "#Global Settings used to generate this library" >> kokkos.cmake
+	echo "set(KOKKOS_PATH $(PREFIX) CACHE PATH \"Kokkos installation path\")" >> kokkos.cmake
+	echo "set(KOKKOS_DEVICES $(KOKKOS_DEVICES) CACHE STRING \"Kokkos devices list\")" >> kokkos.cmake
+	echo "set(KOKKOS_ARCH $(KOKKOS_ARCH) CACHE STRING \"Kokkos architecture flags\")" >> kokkos.cmake
+	echo "set(KOKKOS_DEBUG $(KOKKOS_DEBUG_CMAKE) CACHE BOOL \"Kokkos debug enabled ?)\")" >> kokkos.cmake
+	echo "set(KOKKOS_USE_TPLS $(KOKKOS_USE_TPLS) CACHE STRING \"Kokkos templates list\")" >> kokkos.cmake
+	echo "set(KOKKOS_CXX_STANDARD $(KOKKOS_CXX_STANDARD) CACHE STRING \"Kokkos C++ standard\")" >> kokkos.cmake
+	echo "set(KOKKOS_OPTIONS $(KOKKOS_OPTIONS) CACHE STRING \"Kokkos options\")" >> kokkos.cmake
+	echo "set(KOKKOS_CUDA_OPTIONS $(KOKKOS_CUDA_OPTIONS) CACHE STRING \"Kokkos Cuda options\")" >> kokkos.cmake
+	echo "if(NOT DEFINED ENV{CXX})" >> kokkos.cmake
+	echo "  set(CMAKE_CXX_COMPILER \"$(CXX)\")" >> kokkos.cmake
+	echo "endif()" >> kokkos.cmake
+	echo "if(NOT DEFINED ENV{NVCC_WRAPPER})" >> kokkos.cmake
+	echo "  set(NVCC_WRAPPER \"$(NVCC_WRAPPER)\" CACHE FILEPATH \"Path to command nvcc_wrapper\")" >> kokkos.cmake
+	echo "else()" >> kokkos.cmake
+	echo '  set(NVCC_WRAPPER $$ENV{NVCC_WRAPPER} CACHE FILEPATH "Path to command nvcc_wrapper")' >> kokkos.cmake
+	echo "endif()" >> kokkos.cmake
+	echo "" >> kokkos.cmake  
+	echo "#Source and Header files of Kokkos relative to KOKKOS_PATH" >> kokkos.cmake
+	echo "set(KOKKOS_HEADERS \"$(KOKKOS_HEADERS)\" CACHE STRING \"Kokkos headers list\")" >> kokkos.cmake
+	echo "set(KOKKOS_SRC \"$(KOKKOS_SRC)\" CACHE STRING \"Kokkos source list\")" >> kokkos.cmake
+	echo "" >> kokkos.cmake  
+	echo "#Variables used in application Makefiles" >> kokkos.cmake
+	echo "set(KOKKOS_CPP_DEPENDS \"$(KOKKOS_CPP_DEPENDS)\" CACHE STRING \"\")" >> kokkos.cmake
+	echo "set(KOKKOS_CXXFLAGS \"$(KOKKOS_CXXFLAGS)\" CACHE STRING \"\")" >> kokkos.cmake
+	echo "set(KOKKOS_CPPFLAGS \"$(KOKKOS_CPPFLAGS)\" CACHE STRING \"\")" >> kokkos.cmake
+	echo "set(KOKKOS_LINK_DEPENDS \"$(KOKKOS_LINK_DEPENDS)\" CACHE STRING \"\")" >> kokkos.cmake
+	echo "set(KOKKOS_LIBS \"$(KOKKOS_LIBS)\" CACHE STRING \"\")" >> kokkos.cmake
+	echo "set(KOKKOS_LDFLAGS \"$(KOKKOS_LDFLAGS)\" CACHE STRING \"\")" >> kokkos.cmake
+	echo "" >> kokkos.cmake
+	echo "#Internal settings which need to propagated for Kokkos examples" >> kokkos.cmake
+	echo "set(KOKKOS_INTERNAL_USE_CUDA \"${KOKKOS_INTERNAL_USE_CUDA}\" CACHE STRING \"\")" >> kokkos.cmake
+	echo "set(KOKKOS_INTERNAL_USE_OPENMP \"${KOKKOS_INTERNAL_USE_OPENMP}\" CACHE STRING \"\")" >> kokkos.cmake
+	echo "set(KOKKOS_INTERNAL_USE_PTHREADS \"${KOKKOS_INTERNAL_USE_PTHREADS}\" CACHE STRING \"\")" >> kokkos.cmake
+	echo "mark_as_advanced(KOKKOS_HEADERS KOKKOS_SRC KOKKOS_INTERNAL_USE_CUDA KOKKOS_INTERNAL_USE_OPENMP KOKKOS_INTERNAL_USE_PTHREADS)" >> kokkos.cmake
+	echo "" >> kokkos.cmake
+	sed \
+		-e 's|$(KOKKOS_PATH)/core/src|$(PREFIX)/include|g' \
+	 	-e 's|$(KOKKOS_PATH)/containers/src|$(PREFIX)/include|g' \
+	 	-e 's|$(KOKKOS_PATH)/algorithms/src|$(PREFIX)/include|g' \
+	 	-e 's|-L$(PWD)|-L$(PREFIX)/lib|g' \
+	 	-e 's|= libkokkos.a|= $(PREFIX)/lib/libkokkos.a|g' \
+	 	-e 's|= KokkosCore_config.h|= $(PREFIX)/include/KokkosCore_config.h|g' kokkos.cmake \
+	 	> kokkos.cmake.tmp
+	mv -f kokkos.cmake.tmp kokkos.cmake
+
+build-lib: build-makefile-kokkos build-cmake-kokkos $(KOKKOS_LINK_DEPENDS)
 
 mkdir: 
 	mkdir -p $(PREFIX)
@@ -137,6 +191,7 @@ install: mkdir $(CONDITIONAL_COPIES) build-lib
 	cp $(COPY_FLAG) $(KOKKOS_HEADERS_INCLUDE) $(PREFIX)/include
 	cp $(COPY_FLAG) $(KOKKOS_HEADERS_INCLUDE_IMPL) $(PREFIX)/include/impl
 	cp $(COPY_FLAG) Makefile.kokkos $(PREFIX)
+	cp $(COPY_FLAG) kokkos.cmake $(PREFIX)
 	cp $(COPY_FLAG) libkokkos.a $(PREFIX)/lib
 	cp $(COPY_FLAG) KokkosCore_config.h $(PREFIX)/include
 


### PR DESCRIPTION
This is related to issue #633 

Just outputs file kokkos.cmake, containing the same information as Makefile.kokkos with the intent to be included in a user application already using CMake build system. This file is installed at the same location as Makefile.kokkos

Another potential use could be for people who want to build kokkos as part of their cmake application, they could do a kind of cmake superbuild in 2 steps:
1. the top level CMakeLists builds kokkos as an external project, cmake.kokkos is generated
2. the top level CMakeLists is re-invoked stating Kokkos is installed, includes the generated cmake.kokkos and builds the user application
