### PR TITLE
Prevent direct inclusion of KokkosCore_config.h

### DIFF
--- a/core/cmake/KokkosCore_config.h.in
+++ b/core/cmake/KokkosCore_config.h.in
@@ -1,5 +1,8 @@
-#ifndef KOKKOS_CORE_CONFIG_H
+#if !defined(KOKKOS_MACROS_HPP) || defined(KOKKOS_CORE_CONFIG_H)
+#error "Don't include KokkosCore_config.h directly; include Kokkos_Macros.hpp instead."
+#else
 #define KOKKOS_CORE_CONFIG_H
+#endif
 
 /* The trivial 'src/build_common.sh' creates a config
  * that must stay in sync with this file.
@@ -103,4 +106,3 @@
 #cmakedefine KOKKOS_HAVE_CXX11
 
 #endif // KOKKOS_FOR_SIERRA
-#endif // KOKKOS_CORE_CONFIG_H


### PR DESCRIPTION
Prevent users from making the mistake discussed in #787.