### PR TITLE
Stubbing out task_depend test on Pascal

### DIFF
--- a/core/unit_test/TestTaskScheduler.hpp
+++ b/core/unit_test/TestTaskScheduler.hpp
@@ -647,7 +647,7 @@ TEST_F( TEST_CATEGORY, task_fib )
   }
 }
 
-#if defined( __CUDA_ARCH__ ) && ( 600 <= __CUDA_ARCH__ )
+#if defined(KOKKOS_ARCH_MAXWELL) || defined(KOKKOS_ARCH_PASCAL)
   // TODO: Resolve bug in task DAG for Pascal
   #define KOKKOS_IMPL_DISABLE_UNIT_TEST_TASK_DAG_PASCAL
 #endif

--- a/core/unit_test/TestTaskScheduler.hpp
+++ b/core/unit_test/TestTaskScheduler.hpp
@@ -246,22 +246,6 @@ struct TestTaskDependence {
   KOKKOS_INLINE_FUNCTION
   void operator()( typename sched_type::member_type & )
   {
-#define KOKKOS_IMPL_UNIT_TEST_TASK_DEPEND 1
-
-#if defined( __CUDA_ARCH__ )
-  #if ( 600 <= __CUDA_ARCH__ )
-    // TODO: Resolve bug in task dependence for Pascal
-    #undef KOKKOS_IMPL_UNIT_TEST_TASK_DEPEND
-    #define KOKKOS_IMPL_UNIT_TEST_TASK_DEPEND 0
-  #endif
-#endif
-
-#if ! KOKKOS_IMPL_UNIT_TEST_TASK_DEPEND
-
-    m_accum() = m_count;
-
-#else
-
     enum { CHUNK = 8 };
     const int n = CHUNK < m_count ? CHUNK : m_count;
 
@@ -284,9 +268,6 @@ struct TestTaskDependence {
     else if ( 1 == m_count ) {
       Kokkos::atomic_increment( & m_accum() );
     }
-
-#endif /* KOKKOS_IMPL_UNIT_TEST_TASK_DEPEND */
-#undef KOKKOS_IMPL_UNIT_TEST_TASK_DEPEND
   }
 
   static void run( int n )
@@ -363,24 +344,6 @@ struct TestTaskTeam {
   KOKKOS_INLINE_FUNCTION
   void operator()( typename sched_type::member_type & member )
   {
-#define KOKKOS_IMPL_UNIT_TEST_TASK_TEAM 1
-
-#if defined( __CUDA_ARCH__ )
-  #if ( 600 <= __CUDA_ARCH__ )
-    // TODO: Resolve bug in task team reduction for Pascal
-    #undef KOKKOS_IMPL_UNIT_TEST_TASK_TEAM
-    #define KOKKOS_IMPL_UNIT_TEST_TASK_TEAM 0
-  #endif
-#endif
-
-#if ! KOKKOS_IMPL_UNIT_TEST_TASK_TEAM
-
-    Kokkos::parallel_for( Kokkos::TeamThreadRange( member, 0, nvalue + 1 )
-                        , [&] ( int i ) { parfor_result[i] = i; }
-                        );
-
-#else
-
     const long end   = nvalue + 1;
     const long begin = 0 < end - SPAN ? end - SPAN : 0;
 
@@ -498,9 +461,6 @@ struct TestTaskTeam {
       parreduce_check[i] += result - expected;
     });
 */
-
-#endif /* KOKKOS_IMPL_UNIT_TEST_TASK_TEAM */
-#undef KOKKOS_IMPL_UNIT_TEST_TASK_TEAM
 
   }
 
@@ -678,6 +638,7 @@ struct TestTaskTeamValue {
 } // namespace TestTaskScheduler
 
 namespace Test {
+
 TEST_F( TEST_CATEGORY, task_fib )
 {
   const int N = 24 ; // 25 triggers tbd bug on Cuda/Pascal
@@ -685,6 +646,13 @@ TEST_F( TEST_CATEGORY, task_fib )
     TestTaskScheduler::TestFib< TEST_EXECSPACE >::run( i , ( i + 1 ) * ( i + 1 ) * 10000 );
   }
 }
+
+#if defined( __CUDA_ARCH__ ) && ( 600 <= __CUDA_ARCH__ )
+  // TODO: Resolve bug in task DAG for Pascal
+  #define KOKKOS_IMPL_DISABLE_UNIT_TEST_TASK_DAG_PASCAL
+#endif
+
+#ifndef KOKKOS_IMPL_DISABLE_UNIT_TEST_TASK_DAG_PASCAL
 
 TEST_F( TEST_CATEGORY, task_depend )
 {
@@ -698,6 +666,10 @@ TEST_F( TEST_CATEGORY, task_team )
   TestTaskScheduler::TestTaskTeam< TEST_EXECSPACE >::run( 1000 );
   //TestTaskScheduler::TestTaskTeamValue< TEST_EXECSPACE >::run( 1000 ); // Put back after testing.
 }
+
+#else //ndef KOKKOS_IMPL_DISABLE_UNIT_TEST_TASK_DAG_PASCAL
+#undef KOKKOS_IMPL_DISABLE_UNIT_TEST_TASK_DAG_PASCAL
+#endif //ndef KOKKOS_IMPL_DISABLE_UNIT_TEST_TASK_DAG_PASCAL
 
 }
 #endif // #if defined( KOKKOS_ENABLE_TASKDAG )


### PR DESCRIPTION
per @hcedwar's recommendation in #829
this will remove "BLOCKS PROMOTION" from
issue #829 when merged