### PR TITLE
Reduce performance impact of tracking_enabled()

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1062,16 +1062,16 @@ public:
   View() : m_track(), m_map() {}
 
   KOKKOS_INLINE_FUNCTION
-  View( const View & rhs ) : m_track( rhs.m_track ), m_map( rhs.m_map ) {}
+  View( const View & rhs ) : m_track( rhs.m_track, traits::is_managed ), m_map( rhs.m_map ) {}
 
   KOKKOS_INLINE_FUNCTION
-  View( View && rhs ) : m_track( rhs.m_track ), m_map( rhs.m_map ) {}
+  View( View && rhs ) : m_track( std::move(rhs.m_track) ), m_map( std::move(rhs.m_map) ) {}
 
   KOKKOS_INLINE_FUNCTION
   View & operator = ( const View & rhs ) { m_track = rhs.m_track ; m_map = rhs.m_map ; return *this ; }
 
   KOKKOS_INLINE_FUNCTION
-  View & operator = ( View && rhs ) { m_track = rhs.m_track ; m_map = rhs.m_map ; return *this ; }
+  View & operator = ( View && rhs ) { m_track = std::move(rhs.m_track) ; m_map = std::move(rhs.m_map) ; return *this ; }
 
   //----------------------------------------
   // Compatible view copy constructor and assignment

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -46,24 +46,7 @@
 namespace Kokkos {
 namespace Impl {
 
-namespace {
-
-__thread int t_tracking_enabled = 1;
-
-}
-
-int SharedAllocationRecord< void , void >::tracking_enabled()
-{ return t_tracking_enabled; }
-
-void SharedAllocationRecord< void , void >::tracking_disable()
-{
-  t_tracking_enabled = 0;
-}
-
-void SharedAllocationRecord< void , void >::tracking_enable()
-{
-  t_tracking_enabled = 1;
-}
+__thread int SharedAllocationRecord<void, void>::t_tracking_enabled = 1;
 
 //----------------------------------------------------------------------------
 

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -48,8 +48,6 @@ namespace Impl {
 
 __thread int SharedAllocationRecord<void, void>::t_tracking_enabled = 1;
 
-//----------------------------------------------------------------------------
-
 bool
 SharedAllocationRecord< void , void >::
 is_sane( SharedAllocationRecord< void , void > * arg_record )

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -107,21 +107,24 @@ protected:
                         , size_t                   arg_alloc_size
                         , function_type            arg_dealloc
                         );
+private:
+  
+  static __thread int t_tracking_enabled;
 
 public:
   inline std::string get_label() const { return std::string("Unmanaged"); }
 
-  static int tracking_enabled();
+  static int tracking_enabled() { return t_tracking_enabled; }
 
   /**\brief A host process thread claims and disables the
    *        shared allocation tracking flag.
    */
-  static void tracking_disable();
+  static void tracking_disable() { t_tracking_enabled = 0; }
 
   /**\brief A host process thread releases and enables the
    *        shared allocation tracking flag.
    */
-  static void tracking_enable();
+  static void tracking_enable() { t_tracking_enabled = 1; }
 
   ~SharedAllocationRecord() = default ;
 

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -381,8 +381,8 @@ public:
   KOKKOS_FORCEINLINE_FUNCTION
   SharedAllocationTracker( const SharedAllocationTracker & rhs
                          , const bool enable_tracking )
-    : m_record_bits( KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_ENABLED
-                     && enable_tracking
+    : m_record_bits( enable_tracking
+                     && KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_ENABLED
                    ? rhs.m_record_bits
                    : rhs.m_record_bits | DO_NOT_DEREF_FLAG )
     { KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_INCREMENT }


### PR DESCRIPTION
These changes reduce both the expense of calling `tracking_enabled()` and the frequency at which it gets called due to various View copying scenarios. This became important when said performance impact went up in the Kokkos 2.04.00 release, which in one instance (https://github.com/gahansen/Albany/issues/159) resulted in a 7% slowdown of a climate component application built on Trilinos. This is due to shallow copies of subviews within `Tpetra::CrsMatrix::SumIntoLocalValues` and also certain Intrepid2 functions which do similar "small view" shallow copies. These mitigations were tested on a FELIX test which uses the same Tpetra/Intrepid code, and restored execution time to pre-Kokkos 2.04.00 levels.

Albany and Trilinos developers who may be interested:
@ikalash
@mhoemmen 
@mperego

Spot check test report:
```
Running on machine: sems
Repository Status:  2b046cca5cbe895a2ec866160c3efbbc49166d1d Move correctness and better unmanaged copy


Going to test compilers:  gcc/5.3.0 gcc/6.1.0 intel/17.0.1 clang/3.9.0 cuda/8.0.44
Testing compiler gcc/5.3.0
Testing compiler gcc/6.1.0
  Starting job gcc-5.3.0-OpenMP-release
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  Starting job gcc-6.1.0-Serial-release
  PASSED gcc-6.1.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-6.1.0-Serial-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler clang/3.9.0
  Starting job intel-17.0.1-OpenMP-release
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED gcc-6.1.0-Serial-hwloc-release
  Starting job clang-3.9.0-Pthread_Serial-release
  PASSED clang-3.9.0-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-3.9.0-Pthread_Serial-hwloc-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  PASSED intel-17.0.1-OpenMP-release
  PASSED clang-3.9.0-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-hwloc-release build_time=189 run_time=88
clang-3.9.0-Pthread_Serial-release build_time=198 run_time=213
cuda-8.0.44-Cuda_OpenMP-release build_time=485 run_time=571
gcc-5.3.0-OpenMP-hwloc-release build_time=255 run_time=145
gcc-5.3.0-OpenMP-release build_time=251 run_time=153
gcc-6.1.0-Serial-hwloc-release build_time=190 run_time=130
gcc-6.1.0-Serial-release build_time=198 run_time=193
intel-17.0.1-OpenMP-hwloc-release build_time=546 run_time=209
intel-17.0.1-OpenMP-release build_time=548 run_time=214
```