### PR TITLE
Fix kokkosp_profile_event load

### DIFF
--- a/core/src/impl/Kokkos_Profiling_Interface.cpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.cpp
@@ -279,7 +279,7 @@ void initialize() {
       destroySectionCallee = *((destroyProfileSectionFunction*) &p18);
       
       auto p19 = dlsym(firstProfileLibrary, "kokkosp_profile_event");
-      profileEventCallee = *((profileEventFunction*) &p18);
+      profileEventCallee = *((profileEventFunction*) &p19);
     }
   }
 


### PR DESCRIPTION
Pull request #1198 had a copy-paste error, `kokkosp_profile_event` isn't loaded right.
This was caught by the `-Werror` nightlies as unused variable `p19`, so hurray for `-Werror`!

@crtrott 
@nmhamster 