### PR TITLE
Add concurrent modification warning to Kokkos DualView

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -442,6 +442,10 @@ public:
       modified_host () = (modified_device () > modified_host () ?
                           modified_device () : modified_host ())  + 1;
     }
+
+    if (modified_host() && modified_device())
+      std::cout << "Kokkos::DualView::modify WARNING: Concurrent modification of host"
+                      " and device views in DualView: " << d_view.label() << std::endl;
   }
 
   //@}


### PR DESCRIPTION
Warn if both device and host views in a DualView are modified simultaneously. This can lead to really hard to find bugs with Kokkos CUDA.