### PR TITLE
Deprecate View APIs

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -1530,7 +1530,7 @@ struct fill_random_functor_range<ViewType,RandomPool,loops,1,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0()))
+      if(idx<static_cast<IndexType>(a.extent(0)))
         a(idx) = Rand::draw(gen,range);
     }
     rand_pool.free_state(gen);
@@ -1555,8 +1555,8 @@ struct fill_random_functor_range<ViewType,RandomPool,loops,2,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
           a(idx,k) = Rand::draw(gen,range);
       }
     }
@@ -1583,9 +1583,9 @@ struct fill_random_functor_range<ViewType,RandomPool,loops,3,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
-          for(IndexType l=0;l<static_cast<IndexType>(a.dimension_2());l++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
+          for(IndexType l=0;l<static_cast<IndexType>(a.extent(2));l++)
             a(idx,k,l) = Rand::draw(gen,range);
       }
     }
@@ -1611,10 +1611,10 @@ struct fill_random_functor_range<ViewType,RandomPool,loops,4, IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
-          for(IndexType l=0;l<static_cast<IndexType>(a.dimension_2());l++)
-            for(IndexType m=0;m<static_cast<IndexType>(a.dimension_3());m++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
+          for(IndexType l=0;l<static_cast<IndexType>(a.extent(2));l++)
+            for(IndexType m=0;m<static_cast<IndexType>(a.extent(3));m++)
               a(idx,k,l,m) = Rand::draw(gen,range);
       }
     }
@@ -1640,11 +1640,11 @@ struct fill_random_functor_range<ViewType,RandomPool,loops,5,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
-          for(IndexType l=0;l<static_cast<IndexType>(a.dimension_2());l++)
-            for(IndexType m=0;m<static_cast<IndexType>(a.dimension_3());m++)
-              for(IndexType n=0;n<static_cast<IndexType>(a.dimension_4());n++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
+          for(IndexType l=0;l<static_cast<IndexType>(a.extent(2));l++)
+            for(IndexType m=0;m<static_cast<IndexType>(a.extent(3));m++)
+              for(IndexType n=0;n<static_cast<IndexType>(a.extent(4));n++)
               a(idx,k,l,m,n) = Rand::draw(gen,range);
       }
     }
@@ -1670,12 +1670,12 @@ struct fill_random_functor_range<ViewType,RandomPool,loops,6,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
-          for(IndexType l=0;l<static_cast<IndexType>(a.dimension_2());l++)
-            for(IndexType m=0;m<static_cast<IndexType>(a.dimension_3());m++)
-              for(IndexType n=0;n<static_cast<IndexType>(a.dimension_4());n++)
-                for(IndexType o=0;o<static_cast<IndexType>(a.dimension_5());o++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
+          for(IndexType l=0;l<static_cast<IndexType>(a.extent(2));l++)
+            for(IndexType m=0;m<static_cast<IndexType>(a.extent(3));m++)
+              for(IndexType n=0;n<static_cast<IndexType>(a.extent(4));n++)
+                for(IndexType o=0;o<static_cast<IndexType>(a.extent(5));o++)
               a(idx,k,l,m,n,o) = Rand::draw(gen,range);
       }
     }
@@ -1701,13 +1701,13 @@ struct fill_random_functor_range<ViewType,RandomPool,loops,7,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
-          for(IndexType l=0;l<static_cast<IndexType>(a.dimension_2());l++)
-            for(IndexType m=0;m<static_cast<IndexType>(a.dimension_3());m++)
-              for(IndexType n=0;n<static_cast<IndexType>(a.dimension_4());n++)
-                for(IndexType o=0;o<static_cast<IndexType>(a.dimension_5());o++)
-                  for(IndexType p=0;p<static_cast<IndexType>(a.dimension_6());p++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
+          for(IndexType l=0;l<static_cast<IndexType>(a.extent(2));l++)
+            for(IndexType m=0;m<static_cast<IndexType>(a.extent(3));m++)
+              for(IndexType n=0;n<static_cast<IndexType>(a.extent(4));n++)
+                for(IndexType o=0;o<static_cast<IndexType>(a.extent(5));o++)
+                  for(IndexType p=0;p<static_cast<IndexType>(a.extent(6));p++)
               a(idx,k,l,m,n,o,p) = Rand::draw(gen,range);
       }
     }
@@ -1733,14 +1733,14 @@ struct fill_random_functor_range<ViewType,RandomPool,loops,8,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
-          for(IndexType l=0;l<static_cast<IndexType>(a.dimension_2());l++)
-            for(IndexType m=0;m<static_cast<IndexType>(a.dimension_3());m++)
-              for(IndexType n=0;n<static_cast<IndexType>(a.dimension_4());n++)
-                for(IndexType o=0;o<static_cast<IndexType>(a.dimension_5());o++)
-                  for(IndexType p=0;p<static_cast<IndexType>(a.dimension_6());p++)
-                    for(IndexType q=0;q<static_cast<IndexType>(a.dimension_7());q++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
+          for(IndexType l=0;l<static_cast<IndexType>(a.extent(2));l++)
+            for(IndexType m=0;m<static_cast<IndexType>(a.extent(3));m++)
+              for(IndexType n=0;n<static_cast<IndexType>(a.extent(4));n++)
+                for(IndexType o=0;o<static_cast<IndexType>(a.extent(5));o++)
+                  for(IndexType p=0;p<static_cast<IndexType>(a.extent(6));p++)
+                    for(IndexType q=0;q<static_cast<IndexType>(a.extent(7));q++)
               a(idx,k,l,m,n,o,p,q) = Rand::draw(gen,range);
       }
     }
@@ -1765,7 +1765,7 @@ struct fill_random_functor_begin_end<ViewType,RandomPool,loops,1,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0()))
+      if(idx<static_cast<IndexType>(a.extent(0)))
         a(idx) = Rand::draw(gen,begin,end);
     }
     rand_pool.free_state(gen);
@@ -1790,8 +1790,8 @@ struct fill_random_functor_begin_end<ViewType,RandomPool,loops,2,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
           a(idx,k) = Rand::draw(gen,begin,end);
       }
     }
@@ -1818,9 +1818,9 @@ struct fill_random_functor_begin_end<ViewType,RandomPool,loops,3,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
-          for(IndexType l=0;l<static_cast<IndexType>(a.dimension_2());l++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
+          for(IndexType l=0;l<static_cast<IndexType>(a.extent(2));l++)
             a(idx,k,l) = Rand::draw(gen,begin,end);
       }
     }
@@ -1846,10 +1846,10 @@ struct fill_random_functor_begin_end<ViewType,RandomPool,loops,4,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
-          for(IndexType l=0;l<static_cast<IndexType>(a.dimension_2());l++)
-            for(IndexType m=0;m<static_cast<IndexType>(a.dimension_3());m++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
+          for(IndexType l=0;l<static_cast<IndexType>(a.extent(2));l++)
+            for(IndexType m=0;m<static_cast<IndexType>(a.extent(3));m++)
               a(idx,k,l,m) = Rand::draw(gen,begin,end);
       }
     }
@@ -1875,11 +1875,11 @@ struct fill_random_functor_begin_end<ViewType,RandomPool,loops,5,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())){
-        for(IndexType l=0;l<static_cast<IndexType>(a.dimension_1());l++)
-          for(IndexType m=0;m<static_cast<IndexType>(a.dimension_2());m++)
-            for(IndexType n=0;n<static_cast<IndexType>(a.dimension_3());n++)
-              for(IndexType o=0;o<static_cast<IndexType>(a.dimension_4());o++)
+      if(idx<static_cast<IndexType>(a.extent(0))){
+        for(IndexType l=0;l<static_cast<IndexType>(a.extent(1));l++)
+          for(IndexType m=0;m<static_cast<IndexType>(a.extent(2));m++)
+            for(IndexType n=0;n<static_cast<IndexType>(a.extent(3));n++)
+              for(IndexType o=0;o<static_cast<IndexType>(a.extent(4));o++)
           a(idx,l,m,n,o) = Rand::draw(gen,begin,end);
       }
     }
@@ -1905,12 +1905,12 @@ struct fill_random_functor_begin_end<ViewType,RandomPool,loops,6,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
-          for(IndexType l=0;l<static_cast<IndexType>(a.dimension_2());l++)
-            for(IndexType m=0;m<static_cast<IndexType>(a.dimension_3());m++)
-              for(IndexType n=0;n<static_cast<IndexType>(a.dimension_4());n++)
-                for(IndexType o=0;o<static_cast<IndexType>(a.dimension_5());o++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
+          for(IndexType l=0;l<static_cast<IndexType>(a.extent(2));l++)
+            for(IndexType m=0;m<static_cast<IndexType>(a.extent(3));m++)
+              for(IndexType n=0;n<static_cast<IndexType>(a.extent(4));n++)
+                for(IndexType o=0;o<static_cast<IndexType>(a.extent(5));o++)
           a(idx,k,l,m,n,o) = Rand::draw(gen,begin,end);
       }
     }
@@ -1937,13 +1937,13 @@ struct fill_random_functor_begin_end<ViewType,RandomPool,loops,7,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
-          for(IndexType l=0;l<static_cast<IndexType>(a.dimension_2());l++)
-            for(IndexType m=0;m<static_cast<IndexType>(a.dimension_3());m++)
-              for(IndexType n=0;n<static_cast<IndexType>(a.dimension_4());n++)
-                for(IndexType o=0;o<static_cast<IndexType>(a.dimension_5());o++)
-                  for(IndexType p=0;p<static_cast<IndexType>(a.dimension_6());p++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
+          for(IndexType l=0;l<static_cast<IndexType>(a.extent(2));l++)
+            for(IndexType m=0;m<static_cast<IndexType>(a.extent(3));m++)
+              for(IndexType n=0;n<static_cast<IndexType>(a.extent(4));n++)
+                for(IndexType o=0;o<static_cast<IndexType>(a.extent(5));o++)
+                  for(IndexType p=0;p<static_cast<IndexType>(a.extent(6));p++)
             a(idx,k,l,m,n,o,p) = Rand::draw(gen,begin,end);
       }
     }
@@ -1969,14 +1969,14 @@ struct fill_random_functor_begin_end<ViewType,RandomPool,loops,8,IndexType>{
     typename RandomPool::generator_type gen = rand_pool.get_state();
     for(IndexType j=0;j<loops;j++) {
       const IndexType idx = i*loops+j;
-      if(idx<static_cast<IndexType>(a.dimension_0())) {
-        for(IndexType k=0;k<static_cast<IndexType>(a.dimension_1());k++)
-          for(IndexType l=0;l<static_cast<IndexType>(a.dimension_2());l++)
-            for(IndexType m=0;m<static_cast<IndexType>(a.dimension_3());m++)
-              for(IndexType n=0;n<static_cast<IndexType>(a.dimension_4());n++)
-                for(IndexType o=0;o<static_cast<IndexType>(a.dimension_5());o++)
-                  for(IndexType p=0;p<static_cast<IndexType>(a.dimension_6());p++)
-                    for(IndexType q=0;q<static_cast<IndexType>(a.dimension_7());q++)
+      if(idx<static_cast<IndexType>(a.extent(0))) {
+        for(IndexType k=0;k<static_cast<IndexType>(a.extent(1));k++)
+          for(IndexType l=0;l<static_cast<IndexType>(a.extent(2));l++)
+            for(IndexType m=0;m<static_cast<IndexType>(a.extent(3));m++)
+              for(IndexType n=0;n<static_cast<IndexType>(a.extent(4));n++)
+                for(IndexType o=0;o<static_cast<IndexType>(a.extent(5));o++)
+                  for(IndexType p=0;p<static_cast<IndexType>(a.extent(6));p++)
+                    for(IndexType q=0;q<static_cast<IndexType>(a.extent(7));q++)
               a(idx,k,l,m,n,o,p,q) = Rand::draw(gen,begin,end);
       }
     }
@@ -1988,14 +1988,14 @@ struct fill_random_functor_begin_end<ViewType,RandomPool,loops,8,IndexType>{
 
 template<class ViewType, class RandomPool, class IndexType = int64_t>
 void fill_random(ViewType a, RandomPool g, typename ViewType::const_value_type range) {
-  int64_t LDA = a.dimension_0();
+  int64_t LDA = a.extent(0);
   if(LDA>0)
     parallel_for((LDA+127)/128,Impl::fill_random_functor_range<ViewType,RandomPool,128,ViewType::Rank,IndexType>(a,g,range));
 }
 
 template<class ViewType, class RandomPool, class IndexType = int64_t>
 void fill_random(ViewType a, RandomPool g, typename ViewType::const_value_type begin,typename ViewType::const_value_type end ) {
-  int64_t LDA = a.dimension_0();
+  int64_t LDA = a.extent(0);
   if(LDA>0)
     parallel_for((LDA+127)/128,Impl::fill_random_functor_begin_end<ViewType,RandomPool,128,ViewType::Rank,IndexType>(a,g,begin,end));
 }

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -171,10 +171,10 @@ void test_3D_sort(unsigned int n) {
   double sum_after = 0.0;
   unsigned int sort_fails = 0;
 
-  Kokkos::parallel_reduce(keys.dimension_0(),sum3D<ExecutionSpace, KeyType>(keys),sum_before);
+  Kokkos::parallel_reduce(keys.extent(0),sum3D<ExecutionSpace, KeyType>(keys),sum_before);
 
   int bin_1d = 1;
-  while( bin_1d*bin_1d*bin_1d*4< (int) keys.dimension_0() ) bin_1d*=2;
+  while( bin_1d*bin_1d*bin_1d*4< (int) keys.extent(0) ) bin_1d*=2;
   int bin_max[3] = {bin_1d,bin_1d,bin_1d};
   typename KeyViewType::value_type min[3] = {0,0,0};
   typename KeyViewType::value_type max[3] = {100,100,100};
@@ -186,8 +186,8 @@ void test_3D_sort(unsigned int n) {
   Sorter.create_permute_vector();
   Sorter.template sort< KeyViewType >(keys);
 
-  Kokkos::parallel_reduce(keys.dimension_0(),sum3D<ExecutionSpace, KeyType>(keys),sum_after);
-  Kokkos::parallel_reduce(keys.dimension_0()-1,bin3d_is_sorted_struct<ExecutionSpace, KeyType>(keys,bin_1d,min[0],max[0]),sort_fails);
+  Kokkos::parallel_reduce(keys.extent(0),sum3D<ExecutionSpace, KeyType>(keys),sum_after);
+  Kokkos::parallel_reduce(keys.extent(0)-1,bin3d_is_sorted_struct<ExecutionSpace, KeyType>(keys,bin_1d,min[0],max[0]),sort_fails);
 
   double ratio = sum_before/sum_after;
   double epsilon = 1e-10;

--- a/containers/performance_tests/TestDynRankView.hpp
+++ b/containers/performance_tests/TestDynRankView.hpp
@@ -64,8 +64,8 @@ struct InitViewFunctor {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int i) const {
-    for (unsigned j = 0; j < _inview.dimension(1); ++j) {
-      for (unsigned k = 0; k < _inview.dimension(2); ++k) {
+    for (unsigned j = 0; j < _inview.extent(1); ++j) {
+      for (unsigned k = 0; k < _inview.extent(2); ++k) {
         _inview(i,j,k) = i/2 -j*j + k/3;
       }
     }
@@ -84,8 +84,8 @@ struct InitViewFunctor {
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const int i) const {
-      for (unsigned j = 0; j < _inview.dimension(1); ++j) {
-        for (unsigned k = 0; k < _inview.dimension(2); ++k) {
+      for (unsigned j = 0; j < _inview.extent(1); ++j) {
+        for (unsigned k = 0; k < _inview.extent(2); ++k) {
           _outview(i) += _inview(i,j,k) ;
         }
       }
@@ -104,8 +104,8 @@ struct InitStrideViewFunctor {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int i) const {
-    for (unsigned j = 0; j < _inview.dimension(1); ++j) {
-      for (unsigned k = 0; k < _inview.dimension(2); ++k) {
+    for (unsigned j = 0; j < _inview.extent(1); ++j) {
+      for (unsigned k = 0; k < _inview.extent(2); ++k) {
         _inview(i,j,k) = i/2 -j*j + k/3;
       }
     }
@@ -123,8 +123,8 @@ struct InitViewRank7Functor {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int i) const {
-    for (unsigned j = 0; j < _inview.dimension(1); ++j) {
-      for (unsigned k = 0; k < _inview.dimension(2); ++k) {
+    for (unsigned j = 0; j < _inview.extent(1); ++j) {
+      for (unsigned k = 0; k < _inview.extent(2); ++k) {
         _inview(i,j,k,0,0,0,0) = i/2 -j*j + k/3;
       }
     }
@@ -143,8 +143,8 @@ struct InitDynRankViewFunctor {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int i) const {
-    for (unsigned j = 0; j < _inview.dimension(1); ++j) {
-      for (unsigned k = 0; k < _inview.dimension(2); ++k) {
+    for (unsigned j = 0; j < _inview.extent(1); ++j) {
+      for (unsigned k = 0; k < _inview.extent(2); ++k) {
         _inview(i,j,k) = i/2 -j*j + k/3;
       }
     }
@@ -163,8 +163,8 @@ struct InitDynRankViewFunctor {
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const int i) const {
-      for (unsigned j = 0; j < _inview.dimension(1); ++j) {
-        for (unsigned k = 0; k < _inview.dimension(2); ++k) {
+      for (unsigned j = 0; j < _inview.extent(1); ++j) {
+        for (unsigned k = 0; k < _inview.extent(2); ++k) {
           _outview(i) += _inview(i,j,k) ;
         }
       }

--- a/containers/performance_tests/TestGlobal2LocalIds.hpp
+++ b/containers/performance_tests/TestGlobal2LocalIds.hpp
@@ -76,7 +76,7 @@ struct generate_ids
   generate_ids( local_id_view & ids)
     : local_2_global(ids)
   {
-    Kokkos::parallel_for(local_2_global.dimension_0(), *this);
+    Kokkos::parallel_for(local_2_global.extent(0), *this);
   }
 
 
@@ -116,7 +116,7 @@ struct fill_map
   fill_map( global_id_view gIds, local_id_view lIds)
     : global_2_local(gIds) , local_2_global(lIds)
   {
-    Kokkos::parallel_for(local_2_global.dimension_0(), *this);
+    Kokkos::parallel_for(local_2_global.extent(0), *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -143,7 +143,7 @@ struct find_test
   find_test( global_id_view gIds, local_id_view lIds, value_type & num_errors)
     : global_2_local(gIds) , local_2_global(lIds)
   {
-    Kokkos::parallel_reduce(local_2_global.dimension_0(), *this, num_errors);
+    Kokkos::parallel_reduce(local_2_global.extent(0), *this, num_errors);
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -147,7 +147,7 @@ public:
     if (m_last_block_mask) {
       //clear the unused bits in the last block
       typedef Kokkos::Impl::DeepCopy< typename execution_space::memory_space, Kokkos::HostSpace > raw_deep_copy;
-      raw_deep_copy( m_blocks.ptr_on_device() + (m_blocks.dimension_0() -1u), &m_last_block_mask, sizeof(unsigned));
+      raw_deep_copy( m_blocks.data() + (m_blocks.extent(0) -1u), &m_last_block_mask, sizeof(unsigned));
     }
   }
 
@@ -212,7 +212,7 @@ public:
   KOKKOS_FORCEINLINE_FUNCTION
   unsigned max_hint() const
   {
-    return m_blocks.dimension_0();
+    return m_blocks.extent(0);
   }
 
   /// find a bit set to 1 near the hint
@@ -221,10 +221,10 @@ public:
   KOKKOS_INLINE_FUNCTION
   Kokkos::pair<bool, unsigned> find_any_set_near( unsigned hint , unsigned scan_direction = BIT_SCAN_FORWARD_MOVE_HINT_FORWARD ) const
   {
-    const unsigned block_idx = (hint >> block_shift) < m_blocks.dimension_0() ? (hint >> block_shift) : 0;
+    const unsigned block_idx = (hint >> block_shift) < m_blocks.extent(0) ? (hint >> block_shift) : 0;
     const unsigned offset = hint & block_mask;
     unsigned block = volatile_load(&m_blocks[ block_idx ]);
-    block = !m_last_block_mask || (block_idx < (m_blocks.dimension_0()-1)) ? block : block & m_last_block_mask ;
+    block = !m_last_block_mask || (block_idx < (m_blocks.extent(0)-1)) ? block : block & m_last_block_mask ;
 
     return find_any_helper(block_idx, offset, block, scan_direction);
   }
@@ -238,7 +238,7 @@ public:
     const unsigned block_idx = hint >> block_shift;
     const unsigned offset = hint & block_mask;
     unsigned block = volatile_load(&m_blocks[ block_idx ]);
-    block = !m_last_block_mask || (block_idx < (m_blocks.dimension_0()-1) ) ? ~block : ~block & m_last_block_mask ;
+    block = !m_last_block_mask || (block_idx < (m_blocks.extent(0)-1) ) ? ~block : ~block & m_last_block_mask ;
 
     return find_any_helper(block_idx, offset, block, scan_direction);
   }
@@ -281,8 +281,8 @@ private:
   unsigned update_hint( long long block_idx, unsigned offset, unsigned scan_direction ) const
   {
     block_idx += scan_direction & MOVE_HINT_BACKWARD ? -1 : 1;
-    block_idx = block_idx >= 0 ? block_idx : m_blocks.dimension_0() - 1;
-    block_idx = block_idx < static_cast<long long>(m_blocks.dimension_0()) ? block_idx : 0;
+    block_idx = block_idx >= 0 ? block_idx : m_blocks.extent(0) - 1;
+    block_idx = block_idx < static_cast<long long>(m_blocks.extent(0)) ? block_idx : 0;
 
     return static_cast<unsigned>(block_idx)*block_size + offset;
   }
@@ -407,7 +407,7 @@ void deep_copy( Bitset<DstDevice> & dst, Bitset<SrcDevice> const& src)
   }
 
   typedef Kokkos::Impl::DeepCopy< typename DstDevice::memory_space, typename SrcDevice::memory_space > raw_deep_copy;
-  raw_deep_copy(dst.m_blocks.ptr_on_device(), src.m_blocks.ptr_on_device(), sizeof(unsigned)*src.m_blocks.dimension_0());
+  raw_deep_copy(dst.m_blocks.data(), src.m_blocks.data(), sizeof(unsigned)*src.m_blocks.extent(0));
 }
 
 template <typename DstDevice, typename SrcDevice>
@@ -418,7 +418,7 @@ void deep_copy( Bitset<DstDevice> & dst, ConstBitset<SrcDevice> const& src)
   }
 
   typedef Kokkos::Impl::DeepCopy< typename DstDevice::memory_space, typename SrcDevice::memory_space > raw_deep_copy;
-  raw_deep_copy(dst.m_blocks.ptr_on_device(), src.m_blocks.ptr_on_device(), sizeof(unsigned)*src.m_blocks.dimension_0());
+  raw_deep_copy(dst.m_blocks.data(), src.m_blocks.data(), sizeof(unsigned)*src.m_blocks.extent(0));
 }
 
 template <typename DstDevice, typename SrcDevice>
@@ -429,7 +429,7 @@ void deep_copy( ConstBitset<DstDevice> & dst, ConstBitset<SrcDevice> const& src)
   }
 
   typedef Kokkos::Impl::DeepCopy< typename DstDevice::memory_space, typename SrcDevice::memory_space > raw_deep_copy;
-  raw_deep_copy(dst.m_blocks.ptr_on_device(), src.m_blocks.ptr_on_device(), sizeof(unsigned)*src.m_blocks.dimension_0());
+  raw_deep_copy(dst.m_blocks.data(), src.m_blocks.data(), sizeof(unsigned)*src.m_blocks.extent(0));
 }
 
 } // namespace Kokkos

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -500,15 +500,9 @@ public:
      modified_device() = modified_device()+1;
 
    } else {
-     /* Realloc on Device */
-
-     ::Kokkos::realloc(d_view,n0,n1,n2,n3,n4,n5,n6,n7);
-     t_host temp_view = create_mirror_view( d_view );
-
-     /* Remap on Host */
-     Kokkos::deep_copy( temp_view , h_view );
-
-     h_view = temp_view;
+     /* Resize on Host */
+     ::Kokkos::resize(h_view,n0,n1,n2,n3,n4,n5,n6,n7);
+     d_view = create_mirror_view( typename t_dev::execution_space(), h_view );
 
      /* Mark Host copy as modified */
      modified_host() = modified_host()+1;

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1488,14 +1488,14 @@ struct DynRankViewRemap {
 
   DynRankViewRemap( const OutputView & arg_out , const InputView & arg_in )
     : output( arg_out ), input( arg_in )
-    , n0( std::min( (size_t)arg_out.dimension_0() , (size_t)arg_in.dimension_0() ) )
-    , n1( std::min( (size_t)arg_out.dimension_1() , (size_t)arg_in.dimension_1() ) )
-    , n2( std::min( (size_t)arg_out.dimension_2() , (size_t)arg_in.dimension_2() ) )
-    , n3( std::min( (size_t)arg_out.dimension_3() , (size_t)arg_in.dimension_3() ) )
-    , n4( std::min( (size_t)arg_out.dimension_4() , (size_t)arg_in.dimension_4() ) )
-    , n5( std::min( (size_t)arg_out.dimension_5() , (size_t)arg_in.dimension_5() ) )
-    , n6( std::min( (size_t)arg_out.dimension_6() , (size_t)arg_in.dimension_6() ) )
-    , n7( std::min( (size_t)arg_out.dimension_7() , (size_t)arg_in.dimension_7() ) )
+    , n0( std::min( (size_t)arg_out.extent(0) , (size_t)arg_in.extent(0) ) )
+    , n1( std::min( (size_t)arg_out.extent(1) , (size_t)arg_in.extent(1) ) )
+    , n2( std::min( (size_t)arg_out.extent(2) , (size_t)arg_in.extent(2) ) )
+    , n3( std::min( (size_t)arg_out.extent(3) , (size_t)arg_in.extent(3) ) )
+    , n4( std::min( (size_t)arg_out.extent(4) , (size_t)arg_in.extent(4) ) )
+    , n5( std::min( (size_t)arg_out.extent(5) , (size_t)arg_in.extent(5) ) )
+    , n6( std::min( (size_t)arg_out.extent(6) , (size_t)arg_in.extent(6) ) )
+    , n7( std::min( (size_t)arg_out.extent(7) , (size_t)arg_in.extent(7) ) )
     {
       typedef Kokkos::RangePolicy< ExecSpace > Policy ;
       const Kokkos::Impl::ParallelFor< DynRankViewRemap , Policy > closure( *this , Policy( 0 , n0 ) );
@@ -1629,14 +1629,14 @@ void deep_copy
          dst.span_is_contiguous() &&
          src.span_is_contiguous() &&
          dst.span() == src.span() &&
-         dst.dimension_0() == src.dimension_0() &&
-         dst.dimension_1() == src.dimension_1() &&
-         dst.dimension_2() == src.dimension_2() &&
-         dst.dimension_3() == src.dimension_3() &&
-         dst.dimension_4() == src.dimension_4() &&
-         dst.dimension_5() == src.dimension_5() &&
-         dst.dimension_6() == src.dimension_6() &&
-         dst.dimension_7() == src.dimension_7() ) {
+         dst.extent(0) == src.extent(0) &&
+         dst.extent(1) == src.extent(1) &&
+         dst.extent(2) == src.extent(2) &&
+         dst.extent(3) == src.extent(3) &&
+         dst.extent(4) == src.extent(4) &&
+         dst.extent(5) == src.extent(5) &&
+         dst.extent(6) == src.extent(6) &&
+         dst.extent(7) == src.extent(7) ) {
 
       const size_t nbytes = sizeof(typename dst_type::value_type) * dst.span();
 
@@ -1661,14 +1661,14 @@ void deep_copy
          dst.span_is_contiguous() &&
          src.span_is_contiguous() &&
          dst.span() == src.span() &&
-         dst.dimension_0() == src.dimension_0() &&
-         dst.dimension_1() == src.dimension_1() &&
-         dst.dimension_2() == src.dimension_2() &&
-         dst.dimension_3() == src.dimension_3() &&
-         dst.dimension_4() == src.dimension_4() &&
-         dst.dimension_5() == src.dimension_5() &&
-         dst.dimension_6() == src.dimension_6() &&
-         dst.dimension_7() == src.dimension_7() &&
+         dst.extent(0) == src.extent(0) &&
+         dst.extent(1) == src.extent(1) &&
+         dst.extent(2) == src.extent(2) &&
+         dst.extent(3) == src.extent(3) &&
+         dst.extent(4) == src.extent(4) &&
+         dst.extent(5) == src.extent(5) &&
+         dst.extent(6) == src.extent(6) &&
+         dst.extent(7) == src.extent(7) &&
          dst.stride_0() == src.stride_0() &&
          dst.stride_1() == src.stride_1() &&
          dst.stride_2() == src.stride_2() &&

--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -69,7 +69,7 @@ public:
     clear();
   }
 
-  int getCapacity() const { return m_reports.h_view.dimension_0(); }
+  int getCapacity() const { return m_reports.h_view.extent(0); }
 
   int getNumReports();
 
@@ -90,7 +90,7 @@ public:
   {
     int idx = Kokkos::atomic_fetch_add(&m_numReportsAttempted(), 1);
 
-    if (idx >= 0 && (idx < static_cast<int>(m_reports.d_view.dimension_0()))) {
+    if (idx >= 0 && (idx < static_cast<int>(m_reports.d_view.extent(0)))) {
       m_reporters.d_view(idx) = reporter_id;
       m_reports.d_view(idx)   = report;
       return true;
@@ -118,8 +118,8 @@ inline int ErrorReporter<ReportType, DeviceType>::getNumReports()
 {
   int num_reports = 0;
   Kokkos::deep_copy(num_reports,m_numReportsAttempted);
-  if (num_reports > static_cast<int>(m_reports.h_view.dimension_0())) {
-    num_reports = m_reports.h_view.dimension_0();
+  if (num_reports > static_cast<int>(m_reports.h_view.extent(0))) {
+    num_reports = m_reports.h_view.extent(0);
   }
   return num_reports;
 }

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -70,7 +70,7 @@ namespace Impl {
 
     KOKKOS_INLINE_FUNCTION
     void operator() (const int_type& iRow) const {
-      const int_type num_rows = row_offsets.dimension_0()-1;
+      const int_type num_rows = row_offsets.extent(0)-1;
       const int_type num_entries = row_offsets(num_rows);
       const int_type total_cost = num_entries + num_rows*cost_per_row;
 
@@ -105,7 +105,7 @@ namespace Impl {
           }
         } else {
           if((count >= (current_block + 1) * cost_per_workset) ||
-             (iRow+2 == row_offsets.dimension_0())) {
+             (iRow+2 == row_offsets.extent(0))) {
             if(end_block>current_block+1) {
               int_type num_block = end_block-current_block;
               row_block_offsets(current_block+1) = iRow;
@@ -330,8 +330,8 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   size_type numRows() const {
-    return (row_map.dimension_0 () != 0) ?
-      row_map.dimension_0 () - static_cast<size_type> (1) :
+    return (row_map.extent(0) != 0) ?
+      row_map.extent(0) - static_cast<size_type> (1) :
       static_cast<size_type> (0);
   }
 
@@ -458,7 +458,7 @@ DataType maximum_entry( const StaticCrsGraph< DataType , Arg1Type , Arg2Type , S
   typedef Impl::StaticCrsGraphMaximumEntry< GraphType > FunctorType ;
 
   DataType result = 0 ;
-  Kokkos::parallel_reduce( graph.entries.dimension_0(),
+  Kokkos::parallel_reduce( graph.entries.extent(0),
                            FunctorType(graph), result );
   return result ;
 }

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -477,7 +477,7 @@ public:
   /// kernel.
   KOKKOS_INLINE_FUNCTION
   size_type hash_capacity() const
-  { return m_hash_lists.dimension_0(); }
+  { return m_hash_lists.extent(0); }
 
   //---------------------------------------------------------------------------
   //---------------------------------------------------------------------------
@@ -507,13 +507,13 @@ public:
     int volatile & failed_insert_ref = m_scalars((int)failed_insert_idx) ;
 
     const size_type hash_value = m_hasher(k);
-    const size_type hash_list = hash_value % m_hash_lists.dimension_0();
+    const size_type hash_list = hash_value % m_hash_lists.extent(0);
 
     size_type * curr_ptr   = & m_hash_lists[ hash_list ];
     size_type new_index    = invalid_index ;
 
     // Force integer multiply to long
-    size_type index_hint = static_cast<size_type>( (static_cast<double>(hash_list) * capacity()) / m_hash_lists.dimension_0());
+    size_type index_hint = static_cast<size_type>( (static_cast<double>(hash_list) * capacity()) / m_hash_lists.extent(0));
 
     size_type find_attempts = 0;
 
@@ -645,7 +645,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   size_type find( const key_type & k) const
   {
-    size_type curr = 0u < capacity() ? m_hash_lists( m_hasher(k) % m_hash_lists.dimension_0() ) : invalid_index ;
+    size_type curr = 0u < capacity() ? m_hash_lists( m_hasher(k) % m_hash_lists.extent(0) ) : invalid_index ;
 
     KOKKOS_NONTEMPORAL_PREFETCH_LOAD(&m_keys[curr != invalid_index ? curr : 0]);
     while (curr != invalid_index && !m_equal_to( m_keys[curr], k) ) {
@@ -741,7 +741,7 @@ public:
                           >::type
   create_copy_view( UnorderedMap<SKey, SValue, SDevice, Hasher,EqualTo> const& src)
   {
-    if (m_hash_lists.ptr_on_device() != src.m_hash_lists.ptr_on_device()) {
+    if (m_hash_lists.data() != src.m_hash_lists.data()) {
 
       insertable_map_type tmp;
 
@@ -750,23 +750,23 @@ public:
       tmp.m_equal_to = src.m_equal_to;
       tmp.m_size = src.size();
       tmp.m_available_indexes = bitset_type( src.capacity() );
-      tmp.m_hash_lists        = size_type_view( ViewAllocateWithoutInitializing("UnorderedMap hash list"), src.m_hash_lists.dimension_0() );
-      tmp.m_next_index        = size_type_view( ViewAllocateWithoutInitializing("UnorderedMap next index"), src.m_next_index.dimension_0() );
-      tmp.m_keys              = key_type_view( ViewAllocateWithoutInitializing("UnorderedMap keys"), src.m_keys.dimension_0() );
-      tmp.m_values            = value_type_view( ViewAllocateWithoutInitializing("UnorderedMap values"), src.m_values.dimension_0() );
+      tmp.m_hash_lists        = size_type_view( ViewAllocateWithoutInitializing("UnorderedMap hash list"), src.m_hash_lists.extent(0) );
+      tmp.m_next_index        = size_type_view( ViewAllocateWithoutInitializing("UnorderedMap next index"), src.m_next_index.extent(0) );
+      tmp.m_keys              = key_type_view( ViewAllocateWithoutInitializing("UnorderedMap keys"), src.m_keys.extent(0) );
+      tmp.m_values            = value_type_view( ViewAllocateWithoutInitializing("UnorderedMap values"), src.m_values.extent(0) );
       tmp.m_scalars           = scalars_view("UnorderedMap scalars");
 
       Kokkos::deep_copy(tmp.m_available_indexes, src.m_available_indexes);
 
       typedef Kokkos::Impl::DeepCopy< typename device_type::memory_space, typename SDevice::memory_space > raw_deep_copy;
 
-      raw_deep_copy(tmp.m_hash_lists.ptr_on_device(), src.m_hash_lists.ptr_on_device(), sizeof(size_type)*src.m_hash_lists.dimension_0());
-      raw_deep_copy(tmp.m_next_index.ptr_on_device(), src.m_next_index.ptr_on_device(), sizeof(size_type)*src.m_next_index.dimension_0());
-      raw_deep_copy(tmp.m_keys.ptr_on_device(), src.m_keys.ptr_on_device(), sizeof(key_type)*src.m_keys.dimension_0());
+      raw_deep_copy(tmp.m_hash_lists.data(), src.m_hash_lists.data(), sizeof(size_type)*src.m_hash_lists.extent(0));
+      raw_deep_copy(tmp.m_next_index.data(), src.m_next_index.data(), sizeof(size_type)*src.m_next_index.extent(0));
+      raw_deep_copy(tmp.m_keys.data(), src.m_keys.data(), sizeof(key_type)*src.m_keys.extent(0));
       if (!is_set) {
-        raw_deep_copy(tmp.m_values.ptr_on_device(), src.m_values.ptr_on_device(), sizeof(impl_value_type)*src.m_values.dimension_0());
+        raw_deep_copy(tmp.m_values.data(), src.m_values.data(), sizeof(impl_value_type)*src.m_values.extent(0));
       }
-      raw_deep_copy(tmp.m_scalars.ptr_on_device(), src.m_scalars.ptr_on_device(), sizeof(int)*num_scalars );
+      raw_deep_copy(tmp.m_scalars.data(), src.m_scalars.data(), sizeof(int)*num_scalars );
 
       *this = tmp;
     }
@@ -784,21 +784,21 @@ private: // private member functions
   {
     typedef Kokkos::Impl::DeepCopy< typename device_type::memory_space, Kokkos::HostSpace > raw_deep_copy;
     const int true_ = true;
-    raw_deep_copy(m_scalars.ptr_on_device() + flag, &true_, sizeof(int));
+    raw_deep_copy(m_scalars.data() + flag, &true_, sizeof(int));
   }
 
   void reset_flag(int flag) const
   {
     typedef Kokkos::Impl::DeepCopy< typename device_type::memory_space, Kokkos::HostSpace > raw_deep_copy;
     const int false_ = false;
-    raw_deep_copy(m_scalars.ptr_on_device() + flag, &false_, sizeof(int));
+    raw_deep_copy(m_scalars.data() + flag, &false_, sizeof(int));
   }
 
   bool get_flag(int flag) const
   {
     typedef Kokkos::Impl::DeepCopy< Kokkos::HostSpace, typename device_type::memory_space > raw_deep_copy;
     int result = false;
-    raw_deep_copy(&result, m_scalars.ptr_on_device() + flag, sizeof(int));
+    raw_deep_copy(&result, m_scalars.data() + flag, sizeof(int));
     return result;
   }
 

--- a/containers/src/impl/Kokkos_Bitset_impl.hpp
+++ b/containers/src/impl/Kokkos_Bitset_impl.hpp
@@ -80,7 +80,7 @@ struct BitsetCount
   size_type apply() const
   {
     size_type count = 0u;
-    parallel_reduce( m_bitset.m_blocks.dimension_0(), *this, count );
+    parallel_reduce( m_bitset.m_blocks.extent(0), *this, count );
     return count;
   }
 

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
@@ -102,7 +102,7 @@ struct UnorderedMapErase
 
   void apply() const
   {
-    parallel_for(m_map.m_hash_lists.dimension_0(), *this);
+    parallel_for(m_map.m_hash_lists.extent(0), *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -170,7 +170,7 @@ struct UnorderedMapHistogram
 
   void calculate()
   {
-    parallel_for(m_map.m_hash_lists.dimension_0(), *this);
+    parallel_for(m_map.m_hash_lists.extent(0), *this);
   }
 
   void clear()
@@ -185,7 +185,7 @@ struct UnorderedMapHistogram
     host_histogram_view host_copy = create_mirror_view(m_length);
     Kokkos::deep_copy(host_copy, m_length);
 
-    for (int i=0, size = host_copy.dimension_0(); i<size; ++i)
+    for (int i=0, size = host_copy.extent(0); i<size; ++i)
     {
       out << host_copy[i] << " , ";
     }
@@ -197,7 +197,7 @@ struct UnorderedMapHistogram
     host_histogram_view host_copy = create_mirror_view(m_distance);
     Kokkos::deep_copy(host_copy, m_distance);
 
-    for (int i=0, size = host_copy.dimension_0(); i<size; ++i)
+    for (int i=0, size = host_copy.extent(0); i<size; ++i)
     {
       out << host_copy[i] << " , ";
     }
@@ -209,7 +209,7 @@ struct UnorderedMapHistogram
     host_histogram_view host_copy = create_mirror_view(m_block_distance);
     Kokkos::deep_copy(host_copy, m_block_distance);
 
-    for (int i=0, size = host_copy.dimension_0(); i<size; ++i)
+    for (int i=0, size = host_copy.extent(0); i<size; ++i)
     {
       out << host_copy[i] << " , ";
     }
@@ -261,7 +261,7 @@ struct UnorderedMapPrint
 
   void apply()
   {
-    parallel_for(m_map.m_hash_lists.dimension_0(), *this);
+    parallel_for(m_map.m_hash_lists.extent(0), *this);
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -88,10 +88,10 @@ namespace Impl {
 
       a.template sync<typename ViewType::host_mirror_space>();
       Scalar count = 0;
-      for(unsigned int i = 0; i<a.d_view.dimension_0(); i++)
-        for(unsigned int j = 0; j<a.d_view.dimension_1(); j++)
+      for(unsigned int i = 0; i<a.d_view.extent(0); i++)
+        for(unsigned int j = 0; j<a.d_view.extent(1); j++)
           count += a.h_view(i,j);
-      return count -  a.d_view.dimension_0()*a.d_view.dimension_1()-2-4-3*2;
+      return count -  a.d_view.extent(0)*a.d_view.extent(1)-2-4-3*2;
     }
 
 

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -163,13 +163,13 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 7 >
     long offset ;
 
     offset = -1 ;
-    for ( unsigned i6 = 0 ; i6 < unsigned(left.dimension_6()) ; ++i6 )
-    for ( unsigned i5 = 0 ; i5 < unsigned(left.dimension_5()) ; ++i5 )
-    for ( unsigned i4 = 0 ; i4 < unsigned(left.dimension_4()) ; ++i4 )
-    for ( unsigned i3 = 0 ; i3 < unsigned(left.dimension_3()) ; ++i3 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(left.dimension_2()) ; ++i2 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(left.dimension_1()) ; ++i1 )
-    for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
+    for ( unsigned i6 = 0 ; i6 < unsigned(left.extent(6)) ; ++i6 )
+    for ( unsigned i5 = 0 ; i5 < unsigned(left.extent(5)) ; ++i5 )
+    for ( unsigned i4 = 0 ; i4 < unsigned(left.extent(4)) ; ++i4 )
+    for ( unsigned i3 = 0 ; i3 < unsigned(left.extent(3)) ; ++i3 )
+    for ( unsigned i2 = 0 ; i2 < unsigned(left.extent(2)) ; ++i2 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(left.extent(1)) ; ++i1 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(left.extent(0)) ; ++i0 )
     {
       const long j = & left( i0, i1, i2, i3, i4, i5, i6 ) -
                      & left(  0,  0,  0,  0,  0,  0,  0 );
@@ -178,13 +178,13 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 7 >
     }
 
     offset = -1 ;
-    for ( unsigned i0 = 0 ; i0 < unsigned(right.dimension_0()) ; ++i0 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(right.dimension_1()) ; ++i1 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(right.dimension_2()) ; ++i2 )
-    for ( unsigned i3 = 0 ; i3 < unsigned(right.dimension_3()) ; ++i3 )
-    for ( unsigned i4 = 0 ; i4 < unsigned(right.dimension_4()) ; ++i4 )
-    for ( unsigned i5 = 0 ; i5 < unsigned(right.dimension_5()) ; ++i5 )
-    for ( unsigned i6 = 0 ; i6 < unsigned(right.dimension_6()) ; ++i6 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(right.extent(0)) ; ++i0 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(right.extent(1)) ; ++i1 )
+    for ( unsigned i2 = 0 ; i2 < unsigned(right.extent(2)) ; ++i2 )
+    for ( unsigned i3 = 0 ; i3 < unsigned(right.extent(3)) ; ++i3 )
+    for ( unsigned i4 = 0 ; i4 < unsigned(right.extent(4)) ; ++i4 )
+    for ( unsigned i5 = 0 ; i5 < unsigned(right.extent(5)) ; ++i5 )
+    for ( unsigned i6 = 0 ; i6 < unsigned(right.extent(6)) ; ++i6 )
     {
       const long j = & right( i0, i1, i2, i3, i4, i5, i6 ) -
                      & right(  0,  0,  0,  0,  0,  0,  0 );
@@ -248,12 +248,12 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 6 >
     long offset ;
 
     offset = -1 ;
-    for ( unsigned i5 = 0 ; i5 < unsigned(left.dimension_5()) ; ++i5 )
-    for ( unsigned i4 = 0 ; i4 < unsigned(left.dimension_4()) ; ++i4 )
-    for ( unsigned i3 = 0 ; i3 < unsigned(left.dimension_3()) ; ++i3 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(left.dimension_2()) ; ++i2 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(left.dimension_1()) ; ++i1 )
-    for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
+    for ( unsigned i5 = 0 ; i5 < unsigned(left.extent(5)) ; ++i5 )
+    for ( unsigned i4 = 0 ; i4 < unsigned(left.extent(4)) ; ++i4 )
+    for ( unsigned i3 = 0 ; i3 < unsigned(left.extent(3)) ; ++i3 )
+    for ( unsigned i2 = 0 ; i2 < unsigned(left.extent(2)) ; ++i2 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(left.extent(1)) ; ++i1 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(left.extent(0)) ; ++i0 )
     {
       const long j = & left( i0, i1, i2, i3, i4, i5 ) -
                      & left(  0,  0,  0,  0,  0,  0 );
@@ -262,12 +262,12 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 6 >
     }
 
     offset = -1 ;
-    for ( unsigned i0 = 0 ; i0 < unsigned(right.dimension_0()) ; ++i0 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(right.dimension_1()) ; ++i1 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(right.dimension_2()) ; ++i2 )
-    for ( unsigned i3 = 0 ; i3 < unsigned(right.dimension_3()) ; ++i3 )
-    for ( unsigned i4 = 0 ; i4 < unsigned(right.dimension_4()) ; ++i4 )
-    for ( unsigned i5 = 0 ; i5 < unsigned(right.dimension_5()) ; ++i5 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(right.extent(0)) ; ++i0 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(right.extent(1)) ; ++i1 )
+    for ( unsigned i2 = 0 ; i2 < unsigned(right.extent(2)) ; ++i2 )
+    for ( unsigned i3 = 0 ; i3 < unsigned(right.extent(3)) ; ++i3 )
+    for ( unsigned i4 = 0 ; i4 < unsigned(right.extent(4)) ; ++i4 )
+    for ( unsigned i5 = 0 ; i5 < unsigned(right.extent(5)) ; ++i5 )
     {
       const long j = & right( i0, i1, i2, i3, i4, i5 ) -
                      & right(  0,  0,  0,  0,  0,  0 );
@@ -338,11 +338,11 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 5 >
     long offset ;
 
     offset = -1 ;
-    for ( unsigned i4 = 0 ; i4 < unsigned(left.dimension_4()) ; ++i4 )
-    for ( unsigned i3 = 0 ; i3 < unsigned(left.dimension_3()) ; ++i3 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(left.dimension_2()) ; ++i2 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(left.dimension_1()) ; ++i1 )
-    for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
+    for ( unsigned i4 = 0 ; i4 < unsigned(left.extent(4)) ; ++i4 )
+    for ( unsigned i3 = 0 ; i3 < unsigned(left.extent(3)) ; ++i3 )
+    for ( unsigned i2 = 0 ; i2 < unsigned(left.extent(2)) ; ++i2 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(left.extent(1)) ; ++i1 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(left.extent(0)) ; ++i0 )
     {
       const long j = & left( i0, i1, i2, i3, i4 ) -
                      & left(  0,  0,  0,  0,  0 );
@@ -354,11 +354,11 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 5 >
     }
 
     offset = -1 ;
-    for ( unsigned i0 = 0 ; i0 < unsigned(right.dimension_0()) ; ++i0 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(right.dimension_1()) ; ++i1 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(right.dimension_2()) ; ++i2 )
-    for ( unsigned i3 = 0 ; i3 < unsigned(right.dimension_3()) ; ++i3 )
-    for ( unsigned i4 = 0 ; i4 < unsigned(right.dimension_4()) ; ++i4 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(right.extent(0)) ; ++i0 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(right.extent(1)) ; ++i1 )
+    for ( unsigned i2 = 0 ; i2 < unsigned(right.extent(2)) ; ++i2 )
+    for ( unsigned i3 = 0 ; i3 < unsigned(right.extent(3)) ; ++i3 )
+    for ( unsigned i4 = 0 ; i4 < unsigned(right.extent(4)) ; ++i4 )
     {
       const long j = & right( i0, i1, i2, i3, i4 ) -
                      & right(  0,  0,  0,  0,  0 );
@@ -425,10 +425,10 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 4 >
     long offset ;
 
     offset = -1 ;
-    for ( unsigned i3 = 0 ; i3 < unsigned(left.dimension_3()) ; ++i3 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(left.dimension_2()) ; ++i2 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(left.dimension_1()) ; ++i1 )
-    for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
+    for ( unsigned i3 = 0 ; i3 < unsigned(left.extent(3)) ; ++i3 )
+    for ( unsigned i2 = 0 ; i2 < unsigned(left.extent(2)) ; ++i2 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(left.extent(1)) ; ++i1 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(left.extent(0)) ; ++i0 )
     {
       const long j = & left( i0, i1, i2, i3 ) -
                      & left(  0,  0,  0,  0 );
@@ -437,10 +437,10 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 4 >
     }
 
     offset = -1 ;
-    for ( unsigned i0 = 0 ; i0 < unsigned(right.dimension_0()) ; ++i0 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(right.dimension_1()) ; ++i1 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(right.dimension_2()) ; ++i2 )
-    for ( unsigned i3 = 0 ; i3 < unsigned(right.dimension_3()) ; ++i3 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(right.extent(0)) ; ++i0 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(right.extent(1)) ; ++i1 )
+    for ( unsigned i2 = 0 ; i2 < unsigned(right.extent(2)) ; ++i2 )
+    for ( unsigned i3 = 0 ; i3 < unsigned(right.extent(3)) ; ++i3 )
     {
       const long j = & right( i0, i1, i2, i3 ) -
                      & right(  0,  0,  0,  0 );
@@ -511,9 +511,9 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 3 >
     long offset ;
 
     offset = -1 ;
-    for ( unsigned i2 = 0 ; i2 < unsigned(left.dimension_2()) ; ++i2 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(left.dimension_1()) ; ++i1 )
-    for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
+    for ( unsigned i2 = 0 ; i2 < unsigned(left.extent(2)) ; ++i2 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(left.extent(1)) ; ++i1 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(left.extent(0)) ; ++i0 )
     {
       const long j = & left( i0, i1, i2 ) -
                      & left(  0,  0,  0 );
@@ -524,9 +524,9 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 3 >
     }
 
     offset = -1 ;
-    for ( unsigned i0 = 0 ; i0 < unsigned(right.dimension_0()) ; ++i0 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(right.dimension_1()) ; ++i1 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(right.dimension_2()) ; ++i2 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(right.extent(0)) ; ++i0 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(right.extent(1)) ; ++i1 )
+    for ( unsigned i2 = 0 ; i2 < unsigned(right.extent(2)) ; ++i2 )
     {
       const long j = & right( i0, i1, i2 ) -
                      & right(  0,  0,  0 );
@@ -536,9 +536,9 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 3 >
       if ( & right(i0,i1,i2) != & right_stride(i0,i1,i2) ) { update |= 8 ; }
     }
 
-    for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(left.dimension_1()) ; ++i1 )
-    for ( unsigned i2 = 0 ; i2 < unsigned(left.dimension_2()) ; ++i2 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(left.extent(0)) ; ++i0 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(left.extent(1)) ; ++i1 )
+    for ( unsigned i2 = 0 ; i2 < unsigned(left.extent(2)) ; ++i2 )
     {
       if ( & left(i0,i1,i2)  != & left(i0,i1,i2,0,0,0,0) )  { update |= 3 ; }
       if ( & right(i0,i1,i2) != & right(i0,i1,i2,0,0,0,0) ) { update |= 3 ; }
@@ -600,8 +600,8 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 2 >
     long offset ;
 
     offset = -1 ;
-    for ( unsigned i1 = 0 ; i1 < unsigned(left.dimension_1()) ; ++i1 )
-    for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(left.extent(1)) ; ++i1 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(left.extent(0)) ; ++i0 )
     {
       const long j = & left( i0, i1 ) -
                      & left(  0,  0 );
@@ -610,8 +610,8 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 2 >
     }
 
     offset = -1 ;
-    for ( unsigned i0 = 0 ; i0 < unsigned(right.dimension_0()) ; ++i0 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(right.dimension_1()) ; ++i1 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(right.extent(0)) ; ++i0 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(right.extent(1)) ; ++i1 )
     {
       const long j = & right( i0, i1 ) -
                      & right(  0,  0 );
@@ -619,8 +619,8 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 2 >
       offset = j ;
     }
 
-    for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
-    for ( unsigned i1 = 0 ; i1 < unsigned(left.dimension_1()) ; ++i1 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(left.extent(0)) ; ++i0 )
+    for ( unsigned i1 = 0 ; i1 < unsigned(left.extent(1)) ; ++i1 )
     {
       if ( & left(i0,i1)  != & left(i0,i1,0,0,0,0,0) )  { update |= 3 ; }
       if ( & right(i0,i1) != & right(i0,i1,0,0,0,0,0) ) { update |= 3 ; }
@@ -686,7 +686,7 @@ struct TestViewOperator_LeftAndRight< DataType , DeviceType , 1 >
   KOKKOS_INLINE_FUNCTION
   void operator()( const size_type , value_type & update ) const
   {
-    for ( unsigned i0 = 0 ; i0 < unsigned(left.dimension_0()) ; ++i0 )
+    for ( unsigned i0 = 0 ; i0 < unsigned(left.extent(0)) ; ++i0 )
     {
       if ( & left(i0)  != & left(i0,0,0,0,0,0,0) )  { update |= 3 ; }
       if ( & right(i0) != & right(i0,0,0,0,0,0,0) ) { update |= 3 ; }
@@ -749,15 +749,15 @@ public:
 
     Kokkos::resize(drv0, 5, 10);
     ASSERT_EQ( drv0.rank(), 2);
-    ASSERT_EQ( drv0.dimension_0(), 5);
-    ASSERT_EQ( drv0.dimension_1(), 10);
-    ASSERT_EQ( drv0.dimension_2(), 1);
+    ASSERT_EQ( drv0.extent(0), 5);
+    ASSERT_EQ( drv0.extent(1), 10);
+    ASSERT_EQ( drv0.extent(2), 1);
 
     Kokkos::realloc(drv0, 10, 20);
     ASSERT_EQ( drv0.rank(), 2);
-    ASSERT_EQ( drv0.dimension_0(), 10);
-    ASSERT_EQ( drv0.dimension_1(), 20);
-    ASSERT_EQ( drv0.dimension_2(), 1);
+    ASSERT_EQ( drv0.extent(0), 10);
+    ASSERT_EQ( drv0.extent(1), 20);
+    ASSERT_EQ( drv0.extent(2), 1);
 
   }
 
@@ -786,8 +786,8 @@ public:
       ASSERT_EQ(equal_ptr_h_d ,0);
       ASSERT_EQ(equal_ptr_h2_d,0);
   
-      ASSERT_EQ(a_h.dimension_0(),a_h2.dimension_0());
-      ASSERT_EQ(a_h.dimension_0(),a_d .dimension_0());
+      ASSERT_EQ(a_h.extent(0),a_h2.extent(0));
+      ASSERT_EQ(a_h.extent(0),a_d .extent(0));
 
       ASSERT_EQ(a_h.rank(),a_h2.rank());
       ASSERT_EQ(a_h.rank(),a_d.rank());
@@ -806,8 +806,8 @@ public:
       ASSERT_EQ(equal_ptr_h_d ,0);
       ASSERT_EQ(equal_ptr_h2_d,0);
   
-      ASSERT_EQ(a_h.dimension_0(),a_h2.dimension_0());
-      ASSERT_EQ(a_h.dimension_0(),a_d .dimension_0());
+      ASSERT_EQ(a_h.extent(0),a_h2.extent(0));
+      ASSERT_EQ(a_h.extent(0),a_d .extent(0));
 
       ASSERT_EQ(a_h.rank(),a_h2.rank());
       ASSERT_EQ(a_h.rank(),a_d.rank());
@@ -828,8 +828,8 @@ public:
       ASSERT_EQ(equal_ptr_h_d ,is_same_memspace);
       ASSERT_EQ(equal_ptr_h2_d ,is_same_memspace);
   
-      ASSERT_EQ(a_h.dimension_0(),a_h2.dimension_0());
-      ASSERT_EQ(a_h.dimension_0(),a_d .dimension_0());
+      ASSERT_EQ(a_h.extent(0),a_h2.extent(0));
+      ASSERT_EQ(a_h.extent(0),a_d .extent(0));
 
       ASSERT_EQ(a_h.rank(),a_h2.rank());
       ASSERT_EQ(a_h.rank(),a_d.rank());
@@ -849,8 +849,8 @@ public:
       ASSERT_EQ(equal_ptr_h_d ,is_same_memspace);
       ASSERT_EQ(equal_ptr_h2_d ,is_same_memspace);
   
-      ASSERT_EQ(a_h.dimension_0(),a_h2.dimension_0());
-      ASSERT_EQ(a_h.dimension_0(),a_d .dimension_0());
+      ASSERT_EQ(a_h.extent(0),a_h2.extent(0));
+      ASSERT_EQ(a_h.extent(0),a_d .extent(0));
 
       ASSERT_EQ(a_h.rank(),a_h2.rank());
       ASSERT_EQ(a_h.rank(),a_d.rank());
@@ -872,8 +872,8 @@ public:
       ASSERT_EQ(equal_ptr_h_d ,is_same_memspace);
       ASSERT_EQ(equal_ptr_h2_d ,is_same_memspace);
   
-      ASSERT_EQ(a_h.dimension_0(),a_h2.dimension_0());
-      ASSERT_EQ(a_h.dimension_0(),a_d .dimension_0());
+      ASSERT_EQ(a_h.extent(0),a_h2.extent(0));
+      ASSERT_EQ(a_h.extent(0),a_d .extent(0));
 
       ASSERT_EQ(a_h.rank(),a_h2.rank());
       ASSERT_EQ(a_h.rank(),a_d.rank());
@@ -920,18 +920,18 @@ public:
 
 
     View7 vcast = dx.ConstDownCast();
-    ASSERT_EQ( dx.dimension_0() , vcast.dimension_0() );
-    ASSERT_EQ( dx.dimension_1() , vcast.dimension_1() );
-    ASSERT_EQ( dx.dimension_2() , vcast.dimension_2() );
-    ASSERT_EQ( dx.dimension_3() , vcast.dimension_3() );
-    ASSERT_EQ( dx.dimension_4() , vcast.dimension_4() );
+    ASSERT_EQ( dx.extent(0) , vcast.extent(0) );
+    ASSERT_EQ( dx.extent(1) , vcast.extent(1) );
+    ASSERT_EQ( dx.extent(2) , vcast.extent(2) );
+    ASSERT_EQ( dx.extent(3) , vcast.extent(3) );
+    ASSERT_EQ( dx.extent(4) , vcast.extent(4) );
 
     View7 vcast1( dy.ConstDownCast() );
-    ASSERT_EQ( dy.dimension_0() , vcast1.dimension_0() );
-    ASSERT_EQ( dy.dimension_1() , vcast1.dimension_1() );
-    ASSERT_EQ( dy.dimension_2() , vcast1.dimension_2() );
-    ASSERT_EQ( dy.dimension_3() , vcast1.dimension_3() );
-    ASSERT_EQ( dy.dimension_4() , vcast1.dimension_4() );
+    ASSERT_EQ( dy.extent(0) , vcast1.extent(0) );
+    ASSERT_EQ( dy.extent(1) , vcast1.extent(1) );
+    ASSERT_EQ( dy.extent(2) , vcast1.extent(2) );
+    ASSERT_EQ( dy.extent(3) , vcast1.extent(3) );
+    ASSERT_EQ( dy.extent(4) , vcast1.extent(4) );
 
   //View - DynRankView Interoperability tests
   // copy View to DynRankView
@@ -941,8 +941,8 @@ public:
     auto hvx = Kokkos::create_mirror_view(vx) ;
     Kokkos::deep_copy(hvx , vx);
     ASSERT_EQ( rank(hvx) , rank(hmx) );
-    ASSERT_EQ( hvx.dimension_0() , hmx.dimension_0() );
-    ASSERT_EQ( hvx.dimension_1() , hmx.dimension_1() );
+    ASSERT_EQ( hvx.extent(0) , hmx.extent(0) );
+    ASSERT_EQ( hvx.extent(1) , hmx.extent(1) );
 
   // copy-assign View to DynRankView
     dView0 dfromvy = vy ;
@@ -951,27 +951,27 @@ public:
     auto hvy = Kokkos::create_mirror_view(vy) ;
     Kokkos::deep_copy(hvy , vy);
     ASSERT_EQ( rank(hvy) , rank(hmy) );
-    ASSERT_EQ( hvy.dimension_0() , hmy.dimension_0() );
-    ASSERT_EQ( hvy.dimension_1() , hmy.dimension_1() );
+    ASSERT_EQ( hvy.extent(0) , hmy.extent(0) );
+    ASSERT_EQ( hvy.extent(1) , hmy.extent(1) );
 
 
     View7 vtest1("vtest1",2,2,2,2,2,2,2);
     dView0 dfromv1( vtest1 );
     ASSERT_EQ( dfromv1.rank() , vtest1.Rank );
-    ASSERT_EQ( dfromv1.dimension_0() , vtest1.dimension_0() );
-    ASSERT_EQ( dfromv1.dimension_1() , vtest1.dimension_1() );
+    ASSERT_EQ( dfromv1.extent(0) , vtest1.extent(0) );
+    ASSERT_EQ( dfromv1.extent(1) , vtest1.extent(1) );
     ASSERT_EQ( dfromv1.use_count() , vtest1.use_count() );
 
     dView0 dfromv2( vcast );
     ASSERT_EQ( dfromv2.rank() , vcast.Rank );
-    ASSERT_EQ( dfromv2.dimension_0() , vcast.dimension_0() );
-    ASSERT_EQ( dfromv2.dimension_1() , vcast.dimension_1() );
+    ASSERT_EQ( dfromv2.extent(0) , vcast.extent(0) );
+    ASSERT_EQ( dfromv2.extent(1) , vcast.extent(1) );
     ASSERT_EQ( dfromv2.use_count() , vcast.use_count() );
 
     dView0 dfromv3 = vcast1;
     ASSERT_EQ( dfromv3.rank() , vcast1.Rank );
-    ASSERT_EQ( dfromv3.dimension_0() , vcast1.dimension_0() );
-    ASSERT_EQ( dfromv3.dimension_1() , vcast1.dimension_1() );
+    ASSERT_EQ( dfromv3.extent(0) , vcast1.extent(0) );
+    ASSERT_EQ( dfromv3.extent(1) , vcast1.extent(1) );
     ASSERT_EQ( dfromv3.use_count() , vcast1.use_count() );
   }
 
@@ -993,9 +993,9 @@ public:
     dView0 d_uninitialized(Kokkos::ViewAllocateWithoutInitializing("uninit"),10,20);
     ASSERT_TRUE( d_uninitialized.data() != nullptr );
     ASSERT_EQ( d_uninitialized.rank() , 2 );
-    ASSERT_EQ( d_uninitialized.dimension_0() , 10 );
-    ASSERT_EQ( d_uninitialized.dimension_1() , 20 );
-    ASSERT_EQ( d_uninitialized.dimension_2() , 1  );
+    ASSERT_EQ( d_uninitialized.extent(0) , 10 );
+    ASSERT_EQ( d_uninitialized.extent(1) , 20 );
+    ASSERT_EQ( d_uninitialized.extent(2) , 1  );
 
     dView0 dx , dy , dz ;
     hView0 hx , hy , hz ;
@@ -1009,12 +1009,12 @@ public:
     ASSERT_TRUE( hx.ptr_on_device() == 0 );
     ASSERT_TRUE( hy.ptr_on_device() == 0 );
     ASSERT_TRUE( hz.ptr_on_device() == 0 );
-    ASSERT_EQ( dx.dimension_0() , 0u ); //Okay with UVM
-    ASSERT_EQ( dy.dimension_0() , 0u ); //Okay with UVM
-    ASSERT_EQ( dz.dimension_0() , 0u ); //Okay with UVM
-    ASSERT_EQ( hx.dimension_0() , 0u );
-    ASSERT_EQ( hy.dimension_0() , 0u );
-    ASSERT_EQ( hz.dimension_0() , 0u );
+    ASSERT_EQ( dx.extent(0) , 0u ); //Okay with UVM
+    ASSERT_EQ( dy.extent(0) , 0u ); //Okay with UVM
+    ASSERT_EQ( dz.extent(0) , 0u ); //Okay with UVM
+    ASSERT_EQ( hx.extent(0) , 0u );
+    ASSERT_EQ( hy.extent(0) , 0u );
+    ASSERT_EQ( hz.extent(0) , 0u );
     ASSERT_EQ( dx.rank() , 0u ); //Okay with UVM
     ASSERT_EQ( hx.rank() , 0u );
 
@@ -1024,10 +1024,10 @@ public:
     hx = hView0( "hx" , N1 , N2 , N3 );
     hy = hView0( "hy" , N1 , N2 , N3 );
 
-    ASSERT_EQ( dx.dimension_0() , unsigned(N1) ); //Okay with UVM
-    ASSERT_EQ( dy.dimension_0() , unsigned(N1) ); //Okay with UVM
-    ASSERT_EQ( hx.dimension_0() , unsigned(N1) );
-    ASSERT_EQ( hy.dimension_0() , unsigned(N1) );
+    ASSERT_EQ( dx.extent(0) , unsigned(N1) ); //Okay with UVM
+    ASSERT_EQ( dy.extent(0) , unsigned(N1) ); //Okay with UVM
+    ASSERT_EQ( hx.extent(0) , unsigned(N1) );
+    ASSERT_EQ( hy.extent(0) , unsigned(N1) );
     ASSERT_EQ( dx.rank() , 3 ); //Okay with UVM
     ASSERT_EQ( hx.rank() , 3 );
 
@@ -1036,10 +1036,10 @@ public:
     hx = hView0( "hx" , N0 , N1 , N2 , N3 );
     hy = hView0( "hy" , N0 , N1 , N2 , N3 );
 
-    ASSERT_EQ( dx.dimension_0() , unsigned(N0) );
-    ASSERT_EQ( dy.dimension_0() , unsigned(N0) );
-    ASSERT_EQ( hx.dimension_0() , unsigned(N0) );
-    ASSERT_EQ( hy.dimension_0() , unsigned(N0) );
+    ASSERT_EQ( dx.extent(0) , unsigned(N0) );
+    ASSERT_EQ( dy.extent(0) , unsigned(N0) );
+    ASSERT_EQ( hx.extent(0) , unsigned(N0) );
+    ASSERT_EQ( hy.extent(0) , unsigned(N0) );
     ASSERT_EQ( dx.rank() , 4 );
     ASSERT_EQ( dy.rank() , 4 );
     ASSERT_EQ( hx.rank() , 4 );
@@ -1052,19 +1052,19 @@ public:
 
 
     dView0_unmanaged unmanaged_from_ptr_dx = dView0_unmanaged(dx.ptr_on_device(),
-                                                              dx.dimension_0(),
-                                                              dx.dimension_1(),
-                                                              dx.dimension_2(),
-                                                              dx.dimension_3());
+                                                              dx.extent(0),
+                                                              dx.extent(1),
+                                                              dx.extent(2),
+                                                              dx.extent(3));
 
 
     {
       // Destruction of this view should be harmless
       const_dView0 unmanaged_from_ptr_const_dx( dx.ptr_on_device() ,
-                                                dx.dimension_0() ,
-                                                dx.dimension_1() ,
-                                                dx.dimension_2() ,
-                                                dx.dimension_3() );
+                                                dx.extent(0) ,
+                                                dx.extent(1) ,
+                                                dx.extent(2) ,
+                                                dx.extent(3) );
     }
 
     const_dView0 const_dx = dx ;
@@ -1095,15 +1095,15 @@ public:
     ASSERT_FALSE( dy.ptr_on_device() == 0 );
     ASSERT_NE( dx , dy );
 
-    ASSERT_EQ( dx.dimension_0() , unsigned(N0) );
-    ASSERT_EQ( dx.dimension_1() , unsigned(N1) );
-    ASSERT_EQ( dx.dimension_2() , unsigned(N2) );
-    ASSERT_EQ( dx.dimension_3() , unsigned(N3) );
+    ASSERT_EQ( dx.extent(0) , unsigned(N0) );
+    ASSERT_EQ( dx.extent(1) , unsigned(N1) );
+    ASSERT_EQ( dx.extent(2) , unsigned(N2) );
+    ASSERT_EQ( dx.extent(3) , unsigned(N3) );
 
-    ASSERT_EQ( dy.dimension_0() , unsigned(N0) );
-    ASSERT_EQ( dy.dimension_1() , unsigned(N1) );
-    ASSERT_EQ( dy.dimension_2() , unsigned(N2) );
-    ASSERT_EQ( dy.dimension_3() , unsigned(N3) );
+    ASSERT_EQ( dy.extent(0) , unsigned(N0) );
+    ASSERT_EQ( dy.extent(1) , unsigned(N1) );
+    ASSERT_EQ( dy.extent(2) , unsigned(N2) );
+    ASSERT_EQ( dy.extent(3) , unsigned(N3) );
 
     ASSERT_EQ( unmanaged_from_ptr_dx.capacity(),unsigned(N0)*unsigned(N1)*unsigned(N2)*unsigned(N3) );
 
@@ -1113,15 +1113,15 @@ public:
     ASSERT_EQ( hx.rank() , dx.rank() );
     ASSERT_EQ( hy.rank() , dy.rank() );
 
-    ASSERT_EQ( hx.dimension_0() , unsigned(N0) );
-    ASSERT_EQ( hx.dimension_1() , unsigned(N1) );
-    ASSERT_EQ( hx.dimension_2() , unsigned(N2) );
-    ASSERT_EQ( hx.dimension_3() , unsigned(N3) );
+    ASSERT_EQ( hx.extent(0) , unsigned(N0) );
+    ASSERT_EQ( hx.extent(1) , unsigned(N1) );
+    ASSERT_EQ( hx.extent(2) , unsigned(N2) );
+    ASSERT_EQ( hx.extent(3) , unsigned(N3) );
 
-    ASSERT_EQ( hy.dimension_0() , unsigned(N0) );
-    ASSERT_EQ( hy.dimension_1() , unsigned(N1) );
-    ASSERT_EQ( hy.dimension_2() , unsigned(N2) );
-    ASSERT_EQ( hy.dimension_3() , unsigned(N3) );
+    ASSERT_EQ( hy.extent(0) , unsigned(N0) );
+    ASSERT_EQ( hy.extent(1) , unsigned(N1) );
+    ASSERT_EQ( hy.extent(2) , unsigned(N2) );
+    ASSERT_EQ( hy.extent(3) , unsigned(N3) );
 
     // T v1 = hx() ;    // Generates compile error as intended
     // T v2 = hx(0,0) ; // Generates compile error as intended
@@ -1132,9 +1132,9 @@ public:
     {
       size_t count = 0 ;
       for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
-      for ( size_t i1 = 0 ; i1 < hx.dimension_1() ; ++i1 ) {
-      for ( size_t i2 = 0 ; i2 < hx.dimension_2() ; ++i2 ) {
-      for ( size_t i3 = 0 ; i3 < hx.dimension_3() ; ++i3 ) {
+      for ( size_t i1 = 0 ; i1 < hx.extent(1) ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < hx.extent(2) ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < hx.extent(3) ; ++i3 ) {
         hx(ip,i1,i2,i3) = ++count ;
       }}}}
 
@@ -1165,9 +1165,9 @@ public:
     {
       size_t count = 0 ;
       for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
-      for ( size_t i1 = 0 ; i1 < hx.dimension_1() ; ++i1 ) {
-      for ( size_t i2 = 0 ; i2 < hx.dimension_2() ; ++i2 ) {
-      for ( size_t i3 = 0 ; i3 < hx.dimension_3() ; ++i3 ) {
+      for ( size_t i1 = 0 ; i1 < hx.extent(1) ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < hx.extent(2) ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < hx.extent(3) ; ++i3 ) {
         hx(ip,i1,i2,i3) = ++count ;
       }}}}
 
@@ -1198,9 +1198,9 @@ public:
     {
       size_t count = 0 ;
       for ( size_t ip = 0 ; ip < N0 ; ++ip ) {
-      for ( size_t i1 = 0 ; i1 < hx.dimension_1() ; ++i1 ) {
-      for ( size_t i2 = 0 ; i2 < hx.dimension_2() ; ++i2 ) {
-      for ( size_t i3 = 0 ; i3 < hx.dimension_3() ; ++i3 ) {
+      for ( size_t i1 = 0 ; i1 < hx.extent(1) ; ++i1 ) {
+      for ( size_t i2 = 0 ; i2 < hx.extent(2) ; ++i2 ) {
+      for ( size_t i3 = 0 ; i3 < hx.extent(3) ; ++i3 ) {
         hx(ip,i1,i2,i3) = ++count ;
       }}}}
 
@@ -1259,16 +1259,16 @@ public:
       { ASSERT_EQ( hvxx(i) , hdxx(i) ); }
 
     ASSERT_EQ( rank(hdxx) , rank(hvxx) );
-    ASSERT_EQ( hdxx.dimension_0() , testdim );
-    ASSERT_EQ( hdxx.dimension_0() , hvxx.dimension_0() );
+    ASSERT_EQ( hdxx.extent(0) , testdim );
+    ASSERT_EQ( hdxx.extent(0) , hvxx.extent(0) );
 
     // deep_copy from dynrankview to view
     View1 vdxx("vdxx",testdim);
     auto hvdxx = Kokkos::create_mirror_view(vdxx);
     Kokkos::deep_copy(hvdxx , hdxx);
     ASSERT_EQ( rank(hdxx) , rank(hvdxx) );
-    ASSERT_EQ( hvdxx.dimension_0() , testdim );
-    ASSERT_EQ( hdxx.dimension_0() , hvdxx.dimension_0() );
+    ASSERT_EQ( hvdxx.extent(0) , testdim );
+    ASSERT_EQ( hdxx.extent(0) , hvdxx.extent(0) );
     for (int i = 0; i < testdim; ++i)
       { ASSERT_EQ( hvxx(i) , hvdxx(i) ); }
   }
@@ -1386,12 +1386,12 @@ public:
 //   (i.e. rank 7 rather than 5).
 
 // Check LayoutRight dr5 and LayoutStride d5 dimensions agree (as they should) 
-    ASSERT_EQ( d5.dimension_0() , dr5.dimension_0() );
-    ASSERT_EQ( d5.dimension_1() , dr5.dimension_1() );
-    ASSERT_EQ( d5.dimension_2() , dr5.dimension_2() );
-    ASSERT_EQ( d5.dimension_3() , dr5.dimension_3() );
-    ASSERT_EQ( d5.dimension_4() , dr5.dimension_4() );
-    ASSERT_EQ( d5.dimension_5() , dr5.dimension_5() );
+    ASSERT_EQ( d5.extent(0) , dr5.extent(0) );
+    ASSERT_EQ( d5.extent(1) , dr5.extent(1) );
+    ASSERT_EQ( d5.extent(2) , dr5.extent(2) );
+    ASSERT_EQ( d5.extent(3) , dr5.extent(3) );
+    ASSERT_EQ( d5.extent(4) , dr5.extent(4) );
+    ASSERT_EQ( d5.extent(5) , dr5.extent(5) );
     ASSERT_EQ( d5.rank() , dr5.rank() );
 
 // Rank 5 subview of rank 5 dynamic rank view, layout stride input
@@ -1404,9 +1404,9 @@ public:
     sdView ds5plus = Kokkos::subdynrankview( d5 , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::ALL() , Kokkos::pair<unsigned,unsigned>(0,1) , Kokkos::ALL() );
 
     ASSERT_EQ( ds5.rank() , ds5plus.rank() );
-    ASSERT_EQ( ds5.dimension_0() , ds5plus.dimension_0() );
-    ASSERT_EQ( ds5.dimension_4() , ds5plus.dimension_4() );
-    ASSERT_EQ( ds5.dimension_5() , ds5plus.dimension_5() );
+    ASSERT_EQ( ds5.extent(0) , ds5plus.extent(0) );
+    ASSERT_EQ( ds5.extent(4) , ds5plus.extent(4) );
+    ASSERT_EQ( ds5.extent(5) , ds5plus.extent(5) );
 
 #if ! defined( KOKKOS_ENABLE_CUDA ) || defined ( KOKKOS_ENABLE_CUDA_UVM )
     ASSERT_EQ( & ds5(1,1,1,1,0) - & ds5plus(1,1,1,1,0) , 0 );
@@ -1420,9 +1420,9 @@ public:
 
     ASSERT_EQ( ds4.rank() , ds4plus.rank() );
     ASSERT_EQ( ds4.rank() , 4 );
-    ASSERT_EQ( ds4.dimension_0() , ds4plus.dimension_0() );
-    ASSERT_EQ( ds4.dimension_4() , ds4plus.dimension_4() );
-    ASSERT_EQ( ds4.dimension_5() , ds4plus.dimension_5() );
+    ASSERT_EQ( ds4.extent(0) , ds4plus.extent(0) );
+    ASSERT_EQ( ds4.extent(4) , ds4plus.extent(4) );
+    ASSERT_EQ( ds4.extent(5) , ds4plus.extent(5) );
   }
 
   static void run_test_subview_strided()
@@ -1440,11 +1440,11 @@ public:
     drview_stride yr1 = Kokkos::subdynrankview( xr2 , 0 , Kokkos::ALL() );
     drview_stride yr2 = Kokkos::subdynrankview( xr2 , 1 , Kokkos::ALL() );
 
-    ASSERT_EQ( yl1.dimension_0() , xl2.dimension_1() );
-    ASSERT_EQ( yl2.dimension_0() , xl2.dimension_1() );
+    ASSERT_EQ( yl1.extent(0) , xl2.extent(1) );
+    ASSERT_EQ( yl2.extent(0) , xl2.extent(1) );
 
-    ASSERT_EQ( yr1.dimension_0() , xr2.dimension_1() );
-    ASSERT_EQ( yr2.dimension_0() , xr2.dimension_1() );
+    ASSERT_EQ( yr1.extent(0) , xr2.extent(1) );
+    ASSERT_EQ( yr2.extent(0) , xr2.extent(1) );
 
     ASSERT_EQ( & yl1(0) - & xl2(0,0) , 0 );
     ASSERT_EQ( & yl2(0) - & xl2(1,0) , 0 );
@@ -1459,10 +1459,10 @@ public:
     drview_stride yl4 = Kokkos::subview( xl4 , 1 , Kokkos::ALL() , 2 , Kokkos::ALL() );
     drview_stride yr4 = Kokkos::subview( xr4 , 1 , Kokkos::ALL() , 2 , Kokkos::ALL() );
 
-    ASSERT_EQ( yl4.dimension_0() , xl4.dimension_1() );
-    ASSERT_EQ( yl4.dimension_1() , xl4.dimension_3() );
-    ASSERT_EQ( yr4.dimension_0() , xr4.dimension_1() );
-    ASSERT_EQ( yr4.dimension_1() , xr4.dimension_3() );
+    ASSERT_EQ( yl4.extent(0) , xl4.extent(1) );
+    ASSERT_EQ( yl4.extent(1) , xl4.extent(3) );
+    ASSERT_EQ( yr4.extent(0) , xr4.extent(1) );
+    ASSERT_EQ( yr4.extent(1) , xr4.extent(3) );
     ASSERT_EQ( yl4.rank() , 2);
     ASSERT_EQ( yr4.rank() , 2);
 

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -81,7 +81,7 @@ void test_scatter_view_config(int n)
   }
 #if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
   auto host_view = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), original_view);
-  for (typename decltype(host_view)::size_type i = 0; i < host_view.dimension_0(); ++i) {
+  for (typename decltype(host_view)::size_type i = 0; i < host_view.extent(0); ++i) {
     auto val0 = host_view(i, 0);
     auto val1 = host_view(i, 1);
     auto val2 = host_view(i, 2);

--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -73,7 +73,7 @@ void run_test_graph()
   dx = Kokkos::create_staticcrsgraph<dView>( "dx" , graph );
   hx = Kokkos::create_mirror( dx );
 
-  ASSERT_EQ( hx.row_map.dimension_0() - 1 , LENGTH );
+  ASSERT_EQ( hx.row_map.extent(0) - 1 , LENGTH );
 
   for ( size_t i = 0 ; i < LENGTH ; ++i ) {
     const size_t begin = hx.row_map[i];
@@ -115,17 +115,17 @@ void run_test_graph2()
   hView hx = Kokkos::create_mirror( dx );
   hView mx = Kokkos::create_mirror( dx );
 
-  ASSERT_EQ( (size_t) dx.row_map.dimension_0() , (size_t) LENGTH + 1 );
-  ASSERT_EQ( (size_t) hx.row_map.dimension_0() , (size_t) LENGTH + 1 );
-  ASSERT_EQ( (size_t) mx.row_map.dimension_0() , (size_t) LENGTH + 1 );
+  ASSERT_EQ( (size_t) dx.row_map.extent(0) , (size_t) LENGTH + 1 );
+  ASSERT_EQ( (size_t) hx.row_map.extent(0) , (size_t) LENGTH + 1 );
+  ASSERT_EQ( (size_t) mx.row_map.extent(0) , (size_t) LENGTH + 1 );
 
-  ASSERT_EQ( (size_t) dx.entries.dimension_0() , (size_t) total_length );
-  ASSERT_EQ( (size_t) hx.entries.dimension_0() , (size_t) total_length );
-  ASSERT_EQ( (size_t) mx.entries.dimension_0() , (size_t) total_length );
+  ASSERT_EQ( (size_t) dx.entries.extent(0) , (size_t) total_length );
+  ASSERT_EQ( (size_t) hx.entries.extent(0) , (size_t) total_length );
+  ASSERT_EQ( (size_t) mx.entries.extent(0) , (size_t) total_length );
 
-  ASSERT_EQ( (size_t) dx.entries.dimension_1() , (size_t) 3 );
-  ASSERT_EQ( (size_t) hx.entries.dimension_1() , (size_t) 3 );
-  ASSERT_EQ( (size_t) mx.entries.dimension_1() , (size_t) 3 );
+  ASSERT_EQ( (size_t) dx.entries.extent(1) , (size_t) 3 );
+  ASSERT_EQ( (size_t) hx.entries.extent(1) , (size_t) 3 );
+  ASSERT_EQ( (size_t) mx.entries.extent(1) , (size_t) 3 );
 
   for ( size_t i = 0 ; i < LENGTH ; ++i ) {
     const size_t entry_begin = hx.row_map[i];
@@ -140,7 +140,7 @@ void run_test_graph2()
   Kokkos::deep_copy( dx.entries , hx.entries );
   Kokkos::deep_copy( mx.entries , dx.entries );
 
-  ASSERT_EQ( mx.row_map.dimension_0() , (size_t) LENGTH + 1 );
+  ASSERT_EQ( mx.row_map.extent(0) , (size_t) LENGTH + 1 );
 
   for ( size_t i = 0 ; i < LENGTH ; ++i ) {
     const size_t entry_begin = mx.row_map[i];

--- a/core/perf_test/PerfTestBlasKernels.hpp
+++ b/core/perf_test/PerfTestBlasKernels.hpp
@@ -76,7 +76,7 @@ void axpby( const ConstScalarType & alpha ,
 {
   typedef AXPBY< ConstScalarType , ConstVectorType , VectorType > functor ;
 
-  parallel_for( Y.dimension_0() , functor( alpha , X , beta , Y ) );
+  parallel_for( Y.extent(0) , functor( alpha , X , beta , Y ) );
 }
 
 /** \brief  Y *= alpha */
@@ -86,7 +86,7 @@ void scale( const ConstScalarType & alpha , const VectorType & Y )
 {
   typedef Scale< ConstScalarType , VectorType > functor ;
 
-  parallel_for( Y.dimension_0() , functor( alpha , Y ) );
+  parallel_for( Y.extent(0) , functor( alpha , Y ) );
 }
 
 template< class ConstVectorType ,
@@ -97,7 +97,7 @@ void dot( const ConstVectorType & X ,
 {
   typedef Dot< ConstVectorType >  functor ;
 
-  parallel_reduce( X.dimension_0() , functor( X , Y ) , finalize );
+  parallel_reduce( X.extent(0) , functor( X , Y ) , finalize );
 }
 
 template< class ConstVectorType ,
@@ -107,7 +107,7 @@ void dot( const ConstVectorType & X ,
 {
   typedef DotSingle< ConstVectorType >  functor ;
 
-  parallel_reduce( X.dimension_0() , functor( X ) , finalize );
+  parallel_reduce( X.extent(0) , functor( X ) , finalize );
 }
 
 } /* namespace Kokkos */

--- a/core/perf_test/PerfTestGramSchmidt.cpp
+++ b/core/perf_test/PerfTestGramSchmidt.cpp
@@ -86,7 +86,7 @@ void invnorm2( const VectorView & x ,
                const ValueView  & r ,
                const ValueView  & r_inv )
 {
-  Kokkos::parallel_reduce( x.dimension_0() , InvNorm2< VectorView , ValueView >( x , r , r_inv ) );
+  Kokkos::parallel_reduce( x.extent(0) , InvNorm2< VectorView , ValueView >( x , r , r_inv ) );
 }
 
 // PostProcess : tmp = - ( R(j,k) = result );
@@ -122,7 +122,7 @@ void dot_neg( const VectorView & x ,
               const ValueView  & r ,
               const ValueView  & r_neg )
 {
-  Kokkos::parallel_reduce( x.dimension_0() , DotM< VectorView , ValueView >( x , y , r , r_neg ) );
+  Kokkos::parallel_reduce( x.extent(0) , DotM< VectorView , ValueView >( x , y , r , r_neg ) );
 }
 
 
@@ -151,7 +151,7 @@ struct ModifiedGramSchmidt
   static double factorization( const multivector_type Q_ ,
                                const multivector_type R_ )
   {
-    const size_type count  = Q_.dimension_1();
+    const size_type count  = Q_.extent(1);
     value_view tmp("tmp");
     value_view one("one");
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -862,7 +862,7 @@ public:
   : m_functor( arg_functor )
   , m_policy(  arg_policy )
   , m_reducer( InvalidType() )
-  , m_result_ptr( arg_result.ptr_on_device() )
+  , m_result_ptr( arg_result.data() )
   , m_scratch_space( 0 )
   , m_scratch_flags( 0 )
   , m_unified_space( 0 )
@@ -874,7 +874,7 @@ public:
   : m_functor( arg_functor )
   , m_policy(  arg_policy )
   , m_reducer( reducer )
-  , m_result_ptr( reducer.view().ptr_on_device() )
+  , m_result_ptr( reducer.view().data() )
   , m_scratch_space( 0 )
   , m_scratch_flags( 0 )
   , m_unified_space( 0 )
@@ -1088,7 +1088,7 @@ public:
   : m_functor( arg_functor )
   , m_policy(  arg_policy )
   , m_reducer( InvalidType() )
-  , m_result_ptr( arg_result.ptr_on_device() )
+  , m_result_ptr( arg_result.data() )
   , m_scratch_space( 0 )
   , m_scratch_flags( 0 )
   , m_unified_space( 0 )
@@ -1100,7 +1100,7 @@ public:
   : m_functor( arg_functor )
   , m_policy(  arg_policy )
   , m_reducer( reducer )
-  , m_result_ptr( reducer.view().ptr_on_device() )
+  , m_result_ptr( reducer.view().data() )
   , m_scratch_space( 0 )
   , m_scratch_flags( 0 )
   , m_unified_space( 0 )
@@ -1342,7 +1342,7 @@ public:
                                 ,void*>::type = NULL)
   : m_functor( arg_functor )
   , m_reducer( InvalidType() )
-  , m_result_ptr( arg_result.ptr_on_device() )
+  , m_result_ptr( arg_result.data() )
   , m_scratch_space( 0 )
   , m_scratch_flags( 0 )
   , m_unified_space( 0 )
@@ -1369,7 +1369,7 @@ public:
   {
     // Return Init value if the number of worksets is zero
     if( arg_policy.league_size() == 0) {
-      ValueInit::init( ReducerConditional::select(m_functor , m_reducer) , arg_result.ptr_on_device() );
+      ValueInit::init( ReducerConditional::select(m_functor , m_reducer) , arg_result.data() );
       return ;
     }
 
@@ -1412,7 +1412,7 @@ public:
                 , const ReducerType & reducer)
   : m_functor( arg_functor )
   , m_reducer( reducer )
-  , m_result_ptr( reducer.view().ptr_on_device() )
+  , m_result_ptr( reducer.view().data() )
   , m_scratch_space( 0 )
   , m_scratch_flags( 0 )
   , m_unified_space( 0 )

--- a/core/src/Kokkos_Crs.hpp
+++ b/core/src/Kokkos_Crs.hpp
@@ -130,8 +130,8 @@ public:
    */
   KOKKOS_INLINE_FUNCTION
   size_type numRows() const {
-    return (row_map.dimension_0 () != 0) ?
-      row_map.dimension_0 () - static_cast<size_type> (1) :
+    return (row_map.extent(0) != 0) ?
+      row_map.extent(0) - static_cast<size_type> (1) :
       static_cast<size_type> (0);
   }
 };
@@ -359,7 +359,7 @@ struct CountAndFillBase {
        we could compare to row_map(i + 1), but that is a read from global memory,
        whereas dimension_0() should be part of the View in registers (or constant memory) */
     data_type* fill =
-      (j == static_cast<decltype(j)>(m_crs.entries.dimension_0())) ?
+      (j == static_cast<decltype(j)>(m_crs.entries.extent(0))) ?
       nullptr : (&(m_crs.entries(j)));
     m_functor(i, fill);
   }
@@ -393,7 +393,7 @@ struct CountAndFillBase<CrsType, Functor, Kokkos::Cuda> {
        we could compare to row_map(i + 1), but that is a read from global memory,
        whereas dimension_0() should be part of the View in registers (or constant memory) */
     data_type* fill =
-      (j == static_cast<decltype(j)>(m_crs.entries.dimension_0())) ?
+      (j == static_cast<decltype(j)>(m_crs.entries.extent(0))) ?
       nullptr : (&(m_crs.entries(j)));
     m_functor(i, fill);
   }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -524,6 +524,8 @@ public:
    *  ISO/C++ vocabulary 'extent'.
    */
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+
   template< typename iType >
   KOKKOS_INLINE_FUNCTION constexpr
   typename std::enable_if< std::is_integral<iType>::value , size_t >::type
@@ -537,6 +539,8 @@ public:
   KOKKOS_INLINE_FUNCTION constexpr size_t dimension_5() const { return m_map.dimension_5(); }
   KOKKOS_INLINE_FUNCTION constexpr size_t dimension_6() const { return m_map.dimension_6(); }
   KOKKOS_INLINE_FUNCTION constexpr size_t dimension_7() const { return m_map.dimension_7(); }
+
+#endif
 
   //----------------------------------------
 
@@ -584,15 +588,19 @@ public:
   enum { reference_type_is_lvalue_reference = std::is_lvalue_reference< reference_type >::value };
 
   KOKKOS_INLINE_FUNCTION constexpr size_t span() const { return m_map.span(); }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   // Deprecated, use 'span()' instead
   KOKKOS_INLINE_FUNCTION constexpr size_t capacity() const { return m_map.span(); }
+#endif
   KOKKOS_INLINE_FUNCTION bool span_is_contiguous() const { return m_map.span_is_contiguous(); }
   KOKKOS_INLINE_FUNCTION constexpr pointer_type data() const { return m_map.data(); }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   // Deprecated, use 'span_is_contigous()' instead
   KOKKOS_INLINE_FUNCTION constexpr bool   is_contiguous() const { return m_map.span_is_contiguous(); }
   // Deprecated, use 'data()' instead
   KOKKOS_INLINE_FUNCTION constexpr pointer_type ptr_on_device() const { return m_map.data(); }
+#endif
 
   //----------------------------------------
   // Allow specializations to query their specialized map
@@ -1550,14 +1558,14 @@ bool operator == ( const View<LT,LP...> & lhs ,
     unsigned(lhs_traits::rank) == unsigned(rhs_traits::rank) &&
     lhs.data()        == rhs.data() &&
     lhs.span()        == rhs.span() &&
-    lhs.dimension_0() == rhs.dimension_0() &&
-    lhs.dimension_1() == rhs.dimension_1() &&
-    lhs.dimension_2() == rhs.dimension_2() &&
-    lhs.dimension_3() == rhs.dimension_3() &&
-    lhs.dimension_4() == rhs.dimension_4() &&
-    lhs.dimension_5() == rhs.dimension_5() &&
-    lhs.dimension_6() == rhs.dimension_6() &&
-    lhs.dimension_7() == rhs.dimension_7();
+    lhs.extent(0) == rhs.extent(0) &&
+    lhs.extent(1) == rhs.extent(1) &&
+    lhs.extent(2) == rhs.extent(2) &&
+    lhs.extent(3) == rhs.extent(3) &&
+    lhs.extent(4) == rhs.extent(4) &&
+    lhs.extent(5) == rhs.extent(5) &&
+    lhs.extent(6) == rhs.extent(6) &&
+    lhs.extent(7) == rhs.extent(7);
 }
 
 template< class LT , class ... LP , class RT , class ... RP >
@@ -1648,14 +1656,14 @@ create_mirror( const Kokkos::View<T,P...> & src
   typedef typename src_type::HostMirror  dst_type ;
 
   return dst_type( std::string( src.label() ).append("_mirror")
-                 , src.dimension_0()
-                 , src.dimension_1()
-                 , src.dimension_2()
-                 , src.dimension_3()
-                 , src.dimension_4()
-                 , src.dimension_5()
-                 , src.dimension_6()
-                 , src.dimension_7() );
+                 , src.extent(0)
+                 , src.extent(1)
+                 , src.extent(2)
+                 , src.extent(3)
+                 , src.extent(4)
+                 , src.extent(5)
+                 , src.extent(6)
+                 , src.extent(7) );
 }
 
 template< class T , class ... P >
@@ -1673,14 +1681,14 @@ create_mirror( const Kokkos::View<T,P...> & src
 
   Kokkos::LayoutStride layout ;
 
-  layout.dimension[0] = src.dimension_0();
-  layout.dimension[1] = src.dimension_1();
-  layout.dimension[2] = src.dimension_2();
-  layout.dimension[3] = src.dimension_3();
-  layout.dimension[4] = src.dimension_4();
-  layout.dimension[5] = src.dimension_5();
-  layout.dimension[6] = src.dimension_6();
-  layout.dimension[7] = src.dimension_7();
+  layout.dimension[0] = src.extent(0);
+  layout.dimension[1] = src.extent(1);
+  layout.dimension[2] = src.extent(2);
+  layout.dimension[3] = src.extent(3);
+  layout.dimension[4] = src.extent(4);
+  layout.dimension[5] = src.extent(5);
+  layout.dimension[6] = src.extent(6);
+  layout.dimension[7] = src.extent(7);
 
   layout.stride[0] = src.stride_0();
   layout.stride[1] = src.stride_1();

--- a/core/unit_test/TestAtomicViews.hpp
+++ b/core/unit_test/TestAtomicViews.hpp
@@ -119,7 +119,7 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 1 >
   KOKKOS_INLINE_FUNCTION
   void operator()( const size_type, value_type & update ) const
   {
-    for ( unsigned i0 = 0; i0 < unsigned( left.dimension_0() ); ++i0 )
+    for ( unsigned i0 = 0; i0 < unsigned( left.extent(0) ); ++i0 )
     {
       // Below checks that values match, but unable to check the references.
       // Should this be able to be checked?
@@ -228,7 +228,7 @@ public:
     ASSERT_EQ( ax.use_count(), size_t( 3 ) );
 
     aView4_unmanaged unmanaged_ax_from_ptr_dx =
-      aView4_unmanaged( dx.data(), dx.dimension_0(), dx.dimension_1(), dx.dimension_2(), dx.dimension_3() );
+      aView4_unmanaged( dx.data(), dx.extent(0), dx.extent(1), dx.extent(2), dx.extent(3) );
     ASSERT_EQ( ax.use_count(), size_t( 3 ) );
 
     const_aView4 const_ax = ax;
@@ -244,17 +244,17 @@ public:
 //    Above test results in following runtime error from gtest:
 //    Expected: (ax) != (ay), actual: 32-byte object <30-01 D0-A0 D8-7F 00-00 00-31 44-0C 01-00 00-00 E8-03 00-00 00-00 00-00 69-00 00-00 00-00 00-00> vs 32-byte object <80-01 D0-A0 D8-7F 00-00 00-A1 4A-0C 01-00 00-00 E8-03 00-00 00-00 00-00 69-00 00-00 00-00 00-00>
 
-    ASSERT_EQ( ax.dimension_0(), unsigned( N0 ) );
-    ASSERT_EQ( ax.dimension_1(), unsigned( N1 ) );
-    ASSERT_EQ( ax.dimension_2(), unsigned( N2 ) );
-    ASSERT_EQ( ax.dimension_3(), unsigned( N3 ) );
+    ASSERT_EQ( ax.extent(0), unsigned( N0 ) );
+    ASSERT_EQ( ax.extent(1), unsigned( N1 ) );
+    ASSERT_EQ( ax.extent(2), unsigned( N2 ) );
+    ASSERT_EQ( ax.extent(3), unsigned( N3 ) );
 
-    ASSERT_EQ( ay.dimension_0(), unsigned( N0 ) );
-    ASSERT_EQ( ay.dimension_1(), unsigned( N1 ) );
-    ASSERT_EQ( ay.dimension_2(), unsigned( N2 ) );
-    ASSERT_EQ( ay.dimension_3(), unsigned( N3 ) );
+    ASSERT_EQ( ay.extent(0), unsigned( N0 ) );
+    ASSERT_EQ( ay.extent(1), unsigned( N1 ) );
+    ASSERT_EQ( ay.extent(2), unsigned( N2 ) );
+    ASSERT_EQ( ay.extent(3), unsigned( N3 ) );
 
-    ASSERT_EQ( unmanaged_ax_from_ptr_dx.capacity(), unsigned( N0 ) * unsigned( N1 ) * unsigned( N2 ) * unsigned( N3 ) );
+    ASSERT_EQ( unmanaged_ax_from_ptr_dx.span(), unsigned( N0 ) * unsigned( N1 ) * unsigned( N2 ) * unsigned( N3 ) );
   }
 
   typedef T DataType[2];

--- a/core/unit_test/TestCompilerMacros.hpp
+++ b/core/unit_test/TestCompilerMacros.hpp
@@ -67,7 +67,7 @@ struct AddFunctor {
   type a, b;
   int length;
 
-  AddFunctor( type a_, type b_ ) : a( a_ ), b( b_ ), length( a.dimension_1() ) {}
+  AddFunctor( type a_, type b_ ) : a( a_ ), b( b_ ), length( a.extent(1) ) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()( int i ) const {

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -453,10 +453,10 @@ public:
 
       std::string str( "TestKernelReduce" );
       if ( count % 2 == 0 ) {
-        Kokkos::parallel_reduce( nw, functor_type( nw, count ), host_result.ptr_on_device() );
+        Kokkos::parallel_reduce( nw, functor_type( nw, count ), host_result.data() );
       }
       else {
-        Kokkos::parallel_reduce( str, nw, functor_type( nw, count ), host_result.ptr_on_device() );
+        Kokkos::parallel_reduce( str, nw, functor_type( nw, count ), host_result.data() );
       }
 
       for ( unsigned j = 0; j < count; ++j ) {

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -339,7 +339,7 @@ public:
 
     const long int thread_rank = ind.team_rank() +
                                  ind.team_size() * ind.league_rank();
-    ind.team_scan( 1 + thread_rank, accum.ptr_on_device() );
+    ind.team_scan( 1 + thread_rank, accum.data() );
   }
 };
 
@@ -426,8 +426,8 @@ struct SharedTeamFunctor {
     const shared_int_array_type shared_A( ind.team_shmem(), SHARED_COUNT );
     const shared_int_array_type shared_B( ind.team_shmem(), SHARED_COUNT );
 
-    if ( ( shared_A.ptr_on_device () == NULL && SHARED_COUNT > 0 ) ||
-         ( shared_B.ptr_on_device () == NULL && SHARED_COUNT > 0 ) )
+    if ( ( shared_A.data() == nullptr && SHARED_COUNT > 0 ) ||
+         ( shared_B.data() == nullptr && SHARED_COUNT > 0 ) )
     {
       printf ("member( %d/%d , %d/%d ) Failed to allocate shared memory of size %lu\n"
              , ind.league_rank()
@@ -526,8 +526,8 @@ struct TestLambdaSharedTeam {
       const shared_int_array_type shared_A( ind.team_shmem(), SHARED_COUNT );
       const shared_int_array_type shared_B( ind.team_shmem(), SHARED_COUNT );
 
-      if ( ( shared_A.ptr_on_device () == NULL && SHARED_COUNT > 0 ) ||
-           ( shared_B.ptr_on_device () == NULL && SHARED_COUNT > 0 ) )
+      if ( ( shared_A.data () == nullptr && SHARED_COUNT > 0 ) ||
+           ( shared_B.data () == nullptr && SHARED_COUNT > 0 ) )
       {
         printf( "Failed to allocate shared memory of size %lu\n",
                 static_cast<unsigned long>( SHARED_COUNT ) );
@@ -588,9 +588,9 @@ struct ScratchTeamFunctor {
     const shared_int_array_type scratch_A( ind.team_scratch( 1 ), SHARED_TEAM_COUNT );
     const shared_int_array_type scratch_B( ind.thread_scratch( 1 ), SHARED_THREAD_COUNT );
 
-    if ( ( scratch_ptr.ptr_on_device () == NULL ) ||
-         ( scratch_A.  ptr_on_device () == NULL && SHARED_TEAM_COUNT > 0 ) ||
-         ( scratch_B.  ptr_on_device () == NULL && SHARED_THREAD_COUNT > 0 ) )
+    if ( ( scratch_ptr.data() == nullptr ) ||
+         ( scratch_A.  data() == nullptr && SHARED_TEAM_COUNT > 0 ) ||
+         ( scratch_B.  data() == nullptr && SHARED_THREAD_COUNT > 0 ) )
     {
       printf( "Failed to allocate shared memory of size %lu\n",
               static_cast<unsigned long>( SHARED_TEAM_COUNT ) );
@@ -606,8 +606,8 @@ struct ScratchTeamFunctor {
         scratch_B[i] = 10000 * ind.league_rank() + 100 * ind.team_rank() + i;
       }
 
-      scratch_ptr[ind.team_rank()] = (size_t) scratch_A.ptr_on_device();
-      scratch_ptr[ind.team_rank() + ind.team_size()] = (size_t) scratch_B.ptr_on_device();
+      scratch_ptr[ind.team_rank()] = (size_t) scratch_A.data();
+      scratch_ptr[ind.team_rank() + ind.team_size()] = (size_t) scratch_B.data();
 
       ind.team_barrier();
 

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -203,7 +203,7 @@ struct functor_team_for {
     const size_type shmemSize = team.team_size() * 13;
     shared_int values = shared_int( team.team_shmem(), shmemSize );
 
-    if ( values.ptr_on_device() == NULL || values.dimension_0() < shmemSize ) {
+    if ( values.data() == nullptr || values.extent(0) < shmemSize ) {
       printf( "FAILED to allocate shared memory of size %u\n",
               static_cast<unsigned int>( shmemSize ) );
     }
@@ -352,7 +352,7 @@ struct functor_team_vector_for {
     const size_type shmemSize = team.team_size() * 13;
     shared_int values = shared_int( team.team_shmem(), shmemSize );
 
-    if ( values.ptr_on_device() == NULL || values.dimension_0() < shmemSize ) {
+    if ( values.data() == nullptr || values.extent(0) < shmemSize ) {
       printf( "FAILED to allocate shared memory of size %u\n",
               static_cast<unsigned int>( shmemSize ) );
     }
@@ -542,7 +542,7 @@ struct functor_vec_for {
 
     shared_int values = shared_int( team.team_shmem(), team.team_size() * 13 );
 
-    if ( values.ptr_on_device() == NULL || values.dimension_0() < (unsigned) team.team_size() * 13 ) {
+    if ( values.data() == nullptr || values.extent(0) < (unsigned) team.team_size() * 13 ) {
       printf( "FAILED to allocate memory of size %i\n", static_cast<int>( team.team_size() * 13 ) );
       flag() = 1;
     }

--- a/core/unit_test/TestTile.hpp
+++ b/core/unit_test/TestTile.hpp
@@ -73,10 +73,10 @@ struct ReduceTileErrors
   KOKKOS_INLINE_FUNCTION
   void operator()( size_t iwork ) const
   {
-    const size_t i = iwork % m_array.dimension_0();
-    const size_t j = iwork / m_array.dimension_0();
+    const size_t i = iwork % m_array.extent(0);
+    const size_t j = iwork / m_array.extent(0);
 
-    if ( j < m_array.dimension_1() ) {
+    if ( j < m_array.extent(1) ) {
       m_array( i, j ) = &m_array( i, j ) - &m_array( 0, 0 );
 
       //printf( "m_array(%d, %d) = %d\n", int( i ), int( j ), int( m_array( i, j ) ) );
@@ -87,8 +87,8 @@ struct ReduceTileErrors
   KOKKOS_INLINE_FUNCTION
   void operator()( size_t iwork, value_type & errors ) const
   {
-    const size_t tile_dim0 = ( m_array.dimension_0() + TileLayout::N0 - 1 ) / TileLayout::N0;
-    const size_t tile_dim1 = ( m_array.dimension_1() + TileLayout::N1 - 1 ) / TileLayout::N1;
+    const size_t tile_dim0 = ( m_array.extent(0) + TileLayout::N0 - 1 ) / TileLayout::N0;
+    const size_t tile_dim1 = ( m_array.extent(1) + TileLayout::N1 - 1 ) / TileLayout::N1;
 
     const size_t itile = iwork % tile_dim0;
     const size_t jtile = iwork / tile_dim0;
@@ -105,7 +105,7 @@ struct ReduceTileErrors
             const size_t iglobal = i + itile * TileLayout::N0;
             const size_t jglobal = j + jtile * TileLayout::N1;
 
-            if ( iglobal < m_array.dimension_0() && jglobal < m_array.dimension_1() ) {
+            if ( iglobal < m_array.extent(0) && jglobal < m_array.extent(1) ) {
               if ( tile( i, j ) != ptrdiff_t( tile( 0, 0 ) + i + j * TileLayout::N0 ) ) ++errors;
 
               //printf( "tile(%d, %d)(%d, %d) = %d\n", int( itile ), int( jtile ), int( i ), int( j ), int( tile( i, j ) ) );

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -153,14 +153,14 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 8 >
   {
     long offset = -1;
 
-    for ( unsigned i7 = 0; i7 < unsigned( left.dimension_7() ); ++i7 )
-    for ( unsigned i6 = 0; i6 < unsigned( left.dimension_6() ); ++i6 )
-    for ( unsigned i5 = 0; i5 < unsigned( left.dimension_5() ); ++i5 )
-    for ( unsigned i4 = 0; i4 < unsigned( left.dimension_4() ); ++i4 )
-    for ( unsigned i3 = 0; i3 < unsigned( left.dimension_3() ); ++i3 )
-    for ( unsigned i2 = 0; i2 < unsigned( left.dimension_2() ); ++i2 )
-    for ( unsigned i1 = 0; i1 < unsigned( left.dimension_1() ); ++i1 )
-    for ( unsigned i0 = 0; i0 < unsigned( left.dimension_0() ); ++i0 )
+    for ( unsigned i7 = 0; i7 < unsigned( left.extent(7) ); ++i7 )
+    for ( unsigned i6 = 0; i6 < unsigned( left.extent(6) ); ++i6 )
+    for ( unsigned i5 = 0; i5 < unsigned( left.extent(5) ); ++i5 )
+    for ( unsigned i4 = 0; i4 < unsigned( left.extent(4) ); ++i4 )
+    for ( unsigned i3 = 0; i3 < unsigned( left.extent(3) ); ++i3 )
+    for ( unsigned i2 = 0; i2 < unsigned( left.extent(2) ); ++i2 )
+    for ( unsigned i1 = 0; i1 < unsigned( left.extent(1) ); ++i1 )
+    for ( unsigned i0 = 0; i0 < unsigned( left.extent(0) ); ++i0 )
     {
       const long j = & left( i0, i1, i2, i3, i4, i5, i6, i7 ) -
                      & left(  0,  0,  0,  0,  0,  0,  0,  0 );
@@ -175,14 +175,14 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 8 >
 
     offset = -1;
 
-    for ( unsigned i0 = 0; i0 < unsigned( right.dimension_0() ); ++i0 )
-    for ( unsigned i1 = 0; i1 < unsigned( right.dimension_1() ); ++i1 )
-    for ( unsigned i2 = 0; i2 < unsigned( right.dimension_2() ); ++i2 )
-    for ( unsigned i3 = 0; i3 < unsigned( right.dimension_3() ); ++i3 )
-    for ( unsigned i4 = 0; i4 < unsigned( right.dimension_4() ); ++i4 )
-    for ( unsigned i5 = 0; i5 < unsigned( right.dimension_5() ); ++i5 )
-    for ( unsigned i6 = 0; i6 < unsigned( right.dimension_6() ); ++i6 )
-    for ( unsigned i7 = 0; i7 < unsigned( right.dimension_7() ); ++i7 )
+    for ( unsigned i0 = 0; i0 < unsigned( right.extent(0) ); ++i0 )
+    for ( unsigned i1 = 0; i1 < unsigned( right.extent(1) ); ++i1 )
+    for ( unsigned i2 = 0; i2 < unsigned( right.extent(2) ); ++i2 )
+    for ( unsigned i3 = 0; i3 < unsigned( right.extent(3) ); ++i3 )
+    for ( unsigned i4 = 0; i4 < unsigned( right.extent(4) ); ++i4 )
+    for ( unsigned i5 = 0; i5 < unsigned( right.extent(5) ); ++i5 )
+    for ( unsigned i6 = 0; i6 < unsigned( right.extent(6) ); ++i6 )
+    for ( unsigned i7 = 0; i7 < unsigned( right.extent(7) ); ++i7 )
     {
       const long j = & right( i0, i1, i2, i3, i4, i5, i6, i7 ) -
                      & right(  0,  0,  0,  0,  0,  0,  0,  0 );
@@ -245,13 +245,13 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 7 >
   {
     long offset = -1;
 
-    for ( unsigned i6 = 0; i6 < unsigned( left.dimension_6() ); ++i6 )
-    for ( unsigned i5 = 0; i5 < unsigned( left.dimension_5() ); ++i5 )
-    for ( unsigned i4 = 0; i4 < unsigned( left.dimension_4() ); ++i4 )
-    for ( unsigned i3 = 0; i3 < unsigned( left.dimension_3() ); ++i3 )
-    for ( unsigned i2 = 0; i2 < unsigned( left.dimension_2() ); ++i2 )
-    for ( unsigned i1 = 0; i1 < unsigned( left.dimension_1() ); ++i1 )
-    for ( unsigned i0 = 0; i0 < unsigned( left.dimension_0() ); ++i0 )
+    for ( unsigned i6 = 0; i6 < unsigned( left.extent(6) ); ++i6 )
+    for ( unsigned i5 = 0; i5 < unsigned( left.extent(5) ); ++i5 )
+    for ( unsigned i4 = 0; i4 < unsigned( left.extent(4) ); ++i4 )
+    for ( unsigned i3 = 0; i3 < unsigned( left.extent(3) ); ++i3 )
+    for ( unsigned i2 = 0; i2 < unsigned( left.extent(2) ); ++i2 )
+    for ( unsigned i1 = 0; i1 < unsigned( left.extent(1) ); ++i1 )
+    for ( unsigned i0 = 0; i0 < unsigned( left.extent(0) ); ++i0 )
     {
       const long j = & left( i0, i1, i2, i3, i4, i5, i6 ) -
                      & left(  0,  0,  0,  0,  0,  0,  0 );
@@ -261,13 +261,13 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 7 >
 
     offset = -1;
 
-    for ( unsigned i0 = 0; i0 < unsigned( right.dimension_0() ); ++i0 )
-    for ( unsigned i1 = 0; i1 < unsigned( right.dimension_1() ); ++i1 )
-    for ( unsigned i2 = 0; i2 < unsigned( right.dimension_2() ); ++i2 )
-    for ( unsigned i3 = 0; i3 < unsigned( right.dimension_3() ); ++i3 )
-    for ( unsigned i4 = 0; i4 < unsigned( right.dimension_4() ); ++i4 )
-    for ( unsigned i5 = 0; i5 < unsigned( right.dimension_5() ); ++i5 )
-    for ( unsigned i6 = 0; i6 < unsigned( right.dimension_6() ); ++i6 )
+    for ( unsigned i0 = 0; i0 < unsigned( right.extent(0) ); ++i0 )
+    for ( unsigned i1 = 0; i1 < unsigned( right.extent(1) ); ++i1 )
+    for ( unsigned i2 = 0; i2 < unsigned( right.extent(2) ); ++i2 )
+    for ( unsigned i3 = 0; i3 < unsigned( right.extent(3) ); ++i3 )
+    for ( unsigned i4 = 0; i4 < unsigned( right.extent(4) ); ++i4 )
+    for ( unsigned i5 = 0; i5 < unsigned( right.extent(5) ); ++i5 )
+    for ( unsigned i6 = 0; i6 < unsigned( right.extent(6) ); ++i6 )
     {
       const long j = & right( i0, i1, i2, i3, i4, i5, i6 ) -
                      & right(  0,  0,  0,  0,  0,  0,  0 );
@@ -325,12 +325,12 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 6 >
   {
     long offset = -1;
 
-    for ( unsigned i5 = 0; i5 < unsigned( left.dimension_5() ); ++i5 )
-    for ( unsigned i4 = 0; i4 < unsigned( left.dimension_4() ); ++i4 )
-    for ( unsigned i3 = 0; i3 < unsigned( left.dimension_3() ); ++i3 )
-    for ( unsigned i2 = 0; i2 < unsigned( left.dimension_2() ); ++i2 )
-    for ( unsigned i1 = 0; i1 < unsigned( left.dimension_1() ); ++i1 )
-    for ( unsigned i0 = 0; i0 < unsigned( left.dimension_0() ); ++i0 )
+    for ( unsigned i5 = 0; i5 < unsigned( left.extent(5) ); ++i5 )
+    for ( unsigned i4 = 0; i4 < unsigned( left.extent(4) ); ++i4 )
+    for ( unsigned i3 = 0; i3 < unsigned( left.extent(3) ); ++i3 )
+    for ( unsigned i2 = 0; i2 < unsigned( left.extent(2) ); ++i2 )
+    for ( unsigned i1 = 0; i1 < unsigned( left.extent(1) ); ++i1 )
+    for ( unsigned i0 = 0; i0 < unsigned( left.extent(0) ); ++i0 )
     {
       const long j = & left( i0, i1, i2, i3, i4, i5 ) -
                      & left(  0,  0,  0,  0,  0,  0 );
@@ -340,12 +340,12 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 6 >
 
     offset = -1;
 
-    for ( unsigned i0 = 0; i0 < unsigned( right.dimension_0() ); ++i0 )
-    for ( unsigned i1 = 0; i1 < unsigned( right.dimension_1() ); ++i1 )
-    for ( unsigned i2 = 0; i2 < unsigned( right.dimension_2() ); ++i2 )
-    for ( unsigned i3 = 0; i3 < unsigned( right.dimension_3() ); ++i3 )
-    for ( unsigned i4 = 0; i4 < unsigned( right.dimension_4() ); ++i4 )
-    for ( unsigned i5 = 0; i5 < unsigned( right.dimension_5() ); ++i5 )
+    for ( unsigned i0 = 0; i0 < unsigned( right.extent(0) ); ++i0 )
+    for ( unsigned i1 = 0; i1 < unsigned( right.extent(1) ); ++i1 )
+    for ( unsigned i2 = 0; i2 < unsigned( right.extent(2) ); ++i2 )
+    for ( unsigned i3 = 0; i3 < unsigned( right.extent(3) ); ++i3 )
+    for ( unsigned i4 = 0; i4 < unsigned( right.extent(4) ); ++i4 )
+    for ( unsigned i5 = 0; i5 < unsigned( right.extent(5) ); ++i5 )
     {
       const long j = & right( i0, i1, i2, i3, i4, i5 ) -
                      & right(  0,  0,  0,  0,  0,  0 );
@@ -408,11 +408,11 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 5 >
   {
     long offset = -1;
 
-    for ( unsigned i4 = 0; i4 < unsigned( left.dimension_4() ); ++i4 )
-    for ( unsigned i3 = 0; i3 < unsigned( left.dimension_3() ); ++i3 )
-    for ( unsigned i2 = 0; i2 < unsigned( left.dimension_2() ); ++i2 )
-    for ( unsigned i1 = 0; i1 < unsigned( left.dimension_1() ); ++i1 )
-    for ( unsigned i0 = 0; i0 < unsigned( left.dimension_0() ); ++i0 )
+    for ( unsigned i4 = 0; i4 < unsigned( left.extent(4) ); ++i4 )
+    for ( unsigned i3 = 0; i3 < unsigned( left.extent(3) ); ++i3 )
+    for ( unsigned i2 = 0; i2 < unsigned( left.extent(2) ); ++i2 )
+    for ( unsigned i1 = 0; i1 < unsigned( left.extent(1) ); ++i1 )
+    for ( unsigned i0 = 0; i0 < unsigned( left.extent(0) ); ++i0 )
     {
       const long j = & left( i0, i1, i2, i3, i4 ) -
                      & left(  0,  0,  0,  0,  0 );
@@ -425,11 +425,11 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 5 >
 
     offset = -1;
 
-    for ( unsigned i0 = 0; i0 < unsigned( right.dimension_0() ); ++i0 )
-    for ( unsigned i1 = 0; i1 < unsigned( right.dimension_1() ); ++i1 )
-    for ( unsigned i2 = 0; i2 < unsigned( right.dimension_2() ); ++i2 )
-    for ( unsigned i3 = 0; i3 < unsigned( right.dimension_3() ); ++i3 )
-    for ( unsigned i4 = 0; i4 < unsigned( right.dimension_4() ); ++i4 )
+    for ( unsigned i0 = 0; i0 < unsigned( right.extent(0) ); ++i0 )
+    for ( unsigned i1 = 0; i1 < unsigned( right.extent(1) ); ++i1 )
+    for ( unsigned i2 = 0; i2 < unsigned( right.extent(2) ); ++i2 )
+    for ( unsigned i3 = 0; i3 < unsigned( right.extent(3) ); ++i3 )
+    for ( unsigned i4 = 0; i4 < unsigned( right.extent(4) ); ++i4 )
     {
       const long j = & right( i0, i1, i2, i3, i4 ) -
                      & right(  0,  0,  0,  0,  0 );
@@ -490,10 +490,10 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 4 >
   {
     long offset = -1;
 
-    for ( unsigned i3 = 0; i3 < unsigned( left.dimension_3() ); ++i3 )
-    for ( unsigned i2 = 0; i2 < unsigned( left.dimension_2() ); ++i2 )
-    for ( unsigned i1 = 0; i1 < unsigned( left.dimension_1() ); ++i1 )
-    for ( unsigned i0 = 0; i0 < unsigned( left.dimension_0() ); ++i0 )
+    for ( unsigned i3 = 0; i3 < unsigned( left.extent(3) ); ++i3 )
+    for ( unsigned i2 = 0; i2 < unsigned( left.extent(2) ); ++i2 )
+    for ( unsigned i1 = 0; i1 < unsigned( left.extent(1) ); ++i1 )
+    for ( unsigned i0 = 0; i0 < unsigned( left.extent(0) ); ++i0 )
     {
       const long j = & left( i0, i1, i2, i3 ) -
                      & left(  0,  0,  0,  0 );
@@ -503,10 +503,10 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 4 >
 
     offset = -1;
 
-    for ( unsigned i0 = 0; i0 < unsigned( right.dimension_0() ); ++i0 )
-    for ( unsigned i1 = 0; i1 < unsigned( right.dimension_1() ); ++i1 )
-    for ( unsigned i2 = 0; i2 < unsigned( right.dimension_2() ); ++i2 )
-    for ( unsigned i3 = 0; i3 < unsigned( right.dimension_3() ); ++i3 )
+    for ( unsigned i0 = 0; i0 < unsigned( right.extent(0) ); ++i0 )
+    for ( unsigned i1 = 0; i1 < unsigned( right.extent(1) ); ++i1 )
+    for ( unsigned i2 = 0; i2 < unsigned( right.extent(2) ); ++i2 )
+    for ( unsigned i3 = 0; i3 < unsigned( right.extent(3) ); ++i3 )
     {
       const long j = & right( i0, i1, i2, i3 ) -
                      & right(  0,  0,  0,  0 );
@@ -569,9 +569,9 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 3 >
   {
     long offset = -1;
 
-    for ( unsigned i2 = 0; i2 < unsigned( left.dimension_2() ); ++i2 )
-    for ( unsigned i1 = 0; i1 < unsigned( left.dimension_1() ); ++i1 )
-    for ( unsigned i0 = 0; i0 < unsigned( left.dimension_0() ); ++i0 )
+    for ( unsigned i2 = 0; i2 < unsigned( left.extent(2) ); ++i2 )
+    for ( unsigned i1 = 0; i1 < unsigned( left.extent(1) ); ++i1 )
+    for ( unsigned i0 = 0; i0 < unsigned( left.extent(0) ); ++i0 )
     {
       const long j = & left( i0, i1, i2 ) -
                      & left(  0,  0,  0 );
@@ -583,9 +583,9 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 3 >
 
     offset = -1;
 
-    for ( unsigned i0 = 0; i0 < unsigned( right.dimension_0() ); ++i0 )
-    for ( unsigned i1 = 0; i1 < unsigned( right.dimension_1() ); ++i1 )
-    for ( unsigned i2 = 0; i2 < unsigned( right.dimension_2() ); ++i2 )
+    for ( unsigned i0 = 0; i0 < unsigned( right.extent(0) ); ++i0 )
+    for ( unsigned i1 = 0; i1 < unsigned( right.extent(1) ); ++i1 )
+    for ( unsigned i2 = 0; i2 < unsigned( right.extent(2) ); ++i2 )
     {
       const long j = & right( i0, i1, i2 ) -
                      & right(  0,  0,  0 );
@@ -595,9 +595,9 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 3 >
       if ( & right( i0, i1, i2 ) != & right_stride( i0, i1, i2 ) ) { update |= 8; }
     }
 
-    for ( unsigned i0 = 0; i0 < unsigned( left.dimension_0() ); ++i0 )
-    for ( unsigned i1 = 0; i1 < unsigned( left.dimension_1() ); ++i1 )
-    for ( unsigned i2 = 0; i2 < unsigned( left.dimension_2() ); ++i2 )
+    for ( unsigned i0 = 0; i0 < unsigned( left.extent(0) ); ++i0 )
+    for ( unsigned i1 = 0; i1 < unsigned( left.extent(1) ); ++i1 )
+    for ( unsigned i2 = 0; i2 < unsigned( left.extent(2) ); ++i2 )
     {
       if ( & left( i0, i1, i2 )  != & left( i0, i1, i2, 0, 0, 0, 0, 0 ) )  { update |= 3; }
       if ( & right( i0, i1, i2 ) != & right( i0, i1, i2, 0, 0, 0, 0, 0 ) ) { update |= 3; }
@@ -653,8 +653,8 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 2 >
   {
     long offset = -1;
 
-    for ( unsigned i1 = 0; i1 < unsigned( left.dimension_1() ); ++i1 )
-    for ( unsigned i0 = 0; i0 < unsigned( left.dimension_0() ); ++i0 )
+    for ( unsigned i1 = 0; i1 < unsigned( left.extent(1) ); ++i1 )
+    for ( unsigned i0 = 0; i0 < unsigned( left.extent(0) ); ++i0 )
     {
       const long j = & left( i0, i1 ) -
                      & left(  0,  0 );
@@ -664,8 +664,8 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 2 >
 
     offset = -1;
 
-    for ( unsigned i0 = 0; i0 < unsigned( right.dimension_0() ); ++i0 )
-    for ( unsigned i1 = 0; i1 < unsigned( right.dimension_1() ); ++i1 )
+    for ( unsigned i0 = 0; i0 < unsigned( right.extent(0) ); ++i0 )
+    for ( unsigned i1 = 0; i1 < unsigned( right.extent(1) ); ++i1 )
     {
       const long j = & right( i0, i1 ) -
                      & right(  0,  0 );
@@ -673,8 +673,8 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 2 >
       offset = j;
     }
 
-    for ( unsigned i0 = 0; i0 < unsigned( left.dimension_0() ); ++i0 )
-    for ( unsigned i1 = 0; i1 < unsigned( left.dimension_1() ); ++i1 )
+    for ( unsigned i0 = 0; i0 < unsigned( left.extent(0) ); ++i0 )
+    for ( unsigned i1 = 0; i1 < unsigned( left.extent(1) ); ++i1 )
     {
       if ( & left( i0, i1 )  != & left( i0, i1, 0, 0, 0, 0, 0, 0 ) )  { update |= 3; }
       if ( & right( i0, i1 ) != & right( i0, i1, 0, 0, 0, 0, 0, 0 ) ) { update |= 3; }
@@ -734,7 +734,7 @@ struct TestViewOperator_LeftAndRight< DataType, DeviceType, 1 >
   KOKKOS_INLINE_FUNCTION
   void operator()( const size_type, value_type & update ) const
   {
-    for ( unsigned i0 = 0; i0 < unsigned( left.dimension_0() ); ++i0 )
+    for ( unsigned i0 = 0; i0 < unsigned( left.extent(0) ); ++i0 )
     {
       if ( & left( i0 )  != & left( i0, 0, 0, 0, 0, 0, 0, 0 ) )  { update |= 3; }
       if ( & right( i0 ) != & right( i0, 0, 0, 0, 0, 0, 0, 0 ) ) { update |= 3; }
@@ -762,8 +762,8 @@ struct TestViewMirror
     ASSERT_EQ( equal_ptr_h_d, 0 );
     ASSERT_EQ( equal_ptr_h2_d, 0 );
 
-    ASSERT_EQ( a_h.dimension_0(), a_h2.dimension_0() );
-    ASSERT_EQ( a_h.dimension_0(), a_d .dimension_0() );
+    ASSERT_EQ( a_h.extent(0), a_h2.extent(0) );
+    ASSERT_EQ( a_h.extent(0), a_d .extent(0) );
   }
 
   template< class MemoryTraits >
@@ -782,8 +782,8 @@ struct TestViewMirror
     ASSERT_EQ( equal_ptr_h_d, is_same_memspace );
     ASSERT_EQ( equal_ptr_h2_d, is_same_memspace );
 
-    ASSERT_EQ( a_h.dimension_0(), a_h2.dimension_0() );
-    ASSERT_EQ( a_h.dimension_0(), a_d .dimension_0() );
+    ASSERT_EQ( a_h.extent(0), a_h2.extent(0) );
+    ASSERT_EQ( a_h.extent(0), a_d .extent(0) );
   }
 
   template< class MemoryTraits >
@@ -806,9 +806,9 @@ struct TestViewMirror
     ASSERT_EQ( equal_ptr_h2_d, is_same_memspace );
     ASSERT_EQ( equal_ptr_h3_d, is_same_memspace );
 
-    ASSERT_EQ( a_h.dimension_0(), a_h3.dimension_0() );
-    ASSERT_EQ( a_h.dimension_0(), a_h2.dimension_0() );
-    ASSERT_EQ( a_h.dimension_0(), a_d .dimension_0() );
+    ASSERT_EQ( a_h.extent(0), a_h3.extent(0) );
+    ASSERT_EQ( a_h.extent(0), a_h2.extent(0) );
+    ASSERT_EQ( a_h.extent(0), a_d .extent(0) );
     ASSERT_EQ( a_org(5), a_h3(5) );
   }
 
@@ -945,24 +945,24 @@ public:
     dView4 dx, dy, dz;
     hView4 hx, hy, hz;
 
-    ASSERT_TRUE( dx.ptr_on_device() == 0 );
-    ASSERT_TRUE( dy.ptr_on_device() == 0 );
-    ASSERT_TRUE( dz.ptr_on_device() == 0 );
-    ASSERT_TRUE( hx.ptr_on_device() == 0 );
-    ASSERT_TRUE( hy.ptr_on_device() == 0 );
-    ASSERT_TRUE( hz.ptr_on_device() == 0 );
-    ASSERT_EQ( dx.dimension_0(), 0u );
-    ASSERT_EQ( dy.dimension_0(), 0u );
-    ASSERT_EQ( dz.dimension_0(), 0u );
-    ASSERT_EQ( hx.dimension_0(), 0u );
-    ASSERT_EQ( hy.dimension_0(), 0u );
-    ASSERT_EQ( hz.dimension_0(), 0u );
-    ASSERT_EQ( dx.dimension_1(), unsigned( N1 ) );
-    ASSERT_EQ( dy.dimension_1(), unsigned( N1 ) );
-    ASSERT_EQ( dz.dimension_1(), unsigned( N1 ) );
-    ASSERT_EQ( hx.dimension_1(), unsigned( N1 ) );
-    ASSERT_EQ( hy.dimension_1(), unsigned( N1 ) );
-    ASSERT_EQ( hz.dimension_1(), unsigned( N1 ) );
+    ASSERT_TRUE( dx.data() == 0 );
+    ASSERT_TRUE( dy.data() == 0 );
+    ASSERT_TRUE( dz.data() == 0 );
+    ASSERT_TRUE( hx.data() == 0 );
+    ASSERT_TRUE( hy.data() == 0 );
+    ASSERT_TRUE( hz.data() == 0 );
+    ASSERT_EQ( dx.extent(0), 0u );
+    ASSERT_EQ( dy.extent(0), 0u );
+    ASSERT_EQ( dz.extent(0), 0u );
+    ASSERT_EQ( hx.extent(0), 0u );
+    ASSERT_EQ( hy.extent(0), 0u );
+    ASSERT_EQ( hz.extent(0), 0u );
+    ASSERT_EQ( dx.extent(1), unsigned( N1 ) );
+    ASSERT_EQ( dy.extent(1), unsigned( N1 ) );
+    ASSERT_EQ( dz.extent(1), unsigned( N1 ) );
+    ASSERT_EQ( hx.extent(1), unsigned( N1 ) );
+    ASSERT_EQ( hy.extent(1), unsigned( N1 ) );
+    ASSERT_EQ( hz.extent(1), unsigned( N1 ) );
 
     dx = dView4( "dx", N0 );
     dy = dView4( "dy", N0 );
@@ -972,19 +972,19 @@ public:
     dView4_unmanaged unmanaged_dx = dx;
     ASSERT_EQ( dx.use_count(), size_t( 1 ) );
 
-    dView4_unmanaged unmanaged_from_ptr_dx = dView4_unmanaged( dx.ptr_on_device(),
-                                                               dx.dimension_0(),
-                                                               dx.dimension_1(),
-                                                               dx.dimension_2(),
-                                                               dx.dimension_3() );
+    dView4_unmanaged unmanaged_from_ptr_dx = dView4_unmanaged( dx.data(),
+                                                               dx.extent(0),
+                                                               dx.extent(1),
+                                                               dx.extent(2),
+                                                               dx.extent(3) );
 
     {
       // Destruction of this view should be harmless.
-      const_dView4 unmanaged_from_ptr_const_dx( dx.ptr_on_device(),
-                                                dx.dimension_0(),
-                                                dx.dimension_1(),
-                                                dx.dimension_2(),
-                                                dx.dimension_3() );
+      const_dView4 unmanaged_from_ptr_const_dx( dx.data(),
+                                                dx.extent(0),
+                                                dx.extent(1),
+                                                dx.extent(2),
+                                                dx.extent(3) );
     }
 
     const_dView4 const_dx = dx;
@@ -1007,24 +1007,24 @@ public:
 
     ASSERT_EQ( dx.use_count(), size_t( 2 ) );
 
-    ASSERT_FALSE( dx.ptr_on_device() == 0 );
-    ASSERT_FALSE( const_dx.ptr_on_device() == 0 );
-    ASSERT_FALSE( unmanaged_dx.ptr_on_device() == 0 );
-    ASSERT_FALSE( unmanaged_from_ptr_dx.ptr_on_device() == 0 );
-    ASSERT_FALSE( dy.ptr_on_device() == 0 );
+    ASSERT_FALSE( dx.data() == 0 );
+    ASSERT_FALSE( const_dx.data() == 0 );
+    ASSERT_FALSE( unmanaged_dx.data() == 0 );
+    ASSERT_FALSE( unmanaged_from_ptr_dx.data() == 0 );
+    ASSERT_FALSE( dy.data() == 0 );
     ASSERT_NE( dx, dy );
 
-    ASSERT_EQ( dx.dimension_0(), unsigned( N0 ) );
-    ASSERT_EQ( dx.dimension_1(), unsigned( N1 ) );
-    ASSERT_EQ( dx.dimension_2(), unsigned( N2 ) );
-    ASSERT_EQ( dx.dimension_3(), unsigned( N3 ) );
+    ASSERT_EQ( dx.extent(0), unsigned( N0 ) );
+    ASSERT_EQ( dx.extent(1), unsigned( N1 ) );
+    ASSERT_EQ( dx.extent(2), unsigned( N2 ) );
+    ASSERT_EQ( dx.extent(3), unsigned( N3 ) );
 
-    ASSERT_EQ( dy.dimension_0(), unsigned( N0 ) );
-    ASSERT_EQ( dy.dimension_1(), unsigned( N1 ) );
-    ASSERT_EQ( dy.dimension_2(), unsigned( N2 ) );
-    ASSERT_EQ( dy.dimension_3(), unsigned( N3 ) );
+    ASSERT_EQ( dy.extent(0), unsigned( N0 ) );
+    ASSERT_EQ( dy.extent(1), unsigned( N1 ) );
+    ASSERT_EQ( dy.extent(2), unsigned( N2 ) );
+    ASSERT_EQ( dy.extent(3), unsigned( N3 ) );
 
-    ASSERT_EQ( unmanaged_from_ptr_dx.capacity(), unsigned( N0 ) * unsigned( N1 ) * unsigned( N2 ) * unsigned( N3 ) );
+    ASSERT_EQ( unmanaged_from_ptr_dx.span(), unsigned( N0 ) * unsigned( N1 ) * unsigned( N2 ) * unsigned( N3 ) );
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
 return;
 #endif
@@ -1040,9 +1040,9 @@ return;
       size_t count = 0;
 
       for ( size_t ip = 0; ip < N0; ++ip )
-      for ( size_t i1 = 0; i1 < hx.dimension_1(); ++i1 )
-      for ( size_t i2 = 0; i2 < hx.dimension_2(); ++i2 )
-      for ( size_t i3 = 0; i3 < hx.dimension_3(); ++i3 )
+      for ( size_t i1 = 0; i1 < hx.extent(1); ++i1 )
+      for ( size_t i2 = 0; i2 < hx.extent(2); ++i2 )
+      for ( size_t i3 = 0; i3 < hx.extent(3); ++i3 )
       {
         hx( ip, i1, i2, i3 ) = ++count;
       }
@@ -1076,9 +1076,9 @@ return;
       size_t count = 0;
 
       for ( size_t ip = 0; ip < N0; ++ip )
-      for ( size_t i1 = 0; i1 < hx.dimension_1(); ++i1 )
-      for ( size_t i2 = 0; i2 < hx.dimension_2(); ++i2 )
-      for ( size_t i3 = 0; i3 < hx.dimension_3(); ++i3 )
+      for ( size_t i1 = 0; i1 < hx.extent(1); ++i1 )
+      for ( size_t i2 = 0; i2 < hx.extent(2); ++i2 )
+      for ( size_t i3 = 0; i3 < hx.extent(3); ++i3 )
       {
         hx( ip, i1, i2, i3 ) = ++count;
       }
@@ -1112,9 +1112,9 @@ return;
       size_t count = 0;
 
       for ( size_t ip = 0; ip < N0; ++ip )
-      for ( size_t i1 = 0; i1 < hx.dimension_1(); ++i1 )
-      for ( size_t i2 = 0; i2 < hx.dimension_2(); ++i2 )
-      for ( size_t i3 = 0; i3 < hx.dimension_3(); ++i3 )
+      for ( size_t i1 = 0; i1 < hx.extent(1); ++i1 )
+      for ( size_t i2 = 0; i2 < hx.extent(2); ++i2 )
+      for ( size_t i3 = 0; i3 < hx.extent(3); ++i3 )
       {
         hx( ip, i1, i2, i3 ) = ++count;
       }
@@ -1152,19 +1152,19 @@ return;
     ASSERT_NE( dx, dz );
 
     dx = dView4();
-    ASSERT_TRUE( dx.ptr_on_device() == 0 );
-    ASSERT_FALSE( dy.ptr_on_device() == 0 );
-    ASSERT_FALSE( dz.ptr_on_device() == 0 );
+    ASSERT_TRUE( dx.data() == 0 );
+    ASSERT_FALSE( dy.data() == 0 );
+    ASSERT_FALSE( dz.data() == 0 );
 
     dy = dView4();
-    ASSERT_TRUE( dx.ptr_on_device() == 0 );
-    ASSERT_TRUE( dy.ptr_on_device() == 0 );
-    ASSERT_FALSE( dz.ptr_on_device() == 0 );
+    ASSERT_TRUE( dx.data() == 0 );
+    ASSERT_TRUE( dy.data() == 0 );
+    ASSERT_FALSE( dz.data() == 0 );
 
     dz = dView4();
-    ASSERT_TRUE( dx.ptr_on_device() == 0 );
-    ASSERT_TRUE( dy.ptr_on_device() == 0 );
-    ASSERT_TRUE( dz.ptr_on_device() == 0 );
+    ASSERT_TRUE( dx.data() == 0 );
+    ASSERT_TRUE( dy.data() == 0 );
+    ASSERT_TRUE( dz.data() == 0 );
   }
 
   typedef T DataType[2];
@@ -1197,7 +1197,7 @@ return;
     if ( !std::is_same< typename device::execution_space, Kokkos::Cuda >::value )
 #endif
     {
-      ASSERT_TRUE( x.ptr_on_device() == xr.ptr_on_device() );
+      ASSERT_TRUE( x.data() == xr.data() );
     }
 
     // typeX xf = xc; // Setting non-const from const must not compile.
@@ -1239,10 +1239,10 @@ return;
     view_stride_1 yr1 = Kokkos::subview( xr2, 0, Kokkos::ALL() );
     view_stride_1 yr2 = Kokkos::subview( xr2, 1, Kokkos::ALL() );
 
-    ASSERT_EQ( yl1.dimension_0(), xl2.dimension_1() );
-    ASSERT_EQ( yl2.dimension_0(), xl2.dimension_1() );
-    ASSERT_EQ( yr1.dimension_0(), xr2.dimension_1() );
-    ASSERT_EQ( yr2.dimension_0(), xr2.dimension_1() );
+    ASSERT_EQ( yl1.extent(0), xl2.extent(1) );
+    ASSERT_EQ( yl2.extent(0), xl2.extent(1) );
+    ASSERT_EQ( yr1.extent(0), xr2.extent(1) );
+    ASSERT_EQ( yr2.extent(0), xr2.extent(1) );
 
     ASSERT_EQ( & yl1( 0 ) - & xl2( 0, 0 ), 0 );
     ASSERT_EQ( & yl2( 0 ) - & xl2( 1, 0 ), 0 );
@@ -1255,10 +1255,10 @@ return;
     view_stride_2 yl4 = Kokkos::subview( xl4, 1, Kokkos::ALL(), 2, Kokkos::ALL() );
     view_stride_2 yr4 = Kokkos::subview( xr4, 1, Kokkos::ALL(), 2, Kokkos::ALL() );
 
-    ASSERT_EQ( yl4.dimension_0(), xl4.dimension_1() );
-    ASSERT_EQ( yl4.dimension_1(), xl4.dimension_3() );
-    ASSERT_EQ( yr4.dimension_0(), xr4.dimension_1() );
-    ASSERT_EQ( yr4.dimension_1(), xr4.dimension_3() );
+    ASSERT_EQ( yl4.extent(0), xl4.extent(1) );
+    ASSERT_EQ( yl4.extent(1), xl4.extent(3) );
+    ASSERT_EQ( yr4.extent(0), xr4.extent(1) );
+    ASSERT_EQ( yr4.extent(1), xr4.extent(3) );
 
     ASSERT_EQ( & yl4( 4, 4 ) - & xl4( 1, 4, 2, 4 ), 0 );
     ASSERT_EQ( & yr4( 4, 4 ) - & xr4( 1, 4, 2, 4 ), 0 );

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -708,7 +708,7 @@ void test_view_mapping()
 
     ASSERT_EQ( C::Rank, 1 );
 
-    ASSERT_EQ( vr1.dimension_0(), N );
+    ASSERT_EQ( vr1.extent(0), N );
 
     if ( Kokkos::Impl::SpaceAccessibility< Kokkos::HostSpace, typename Space::memory_space >::accessible ) {
       for ( int i = 0; i < N; ++i ) data[i] = i + 1;
@@ -751,7 +751,7 @@ void test_view_mapping()
     ASSERT_TRUE( ( std::is_same< typename T::reference_type, int & >::value ) );
     ASSERT_EQ( T::Rank, 1 );
 
-    ASSERT_EQ( vr1.dimension_0(), N );
+    ASSERT_EQ( vr1.extent(0), N );
 
     if ( Kokkos::Impl::SpaceAccessibility< Kokkos::HostSpace, typename Space::memory_space >::accessible ) {
       for ( int i = 0; i < N; ++i ) vr1( i ) = i + 1;
@@ -778,8 +778,8 @@ void test_view_mapping()
     T vr1( "vr1", N );
     C cr1( vr1 );
 
-    ASSERT_EQ( vr1.dimension_0(), 0 );
-    ASSERT_EQ( cr1.dimension_0(), 0 );
+    ASSERT_EQ( vr1.extent(0), 0 );
+    ASSERT_EQ( cr1.extent(0), 0 );
   }
 
   // Testing using space instance for allocation.
@@ -881,12 +881,12 @@ void test_view_mapping()
     Kokkos::realloc( c, 5, 6 );
     Kokkos::realloc( d, 5, 6 );
 
-    ASSERT_EQ( b.dimension_0(), 5 );
-    ASSERT_EQ( b.dimension_1(), 6 );
-    ASSERT_EQ( c.dimension_0(), 5 );
-    ASSERT_EQ( c.dimension_1(), 6 );
-    ASSERT_EQ( d.dimension_0(), 5 );
-    ASSERT_EQ( d.dimension_1(), 6 );
+    ASSERT_EQ( b.extent(0), 5 );
+    ASSERT_EQ( b.extent(1), 6 );
+    ASSERT_EQ( c.extent(0), 5 );
+    ASSERT_EQ( c.extent(1), 6 );
+    ASSERT_EQ( d.extent(0), 5 );
+    ASSERT_EQ( d.extent(1), 6 );
 
     layout_type layout( 7, 8 );
     Kokkos::resize( b, layout );
@@ -912,12 +912,12 @@ void test_view_mapping()
     Kokkos::realloc( c, layout );
     Kokkos::realloc( d, layout );
 
-    ASSERT_EQ( b.dimension_0(), 7 );
-    ASSERT_EQ( b.dimension_1(), 8 );
-    ASSERT_EQ( c.dimension_0(), 7 );
-    ASSERT_EQ( c.dimension_1(), 8 );
-    ASSERT_EQ( d.dimension_0(), 7 );
-    ASSERT_EQ( d.dimension_1(), 8 );
+    ASSERT_EQ( b.extent(0), 7 );
+    ASSERT_EQ( b.extent(1), 8 );
+    ASSERT_EQ( c.extent(0), 7 );
+    ASSERT_EQ( c.extent(1), 8 );
+    ASSERT_EQ( d.extent(0), 7 );
+    ASSERT_EQ( d.extent(1), 8 );
   }
 
   {
@@ -967,12 +967,12 @@ void test_view_mapping()
     Kokkos::realloc( c, layout );
     Kokkos::realloc( d, layout );
 
-    ASSERT_EQ( b.dimension_0(), 7 );
-    ASSERT_EQ( b.dimension_1(), 8 );
-    ASSERT_EQ( c.dimension_0(), 7 );
-    ASSERT_EQ( c.dimension_1(), 8 );
-    ASSERT_EQ( d.dimension_0(), 7 );
-    ASSERT_EQ( d.dimension_1(), 8 );
+    ASSERT_EQ( b.extent(0), 7 );
+    ASSERT_EQ( b.extent(1), 8 );
+    ASSERT_EQ( c.extent(0), 7 );
+    ASSERT_EQ( c.extent(1), 8 );
+    ASSERT_EQ( d.extent(0), 7 );
+    ASSERT_EQ( d.extent(1), 8 );
 
   }
 
@@ -1049,13 +1049,13 @@ struct TestViewMapOperator {
   void test_left( size_t i0, long & error_count ) const
   {
     typename ViewType::value_type * const base_ptr = & v( 0, 0, 0, 0, 0, 0, 0, 0 );
-    const size_t n1 = v.dimension_1();
-    const size_t n2 = v.dimension_2();
-    const size_t n3 = v.dimension_3();
-    const size_t n4 = v.dimension_4();
-    const size_t n5 = v.dimension_5();
-    const size_t n6 = v.dimension_6();
-    const size_t n7 = v.dimension_7();
+    const size_t n1 = v.extent(1);
+    const size_t n2 = v.extent(2);
+    const size_t n3 = v.extent(3);
+    const size_t n4 = v.extent(4);
+    const size_t n5 = v.extent(5);
+    const size_t n6 = v.extent(6);
+    const size_t n7 = v.extent(7);
 
     long offset = 0;
 
@@ -1079,13 +1079,13 @@ struct TestViewMapOperator {
   void test_right( size_t i0, long & error_count ) const
   {
     typename ViewType::value_type * const base_ptr = & v( 0, 0, 0, 0, 0, 0, 0, 0 );
-    const size_t n1 = v.dimension_1();
-    const size_t n2 = v.dimension_2();
-    const size_t n3 = v.dimension_3();
-    const size_t n4 = v.dimension_4();
-    const size_t n5 = v.dimension_5();
-    const size_t n6 = v.dimension_6();
-    const size_t n7 = v.dimension_7();
+    const size_t n1 = v.extent(1);
+    const size_t n2 = v.extent(2);
+    const size_t n3 = v.extent(3);
+    const size_t n4 = v.extent(4);
+    const size_t n5 = v.extent(5);
+    const size_t n6 = v.extent(6);
+    const size_t n7 = v.extent(7);
 
     long offset = 0;
 
@@ -1129,27 +1129,27 @@ struct TestViewMapOperator {
 
   void run()
   {
-    ASSERT_EQ( v.dimension_0(), ( 0 < ViewType::rank ? TestViewMapOperator<ViewType>::N0 : 1 ) );
-    ASSERT_EQ( v.dimension_1(), ( 1 < ViewType::rank ? TestViewMapOperator<ViewType>::N1 : 1 ) );
-    ASSERT_EQ( v.dimension_2(), ( 2 < ViewType::rank ? TestViewMapOperator<ViewType>::N2 : 1 ) );
-    ASSERT_EQ( v.dimension_3(), ( 3 < ViewType::rank ? TestViewMapOperator<ViewType>::N3 : 1 ) );
-    ASSERT_EQ( v.dimension_4(), ( 4 < ViewType::rank ? TestViewMapOperator<ViewType>::N4 : 1 ) );
-    ASSERT_EQ( v.dimension_5(), ( 5 < ViewType::rank ? TestViewMapOperator<ViewType>::N5 : 1 ) );
-    ASSERT_EQ( v.dimension_6(), ( 6 < ViewType::rank ? TestViewMapOperator<ViewType>::N6 : 1 ) );
-    ASSERT_EQ( v.dimension_7(), ( 7 < ViewType::rank ? TestViewMapOperator<ViewType>::N7 : 1 ) );
+    ASSERT_EQ( v.extent(0), ( 0 < ViewType::rank ? TestViewMapOperator<ViewType>::N0 : 1 ) );
+    ASSERT_EQ( v.extent(1), ( 1 < ViewType::rank ? TestViewMapOperator<ViewType>::N1 : 1 ) );
+    ASSERT_EQ( v.extent(2), ( 2 < ViewType::rank ? TestViewMapOperator<ViewType>::N2 : 1 ) );
+    ASSERT_EQ( v.extent(3), ( 3 < ViewType::rank ? TestViewMapOperator<ViewType>::N3 : 1 ) );
+    ASSERT_EQ( v.extent(4), ( 4 < ViewType::rank ? TestViewMapOperator<ViewType>::N4 : 1 ) );
+    ASSERT_EQ( v.extent(5), ( 5 < ViewType::rank ? TestViewMapOperator<ViewType>::N5 : 1 ) );
+    ASSERT_EQ( v.extent(6), ( 6 < ViewType::rank ? TestViewMapOperator<ViewType>::N6 : 1 ) );
+    ASSERT_EQ( v.extent(7), ( 7 < ViewType::rank ? TestViewMapOperator<ViewType>::N7 : 1 ) );
 
-    ASSERT_LE( v.dimension_0() *
-               v.dimension_1() *
-               v.dimension_2() *
-               v.dimension_3() *
-               v.dimension_4() *
-               v.dimension_5() *
-               v.dimension_6() *
-               v.dimension_7()
+    ASSERT_LE( v.extent(0) *
+               v.extent(1) *
+               v.extent(2) *
+               v.extent(3) *
+               v.extent(4) *
+               v.extent(5) *
+               v.extent(6) *
+               v.extent(7)
              , v.span() );
 
     long error_count;
-    Kokkos::RangePolicy< typename ViewType::execution_space > range( 0, v.dimension_0() );
+    Kokkos::RangePolicy< typename ViewType::execution_space > range( 0, v.extent(0) );
     Kokkos::parallel_reduce( range, *this, error_count );
     ASSERT_EQ( 0, error_count );
 }

--- a/core/unit_test/TestViewMapping_subview.hpp
+++ b/core/unit_test/TestViewMapping_subview.hpp
@@ -167,34 +167,34 @@ struct TestViewMappingSubview
 
     TestViewMappingSubview< ExecSpace > self;
 
-    ASSERT_EQ( Aa.dimension_0(), AN );
-    ASSERT_EQ( Ab.dimension_0(), AN - 2 );
-    ASSERT_EQ( Ac.dimension_0(), AN - 2 );
-    ASSERT_EQ( Ba.dimension_0(), BN0 );
-    ASSERT_EQ( Ba.dimension_1(), BN1 );
-    ASSERT_EQ( Ba.dimension_2(), BN2 );
-    ASSERT_EQ( Bb.dimension_0(), BN0 - 2 );
-    ASSERT_EQ( Bb.dimension_1(), BN1 - 2 );
-    ASSERT_EQ( Bb.dimension_2(), BN2 - 2 );
+    ASSERT_EQ( Aa.extent(0), AN );
+    ASSERT_EQ( Ab.extent(0), AN - 2 );
+    ASSERT_EQ( Ac.extent(0), AN - 2 );
+    ASSERT_EQ( Ba.extent(0), BN0 );
+    ASSERT_EQ( Ba.extent(1), BN1 );
+    ASSERT_EQ( Ba.extent(2), BN2 );
+    ASSERT_EQ( Bb.extent(0), BN0 - 2 );
+    ASSERT_EQ( Bb.extent(1), BN1 - 2 );
+    ASSERT_EQ( Bb.extent(2), BN2 - 2 );
 
-    ASSERT_EQ( Ca.dimension_0(), CN0 );
-    ASSERT_EQ( Ca.dimension_1(), CN1 );
-    ASSERT_EQ( Ca.dimension_2(), CN2 );
-    ASSERT_EQ( Ca.dimension_3(), 13 ); 
-    ASSERT_EQ( Ca.dimension_4(), 14 );
-    ASSERT_EQ( Cb.dimension_0(), CN0 - 2 );
-    ASSERT_EQ( Cb.dimension_1(), CN1 - 2 );
-    ASSERT_EQ( Cb.dimension_2(), CN2 - 2 );
+    ASSERT_EQ( Ca.extent(0), CN0 );
+    ASSERT_EQ( Ca.extent(1), CN1 );
+    ASSERT_EQ( Ca.extent(2), CN2 );
+    ASSERT_EQ( Ca.extent(3), 13 ); 
+    ASSERT_EQ( Ca.extent(4), 14 );
+    ASSERT_EQ( Cb.extent(0), CN0 - 2 );
+    ASSERT_EQ( Cb.extent(1), CN1 - 2 );
+    ASSERT_EQ( Cb.extent(2), CN2 - 2 );
 
-    ASSERT_EQ( Da.dimension_0(), DN0 );
-    ASSERT_EQ( Da.dimension_1(), DN1 );
-    ASSERT_EQ( Da.dimension_2(), DN2 );
-    ASSERT_EQ( Da.dimension_3(), DN3 );
-    ASSERT_EQ( Da.dimension_4(), DN4 );
+    ASSERT_EQ( Da.extent(0), DN0 );
+    ASSERT_EQ( Da.extent(1), DN1 );
+    ASSERT_EQ( Da.extent(2), DN2 );
+    ASSERT_EQ( Da.extent(3), DN3 );
+    ASSERT_EQ( Da.extent(4), DN4 );
 
-    ASSERT_EQ( Db.dimension_0(), DN1 - 2 );
-    ASSERT_EQ( Db.dimension_1(), DN2 - 2 );
-    ASSERT_EQ( Db.dimension_2(), DN3 - 2 );
+    ASSERT_EQ( Db.extent(0), DN1 - 2 );
+    ASSERT_EQ( Db.extent(1), DN2 - 2 );
+    ASSERT_EQ( Db.extent(2), DN3 - 2 );
 
     ASSERT_EQ( Da.stride_1(), Db.stride_0() );
     ASSERT_EQ( Da.stride_2(), Db.stride_1() );

--- a/core/unit_test/TestViewOfClass.hpp
+++ b/core/unit_test/TestViewOfClass.hpp
@@ -62,14 +62,14 @@ public:
   NestedView & operator=( const Kokkos::View< int*, Space > & lhs )
   {
     member = lhs;
-    if ( member.dimension_0() ) Kokkos::atomic_add( & member( 0 ), 1 );
+    if ( member.extent(0) ) Kokkos::atomic_add( & member( 0 ), 1 );
     return *this;
   }
 
   KOKKOS_INLINE_FUNCTION
   ~NestedView()
   {
-    if ( member.dimension_0() ) {
+    if ( member.extent(0) ) {
       Kokkos::atomic_add( & member( 0 ), -1 );
     }
   }

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -99,7 +99,7 @@ struct fill_2D {
   KOKKOS_INLINE_FUNCTION
   void operator()( const int i ) const
   {
-    for ( int j = 0; j < static_cast< int >( a.dimension_1() ); j++ ) {
+    for ( int j = 0; j < static_cast< int >( a.extent(1) ); j++ ) {
       a( i, j ) = val;
     }
   }
@@ -122,7 +122,7 @@ void test_auto_1d ()
   typename mv_type::HostMirror X_h = Kokkos::create_mirror_view( X );
 
   fill_2D< mv_type, Space > f1( X, ONE );
-  Kokkos::parallel_for( X.dimension_0(), f1 );
+  Kokkos::parallel_for( X.extent(0), f1 );
   Kokkos::fence();
   Kokkos::deep_copy( X_h, X );
   for ( size_type j = 0; j < numCols; ++j ) {
@@ -132,7 +132,7 @@ void test_auto_1d ()
   }
 
   fill_2D< mv_type, Space > f2( X, 0.0 );
-  Kokkos::parallel_for( X.dimension_0(), f2 );
+  Kokkos::parallel_for( X.extent(0), f2 );
   Kokkos::fence();
   Kokkos::deep_copy( X_h, X );
   for ( size_type j = 0; j < numCols; ++j ) {
@@ -142,7 +142,7 @@ void test_auto_1d ()
   }
 
   fill_2D< mv_type, Space > f3( X, TWO );
-  Kokkos::parallel_for( X.dimension_0(), f3 );
+  Kokkos::parallel_for( X.extent(0), f3 );
   Kokkos::fence();
   Kokkos::deep_copy( X_h, X );
   for ( size_type j = 0; j < numCols; ++j ) {
@@ -155,7 +155,7 @@ void test_auto_1d ()
     auto X_j = Kokkos::subview( X, Kokkos::ALL, j );
 
     fill_1D< decltype( X_j ), Space > f4( X_j, ZERO );
-    Kokkos::parallel_for( X_j.dimension_0(), f4 );
+    Kokkos::parallel_for( X_j.extent(0), f4 );
     Kokkos::fence();
     Kokkos::deep_copy( X_h, X );
     for ( size_type i = 0; i < numRows; ++i ) {
@@ -165,7 +165,7 @@ void test_auto_1d ()
     for ( size_type jj = 0; jj < numCols; ++jj ) {
       auto X_jj = Kokkos::subview ( X, Kokkos::ALL, jj );
       fill_1D< decltype( X_jj ), Space > f5( X_jj, ONE );
-      Kokkos::parallel_for( X_jj.dimension_0(), f5 );
+      Kokkos::parallel_for( X_jj.extent(0), f5 );
       Kokkos::fence();
       Kokkos::deep_copy( X_h, X );
       for ( size_type i = 0; i < numRows; ++i ) {
@@ -243,17 +243,17 @@ void test_left_0()
   if ( Kokkos::Impl::SpaceAccessibility< Kokkos::HostSpace, typename Space::memory_space >::accessible ) {
     view_static_8_type x_static_8( "x_static_left_8" );
 
-    ASSERT_TRUE( x_static_8.is_contiguous() );
+    ASSERT_TRUE( x_static_8.span_is_contiguous() );
 
     Kokkos::View< int, Kokkos::LayoutLeft, Space > x0 = Kokkos::subview( x_static_8, 0, 0, 0, 0, 0, 0, 0, 0 );
 
-    ASSERT_TRUE( x0.is_contiguous() );
+    ASSERT_TRUE( x0.span_is_contiguous() );
     ASSERT_TRUE( & x0() == & x_static_8( 0, 0, 0, 0, 0, 0, 0, 0 ) );
 
     Kokkos::View< int*, Kokkos::LayoutLeft, Space > x1 =
       Kokkos::subview( x_static_8, Kokkos::pair< int, int >( 0, 2 ), 1, 2, 3, 0, 1, 2, 3 );
 
-    ASSERT_TRUE( x1.is_contiguous() );
+    ASSERT_TRUE( x1.span_is_contiguous() );
     ASSERT_TRUE( & x1( 0 ) == & x_static_8( 0, 1, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & x1( 1 ) == & x_static_8( 1, 1, 2, 3, 0, 1, 2, 3 ) );
 
@@ -261,7 +261,7 @@ void test_left_0()
       Kokkos::subview( x_static_8, Kokkos::pair< int, int >( 0, 2 ), 1, 2, 3
                                  , Kokkos::pair< int, int >( 0, 2 ), 1, 2, 3 );
 
-    ASSERT_TRUE( ! x2.is_contiguous() );
+    ASSERT_TRUE( ! x2.span_is_contiguous() );
     ASSERT_TRUE( & x2( 0, 0 ) == & x_static_8( 0, 1, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & x2( 1, 0 ) == & x_static_8( 1, 1, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & x2( 0, 1 ) == & x_static_8( 0, 1, 2, 3, 1, 1, 2, 3 ) );
@@ -272,7 +272,7 @@ void test_left_0()
       Kokkos::subview( x_static_8, 1, Kokkos::pair< int, int >( 0, 2 ), 2, 3
                                     , Kokkos::pair< int, int >( 0, 2 ), 1, 2, 3 );
 
-    ASSERT_TRUE( ! sx2.is_contiguous() );
+    ASSERT_TRUE( ! sx2.span_is_contiguous() );
     ASSERT_TRUE( & sx2( 0, 0 ) == & x_static_8( 1, 0, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & sx2( 1, 0 ) == & x_static_8( 1, 1, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & sx2( 0, 1 ) == & x_static_8( 1, 0, 2, 3, 1, 1, 2, 3 ) );
@@ -285,12 +285,12 @@ void test_left_0()
                                  , 2, Kokkos::pair< int, int >( 2, 4 ) /* of [5] */
                      );
 
-    ASSERT_TRUE( ! sx4.is_contiguous() );
+    ASSERT_TRUE( ! sx4.span_is_contiguous() );
 
-    for ( int i0 = 0; i0 < (int) sx4.dimension_0(); ++i0 )
-    for ( int i1 = 0; i1 < (int) sx4.dimension_1(); ++i1 )
-    for ( int i2 = 0; i2 < (int) sx4.dimension_2(); ++i2 )
-    for ( int i3 = 0; i3 < (int) sx4.dimension_3(); ++i3 )
+    for ( int i0 = 0; i0 < (int) sx4.extent(0); ++i0 )
+    for ( int i1 = 0; i1 < (int) sx4.extent(1); ++i1 )
+    for ( int i2 = 0; i2 < (int) sx4.extent(2); ++i2 )
+    for ( int i3 = 0; i3 < (int) sx4.extent(3); ++i3 )
     {
       ASSERT_TRUE( & sx4( i0, i1, i2, i3 ) == & x_static_8( 0, 0 + i0, 1, 1 + i1, 1, 0 + i2, 2, 2 + i3 ) );
     }
@@ -305,17 +305,17 @@ void test_left_1()
   if ( Kokkos::Impl::SpaceAccessibility< Kokkos::HostSpace, typename Space::memory_space >::accessible ) {
     view_type x8( "x_left_8", 2, 3, 4, 5 );
 
-    ASSERT_TRUE( x8.is_contiguous() );
+    ASSERT_TRUE( x8.span_is_contiguous() );
 
     Kokkos::View< int, Kokkos::LayoutLeft, Space > x0 = Kokkos::subview( x8, 0, 0, 0, 0, 0, 0, 0, 0 );
 
-    ASSERT_TRUE( x0.is_contiguous() );
+    ASSERT_TRUE( x0.span_is_contiguous() );
     ASSERT_TRUE( & x0() == & x8( 0, 0, 0, 0, 0, 0, 0, 0 ) );
 
     Kokkos::View< int*, Kokkos::LayoutLeft, Space > x1 =
       Kokkos::subview( x8, Kokkos::pair< int, int >( 0, 2 ), 1, 2, 3, 0, 1, 2, 3 );
 
-    ASSERT_TRUE( x1.is_contiguous() );
+    ASSERT_TRUE( x1.span_is_contiguous() );
     ASSERT_TRUE( & x1( 0 ) == & x8( 0, 1, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & x1( 1 ) == & x8( 1, 1, 2, 3, 0, 1, 2, 3 ) );
 
@@ -323,7 +323,7 @@ void test_left_1()
       Kokkos::subview( x8, Kokkos::pair< int, int >( 0, 2 ), 1, 2, 3
                          , Kokkos::pair< int, int >( 0, 2 ), 1, 2, 3 );
 
-    ASSERT_TRUE( ! x2.is_contiguous() );
+    ASSERT_TRUE( ! x2.span_is_contiguous() );
     ASSERT_TRUE( & x2( 0, 0 ) == & x8( 0, 1, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & x2( 1, 0 ) == & x8( 1, 1, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & x2( 0, 1 ) == & x8( 0, 1, 2, 3, 1, 1, 2, 3 ) );
@@ -334,7 +334,7 @@ void test_left_1()
       Kokkos::subview( x8, 1, Kokkos::pair< int, int >( 0, 2 ), 2, 3
                             , Kokkos::pair< int, int >( 0, 2 ), 1, 2, 3 );
 
-    ASSERT_TRUE( ! sx2.is_contiguous() );
+    ASSERT_TRUE( ! sx2.span_is_contiguous() );
     ASSERT_TRUE( & sx2( 0, 0 ) == & x8( 1, 0, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & sx2( 1, 0 ) == & x8( 1, 1, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & sx2( 0, 1 ) == & x8( 1, 0, 2, 3, 1, 1, 2, 3 ) );
@@ -347,12 +347,12 @@ void test_left_1()
                          , 2, Kokkos::pair< int, int >( 2, 4 ) /* of [5] */
                      );
 
-    ASSERT_TRUE( ! sx4.is_contiguous() );
+    ASSERT_TRUE( ! sx4.span_is_contiguous() );
 
-    for ( int i0 = 0; i0 < (int) sx4.dimension_0(); ++i0 )
-    for ( int i1 = 0; i1 < (int) sx4.dimension_1(); ++i1 )
-    for ( int i2 = 0; i2 < (int) sx4.dimension_2(); ++i2 )
-    for ( int i3 = 0; i3 < (int) sx4.dimension_3(); ++i3 )
+    for ( int i0 = 0; i0 < (int) sx4.extent(0); ++i0 )
+    for ( int i1 = 0; i1 < (int) sx4.extent(1); ++i1 )
+    for ( int i2 = 0; i2 < (int) sx4.extent(2); ++i2 )
+    for ( int i3 = 0; i3 < (int) sx4.extent(3); ++i3 )
     {
       ASSERT_TRUE( & sx4( i0, i1, i2, i3 ) == & x8( 0, 0 + i0, 1, 1 + i1, 1, 0 + i2, 2, 2 + i3 ) );
     }
@@ -367,17 +367,17 @@ void test_left_2()
   if ( Kokkos::Impl::SpaceAccessibility<Kokkos::HostSpace, typename Space::memory_space>::accessible ) {
     view_type x4( "x4", 2, 3, 4, 5 );
 
-    ASSERT_TRUE( x4.is_contiguous() );
+    ASSERT_TRUE( x4.span_is_contiguous() );
 
     Kokkos::View< int, Kokkos::LayoutLeft, Space > x0 = Kokkos::subview( x4, 0, 0, 0, 0 );
 
-    ASSERT_TRUE( x0.is_contiguous() );
+    ASSERT_TRUE( x0.span_is_contiguous() );
     ASSERT_TRUE( & x0() == & x4( 0, 0, 0, 0 ) );
 
     Kokkos::View< int*, Kokkos::LayoutLeft, Space > x1 =
       Kokkos::subview( x4, Kokkos::pair< int, int >( 0, 2 ), 1, 2, 3 );
 
-    ASSERT_TRUE( x1.is_contiguous() );
+    ASSERT_TRUE( x1.span_is_contiguous() );
     ASSERT_TRUE( & x1( 0 ) == & x4( 0, 1, 2, 3 ) );
     ASSERT_TRUE( & x1( 1 ) == & x4( 1, 1, 2, 3 ) );
 
@@ -385,7 +385,7 @@ void test_left_2()
       Kokkos::subview( x4, Kokkos::pair< int, int >( 0, 2 ), 1
                          , Kokkos::pair< int, int >( 1, 3 ), 2 );
 
-    ASSERT_TRUE( ! x2.is_contiguous() );
+    ASSERT_TRUE( ! x2.span_is_contiguous() );
     ASSERT_TRUE( & x2( 0, 0 ) == & x4( 0, 1, 1, 2 ) );
     ASSERT_TRUE( & x2( 1, 0 ) == & x4( 1, 1, 1, 2 ) );
     ASSERT_TRUE( & x2( 0, 1 ) == & x4( 0, 1, 2, 2 ) );
@@ -396,7 +396,7 @@ void test_left_2()
       Kokkos::subview( x4, 1, Kokkos::pair< int, int >( 0, 2 )
                          , 2, Kokkos::pair< int, int >( 1, 4 ) );
 
-    ASSERT_TRUE( ! sx2.is_contiguous() );
+    ASSERT_TRUE( ! sx2.span_is_contiguous() );
     ASSERT_TRUE( & sx2( 0, 0 ) == & x4( 1, 0, 2, 1 ) );
     ASSERT_TRUE( & sx2( 1, 0 ) == & x4( 1, 1, 2, 1 ) );
     ASSERT_TRUE( & sx2( 0, 1 ) == & x4( 1, 0, 2, 2 ) );
@@ -411,12 +411,12 @@ void test_left_2()
                          , Kokkos::pair< int, int >( 2, 4 ) /* of [5] */
                      );
 
-    ASSERT_TRUE( ! sx4.is_contiguous() );
+    ASSERT_TRUE( ! sx4.span_is_contiguous() );
 
-    for ( int i0 = 0; i0 < (int) sx4.dimension_0(); ++i0 )
-    for ( int i1 = 0; i1 < (int) sx4.dimension_1(); ++i1 )
-    for ( int i2 = 0; i2 < (int) sx4.dimension_2(); ++i2 )
-    for ( int i3 = 0; i3 < (int) sx4.dimension_3(); ++i3 )
+    for ( int i0 = 0; i0 < (int) sx4.extent(0); ++i0 )
+    for ( int i1 = 0; i1 < (int) sx4.extent(1); ++i1 )
+    for ( int i2 = 0; i2 < (int) sx4.extent(2); ++i2 )
+    for ( int i3 = 0; i3 < (int) sx4.extent(3); ++i3 )
     {
       ASSERT_TRUE( & sx4( i0, i1, i2, i3 ) == & x4( 1 + i0, 1 + i1, 0 + i2, 2 + i3 ) );
     }
@@ -431,26 +431,26 @@ void test_left_3()
   if ( Kokkos::Impl::SpaceAccessibility< Kokkos::HostSpace, typename Space::memory_space >::accessible ) {
     view_type xm( "x4", 10, 5 );
 
-    ASSERT_TRUE( xm.is_contiguous() );
+    ASSERT_TRUE( xm.span_is_contiguous() );
 
     Kokkos::View< int, Kokkos::LayoutLeft, Space > x0 = Kokkos::subview( xm, 5, 3 );
 
-    ASSERT_TRUE( x0.is_contiguous() );
+    ASSERT_TRUE( x0.span_is_contiguous() );
     ASSERT_TRUE( & x0() == & xm( 5, 3 ) );
 
     Kokkos::View< int*, Kokkos::LayoutLeft, Space > x1 = Kokkos::subview( xm, Kokkos::ALL, 3 );
 
-    ASSERT_TRUE( x1.is_contiguous() );
-    for ( int i = 0; i < int( xm.dimension_0() ); ++i ) {
+    ASSERT_TRUE( x1.span_is_contiguous() );
+    for ( int i = 0; i < int( xm.extent(0) ); ++i ) {
       ASSERT_TRUE( & x1( i ) == & xm( i, 3 ) );
     }
 
     Kokkos::View< int**, Kokkos::LayoutLeft, Space > x2 =
       Kokkos::subview( xm, Kokkos::pair< int, int >( 1, 9 ), Kokkos::ALL );
 
-    ASSERT_TRUE( ! x2.is_contiguous() );
-    for ( int j = 0; j < int( x2.dimension_1() ); ++j )
-    for ( int i = 0; i < int( x2.dimension_0() ); ++i )
+    ASSERT_TRUE( ! x2.span_is_contiguous() );
+    for ( int j = 0; j < int( x2.extent(1) ); ++j )
+    for ( int i = 0; i < int( x2.extent(0) ); ++i )
     {
       ASSERT_TRUE( & x2( i, j ) == & xm( 1 + i, j ) );
     }
@@ -458,9 +458,9 @@ void test_left_3()
     Kokkos::View< int**, Kokkos::LayoutLeft, Space > x2c =
       Kokkos::subview( xm, Kokkos::ALL, std::pair< int, int >( 2, 4 ) );
 
-    ASSERT_TRUE( x2c.is_contiguous() );
-    for ( int j = 0; j < int( x2c.dimension_1() ); ++j )
-    for ( int i = 0; i < int( x2c.dimension_0() ); ++i )
+    ASSERT_TRUE( x2c.span_is_contiguous() );
+    for ( int j = 0; j < int( x2c.extent(1) ); ++j )
+    for ( int i = 0; i < int( x2c.extent(0) ); ++i )
     {
       ASSERT_TRUE( & x2c( i, j ) == & xm( i, 2 + j ) );
     }
@@ -468,14 +468,14 @@ void test_left_3()
     Kokkos::View< int**, Kokkos::LayoutLeft, Space > x2_n1 =
       Kokkos::subview( xm, std::pair< int, int >( 1, 1 ), Kokkos::ALL );
 
-    ASSERT_TRUE( x2_n1.dimension_0() == 0 );
-    ASSERT_TRUE( x2_n1.dimension_1() == xm.dimension_1() );
+    ASSERT_TRUE( x2_n1.extent(0) == 0 );
+    ASSERT_TRUE( x2_n1.extent(1) == xm.extent(1) );
 
     Kokkos::View< int**, Kokkos::LayoutLeft, Space > x2_n2 =
       Kokkos::subview( xm, Kokkos::ALL, std::pair< int, int >( 1, 1 ) );
 
-    ASSERT_TRUE( x2_n2.dimension_0() == xm.dimension_0() );
-    ASSERT_TRUE( x2_n2.dimension_1() == 0 );
+    ASSERT_TRUE( x2_n2.extent(0) == xm.extent(0) );
+    ASSERT_TRUE( x2_n2.extent(1) == 0 );
   }
 }
 
@@ -496,7 +496,7 @@ void test_right_0()
     Kokkos::View< int*, Kokkos::LayoutRight, Space > x1 =
       Kokkos::subview( x_static_8, 0, 1, 2, 3, 0, 1, 2, Kokkos::pair< int, int >( 1, 3 ) );
 
-    ASSERT_TRUE( x1.dimension_0() == 2 );
+    ASSERT_TRUE( x1.extent(0) == 2 );
     ASSERT_TRUE( & x1( 0 ) == & x_static_8( 0, 1, 2, 3, 0, 1, 2, 1 ) );
     ASSERT_TRUE( & x1( 1 ) == & x_static_8( 0, 1, 2, 3, 0, 1, 2, 2 ) );
 
@@ -504,8 +504,8 @@ void test_right_0()
       Kokkos::subview( x_static_8, 0, 1, 2, Kokkos::pair< int, int >( 1, 3 )
                                  , 0, 1, 2, Kokkos::pair< int, int >( 1, 3 ) );
 
-    ASSERT_TRUE( x2.dimension_0() == 2 );
-    ASSERT_TRUE( x2.dimension_1() == 2 );
+    ASSERT_TRUE( x2.extent(0) == 2 );
+    ASSERT_TRUE( x2.extent(1) == 2 );
     ASSERT_TRUE( & x2( 0, 0 ) == & x_static_8( 0, 1, 2, 1, 0, 1, 2, 1 ) );
     ASSERT_TRUE( & x2( 1, 0 ) == & x_static_8( 0, 1, 2, 2, 0, 1, 2, 1 ) );
     ASSERT_TRUE( & x2( 0, 1 ) == & x_static_8( 0, 1, 2, 1, 0, 1, 2, 2 ) );
@@ -516,8 +516,8 @@ void test_right_0()
       Kokkos::subview( x_static_8, 1, Kokkos::pair< int, int >( 0, 2 ), 2, 3
                                     , Kokkos::pair< int, int >( 0, 2 ), 1, 2, 3 );
 
-    ASSERT_TRUE( sx2.dimension_0() == 2 );
-    ASSERT_TRUE( sx2.dimension_1() == 2 );
+    ASSERT_TRUE( sx2.extent(0) == 2 );
+    ASSERT_TRUE( sx2.extent(1) == 2 );
     ASSERT_TRUE( & sx2( 0, 0 ) == & x_static_8( 1, 0, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & sx2( 1, 0 ) == & x_static_8( 1, 1, 2, 3, 0, 1, 2, 3 ) );
     ASSERT_TRUE( & sx2( 0, 1 ) == & x_static_8( 1, 0, 2, 3, 1, 1, 2, 3 ) );
@@ -530,14 +530,14 @@ void test_right_0()
                                  , 2, Kokkos::pair< int, int >( 2, 4 ) /* of [5] */
                      );
 
-    ASSERT_TRUE( sx4.dimension_0() == 2 );
-    ASSERT_TRUE( sx4.dimension_1() == 2 );
-    ASSERT_TRUE( sx4.dimension_2() == 2 );
-    ASSERT_TRUE( sx4.dimension_3() == 2 );
-    for ( int i0 = 0; i0 < (int) sx4.dimension_0(); ++i0 )
-    for ( int i1 = 0; i1 < (int) sx4.dimension_1(); ++i1 )
-    for ( int i2 = 0; i2 < (int) sx4.dimension_2(); ++i2 )
-    for ( int i3 = 0; i3 < (int) sx4.dimension_3(); ++i3 )
+    ASSERT_TRUE( sx4.extent(0) == 2 );
+    ASSERT_TRUE( sx4.extent(1) == 2 );
+    ASSERT_TRUE( sx4.extent(2) == 2 );
+    ASSERT_TRUE( sx4.extent(3) == 2 );
+    for ( int i0 = 0; i0 < (int) sx4.extent(0); ++i0 )
+    for ( int i1 = 0; i1 < (int) sx4.extent(1); ++i1 )
+    for ( int i2 = 0; i2 < (int) sx4.extent(2); ++i2 )
+    for ( int i3 = 0; i3 < (int) sx4.extent(3); ++i3 )
     {
       ASSERT_TRUE( & sx4( i0, i1, i2, i3 ) == & x_static_8( 0, 0 + i0, 1, 1 + i1, 1, 0 + i2, 2, 2 + i3 ) );
     }
@@ -588,10 +588,10 @@ void test_right_1()
                          , 2, Kokkos::pair< int, int >( 2, 4 ) /* of [5] */
                      );
 
-    for ( int i0 = 0; i0 < (int) sx4.dimension_0(); ++i0 )
-    for ( int i1 = 0; i1 < (int) sx4.dimension_1(); ++i1 )
-    for ( int i2 = 0; i2 < (int) sx4.dimension_2(); ++i2 )
-    for ( int i3 = 0; i3 < (int) sx4.dimension_3(); ++i3 )
+    for ( int i0 = 0; i0 < (int) sx4.extent(0); ++i0 )
+    for ( int i1 = 0; i1 < (int) sx4.extent(1); ++i1 )
+    for ( int i2 = 0; i2 < (int) sx4.extent(2); ++i2 )
+    for ( int i3 = 0; i3 < (int) sx4.extent(3); ++i3 )
     {
       ASSERT_TRUE( & sx4( i0, i1, i2, i3 ) == & x8( 0, 0 + i0, 1, 1 + i1, 1, 0 + i2, 2, 2 + i3 ) );
     }
@@ -606,35 +606,35 @@ void test_right_3()
   if ( Kokkos::Impl::SpaceAccessibility< Kokkos::HostSpace, typename Space::memory_space >::accessible ) {
     view_type xm( "x4", 10, 5 );
 
-    ASSERT_TRUE( xm.is_contiguous() );
+    ASSERT_TRUE( xm.span_is_contiguous() );
 
     Kokkos::View< int, Kokkos::LayoutRight, Space > x0 = Kokkos::subview( xm, 5, 3 );
 
-    ASSERT_TRUE( x0.is_contiguous() );
+    ASSERT_TRUE( x0.span_is_contiguous() );
     ASSERT_TRUE( & x0() == & xm( 5, 3 ) );
 
     Kokkos::View< int*, Kokkos::LayoutRight, Space > x1 = Kokkos::subview( xm, 3, Kokkos::ALL );
 
-    ASSERT_TRUE( x1.is_contiguous() );
-    for ( int i = 0; i < int( xm.dimension_1() ); ++i ) {
+    ASSERT_TRUE( x1.span_is_contiguous() );
+    for ( int i = 0; i < int( xm.extent(1) ); ++i ) {
       ASSERT_TRUE( & x1( i ) == & xm( 3, i ) );
     }
 
     Kokkos::View< int**, Kokkos::LayoutRight, Space > x2c =
       Kokkos::subview( xm, Kokkos::pair< int, int >( 1, 9 ), Kokkos::ALL );
 
-    ASSERT_TRUE( x2c.is_contiguous() );
-    for ( int j = 0; j < int( x2c.dimension_1() ); ++j )
-    for ( int i = 0; i < int( x2c.dimension_0() ); ++i ) {
+    ASSERT_TRUE( x2c.span_is_contiguous() );
+    for ( int j = 0; j < int( x2c.extent(1) ); ++j )
+    for ( int i = 0; i < int( x2c.extent(0) ); ++i ) {
       ASSERT_TRUE( & x2c( i, j ) == & xm( 1 + i, j ) );
     }
 
     Kokkos::View< int**, Kokkos::LayoutRight, Space > x2 =
       Kokkos::subview( xm, Kokkos::ALL, std::pair< int, int >( 2, 4 ) );
 
-    ASSERT_TRUE( ! x2.is_contiguous() );
-    for ( int j = 0; j < int( x2.dimension_1() ); ++j )
-    for ( int i = 0; i < int( x2.dimension_0() ); ++i )
+    ASSERT_TRUE( ! x2.span_is_contiguous() );
+    for ( int j = 0; j < int( x2.extent(1) ); ++j )
+    for ( int i = 0; i < int( x2.extent(0) ); ++i )
     {
       ASSERT_TRUE( & x2( i, j ) == & xm( i, 2 + j ) );
     }
@@ -642,14 +642,14 @@ void test_right_3()
     Kokkos::View< int**, Kokkos::LayoutRight, Space > x2_n1 =
       Kokkos::subview( xm, std::pair< int, int >( 1, 1 ), Kokkos::ALL );
 
-    ASSERT_TRUE( x2_n1.dimension_0() == 0 );
-    ASSERT_TRUE( x2_n1.dimension_1() == xm.dimension_1() );
+    ASSERT_TRUE( x2_n1.extent(0) == 0 );
+    ASSERT_TRUE( x2_n1.extent(1) == xm.extent(1) );
 
     Kokkos::View< int**, Kokkos::LayoutRight, Space > x2_n2 =
       Kokkos::subview( xm, Kokkos::ALL, std::pair< int, int >( 1, 1 ) );
 
-    ASSERT_TRUE( x2_n2.dimension_0() == xm.dimension_0() );
-    ASSERT_TRUE( x2_n2.dimension_1() == 0 );
+    ASSERT_TRUE( x2_n2.extent(0) == xm.extent(0) );
+    ASSERT_TRUE( x2_n2.extent(1) == 0 );
   }
 }
 
@@ -1091,16 +1091,16 @@ struct FillView_3D {
   void operator()( const int & ii ) const
   {
     const int i = std::is_same< Layout, Kokkos::LayoutLeft >::value
-                ? ii % a.dimension_0()
-                : ii / ( a.dimension_1() * a.dimension_2() );
+                ? ii % a.extent(0)
+                : ii / ( a.extent(1) * a.extent(2) );
 
     const int j = std::is_same< Layout, Kokkos::LayoutLeft >::value
-                ? ( ii / a.dimension_0() ) % a.dimension_1()
-                : ( ii / a.dimension_2() ) % a.dimension_1();
+                ? ( ii / a.extent(0) ) % a.extent(1)
+                : ( ii / a.extent(2) ) % a.extent(1);
 
     const int k = std::is_same< Layout, Kokkos::LayoutRight >::value
-                ? ii / ( a.dimension_0() * a.dimension_1() )
-                : ii % a.dimension_2();
+                ? ii / ( a.extent(0) * a.extent(1) )
+                : ii % a.extent(2);
 
     a( i, j, k ) = 1000000 * i + 1000 * j + k;
   }
@@ -1113,20 +1113,20 @@ struct FillView_4D {
   KOKKOS_INLINE_FUNCTION
   void operator()( const int & ii ) const {
     const int i = std::is_same< Layout, Kokkos::LayoutLeft >::value
-              ? ii % a.dimension_0()
-              : ii / ( a.dimension_1() * a.dimension_2() * a.dimension_3() );
+              ? ii % a.extent(0)
+              : ii / ( a.extent(1) * a.extent(2) * a.extent(3) );
 
     const int j = std::is_same< Layout, Kokkos::LayoutLeft >::value
-              ? ( ii / a.dimension_0() ) % a.dimension_1()
-              : ( ii / ( a.dimension_2() * a.dimension_3() ) % a.dimension_1() );
+              ? ( ii / a.extent(0) ) % a.extent(1)
+              : ( ii / ( a.extent(2) * a.extent(3) ) % a.extent(1) );
 
     const int k = std::is_same< Layout, Kokkos::LayoutRight >::value
-              ? ( ii / ( a.dimension_0() * a.dimension_1() ) ) % a.dimension_2()
-              : ( ii / a.dimension_3() ) % a.dimension_2();
+              ? ( ii / ( a.extent(0) * a.extent(1) ) ) % a.extent(2)
+              : ( ii / a.extent(3) ) % a.extent(2);
 
     const int l = std::is_same< Layout, Kokkos::LayoutRight >::value
-                ? ii / ( a.dimension_0() * a.dimension_1() * a.dimension_2() )
-                : ii % a.dimension_3();
+                ? ii / ( a.extent(0) * a.extent(1) * a.extent(2) )
+                : ii % a.extent(3);
 
     a( i, j, k, l ) = 1000000 * i + 10000 * j + 100 * k + l;
   }
@@ -1142,16 +1142,16 @@ struct CheckSubviewCorrectness_3D_3D {
   void operator()( const int & ii ) const
   {
     const int i = std::is_same< Layout, Kokkos::LayoutLeft >::value
-                ? ii % b.dimension_0()
-                : ii / ( b.dimension_1() * b.dimension_2() );
+                ? ii % b.extent(0)
+                : ii / ( b.extent(1) * b.extent(2) );
 
     const int j = std::is_same< Layout, Kokkos::LayoutLeft >::value
-                ? ( ii / b.dimension_0() ) % b.dimension_1()
-                : ( ii / b.dimension_2() ) % b.dimension_1();
+                ? ( ii / b.extent(0) ) % b.extent(1)
+                : ( ii / b.extent(2) ) % b.extent(1);
 
     const int k = std::is_same< Layout, Kokkos::LayoutRight >::value
-                ? ii / ( b.dimension_0() * b.dimension_1() )
-                : ii % b.dimension_2();
+                ? ii / ( b.extent(0) * b.extent(1) )
+                : ii % b.extent(2);
 
     if ( a( i + offset_0, j, k + offset_2 ) != b( i, j, k ) ) {
       Kokkos::abort( "Error: check_subview_correctness 3D-3D (LayoutLeft -> LayoutLeft or LayoutRight -> LayoutRight)" );
@@ -1168,16 +1168,16 @@ struct CheckSubviewCorrectness_3D_4D {
   KOKKOS_INLINE_FUNCTION
   void operator()( const int & ii ) const {
     const int i = std::is_same< Layout, Kokkos::LayoutLeft >::value
-                ? ii % b.dimension_0()
-                : ii / ( b.dimension_1() * b.dimension_2() );
+                ? ii % b.extent(0)
+                : ii / ( b.extent(1) * b.extent(2) );
 
     const int j = std::is_same< Layout, Kokkos::LayoutLeft >::value
-                ? ( ii / b.dimension_0() ) % b.dimension_1()
-                : ( ii / b.dimension_2() ) % b.dimension_1();
+                ? ( ii / b.extent(0) ) % b.extent(1)
+                : ( ii / b.extent(2) ) % b.extent(1);
 
     const int k = std::is_same< Layout, Kokkos::LayoutRight >::value
-                ? ii / ( b.dimension_0() * b.dimension_1() )
-                : ii % b.dimension_2();
+                ? ii / ( b.extent(0) * b.extent(1) )
+                : ii % b.extent(2);
 
     int i0, i1, i2, i3;
 
@@ -1306,7 +1306,7 @@ struct TestUnmanagedSubviewReset
     {
       auto sub_a = Kokkos::subview(a,0,Kokkos::ALL,Kokkos::ALL,Kokkos::ALL);
 
-      for ( int i = 0 ; i < int(a.dimension(0)) ; ++i ) {
+      for ( int i = 0 ; i < int(a.extent(0)) ; ++i ) {
         sub_a.assign_data( & a(i,0,0,0) );
         if ( & sub_a(1,1,1) != & a(i,1,1,1) ) {
           Kokkos::abort("TestUnmanagedSubviewReset");


### PR DESCRIPTION
This pull request puts `#ifdef KOKKOS_ENABLE_DEPRECATED_CODE` around:
 - `View::dimension_?()`
 - `View::dimension(?)`
 - `View::is_contiguous()`
 - `View::ptr_on_device()`

It also goes through the large amounts of code in Kokkos itself that use them and replaces these deprecated functions with calls to their new counterparts. Finally, it fixes an issue where `DualView::resize` was relying on the deprecated support for `deep_copy` between views of different extents.

I recommend this NOT be merged until @dsunder 's expected changes are merged.