### PR TITLE
Send warning messages to standard error output stream

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Impl.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Impl.cpp
@@ -455,7 +455,7 @@ void CudaInternal::initialize( int cuda_device_id , int stream_count )
     m_scratchUnifiedSupported = cudaProp.unifiedAddressing ;
 
     if ( Kokkos::show_warnings() && ! m_scratchUnifiedSupported ) {
-      std::cout << "Kokkos::Cuda device "
+      std::cerr << "Kokkos::Cuda device "
                 << cudaProp.name << " capability "
                 << cudaProp.major << "." << cudaProp.minor
                 << " does not support unified virtual address space"
@@ -533,10 +533,10 @@ void CudaInternal::initialize( int cuda_device_id , int stream_count )
 
   #ifdef KOKKOS_ENABLE_CUDA_UVM
     if( Kokkos::show_warnings() && !cuda_launch_blocking() ) {
-      std::cout << "Kokkos::Cuda::initialize WARNING: Cuda is allocating into UVMSpace by default" << std::endl;
-      std::cout << "                                  without setting CUDA_LAUNCH_BLOCKING=1." << std::endl;
-      std::cout << "                                  The code must call Cuda::fence() after each kernel" << std::endl;
-      std::cout << "                                  or will likely crash when accessing data on the host." << std::endl;
+      std::cerr << "Kokkos::Cuda::initialize WARNING: Cuda is allocating into UVMSpace by default" << std::endl;
+      std::cerr << "                                  without setting CUDA_LAUNCH_BLOCKING=1." << std::endl;
+      std::cerr << "                                  The code must call Cuda::fence() after each kernel" << std::endl;
+      std::cerr << "                                  or will likely crash when accessing data on the host." << std::endl;
     }
 
     const char * env_force_device_alloc = getenv("CUDA_MANAGED_FORCE_DEVICE_ALLOC");
@@ -549,11 +549,11 @@ void CudaInternal::initialize( int cuda_device_id , int stream_count )
     if (env_visible_devices == 0) visible_devices_one=false;
 
     if( Kokkos::show_warnings() && (!visible_devices_one && !force_device_alloc) ) {
-      std::cout << "Kokkos::Cuda::initialize WARNING: Cuda is allocating into UVMSpace by default" << std::endl;
-      std::cout << "                                  without setting CUDA_MANAGED_FORCE_DEVICE_ALLOC=1 or " << std::endl;
-      std::cout << "                                  setting CUDA_VISIBLE_DEVICES." << std::endl;
-      std::cout << "                                  This could on multi GPU systems lead to severe performance" << std::endl;
-      std::cout << "                                  penalties." << std::endl;
+      std::cerr << "Kokkos::Cuda::initialize WARNING: Cuda is allocating into UVMSpace by default" << std::endl;
+      std::cerr << "                                  without setting CUDA_MANAGED_FORCE_DEVICE_ALLOC=1 or " << std::endl;
+      std::cerr << "                                  setting CUDA_VISIBLE_DEVICES." << std::endl;
+      std::cerr << "                                  This could on multi GPU systems lead to severe performance" << std::endl;
+      std::cerr << "                                  penalties." << std::endl;
     }
   #endif
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
@@ -365,10 +365,10 @@ void OpenMP::initialize( int thread_count )
 
   // Check for over-subscription
   if( Kokkos::show_warnings() && (Impl::mpi_ranks_per_node() * long(thread_count) > Impl::processors_per_node()) ) {
-    std::cout << "Kokkos::OpenMP::initialize WARNING: You are likely oversubscribing your CPU cores." << std::endl;
-    std::cout << "                                    Detected: " << Impl::processors_per_node() << " cores per node." << std::endl;
-    std::cout << "                                    Detected: " << Impl::mpi_ranks_per_node() << " MPI_ranks per node." << std::endl;
-    std::cout << "                                    Requested: " << thread_count << " threads per process." << std::endl;
+    std::cerr << "Kokkos::OpenMP::initialize WARNING: You are likely oversubscribing your CPU cores." << std::endl;
+    std::cerr << "                                    Detected: " << Impl::processors_per_node() << " cores per node." << std::endl;
+    std::cerr << "                                    Detected: " << Impl::mpi_ranks_per_node() << " MPI_ranks per node." << std::endl;
+    std::cerr << "                                    Requested: " << thread_count << " threads per process." << std::endl;
   }
   // Init the array for used for arbitrarily sized atomics
   Impl::init_lock_array_host_space();

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -717,10 +717,10 @@ void ThreadsExec::initialize( unsigned thread_count ,
 
   // Check for over-subscription
   if( Kokkos::show_warnings() && (Impl::mpi_ranks_per_node() * long(thread_count) > Impl::processors_per_node()) ) {
-    std::cout << "Kokkos::Threads::initialize WARNING: You are likely oversubscribing your CPU cores." << std::endl;
-    std::cout << "                                    Detected: " << Impl::processors_per_node() << " cores per node." << std::endl;
-    std::cout << "                                    Detected: " << Impl::mpi_ranks_per_node() << " MPI_ranks per node." << std::endl;
-    std::cout << "                                    Requested: " << thread_count << " threads per process." << std::endl;
+    std::cerr << "Kokkos::Threads::initialize WARNING: You are likely oversubscribing your CPU cores." << std::endl;
+    std::cerr << "                                    Detected: " << Impl::processors_per_node() << " cores per node." << std::endl;
+    std::cerr << "                                    Detected: " << Impl::mpi_ranks_per_node() << " MPI_ranks per node." << std::endl;
+    std::cerr << "                                    Requested: " << thread_count << " threads per process." << std::endl;
   }
 
   // Init the array for used for arbitrarily sized atomics


### PR DESCRIPTION
Some of the warnings were already sent to `std::cerr`.  See [here](https://github.com/kokkos/kokkos/blob/master/core/src/Cuda/Kokkos_Cuda_Impl.cpp#L424-L429) for instance.  I realized it while trying to pipe the standard error to `/dev/null`.