### PR TITLE
Fix value_type derivation in ROCm

### DIFF
--- a/core/src/ROCm/Kokkos_ROCm_Parallel.hpp
+++ b/core/src/ROCm/Kokkos_ROCm_Parallel.hpp
@@ -197,14 +197,14 @@ public:
   KOKKOS_INLINE_FUNCTION static
   int team_size_max( const Functor_Type & functor)
   {
-    typedef typename Kokkos::Impl::FunctorValueTraits<Functor_Type, void>::value_type value_type;
+    typedef typename Kokkos::Impl::FunctorValueTraits<Functor_Type, typename traits::work_tag>::value_type value_type;
     return team_size_recommended(functor);
     // return std::min(Kokkos::Impl::get_max_tile_size() / sizeof(value_type), Kokkos::Impl::get_max_tile_thread());
   }
 
   template< class Functor_Type>
   KOKKOS_INLINE_FUNCTION static int team_size_recommended(const Functor_Type & functor)
-  { return Kokkos::Impl::get_tile_size<typename Kokkos::Impl::FunctorValueTraits<Functor_Type, void>::value_type>(); }
+  { return Kokkos::Impl::get_tile_size<typename Kokkos::Impl::FunctorValueTraits<Functor_Type, typename traits::work_tag>::value_type>(); }
 
   template< class Functor_Type >
   KOKKOS_INLINE_FUNCTION static int team_size_recommended(const Functor_Type &functor, const int vector_length)

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -106,7 +106,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_ROCM), 1)
 # compile fails
 #        OBJ_ROCM += TestROCm_TeamReductionScan.o
 # compile fails
-#        OBJ_ROCM += TestROCm_TeamScratch.o
+        OBJ_ROCM += TestROCm_TeamScratch.o
         OBJ_ROCM += TestROCm_ViewAPI_b.o
         OBJ_ROCM += TestROCm_ViewMapping_a.o
         OBJ_ROCM += TestROCm_ViewMapping_b.o


### PR DESCRIPTION
Not properly providing the work tag
was what prevented the TeamScratch
test from compiling

These are my fixes from this morning's ROCm hackathon, with @crtrott 's help