### PR TITLE
Fix Task DAG on Volta with Cuda 9 : Issue 1395

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -124,14 +124,24 @@ namespace Impl {
  *  where
  *    blockDim.x * blockDim.y == WarpSize
  *
+ *  Current implementation requires blockDim.x == 1.
+ *  Vector level parallelism with blockDim.y > 1 on Volta will
+ *  require a vector-level synchronization mask for vector-level
+ *  collective operaitons.
+ *
  *  Both single thread and thread team tasks are run by a full Cuda warp.
  *  A single thread task is called by warp lane #0 and the remaining
  *  lanes of the warp are idle.
+ *
+ *  When executing a single thread task the syncwarp or other
+ *  warp synchronizing functions must not be called.
  */
 template<>
 class TaskExec< Kokkos::Cuda >
 {
 private:
+
+  enum : int { WarpSize = Kokkos::Impl::CudaTraits::WarpSize };
 
   TaskExec( TaskExec && ) = delete ;
   TaskExec( TaskExec const & ) = delete ;
@@ -144,6 +154,8 @@ private:
   int32_t * m_team_shmem ;
   const int m_team_size ;
 
+  // If constructed with arg_team_size == 1 the object
+  // can only be used by 0 == threadIdx.y.
   __device__
   TaskExec( int32_t * arg_team_shmem , int arg_team_size = blockDim.y )
     : m_team_shmem( arg_team_shmem )
@@ -170,7 +182,7 @@ public:
         // thread_id < blockDim.y
         KOKKOS_IMPL_CUDA_SYNCWARP ;
         ValueType tmp( val ); // input might not be register variable
-        cuda_shfl( val, tmp, blockDim.x * thread_id, blockDim.X * blockDim.y );
+        cuda_shfl( val, tmp, blockDim.x * thread_id, WarpSize );
       }
     }
 
@@ -443,12 +455,18 @@ void parallel_reduce
   }
   initialized_result = result;
 
-  strided_shfl_warp_reduction(
-                          [&] (ValueType& val1, const ValueType& val2) { val1 += val2; },
-                          initialized_result,
-                          loop_boundaries.thread.team_size(),
-                          blockDim.x);
-  initialized_result = shfl_warp_broadcast<ValueType>( initialized_result, threadIdx.x, Impl::CudaTraits::WarpSize );
+  if ( 1 < loop_boundaries.thread.team_size() ) {
+
+    strided_shfl_warp_reduction(
+      [&] (ValueType& val1, const ValueType& val2) { val1 += val2; },
+      initialized_result,
+      loop_boundaries.thread.team_size(),
+      blockDim.x);
+
+    initialized_result =
+      shfl_warp_broadcast<ValueType>(
+        initialized_result, threadIdx.x, Impl::CudaTraits::WarpSize );
+  }
 }
 
 template< typename iType, class Lambda, typename ReducerType >
@@ -467,12 +485,20 @@ void parallel_reduce
     lambda(i,result);
   }
 
-  strided_shfl_warp_reduction(
-                          [&] (ValueType& val1, const ValueType& val2) { reducer.join(val1,val2); },
-                          result,
-                          loop_boundaries.thread.team_size(),
-                          blockDim.x);
-  reducer.reference() = shfl_warp_broadcast<ValueType>( result, threadIdx.x, Impl::CudaTraits::WarpSize );
+  if ( 1 < loop_boundaries.thread.team_size() ) {
+    strided_shfl_warp_reduction(
+      [&] (ValueType& val1, const ValueType& val2) { reducer.join(val1,val2); },
+      result,
+      loop_boundaries.thread.team_size(),
+      blockDim.x);
+
+    reducer.reference() =
+      shfl_warp_broadcast<ValueType>(
+        result, threadIdx.x, Impl::CudaTraits::WarpSize );
+  }
+  else {
+    reducer.reference() = result ;
+  }
 }
 // all-reduce within team members within warp
 // assume vec_length*team_size == warp_size
@@ -520,12 +546,16 @@ void parallel_reduce
 
   initialized_result = result;
 
-  //initialized_result = multi_shfl_warp_reduction(
-  multi_shfl_warp_reduction(
-                          [&] (ValueType& val1, const ValueType& val2) { val1 += val2; },
-                          initialized_result,
-                          blockDim.x);
-  initialized_result = shfl_warp_broadcast<ValueType>( initialized_result, 0, blockDim.x );
+  if ( 1 < loop_boundaries.thread.team_size() ) {
+    //initialized_result = multi_shfl_warp_reduction(
+    multi_shfl_warp_reduction(
+      [&] (ValueType& val1, const ValueType& val2) { val1 += val2; },
+      initialized_result,
+      blockDim.x);
+
+    initialized_result =
+      shfl_warp_broadcast<ValueType>( initialized_result, 0, blockDim.x );
+  }
 }
 
 template< typename iType, class Lambda, typename ReducerType >
@@ -544,11 +574,18 @@ void parallel_reduce
     lambda(i,result);
   }
 
-  multi_shfl_warp_reduction(
-                          [&] (ValueType& val1, const ValueType& val2) { reducer.join(val1, val2); },
-                          result,
-                          blockDim.x);
-  reducer.reference() = shfl_warp_broadcast<ValueType>( result, 0, blockDim.x );
+  if ( 1 < loop_boundaries.thread.team_size() ) {
+    multi_shfl_warp_reduction(
+      [&] (ValueType& val1, const ValueType& val2) { reducer.join(val1,val2); },
+      result,
+      blockDim.x);
+
+    reducer.reference() =
+      shfl_warp_broadcast<ValueType>( result, 0, blockDim.x );
+  }
+  else {
+    reducer.reference() = result ;
+  }
 }
 // scan across corresponding vector lanes between team members within warp
 // assume vec_length*team_size == warp_size
@@ -570,35 +607,47 @@ void parallel_scan
       , void
       , Closure >::value_type ;
 
-  value_type accum = 0 ;
-  value_type val, y, local_total;
+  if ( 1 < loop_boundaries.thread.team_size() ) {
+    // TODO:  This is not a performant algorithm and needs to be replaced.
+    // TODO:  This algorithm is erroneous when all threads of the warp
+    //        do not have the exact same iteration.
 
-  for( iType i = loop_boundaries.start; i < loop_boundaries.end; i+=loop_boundaries.increment) {
-    val = 0;
-    closure(i,val,false);
+    value_type accum = 0 ;
+    value_type val, y, local_total;
 
-    // intra-blockDim.y exclusive scan on 'val'
-    // accum = accumulated, sum in total for this iteration
+    for( iType i = loop_boundaries.start; i < loop_boundaries.end; i+=loop_boundaries.increment) {
+      val = 0;
+      closure(i,val,false);
 
-    // INCLUSIVE scan
-    for( int offset = blockDim.x ; offset < Impl::CudaTraits::WarpSize ; offset <<= 1 ) {
-      y = Kokkos::shfl_up(val, offset, Impl::CudaTraits::WarpSize);
-      if(threadIdx.y*blockDim.x >= offset) { val += y; }
-    }
+      // intra-blockDim.y exclusive scan on 'val'
+      // accum = accumulated, sum in total for this iteration
 
-    // pass accum to all threads
-    local_total = shfl_warp_broadcast<value_type>(val,
+      // INCLUSIVE scan
+      for( int offset = blockDim.x ; offset < Impl::CudaTraits::WarpSize ; offset <<= 1 ) {
+        y = Kokkos::shfl_up(val, offset, Impl::CudaTraits::WarpSize);
+        if(threadIdx.y*blockDim.x >= offset) { val += y; }
+      }
+
+      // pass accum to all threads
+      local_total = shfl_warp_broadcast<value_type>(val,
                                             threadIdx.x+Impl::CudaTraits::WarpSize-blockDim.x,
                                             Impl::CudaTraits::WarpSize);
 
-    // make EXCLUSIVE scan by shifting values over one
-    KOKKOS_IMPL_CUDA_SYNCWARP ;
-    val = Kokkos::shfl_up(val, blockDim.x, Impl::CudaTraits::WarpSize);
-    if ( threadIdx.y == 0 ) { val = 0 ; }
+      // make EXCLUSIVE scan by shifting values over one
+      KOKKOS_IMPL_CUDA_SYNCWARP ;
+      val = Kokkos::shfl_up(val, blockDim.x, Impl::CudaTraits::WarpSize);
+      if ( threadIdx.y == 0 ) { val = 0 ; }
 
-    val += accum;
-    closure(i,val,true);
-    accum += local_total;
+      val += accum;
+      closure(i,val,true);
+      accum += local_total;
+    }
+  }
+  else {
+    value_type accum = 0 ;
+    for( iType i = loop_boundaries.start; i < loop_boundaries.end; i+=loop_boundaries.increment) {
+      closure(i,accum,true);
+    }
   }
 }
 
@@ -622,34 +671,46 @@ void parallel_scan
       , void
       , Closure >::value_type ;
 
-  value_type accum = 0 ;
-  value_type val, y, local_total;
+  if ( 1 < loop_boundaries.thread.team_size() ) {
+    // TODO:  This is not a performant algorithm and needs to be replaced.
+    // TODO:  This algorithm is erroneous when all threads of the warp
+    //        do not have the exact same iteration.
 
-  for( iType i = loop_boundaries.start; i < loop_boundaries.end; i+=loop_boundaries.increment) {
-    val = 0;
-    closure(i,val,false);
+    value_type accum = 0 ;
+    value_type val, y, local_total;
 
-    // intra-blockDim.x exclusive scan on 'val'
-    // accum = accumulated, sum in total for this iteration
+    for( iType i = loop_boundaries.start; i < loop_boundaries.end; i+=loop_boundaries.increment) {
+      val = 0;
+      closure(i,val,false);
 
-    // INCLUSIVE scan
-    for( int offset = 1 ; offset < blockDim.x ; offset <<= 1 ) {
+      // intra-blockDim.x exclusive scan on 'val'
+      // accum = accumulated, sum in total for this iteration
+
+      // INCLUSIVE scan
+      for( int offset = 1 ; offset < blockDim.x ; offset <<= 1 ) {
+        KOKKOS_IMPL_CUDA_SYNCWARP ;
+        y = Kokkos::shfl_up(val, offset, blockDim.x);
+        if(threadIdx.x >= offset) { val += y; }
+      }
+
+      // pass accum to all threads
+      local_total = shfl_warp_broadcast<value_type>(val, blockDim.x-1, blockDim.x);
+
+      // make EXCLUSIVE scan by shifting values over one
       KOKKOS_IMPL_CUDA_SYNCWARP ;
-      y = Kokkos::shfl_up(val, offset, blockDim.x);
-      if(threadIdx.x >= offset) { val += y; }
+      val = Kokkos::shfl_up(val, 1, blockDim.x);
+      if ( threadIdx.x == 0 ) { val = 0 ; }
+
+      val += accum;
+      closure(i,val,true);
+      accum += local_total;
     }
-
-    // pass accum to all threads
-    local_total = shfl_warp_broadcast<value_type>(val, blockDim.x-1, blockDim.x);
-
-    // make EXCLUSIVE scan by shifting values over one
-    KOKKOS_IMPL_CUDA_SYNCWARP ;
-    val = Kokkos::shfl_up(val, 1, blockDim.x);
-    if ( threadIdx.x == 0 ) { val = 0 ; }
-
-    val += accum;
-    closure(i,val,true);
-    accum += local_total;
+  }
+  else {
+    value_type accum = 0 ;
+    for( iType i = loop_boundaries.start; i < loop_boundaries.end; i+=loop_boundaries.increment) {
+      closure(i,accum,true);
+    }
   }
 }
 
@@ -675,11 +736,13 @@ namespace Kokkos {
   
   template<class FunctorType, class ValueType>
   KOKKOS_INLINE_FUNCTION
-  void single(const Impl::VectorSingleStruct<Impl::TaskExec< Kokkos::Cuda > >& , const FunctorType& lambda, ValueType& val) {
+  void single(const Impl::VectorSingleStruct<Impl::TaskExec< Kokkos::Cuda > >& s , const FunctorType& lambda, ValueType& val) {
 #ifdef __CUDA_ARCH__
     if(threadIdx.x == 0) lambda(val);
-    KOKKOS_IMPL_CUDA_SYNCWARP ;
-    val = shfl(val,0,blockDim.x);
+    if ( 1 < s.team_member.team_size() ) {
+      KOKKOS_IMPL_CUDA_SYNCWARP ;
+      val = shfl(val,0,blockDim.x);
+    }
 #endif
   }
   

--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -152,15 +152,14 @@ private:
 public:
 
 #if defined( __CUDA_ARCH__ )
-#if ( 700 <= __CUDA_ARCH__ )
-  #error "TBD: Warp level collectives for Volta with non-synchronous warps"
-#else
   __device__ int  team_rank() const { return threadIdx.y ; }
   __device__ int  team_size() const { return m_team_size ; }
+
   __device__ void team_barrier() const
     {
-      __threadfence_block();
+      KOKKOS_IMPL_CUDA_SYNCWARP ;
     }
+
   template< class ValueType >
   __device__ void team_broadcast( ValueType & val , const int thread_id ) const
     {
@@ -169,7 +168,7 @@ public:
       ValueType tmp( val ); // input might not be register variable
       cuda_shfl( val, tmp, blockDim.x * thread_id, blockDim.X * blockDim.y );
     }
-#endif
+
 #else
   __host__ int  team_rank() const { return 0 ; }
   __host__ int  team_size() const { return 0 ; }

--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -180,7 +180,6 @@ public:
       if ( 1 < m_team_size ) {
         // WarpSize = blockDim.X * blockDim.y
         // thread_id < blockDim.y
-        KOKKOS_IMPL_CUDA_SYNCWARP ;
         ValueType tmp( val ); // input might not be register variable
         cuda_shfl( val, tmp, blockDim.x * thread_id, WarpSize );
       }
@@ -370,7 +369,6 @@ void strided_shfl_warp_reduction
    int stride)
 {
   for (int lane_delta=(team_size*stride)>>1; lane_delta>=stride; lane_delta>>=1) {
-    KOKKOS_IMPL_CUDA_SYNCWARP ;
     join(val, Kokkos::shfl_down(val, lane_delta, team_size*stride));
   }
 }
@@ -384,7 +382,6 @@ void multi_shfl_warp_reduction
    int vec_length)
 {
   for (int lane_delta=vec_length>>1; lane_delta; lane_delta>>=1) {
-    KOKKOS_IMPL_CUDA_SYNCWARP ;
     join(val, Kokkos::shfl_down(val, lane_delta, vec_length));
   }
 }
@@ -398,7 +395,6 @@ ValueType shfl_warp_broadcast
    int width)
 {
   if ( 1 < width ) {
-    KOKKOS_IMPL_CUDA_SYNCWARP ;
     return Kokkos::shfl(val, src_lane, width);
   }
   else {
@@ -689,7 +685,6 @@ void parallel_scan
 
       // INCLUSIVE scan
       for( int offset = 1 ; offset < blockDim.x ; offset <<= 1 ) {
-        KOKKOS_IMPL_CUDA_SYNCWARP ;
         y = Kokkos::shfl_up(val, offset, blockDim.x);
         if(threadIdx.x >= offset) { val += y; }
       }
@@ -698,7 +693,6 @@ void parallel_scan
       local_total = shfl_warp_broadcast<value_type>(val, blockDim.x-1, blockDim.x);
 
       // make EXCLUSIVE scan by shifting values over one
-      KOKKOS_IMPL_CUDA_SYNCWARP ;
       val = Kokkos::shfl_up(val, 1, blockDim.x);
       if ( threadIdx.x == 0 ) { val = 0 ; }
 
@@ -741,7 +735,6 @@ namespace Kokkos {
 #ifdef __CUDA_ARCH__
     if(threadIdx.x == 0) lambda(val);
     if ( 1 < s.team_member.team_size() ) {
-      KOKKOS_IMPL_CUDA_SYNCWARP ;
       val = shfl(val,0,blockDim.x);
     }
 #endif

--- a/core/src/Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp
@@ -1,4 +1,5 @@
 #include<Kokkos_Macros.hpp>
+#if defined( __CUDA_ARCH__ )
 #if ( CUDA_VERSION < 9000 )
 #define KOKKOS_IMPL_CUDA_SYNCWARP __threadfence_block()
 #define KOKKOS_IMPL_CUDA_BALLOT(x) __ballot(x)
@@ -12,3 +13,50 @@
 #define KOKKOS_IMPL_CUDA_SHFL_UP(x,y,z) __shfl_up_sync(0xffffffff,x,y,z)
 #define KOKKOS_IMPL_CUDA_SHFL_DOWN(x,y,z) __shfl_down_sync(0xffffffff,x,y,z)
 #endif 
+#else
+#define KOKKOS_IMPL_CUDA_SYNCWARP 
+#define KOKKOS_IMPL_CUDA_BALLOT(x) 0
+#define KOKKOS_IMPL_CUDA_SHFL(x,y,z) 0
+#define KOKKOS_IMPL_CUDA_SHFL_UP(x,y,z) 0
+#define KOKKOS_IMPL_CUDA_SHFL_DOWN(x,y,z) 0
+#endif 
+
+#if defined( __CUDA_ARCH__ )
+#if ( CUDA_VERSION < 9000 )
+#define KOKKOS_IMPL_CUDA_SYNCWARP_OR_RETURN( MSG ) { \
+  const unsigned b = __ballot(1); \
+  if ( b != 0xffffffff ) { \
+    printf(" SYNCWARP AT %s (%d,%d,%d) (%d,%d,%d) failed %x\n" \
+      , MSG \
+      , blockIdx.x \
+      , blockIdx.y \
+      , blockIdx.z \
+      , threadIdx.x \
+      , threadIdx.y \
+      , threadIdx.z \
+      , b ); \
+    return ; \
+  } \
+}
+#else
+#define KOKKOS_IMPL_CUDA_SYNCWARP_OR_RETURN( MSG ) { \
+  __syncwarp(); \
+  const unsigned b = __activemask(); \
+  if ( b != 0xffffffff ) { \
+    printf(" SYNCWARP AT %s (%d,%d,%d) (%d,%d,%d) failed %x\n" \
+      , MSG \
+      , blockIdx.x \
+      , blockIdx.y \
+      , blockIdx.z \
+      , threadIdx.x \
+      , threadIdx.y \
+      , threadIdx.z \
+      , b ); \
+    return ; \
+  } \
+}
+#endif 
+#else
+#define KOKKOS_IMPL_CUDA_SYNCWARP_OR_RETURN( MSG ) 
+#endif 
+

--- a/core/src/Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp
@@ -1,12 +1,12 @@
 #include<Kokkos_Macros.hpp>
 #if ( CUDA_VERSION < 9000 )
-#define KOKKOS_IMPL_CUDA_SYNCWARP (void) __ballot(1)
+#define KOKKOS_IMPL_CUDA_SYNCWARP __threadfence_block()
 #define KOKKOS_IMPL_CUDA_BALLOT(x) __ballot(x)
 #define KOKKOS_IMPL_CUDA_SHFL(x,y,z) __shfl(x,y,z)
 #define KOKKOS_IMPL_CUDA_SHFL_UP(x,y,z) __shfl_up(x,y,z)
 #define KOKKOS_IMPL_CUDA_SHFL_DOWN(x,y,z) __shfl_down(x,y,z)
 #else
-#define KOKKOS_IMPL_CUDA_SYNCWARP __syncwarp()
+#define KOKKOS_IMPL_CUDA_SYNCWARP __syncwarp(0xffffffff)
 #define KOKKOS_IMPL_CUDA_BALLOT(x) __ballot_sync(0xffffffff,x)
 #define KOKKOS_IMPL_CUDA_SHFL(x,y,z) __shfl_sync(0xffffffff,x,y,z)
 #define KOKKOS_IMPL_CUDA_SHFL_UP(x,y,z) __shfl_up_sync(0xffffffff,x,y,z)

--- a/core/src/Kokkos_TaskScheduler.hpp
+++ b/core/src/Kokkos_TaskScheduler.hpp
@@ -418,17 +418,21 @@ public:
   KOKKOS_INLINE_FUNCTION
   TaskScheduler() : m_track(), m_queue(0) {}
 
-  KOKKOS_INLINE_FUNCTION_DEFAULTED
-  TaskScheduler( TaskScheduler && rhs ) = default ;
+  KOKKOS_INLINE_FUNCTION
+  TaskScheduler( TaskScheduler && rhs )
+    : m_track( rhs.m_track ), m_queue( rhs.m_queue ) {}
 
-  KOKKOS_INLINE_FUNCTION_DEFAULTED
-  TaskScheduler( TaskScheduler const & rhs ) = default ;
+  KOKKOS_INLINE_FUNCTION
+  TaskScheduler( TaskScheduler const & rhs )
+    : m_track( rhs.m_track ), m_queue( rhs.m_queue ) {}
 
-  KOKKOS_INLINE_FUNCTION_DEFAULTED
-  TaskScheduler & operator = ( TaskScheduler && rhs ) = default ;
+  KOKKOS_INLINE_FUNCTION
+  TaskScheduler & operator = ( TaskScheduler && rhs )
+    { m_track = rhs.m_track ; m_queue =  rhs.m_queue ; return *this ; }
 
-  KOKKOS_INLINE_FUNCTION_DEFAULTED
-  TaskScheduler & operator = ( TaskScheduler const & rhs ) = default ;
+  KOKKOS_INLINE_FUNCTION
+  TaskScheduler & operator = ( TaskScheduler const & rhs )
+    { m_track = rhs.m_track ; m_queue =  rhs.m_queue ; return *this ; }
 
   TaskScheduler( memory_pool const & arg_memory_pool )
     : m_track()


### PR DESCRIPTION
Fix Task DAG on Volta with Cuda 9 : Issue #1395 
Passes spot check:

Repository Status:  4694f06190665686477147a3de88fd1cb64cda1f Revise task team scan to make sure all threads of a team consistently call all warp synchronizing operations.


Going to test compilers:  gcc/5.3.0 gcc/6.1.0 intel/17.0.1 clang/3.9.0 cuda/8.0.44
Testing compiler gcc/5.3.0
Testing compiler gcc/6.1.0
  Starting job gcc-5.3.0-OpenMP-release
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  Starting job gcc-6.1.0-Serial-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler intel/17.0.1
  Starting job gcc-6.1.0-Serial-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-6.1.0-Serial-release
Testing compiler clang/3.9.0
  Starting job intel-17.0.1-OpenMP-release
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED gcc-6.1.0-Serial-hwloc-release
  Starting job clang-3.9.0-Pthread_Serial-release
  PASSED clang-3.9.0-Pthread_Serial-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
Testing compiler cuda/8.0.44
  Starting job clang-3.9.0-Pthread_Serial-hwloc-release
  PASSED intel-17.0.1-OpenMP-release
  PASSED clang-3.9.0-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-hwloc-release build_time=193 run_time=89
clang-3.9.0-Pthread_Serial-release build_time=201 run_time=229
cuda-8.0.44-Cuda_OpenMP-release build_time=492 run_time=564
gcc-5.3.0-OpenMP-hwloc-release build_time=255 run_time=142
gcc-5.3.0-OpenMP-release build_time=255 run_time=141
gcc-6.1.0-Serial-hwloc-release build_time=212 run_time=131
gcc-6.1.0-Serial-release build_time=205 run_time=192
intel-17.0.1-OpenMP-hwloc-release build_time=599 run_time=172
intel-17.0.1-OpenMP-release build_time=599 run_time=176
