### PR TITLE
Add error check with meaningful message for issue #615.

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -127,11 +127,11 @@ struct CudaTextureFetch {
   template< class CudaMemorySpace >
   inline explicit
   CudaTextureFetch( const ValueType * const arg_ptr
-                  , Kokkos::Experimental::Impl::SharedAllocationRecord< CudaMemorySpace , void > & record
+                  , Kokkos::Impl::SharedAllocationRecord< CudaMemorySpace , void > * record
                   )
-    : m_obj( record.template attach_texture_object< AliasType >() )
+    : m_obj( record->template attach_texture_object< AliasType >() )
     , m_ptr( arg_ptr )
-    , m_offset( record.attach_texture_object_offset( reinterpret_cast<const AliasType*>( arg_ptr ) ) )
+    , m_offset( record->attach_texture_object_offset( reinterpret_cast<const AliasType*>( arg_ptr ) ) )
     {}
 
   // Texture object spans the entire allocation.
@@ -199,8 +199,8 @@ struct CudaLDGFetch {
   template< class CudaMemorySpace >
   inline explicit
   CudaLDGFetch( const ValueType * const arg_ptr
-                  , Kokkos::Experimental::Impl::SharedAllocationRecord< CudaMemorySpace , void > const &
-                  )
+              , Kokkos::Impl::SharedAllocationRecord<CudaMemorySpace,void>*
+              )
     : m_ptr( arg_ptr )
     {}
 
@@ -285,7 +285,21 @@ public:
       // Assignment of texture = non-texture requires creation of a texture object
       // which can only occur on the host.  In addition, 'get_record' is only valid
       // if called in a host execution space
-      return handle_type( arg_data_ptr , arg_tracker.template get_record< typename Traits::memory_space >() );
+
+
+      typedef typename Traits::memory_space memory_space ;
+      typedef typename Impl::SharedAllocationRecord<memory_space,void> record ;
+
+      record * const r = arg_tracker.template get_record< memory_space >();
+
+#if ! defined( KOKKOS_ENABLE_CUDA_LDG_INTRINSIC )
+      if ( 0 == r ) {
+        Kokkos::abort("Cuda const random access View using Cuda texture memory requires Kokkos to allocate the View's memory");
+      }
+#endif
+
+      return handle_type( arg_data_ptr , r );
+
 #else
       Kokkos::Impl::cuda_abort("Cannot create Cuda texture object from within a Cuda kernel");
       return handle_type();

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -294,9 +294,13 @@ public:
 
   template< class MemorySpace >
   constexpr
-  SharedAllocationRecord< MemorySpace , void > &
-  get_record() const
-    { return * static_cast< SharedAllocationRecord< MemorySpace , void > * >( m_record ); }
+  SharedAllocationRecord< MemorySpace , void > *
+  get_record() const noexcept
+    {
+      return ( m_record_bits & DO_NOT_DEREF_FLAG )
+             ? (SharedAllocationRecord< MemorySpace,void>*) 0
+             : static_cast<SharedAllocationRecord<MemorySpace,void>*>(m_record);
+    }
 
   template< class MemorySpace >
   std::string get_label() const


### PR DESCRIPTION
Creating a const random access Cuda memory View assumes
the use of texture objects, so verify the texture object
can be created or retrieved.
Resolves issue #615.
Cuda tests passed.