### PR TITLE
Fix #714 (add Kokkos::push_finalize_hook function & tests)

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -90,7 +90,7 @@
 #include <Kokkos_Complex.hpp>
 
 #include <Kokkos_CopyViews.hpp>
-
+#include <functional>
 #include <iosfwd>
 
 //----------------------------------------------------------------------------
@@ -125,6 +125,28 @@ bool show_warnings() noexcept;
 
 /** \brief  Finalize the spaces that were initialized via Kokkos::initialize */
 void finalize();
+
+/**
+ * \brief Push a user-defined function to be called in
+ *   Kokkos::finalize, before any Kokkos state is finalized.
+ *
+ * \warning Only call this after Kokkos::initialize, but before
+ *   Kokkos::finalize.
+ *
+ * This function is the Kokkos analog to std::atexit.  If you call
+ * this with a function f, then your function will get called when
+ * Kokkos::finalize is called.  Specifically, it will be called BEFORE
+ * Kokkos does any finalization.  This means that all execution
+ * spaces, memory spaces, etc. that were initialized will still be
+ * initialized when your function is called.
+ *
+ * Just like std::atexit, if you call push_finalize_hook in sequence
+ * with multiple functions (f, g, h), Kokkos::finalize will call them
+ * in reverse order (h, g, f), as if popping a stack.  Furthermore,
+ * just like std::atexit, if any of your functions throws but does not
+ * catch an exception, Kokkos::finalize will call std::terminate.
+ */
+void push_finalize_hook(std::function<void()> f);
 
 /** \brief  Finalize all known execution spaces */
 void finalize_all();

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -284,6 +284,26 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
     TESTONLYLIBS kokkos_gtest ${TEST_LINK_TARGETS}
 )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_PushFinalizeHook
+  SOURCES
+    UnitTest_PushFinalizeHook.cpp
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  FAIL_REGULAR_EXPRESSION "FAILED"
+    TESTONLYLIBS kokkos_gtest ${TEST_LINK_TARGETS}
+)
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_PushFinalizeHook_terminate
+  SOURCES
+    UnitTest_PushFinalizeHook_terminate.cpp
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  PASS_REGULAR_EXPRESSION "PASSED: I am the custom std::terminate handler."
+    TESTONLYLIBS kokkos_gtest ${TEST_LINK_TARGETS}
+)
+
 foreach(INITTESTS_NUM RANGE 1 16)
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   UnitTest_DefaultInit_${INITTESTS_NUM}

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -295,6 +295,12 @@ endif
 TARGETS += KokkosCore_UnitTest_Default
 TEST_TARGETS += test-default
 
+TARGETS += KokkosCore_UnitTest_PushFinalizeHook
+TEST_TARGETS += test-push-finalize-hook
+
+TARGETS += KokkosCore_UnitTest_PushFinalizeHook_terminate
+TEST_TARGETS += test-push-finalize-hook-terminate
+
 NUM_INITTESTS = 16
 INITTESTS_NUMBERS := $(shell seq 1 ${NUM_INITTESTS})
 INITTESTS_TARGETS := $(addprefix KokkosCore_UnitTest_DefaultDeviceTypeInit_,${INITTESTS_NUMBERS})
@@ -335,6 +341,13 @@ KokkosCore_UnitTest_AllocationTracker: $(OBJ_ALLOCATIONTRACKER) $(KOKKOS_LINK_DE
 KokkosCore_UnitTest_Default: $(OBJ_DEFAULT) $(KOKKOS_LINK_DEPENDS)
 	$(LINK) $(EXTRA_PATH) $(OBJ_DEFAULT) $(KOKKOS_LIBS) $(LIB) $(KOKKOS_LDFLAGS) $(LDFLAGS) -o KokkosCore_UnitTest_Default
 
+KokkosCore_UnitTest_PushFinalizeHook: $(OBJ_DEFAULT) $(KOKKOS_LINK_DEPENDS)
+	$(LINK) $(EXTRA_PATH) $(OBJ_DEFAULT) $(KOKKOS_LIBS) $(LIB) $(KOKKOS_LDFLAGS) $(LDFLAGS) -o KokkosCore_UnitTest_PushFinalizeHook
+
+KokkosCore_UnitTest_PushFinalizeHook_terminate: $(OBJ_DEFAULT) $(KOKKOS_LINK_DEPENDS)
+	$(LINK) $(EXTRA_PATH) $(OBJ_DEFAULT) $(KOKKOS_LIBS) $(LIB) $(KOKKOS_LDFLAGS) $(LDFLAGS) -o KokkosCore_UnitTest_PushFinalizeHook_terminate
+
+
 ${INITTESTS_TARGETS}: KokkosCore_UnitTest_DefaultDeviceTypeInit_%: TestDefaultDeviceTypeInit_%.o UnitTestMain.o gtest-all.o $(KOKKOS_LINK_DEPENDS)
 	$(LINK) $(EXTRA_PATH) TestDefaultDeviceTypeInit_$*.o UnitTestMain.o gtest-all.o $(KOKKOS_LIBS) $(LIB) $(KOKKOS_LDFLAGS) $(LDFLAGS) -o KokkosCore_UnitTest_DefaultDeviceTypeInit_$*
 
@@ -368,6 +381,12 @@ test-allocationtracker: KokkosCore_UnitTest_AllocationTracker
 
 test-default: KokkosCore_UnitTest_Default
 	./KokkosCore_UnitTest_Default
+
+test-push-finalize-hook: KokkosCore_UnitTest_PushFinalizeHook
+	./KokkosCore_UnitTest_PushFinalizeHook
+
+test-push-finalize-hook-terminate: KokkosCore_UnitTest_PushFinalizeHook_terminate
+	./KokkosCore_UnitTest_PushFinalizeHook_terminate
 
 ${INITTESTS_TEST_TARGETS}: test-default-init-%: KokkosCore_UnitTest_DefaultDeviceTypeInit_%
 	./KokkosCore_UnitTest_DefaultDeviceTypeInit_$*

--- a/core/unit_test/UnitTest_PushFinalizeHook.cpp
+++ b/core/unit_test/UnitTest_PushFinalizeHook.cpp
@@ -1,0 +1,139 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <sstream>
+#include <Kokkos_Core.hpp>
+
+namespace { // (anonymous)
+
+// Output for the finalize hooks.  Use this to make sure that all the
+// hooks ran, and that they ran in the correct order.
+std::ostringstream hookOutput;
+
+const char hook1str[] = "Behold, I am Hook 1; first pushed, last to be called.";
+const char hook2str[] = "Yea verily, I am Hook 2.";
+const char hook3str[] = "Indeed, I am Hook 3.";
+const char hook4str[] = "Last but not least, I am Hook 4.";
+
+} // namespace (anonymous)
+
+// Don't just have all the hooks print the same thing except for a
+// number.  Have them print different things, so we can detect
+// interleaving.  The hooks need to run sequentially, in LIFO order.
+// Also, make sure that the function accepts at least the following
+// kinds of hooks:
+//
+// 1. A plain old function that takes no arguments and returns nothing.
+// 2. Lambda, that can be assigned to std::function<void()>
+// 3. An actual std::function<void()>
+// 4. A named object with operator().  This is what C++ programmers
+//    unfortunately like to call "functor," even though this word
+//    means something different in other languages.
+
+void hook1 () {
+  hookOutput << hook1str << std::endl;
+}
+
+struct Hook4 {
+  void operator () () const {
+    hookOutput << hook4str << std::endl;
+  }
+};
+
+int main( int argc, char *argv[] ) {
+  using std::cout;
+  using std::endl;
+
+  const std::string expectedOutput ([] {
+      std::ostringstream os;
+      os << hook4str << endl
+         << hook3str << endl
+         << hook2str << endl
+         << hook1str << endl;
+      return os.str();
+    }());
+
+  Kokkos::initialize(argc, argv);
+
+  Kokkos::push_finalize_hook(hook1); // plain old function
+  Kokkos::push_finalize_hook ([] {
+      hookOutput << hook2str << endl;
+    }); // lambda
+  std::function<void()> hook3 = [] {
+    hookOutput << hook3str << endl;
+  };
+  Kokkos::push_finalize_hook(hook3); // actual std::function
+  Hook4 hook4;
+  Kokkos::push_finalize_hook(hook4); // function object instance
+
+  // This should invoke the finalize hooks in reverse order.
+  // Furthermore, it should not throw an exception.
+  try {
+    Kokkos::finalize();
+  }
+  catch (std::exception& e) {
+    cout << "FAILED: Kokkos::finalize threw an exception: " << e.what() << endl;
+    return EXIT_FAILURE;
+  }
+  catch (...) {
+    cout << "FAILED: Kokkos::finalize threw an exception whose base class "
+      "is not std::exception." << endl;
+    return EXIT_FAILURE;
+  }
+
+  const bool success = (hookOutput.str() == expectedOutput);
+  if (success) {
+    cout << "SUCCESS" << endl;
+  }
+  else {
+    cout << "FAILED:" << endl
+         << "  Expected output:" << endl
+         << expectedOutput << endl
+         << "  Actual output:" << endl
+         << hookOutput << endl;
+  }
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/core/unit_test/UnitTest_PushFinalizeHook_terminate.cpp
+++ b/core/unit_test/UnitTest_PushFinalizeHook_terminate.cpp
@@ -1,0 +1,86 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact  H. Carter Edwards (hcedwar@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <cstdlib>
+#include <iostream>
+#include <exception>
+#include <Kokkos_Core.hpp>
+
+// If any of the finalize hooks given to Kokkos::push_finalize_hook
+// throws but does not catch an exception, make sure that
+// Kokkos::finalize calls std::terminate.
+
+namespace { // (anonymous)
+
+// If you change this, change CMakeLists.txt in this directory too!
+// I verified that changing this string makes the test fail.
+const char my_terminate_str[] = "PASSED: I am the custom std::terminate handler.";
+
+void my_terminate_handler ()
+{
+  std::cerr << my_terminate_str << std::endl;
+  std::abort(); // terminate handlers normally would end by calling this
+}
+
+} // namespace (anonymous)
+
+
+int main(int argc, char *argv[])
+{
+  std::set_terminate (my_terminate_handler);
+
+
+  Kokkos::initialize(argc, argv);
+  Kokkos::push_finalize_hook([] {
+      throw std::runtime_error ("I am an uncaught exception!");
+    });
+
+  // This should call std::terminate, which in turn will call
+  // my_terminate_handler above.  That will print the message that
+  // makes this test count as passed.
+  Kokkos::finalize();
+
+  // The test actually failed if we got to this point.
+  std::cerr << "FAILED to call std::terminate!" << std::endl;
+  return EXIT_FAILURE;
+}


### PR DESCRIPTION
Add Kokkos::push_finalize_hook function.  It lets users set
function(s) to be called in Kokkos::finalize, BEFORE Kokkos finalizes
anything.  I also added unit tests that ensure the following:

  1. Kokkos::finalize actually calls the finalize hooks.
  2. Kokkos::finalize calls the functions in reverse (LIFO) order.
     That is, it calls them backwards from the order in which they
     were added, just as std::atexit does.
  3. If a finalize hook throws an uncaught exception, then
     Kokkos::finalize calls std::terminate, just as std::atexit does.

NOTE: I only tested whether this builds with the CMake-based
build system.  I made a best effort to add the unit tests to the
Makefile-based build system, but I didn't try building with that
system.

This pull request will fix #714.
  