### PR TITLE
Improvements to SharedAllocationRecord

### DIFF
--- a/containers/performance_tests/TestCuda.cpp
+++ b/containers/performance_tests/TestCuda.cpp
@@ -70,13 +70,12 @@ protected:
   static void SetUpTestCase()
   {
     std::cout << std::setprecision(5) << std::scientific;
-    Kokkos::HostSpace::execution_space::initialize();
-    Kokkos::Cuda::initialize( Kokkos::Cuda::SelectDevice(0) );
+    Kokkos::InitArguments args(-1, -1, 0);
+    Kokkos::initialize(args);
   }
   static void TearDownTestCase()
   {
-    Kokkos::Cuda::finalize();
-    Kokkos::HostSpace::execution_space::finalize();
+    Kokkos::finalize();
   }
 };
 

--- a/containers/performance_tests/TestOpenMP.cpp
+++ b/containers/performance_tests/TestOpenMP.cpp
@@ -70,13 +70,13 @@ protected:
   {
     std::cout << std::setprecision(5) << std::scientific;
 
-    Kokkos::OpenMP::initialize();
+    Kokkos::initialize();
     Kokkos::OpenMP::print_configuration( std::cout );
   }
 
   static void TearDownTestCase()
   {
-    Kokkos::OpenMP::finalize();
+    Kokkos::finalize();
   }
 };
 

--- a/containers/performance_tests/TestThreads.cpp
+++ b/containers/performance_tests/TestThreads.cpp
@@ -81,12 +81,12 @@ protected:
 
     std::cout << "Threads: " << num_threads << std::endl;
 
-    Kokkos::Threads::initialize( num_threads );
+    Kokkos::initialize( Kokkos::InitArguments(num_threads) );
   }
 
   static void TearDownTestCase()
   {
-    Kokkos::Threads::finalize();
+    Kokkos::finalize();
   }
 };
 

--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -42,3 +42,17 @@ TRIBITS_ADD_TEST(
   CATEGORIES PERFORMANCE
   FAIL_REGULAR_EXPRESSION "  FAILED  "
   )
+
+TRIBITS_ADD_EXECUTABLE(
+  PerformanceTest_TaskDAG
+  SOURCES test_taskdag.cpp
+  COMM serial mpi
+  )
+
+TRIBITS_ADD_TEST(
+  PerformanceTest_TaskDAG
+  NAME PerformanceTest_TaskDAG
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  CATEGORIES PERFORMANCE
+  )

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -242,6 +242,7 @@ void CudaHostPinnedSpace::deallocate( void * const arg_alloc_ptr , const size_t 
 namespace Kokkos {
 namespace Impl {
 
+#ifdef KOKKOS_DEBUG
 SharedAllocationRecord< void , void >
 SharedAllocationRecord< Kokkos::CudaSpace , void >::s_root_record ;
 
@@ -250,6 +251,7 @@ SharedAllocationRecord< Kokkos::CudaUVMSpace , void >::s_root_record ;
 
 SharedAllocationRecord< void , void >
 SharedAllocationRecord< Kokkos::CudaHostPinnedSpace , void >::s_root_record ;
+#endif
 
 ::cudaTextureObject_t
 SharedAllocationRecord< Kokkos::CudaSpace , void >::
@@ -425,8 +427,11 @@ SharedAllocationRecord( const Kokkos::CudaSpace & arg_space
   // Pass through allocated [ SharedAllocationHeader , user_memory ]
   // Pass through deallocation function
   : SharedAllocationRecord< void , void >
-      ( & SharedAllocationRecord< Kokkos::CudaSpace , void >::s_root_record
-      , reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
+      (
+#ifdef KOKKOS_DEBUG
+        & SharedAllocationRecord< Kokkos::CudaSpace , void >::s_root_record,
+#endif
+        reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
       , sizeof(SharedAllocationHeader) + arg_alloc_size
       , arg_dealloc
       )
@@ -462,8 +467,11 @@ SharedAllocationRecord( const Kokkos::CudaUVMSpace & arg_space
   // Pass through allocated [ SharedAllocationHeader , user_memory ]
   // Pass through deallocation function
   : SharedAllocationRecord< void , void >
-      ( & SharedAllocationRecord< Kokkos::CudaUVMSpace , void >::s_root_record
-      , reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
+      (
+#ifdef KOKKOS_DEBUG
+        & SharedAllocationRecord< Kokkos::CudaUVMSpace , void >::s_root_record,
+#endif
+        reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
       , sizeof(SharedAllocationHeader) + arg_alloc_size
       , arg_dealloc
       )
@@ -494,8 +502,11 @@ SharedAllocationRecord( const Kokkos::CudaHostPinnedSpace & arg_space
   // Pass through allocated [ SharedAllocationHeader , user_memory ]
   // Pass through deallocation function
   : SharedAllocationRecord< void , void >
-      ( & SharedAllocationRecord< Kokkos::CudaHostPinnedSpace , void >::s_root_record
-      , reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
+      (
+#ifdef KOKKOS_DEBUG
+        & SharedAllocationRecord< Kokkos::CudaHostPinnedSpace , void >::s_root_record,
+#endif
+        reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
       , sizeof(SharedAllocationHeader) + arg_alloc_size
       , arg_dealloc
       )
@@ -705,6 +716,7 @@ void
 SharedAllocationRecord< Kokkos::CudaSpace , void >::
 print_records( std::ostream & s , const Kokkos::CudaSpace & , bool detail )
 {
+#ifdef KOKKOS_DEBUG
   SharedAllocationRecord< void , void > * r = & s_root_record ;
 
   char buffer[256] ;
@@ -775,20 +787,31 @@ print_records( std::ostream & s , const Kokkos::CudaSpace & , bool detail )
       r = r->m_next ;
     } while ( r != & s_root_record );
   }
+#else
+  Kokkos::Impl::throw_runtime_exception("SharedAllocationHeader<CudaSpace>::print_records only works with KOKKOS_DEBUG enabled");
+#endif
 }
 
 void
 SharedAllocationRecord< Kokkos::CudaUVMSpace , void >::
 print_records( std::ostream & s , const Kokkos::CudaUVMSpace & , bool detail )
 {
+#ifdef KOKKOS_DEBUG
   SharedAllocationRecord< void , void >::print_host_accessible_records( s , "CudaUVM" , & s_root_record , detail );
+#else
+  Kokkos::Impl::throw_runtime_exception("SharedAllocationHeader<CudaSpace>::print_records only works with KOKKOS_DEBUG enabled");
+#endif
 }
 
 void
 SharedAllocationRecord< Kokkos::CudaHostPinnedSpace , void >::
 print_records( std::ostream & s , const Kokkos::CudaHostPinnedSpace & , bool detail )
 {
+#ifdef KOKKOS_DEBUG
   SharedAllocationRecord< void , void >::print_host_accessible_records( s , "CudaHostPinned" , & s_root_record , detail );
+#else
+  Kokkos::Impl::throw_runtime_exception("SharedAllocationHeader<CudaSpace>::print_records only works with KOKKOS_DEBUG enabled");
+#endif
 }
 
 void* cuda_resize_scratch_space(std::int64_t bytes, bool force_shrink) {

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -650,7 +650,6 @@ SharedAllocationRecord< Kokkos::CudaSpace , void >::get_record( void * alloc_ptr
   using RecordBase = SharedAllocationRecord< void , void > ;
   using RecordCuda = SharedAllocationRecord< Kokkos::CudaSpace , void > ;
 
-#if 0
   using Header     = SharedAllocationHeader ;
 
   // Copy the header from the allocation
@@ -667,19 +666,6 @@ SharedAllocationRecord< Kokkos::CudaSpace , void >::get_record( void * alloc_ptr
   if ( ! alloc_ptr || record->m_alloc_ptr != head_cuda ) {
     Kokkos::Impl::throw_runtime_exception( std::string("Kokkos::Impl::SharedAllocationRecord< Kokkos::CudaSpace , void >::get_record ERROR" ) );
   }
-
-#else
-
-  // Iterate the list to search for the record among all allocations
-  // requires obtaining the root of the list and then locking the list.
-
-  RecordCuda * const record = static_cast< RecordCuda * >( RecordBase::find( & s_root_record , alloc_ptr ) );
-
-  if ( record == 0 ) {
-    Kokkos::Impl::throw_runtime_exception( std::string("Kokkos::Impl::SharedAllocationRecord< Kokkos::CudaSpace , void >::get_record ERROR" ) );
-  }
-
-#endif
 
   return record ;
 }

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -720,7 +720,9 @@ private:
                        , void * const   alloc_ptr
                        , const size_t   alloc_size );
 
+#ifdef KOKKOS_DEBUG
   static RecordBase s_root_record ;
+#endif
 
   ::cudaTextureObject_t   m_tex_obj ;
   const Kokkos::CudaSpace m_space ;

--- a/core/src/Kokkos_HBWSpace.hpp
+++ b/core/src/Kokkos_HBWSpace.hpp
@@ -180,8 +180,10 @@ private:
 
   static void deallocate( RecordBase * );
 
+#ifdef KOKKOS_DEBUG
   /**\brief  Root record for tracked allocations from this HBWSpace instance */
   static RecordBase s_root_record;
+#endif
 
   const Kokkos::Experimental::HBWSpace m_space;
 

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -222,8 +222,10 @@ private:
 
   static void deallocate( RecordBase * );
 
+#ifdef KOKKOS_DEBUG
   /**\brief  Root record for tracked allocations from this HostSpace instance */
   static RecordBase s_root_record;
+#endif
 
   const Kokkos::HostSpace m_space;
 

--- a/core/src/Kokkos_ROCmSpace.hpp
+++ b/core/src/Kokkos_ROCmSpace.hpp
@@ -513,7 +513,9 @@ private:
 
   static void deallocate( RecordBase * );
 
+#ifdef KOKKOS_DEBUG
   static RecordBase s_root_record ;
+#endif
 
   const Kokkos::Experimental::ROCmSpace m_space ;
 
@@ -568,7 +570,9 @@ private:
 
   static void deallocate( RecordBase * );
 
+#ifdef KOKKOS_DEBUG
   static RecordBase s_root_record ;
+#endif
 
   const Kokkos::Experimental::ROCmHostPinnedSpace m_space ;
 

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -99,8 +99,10 @@ void OpenMPTargetSpace::deallocate( void * const arg_alloc_ptr , const size_t ar
 namespace Kokkos {
 namespace Impl {
 
+#ifdef KOKKOS_DEBUG
 SharedAllocationRecord< void , void >
 SharedAllocationRecord< Kokkos::Experimental::OpenMPTargetSpace , void >::s_root_record ;
+#endif
 
 SharedAllocationRecord< Kokkos::Experimental::OpenMPTargetSpace , void >::
 ~SharedAllocationRecord()
@@ -140,8 +142,11 @@ SharedAllocationRecord( const Kokkos::Experimental::OpenMPTargetSpace & arg_spac
   // Pass through allocated [ SharedAllocationHeader , user_memory ]
   // Pass through deallocation function
   : SharedAllocationRecord< void , void >
-      ( & SharedAllocationRecord< Kokkos::Experimental::OpenMPTargetSpace , void >::s_root_record
-      , reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
+      (
+#ifdef KOKKOS_DEBUG
+        & SharedAllocationRecord< Kokkos::Experimental::OpenMPTargetSpace , void >::s_root_record,
+#endif
+        reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
       , sizeof(SharedAllocationHeader) + arg_alloc_size
       , arg_dealloc
       )
@@ -224,7 +229,12 @@ SharedAllocationRecord< Kokkos::Experimental::OpenMPTargetSpace , void >::get_re
 void SharedAllocationRecord< Kokkos::Experimental::OpenMPTargetSpace , void >::
 print_records( std::ostream & s , const Kokkos::Experimental::OpenMPTargetSpace & space , bool detail )
 {
+#ifdef KOKKOS_DEBUG
   SharedAllocationRecord< void , void >::print_host_accessible_records( s , "OpenMPTargetSpace" , & s_root_record , detail );
+#else
+  throw_runtime_exception("SharedAllocationRecord<OpenMPTargetSpace>::print_records"
+      " only works with KOKKOS_DEBUG enabled");
+#endif
 }
 
 } // namespace Impl

--- a/core/src/ROCm/Kokkos_ROCm_Space.cpp
+++ b/core/src/ROCm/Kokkos_ROCm_Space.cpp
@@ -234,12 +234,13 @@ void Experimental::ROCmHostPinnedSpace::deallocate( void * const arg_alloc_ptr ,
 namespace Kokkos {
 namespace Impl {
 
+#ifdef KOKKOS_DEBUG
 SharedAllocationRecord< void , void >
 SharedAllocationRecord< Kokkos::Experimental::ROCmSpace , void >::s_root_record ;
 
 SharedAllocationRecord< void , void >
 SharedAllocationRecord< Kokkos::Experimental::ROCmHostPinnedSpace , void >::s_root_record ;
-
+#endif
 
 std::string
 SharedAllocationRecord< Kokkos::Experimental::ROCmSpace , void >::get_label() const
@@ -336,8 +337,11 @@ SharedAllocationRecord( const Kokkos::Experimental::ROCmSpace & arg_space
   // Pass through allocated [ SharedAllocationHeader , user_memory ]
   // Pass through deallocation function
   : SharedAllocationRecord< void , void >
-      ( & SharedAllocationRecord< Kokkos::Experimental::ROCmSpace , void >::s_root_record
-      , reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
+      (
+#ifdef KOKKOS_DEBUG
+        & SharedAllocationRecord< Kokkos::Experimental::ROCmSpace , void >::s_root_record,
+#endif
+        reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
       , sizeof(SharedAllocationHeader) + arg_alloc_size
       , arg_dealloc
       )
@@ -372,8 +376,11 @@ SharedAllocationRecord( const Kokkos::Experimental::ROCmHostPinnedSpace & arg_sp
   // Pass through allocated [ SharedAllocationHeader , user_memory ]
   // Pass through deallocation function
   : SharedAllocationRecord< void , void >
-      ( & SharedAllocationRecord< Kokkos::Experimental::ROCmHostPinnedSpace , void >::s_root_record
-      , reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
+      (
+#ifdef KOKKOS_DEBUG
+        & SharedAllocationRecord< Kokkos::Experimental::ROCmHostPinnedSpace , void >::s_root_record,
+#endif
+        reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
       , sizeof(SharedAllocationHeader) + arg_alloc_size
       , arg_dealloc
       )
@@ -489,7 +496,6 @@ SharedAllocationRecord< Kokkos::Experimental::ROCmSpace , void >::get_record( vo
   using RecordBase = SharedAllocationRecord< void , void > ;
   using RecordROCm = SharedAllocationRecord< Kokkos::Experimental::ROCmSpace , void > ;
 
-#if 0
   // Copy the header from the allocation
   Header head ;
 
@@ -504,19 +510,6 @@ SharedAllocationRecord< Kokkos::Experimental::ROCmSpace , void >::get_record( vo
   if ( ! alloc_ptr || record->m_alloc_ptr != head_rocm ) {
     Kokkos::Impl::throw_runtime_exception( std::string("Kokkos::Impl::SharedAllocationRecord< Kokkos::Experimental::ROCmSpace , void >::get_record ERROR" ) );
   }
-
-#else
-
-  // Iterate the list to search for the record among all allocations
-  // requires obtaining the root of the list and then locking the list.
-
-  RecordROCm * const record = static_cast< RecordROCm * >( RecordBase::find( & s_root_record , alloc_ptr ) );
-
-  if ( record == 0 ) {
-    Kokkos::Impl::throw_runtime_exception( std::string("Kokkos::Impl::SharedAllocationRecord< Kokkos::Experimental::ROCmSpace , void >::get_record ERROR" ) );
-  }
-
-#endif
 
   return record ;
 }
@@ -543,6 +536,7 @@ void
 SharedAllocationRecord< Kokkos::Experimental::ROCmSpace , void >::
 print_records( std::ostream & s , const Kokkos::Experimental::ROCmSpace & space , bool detail )
 {
+#ifdef KOKKOS_DEBUG
   SharedAllocationRecord< void , void > * r = & s_root_record ;
 
   char buffer[256] ;
@@ -613,15 +607,11 @@ print_records( std::ostream & s , const Kokkos::Experimental::ROCmSpace & space 
       r = r->m_next ;
     } while ( r != & s_root_record );
   }
+#else
+  throw_runtime_exception("Kokkos::Impl::SharedAllocationRecord<ROCmSpace>::print_records"
+      " only works with KOKKOS_DEBUG enabled");
+#endif
 }
-#if 0
-void
-SharedAllocationRecord< Kokkos::Experimental::ROCmHostPinnedSpace , void >::
-print_records( std::ostream & s , const Kokkos::Experimental::ROCmHostPinnedSpace & space , bool detail )
-{
-  SharedAllocationRecord< void , void >::print_host_accessible_records( s , "ROCmHostPinned" , & s_root_record , detail );
-}
-#endif 
 
 } // namespace Impl
 } // namespace Kokkos
@@ -630,75 +620,6 @@ print_records( std::ostream & s , const Kokkos::Experimental::ROCmHostPinnedSpac
 /*--------------------------------------------------------------------------*/
 namespace Kokkos {
 namespace {
-#if 0
-  KOKKOS_INLINE_FUNCTION void init_lock_array_kernel_atomic() {
-    unsigned i = tindex()*team_size() + lindex();
-
-    if(i<ROCM_SPACE_ATOMIC_MASK+1)
-      kokkos_impl_rocm_lock_arrays.atomic[i] = 0;
-  }
-
-  KOKKOS_INLINE_FUNCTION void init_lock_array_kernel_scratch_threadid(int N) {
-    unsigned i = tindex()*team_size() + lindex();
-
-    if(i<N) {
-      kokkos_impl_rocm_lock_arrays.scratch[i] = 0;
-      kokkos_impl_rocm_lock_arrays.threadid[i] = 0;
-    }
-  }
-}
-
-
-namespace Impl {
-int* atomic_lock_array_rocm_space_ptr(bool deallocate) {
-  static int* ptr = NULL;
-  if(deallocate) {
-    rocmFree(ptr);
-    ptr = NULL;
-  }
-
-  if(ptr==NULL && !deallocate)
-    rocmMalloc(&ptr,sizeof(int)*(ROCM_SPACE_ATOMIC_MASK+1));
-  return ptr;
-}
-
-int* scratch_lock_array_rocm_space_ptr(bool deallocate) {
-  static int* ptr = NULL;
-  if(deallocate) {
-    rocmFree(ptr);
-    ptr = NULL;
-  }
-
-  if(ptr==NULL && !deallocate)
-    rocmMalloc(&ptr,sizeof(int)*(ROCm::concurrency()));
-  return ptr;
-}
-
-int* threadid_lock_array_rocm_space_ptr(bool deallocate) {
-  static int* ptr = NULL;
-  if(deallocate) {
-    rocmFree(ptr);
-    ptr = NULL;
-  }
-
-  if(ptr==NULL && !deallocate)
-    rocmMalloc(&ptr,sizeof(int)*(ROCm::concurrency()));
-  return ptr;
-}
-
-void init_lock_arrays_rocm_space() {
-  static int is_initialized = 0;
-  if(! is_initialized) {
-    Kokkos::Impl::ROCmLockArraysStruct locks;
-    locks.atomic = atomic_lock_array_rocm_space_ptr(false);
-    locks.scratch = scratch_lock_array_rocm_space_ptr(false);
-    locks.threadid = threadid_lock_array_rocm_space_ptr(false);
-    am_copyToSymbol( kokkos_impl_rocm_lock_arrays , & locks , sizeof(ROCmLockArraysStruct) );
-    init_lock_array_kernel_atomic<<<(ROCM_SPACE_ATOMIC_MASK+255)/256,256>>>();
-    init_lock_array_kernel_scratch_threadid<<<(Kokkos::Experimental::ROCm::concurrency()+255)/256,256>>>(Kokkos::Experimental::ROCm::concurrency());
-  }
-}
-#endif 
 
 void* rocm_resize_scratch_space(size_t bytes, bool force_shrink) {
   static void* ptr = NULL;

--- a/core/src/impl/Kokkos_HBWSpace.cpp
+++ b/core/src/impl/Kokkos_HBWSpace.cpp
@@ -175,8 +175,10 @@ void HBWSpace::deallocate( void * const arg_alloc_ptr , const size_t arg_alloc_s
 namespace Kokkos {
 namespace Impl {
 
+#ifdef KOKKOS_DEBUG
 SharedAllocationRecord< void , void >
 SharedAllocationRecord< Kokkos::Experimental::HBWSpace , void >::s_root_record ;
+#endif
 
 void
 SharedAllocationRecord< Kokkos::Experimental::HBWSpace , void >::
@@ -210,8 +212,11 @@ SharedAllocationRecord( const Kokkos::Experimental::HBWSpace & arg_space
   // Pass through allocated [ SharedAllocationHeader , user_memory ]
   // Pass through deallocation function
   : SharedAllocationRecord< void , void >
-      ( & SharedAllocationRecord< Kokkos::Experimental::HBWSpace , void >::s_root_record
-      , reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
+      (
+#ifdef KOKKOS_DEBUG
+        & SharedAllocationRecord< Kokkos::Experimental::HBWSpace , void >::s_root_record,
+#endif
+        reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
       , sizeof(SharedAllocationHeader) + arg_alloc_size
       , arg_dealloc
       )
@@ -295,7 +300,12 @@ SharedAllocationRecord< Kokkos::Experimental::HBWSpace , void >::get_record( voi
 void SharedAllocationRecord< Kokkos::Experimental::HBWSpace , void >::
 print_records( std::ostream & s , const Kokkos::Experimental::HBWSpace & space , bool detail )
 {
+#ifdef KOKKOS_DEBUG
   SharedAllocationRecord< void , void >::print_host_accessible_records( s , "HBWSpace" , & s_root_record , detail );
+#else
+  throw_runtime_exception("SharedAllocationRecord<HBWSpace>::print_records"
+      " only works with KOKKOS_DEBUG enabled");
+#endif
 }
 
 } // namespace Impl

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -297,8 +297,10 @@ void HostSpace::deallocate( void * const arg_alloc_ptr
 namespace Kokkos {
 namespace Impl {
 
+#ifdef KOKKOS_DEBUG
 SharedAllocationRecord< void , void >
 SharedAllocationRecord< Kokkos::HostSpace , void >::s_root_record ;
+#endif
 
 void
 SharedAllocationRecord< Kokkos::HostSpace , void >::
@@ -332,8 +334,11 @@ SharedAllocationRecord( const Kokkos::HostSpace & arg_space
   // Pass through allocated [ SharedAllocationHeader , user_memory ]
   // Pass through deallocation function
   : SharedAllocationRecord< void , void >
-      ( & SharedAllocationRecord< Kokkos::HostSpace , void >::s_root_record
-      , reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
+      (
+#ifdef KOKKOS_DEBUG
+      & SharedAllocationRecord< Kokkos::HostSpace , void >::s_root_record,
+#endif
+        reinterpret_cast<SharedAllocationHeader*>( arg_space.allocate( sizeof(SharedAllocationHeader) + arg_alloc_size ) )
       , sizeof(SharedAllocationHeader) + arg_alloc_size
       , arg_dealloc
       )
@@ -416,7 +421,11 @@ SharedAllocationRecord< Kokkos::HostSpace , void >::get_record( void * alloc_ptr
 void SharedAllocationRecord< Kokkos::HostSpace , void >::
 print_records( std::ostream & s , const Kokkos::HostSpace & , bool detail )
 {
+#ifdef KOKKOS_DEBUG
   SharedAllocationRecord< void , void >::print_host_accessible_records( s , "HostSpace" , & s_root_record , detail );
+#else
+  throw_runtime_exception("SharedAllocationRecord<HostSpace>::print_records only works with KOKKOS_DEBUG enabled");
+#endif
 }
 
 } // namespace Impl

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -52,8 +52,7 @@ bool
 SharedAllocationRecord< void , void >::
 is_sane( SharedAllocationRecord< void , void > * arg_record )
 {
-  constexpr static SharedAllocationRecord * zero = 0 ;
-
+#ifdef KOKKOS_DEBUG
   SharedAllocationRecord * const root = arg_record ? arg_record->m_root : 0 ;
 
   bool ok = root != 0 && root->use_count() == 0 ;
@@ -62,7 +61,7 @@ is_sane( SharedAllocationRecord< void , void > * arg_record )
     SharedAllocationRecord * root_next = 0 ;
 
     // Lock the list:
-    while ( ( root_next = Kokkos::atomic_exchange( & root->m_next , zero ) ) == zero );
+    while ( ( root_next = Kokkos::atomic_exchange( & root->m_next , nullptr ) ) == nullptr );
 
     for ( SharedAllocationRecord * rec = root_next ; ok && rec != root ; rec = rec->m_next ) {
       const bool ok_non_null  = rec && rec->m_prev && ( rec == root || rec->m_next );
@@ -73,48 +72,50 @@ is_sane( SharedAllocationRecord< void , void > * arg_record )
 
       ok = ok_root && ok_prev_next && ok_next_prev && ok_count ;
 
-if ( ! ok ) {
-  //Formatting dependent on sizeof(uintptr_t)
-  const char * format_string;
+      if ( ! ok ) {
+        //Formatting dependent on sizeof(uintptr_t)
+        const char * format_string;
 
-  if (sizeof(uintptr_t) == sizeof(unsigned long)) {
-     format_string = "Kokkos::Impl::SharedAllocationRecord failed is_sane: rec(0x%.12lx){ m_count(%d) m_root(0x%.12lx) m_next(0x%.12lx) m_prev(0x%.12lx) m_next->m_prev(0x%.12lx) m_prev->m_next(0x%.12lx) }\n";
-  }
-  else if (sizeof(uintptr_t) == sizeof(unsigned long long)) {
-     format_string = "Kokkos::Impl::SharedAllocationRecord failed is_sane: rec(0x%.12llx){ m_count(%d) m_root(0x%.12llx) m_next(0x%.12llx) m_prev(0x%.12llx) m_next->m_prev(0x%.12llx) m_prev->m_next(0x%.12llx) }\n";
-  }
+        if (sizeof(uintptr_t) == sizeof(unsigned long)) {
+          format_string = "Kokkos::Impl::SharedAllocationRecord failed is_sane: rec(0x%.12lx){ m_count(%d) m_root(0x%.12lx) m_next(0x%.12lx) m_prev(0x%.12lx) m_next->m_prev(0x%.12lx) m_prev->m_next(0x%.12lx) }\n";
+        }
+        else if (sizeof(uintptr_t) == sizeof(unsigned long long)) {
+          format_string = "Kokkos::Impl::SharedAllocationRecord failed is_sane: rec(0x%.12llx){ m_count(%d) m_root(0x%.12llx) m_next(0x%.12llx) m_prev(0x%.12llx) m_next->m_prev(0x%.12llx) m_prev->m_next(0x%.12llx) }\n";
+        }
 
-  fprintf(stderr
-        , format_string
-        , reinterpret_cast< uintptr_t >( rec )
-        , rec->use_count()
-        , reinterpret_cast< uintptr_t >( rec->m_root )
-        , reinterpret_cast< uintptr_t >( rec->m_next )
-        , reinterpret_cast< uintptr_t >( rec->m_prev )
-        , reinterpret_cast< uintptr_t >( rec->m_next != NULL ? rec->m_next->m_prev : NULL )
-        , reinterpret_cast< uintptr_t >( rec->m_prev != rec->m_root ? rec->m_prev->m_next : root_next )
-        );
-}
+        fprintf(stderr
+            , format_string
+            , reinterpret_cast< uintptr_t >( rec )
+            , rec->use_count()
+            , reinterpret_cast< uintptr_t >( rec->m_root )
+            , reinterpret_cast< uintptr_t >( rec->m_next )
+            , reinterpret_cast< uintptr_t >( rec->m_prev )
+            , reinterpret_cast< uintptr_t >( rec->m_next != NULL ? rec->m_next->m_prev : NULL )
+            , reinterpret_cast< uintptr_t >( rec->m_prev != rec->m_root ? rec->m_prev->m_next : root_next )
+            );
+      }
 
     }
 
-    if ( zero != Kokkos::atomic_exchange( & root->m_next , root_next ) ) {
+    if ( nullptr != Kokkos::atomic_exchange( & root->m_next , root_next ) ) {
       Kokkos::Impl::throw_runtime_exception("Kokkos::Impl::SharedAllocationRecord failed is_sane unlocking");
     }
   }
-
   return ok ;
+#else
+  Kokkos::Impl::throw_runtime_exception("Kokkos::Impl::SharedAllocationRecord::is_sane only works with KOKKOS_DEBUG enabled");
+  return false ;
+#endif
 }
 
 SharedAllocationRecord<void,void> *
 SharedAllocationRecord<void,void>::find( SharedAllocationRecord<void,void> * const arg_root , void * const arg_data_ptr )
 {
-  constexpr static SharedAllocationRecord * zero = 0 ;
-
+#ifdef KOKKOS_DEBUG
   SharedAllocationRecord * root_next = 0 ;
 
   // Lock the list:
-  while ( ( root_next = Kokkos::atomic_exchange( & arg_root->m_next , zero ) ) == zero );
+  while ( ( root_next = Kokkos::atomic_exchange( & arg_root->m_next , nullptr ) ) == nullptr );
 
   // Iterate searching for the record with this data pointer
 
@@ -124,11 +125,14 @@ SharedAllocationRecord<void,void>::find( SharedAllocationRecord<void,void> * con
 
   if ( r == arg_root ) { r = 0 ; }
 
-  if ( zero != Kokkos::atomic_exchange( & arg_root->m_next , root_next ) ) {
+  if ( nullptr != Kokkos::atomic_exchange( & arg_root->m_next , root_next ) ) {
     Kokkos::Impl::throw_runtime_exception("Kokkos::Impl::SharedAllocationRecord failed locking/unlocking");
   }
-
   return r ;
+#else
+  Kokkos::Impl::throw_runtime_exception("Kokkos::Impl::SharedAllocationRecord::find only works with KOKKOS_DEBUG enabled");
+  return nullptr;
+#endif
 }
 
 
@@ -136,23 +140,27 @@ SharedAllocationRecord<void,void>::find( SharedAllocationRecord<void,void> * con
  *         use_count is zero.
  */
 SharedAllocationRecord< void , void >::
-SharedAllocationRecord( SharedAllocationRecord<void,void> * arg_root
-                      , SharedAllocationHeader            * arg_alloc_ptr
+SharedAllocationRecord(
+#ifdef KOKKOS_DEBUG
+                        SharedAllocationRecord<void,void> * arg_root,
+#endif
+                        SharedAllocationHeader            * arg_alloc_ptr
                       , size_t                              arg_alloc_size
                       , SharedAllocationRecord< void , void >::function_type  arg_dealloc
                       )
   : m_alloc_ptr(  arg_alloc_ptr )
   , m_alloc_size( arg_alloc_size )
   , m_dealloc(    arg_dealloc )
+#ifdef KOKKOS_DEBUG
   , m_root( arg_root )
   , m_prev( 0 )
   , m_next( 0 )
+#endif
   , m_count( 0 )
 {
-  constexpr static SharedAllocationRecord * zero = 0 ;
-
   if ( 0 != arg_alloc_ptr ) {
 
+#ifdef KOKKOS_DEBUG
     // Insert into the root double-linked list for tracking
     //
     // before:  arg_root->m_next == next ; next->m_prev == arg_root
@@ -161,17 +169,19 @@ SharedAllocationRecord( SharedAllocationRecord<void,void> * arg_root
 
     m_prev = m_root ;
 
-    // Read root->m_next and lock by setting to zero
-    while ( ( m_next = Kokkos::atomic_exchange( & m_root->m_next , zero ) ) == zero );
+    // Read root->m_next and lock by setting to NULL
+    while ( ( m_next = Kokkos::atomic_exchange( & m_root->m_next , nullptr ) ) == nullptr );
 
     m_next->m_prev = this ;
 
     // memory fence before completing insertion into linked list
     Kokkos::memory_fence();
 
-    if ( zero != Kokkos::atomic_exchange( & m_root->m_next , this ) ) {
+    if ( nullptr != Kokkos::atomic_exchange( & m_root->m_next , this ) ) {
       Kokkos::Impl::throw_runtime_exception("Kokkos::Impl::SharedAllocationRecord failed locking/unlocking");
     }
+#endif
+
   }
   else {
     Kokkos::Impl::throw_runtime_exception("Kokkos::Impl::SharedAllocationRecord given NULL allocation");
@@ -193,12 +203,13 @@ SharedAllocationRecord< void , void > *
 SharedAllocationRecord< void , void >::
 decrement( SharedAllocationRecord< void , void > * arg_record )
 {
-  constexpr static SharedAllocationRecord * zero = 0 ;
-
   const int old_count = Kokkos::atomic_fetch_add( & arg_record->m_count , -1 );
 
   if ( old_count == 1 ) {
 
+    // TODO: check Kokkos::is_initialized()
+
+#ifdef KOKKOS_DEBUG
     // before:  arg_record->m_prev->m_next == arg_record  &&
     //          arg_record->m_next->m_prev == arg_record
     //
@@ -208,7 +219,7 @@ decrement( SharedAllocationRecord< void , void > * arg_record )
     SharedAllocationRecord * root_next = 0 ;
 
     // Lock the list:
-    while ( ( root_next = Kokkos::atomic_exchange( & arg_record->m_root->m_next , zero ) ) == zero );
+    while ( ( root_next = Kokkos::atomic_exchange( & arg_record->m_root->m_next , nullptr ) ) == nullptr );
 
     arg_record->m_next->m_prev = arg_record->m_prev ;
 
@@ -224,12 +235,13 @@ decrement( SharedAllocationRecord< void , void > * arg_record )
     Kokkos::memory_fence();
 
     // Unlock the list:
-    if ( zero != Kokkos::atomic_exchange( & arg_record->m_root->m_next , root_next ) ) {
+    if ( nullptr != Kokkos::atomic_exchange( & arg_record->m_root->m_next , root_next ) ) {
       Kokkos::Impl::throw_runtime_exception("Kokkos::Impl::SharedAllocationRecord failed decrement unlocking");
     }
 
     arg_record->m_next = 0 ;
     arg_record->m_prev = 0 ;
+#endif
 
     function_type d = arg_record->m_dealloc ;
     (*d)( arg_record );
@@ -251,6 +263,7 @@ print_host_accessible_records( std::ostream & s
                              , const SharedAllocationRecord * const root
                              , const bool detail )
 {
+#ifdef KOKKOS_DEBUG
   const SharedAllocationRecord< void , void > * r = root ;
 
   char buffer[256] ;
@@ -311,6 +324,11 @@ print_host_accessible_records( std::ostream & s
       r = r->m_next ;
     } while ( r != root );
   }
+#else
+  Kokkos::Impl::throw_runtime_exception(
+      "Kokkos::Impl::SharedAllocationRecord::print_host_accessible_records"
+      " only works with KOKKOS_DEBUG enabled");
+#endif
 }
 
 } /* namespace Impl */

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -213,7 +213,12 @@ decrement( SharedAllocationRecord< void , void > * arg_record )
       ss << arg_record->get_label();
       ss << "\" is being deallocated after Kokkos::finalize was called\n";
       auto s = ss.str();
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+      std::cerr << s;
+      std::cerr << "This behavior is incorrect Kokkos usage, and will crash in future releases\n";
+#else
       Kokkos::Impl::throw_runtime_exception(s);
+#endif
     }
 
 #ifdef KOKKOS_DEBUG

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -197,14 +197,6 @@ decrement( SharedAllocationRecord< void , void > * arg_record )
 
   const int old_count = Kokkos::atomic_fetch_add( & arg_record->m_count , -1 );
 
-#if 0
-  if ( old_count <= 1 ) {
-    fprintf(stderr,"Kokkos::Impl::SharedAllocationRecord '%s' at 0x%lx delete count = %d\n", arg_record->m_alloc_ptr->m_label , (unsigned long) arg_record , old_count );
-    fflush(stderr);
-  }
-#endif
-
-
   if ( old_count == 1 ) {
 
     // before:  arg_record->m_prev->m_next == arg_record  &&

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -203,7 +203,7 @@ SharedAllocationRecord< void , void > *
 SharedAllocationRecord< void , void >::
 decrement( SharedAllocationRecord< void , void > * arg_record )
 {
-  const int old_count = Kokkos::atomic_fetch_add( & arg_record->m_count , -1 );
+  const int old_count = Kokkos::atomic_fetch_sub( & arg_record->m_count , 1 );
 
   if ( old_count == 1 ) {
 

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -207,7 +207,14 @@ decrement( SharedAllocationRecord< void , void > * arg_record )
 
   if ( old_count == 1 ) {
 
-    // TODO: check Kokkos::is_initialized()
+    if (!Kokkos::is_initialized()) {
+      std::stringstream ss;
+      ss << "Kokkos allocation \"";
+      ss << arg_record->get_label();
+      ss << "\" is being deallocated after Kokkos::finalize was called\n";
+      auto s = ss.str();
+      Kokkos::Impl::throw_runtime_exception(s);
+    }
 
 #ifdef KOKKOS_DEBUG
     // before:  arg_record->m_prev->m_next == arg_record  &&

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -89,9 +89,11 @@ protected:
   SharedAllocationHeader * const m_alloc_ptr ;
   size_t                   const m_alloc_size ;
   function_type            const m_dealloc ;
+#ifdef KOKKOS_DEBUG
   SharedAllocationRecord * const m_root ;
   SharedAllocationRecord *       m_prev ;
   SharedAllocationRecord *       m_next ;
+#endif
   int                            m_count ;
 
   SharedAllocationRecord( SharedAllocationRecord && ) = delete ;
@@ -102,8 +104,11 @@ protected:
   /**\brief  Construct and insert into 'arg_root' tracking set.
    *         use_count is zero.
    */
-  SharedAllocationRecord( SharedAllocationRecord * arg_root
-                        , SharedAllocationHeader * arg_alloc_ptr
+  SharedAllocationRecord(
+#ifdef KOKKOS_DEBUG
+                          SharedAllocationRecord * arg_root,
+#endif
+                          SharedAllocationHeader * arg_alloc_ptr
                         , size_t                   arg_alloc_size
                         , function_type            arg_dealloc
                         );
@@ -132,9 +137,11 @@ public:
     : m_alloc_ptr( 0 )
     , m_alloc_size( 0 )
     , m_dealloc( 0 )
+#ifdef KOKKOS_DEBUG
     , m_root( this )
     , m_prev( this )
     , m_next( this )
+#endif
     , m_count( 0 )
     {}
 

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -117,7 +117,7 @@ private:
   static __thread int t_tracking_enabled;
 
 public:
-  inline std::string get_label() const { return std::string("Unmanaged"); }
+  virtual std::string get_label() const { return std::string("Unmanaged"); }
 
   static int tracking_enabled() { return t_tracking_enabled; }
 
@@ -131,7 +131,7 @@ public:
    */
   static void tracking_enable() { t_tracking_enabled = 1; }
 
-  ~SharedAllocationRecord() = default ;
+  virtual ~SharedAllocationRecord() = default ;
 
   SharedAllocationRecord()
     : m_alloc_ptr( 0 )

--- a/core/unit_test/TestSharedAlloc.hpp
+++ b/core/unit_test/TestSharedAlloc.hpp
@@ -107,13 +107,17 @@ void test_shared_alloc()
       ASSERT_EQ( r[i], RecordMemS::get_record( r[i]->data() ) );
     });
 
+#ifdef KOKKOS_DEBUG
     // Sanity check for the whole set of allocation records to which this record belongs.
     RecordBase::is_sane( r[0] );
     // RecordMemS::print_records( std::cout, s, true );
+#endif
 
     Kokkos::parallel_for( range, [=] ( size_t i ) {
       while ( 0 != ( r[i] = static_cast< RecordMemS * >( RecordBase::decrement( r[i] ) ) ) ) {
+#ifdef KOKKOS_DEBUG
         if ( r[i]->use_count() == 1 ) RecordBase::is_sane( r[i] );
+#endif
       }
     });
   }
@@ -141,11 +145,15 @@ void test_shared_alloc()
       ASSERT_EQ( r[i], RecordMemS::get_record( r[i]->data() ) );
     });
 
+#ifdef KOKKOS_DEBUG
     RecordBase::is_sane( r[0] );
+#endif
 
     Kokkos::parallel_for( range, [=] ( size_t i ) {
       while ( 0 != ( r[i] = static_cast< RecordMemS * >( RecordBase::decrement( r[i] ) ) ) ) {
+#ifdef KOKKOS_DEBUG
         if ( r[i]->use_count() == 1 ) RecordBase::is_sane( r[i] );
+#endif
       }
     });
 

--- a/example/tutorial/03_simple_view/simple_view.cpp
+++ b/example/tutorial/03_simple_view/simple_view.cpp
@@ -114,29 +114,31 @@ struct ReduceFunctor {
 
 int main (int argc, char* argv[]) {
   Kokkos::initialize (argc, argv);
-  const int N = 10;
+  {
+    const int N = 10;
 
-  // Allocate the View.  The first dimension is a run-time parameter
-  // N.  We set N = 10 here.  The second dimension is a compile-time
-  // parameter, 3.  We don't specify it here because we already set it
-  // by declaring the type of the View.
-  //
-  // Views get initialized to zero by default.  This happens in
-  // parallel, using the View's memory space's default execution
-  // space.  Parallel initialization ensures first-touch allocation.
-  // There is a way to shut off default initialization.
-  //
-  // You may NOT allocate a View inside of a parallel_{for, reduce,
-  // scan}.  Treat View allocation as a "thread collective."
-  //
-  // The string "A" is just the label; it only matters for debugging.
-  // Different Views may have the same label.
-  view_type a ("A", N);
+    // Allocate the View.  The first dimension is a run-time parameter
+    // N.  We set N = 10 here.  The second dimension is a compile-time
+    // parameter, 3.  We don't specify it here because we already set it
+    // by declaring the type of the View.
+    //
+    // Views get initialized to zero by default.  This happens in
+    // parallel, using the View's memory space's default execution
+    // space.  Parallel initialization ensures first-touch allocation.
+    // There is a way to shut off default initialization.
+    //
+    // You may NOT allocate a View inside of a parallel_{for, reduce,
+    // scan}.  Treat View allocation as a "thread collective."
+    //
+    // The string "A" is just the label; it only matters for debugging.
+    // Different Views may have the same label.
+    view_type a ("A", N);
 
-  Kokkos::parallel_for (N, InitView (a));
-  double sum = 0;
-  Kokkos::parallel_reduce (N, ReduceFunctor (a), sum);
-  printf ("Result: %f\n", sum);
+    Kokkos::parallel_for (N, InitView (a));
+    double sum = 0;
+    Kokkos::parallel_reduce (N, ReduceFunctor (a), sum);
+    printf ("Result: %f\n", sum);
+  } // use this scope to ensure the lifetime of "A" ends before finalize
   Kokkos::finalize ();
 }
 

--- a/example/tutorial/04_simple_memoryspaces/simple_memoryspaces.cpp
+++ b/example/tutorial/04_simple_memoryspaces/simple_memoryspaces.cpp
@@ -76,25 +76,27 @@ struct ReduceFunctor {
 int main() {
   Kokkos::initialize();
 
-  view_type a ("A", 10);
-  // If view_type and host_mirror_type live in the same memory space,
-  // a "mirror view" is just an alias, and deep_copy does nothing.
-  // Otherwise, a mirror view of a device View lives in host memory,
-  // and deep_copy does a deep copy.
-  host_view_type h_a = Kokkos::create_mirror_view (a);
+  {
+    view_type a ("A", 10);
+    // If view_type and host_mirror_type live in the same memory space,
+    // a "mirror view" is just an alias, and deep_copy does nothing.
+    // Otherwise, a mirror view of a device View lives in host memory,
+    // and deep_copy does a deep copy.
+    host_view_type h_a = Kokkos::create_mirror_view (a);
 
-  // The View h_a lives in host (CPU) memory, so it's legal to fill
-  // the view sequentially using ordinary code, like this.
-  for (int i = 0; i < 10; i++) {
-    for (int j = 0; j < 3; j++) {
-      h_a(i,j) = i*10 + j;
+    // The View h_a lives in host (CPU) memory, so it's legal to fill
+    // the view sequentially using ordinary code, like this.
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 3; j++) {
+        h_a(i,j) = i*10 + j;
+      }
     }
-  }
-  Kokkos::deep_copy (a, h_a); // Copy from host to device.
+    Kokkos::deep_copy (a, h_a); // Copy from host to device.
 
-  int sum = 0;
-  Kokkos::parallel_reduce (10, ReduceFunctor (a), sum);
-  printf ("Result is %i\n",sum);
+    int sum = 0;
+    Kokkos::parallel_reduce (10, ReduceFunctor (a), sum);
+    printf ("Result is %i\n",sum);
+  }
 
   Kokkos::finalize ();
 }

--- a/example/tutorial/Advanced_Views/01_data_layouts/data_layouts.cpp
+++ b/example/tutorial/Advanced_Views/01_data_layouts/data_layouts.cpp
@@ -127,44 +127,46 @@ int main (int narg, char* arg[]) {
   // arguments from the list that start with '--kokkos-'.
   Kokkos::initialize (narg, arg);
 
-  int size = 10000;
-  view_type a("A",size);
+  {
+    int size = 10000;
+    view_type a("A",size);
 
-  // Define two views with LayoutLeft and LayoutRight.
-  left_type l("L",size,10000);
-  right_type r("R",size,10000);
+    // Define two views with LayoutLeft and LayoutRight.
+    left_type l("L",size,10000);
+    right_type r("R",size,10000);
 
-  // Initialize the data in the views.
-  Kokkos::parallel_for(size,init_view<left_type>(l));
-  Kokkos::parallel_for(size,init_view<right_type>(r));
-  Kokkos::fence();
+    // Initialize the data in the views.
+    Kokkos::parallel_for(size,init_view<left_type>(l));
+    Kokkos::parallel_for(size,init_view<right_type>(r));
+    Kokkos::fence();
 
-  // Measure time to execute the contraction kernel when giving it a
-  // LayoutLeft view for v1 and a LayoutRight view for v2. This should be
-  // fast on GPUs and slow on CPUs
-  Kokkos::Timer time1;
-  Kokkos::parallel_for(size,contraction<left_type,right_type>(a,l,r));
-  Kokkos::fence();
-  double sec1 = time1.seconds();
+    // Measure time to execute the contraction kernel when giving it a
+    // LayoutLeft view for v1 and a LayoutRight view for v2. This should be
+    // fast on GPUs and slow on CPUs
+    Kokkos::Timer time1;
+    Kokkos::parallel_for(size,contraction<left_type,right_type>(a,l,r));
+    Kokkos::fence();
+    double sec1 = time1.seconds();
 
-  double sum1 = 0;
-  Kokkos::parallel_reduce(size,dot(a),sum1);
-  Kokkos::fence();
+    double sum1 = 0;
+    Kokkos::parallel_reduce(size,dot(a),sum1);
+    Kokkos::fence();
 
-  // Measure time to execute the contraction kernel when giving it a
-  // LayoutRight view for v1 and a LayoutLeft view for v2. This should be
-  // fast on CPUs and slow on GPUs
-  Kokkos::Timer time2;
-  Kokkos::parallel_for(size,contraction<right_type,left_type>(a,r,l));
-  Kokkos::fence();
-  double sec2 = time2.seconds();
+    // Measure time to execute the contraction kernel when giving it a
+    // LayoutRight view for v1 and a LayoutLeft view for v2. This should be
+    // fast on CPUs and slow on GPUs
+    Kokkos::Timer time2;
+    Kokkos::parallel_for(size,contraction<right_type,left_type>(a,r,l));
+    Kokkos::fence();
+    double sec2 = time2.seconds();
 
-  double sum2 = 0;
-  Kokkos::parallel_reduce(size,dot(a),sum2);
+    double sum2 = 0;
+    Kokkos::parallel_reduce(size,dot(a),sum2);
 
-  // Kokkos' reductions are deterministic.
-  // The results should always be equal.
-  printf("Result Left/Right %f Right/Left %f (equal result: %i)\n",sec1,sec2,sum2==sum1);
+    // Kokkos' reductions are deterministic.
+    // The results should always be equal.
+    printf("Result Left/Right %f Right/Left %f (equal result: %i)\n",sec1,sec2,sum2==sum1);
+  }
 
   Kokkos::finalize();
 }

--- a/example/tutorial/Advanced_Views/02_memory_traits/memory_traits.cpp
+++ b/example/tutorial/Advanced_Views/02_memory_traits/memory_traits.cpp
@@ -99,42 +99,44 @@ struct localsum {
 int main(int narg, char* arg[]) {
   Kokkos::initialize (narg, arg);
 
-  int size = 1000000;
+  {
+    int size = 1000000;
 
-  idx_type idx("Idx",size,64);
-  idx_type_host h_idx = Kokkos::create_mirror_view (idx);
+    idx_type idx("Idx",size,64);
+    idx_type_host h_idx = Kokkos::create_mirror_view (idx);
 
-  view_type dest ("Dest", size);
-  view_type src ("Src", size);
+    view_type dest ("Dest", size);
+    view_type src ("Src", size);
 
-  srand(134231);
+    srand(134231);
 
-  for (int i = 0; i < size; i++) {
-    for (view_type::size_type j = 0; j < h_idx.extent(1); ++j) {
-      h_idx(i,j) = (size + i + (rand () % 500 - 250)) % size;
+    for (int i = 0; i < size; i++) {
+      for (view_type::size_type j = 0; j < h_idx.extent(1); ++j) {
+        h_idx(i,j) = (size + i + (rand () % 500 - 250)) % size;
+      }
     }
+
+    // Deep copy the initial data to the device
+    Kokkos::deep_copy(idx,h_idx);
+    // Run the first kernel to warmup caches
+    Kokkos::parallel_for(size,localsum<view_type,view_type_rnd>(idx,dest,src));
+    Kokkos::fence();
+
+    // Run the localsum functor using the RandomAccess trait. On CPUs there should
+    // not be any different in performance to not using the RandomAccess trait.
+    // On GPUs where can be a dramatic difference
+    Kokkos::Timer time1;
+    Kokkos::parallel_for(size,localsum<view_type,view_type_rnd>(idx,dest,src));
+    Kokkos::fence();
+    double sec1 = time1.seconds();
+
+    Kokkos::Timer time2;
+    Kokkos::parallel_for(size,localsum<view_type,view_type>(idx,dest,src));
+    Kokkos::fence();
+    double sec2 = time2.seconds();
+
+    printf("Time with Trait RandomAccess: %f with Plain: %f \n",sec1,sec2);
   }
-
-  // Deep copy the initial data to the device
-  Kokkos::deep_copy(idx,h_idx);
-  // Run the first kernel to warmup caches
-  Kokkos::parallel_for(size,localsum<view_type,view_type_rnd>(idx,dest,src));
-  Kokkos::fence();
-
-  // Run the localsum functor using the RandomAccess trait. On CPUs there should
-  // not be any different in performance to not using the RandomAccess trait.
-  // On GPUs where can be a dramatic difference
-  Kokkos::Timer time1;
-  Kokkos::parallel_for(size,localsum<view_type,view_type_rnd>(idx,dest,src));
-  Kokkos::fence();
-  double sec1 = time1.seconds();
-
-  Kokkos::Timer time2;
-  Kokkos::parallel_for(size,localsum<view_type,view_type>(idx,dest,src));
-  Kokkos::fence();
-  double sec2 = time2.seconds();
-
-  printf("Time with Trait RandomAccess: %f with Plain: %f \n",sec1,sec2);
 
   Kokkos::finalize();
 }

--- a/example/tutorial/Advanced_Views/03_subviews/subviews.cpp
+++ b/example/tutorial/Advanced_Views/03_subviews/subviews.cpp
@@ -145,46 +145,48 @@ int main (int narg, char* arg[]) {
 
   Kokkos::initialize (narg, arg);
 
-  // The number of mesh points along each dimension of the mesh, not
-  // including boundaries.
-  const size_type size = 100;
+  {
+    // The number of mesh points along each dimension of the mesh, not
+    // including boundaries.
+    const size_type size = 100;
 
-  // A is the full cubic 3-D mesh, including the boundaries.
-  mesh_type A ("A", size+2, size+2, size+2);
-  // Ai is the "inner" part of A, _not_ including the boundaries.
-  //
-  // A pair of indices in a particular dimension means the contiguous
-  // zero-based index range in that dimension, including the first
-  // entry of the pair but _not_ including the second entry.
-  inner_mesh_type Ai = subview(A, pair<size_type, size_type> (1, size+1),
-                                  pair<size_type, size_type> (1, size+1),
-                                  pair<size_type, size_type> (1, size+1));
-  // A has six boundaries, one for each face of the cube.
-  // Create a View of each of these boundaries.
-  // ALL() means "select all indices in that dimension."
-  xy_plane_type Zneg_halo = subview(A, ALL (), ALL (), 0);
-  xy_plane_type Zpos_halo = subview(A, ALL (), ALL (), 101);
-  xz_plane_type Yneg_halo = subview(A, ALL (), 0, ALL ());
-  xz_plane_type Ypos_halo = subview(A, ALL (), 101, ALL ());
-  yz_plane_type Xneg_halo = subview(A, 0, ALL (), ALL ());
-  yz_plane_type Xpos_halo = subview(A, 101, ALL (), ALL ());
+    // A is the full cubic 3-D mesh, including the boundaries.
+    mesh_type A ("A", size+2, size+2, size+2);
+    // Ai is the "inner" part of A, _not_ including the boundaries.
+    //
+    // A pair of indices in a particular dimension means the contiguous
+    // zero-based index range in that dimension, including the first
+    // entry of the pair but _not_ including the second entry.
+    inner_mesh_type Ai = subview(A, pair<size_type, size_type> (1, size+1),
+                                    pair<size_type, size_type> (1, size+1),
+                                    pair<size_type, size_type> (1, size+1));
+    // A has six boundaries, one for each face of the cube.
+    // Create a View of each of these boundaries.
+    // ALL() means "select all indices in that dimension."
+    xy_plane_type Zneg_halo = subview(A, ALL (), ALL (), 0);
+    xy_plane_type Zpos_halo = subview(A, ALL (), ALL (), 101);
+    xz_plane_type Yneg_halo = subview(A, ALL (), 0, ALL ());
+    xz_plane_type Ypos_halo = subview(A, ALL (), 101, ALL ());
+    yz_plane_type Xneg_halo = subview(A, 0, ALL (), ALL ());
+    yz_plane_type Xpos_halo = subview(A, 101, ALL (), ALL ());
 
-  // Set the boundaries to their initial conditions.
-  parallel_for (Zneg_halo.extent(0), set_boundary<xy_plane_type> (Zneg_halo,  1));
-  parallel_for (Zpos_halo.extent(0), set_boundary<xy_plane_type> (Zpos_halo, -1));
-  parallel_for (Yneg_halo.extent(0), set_boundary<xz_plane_type> (Yneg_halo,  2));
-  parallel_for (Ypos_halo.extent(0), set_boundary<xz_plane_type> (Ypos_halo, -2));
-  parallel_for (Xneg_halo.extent(0), set_boundary<yz_plane_type> (Xneg_halo,  3));
-  parallel_for (Xpos_halo.extent(0), set_boundary<yz_plane_type> (Xpos_halo, -3));
+    // Set the boundaries to their initial conditions.
+    parallel_for (Zneg_halo.extent(0), set_boundary<xy_plane_type> (Zneg_halo,  1));
+    parallel_for (Zpos_halo.extent(0), set_boundary<xy_plane_type> (Zpos_halo, -1));
+    parallel_for (Yneg_halo.extent(0), set_boundary<xz_plane_type> (Yneg_halo,  2));
+    parallel_for (Ypos_halo.extent(0), set_boundary<xz_plane_type> (Ypos_halo, -2));
+    parallel_for (Xneg_halo.extent(0), set_boundary<yz_plane_type> (Xneg_halo,  3));
+    parallel_for (Xpos_halo.extent(0), set_boundary<yz_plane_type> (Xpos_halo, -3));
 
-  // Set the interior of the mesh to its initial condition.
-  parallel_for (Ai.extent(0), set_inner<inner_mesh_type> (Ai, 0));
+    // Set the interior of the mesh to its initial condition.
+    parallel_for (Ai.extent(0), set_inner<inner_mesh_type> (Ai, 0));
 
-  // Update the interior of the mesh.
-  // This simulates one timestep with dt = 0.1.
-  parallel_for (Ai.extent(0), update<mesh_type> (A, 0.1));
+    // Update the interior of the mesh.
+    // This simulates one timestep with dt = 0.1.
+    parallel_for (Ai.extent(0), update<mesh_type> (A, 0.1));
 
-  printf ("Done\n");
+    printf ("Done\n");
+  }
   Kokkos::finalize ();
 }
 

--- a/example/tutorial/Advanced_Views/05_NVIDIA_UVM/uvm_example.cpp
+++ b/example/tutorial/Advanced_Views/05_NVIDIA_UVM/uvm_example.cpp
@@ -83,57 +83,59 @@ struct localsum {
 int main(int narg, char* arg[]) {
   Kokkos::initialize(narg,arg);
 
-  int size = 1000000;
+  {
+    int size = 1000000;
 
-  // Create Views
-  idx_type idx("Idx",size,64);
-  view_type dest("Dest",size);
-  view_type src("Src",size);
+    // Create Views
+    idx_type idx("Idx",size,64);
+    view_type dest("Dest",size);
+    view_type src("Src",size);
 
-  srand(134231);
+    srand(134231);
 
-  Kokkos::fence();
+    Kokkos::fence();
 
-  // When using UVM Cuda views can be accessed on the Host directly
-  for(int i=0; i<size; i++) {
-    for(int j=0; j<int(idx.extent(1)); j++)
-      idx(i,j) = (size + i + (rand()%500 - 250))%size;
+    // When using UVM Cuda views can be accessed on the Host directly
+    for(int i=0; i<size; i++) {
+      for(int j=0; j<int(idx.extent(1)); j++)
+        idx(i,j) = (size + i + (rand()%500 - 250))%size;
+    }
+
+    Kokkos::fence();
+    // Run on the device
+    // This will cause a sync of idx to the device since it was modified on the host
+    Kokkos::Timer timer;
+    Kokkos::parallel_for(size,localsum<view_type::execution_space>(idx,dest,src));
+    Kokkos::fence();
+    double sec1_dev = timer.seconds();
+
+    // No data transfer will happen now, since nothing is accessed on the host
+    timer.reset();
+    Kokkos::parallel_for(size,localsum<view_type::execution_space>(idx,dest,src));
+    Kokkos::fence();
+    double sec2_dev = timer.seconds();
+
+    // Run on the host
+    // This will cause a sync back to the host of dest which was changed on the device
+    // Compare runtime here with the dual_view example: dest will be copied back in 4k blocks
+    // when they are accessed the first time during the parallel_for. Due to the latency of a memcpy
+    // this gives lower effective bandwidth when doing a manual copy via dual views
+    timer.reset();
+    Kokkos::parallel_for(size,localsum<Kokkos::HostSpace::execution_space>(idx,dest,src));
+    Kokkos::fence();
+    double sec1_host = timer.seconds();
+
+    // No data transfers will happen now
+    timer.reset();
+    Kokkos::parallel_for(size,localsum<Kokkos::HostSpace::execution_space>(idx,dest,src));
+    Kokkos::fence();
+    double sec2_host = timer.seconds();
+
+
+
+    printf("Device Time with Sync: %e without Sync: %e \n",sec1_dev,sec2_dev);
+    printf("Host   Time with Sync: %e without Sync: %e \n",sec1_host,sec2_host);
   }
-
-  Kokkos::fence();
-  // Run on the device
-  // This will cause a sync of idx to the device since it was modified on the host
-  Kokkos::Timer timer;
-  Kokkos::parallel_for(size,localsum<view_type::execution_space>(idx,dest,src));
-  Kokkos::fence();
-  double sec1_dev = timer.seconds();
-
-  // No data transfer will happen now, since nothing is accessed on the host
-  timer.reset();
-  Kokkos::parallel_for(size,localsum<view_type::execution_space>(idx,dest,src));
-  Kokkos::fence();
-  double sec2_dev = timer.seconds();
-
-  // Run on the host
-  // This will cause a sync back to the host of dest which was changed on the device
-  // Compare runtime here with the dual_view example: dest will be copied back in 4k blocks
-  // when they are accessed the first time during the parallel_for. Due to the latency of a memcpy
-  // this gives lower effective bandwidth when doing a manual copy via dual views
-  timer.reset();
-  Kokkos::parallel_for(size,localsum<Kokkos::HostSpace::execution_space>(idx,dest,src));
-  Kokkos::fence();
-  double sec1_host = timer.seconds();
-
-  // No data transfers will happen now
-  timer.reset();
-  Kokkos::parallel_for(size,localsum<Kokkos::HostSpace::execution_space>(idx,dest,src));
-  Kokkos::fence();
-  double sec2_host = timer.seconds();
-
-
-
-  printf("Device Time with Sync: %e without Sync: %e \n",sec1_dev,sec2_dev);
-  printf("Host   Time with Sync: %e without Sync: %e \n",sec1_host,sec2_host);
 
   Kokkos::finalize();
 }

--- a/example/tutorial/Hierarchical_Parallelism/03_vectorization/vectorization.cpp
+++ b/example/tutorial/Hierarchical_Parallelism/03_vectorization/vectorization.cpp
@@ -130,30 +130,32 @@ struct SomeCorrelation {
 int main(int narg, char* args[]) {
   Kokkos::initialize(narg,args);
 
-  // Produce some 3D random data (see Algorithms/01_random_numbers for more info)
-  Kokkos::View<int***,Kokkos::LayoutRight> data("Data",512,512,32);
-  Kokkos::Random_XorShift64_Pool<> rand_pool64(5374857);
-  Kokkos::fill_random(data,rand_pool64,100);
+  {
+    // Produce some 3D random data (see Algorithms/01_random_numbers for more info)
+    Kokkos::View<int***,Kokkos::LayoutRight> data("Data",512,512,32);
+    Kokkos::Random_XorShift64_Pool<> rand_pool64(5374857);
+    Kokkos::fill_random(data,rand_pool64,100);
 
-  // A global value to put the result in
-  Kokkos::View<int> gsum("Sum");
+    // A global value to put the result in
+    Kokkos::View<int> gsum("Sum");
 
-  // Each team handles a slice of the data
-  // Set up TeamPolicy with 512 teams with maximum number of threads per team and 16 vector lanes.
-  // Kokkos::AUTO will determine the number of threads
-  // The maximum vector length is hardware dependent but can always be smaller than the hardware allows.
-  // The vector length must be a power of 2.
+    // Each team handles a slice of the data
+    // Set up TeamPolicy with 512 teams with maximum number of threads per team and 16 vector lanes.
+    // Kokkos::AUTO will determine the number of threads
+    // The maximum vector length is hardware dependent but can always be smaller than the hardware allows.
+    // The vector length must be a power of 2.
 
-  const Kokkos::TeamPolicy<> policy( 512 , Kokkos::AUTO , 16);
+    const Kokkos::TeamPolicy<> policy( 512 , Kokkos::AUTO , 16);
 
-  Kokkos::parallel_for( policy , SomeCorrelation(data,gsum) );
+    Kokkos::parallel_for( policy , SomeCorrelation(data,gsum) );
 
-  Kokkos::fence();
+    Kokkos::fence();
 
-  // Copy result value back
-  int sum = 0;
-  Kokkos::deep_copy(sum,gsum);
-  printf("Result %i\n",sum);
+    // Copy result value back
+    int sum = 0;
+    Kokkos::deep_copy(sum,gsum);
+    printf("Result %i\n",sum);
+  }
 
   Kokkos::finalize();
 }

--- a/example/tutorial/Hierarchical_Parallelism/04_team_scan/team_scan.cpp
+++ b/example/tutorial/Hierarchical_Parallelism/04_team_scan/team_scan.cpp
@@ -104,7 +104,8 @@ struct find_2_tuples {
 
 int main(int narg, char* args[]) {
   Kokkos::initialize(narg,args);
-  
+
+  {
   int chunk_size = 1024;
   int nchunks = 100000; //1024*1024;
   Kokkos::DualView<int*> data("data",nchunks*chunk_size+1);
@@ -139,6 +140,7 @@ int main(int narg, char* args[]) {
     printf("\n");
   }
   printf("Result: %i %i\n",sum,chunk_size*nchunks);
+  }
   Kokkos::finalize();
 }
 


### PR DESCRIPTION
This PR encompasses these major changes:
1. The linked list tying together all allocations for one memory space now only exists when `KOKKOS_DEBUG` is defined. Otherwise, it does not exist and associated debug functions throw exceptions.
2. `~SharedAllocationRecord()` checks `Kokkos::is_initialized()`, and throws an exception if the result is false (including the allocation's name).

As such it addresses #1464 and #1465.

The latter change exposed bugs in many unit tests and even our most basic tutorial examples. These were worked around with extra curly braces to add scope, and also changing the unit tests to call `Kokkos::initialize` instead of `Kokkos::ExecSpace::initialize`.

In terms of performance, going solely by the runtime of the CUDA unit tests, removing the linked list improved performance (33s to 31s), and checking `Kokkos::is_initialized()` made no significant difference.