### PR TITLE
Issue #930 Fix

### DIFF
--- a/containers/unit_tests/TestCuda.cpp
+++ b/containers/unit_tests/TestCuda.cpp
@@ -69,6 +69,8 @@
 #include <Kokkos_ErrorReporter.hpp>
 #include <TestErrorReporter.hpp>
 
+#include <TestViewCtorPropEmbeddedDim.hpp>
+
 //----------------------------------------------------------------------------
 
 
@@ -92,6 +94,10 @@ protected:
 
 TEST_F( cuda , dyn_view_api) {
   TestDynViewAPI< double , Kokkos::Cuda >();
+}
+
+TEST_F( cuda, viewctorprop_embedded_dim ) {
+  TestViewCtorProp_EmbeddedDim< Kokkos::Cuda >::test_vcpt( 2, 3 );
 }
 
 TEST_F( cuda , staticcrsgraph )

--- a/containers/unit_tests/TestOpenMP.cpp
+++ b/containers/unit_tests/TestOpenMP.cpp
@@ -66,6 +66,8 @@
 #include <Kokkos_ErrorReporter.hpp>
 #include <TestErrorReporter.hpp>
 
+#include <TestViewCtorPropEmbeddedDim.hpp>
+
 #include <iomanip>
 
 namespace Test {
@@ -87,6 +89,10 @@ protected:
 
 TEST_F( openmp, dyn_view_api) {
   TestDynViewAPI< double , Kokkos::OpenMP >();
+}
+
+TEST_F( openmp, viewctorprop_embedded_dim ) {
+  TestViewCtorProp_EmbeddedDim< Kokkos::OpenMP >::test_vcpt( 2, 3 );
 }
 
 TEST_F( openmp, bitset )

--- a/containers/unit_tests/TestSerial.cpp
+++ b/containers/unit_tests/TestSerial.cpp
@@ -67,6 +67,8 @@
 #include <Kokkos_ErrorReporter.hpp>
 #include <TestErrorReporter.hpp>
 
+#include <TestViewCtorPropEmbeddedDim.hpp>
+
 namespace Test {
 
 class serial : public ::testing::Test {
@@ -83,6 +85,10 @@ protected:
 
 TEST_F( serial, dyn_view_api) {
   TestDynViewAPI< double , Kokkos::Serial >();
+}
+
+TEST_F( serial, viewctorprop_embedded_dim ) {
+  TestViewCtorProp_EmbeddedDim< Kokkos::Serial >::test_vcpt( 2, 3 );
 }
 
 TEST_F( serial , staticcrsgraph )

--- a/containers/unit_tests/TestThreads.cpp
+++ b/containers/unit_tests/TestThreads.cpp
@@ -70,6 +70,8 @@
 #include <Kokkos_ErrorReporter.hpp>
 #include <TestErrorReporter.hpp>
 
+#include <TestViewCtorPropEmbeddedDim.hpp>
+
 namespace Test {
 
 class threads : public ::testing::Test {
@@ -101,6 +103,10 @@ protected:
 
 TEST_F( threads , dyn_view_api) {
   TestDynViewAPI< double , Kokkos::Threads >();
+}
+
+TEST_F( threads, viewctorprop_embedded_dim ) {
+  TestViewCtorProp_EmbeddedDim< Kokkos::Threads >::test_vcpt( 2, 3 );
 }
 
 TEST_F( threads , staticcrsgraph )


### PR DESCRIPTION
TestViewCtorPropEmbeddedDim is tested within core/unit_test; it should
contain no dependency on containers - move DynRankView-related tests to
containers/unit_tests to fix this.