### PR TITLE
Fixes label in OpenMP parallel_reduce verify_initialized

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -228,8 +228,8 @@ public:
       enum { is_dynamic = std::is_same< typename Policy::schedule_type::type
                                       , Kokkos::Dynamic >::value };
 
-      OpenMPExec::verify_is_process("Kokkos::OpenMP parallel_for");
-      OpenMPExec::verify_initialized("Kokkos::OpenMP parallel_for");
+      OpenMPExec::verify_is_process("Kokkos::OpenMP parallel_reduce");
+      OpenMPExec::verify_initialized("Kokkos::OpenMP parallel_reduce");
 
       const size_t pool_reduce_bytes =
         Analysis::value_size( ReducerConditional::select(m_functor, m_reducer));


### PR DESCRIPTION
part of #832, not critical but this typo did throw me off when tracking down the failure.

@dsunder @crtrott 