### PR TITLE
Fix #1208 by using __gnu_parallel::sort if available

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -48,7 +48,7 @@
 #include <Kokkos_Core.hpp>
 
 #include <algorithm>
-#if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)) && defined(_OPENMP) && defined(KOKKOS_ENABLE_OPENMP)
+#if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)) && !defined(KOKKOS_COMPILER_NVCC) && defined(_OPENMP) && defined(KOKKOS_ENABLE_OPENMP)
 #  include <parallel/algorithm> // __gnu_parallel::sort
 #endif // (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)) && defined(_OPENMP) && defined(KOKKOS_ENABLE_OPENMP)
 
@@ -481,7 +481,7 @@ struct BinOp3D {
 
 namespace Impl {
 
-#if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)) && defined(_OPENMP) && defined(KOKKOS_ENABLE_OPENMP)
+#if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)) && !defined(KOKKOS_COMPILER_NVCC) && defined(_OPENMP) && defined(KOKKOS_ENABLE_OPENMP)
 template<class ViewType>
 bool try_gnu_sort (const ViewType& view) {
   // Put the constexpr tests first.


### PR DESCRIPTION
This is a redo of #1388.
Thanks to @ibaned and @crtrott for reviews and fixes!

I made all changes to Kokkos_Sort.hpp.  Here is what I did:

    1. Conditionally include header for `__gnu_parallel::sort`
    2. Add `try_gnu_sort`, analogous to `try_std_sort`.  It always returns
       false if the above header is not available.  Otherwise, it returns
       true if and only if OpenMP has been initialized, the View's rank is
       1, and the View's stride is 1.
