### PR TITLE
Feature/spinwait

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMPexec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMPexec.hpp
@@ -47,7 +47,6 @@
 #include <Kokkos_OpenMP.hpp>
 
 #include <impl/Kokkos_Traits.hpp>
-#include <impl/Kokkos_spinwait.hpp>
 #include <impl/Kokkos_HostThreadTeam.hpp>
 
 #include <Kokkos_Atomic.hpp>

--- a/core/src/Qthreads/Kokkos_QthreadsExec.hpp
+++ b/core/src/Qthreads/Kokkos_QthreadsExec.hpp
@@ -101,12 +101,12 @@ public:
     int n, j;
 
     for ( n = 1; ( ! ( rev_rank & n ) ) && ( ( j = rev_rank + n ) < m_worker_size ); n <<= 1 ) {
-      Impl::spinwait( m_worker_base[j]->m_worker_state, QthreadsExec::Active );
+      Impl::spinwait_while_equal( m_worker_base[j]->m_worker_state, QthreadsExec::Active );
     }
 
     if ( rev_rank ) {
       m_worker_state = QthreadsExec::Inactive;
-      Impl::spinwait( m_worker_state, QthreadsExec::Inactive );
+      Impl::spinwait_while_equal( m_worker_state, QthreadsExec::Inactive );
     }
 
     for ( n = 1; ( ! ( rev_rank & n ) ) && ( ( j = rev_rank + n ) < m_worker_size ); n <<= 1 ) {
@@ -124,12 +124,12 @@ public:
       int n, j;
 
       for ( n = 1; ( ! ( rev_rank & n ) ) && ( ( j = rev_rank + n ) < team_size ); n <<= 1 ) {
-        Impl::spinwait( m_shepherd_base[j]->m_worker_state, QthreadsExec::Active );
+        Impl::spinwait_while_equal( m_shepherd_base[j]->m_worker_state, QthreadsExec::Active );
       }
 
       if ( rev_rank ) {
         m_worker_state = QthreadsExec::Inactive;
-        Impl::spinwait( m_worker_state, QthreadsExec::Inactive );
+        Impl::spinwait_while_equal( m_worker_state, QthreadsExec::Inactive );
       }
 
       for ( n = 1; ( ! ( rev_rank & n ) ) && ( ( j = rev_rank + n ) < team_size ); n <<= 1 ) {
@@ -154,14 +154,14 @@ public:
     for ( n = 1; ( ! ( rev_rank & n ) ) && ( ( j = rev_rank + n ) < m_worker_size ); n <<= 1 ) {
       const QthreadsExec & fan = *m_worker_base[j];
 
-      Impl::spinwait( fan.m_worker_state, QthreadsExec::Active );
+      Impl::spinwait_while_equal( fan.m_worker_state, QthreadsExec::Active );
 
       ValueJoin::join( ReducerConditional::select( func, reduce ), m_scratch_alloc, fan.m_scratch_alloc );
     }
 
     if ( rev_rank ) {
       m_worker_state = QthreadsExec::Inactive;
-      Impl::spinwait( m_worker_state, QthreadsExec::Inactive );
+      Impl::spinwait_while_equal( m_worker_state, QthreadsExec::Inactive );
     }
 
     for ( n = 1; ( ! ( rev_rank & n ) ) && ( ( j = rev_rank + n ) < m_worker_size ); n <<= 1 ) {
@@ -183,12 +183,12 @@ public:
     int n, j;
 
     for ( n = 1; ( ! ( rev_rank & n ) ) && ( ( j = rev_rank + n ) < m_worker_size ); n <<= 1 ) {
-      Impl::spinwait( m_worker_base[j]->m_worker_state, QthreadsExec::Active );
+      Impl::spinwait_while_equal( m_worker_base[j]->m_worker_state, QthreadsExec::Active );
     }
 
     if ( rev_rank ) {
       m_worker_state = QthreadsExec::Inactive;
-      Impl::spinwait( m_worker_state, QthreadsExec::Inactive );
+      Impl::spinwait_while_equal( m_worker_state, QthreadsExec::Inactive );
     }
     else {
       // Root thread scans across values before releasing threads.
@@ -252,12 +252,12 @@ public:
     int n, j;
 
     for ( n = 1; ( ! ( rev_rank & n ) ) && ( ( j = rev_rank + n ) < team_size ); n <<= 1 ) {
-      Impl::spinwait( m_shepherd_base[j]->m_worker_state, QthreadsExec::Active );
+      Impl::spinwait_while_equal( m_shepherd_base[j]->m_worker_state, QthreadsExec::Active );
     }
 
     if ( rev_rank ) {
       m_worker_state = QthreadsExec::Inactive;
-      Impl::spinwait( m_worker_state, QthreadsExec::Inactive );
+      Impl::spinwait_while_equal( m_worker_state, QthreadsExec::Inactive );
     }
     else {
       Type & accum = *m_shepherd_base[0]->shepherd_team_scratch_value<Type>();
@@ -298,12 +298,12 @@ public:
     int n, j;
 
     for ( n = 1; ( ! ( rev_rank & n ) ) && ( ( j = rev_rank + n ) < team_size ); n <<= 1 ) {
-      Impl::spinwait( m_shepherd_base[j]->m_worker_state, QthreadsExec::Active );
+      Impl::spinwait_while_equal( m_shepherd_base[j]->m_worker_state, QthreadsExec::Active );
     }
 
     if ( rev_rank ) {
       m_worker_state = QthreadsExec::Inactive;
-      Impl::spinwait( m_worker_state, QthreadsExec::Inactive );
+      Impl::spinwait_while_equal( m_worker_state, QthreadsExec::Inactive );
     }
     else {
       volatile Type & accum = *m_shepherd_base[0]->shepherd_team_scratch_value<Type>();
@@ -339,12 +339,12 @@ public:
     int n, j;
 
     for ( n = 1; ( ! ( rev_rank & n ) ) && ( ( j = rev_rank + n ) < team_size ); n <<= 1 ) {
-      Impl::spinwait( m_shepherd_base[j]->m_worker_state, QthreadsExec::Active );
+      Impl::spinwait_while_equal( m_shepherd_base[j]->m_worker_state, QthreadsExec::Active );
     }
 
     if ( rev_rank ) {
       m_worker_state = QthreadsExec::Inactive;
-      Impl::spinwait( m_worker_state, QthreadsExec::Inactive );
+      Impl::spinwait_while_equal( m_worker_state, QthreadsExec::Inactive );
     }
     else {
       // Root thread scans across values before releasing threads.

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -264,7 +264,7 @@ void ThreadsExec::execute_sleep( ThreadsExec & exec , const void * )
   const int rank_rev = exec.m_pool_size - ( exec.m_pool_rank + 1 );
 
   for ( int i = 0 ; i < n ; ++i ) {
-    Impl::spinwait( exec.m_pool_base[ rank_rev + (1<<i) ]->m_pool_state , ThreadsExec::Active );
+    Impl::spinwait_while_equal( exec.m_pool_base[ rank_rev + (1<<i) ]->m_pool_state , ThreadsExec::Active );
   }
 
   exec.m_pool_state = ThreadsExec::Inactive ;
@@ -308,7 +308,7 @@ void ThreadsExec::fence()
 {
   if ( s_thread_pool_size[0] ) {
     // Wait for the root thread to complete:
-    Impl::spinwait( s_threads_exec[0]->m_pool_state , ThreadsExec::Active );
+    Impl::spinwait_while_equal( s_threads_exec[0]->m_pool_state , ThreadsExec::Active );
   }
 
   s_current_function     = 0 ;

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -187,13 +187,13 @@ public:
       // Fan-in reduction with highest ranking thread as the root
       for ( int i = 0 ; i < m_pool_fan_size ; ++i ) {
         // Wait: Active -> Rendezvous
-        Impl::spinwait( m_pool_base[ rev_rank + (1<<i) ]->m_pool_state , ThreadsExec::Active );
+        Impl::spinwait_while_equal( m_pool_base[ rev_rank + (1<<i) ]->m_pool_state , ThreadsExec::Active );
       }
 
       if ( rev_rank ) {
         m_pool_state = ThreadsExec::Rendezvous ;
         // Wait: Rendezvous -> Active
-        Impl::spinwait( m_pool_state , ThreadsExec::Rendezvous );
+        Impl::spinwait_while_equal( m_pool_state , ThreadsExec::Rendezvous );
       }
       else {
         // Root thread does the reduction and broadcast
@@ -229,13 +229,13 @@ public:
       // Fan-in reduction with highest ranking thread as the root
       for ( int i = 0 ; i < m_pool_fan_size ; ++i ) {
         // Wait: Active -> Rendezvous
-        Impl::spinwait( m_pool_base[ rev_rank + (1<<i) ]->m_pool_state , ThreadsExec::Active );
+        Impl::spinwait_while_equal( m_pool_base[ rev_rank + (1<<i) ]->m_pool_state , ThreadsExec::Active );
       }
 
       if ( rev_rank ) {
         m_pool_state = ThreadsExec::Rendezvous ;
         // Wait: Rendezvous -> Active
-        Impl::spinwait( m_pool_state , ThreadsExec::Rendezvous );
+        Impl::spinwait_while_equal( m_pool_state , ThreadsExec::Rendezvous );
       }
       else {
         // Root thread does the reduction and broadcast
@@ -264,7 +264,7 @@ public:
 
         ThreadsExec & fan = *m_pool_base[ rev_rank + ( 1 << i ) ] ;
 
-        Impl::spinwait( fan.m_pool_state , ThreadsExec::Active );
+        Impl::spinwait_while_equal( fan.m_pool_state , ThreadsExec::Active );
 
         Join::join( f , reduce_memory() , fan.reduce_memory() );
       }
@@ -280,7 +280,7 @@ public:
       const int rev_rank = m_pool_size - ( m_pool_rank + 1 );
 
       for ( int i = 0 ; i < m_pool_fan_size ; ++i ) {
-        Impl::spinwait( m_pool_base[rev_rank+(1<<i)]->m_pool_state , ThreadsExec::Active );
+        Impl::spinwait_while_equal( m_pool_base[rev_rank+(1<<i)]->m_pool_state , ThreadsExec::Active );
       }
     }
 
@@ -312,7 +312,7 @@ public:
         ThreadsExec & fan = *m_pool_base[ rev_rank + (1<<i) ];
 
         // Wait: Active -> ReductionAvailable (or ScanAvailable)
-        Impl::spinwait( fan.m_pool_state , ThreadsExec::Active );
+        Impl::spinwait_while_equal( fan.m_pool_state , ThreadsExec::Active );
         Join::join( f , work_value , fan.reduce_memory() );
       }
 
@@ -330,8 +330,8 @@ public:
 
           // Wait: Active             -> ReductionAvailable
           // Wait: ReductionAvailable -> ScanAvailable
-          Impl::spinwait( th.m_pool_state , ThreadsExec::Active );
-          Impl::spinwait( th.m_pool_state , ThreadsExec::ReductionAvailable );
+          Impl::spinwait_while_equal( th.m_pool_state , ThreadsExec::Active );
+          Impl::spinwait_while_equal( th.m_pool_state , ThreadsExec::ReductionAvailable );
 
           Join::join( f , work_value + count , ((scalar_type *)th.reduce_memory()) + count );
         }
@@ -342,7 +342,7 @@ public:
 
         // Wait for all threads to complete inclusive scan
         // Wait: ScanAvailable -> Rendezvous
-        Impl::spinwait( m_pool_state , ThreadsExec::ScanAvailable );
+        Impl::spinwait_while_equal( m_pool_state , ThreadsExec::ScanAvailable );
       }
 
       //--------------------------------
@@ -350,7 +350,7 @@ public:
       for ( int i = 0 ; i < m_pool_fan_size ; ++i ) {
         ThreadsExec & fan = *m_pool_base[ rev_rank + (1<<i) ];
         // Wait: ReductionAvailable -> ScanAvailable
-        Impl::spinwait( fan.m_pool_state , ThreadsExec::ReductionAvailable );
+        Impl::spinwait_while_equal( fan.m_pool_state , ThreadsExec::ReductionAvailable );
         // Set: ScanAvailable -> Rendezvous
         fan.m_pool_state = ThreadsExec::Rendezvous ;
       }
@@ -377,13 +377,13 @@ public:
       // Wait for all threads to copy previous thread's inclusive scan value
       // Wait for all threads: Rendezvous -> ScanCompleted
       for ( int i = 0 ; i < m_pool_fan_size ; ++i ) {
-        Impl::spinwait( m_pool_base[ rev_rank + (1<<i) ]->m_pool_state , ThreadsExec::Rendezvous );
+        Impl::spinwait_while_equal( m_pool_base[ rev_rank + (1<<i) ]->m_pool_state , ThreadsExec::Rendezvous );
       }
       if ( rev_rank ) {
         // Set: ScanAvailable -> ScanCompleted
         m_pool_state = ThreadsExec::ScanCompleted ;
         // Wait: ScanCompleted -> Active
-        Impl::spinwait( m_pool_state , ThreadsExec::ScanCompleted );
+        Impl::spinwait_while_equal( m_pool_state , ThreadsExec::ScanCompleted );
       }
       // Set: ScanCompleted -> Active
       for ( int i = 0 ; i < m_pool_fan_size ; ++i ) {
@@ -410,7 +410,7 @@ public:
       // Fan-in reduction with highest ranking thread as the root
       for ( int i = 0 ; i < m_pool_fan_size ; ++i ) {
         // Wait: Active -> Rendezvous
-        Impl::spinwait( m_pool_base[ rev_rank + (1<<i) ]->m_pool_state , ThreadsExec::Active );
+        Impl::spinwait_while_equal( m_pool_base[ rev_rank + (1<<i) ]->m_pool_state , ThreadsExec::Active );
       }
 
       for ( unsigned i = 0 ; i < count ; ++i ) { work_value[i+count] = work_value[i]; }
@@ -418,7 +418,7 @@ public:
       if ( rev_rank ) {
         m_pool_state = ThreadsExec::Rendezvous ;
         // Wait: Rendezvous -> Active
-        Impl::spinwait( m_pool_state , ThreadsExec::Rendezvous );
+        Impl::spinwait_while_equal( m_pool_state , ThreadsExec::Rendezvous );
       }
       else {
         // Root thread does the thread-scan before releasing threads

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -104,13 +104,13 @@ public:
 
       // Wait for fan-in threads
       for ( n = 1 ; ( ! ( m_team_rank_rev & n ) ) && ( ( j = m_team_rank_rev + n ) < m_team_size ) ; n <<= 1 ) {
-        Impl::spinwait( m_team_base[j]->state() , ThreadsExec::Active );
+        Impl::spinwait_while_equal( m_team_base[j]->state() , ThreadsExec::Active );
       }
 
       // If not root then wait for release
       if ( m_team_rank_rev ) {
         m_exec->state() = ThreadsExec::Rendezvous ;
-        Impl::spinwait( m_exec->state() , ThreadsExec::Rendezvous );
+        Impl::spinwait_while_equal( m_exec->state() , ThreadsExec::Rendezvous );
       }
 
       return ! m_team_rank_rev ;

--- a/core/src/impl/Kokkos_BitOps.hpp
+++ b/core/src/impl/Kokkos_BitOps.hpp
@@ -56,12 +56,13 @@ int bit_scan_forward( unsigned i )
 {
 #if defined( __CUDA_ARCH__ )
   return __ffs(i) - 1;
-#elif defined( __GNUC__ ) || defined( __GNUG__ )
-  return __builtin_ffs(i) - 1;
-#elif defined( __INTEL_COMPILER )
+#elif defined( KOKKOS_COMPILER_INTEL )
   return _bit_scan_forward(i);
+#elif defined( KOKKOS_COMPILER_IBM )
+  return __cnttz4(i);
+#elif defined( KOKKOS_COMPILER_GNU ) || defined( __GNUC__ ) || defined( __GNUG__ )
+  return __builtin_ffs(i) - 1;
 #else
-
   unsigned t = 1u;
   int r = 0;
   while ( i && ( i & t == 0 ) )
@@ -79,10 +80,12 @@ int bit_scan_reverse( unsigned i )
   enum { shift = static_cast<int>( sizeof(unsigned) * CHAR_BIT - 1 ) };
 #if defined( __CUDA_ARCH__ )
   return shift - __clz(i);
+#elif defined( KOKKOS_COMPILER_INTEL )
+  return _bit_scan_reverse(i);
+#elif defined( KOKKOS_COMPILER_IBM )
+  return shift - __cntlz4(i);
 #elif defined( __GNUC__ ) || defined( __GNUG__ )
   return shift - __builtin_clz(i);
-#elif defined( __INTEL_COMPILER )
-  return _bit_scan_reverse(i);
 #else
   unsigned t = 1u << shift;
   int r = 0;
@@ -101,10 +104,12 @@ int bit_count( unsigned i )
 {
 #if defined( __CUDA_ARCH__ )
   return __popc(i);
-#elif defined( __GNUC__ ) || defined( __GNUG__ )
-  return __builtin_popcount(i);
 #elif defined ( __INTEL_COMPILER )
   return _popcnt32(i);
+#elif defined( KOKKOS_COMPILER_IBM )
+  return __popcnt4(i);
+#elif defined( __GNUC__ ) || defined( __GNUG__ )
+  return __builtin_popcount(i);
 #else
   // http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetNaive
   i = i - ( ( i >> 1 ) & ~0u / 3u );                             // temp

--- a/core/src/impl/Kokkos_HostThreadTeam.cpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.cpp
@@ -45,49 +45,7 @@
 #include <Kokkos_Macros.hpp>
 #include <impl/Kokkos_HostThreadTeam.hpp>
 #include <impl/Kokkos_Error.hpp>
-
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
-
-#if ( KOKKOS_ENABLE_ASM )
-  #if defined( __arm__ ) || defined( __aarch64__ )
-    /* No-operation instruction to idle the thread. */
-    #define YIELD   asm volatile("nop")
-  #else
-    /* Pause instruction to prevent excess processor bus usage */
-    #define YIELD   asm volatile("pause\n":::"memory")
-  #endif
-#elif defined ( KOKKOS_ENABLE_WINTHREAD )
-  #include <process.h>
-  #define YIELD  Sleep(0)
-#elif defined ( _WIN32)  && defined (_MSC_VER)
-  /* Windows w/ Visual Studio */
-  #define NOMINMAX
-  #include <winsock2.h>
-  #include <windows.h>
-#define YIELD YieldProcessor();
-#elif defined ( _WIN32 )
-  /* Windows w/ Intel*/
-  #define YIELD __asm__ __volatile__("pause\n":::"memory")
-#else
-  #include <sched.h>
-  #define YIELD  sched_yield()
-#endif
-
-namespace Kokkos {
-namespace Impl {
-namespace {
-
-void wait_until_equal( int64_t const value , int64_t volatile * const sync )
-{
-  while ( value != *sync ) {
-    YIELD ;
-  }
-}
-
-}
-} // namespace Impl
-} // namespace Kokkos
+#include <impl/Kokkos_spinwait.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -194,11 +152,11 @@ int HostThreadTeamData::organize_team( const int team_size )
 
     m_team_scratch = pool[ team_base_rank ]->m_scratch ;
     m_team_base    = team_base_rank ;
-    // This needs to check overflow, if m_pool_size % team_alloc_size !=0 
+    // This needs to check overflow, if m_pool_size % team_alloc_size !=0
     // there are two corner cases:
-    // (i) if team_alloc_size == team_size there might be a non-full 
+    // (i) if team_alloc_size == team_size there might be a non-full
     //     zombi team around (for example m_pool_size = 5 and team_size = 2
-    // (ii) if team_alloc > team_size then the last team might have less 
+    // (ii) if team_alloc > team_size then the last team might have less
     //      threads than the others
     m_team_rank    = ( team_base_rank + team_size <= m_pool_size ) &&
                      ( team_alloc_rank < team_size ) ?
@@ -300,7 +258,7 @@ int HostThreadTeamData::rendezvous( int64_t * const buffer
       value.full = 0 ;
       const int n = ( size - group ) < 8 ? size - group : 8 ;
       for ( int i = 0 ; i < n ; ++i ) value.byte[i] = step ;
-      wait_until_equal( value.full , sync_base + rank );
+      spinwait_until_equal( sync_base[rank], value.full );
     }
   }
 
@@ -323,7 +281,7 @@ int HostThreadTeamData::rendezvous( int64_t * const buffer
     for ( int i = 1 ; i < n ; ++i ) value.byte[i] = step ;
     value.byte[0] = rank ? step : ((volatile int8_t*) sync_base)[0];
 
-    wait_until_equal( value.full , sync_base );
+    spinwait_until_equal( sync_base[0], value.full );
   }
 
   return rank ? 0 : 1 ;
@@ -420,7 +378,7 @@ int HostThreadTeamData::get_work_stealing() noexcept
           // We need to figure out whether the next team is active
           // m_steal_rank + m_team_alloc could be the next base_rank to steal from
           // but only if there are another m_team_size threads available so that that
-          // base rank has a full team. 
+          // base rank has a full team.
           m_steal_rank = m_steal_rank + m_team_alloc + m_team_size <= m_pool_size ?
                          m_steal_rank + m_team_alloc : 0;
 

--- a/core/src/impl/Kokkos_Memory_Fence.hpp
+++ b/core/src/impl/Kokkos_Memory_Fence.hpp
@@ -52,6 +52,10 @@ void memory_fence()
 {
 #if defined( __CUDA_ARCH__ )
   __threadfence();
+#elif defined( KOKKOS_ENABLE_ASM ) && defined( KOKKOS_ENABLE_ISA_X86_64 )
+  asm volatile (
+	  "mfence" ::: "memory"
+  );
 #elif defined( KOKKOS_ENABLE_GNU_ATOMICS ) || \
       ( defined( KOKKOS_COMPILER_NVCC ) && defined( KOKKOS_ENABLE_INTEL_ATOMICS ) )
   __sync_synchronize();
@@ -76,8 +80,8 @@ void store_fence()
 {
 #if defined( KOKKOS_ENABLE_ASM ) && defined( KOKKOS_ENABLE_ISA_X86_64 )
   asm volatile (
-	"sfence" ::: "memory"
-  	);
+	  "sfence" ::: "memory"
+  );
 #else
   memory_fence();
 #endif
@@ -93,8 +97,8 @@ void load_fence()
 {
 #if defined( KOKKOS_ENABLE_ASM ) && defined( KOKKOS_ENABLE_ISA_X86_64 )
   asm volatile (
-	"lfence" ::: "memory"
-  	);
+	  "lfence" ::: "memory"
+  );
 #else
   memory_fence();
 #endif

--- a/core/src/impl/Kokkos_spinwait.cpp
+++ b/core/src/impl/Kokkos_spinwait.cpp
@@ -54,12 +54,12 @@
   #if ( KOKKOS_ENABLE_ASM )
     #if defined( __arm__ ) || defined( __aarch64__ )
       /* No-operation instruction to idle the thread. */
-      #define KOKKOS_INTERNAL_PAUSE   asm volatile("nop\n" "nop\n")
+      #define KOKKOS_INTERNAL_PAUSE
     #else
       /* Pause instruction to prevent excess processor bus usage */
       #define KOKKOS_INTERNAL_PAUSE   asm volatile("pause\n":::"memory")
     #endif
-    #define KOKKOS_INTERNAL_NOP2    KOKKOS_INTERNAL_PAUSE
+    #define KOKKOS_INTERNAL_NOP2    asm volatile("nop\n" "nop\n")
     #define KOKKOS_INTERNAL_NOP4    KOKKOS_INTERNAL_NOP2;  KOKKOS_INTERNAL_NOP2
     #define KOKKOS_INTERNAL_NOP8    KOKKOS_INTERNAL_NOP4;  KOKKOS_INTERNAL_NOP4;
     #define KOKKOS_INTERNAL_NOP16   KOKKOS_INTERNAL_NOP8;  KOKKOS_INTERNAL_NOP8;
@@ -73,6 +73,7 @@
       case 3u:  KOKKOS_INTERNAL_NOP16; break;
       default: KOKKOS_INTERNAL_NOP32;
       }
+      KOKKOS_INTERNAL_PAUSE;
     }
     }
   #else
@@ -102,7 +103,7 @@
     }
   #else
     #define KOKKOS_INTERNAL_PAUSE   __asm__ __volatile__("pause\n":::"memory")
-    #define KOKKOS_INTERNAL_NOP2    KOKKOS_INTERNAL_PAUSE
+    #define KOKKOS_INTERNAL_NOP2    __asm__ __volatile__("nop\n" "nop")
     #define KOKKOS_INTERNAL_NOP4    KOKKOS_INTERNAL_NOP2;  KOKKOS_INTERNAL_NOP2
     #define KOKKOS_INTERNAL_NOP8    KOKKOS_INTERNAL_NOP4;  KOKKOS_INTERNAL_NOP4;
     #define KOKKOS_INTERNAL_NOP16   KOKKOS_INTERNAL_NOP8;  KOKKOS_INTERNAL_NOP8;
@@ -116,6 +117,7 @@
       case 3:  KOKKOS_INTERNAL_NOP16; break;
       default: KOKKOS_INTERNAL_NOP32;
       }
+      KOKKOS_INTERNAL_PAUSE;
     }
     }
   #endif

--- a/core/src/impl/Kokkos_spinwait.cpp
+++ b/core/src/impl/Kokkos_spinwait.cpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,52 +36,142 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
 
 #include <Kokkos_Macros.hpp>
+
 #include <impl/Kokkos_spinwait.hpp>
+
+#include <Kokkos_Atomic.hpp>
+#include <impl/Kokkos_BitOps.hpp>
 
 /*--------------------------------------------------------------------------*/
 
-#if ( KOKKOS_ENABLE_ASM )
-  #if defined( __arm__ ) || defined( __aarch64__ )
-    /* No-operation instruction to idle the thread. */
-    #define YIELD   asm volatile("nop")
+#if !defined( _WIN32 )
+  #if ( KOKKOS_ENABLE_ASM )
+    #if defined( __arm__ ) || defined( __aarch64__ )
+      /* No-operation instruction to idle the thread. */
+      #define KOKKOS_INTERNAL_PAUSE   asm volatile("nop\n" "nop\n")
+    #else
+      /* Pause instruction to prevent excess processor bus usage */
+      #define KOKKOS_INTERNAL_PAUSE   asm volatile("pause\n":::"memory")
+    #endif
+    #define KOKKOS_INTERNAL_NOP2    KOKKOS_INTERNAL_PAUSE
+    #define KOKKOS_INTERNAL_NOP4    KOKKOS_INTERNAL_NOP2;  KOKKOS_INTERNAL_NOP2
+    #define KOKKOS_INTERNAL_NOP8    KOKKOS_INTERNAL_NOP4;  KOKKOS_INTERNAL_NOP4;
+    #define KOKKOS_INTERNAL_NOP16   KOKKOS_INTERNAL_NOP8;  KOKKOS_INTERNAL_NOP8;
+    #define KOKKOS_INTERNAL_NOP32   KOKKOS_INTERNAL_NOP16; KOKKOS_INTERNAL_NOP16;
+    namespace {
+    inline void kokkos_internal_yield( const unsigned i ) noexcept {
+      switch (Kokkos::Impl::bit_scan_reverse((i >> 2)+1u)) {
+      case 0u:  KOKKOS_INTERNAL_NOP2;  break;
+      case 1u:  KOKKOS_INTERNAL_NOP4;  break;
+      case 2u:  KOKKOS_INTERNAL_NOP8;  break;
+      case 3u:  KOKKOS_INTERNAL_NOP16; break;
+      default: KOKKOS_INTERNAL_NOP32;
+      }
+    }
+    }
   #else
-    /* Pause instruction to prevent excess processor bus usage */
-    #define YIELD   asm volatile("pause\n":::"memory")
+    #include <sched.h>
+    namespace {
+    inline void kokkos_internal_yield( const unsigned ) noexcept {
+      sched_yield();
+    }
+    }
   #endif
-#elif defined ( KOKKOS_ENABLE_WINTHREAD )
-  #include <process.h>
-  #define YIELD  Sleep(0)
-#elif defined ( _WIN32)  && defined (_MSC_VER)
-  /* Windows w/ Visual Studio */
-  #define NOMINMAX
-  #include <winsock2.h>
-  #include <windows.h>
-#define YIELD YieldProcessor();
-#elif defined ( _WIN32 )
-  /* Windows w/ Intel*/
-  #define YIELD __asm__ __volatile__("pause\n":::"memory")
-#else
-  #include <sched.h>
-  #define YIELD  sched_yield()
+#else // defined( _WIN32 )
+  #if defined ( KOKKOS_ENABLE_WINTHREAD )
+    #include <process.h>
+    namespace {
+    inline void kokkos_internal_yield( const unsigned ) noexcept {
+      Sleep(0);
+    }
+    }
+  #elif defined( _MSC_VER )
+    #define NOMINMAX
+    #include <winsock2.h>
+    #include <windows.h>
+    namespace {
+    inline void kokkos_internal_yield( const unsigned ) noexcept {
+      YieldProcessor();
+    }
+    }
+  #else
+    #define KOKKOS_INTERNAL_PAUSE   __asm__ __volatile__("pause\n":::"memory")
+    #define KOKKOS_INTERNAL_NOP2    KOKKOS_INTERNAL_PAUSE
+    #define KOKKOS_INTERNAL_NOP4    KOKKOS_INTERNAL_NOP2;  KOKKOS_INTERNAL_NOP2
+    #define KOKKOS_INTERNAL_NOP8    KOKKOS_INTERNAL_NOP4;  KOKKOS_INTERNAL_NOP4;
+    #define KOKKOS_INTERNAL_NOP16   KOKKOS_INTERNAL_NOP8;  KOKKOS_INTERNAL_NOP8;
+    #define KOKKOS_INTERNAL_NOP32   KOKKOS_INTERNAL_NOP16; KOKKOS_INTERNAL_NOP16;
+    namespace {
+    inline void kokkos_internal_yield( const unsigned i ) noexcept {
+      switch (Kokkos::Impl::bit_scan_reverse((i >> 2)+1u)) {
+      case 0:  KOKKOS_INTERNAL_NOP2;  break;
+      case 1:  KOKKOS_INTERNAL_NOP4;  break;
+      case 2:  KOKKOS_INTERNAL_NOP8;  break;
+      case 3:  KOKKOS_INTERNAL_NOP16; break;
+      default: KOKKOS_INTERNAL_NOP32;
+      }
+    }
+    }
+  #endif
 #endif
+
 
 /*--------------------------------------------------------------------------*/
 
 namespace Kokkos {
 namespace Impl {
 #if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
-void spinwait( volatile int & flag , const int value )
+
+void spinwait_while_equal( volatile int32_t & flag , const int32_t value )
 {
+  Kokkos::store_fence();
+  unsigned i = 0;
   while ( value == flag ) {
-    YIELD ;
+    kokkos_internal_yield(i);
+    ++i;
   }
+  Kokkos::load_fence();
 }
+
+void spinwait_until_equal( volatile int32_t & flag , const int32_t value )
+{
+  Kokkos::store_fence();
+  unsigned i = 0;
+  while ( value != flag ) {
+    kokkos_internal_yield(i);
+    ++i;
+  }
+  Kokkos::load_fence();
+}
+
+void spinwait_while_equal( volatile int64_t & flag , const int64_t value )
+{
+  Kokkos::store_fence();
+  unsigned i = 0;
+  while ( value == flag ) {
+    kokkos_internal_yield(i);
+    ++i;
+  }
+  Kokkos::load_fence();
+}
+
+void spinwait_until_equal( volatile int64_t & flag , const int64_t value )
+{
+  Kokkos::store_fence();
+  unsigned i = 0;
+  while ( value != flag ) {
+    kokkos_internal_yield(i);
+    ++i;
+  }
+  Kokkos::load_fence();
+}
+
 #endif
 
 } /* namespace Impl */

--- a/core/src/impl/Kokkos_spinwait.hpp
+++ b/core/src/impl/Kokkos_spinwait.hpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -47,14 +47,30 @@
 
 #include <Kokkos_Macros.hpp>
 
+#include <cstdint>
+
 namespace Kokkos {
 namespace Impl {
 
 #if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
-void spinwait( volatile int & flag , const int value );
+
+void spinwait_while_equal( volatile int32_t & flag , const int32_t value );
+void spinwait_until_equal( volatile int32_t & flag , const int32_t value );
+
+void spinwait_while_equal( volatile int64_t & flag , const int64_t value );
+void spinwait_until_equal( volatile int64_t & flag , const int64_t value );
 #else
+
 KOKKOS_INLINE_FUNCTION
-void spinwait( volatile int & , const int ) {}
+void spinwait_while_equal( volatile int32_t & , const int32_t ) {}
+KOKKOS_INLINE_FUNCTION
+void spinwait_until_equal( volatile int32_t & , const int32_t ) {}
+
+KOKKOS_INLINE_FUNCTION
+void spinwait_while_equal( volatile int64_t & , const int64_t ) {}
+KOKKOS_INLINE_FUNCTION
+void spinwait_until_equal( volatile int64_t & , const int64_t ) {}
+
 #endif
 
 } /* namespace Impl */


### PR DESCRIPTION
Consolidate spinwait code into a single implementation and add memory barriers.

Spinwait refactored into two different functions with simple exponential backoff behavior.
      spinwait_while_equal( volatile int & flag, const int value );
      spinwait_until_equal( volatile int & flag, const int value );

This should fix the bug were a triple_nested_parallelism got the wrong answer. 
Issue #685