### PR TITLE
Fix Serial::is_initialized

### DIFF
--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -145,7 +145,7 @@ public:
                           unsigned use_cores_per_numa = 0 ,
                           bool allow_asynchronous_threadpool = false);
 
-  static int is_initialized();
+  static bool is_initialized();
 
   /** \brief  Return the maximum amount of concurrency.  */
   static int concurrency() {return 1;};

--- a/core/src/impl/Kokkos_Serial.cpp
+++ b/core/src/impl/Kokkos_Serial.cpp
@@ -157,6 +157,9 @@ void Serial::initialize( unsigned threads_count
 
   // Init the array of locks used for arbitrarily sized atomics
   Impl::init_lock_array_host_space();
+  #if defined(KOKKOS_ENABLE_PROFILING)
+    Kokkos::Profiling::initialize();
+  #endif
 
   Impl::g_serial_is_initialized = true;
 }
@@ -174,6 +177,10 @@ void Serial::finalize()
 
     Impl::g_serial_thread_team_data.scratch_assign( (void*) 0, 0, 0, 0, 0, 0 );
   }
+
+  #if defined(KOKKOS_ENABLE_PROFILING)
+    Kokkos::Profiling::finalize();
+  #endif
 
   Impl::g_serial_is_initialized = false;
 }

--- a/core/src/impl/Kokkos_Serial.cpp
+++ b/core/src/impl/Kokkos_Serial.cpp
@@ -60,6 +60,8 @@ namespace {
 
 HostThreadTeamData g_serial_thread_team_data ;
 
+bool g_serial_is_initialized = false;
+
 }
 
 // Resize thread team data scratch memory
@@ -136,9 +138,9 @@ HostThreadTeamData * serial_get_thread_team_data()
 
 namespace Kokkos {
 
-int Serial::is_initialized()
+bool Serial::is_initialized()
 {
-  return 1 ;
+  return Impl::g_serial_is_initialized ;
 }
 
 void Serial::initialize( unsigned threads_count
@@ -155,9 +157,8 @@ void Serial::initialize( unsigned threads_count
 
   // Init the array of locks used for arbitrarily sized atomics
   Impl::init_lock_array_host_space();
-  #if defined(KOKKOS_ENABLE_PROFILING)
-    Kokkos::Profiling::initialize();
-  #endif
+
+  Impl::g_serial_is_initialized = true;
 }
 
 void Serial::finalize()
@@ -174,9 +175,7 @@ void Serial::finalize()
     Impl::g_serial_thread_team_data.scratch_assign( (void*) 0, 0, 0, 0, 0, 0 );
   }
 
-  #if defined(KOKKOS_ENABLE_PROFILING)
-    Kokkos::Profiling::finalize();
-  #endif
+  Impl::g_serial_is_initialized = false;
 }
 
 const char* Serial::name() { return "Serial"; }


### PR DESCRIPTION
Change this function to return a boolean
which actually reflects the state of
initialize/finalize calls.
Also remove the calls to Profiling::initialize,
because those are already handled in Kokkos::initialize.
[#1184]