### PR TITLE
Kokkos:  Add ability to control memory alignment threshold.

### DIFF
--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -109,7 +109,11 @@ enum { MEMORY_ALIGNMENT =
 #else
     ( 1 << Kokkos::Impl::integral_power_of_two( 128 ) )
 #endif
-  , MEMORY_ALIGNMENT_THRESHOLD = 4 
+#if defined( KOKKOS_MEMORY_ALIGNMENT_THRESHOLD )
+  , MEMORY_ALIGNMENT_THRESHOLD = KOKKOS_MEMORY_ALIGNMENT_THRESHOLD
+#else
+  , MEMORY_ALIGNMENT_THRESHOLD = 4
+#endif
   };
 
 


### PR DESCRIPTION
This commit adds the ability to set the memory alignment threshold, in a
manner similar to how it was done with the memory alignment.  Just
define KOKKOS_MEMORY_ALIGNMENT_THRESHOLD to the value you want to
override the default value of 4.  For example, set it to 0 to make sure
padding always happens.

Relates to issue #809 