### PR TITLE
Cuda task-team collectives and stack size

### DIFF
--- a/core/src/impl/Kokkos_TaskQueue.hpp
+++ b/core/src/impl/Kokkos_TaskQueue.hpp
@@ -526,7 +526,14 @@ public:
 
       member->team_barrier();
 
-      if ( 0 == member->team_rank() && !(task->requested_respawn()) ) {
+      const bool only_one_thread =
+#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA)
+        0 == threadIdx.x && 0 == threadIdx.y ;
+#else
+        0 == member->team_rank();
+#endif
+
+      if ( only_one_thread && !(task->requested_respawn()) ) {
         // Did not respawn, destroy the functor to free memory.
         static_cast<functor_type*>(task)->~functor_type();
         // Cannot destroy and deallocate the task until its dependences


### PR DESCRIPTION
For issue #1353 
test_all_sandia results:
nohup: ignoring input
Running on machine: sems

Repository Status:  6fc364da44bdcc8f8e688a7f2d0aa0b8e69f0478 Add missing Cuda task-team collectives and increase Cuda task stack size for #1353


Going to test compilers:  gcc/4.8.4 gcc/4.9.3 gcc/5.3.0 gcc/6.1.0 intel/15.0.2 intel/16.0.1 intel/16.0.3 clang/3.6.1 clang/3.7.1 clang/3.8.1 clang/3.9.0 cuda/7.0.28 cuda/7.5.18 cuda/8.0.44
Testing compiler gcc/4.8.4
 #######################################################
PASSED TESTS
#######################################################
clang-3.6.1-Pthread-hwloc-release build_time=243 run_time=139
clang-3.6.1-Pthread-release build_time=147 run_time=404
clang-3.6.1-Pthread_Serial-hwloc-release build_time=168 run_time=176
clang-3.6.1-Pthread_Serial-release build_time=215 run_time=296
clang-3.6.1-Serial-hwloc-release build_time=200 run_time=259
clang-3.6.1-Serial-release build_time=222 run_time=305
clang-3.7.1-Pthread-hwloc-release build_time=254 run_time=124
clang-3.7.1-Pthread-release build_time=197 run_time=296
clang-3.7.1-Pthread_Serial-hwloc-release build_time=231 run_time=227
clang-3.7.1-Pthread_Serial-release build_time=227 run_time=347
clang-3.7.1-Serial-hwloc-release build_time=247 run_time=212
clang-3.7.1-Serial-release build_time=239 run_time=235
clang-3.8.1-Pthread-hwloc-release build_time=194 run_time=192
clang-3.8.1-Pthread-release build_time=372 run_time=289
clang-3.8.1-Pthread_Serial-hwloc-release build_time=252 run_time=352
clang-3.8.1-Pthread_Serial-release build_time=306 run_time=495
clang-3.8.1-Serial-hwloc-release build_time=269 run_time=324
clang-3.8.1-Serial-release build_time=171 run_time=327
clang-3.9.0-Pthread-hwloc-release build_time=225 run_time=152
clang-3.9.0-Pthread-release build_time=303 run_time=309
clang-3.9.0-Pthread_Serial-hwloc-release build_time=263 run_time=237
clang-3.9.0-Pthread_Serial-release build_time=334 run_time=372
clang-3.9.0-Serial-hwloc-release build_time=286 run_time=203
clang-3.9.0-Serial-release build_time=235 run_time=287
cuda-7.0.28-Cuda_OpenMP-release build_time=684 run_time=577
cuda-7.0.28-Cuda_Pthread-release build_time=670 run_time=559
cuda-7.0.28-Cuda_Serial-release build_time=623 run_time=540
cuda-7.5.18-Cuda_OpenMP-release build_time=590 run_time=592
cuda-7.5.18-Cuda_Pthread-release build_time=657 run_time=547
cuda-7.5.18-Cuda_Serial-release build_time=596 run_time=558
cuda-8.0.44-Cuda_OpenMP-release build_time=568 run_time=539
cuda-8.0.44-Cuda_Pthread-release build_time=634 run_time=562
cuda-8.0.44-Cuda_Serial-release build_time=609 run_time=550
gcc-4.8.4-OpenMP-hwloc-release build_time=205 run_time=474
gcc-4.8.4-OpenMP-release build_time=205 run_time=475
gcc-4.8.4-OpenMP_Serial-hwloc-release build_time=216 run_time=305
gcc-4.8.4-OpenMP_Serial-release build_time=237 run_time=516
gcc-4.8.4-Pthread-hwloc-release build_time=173 run_time=219
gcc-4.8.4-Pthread-release build_time=191 run_time=579
gcc-4.8.4-Pthread_Serial-hwloc-release build_time=170 run_time=330
gcc-4.8.4-Pthread_Serial-release build_time=175 run_time=798
gcc-4.8.4-Serial-hwloc-release build_time=167 run_time=862
gcc-4.8.4-Serial-release build_time=155 run_time=773
gcc-4.9.3-OpenMP-hwloc-release build_time=226 run_time=397
gcc-4.9.3-OpenMP-release build_time=307 run_time=452
gcc-4.9.3-OpenMP_Serial-hwloc-release build_time=203 run_time=164
gcc-4.9.3-OpenMP_Serial-release build_time=200 run_time=159
gcc-4.9.3-Pthread-hwloc-release build_time=189 run_time=283
gcc-4.9.3-Pthread-release build_time=203 run_time=546
gcc-4.9.3-Pthread_Serial-hwloc-release build_time=191 run_time=139
gcc-4.9.3-Pthread_Serial-release build_time=193 run_time=325
gcc-4.9.3-Serial-hwloc-release build_time=156 run_time=233
gcc-4.9.3-Serial-release build_time=192 run_time=467
gcc-5.3.0-OpenMP-hwloc-release build_time=221 run_time=93
gcc-5.3.0-OpenMP-release build_time=267 run_time=107
gcc-5.3.0-OpenMP_Serial-hwloc-release build_time=268 run_time=164
gcc-5.3.0-OpenMP_Serial-release build_time=235 run_time=167
gcc-5.3.0-Pthread-hwloc-release build_time=176 run_time=113
gcc-5.3.0-Pthread-release build_time=187 run_time=188
gcc-5.3.0-Pthread_Serial-hwloc-release build_time=202 run_time=151
gcc-5.3.0-Pthread_Serial-release build_time=223 run_time=253
gcc-5.3.0-Serial-hwloc-release build_time=184 run_time=155
gcc-5.3.0-Serial-release build_time=245 run_time=130
gcc-6.1.0-OpenMP-hwloc-release build_time=185 run_time=103
gcc-6.1.0-OpenMP-release build_time=224 run_time=92
gcc-6.1.0-OpenMP_Serial-hwloc-release build_time=223 run_time=154
gcc-6.1.0-OpenMP_Serial-release build_time=236 run_time=135
gcc-6.1.0-Pthread-hwloc-release build_time=182 run_time=68
gcc-6.1.0-Pthread-release build_time=163 run_time=151
gcc-6.1.0-Pthread_Serial-hwloc-release build_time=206 run_time=132
gcc-6.1.0-Pthread_Serial-release build_time=214 run_time=216
gcc-6.1.0-Serial-hwloc-release build_time=196 run_time=141
gcc-6.1.0-Serial-release build_time=156 run_time=171
intel-15.0.2-OpenMP-hwloc-release build_time=434 run_time=231
intel-15.0.2-OpenMP-release build_time=473 run_time=160
intel-15.0.2-OpenMP_Serial-hwloc-release build_time=447 run_time=276
intel-15.0.2-OpenMP_Serial-release build_time=473 run_time=197
intel-15.0.2-Pthread-hwloc-release build_time=373 run_time=127
intel-15.0.2-Pthread-release build_time=340 run_time=261
intel-15.0.2-Pthread_Serial-hwloc-release build_time=419 run_time=165
intel-15.0.2-Pthread_Serial-release build_time=387 run_time=302
intel-15.0.2-Serial-hwloc-release build_time=321 run_time=243
intel-15.0.2-Serial-release build_time=309 run_time=228
intel-16.0.1-OpenMP-hwloc-release build_time=556 run_time=215
intel-16.0.1-OpenMP-release build_time=560 run_time=213
intel-16.0.1-OpenMP_Serial-hwloc-release build_time=531 run_time=277
intel-16.0.1-OpenMP_Serial-release build_time=549 run_time=219
intel-16.0.1-Pthread-hwloc-release build_time=404 run_time=150
intel-16.0.1-Pthread-release build_time=361 run_time=239
intel-16.0.1-Pthread_Serial-hwloc-release build_time=419 run_time=163
intel-16.0.1-Pthread_Serial-release build_time=382 run_time=321
intel-16.0.1-Serial-hwloc-release build_time=324 run_time=260
intel-16.0.1-Serial-release build_time=349 run_time=263
intel-16.0.3-OpenMP-hwloc-release build_time=534 run_time=175
intel-16.0.3-OpenMP-release build_time=523 run_time=169
intel-16.0.3-OpenMP_Serial-hwloc-release build_time=517 run_time=287
intel-16.0.3-OpenMP_Serial-release build_time=546 run_time=254
intel-16.0.3-Pthread-hwloc-release build_time=361 run_time=197
intel-16.0.3-Pthread-release build_time=378 run_time=220
intel-16.0.3-Pthread_Serial-hwloc-release build_time=458 run_time=297
intel-16.0.3-Pthread_Serial-release build_time=452 run_time=534
intel-16.0.3-Serial-hwloc-release build_time=413 run_time=204
intel-16.0.3-Serial-release build_time=312 run_time=299
