### PR TITLE
MDRangePolicy: Lambda fix

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -2068,8 +2068,39 @@ namespace Impl {
     __device__ inline
     void operator() (typename ExecPolicy::work_tag, const typename ExecPolicy::member_type& i, ValueType& val) const {
       //Insert Static Assert with decltype on ValueType equals third argument type of FunctorType::operator()
-      f(typename ExecPolicy::work_tag(), i,val);
+      f(typename ExecPolicy::work_tag(), i, val);
     }
+
+    __device__ inline
+    void operator() (typename ExecPolicy::work_tag, const typename ExecPolicy::member_type& i, const typename ExecPolicy::member_type& j, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals third argument type of FunctorType::operator()
+      f(typename ExecPolicy::work_tag(), i, j, val);
+    }
+
+    __device__ inline
+    void operator() (typename ExecPolicy::work_tag, const typename ExecPolicy::member_type& i, const typename ExecPolicy::member_type& j, const typename ExecPolicy::member_type& k, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals third argument type of FunctorType::operator()
+      f(typename ExecPolicy::work_tag(), i, j, k, val);
+    }
+
+    __device__ inline
+    void operator() (typename ExecPolicy::work_tag, const typename ExecPolicy::member_type& i, const typename ExecPolicy::member_type& j, const typename ExecPolicy::member_type& k, const typename ExecPolicy::member_type& l, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals third argument type of FunctorType::operator()
+      f(typename ExecPolicy::work_tag(), i, j, k, l, val);
+    }
+
+    __device__ inline
+    void operator() (typename ExecPolicy::work_tag, const typename ExecPolicy::member_type& i, const typename ExecPolicy::member_type& j, const typename ExecPolicy::member_type& k, const typename ExecPolicy::member_type& l, const typename ExecPolicy::member_type& m, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals third argument type of FunctorType::operator()
+      f(typename ExecPolicy::work_tag(), i, j, k, l, m, val);
+    }
+
+    __device__ inline
+    void operator() (typename ExecPolicy::work_tag, const typename ExecPolicy::member_type& i, const typename ExecPolicy::member_type& j, const typename ExecPolicy::member_type& k, const typename ExecPolicy::member_type& l, const typename ExecPolicy::member_type& m, const typename ExecPolicy::member_type& n, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals third argument type of FunctorType::operator()
+      f(typename ExecPolicy::work_tag(), i, j, k, l, m, n, val);
+    }
+
   };
 
   template< class FunctorType, class ExecPolicy, class ValueType >
@@ -2083,10 +2114,72 @@ namespace Impl {
       //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
       f(i,val);
     }
+
+    __device__ inline
+    void operator() (const typename ExecPolicy::member_type& i, const typename ExecPolicy::member_type& j, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
+      f(i,j,val);
+    }
+
+    __device__ inline
+    void operator() (const typename ExecPolicy::member_type& i, const typename ExecPolicy::member_type& j, const typename ExecPolicy::member_type& k, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
+      f(i,j,k,val);
+    }
+
+    __device__ inline
+    void operator() (const typename ExecPolicy::member_type& i, const typename ExecPolicy::member_type& j, const typename ExecPolicy::member_type& k, const typename ExecPolicy::member_type& l, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
+      f(i,j,k,l,val);
+    }
+
+    __device__ inline
+    void operator() (const typename ExecPolicy::member_type& i, const typename ExecPolicy::member_type& j, const typename ExecPolicy::member_type& k, const typename ExecPolicy::member_type& l, const typename ExecPolicy::member_type& m, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
+      f(i,j,k,l,m,val);
+    }
+
+    __device__ inline
+    void operator() (const typename ExecPolicy::member_type& i, const typename ExecPolicy::member_type& j, const typename ExecPolicy::member_type& k, const typename ExecPolicy::member_type& l, const typename ExecPolicy::member_type& m, const typename ExecPolicy::member_type& n, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
+      f(i,j,k,l,m,n,val);
+    }
+
+
     __device__ inline
     void operator() (typename ExecPolicy::member_type& i, ValueType& val) const {
       //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
       f(i,val);
+    }
+
+    __device__ inline
+    void operator() (typename ExecPolicy::member_type& i, typename ExecPolicy::member_type& j, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
+      f(i,j,val);
+    }
+
+    __device__ inline
+    void operator() (typename ExecPolicy::member_type& i, typename ExecPolicy::member_type& j, typename ExecPolicy::member_type& k, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
+      f(i,j,k,val);
+    }
+
+    __device__ inline
+    void operator() (typename ExecPolicy::member_type& i, typename ExecPolicy::member_type& j, typename ExecPolicy::member_type& k, typename ExecPolicy::member_type& l, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
+      f(i,j,k,l,val);
+    }
+
+    __device__ inline
+    void operator() (typename ExecPolicy::member_type& i, typename ExecPolicy::member_type& j, typename ExecPolicy::member_type& k, typename ExecPolicy::member_type& l, typename ExecPolicy::member_type& m, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
+      f(i,j,k,l,m,val);
+    }
+
+    __device__ inline
+    void operator() (typename ExecPolicy::member_type& i, typename ExecPolicy::member_type& j, typename ExecPolicy::member_type& k, typename ExecPolicy::member_type& l, typename ExecPolicy::member_type& m, typename ExecPolicy::member_type& n, ValueType& val) const {
+      //Insert Static Assert with decltype on ValueType equals second argument type of FunctorType::operator()
+      f(i,j,k,l,m,n,val);
     }
 
   };

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -705,21 +705,20 @@ private:
   typedef typename ReducerConditional::type ReducerTypeFwd;
   typedef typename Kokkos::Impl::if_c< std::is_same<InvalidType,ReducerType>::value, WorkTag, void>::type WorkTagFwd;
 
-  typedef typename ReducerTypeFwd::value_type ValueType; 
-
-  typedef FunctorAnalysis< FunctorPatternInterface::REDUCE , Policy , FunctorType > Analysis ;
+  typedef FunctorAnalysis< FunctorPatternInterface::REDUCE , MDRangePolicy , FunctorType > Analysis ;
 
   typedef Kokkos::Impl::FunctorValueInit<   ReducerTypeFwd , WorkTagFwd >  ValueInit ;
 
   typedef typename Analysis::pointer_type    pointer_type ;
+  typedef typename Analysis::value_type      value_type ;
   typedef typename Analysis::reference_type  reference_type ;
 
 
   using iterate_type = typename Kokkos::Impl::HostIterateTile< MDRangePolicy
-                                                                           , FunctorType
-                                                                           , WorkTag
-                                                                           , ValueType
-                                                                           >;
+                                                             , FunctorType
+                                                             , WorkTag
+                                                             , reference_type
+                                                             >;
 
 
   const FunctorType   m_functor ;

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -460,25 +460,24 @@ private:
   typedef typename Policy::WorkRange                        WorkRange ;
   typedef typename Policy::member_type                      Member ;
 
-  typedef FunctorAnalysis< FunctorPatternInterface::REDUCE , Policy , FunctorType > Analysis ;
+  typedef FunctorAnalysis< FunctorPatternInterface::REDUCE , MDRangePolicy , FunctorType > Analysis ;
 
   typedef Kokkos::Impl::if_c< std::is_same<InvalidType,ReducerType>::value, FunctorType, ReducerType> ReducerConditional;
   typedef typename ReducerConditional::type ReducerTypeFwd;
   typedef typename Kokkos::Impl::if_c< std::is_same<InvalidType,ReducerType>::value, WorkTag, void>::type WorkTagFwd;
 
-  typedef typename ReducerTypeFwd::value_type ValueType; 
-
   typedef Kokkos::Impl::FunctorValueInit<   ReducerTypeFwd, WorkTagFwd > ValueInit ;
   typedef Kokkos::Impl::FunctorValueJoin<   ReducerTypeFwd, WorkTagFwd > ValueJoin ;
 
   typedef typename Analysis::pointer_type    pointer_type ;
+  typedef typename Analysis::value_type      value_type ;
   typedef typename Analysis::reference_type  reference_type ;
 
   using iterate_type = typename Kokkos::Impl::HostIterateTile< MDRangePolicy
-                                                                           , FunctorType
-                                                                           , WorkTag
-                                                                           , ValueType
-                                                                           >;
+                                                             , FunctorType
+                                                             , WorkTag
+                                                             , reference_type
+                                                             >;
 
         OpenMPExec   * m_instance ;
   const FunctorType   m_functor ;

--- a/core/src/Threads/Kokkos_Threads_Parallel.hpp
+++ b/core/src/Threads/Kokkos_Threads_Parallel.hpp
@@ -567,18 +567,17 @@ private:
   typedef typename ReducerConditional::type ReducerTypeFwd;
   typedef typename Kokkos::Impl::if_c< std::is_same<InvalidType,ReducerType>::value, WorkTag, void>::type WorkTagFwd;
 
-  typedef typename ReducerTypeFwd::value_type ValueType; 
-
   typedef Kokkos::Impl::FunctorValueTraits< ReducerTypeFwd , WorkTagFwd > ValueTraits ;
   typedef Kokkos::Impl::FunctorValueInit<   ReducerTypeFwd , WorkTagFwd > ValueInit ;
 
   typedef typename ValueTraits::pointer_type    pointer_type ;
+  typedef typename ValueTraits::value_type      value_type ;
   typedef typename ValueTraits::reference_type  reference_type ;
 
   using iterate_type = typename Kokkos::Impl::HostIterateTile< MDRangePolicy
                                                                            , FunctorType
                                                                            , WorkTag
-                                                                           , ValueType
+                                                                           , reference_type
                                                                            >;
 
   const FunctorType   m_functor ;

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -226,7 +226,65 @@ private:
 
   template< class ArgMember >
   KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
   static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
 
   template< class TagType , class ArgMember >
   KOKKOS_INLINE_FUNCTION
@@ -234,7 +292,66 @@ private:
 
   template< class TagType , class ArgMember >
   KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
   static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+
 
   template< class TagType , class ArgMember >
   KOKKOS_INLINE_FUNCTION
@@ -242,7 +359,65 @@ private:
 
   template< class TagType , class ArgMember >
   KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
   static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class TagType , class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
 
   //----------------------------------------
   // parallel_for operator with a tag:
@@ -253,7 +428,65 @@ private:
 
   template< class ArgMember >
   KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
   static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember ) const ) {}
+
 
   template< class ArgMember >
   KOKKOS_INLINE_FUNCTION
@@ -261,18 +494,134 @@ private:
 
   template< class ArgMember >
   KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
   static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
+  template< class ArgMember >
+  KOKKOS_INLINE_FUNCTION
+  static VOIDTAG deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & ) const ) {}
+
 
   //----------------------------------------
   // parallel_reduce operator without a tag:
-
+// TODO Begin here to fix...
   template< class ArgMember , class T >
   KOKKOS_INLINE_FUNCTION
   static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , T & ) const ) {}
 
   template< class ArgMember , class T >
   KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
   static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
 
   template< class TagType , class ArgMember , class T >
   KOKKOS_INLINE_FUNCTION
@@ -280,7 +629,65 @@ private:
 
   template< class TagType , class ArgMember , class T >
   KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
   static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( TagType , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
 
   template< class TagType , class ArgMember , class T >
   KOKKOS_INLINE_FUNCTION
@@ -288,7 +695,64 @@ private:
 
   template< class TagType , class ArgMember , class T >
   KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
   static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class TagType , class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static REJECTTAG deduce_reduce_type( VOIDTAG , void (FunctorType::*)( const TagType & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
 
   //----------------------------------------
   // parallel_reduce operator with a tag:
@@ -299,7 +763,65 @@ private:
 
   template< class ArgMember , class T >
   KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
   static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , ArgMember , T & ) const ) {}
+
 
   template< class ArgMember , class T >
   KOKKOS_INLINE_FUNCTION
@@ -307,7 +829,64 @@ private:
 
   template< class ArgMember , class T >
   KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( tag_type , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
   static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
+
+  template< class ArgMember , class T >
+  KOKKOS_INLINE_FUNCTION
+  static T deduce_reduce_type( tag_type , void (FunctorType::*)( const tag_type & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , const ArgMember & , T & ) const ) {}
 
   //----------------------------------------
   // parallel_scan operator without a tag:
@@ -467,7 +1046,7 @@ struct FunctorValueInitFunction< FunctorType , void > {
 // If a proper FunctorType::init is declared then use it,
 // otherwise use default constructor.
 template< class FunctorType , class ArgTag
-        , class T = typename FunctorValueTraits<FunctorType,ArgTag>::reference_type
+        , class T = typename FunctorValueTraits<FunctorType,ArgTag>::reference_type // FIXME Fix FunctorValueTraits for multi-dim operator
         , class Enable = void >
 struct FunctorValueInit ;
 

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -556,7 +556,6 @@ private:
 
   //----------------------------------------
   // parallel_reduce operator without a tag:
-// TODO Begin here to fix...
   template< class ArgMember , class T >
   KOKKOS_INLINE_FUNCTION
   static T deduce_reduce_type( VOIDTAG , void (FunctorType::*)( ArgMember , T & ) const ) {}

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -160,6 +160,34 @@ private:
     KOKKOS_INLINE_FUNCTION static
     A deduce( void (Functor::*)( M , A & ) const );
 
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( M , M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( M , M , M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( M , M , M , M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( M , M , M , M , M , M , M , M , A & ) const );
+
     using type = decltype( deduce( & F::operator() ) );
   };
 
@@ -172,7 +200,64 @@ private:
 
     template< typename M , typename A >
     KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag , M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag , M , M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag , M , M , M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag , M , M , M , M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag , M , M , M , M , M , M , M , M , A & ) const );
+
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
     A deduce( void (Functor::*)( WTag const & , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag const & , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag const & , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag const & , M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag const & , M , M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag const & , M , M , M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag const & , M , M , M , M , M , M , M , A & ) const );
+
+    template< typename M , typename A >
+    KOKKOS_INLINE_FUNCTION static
+    A deduce( void (Functor::*)( WTag const & , M , M , M , M , M , M , M , M , A & ) const );
 
     using type = decltype( deduce( & F::operator() ) );
   };

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -265,6 +265,8 @@ struct TestMDRange_2D {
 
   static void test_reduce2( const int N0, const int N1 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
@@ -279,6 +281,8 @@ struct TestMDRange_2D {
         , sum );
       ASSERT_EQ( sum, N0 * N1 );
     }
+#endif
+#endif
 
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int> > range_type;
@@ -454,6 +458,8 @@ struct TestMDRange_2D {
   static void test_for2( const int N0, const int N1 )
   {
 
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
@@ -490,6 +496,8 @@ struct TestMDRange_2D {
 
       ASSERT_EQ( counter, 0 );
     }
+#endif
+#endif
 
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int>, InitTag > range_type;
@@ -796,6 +804,8 @@ struct TestMDRange_3D {
 
   static void test_reduce3( const int N0, const int N1, const int N2 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
@@ -810,6 +820,8 @@ struct TestMDRange_3D {
         , sum );
       ASSERT_EQ( sum, N0 * N1 * N2 );
     }
+#endif
+#endif
 
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int> > range_type;
@@ -986,6 +998,8 @@ struct TestMDRange_3D {
 
   static void test_for3( const int N0, const int N1, const int N2 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
@@ -1024,6 +1038,8 @@ struct TestMDRange_3D {
 
       ASSERT_EQ( counter, 0 );
     }
+#endif
+#endif
 
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3> > range_type;
@@ -1310,6 +1326,8 @@ struct TestMDRange_4D {
 
   static void test_reduce4( const int N0, const int N1, const int N2, const int N3 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
@@ -1324,6 +1342,8 @@ struct TestMDRange_4D {
         , sum );
       ASSERT_EQ( sum, N0 * N1 * N2 * N3 );
     }
+#endif
+#endif
 
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4>, Kokkos::IndexType<int> > range_type;
@@ -1505,6 +1525,8 @@ struct TestMDRange_4D {
 
   static void test_for4( const int N0, const int N1, const int N2, const int N3 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
@@ -1545,6 +1567,8 @@ struct TestMDRange_4D {
 
       ASSERT_EQ( counter, 0 );
     }
+#endif
+#endif
 
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4> > range_type;
@@ -1845,6 +1869,8 @@ struct TestMDRange_5D {
 
   static void test_reduce5( const int N0, const int N1, const int N2, const int N3, const int N4 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
@@ -1859,6 +1885,8 @@ struct TestMDRange_5D {
         , sum );
       ASSERT_EQ( sum, N0 * N1 * N2 * N3 * N4 );
     }
+#endif
+#endif
 
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5>, Kokkos::IndexType<int> > range_type;
@@ -1960,6 +1988,8 @@ struct TestMDRange_5D {
 
   static void test_for5( const int N0, const int N1, const int N2, const int N3, const int N4 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
@@ -2002,6 +2032,8 @@ struct TestMDRange_5D {
 
       ASSERT_EQ( counter, 0 );
     }
+#endif
+#endif
 
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5> > range_type;
@@ -2311,6 +2343,8 @@ struct TestMDRange_6D {
 
   static void test_reduce6( const int N0, const int N1, const int N2, const int N3, const int N4, const int N5 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
@@ -2325,6 +2359,8 @@ struct TestMDRange_6D {
         , sum );
       ASSERT_EQ( sum, N0 * N1 * N2 * N3 * N4 * N5 );
     }
+#endif
+#endif
 
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6>, Kokkos::IndexType<int> > range_type;
@@ -2428,6 +2464,8 @@ struct TestMDRange_6D {
 
   static void test_for6( const int N0, const int N1, const int N2, const int N3, const int N4, const int N5 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
@@ -2472,6 +2510,8 @@ struct TestMDRange_6D {
 
       ASSERT_EQ( counter, 0 );
     }
+#endif
+#endif
 
     {
       typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6> > range_type;

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -51,6 +51,8 @@ namespace Test {
 
 namespace {
 
+using namespace Kokkos;
+
 template <typename ExecSpace >
 struct TestMDRange_ReduceArray_2D {
 
@@ -110,11 +112,10 @@ struct TestMDRange_ReduceArray_2D {
 
   static void test_arrayreduce2( const int N0, const int N1 )
   {
-    using namespace Kokkos::Experimental;
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2>, Kokkos::IndexType<int>, InitTag > range_type_init;
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int>, InitTag > range_type_init;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -198,11 +199,10 @@ struct TestMDRange_ReduceArray_3D {
 
   static void test_arrayreduce3( const int N0, const int N1, const int N2 )
   {
-    using namespace Kokkos::Experimental;
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3>, Kokkos::IndexType<int>, InitTag > range_type_init;
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int>, InitTag > range_type_init;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -265,10 +265,23 @@ struct TestMDRange_2D {
 
   static void test_reduce2( const int N0, const int N1 )
   {
-    using namespace Kokkos::Experimental;
+    {
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int> > range_type;
+      typedef typename range_type::tile_type tile_type;
+      typedef typename range_type::point_type point_type;
+
+      range_type range( point_type{ { 0, 0 } }, point_type{ { N0, N1 } }, tile_type{ { 3, 3 } } );
+      double sum = 0.0;
+      parallel_reduce( range
+        , KOKKOS_LAMBDA(const int i, const int j, double &lsum) {
+            lsum+=1.0;
+          }
+        , sum );
+      ASSERT_EQ( sum, N0 * N1 );
+    }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -285,7 +298,7 @@ struct TestMDRange_2D {
 
     // Test with reducers - scalar
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int> > range_type;
       int s0 = 1;
       int s1 = 1;
       range_type range( {{ s0, s1 }}, {{ N0, N1 }}, {{ 3, 3 }} );
@@ -303,7 +316,7 @@ struct TestMDRange_2D {
     }
     // Test with reducers - scalar view
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int> > range_type;
       range_type range( {{ 0, 0 }}, {{ N0, N1 }}, {{ 3, 3 }} );
 
       TestMDRange_2D functor( N0, N1 );
@@ -323,7 +336,7 @@ struct TestMDRange_2D {
 
     // Tagged operator test
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int>, InitTag > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -358,7 +371,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -374,7 +387,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -390,7 +403,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -406,7 +419,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -422,7 +435,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -440,10 +453,46 @@ struct TestMDRange_2D {
 
   static void test_for2( const int N0, const int N1 )
   {
-    using namespace Kokkos::Experimental;
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2>, Kokkos::IndexType<int>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int> > range_type;
+      typedef typename range_type::tile_type tile_type;
+      typedef typename range_type::point_type point_type;
+
+      const int s0 = 1;
+      const int s1 = 1;
+
+      range_type range( point_type{ { s0, s1 } }, point_type{ { N0, N1 } }, tile_type{ { 3, 3 } } );
+
+      TestMDRange_2D::ViewType v( "v", N0, N1 );
+
+      parallel_for( range, 
+          KOKKOS_LAMBDA ( const int i , const int j ) {
+            v(i, j) = 3;
+          }
+        );
+
+      TestMDRange_2D::HostViewType h_view = Kokkos::create_mirror_view( v );
+      Kokkos::deep_copy( h_view, v );
+
+      int counter = 0;
+      for ( int i = s0; i < N0; ++i )
+      for ( int j = s1; j < N1; ++j )
+      {
+        if ( h_view( i, j ) != 3 ) {
+          ++counter;
+        }
+      }
+
+      if ( counter != 0 ) {
+        printf( "Offset Start + Default Layouts + InitTag op(): Errors in test_for2; mismatches = %d\n\n", counter );
+      }
+
+      ASSERT_EQ( counter, 0 );
+    }
+
+    {
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int>, InitTag > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -474,7 +523,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, InitTag > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -503,7 +552,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, InitTag > range_type;
       typedef typename range_type::point_type point_type;
 
       range_type range( point_type{ { 0, 0 } }, point_type{ { N0, N1 } } );
@@ -531,7 +580,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -560,7 +609,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -589,7 +638,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -618,7 +667,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -647,7 +696,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -676,7 +725,7 @@ struct TestMDRange_2D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -747,10 +796,23 @@ struct TestMDRange_3D {
 
   static void test_reduce3( const int N0, const int N1, const int N2 )
   {
-    using namespace Kokkos::Experimental;
+    {
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int> > range_type;
+      typedef typename range_type::tile_type tile_type;
+      typedef typename range_type::point_type point_type;
+
+      range_type range( point_type{ { 0, 0, 0 } }, point_type{ { N0, N1, N2 } }, tile_type{ { 3, 3, 3 } } );
+      double sum = 0.0;
+      parallel_reduce( range
+        , KOKKOS_LAMBDA(const int i, const int j, const int k, double &lsum) {
+            lsum+=1.0;
+          }
+        , sum );
+      ASSERT_EQ( sum, N0 * N1 * N2 );
+    }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -770,7 +832,7 @@ struct TestMDRange_3D {
 
     // Test with reducers - scalar
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int> > range_type;
       range_type range( {{ 0, 0, 0 }}, {{ N0, N1, N2 }}, {{ 3, 3, 3 }} );
 
       TestMDRange_3D functor( N0, N1, N2 );
@@ -786,7 +848,7 @@ struct TestMDRange_3D {
     }
     // Test with reducers - scalar view
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int> > range_type;
       range_type range( {{ 0, 0, 0 }}, {{ N0, N1, N2 }}, {{ 3, 3, 3 }} );
 
       TestMDRange_3D functor( N0, N1, N2 );
@@ -806,7 +868,7 @@ struct TestMDRange_3D {
 
     // Tagged operator test
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int>, InitTag > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -842,7 +904,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -858,7 +920,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -874,7 +936,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -890,7 +952,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -906,7 +968,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -924,10 +986,47 @@ struct TestMDRange_3D {
 
   static void test_for3( const int N0, const int N1, const int N2 )
   {
-    using namespace Kokkos::Experimental;
+    {
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int> > range_type;
+      typedef typename range_type::tile_type tile_type;
+      typedef typename range_type::point_type point_type;
+
+      const int s0 = 1;
+      const int s1 = 1;
+      const int s2 = 1;
+
+      range_type range( point_type{ { s0, s1, s2 } }, point_type{ { N0, N1, N2 } }, tile_type{ { 3, 3, 3 } } );
+
+      TestMDRange_3D::ViewType v( "v", N0, N1, N2 );
+
+      parallel_for( range, 
+          KOKKOS_LAMBDA ( const int i , const int j , const int k ) {
+            v(i, j, k) = 3;
+          }
+        );
+
+      TestMDRange_3D::HostViewType h_view = Kokkos::create_mirror_view( v );
+      Kokkos::deep_copy( h_view, v );
+
+      int counter = 0;
+      for ( int i = s0; i < N0; ++i )
+      for ( int j = s1; j < N1; ++j )
+      for ( int k = s2; k < N2; ++k )
+      {
+        if ( h_view( i, j, k ) != 3 ) {
+          ++counter;
+        }
+      }
+
+      if ( counter != 0 ) {
+        printf( "Offset Start + Default Layouts + InitTag op(): Errors in test_for3; mismatches = %d\n\n", counter );
+      }
+
+      ASSERT_EQ( counter, 0 );
+    }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3> > range_type;
       typedef typename range_type::point_type point_type;
 
       range_type range( point_type{ { 0, 0, 0 } }, point_type{ { N0, N1, N2 } } );
@@ -956,7 +1055,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3>, Kokkos::IndexType<int>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int>, InitTag > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -989,7 +1088,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1020,7 +1119,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1050,7 +1149,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1080,7 +1179,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1110,7 +1209,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1140,7 +1239,7 @@ struct TestMDRange_3D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1211,10 +1310,23 @@ struct TestMDRange_4D {
 
   static void test_reduce4( const int N0, const int N1, const int N2, const int N3 )
   {
-    using namespace Kokkos::Experimental;
+    {
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4>, Kokkos::IndexType<int> > range_type;
+      typedef typename range_type::tile_type tile_type;
+      typedef typename range_type::point_type point_type;
+
+      range_type range( point_type{ { 0, 0, 0, 0 } }, point_type{ { N0, N1, N2, N3 } }, tile_type{ { 3, 3, 3, 3 } } );
+      double sum = 0.0;
+      parallel_reduce( range
+        , KOKKOS_LAMBDA(const int i, const int j, const int k, const int l, double &lsum) {
+            lsum+=1.0;
+          }
+        , sum );
+      ASSERT_EQ( sum, N0 * N1 * N2 * N3 );
+    }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1235,7 +1347,7 @@ struct TestMDRange_4D {
 
     // Test with reducers - scalar
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4>, Kokkos::IndexType<int> > range_type;
       range_type range( {{ 0, 0, 0, 0 }}, {{ N0, N1, N2, N3 }}, {{ 3, 3, 3, 3 }} );
 
       TestMDRange_4D functor( N0, N1, N2, N3 );
@@ -1252,7 +1364,7 @@ struct TestMDRange_4D {
 
     // Test with reducers - scalar view
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4>, Kokkos::IndexType<int> > range_type;
       range_type range( {{ 0, 0, 0, 0 }}, {{ N0, N1, N2, N3 }}, {{ 3, 3, 3, 3 }} );
 
       TestMDRange_4D functor( N0, N1, N2, N3 );
@@ -1272,7 +1384,7 @@ struct TestMDRange_4D {
 
     // Tagged operator test
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int>, InitTag > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1309,7 +1421,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1325,7 +1437,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1341,7 +1453,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1357,7 +1469,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1373,7 +1485,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1393,10 +1505,49 @@ struct TestMDRange_4D {
 
   static void test_for4( const int N0, const int N1, const int N2, const int N3 )
   {
-    using namespace Kokkos::Experimental;
+    {
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4>, Kokkos::IndexType<int> > range_type;
+      typedef typename range_type::tile_type tile_type;
+      typedef typename range_type::point_type point_type;
+
+      const int s0 = 1;
+      const int s1 = 1;
+      const int s2 = 1;
+      const int s3 = 1;
+
+      range_type range( point_type{ { s0, s1, s2, s3 } }, point_type{ { N0, N1, N2, N3 } }, tile_type{ { 3, 3, 3, 3 } } );
+
+      TestMDRange_4D::ViewType v( "v", N0, N1, N2, N3 );
+
+      parallel_for( range, 
+          KOKKOS_LAMBDA ( const int i , const int j , const int k, const int l ) {
+            v(i, j, k, l) = 3;
+          }
+        );
+
+      TestMDRange_4D::HostViewType h_view = Kokkos::create_mirror_view( v );
+      Kokkos::deep_copy( h_view, v );
+
+      int counter = 0;
+      for ( int i = s0; i < N0; ++i )
+      for ( int j = s1; j < N1; ++j )
+      for ( int k = s2; k < N2; ++k )
+      for ( int l = s3; l < N3; ++l )
+      {
+        if ( h_view( i, j, k, l ) != 3 ) {
+          ++counter;
+        }
+      }
+
+      if ( counter != 0 ) {
+        printf( "Offset Start + Default Layouts + InitTag op(): Errors in test_for4; mismatches = %d\n\n", counter );
+      }
+
+      ASSERT_EQ( counter, 0 );
+    }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4> > range_type;
       typedef typename range_type::point_type point_type;
 
       range_type range( point_type{ { 0, 0, 0, 0 } }, point_type{ { N0, N1, N2, N3 } } );
@@ -1426,7 +1577,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4>, Kokkos::IndexType<int>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4>, Kokkos::IndexType<int>, InitTag > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1461,7 +1612,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1493,7 +1644,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1525,7 +1676,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1557,7 +1708,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1589,7 +1740,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1621,7 +1772,7 @@ struct TestMDRange_4D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1694,10 +1845,23 @@ struct TestMDRange_5D {
 
   static void test_reduce5( const int N0, const int N1, const int N2, const int N3, const int N4 )
   {
-    using namespace Kokkos::Experimental;
+    {
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5>, Kokkos::IndexType<int> > range_type;
+      typedef typename range_type::tile_type tile_type;
+      typedef typename range_type::point_type point_type;
+
+      range_type range( point_type{ { 0, 0, 0, 0, 0 } }, point_type{ { N0, N1, N2, N3, N4 } }, tile_type{ { 3, 3, 3, 3, 1 } } );
+      double sum = 0.0;
+      parallel_reduce( range
+        , KOKKOS_LAMBDA(const int i, const int j, const int k, const int l, const int m, double &lsum) {
+            lsum+=1.0;
+          }
+        , sum );
+      ASSERT_EQ( sum, N0 * N1 * N2 * N3 * N4 );
+    }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1719,7 +1883,7 @@ struct TestMDRange_5D {
 
     // Test with reducers - scalar
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5>, Kokkos::IndexType<int> > range_type;
       range_type range( {{ 0, 0, 0, 0, 0 }}, {{ N0, N1, N2, N3, N4 }}, {{ 3, 3, 3, 3, 3 }} );
 
       TestMDRange_5D functor( N0, N1, N2, N3, N4 );
@@ -1736,7 +1900,7 @@ struct TestMDRange_5D {
 
     // Test with reducers - scalar view
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5>, Kokkos::IndexType<int> > range_type;
       range_type range( {{ 0, 0, 0, 0, 0 }}, {{ N0, N1, N2, N3, N4 }}, {{ 3, 3, 3, 3, 3 }} );
 
       TestMDRange_5D functor( N0, N1, N2, N3, N4 );
@@ -1756,7 +1920,7 @@ struct TestMDRange_5D {
 
     // Tagged operator test
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int>, InitTag > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1796,10 +1960,51 @@ struct TestMDRange_5D {
 
   static void test_for5( const int N0, const int N1, const int N2, const int N3, const int N4 )
   {
-    using namespace Kokkos::Experimental;
+    {
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5>, Kokkos::IndexType<int> > range_type;
+      typedef typename range_type::tile_type tile_type;
+      typedef typename range_type::point_type point_type;
+
+      const int s0 = 1;
+      const int s1 = 1;
+      const int s2 = 1;
+      const int s3 = 1;
+      const int s4 = 1;
+
+      range_type range( point_type{ { s0, s1, s2, s3, s4 } }, point_type{ { N0, N1, N2, N3, N4 } }, tile_type{ { 3, 3, 3, 3, 1 } } );
+
+      TestMDRange_5D::ViewType v( "v", N0, N1, N2, N3, N4 );
+
+      parallel_for( range, 
+          KOKKOS_LAMBDA ( const int i , const int j , const int k, const int l, const int m ) {
+            v(i, j, k, l, m) = 3;
+          }
+        );
+
+      TestMDRange_5D::HostViewType h_view = Kokkos::create_mirror_view( v );
+      Kokkos::deep_copy( h_view, v );
+
+      int counter = 0;
+      for ( int i = s0; i < N0; ++i )
+      for ( int j = s1; j < N1; ++j )
+      for ( int k = s2; k < N2; ++k )
+      for ( int l = s3; l < N3; ++l )
+      for ( int m = s4; m < N4; ++m )
+      {
+        if ( h_view( i, j, k, l, m ) != 3 ) {
+          ++counter;
+        }
+      }
+
+      if ( counter != 0 ) {
+        printf( "Offset Start + Default Layouts + InitTag op(): Errors in test_for5; mismatches = %d\n\n", counter );
+      }
+
+      ASSERT_EQ( counter, 0 );
+    }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5> > range_type;
       typedef typename range_type::point_type point_type;
 
       range_type range( point_type{ { 0, 0, 0, 0, 0 } }, point_type{ { N0, N1, N2, N3, N4 } } );
@@ -1830,7 +2035,7 @@ struct TestMDRange_5D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5>, Kokkos::IndexType<int>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5>, Kokkos::IndexType<int>, InitTag > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1867,7 +2072,7 @@ struct TestMDRange_5D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1900,7 +2105,7 @@ struct TestMDRange_5D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1933,7 +2138,7 @@ struct TestMDRange_5D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1966,7 +2171,7 @@ struct TestMDRange_5D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -1999,7 +2204,7 @@ struct TestMDRange_5D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2032,7 +2237,7 @@ struct TestMDRange_5D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2106,10 +2311,23 @@ struct TestMDRange_6D {
 
   static void test_reduce6( const int N0, const int N1, const int N2, const int N3, const int N4, const int N5 )
   {
-    using namespace Kokkos::Experimental;
+    {
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6>, Kokkos::IndexType<int> > range_type;
+      typedef typename range_type::tile_type tile_type;
+      typedef typename range_type::point_type point_type;
+
+      range_type range( point_type{ { 0, 0, 0, 0, 0, 0 } }, point_type{ { N0, N1, N2, N3, N4, N5 } }, tile_type{ { 3, 3, 3, 3, 1, 1 } } );
+      double sum = 0.0;
+      parallel_reduce( range
+        , KOKKOS_LAMBDA(const int i, const int j, const int k, const int l, const int m, const int n, double &lsum) {
+            lsum+=1.0;
+          }
+        , sum );
+      ASSERT_EQ( sum, N0 * N1 * N2 * N3 * N4 * N5 );
+    }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2132,7 +2350,7 @@ struct TestMDRange_6D {
 
     // Test with reducers - scalar
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6>, Kokkos::IndexType<int> > range_type;
       range_type range( {{ 0, 0, 0, 0, 0, 0 }}, {{ N0, N1, N2, N3, N4, N5 }}, {{ 3, 3, 3, 3, 3, 2 }} );
 
       TestMDRange_6D functor( N0, N1, N2, N3, N4, N5 );
@@ -2149,7 +2367,7 @@ struct TestMDRange_6D {
 
     // Test with reducers - scalar view
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6>, Kokkos::IndexType<int> > range_type;
       range_type range( {{ 0, 0, 0, 0, 0, 0 }}, {{ N0, N1, N2, N3, N4, N5 }}, {{ 3, 3, 3, 3, 3, 2 }} );
 
       TestMDRange_6D functor( N0, N1, N2, N3, N4, N5 );
@@ -2169,7 +2387,7 @@ struct TestMDRange_6D {
 
     // Tagged operator test
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6, Iterate::Default, Iterate::Default >, Kokkos::IndexType<int>, InitTag > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2210,10 +2428,53 @@ struct TestMDRange_6D {
 
   static void test_for6( const int N0, const int N1, const int N2, const int N3, const int N4, const int N5 )
   {
-    using namespace Kokkos::Experimental;
+    {
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6>, Kokkos::IndexType<int> > range_type;
+      typedef typename range_type::tile_type tile_type;
+      typedef typename range_type::point_type point_type;
+
+      const int s0 = 1;
+      const int s1 = 1;
+      const int s2 = 1;
+      const int s3 = 1;
+      const int s4 = 1;
+      const int s5 = 1;
+
+      range_type range( point_type{ { s0, s1, s2, s3, s4, s5 } }, point_type{ { N0, N1, N2, N3, N4, N5 } }, tile_type{ { 3, 3, 3, 3, 1, 1 } } );
+
+      TestMDRange_6D::ViewType v( "v", N0, N1, N2, N3, N4, N5 );
+
+      parallel_for( range, 
+          KOKKOS_LAMBDA ( const int i , const int j , const int k, const int l, const int m, const int n ) {
+            v(i, j, k, l, m, n) = 3;
+          }
+        );
+
+      TestMDRange_6D::HostViewType h_view = Kokkos::create_mirror_view( v );
+      Kokkos::deep_copy( h_view, v );
+
+      int counter = 0;
+      for ( int i = s0; i < N0; ++i )
+      for ( int j = s1; j < N1; ++j )
+      for ( int k = s2; k < N2; ++k )
+      for ( int l = s3; l < N3; ++l )
+      for ( int m = s4; m < N4; ++m )
+      for ( int n = s5; n < N5; ++n )
+      {
+        if ( h_view( i, j, k, l, m, n ) != 3 ) {
+          ++counter;
+        }
+      }
+
+      if ( counter != 0 ) {
+        printf( "Offset Start + Default Layouts + InitTag op(): Errors in test_for6; mismatches = %d\n\n", counter );
+      }
+
+      ASSERT_EQ( counter, 0 );
+    }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6> > range_type;
       typedef typename range_type::point_type point_type;
 
       range_type range( point_type{ { 0, 0, 0, 0, 0, 0 } }, point_type{ { N0, N1, N2, N3, N4, N5 } } );
@@ -2245,7 +2506,7 @@ struct TestMDRange_6D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6>, Kokkos::IndexType<int>, InitTag > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6>, Kokkos::IndexType<int>, InitTag > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2284,7 +2545,7 @@ struct TestMDRange_6D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2318,7 +2579,7 @@ struct TestMDRange_6D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6, Iterate::Default, Iterate::Default>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2352,7 +2613,7 @@ struct TestMDRange_6D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6, Iterate::Left, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2386,7 +2647,7 @@ struct TestMDRange_6D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6, Iterate::Left, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2420,7 +2681,7 @@ struct TestMDRange_6D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6, Iterate::Right, Iterate::Left>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2454,7 +2715,7 @@ struct TestMDRange_6D {
     }
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6, Iterate::Right, Iterate::Right>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2523,10 +2784,9 @@ struct TestMDRange_2D_NegIdx {
 
   static void test_2D_negidx( const int N0, const int N1 )
   {
-    using namespace Kokkos::Experimental;
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<2>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<2>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2581,10 +2841,9 @@ struct TestMDRange_3D_NegIdx {
 
   static void test_3D_negidx( const int N0, const int N1, const int N2 )
   {
-    using namespace Kokkos::Experimental;
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<3>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<3>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2640,10 +2899,9 @@ struct TestMDRange_4D_NegIdx {
 
   static void test_4D_negidx( const int N0, const int N1, const int N2, const int N3 )
   {
-    using namespace Kokkos::Experimental;
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<4>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<4>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2700,10 +2958,9 @@ struct TestMDRange_5D_NegIdx {
 
   static void test_5D_negidx( const int N0, const int N1, const int N2, const int N3, const int N4 )
   {
-    using namespace Kokkos::Experimental;
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<5>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<5>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 
@@ -2761,10 +3018,9 @@ struct TestMDRange_6D_NegIdx {
 
   static void test_6D_negidx( const int N0, const int N1, const int N2, const int N3, const int N4, const int N5 )
   {
-    using namespace Kokkos::Experimental;
 
     {
-      typedef typename Kokkos::Experimental::MDRangePolicy< ExecSpace, Rank<6>, Kokkos::IndexType<int> > range_type;
+      typedef typename Kokkos::MDRangePolicy< ExecSpace, Kokkos::Rank<6>, Kokkos::IndexType<int> > range_type;
       typedef typename range_type::tile_type tile_type;
       typedef typename range_type::point_type point_type;
 


### PR DESCRIPTION
Commit addresses issue #1379 and #1054
Fix to allow lambda with MDRangePolicy within parallel_for and
parallel_reduce
Unit test with lambda added for ranks 1 to 6