### PR TITLE
Fix rendezvous for big endian machines

### DIFF
--- a/core/src/impl/Kokkos_HostThreadTeam.cpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.cpp
@@ -287,9 +287,21 @@ int HostThreadTeamData::rendezvous( int64_t * const buffer
       //   ( rank % size_byte ) +
       //   ( ( rank / size_byte ) * size_byte * size_mem_cycle ) +
       //   ( sync_offset * size_byte )
-      const int offset = ( rank & mask_byte )
-                       + ( ( rank & ~mask_byte ) << shift_mem_cycle )
-                       + ( sync_offset << shift_byte );
+      int offset = ( rank & mask_byte )
+                 + ( ( rank & ~mask_byte ) << shift_mem_cycle )
+                 + ( sync_offset << shift_byte );
+
+
+      // Switch designated byte if running on big endian machine
+      volatile uint16_t value = 1;
+      volatile uint8_t* byte = (uint8_t*) &value;
+      volatile bool is_big_endian = (!(byte[0] == 1));
+      if (is_big_endian) {
+        int remainder = ((offset) % 8);
+        int base = offset - remainder;
+        int shift = 7 - remainder;
+        offset = base + shift;
+      }
 
       // All of this thread's previous memory stores must be complete before
       // this thread stores the step value at this thread's designated byte

--- a/core/src/impl/Kokkos_Rendezvous.cpp
+++ b/core/src/impl/Kokkos_Rendezvous.cpp
@@ -133,9 +133,22 @@ int rendezvous( volatile int64_t * const buffer
       //   ( rank % size_byte ) +
       //   ( ( rank / size_byte ) * size_byte * size_mem_cycle ) +
       //   ( sync_offset * size_byte )
-      const int offset = ( rank & mask_byte )
-                       + ( ( rank & ~mask_byte ) << shift_mem_cycle )
-                       + ( sync_offset << shift_byte );
+      int offset = ( rank & mask_byte )
+                 + ( ( rank & ~mask_byte ) << shift_mem_cycle )
+                 + ( sync_offset << shift_byte );
+
+
+      // Switch designated byte if running on big endian machine
+      volatile uint16_t value = 1;
+      volatile uint8_t* byte = (uint8_t*) &value;
+      volatile bool is_big_endian = (!(byte[0] == 1));
+      if (is_big_endian) {
+        int remainder = ((offset) % 8);
+        int base = offset - remainder;
+        int shift = 7 - remainder;
+        offset = base + shift;
+      }
+
 
       // All of this thread's previous memory stores must be complete before
       // this thread stores the step value at this thread's designated byte


### PR DESCRIPTION
This PR addresses #1235 and fixes #1234. There may be a more elegant solution, but with this change, the OpenMP core unit tests passed on BG/Q using 4 OpenMP threads:

```
[----------] Global test environment tear-down
[==========] 88 tests from 1 test case ran. (48545 ms total)
[  PASSED  ] 88 tests.
```
