### PR TITLE
Fix #1212 (CMakeLists.txt for KokkosAlgorithms unit tests)

### DIFF
--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -3,6 +3,22 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../src )
 
+SET(GTEST_SOURCE_DIR ${${PARENT_PACKAGE_NAME}_SOURCE_DIR}/tpls/gtest)
+INCLUDE_DIRECTORIES(${GTEST_SOURCE_DIR})
+
+# mfh 03 Nov 2017: The gtest library used here must have a different
+# name than that of the gtest library built in KokkosCore.  We can't
+# just refer to the library in KokkosCore's tests, because it's
+# possible to build only (e.g.,) KokkosAlgorithms tests, without
+# building KokkosCore tests.
+
+TRIBITS_ADD_LIBRARY(
+  kokkosalgorithms_gtest
+  HEADERS ${GTEST_SOURCE_DIR}/gtest/gtest.h
+  SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
+  TESTONLY
+  )
+
 SET(SOURCES
   UnitTestMain.cpp 
   TestCuda.cpp
@@ -34,5 +50,5 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM serial mpi
   NUM_MPI_PROCS 1
   FAIL_REGULAR_EXPRESSION "  FAILED  "
-  TESTONLYLIBS kokkos_gtest
+  TESTONLYLIBS kokkosalgorithms_gtest
   )


### PR DESCRIPTION
This commit fixes #1212, which is a CMake configure-time error.
One can manifest the error by using Trilinos' check-in test script
with `--enable-packages=KokkosAlgorithms` and/or
`--enable-packages=KokkosCore,KokkosAlgorithms`.
