### PR TITLE
Improve rendezvous performance when hardware is oversubscribed

### DIFF
--- a/core/src/impl/Kokkos_HostBarrier.cpp
+++ b/core/src/impl/Kokkos_HostBarrier.cpp
@@ -47,11 +47,11 @@
 #include <impl/Kokkos_HostBarrier.hpp>
 #include <impl/Kokkos_Spinwait.hpp>
 
+#include <chrono>
+
 namespace Kokkos { namespace Impl {
 
 namespace {
-
-enum : int { HEADER_SIZE = HostBarrier::HEADER / sizeof(uint64_t) };
 
 inline constexpr int length64( const int nthreads ) noexcept
 {
@@ -92,11 +92,11 @@ void rendezvous_initialize( volatile void * buffer
   else {
 
     const int n = length64(size);
-    volatile uint64_t * buff = reinterpret_cast<volatile uint64_t *>(buffer) + HEADER_SIZE;
+    volatile uint64_t * buff = reinterpret_cast<volatile uint64_t *>(buffer) + RENDEZVOUS_HEADER/sizeof(uint64_t);
 
     // wait for other threads to finish initializing
     for (int i=0; i<n; ++i) {
-      spinwait_until_equal( buff[i], zero64 );
+      root_spinwait_until_equal( buff[i], zero64 );
     }
 
     // release the waiting threads
@@ -146,7 +146,7 @@ bool rendezvous( volatile void * buffer
     }
   }
   else { // rank 0
-    volatile uint64_t * buff = reinterpret_cast<volatile uint64_t *>(buffer) + HEADER_SIZE;
+    volatile uint64_t * buff = reinterpret_cast<volatile uint64_t *>(buffer) + RENDEZVOUS_HEADER/sizeof(uint64_t);
     const int n = length64(size);
 
     uint64_t comp = byte_value;
@@ -168,9 +168,9 @@ bool rendezvous( volatile void * buffer
     const uint64_t tail = rem ? tmp.value : comp;
 
     for (int i=0; i<n-1; ++i) {
-      spinwait_until_equal( buff[i], comp );
+      root_spinwait_until_equal( buff[i], comp );
     }
-    spinwait_until_equal( buff[n-1], tail );
+    root_spinwait_until_equal( buff[n-1], tail );
 
   }
 

--- a/core/src/impl/Kokkos_Spinwait.cpp
+++ b/core/src/impl/Kokkos_Spinwait.cpp
@@ -71,45 +71,64 @@ void host_thread_yield( const uint32_t i , const WaitMode mode )
 
   const int c = Kokkos::Impl::bit_scan_reverse(i);
 
-  if ( mode != WaitMode::ROOT && (sleep_limit < i) ) {
+  if ( WaitMode::ROOT != mode ) {
+    if ( sleep_limit < i ) {
 
-    // Attempt to put the thread to sleep for 'c' milliseconds
+      // Attempt to put the thread to sleep for 'c' milliseconds
 
-    #if defined( KOKKOS_ENABLE_STDTHREAD ) || defined( _WIN32 )
-      auto start = std::chrono::high_resolution_clock::now();
-      std::this_thread::yield();
-      std::this_thread::sleep_until( start + std::chrono::nanoseconds( c * 1000 ) );
-    #else
-      timespec req ;
-      req.tv_sec  = 0 ;
-      req.tv_nsec = 1000 * c ;
-      nanosleep( &req, nullptr );
-    #endif
+      #if defined( KOKKOS_ENABLE_STDTHREAD ) || defined( _WIN32 )
+        auto start = std::chrono::high_resolution_clock::now();
+        std::this_thread::yield();
+        std::this_thread::sleep_until( start + std::chrono::nanoseconds( c * 1000 ) );
+      #else
+        timespec req ;
+        req.tv_sec  = 0 ;
+        req.tv_nsec = 1000 * c ;
+        nanosleep( &req, nullptr );
+      #endif
+    }
+
+    else if ( mode == WaitMode::PASSIVE || yield_limit < i ) {
+
+      // Attempt to yield thread resources to runtime
+
+      #if defined( KOKKOS_ENABLE_STDTHREAD ) || defined( _WIN32 )
+        std::this_thread::yield();
+      #else
+        sched_yield();
+      #endif
+    }
+
+    #if defined( KOKKOS_ENABLE_ASM )
+
+    else if ( (1u<<4) < i ) {
+
+      // Insert a few no-ops to quiet the thread:
+
+      for ( int k = 0 ; k < c ; ++k ) {
+        #if defined( __amd64 ) || defined( __amd64__ ) || \
+              defined( __x86_64 ) || defined( __x86_64__ )
+          #if !defined( _WIN32 ) /* IS NOT Microsoft Windows */
+            asm volatile( "nop\n" );
+          #else
+            __asm__ __volatile__( "nop\n" );
+          #endif
+        #elif defined(__PPC64__)
+            asm volatile( "nop\n" );
+        #endif
+      }
+    }
+    #endif /* defined( KOKKOS_ENABLE_ASM ) */
   }
-
-  else if ( mode != WaitMode::ROOT && (mode == WaitMode::PASSIVE || yield_limit < i) ) {
-
-    // Attempt to yield thread resources to runtime
-
-    #if defined( KOKKOS_ENABLE_STDTHREAD ) || defined( _WIN32 )
-      std::this_thread::yield();
-    #else
-      sched_yield();
-    #endif
-  }
-
   #if defined( KOKKOS_ENABLE_ASM )
-
-  else if ( (1u<<4) < i ) {
-
-    // Insert a few no-ops to quiet the thread:
-
+  else if ( (1u<<3) < i ) {
+    // no-ops for root thread
     for ( int k = 0 ; k < c ; ++k ) {
       #if defined( __amd64 ) || defined( __amd64__ ) || \
-       	    defined( __x86_64 ) || defined( __x86_64__ )
-    	  #if !defined( _WIN32 ) /* IS NOT Microsoft Windows */
+            defined( __x86_64 ) || defined( __x86_64__ )
+        #if !defined( _WIN32 ) /* IS NOT Microsoft Windows */
           asm volatile( "nop\n" );
-	      #else
+        #else
           __asm__ __volatile__( "nop\n" );
         #endif
       #elif defined(__PPC64__)

--- a/core/src/impl/Kokkos_Spinwait.cpp
+++ b/core/src/impl/Kokkos_Spinwait.cpp
@@ -71,7 +71,7 @@ void host_thread_yield( const uint32_t i , const WaitMode mode )
 
   const int c = Kokkos::Impl::bit_scan_reverse(i);
 
-  if ( sleep_limit < i ) {
+  if ( mode != WaitMode::ROOT && (sleep_limit < i) ) {
 
     // Attempt to put the thread to sleep for 'c' milliseconds
 
@@ -87,7 +87,7 @@ void host_thread_yield( const uint32_t i , const WaitMode mode )
     #endif
   }
 
-  else if ( mode == WaitMode::PASSIVE || yield_limit < i ) {
+  else if ( mode != WaitMode::ROOT && (mode == WaitMode::PASSIVE || yield_limit < i) ) {
 
     // Attempt to yield thread resources to runtime
 


### PR DESCRIPTION
The root thread will no longer sleep or yield inside a spinwait.