### PR TITLE
Add TSX-RTM Transaction Regions to HostSpace for Fast Lock Acquire/Release

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -505,8 +505,8 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_BDW), 1)
         KOKKOS_LDFLAGS  += -tp=haswell
       else
         # Assume that this is a really a GNU compiler.
-        KOKKOS_CXXFLAGS += -march=broadwell -mtune=broadwell -mrtm
-        KOKKOS_LDFLAGS  += -march=broadwell -mtune=broadwell -mrtm
+        KOKKOS_CXXFLAGS += -march=core-avx2 -mtune=core-avx2 -mrtm
+        KOKKOS_LDFLAGS  += -march=core-avx2 -mtune=core-avx2 -mrtm
       endif
     endif
   endif

--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -483,8 +483,8 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_HSW), 1)
         KOKKOS_LDFLAGS  += -tp=haswell
       else
         # Assume that this is a really a GNU compiler.
-        KOKKOS_CXXFLAGS += -march=haswell -mtune=haswell
-        KOKKOS_LDFLAGS  += -march=haswell -mtune=haswell
+        KOKKOS_CXXFLAGS += -march=core-avx2 -mtune=core-avx2
+        KOKKOS_LDFLAGS  += -march=core-avx2 -mtune=core-avx2
       endif
     endif
   endif

--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -468,7 +468,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_POWER9), 1)
   endif
 endif
 
-ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AVX2), 1)
+ifeq ($(KOKKOS_INTERNAL_USE_ARCH_HSW), 1)
   tmp := $(shell echo "\#define KOKKOS_ARCH_AVX2 1" >> KokkosCore_config.tmp )
 
   ifeq ($(KOKKOS_INTERNAL_COMPILER_INTEL), 1)
@@ -483,8 +483,30 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AVX2), 1)
         KOKKOS_LDFLAGS  += -tp=haswell
       else
         # Assume that this is a really a GNU compiler.
-        KOKKOS_CXXFLAGS += -march=core-avx2 -mtune=core-avx2
-        KOKKOS_LDFLAGS  += -march=core-avx2 -mtune=core-avx2
+        KOKKOS_CXXFLAGS += -march=haswell -mtune=haswell
+        KOKKOS_LDFLAGS  += -march=haswell -mtune=haswell
+      endif
+    endif
+  endif
+endif
+
+ifeq ($(KOKKOS_INTERNAL_USE_ARCH_BDW), 1)
+  tmp := $(shell echo "\#define KOKKOS_ARCH_AVX2 1" >> KokkosCore_config.tmp )
+
+  ifeq ($(KOKKOS_INTERNAL_COMPILER_INTEL), 1)
+    KOKKOS_CXXFLAGS += -xCORE-AVX2
+    KOKKOS_LDFLAGS  += -xCORE-AVX2
+  else
+    ifeq ($(KOKKOS_INTERNAL_COMPILER_CRAY), 1)
+
+    else
+      ifeq ($(KOKKOS_INTERNAL_COMPILER_PGI), 1)
+        KOKKOS_CXXFLAGS += -tp=haswell
+        KOKKOS_LDFLAGS  += -tp=haswell
+      else
+        # Assume that this is a really a GNU compiler.
+        KOKKOS_CXXFLAGS += -march=broadwell -mtune=broadwell -mrtm
+        KOKKOS_LDFLAGS  += -march=broadwell -mtune=broadwell -mrtm
       endif
     endif
   endif
@@ -504,8 +526,8 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AVX512MIC), 1)
 
       else
         # Asssume that this is really a GNU compiler.
-        KOKKOS_CXXFLAGS += -march=knl
-        KOKKOS_LDFLAGS  += -march=knl
+        KOKKOS_CXXFLAGS += -march=knl -mtune=knl
+        KOKKOS_LDFLAGS  += -march=knl -mtune=knl
       endif
     endif
   endif
@@ -525,8 +547,8 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AVX512XEON), 1)
 
       else
         # Nothing here yet.
-        KOKKOS_CXXFLAGS += -march=skylake-avx512 -mrtm
-        KOKKOS_LDFLAGS  += -march=skylake-avx512 -mrtm
+        KOKKOS_CXXFLAGS += -march=skylake-avx512 -mtune=skylake-avx512 -mrtm
+        KOKKOS_LDFLAGS  += -march=skylake-avx512 -mtune=skylake-avx512 -mrtm
       endif
     endif
   endif

--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -196,6 +196,9 @@ KOKKOS_INTERNAL_USE_ISA_X86_64    := $(strip $(shell echo $(KOKKOS_INTERNAL_USE_
 KOKKOS_INTERNAL_USE_ISA_KNC       := $(strip $(shell echo $(KOKKOS_INTERNAL_USE_ARCH_KNC) | bc ))
 KOKKOS_INTERNAL_USE_ISA_POWERPCLE := $(strip $(shell echo $(KOKKOS_INTERNAL_USE_ARCH_POWER8)+$(KOKKOS_INTERNAL_USE_ARCH_POWER9) | bc ))
 
+# Decide whether we can support transactional memory
+KOKKOS_INTERNAL_USE_TM            := $(strip $(shell echo $(KOKKOS_INTERNAL_USE_ARCH_BDW)+$(KOKKOS_INTERNAL_USE_ARCH_SKX) | bc ))
+
 # Incompatible flags?
 KOKKOS_INTERNAL_USE_ARCH_MULTIHOST := $(strip $(shell echo "$(KOKKOS_INTERNAL_USE_ARCH_AVX)+$(KOKKOS_INTERNAL_USE_ARCH_AVX2)+$(KOKKOS_INTERNAL_USE_ARCH_KNC)+$(KOKKOS_INTERNAL_USE_ARCH_IBM)+$(KOKKOS_INTERNAL_USE_ARCH_AMDAVX)+$(KOKKOS_INTERNAL_USE_ARCH_ARMV80)+$(KOKKOS_INTERNAL_USE_ARCH_ARMV81)+$(KOKKOS_INTERNAL_USE_ARCH_ARMV8_THUNDERX)>1" | bc ))
 KOKKOS_INTERNAL_USE_ARCH_MULTIGPU := $(strip $(shell echo "$(KOKKOS_INTERNAL_USE_ARCH_NVIDIA)>1" | bc))
@@ -250,6 +253,12 @@ endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_SERIAL), 1)
   tmp := $(shell echo "\#define KOKKOS_HAVE_SERIAL 1" >> KokkosCore_config.tmp )
+endif
+
+ifeq ($(KOKKOS_INTERNAL_USE_TM), 1)
+  tmp := $(shell echo "\#ifndef __CUDA_ARCH__" >> KokkosCore_config.tmp )
+  tmp := $(shell echo "\#define KOKKOS_ENABLE_TM" >> KokkosCore_config.tmp )
+  tmp := $(shell echo "\#endif" >> KokkosCore_config.tmp )
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_ISA_X86_64), 1)
@@ -516,8 +525,8 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AVX512XEON), 1)
 
       else
         # Nothing here yet.
-        KOKKOS_CXXFLAGS += -march=skylake-avx512
-        KOKKOS_LDFLAGS  += -march=skylake-avx512
+        KOKKOS_CXXFLAGS += -march=skylake-avx512 -mrtm
+        KOKKOS_LDFLAGS  += -march=skylake-avx512 -mrtm
       endif
     endif
   endif

--- a/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
@@ -44,6 +44,10 @@
 #if defined( KOKKOS_ATOMIC_HPP ) && ! defined( KOKKOS_ATOMIC_FETCH_ADD_HPP )
 #define KOKKOS_ATOMIC_FETCH_ADD_HPP
 
+#if defined(KOKKOS_ENABLE_ISA_X86_64) && defined(KOKKOS_ENABLE_ASM)
+#include <immintrin.h>
+#endif
+
 namespace Kokkos {
 
 //----------------------------------------------------------------------------
@@ -277,21 +281,43 @@ T atomic_fetch_add( volatile T * const dest ,
               #endif
                  , const T >::type& val )
 {
-  while( !Impl::lock_address_host_space( (void*) dest ) );
-  T return_val = *dest;
-  // Don't use the following line of code here:
-  //
-  //const T tmp = *dest = return_val + val;
-  //
-  // Instead, put each assignment in its own statement.  This is
-  // because the overload of T::operator= for volatile *this should
-  // return void, not volatile T&.  See Kokkos #177:
-  //
-  // https://github.com/kokkos/kokkos/issues/177
-  *dest = return_val + val;
-  const T tmp = *dest;
-  (void) tmp;
-  Impl::unlock_address_host_space( (void*) dest );
+  T return_val;
+
+#define KOKKOS_ENABLE_TM
+#if defined(KOKKOS_ENABLE_TM) && defined(KOKKOS_ENABLE_ISA_X86_64)
+  unsigned transaction_status = _xbegin();
+
+  if( transaction_status == _XBEGIN_STARTED ) {
+	return_val = *dest;
+
+	const T tmp = return_val + val;
+	*dest = tmp;
+
+	_xend();
+  } else {
+#endif
+
+  	while( !Impl::lock_address_host_space( (void*) dest ) );
+  	return_val = *dest;
+
+	// Don't use the following line of code here:
+  	//
+  	//const T tmp = *dest = return_val + val;
+  	//
+  	// Instead, put each assignment in its own statement.  This is
+  	// because the overload of T::operator= for volatile *this should
+  	// return void, not volatile T&.  See Kokkos #177:
+  	//
+  	// https://github.com/kokkos/kokkos/issues/177
+  	*dest = return_val + val;
+  	const T tmp = *dest;
+  	(void) tmp;
+  	Impl::unlock_address_host_space( (void*) dest );
+
+#if defined(KOKKOS_ENABLE_TM) && defined(KOKKOS_ENABLE_ISA_X86_64)
+  }
+#endif
+
   return return_val;
 }
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -43,9 +43,15 @@
 
 #include <algorithm>
 #include <Kokkos_Macros.hpp>
+
 #if (KOKKOS_ENABLE_PROFILING)
 #include <impl/Kokkos_Profiling_Interface.hpp>
 #endif
+
+#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM )
+#include <immintrin.h>
+#endif
+
 /*--------------------------------------------------------------------------*/
 
 #if defined( __INTEL_COMPILER ) && ! defined ( KOKKOS_ENABLE_CUDA )

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -48,10 +48,6 @@
 #include <impl/Kokkos_Profiling_Interface.hpp>
 #endif
 
-#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM )
-#include <immintrin.h>
-#endif
-
 /*--------------------------------------------------------------------------*/
 
 #if defined( __INTEL_COMPILER ) && ! defined ( KOKKOS_ENABLE_CUDA )
@@ -104,7 +100,7 @@
 #include <impl/Kokkos_Error.hpp>
 #include <Kokkos_Atomic.hpp>
 
-#if defined( KOKKOS_ENABLE_ASM) && defined ( KOKKOS_ENABLE_ISA_X86_64 )
+#if ( defined( KOKKOS_ENABLE_ASM ) || defined ( KOKKOS_ENABLE_TM ) ) && defined ( KOKKOS_ENABLE_ISA_X86_64 )
 #include <immintrin.h>
 #endif
 

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -98,6 +98,10 @@
 #include <impl/Kokkos_Error.hpp>
 #include <Kokkos_Atomic.hpp>
 
+#if defined( KOKKOS_ENABLE_ASM) && defined ( KOKKOS_ENABLE_ISA_X86_64 )
+#include <immintrin.h>
+#endif
+
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
@@ -490,15 +494,48 @@ void init_lock_array_host_space() {
 }
 
 bool lock_address_host_space(void* ptr) {
+#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM )
+  const unsigned status = _xbegin();
+
+  if( _XBEGIN_STARTED == status ) {
+	const int val = HOST_SPACE_ATOMIC_LOCKS[(( size_t(ptr) >> 2 ) &
+		HOST_SPACE_ATOMIC_MASK) ^ HOST_SPACE_ATOMIC_XOR_MASK];
+
+	if( 0 == val ) {
+		HOST_SPACE_ATOMIC_LOCKS[(( size_t(ptr) >> 2 ) &
+                   HOST_SPACE_ATOMIC_MASK) ^ HOST_SPACE_ATOMIC_XOR_MASK] = 1;
+	} else {
+		_xabort( 1 );
+	}
+
+	_xend();
+
+	return 1;
+  } else {
+#endif
   return 0 == atomic_compare_exchange( &HOST_SPACE_ATOMIC_LOCKS[
       (( size_t(ptr) >> 2 ) & HOST_SPACE_ATOMIC_MASK) ^ HOST_SPACE_ATOMIC_XOR_MASK] ,
                                   0 , 1);
+#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM )
+  }
+#endif
 }
 
 void unlock_address_host_space(void* ptr) {
+#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM )
+  const unsigned status = _xbegin();
+
+  if( _XBEGIN_STARTED == status ) {
+	HOST_SPACE_ATOMIC_LOCKS[(( size_t(ptr) >> 2 ) &
+        	HOST_SPACE_ATOMIC_MASK) ^ HOST_SPACE_ATOMIC_XOR_MASK] = 0;
+  } else {
+#endif
    atomic_exchange( &HOST_SPACE_ATOMIC_LOCKS[
       (( size_t(ptr) >> 2 ) & HOST_SPACE_ATOMIC_MASK) ^ HOST_SPACE_ATOMIC_XOR_MASK] ,
                     0);
+#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM )
+  }
+#endif
 }
 
 }


### PR DESCRIPTION
1. Add's TSX-RTM Transaction Regions (`XBEGIN` and `XEND`) to `HostSpace` for faster lock acquire and release.
2. Add support for `KOKKOS_ENABLE_TM` to build system if BDW and SKX system architecture is selected.
3. Add `-mrtm` calls when GCC is used to enable TSX-RTM code generation on `SKL`