### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+sudo: false
+
+language: cpp
+
+os:
+  - linux
+  - osx
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - cmake
+      - clang
+
+compiler:
+  - gcc
+  - clang
+
+env:
+  - THREADING="serial"
+  - THREADING="openmp"
+  - THREADING="pthread"
+
+# Apple GCC does not support OpenMP.  GCC with OpenMP requires Homebrew.
+# Apple Clang does not support OpenMP.  Clang with OpenMP requires Homebrew.
+# Clang OpenMP support is not always available.
+matrix:
+  exclude:
+    - compiler: clang
+      env: THREADING="openmp"
+    - os: osx
+      env: THREADING="openmp"
+    - os: osx
+      compiler: gcc
+
+script:
+  - mkdir build
+  - cd build
+  - ../generate_makefile.bash --compiler=$CXX --with-$THREADING --with-options=compiler_warnings
+  - make
+  - make test


### PR DESCRIPTION
This implements a modest test matrix for Kokkos that currently passes in Travis CI.

There are issues with OpenMP in a few contexts, most of which can be resolved with some effort, but it does not see critical to fix them because of the lower priority of Mac, at least.

The Mac OpenMP issues can be solved using Homebrew compilers but that adds another layer of complexity.