### PR TITLE
Split deep_copy Profiling hook into begin/end

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1799,6 +1799,20 @@ void deep_copy
 
   if ( (void *) dst.data() != (void*) src.data() ) {
 
+#if defined(KOKKOS_ENABLE_PROFILING)
+    if (Kokkos::Profiling::profileLibraryLoaded()) {
+      const size_t nbytes = sizeof(typename dst_type::value_type) * dst.span();
+      Kokkos::Profiling::beginDeepCopy(
+          Kokkos::Profiling::SpaceHandle(dst_memory_space::name()),
+          dst.label(),
+          dst.data(),
+          Kokkos::Profiling::SpaceHandle(src_memory_space::name()),
+          src.label(),
+          src.data(),
+          nbytes);
+    }
+#endif
+
     // Concern: If overlapping views then a parallel copy will be erroneous.
     // ...
 
@@ -1886,20 +1900,14 @@ void deep_copy
     else {
       Kokkos::Impl::throw_runtime_exception("deep_copy given views that would require a temporary allocation");
     }
+
 #if defined(KOKKOS_ENABLE_PROFILING)
     if (Kokkos::Profiling::profileLibraryLoaded()) {
-      const size_t nbytes = sizeof(typename dst_type::value_type) * dst.span();
-      Kokkos::Profiling::deepCopy(
-          Kokkos::Profiling::SpaceHandle(dst_memory_space::name()),
-          dst.label(),
-          dst.data(),
-          Kokkos::Profiling::SpaceHandle(src_memory_space::name()),
-          src.label(),
-          src.data(),
-          nbytes);
+      Kokkos::Profiling::endDeepCopy();
     }
 #endif
-  }
+
+  } // ( (void *) dst.data() != (void*) src.data() )
 }
 
 } /* namespace Kokkos */

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -81,10 +81,11 @@ typedef void (*popFunction)();
 typedef void (*allocateDataFunction)(const SpaceHandle, const char*, const void*, const uint64_t);
 typedef void (*deallocateDataFunction)(const SpaceHandle, const char*, const void*, const uint64_t);
 
-typedef void (*deepCopyFunction)(
-    const SpaceHandle, const char*, const void*,
-    const SpaceHandle, const char*, const void*,
-    const uint64_t);
+typedef void (*beginDeepCopyFunction)(
+    SpaceHandle, const char*, const void*,
+    SpaceHandle, const char*, const void*,
+    uint64_t);
+typedef void (*endDeepCopyFunction)();
 
 bool profileLibraryLoaded();
 
@@ -101,9 +102,10 @@ void popRegion();
 void allocateData(const SpaceHandle space, const std::string label, const void* ptr, const uint64_t size);
 void deallocateData(const SpaceHandle space, const std::string label, const void* ptr, const uint64_t size);
 
-void deepCopy(const SpaceHandle dst_space, const std::string dst_label, const void* dst_ptr,
+void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label, const void* dst_ptr,
     const SpaceHandle src_space, const std::string src_label, const void* src_ptr,
     const uint64_t size);
+void endDeepCopy();
 
 void initialize();
 void finalize();


### PR DESCRIPTION
[#890]

passed the following `test_all_sandia` on `kokkos-dev`:
```
gcc-4.7.2-OpenMP_Serial-hwloc-release build_time=147 run_time=106
gcc-4.7.2-OpenMP_Serial-release build_time=147 run_time=105
cuda-7.0.28-Cuda_OpenMP-release build_time=411 run_time=576
```

Also tested by adding support for this in one of the `kokkos-tools`, will create a PR for that next.