### PR TITLE
Improve kokkos_impl_cuda_lock_arrays

### DIFF
--- a/Makefile.targets
+++ b/Makefile.targets
@@ -38,6 +38,8 @@ Kokkos_CudaSpace.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/Cuda/Kokkos_Cu
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/Cuda/Kokkos_CudaSpace.cpp
 Kokkos_Cuda_Task.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/Cuda/Kokkos_Cuda_Task.cpp
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/Cuda/Kokkos_Cuda_Task.cpp
+Kokkos_Cuda_Locks.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/Cuda/Kokkos_Cuda_Locks.cpp
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/Cuda/Kokkos_Cuda_Locks.cpp
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_PTHREADS), 1)

--- a/core/src/Cuda/Kokkos_CudaExec.hpp
+++ b/core/src/Cuda/Kokkos_CudaExec.hpp
@@ -207,14 +207,7 @@ struct CudaParallelLaunch< DriverType , true > {
       // Copy functor to constant memory on the device
       cudaMemcpyToSymbol( kokkos_impl_cuda_constant_memory_buffer , & driver , sizeof(DriverType) );
 
-      #ifndef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
-      Kokkos::Impl::CudaLockArraysStruct locks;
-      locks.atomic = atomic_lock_array_cuda_space_ptr(false);
-      locks.scratch = scratch_lock_array_cuda_space_ptr(false);
-      locks.threadid = threadid_lock_array_cuda_space_ptr(false);
-      locks.n = Kokkos::Cuda::concurrency();
-      cudaMemcpyToSymbol( kokkos_impl_cuda_lock_arrays , & locks , sizeof(CudaLockArraysStruct) );
-      #endif
+      KOKKOS_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
 
       // Invoke the driver function on the device
       cuda_parallel_launch_constant_memory< DriverType ><<< grid , block , shmem , stream >>>();
@@ -250,7 +243,7 @@ struct CudaParallelLaunch< DriverType , false > {
       }
       #endif
 
-      Kokkos::Impl::ensure_cuda_lock_arrays_on_device();
+      KOKKOS_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
 
       cuda_parallel_launch_local_memory< DriverType ><<< grid , block , shmem , stream >>>( driver );
 

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -800,83 +800,6 @@ print_records( std::ostream & s , const Kokkos::CudaHostPinnedSpace & space , bo
   SharedAllocationRecord< void , void >::print_host_accessible_records( s , "CudaHostPinned" , & s_root_record , detail );
 }
 
-} // namespace Impl
-} // namespace Kokkos
-
-/*--------------------------------------------------------------------------*/
-/*--------------------------------------------------------------------------*/
-
-namespace Kokkos {
-namespace {
-  __global__ void init_lock_array_kernel_atomic() {
-    unsigned i = blockIdx.x*blockDim.x + threadIdx.x;
-
-    if(i<CUDA_SPACE_ATOMIC_MASK+1)
-      kokkos_impl_cuda_lock_arrays.atomic[i] = 0;
-  }
-
-  __global__ void init_lock_array_kernel_scratch_threadid(int N) {
-    unsigned i = blockIdx.x*blockDim.x + threadIdx.x;
-
-    if(i<N) {
-      kokkos_impl_cuda_lock_arrays.scratch[i] = 0;
-      kokkos_impl_cuda_lock_arrays.threadid[i] = 0;
-    }
-  }
-}
-
-
-namespace Impl {
-int* atomic_lock_array_cuda_space_ptr(bool deallocate) {
-  static int* ptr = NULL;
-  if(deallocate) {
-    cudaFree(ptr);
-    ptr = NULL;
-  }
-
-  if(ptr==NULL && !deallocate)
-    cudaMalloc(&ptr,sizeof(int)*(CUDA_SPACE_ATOMIC_MASK+1));
-  return ptr;
-}
-
-int* scratch_lock_array_cuda_space_ptr(bool deallocate) {
-  static int* ptr = NULL;
-  if(deallocate) {
-    cudaFree(ptr);
-    ptr = NULL;
-  }
-
-  if(ptr==NULL && !deallocate)
-    cudaMalloc(&ptr,sizeof(int)*(Cuda::concurrency()));
-  return ptr;
-}
-
-int* threadid_lock_array_cuda_space_ptr(bool deallocate) {
-  static int* ptr = NULL;
-  if(deallocate) {
-    cudaFree(ptr);
-    ptr = NULL;
-  }
-
-  if(ptr==NULL && !deallocate)
-    cudaMalloc(&ptr,sizeof(int)*(Cuda::concurrency()));
-  return ptr;
-}
-
-void init_lock_arrays_cuda_space() {
-  static int is_initialized = 0;
-  if(! is_initialized) {
-    Kokkos::Impl::CudaLockArraysStruct locks;
-    locks.atomic = atomic_lock_array_cuda_space_ptr(false);
-    locks.scratch = scratch_lock_array_cuda_space_ptr(false);
-    locks.threadid = threadid_lock_array_cuda_space_ptr(false);
-    locks.n = Kokkos::Cuda::concurrency();
-    cudaMemcpyToSymbol( kokkos_impl_cuda_lock_arrays , & locks , sizeof(CudaLockArraysStruct) );
-    init_lock_array_kernel_atomic<<<(CUDA_SPACE_ATOMIC_MASK+255)/256,256>>>();
-    init_lock_array_kernel_scratch_threadid<<<(Kokkos::Cuda::concurrency()+255)/256,256>>>(Kokkos::Cuda::concurrency());
-  }
-}
-
 void* cuda_resize_scratch_space(std::int64_t bytes, bool force_shrink) {
   static void* ptr = NULL;
   static std::int64_t current_size = 0;
@@ -896,8 +819,8 @@ void* cuda_resize_scratch_space(std::int64_t bytes, bool force_shrink) {
   return ptr;
 }
 
-}
-}
+} // namespace Impl
+} // namespace Kokkos
 #else
 void KOKKOS_CORE_SRC_CUDA_CUDASPACE_PREVENT_LINK_ERROR() {}
 #endif // KOKKOS_ENABLE_CUDA

--- a/core/src/Cuda/Kokkos_Cuda_Impl.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Impl.cpp
@@ -51,6 +51,7 @@
 
 #include <Cuda/Kokkos_Cuda_Error.hpp>
 #include <Cuda/Kokkos_Cuda_Internal.hpp>
+#include <Cuda/Kokkos_Cuda_Locks.hpp>
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
 
@@ -68,9 +69,6 @@
 
 __device__ __constant__
 unsigned long kokkos_impl_cuda_constant_memory_buffer[ Kokkos::Impl::CudaTraits::ConstantMemoryUsage / sizeof(unsigned long) ] ;
-
-__device__ __constant__
-Kokkos::Impl::CudaLockArraysStruct kokkos_impl_cuda_lock_arrays ;
 
 #endif
 
@@ -543,16 +541,7 @@ void CudaInternal::initialize( int cuda_device_id , int stream_count )
   cudaThreadSetCacheConfig(cudaFuncCachePreferShared);
 
   // Init the array for used for arbitrarily sized atomics
-  Impl::init_lock_arrays_cuda_space();
-
-  #ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
-  Kokkos::Impl::CudaLockArraysStruct locks;
-  locks.atomic = atomic_lock_array_cuda_space_ptr(false);
-  locks.scratch = scratch_lock_array_cuda_space_ptr(false);
-  locks.threadid = threadid_lock_array_cuda_space_ptr(false);
-  locks.n = Kokkos::Cuda::concurrency();
-  cudaMemcpyToSymbol( kokkos_impl_cuda_lock_arrays , & locks , sizeof(CudaLockArraysStruct) );
-  #endif
+  Impl::initialize_host_cuda_lock_arrays();
 }
 
 //----------------------------------------------------------------------------
@@ -635,9 +624,7 @@ void CudaInternal::finalize()
   was_finalized = 1;
   if ( 0 != m_scratchSpace || 0 != m_scratchFlags ) {
 
-    atomic_lock_array_cuda_space_ptr(true);
-    scratch_lock_array_cuda_space_ptr(true);
-    threadid_lock_array_cuda_space_ptr(true);
+    Impl::finalize_host_cuda_lock_arrays();
 
     if ( m_stream ) {
       for ( size_type i = 1 ; i < m_streamCount ; ++i ) {

--- a/core/src/Cuda/Kokkos_Cuda_Locks.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.cpp
@@ -72,7 +72,7 @@ __global__ void init_lock_array_kernel_atomic() {
 __global__ void init_lock_array_kernel_threadid(int N) {
   unsigned i = blockIdx.x*blockDim.x + threadIdx.x;
   if(i<N) {
-    Kokkos::Impl::g_device_cuda_lock_arrays.threadid[i] = 0;
+    Kokkos::Impl::g_device_cuda_lock_arrays.scratch[i] = 0;
   }
 }
 
@@ -86,7 +86,7 @@ void initialize_host_cuda_lock_arrays() {
   if (g_host_cuda_lock_arrays.atomic != nullptr) return;
   CUDA_SAFE_CALL(cudaMalloc(&g_host_cuda_lock_arrays.atomic,
                  sizeof(int)*(CUDA_SPACE_ATOMIC_MASK+1)));
-  CUDA_SAFE_CALL(cudaMalloc(&g_host_cuda_lock_arrays.threadid,
+  CUDA_SAFE_CALL(cudaMalloc(&g_host_cuda_lock_arrays.scratch,
                  sizeof(int)*(Cuda::concurrency())));
   CUDA_SAFE_CALL(cudaDeviceSynchronize());
   g_host_cuda_lock_arrays.n = Cuda::concurrency();
@@ -100,8 +100,8 @@ void finalize_host_cuda_lock_arrays() {
   if (g_host_cuda_lock_arrays.atomic == nullptr) return;
   cudaFree(g_host_cuda_lock_arrays.atomic);
   g_host_cuda_lock_arrays.atomic = nullptr;
-  cudaFree(g_host_cuda_lock_arrays.threadid);
-  g_host_cuda_lock_arrays.threadid = nullptr;
+  cudaFree(g_host_cuda_lock_arrays.scratch);
+  g_host_cuda_lock_arrays.scratch = nullptr;
   g_host_cuda_lock_arrays.n = 0;
 #ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
   KOKKOS_COPY_CUDA_LOCK_ARRAYS_TO_DEVICE();

--- a/core/src/Cuda/Kokkos_Cuda_Locks.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.cpp
@@ -1,0 +1,103 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Macros.hpp>
+
+#ifdef KOKKOS_ENABLE_CUDA
+
+#include <Cuda/Kokkos_Cuda_Locks.hpp>
+#include <Cuda/Kokkos_Cuda_Error.hpp>
+
+#ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
+__device__ __constant__
+Kokkos::Impl::CudaLockArrays kokkos_impl_cuda_lock_arrays ;
+#endif
+
+namespace Kokkos {
+
+namespace {
+
+__global__ void init_lock_array_kernel_atomic() {
+  unsigned i = blockIdx.x*blockDim.x + threadIdx.x;
+  if(i<CUDA_SPACE_ATOMIC_MASK+1)
+    kokkos_impl_cuda_lock_arrays.atomic[i] = 0;
+}
+
+__global__ void init_lock_array_kernel_threadid(int N) {
+  unsigned i = blockIdx.x*blockDim.x + threadIdx.x;
+  if(i<N) {
+    kokkos_impl_cuda_lock_arrays.threadid[i] = 0;
+  }
+}
+
+} // namespace
+
+namespace Impl {
+
+Kokkos::Impl::CudaLockArrays host_cuda_lock_arrays ;
+
+void initialize_host_cuda_lock_arrays() {
+  CUDA_SAFE_CALL(cudaMalloc(&host_cuda_lock_arrays.atomic,
+                 sizeof(int)*(CUDA_SPACE_ATOMIC_MASK+1)));
+  CUDA_SAFE_CALL(cudaMalloc(&host_cuda_lock_arrays.threadid,
+                 sizeof(int)*(Cuda::concurrency())));
+  host_cuda_lock_arrays.n = Kokkos::Cuda::concurrency();
+  copy_cuda_lock_arrays_to_device();
+  init_lock_array_kernel_atomic<<<(CUDA_SPACE_ATOMIC_MASK+255)/256,256>>>();
+  init_lock_array_kernel_threadid<<<(Kokkos::Cuda::concurrency()+255)/256,256>>>(Kokkos::Cuda::concurrency());
+}
+
+void finalize_host_cuda_lock_arrays() {
+  cudaFree(host_cuda_lock_arrays.atomic);
+  host_cuda_lock_arrays.atomic = nullptr;
+}
+
+} // namespace Impl
+
+} // namespace Kokkos
+
+#else
+
+void KOKKOS_CORE_SRC_CUDA_CUDA_LOCKS_PREVENT_LINK_ERROR() {}
+
+#endif

--- a/core/src/Cuda/Kokkos_Cuda_Locks.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.cpp
@@ -50,7 +50,7 @@
 
 #ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
 __device__ __constant__
-Kokkos::Impl::CudaLockArrays kokkos_impl_cuda_lock_arrays ;
+Kokkos::Impl::CudaLockArrays kokkos_impl_cuda_lock_arrays = { nullptr, nullptr, 0 };
 #endif
 
 namespace Kokkos {
@@ -74,7 +74,7 @@ __global__ void init_lock_array_kernel_threadid(int N) {
 
 namespace Impl {
 
-Kokkos::Impl::CudaLockArrays host_cuda_lock_arrays ;
+Kokkos::Impl::CudaLockArrays host_cuda_lock_arrays = { nullptr, nullptr, 0 };
 
 void initialize_host_cuda_lock_arrays() {
   CUDA_SAFE_CALL(cudaMalloc(&host_cuda_lock_arrays.atomic,
@@ -90,6 +90,9 @@ void initialize_host_cuda_lock_arrays() {
 void finalize_host_cuda_lock_arrays() {
   cudaFree(host_cuda_lock_arrays.atomic);
   host_cuda_lock_arrays.atomic = nullptr;
+  cudaFree(host_cuda_lock_arrays.threadid);
+  host_cuda_lock_arrays.threadid = nullptr;
+  host_cuda_lock_arrays.n = 0;
 }
 
 } // namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda_Locks.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.cpp
@@ -80,9 +80,10 @@ __global__ void init_lock_array_kernel_threadid(int N) {
 
 namespace Impl {
 
-CudaLockArrays g_host_cuda_lock_arrays;
+CudaLockArrays g_host_cuda_lock_arrays = { nullptr, nullptr, 0 };
 
 void initialize_host_cuda_lock_arrays() {
+  if (g_host_cuda_lock_arrays.atomic != nullptr) return;
   CUDA_SAFE_CALL(cudaMalloc(&g_host_cuda_lock_arrays.atomic,
                  sizeof(int)*(CUDA_SPACE_ATOMIC_MASK+1)));
   CUDA_SAFE_CALL(cudaMalloc(&g_host_cuda_lock_arrays.threadid,
@@ -96,6 +97,7 @@ void initialize_host_cuda_lock_arrays() {
 }
 
 void finalize_host_cuda_lock_arrays() {
+  if (g_host_cuda_lock_arrays.atomic == nullptr) return;
   cudaFree(g_host_cuda_lock_arrays.atomic);
   g_host_cuda_lock_arrays.atomic = nullptr;
   cudaFree(g_host_cuda_lock_arrays.threadid);

--- a/core/src/Cuda/Kokkos_Cuda_Locks.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.cpp
@@ -50,8 +50,12 @@
 #include <Kokkos_Cuda.hpp>
 
 #ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
+namespace Kokkos {
+namespace Impl {
 __device__ __constant__
-Kokkos::Impl::CudaLockArrays kokkos_impl_cuda_lock_arrays = { nullptr, nullptr, 0 };
+CudaLockArrays device_cuda_lock_arrays = { nullptr, nullptr, 0 };
+}
+}
 #endif
 
 namespace Kokkos {
@@ -61,14 +65,14 @@ namespace {
 __global__ void init_lock_array_kernel_atomic() {
   unsigned i = blockIdx.x*blockDim.x + threadIdx.x;
   if(i<CUDA_SPACE_ATOMIC_MASK+1) {
-    kokkos_impl_cuda_lock_arrays.atomic[i] = 0;
+    Kokkos::Impl::device_cuda_lock_arrays.atomic[i] = 0;
   }
 }
 
 __global__ void init_lock_array_kernel_threadid(int N) {
   unsigned i = blockIdx.x*blockDim.x + threadIdx.x;
   if(i<N) {
-    kokkos_impl_cuda_lock_arrays.threadid[i] = 0;
+    Kokkos::Impl::device_cuda_lock_arrays.threadid[i] = 0;
   }
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_Locks.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.cpp
@@ -103,6 +103,9 @@ void finalize_host_cuda_lock_arrays() {
   cudaFree(g_host_cuda_lock_arrays.threadid);
   g_host_cuda_lock_arrays.threadid = nullptr;
   g_host_cuda_lock_arrays.n = 0;
+#ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
+  KOKKOS_COPY_CUDA_LOCK_ARRAYS_TO_DEVICE();
+#endif
 }
 
 } // namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda_Locks.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.hpp
@@ -115,7 +115,7 @@ void unlock_address_cuda_space(void* ptr) {
 } // namespace Kokkos
 
 /* Dan Ibanez: it is critical that this code be a macro, so that it will
-   captures the right address for kokkos_impl_cuda_lock_arrays!
+   capture the right address for kokkos_impl_cuda_lock_arrays!
    putting this in an inline function will NOT do the right thing! */
 #define KOKKOS_COPY_CUDA_LOCK_ARRAYS_TO_DEVICE() \
 do { \

--- a/core/src/Cuda/Kokkos_Cuda_Locks.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.hpp
@@ -84,6 +84,11 @@ Kokkos::Impl::CudaLockArrays kokkos_impl_cuda_lock_arrays ;
 namespace Kokkos {
 namespace Impl {
 
+/// \brief Aquire a lock for the address
+///
+/// This function tries to aquire the lock for the hash value derived
+/// from the provided ptr. If the lock is successfully aquired the
+/// function returns true. Otherwise it returns false.
 __device__ inline
 bool lock_address_cuda_space(void* ptr) {
   size_t offset = size_t(ptr);
@@ -92,6 +97,12 @@ bool lock_address_cuda_space(void* ptr) {
   return (0 == atomicCAS(&kokkos_impl_cuda_lock_arrays.atomic[offset],0,1));
 }
 
+/// \brief Release lock for the address
+///
+/// This function releases the lock for the hash value derived
+/// from the provided ptr. This function should only be called
+/// after previously successfully aquiring a lock with
+/// lock_address.
 __device__ inline
 void unlock_address_cuda_space(void* ptr) {
   size_t offset = size_t(ptr);

--- a/core/src/Cuda/Kokkos_Cuda_Locks.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.hpp
@@ -49,9 +49,6 @@
 #ifdef KOKKOS_ENABLE_CUDA
 
 #include <cstdint>
-#include <iostream>
-#include <cassert>
-#include <stdio.h>
 
 #include <Cuda/Kokkos_Cuda_Error.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_Locks.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.hpp
@@ -1,0 +1,121 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_CUDA_LOCKS_HPP
+#define KOKKOS_CUDA_LOCKS_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#ifdef KOKKOS_ENABLE_CUDA
+
+#include <cstdint>
+
+namespace Kokkos {
+namespace Impl {
+
+struct CudaLockArrays {
+  int* atomic;
+  int* threadid;
+  int n;
+};
+
+extern Kokkos::Impl::CudaLockArrays host_cuda_lock_arrays ;
+
+void initialize_host_cuda_lock_arrays();
+void finalize_host_cuda_lock_arrays();
+
+} // namespace Impl
+} // namespace Kokkos
+
+#if defined( __CUDACC__ )
+
+__device__ __constant__
+#ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
+extern
+#endif
+Kokkos::Impl::CudaLockArrays kokkos_impl_cuda_lock_arrays ;
+
+#define CUDA_SPACE_ATOMIC_MASK 0x1FFFF
+#define CUDA_SPACE_ATOMIC_XOR_MASK 0x15A39
+
+namespace Kokkos {
+namespace Impl {
+
+__device__ inline
+bool lock_address_cuda_space(void* ptr) {
+  size_t offset = size_t(ptr);
+  offset = offset >> 2;
+  offset = offset & CUDA_SPACE_ATOMIC_MASK;
+  return (0 == atomicCAS(&kokkos_impl_cuda_lock_arrays.atomic[offset],0,1));
+}
+
+__device__ inline
+void unlock_address_cuda_space(void* ptr) {
+  size_t offset = size_t(ptr);
+  offset = offset >> 2;
+  offset = offset & CUDA_SPACE_ATOMIC_MASK;
+  atomicExch( &kokkos_impl_cuda_lock_arrays.atomic[ offset ], 0);
+}
+
+inline
+void copy_cuda_lock_arrays_to_device() {
+  cudaMemcpyToSymbol( kokkos_impl_cuda_lock_arrays ,
+                      & Kokkos::Impl::host_cuda_lock_arrays ,
+                      sizeof(CudaLockArrays) );
+}
+
+inline
+void ensure_cuda_lock_arrays_on_device() {
+#ifndef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
+  copy_cuda_lock_arrays_to_device();
+#endif
+}
+
+} // namespace Impl
+} // namespace Kokkos
+
+#endif /* defined( __CUDACC__ ) */
+
+#endif /* defined( KOKKOS_ENABLE_CUDA ) */
+
+#endif /* #ifndef KOKKOS_CUDA_LOCKS_HPP */

--- a/core/src/Cuda/Kokkos_Cuda_Locks.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.hpp
@@ -57,7 +57,7 @@ namespace Impl {
 
 struct CudaLockArrays {
   std::int32_t* atomic;
-  std::int32_t* threadid;
+  std::int32_t* scratch;
   std::int32_t n;
 };
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -58,6 +58,7 @@
 #include <Cuda/Kokkos_CudaExec.hpp>
 #include <Cuda/Kokkos_Cuda_ReduceScan.hpp>
 #include <Cuda/Kokkos_Cuda_Internal.hpp>
+#include <Cuda/Kokkos_Cuda_Locks.hpp>
 #include <Kokkos_Vectorization.hpp>
 
 #if defined(KOKKOS_ENABLE_PROFILING)
@@ -435,7 +436,7 @@ public:
         if(threadid > kokkos_impl_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
         int done = 0;
         while (!done) {
-          done = (0 == atomicCAS(&kokkos_impl_cuda_lock_arrays.atomic[threadid],0,1));
+          done = (0 == atomicCAS(&kokkos_impl_cuda_lock_arrays.threadid[threadid],0,1));
           if(!done) {
             threadid += blockDim.x * blockDim.y;
             if(threadid > kokkos_impl_cuda_lock_arrays.n) threadid = 0;
@@ -462,7 +463,7 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __syncthreads();
       if (threadIdx.x==0 && threadIdx.y==0 )
-        kokkos_impl_cuda_lock_arrays.atomic[threadid]=0;
+        kokkos_impl_cuda_lock_arrays.threadid[threadid]=0;
     }
   }
 
@@ -824,7 +825,7 @@ public:
         if(threadid > kokkos_impl_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
         int done = 0;
         while (!done) {
-          done = (0 == atomicCAS(&kokkos_impl_cuda_lock_arrays.atomic[threadid],0,1));
+          done = (0 == atomicCAS(&kokkos_impl_cuda_lock_arrays.threadid[threadid],0,1));
           if(!done) {
             threadid += blockDim.x * blockDim.y;
             if(threadid > kokkos_impl_cuda_lock_arrays.n) threadid = 0;
@@ -840,7 +841,7 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __syncthreads();
       if (threadIdx.x==0 && threadIdx.y==0 )
-        kokkos_impl_cuda_lock_arrays.atomic[threadid]=0;
+        kokkos_impl_cuda_lock_arrays.threadid[threadid]=0;
     }
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -431,15 +431,15 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __shared__ int base_thread_id;
       if (threadIdx.x==0 && threadIdx.y==0 ) {
-        threadid = ((blockIdx.x*blockDim.z + threadIdx.z) * blockDim.x * blockDim.y) % Kokkos::Impl::device_cuda_lock_arrays.n;
+        threadid = ((blockIdx.x*blockDim.z + threadIdx.z) * blockDim.x * blockDim.y) % Kokkos::Impl::g_device_cuda_lock_arrays.n;
         threadid = ((threadid + blockDim.x * blockDim.y-1)/(blockDim.x * blockDim.y)) * blockDim.x * blockDim.y;
-        if(threadid > Kokkos::Impl::device_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
+        if(threadid > Kokkos::Impl::g_device_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
         int done = 0;
         while (!done) {
-          done = (0 == atomicCAS(&Kokkos::Impl::device_cuda_lock_arrays.threadid[threadid],0,1));
+          done = (0 == atomicCAS(&Kokkos::Impl::g_device_cuda_lock_arrays.threadid[threadid],0,1));
           if(!done) {
             threadid += blockDim.x * blockDim.y;
-            if(threadid > Kokkos::Impl::device_cuda_lock_arrays.n) threadid = 0;
+            if(threadid > Kokkos::Impl::g_device_cuda_lock_arrays.n) threadid = 0;
           }
         }
         base_thread_id = threadid;
@@ -463,7 +463,7 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __syncthreads();
       if (threadIdx.x==0 && threadIdx.y==0 )
-        Kokkos::Impl::device_cuda_lock_arrays.threadid[threadid]=0;
+        Kokkos::Impl::g_device_cuda_lock_arrays.threadid[threadid]=0;
     }
   }
 
@@ -820,15 +820,15 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __shared__ int base_thread_id;
       if (threadIdx.x==0 && threadIdx.y==0 ) {
-        threadid = ((blockIdx.x*blockDim.z + threadIdx.z) * blockDim.x * blockDim.y) % Kokkos::Impl::device_cuda_lock_arrays.n;
+        threadid = ((blockIdx.x*blockDim.z + threadIdx.z) * blockDim.x * blockDim.y) % Kokkos::Impl::g_device_cuda_lock_arrays.n;
         threadid = ((threadid + blockDim.x * blockDim.y-1)/(blockDim.x * blockDim.y)) * blockDim.x * blockDim.y;
-        if(threadid > Kokkos::Impl::device_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
+        if(threadid > Kokkos::Impl::g_device_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
         int done = 0;
         while (!done) {
-          done = (0 == atomicCAS(&Kokkos::Impl::device_cuda_lock_arrays.threadid[threadid],0,1));
+          done = (0 == atomicCAS(&Kokkos::Impl::g_device_cuda_lock_arrays.threadid[threadid],0,1));
           if(!done) {
             threadid += blockDim.x * blockDim.y;
-            if(threadid > Kokkos::Impl::device_cuda_lock_arrays.n) threadid = 0;
+            if(threadid > Kokkos::Impl::g_device_cuda_lock_arrays.n) threadid = 0;
           }
         }
         base_thread_id = threadid;
@@ -841,7 +841,7 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __syncthreads();
       if (threadIdx.x==0 && threadIdx.y==0 )
-        Kokkos::Impl::device_cuda_lock_arrays.threadid[threadid]=0;
+        Kokkos::Impl::g_device_cuda_lock_arrays.threadid[threadid]=0;
     }
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -436,7 +436,7 @@ public:
         if(threadid > Kokkos::Impl::g_device_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
         int done = 0;
         while (!done) {
-          done = (0 == atomicCAS(&Kokkos::Impl::g_device_cuda_lock_arrays.threadid[threadid],0,1));
+          done = (0 == atomicCAS(&Kokkos::Impl::g_device_cuda_lock_arrays.scratch[threadid],0,1));
           if(!done) {
             threadid += blockDim.x * blockDim.y;
             if(threadid > Kokkos::Impl::g_device_cuda_lock_arrays.n) threadid = 0;
@@ -463,7 +463,7 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __syncthreads();
       if (threadIdx.x==0 && threadIdx.y==0 )
-        Kokkos::Impl::g_device_cuda_lock_arrays.threadid[threadid]=0;
+        Kokkos::Impl::g_device_cuda_lock_arrays.scratch[threadid]=0;
     }
   }
 
@@ -825,7 +825,7 @@ public:
         if(threadid > Kokkos::Impl::g_device_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
         int done = 0;
         while (!done) {
-          done = (0 == atomicCAS(&Kokkos::Impl::g_device_cuda_lock_arrays.threadid[threadid],0,1));
+          done = (0 == atomicCAS(&Kokkos::Impl::g_device_cuda_lock_arrays.scratch[threadid],0,1));
           if(!done) {
             threadid += blockDim.x * blockDim.y;
             if(threadid > Kokkos::Impl::g_device_cuda_lock_arrays.n) threadid = 0;
@@ -841,7 +841,7 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __syncthreads();
       if (threadIdx.x==0 && threadIdx.y==0 )
-        Kokkos::Impl::g_device_cuda_lock_arrays.threadid[threadid]=0;
+        Kokkos::Impl::g_device_cuda_lock_arrays.scratch[threadid]=0;
     }
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -431,15 +431,15 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __shared__ int base_thread_id;
       if (threadIdx.x==0 && threadIdx.y==0 ) {
-        threadid = ((blockIdx.x*blockDim.z + threadIdx.z) * blockDim.x * blockDim.y) % kokkos_impl_cuda_lock_arrays.n;
+        threadid = ((blockIdx.x*blockDim.z + threadIdx.z) * blockDim.x * blockDim.y) % Kokkos::Impl::device_cuda_lock_arrays.n;
         threadid = ((threadid + blockDim.x * blockDim.y-1)/(blockDim.x * blockDim.y)) * blockDim.x * blockDim.y;
-        if(threadid > kokkos_impl_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
+        if(threadid > Kokkos::Impl::device_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
         int done = 0;
         while (!done) {
-          done = (0 == atomicCAS(&kokkos_impl_cuda_lock_arrays.threadid[threadid],0,1));
+          done = (0 == atomicCAS(&Kokkos::Impl::device_cuda_lock_arrays.threadid[threadid],0,1));
           if(!done) {
             threadid += blockDim.x * blockDim.y;
-            if(threadid > kokkos_impl_cuda_lock_arrays.n) threadid = 0;
+            if(threadid > Kokkos::Impl::device_cuda_lock_arrays.n) threadid = 0;
           }
         }
         base_thread_id = threadid;
@@ -463,7 +463,7 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __syncthreads();
       if (threadIdx.x==0 && threadIdx.y==0 )
-        kokkos_impl_cuda_lock_arrays.threadid[threadid]=0;
+        Kokkos::Impl::device_cuda_lock_arrays.threadid[threadid]=0;
     }
   }
 
@@ -820,15 +820,15 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __shared__ int base_thread_id;
       if (threadIdx.x==0 && threadIdx.y==0 ) {
-        threadid = ((blockIdx.x*blockDim.z + threadIdx.z) * blockDim.x * blockDim.y) % kokkos_impl_cuda_lock_arrays.n;
+        threadid = ((blockIdx.x*blockDim.z + threadIdx.z) * blockDim.x * blockDim.y) % Kokkos::Impl::device_cuda_lock_arrays.n;
         threadid = ((threadid + blockDim.x * blockDim.y-1)/(blockDim.x * blockDim.y)) * blockDim.x * blockDim.y;
-        if(threadid > kokkos_impl_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
+        if(threadid > Kokkos::Impl::device_cuda_lock_arrays.n) threadid-=blockDim.x * blockDim.y;
         int done = 0;
         while (!done) {
-          done = (0 == atomicCAS(&kokkos_impl_cuda_lock_arrays.threadid[threadid],0,1));
+          done = (0 == atomicCAS(&Kokkos::Impl::device_cuda_lock_arrays.threadid[threadid],0,1));
           if(!done) {
             threadid += blockDim.x * blockDim.y;
-            if(threadid > kokkos_impl_cuda_lock_arrays.n) threadid = 0;
+            if(threadid > Kokkos::Impl::device_cuda_lock_arrays.n) threadid = 0;
           }
         }
         base_thread_id = threadid;
@@ -841,7 +841,7 @@ public:
     if ( m_scratch_size[1]>0 ) {
       __syncthreads();
       if (threadIdx.x==0 && threadIdx.y==0 )
-        kokkos_impl_cuda_lock_arrays.threadid[threadid]=0;
+        Kokkos::Impl::device_cuda_lock_arrays.threadid[threadid]=0;
     }
   }
 

--- a/core/src/Kokkos_Atomic.hpp
+++ b/core/src/Kokkos_Atomic.hpp
@@ -114,40 +114,9 @@
 #endif /* Not pre-selected atomic implementation */
 #endif
 
-//----------------------------------------------------------------------------
-
-// Forward decalaration of functions supporting arbitrary sized atomics
-// This is necessary since Kokkos_Atomic.hpp is internally included very early
-// through Kokkos_HostSpace.hpp as well as the allocation tracker.
 #ifdef KOKKOS_ENABLE_CUDA
-namespace Kokkos {
-namespace Impl {
-/// \brief Aquire a lock for the address
-///
-/// This function tries to aquire the lock for the hash value derived
-/// from the provided ptr. If the lock is successfully aquired the
-/// function returns true. Otherwise it returns false.
-#ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
-extern
+#include <Cuda/Kokkos_Cuda_Locks.hpp>
 #endif
-__device__ inline
-bool lock_address_cuda_space(void* ptr);
-
-/// \brief Release lock for the address
-///
-/// This function releases the lock for the hash value derived
-/// from the provided ptr. This function should only be called
-/// after previously successfully aquiring a lock with
-/// lock_address.
-#ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
-extern
-#endif
-__device__ inline
-void unlock_address_cuda_space(void* ptr);
-}
-}
-#endif
-
 
 namespace Kokkos {
 template <typename T>


### PR DESCRIPTION
This small refactor of the `kokkos_impl_cuda_lock_arrays` system does a few things:

1. Fixes #852, i.e. many many warnings about `lock_address_cuda_space` when compiling with CUDA
2. Actually use `kokkos_impl_cuda_lock_arrays.threadid` for what I think its intended purpose was (`Kokkos_Cuda_Parallel.hpp`).
3. Remove `kokkos_impl_cuda_lock_arrays.scratch`, whose intended purpose I can't decipher, and which was being ignored along with `threadid`.
4. Uses a struct on the host to make it clearer how these arrays are initialized / used etc.

b18b9e7 passed the following `test_all_sandia` on `kokkos_dev`:
```
cuda-7.0.28-Cuda_OpenMP-release build_time=425 run_time=563
cuda-7.0.28-Cuda_Serial-release build_time=400 run_time=542
cuda-8.0.44-Cuda_OpenMP-release build_time=352 run_time=546
cuda-8.0.44-Cuda_Serial-release build_time=335 run_time=526
```
It was also tested with and without RDC on Pascal.