### PR TITLE
Allow on-device label access for zero-span views

### DIFF
--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2826,7 +2826,13 @@ public:
                            , ( (Kokkos::Impl::ViewCtorProp<void,std::string>  const &) arg_prop ).value
                            , alloc_size );
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+    if ( alloc_size ) {
+#endif
     m_handle = handle_type( reinterpret_cast< pointer_type >( record->data() ) );
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+    }
+#endif
 
     //  Only initialize if the allocation is non-zero.
     //  May be zero if one of the dimensions is zero.


### PR DESCRIPTION
[#1411]
This also changes behavior, now (data() != NULL)
even for zero-span views.