### PR TITLE
More improvements to atomics

### DIFF
--- a/core/src/impl/Kokkos_Atomic_Decrement.hpp
+++ b/core/src/impl/Kokkos_Atomic_Decrement.hpp
@@ -61,15 +61,17 @@ void atomic_decrement<char>(volatile char* a) {
 #if defined( KOKKOS_ENABLE_RFO_PREFETCH )
   _mm_prefetch( (const char*) a, _MM_HINT_ET0 );
 #endif
-
   __asm__ __volatile__(
       "lock decb %0"
       : /* no output registers */
       : "m" (a[0])
       : "memory"
     );
+#elif defined( KOKKOS_ENABLE_SERIAL_ATOMICS )
+  char* a_nv = const_cast<char*>(a);
+  --(*a_nv);
 #else
-  Kokkos::atomic_fetch_sub(a, (char)1);
+  Kokkos::atomic_fetch_sub(a, char(1));
 #endif
 }
 
@@ -80,15 +82,17 @@ void atomic_decrement<short>(volatile short* a) {
 #if defined( KOKKOS_ENABLE_RFO_PREFETCH )
   _mm_prefetch( (const char*) a, _MM_HINT_ET0 );
 #endif
-
   __asm__ __volatile__(
       "lock decw %0"
       : /* no output registers */
       : "m" (a[0])
       : "memory"
     );
+#elif defined( KOKKOS_ENABLE_SERIAL_ATOMICS )
+  short* a_nv = const_cast<short*>(a);
+  --(*a_nv);
 #else
-  Kokkos::atomic_fetch_sub(a, (short)1);
+  Kokkos::atomic_fetch_sub(a, short(1));
 #endif
 }
 
@@ -99,15 +103,17 @@ void atomic_decrement<int>(volatile int* a) {
 #if defined( KOKKOS_ENABLE_RFO_PREFETCH )
   _mm_prefetch( (const char*) a, _MM_HINT_ET0 );
 #endif
-
   __asm__ __volatile__(
       "lock decl %0"
       : /* no output registers */
       : "m" (a[0])
       : "memory"
     );
+#elif defined( KOKKOS_ENABLE_SERIAL_ATOMICS )
+  int* a_nv = const_cast<int*>(a);
+  --(*a_nv);
 #else
-  Kokkos::atomic_fetch_sub(a, (int)1);
+  Kokkos::atomic_fetch_sub(a, int(1));
 #endif
 }
 
@@ -124,15 +130,24 @@ void atomic_decrement<long long int>(volatile long long int* a) {
       : "m" (a[0])
       : "memory"
     );
+#elif defined( KOKKOS_ENABLE_SERIAL_ATOMICS )
+  long long int* a_nv = const_cast<long long int*>(a);
+  --(*a_nv);
 #else
-  Kokkos::atomic_fetch_sub(a, (long long int)1);
+  using T = long long int;
+  Kokkos::atomic_fetch_sub(a, T(1));
 #endif
 }
 
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 void atomic_decrement(volatile T* a) {
-  Kokkos::atomic_fetch_sub(a, (T)1);
+#if defined( KOKKOS_ENABLE_SERIAL_ATOMICS )
+  T* a_nv = const_cast<T*>(a);
+  --(*a_nv);
+#else
+  Kokkos::atomic_fetch_sub(a, T(1));
+#endif
 }
 
 } // End of namespace Kokkos

--- a/core/src/impl/Kokkos_Atomic_Increment.hpp
+++ b/core/src/impl/Kokkos_Atomic_Increment.hpp
@@ -69,7 +69,7 @@ void atomic_increment<char>(volatile char* a) {
   char* a_nv = const_cast<char*>(a);
   ++(*a_nv);
 #else
-  Kokkos::atomic_fetch_add(a,(char)1);
+  Kokkos::atomic_fetch_add(a, char(1));
 #endif
 }
 
@@ -90,7 +90,7 @@ void atomic_increment<short>(volatile short* a) {
   short* a_nv = const_cast<short*>(a);
   ++(*a_nv);
 #else
-  Kokkos::atomic_fetch_add(a,(short)1);
+  Kokkos::atomic_fetch_add(a, short(1));
 #endif
 }
 
@@ -111,7 +111,7 @@ void atomic_increment<int>(volatile int* a) {
   int* a_nv = const_cast<int*>(a);
   ++(*a_nv);
 #else
-  Kokkos::atomic_fetch_add(a,(int)1);
+  Kokkos::atomic_fetch_add(a,int(1));
 #endif
 }
 
@@ -132,7 +132,8 @@ void atomic_increment<long long int>(volatile long long int* a) {
   long long int* a_nv = const_cast<long long int*>(a);
   ++(*a_nv);
 #else
-  Kokkos::atomic_fetch_add(a,(long long int)1);
+  using T = long long int;
+  Kokkos::atomic_fetch_add(a,T(1));
 #endif
 }
 
@@ -141,9 +142,9 @@ KOKKOS_INLINE_FUNCTION
 void atomic_increment(volatile T* a) {
 #if defined( KOKKOS_ENABLE_SERIAL_ATOMICS )
   T* a_nv = const_cast<T*>(a);
-  *a_nv += T(1);
+  ++(*a_nv);
 #else
-  Kokkos::atomic_fetch_add(a,(T)1);
+  Kokkos::atomic_fetch_add(a,T(1));
 #endif
 }
 

--- a/core/src/impl/Kokkos_Atomic_View.hpp
+++ b/core/src/impl/Kokkos_Atomic_View.hpp
@@ -86,24 +86,24 @@ public:
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator ++ () const {
-    const_value_type tmp = Kokkos::atomic_fetch_add(ptr,(non_const_value_type)1);
+    const_value_type tmp = Kokkos::atomic_fetch_add(ptr,non_const_value_type(1));
     return tmp+1;
   }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator -- () const {
-    const_value_type tmp = Kokkos::atomic_fetch_add(ptr,(non_const_value_type)-1);
+    const_value_type tmp = Kokkos::atomic_fetch_sub(ptr,non_const_value_type(1));
     return tmp-1;
   }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator ++ (int) const {
-    return Kokkos::atomic_fetch_add(ptr,(non_const_value_type)1);
+    return Kokkos::atomic_fetch_add(ptr,non_const_value_type(1));
   }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator -- (int) const {
-    return Kokkos::atomic_fetch_add(ptr,(non_const_value_type)-1);
+    return Kokkos::atomic_fetch_sub(ptr,non_const_value_type(1));
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -119,12 +119,12 @@ public:
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator -= (const_value_type& val) const {
-    const_value_type tmp = Kokkos::atomic_fetch_add(ptr,-val);
+    const_value_type tmp = Kokkos::atomic_fetch_sub(ptr,val);
     return tmp-val;
   }
   KOKKOS_INLINE_FUNCTION
   const_value_type operator -= (volatile const_value_type& val) const {
-    const_value_type tmp = Kokkos::atomic_fetch_add(ptr,-val);
+    const_value_type tmp = Kokkos::atomic_fetch_sub(ptr,val);
     return tmp-val;
   }
 


### PR DESCRIPTION
1. Replace C-style casts with C++-style ones
2. Replace atomic_fetch_add(x, -val) calls with
   atomic_fetch_sub(x, val)
3. Add special Serial implementations of
   atomic_decrement to match atomic_increment

Note: I couldn't change `operator++` in the atomic view to use `atomic_increment`, because it needs to return the old value.

passes spot check:
```
Running on machine: sems
Repository Status:  d112ceb75e3ea52f6c9344868986f3f090a07fea More improvements to atomics


Going to test compilers:  gcc/5.3.0 gcc/6.1.0 intel/17.0.1 clang/3.9.0 cuda/8.0.44
Testing compiler gcc/5.3.0
Testing compiler gcc/6.1.0
  Starting job gcc-5.3.0-OpenMP-release
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  Starting job gcc-6.1.0-Serial-release
  PASSED gcc-6.1.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-6.1.0-Serial-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler clang/3.9.0
  Starting job intel-17.0.1-OpenMP-release
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED gcc-6.1.0-Serial-hwloc-release
  Starting job clang-3.9.0-Pthread_Serial-release
  PASSED clang-3.9.0-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-3.9.0-Pthread_Serial-hwloc-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  PASSED intel-17.0.1-OpenMP-release
  PASSED clang-3.9.0-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-hwloc-release build_time=196 run_time=87
clang-3.9.0-Pthread_Serial-release build_time=210 run_time=214
cuda-8.0.44-Cuda_OpenMP-release build_time=507 run_time=557
gcc-5.3.0-OpenMP-hwloc-release build_time=265 run_time=105
gcc-5.3.0-OpenMP-release build_time=266 run_time=105
gcc-6.1.0-Serial-hwloc-release build_time=210 run_time=129
gcc-6.1.0-Serial-release build_time=207 run_time=120
intel-17.0.1-OpenMP-hwloc-release build_time=588 run_time=183
intel-17.0.1-OpenMP-release build_time=589 run_time=188
```