### PR TITLE
Issues 1370 1369 1269

### DIFF
--- a/benchmarks/benchmark_suite/scripts/run_tests.bash
+++ b/benchmarks/benchmark_suite/scripts/run_tests.bash
@@ -3,7 +3,7 @@
 # BytesAndFlops
 cd build/bytes_and_flops
 
-USE_CUDA=`grep "_CUDA 1" KokkosCore_config.h | wc -l`
+USE_CUDA=`grep "_CUDA" KokkosCore_config.h | wc -l`
 
 if [[ ${USE_CUDA} > 0 ]]; then
   BAF_EXE=bytes_and_flops.cuda

--- a/core/src/Cuda/Kokkos_Cuda_Impl.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Impl.cpp
@@ -437,19 +437,7 @@ void CudaInternal::initialize( int cuda_device_id , int stream_count )
     // Maximum number of warps,
     // at most one warp per thread in a warp for reduction.
 
-    // HCE 2012-February :
-    // Found bug in CUDA 4.1 that sometimes a kernel launch would fail
-    // if the thread count == 1024 and a functor is passed to the kernel.
-    // Copying the kernel to constant memory and then launching with
-    // thread count == 1024 would work fine.
-    //
-    // HCE 2012-October :
-    // All compute capabilities support at least 16 warps (512 threads).
-    // However, we have found that 8 warps typically gives better performance.
-
-    m_maxWarpCount = 8 ;
-
-    // m_maxWarpCount = cudaProp.maxThreadsPerBlock / Impl::CudaTraits::WarpSize ;
+    m_maxWarpCount = cudaProp.maxThreadsPerBlock / Impl::CudaTraits::WarpSize ;
 
     if ( Impl::CudaTraits::WarpSize < m_maxWarpCount ) {
       m_maxWarpCount = Impl::CudaTraits::WarpSize ;

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -390,7 +390,8 @@ public:
   void execute() const
     {
       const int nwork = m_policy.end() - m_policy.begin();
-      const dim3 block(  1 , CudaTraits::WarpSize * cuda_internal_maximum_warp_count(), 1);
+      const int block_size = Kokkos::Impl::cuda_get_opt_block_size< ParallelFor >( m_functor , 1, 0 , 0 );
+      const dim3 block(  1 , block_size , 1);
       const dim3 grid( std::min( ( nwork + block.y - 1 ) / block.y , cuda_internal_maximum_grid_count() ) , 1 , 1);
 
       CudaParallelLaunch< ParallelFor, LaunchBounds >( *this , grid , block , 0 );

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1105,7 +1105,7 @@ void deep_copy
   static_assert( ViewTraits<ST,SP...>::rank == 0
                , "ERROR: Non-rank-zero view in deep_copy( value , View )" );
 
-  if(dst.data() == NULL && src.data() == NULL) {
+  if(src.data() == NULL) {
     Kokkos::fence();
     return;
   }
@@ -1344,7 +1344,7 @@ void deep_copy
   static_assert( ViewTraits<ST,SP...>::rank == 0
                , "ERROR: Non-rank-zero view in deep_copy( value , View )" );
 
-  if(dst.data() == NULL && src.data() == NULL) {
+  if(src.data() == NULL) {
     exec_space.fence();
     return;
   }

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1034,6 +1034,10 @@ void deep_copy
     >::type * = 0 )
 {
   typedef View<DT,DP...> ViewType;
+  if(dst.data() == NULL ) {
+    Kokkos::fence();
+    return;
+  }
 
   Kokkos::fence();
   static_assert(
@@ -1101,6 +1105,11 @@ void deep_copy
   static_assert( ViewTraits<ST,SP...>::rank == 0
                , "ERROR: Non-rank-zero view in deep_copy( value , View )" );
 
+  if(dst.data() == NULL && src.data() == NULL) {
+    Kokkos::fence();
+    return;
+  }
+
   typedef ViewTraits<ST,SP...>               src_traits ;
   typedef typename src_traits::memory_space  src_memory_space ;
   Kokkos::Impl::DeepCopy< HostSpace , src_memory_space >( & dst , src.data() , sizeof(ST) );
@@ -1124,6 +1133,11 @@ void deep_copy
     std::is_same< typename ViewTraits<DT,DP...>::value_type ,
                   typename ViewTraits<ST,SP...>::non_const_value_type >::value
     , "deep_copy requires matching non-const destination type" );
+
+  if(dst.data() == NULL && src.data() == NULL) {
+    Kokkos::fence();
+    return;
+  }
 
   typedef View<DT,DP...>  dst_type ;
   typedef View<ST,SP...>  src_type ;
@@ -1174,6 +1188,10 @@ void deep_copy
   typedef typename src_type::memory_space     src_memory_space ;
   typedef typename dst_type::value_type       dst_value_type ;
   typedef typename src_type::value_type       src_value_type ;
+  if(dst.data() == NULL && src.data() == NULL) {
+    Kokkos::fence();
+    return;
+  }
 
   enum { DstExecCanAccessSrc =
    Kokkos::Impl::SpaceAccessibility< dst_execution_space , src_memory_space >::accessible };
@@ -1326,6 +1344,11 @@ void deep_copy
   static_assert( ViewTraits<ST,SP...>::rank == 0
                , "ERROR: Non-rank-zero view in deep_copy( value , View )" );
 
+  if(dst.data() == NULL && src.data() == NULL) {
+    exec_space.fence();
+    return;
+  }
+
   typedef ViewTraits<ST,SP...>               src_traits ;
   typedef typename src_traits::memory_space  src_memory_space ;
   Kokkos::Impl::DeepCopy< HostSpace , src_memory_space , ExecSpace >
@@ -1359,6 +1382,10 @@ void deep_copy
   typedef typename dst_type::value_type    value_type ;
   typedef typename dst_type::memory_space  dst_memory_space ;
   typedef typename src_type::memory_space  src_memory_space ;
+  if(dst.data() == NULL && src.data() == NULL) {
+    exec_space.fence();
+    return;
+  }
 
   exec_space.fence();
   if ( dst.data() != src.data() ) {
@@ -1405,6 +1432,11 @@ void deep_copy
   typedef typename src_type::memory_space     src_memory_space ;
   typedef typename dst_type::value_type       dst_value_type ;
   typedef typename src_type::value_type       src_value_type ;
+
+  if(dst.data() == NULL && src.data() == NULL) {
+    exec_space.fence();
+    return;
+  }
 
   enum { ExecCanAccessSrcDst =
       Kokkos::Impl::SpaceAccessibility< ExecSpace , dst_memory_space >::accessible &&

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
@@ -391,10 +391,11 @@ void OpenMP::finalize()
   }
 
   if ( Impl::t_openmp_instance ) {
-
+    // Silence Cuda Warning
     const int nthreads = Impl::t_openmp_instance->m_pool_size <= Impl::g_openmp_hardware_max_threads
                        ? Impl::g_openmp_hardware_max_threads
                        : Impl::t_openmp_instance->m_pool_size;
+    (void) nthreads;
 
     using Exec = Impl::OpenMPExec;
     Exec * instance = Impl::t_openmp_instance;

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1166,14 +1166,30 @@ return;
     ASSERT_TRUE( dy.ptr_on_device() == 0 );
     ASSERT_TRUE( dz.ptr_on_device() == 0 );
 
+    // Check Deep Copy of LayoutLeft to LayoutRight
     {
-      // Check Deep Copy of LayoutLeft to LayoutRight
-
       Kokkos::View<double*,Kokkos::LayoutLeft> dll("dll",10);
       Kokkos::View<double*,Kokkos::LayoutRight,Kokkos::HostSpace> hlr("hlr",10);
       Kokkos::deep_copy(dll,hlr);
       Kokkos::deep_copy(hlr,dll);
     }
+
+    // Check Deep Copy of two empty 1D views
+    {
+      Kokkos::View<double*> d;
+      Kokkos::View<double*,Kokkos::HostSpace> h;
+      Kokkos::deep_copy(d,h);
+      Kokkos::deep_copy(h,d);
+    }
+
+    // Check Deep Copy of two empty 2D views
+    {
+      Kokkos::View<double*[3],Kokkos::LayoutRight> d;
+      Kokkos::View<double*[3],Kokkos::LayoutRight,Kokkos::HostSpace> h;
+      Kokkos::deep_copy(d,h);
+      Kokkos::deep_copy(h,d);
+    }
+
   }
 
   typedef T DataType[2];


### PR DESCRIPTION
Tests performed:
```
ModuleCmd_Load.c(213):ERROR:105: Unable to locate a modulefile for 'git'
Running on machine: apollo
Repository Status:  1e4571a45a6e231d5307f915dc3539fe347a4b29 Fix issue in deep_copy changes


Going to test compilers:  gcc/4.8.4 gcc/5.1.0 intel/16.0.1 clang/3.9.0 clang/4.0.0 cuda/8.0.44
Testing compiler gcc/4.8.4
Testing compiler gcc/5.1.0
  Starting job gcc-4.8.4-Pthread-release
  Starting job gcc-4.8.4-OpenMP-release
  PASSED gcc-4.8.4-OpenMP-release
Testing compiler intel/16.0.1
  Starting job gcc-5.1.0-Serial-release
  PASSED gcc-4.8.4-Pthread-release
Testing compiler clang/3.9.0
  Starting job intel-16.0.1-OpenMP-release
  PASSED gcc-5.1.0-Serial-release
Testing compiler clang/4.0.0
  Starting job clang-3.9.0-Pthread_Serial-release
  PASSED clang-3.9.0-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-4.0.0-Cuda_Pthread-release
  PASSED intel-16.0.1-OpenMP-release
  PASSED clang-4.0.0-Cuda_Pthread-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-release build_time=152 run_time=204
clang-4.0.0-Cuda_Pthread-release build_time=286 run_time=264
cuda-8.0.44-Cuda_OpenMP-release build_time=320 run_time=252
gcc-4.8.4-OpenMP-release build_time=142 run_time=115
gcc-4.8.4-Pthread-release build_time=126 run_time=213
gcc-5.1.0-Serial-release build_time=136 run_time=118
intel-16.0.1-OpenMP-release build_time=403 run_time=137
```