### PR TITLE
Fix CUDA 7 build errors

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -58,12 +58,14 @@ class ParallelFor< FunctorType ,
                           Traits ...
                         >
 {
-private:
+public:
 
   typedef Kokkos::Experimental::WorkGraphPolicy< Traits ... >   Policy ;
   typedef Kokkos::Impl::Experimental::
           WorkGraphExec<FunctorType, Kokkos::Cuda, Traits ... > Base ;
   typedef ParallelFor<FunctorType, Policy, Kokkos::Cuda>        Self ;
+
+private:
 
   template< class TagType >
   __device__


### PR DESCRIPTION
typedefs accessed from public code
can't be private (according to this compiler)
[#929]