### PR TITLE
Try to fix get_work_partition overflow

### DIFF
--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -402,10 +402,13 @@ fflush(stdout);
 
   std::pair<int64_t,int64_t> get_work_partition() noexcept
     {
+      int64_t first = m_work_range.first;
+      int64_t second = m_work_range.second;
+      first *= m_work_chunk;
+      second *= m_work_chunk;
       return std::pair<int64_t,int64_t>
-        ( m_work_range.first * m_work_chunk
-        , m_work_range.second * m_work_chunk < m_work_end
-        ? m_work_range.second * m_work_chunk : m_work_end );
+        ( first
+        , second < m_work_end ? second : m_work_end );
     }
 
   std::pair<int64_t,int64_t> get_work_stealing_chunk() noexcept


### PR DESCRIPTION
[#1327]


```
Running on machine: sems
Repository Status:  1c176ac0497e3fdfe4bcb6626cc4ded06e38654c Try to fix get_work_partition overflow


Going to test compilers:  gcc/5.3.0 gcc/6.1.0 intel/17.0.1 clang/3.9.0 cuda/8.0.44
Testing compiler gcc/5.3.0
Testing compiler gcc/6.1.0
  Starting job gcc-5.3.0-OpenMP-release
  Starting job gcc-6.1.0-Serial-release
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-6.1.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-6.1.0-Serial-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler clang/3.9.0
  Starting job intel-17.0.1-OpenMP-release
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED gcc-6.1.0-Serial-hwloc-release
  Starting job clang-3.9.0-Pthread_Serial-release
  PASSED clang-3.9.0-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-3.9.0-Pthread_Serial-hwloc-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  PASSED intel-17.0.1-OpenMP-release
  PASSED clang-3.9.0-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-hwloc-release build_time=211 run_time=85
clang-3.9.0-Pthread_Serial-release build_time=196 run_time=273
cuda-8.0.44-Cuda_OpenMP-release build_time=481 run_time=611
gcc-5.3.0-OpenMP-hwloc-release build_time=256 run_time=390
gcc-5.3.0-OpenMP-release build_time=257 run_time=389
gcc-6.1.0-Serial-hwloc-release build_time=215 run_time=141
gcc-6.1.0-Serial-release build_time=203 run_time=375
intel-17.0.1-OpenMP-hwloc-release build_time=539 run_time=357
intel-17.0.1-OpenMP-release build_time=548 run_time=359
#######################################################
FAILED TESTS
#######################################################
```