### PR TITLE
Fix potential ADL conflict with user functions

### DIFF
--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -241,7 +241,7 @@ void parallel_for( const std::string & str
   std::cout << "KOKKOS_DEBUG Start parallel_for kernel: " << str << std::endl;
   #endif
 
-  parallel_for(policy,functor,str);
+  ::Kokkos::parallel_for(policy,functor,str);
 
   #if KOKKOS_ENABLE_DEBUG_PRINT_KERNEL_NAMES
   Kokkos::fence();
@@ -487,7 +487,7 @@ void parallel_scan( const std::string& str
   std::cout << "KOKKOS_DEBUG Start parallel_scan kernel: " << str << std::endl;
   #endif
 
-  parallel_scan(policy,functor,str);
+  ::Kokkos::parallel_scan(policy,functor,str);
 
   #if KOKKOS_ENABLE_DEBUG_PRINT_KERNEL_NAMES
   Kokkos::fence();


### PR DESCRIPTION
see #1219.
These unqualified calls to parallel_for
and parallel_scan could resolve to user-defined
functions with the same name under certain
(fairly common) conditions.