### PR TITLE
Issue #1113 Fix mdrange_neg_idx unit tests for rank > 3

### DIFF
--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -2611,7 +2611,7 @@ struct TestMDRange_4D_NegIdx {
   using value_type = double;
 
   using DataType     = int;
-  using ViewType     = typename Kokkos::View< DataType***, ExecSpace >;
+  using ViewType     = typename Kokkos::View< DataType****, ExecSpace >;
   using HostViewType = typename ViewType::HostMirror;
 
   ViewType input_view;
@@ -2670,7 +2670,7 @@ struct TestMDRange_5D_NegIdx {
   using value_type = double;
 
   using DataType     = int;
-  using ViewType     = typename Kokkos::View< DataType***, ExecSpace >;
+  using ViewType     = typename Kokkos::View< DataType*****, ExecSpace >;
   using HostViewType = typename ViewType::HostMirror;
 
   ViewType input_view;
@@ -2730,7 +2730,7 @@ struct TestMDRange_6D_NegIdx {
   using value_type = double;
 
   using DataType     = int;
-  using ViewType     = typename Kokkos::View< DataType***, ExecSpace >;
+  using ViewType     = typename Kokkos::View< DataType******, ExecSpace >;
   using HostViewType = typename ViewType::HostMirror;
 
   ViewType input_view;


### PR DESCRIPTION
ViewType did not have the correct rank in template parameter for rank >
3 tests, detected with debug build.