### PR TITLE
add Kokkos::complex setters like std::complex

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -232,6 +232,16 @@ public:
     return re_;
   }
 
+  //! Set the imaginary part of this complex number.
+  KOKKOS_INLINE_FUNCTION void imag (RealType v) {
+    im_ = v;
+  }
+
+  //! Set the real part of this complex number.
+  KOKKOS_INLINE_FUNCTION void real (RealType v) {
+    re_ = v;
+  }
+
   KOKKOS_INLINE_FUNCTION
   complex<RealType>& operator += (const complex<RealType>& src) {
     re_ += src.re_;

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -158,7 +158,8 @@ struct TestComplexBasicMath {
     d_results(1) = a-b;
     d_results(2) = a*b;
     d_results(3) = a/b;
-    d_results(4) = Kokkos::complex<double>(1.0,2.0);
+    d_results(4).real(1.0);
+    d_results(4).imag(2.0);
     d_results(4) += a;
     d_results(5) = Kokkos::complex<double>(1.0,2.0);
     d_results(5) -= a;
@@ -173,7 +174,8 @@ struct TestComplexBasicMath {
     d_results(9) = a-c;
     d_results(10) = a*c;
     d_results(11) = a/c;
-    d_results(12) = Kokkos::complex<double>(1.0,2.0);
+    d_results(12).real(1.0);
+    d_results(12).imag(2.0);
     d_results(12) += c;
     d_results(13) = Kokkos::complex<double>(1.0,2.0);
     d_results(13) -= c;


### PR DESCRIPTION
These missing functions were reported in #1011 .

This PR also adds unit testing for the new setter functions.

Passed `test_all_sandia` spot check on `kokkos-dev`:
```
cuda-8.0.44-Cuda_OpenMP-release build_time=366 run_time=546
```