### PR TITLE
silence warning when UVM disabled

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Impl.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Impl.cpp
@@ -103,6 +103,7 @@ int cuda_kernel_arch()
   return arch ;
 }
 
+#ifdef KOKKOS_ENABLE_CUDA_UVM
 bool cuda_launch_blocking()
 {
   const char * env = getenv("CUDA_LAUNCH_BLOCKING");
@@ -111,16 +112,13 @@ bool cuda_launch_blocking()
 
   return atoi(env);
 }
+#endif
 
 }
 
 void cuda_device_synchronize()
 {
-//  static const bool launch_blocking = cuda_launch_blocking();
-
-//  if (!launch_blocking) {
-    CUDA_SAFE_CALL( cudaDeviceSynchronize() );
-//  }
+  CUDA_SAFE_CALL( cudaDeviceSynchronize() );
 }
 
 void cuda_internal_error_throw( cudaError e , const char * name, const char * file, const int line )


### PR DESCRIPTION
[#853]

`test_all_sandia` spot check:
```
cuda-7.0.28-Cuda_OpenMP-release build_time=405 run_time=550
cuda-7.0.28-Cuda_Serial-release build_time=375 run_time=540
cuda-8.0.44-Cuda_OpenMP-release build_time=348 run_time=546
cuda-8.0.44-Cuda_Serial-release build_time=335 run_time=522
```