### PR TITLE
MDRange: Minor perf test fixes for KNL

### DIFF
--- a/core/perf_test/PerfTestCuda.cpp
+++ b/core/perf_test/PerfTestCuda.cpp
@@ -75,11 +75,11 @@ class cuda : public ::testing::Test {
 };
 
 TEST_F( cuda, mdrange_lr ) {
-  EXPECT_NO_THROW( (run_test_mdrange<Kokkos::Cuda , Kokkos::LayoutRight>( 5, 10, "Kokkos::Cuda" )) );
+  EXPECT_NO_THROW( (run_test_mdrange<Kokkos::Cuda , Kokkos::LayoutRight>( 5, 8, "Kokkos::Cuda" )) );
 }
 
 TEST_F( cuda, mdrange_ll ) {
-  EXPECT_NO_THROW( (run_test_mdrange<Kokkos::Cuda , Kokkos::LayoutLeft>( 5, 10, "Kokkos::Cuda" )) );
+  EXPECT_NO_THROW( (run_test_mdrange<Kokkos::Cuda , Kokkos::LayoutLeft>( 5, 8, "Kokkos::Cuda" )) );
 }
 
 TEST_F( cuda, hexgrad )

--- a/core/perf_test/PerfTestDriver.hpp
+++ b/core/perf_test/PerfTestDriver.hpp
@@ -70,7 +70,7 @@ void run_test_mdrange( int exp_beg , int exp_end, const char deviceTypeName[], i
   label_mdrange.append( " >\"" );
 
   std::string label_range_col2 ;
-  label_range_col2.append( "\"RangeCol2< double , " );
+  label_range_col2.append( "\"RangeColTwo< double , " );
   label_range_col2.append( deviceTypeName );
   label_range_col2.append( " >\"" );
 
@@ -129,7 +129,8 @@ void run_test_mdrange( int exp_beg , int exp_end, const char deviceTypeName[], i
 #endif
 
         // Run 1 with tiles LayoutRight style
-        const double seconds_1 = MultiDimRangePerf3D< DeviceType , double , LayoutType >::test_multi_index(range_length,range_length,range_length, t0, t1, t2) ;
+        double seconds_1 = 0;
+        { seconds_1 = MultiDimRangePerf3D< DeviceType , double , LayoutType >::test_multi_index(range_length,range_length,range_length, t0, t1, t2) ; }
 
 #if MDRANGE_PERFORMANCE_OUTPUT_VERBOSE
         std::cout << label_mdrange
@@ -154,8 +155,9 @@ void run_test_mdrange( int exp_beg , int exp_end, const char deviceTypeName[], i
           }
         }
 
-        // Run 2 with tiles LayoutLeft style
-        const double seconds_1rev = MultiDimRangePerf3D< DeviceType , double , LayoutType >::test_multi_index(range_length,range_length,range_length, t0_rev, t1_rev, t2_rev) ;
+        // Run 2 with tiles LayoutLeft style - reverse order of tile dims
+        double seconds_1rev = 0;
+        { seconds_1rev = MultiDimRangePerf3D< DeviceType , double , LayoutType >::test_multi_index(range_length,range_length,range_length, t0_rev, t1_rev, t2_rev) ; }
 
 #if MDRANGE_PERFORMANCE_OUTPUT_VERBOSE
         std::cout << label_mdrange
@@ -199,7 +201,8 @@ void run_test_mdrange( int exp_beg , int exp_end, const char deviceTypeName[], i
     if ( std::is_same<LayoutType, Kokkos::LayoutRight>::value ) {
       for ( unsigned int T0 = min_bnd; T0 < static_cast<unsigned int>(range_length); T0<<=1 ) {
         for ( unsigned int T1 = min_bnd; T1 < static_cast<unsigned int>(range_length); T1<<=1 ) {
-          const double seconds_c = MultiDimRangePerf3D< DeviceType , double , LayoutType >::test_multi_index(range_length,range_length,range_length, T0, T1, 0) ;
+          double seconds_c = 0;
+          { seconds_c = MultiDimRangePerf3D< DeviceType , double , LayoutType >::test_multi_index(range_length,range_length,range_length, T0, T1, 0) ; }
 
 #if MDRANGE_PERFORMANCE_OUTPUT_VERBOSE
           std::cout << " MDRange LR with '0' tile - collapse-like \n"
@@ -230,7 +233,8 @@ void run_test_mdrange( int exp_beg , int exp_end, const char deviceTypeName[], i
     else {
       for ( unsigned int T1 = min_bnd; T1 <= static_cast<unsigned int>(range_length); T1<<=1 ) {
         for ( unsigned int T2 = min_bnd; T2 <= static_cast<unsigned int>(range_length); T2<<=1 ) {
-          const double seconds_c = MultiDimRangePerf3D< DeviceType , double , LayoutType >::test_multi_index(range_length,range_length,range_length, 0, T1, T2) ;
+          double seconds_c = 0;
+          { seconds_c = MultiDimRangePerf3D< DeviceType , double , LayoutType >::test_multi_index(range_length,range_length,range_length, 0, T1, T2) ; }
 
 #if MDRANGE_PERFORMANCE_OUTPUT_VERBOSE
           std::cout << " MDRange LL with '0' tile - collapse-like \n"
@@ -275,22 +279,30 @@ void run_test_mdrange( int exp_beg , int exp_end, const char deviceTypeName[], i
 
 
     // Test 2: RangePolicy Collapse2 style
-    const double seconds_2 = MultiDimRangePerf3D_Collapse< DeviceType , double , LayoutType >::test_index_collapse(range_length,range_length,range_length) ;
+    double seconds_2 = 0;
+    { seconds_2 = RangePolicyCollapseTwo< DeviceType , double , LayoutType >::test_index_collapse_two(range_length,range_length,range_length) ; }
     std::cout << label_range_col2
       << " , " << range_length
       << " , " << seconds_2
       << std::endl ;
 
 
-    // Test 3: RangePolicy Collapse all style
-    const double seconds_3 = MultiDimRangePerf3D_CollapseAll< DeviceType , double , LayoutType >::test_collapse_all(range_length,range_length,range_length) ;
+    // Test 3: RangePolicy Collapse all style - not necessary, always slow
+    /*
+    double seconds_3 = 0;
+    { seconds_3 = RangePolicyCollapseAll< DeviceType , double , LayoutType >::test_collapse_all(range_length,range_length,range_length) ; }
     std::cout << label_range_col_all
       << " , " << range_length
       << " , " << seconds_3
       << "\n---------------------------------------------------------------"
       << std::endl ;
+    */
 
-    // Compare fastest times... will never be collapse all
+    // Compare fastest times... will never be collapse all so ignore it
+    // seconds_min = tiled MDRange
+    // seconds_min_c = collapse<2>-like MDRange (tiledim = span for fast dim)
+    // seconds_2 = collapse<2>-style RangePolicy
+    // seconds_3 = collapse<3>-style RangePolicy
     if ( seconds_min < seconds_min_c ) {
       if ( seconds_min < seconds_2 ) {
         std::cout << "--------------------------------------------------------------\n"
@@ -298,7 +310,7 @@ void run_test_mdrange( int exp_beg , int exp_end, const char deviceTypeName[], i
           << " Time: " << seconds_min
           << " Difference: " << seconds_2 - seconds_min
           << " Other times: \n"
-          << "   MDrange Collapse type: " << seconds_min_c << "\n"
+          << "   MDrange collapse-like (tiledim = span on fast dim) type: " << seconds_min_c << "\n"
           << "   Collapse2 Range Policy: " << seconds_2 << "\n"
           << "\n--------------------------------------------------------------"
           << "\n--------------------------------------------------------------"
@@ -311,7 +323,7 @@ void run_test_mdrange( int exp_beg , int exp_end, const char deviceTypeName[], i
           << " Difference: " << seconds_min - seconds_2
           << " Other times: \n"
           << "   MDrange Tiled: " << seconds_min << "\n"
-          << "   MDrange Collapse type: " << seconds_min_c << "\n"
+          << "   MDrange collapse-like (tiledim = span on fast dim) type: " << seconds_min_c << "\n"
           << "\n--------------------------------------------------------------"
           << "\n--------------------------------------------------------------"
           << "\n\n"
@@ -321,7 +333,7 @@ void run_test_mdrange( int exp_beg , int exp_end, const char deviceTypeName[], i
     else if ( seconds_min > seconds_min_c ) {
       if ( seconds_min_c < seconds_2 ) {
         std::cout << "--------------------------------------------------------------\n"
-          << " Fastest run: MDRange Collapse type\n"
+          << " Fastest run: MDRange collapse-like (tiledim = span on fast dim) type\n"
           << " Time: " << seconds_min_c
           << " Difference: " << seconds_2 - seconds_min_c
           << " Other times: \n"
@@ -338,7 +350,7 @@ void run_test_mdrange( int exp_beg , int exp_end, const char deviceTypeName[], i
           << " Difference: " << seconds_min_c - seconds_2
           << " Other times: \n"
           << "   MDrange Tiled: " << seconds_min << "\n"
-          << "   MDrange Collapse type: " << seconds_min_c << "\n"
+          << "   MDrange collapse-like (tiledim = span on fast dim) type: " << seconds_min_c << "\n"
           << "\n--------------------------------------------------------------"
           << "\n--------------------------------------------------------------"
           << "\n\n"

--- a/core/perf_test/PerfTestHost.cpp
+++ b/core/perf_test/PerfTestHost.cpp
@@ -105,11 +105,11 @@ protected:
 };
 
 //TEST_F( host, mdrange_lr ) {
-//  EXPECT_NO_THROW( (run_test_mdrange<TestHostDevice , Kokkos::LayoutRight> (5, 11, TestHostDeviceName) ) );
+//  EXPECT_NO_THROW( (run_test_mdrange<TestHostDevice , Kokkos::LayoutRight> (5, 8, TestHostDeviceName) ) );
 //}
 
 //TEST_F( host, mdrange_ll ) {
-//  EXPECT_NO_THROW( (run_test_mdrange<TestHostDevice , Kokkos::LayoutLeft> (5, 8, TestHostDeviceName) ) ); //uncommenting and running both leads to segfault during run of the test above?????
+//  EXPECT_NO_THROW( (run_test_mdrange<TestHostDevice , Kokkos::LayoutLeft> (5, 8, TestHostDeviceName) ) );
 //}
 
 TEST_F( host, hexgrad ) {

--- a/core/perf_test/PerfTestMDRange.hpp
+++ b/core/perf_test/PerfTestMDRange.hpp
@@ -58,18 +58,18 @@ struct MultiDimRangePerf3D
 
   view_type A;
   view_type B;
-  const int irange;
-  const int jrange;
-  const int krange;
+  const long irange;
+  const long jrange;
+  const long krange;
 
-  MultiDimRangePerf3D(const view_type & A_, const view_type & B_, const int &irange_,  const int &jrange_, const int &krange_)
+  MultiDimRangePerf3D(const view_type & A_, const view_type & B_, const long &irange_,  const long &jrange_, const long &krange_)
   : A(A_), B(B_), irange(irange_), jrange(jrange_), krange(krange_)
   {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const int i, const int j, const int k) const
+  void operator()(const long i, const long j, const long k) const
   {
-    A(i,j,k) = 0.143*(double)( B(i+2,j,k) + B(i+1,j,k)
+    A(i,j,k) = 0.143*(ScalarType)( B(i+2,j,k) + B(i+1,j,k)
                              + B(i,j+2,k) + B(i,j+1,k)
                              + B(i,j,k+2) + B(i,j,k+1)
                              + B(i,j,k) );
@@ -82,29 +82,29 @@ struct MultiDimRangePerf3D
   struct Init
   {
 
-    Init(const view_type & input_, const int &irange_,  const int &jrange_, const int &krange_)
+    Init(const view_type & input_, const long &irange_,  const long &jrange_, const long &krange_)
     : input(input_), irange(irange_), jrange(jrange_), krange(krange_) {}
 
     KOKKOS_INLINE_FUNCTION
-    void operator()(const int i, const int j, const int k) const
+    void operator()(const long i, const long j, const long k) const
     {
       input(i,j,k) = 1.0;
     }
 
     KOKKOS_INLINE_FUNCTION
-    void operator()(const InitZeroTag&, const int i, const int j, const int k) const
+    void operator()(const InitZeroTag&, const long i, const long j, const long k) const
     {
       input(i,j,k) = 0;
     }
 
     view_type input;
-    const int irange;
-    const int jrange;
-    const int krange;
+    const long irange;
+    const long jrange;
+    const long krange;
   };
 
 
-  static double test_multi_index(const unsigned icount, const unsigned jcount, const unsigned kcount, const unsigned int Ti = 1, const unsigned int Tj = 1, const unsigned int Tk = 1, const int iter = 1)
+  static double test_multi_index(const unsigned icount, const unsigned jcount, const unsigned kcount, const unsigned long Ti = 1, const unsigned long Tj = 1, const unsigned long Tk = 1, const long iter = 1)
   {
     //This test performs multidim range over all dims
     view_type Atest("Atest", icount, jcount, kcount);
@@ -113,8 +113,9 @@ struct MultiDimRangePerf3D
 
     double dt_min = 0;
 
+    // LayoutRight
     if ( std::is_same<TestLayout, Kokkos::LayoutRight>::value ) {
-      Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3, iterate_type::Right, iterate_type::Right>, execution_space > policy_init({{0,0,0}},{{icount,jcount,kcount}},{{Ti,Tj,Tk}}); 
+      Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3, iterate_type::Right, iterate_type::Right>, execution_space > policy_initA({{0,0,0}},{{icount,jcount,kcount}},{{Ti,Tj,Tk}}); 
       Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3, iterate_type::Right, iterate_type::Right>, execution_space > policy_initB({{0,0,0}},{{icount+2,jcount+2,kcount+2}},{{Ti,Tj,Tk}}); 
 
       typedef typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3, iterate_type::Right, iterate_type::Right>, execution_space > MDRangeType;
@@ -123,7 +124,7 @@ struct MultiDimRangePerf3D
 
       Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3, iterate_type::Right, iterate_type::Right>, execution_space > policy(point_type{{0,0,0}},point_type{{icount,jcount,kcount}},tile_type{{Ti,Tj,Tk}} );
 
-      Kokkos::Experimental::md_parallel_for( policy_init, Init(Atest, icount, jcount, kcount) );
+      Kokkos::Experimental::md_parallel_for( policy_initA, Init(Atest, icount, jcount, kcount) );
       execution_space::fence();
       Kokkos::Experimental::md_parallel_for( policy_initB, Init(Btest, icount+2, jcount+2, kcount+2) );
       execution_space::fence();
@@ -140,44 +141,55 @@ struct MultiDimRangePerf3D
       //Correctness check - only the first run
       if ( 0 == i )
       {
-        int numErrors = 0;
+        long numErrors = 0;
         host_view_type Ahost("Ahost", icount, jcount, kcount);
         Kokkos::deep_copy(Ahost, Atest);
         host_view_type Bhost("Bhost", icount+2, jcount+2, kcount+2);
         Kokkos::deep_copy(Bhost, Btest);
 
-        for ( int l = 0; l < static_cast<int>(icount); ++l ) {
-        for ( int j = 0; j < static_cast<int>(jcount); ++j ) {
-        for ( int k = 0; k < static_cast<int>(kcount); ++k ) {
-          //double check = (l*l + j - k*l + 2.0*k*j - j*j*j);
-          double check  = 0.143*(double)( Bhost(i+2,j,k) + Bhost(i+1,j,k)
+        // On KNL, this may vectorize - add print statement to prevent
+        // Also, compare against epsilon, as vectorization can change bitwise answer
+        for ( long l = 0; l < static_cast<long>(icount); ++l ) {
+        for ( long j = 0; j < static_cast<long>(jcount); ++j ) {
+        for ( long k = 0; k < static_cast<long>(kcount); ++k ) {
+          ScalarType check  = 0.143*(ScalarType)( Bhost(i+2,j,k) + Bhost(i+1,j,k)
                                         + Bhost(i,j+2,k) + Bhost(i,j+1,k)
                                         + Bhost(i,j,k+2) + Bhost(i,j,k+1)
                                         + Bhost(i,j,k) );
           if ( Ahost(l,j,k) - check != 0 ) {
             ++numErrors;
-            std::cout << "  Correctness error at " << l << " "<<j<<" "<<k<<"\n"
+            std::cout << "  Correctness error at index: " << l << ","<<j<<","<<k<<"\n"
                       << "  multi Ahost = " << Ahost(l,j,k) << "  expected = " << check  
                       << "  multi Bhost(ijk) = " << Bhost(l,j,k) 
                       << "  multi Bhost(i+1jk) = " << Bhost(l+1,j,k) 
                       << "  multi Bhost(i+2jk) = " << Bhost(l+2,j,k) 
+                      << "  multi Bhost(ij+1k) = " << Bhost(l,j+1,k) 
+                      << "  multi Bhost(ij+2k) = " << Bhost(l,j+2,k) 
+                      << "  multi Bhost(ijk+1) = " << Bhost(l,j,k+1) 
+                      << "  multi Bhost(ijk+2) = " << Bhost(l,j,k+2) 
                       << std::endl;
             //exit(-1);
           }
         } } }
-        if ( numErrors != 0 ) { std::cout << "LR multi: errors " << numErrors <<  std::endl; }
+        if ( numErrors != 0 ) { std::cout << "LR multi: errors " << numErrors << "  range product " << icount*jcount*kcount << "  LL " << jcount*kcount << "  LR " << icount*jcount << std::endl; }
         //else { std::cout << " multi: No errors!" <<  std::endl; }
       }
     } //end for
 
     } 
+    // LayoutLeft
     else {
-      Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3,iterate_type::Left,iterate_type::Left>, execution_space > policy_init({{0,0,0}},{{icount,jcount,kcount}},{{Ti,Tj,Tk}}); 
-      Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3,iterate_type::Right,iterate_type::Right>, execution_space > policy_initB({{0,0,0}},{{icount+2,jcount+2,kcount+2}},{{Ti,Tj,Tk}}); 
+      Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3,iterate_type::Left,iterate_type::Left>, execution_space > policy_initA({{0,0,0}},{{icount,jcount,kcount}},{{Ti,Tj,Tk}}); 
+      Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3,iterate_type::Left,iterate_type::Left>, execution_space > policy_initB({{0,0,0}},{{icount+2,jcount+2,kcount+2}},{{Ti,Tj,Tk}}); 
 
+      typedef typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3, iterate_type::Left, iterate_type::Left>, execution_space > MDRangeType;
+      using tile_type = typename MDRangeType::tile_type;
+      using point_type = typename MDRangeType::point_type;
+
+      //Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3, iterate_type::Left, iterate_type::Left>, execution_space > policy(point_type{{0,0,0}},point_type{{icount,jcount,kcount}},tile_type{{Ti,Tj,Tk}} );
       Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3, iterate_type::Left, iterate_type::Left>, execution_space > policy({{0,0,0}},{{icount,jcount,kcount}},{{Ti,Tj,Tk}} ); 
 
-      Kokkos::Experimental::md_parallel_for( policy_init, Init(Atest, icount, jcount, kcount) );
+      Kokkos::Experimental::md_parallel_for( policy_initA, Init(Atest, icount, jcount, kcount) );
       execution_space::fence();
       Kokkos::Experimental::md_parallel_for( policy_initB, Init(Btest, icount+2, jcount+2, kcount+2) );
       execution_space::fence();
@@ -194,32 +206,37 @@ struct MultiDimRangePerf3D
       //Correctness check - only the first run
       if ( 0 == i )
       {
-        int numErrors = 0;
+        long numErrors = 0;
         host_view_type Ahost("Ahost", icount, jcount, kcount);
         Kokkos::deep_copy(Ahost, Atest);
         host_view_type Bhost("Bhost", icount+2, jcount+2, kcount+2);
         Kokkos::deep_copy(Bhost, Btest);
 
-        for ( int l = 0; l < static_cast<int>(icount); ++l ) {
-        for ( int j = 0; j < static_cast<int>(jcount); ++j ) {
-        for ( int k = 0; k < static_cast<int>(kcount); ++k ) {
-          //double check = (l*l + j - k*l + 2.0*k*j - j*j*j);
-          double check  = 0.143*(double)( Bhost(i+2,j,k) + Bhost(i+1,j,k)
+        // On KNL, this may vectorize - add print statement to prevent
+        // Also, compare against epsilon, as vectorization can change bitwise answer
+        for ( long l = 0; l < static_cast<long>(icount); ++l ) {
+        for ( long j = 0; j < static_cast<long>(jcount); ++j ) {
+        for ( long k = 0; k < static_cast<long>(kcount); ++k ) {
+          ScalarType check  = 0.143*(ScalarType)( Bhost(i+2,j,k) + Bhost(i+1,j,k)
                                         + Bhost(i,j+2,k) + Bhost(i,j+1,k)
                                         + Bhost(i,j,k+2) + Bhost(i,j,k+1)
                                         + Bhost(i,j,k) );
           if ( Ahost(l,j,k) - check != 0 ) {
             ++numErrors;
-            std::cout << "  Correctness error at " << l << " "<<j<<" "<<k<<"\n"
+            std::cout << "  Correctness error at index: " << l << ","<<j<<","<<k<<"\n"
                       << "  multi Ahost = " << Ahost(l,j,k) << "  expected = " << check  
                       << "  multi Bhost(ijk) = " << Bhost(l,j,k) 
                       << "  multi Bhost(i+1jk) = " << Bhost(l+1,j,k) 
                       << "  multi Bhost(i+2jk) = " << Bhost(l+2,j,k) 
+                      << "  multi Bhost(ij+1k) = " << Bhost(l,j+1,k) 
+                      << "  multi Bhost(ij+2k) = " << Bhost(l,j+2,k) 
+                      << "  multi Bhost(ijk+1) = " << Bhost(l,j,k+1) 
+                      << "  multi Bhost(ijk+2) = " << Bhost(l,j,k+2) 
                       << std::endl;
             //exit(-1);
           }
         } } }
-        if ( numErrors != 0 ) { std::cout << " LL multi run: errors " << numErrors <<  std::endl; }
+        if ( numErrors != 0 ) { std::cout << " LL multi run: errors " << numErrors << "  range product " << icount*jcount*kcount << "  LL " << jcount*kcount << "  LR " << icount*jcount << std::endl; }
         //else { std::cout << " multi: No errors!" <<  std::endl; }
 
       }
@@ -236,12 +253,13 @@ template< class DeviceType
         , typename ScalarType = double  
         , typename TestLayout = Kokkos::LayoutRight  
         >
-struct MultiDimRangePerf3D_Collapse
+struct RangePolicyCollapseTwo
 {
-  // 3D Range, but will collapse only 2 dims => Rank<2> for multi-dim; unroll 2 dims in one-dim
+  // RangePolicy for 3D range, but will collapse only 2 dims => like Rank<2> for multi-dim; unroll 2 dims in one-dim
 
   typedef DeviceType execution_space;
   typedef typename execution_space::size_type  size_type;
+  typedef TestLayout layout;
 
   using iterate_type = Kokkos::Experimental::Iterate;
 
@@ -250,28 +268,25 @@ struct MultiDimRangePerf3D_Collapse
 
   view_type A;
   view_type B;
-  const int irange;
-  const int jrange;
-  const int krange;
+  const long irange;
+  const long jrange;
+  const long krange;
 
-  MultiDimRangePerf3D_Collapse(const view_type & A_, const view_type & B_, const int &irange_,  const int &jrange_, const int &krange_)
+  RangePolicyCollapseTwo(view_type & A_, const view_type & B_, const long &irange_,  const long &jrange_, const long &krange_)
   : A(A_), B(B_) , irange(irange_), jrange(jrange_), krange(krange_)
   {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const int r) const
+  void operator()(const long r) const
   {
     if ( std::is_same<TestLayout, Kokkos::LayoutRight>::value )
     {
 //id(i,j,k) = k + j*Nk + i*Nk*Nj = k + Nk*(j + i*Nj) = k + Nk*r
-//      const int i = r / (jrange*krange);
-//      const int j = (r - i*jrange*krange)/jrange;
 //r = j + i*Nj
-      const int i = r / (jrange); 
-      const int j = ( r - i*jrange);
+      long i = int(r / jrange); 
+      long j = int( r - i*jrange);
       for (int k = 0; k < krange; ++k) {
-    //    A(i,j,k) = (double)(i*i + j - k*i + 2.0*k*j - j*j*j);
-        A(i,j,k) = 0.143*(double)( B(i+2,j,k) + B(i+1,j,k)
+        A(i,j,k) = 0.143*(ScalarType)( B(i+2,j,k) + B(i+1,j,k)
                                  + B(i,j+2,k) + B(i,j+1,k)
                                  + B(i,j,k+2) + B(i,j,k+1)
                                  + B(i,j,k) );
@@ -280,76 +295,67 @@ struct MultiDimRangePerf3D_Collapse
     else if ( std::is_same<TestLayout, Kokkos::LayoutLeft>::value )
     {
 //id(i,j,k) = i + j*Ni + k*Ni*Nj = i + Ni*(j + k*Nj) = i + Ni*r
-//      const int k = r / (irange*jrange); 
-//      const int j = ( r - k*irange*jrange)/irange;
 //r = j + k*Nj
-      const int k = r / (jrange); 
-      const int j = ( r - k*jrange);
+      long k = int(r / jrange); 
+      long j = int( r - k*jrange);
       for (int i = 0; i < irange; ++i) {
-    //    A(i,j,k) = (double)(i*i + j - k*i + 2.0*k*j - j*j*j);
-        A(i,j,k) = 0.143*(double)( B(i+2,j,k) + B(i+1,j,k)
+        A(i,j,k) = 0.143*(ScalarType)( B(i+2,j,k) + B(i+1,j,k)
                                  + B(i,j+2,k) + B(i,j+1,k)
                                  + B(i,j,k+2) + B(i,j,k+1)
                                  + B(i,j,k) );
       }
     }
-
   }
 
 
   struct Init
   {
     view_type input;
-    const int irange;
-    const int jrange;
-    const int krange;
+    const long irange;
+    const long jrange;
+    const long krange;
 
-    Init(const view_type & input_, const int &irange_,  const int &jrange_, const int &krange_)
+    Init(const view_type & input_, const long &irange_,  const long &jrange_, const long &krange_)
     : input(input_), irange(irange_), jrange(jrange_), krange(krange_) {}
 
     KOKKOS_INLINE_FUNCTION
-    void operator()(const int r) const
+    void operator()(const long r) const
     {
       if ( std::is_same<TestLayout, Kokkos::LayoutRight>::value )
       {
-        const int i = r / (jrange*krange); 
-        const int j = ( r - i*jrange*krange)/krange;
-        const int k = r - i*jrange*krange - j*krange;
-        input(i,j,k) = 1;
+        long i = int(r / jrange); 
+        long j = int( r - i*jrange);
+        for (int k = 0; k < krange; ++k) {
+          input(i,j,k) = 1;
+        }
       }
       else if ( std::is_same<TestLayout, Kokkos::LayoutLeft>::value )
       {
-        const int k = r / (irange*jrange); 
-        const int j = ( r - k*irange*jrange)/irange;
-        const int i = r - k*irange*jrange - j*irange;
-        input(i,j,k) = 1;
+        long k = int(r / jrange); 
+        long j = int( r - k*jrange);
+        for (int i = 0; i < irange; ++i) {
+          input(i,j,k) = 1;
+        }
       }
     }
-
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const int i, const int j, const int k) const
-    {
-      input(i,j,k) = 1;
-    }
-
   };
 
 
-  static double test_index_collapse(const unsigned icount, const unsigned jcount, const unsigned kcount, const int iter = 1)
+  static double test_index_collapse_two(const unsigned icount, const unsigned jcount, const unsigned kcount, const long iter = 1)
   {
     // This test refers to collapsing two dims while using the RangePolicy
     view_type Atest("Atest", icount, jcount, kcount);
     view_type Btest("Btest", icount+2, jcount+2, kcount+2);
-    typedef MultiDimRangePerf3D_Collapse<execution_space,ScalarType,TestLayout> FunctorType;
+    typedef RangePolicyCollapseTwo<execution_space,ScalarType,TestLayout> FunctorType;
 
-    int collapse_index_range = 0;
-    int collapse_index_rangeB = 0;
+    long collapse_index_rangeA = 0;
+    long collapse_index_rangeB = 0;
     if ( std::is_same<TestLayout, Kokkos::LayoutRight>::value ) {
-      collapse_index_range = icount*jcount;
+      collapse_index_rangeA = icount*jcount;
       collapse_index_rangeB = (icount+2)*(jcount+2);
 //      std::cout << "   LayoutRight " << std::endl;
     } else if ( std::is_same<TestLayout, Kokkos::LayoutLeft>::value ) {
-      collapse_index_range = kcount*jcount;
+      collapse_index_rangeA = kcount*jcount;
       collapse_index_rangeB = (kcount+2)*(jcount+2);
 //      std::cout << "   LayoutLeft " << std::endl;
     } else {
@@ -357,10 +363,8 @@ struct MultiDimRangePerf3D_Collapse
       exit(-1);
     }
 
-    Kokkos::RangePolicy<execution_space> policy(0, (collapse_index_range) );
+    Kokkos::RangePolicy<execution_space> policy(0, (collapse_index_rangeA) );
     Kokkos::RangePolicy<execution_space> policy_initB(0, (collapse_index_rangeB) );
-//    std::cout << "   Full flattened range (i.e. product of ranges) " << icount*jcount*kcount << std::endl;
-//    std::cout << "   Value outside of the if-guard " << collapse_index_range << std::endl;
 
     double dt_min = 0;
 
@@ -378,33 +382,33 @@ struct MultiDimRangePerf3D_Collapse
       if ( 0 == i ) dt_min = dt ;
       else dt_min = dt < dt_min ? dt : dt_min ;
 
-      //Correctness check
+      //Correctness check - first iteration only
       if ( 0 == i )
       {
-        int numErrors = 0;
+        long numErrors = 0;
         host_view_type Ahost("Ahost", icount, jcount, kcount);
         Kokkos::deep_copy(Ahost, Atest);
         host_view_type Bhost("Bhost", icount+2, jcount+2, kcount+2);
         Kokkos::deep_copy(Bhost, Btest);
 
-        for ( int l = 0; l < static_cast<int>(icount); ++l ) {
-        for ( int j = 0; j < static_cast<int>(jcount); ++j ) {
-        for ( int k = 0; k < static_cast<int>(kcount); ++k ) {
-          //double check = (l*l + j - k*l + 2.0*k*j - j*j*j);
-          double check  = 0.143*(double)( Bhost(l+2,j,k) + Bhost(l+1,j,k)
+        // On KNL, this may vectorize - add print statement to prevent
+        // Also, compare against epsilon, as vectorization can change bitwise answer
+        for ( long l = 0; l < static_cast<long>(icount); ++l ) {
+        for ( long j = 0; j < static_cast<long>(jcount); ++j ) {
+        for ( long k = 0; k < static_cast<long>(kcount); ++k ) {
+          ScalarType check  = 0.143*(ScalarType)( Bhost(l+2,j,k) + Bhost(l+1,j,k)
                                         + Bhost(l,j+2,k) + Bhost(l,j+1,k)
                                         + Bhost(l,j,k+2) + Bhost(l,j,k+1)
                                         + Bhost(l,j,k) );
           if ( Ahost(l,j,k) - check != 0 ) {
             ++numErrors;
-//           std::cout << "  Correctness error at " << l << " "<<j<<" "<<k<<"\n"
-//                      << "  flat Ahost = " << Ahost(l,j,k) << "  expected = " << check  << std::endl;
+            std::cout << "  Correctness error at index: " << l << ","<<j<<","<<k<<"\n"
+                      << "  flat Ahost = " << Ahost(l,j,k) << "  expected = " << check  << std::endl;
             //exit(-1);
           }
         } } }
-        if ( numErrors != 0 ) { std::cout << " RP collapse2: errors " << numErrors <<  std::endl; }
+        if ( numErrors != 0 ) { std::cout << " RP collapse2: errors " << numErrors << "  range product " << icount*jcount*kcount << "  LL " << jcount*kcount << "  LR " << icount*jcount << std::endl; }
         //else { std::cout << " RP collapse2: Pass! " << std::endl; }
-//        if ( numErrors == 0 ) { std::cout << " flattened: 0 errors, good deal " << std::endl; }
       }
     }
 
@@ -413,130 +417,104 @@ struct MultiDimRangePerf3D_Collapse
 
 };
 
+
 template< class DeviceType 
         , typename ScalarType = double  
         , typename TestLayout = Kokkos::LayoutRight  
         >
-struct MultiDimRangePerf3D_CollapseAll
+struct RangePolicyCollapseAll
 {
-  // 3D Range, but will collapse only 2 dims => Rank<2> for multi-dim; unroll 2 dims in one-dim
+  // RangePolicy for 3D range, but will collapse all dims
 
   typedef DeviceType execution_space;
   typedef typename execution_space::size_type  size_type;
-
-  using iterate_type = Kokkos::Experimental::Iterate;
-
-  iterate_type inner_direction;
-  iterate_type outer_direction;
-
-//  typedef MultiDimRangePerf3D<DeviceType,ScalarType,TestLayout> self_type;
+  typedef TestLayout layout;
 
   typedef Kokkos::View<ScalarType***, TestLayout, DeviceType> view_type;
   typedef typename view_type::HostMirror host_view_type;
 
   view_type A;
   view_type B;
-  const int irange;
-  const int jrange;
-  const int krange;
+  const long irange;
+  const long jrange;
+  const long krange;
 
-  MultiDimRangePerf3D_CollapseAll(const view_type & A_, const view_type & B_, const int &irange_,  const int &jrange_, const int &krange_)
+  RangePolicyCollapseAll(view_type & A_, const view_type & B_, const long &irange_,  const long &jrange_, const long &krange_)
   : A(A_), B(B_), irange(irange_), jrange(jrange_), krange(krange_)
-  {
-    if ( std::is_same<TestLayout , Kokkos::LayoutRight>::value ) {
-      inner_direction = iterate_type::Right;
-      outer_direction = iterate_type::Right;
-    }
-    else {
-      inner_direction = iterate_type::Left;
-      outer_direction = iterate_type::Left;
-    }
-  }
+  {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const int r) const
+  void operator()(const long r) const
   {
     if ( std::is_same<TestLayout, Kokkos::LayoutRight>::value )
     {
-      const int i = r / (jrange*krange); 
-      const int j = ( r - i*jrange*krange)/krange;
-      const int k = r - i*jrange*krange - j*krange;
-        //A(i,j,k) = (double)(i*i + j - k*i + 2.0*k*j - j*j*j);
-        A(i,j,k) = 0.143*(double)( B(i+2,j,k) + B(i+1,j,k)
+      long i = int(r / (jrange*krange)); 
+      long j = int(( r - i*jrange*krange)/krange);
+      long k = int(r - i*jrange*krange - j*krange);
+        A(i,j,k) = 0.143*(ScalarType)( B(i+2,j,k) + B(i+1,j,k)
             + B(i,j+2,k) + B(i,j+1,k)
             + B(i,j,k+2) + B(i,j,k+1)
             + B(i,j,k) );
     }
     else if ( std::is_same<TestLayout, Kokkos::LayoutLeft>::value )
     {
-      const int k = r / (irange*jrange); 
-      const int j = ( r - k*irange*jrange)/irange;
-      const int i = r - k*irange*jrange - j*irange;
-        //A(i,j,k) = (double)(i*i + j - k*i + 2.0*k*j - j*j*j);
-        A(i,j,k) = 0.143*(double)( B(i+2,j,k) + B(i+1,j,k)
+      long k = int(r / (irange*jrange)); 
+      long j = int(( r - k*irange*jrange)/irange);
+      long i = int(r - k*irange*jrange - j*irange);
+        A(i,j,k) = 0.143*(ScalarType)( B(i+2,j,k) + B(i+1,j,k)
             + B(i,j+2,k) + B(i,j+1,k)
             + B(i,j,k+2) + B(i,j,k+1)
             + B(i,j,k) );
     }
-
   }
 
 
   struct Init
   {
     view_type input;
-    const int irange;
-    const int jrange;
-    const int krange;
+    const long irange;
+    const long jrange;
+    const long krange;
 
-    Init(const view_type & input_, const int &irange_,  const int &jrange_, const int &krange_)
+    Init(const view_type & input_, const long &irange_,  const long &jrange_, const long &krange_)
     : input(input_), irange(irange_), jrange(jrange_), krange(krange_) {}
 
     KOKKOS_INLINE_FUNCTION
-    void operator()(const int r) const
+    void operator()(const long r) const
     {
-    if ( std::is_same<TestLayout, Kokkos::LayoutRight>::value )
-    {
-      const int i = r / (jrange*krange); 
-      const int j = ( r - i*jrange*krange)/krange;
-      const int k = r - i*jrange*krange - j*krange;
-      input(i,j,k) = 1;
+      if ( std::is_same<TestLayout, Kokkos::LayoutRight>::value )
+      {
+        long i = int(r / (jrange*krange)); 
+        long j = int(( r - i*jrange*krange)/krange);
+        long k = int(r - i*jrange*krange - j*krange);
+        input(i,j,k) = 1;
+      }
+      else if ( std::is_same<TestLayout, Kokkos::LayoutLeft>::value )
+      {
+        long k = int(r / (irange*jrange));
+        long j = int(( r - k*irange*jrange)/irange);
+        long i = int(r - k*irange*jrange - j*irange);
+        input(i,j,k) = 1;
+      }
     }
-    else if ( std::is_same<TestLayout, Kokkos::LayoutLeft>::value )
-    {
-      const int k = r / (irange*jrange); 
-      const int j = ( r - k*irange*jrange)/irange;
-      const int i = r - k*irange*jrange - j*irange;
-      input(i,j,k) = 1;
-    }
-    }
-
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const int i, const int j, const int k) const
-    {
-      input(i,j,k) = 1;
-    }
-
   };
 
 
-  static double test_collapse_all(const unsigned icount, const unsigned jcount, const unsigned kcount, const int iter = 1)
+  static double test_collapse_all(const unsigned icount, const unsigned jcount, const unsigned kcount, const long iter = 1)
   {
     //This test refers to collapsing all dims using the RangePolicy
     view_type Atest("Atest", icount, jcount, kcount);
     view_type Btest("Btest", icount+2, jcount+2, kcount+2);
-    typedef MultiDimRangePerf3D_CollapseAll<execution_space,ScalarType,TestLayout> FunctorType;
+    typedef RangePolicyCollapseAll<execution_space,ScalarType,TestLayout> FunctorType;
 
-    int flat_index_range = 0;
-    flat_index_range = icount*jcount*kcount;
+    const long flat_index_range = icount*jcount*kcount;
     Kokkos::RangePolicy<execution_space> policy(0, flat_index_range );
     Kokkos::RangePolicy<execution_space> policy_initB(0, (icount+2)*(jcount+2)*(kcount+2) );
-//    std::cout << "   Full flattened range (i.e. product of ranges) " << icount*jcount*kcount << std::endl;
-//    std::cout << "   Value outside of the if-guard " << flat_index_range << std::endl;
 
     double dt_min = 0;
 
     Kokkos::parallel_for( policy, Init(Atest,icount,jcount,kcount) );
+    execution_space::fence();
     Kokkos::parallel_for( policy_initB, Init(Btest,icount+2,jcount+2,kcount+2) );
     execution_space::fence();
 
@@ -549,33 +527,33 @@ struct MultiDimRangePerf3D_CollapseAll
       if ( 0 == i ) dt_min = dt ;
       else dt_min = dt < dt_min ? dt : dt_min ;
 
-      //Correctness check
+      //Correctness check - first iteration only
       if ( 0 == i )
       {
-        int numErrors = 0;
+        long numErrors = 0;
         host_view_type Ahost("Ahost", icount, jcount, kcount);
         Kokkos::deep_copy(Ahost, Atest);
         host_view_type Bhost("Bhost", icount+2, jcount+2, kcount+2);
         Kokkos::deep_copy(Bhost, Btest);
 
-        for ( int l = 0; l < static_cast<int>(icount); ++l ) {
-        for ( int j = 0; j < static_cast<int>(jcount); ++j ) {
-        for ( int k = 0; k < static_cast<int>(kcount); ++k ) {
-          //double check = (l*l + j - k*l + 2.0*k*j - j*j*j);
-          double check  = 0.143*(double)( Bhost(l+2,j,k) + Bhost(l+1,j,k)
+        // On KNL, this may vectorize - add print statement to prevent
+        // Also, compare against epsilon, as vectorization can change bitwise answer
+        for ( long l = 0; l < static_cast<long>(icount); ++l ) {
+        for ( long j = 0; j < static_cast<long>(jcount); ++j ) {
+        for ( long k = 0; k < static_cast<long>(kcount); ++k ) {
+          ScalarType check  = 0.143*(ScalarType)( Bhost(l+2,j,k) + Bhost(l+1,j,k)
                                         + Bhost(l,j+2,k) + Bhost(l,j+1,k)
                                         + Bhost(l,j,k+2) + Bhost(l,j,k+1)
                                         + Bhost(l,j,k) );
           if ( Ahost(l,j,k) - check != 0 ) {
             ++numErrors;
-//           std::cout << "  Correctness error at " << l << " "<<j<<" "<<k<<"\n"
-//                      << "  flat Ahost = " << Ahost(l,j,k) << "  expected = " << check  << std::endl;
+            std::cout << "  Callapse ALL Correctness error at index: " << l << ","<<j<<","<<k<<"\n"
+                      << "  flat Ahost = " << Ahost(l,j,k) << "  expected = " << check  << std::endl;
             //exit(-1);
           }
         } } }
-        if ( numErrors != 0 ) { std::cout << " RP collapse all: errors " << numErrors <<  std::endl; }
+        if ( numErrors != 0 ) { std::cout << " RP collapse all: errors " << numErrors << "  range product " << icount*jcount*kcount << "  LL " << jcount*kcount << "  LR " << icount*jcount << std::endl; }
         //else { std::cout << " RP collapse all: Pass! " << std::endl; }
-//        if ( numErrors == 0 ) { std::cout << " flattened: 0 errors, good deal " << std::endl; }
       }
     }
 


### PR DESCRIPTION
Tests are still commented out for now, but removed running a slow test,
reduced the number of tests, and made minor fixes when checking results
during the first iteration (vectorization may have occurred and made
the check no longer bitwise correct; epsilon comparison should be added
as well as option to not check correctness which will speed up the tests)