### PR TITLE
Fix anonymous space test for CUDA

### DIFF
--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1467,6 +1467,8 @@ TEST_F( TEST_CATEGORY, view_stride_method )
 }
 
 inline void test_anonymous_space() {
+  /* apparently TEST_EXECSPACE is sometimes a memory space. */
+  using ExecSpace = TEST_EXECSPACE::execution_space;
   int host_array[10];
   Kokkos::View<int[10], Kokkos::AnonymousSpace> host_anon_stat_view(host_array);
   Kokkos::View<int*, Kokkos::AnonymousSpace> host_anon_dyn_view(host_array, 10);
@@ -1476,9 +1478,9 @@ inline void test_anonymous_space() {
     host_anon_stat_view(i) = host_anon_dyn_view(i) = 142;
     host_anon_assign_view(i) = 142;
   }
-  Kokkos::View<int**, Kokkos::LayoutRight, TEST_EXECSPACE> d_view("d_view", 100, 10);
+  Kokkos::View<int**, Kokkos::LayoutRight, ExecSpace> d_view("d_view", 100, 10);
 #ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
-  Kokkos::parallel_for(100, KOKKOS_LAMBDA(int i) {
+  Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, int>(0, 100), KOKKOS_LAMBDA(int i) {
     int* ptr = &(d_view(i, 0));
     Kokkos::View<int[10], Kokkos::AnonymousSpace> d_anon_stat_view(ptr);
     Kokkos::View<int*, Kokkos::AnonymousSpace> d_anon_dyn_view(ptr, 10);


### PR DESCRIPTION
I guess our spot checks must not
enable CUDA lambdas, because this
test was quite broken when CUDA
is enabled and TEST_EXECSPACE=Serial