### PR TITLE
Fix warnings in -Wall -Wextra application build

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -517,7 +517,7 @@ public:
 
     size_type find_attempts = 0;
 
-    enum { bounded_find_attempts = 32u };
+    enum : unsigned { bounded_find_attempts = 32u };
     const size_type max_attempts = (m_bounded_insert && (bounded_find_attempts < m_available_indexes.max_hint()) ) ?
                                     bounded_find_attempts :
                                     m_available_indexes.max_hint();

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -713,7 +713,7 @@ SharedAllocationRecord< Kokkos::CudaHostPinnedSpace , void >::get_record( void *
 // Iterate records to print orphaned memory ...
 void
 SharedAllocationRecord< Kokkos::CudaSpace , void >::
-print_records( std::ostream & s , const Kokkos::CudaSpace & space , bool detail )
+print_records( std::ostream & s , const Kokkos::CudaSpace & , bool detail )
 {
   SharedAllocationRecord< void , void > * r = & s_root_record ;
 
@@ -751,7 +751,7 @@ print_records( std::ostream & s , const Kokkos::CudaSpace & space , bool detail 
               , reinterpret_cast<uintptr_t>( r->m_dealloc )
               , head.m_label
               );
-      std::cout << buffer ;
+      s << buffer ;
       r = r->m_next ;
     } while ( r != & s_root_record );
   }
@@ -781,7 +781,7 @@ print_records( std::ostream & s , const Kokkos::CudaSpace & space , bool detail 
       else {
         snprintf( buffer , 256 , "Cuda [ 0 + 0 ]\n" );
       }
-      std::cout << buffer ;
+      s << buffer ;
       r = r->m_next ;
     } while ( r != & s_root_record );
   }
@@ -789,14 +789,14 @@ print_records( std::ostream & s , const Kokkos::CudaSpace & space , bool detail 
 
 void
 SharedAllocationRecord< Kokkos::CudaUVMSpace , void >::
-print_records( std::ostream & s , const Kokkos::CudaUVMSpace & space , bool detail )
+print_records( std::ostream & s , const Kokkos::CudaUVMSpace & , bool detail )
 {
   SharedAllocationRecord< void , void >::print_host_accessible_records( s , "CudaUVM" , & s_root_record , detail );
 }
 
 void
 SharedAllocationRecord< Kokkos::CudaHostPinnedSpace , void >::
-print_records( std::ostream & s , const Kokkos::CudaHostPinnedSpace & space , bool detail )
+print_records( std::ostream & s , const Kokkos::CudaHostPinnedSpace & , bool detail )
 {
   SharedAllocationRecord< void , void >::print_host_accessible_records( s , "CudaHostPinned" , & s_root_record , detail );
 }

--- a/core/src/Kokkos_Crs.hpp
+++ b/core/src/Kokkos_Crs.hpp
@@ -336,22 +336,27 @@ void transpose_crs(
 }
 
 template< class CrsType,
-          class Functor>
-struct CountAndFill {
+          class Functor,
+          class ExecutionSpace = typename CrsType::execution_space>
+struct CountAndFillBase;
+
+template< class CrsType,
+          class Functor,
+          class ExecutionSpace>
+struct CountAndFillBase {
   using data_type = typename CrsType::size_type;
   using size_type = typename CrsType::size_type;
   using row_map_type = typename CrsType::row_map_type;
-  using entries_type = typename CrsType::entries_type;
   using counts_type = row_map_type;
   CrsType m_crs;
   Functor m_functor;
   counts_type m_counts;
   struct Count {};
-  KOKKOS_INLINE_FUNCTION void operator()(Count, size_type i) const {
+  inline void operator()(Count, size_type i) const {
     m_counts(i) = m_functor(i, nullptr);
   }
   struct Fill {};
-  KOKKOS_INLINE_FUNCTION void operator()(Fill, size_type i) const {
+  inline void operator()(Fill, size_type i) const {
     auto j = m_crs.row_map(i);
     /* we don't want to access entries(entries.size()), even if its just to get its
        address and never use it.
@@ -363,13 +368,63 @@ struct CountAndFill {
       nullptr : (&(m_crs.entries(j)));
     m_functor(i, fill);
   }
-  using self_type = CountAndFill<CrsType, Functor>;
-  CountAndFill(CrsType& crs, size_type nrows, Functor const& f):
+  CountAndFillBase(CrsType& crs, Functor const& f):
     m_crs(crs),
     m_functor(f)
+  {}
+};
+
+#if defined( KOKKOS_ENABLE_CUDA )
+template< class CrsType,
+          class Functor>
+struct CountAndFillBase<CrsType, Functor, Kokkos::Cuda> {
+  using data_type = typename CrsType::size_type;
+  using size_type = typename CrsType::size_type;
+  using row_map_type = typename CrsType::row_map_type;
+  using counts_type = row_map_type;
+  CrsType m_crs;
+  Functor m_functor;
+  counts_type m_counts;
+  struct Count {};
+  __device__ inline void operator()(Count, size_type i) const {
+    m_counts(i) = m_functor(i, nullptr);
+  }
+  struct Fill {};
+  __device__ inline void operator()(Fill, size_type i) const {
+    auto j = m_crs.row_map(i);
+    /* we don't want to access entries(entries.size()), even if its just to get its
+       address and never use it.
+       this can happen when row (i) is empty and all rows after it are also empty.
+       we could compare to row_map(i + 1), but that is a read from global memory,
+       whereas dimension_0() should be part of the View in registers (or constant memory) */
+    data_type* fill =
+      (j == static_cast<decltype(j)>(m_crs.entries.dimension_0())) ?
+      nullptr : (&(m_crs.entries(j)));
+    m_functor(i, fill);
+  }
+  CountAndFillBase(CrsType& crs, Functor const& f):
+    m_crs(crs),
+    m_functor(f)
+  {}
+};
+#endif
+
+template< class CrsType,
+          class Functor>
+struct CountAndFill : public CountAndFillBase<CrsType, Functor> {
+  using base_type = CountAndFillBase<CrsType, Functor>;
+  using typename base_type::data_type;
+  using typename base_type::size_type;
+  using typename base_type::counts_type;
+  using typename base_type::Count;
+  using typename base_type::Fill;
+  using entries_type = typename CrsType::entries_type;
+  using self_type = CountAndFill<CrsType, Functor>;
+  CountAndFill(CrsType& crs, size_type nrows, Functor const& f):
+    base_type(crs, f)
   {
     using execution_space = typename CrsType::execution_space;
-    m_counts = counts_type("counts", nrows);
+    this->m_counts = counts_type("counts", nrows);
     {
     using count_policy_type = RangePolicy<size_type, execution_space, Count>;
     using count_closure_type =
@@ -378,9 +433,9 @@ struct CountAndFill {
     closure.execute();
     }
     auto nentries = Kokkos::Experimental::
-      get_crs_row_map_from_counts(m_crs.row_map, m_counts);
-    m_counts = counts_type();
-    m_crs.entries = entries_type("entries", nentries);
+      get_crs_row_map_from_counts(this->m_crs.row_map, this->m_counts);
+    this->m_counts = counts_type();
+    this->m_crs.entries = entries_type("entries", nentries);
     {
     using fill_policy_type = RangePolicy<size_type, execution_space, Fill>;
     using fill_closure_type =
@@ -388,7 +443,7 @@ struct CountAndFill {
     const fill_closure_type closure(*this, fill_policy_type(0, nrows));
     closure.execute();
     }
-    crs = m_crs;
+    crs = this->m_crs;
   }
 };
 

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -476,7 +476,7 @@ template< class FunctorType , class ArgTag , class T , class Enable >
 struct FunctorValueInit< FunctorType , ArgTag , T & , Enable >
 {
   KOKKOS_FORCEINLINE_FUNCTION static
-  T & init( const FunctorType & f , void * p )
+  T & init( const FunctorType & , void * p )
     { return *( new(p) T() ); };
 };
 

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -254,7 +254,12 @@ void * HostSpace::allocate( const size_t arg_alloc_size ) const
 }
 
 
-void HostSpace::deallocate( void * const arg_alloc_ptr , const size_t arg_alloc_size ) const
+void HostSpace::deallocate( void * const arg_alloc_ptr
+    , const size_t
+#if defined( KOKKOS_IMPL_POSIX_MMAP_FLAGS )
+    arg_alloc_size
+#endif
+    ) const
 {
   if ( arg_alloc_ptr ) {
 
@@ -409,7 +414,7 @@ SharedAllocationRecord< Kokkos::HostSpace , void >::get_record( void * alloc_ptr
 
 // Iterate records to print orphaned memory ...
 void SharedAllocationRecord< Kokkos::HostSpace , void >::
-print_records( std::ostream & s , const Kokkos::HostSpace & space , bool detail )
+print_records( std::ostream & s , const Kokkos::HostSpace & , bool detail )
 {
   SharedAllocationRecord< void , void >::print_host_accessible_records( s , "HostSpace" , & s_root_record , detail );
 }

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -306,7 +306,7 @@ print_host_accessible_records( std::ostream & s
               , reinterpret_cast<uintptr_t>( r->m_dealloc )
               , r->m_alloc_ptr->m_label
               );
-      std::cout << buffer ;
+      s << buffer ;
       r = r->m_next ;
     } while ( r != root );
   }
@@ -334,7 +334,7 @@ print_host_accessible_records( std::ostream & s
       else {
         snprintf( buffer , 256 , "%s [ 0 + 0 ]\n" , space_name );
       }
-      std::cout << buffer ;
+      s << buffer ;
       r = r->m_next ;
     } while ( r != root );
   }

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -369,9 +369,9 @@ private:
 
   template< size_t ... DimArgs >
   KOKKOS_FORCEINLINE_FUNCTION
-  bool set( unsigned domain_rank
-          , unsigned range_rank
-          , const ViewDimension< DimArgs ... > & dim )
+  bool set( unsigned
+          , unsigned
+          , const ViewDimension< DimArgs ... > & )
     { return true ; }
 
   template< class T , size_t ... DimArgs , class ... Args >
@@ -1047,7 +1047,7 @@ struct ViewOffset< Dimension , Kokkos::LayoutLeft
   template< class DimRHS >
   KOKKOS_INLINE_FUNCTION
   constexpr ViewOffset(
-    const ViewOffset< DimRHS , Kokkos::LayoutLeft , void > & rhs ,
+    const ViewOffset< DimRHS , Kokkos::LayoutLeft , void > & ,
     const SubviewExtents< DimRHS::rank , dimension_type::rank > & sub )
     : m_dim( sub.range_extent(0), 0, 0, 0, 0, 0, 0, 0 )
     {
@@ -1252,7 +1252,7 @@ public:
   template< unsigned TrivialScalarSize >
   KOKKOS_INLINE_FUNCTION
   constexpr ViewOffset
-    ( std::integral_constant<unsigned,TrivialScalarSize> const & padding_type_size
+    ( std::integral_constant<unsigned,TrivialScalarSize> const &
     , Kokkos::LayoutLeft const & arg_layout
     )
     : m_dim( arg_layout.dimension[0] , arg_layout.dimension[1]
@@ -1741,7 +1741,7 @@ public:
   template< unsigned TrivialScalarSize >
   KOKKOS_INLINE_FUNCTION
   constexpr ViewOffset
-    ( std::integral_constant<unsigned,TrivialScalarSize> const & padding_type_size
+    ( std::integral_constant<unsigned,TrivialScalarSize> const &
     , Kokkos::LayoutRight const & arg_layout
     )
     : m_dim( arg_layout.dimension[0] , arg_layout.dimension[1]


### PR DESCRIPTION
The most significant thing here is the fix
for Crs CountAndFill, where I had to make
a template specialization such that `__host__`
functors were not being called from
`__host__ __device__` functions

The second most significant fix is the printout
of still-reachable records in each execution
space. Although they took a std::ostream argument,
they were hardcoded to std::cout anyway.
I changed them to output to the given ostream.

@stanmoore1 these are the backported fixes

Spot-checked with a CUDA build of Kokkos in Trilinos.
Will do another check with `test_all_sandia`...