### PR TITLE
Add support for POWER7 systems back to Kokkos ARCH List

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -267,6 +267,7 @@ KOKKOS_INTERNAL_USE_ARCH_AVX512XEON := $(strip $(shell echo $(KOKKOS_INTERNAL_US
 KOKKOS_INTERNAL_USE_ISA_X86_64    := $(strip $(shell echo $(KOKKOS_INTERNAL_USE_ARCH_WSM)+$(KOKKOS_INTERNAL_USE_ARCH_SNB)+$(KOKKOS_INTERNAL_USE_ARCH_HSW)+$(KOKKOS_INTERNAL_USE_ARCH_BDW)+$(KOKKOS_INTERNAL_USE_ARCH_KNL)+$(KOKKOS_INTERNAL_USE_ARCH_SKX) | bc ))
 KOKKOS_INTERNAL_USE_ISA_KNC       := $(strip $(shell echo $(KOKKOS_INTERNAL_USE_ARCH_KNC) | bc ))
 KOKKOS_INTERNAL_USE_ISA_POWERPCLE := $(strip $(shell echo $(KOKKOS_INTERNAL_USE_ARCH_POWER8)+$(KOKKOS_INTERNAL_USE_ARCH_POWER9) | bc ))
+KOKKOS_INTERNAL_USE_ISA_POWERPCBE := $(strip $(shell echo $(KOKKOS_INTERNAL_USE_ARCH_POWER7) | bc ))
 
 # Decide whether we can support transactional memory
 KOKKOS_INTERNAL_USE_TM            := $(strip $(shell echo $(KOKKOS_INTERNAL_USE_ARCH_BDW)+$(KOKKOS_INTERNAL_USE_ARCH_SKX) | bc ))
@@ -356,6 +357,12 @@ endif
 ifeq ($(KOKKOS_INTERNAL_USE_ISA_POWERPCLE), 1)
   tmp := $(shell echo "\#ifndef __CUDA_ARCH__" >> KokkosCore_config.tmp )
   tmp := $(shell echo "\#define KOKKOS_USE_ISA_POWERPCLE" >> KokkosCore_config.tmp )
+  tmp := $(shell echo "\#endif" >> KokkosCore_config.tmp )
+endif
+
+ifeq ($(KOKKOS_INTERNAL_USE_ISA_POWERPCBE), 1)
+  tmp := $(shell echo "\#ifndef __CUDA_ARCH__" >> KokkosCore_config.tmp )
+  tmp := $(shell echo "\#define KOKKOS_USE_ISA_POWERPCBE" >> KokkosCore_config.tmp )
   tmp := $(shell echo "\#endif" >> KokkosCore_config.tmp )
 endif
 
@@ -554,6 +561,18 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_AVX), 1)
         KOKKOS_LDFLAGS  += -mavx
       endif
     endif
+  endif
+endif
+
+ifeq ($(KOKKOS_INTERNAL_USE_ARCH_POWER7), 1)
+  tmp := $(shell echo "\#define KOKKOS_ARCH_POWER7 1" >> KokkosCore_config.tmp )
+
+  ifeq ($(KOKKOS_INTERNAL_COMPILER_PGI), 1)
+
+  else
+    # Assume that this is a really a GNU compiler or it could be XL on P8.
+    KOKKOS_CXXFLAGS += -mcpu=power7 -mtune=power7
+    KOKKOS_LDFLAGS  += -mcpu=power7 -mtune=power7
   endif
 endif
 

--- a/README
+++ b/README
@@ -80,6 +80,9 @@ Other compilers working:
   X86:
    Cygwin 2.1.0 64bit with gcc 4.9.3
 
+Limited testing of the following compilers on POWER7+ systems:
+  GCC 4.8.5 (on RHEL7.1 POWER7+)
+
 Known non-working combinations:
   Power8:
    Pthreads backend

--- a/generate_makefile.bash
+++ b/generate_makefile.bash
@@ -117,6 +117,7 @@ do
       echo "                 ARMv81         = ARMv8.1 Compatible CPU"
       echo "                 ARMv8-ThunderX = ARMv8 Cavium ThunderX CPU"
       echo "               [IBM]"
+      echo "                 Power7         = IBM POWER7 and POWER7+ CPUs"
       echo "                 Power8         = IBM POWER8 CPUs"
       echo "                 Power9         = IBM POWER9 CPUs"
       echo "               [Intel]"


### PR DESCRIPTION
Add support for POWER7/7+ systems back to Kokkos list. Tested using GCC 4.8.5 on POWER7+ systems running RHEL7.