### PR TITLE
Add resize and realloc functions to Kokkos_ScatterView

### DIFF
--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -661,7 +661,7 @@ public:
            const size_t n4 = 0,
            const size_t n5 = 0,
            const size_t n6 = 0) {
-    ::Kokkos::resize(internal_view,internal_view.extent(0),n0,n1,n2,n3,n4,n5,n6);
+    ::Kokkos::resize(internal_view,unique_token.size(),n0,n1,n2,n3,n4,n5,n6);
   }
 
   void realloc(const size_t n0 = 0,
@@ -671,7 +671,7 @@ public:
            const size_t n4 = 0,
            const size_t n5 = 0,
            const size_t n6 = 0) {
-    ::Kokkos::realloc(internal_view,internal_view.extent(0),n0,n1,n2,n3,n4,n5,n6);
+    ::Kokkos::realloc(internal_view,unique_token.size(),n0,n1,n2,n3,n4,n5,n6);
   }
 
 protected:
@@ -821,7 +821,7 @@ public:
 
     size_t arg_N[8] = {n0,n1,n2,n3,n4,n5,n6,0};
     const int i = internal_view.rank-1;
-    arg_N[i] = internal_view.extent(i);
+    arg_N[i] = unique_token.size();
 
     ::Kokkos::resize(internal_view,
         arg_N[0], arg_N[1], arg_N[2], arg_N[3],
@@ -838,7 +838,7 @@ public:
 
     size_t arg_N[8] = {n0,n1,n2,n3,n4,n5,n6,0};
     const int i = internal_view.rank-1;
-    arg_N[i] = internal_view.extent(i);
+    arg_N[i] = unique_token.size();
 
     ::Kokkos::realloc(internal_view,
         arg_N[0], arg_N[1], arg_N[2], arg_N[3],

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -660,9 +660,8 @@ public:
            const size_t n3 = 0,
            const size_t n4 = 0,
            const size_t n5 = 0,
-           const size_t n6 = 0,
-           const size_t n7 = 0) {
-    ::Kokkos::resize(internal_view,n0,n1,n2,n3,n4,n5,n6,n7);
+           const size_t n6 = 0) {
+    ::Kokkos::resize(internal_view,internal_view.extent(0),n0,n1,n2,n3,n4,n5,n6);
   }
 
   void realloc(const size_t n0 = 0,
@@ -671,9 +670,8 @@ public:
            const size_t n3 = 0,
            const size_t n4 = 0,
            const size_t n5 = 0,
-           const size_t n6 = 0,
-           const size_t n7 = 0) {
-    ::Kokkos::realloc(internal_view,n0,n1,n2,n3,n4,n5,n6,n7);
+           const size_t n6 = 0) {
+    ::Kokkos::realloc(internal_view,internal_view.extent(0),n0,n1,n2,n3,n4,n5,n6);
   }
 
 protected:
@@ -819,9 +817,15 @@ public:
            const size_t n3 = 0,
            const size_t n4 = 0,
            const size_t n5 = 0,
-           const size_t n6 = 0,
-           const size_t n7 = 0) {
-    ::Kokkos::resize(internal_view,n0,n1,n2,n3,n4,n5,n6,n7);
+           const size_t n6 = 0) {
+
+    size_t arg_N[8] = {n0,n1,n2,n3,n4,n5,n6,0};
+    const int i = internal_view.rank-1;
+    arg_N[i] = internal_view.extent(i);
+
+    ::Kokkos::resize(internal_view,
+        arg_N[0], arg_N[1], arg_N[2], arg_N[3],
+        arg_N[4], arg_N[5], arg_N[6], arg_N[7]);
   }
 
   void realloc(const size_t n0 = 0,
@@ -830,9 +834,15 @@ public:
            const size_t n3 = 0,
            const size_t n4 = 0,
            const size_t n5 = 0,
-           const size_t n6 = 0,
-           const size_t n7 = 0) {
-    ::Kokkos::realloc(internal_view,n0,n1,n2,n3,n4,n5,n6,n7);
+           const size_t n6 = 0) {
+
+    size_t arg_N[8] = {n0,n1,n2,n3,n4,n5,n6,0};
+    const int i = internal_view.rank-1;
+    arg_N[i] = internal_view.extent(i);
+
+    ::Kokkos::realloc(internal_view,
+        arg_N[0], arg_N[1], arg_N[2], arg_N[3],
+        arg_N[4], arg_N[5], arg_N[6], arg_N[7]);
   }
 
 protected:

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -729,12 +729,7 @@ public:
       original_view.extent(6),
       0
     };
-    for (int i = 0; i < 8; ++i) {
-      if (arg_N[i] == 0) {
-        arg_N[i] = unique_token.size();
-        break;
-      }
-    }
+    arg_N[original_view.rank] = unique_token.size();
     internal_view = internal_view_type(
         Kokkos::ViewAllocateWithoutInitializing(
           std::string("duplicated_") + original_view.label()),

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -465,6 +465,28 @@ public:
     if (view.data() != internal_view.data()) reset();
   }
 
+  void resize(const size_t n0 = 0,
+           const size_t n1 = 0,
+           const size_t n2 = 0,
+           const size_t n3 = 0,
+           const size_t n4 = 0,
+           const size_t n5 = 0,
+           const size_t n6 = 0,
+           const size_t n7 = 0) {
+    ::Kokkos::resize(internal_view,n0,n1,n2,n3,n4,n5,n6,n7);
+  }
+
+  void realloc(const size_t n0 = 0,
+           const size_t n1 = 0,
+           const size_t n2 = 0,
+           const size_t n3 = 0,
+           const size_t n4 = 0,
+           const size_t n5 = 0,
+           const size_t n6 = 0,
+           const size_t n7 = 0) {
+    ::Kokkos::realloc(internal_view,n0,n1,n2,n3,n4,n5,n6,n7);
+  }
+
 protected:
   template <typename ... Args>
   KOKKOS_FORCEINLINE_FUNCTION
@@ -632,6 +654,28 @@ public:
         internal_view.label());
   }
 
+  void resize(const size_t n0 = 0,
+           const size_t n1 = 0,
+           const size_t n2 = 0,
+           const size_t n3 = 0,
+           const size_t n4 = 0,
+           const size_t n5 = 0,
+           const size_t n6 = 0,
+           const size_t n7 = 0) {
+    ::Kokkos::resize(internal_view,n0,n1,n2,n3,n4,n5,n6,n7);
+  }
+
+  void realloc(const size_t n0 = 0,
+           const size_t n1 = 0,
+           const size_t n2 = 0,
+           const size_t n3 = 0,
+           const size_t n4 = 0,
+           const size_t n5 = 0,
+           const size_t n6 = 0,
+           const size_t n7 = 0) {
+    ::Kokkos::realloc(internal_view,n0,n1,n2,n3,n4,n5,n6,n7);
+  }
+
 protected:
   template <typename ... Args>
   KOKKOS_FORCEINLINE_FUNCTION
@@ -767,6 +811,28 @@ public:
         internal_view.data() + view.size(),
         internal_view.size() - view.size(),
         internal_view.label());
+  }
+
+  void resize(const size_t n0 = 0,
+           const size_t n1 = 0,
+           const size_t n2 = 0,
+           const size_t n3 = 0,
+           const size_t n4 = 0,
+           const size_t n5 = 0,
+           const size_t n6 = 0,
+           const size_t n7 = 0) {
+    ::Kokkos::resize(internal_view,n0,n1,n2,n3,n4,n5,n6,n7);
+  }
+
+  void realloc(const size_t n0 = 0,
+           const size_t n1 = 0,
+           const size_t n2 = 0,
+           const size_t n3 = 0,
+           const size_t n4 = 0,
+           const size_t n5 = 0,
+           const size_t n6 = 0,
+           const size_t n7 = 0) {
+    ::Kokkos::realloc(internal_view,n0,n1,n2,n3,n4,n5,n6,n7);
   }
 
 protected:


### PR DESCRIPTION
@ibaned can we add `resize` and `realloc` functions to `ScatterView` like in this PR? These are useful for persistent memory.