### PR TITLE
Don't use defaulted virtual destructor

### DIFF
--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -131,7 +131,7 @@ public:
    */
   static void tracking_enable() { t_tracking_enabled = 1; }
 
-  virtual ~SharedAllocationRecord() = default ;
+  virtual ~SharedAllocationRecord() {}
 
   SharedAllocationRecord()
     : m_alloc_ptr( 0 )


### PR DESCRIPTION
Intel compilers prior to 17 fail to compile this

This fixes issue #1507