### PR TITLE
Include View label in bounds error on GPU

### DIFF
--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -71,6 +71,9 @@ public:
   KOKKOS_INLINE_FUNCTION static
   const SharedAllocationHeader * get_header( void * alloc_ptr )
     { return reinterpret_cast<SharedAllocationHeader*>( reinterpret_cast<char*>(alloc_ptr) - sizeof(SharedAllocationHeader) ); }
+
+  KOKKOS_INLINE_FUNCTION
+  const char* implementation_get_private_label() const { return m_label; }
 };
 
 template<>

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -73,7 +73,7 @@ public:
     { return reinterpret_cast<SharedAllocationHeader*>( reinterpret_cast<char*>(alloc_ptr) - sizeof(SharedAllocationHeader) ); }
 
   KOKKOS_INLINE_FUNCTION
-  const char* implementation_get_private_label() const { return m_label; }
+  const char* label() const { return m_label; }
 };
 
 template<>

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -315,6 +315,11 @@ public:
 #endif
     }
 
+  KOKKOS_INLINE_FUNCTION
+  bool has_record() const {
+    return (m_record_bits & (~DO_NOT_DEREF_FLAG)) != 0;
+  }
+
   KOKKOS_FORCEINLINE_FUNCTION
   ~SharedAllocationTracker()
     { KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_DECREMENT }

--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -213,6 +213,9 @@ struct enable_if< true , T > { typedef T type ; };
 
 //----------------------------------------------------------------------------
 
+template< class T , class R = void >
+struct enable_if_type { typedef R type; };
+
 } // namespace Impl
 } // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -213,9 +213,6 @@ struct enable_if< true , T > { typedef T type ; };
 
 //----------------------------------------------------------------------------
 
-template< class T , class R = void >
-struct enable_if_type { typedef R type; };
-
 } // namespace Impl
 } // namespace Kokkos
 

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3178,7 +3178,7 @@ static void run(MapType const& map) {
   char const* const header_start = user_alloc_start - sizeof(SharedAllocationHeader);
   SharedAllocationHeader const* const header =
     reinterpret_cast<SharedAllocationHeader const*>(header_start);
-  char const* const label = header->implementation_get_private_label();
+  char const* const label = header->label();
   enum { LEN = 128 };
   char msg[LEN];
   char const* const first_part = "View bounds error of view ";


### PR DESCRIPTION
This implements request #870.

Passed the following `test_all_sandia` on `kokkos_dev`
```
cuda-7.0.28-Cuda_OpenMP-debug build_time=596 run_time=675
cuda-7.0.28-Cuda_Serial-debug build_time=435 run_time=797
cuda-8.0.44-Cuda_OpenMP-debug build_time=397 run_time=716
cuda-8.0.44-Cuda_Serial-debug build_time=322 run_time=731
```