### PR TITLE
Layout order_dimensions: fix out-of-bounds read

### DIFF
--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -156,6 +156,8 @@ struct LayoutStride {
       for ( int r = 0 ; r < ARRAY_LAYOUT_MAX_RANK ; ++r ) {
         tmp.dimension[r] = 0 ;
         tmp.stride[r]    = 0 ;
+      }
+      for ( int r = 0 ; r < rank ; ++r ) {
         check_input &= ~int( 1 << order[r] );
       }
       if ( 0 == check_input ) {


### PR DESCRIPTION
[#975]

(if the provided `order` array is only of size `rank`, prevents reading past the end of it)