### PR TITLE
finalize(): Move finalize_hooks code to finalize_internal

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -190,6 +190,26 @@ setenv("MEMKIND_HBW_NODES", "1", 0);
 void finalize_internal( const bool all_spaces = false )
 {
 
+  typename decltype(finalize_hooks)::size_type  numSuccessfulCalls = 0;
+  while(! finalize_hooks.empty()) {
+    auto f = finalize_hooks.top();
+    try {
+      f();
+    }
+    catch(...) {
+      std::cerr << "Kokkos::finalize: A finalize hook (set via "
+        "Kokkos::push_finalize_hook) threw an exception that it did not catch."
+        "  Per std::atexit rules, this results in std::terminate.  This is "
+        "finalize hook number " << numSuccessfulCalls << " (1-based indexing) "
+        "out of " << finalize_hooks.size() << " to call.  Remember that "
+        "Kokkos::finalize calls finalize hooks in reverse order from how they "
+        "were pushed." << std::endl;
+      std::terminate();
+    }
+    finalize_hooks.pop();
+    ++numSuccessfulCalls;
+  }
+
 #if defined(KOKKOS_ENABLE_PROFILING)
     Kokkos::Profiling::finalize();
 #endif
@@ -486,26 +506,6 @@ void push_finalize_hook(std::function<void()> f)
 
 void finalize()
 {
-  typename decltype(finalize_hooks)::size_type  numSuccessfulCalls = 0;
-  while(! finalize_hooks.empty()) {
-    auto f = finalize_hooks.top();
-    try {
-      f();
-    }
-    catch(...) {
-      std::cerr << "Kokkos::finalize: A finalize hook (set via "
-        "Kokkos::push_finalize_hook) threw an exception that it did not catch."
-        "  Per std::atexit rules, this results in std::terminate.  This is "
-        "finalize hook number " << numSuccessfulCalls << " (1-based indexing) "
-        "out of " << finalize_hooks.size() << " to call.  Remember that "
-        "Kokkos::finalize calls finalize hooks in reverse order from how they "
-        "were pushed." << std::endl;
-      std::terminate();
-    }
-    finalize_hooks.pop();
-    ++numSuccessfulCalls;
-  }
-
   Impl::finalize_internal();
 }
 


### PR DESCRIPTION
Both finalize and finalize_all call finalize_interal, place
finalize_hooks code here so it can be used by both routines.