### PR TITLE
Two fixes to get the pure CMake build example working.

### DIFF
--- a/cmake/kokkos.cmake
+++ b/cmake/kokkos.cmake
@@ -999,7 +999,11 @@ SET (Kokkos_INCLUDE_DIRS
     ${Kokkos_SOURCE_DIR}/containers/src
     ${Kokkos_SOURCE_DIR}/algorithms/src
     ${Kokkos_BINARY_DIR}  # to find KokkosCore_config.h
+    ${KOKKOS_INCLUDE_DIRS}
 )
+
+# pass include dirs back to parent scope
+SET(Kokkos_INCLUDE_DIRS_RET ${Kokkos_INCLUDE_DIRS} PARENT_SCOPE)
 
 INCLUDE_DIRECTORIES(${Kokkos_INCLUDE_DIRS})
 

--- a/example/cmake_build/CMakeLists.txt
+++ b/example/cmake_build/CMakeLists.txt
@@ -40,5 +40,7 @@ list(APPEND CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -O3)
 
 add_subdirectory(${Example_SOURCE_DIR}/../.. ${Example_BINARY_DIR}/kokkos)
 
+include_directories(${Kokkos_INCLUDE_DIRS_RET})
+
 add_executable(example cmake_example.cpp)
 target_link_libraries(example kokkos)


### PR DESCRIPTION
Following the directions in example/cmake_build/CMakeLists.txt, I ran
into several build issues:

1.  The Kokkos include directories aren't automatically added to the
outer project.

2.  The TPL include directories aren't being added to the Kokkos include
directories.

This commit fixes these issues by

1.  Creating a variable Kokkos_INCLUDE_DIRS_RET that the outer project
can use to add to its include directories.

2.  Added the TPL include directories to the above.

I also updated the cmake_build example to use Kokkos_INCLUDE_DIRS_RET,
so that now builds.

For issue #874 