### PR TITLE
Disable team size 32 triple_nested_parallelism for CUDA+DEBUG

### DIFF
--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -903,12 +903,12 @@ TEST_F( TEST_CATEGORY, triple_nested_parallelism )
 // With KOKKOS_DEBUG enabled, the functor uses too many registers to run
 // with a team size of 32 on GPUs, 16 is the max possible (at least on a K80 GPU)
 // See https://github.com/kokkos/kokkos/issues/1513
-#if defined(KOKKOS_DEBUG)
+#if defined(KOKKOS_DEBUG) && defined(KOKKOS_ENABLE_CUDA)
   if (!std::is_same<TEST_EXECSPACE, Kokkos::Cuda>::value) {
 #endif
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 32, 32 );
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 32, 16 );
-#if defined(KOKKOS_DEBUG)
+#if defined(KOKKOS_DEBUG) && defined(KOKKOS_ENABLE_CUDA)
   }
 #endif
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 16, 16 );

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -900,8 +900,17 @@ TEST_F( TEST_CATEGORY, team_vector )
 #ifndef SKIP_TEST
 TEST_F( TEST_CATEGORY, triple_nested_parallelism )
 {
+// With KOKKOS_DEBUG enabled, the functor uses too many registers to run
+// with a team size of 32 on GPUs, 16 is the max possible (at least on a K80 GPU)
+// See https://github.com/kokkos/kokkos/issues/1513
+#if defined(KOKKOS_DEBUG)
+  if (!std::is_same<TEST_EXECSPACE, Kokkos::Cuda>::value) {
+#endif
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 32, 32 );
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 32, 16 );
+#if defined(KOKKOS_DEBUG)
+  }
+#endif
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 16, 16 );
 }
 #endif


### PR DESCRIPTION
This fixes issue #1513, and should be patched onto Trilinos ASAP.