### PR TITLE
Allow and test shmem_size(layout), w/ LayoutStride

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -2148,15 +2148,19 @@ public:
   // Shared scratch memory constructor
 
   static inline
-  size_t shmem_size( const size_t arg_N0 = ~size_t(0) ,
-                     const size_t arg_N1 = ~size_t(0) ,
-                     const size_t arg_N2 = ~size_t(0) ,
-                     const size_t arg_N3 = ~size_t(0) ,
-                     const size_t arg_N4 = ~size_t(0) ,
-                     const size_t arg_N5 = ~size_t(0) ,
-                     const size_t arg_N6 = ~size_t(0) ,
-                     const size_t arg_N7 = ~size_t(0) )
+  size_t
+  shmem_size( const size_t arg_N0 = ~size_t(0) ,
+              const size_t arg_N1 = ~size_t(0) ,
+              const size_t arg_N2 = ~size_t(0) ,
+              const size_t arg_N3 = ~size_t(0) ,
+              const size_t arg_N4 = ~size_t(0) ,
+              const size_t arg_N5 = ~size_t(0) ,
+              const size_t arg_N6 = ~size_t(0) ,
+              const size_t arg_N7 = ~size_t(0) )
   {
+    if ( is_layout_stride ) {
+      Kokkos::abort( "Kokkos::View::shmem_size(extents...) doesn't work with LayoutStride. Pass a LayoutStride object instead" );
+    }
     const size_t num_passed_args =
       ( arg_N0 != ~size_t(0) ) + ( arg_N1 != ~size_t(0) ) + ( arg_N2 != ~size_t(0) ) +
       ( arg_N3 != ~size_t(0) ) + ( arg_N4 != ~size_t(0) ) + ( arg_N5 != ~size_t(0) ) +
@@ -2166,10 +2170,16 @@ public:
       Kokkos::abort( "Kokkos::View::shmem_size() rank_dynamic != number of arguments.\n" );
     }
 
-    return map_type::memory_span(
+    return View::shmem_size(
            typename traits::array_layout
             ( arg_N0 , arg_N1 , arg_N2 , arg_N3
             , arg_N4 , arg_N5 , arg_N6 , arg_N7 ) );
+  }
+
+  static inline
+  size_t shmem_size( typename traits::array_layout const& arg_layout )
+  {
+    return map_type::memory_span( arg_layout );
   }
 
   explicit KOKKOS_INLINE_FUNCTION

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -954,8 +954,19 @@ struct TestShmemSize {
     size_t size = view_type::shmem_size( d1, d2, d3 );
 
     ASSERT_EQ( size, d1 * d2 * d3 * sizeof( long ) );
+
+    test_layout_stride();
+  }
+
+  void test_layout_stride()
+  {
+    int rank = 3;
+    int order[3] = {2, 0, 1};
+    int extents[3] = {100, 10, 3};
+    auto s1 = Kokkos::View<double***, Kokkos::LayoutStride, ExecSpace>::shmem_size(Kokkos::LayoutStride::order_dimensions(rank, order, extents));
+    auto s2 = Kokkos::View<double***, Kokkos::LayoutRight, ExecSpace>::shmem_size(extents[0], extents[1], extents[2]);
+    ASSERT_EQ(s1, s2);
   }
 };
-
 
 } // namespace Test


### PR DESCRIPTION
Should address issue #1291 

Passes spot check:
```
Running on machine: sems
Repository Status:  c5b3bea61bbfd46e5b36e920db98adccc3913dc5 Allow and test shmem_size(layout), w/ LayoutStride


Going to test compilers:  gcc/5.3.0 gcc/6.1.0 intel/17.0.1 clang/3.9.0 cuda/8.0.44
Testing compiler gcc/5.3.0
Testing compiler gcc/6.1.0
  Starting job gcc-5.3.0-OpenMP-release
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  Starting job gcc-6.1.0-Serial-release
  PASSED gcc-6.1.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-6.1.0-Serial-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  Starting job intel-17.0.1-OpenMP-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler clang/3.9.0
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED gcc-6.1.0-Serial-hwloc-release
  Starting job clang-3.9.0-Pthread_Serial-release
  PASSED clang-3.9.0-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-3.9.0-Pthread_Serial-hwloc-release
  PASSED intel-17.0.1-OpenMP-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  PASSED clang-3.9.0-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-hwloc-release build_time=195 run_time=90
clang-3.9.0-Pthread_Serial-release build_time=199 run_time=218
cuda-8.0.44-Cuda_OpenMP-release build_time=498 run_time=540
gcc-5.3.0-OpenMP-hwloc-release build_time=256 run_time=105
gcc-5.3.0-OpenMP-release build_time=262 run_time=103
gcc-6.1.0-Serial-hwloc-release build_time=203 run_time=135
gcc-6.1.0-Serial-release build_time=202 run_time=124
intel-17.0.1-OpenMP-hwloc-release build_time=567 run_time=186
intel-17.0.1-OpenMP-release build_time=564 run_time=182
```