### PR TITLE
Fix complex<float>

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -104,7 +104,7 @@ public:
   ///   imaginary part to zero.
   template<class InputRealType>
   KOKKOS_INLINE_FUNCTION complex (const InputRealType& val) :
-    re_ (val), im_ (0.0)
+    re_ (val), im_ (static_cast<InputRealType>(0.0))
   {}
 
   // BUG HCC WORKAROUND


### PR DESCRIPTION
Original title: "Kokkos: Fix compilation with complex float
by adding some static casts to scalar constants"

Author: Jonas Thies jonas.thies@dlr.de
Editor: Mark Hoemmen mhoemme@sandia.gov

Editor's note: Both kokkos and kokkos-kernels have their own
repositories. They are periodically snapshotted into the Trilinos
repository. Jonas submitted his original patch to Trilinos, as pull
request 2077:

https://github.com/trilinos/Trilinos/pull/2077

In order to turn this into pull requests for kokkos and
kokkos-kernels, I had to split the original patch into two patches,
and edit paths in each.  I also changed the original title
slightly. Otherwise, I made no other changes to the original
patch. Thanks Jonas! :-D