### PR TITLE
Fix #1340

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -294,14 +294,23 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
     TESTONLYLIBS kokkos_gtest ${TEST_LINK_TARGETS}
 )
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  UnitTest_PushFinalizeHook_terminate
-  SOURCES
-    UnitTest_PushFinalizeHook_terminate.cpp
-  COMM serial mpi
-  NUM_MPI_PROCS 1
-  PASS_REGULAR_EXPRESSION "PASSED: I am the custom std::terminate handler."
-    TESTONLYLIBS kokkos_gtest ${TEST_LINK_TARGETS}
+# This test is special, because it passes exactly when it prints the
+# message "PASSED: I am the custom std::terminate handler.", AND calls
+# std::terminate.  This means that we can't use
+# TRIBITS_ADD_EXECUTABLE_AND_TEST.  See GitHub issue #2147.
+
+TRIBITS_ADD_EXECUTABLE( push_finalize_hook_terminate
+  SOURCES UnitTest_PushFinalizeHook_terminate.cpp
+  TESTONLYLIBS kokkos_gtest ${TEST_LINK_TARGETS}
+)
+
+TRIBITS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
+  TEST_0
+    EXEC push_finalize_hook_terminate
+    NUM_MPI_PROCS 1
+    PASS_REGULAR_EXPRESSION
+      "PASSED: I am the custom std::terminate handler."
+    ALWAYS_FAIL_ON_ZERO_RETURN
 )
 
 foreach(INITTESTS_NUM RANGE 1 16)

--- a/core/unit_test/UnitTest_PushFinalizeHook_terminate.cpp
+++ b/core/unit_test/UnitTest_PushFinalizeHook_terminate.cpp
@@ -56,7 +56,8 @@ namespace { // (anonymous)
 // I verified that changing this string makes the test fail.
 const char my_terminate_str[] = "PASSED: I am the custom std::terminate handler.";
 
-void my_terminate_handler ()
+// Tell compilers not to complain that this function doesn't return.
+[[ noreturn ]] void my_terminate_handler ()
 {
   std::cerr << my_terminate_str << std::endl;
   std::abort(); // terminate handlers normally would end by calling this
@@ -64,11 +65,10 @@ void my_terminate_handler ()
 
 } // namespace (anonymous)
 
-
 int main(int argc, char *argv[])
 {
+  // If std::terminate is called, it will call my_terminate_handler.
   std::set_terminate (my_terminate_handler);
-
 
   Kokkos::initialize(argc, argv);
   Kokkos::push_finalize_hook([] {


### PR DESCRIPTION
#1340 relates to a test that Kokkos::push_finalize_hook does the right thing
if a finalize hook raises a exception that it does not catch.