### PR TITLE
Factor bit twiddling in power_of_two_if_valid.

### DIFF
--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -47,6 +47,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <Kokkos_Macros.hpp>
+#include <impl/Kokkos_BitOps.hpp>
 #include <string>
 #include <type_traits>
 
@@ -439,17 +440,8 @@ static KOKKOS_FORCEINLINE_FUNCTION
 unsigned power_of_two_if_valid( const unsigned N )
 {
   unsigned p = ~0u ;
-  if ( N && ! ( N & ( N - 1 ) ) ) {
-#if defined( __CUDA_ARCH__ ) && defined( KOKKOS_ENABLE_CUDA )
-    p = __ffs(N) - 1 ;
-#elif defined( __GNUC__ ) || defined( __GNUG__ )
-    p = __builtin_ffs(N) - 1 ;
-#elif defined( __INTEL_COMPILER )
-    p = _bit_scan_forward(N);
-#else
-    p = 0 ;
-    for ( unsigned j = 1 ; ! ( N & j ) ; j <<= 1 ) { ++p ; }
-#endif
+  if ( is_integral_power_of_two ( N ) ) {
+    p = bit_scan_forward ( N ) ;
   }
   return p ;
 }


### PR DESCRIPTION
This avoids duplicate compiler preprocessing logic.