### PR TITLE
Yet another attempt to address #935

### DIFF
--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -176,11 +176,22 @@ public:
   inline
   int pool_rendezvous() const noexcept
     {
+      static constexpr int yield_wait =
+        #if defined( KOKKOS_COMPILER_IBM )
+            // If running on IBM POWER architecture the global
+            // level rendzvous should immediately yield when
+            // waiting for other threads in the pool to arrive.
+          1
+        #else
+          0
+        #endif
+          ;
       return 1 == m_pool_size ? 1 :
              Kokkos::Impl::
              rendezvous( m_pool_scratch + m_pool_rendezvous
                        , m_pool_size
-                       , m_pool_rank );
+                       , m_pool_rank
+                       , yield_wait );
     }
 
   inline

--- a/core/src/impl/Kokkos_Rendezvous.hpp
+++ b/core/src/impl/Kokkos_Rendezvous.hpp
@@ -54,19 +54,29 @@ constexpr int rendezvous_buffer_size( int max_members ) noexcept
   return (((max_members + 7) / 8) * 4) + 4 + 4;
 }
 
-// Rendezvous pattern:
-//   if ( rendezvous(root) ) {
-//     ... only root thread here while all others wait ...
-//     rendezvous_release();
-//   }
-//   else {
-//     ... all other threads release here ...
-//   }
-//
-// Requires: buffer[ rendezvous_buffer_size( max_threads ) ];
+/** \brief  Thread pool rendezvous
+ *
+ *  Rendezvous pattern:
+ *   if ( rendezvous(root) ) {
+ *     ... only root thread here while all others wait ...
+ *     rendezvous_release();
+ *   }
+ *   else {
+ *     ... all other threads release here ...
+ *   }
+ *
+ *  Requires: buffer[ rendezvous_buffer_size( max_threads ) ];
+ *
+ *  When slow != 0 the expectation is thread arrival will be 
+ *  slow so the threads that arrive early should quickly yield
+ *  their core to the runtime thus possibly allowing the late
+ *  arriving threads to have more resources
+ *  (e.g., power and clock frequency).
+ */
 int rendezvous( volatile int64_t * const buffer
               , int const size
-              , int const rank ) noexcept ;
+              , int const rank
+              , int const slow = 0 ) noexcept ;
 
 void rendezvous_release( volatile int64_t * const buffer ) noexcept ;
 

--- a/core/src/impl/Kokkos_Spinwait.hpp
+++ b/core/src/impl/Kokkos_Spinwait.hpp
@@ -60,6 +60,12 @@ void spinwait_until_equal( volatile int32_t & flag , const int32_t value );
 void spinwait_while_equal( volatile int64_t & flag , const int64_t value );
 void spinwait_until_equal( volatile int64_t & flag , const int64_t value );
 
+void yield_while_equal( volatile int32_t & flag , const int32_t value );
+void yield_until_equal( volatile int32_t & flag , const int32_t value );
+
+void yield_while_equal( volatile int64_t & flag , const int64_t value );
+void yield_until_equal( volatile int64_t & flag , const int64_t value );
+
 #else
 
 KOKKOS_INLINE_FUNCTION
@@ -71,6 +77,16 @@ KOKKOS_INLINE_FUNCTION
 void spinwait_while_equal( volatile int64_t & , const int64_t ) {}
 KOKKOS_INLINE_FUNCTION
 void spinwait_until_equal( volatile int64_t & , const int64_t ) {}
+
+KOKKOS_INLINE_FUNCTION
+void yield_while_equal( volatile int32_t & , const int32_t ) {}
+KOKKOS_INLINE_FUNCTION
+void yield_until_equal( volatile int32_t & , const int32_t ) {}
+
+KOKKOS_INLINE_FUNCTION
+void yield_while_equal( volatile int64_t & , const int64_t ) {}
+KOKKOS_INLINE_FUNCTION
+void yield_until_equal( volatile int64_t & , const int64_t ) {}
 
 #endif
 


### PR DESCRIPTION
On IBM POWER architecture the global rendezvous uses yielding spinwait
while the team rendezvous uses polling / exponential backoff spinwait.

All other architectures' rendezvous operations use
polling / exponential backoff spinwait.