### PR TITLE
Remove potential memory race in OpenMP global reduction

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -1045,6 +1045,16 @@ public:
         }
 
         data.disband_team();
+
+        //  This thread has updated 'pool_reduce_local()' with its
+        //  contributions to the reduction.  The parallel region is
+        //  about to terminate and the master thread will load and
+        //  reduce each 'pool_reduce_local()' contribution.
+        //  Must 'memory_fence()' to guarantee that storing the update to
+        //  'pool_reduce_local()' will complete before this thread
+        //  exits the parallel region.
+
+        memory_fence();
       }
 
       // Reduction:


### PR DESCRIPTION
Introduce memory_fence() to the OpenMP global reduction operation to guarantee that a reduction value is stored before the flag indicating the reduction value is available.

This opportunity for a memory race could be the root cause of issue #724.

Tested build with gcc and intel