### PR TITLE
Fix containers DynamicView unit test failure

### DIFF
--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -211,12 +211,15 @@ void test_dynamic_view_sort(unsigned int n )
 
   const size_t upper_bound = 2 * n ;
 
+  const size_t total_alloc_size = n * sizeof(KeyType) * 1.2 ;
+  const size_t superblock_size  = std::min(total_alloc_size, size_t(1000000));
+
   typename KeyDynamicViewType::memory_pool
     pool( memory_space()
         , n * sizeof(KeyType) * 1.2
         ,     500 /* min block size in bytes */
         ,   30000 /* max block size in bytes */
-        , 1000000 /* min superblock size in bytes */
+        , superblock_size
         );
 
   KeyDynamicViewType keys("Keys",pool,upper_bound);

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -131,11 +131,14 @@ struct TestDynamicView
 
 // printf("TestDynamicView::run(%d) construct memory pool\n",arg_total_size);
 
+    const size_t total_size = arg_total_size * sizeof(Scalar) * 1.2 ;
+    const size_t superblock = std::min( total_size , size_t(1000000) );
+
     memory_pool_type pool( memory_space()
-                         , arg_total_size * sizeof(Scalar) * 1.2
+                         , total_size
                          ,     500 /* min block size in bytes */
                          ,   30000 /* max block size in bytes */
-                         , 1000000 /* min superblock size in bytes */
+                         , superblock
                          );
 
 // printf("TestDynamicView::run(%d) construct dynamic view\n",arg_total_size);

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -131,11 +131,11 @@ struct TestDynamicView
 
 // printf("TestDynamicView::run(%d) construct memory pool\n",arg_total_size);
 
-    const size_t total_size = arg_total_size * sizeof(Scalar) * 1.2 ;
-    const size_t superblock = std::min( total_size , size_t(1000000) );
+    const size_t total_alloc_size = arg_total_size * sizeof(Scalar) * 1.2 ;
+    const size_t superblock = std::min( total_alloc_size , size_t(1000000) );
 
     memory_pool_type pool( memory_space()
-                         , total_size
+                         , total_alloc_size
                          ,     500 /* min block size in bytes */
                          ,   30000 /* max block size in bytes */
                          , superblock


### PR DESCRIPTION

Fix containers DynamicView unit test failure due to tightened MemoryPool size parameter checking.