### PR TITLE
Fix #1324 (build error in test on some compilers)

### DIFF
--- a/core/unit_test/UnitTest_PushFinalizeHook.cpp
+++ b/core/unit_test/UnitTest_PushFinalizeHook.cpp
@@ -133,7 +133,7 @@ int main( int argc, char *argv[] ) {
          << "  Expected output:" << endl
          << expectedOutput << endl
          << "  Actual output:" << endl
-         << hookOutput << endl;
+         << hookOutput.str() << endl;
   }
   return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
This is a Kokkos issue mirroring the following Trilinos issue:

https://github.com/trilinos/Trilinos/issues/2133

Summary: Not all compilers implement `operator<<(std::ostream&, const std::ostringstream&)`. Test on multiple compilers before pushing.

Reported by @ikalash thanks to the Albany Dashboard.  Thanks!