### PR TITLE
Kokkos - complex suggestion for issue #1052

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -244,9 +244,10 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          complex<RealType>&>::type 
+  complex<RealType>&
   operator += (const complex<InputRealType>& src) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
     re_ += src.re_;
     im_ += src.im_;
     return *this;
@@ -254,35 +255,39 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          void>::type
+  void
   operator += (const volatile complex<InputRealType>& src) volatile {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
     re_ += src.re_;
     im_ += src.im_;
   }
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          complex<RealType>&>::type
+  complex<RealType>&
   operator += (const InputRealType& src) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
     re_ += src;
     return *this;
   }
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          void>::type
+  void
   operator += (const volatile InputRealType& src) volatile {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
     re_ += src;
   }
   
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          complex<RealType>&>::type
+  complex<RealType>&
   operator -= (const complex<InputRealType>& src) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
     re_ -= src.re_;
     im_ -= src.im_;
     return *this;
@@ -290,18 +295,20 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          complex<RealType>&>::type
+  complex<RealType>&
   operator -= (const InputRealType& src) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
     re_ -= src;
     return *this;
   }
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          complex<RealType>&>::type
+  complex<RealType>&
   operator *= (const complex<InputRealType>& src) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
     const RealType realPart = re_ * src.re_ - im_ * src.im_;
     const RealType imagPart = re_ * src.im_ + im_ * src.re_;
     re_ = realPart;
@@ -311,9 +318,10 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          void>::type
+  void
   operator *= (const volatile complex<InputRealType>& src) volatile {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
     const RealType realPart = re_ * src.re_ - im_ * src.im_;
     const RealType imagPart = re_ * src.im_ + im_ * src.re_;
     re_ = realPart;
@@ -322,9 +330,10 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          complex<RealType>&>::type
+  complex<RealType>&
   operator *= (const InputRealType& src) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
     re_ *= src;
     im_ *= src;
     return *this;
@@ -332,18 +341,21 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          void>::type
+  void
   operator *= (const volatile InputRealType& src) volatile {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
     re_ *= src;
     im_ *= src;
   }
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          complex<RealType>&>::type
+  complex<RealType>&
   operator /= (const complex<InputRealType>& y) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
+
     // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
     // If the real part is +/-Inf and the imaginary part is -/+Inf,
     // this won't change the result.
@@ -369,9 +381,11 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          complex<RealType>&>::type
+  complex<RealType>&
   operator /= (const InputRealType& src) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
+
     re_ /= src;
     im_ /= src;
     return *this;
@@ -379,33 +393,41 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          bool>::type
+  bool
   operator == (const complex<InputRealType>& src) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
+
     return (re_ == static_cast<RealType>(src.re_)) && (im_ == static_cast<RealType>(src.im_));
   }
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          bool>::type
+  bool
   operator == (const InputRealType src) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
+
     return (re_ == static_cast<RealType>(src)) && (im_ == RealType(0));
   }
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          bool>::type
+  bool
   operator != (const complex<InputRealType>& src) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
+
     return (re_ != static_cast<RealType>(src.re_)) || (im_ != static_cast<RealType>(src.im_));
   }
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
-                          bool>::type
-    operator != (const InputRealType src) {
+  bool
+  operator != (const InputRealType src) {
+    static_assert(std::is_convertible<InputRealType,RealType>::value, 
+                  "InputRealType must be convertible to RealType");
+
     return (re_ != static_cast<RealType>(src)) || (im_ != RealType(0));
   }
   

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -50,6 +50,21 @@
 
 namespace Kokkos {
 
+template<typename From, typename To, typename dummy = To>
+struct is_convertible {
+  static const bool value = true;
+};
+  
+template<typename From, typename To>
+struct is_convertible<From,To,typename std::enable_if<std::is_integral<To>::value>::type> {
+  static const bool value = std::is_integral<From>::value;
+};
+  
+template<typename From, typename To>
+struct is_convertible<From,To,typename std::enable_if<std::is_floating_point<To>::value>::type> {
+  static const bool value = std::is_arithmetic<From>::value;
+};
+  
 /// \class complex
 /// \brief Partial reimplementation of std::complex that works as the
 ///   result of a Kokkos::parallel_reduce.
@@ -242,45 +257,66 @@ public:
     re_ = v;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  complex<RealType>& operator += (const complex<RealType>& src) {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          complex<RealType>&>::type 
+  operator += (const complex<InputRealType>& src) {
     re_ += src.re_;
     im_ += src.im_;
     return *this;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  void operator += (const volatile complex<RealType>& src) volatile {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          void>::type
+  operator += (const volatile complex<InputRealType>& src) volatile {
     re_ += src.re_;
     im_ += src.im_;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  complex<RealType>& operator += (const RealType& src) {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          complex<RealType>&>::type
+  operator += (const InputRealType& src) {
     re_ += src;
     return *this;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  void operator += (const volatile RealType& src) volatile {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          void>::type
+  operator += (const volatile InputRealType& src) volatile {
     re_ += src;
   }
-
+  
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  complex<RealType>& operator -= (const complex<RealType>& src) {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          complex<RealType>&>::type
+  operator -= (const complex<InputRealType>& src) {
     re_ -= src.re_;
     im_ -= src.im_;
     return *this;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  complex<RealType>& operator -= (const RealType& src) {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          complex<RealType>&>::type
+  operator -= (const InputRealType& src) {
     re_ -= src;
     return *this;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  complex<RealType>& operator *= (const complex<RealType>& src) {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          complex<RealType>&>::type
+  operator *= (const complex<InputRealType>& src) {
     const RealType realPart = re_ * src.re_ - im_ * src.im_;
     const RealType imagPart = re_ * src.im_ + im_ * src.re_;
     re_ = realPart;
@@ -288,29 +324,41 @@ public:
     return *this;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  void operator *= (const volatile complex<RealType>& src) volatile {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          void>::type
+  operator *= (const volatile complex<InputRealType>& src) volatile {
     const RealType realPart = re_ * src.re_ - im_ * src.im_;
     const RealType imagPart = re_ * src.im_ + im_ * src.re_;
     re_ = realPart;
     im_ = imagPart;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  complex<RealType>& operator *= (const RealType& src) {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          complex<RealType>&>::type
+  operator *= (const InputRealType& src) {
     re_ *= src;
     im_ *= src;
     return *this;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  void operator *= (const volatile RealType& src) volatile {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          void>::type
+  operator *= (const volatile InputRealType& src) volatile {
     re_ *= src;
     im_ *= src;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  complex<RealType>& operator /= (const complex<RealType>& y) {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          complex<RealType>&>::type
+  operator /= (const complex<InputRealType>& y) {
     // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
     // If the real part is +/-Inf and the imaginary part is -/+Inf,
     // this won't change the result.
@@ -334,57 +382,75 @@ public:
     return *this;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  complex<RealType>& operator /= (const RealType& src) {
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          complex<RealType>&>::type
+  operator /= (const InputRealType& src) {
     re_ /= src;
     im_ /= src;
     return *this;
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  bool operator == (const complex<RealType>& src) {
-    return (re_ == src.re_) && (im_ == src.im_);
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          bool>::type
+  operator == (const complex<InputRealType>& src) {
+    return (re_ == static_cast<RealType>(src.re_)) && (im_ == static_cast<RealType>(src.im_));
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  bool operator == (const RealType src) {
-    return (re_ == src) && (im_ == RealType(0));
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          bool>::type
+  operator == (const InputRealType src) {
+    return (re_ == static_cast<RealType>(src)) && (im_ == RealType(0));
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  bool operator != (const complex<RealType>& src) {
-    return (re_ != src.re_) || (im_ != src.im_);
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          bool>::type
+  operator != (const complex<InputRealType>& src) {
+    return (re_ != static_cast<RealType>(src.re_)) || (im_ != static_cast<RealType>(src.im_));
   }
 
+  template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  bool operator != (const RealType src) {
-    return (re_ != src) || (im_ != RealType(0));
+  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+                          bool>::type
+    operator != (const InputRealType src) {
+    return (re_ != static_cast<RealType>(src)) || (im_ != RealType(0));
   }
-
+  
 };
 
 //! Binary + operator for complex complex.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType>
-operator + (const complex<RealType>& x, const complex<RealType>& y) {
-  return complex<RealType> (x.real () + y.real (), x.imag () + y.imag ());
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
+operator + (const complex<RealType1>& x, const complex<RealType2>& y) {
+  return complex<RealType1> (x.real () + y.real (), x.imag () + y.imag ());
 }
 
 //! Binary + operator for complex scalar.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType>
-operator + (const complex<RealType>& x, const RealType& y) {
-  return complex<RealType> (x.real () + y , x.imag ());
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
+operator + (const complex<RealType1>& x, const RealType2& y) {
+  return complex<RealType1> (x.real () + y , x.imag ());
 }
 
 //! Binary + operator for scalar complex.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType>
-operator + (const RealType& x, const complex<RealType>& y) {
-  return complex<RealType> (x + y.real (), y.imag ());
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
+operator + (const RealType1& x, const complex<RealType2>& y) {
+  return complex<RealType1> (x + y.real (), y.imag ());
 }
 
 //! Unary + operator for complex.
@@ -396,27 +462,30 @@ operator + (const complex<RealType>& x) {
 }
 
 //! Binary - operator for complex.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType>
-operator - (const complex<RealType>& x, const complex<RealType>& y) {
-  return complex<RealType> (x.real () - y.real (), x.imag () - y.imag ());
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
+operator - (const complex<RealType1>& x, const complex<RealType2>& y) {
+  return complex<RealType1> (x.real () - y.real (), x.imag () - y.imag ());
 }
 
 //! Binary - operator for complex scalar.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType>
-operator - (const complex<RealType>& x, const RealType& y) {
-  return complex<RealType> (x.real () - y , x.imag ());
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
+operator - (const complex<RealType1>& x, const RealType2& y) {
+  return complex<RealType1> (x.real () - y , x.imag ());
 }
 
 //! Binary - operator for scalar complex.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType>
-operator - (const RealType& x, const complex<RealType>& y) {
-  return complex<RealType> (x - y.real (), - y.imag ());
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
+operator - (const RealType1& x, const complex<RealType2>& y) {
+  return complex<RealType1> (x - y.real (), - y.imag ());
 }
 
 //! Unary - operator for complex.
@@ -428,11 +497,12 @@ operator - (const complex<RealType>& x) {
 }
 
 //! Binary * operator for complex.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType>
-operator * (const complex<RealType>& x, const complex<RealType>& y) {
-  return complex<RealType> (x.real () * y.real () - x.imag () * y.imag (),
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
+operator * (const complex<RealType1>& x, const complex<RealType2>& y) {
+  return complex<RealType1> (x.real () * y.real () - x.imag () * y.imag (),
                             x.real () * y.imag () + x.imag () * y.real ());
 }
 
@@ -446,33 +516,37 @@ operator * (const complex<RealType>& x, const complex<RealType>& y) {
 /// This function cannot be called in a CUDA device function, because
 /// std::complex's methods and nonmember functions are not marked as
 /// CUDA device functions.
-template<class RealType>
-complex<RealType>
-operator * (const std::complex<RealType>& x, const complex<RealType>& y) {
-  return complex<RealType> (x.real () * y.real () - x.imag () * y.imag (),
-                            x.real () * y.imag () + x.imag () * y.real ());
+template<class RealType1, class RealType2>
+KOKKOS_INLINE_FUNCTION
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
+operator * (const std::complex<RealType1>& x, const complex<RealType2>& y) {
+  return complex<RealType1> (x.real () * y.real () - x.imag () * y.imag (),
+                             x.real () * y.imag () + x.imag () * y.real ());
 }
 
 /// \brief Binary * operator for RealType times complex.
 ///
 /// This function exists because the compiler doesn't know that
 /// RealType and complex<RealType> commute with respect to operator*.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType>
-operator * (const RealType& x, const complex<RealType>& y) {
-  return complex<RealType> (x * y.real (), x * y.imag ());
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
+operator * (const RealType1& x, const complex<RealType2>& y) {
+  return complex<RealType1> (x * y.real (), x * y.imag ());
 }
 
 /// \brief Binary * operator for RealType times complex.
 ///
 /// This function exists because the compiler doesn't know that
 /// RealType and complex<RealType> commute with respect to operator*.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType>
-operator * (const complex<RealType>& y, const RealType& x) {
-  return complex<RealType> (x * y.real (), x * y.imag ());
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
+operator * (const complex<RealType1>& y, const RealType2& x) {
+  return complex<RealType1> (x * y.real (), x * y.imag ());
 }
 
 //! Imaginary part of a complex number.
@@ -539,33 +613,35 @@ complex<RealType> pow (const complex<RealType>& x) {
 //! Binary operator / for complex and real numbers
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType1>
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
 operator / (const complex<RealType1>& x, const RealType2& y) {
   return complex<RealType1> (real (x) / y, imag (x) / y);
 }
 
 //! Binary operator / for complex.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType>
-operator / (const complex<RealType>& x, const complex<RealType>& y) {
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
+operator / (const complex<RealType1>& x, const complex<RealType2>& y) {
   // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
   // If the real part is +/-Inf and the imaginary part is -/+Inf,
   // this won't change the result.
-  const RealType s = std::fabs (real (y)) + std::fabs (imag (y));
+  const RealType1 s = std::fabs (real (y)) + std::fabs (imag (y));
 
   // If s is 0, then y is zero, so x/y == real(x)/0 + i*imag(x)/0.
   // In that case, the relation x/y == (x/s) / (y/s) doesn't hold,
   // because y/s is NaN.
   if (s == 0.0) {
-    return complex<RealType> (real (x) / s, imag (x) / s);
+    return complex<RealType1> (real (x) / s, imag (x) / s);
   }
   else {
-    const complex<RealType> x_scaled (real (x) / s, imag (x) / s);
-    const complex<RealType> y_conj_scaled (real (y) / s, -imag (y) / s);
-    const RealType y_scaled_abs = real (y_conj_scaled) * real (y_conj_scaled) +
+    const complex<RealType1> x_scaled (real (x) / s, imag (x) / s);
+    const complex<RealType1> y_conj_scaled (real (y) / s, -imag (y) / s);
+    const RealType1 y_scaled_abs = real (y_conj_scaled) * real (y_conj_scaled) +
       imag (y_conj_scaled) * imag (y_conj_scaled); // abs(y) == abs(conj(y))
-    complex<RealType> result = x_scaled * y_conj_scaled;
+    complex<RealType1> result = x_scaled * y_conj_scaled;
     result /= y_scaled_abs;
     return result;
   }
@@ -574,16 +650,19 @@ operator / (const complex<RealType>& x, const complex<RealType>& y) {
 //! Binary operator / for complex and real numbers
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-complex<RealType1>
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        complex<RealType1> >::type
 operator / (const RealType1& x, const complex<RealType2>& y) {
   return complex<RealType1> (x)/y;
 }
 
 //! Equality operator for two complex numbers.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-bool operator == (const complex<RealType>& x, const complex<RealType>& y) {
-  return real (x) == real (y) && imag (x) == imag (y);
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        bool>::type
+operator == (const complex<RealType1>& x, const complex<RealType2>& y) {
+  return real (x) == static_cast<RealType1>(real (y)) && imag (x) == static_cast<RealType1>(imag (y));
 }
 
 /// \brief Equality operator for std::complex and Kokkos::complex.
@@ -592,50 +671,65 @@ bool operator == (const complex<RealType>& x, const complex<RealType>& y) {
 /// Otherwise, CUDA builds will give compiler warnings ("warning:
 /// calling a constexpr __host__ function("real") from a __host__
 /// __device__ function("operator==") is not allowed").
-template<class RealType>
-bool operator == (const std::complex<RealType>& x, const complex<RealType>& y) {
-  return std::real (x) == real (y) && std::imag (x) == imag (y);
+template<class RealType1, class RealType2>
+KOKKOS_INLINE_FUNCTION
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        bool>::type
+operator == (const std::complex<RealType1>& x, const complex<RealType2>& y) {
+  return std::real (x) == static_cast<RealType1>(real (y)) && std::imag (x) == static_cast<RealType1>(imag (y));
 }
 
 //! Equality operator for complex and real number.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-bool operator == (const complex<RealType1>& x, const RealType2& y) {
-  return real (x) == y && imag (x) == static_cast<RealType1> (0.0);
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        bool>::type
+operator == (const complex<RealType1>& x, const RealType2& y) {
+  return real (x) == static_cast<RealType1>(y) && imag (x) == static_cast<RealType1> (0.0);
 }
 
 //! Equality operator for real and complex number.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-bool operator == (const RealType& x, const complex<RealType>& y) {
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        bool>::type
+operator == (const RealType1& x, const complex<RealType2>& y) {
   return y == x;
 }
 
 //! Inequality operator for two complex numbers.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-bool operator != (const complex<RealType>& x, const complex<RealType>& y) {
-  return real (x) != real (y) || imag (x) != imag (y);
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        bool>::type
+operator != (const complex<RealType1>& x, const complex<RealType2>& y) {
+  return real (x) != static_cast<RealType1>(real (y)) || imag (x) != static_cast<RealType1>(imag (y));
 }
 
 //! Inequality operator for std::complex and Kokkos::complex.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-bool operator != (const std::complex<RealType>& x, const complex<RealType>& y) {
-  return std::real (x) != real (y) || std::imag (x) != imag (y);
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        bool>::type
+operator != (const std::complex<RealType1>& x, const complex<RealType2>& y) {
+  return std::real (x) != static_cast<RealType1>(real (y)) || std::imag (x) != static_cast<RealType1>(imag (y));
 }
 
 //! Inequality operator for complex and real number.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-bool operator != (const complex<RealType1>& x, const RealType2& y) {
-  return real (x) != y || imag (x) != static_cast<RealType1> (0.0);
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        bool>::type
+operator != (const complex<RealType1>& x, const RealType2& y) {
+  return real (x) != static_cast<RealType1>(y) || imag (x) != static_cast<RealType1> (0.0);
 }
 
 //! Inequality operator for real and complex number.
-template<class RealType>
+template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-bool operator != (const RealType& x, const complex<RealType>& y) {
+typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+                        bool>::type
+operator != (const RealType1& x, const complex<RealType2>& y) {
   return y != x;
 }
 

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -50,21 +50,6 @@
 
 namespace Kokkos {
 
-template<typename From, typename To, typename dummy = To>
-struct is_convertible {
-  static const bool value = true;
-};
-  
-template<typename From, typename To>
-struct is_convertible<From,To,typename std::enable_if<std::is_integral<To>::value>::type> {
-  static const bool value = std::is_integral<From>::value;
-};
-  
-template<typename From, typename To>
-struct is_convertible<From,To,typename std::enable_if<std::is_floating_point<To>::value>::type> {
-  static const bool value = std::is_arithmetic<From>::value;
-};
-  
 /// \class complex
 /// \brief Partial reimplementation of std::complex that works as the
 ///   result of a Kokkos::parallel_reduce.
@@ -259,7 +244,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           complex<RealType>&>::type 
   operator += (const complex<InputRealType>& src) {
     re_ += src.re_;
@@ -269,7 +254,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           void>::type
   operator += (const volatile complex<InputRealType>& src) volatile {
     re_ += src.re_;
@@ -278,7 +263,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           complex<RealType>&>::type
   operator += (const InputRealType& src) {
     re_ += src;
@@ -287,7 +272,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           void>::type
   operator += (const volatile InputRealType& src) volatile {
     re_ += src;
@@ -295,7 +280,7 @@ public:
   
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           complex<RealType>&>::type
   operator -= (const complex<InputRealType>& src) {
     re_ -= src.re_;
@@ -305,7 +290,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           complex<RealType>&>::type
   operator -= (const InputRealType& src) {
     re_ -= src;
@@ -314,7 +299,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           complex<RealType>&>::type
   operator *= (const complex<InputRealType>& src) {
     const RealType realPart = re_ * src.re_ - im_ * src.im_;
@@ -326,7 +311,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           void>::type
   operator *= (const volatile complex<InputRealType>& src) volatile {
     const RealType realPart = re_ * src.re_ - im_ * src.im_;
@@ -337,7 +322,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           complex<RealType>&>::type
   operator *= (const InputRealType& src) {
     re_ *= src;
@@ -347,7 +332,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           void>::type
   operator *= (const volatile InputRealType& src) volatile {
     re_ *= src;
@@ -356,7 +341,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           complex<RealType>&>::type
   operator /= (const complex<InputRealType>& y) {
     // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
@@ -384,7 +369,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           complex<RealType>&>::type
   operator /= (const InputRealType& src) {
     re_ /= src;
@@ -394,7 +379,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           bool>::type
   operator == (const complex<InputRealType>& src) {
     return (re_ == static_cast<RealType>(src.re_)) && (im_ == static_cast<RealType>(src.im_));
@@ -402,7 +387,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           bool>::type
   operator == (const InputRealType src) {
     return (re_ == static_cast<RealType>(src)) && (im_ == RealType(0));
@@ -410,7 +395,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           bool>::type
   operator != (const complex<InputRealType>& src) {
     return (re_ != static_cast<RealType>(src.re_)) || (im_ != static_cast<RealType>(src.im_));
@@ -418,7 +403,7 @@ public:
 
   template<typename InputRealType>
   KOKKOS_INLINE_FUNCTION
-  typename std::enable_if<is_convertible<InputRealType,RealType>::value,
+  typename std::enable_if<std::is_convertible<InputRealType,RealType>::value,
                           bool>::type
     operator != (const InputRealType src) {
     return (re_ != static_cast<RealType>(src)) || (im_ != RealType(0));
@@ -429,28 +414,31 @@ public:
 //! Binary + operator for complex complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator + (const complex<RealType1>& x, const complex<RealType2>& y) {
-  return complex<RealType1> (x.real () + y.real (), x.imag () + y.imag ());
+  return complex<typename std::common_type<RealType1,RealType2>::type > (x.real () + y.real (), x.imag () + y.imag ());
 }
 
 //! Binary + operator for complex scalar.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator + (const complex<RealType1>& x, const RealType2& y) {
-  return complex<RealType1> (x.real () + y , x.imag ());
+  return complex<typename std::common_type<RealType1,RealType2>::type> (x.real () + y , x.imag ());
 }
 
 //! Binary + operator for scalar complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator + (const RealType1& x, const complex<RealType2>& y) {
-  return complex<RealType1> (x + y.real (), y.imag ());
+  return complex<typename std::common_type<RealType1,RealType2>::type> (x + y.real (), y.imag ());
 }
 
 //! Unary + operator for complex.
@@ -464,28 +452,31 @@ operator + (const complex<RealType>& x) {
 //! Binary - operator for complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator - (const complex<RealType1>& x, const complex<RealType2>& y) {
-  return complex<RealType1> (x.real () - y.real (), x.imag () - y.imag ());
+  return complex<typename std::common_type<RealType1,RealType2>::type> (x.real () - y.real (), x.imag () - y.imag ());
 }
 
 //! Binary - operator for complex scalar.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator - (const complex<RealType1>& x, const RealType2& y) {
-  return complex<RealType1> (x.real () - y , x.imag ());
+  return complex<typename std::common_type<RealType1,RealType2>::type> (x.real () - y , x.imag ());
 }
 
 //! Binary - operator for scalar complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator - (const RealType1& x, const complex<RealType2>& y) {
-  return complex<RealType1> (x - y.real (), - y.imag ());
+  return complex<typename std::common_type<RealType1,RealType2>::type> (x - y.real (), - y.imag ());
 }
 
 //! Unary - operator for complex.
@@ -499,11 +490,12 @@ operator - (const complex<RealType>& x) {
 //! Binary * operator for complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator * (const complex<RealType1>& x, const complex<RealType2>& y) {
-  return complex<RealType1> (x.real () * y.real () - x.imag () * y.imag (),
-                            x.real () * y.imag () + x.imag () * y.real ());
+  return complex<typename std::common_type<RealType1,RealType2>::type> (x.real () * y.real () - x.imag () * y.imag (),
+                                                                        x.real () * y.imag () + x.imag () * y.real ());
 }
 
 /// \brief Binary * operator for std::complex and complex.
@@ -518,11 +510,12 @@ operator * (const complex<RealType1>& x, const complex<RealType2>& y) {
 /// CUDA device functions.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator * (const std::complex<RealType1>& x, const complex<RealType2>& y) {
-  return complex<RealType1> (x.real () * y.real () - x.imag () * y.imag (),
-                             x.real () * y.imag () + x.imag () * y.real ());
+  return complex<typename std::common_type<RealType1,RealType2>::type> (x.real () * y.real () - x.imag () * y.imag (),
+                                                                        x.real () * y.imag () + x.imag () * y.real ());
 }
 
 /// \brief Binary * operator for RealType times complex.
@@ -531,10 +524,11 @@ operator * (const std::complex<RealType1>& x, const complex<RealType2>& y) {
 /// RealType and complex<RealType> commute with respect to operator*.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator * (const RealType1& x, const complex<RealType2>& y) {
-  return complex<RealType1> (x * y.real (), x * y.imag ());
+  return complex<typename std::common_type<RealType1,RealType2>::type> (x * y.real (), x * y.imag ());
 }
 
 /// \brief Binary * operator for RealType times complex.
@@ -543,10 +537,11 @@ operator * (const RealType1& x, const complex<RealType2>& y) {
 /// RealType and complex<RealType> commute with respect to operator*.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator * (const complex<RealType1>& y, const RealType2& x) {
-  return complex<RealType1> (x * y.real (), x * y.imag ());
+  return complex<typename std::common_type<RealType1,RealType2>::type> (x * y.real (), x * y.imag ());
 }
 
 //! Imaginary part of a complex number.
@@ -613,35 +608,38 @@ complex<RealType> pow (const complex<RealType>& x) {
 //! Binary operator / for complex and real numbers
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator / (const complex<RealType1>& x, const RealType2& y) {
-  return complex<RealType1> (real (x) / y, imag (x) / y);
+  return complex<typename std::common_type<RealType1,RealType2>::type> (real (x) / y, imag (x) / y);
 }
 
 //! Binary operator / for complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator / (const complex<RealType1>& x, const complex<RealType2>& y) {
   // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
   // If the real part is +/-Inf and the imaginary part is -/+Inf,
   // this won't change the result.
-  const RealType1 s = std::fabs (real (y)) + std::fabs (imag (y));
+  typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
+  const common_real_type s = std::fabs (real (y)) + std::fabs (imag (y));
 
   // If s is 0, then y is zero, so x/y == real(x)/0 + i*imag(x)/0.
   // In that case, the relation x/y == (x/s) / (y/s) doesn't hold,
   // because y/s is NaN.
   if (s == 0.0) {
-    return complex<RealType1> (real (x) / s, imag (x) / s);
+    return complex<common_real_type> (real (x) / s, imag (x) / s);
   }
   else {
-    const complex<RealType1> x_scaled (real (x) / s, imag (x) / s);
-    const complex<RealType1> y_conj_scaled (real (y) / s, -imag (y) / s);
+    const complex<common_real_type> x_scaled (real (x) / s, imag (x) / s);
+    const complex<common_real_type> y_conj_scaled (real (y) / s, -imag (y) / s);
     const RealType1 y_scaled_abs = real (y_conj_scaled) * real (y_conj_scaled) +
       imag (y_conj_scaled) * imag (y_conj_scaled); // abs(y) == abs(conj(y))
-    complex<RealType1> result = x_scaled * y_conj_scaled;
+    complex<common_real_type> result = x_scaled * y_conj_scaled;
     result /= y_scaled_abs;
     return result;
   }
@@ -650,19 +648,23 @@ operator / (const complex<RealType1>& x, const complex<RealType2>& y) {
 //! Binary operator / for complex and real numbers
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
-                        complex<RealType1> >::type
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
+                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
 operator / (const RealType1& x, const complex<RealType2>& y) {
-  return complex<RealType1> (x)/y;
+  return complex<typename std::common_type<RealType1,RealType2>::type> (x)/y;
 }
 
 //! Equality operator for two complex numbers.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
                         bool>::type
 operator == (const complex<RealType1>& x, const complex<RealType2>& y) {
-  return real (x) == static_cast<RealType1>(real (y)) && imag (x) == static_cast<RealType1>(imag (y));
+  typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
+  return ( static_cast<common_real_type>(real (x)) == static_cast<common_real_type>(real (y)) && 
+           static_cast<common_real_type>(imag (x)) == static_cast<common_real_type>(imag (y)) );
 }
 
 /// \brief Equality operator for std::complex and Kokkos::complex.
@@ -673,25 +675,32 @@ operator == (const complex<RealType1>& x, const complex<RealType2>& y) {
 /// __device__ function("operator==") is not allowed").
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
                         bool>::type
 operator == (const std::complex<RealType1>& x, const complex<RealType2>& y) {
-  return std::real (x) == static_cast<RealType1>(real (y)) && std::imag (x) == static_cast<RealType1>(imag (y));
+  typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
+  return ( static_cast<common_real_type>(std::real (x)) == static_cast<common_real_type>(real (y)) && 
+           static_cast<common_real_type>(std::imag (x)) == static_cast<common_real_type>(imag (y)) );
 }
-
+  
 //! Equality operator for complex and real number.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
                         bool>::type
 operator == (const complex<RealType1>& x, const RealType2& y) {
-  return real (x) == static_cast<RealType1>(y) && imag (x) == static_cast<RealType1> (0.0);
+  typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
+  return ( static_cast<common_real_type>(real (x)) == static_cast<common_real_type>(y) && 
+           static_cast<common_real_type>(imag (x)) == static_cast<common_real_type>(0.0) );
 }
 
 //! Equality operator for real and complex number.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
                         bool>::type
 operator == (const RealType1& x, const complex<RealType2>& y) {
   return y == x;
@@ -700,34 +709,44 @@ operator == (const RealType1& x, const complex<RealType2>& y) {
 //! Inequality operator for two complex numbers.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
                         bool>::type
 operator != (const complex<RealType1>& x, const complex<RealType2>& y) {
-  return real (x) != static_cast<RealType1>(real (y)) || imag (x) != static_cast<RealType1>(imag (y));
+  typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
+  return ( static_cast<common_real_type>(real (x)) != static_cast<common_real_type>(real (y)) || 
+           static_cast<common_real_type>(imag (x)) != static_cast<common_real_type>(imag (y)) );
 }
 
 //! Inequality operator for std::complex and Kokkos::complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
                         bool>::type
 operator != (const std::complex<RealType1>& x, const complex<RealType2>& y) {
-  return std::real (x) != static_cast<RealType1>(real (y)) || std::imag (x) != static_cast<RealType1>(imag (y));
+  typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
+  return ( static_cast<common_real_type>(std::real (x)) != static_cast<common_real_type>(real (y)) || 
+           static_cast<common_real_type>(std::imag (x)) != static_cast<common_real_type>(imag (y)) );
 }
 
 //! Inequality operator for complex and real number.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
                         bool>::type
 operator != (const complex<RealType1>& x, const RealType2& y) {
-  return real (x) != static_cast<RealType1>(y) || imag (x) != static_cast<RealType1> (0.0);
+  typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
+  return ( static_cast<common_real_type>(real (x)) != static_cast<common_real_type>(y) || 
+           static_cast<common_real_type>(imag (x)) != static_cast<common_real_type>(0.0) );
 }
 
 //! Inequality operator for real and complex number.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<is_convertible<RealType2,RealType1>::value,
+typename std::enable_if<std::is_arithmetic<RealType1>::value &&
+                        std::is_arithmetic<RealType2>::value,
                         bool>::type
 operator != (const RealType1& x, const complex<RealType2>& y) {
   return y != x;

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -414,9 +414,7 @@ public:
 //! Binary + operator for complex complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator + (const complex<RealType1>& x, const complex<RealType2>& y) {
   return complex<typename std::common_type<RealType1,RealType2>::type > (x.real () + y.real (), x.imag () + y.imag ());
 }
@@ -424,9 +422,7 @@ operator + (const complex<RealType1>& x, const complex<RealType2>& y) {
 //! Binary + operator for complex scalar.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator + (const complex<RealType1>& x, const RealType2& y) {
   return complex<typename std::common_type<RealType1,RealType2>::type> (x.real () + y , x.imag ());
 }
@@ -434,9 +430,7 @@ operator + (const complex<RealType1>& x, const RealType2& y) {
 //! Binary + operator for scalar complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator + (const RealType1& x, const complex<RealType2>& y) {
   return complex<typename std::common_type<RealType1,RealType2>::type> (x + y.real (), y.imag ());
 }
@@ -452,9 +446,7 @@ operator + (const complex<RealType>& x) {
 //! Binary - operator for complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator - (const complex<RealType1>& x, const complex<RealType2>& y) {
   return complex<typename std::common_type<RealType1,RealType2>::type> (x.real () - y.real (), x.imag () - y.imag ());
 }
@@ -462,9 +454,7 @@ operator - (const complex<RealType1>& x, const complex<RealType2>& y) {
 //! Binary - operator for complex scalar.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator - (const complex<RealType1>& x, const RealType2& y) {
   return complex<typename std::common_type<RealType1,RealType2>::type> (x.real () - y , x.imag ());
 }
@@ -472,9 +462,7 @@ operator - (const complex<RealType1>& x, const RealType2& y) {
 //! Binary - operator for scalar complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator - (const RealType1& x, const complex<RealType2>& y) {
   return complex<typename std::common_type<RealType1,RealType2>::type> (x - y.real (), - y.imag ());
 }
@@ -490,9 +478,7 @@ operator - (const complex<RealType>& x) {
 //! Binary * operator for complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator * (const complex<RealType1>& x, const complex<RealType2>& y) {
   return complex<typename std::common_type<RealType1,RealType2>::type> (x.real () * y.real () - x.imag () * y.imag (),
                                                                         x.real () * y.imag () + x.imag () * y.real ());
@@ -510,9 +496,7 @@ operator * (const complex<RealType1>& x, const complex<RealType2>& y) {
 /// CUDA device functions.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator * (const std::complex<RealType1>& x, const complex<RealType2>& y) {
   return complex<typename std::common_type<RealType1,RealType2>::type> (x.real () * y.real () - x.imag () * y.imag (),
                                                                         x.real () * y.imag () + x.imag () * y.real ());
@@ -524,9 +508,7 @@ operator * (const std::complex<RealType1>& x, const complex<RealType2>& y) {
 /// RealType and complex<RealType> commute with respect to operator*.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator * (const RealType1& x, const complex<RealType2>& y) {
   return complex<typename std::common_type<RealType1,RealType2>::type> (x * y.real (), x * y.imag ());
 }
@@ -537,9 +519,7 @@ operator * (const RealType1& x, const complex<RealType2>& y) {
 /// RealType and complex<RealType> commute with respect to operator*.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator * (const complex<RealType1>& y, const RealType2& x) {
   return complex<typename std::common_type<RealType1,RealType2>::type> (x * y.real (), x * y.imag ());
 }
@@ -608,9 +588,7 @@ complex<RealType> pow (const complex<RealType>& x) {
 //! Binary operator / for complex and real numbers
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator / (const complex<RealType1>& x, const RealType2& y) {
   return complex<typename std::common_type<RealType1,RealType2>::type> (real (x) / y, imag (x) / y);
 }
@@ -618,9 +596,7 @@ operator / (const complex<RealType1>& x, const RealType2& y) {
 //! Binary operator / for complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator / (const complex<RealType1>& x, const complex<RealType2>& y) {
   // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
   // If the real part is +/-Inf and the imaginary part is -/+Inf,
@@ -648,9 +624,7 @@ operator / (const complex<RealType1>& x, const complex<RealType2>& y) {
 //! Binary operator / for complex and real numbers
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        complex<typename std::common_type<RealType1,RealType2>::type> >::type
+complex<typename std::common_type<RealType1,RealType2>::type>
 operator / (const RealType1& x, const complex<RealType2>& y) {
   return complex<typename std::common_type<RealType1,RealType2>::type> (x)/y;
 }
@@ -658,9 +632,7 @@ operator / (const RealType1& x, const complex<RealType2>& y) {
 //! Equality operator for two complex numbers.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        bool>::type
+bool
 operator == (const complex<RealType1>& x, const complex<RealType2>& y) {
   typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
   return ( static_cast<common_real_type>(real (x)) == static_cast<common_real_type>(real (y)) && 
@@ -675,9 +647,7 @@ operator == (const complex<RealType1>& x, const complex<RealType2>& y) {
 /// __device__ function("operator==") is not allowed").
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        bool>::type
+bool
 operator == (const std::complex<RealType1>& x, const complex<RealType2>& y) {
   typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
   return ( static_cast<common_real_type>(std::real (x)) == static_cast<common_real_type>(real (y)) && 
@@ -687,9 +657,7 @@ operator == (const std::complex<RealType1>& x, const complex<RealType2>& y) {
 //! Equality operator for complex and real number.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        bool>::type
+bool
 operator == (const complex<RealType1>& x, const RealType2& y) {
   typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
   return ( static_cast<common_real_type>(real (x)) == static_cast<common_real_type>(y) && 
@@ -699,9 +667,7 @@ operator == (const complex<RealType1>& x, const RealType2& y) {
 //! Equality operator for real and complex number.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        bool>::type
+bool
 operator == (const RealType1& x, const complex<RealType2>& y) {
   return y == x;
 }
@@ -709,9 +675,7 @@ operator == (const RealType1& x, const complex<RealType2>& y) {
 //! Inequality operator for two complex numbers.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        bool>::type
+bool
 operator != (const complex<RealType1>& x, const complex<RealType2>& y) {
   typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
   return ( static_cast<common_real_type>(real (x)) != static_cast<common_real_type>(real (y)) || 
@@ -721,9 +685,7 @@ operator != (const complex<RealType1>& x, const complex<RealType2>& y) {
 //! Inequality operator for std::complex and Kokkos::complex.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        bool>::type
+bool
 operator != (const std::complex<RealType1>& x, const complex<RealType2>& y) {
   typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
   return ( static_cast<common_real_type>(std::real (x)) != static_cast<common_real_type>(real (y)) || 
@@ -733,9 +695,7 @@ operator != (const std::complex<RealType1>& x, const complex<RealType2>& y) {
 //! Inequality operator for complex and real number.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        bool>::type
+bool
 operator != (const complex<RealType1>& x, const RealType2& y) {
   typedef typename std::common_type<RealType1,RealType2>::type common_real_type;
   return ( static_cast<common_real_type>(real (x)) != static_cast<common_real_type>(y) || 
@@ -745,9 +705,7 @@ operator != (const complex<RealType1>& x, const RealType2& y) {
 //! Inequality operator for real and complex number.
 template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
-typename std::enable_if<std::is_arithmetic<RealType1>::value &&
-                        std::is_arithmetic<RealType2>::value,
-                        bool>::type
+bool
 operator != (const RealType1& x, const complex<RealType2>& y) {
   return y != x;
 }

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -114,7 +114,7 @@ struct TestComplexBasicMath {
   typename Kokkos::View<Kokkos::complex<double>*,ExecSpace>::HostMirror h_results;
 
   void testit () {
-    d_results = Kokkos::View<Kokkos::complex<double>*,ExecSpace>("TestComplexBasicMath",20);
+    d_results = Kokkos::View<Kokkos::complex<double>*,ExecSpace>("TestComplexBasicMath",24);
     h_results = Kokkos::create_mirror_view(d_results);
 
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0,1), *this);
@@ -125,6 +125,7 @@ struct TestComplexBasicMath {
     std::complex<double> b(3.25,5.75);
     std::complex<double> d(1.0,2.0);
     double c = 9.3;
+    int e = 2;
 
     std::complex<double> r;
     r = a+b; ASSERT_FLOAT_EQ(h_results(0).real(),  r.real()); ASSERT_FLOAT_EQ(h_results(0).imag(),  r.imag());
@@ -147,6 +148,12 @@ struct TestComplexBasicMath {
     r = c-a; ASSERT_FLOAT_EQ(h_results(17).real(), r.real()); ASSERT_FLOAT_EQ(h_results(17).imag(), r.imag());
     r = c*a; ASSERT_FLOAT_EQ(h_results(18).real(), r.real()); ASSERT_FLOAT_EQ(h_results(18).imag(), r.imag());
     r = c/a; ASSERT_FLOAT_EQ(h_results(19).real(), r.real()); ASSERT_FLOAT_EQ(h_results(19).imag(), r.imag());
+
+    r = a; 
+    /* r = a+e; */ ASSERT_FLOAT_EQ(h_results(20).real(),  r.real()+e); ASSERT_FLOAT_EQ(h_results(20).imag(),  r.imag());
+    /* r = a-e; */ ASSERT_FLOAT_EQ(h_results(21).real(),  r.real()-e); ASSERT_FLOAT_EQ(h_results(21).imag(),  r.imag());
+    /* r = a*e; */ ASSERT_FLOAT_EQ(h_results(22).real(),  r.real()*e); ASSERT_FLOAT_EQ(h_results(22).imag(),  r.imag()*e);
+    /* r = a/e; */ ASSERT_FLOAT_EQ(h_results(23).real(),  r.real()/2); ASSERT_FLOAT_EQ(h_results(23).imag(),  r.imag()/e);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -190,6 +197,12 @@ struct TestComplexBasicMath {
     d_results(17) = c-a;
     d_results(18) = c*a;
     d_results(19) = c/a;
+
+    int e = 2;
+    d_results(20) = a+e;
+    d_results(21) = a-e;
+    d_results(22) = a*e;
+    d_results(23) = a/e;
   }
 };
 


### PR DESCRIPTION
Kokkos complex modification
======================

1. ``is_convertible`` is defined in the same Kokkos_Complex header to define what are valid types for mixed computation. Although there is ``std::is_convertible``, I would like to control that in kokkos level. Here I only allow integer to integer and arithmetic types to floating point. To clarify, we can also cahnge the struct name. 

2. All complex arithmetic operators are changed with ``enable_if<is_convertible>``. Tested with gcc 4.7.2 and 4.8.4. 

3. When binary operators take two different types, the return type always follows the left operand type.  For instance in the following opeator, it always use RealType1 as its return type. 
```
template<class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION
typename std::enable_if<is_convertible<RealType2,RealType1>::value,
                        complex<RealType1> >::type
operator - (const complex<RealType1>& x, const complex<RealType2>& y) {
  return complex<RealType1> (x.real () - y.real (), x.imag () - y.imag ());
}
```
3. Test include complex<double> and integer arithmetic operations. 
