### PR TITLE
Enable heterogeneous dynamic task dag to work on Pascal GPU

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -57,7 +57,7 @@ namespace {
 template< typename TaskType >
 __global__
 void set_cuda_task_base_apply_function_pointer
-  ( TaskBase<Kokkos::Cuda,void,void>::function_type * ptr )
+  ( TaskBase<void,void,void>::function_type * ptr )
 { *ptr = TaskType::apply ; }
 
 }
@@ -78,7 +78,7 @@ public:
   void iff_single_thread_recursive_execute( queue_type * const ) {}
 
   __device__
-  static void driver( queue_type * const );
+  static void driver( queue_type * const , int32_t );
 
   static
   void execute( queue_type * const );
@@ -106,7 +106,14 @@ public:
 
 extern template class TaskQueue< Kokkos::Cuda > ;
 
+}} /* namespace Kokkos::Impl */
+
 //----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace Kokkos {
+namespace Impl {
+
 /**\brief  Impl::TaskExec<Cuda> is the TaskScheduler<Cuda>::member_type
  *         passed to tasks running in a Cuda space.
  *
@@ -134,11 +141,13 @@ private:
   friend class Kokkos::Impl::TaskQueue< Kokkos::Cuda > ;
   friend class Kokkos::Impl::TaskQueueSpecialization< Kokkos::Cuda > ;
 
+  int32_t * m_team_shmem ;
   const int m_team_size ;
 
   __device__
-  TaskExec( int arg_team_size = blockDim.y )
-    : m_team_size( arg_team_size ) {}
+  TaskExec( int32_t * arg_team_shmem , int arg_team_size = blockDim.y )
+    : m_team_shmem( arg_team_shmem )
+    , m_team_size( arg_team_size ) {}
 
 public:
 
@@ -154,7 +163,13 @@ public:
 
 };
 
+}} /* namespace Kokkos::Impl */
+
 //----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace Kokkos {
+namespace Impl {
 
 template<typename iType>
 struct TeamThreadRangeBoundariesStruct<iType, TaskExec< Kokkos::Cuda > >

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
@@ -105,7 +105,7 @@ void TaskQueueSpecialization< Kokkos::OpenMP >::execute
 {
   using execution_space = Kokkos::OpenMP ;
   using queue_type      = TaskQueue< execution_space > ;
-  using task_root_type  = TaskBase< execution_space , void , void > ;
+  using task_root_type  = TaskBase< void , void , void > ;
   using Member          = Impl::HostThreadTeamMember< execution_space > ;
 
   static task_root_type * const end =
@@ -155,7 +155,7 @@ void TaskQueueSpecialization< Kokkos::OpenMP >::execute
             if ( 0 != task && end != task ) {
               // team member #0 completes the previously executed task,
               // completion may delete the task
-              queue->complete( task );
+              queue->complete_runnable( task );
             }
 
             // If 0 == m_ready_count then set task = 0
@@ -211,7 +211,7 @@ void TaskQueueSpecialization< Kokkos::OpenMP >::
 {
   using execution_space = Kokkos::OpenMP ;
   using queue_type      = TaskQueue< execution_space > ;
-  using task_root_type  = TaskBase< execution_space , void , void > ;
+  using task_root_type  = TaskBase< void , void , void > ;
   using Member          = Impl::HostThreadTeamMember< execution_space > ;
 
   if ( 1 == OpenMP::thread_pool_size() ) {
@@ -240,7 +240,7 @@ void TaskQueueSpecialization< Kokkos::OpenMP >::
 
       (*task->m_apply)( task , & single_exec );
 
-      queue->complete( task );
+      queue->complete_runnable( task );
 
     } while(1);
   }

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
@@ -155,7 +155,7 @@ void TaskQueueSpecialization< Kokkos::OpenMP >::execute
             if ( 0 != task && end != task ) {
               // team member #0 completes the previously executed task,
               // completion may delete the task
-              queue->complete_runnable( task );
+              queue->complete( task );
             }
 
             // If 0 == m_ready_count then set task = 0
@@ -240,7 +240,7 @@ void TaskQueueSpecialization< Kokkos::OpenMP >::
 
       (*task->m_apply)( task , & single_exec );
 
-      queue->complete_runnable( task );
+      queue->complete( task );
 
     } while(1);
   }

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -60,7 +60,7 @@ public:
 
   using execution_space = Kokkos::OpenMP ;
   using queue_type      = Kokkos::Impl::TaskQueue< execution_space > ;
-  using task_base_type  = Kokkos::Impl::TaskBase< execution_space , void , void > ;
+  using task_base_type  = Kokkos::Impl::TaskBase< void , void , void > ;
   using member_type     = Kokkos::Impl::HostThreadTeamMember< execution_space > ;
 
   // Must specify memory space

--- a/core/src/impl/Kokkos_Serial_Task.cpp
+++ b/core/src/impl/Kokkos_Serial_Task.cpp
@@ -108,7 +108,7 @@ void TaskQueueSpecialization< Kokkos::Serial >::execute
 
       // If a respawn then re-enqueue otherwise the task is complete
       // and all tasks waiting on this task are updated.
-      queue->complete_runnable( task );
+      queue->complete( task );
     }
     else if ( 0 != queue->m_ready_count ) {
       Kokkos::abort("TaskQueue<Serial>::execute ERROR: ready_count");
@@ -149,7 +149,7 @@ void TaskQueueSpecialization< Kokkos::Serial > ::
 
     (*task->m_apply)( task , & exec );
 
-    queue->complete_runnable( task );
+    queue->complete( task );
 
   } while(1);
 }

--- a/core/src/impl/Kokkos_Serial_Task.cpp
+++ b/core/src/impl/Kokkos_Serial_Task.cpp
@@ -62,7 +62,7 @@ void TaskQueueSpecialization< Kokkos::Serial >::execute
 {
   using execution_space = Kokkos::Serial ;
   using queue_type      = TaskQueue< execution_space > ;
-  using task_root_type  = TaskBase< execution_space , void , void > ;
+  using task_root_type  = TaskBase< void , void , void > ;
   using Member          = Impl::HostThreadTeamMember< execution_space > ;
 
   task_root_type * const end = (task_root_type *) task_root_type::EndTag ;
@@ -108,7 +108,7 @@ void TaskQueueSpecialization< Kokkos::Serial >::execute
 
       // If a respawn then re-enqueue otherwise the task is complete
       // and all tasks waiting on this task are updated.
-      queue->complete( task );
+      queue->complete_runnable( task );
     }
     else if ( 0 != queue->m_ready_count ) {
       Kokkos::abort("TaskQueue<Serial>::execute ERROR: ready_count");
@@ -122,7 +122,7 @@ void TaskQueueSpecialization< Kokkos::Serial > ::
 {
   using execution_space = Kokkos::Serial ;
   using queue_type      = TaskQueue< execution_space > ;
-  using task_root_type  = TaskBase< execution_space , void , void > ;
+  using task_root_type  = TaskBase< void , void , void > ;
   using Member          = Impl::HostThreadTeamMember< execution_space > ;
 
   task_root_type * const end = (task_root_type *) task_root_type::EndTag ;
@@ -149,7 +149,7 @@ void TaskQueueSpecialization< Kokkos::Serial > ::
 
     (*task->m_apply)( task , & exec );
 
-    queue->complete( task );
+    queue->complete_runnable( task );
 
   } while(1);
 }

--- a/core/src/impl/Kokkos_Serial_Task.hpp
+++ b/core/src/impl/Kokkos_Serial_Task.hpp
@@ -65,7 +65,7 @@ public:
   using execution_space = Kokkos::Serial ;
   using memory_space    = Kokkos::HostSpace ;
   using queue_type      = Kokkos::Impl::TaskQueue< execution_space > ;
-  using task_base_type  = Kokkos::Impl::TaskBase< execution_space , void , void > ;
+  using task_base_type  = Kokkos::Impl::TaskBase< void , void , void > ;
   using member_type     = Kokkos::Impl::HostThreadTeamMember< execution_space > ;
 
   static

--- a/core/src/impl/Kokkos_TaskQueue.hpp
+++ b/core/src/impl/Kokkos_TaskQueue.hpp
@@ -59,187 +59,15 @@
 namespace Kokkos {
 namespace Impl {
 
-/*\brief  Implementation data for task data management, access, and execution.
- *
- *  Curiously recurring template pattern (CRTP)
- *  to allow static_cast from the
- *  task root type and a task's FunctorType.
- *
- *    TaskBase< Space , ResultType , FunctorType >
- *      : TaskBase< Space , ResultType , void >
- *      , FunctorType
- *      { ... };
- *
- *    TaskBase< Space , ResultType , void >
- *      : TaskBase< Space , void , void >
- *      { ... };
- */
 template< typename Space , typename ResultType , typename FunctorType >
 class TaskBase ;
 
-} /* namespace Impl */
-} /* namespace Kokkos */
-
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
-
-namespace Kokkos {
-namespace Impl {
+template< typename Space >
+class TaskQueue ;
 
 template< typename Space >
 class TaskQueueSpecialization ;
 
-/** \brief  Manage task allocation, deallocation, and scheduling.
- *
- *  Task execution is deferred to the TaskQueueSpecialization.
- *  All other aspects of task management have shared implementation.
- */
-template< typename ExecSpace >
-class TaskQueue {
-private:
-
-  friend class TaskQueueSpecialization< ExecSpace > ;
-  friend class Kokkos::TaskScheduler< ExecSpace > ;
-
-  using execution_space = ExecSpace ;
-  using specialization  = TaskQueueSpecialization< execution_space > ;
-  using memory_space    = typename specialization::memory_space ;
-  using device_type     = Kokkos::Device< execution_space , memory_space > ;
-  using memory_pool     = Kokkos::MemoryPool< device_type > ;
-  using task_root_type  = Kokkos::Impl::TaskBase<execution_space,void,void> ;
-
-  struct Destroy {
-    TaskQueue * m_queue ;
-    void destroy_shared_allocation();
-  };
-
-  //----------------------------------------
-
-  enum : int { NumQueue = 3 };
-
-  // Queue is organized as [ priority ][ type ]
-
-  memory_pool               m_memory ;
-  task_root_type * volatile m_ready[ NumQueue ][ 2 ];
-  long                      m_accum_alloc ; // Accumulated number of allocations
-  int                       m_count_alloc ; // Current number of allocations
-  int                       m_max_alloc ;   // Maximum number of allocations
-  int                       m_ready_count ; // Number of ready or executing
-
-  //----------------------------------------
-
-  ~TaskQueue();
-  TaskQueue() = delete ;
-  TaskQueue( TaskQueue && ) = delete ;
-  TaskQueue( TaskQueue const & ) = delete ;
-  TaskQueue & operator = ( TaskQueue && ) = delete ;
-  TaskQueue & operator = ( TaskQueue const & ) = delete ;
-
-  TaskQueue( const memory_pool & arg_memory_pool );
-
-  // Schedule a task
-  //   Precondition:
-  //     task is not executing
-  //     task->m_next is the dependence or zero
-  //   Postcondition:
-  //     task->m_next is linked list membership
-  KOKKOS_FUNCTION void schedule_runnable(  task_root_type * const );
-  KOKKOS_FUNCTION void schedule_aggregate( task_root_type * const );
-
-  // Reschedule a task
-  //   Precondition:
-  //     task is in Executing state
-  //     task->m_next == LockTag
-  //   Postcondition:
-  //     task is in Executing-Respawn state
-  //     task->m_next == 0 (no dependence)
-  KOKKOS_FUNCTION
-  void reschedule( task_root_type * );
-
-  // Complete a task
-  //   Precondition:
-  //     task is not executing
-  //     task->m_next == LockTag  =>  task is complete
-  //     task->m_next != LockTag  =>  task is respawn
-  //   Postcondition:
-  //     task->m_wait == LockTag  =>  task is complete
-  //     task->m_wait != LockTag  =>  task is waiting
-  KOKKOS_FUNCTION
-  void complete( task_root_type * );
-
-  KOKKOS_FUNCTION
-  static bool push_task( task_root_type * volatile * const
-                       , task_root_type * const );
-
-  KOKKOS_FUNCTION
-  static task_root_type * pop_ready_task( task_root_type * volatile * const );
-
-  KOKKOS_FUNCTION static
-  void decrement( task_root_type * task );
-
-public:
-
-  // If and only if the execution space is a single thread
-  // then execute ready tasks.
-  KOKKOS_INLINE_FUNCTION
-  void iff_single_thread_recursive_execute()
-    {
-#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
-      specialization::iff_single_thread_recursive_execute( this );
-#endif
-    }
-
-  void execute() { specialization::execute( this ); }
-
-  template< typename FunctorType >
-  void proc_set_apply( typename task_root_type::function_type * ptr )
-    {
-      specialization::template proc_set_apply< FunctorType >( ptr );
-    }
-
-  // Assign task pointer with reference counting of assigned tasks
-  template< typename LV , typename RV >
-  KOKKOS_FUNCTION static
-  void assign( TaskBase< execution_space,LV,void> ** const lhs
-             , TaskBase< execution_space,RV,void> *  const rhs )
-    {
-      using task_lhs = TaskBase< execution_space,LV,void> ;
-#if 0
-  {
-    printf( "assign( 0x%lx { 0x%lx %d %d } , 0x%lx { 0x%lx %d %d } )\n"
-          , uintptr_t( lhs ? *lhs : 0 )
-          , uintptr_t( lhs && *lhs ? (*lhs)->m_next : 0 )
-          , int( lhs && *lhs ? (*lhs)->m_task_type : 0 )
-          , int( lhs && *lhs ? (*lhs)->m_ref_count : 0 )
-          , uintptr_t(rhs)
-          , uintptr_t( rhs ? rhs->m_next : 0 )
-          , int( rhs ? rhs->m_task_type : 0 )
-          , int( rhs ? rhs->m_ref_count : 0 )
-          );
-    fflush( stdout );
-  }
-#endif
-
-      if ( *lhs ) decrement( *lhs );
-      if ( rhs ) { Kokkos::atomic_increment( &(rhs->m_ref_count) ); }
-
-      // Force write of *lhs
-
-      *static_cast< task_lhs * volatile * >(lhs) = rhs ;
-
-      Kokkos::memory_fence();
-    }
-
-  KOKKOS_FUNCTION
-  size_t allocate_block_size( size_t n ); ///< Actual block size allocated
-
-  KOKKOS_FUNCTION
-  void * allocate( size_t n ); ///< Allocate from the memory pool
-
-  KOKKOS_FUNCTION
-  void deallocate( void * p , size_t n ); ///< Deallocate to the memory pool
-};
-
 } /* namespace Impl */
 } /* namespace Kokkos */
 
@@ -248,29 +76,19 @@ public:
 
 namespace Kokkos {
 namespace Impl {
-
-template<>
-class TaskBase< void , void , void > {
-public:
-  enum : int16_t   { TaskTeam = 0 , TaskSingle = 1 , Aggregate = 2 };
-  enum : uintptr_t { LockTag = ~uintptr_t(0) , EndTag = ~uintptr_t(1) };
-};
 
 /** \brief  Base class for task management, access, and execution.
  *
  *  Inheritance structure to allow static_cast from the task root type
  *  and a task's FunctorType.
  *
- *    // Enable a Future to access result data
- *    TaskBase< Space , ResultType , void >
- *      : TaskBase< void , void , void >
- *      { ... };
- *
  *    // Enable a functor to access the base class
+ *    // and provide memory for result value.
  *    TaskBase< Space , ResultType , FunctorType >
- *      : TaskBase< Space , ResultType , void >
+ *      : TaskBase< void , void , void >
  *      , FunctorType
  *      { ... };
+ *    Followed by memory allocated for result value.
  *
  *
  *  States of a task:
@@ -331,38 +149,32 @@ public:
  *      m_next == LockTag: not a member of a wait queue
  *
  */
-template< typename ExecSpace >
-class TaskBase< ExecSpace , void , void >
+template<>
+class TaskBase< void , void , void >
 {
 public:
 
-  enum : int16_t   { TaskTeam   = TaskBase<void,void,void>::TaskTeam
-                   , TaskSingle = TaskBase<void,void,void>::TaskSingle
-                   , Aggregate  = TaskBase<void,void,void>::Aggregate };
-
-  enum : uintptr_t { LockTag = TaskBase<void,void,void>::LockTag
-                   , EndTag  = TaskBase<void,void,void>::EndTag };
-
-  using execution_space = ExecSpace ;
-  using queue_type      = TaskQueue< execution_space > ;
+  enum : int16_t   { TaskTeam = 0 , TaskSingle = 1 , Aggregate = 2 };
+  enum : uintptr_t { LockTag = ~uintptr_t(0) , EndTag = ~uintptr_t(1) };
 
   template< typename > friend class Kokkos::TaskScheduler ;
+
+  typedef TaskQueue< void > queue_type ;
 
   typedef void (* function_type) ( TaskBase * , void * );
 
   // sizeof(TaskBase) == 48
 
   function_type  m_apply ;       ///< Apply function pointer
-  queue_type   * m_queue ;       ///< Queue in which this task resides
+  queue_type   * m_queue ;       ///< Pointer to queue
   TaskBase     * m_wait ;        ///< Linked list of tasks waiting on this
   TaskBase     * m_next ;        ///< Waiting linked-list next
   int32_t        m_ref_count ;   ///< Reference count
   int32_t        m_alloc_size ;  ///< Allocation size
-  int32_t        m_dep_count ;   ///< Aggregate's number of dependences
+  int32_t        m_count ;       ///< Result count OR number of dependences
   int16_t        m_task_type ;   ///< Type of task
   int16_t        m_priority ;    ///< Priority of runnable task
 
-  TaskBase() = delete ;
   TaskBase( TaskBase && ) = delete ;
   TaskBase( const TaskBase & ) = delete ;
   TaskBase & operator = ( TaskBase && ) = delete ;
@@ -370,50 +182,24 @@ public:
 
   KOKKOS_INLINE_FUNCTION ~TaskBase() = default ;
 
-  // Constructor for a runnable task
-  KOKKOS_INLINE_FUNCTION
-  constexpr TaskBase( function_type arg_apply
-                    , queue_type  * arg_queue
-                    , TaskBase    * arg_dependence
-                    , int           arg_ref_count
-                    , int           arg_alloc_size
-                    , int           arg_task_type
-                    , int           arg_priority
-                    ) noexcept
-    : m_apply(      arg_apply )
-    , m_queue(      arg_queue )
-    , m_wait( 0 )
-    , m_next(       arg_dependence )
-    , m_ref_count(  arg_ref_count )
-    , m_alloc_size( arg_alloc_size )
-    , m_dep_count( 0 )
-    , m_task_type(  arg_task_type )
-    , m_priority(   arg_priority )
-    {}
-
-  // Constructor for an aggregate task
-  KOKKOS_INLINE_FUNCTION
-  constexpr TaskBase( queue_type  * arg_queue
-                    , int           arg_ref_count
-                    , int           arg_alloc_size
-                    , int           arg_dep_count
-                    ) noexcept
-    : m_apply( 0 )
-    , m_queue( arg_queue )
-    , m_wait( 0 )
-    , m_next( 0 )
-    , m_ref_count(  arg_ref_count )
-    , m_alloc_size( arg_alloc_size )
-    , m_dep_count(  arg_dep_count )
-    , m_task_type(  Aggregate )
-    , m_priority( 0 )
+  KOKKOS_INLINE_FUNCTION constexpr
+  TaskBase()
+    : m_apply(      0 )
+    , m_queue(      0 )
+    , m_wait(       0 )
+    , m_next(       0 )
+    , m_ref_count(  0 )
+    , m_alloc_size( 0 )
+    , m_count(      0 )
+    , m_task_type(  0 )
+    , m_priority(   0 )
     {}
 
   //----------------------------------------
 
   KOKKOS_INLINE_FUNCTION
-  TaskBase ** aggregate_dependences()
-    { return reinterpret_cast<TaskBase**>( this + 1 ); }
+  TaskBase * volatile * aggregate_dependences() volatile
+    { return reinterpret_cast<TaskBase*volatile*>( this + 1 ); }
 
   KOKKOS_INLINE_FUNCTION
   bool requested_respawn()
@@ -425,7 +211,7 @@ public:
     }
 
   KOKKOS_INLINE_FUNCTION
-  void add_dependence( TaskBase* dep )
+  void request_respawn( TaskBase * arg_dep , int arg_priority )
     {
       // Precondition: lock == m_next
 
@@ -433,77 +219,208 @@ public:
 
       // Assign dependence to m_next.  It will be processed in the subsequent
       // call to schedule.  Error if the dependence is reset.
-      if ( lock != Kokkos::atomic_exchange( & m_next, dep ) ) {
+      if ( lock != Kokkos::atomic_exchange( & m_next, arg_dep ) ) {
         Kokkos::abort("TaskScheduler ERROR: resetting task dependence");
       }
 
-      if ( 0 != dep ) {
+      m_priority = int16_t(arg_priority);
+
+      if ( 0 != arg_dep ) {
         // The future may be destroyed upon returning from this call
         // so increment reference count to track this assignment.
-        Kokkos::atomic_increment( &(dep->m_ref_count) );
+        Kokkos::atomic_increment( &(arg_dep->m_ref_count) );
       }
     }
 
-  using get_return_type = void ;
+  //----------------------------------------
 
   KOKKOS_INLINE_FUNCTION
-  get_return_type get() const {}
+  int32_t reference_count() const
+    { return *((int32_t volatile *)( & m_ref_count )); }
+
+  template< typename ResultType >
+  KOKKOS_FUNCTION
+  ResultType * result_ptr()
+    {
+      return reinterpret_cast< ResultType * >
+        ( reinterpret_cast<char*>(this) +
+          *((const volatile int32_t *) & m_alloc_size) -
+          *((const volatile int32_t *) & m_count) );
+    }
 };
 
-template < typename ExecSpace , typename ResultType >
-class TaskBase< ExecSpace , ResultType , void >
-  : public TaskBase< ExecSpace , void , void >
-{
+static_assert( sizeof(TaskBase<void,void,void>) == 48
+             , "Verifying expected sizeof(TaskBase<void,void,void>)" );
+
+} /* namespace Impl */
+} /* namespace Kokkos */
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace Kokkos {
+namespace Impl {
+
+template<>
+class TaskQueue< void > {};
+
+/** \brief  Manage task allocation, deallocation, and scheduling.
+ *
+ *  Task execution is deferred to the TaskQueueSpecialization.
+ *  All other aspects of task management have shared implementation.
+ */
+template< typename ExecSpace >
+class TaskQueue : public TaskQueue<void> {
 private:
 
-  using root_type     = TaskBase<ExecSpace,void,void> ;
-  using function_type = typename root_type::function_type ;
-  using queue_type    = typename root_type::queue_type ;
+  friend class TaskQueueSpecialization< ExecSpace > ;
+  friend class Kokkos::TaskScheduler< ExecSpace > ;
 
-  static_assert( sizeof(root_type) == 48 , "" );
+  using execution_space = ExecSpace ;
+  using specialization  = TaskQueueSpecialization< execution_space > ;
+  using memory_space    = typename specialization::memory_space ;
+  using device_type     = Kokkos::Device< execution_space , memory_space > ;
+  using memory_pool     = Kokkos::MemoryPool< device_type > ;
+  using task_root_type  = Kokkos::Impl::TaskBase<void,void,void> ;
 
-  TaskBase() = delete ;
-  TaskBase( TaskBase && ) = delete ;
-  TaskBase( const TaskBase & ) = delete ;
-  TaskBase & operator = ( TaskBase && ) = delete ;
-  TaskBase & operator = ( const TaskBase & ) = delete ;
+  struct Destroy {
+    TaskQueue * m_queue ;
+    void destroy_shared_allocation();
+  };
+
+  //----------------------------------------
+
+  enum : int { NumQueue = 3 };
+
+  // Queue is organized as [ priority ][ type ]
+
+  memory_pool               m_memory ;
+  task_root_type * volatile m_ready[ NumQueue ][ 2 ];
+  long                      m_accum_alloc ; // Accumulated number of allocations
+  int                       m_count_alloc ; // Current number of allocations
+  int                       m_max_alloc ;   // Maximum number of allocations
+  int                       m_ready_count ; // Number of ready or executing
+
+  //----------------------------------------
+
+  ~TaskQueue();
+  TaskQueue() = delete ;
+  TaskQueue( TaskQueue && ) = delete ;
+  TaskQueue( TaskQueue const & ) = delete ;
+  TaskQueue & operator = ( TaskQueue && ) = delete ;
+  TaskQueue & operator = ( TaskQueue const & ) = delete ;
+
+  TaskQueue( const memory_pool & arg_memory_pool );
+
+  // Schedule a task
+  //   Precondition:
+  //     task is not executing
+  //     task->m_wait == head of queue (linked list)
+  //     task->m_next == 0
+  //   Postcondition:
+  //     task->m_wait == head of queue (linked list)
+  //     task->m_next is linked list membership
+  KOKKOS_FUNCTION void schedule_runnable(  task_root_type * const task
+                                        ,  task_root_type * const dep );
+  KOKKOS_FUNCTION void schedule_aggregate( task_root_type * );
+
+  // Complete a task
+  //   Precondition:
+  //     task is not executing
+  //     task->m_next == LockTag  =>  task is complete
+  //     task->m_next != LockTag  =>  task is respawn
+  //   Postcondition:
+  //     task->m_wait == LockTag  =>  task is complete
+  //     task->m_wait != LockTag  =>  task is waiting
+  KOKKOS_FUNCTION
+  void complete_runnable( task_root_type * );
+
+  KOKKOS_FUNCTION
+  static bool push_task( task_root_type * volatile * const
+                       , task_root_type * const );
+
+  // Pop a task from a ready queue for immediate execution
+  // If    task == end then ready queue is empty
+  // Else  task->m_next == LockTag; task cannot be a member of a queue
+  KOKKOS_FUNCTION
+  static task_root_type * pop_ready_task( task_root_type * volatile * const );
+
+  KOKKOS_FUNCTION static
+  void decrement( task_root_type * task );
 
 public:
 
-  ResultType   m_result ;
-
-  KOKKOS_INLINE_FUNCTION ~TaskBase() = default ;
-
-  // Constructor for runnable task
+  // If and only if the execution space is a single thread
+  // then execute ready tasks.
   KOKKOS_INLINE_FUNCTION
-  constexpr TaskBase( function_type arg_apply
-                    , queue_type  * arg_queue
-                    , root_type   * arg_dependence
-                    , int           arg_ref_count
-                    , int           arg_alloc_size
-                    , int           arg_task_type
-                    , int           arg_priority
-                    )
-    : root_type( arg_apply
-               , arg_queue
-               , arg_dependence
-               , arg_ref_count
-               , arg_alloc_size
-               , arg_task_type
-               , arg_priority
-               )
-    , m_result()
-    {}
+  void iff_single_thread_recursive_execute()
+    {
+#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+      specialization::iff_single_thread_recursive_execute( this );
+#endif
+    }
 
-  using get_return_type = ResultType const & ;
+  void execute() { specialization::execute( this ); }
 
-  KOKKOS_INLINE_FUNCTION
-  get_return_type get() const { return m_result ; }
+  template< typename FunctorType >
+  void proc_set_apply( typename task_root_type::function_type * ptr )
+    {
+      specialization::template proc_set_apply< FunctorType >( ptr );
+    }
+
+  // Assign task pointer with reference counting of assigned tasks
+  KOKKOS_FUNCTION static
+  void assign( task_root_type ** const lhs
+             , task_root_type *  const rhs )
+    {
+#if 0
+  {
+    printf( "assign( 0x%lx { 0x%lx %d %d } , 0x%lx { 0x%lx %d %d } )\n"
+          , uintptr_t( lhs ? *lhs : 0 )
+          , uintptr_t( lhs && *lhs ? (*lhs)->m_next : 0 )
+          , int( lhs && *lhs ? (*lhs)->m_task_type : 0 )
+          , int( lhs && *lhs ? (*lhs)->m_ref_count : 0 )
+          , uintptr_t(rhs)
+          , uintptr_t( rhs ? rhs->m_next : 0 )
+          , int( rhs ? rhs->m_task_type : 0 )
+          , int( rhs ? rhs->m_ref_count : 0 )
+          );
+    fflush( stdout );
+  }
+#endif
+
+      if ( *lhs ) decrement( *lhs );
+      if ( rhs ) { Kokkos::atomic_increment( &(rhs->m_ref_count) ); }
+
+      // Force write of *lhs
+
+      *static_cast< task_root_type * volatile * >(lhs) = rhs ;
+
+      Kokkos::memory_fence();
+    }
+
+  KOKKOS_FUNCTION
+  size_t allocate_block_size( size_t n ); ///< Actual block size allocated
+
+  KOKKOS_FUNCTION
+  void * allocate( size_t n ); ///< Allocate from the memory pool
+
+  KOKKOS_FUNCTION
+  void deallocate( void * p , size_t n ); ///< Deallocate to the memory pool
 };
+
+} /* namespace Impl */
+} /* namespace Kokkos */
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace Kokkos {
+namespace Impl {
 
 template< typename ExecSpace , typename ResultType , typename FunctorType >
 class TaskBase
-  : public TaskBase< ExecSpace , ResultType , void >
+  : public TaskBase< void , void , void >
   , public FunctorType
 {
 private:
@@ -516,50 +433,31 @@ private:
 
 public:
 
-  using root_type       = TaskBase< ExecSpace , void , void > ;
-  using base_type       = TaskBase< ExecSpace , ResultType , void > ;
-  using specialization  = TaskQueueSpecialization< ExecSpace > ;
-  using function_type   = typename root_type::function_type ;
-  using queue_type      = typename root_type::queue_type ;
-  using member_type     = typename specialization::member_type ;
+  using root_type       = TaskBase< void , void , void > ;
   using functor_type    = FunctorType ;
   using result_type     = ResultType ;
 
-  template< typename Type >
-  KOKKOS_INLINE_FUNCTION static
-  void apply_functor
-    ( Type * const task
-    , typename std::enable_if
-        < std::is_same< typename Type::result_type , void >::value
-        , member_type * const
-        >::type member
-    )
-    {
-      using fType = typename Type::functor_type ;
-      static_cast<fType*>(task)->operator()( *member );
-    }
+  using specialization  = TaskQueueSpecialization< ExecSpace > ;
+  using member_type     = typename specialization::member_type ;
 
-  template< typename Type >
-  KOKKOS_INLINE_FUNCTION static
-  void apply_functor
-    ( Type * const task
-    , typename std::enable_if
-        < ! std::is_same< typename Type::result_type , void >::value
-        , member_type * const
-        >::type member
-    )
-    {
-      using fType = typename Type::functor_type ;
-      static_cast<fType*>(task)->operator()( *member , task->m_result );
-    }
+  KOKKOS_INLINE_FUNCTION
+  void apply_functor( member_type * const member , void * )
+    { functor_type::operator()( *member ); }
+
+  template< typename T >
+  KOKKOS_INLINE_FUNCTION
+  void apply_functor( member_type * const member
+                    , T           * const result )
+    { functor_type::operator()( *member , *result ); }
 
   KOKKOS_FUNCTION static
   void apply( root_type * root , void * exec )
     {
       TaskBase    * const task   = static_cast< TaskBase * >( root );
       member_type * const member = reinterpret_cast< member_type * >( exec );
+      result_type * const result = root->template result_ptr< result_type >();
 
-      TaskBase::template apply_functor( task , member );
+      task->apply_functor( member , result );
 
       // Task may be serial or team.
       // If team then must synchronize before querying if respawn was requested.
@@ -576,26 +474,9 @@ public:
     }
 
   // Constructor for runnable task
-  KOKKOS_INLINE_FUNCTION
-  constexpr TaskBase( function_type arg_apply
-                    , queue_type  * arg_queue
-                    , root_type   * arg_dependence
-                    , int           arg_ref_count
-                    , int           arg_alloc_size
-                    , int           arg_task_type
-                    , int           arg_priority
-                    , FunctorType && arg_functor
-                    )
-    : base_type( arg_apply
-               , arg_queue
-               , arg_dependence
-               , arg_ref_count
-               , arg_alloc_size
-               , arg_task_type
-               , arg_priority
-               )
-    , functor_type( arg_functor )
-    {}
+  KOKKOS_INLINE_FUNCTION constexpr
+  TaskBase( FunctorType && arg_functor )
+    : root_type() , functor_type( std::move(arg_functor) ) {}
 
   KOKKOS_INLINE_FUNCTION
   ~TaskBase() {}

--- a/core/src/impl/Kokkos_TaskQueue_impl.hpp
+++ b/core/src/impl/Kokkos_TaskQueue_impl.hpp
@@ -44,6 +44,8 @@
 #include <Kokkos_Macros.hpp>
 #if defined( KOKKOS_ENABLE_TASKDAG )
 
+#define KOKKOS_IMPL_DEBUG_TASKDAG_SCHEDULING 0
+
 namespace Kokkos {
 namespace Impl {
 
@@ -104,13 +106,13 @@ void TaskQueue< ExecSpace >::decrement
 
   const int count = Kokkos::atomic_fetch_add(&(t.m_ref_count),-1);
 
-#if 0
+#if KOKKOS_IMPL_DEBUG_TASKDAG_SCHEDULING
   if ( 1 == count ) {
     printf( "decrement-destroy( 0x%lx { 0x%lx %d %d } )\n"
           , uintptr_t( task )
-          , uintptr_t( task.m_next )
-          , int( task.m_task_type )
-          , int( task.m_ref_count )
+          , uintptr_t( task->m_next )
+          , int( task->m_task_type )
+          , int( task->m_ref_count )
           );
   }
 #endif
@@ -177,7 +179,7 @@ bool TaskQueue< ExecSpace >::push_task
   // Fail the push attempt if the queue is locked;
   // otherwise retry until the push succeeds.
 
-#if 0
+#if KOKKOS_IMPL_DEBUG_TASKDAG_SCHEDULING
   printf( "push_task( 0x%lx { 0x%lx } 0x%lx { 0x%lx 0x%lx %d %d %d } )\n"
         , uintptr_t(queue)
         , uintptr_t(*queue)
@@ -282,7 +284,7 @@ TaskQueue< ExecSpace >::pop_ready_task
 
       Kokkos::memory_fence();
 
-#if 0
+#if KOKKOS_IMPL_DEBUG_TASKDAG_SCHEDULING
       printf( "pop_ready_task( 0x%lx 0x%lx { 0x%lx 0x%lx %d %d %d } )\n"
             , uintptr_t(queue)
             , uintptr_t(task)
@@ -331,7 +333,7 @@ void TaskQueue< ExecSpace >::schedule_runnable
   //     task->m_wait == head of linked list (queue)
   //     task->m_next == member of linked list (queue)
 
-#if 0
+#if KOKKOS_IMPL_DEBUG_TASKDAG_SCHEDULING
   printf( "schedule_runnable( 0x%lx { 0x%lx 0x%lx %d %d %d }\n"
         , uintptr_t(task)
         , uintptr_t(task->m_wait)
@@ -453,7 +455,7 @@ void TaskQueue< ExecSpace >::schedule_aggregate
   //     task->m_wait == head of linked list (queue)
   //     task->m_next == member of linked list (queue)
 
-#if 0
+#if KOKKOS_IMPL_DEBUG_TASKDAG_SCHEDULING
   printf( "schedule_aggregate( 0x%lx { 0x%lx 0x%lx %d %d %d }\n"
         , uintptr_t(task)
         , uintptr_t(task->m_wait)
@@ -587,7 +589,7 @@ void TaskQueue< ExecSpace >::complete
   task_root_type * const lock = (task_root_type *) task_root_type::LockTag ;
   task_root_type * const end  = (task_root_type *) task_root_type::EndTag ;
 
-#if 0
+#if KOKKOS_IMPL_DEBUG_TASKDAG_SCHEDULING
   printf( "complete( 0x%lx { 0x%lx 0x%lx %d %d %d }\n"
         , uintptr_t(task)
         , uintptr_t(task->m_wait)

--- a/core/src/impl/Kokkos_TaskQueue_impl.hpp
+++ b/core/src/impl/Kokkos_TaskQueue_impl.hpp
@@ -100,25 +100,34 @@ KOKKOS_FUNCTION
 void TaskQueue< ExecSpace >::decrement
   ( TaskQueue< ExecSpace >::task_root_type * task )
 {
-  const int count = Kokkos::atomic_fetch_add(&(task->m_ref_count),-1);
+  task_root_type volatile & t = *task ;
+
+  const int count = Kokkos::atomic_fetch_add(&(t.m_ref_count),-1);
 
 #if 0
   if ( 1 == count ) {
     printf( "decrement-destroy( 0x%lx { 0x%lx %d %d } )\n"
           , uintptr_t( task )
-          , uintptr_t( task->m_next )
-          , int( task->m_task_type )
-          , int( task->m_ref_count )
+          , uintptr_t( task.m_next )
+          , int( task.m_task_type )
+          , int( task.m_ref_count )
           );
   }
 #endif
 
   if ( ( 1 == count ) &&
-       ( task->m_next == (task_root_type *) task_root_type::LockTag ) ) {
+       ( t.m_next == (task_root_type *) task_root_type::LockTag ) ) {
+
     // Reference count is zero and task is complete, deallocate.
-    task->m_queue->deallocate( task , task->m_alloc_size );
+
+    TaskQueue< ExecSpace > * const queue =
+      static_cast< TaskQueue< ExecSpace > * >( t.m_queue );
+
+    queue->deallocate( task , t.m_alloc_size );
   }
   else if ( count <= 1 ) {
+    // Reference count is negative or 
+    // Reference count is zero and task is incomplete
     Kokkos::abort("TaskScheduler task has negative reference count or is incomplete" );
   }
 }
@@ -186,9 +195,9 @@ bool TaskQueue< ExecSpace >::push_task
   task_root_type * const zero = (task_root_type *) 0 ;
   task_root_type * const lock = (task_root_type *) task_root_type::LockTag ;
 
-  task_root_type * volatile * const next = & task->m_next ;
+  task_root_type * volatile & next = task->m_next ;
 
-  if ( zero != *next ) {
+  if ( zero != next ) {
     Kokkos::abort("TaskQueue::push_task ERROR: already a member of another queue" );
   }
 
@@ -196,9 +205,9 @@ bool TaskQueue< ExecSpace >::push_task
 
   while ( lock != y ) {
 
-    *next = y ;
+    next = y ;
 
-    // Do not proceed until '*next' has been stored.
+    // Do not proceed until 'next' has been stored.
     Kokkos::memory_fence();
 
     task_root_type * const x = y ;
@@ -211,9 +220,9 @@ bool TaskQueue< ExecSpace >::push_task
   // Failed, replace 'task->m_next' value since 'task' remains
   // not a member of a queue.
 
-  *next = zero ;
+  next = zero ;
 
-  // Do not proceed until '*next' has been stored.
+  // Do not proceed until 'next' has been stored.
   Kokkos::memory_fence();
 
   return false ;
@@ -270,7 +279,9 @@ TaskQueue< ExecSpace >::pop_ready_task
       // This thread has exclusive access to
       // the queue and the popped task's m_next.
 
-      *queue = task->m_next ; task->m_next = lock ;
+      task_root_type * volatile & next = task->m_next ;
+
+      *queue = next ; next = lock ;
 
       Kokkos::memory_fence();
 
@@ -297,68 +308,46 @@ TaskQueue< ExecSpace >::pop_ready_task
 template< typename ExecSpace >
 KOKKOS_FUNCTION
 void TaskQueue< ExecSpace >::schedule_runnable
-  ( TaskQueue< ExecSpace >::task_root_type * const task )
+  ( TaskQueue< ExecSpace >::task_root_type * const task
+  , TaskQueue< ExecSpace >::task_root_type * const dep )
 {
   // Schedule a runnable task upon construction / spawn
   // and upon completion of other tasks that 'task' is waiting on.
   //
   // Precondition:
-  // - called by a single thread for the input task
-  // - calling thread has exclusive access to the task
-  // - task is not a member of a queue
-  // - if runnable then task is either constructing or respawning
+  //   - called by a single thread for the input task
+  //   - calling thread has exclusive access to the task
   //
-  //   Constructing state:
-  //     task->m_wait == 0
-  //     task->m_next == dependence or 0
-  //   Respawn state:
-  //     task->m_wait == head of linked list: 'end' or valid task
-  //     task->m_next == dependence or 0
+  //   task->m_wait == head of queue (linked list)
+  //   task->m_next == 0 ; not a member of a queue (linked list)
   //
   //  Task state transition:
   //     Constructing ->  Waiting
   //     Respawn      ->  Waiting
   //
   //  Postcondition on task state:
-  //     task->m_wait == head of linked list (queue)
-  //     task->m_next == member of linked list (queue)
+  //     task->m_wait == head of queue (linked list)
+  //     task->m_next == member of queue (linked list)
 
 #if 0
-  printf( "schedule_runnable( 0x%lx { 0x%lx 0x%lx %d %d %d }\n"
+  printf( "schedule_runnable( 0x%lx { 0x%lx 0x%lx %d %d %d } 0x%lx\n"
         , uintptr_t(task)
         , uintptr_t(task->m_wait)
         , uintptr_t(task->m_next)
         , task->m_task_type
         , task->m_priority
-        , task->m_ref_count );
+        , task->m_ref_count
+        , uintptr_t(dep) );
 #endif
 
-  task_root_type * const zero = (task_root_type *) 0 ;
-  task_root_type * const lock = (task_root_type *) task_root_type::LockTag ;
-  task_root_type * const end  = (task_root_type *) task_root_type::EndTag ;
-
-  bool respawn = false ;
+  task_root_type volatile & t = *task ;
 
   //----------------------------------------
 
-  if ( zero == task->m_wait ) {
-    // Task in Constructing state
-    // - Transition to Waiting state
-    // Preconditions:
-    // - call occurs exclusively within a single thread
-
-    task->m_wait = end ;
-    // Task in Waiting state
-  }
-  else if ( lock != task->m_wait ) {
-    // Task in Executing state with Respawn request
-    // - Update dependence
-    // - Transition to Waiting state
-    respawn = true ;
-  }
-  else {
-    // Task in Complete state
-    Kokkos::abort("TaskQueue::schedule_runnable ERROR: task is complete");
+  if ( ((task_root_type *) task_root_type::LockTag) == t.m_wait ||
+       ((task_root_type *) 0)                       == t.m_wait ||
+       ((task_root_type *) 0)                       != t.m_next ) {
+    Kokkos::abort("TaskQueue::schedule_runnable ERROR: task is not constructing or respawning");
   }
 
   //----------------------------------------
@@ -371,24 +360,7 @@ void TaskQueue< ExecSpace >::schedule_runnable
   // If the push fails then 'dep' is complete and 'task'
   // is ready to execute.
 
-  // Exclusive access so don't need an atomic exchange
-  // task_root_type * dep = Kokkos::atomic_exchange( & task->m_next , zero );
-  task_root_type * dep = task->m_next ; task->m_next = zero ;
-
-  const bool is_ready =
-    ( 0 == dep ) || ( ! push_task( & dep->m_wait , task ) );
-
-  if ( ( 0 != dep ) && respawn ) {
-    // Reference count for dep was incremented when
-    // respawn assigned dependency to task->m_next
-    // so that if dep completed prior to the
-    // above push_task dep would not be destroyed.
-    // dep reference count can now be decremented,
-    // which may deallocate the task.
-    TaskQueue::assign( & dep , (task_root_type *)0 );
-  }
-
-  if ( is_ready ) {
+  if ( ( 0 == dep ) || ( ! push_task( & dep->m_wait , task ) ) ) {
 
     // No dependence or 'dep' is complete so push task into ready queue.
     // Increment the ready count before pushing into ready queue
@@ -398,7 +370,7 @@ void TaskQueue< ExecSpace >::schedule_runnable
     Kokkos::atomic_increment( & m_ready_count );
 
     task_root_type * volatile * const ready_queue =
-      & m_ready[ task->m_priority ][ task->m_task_type ];
+      & m_ready[ t.m_priority ][ t.m_task_type ];
 
     // A push_task fails if the ready queue is locked.
     // A ready queue is only locked during a push or pop;
@@ -420,26 +392,14 @@ void TaskQueue< ExecSpace >::schedule_runnable
 template< typename ExecSpace >
 KOKKOS_FUNCTION
 void TaskQueue< ExecSpace >::schedule_aggregate
-  ( TaskQueue< ExecSpace >::task_root_type * const task )
+  ( TaskQueue< ExecSpace >::task_root_type * task )
 {
   // Schedule an aggregate task upon construction
   // and upon completion of other tasks that 'task' is waiting on.
   //
   // Precondition:
-  // - called by a single thread for the input task
-  // - calling thread has exclusive access to the task
-  // - task is not a member of a queue
-  //
-  //   Constructing state:
-  //     task->m_wait == 0
-  //     task->m_next == dependence or 0
-  //
-  //  Task state transition:
-  //     Constructing ->  Waiting
-  //
-  //  Postcondition on task state:
-  //     task->m_wait == head of linked list (queue)
-  //     task->m_next == member of linked list (queue)
+  //   - called by a single thread for the input task
+  //   - calling thread has exclusive access to the task
 
 #if 0
   printf( "schedule_aggregate( 0x%lx { 0x%lx 0x%lx %d %d %d }\n"
@@ -452,68 +412,68 @@ void TaskQueue< ExecSpace >::schedule_aggregate
 #endif
 
   task_root_type * const zero = (task_root_type *) 0 ;
-  task_root_type * const lock = (task_root_type *) task_root_type::LockTag ;
   task_root_type * const end  = (task_root_type *) task_root_type::EndTag ;
-
-  //----------------------------------------
-
-  if ( zero == task->m_wait ) {
-    // Task in Constructing state
-    // - Transition to Waiting state
-    // Preconditions:
-    // - call occurs exclusively within a single thread
-
-    task->m_wait = end ;
-    // Task in Waiting state
-  }
-  else if ( lock == task->m_wait ) {
-    // Task in Complete state
-    Kokkos::abort("TaskQueue::schedule_aggregate ERROR: task is complete");
-  }
-
-  //----------------------------------------
-  // Scheduling a 'when_all' task with multiple dependences.
-  // This scheduling may be called when the 'when_all' is
-  // (1) created or
-  // (2) being removed from a completed task's wait list.
-
-  task_root_type ** const aggr = task->aggregate_dependences();
+  task_root_type * const lock = (task_root_type *) task_root_type::LockTag ;
 
   // Assume the 'when_all' is complete until a dependence is
   // found that is not complete.
 
   bool is_complete = true ;
 
-  for ( int i = task->m_dep_count ; 0 < i && is_complete ; ) {
+  {
+    task_root_type volatile & t = *task ;
 
-    --i ;
+    //----------------------------------------
 
-    // Loop dependences looking for an incomplete task.
-    // Add this task to the incomplete task's wait queue.
+    if ( lock == t.m_wait || zero == t.m_wait || zero != t.m_next ) {
+      Kokkos::abort("TaskQueue::schedule_aggregate ERROR: task is complete");
+    }
 
-    // Remove a task 'x' from the dependence list.
-    // The reference count of 'x' was incremented when
-    // it was assigned into the dependence list.
+    //----------------------------------------
+    // Scheduling a 'when_all' task with multiple dependences.
+    // This scheduling may be called when the 'when_all' is
+    // (1) created or
+    // (2) being removed from a completed task's wait list.
 
-    // Exclusive access so don't need an atomic exchange
-    // task_root_type * x = Kokkos::atomic_exchange( aggr + i , zero );
-    task_root_type * x = aggr[i] ; aggr[i] = zero ;
+    task_root_type * volatile * const aggr = t.aggregate_dependences();
 
-    if ( x ) {
+    for ( int i = t.m_count ; 0 < i && is_complete ; ) {
 
-      // If x->m_wait is not locked then push succeeds
-      // and the aggregate is not complete.
-      // If the push succeeds then this when_all 'task' may be
-      // processed by another thread at any time.
-      // For example, 'x' may be completeed by another
-      // thread and then re-schedule this when_all 'task'.
+      --i ;
 
-      is_complete = ! push_task( & x->m_wait , task );
+      // Loop dependences looking for an incomplete task.
+      // Add this task to the incomplete task's wait queue.
 
-      // Decrement reference count which had been incremented
-      // when 'x' was added to the dependence list.
+      // Remove a task 'x' from the dependence list.
+      // The reference count of 'x' was incremented when
+      // it was assigned into the dependence list.
 
-      TaskQueue::assign( & x , zero );
+      // Exclusive access so don't need an atomic exchange
+
+      task_root_type * x = aggr[i] ;
+
+      if ( zero != x ) {
+
+        aggr[i] = 0 ;
+
+        Kokkos::memory_fence();
+
+        // If x->m_wait is not locked then push succeeds
+        // and the aggregate is not complete.
+        // If the push succeeds then this when_all 'task' may be
+        // processed by another thread at any time.
+        // For example, 'x' may be completeed by another
+        // thread and then re-schedule this when_all 'task'.
+
+        is_complete = ! push_task( & x->m_wait , task );
+
+        // task 'x' is in a queue and could be updated at any time..
+
+        // Decrement reference count which had been incremented
+        // when 'x' was added to the dependence list.
+
+        TaskQueue::assign( & x , zero );
+      }
     }
   }
 
@@ -523,10 +483,49 @@ void TaskQueue< ExecSpace >::schedule_aggregate
     // Complete the when_all 'task' to schedule other tasks
     // that are waiting for the when_all 'task' to complete.
 
-    task->m_next = lock ;
 
-    complete( task );
+    // Any of the runnable tasks that this aggregate depends upon
+    // may be attempting to complete this aggregate.
+    // Must only transition a task once to complete status.
+    // This is controled by atomically locking the wait queue.
 
+    // Stop other tasks from adding themselves to this task's wait queue
+    // by locking the head of this task's wait queue.
+
+    task_root_type * x = Kokkos::atomic_exchange( & task->m_wait , lock );
+
+    if ( lock != x ) {
+
+      // This thread has transitioned this aggregate to complete.
+
+      task->m_next = lock ;
+
+      Kokkos::memory_fence();
+
+      TaskQueue::assign( & task , zero );
+
+      // task may have just been deallocated
+
+      // This thread has exclusive access to the wait list so
+      // the concurrency-safe pop_ready_task function is not needed.
+      // Schedule the tasks that have been waiting on the input 'task',
+      // which may have been deleted.
+
+      while ( x != end ) {
+        // Have exclusive access to 'x' until it is scheduled
+        // Set x->m_next = zero  <=  not in a queue
+
+        task_root_type volatile & vx = *x ;
+
+        task_root_type * const next = vx.m_next ; vx.m_next = 0 ;
+
+        Kokkos::memory_fence();
+
+        schedule_runnable( x , zero );
+
+        x = next ;
+      }
+    }
     // '*task' may have been deleted upon completion
   }
 
@@ -541,29 +540,7 @@ void TaskQueue< ExecSpace >::schedule_aggregate
 
 template< typename ExecSpace >
 KOKKOS_FUNCTION
-void TaskQueue< ExecSpace >::reschedule( task_root_type * task )
-{
-  // Precondition:
-  //   task is in Executing state
-  //   task->m_next == LockTag
-  //
-  // Postcondition:
-  //   task is in Executing-Respawn state
-  //   task->m_next == 0 (no dependence)
-
-  task_root_type * const zero = (task_root_type *) 0 ;
-  task_root_type * const lock = (task_root_type *) task_root_type::LockTag ;
-
-  if ( lock != Kokkos::atomic_exchange( & task->m_next, zero ) ) {
-    Kokkos::abort("TaskScheduler::respawn ERROR: already respawned");
-  }
-}
-
-//----------------------------------------------------------------------------
-
-template< typename ExecSpace >
-KOKKOS_FUNCTION
-void TaskQueue< ExecSpace >::complete
+void TaskQueue< ExecSpace >::complete_runnable
   ( TaskQueue< ExecSpace >::task_root_type * task )
 {
   // Complete a runnable task that has finished executing
@@ -584,32 +561,52 @@ void TaskQueue< ExecSpace >::complete
   fflush( stdout );
 #endif
 
-  const bool runnable = task_root_type::Aggregate != task->m_task_type ;
+  task_root_type volatile & t = *task ;
 
   //----------------------------------------
 
-  if ( runnable && lock != task->m_next ) {
-    // Is a runnable task has finished executing and requested respawn.
-    // Schedule the task for subsequent execution.
+  task_root_type * dep = t.m_next ;
 
-    schedule_runnable( task );
+  if ( lock != dep ) {
+
+    // Requested respawn.  Schedule the task for subsequent execution.
+
+    // Exclusive access so don't need an atomic exchange
+    // task_root_type * dep = Kokkos::atomic_exchange( & task->m_next , zero );
+
+    if ( zero != dep ) {
+
+      t.m_next = zero ;
+
+      Kokkos::memory_fence();
+    }
+
+    schedule_runnable( task , dep );
+
+    if ( zero != dep ) {
+      // Reference count for dep was incremented when
+      // respawn assigned dependency to task->m_next
+      // so that if dep completed prior to the
+      // above push_task dep would not be destroyed.
+      // dep reference count can now be decremented,
+      // which may deallocate the task.
+
+      TaskQueue::assign( & dep , zero );
+    }
   }
   //----------------------------------------
   else {
-    // Is either an aggregate or a runnable task that executed
-    // and did not respawn.  Transition this task to complete.
+    // Did not request respawn.  Transition this task to complete.
 
-    // If 'task' is an aggregate then any of the runnable tasks that
-    // it depends upon may be attempting to complete this 'task'.
     // Must only transition a task once to complete status.
     // This is controled by atomically locking the wait queue.
 
     // Stop other tasks from adding themselves to this task's wait queue
     // by locking the head of this task's wait queue.
 
-    task_root_type * x = Kokkos::atomic_exchange( & task->m_wait , lock );
+    task_root_type * x = Kokkos::atomic_exchange( & t.m_wait , lock );
 
-    if ( x != (task_root_type *) lock ) {
+    if ( lock != x ) {
 
       // This thread has transitioned this 'task' to complete.
       // 'task' is no longer in a queue and is not executing
@@ -627,10 +624,14 @@ void TaskQueue< ExecSpace >::complete
         // Have exclusive access to 'x' until it is scheduled
         // Set x->m_next = zero  <=  no dependence, not a respawn
 
-        task_root_type * const next = x->m_next ; x->m_next = 0 ;
+        task_root_type volatile & vx = *x ;
 
-        if ( task_root_type::Aggregate != x->m_task_type ) {
-          schedule_runnable( x );
+        task_root_type * const next = vx.m_next ; vx.m_next = 0 ;
+
+        Kokkos::memory_fence();
+
+        if ( task_root_type::Aggregate != vx.m_task_type ) {
+          schedule_runnable( x , zero );
         }
         else {
           schedule_aggregate( x );
@@ -641,12 +642,10 @@ void TaskQueue< ExecSpace >::complete
     }
   }
 
-  if ( runnable ) {
-    // A runnable task was popped from a ready queue and executed.
-    // If respawned into a ready queue then the ready count was incremented
-    // so decrement whether respawned or not.
-    Kokkos::atomic_decrement( & m_ready_count );
-  }
+  // A runnable task was popped from a ready queue and executed.
+  // If respawned into a ready queue then the ready count was incremented
+  // so decrement whether respawned or not.
+  Kokkos::atomic_decrement( & m_ready_count );
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -491,28 +491,6 @@ struct is_integral_constant< integral_constant<T,v> > : public true_
   enum { integral_value = v };
 };
 
-//----------------------------------------------------------------------------
-
-template< typename T , unsigned align >
-struct Sizeof {
-  static_assert( is_power_of_two< align >::value
-               , "alignment must be power of two" );
-  
-  KOKKOS_INLINE_FUNCTION static
-  unsigned value()
-    {
-      enum : unsigned { mask = align - 1 };
-      return ( sizeof(T) + mask ) & ~mask ;
-    }
-};
-
-template< unsigned align >
-struct Sizeof< void , align >
-{
-  KOKKOS_INLINE_FUNCTION static
-  unsigned value() { return 0 ; }
-};
-
 } // namespace Impl
 } // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -491,6 +491,28 @@ struct is_integral_constant< integral_constant<T,v> > : public true_
   enum { integral_value = v };
 };
 
+//----------------------------------------------------------------------------
+
+template< typename T , unsigned align >
+struct Sizeof {
+  static_assert( is_power_of_two< align >::value
+               , "alignment must be power of two" );
+  
+  KOKKOS_INLINE_FUNCTION static
+  unsigned value()
+    {
+      enum : unsigned { mask = align - 1 };
+      return ( sizeof(T) + mask ) & ~mask ;
+    }
+};
+
+template< unsigned align >
+struct Sizeof< void , align >
+{
+  KOKKOS_INLINE_FUNCTION static
+  unsigned value() { return 0 ; }
+};
+
 } // namespace Impl
 } // namespace Kokkos
 

--- a/core/unit_test/TestTaskScheduler.hpp
+++ b/core/unit_test/TestTaskScheduler.hpp
@@ -641,18 +641,11 @@ namespace Test {
 
 TEST_F( TEST_CATEGORY, task_fib )
 {
-  const int N = 24 ; // 25 triggers tbd bug on Cuda/Pascal
+  const int N = 27 ;
   for ( int i = 0; i < N; ++i ) {
     TestTaskScheduler::TestFib< TEST_EXECSPACE >::run( i , ( i + 1 ) * ( i + 1 ) * 10000 );
   }
 }
-
-#if defined(KOKKOS_ARCH_MAXWELL) || defined(KOKKOS_ARCH_PASCAL)
-  // TODO: Resolve bug in task DAG for Pascal
-  #define KOKKOS_IMPL_DISABLE_UNIT_TEST_TASK_DAG_PASCAL
-#endif
-
-#ifndef KOKKOS_IMPL_DISABLE_UNIT_TEST_TASK_DAG_PASCAL
 
 TEST_F( TEST_CATEGORY, task_depend )
 {
@@ -666,10 +659,6 @@ TEST_F( TEST_CATEGORY, task_team )
   TestTaskScheduler::TestTaskTeam< TEST_EXECSPACE >::run( 1000 );
   //TestTaskScheduler::TestTaskTeamValue< TEST_EXECSPACE >::run( 1000 ); // Put back after testing.
 }
-
-#else //ndef KOKKOS_IMPL_DISABLE_UNIT_TEST_TASK_DAG_PASCAL
-#undef KOKKOS_IMPL_DISABLE_UNIT_TEST_TASK_DAG_PASCAL
-#endif //ndef KOKKOS_IMPL_DISABLE_UNIT_TEST_TASK_DAG_PASCAL
 
 }
 #endif // #if defined( KOKKOS_ENABLE_TASKDAG )

--- a/core/unit_test/TestTaskScheduler.hpp
+++ b/core/unit_test/TestTaskScheduler.hpp
@@ -643,7 +643,7 @@ TEST_F( TEST_CATEGORY, task_fib )
 {
   const int N = 27 ;
   for ( int i = 0; i < N; ++i ) {
-    TestTaskScheduler::TestFib< TEST_EXECSPACE >::run( i , ( i + 1 ) * ( i + 1 ) * 10000 );
+    TestTaskScheduler::TestFib< TEST_EXECSPACE >::run( i , ( i + 1 ) * ( i + 1 ) * 2000 );
   }
 }
 
@@ -661,6 +661,7 @@ TEST_F( TEST_CATEGORY, task_team )
 }
 
 }
+
 #endif // #if defined( KOKKOS_ENABLE_TASKDAG )
 #endif // #ifndef KOKKOS_UNITTEST_TASKSCHEDULER_HPP
 


### PR DESCRIPTION
Address the L1 cache non-coherency on Pascal GPU.

Delicately work around the known warp divergence challenge on Pascal GPU.  The warp-divergence work around is a temporary measure until CUDA 9 is released, in wide spread usage, and its sub-block synchronization mechanisms can be used to explicitly manage and avoid warp divergence.