### PR TITLE
create_mirror_copy

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -2256,16 +2256,9 @@ typename Impl::MirrorViewType<Space,T,P ...>::view_type
 create_mirror_copy(const Space& , const Kokkos::View<T,P...> & src
   , typename std::enable_if<!Impl::MirrorViewType<Space,T,P ...>::is_same_memspace>::type* = 0 ) {
   using Mirror = typename Impl::MirrorViewType<Space,T,P ...>::view_type;
-  auto mirror = Mirror(ViewAllocateWithoutInitializing(src.label(), src.layout());
+  auto mirror = Mirror(ViewAllocateWithoutInitializing(src.label()), src.layout());
   deep_copy(mirror, src);
   return mirror;
-}
-
-// Create a mirror view and deep_copy in default execution space
-template<class T, class ... P>
-typename Impl::MirrorViewType<DefaultExecutionSpace,T,P ...>::view_type
-create_mirror_copy(const Kokkos::View<T,P...> & src) {
-  return create_mirror_copy(DefaultExecutionSpace(), src);
 }
 
 } /* namespace Kokkos */

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -2246,7 +2246,9 @@ create_mirror_view(const Space& , const Kokkos::View<T,P...> & src
 template<class Space, class T, class ... P>
 typename Impl::MirrorViewType<Space,T,P ...>::view_type
 create_mirror_copy(const Space& , const Kokkos::View<T,P...> & src
+  , std::string const& name = ""
   , typename std::enable_if<Impl::MirrorViewType<Space,T,P ...>::is_same_memspace>::type* = 0 ) {
+  (void)name;
   return src;
 }
 
@@ -2254,9 +2256,11 @@ create_mirror_copy(const Space& , const Kokkos::View<T,P...> & src
 template<class Space, class T, class ... P>
 typename Impl::MirrorViewType<Space,T,P ...>::view_type
 create_mirror_copy(const Space& , const Kokkos::View<T,P...> & src
+  , std::string const& name = ""
   , typename std::enable_if<!Impl::MirrorViewType<Space,T,P ...>::is_same_memspace>::type* = 0 ) {
   using Mirror = typename Impl::MirrorViewType<Space,T,P ...>::view_type;
-  auto mirror = Mirror(ViewAllocateWithoutInitializing(src.label()), src.layout());
+  std::string label = name.empty() ? src.label() : name;
+  auto mirror = Mirror(ViewAllocateWithoutInitializing(label), src.layout());
   deep_copy(mirror, src);
   return mirror;
 }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -2245,7 +2245,7 @@ create_mirror_view(const Space& , const Kokkos::View<T,P...> & src
 // Create a mirror view and deep_copy in a new space (specialization for same space)
 template<class Space, class T, class ... P>
 typename Impl::MirrorViewType<Space,T,P ...>::view_type
-create_mirror_copy(const Space& , const Kokkos::View<T,P...> & src
+create_mirror_view_and_copy(const Space& , const Kokkos::View<T,P...> & src
   , std::string const& name = ""
   , typename std::enable_if<Impl::MirrorViewType<Space,T,P ...>::is_same_memspace>::type* = 0 ) {
   (void)name;
@@ -2255,7 +2255,7 @@ create_mirror_copy(const Space& , const Kokkos::View<T,P...> & src
 // Create a mirror view and deep_copy in a new space (specialization for different space)
 template<class Space, class T, class ... P>
 typename Impl::MirrorViewType<Space,T,P ...>::view_type
-create_mirror_copy(const Space& , const Kokkos::View<T,P...> & src
+create_mirror_view_and_copy(const Space& , const Kokkos::View<T,P...> & src
   , std::string const& name = ""
   , typename std::enable_if<!Impl::MirrorViewType<Space,T,P ...>::is_same_memspace>::type* = 0 ) {
   using Mirror = typename Impl::MirrorViewType<Space,T,P ...>::view_type;

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -791,9 +791,9 @@ struct TestViewMirror
     Kokkos::View< double*, Layout, Kokkos::HostSpace > a_org( "A", 10 );
     a_org(5) = 42.0;
     Kokkos::View< double*, Layout, Kokkos::HostSpace, MemoryTraits > a_h = a_org;
-    auto a_h2 = Kokkos::create_mirror_copy( Kokkos::HostSpace(), a_h );
-    auto a_d = Kokkos::create_mirror_copy( DeviceType(), a_h );
-    auto a_h3 = Kokkos::create_mirror_copy( Kokkos::HostSpace(), a_d );
+    auto a_h2 = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), a_h );
+    auto a_d = Kokkos::create_mirror_view_and_copy( DeviceType(), a_h );
+    auto a_h3 = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), a_d );
 
     int equal_ptr_h_h2 = a_h.data()  == a_h2.data() ? 1 : 0;
     int equal_ptr_h_d  = a_h.data()  ==  a_d.data() ? 1 : 0;

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -809,7 +809,7 @@ struct TestViewMirror
     ASSERT_EQ( a_h.dimension_0(), a_h3.dimension_0() );
     ASSERT_EQ( a_h.dimension_0(), a_h2.dimension_0() );
     ASSERT_EQ( a_h.dimension_0(), a_d .dimension_0() );
-    ASSERT_EQ( a_org(5) == a_h3(5) );
+    ASSERT_EQ( a_org(5), a_h3(5) );
   }
 
 

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -786,11 +786,40 @@ struct TestViewMirror
     ASSERT_EQ( a_h.dimension_0(), a_d .dimension_0() );
   }
 
+  template< class MemoryTraits >
+  void static test_mirror_copy() {
+    Kokkos::View< double*, Layout, Kokkos::HostSpace > a_org( "A", 10 );
+    a_org(5) = 42.0;
+    Kokkos::View< double*, Layout, Kokkos::HostSpace, MemoryTraits > a_h = a_org;
+    auto a_h2 = Kokkos::create_mirror_copy( Kokkos::HostSpace(), a_h );
+    auto a_d = Kokkos::create_mirror_copy( DeviceType(), a_h );
+    auto a_h3 = Kokkos::create_mirror_copy( Kokkos::HostSpace(), a_d );
+
+    int equal_ptr_h_h2 = a_h.data()  == a_h2.data() ? 1 : 0;
+    int equal_ptr_h_d  = a_h.data()  ==  a_d.data() ? 1 : 0;
+    int equal_ptr_h2_d = a_h2.data() ==  a_d.data() ? 1 : 0;
+    int equal_ptr_h3_d = a_h3.data() ==  a_d.data() ? 1 : 0;
+
+    int is_same_memspace = std::is_same< Kokkos::HostSpace, typename DeviceType::memory_space >::value ? 1 : 0;
+    ASSERT_EQ( equal_ptr_h_h2, 1 );
+    ASSERT_EQ( equal_ptr_h_d, is_same_memspace );
+    ASSERT_EQ( equal_ptr_h2_d, is_same_memspace );
+    ASSERT_EQ( equal_ptr_h3_d, is_same_memspace );
+
+    ASSERT_EQ( a_h.dimension_0(), a_h3.dimension_0() );
+    ASSERT_EQ( a_h.dimension_0(), a_h2.dimension_0() );
+    ASSERT_EQ( a_h.dimension_0(), a_d .dimension_0() );
+    ASSERT_EQ( a_org(5) == a_h3(5) );
+  }
+
+
   void static testit() {
     test_mirror< Kokkos::MemoryTraits<0> >();
     test_mirror< Kokkos::MemoryTraits<Kokkos::Unmanaged> >();
     test_mirror_view< Kokkos::MemoryTraits<0> >();
     test_mirror_view< Kokkos::MemoryTraits<Kokkos::Unmanaged> >();
+    test_mirror_copy< Kokkos::MemoryTraits<0> >();
+    test_mirror_copy< Kokkos::MemoryTraits<Kokkos::Unmanaged> >();
   }
 };
 


### PR DESCRIPTION
Implements the enhancement proposed in #1161.
Passed spot check `test_all_sandia` on `kokkos-dev`:
```
cuda-8.0.44-Cuda_OpenMP-release build_time=406 run_time=556
```