### PR TITLE
Include the var name in the error message for KOKKOS_ARCH

### DIFF
--- a/cmake/kokkos_settings.cmake
+++ b/cmake/kokkos_settings.cmake
@@ -17,7 +17,8 @@
 foreach(arch ${KOKKOS_ARCH})
   list(FIND KOKKOS_ARCH_LIST ${arch} indx)
   if (indx EQUAL -1)
-    message(FATAL_ERROR "${arch} is not an accepted architecture.  Please pick from these choices: ${KOKKOS_INTERNAL_ARCH_DOCSTR}")
+    message(FATAL_ERROR "${arch} is not an accepted value for KOKKOS_ARCH."
+      "  Please pick from these choices: ${KOKKOS_INTERNAL_ARCH_DOCSTR}")
   endif ()
 endforeach()
 


### PR DESCRIPTION
This commit improves the error message when KOKKOS_ARCH is not set to a valid value.