### PR TITLE
do not include cstdalign - not used, breaks on MacOS

### DIFF
--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -50,7 +50,6 @@
 #include <cstdio>
 
 #include <utility>
-#include <cstdalign>
 #include <impl/Kokkos_Spinwait.hpp>
 #include <impl/Kokkos_FunctorAdapter.hpp>
 


### PR DESCRIPTION
cstdalign is not present in MacOS toolchain.  Attempting to include it
breaks MacOS builds using LLVM and Intel compilers.  It works with GCC
because the header comes with GCC/libstdc++.

This header is not used and nothing breaks if it is not included.

# History

I reported this to the mailing list on 11/13/2017 when it was observed via Travis CI.  It also fails on my laptop with the Intel 18 update 1 compiler.