### PR TITLE
allow an enum to be used as input to operator() of a Kokkos::Array

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -84,7 +84,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   reference operator[]( const iType & i )
     {
-      static_assert( std::is_integral<iType>::value , "Must be integral argument" );
+      static_assert( ( std::is_integral<iType>::value || std::is_enum<iType>::value ) , "Must be integral argument" );
       return m_internal_implementation_private_member_data[i];
     }
 
@@ -92,7 +92,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   const_reference operator[]( const iType & i ) const
     {
-      static_assert( std::is_integral<iType>::value , "Must be integral argument" );
+      static_assert( ( std::is_integral<iType>::value || std::is_enum<iType>::value ) , "Must be integral argument" );
       return m_internal_implementation_private_member_data[i];
     }
 
@@ -136,7 +136,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   value_type operator[]( const iType & )
     {
-      static_assert( std::is_integral<iType>::value , "Must be integer argument" );
+      static_assert( ( std::is_integral<iType>::value || std::is_enum<iType>::value ) , "Must be integer argument" );
       return value_type();
     }
 
@@ -144,7 +144,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   value_type operator[]( const iType & ) const
     {
-      static_assert( std::is_integral<iType>::value , "Must be integer argument" );
+      static_assert( ( std::is_integral<iType>::value || std::is_enum<iType>::value ) , "Must be integer argument" );
       return value_type();
     }
 
@@ -193,7 +193,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   reference operator[]( const iType & i )
     {
-      static_assert( std::is_integral<iType>::value , "Must be integral argument" );
+      static_assert( ( std::is_integral<iType>::value || std::is_enum<iType>::value ) , "Must be integral argument" );
       return m_elem[i];
     }
 
@@ -201,7 +201,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   const_reference operator[]( const iType & i ) const
     {
-      static_assert( std::is_integral<iType>::value , "Must be integral argument" );
+      static_assert( ( std::is_integral<iType>::value || std::is_enum<iType>::value ) , "Must be integral argument" );
       return m_elem[i];
     }
 
@@ -262,7 +262,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   reference operator[]( const iType & i )
     {
-      static_assert( std::is_integral<iType>::value , "Must be integral argument" );
+      static_assert( ( std::is_integral<iType>::value || std::is_enum<iType>::value ) , "Must be integral argument" );
       return m_elem[i*m_stride];
     }
 
@@ -270,7 +270,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   const_reference operator[]( const iType & i ) const
     {
-      static_assert( std::is_integral<iType>::value , "Must be integral argument" );
+      static_assert( ( std::is_integral<iType>::value || std::is_enum<iType>::value ) , "Must be integral argument" );
       return m_elem[i*m_stride];
     }
 


### PR DESCRIPTION
this is related to issue #227 
The same modification can be applied to a Kokkos::Array
