### PR TITLE
DualView,Vector: Guard deprecated functions with macro

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -533,9 +533,20 @@ public:
   //! \name Methods for getting capacity, stride, or dimension(s).
   //@{
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   //! The allocation size (same as Kokkos::View::capacity).
   size_t capacity() const {
     return d_view.span();
+  }
+#endif
+
+  //! The allocation size (same as Kokkos::View::span).
+  KOKKOS_INLINE_FUNCTION constexpr size_t span() const {
+    return d_view.span();
+  }
+
+  KOKKOS_INLINE_FUNCTION bool span_is_contiguous() const { 
+    return d_view.span_is_contiguous(); 
   }
 
   //! Get stride(s) for each dimension.
@@ -556,6 +567,11 @@ public:
    extent_int( const iType & r ) const
      { return static_cast<int>(d_view.extent(r)); }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+  /*  Deprecate all 'dimension' functions in favor of
+   *  ISO/C++ vocabulary 'extent'.
+   */
+
   /* \brief return size of dimension 0 */
   size_t dimension_0() const {return d_view.extent(0);}
   /* \brief return size of dimension 1 */
@@ -572,6 +588,7 @@ public:
   size_t dimension_6() const {return d_view.extent(6);}
   /* \brief return size of dimension 7 */
   size_t dimension_7() const {return d_view.extent(7);}
+#endif
 
   //@}
 };

--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -100,7 +100,7 @@ public:
 
 
   void resize(size_t n) {
-    if(n>=capacity())
+    if(n>=span())
       DV::resize(size_t (n*_extra_storage));
     _size = n;
   }
@@ -113,7 +113,7 @@ public:
 
     /* Resize if necessary (behavour of std:vector) */
 
-    if(n>capacity())
+    if(n>span())
       DV::resize(size_t (n*_extra_storage));
     _size = n;
 
@@ -138,7 +138,7 @@ public:
 
   void push_back(Scalar val) {
     DV::modified_host()++;
-    if(_size == capacity()) {
+    if(_size == span()) {
       size_t new_size = _size*_extra_storage;
       if(new_size == _size) new_size++;
       DV::resize(new_size);
@@ -159,7 +159,10 @@ public:
 
   size_type size() const {return _size;}
   size_type max_size() const {return 2000000000;}
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   size_type capacity() const {return DV::capacity();}
+#endif
+  size_type span() const {return DV::span();}
   bool empty() const {return _size==0;}
 
   iterator begin() const {return &DV::h_view(0);}


### PR DESCRIPTION
Mark deprecated functions dimension_*, capacity(), is_contiguous(), and
ptr_on_device(); add replacement functions with new name as needed.

Partially addresses issue #1277