### PR TITLE
Change CMake warning to status

### DIFF
--- a/cmake/tribits.cmake
+++ b/cmake/tribits.cmake
@@ -3,7 +3,7 @@ INCLUDE(CTest)
 
 cmake_policy(SET CMP0054 NEW)
 
-MESSAGE(WARNING "The project name is: ${PROJECT_NAME}")
+MESSAGE(STATUS "The project name is: ${PROJECT_NAME}")
 
 IF(NOT DEFINED ${PROJECT_NAME}_ENABLE_OpenMP)
   SET(${PROJECT_NAME}_ENABLE_OpenMP OFF)


### PR DESCRIPTION
This "warning" always gets printed
when using the pure CMake build system,
this is not what warnings are for.