### PR TITLE
Fix unit test compile on OS X

### DIFF
--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -47,6 +47,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <cstdint>
+#include <cinttypes>
 
 namespace TestTeamVector {
 


### PR DESCRIPTION
Technically `<cinttypes>` needs to
be included to have PRId64 etc.