### PR TITLE
Fix WorkGraph unit test livelock with GCC 6.1

### DIFF
--- a/core/unit_test/TestWorkGraph.hpp
+++ b/core/unit_test/TestWorkGraph.hpp
@@ -156,13 +156,13 @@ struct TestWorkGraph {
 
 } // anonymous namespace
 
-TEST_F( TEST_CATEGORY, DISABLED_workgraph_fib )
+TEST_F( TEST_CATEGORY, workgraph_fib )
 {
-  #ifdef KOKKOS_IMPL_CUDA_CLANG_WORKAROUND
-  int limit = 15;
-  #else
+//#ifdef KOKKOS_IMPL_CUDA_CLANG_WORKAROUND
+//int limit = 15;
+//#else
   int limit = 27;
-  #endif
+//#endif
   for ( int i = 0; i < limit; ++i) {
     TestWorkGraph< TEST_EXECSPACE > f(i);
     f.test_for();


### PR DESCRIPTION
Many thanks to @hcedwar for suggesting a
solution to the observed livelock.
Re-enabling this test.