### PR TITLE
Allow sorting a subset of a View

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -304,7 +304,7 @@ public:
                           , offset_type       /* PermuteViewType */
                           , ValuesViewType    /* SrcViewType */
                           >
-        functor( sorted_values , sort_order , values, values_range_begin );
+        functor( sorted_values , sort_order , values, values_range_begin - range_begin );
 
       parallel_for( Kokkos::RangePolicy<execution_space>(0,len),functor);
     }
@@ -340,7 +340,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   void operator() (const bin_count_tag& tag, const int& i) const {
     const int j = range_begin + i ;
-    bin_count_atomic(bin_op.bin(keys,j))++;
+    bin_count_atomic(bin_op.bin(keys, j))++;
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -120,7 +120,6 @@ public:
 
     KOKKOS_INLINE_FUNCTION
     void operator() (const int& i) const {
-      // printf("copy: dst(%i) src(%i)\n",i+dst_offset,i);
       copy_op::copy(dst_values,i+dst_offset,src_values,i);
     }
   };
@@ -151,20 +150,22 @@ public:
     DstViewType     dst_values ;
     perm_view_type  sort_order ;
     src_view_type   src_values ;
+    int             src_offset ;
 
     copy_permute_functor( DstViewType     const & dst_values_
                         , PermuteViewType const & sort_order_
                         , SrcViewType     const & src_values_
+                        , int             const & src_offset_
                         )
       : dst_values( dst_values_ )
       , sort_order( sort_order_ )
       , src_values( src_values_ )
+      , src_offset( src_offset_ )
       {}
 
     KOKKOS_INLINE_FUNCTION
     void operator() (const int& i)  const {
-      // printf("copy_permute: dst(%i) src(%i)\n",i,sort_order(i));
-      copy_op::copy(dst_values,i,src_values,sort_order(i));
+      copy_op::copy(dst_values,i,src_values,src_offset+sort_order(i));
     }
   };
 
@@ -269,9 +270,11 @@ public:
       Kokkos::parallel_for (Kokkos::RangePolicy<execution_space,bin_sort_bins_tag>(0,bin_op.max_bins()) ,*this);
   }
 
-  // Sort a view with respect ot the first dimension using the permutation array
+  // Sort a subset of a view with respect to the first dimension using the permutation array
   template<class ValuesViewType>
-  void sort( ValuesViewType const & values) const
+  void sort( ValuesViewType const & values
+           , int values_range_begin
+           , int values_range_end) const
   {
     typedef
       Kokkos::View< typename ValuesViewType::data_type,
@@ -280,6 +283,10 @@ public:
         scratch_view_type ;
 
     const size_t len = range_end - range_begin ;
+    const size_t values_len = values_range_end - values_range_begin ;
+    if (len != values_len) {
+      Kokkos::abort("BinSort::sort: values range length != permutation vector length");
+    }
 
     scratch_view_type
       sorted_values("Scratch",
@@ -297,7 +304,7 @@ public:
                           , offset_type       /* PermuteViewType */
                           , ValuesViewType    /* SrcViewType */
                           >
-        functor( sorted_values , sort_order , values );
+        functor( sorted_values , sort_order , values, values_range_begin );
 
       parallel_for( Kokkos::RangePolicy<execution_space>(0,len),functor);
     }
@@ -308,6 +315,12 @@ public:
 
       parallel_for( Kokkos::RangePolicy<execution_space>(0,len),functor);
     }
+  }
+
+  template<class ValuesViewType>
+  void sort( ValuesViewType const & values ) const
+  {
+    this->sort( values, 0, values.extent(0) );
   }
 
   // Get the permutation vector
@@ -543,6 +556,7 @@ void sort( ViewType view
   bin_sort.create_permute_vector();
   bin_sort.sort(view);
 }
+
 }
 
 #endif

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -320,7 +320,7 @@ public:
   template<class ValuesViewType>
   void sort( ValuesViewType const & values ) const
   {
-    this->sort( values, 0, values.extent(0) );
+    this->sort( values, 0, /*values.extent(0)*/ range_end - range_begin );
   }
 
   // Get the permutation vector
@@ -554,7 +554,7 @@ void sort( ViewType view
     bin_sort(view,begin,end,CompType((end-begin)/2,result.min_val,result.max_val),true);
 
   bin_sort.create_permute_vector();
-  bin_sort.sort(view);
+  bin_sort.sort(view,begin,end);
 }
 
 }

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -280,17 +280,16 @@ void test_issue_1160()
   auto h_x = Kokkos::create_mirror_view(x_);
   auto h_v = Kokkos::create_mirror_view(v_);
 
-  h_element(0) = 142;
-  h_element(1) = 141;
-  h_element(2) = 140;
-  h_element(3) = 5;
-  h_element(4) = 4;
-  h_element(5) = 3;
-  h_element(6) = 2;
-  h_element(7) = 1;
-  h_element(8) = 0;
-  h_element(9) = -1;
-  h_element(10) = -2;
+  h_element(0) = 9;
+  h_element(1) = 8;
+  h_element(2) = 7;
+  h_element(3) = 6;
+  h_element(4) = 5;
+  h_element(5) = 4;
+  h_element(6) = 3;
+  h_element(7) = 2;
+  h_element(8) = 1;
+  h_element(9) = 0;
 
   for (int i = 0; i < 10; ++i) {
     h_v(i, 0) = h_x(i, 0) = double(h_element(i));
@@ -299,14 +298,16 @@ void test_issue_1160()
   Kokkos::deep_copy(x_, h_x);
   Kokkos::deep_copy(v_, h_v);
 
-  typedef Kokkos::View<LocalOrdinal*, ExecutionSpace> KeyViewType;
+  typedef decltype(element_) KeyViewType;
   typedef Kokkos::BinOp1D< KeyViewType > BinOp;
 
   int begin = 3;
   int end = 8;
-  BinOp1D binner(end - begin, begin, end - 1);
+  auto max = h_element(begin);
+  auto min = h_element(end - 1);
+  BinOp binner(end - begin, min, max);
 
-  Kokkos::BinSort<decltype(element_) , BinOp > Sorter(element_,begin,end,binner,false);
+  Kokkos::BinSort<KeyViewType , BinOp > Sorter(element_,begin,end,binner,false);
   Sorter.create_permute_vector();
   Sorter.sort(element_,begin,end);
 
@@ -317,17 +318,16 @@ void test_issue_1160()
   Kokkos::deep_copy(h_x, x_);
   Kokkos::deep_copy(h_v, v_);
 
-  ASSERT_EQ(h_element(0), 142);
-  ASSERT_EQ(h_element(1), 141);
-  ASSERT_EQ(h_element(2), 140);
-  ASSERT_EQ(h_element(3), 1);
-  ASSERT_EQ(h_element(4), 2);
-  ASSERT_EQ(h_element(5), 3);
-  ASSERT_EQ(h_element(6), 4);
-  ASSERT_EQ(h_element(7), 5);
-  ASSERT_EQ(h_element(8), 0);
-  ASSERT_EQ(h_element(9), -1);
-  ASSERT_EQ(h_element(10), -2);
+  ASSERT_EQ(h_element(0), 9);
+  ASSERT_EQ(h_element(1), 8);
+  ASSERT_EQ(h_element(2), 7);
+  ASSERT_EQ(h_element(3), 2);
+  ASSERT_EQ(h_element(4), 3);
+  ASSERT_EQ(h_element(5), 4);
+  ASSERT_EQ(h_element(6), 5);
+  ASSERT_EQ(h_element(7), 6);
+  ASSERT_EQ(h_element(8), 1);
+  ASSERT_EQ(h_element(9), 0);
 
   for (int i = 0; i < 10; ++i) {
     ASSERT_EQ(h_element(i), int(h_x(i, 0)));


### PR DESCRIPTION
[#1160]

Includes a unit test for the new functionality.

```
Running on machine: sems
Repository Status:  0773d8b824aceb81127693f05da870a6d463a5f1 Fix bugs in subset sort and test


Going to test compilers:  gcc/5.3.0 gcc/6.1.0 intel/17.0.1 clang/3.9.0 cuda/8.0.44
Testing compiler gcc/5.3.0
Testing compiler gcc/6.1.0
  Starting job gcc-6.1.0-Serial-release
  Starting job gcc-5.3.0-OpenMP-release
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-6.1.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-6.1.0-Serial-hwloc-release
  PASSED gcc-5.3.0-OpenMP-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
Testing compiler clang/3.9.0
  Starting job intel-17.0.1-OpenMP-release
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED gcc-6.1.0-Serial-hwloc-release
  Starting job clang-3.9.0-Pthread_Serial-release
  PASSED clang-3.9.0-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-3.9.0-Pthread_Serial-hwloc-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  PASSED intel-17.0.1-OpenMP-release
  PASSED clang-3.9.0-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-hwloc-release build_time=195 run_time=83
clang-3.9.0-Pthread_Serial-release build_time=201 run_time=198
cuda-8.0.44-Cuda_OpenMP-release build_time=479 run_time=569
gcc-5.3.0-OpenMP-hwloc-release build_time=261 run_time=250
gcc-5.3.0-OpenMP-release build_time=259 run_time=251
gcc-6.1.0-Serial-hwloc-release build_time=205 run_time=120
gcc-6.1.0-Serial-release build_time=205 run_time=272
intel-17.0.1-OpenMP-hwloc-release build_time=583 run_time=244
intel-17.0.1-OpenMP-release build_time=595 run_time=242
```