### PR TITLE
Remove <cstdalign>

### DIFF
--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -50,7 +50,6 @@
 #include <cstdio>
 
 #include <utility>
-#include <cstdalign>
 #include <impl/Kokkos_Spinwait.hpp>
 #include <impl/Kokkos_FunctorAdapter.hpp>
 


### PR DESCRIPTION
This header doesn't exist on OS X and
doesn't seem to be necessary at all.

Fixes #1232