### PR TITLE
Enable deterministic use of Random_XorShift*_Pool

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -755,6 +755,12 @@ namespace Kokkos {
       return Random_XorShift64<DeviceType>(state_(i),i);
     }
 
+    // NOTE: state_idx MUST be unique and less than num_states
+    KOKKOS_INLINE_FUNCTION
+    Random_XorShift64<DeviceType> get_state(const int state_idx) const {
+      return Random_XorShift64<DeviceType>(state_(state_idx),state_idx);
+    }
+
     KOKKOS_INLINE_FUNCTION
     void free_state(const Random_XorShift64<DeviceType>& state) const {
       state_(state.state_idx_) = state.state_;
@@ -1010,6 +1016,12 @@ namespace Kokkos {
       return Random_XorShift1024<DeviceType>(state_,p_(i),i);
     };
 
+    // NOTE: state_idx MUST be unique and less than num_states
+    KOKKOS_INLINE_FUNCTION
+    Random_XorShift1024<DeviceType> get_state(const int state_idx) const {
+      return Random_XorShift1024<DeviceType>(state_,p_(state_idx),state_idx);
+    }
+
     KOKKOS_INLINE_FUNCTION
     void free_state(const Random_XorShift1024<DeviceType>& state) const {
       for(int i = 0; i<16; i++)
@@ -1208,8 +1220,8 @@ Random_XorShift64<Kokkos::Cuda> Random_XorShift64_Pool<Kokkos::Cuda>::get_state(
 template<>
 KOKKOS_INLINE_FUNCTION
 void Random_XorShift64_Pool<Kokkos::Cuda>::free_state(const Random_XorShift64<Kokkos::Cuda> &state) const {
-#ifdef __CUDA_ARCH__
   state_(state.state_idx_) = state.state_;
+#ifdef __CUDA_ARCH__
   locks_(state.state_idx_) = 0;
   return;
 #endif
@@ -1244,9 +1256,9 @@ Random_XorShift1024<Kokkos::Cuda> Random_XorShift1024_Pool<Kokkos::Cuda>::get_st
 template<>
 KOKKOS_INLINE_FUNCTION
 void Random_XorShift1024_Pool<Kokkos::Cuda>::free_state(const Random_XorShift1024<Kokkos::Cuda> &state) const {
-#ifdef __CUDA_ARCH__
   for(int i=0; i<16; i++)
     state_(state.state_idx_,i) = state.state_[i];
+#ifdef __CUDA_ARCH__
   locks_(state.state_idx_) = 0;
   return;
 #endif


### PR DESCRIPTION
From @timattox
Enable deterministic use of Random_XorShift*_Pool.
    Add support for lock-free and deterministic use of Random_XorShift*_Pool
    by giving state_idx selection and lock responsibility up to the
    application.  Done by an overload of get_state() to take state_idx as
    an argument that the appplication guarantees is concurrently unique
    and within the range of num_states that the application passed to init().
    In other words, this allows the RNG state to be associated with some
    application specific index, rather than a runtime arbitrary thread ID,
    and thus the application can control which work is performed using
    which RNG in a deterministic manner, regardless of which thread
    performs the work.

Also fix a bug: 
On a CUDA host, the random state wasn't preserved.
    Random_XorShift*_Pool<Kokkos::Cuda>::free_state() has two purposes:
    1) update the state value kept in the pool
    2) unlock the state
    For a CUDA host thread, ONLY skip step 2, not both.