### PR TITLE
Move WorkGraphExec::setup to WorkGraphPolicy ctor

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -96,7 +96,6 @@ public:
   inline
   void execute()
   {
-    Base::setup();
     const int warps_per_block = 4 ;
     const dim3 grid( Kokkos::Impl::cuda_internal_multiprocessor_count() , 1 , 1 );
     const dim3 block( 1 , Kokkos::Impl::CudaTraits::WarpSize , warps_per_block );

--- a/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
@@ -82,7 +82,6 @@ public:
   inline
   void execute()
   {
-    Base::setup();
     const int pool_size = OpenMP::thread_pool_size();
 
     #pragma omp parallel num_threads(pool_size)

--- a/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
@@ -97,7 +97,6 @@ public:
   inline
   void execute()
   {
-    Base::setup();
     ThreadsExec::start( & Self::thread_main, this );
     ThreadsExec::fence();
   }

--- a/core/src/impl/Kokkos_Serial_WorkGraphPolicy.hpp
+++ b/core/src/impl/Kokkos_Serial_WorkGraphPolicy.hpp
@@ -82,7 +82,6 @@ public:
   inline
   void execute()
   {
-    Base::setup();
     for (std::int32_t i; (-1 != (i = Base::before_work())); ) {
       exec_one< typename Policy::work_tag >( i );
       Base::after_work(i);


### PR DESCRIPTION
this moves all the construction of helper Views
into the WorkGraphPolicy constructor and out of
the WorkGraphExec derived execute() method.
@crtrott and I suspect that it fixes a design bug
in which these views end up on the GPU with
tracking enabled.

we hope this will help #944

so far this has passed the following `test_all_sandia` on `kokkos-dev`
```
cuda-7.0.28-Cuda_OpenMP-release build_time=419 run_time=587
```