### PR TITLE
Add support for hardware yield into POWER8 backends

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -350,7 +350,7 @@
 
   #if defined( KOKKOS_ARCH_AVX512MIC )
       #define KOKKOS_ENABLE_RFO_PREFETCH 1
-  #endif 
+  #endif
 
   #if !defined( KOKKOS_FORCEINLINE_FUNCTION )
     #define KOKKOS_FORCEINLINE_FUNCTION inline __attribute__((always_inline))
@@ -358,7 +358,8 @@
 
   #if !defined( KOKKOS_ENABLE_ASM ) && !defined( __PGIC__ ) && \
       ( defined( __amd64 ) || defined( __amd64__ ) || \
-        defined( __x86_64 ) || defined( __x86_64__ ) )
+        defined( __x86_64 ) || defined( __x86_64__ ) || \
+	defined(__PPC64__) )
     #define KOKKOS_ENABLE_ASM 1
   #endif
 #endif

--- a/core/src/impl/Kokkos_Spinwait.cpp
+++ b/core/src/impl/Kokkos_Spinwait.cpp
@@ -108,23 +108,30 @@ void host_thread_yield( const uint32_t i , const int force_yield )
     // Insert a few no-ops to quiet the thread:
 
     for ( int k = 0 ; k < c ; ++k ) {
-      #if !defined( _WIN32 ) /* IS NOT Microsoft Windows */
-        asm volatile("nop\n");
-      #else /* IS Microsoft Windows */
-        __asm__ __volatile__("nop\n");
+      #if defined( __amd64 ) || defined( __amd64__ ) || \
+       	    defined( __x86_64 ) || defined( __x86_64__ )
+    	#if !defined( _WIN32 ) /* IS NOT Microsoft Windows */
+          asm volatile( "nop\n" );
+	#else
+          __asm__ __volatile__( "nop\n" );
+        #endif
+      #elif defined(__PPC64__)
+          asm volatile( "nop\n" );
       #endif
     }
   }
 
   {
     // Insert memory pause
-
-      #if !defined( _WIN32 ) /* IS NOT Microsoft Windows */
-        #if !defined( __arm__ ) && !defined( __aarch64__ )
-          asm volatile("pause\n":::"memory");
+      #if defined( __amd64 ) || defined( __amd64__ ) || \
+       	    defined( __x86_64 ) || defined( __x86_64__ )
+    	#if !defined( _WIN32 ) /* IS NOT Microsoft Windows */
+          asm volatile( "pause\n":::"memory" );
+	#else
+          __asm__ __volatile__( "pause\n":::"memory" );
         #endif
-      #else /* IS Microsoft Windows */
-        __asm__ __volatile__("pause\n":::"memory");
+      #elif defined(__PPC64__)
+	asm volatile( "or 27, 27, 27" ::: "memory" );
       #endif
   }
 


### PR DESCRIPTION
Add support for hardware yield into POWER8 backends by using the processor hint `OR 27,27,27`. This hint tells the hardware that "performance will be improved by releasing shared resources for other processors." GCC will convert this assembly sequence into an assembly `yield` statement. Tested on POWER8 with pthreads and OpenMP backends.