### PR TITLE
View, ViewCtorProp: Address issue #1170

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -408,7 +408,7 @@ view_alloc( Args const & ... args )
 }
 
 template< class ... Args >
-inline
+KOKKOS_INLINE_FUNCTION
 Impl::ViewCtorProp< typename Impl::ViewCtorProp< void , Args >::type ... >
 view_wrap( Args const & ... args )
 {
@@ -2462,6 +2462,7 @@ struct CommonViewAllocProp< void, ValueType >
   using scalar_array_type = ValueType;
 
   template < class ... Views >
+  KOKKOS_INLINE_FUNCTION
   CommonViewAllocProp( const Views & ... ) {}
 };
 
@@ -2529,6 +2530,7 @@ using DeducedCommonPropsType = typename Impl::DeduceCommonViewAllocProp<Views...
 
 // User function
 template < class ... Views >
+KOKKOS_INLINE_FUNCTION
 DeducedCommonPropsType<Views...> 
 common_view_alloc_prop( Views const & ... views )
 {

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -111,7 +111,9 @@ struct ViewCtorProp< void , CommonViewAllocProp<Specialize,T> >
 
   using type = CommonViewAllocProp<Specialize,T> ;
 
+  KOKKOS_INLINE_FUNCTION
   ViewCtorProp( const type & arg ) : value( arg ) {}
+  KOKKOS_INLINE_FUNCTION
   ViewCtorProp( type && arg ) : value( arg ) {}
 
   type value ;
@@ -128,6 +130,7 @@ struct ViewCtorProp< void , std::integral_constant<unsigned,I> >
   ViewCtorProp & operator = ( const ViewCtorProp & ) = default ;
 
   template< typename P >
+  KOKKOS_INLINE_FUNCTION
   ViewCtorProp( const P & ) {}
 };
 


### PR DESCRIPTION
Addresses issue #1170
Add KOKKOS_INLINE_FUNCTION to necessary functions ( view_wrap,
    common_view_alloc_prop) and constructors to enable construction of
an unmanaged view within a device function using the
common_view_alloc_prop and view_wrap functions.