### PR TITLE
Issue 52 rm exp

### DIFF
--- a/core/src/Cuda/KokkosExp_Cuda_IterateTile.hpp
+++ b/core/src/Cuda/KokkosExp_Cuda_IterateTile.hpp
@@ -63,7 +63,7 @@
 #include <typeinfo>
 #endif
 
-namespace Kokkos { namespace Experimental { namespace Impl {
+namespace Kokkos { namespace Impl {
 
 // ------------------------------------------------------------------ //
 
@@ -1256,7 +1256,7 @@ protected:
   const Functor    m_func;
 };
 
-} } } //end namespace Kokkos::Experimental::Impl
+} } //end namespace Kokkos::Impl
 
 #endif
 #endif

--- a/core/src/Cuda/KokkosExp_Cuda_IterateTile_Refactor.hpp
+++ b/core/src/Cuda/KokkosExp_Cuda_IterateTile_Refactor.hpp
@@ -63,7 +63,7 @@
 #include <typeinfo>
 #endif
 
-namespace Kokkos { namespace Experimental { namespace Impl {
+namespace Kokkos { namespace Impl {
 
 namespace Refactor {
 
@@ -2709,7 +2709,7 @@ private:
 
 // ----------------------------------------------------------------------------------
 
-} } } //end namespace Kokkos::Experimental::Impl
+} } //end namespace Kokkos::Impl
 
 #endif
 #endif

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -381,12 +381,12 @@ public:
 // MDRangePolicy impl
 template< class FunctorType , class ... Traits >
 class ParallelFor< FunctorType
-                 , Kokkos::Experimental::MDRangePolicy< Traits ... >
+                 , Kokkos::MDRangePolicy< Traits ... >
                  , Kokkos::Cuda
                  >
 {
 private:
-  typedef Kokkos::Experimental::MDRangePolicy< Traits ...  > Policy ;
+  typedef Kokkos::MDRangePolicy< Traits ...  > Policy ;
   using RP = Policy;
   typedef typename Policy::array_index_type array_index_type;
   typedef typename Policy::index_type index_type;
@@ -402,7 +402,7 @@ public:
   __device__
   void operator()(void) const
     {
-      Kokkos::Experimental::Impl::Refactor::DeviceIterateTile<Policy::rank,Policy,FunctorType,typename Policy::work_tag>(m_rp,m_functor).exec_range();
+      Kokkos::Impl::Refactor::DeviceIterateTile<Policy::rank,Policy,FunctorType,typename Policy::work_tag>(m_rp,m_functor).exec_range();
     }
 
 
@@ -858,14 +858,14 @@ public:
 // MDRangePolicy impl
 template< class FunctorType , class ReducerType, class ... Traits >
 class ParallelReduce< FunctorType
-                    , Kokkos::Experimental::MDRangePolicy< Traits ... >
+                    , Kokkos::MDRangePolicy< Traits ... >
                     , ReducerType
                     , Kokkos::Cuda
                     >
 {
 private:
 
-  typedef Kokkos::Experimental::MDRangePolicy< Traits ... > Policy ;
+  typedef Kokkos::MDRangePolicy< Traits ... > Policy ;
   typedef typename Policy::array_index_type                 array_index_type;
   typedef typename Policy::index_type                       index_type;
 
@@ -898,7 +898,7 @@ public:
   size_type *         m_scratch_flags ;
   size_type *         m_unified_space ;
 
-  typedef typename Kokkos::Experimental::Impl::Reduce::DeviceIterateTile<Policy::rank, Policy, FunctorType, typename Policy::work_tag, reference_type> DeviceIteratePattern;
+  typedef typename Kokkos::Impl::Reduce::DeviceIterateTile<Policy::rank, Policy, FunctorType, typename Policy::work_tag, reference_type> DeviceIteratePattern;
 
   // Shall we use the shfl based reduction or not (only use it for static sized types of more than 128bit
   enum { UseShflReduction = ((sizeof(value_type)>2*sizeof(double)) && ValueTraits::StaticValueSize) };
@@ -913,7 +913,7 @@ public:
   void
   exec_range( reference_type update ) const
   {
-    Kokkos::Experimental::Impl::Reduce::DeviceIterateTile<Policy::rank,Policy,FunctorType,typename Policy::work_tag, reference_type>(m_policy, m_functor, update).exec_range();
+    Kokkos::Impl::Reduce::DeviceIterateTile<Policy::rank,Policy,FunctorType,typename Policy::work_tag, reference_type>(m_policy, m_functor, update).exec_range();
   }
 
   inline

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -397,7 +397,7 @@ void md_parallel_for( const std::string& str
                       ) >::type* = 0
                     )
 {
-  Impl::DeviceIterateTile<MDRange, Functor, typename MDRange::work_tag> closure(range, f);
+  Kokkos::Impl::DeviceIterateTile<MDRange, Functor, typename MDRange::work_tag> closure(range, f);
   closure.execute();
 }
 
@@ -412,7 +412,7 @@ void md_parallel_for( MDRange const& range
                       ) >::type* = 0
                     )
 {
-  Impl::DeviceIterateTile<MDRange, Functor, typename MDRange::work_tag> closure(range, f);
+  Kokkos::Impl::DeviceIterateTile<MDRange, Functor, typename MDRange::work_tag> closure(range, f);
   closure.execute();
 }
 #endif

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -55,7 +55,7 @@
 #include <Cuda/KokkosExp_Cuda_IterateTile_Refactor.hpp>
 #endif
 
-namespace Kokkos { namespace Experimental {
+namespace Kokkos {
 
 // ------------------------------------------------------------------ //
 
@@ -331,11 +331,23 @@ struct MDRangePolicy
   }
 
 };
+
+} // namespace Kokkos
+
+// For backward compatibility
+namespace Kokkos { namespace Experimental {
+  using Kokkos::MDRangePolicy;
+  using Kokkos::Rank;
+  using Kokkos::Iterate;
+} } // end Kokkos::Experimental
 // ------------------------------------------------------------------ //
 
 // ------------------------------------------------------------------ //
 //md_parallel_for - deprecated use parallel_for
 // ------------------------------------------------------------------ //
+
+namespace Kokkos { namespace Experimental {
+
 template <typename MDRange, typename Functor, typename Enable = void>
 void md_parallel_for( MDRange const& range
                     , Functor const& f
@@ -347,7 +359,7 @@ void md_parallel_for( MDRange const& range
                       ) >::type* = 0
                     )
 {
-  Impl::MDFunctor<MDRange, Functor, void> g(range, f);
+  Kokkos::Impl::Experimental::MDFunctor<MDRange, Functor, void> g(range, f);
 
   using range_policy = typename MDRange::impl_range_policy;
 
@@ -365,7 +377,7 @@ void md_parallel_for( const std::string& str
                       ) >::type* = 0
                     )
 {
-  Impl::MDFunctor<MDRange, Functor, void> g(range, f);
+  Kokkos::Impl::Experimental::MDFunctor<MDRange, Functor, void> g(range, f);
 
   using range_policy = typename MDRange::impl_range_policy;
 
@@ -421,7 +433,7 @@ void md_parallel_reduce( MDRange const& range
                       ) >::type* = 0
                     )
 {
-  Impl::MDFunctor<MDRange, Functor, ValueType> g(range, f);
+  Kokkos::Impl::Experimental::MDFunctor<MDRange, Functor, ValueType> g(range, f);
 
   using range_policy = typename MDRange::impl_range_policy;
   Kokkos::parallel_reduce( str, range_policy(0, range.m_num_tiles).set_chunk_size(1), g, v );
@@ -439,7 +451,7 @@ void md_parallel_reduce( const std::string& str
                       ) >::type* = 0
                     )
 {
-  Impl::MDFunctor<MDRange, Functor, ValueType> g(range, f);
+  Kokkos::Impl::Experimental::MDFunctor<MDRange, Functor, ValueType> g(range, f);
 
   using range_policy = typename MDRange::impl_range_policy;
 
@@ -448,7 +460,7 @@ void md_parallel_reduce( const std::string& str
 
 // Cuda - md_parallel_reduce not implemented - use parallel_reduce
 
-}} // namespace Kokkos::Experimental
+} } // namespace Kokkos::Experimental
 
 #endif //KOKKOS_CORE_EXP_MD_RANGE_POLICY_HPP
 

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -619,16 +619,16 @@ namespace Impl {
 
 template< class FunctorType , class ... Traits >
 class ParallelFor< FunctorType ,
-                   Kokkos::Experimental::MDRangePolicy< Traits ... > ,
+                   Kokkos::MDRangePolicy< Traits ... > ,
                    Kokkos::Serial
                  >
 {
 private:
 
-  typedef Kokkos::Experimental::MDRangePolicy< Traits ... > MDRangePolicy ;
+  typedef Kokkos::MDRangePolicy< Traits ... > MDRangePolicy ;
   typedef typename MDRangePolicy::impl_range_policy Policy ;
 
-  typedef typename Kokkos::Experimental::Impl::HostIterateTile< MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void > iterate_type;
+  typedef typename Kokkos::Impl::HostIterateTile< MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void > iterate_type;
 
   const FunctorType   m_functor ;
   const MDRangePolicy m_mdr_policy ;
@@ -661,14 +661,14 @@ public:
 
 template< class FunctorType , class ReducerType , class ... Traits >
 class ParallelReduce< FunctorType
-                    , Kokkos::Experimental::MDRangePolicy< Traits ... >
+                    , Kokkos::MDRangePolicy< Traits ... >
                     , ReducerType
                     , Kokkos::Serial
                     >
 {
 private:
 
-  typedef Kokkos::Experimental::MDRangePolicy< Traits ... > MDRangePolicy ;
+  typedef Kokkos::MDRangePolicy< Traits ... > MDRangePolicy ;
   typedef typename MDRangePolicy::impl_range_policy Policy ;
 
   typedef typename MDRangePolicy::work_tag                                  WorkTag ;
@@ -686,7 +686,7 @@ private:
   typedef typename Analysis::reference_type  reference_type ;
 
 
-  using iterate_type = typename Kokkos::Experimental::Impl::HostIterateTile< MDRangePolicy
+  using iterate_type = typename Kokkos::Impl::HostIterateTile< MDRangePolicy
                                                                            , FunctorType
                                                                            , WorkTag
                                                                            , ValueType

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -170,20 +170,20 @@ public:
 // MDRangePolicy impl
 template< class FunctorType , class ... Traits >
 class ParallelFor< FunctorType
-                 , Kokkos::Experimental::MDRangePolicy< Traits ... >
+                 , Kokkos::MDRangePolicy< Traits ... >
                  , Kokkos::OpenMP
                  >
 {
 private:
 
-  typedef Kokkos::Experimental::MDRangePolicy< Traits ... > MDRangePolicy ;
+  typedef Kokkos::MDRangePolicy< Traits ... > MDRangePolicy ;
   typedef typename MDRangePolicy::impl_range_policy         Policy ;
   typedef typename MDRangePolicy::work_tag                  WorkTag ;
 
   typedef typename Policy::WorkRange    WorkRange ;
   typedef typename Policy::member_type  Member ;
 
-  typedef typename Kokkos::Experimental::Impl::HostIterateTile< MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void > iterate_type;
+  typedef typename Kokkos::Impl::HostIterateTile< MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void > iterate_type;
 
         OpenMPExec   * m_instance ;
   const FunctorType   m_functor ;
@@ -445,14 +445,14 @@ public:
 // MDRangePolicy impl
 template< class FunctorType , class ReducerType, class ... Traits >
 class ParallelReduce< FunctorType
-                    , Kokkos::Experimental::MDRangePolicy< Traits ...>
+                    , Kokkos::MDRangePolicy< Traits ...>
                     , ReducerType
                     , Kokkos::OpenMP
                     >
 {
 private:
 
-  typedef Kokkos::Experimental::MDRangePolicy< Traits ... > MDRangePolicy ;
+  typedef Kokkos::MDRangePolicy< Traits ... > MDRangePolicy ;
   typedef typename MDRangePolicy::impl_range_policy         Policy ;
 
   typedef typename MDRangePolicy::work_tag                  WorkTag ;
@@ -472,7 +472,7 @@ private:
   typedef typename Analysis::pointer_type    pointer_type ;
   typedef typename Analysis::reference_type  reference_type ;
 
-  using iterate_type = typename Kokkos::Experimental::Impl::HostIterateTile< MDRangePolicy
+  using iterate_type = typename Kokkos::Impl::HostIterateTile< MDRangePolicy
                                                                            , FunctorType
                                                                            , WorkTag
                                                                            , ValueType

--- a/core/src/Threads/Kokkos_Threads_Parallel.hpp
+++ b/core/src/Threads/Kokkos_Threads_Parallel.hpp
@@ -180,12 +180,12 @@ public:
 // MDRangePolicy impl
 template< class FunctorType , class ... Traits >
 class ParallelFor< FunctorType
-                 , Kokkos::Experimental::MDRangePolicy< Traits ... >
+                 , Kokkos::MDRangePolicy< Traits ... >
                  , Kokkos::Threads
                  >
 {
 private:
-  typedef Kokkos::Experimental::MDRangePolicy< Traits ... > MDRangePolicy ;
+  typedef Kokkos::MDRangePolicy< Traits ... > MDRangePolicy ;
   typedef typename MDRangePolicy::impl_range_policy         Policy ;
 
   typedef typename MDRangePolicy::work_tag                  WorkTag ;
@@ -193,7 +193,7 @@ private:
   typedef typename Policy::WorkRange   WorkRange ;
   typedef typename Policy::member_type Member ;
 
-  typedef typename Kokkos::Experimental::Impl::HostIterateTile< MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void > iterate_type;
+  typedef typename Kokkos::Impl::HostIterateTile< MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void > iterate_type;
 
   const FunctorType   m_functor ;
   const MDRangePolicy m_mdr_policy ;
@@ -548,14 +548,14 @@ public:
 // MDRangePolicy impl
 template< class FunctorType , class ReducerType, class ... Traits >
 class ParallelReduce< FunctorType
-                    , Kokkos::Experimental::MDRangePolicy< Traits ... >
+                    , Kokkos::MDRangePolicy< Traits ... >
                     , ReducerType
                     , Kokkos::Threads
                     >
 {
 private:
 
-  typedef Kokkos::Experimental::MDRangePolicy< Traits ... > MDRangePolicy ;
+  typedef Kokkos::MDRangePolicy< Traits ... > MDRangePolicy ;
   typedef typename MDRangePolicy::impl_range_policy Policy ;
 
   typedef typename MDRangePolicy::work_tag    WorkTag ;
@@ -573,7 +573,7 @@ private:
   typedef typename ValueTraits::pointer_type    pointer_type ;
   typedef typename ValueTraits::reference_type  reference_type ;
 
-  using iterate_type = typename Kokkos::Experimental::Impl::HostIterateTile< MDRangePolicy
+  using iterate_type = typename Kokkos::Impl::HostIterateTile< MDRangePolicy
                                                                            , FunctorType
                                                                            , WorkTag
                                                                            , ValueType

--- a/core/src/impl/KokkosExp_Host_IterateTile.hpp
+++ b/core/src/impl/KokkosExp_Host_IterateTile.hpp
@@ -59,7 +59,7 @@
 #include <algorithm>
 #include <cstdio>
 
-namespace Kokkos { namespace Experimental { namespace Impl {
+namespace Kokkos { namespace Impl {
 
 // Temporary, for testing new loop macros
 #define KOKKOS_ENABLE_NEW_LOOP_MACROS 1
@@ -1274,7 +1274,7 @@ struct Tile_Loop_Type<8, IsLeft, IType, Tagged, typename std::enable_if< !std::i
 
 
 template <typename T>
-using is_void = std::is_same< T , void >;
+using is_void_type = std::is_same< T , void >;
 
 template <typename T>
 struct is_type_array : std::false_type 
@@ -1303,7 +1303,7 @@ template < typename RP
          , typename Tag
          , typename ValueType
          >
-struct HostIterateTile < RP , Functor , Tag , ValueType , typename std::enable_if< is_void<ValueType >::value >::type >
+struct HostIterateTile < RP , Functor , Tag , ValueType , typename std::enable_if< is_void_type<ValueType >::value >::type >
 {
   using index_type = typename RP::index_type;
   using point_type = typename RP::point_type;
@@ -1781,7 +1781,7 @@ template < typename RP
          , typename Tag
          , typename ValueType
          >
-struct HostIterateTile < RP , Functor , Tag , ValueType , typename std::enable_if< !is_void<ValueType >::value && !is_type_array<ValueType>::value >::type >
+struct HostIterateTile < RP , Functor , Tag , ValueType , typename std::enable_if< !is_void_type<ValueType >::value && !is_type_array<ValueType>::value >::type >
 {
   using index_type = typename RP::index_type;
   using point_type = typename RP::point_type;
@@ -2268,7 +2268,7 @@ template < typename RP
          , typename Tag
          , typename ValueType
          >
-struct HostIterateTile < RP , Functor , Tag , ValueType , typename std::enable_if< !is_void<ValueType >::value && is_type_array<ValueType>::value >::type >
+struct HostIterateTile < RP , Functor , Tag , ValueType , typename std::enable_if< !is_void_type<ValueType >::value && is_type_array<ValueType>::value >::type >
 {
   using index_type = typename RP::index_type;
   using point_type = typename RP::point_type;
@@ -2750,6 +2750,8 @@ struct HostIterateTile < RP , Functor , Tag , ValueType , typename std::enable_i
 // Cuda uses DeviceIterateTile directly within md_parallel_for
 // TODO Once md_parallel_{for,reduce} removed, this can be removed
 
+namespace Experimental { 
+
 // ParallelReduce - scalar reductions
 template < typename MDRange, typename Functor, typename ValueType = void >
 struct MDFunctor
@@ -2759,11 +2761,11 @@ struct MDFunctor
   using value_type   = ValueType;
   using work_tag     = typename range_policy::work_tag;
   using index_type   = typename range_policy::index_type;
-  using iterate_type = typename Kokkos::Experimental::Impl::HostIterateTile< MDRange
-                                                                           , Functor
-                                                                           , work_tag
-                                                                           , value_type
-                                                                           >;
+  using iterate_type = typename Kokkos::Impl::HostIterateTile< MDRange
+                                                             , Functor
+                                                             , work_tag
+                                                             , value_type
+                                                             >;
 
 
   inline
@@ -2804,11 +2806,11 @@ struct MDFunctor< MDRange, Functor, ValueType[] >
   using value_type   = ValueType[];
   using work_tag     = typename range_policy::work_tag;
   using index_type   = typename range_policy::index_type;
-  using iterate_type = typename Kokkos::Experimental::Impl::HostIterateTile< MDRange
-                                                                           , Functor
-                                                                           , work_tag
-                                                                           , value_type
-                                                                           >;
+  using iterate_type = typename Kokkos::Impl::HostIterateTile< MDRange
+                                                             , Functor
+                                                             , work_tag
+                                                             , value_type
+                                                             >;
 
 
   inline
@@ -2852,11 +2854,11 @@ struct MDFunctor< MDRange, Functor, void >
   using functor_type = Functor;
   using work_tag     = typename range_policy::work_tag;
   using index_type   = typename range_policy::index_type;
-  using iterate_type = typename Kokkos::Experimental::Impl::HostIterateTile< MDRange
-                                                                           , Functor
-                                                                           , work_tag
-                                                                           , void
-                                                                           >;
+  using iterate_type = typename Kokkos::Impl::HostIterateTile< MDRange
+                                                             , Functor
+                                                             , work_tag
+                                                             , void
+                                                             >;
 
 
   inline
@@ -2887,8 +2889,9 @@ struct MDFunctor< MDRange, Functor, void >
   Functor m_func;
 };
 
+} // end namespace Experimental
 #undef KOKKOS_ENABLE_NEW_LOOP_MACROS
 
-} } } //end namespace Kokkos::Experimental::Impl
+} } //end namespace Kokkos::Impl
 
 #endif


### PR DESCRIPTION
Ran test_all_sandia on kokkos-dev with spot check enabled. No functional changes, only removed Experimental namespace, so testing each compiler should be sufficient (knl, power shouldn't need testing). 
Also tested with Trilinos with Intrepid2 enabled which uses the `md_parallel_for`, builds and tests pass. 