### PR TITLE
Fix alignment needed for vector intrinsics

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -439,11 +439,11 @@
 // Define Macro for alignment:
 
 #if ! defined( KOKKOS_MEMORY_ALIGNMENT )
-  #define KOKKOS_MEMORY_ALIGNMENT 16
+  #define KOKKOS_MEMORY_ALIGNMENT 64
 #endif
 
 #if ! defined( KOKKOS_MEMORY_ALIGNMENT_THRESHOLD )
-  #define KOKKOS_MEMORY_ALIGNMENT_THRESHOLD 4
+  #define KOKKOS_MEMORY_ALIGNMENT_THRESHOLD 1
 #endif
 
 #if !defined( KOKKOS_IMPL_ALIGN_PTR )


### PR DESCRIPTION
Vector intrinsics must be alligned, that means Kokkos views of
vector intrinsics must be alligned, even for a scalar view.
That means we need a real fix with a minimum allignment argument
to all the allocation calls in memory spaces. Until then, minimum
allignment is set to 64 for any length of view.