### PR TITLE
Fix #1208 by using __gnu_parallel::sort if available

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -1,13 +1,13 @@
 /*
 //@HEADER
 // ************************************************************************
-// 
+//
 //                        Kokkos v. 2.0
 //              Copyright (2014) Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -36,7 +36,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
-// 
+//
 // ************************************************************************
 //@HEADER
 */
@@ -48,6 +48,10 @@
 #include <Kokkos_Core.hpp>
 
 #include <algorithm>
+#if defined(__GNUC__) && defined(_OPENMP) && defined(KOKKOS_ENABLE_OPENMP)
+#  include <parallel/algorithm> // __gnu_parallel::sort
+#endif // defined(__GNUC__) && defined(_OPENMP) && defined(KOKKOS_ENABLE_OPENMP)
+
 
 namespace Kokkos {
 
@@ -465,6 +469,37 @@ struct BinOp3D {
 
 namespace Impl {
 
+#if defined(__GNUC__) && defined(_OPENMP) && defined(KOKKOS_ENABLE_OPENMP)
+template<class ViewType>
+bool try_gnu_sort(ViewType view) {
+  bool possible = true;
+  size_t stride[8] = { view.stride_0()
+                     , view.stride_1()
+                     , view.stride_2()
+                     , view.stride_3()
+                     , view.stride_4()
+                     , view.stride_5()
+                     , view.stride_6()
+                     , view.stride_7()
+                     };
+  possible  = possible && std::is_same<typename ViewType::memory_space, HostSpace>::value;
+  // It doesn't matter if the View is an OpenMP View, but we do need
+  // OpenMP to have been initialized.
+  possible  = possible && OpenMP::is_initialized();
+  possible  = possible && (ViewType::Rank == 1);
+  possible  = possible && (stride[0] == 1);
+  if(possible) {
+    __gnu_parallel::sort(view.data(), view.data() + view.extent(0));
+  }
+  return possible;
+}
+#else
+template<class ViewType>
+bool try_gnu_sort(ViewType /* view */) {
+  return false;
+}
+#endif // defined(__GNUC__) && defined(_OPENMP) && defined(KOKKOS_ENABLE_OPENMP)
+
 template<class ViewType>
 bool try_std_sort(ViewType view) {
   bool possible = true;
@@ -506,6 +541,7 @@ template<class ViewType>
 void sort( ViewType const & view , bool const always_use_kokkos_sort = false)
 {
   if(!always_use_kokkos_sort) {
+    if(Impl::try_gnu_sort(view)) return;
     if(Impl::try_std_sort(view)) return;
   }
   typedef BinOp1D<ViewType> CompType;


### PR DESCRIPTION
I made all changes to Kokkos_Sort.hpp.  Here is what I did:

1. Conditionally include header for `__gnu_parallel::sort`

2. Add `try_gnu_sort`, analogous to `try_std_sort`.  It always returns
   false if the above header is not available.  Otherwise, it returns
   true if and only if OpenMP has been initialized, the View's rank is
   1, and the View's stride is 1.