### PR TITLE
Remove potential memory race in Threads global reduction

### DIFF
--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -276,6 +276,17 @@ public:
       if ( ! rev_rank ) {
         Final::final( f , reduce_memory() );
       }
+
+      //  This thread has updated 'reduce_memory()' and upon returning
+      //  from this function will set 'm_pool_state' to inactive.
+      //  If this is a non-root thread then setting 'm_pool_state'
+      //  to inactive triggers another thread to exit a spinwait
+      //  and read the 'reduce_memory'.
+      //  Must 'memory_fence()' to guarantee that storing the update to
+      //  'reduce_memory()' will complete before storing the the update to
+      //  'm_pool_state'.
+
+      memory_fence();
     }
 
   inline


### PR DESCRIPTION
Introduce memory_fence() to the Threads global reduction operation to guarantee that a reduction value is stored before the flag indicating the reduction value is available.

This opportunity for a memory race could be the root cause of issue #724.

Tested build with gcc, intel, and clang
