### PR TITLE
Allow KOKKOS_ARCH with commas in CMake

### DIFF
--- a/cmake/kokkos_settings.cmake
+++ b/cmake/kokkos_settings.cmake
@@ -14,12 +14,16 @@
 #-------------------------------------------------------------------------------
 
 # Ensure that KOKKOS_ARCH is in the ARCH_LIST
+if (KOKKOS_ARCH MATCHES ",")
+  message("-- Detected a comma in: KOKKOS_ARCH=${KOKKOS_ARCH}")
+  message("-- Although we prefer KOKKOS_ARCH to be semicolon-delimited, we do allow")
+  message("-- comma-delimited values for compatibility with scripts (see github.com/trilinos/Trilinos/issues/2330)")
+  string(REPLACE "," ";" KOKKOS_ARCH "${KOKKOS_ARCH}")
+  message("-- Commas were changed to semicolons, now KOKKOS_ARCH=${KOKKOS_ARCH}")
+endif()
 foreach(arch ${KOKKOS_ARCH})
   list(FIND KOKKOS_ARCH_LIST ${arch} indx)
   if (indx EQUAL -1)
-    if (arch MATCHES ",")
-      message(FATAL_ERROR "KOKKOS_ARCH=${arch} should only contain semicolons (;), not commas (,).")
-    endif()
     message(FATAL_ERROR "${arch} is not an accepted value for KOKKOS_ARCH."
       "  Please pick from these choices: ${KOKKOS_INTERNAL_ARCH_DOCSTR}")
   endif ()


### PR DESCRIPTION
[trilinos/Trilinos#2330]

Since this only changes CMake, I won't bother running `test_all_sandia`, since that doesn't exercise CMake.