### PR TITLE
Check array bounds

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -62,7 +62,7 @@ struct ArrayBoundsCheck<Integral, true> {
     if (i < 0) {
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
       std::string s = "Kokkos::Array: index ";
-      s += std::to_string(ssize_t i);
+      s += std::to_string(i);
       s += " < 0";
       Kokkos::Impl::throw_runtime_exception(s);
 #else
@@ -79,8 +79,8 @@ struct ArrayBoundsCheck<Integral, false> {
     if (i >= N) {
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
       std::string s = "Kokkos::Array: index ";
-      s += std::to_string(ssize_t i);
-      s += " >= "
+      s += std::to_string(i);
+      s += " >= ";
       s += std::to_string(N);
       Kokkos::Impl::throw_runtime_exception(s);
 #else

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -223,7 +223,7 @@ public:
 
 
 template<>
-struct Array<void,~size_t(0),void>
+struct Array<void,KOKKOS_INVALID_INDEX,void>
 {
   struct contiguous {};
   struct strided {};

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -59,9 +59,9 @@ is_sane( SharedAllocationRecord< void , void > * arg_record )
 
   if ( ok ) {
     SharedAllocationRecord * root_next = 0 ;
-
+    static constexpr SharedAllocationRecord * zero = nullptr;
     // Lock the list:
-    while ( ( root_next = Kokkos::atomic_exchange( & root->m_next , nullptr ) ) == nullptr );
+    while ( ( root_next = Kokkos::atomic_exchange( & root->m_next , zero ) ) == nullptr );
 
     for ( SharedAllocationRecord * rec = root_next ; ok && rec != root ; rec = rec->m_next ) {
       const bool ok_non_null  = rec && rec->m_prev && ( rec == root || rec->m_next );
@@ -113,9 +113,10 @@ SharedAllocationRecord<void,void>::find( SharedAllocationRecord<void,void> * con
 {
 #ifdef KOKKOS_DEBUG
   SharedAllocationRecord * root_next = 0 ;
+  static constexpr SharedAllocationRecord * zero = nullptr;
 
   // Lock the list:
-  while ( ( root_next = Kokkos::atomic_exchange( & arg_root->m_next , nullptr ) ) == nullptr );
+  while ( ( root_next = Kokkos::atomic_exchange( & arg_root->m_next , zero ) ) == nullptr );
 
   // Iterate searching for the record with this data pointer
 
@@ -168,9 +169,10 @@ SharedAllocationRecord(
     //              this->m_next == next ; next->m_prev == this
 
     m_prev = m_root ;
+    static constexpr SharedAllocationRecord * zero = nullptr;
 
     // Read root->m_next and lock by setting to NULL
-    while ( ( m_next = Kokkos::atomic_exchange( & m_root->m_next , nullptr ) ) == nullptr );
+    while ( ( m_next = Kokkos::atomic_exchange( & m_root->m_next , zero ) ) == nullptr );
 
     m_next->m_prev = this ;
 
@@ -229,9 +231,10 @@ decrement( SharedAllocationRecord< void , void > * arg_record )
     //          arg_record->m_next->m_prev == arg_record->m_prev
 
     SharedAllocationRecord * root_next = 0 ;
+    static constexpr SharedAllocationRecord * zero = nullptr;
 
     // Lock the list:
-    while ( ( root_next = Kokkos::atomic_exchange( & arg_record->m_root->m_next , nullptr ) ) == nullptr );
+    while ( ( root_next = Kokkos::atomic_exchange( & arg_record->m_root->m_next , zero ) ) == nullptr );
 
     arg_record->m_next->m_prev = arg_record->m_prev ;
 


### PR DESCRIPTION
This PR addresses issue #1342. Turns out Dan did all the work a while ago.  In debug mode, Kokkos::Array<> access operator will do bounds checking.  

release testing passed on ride:

#######################################################
PASSED TESTS
#######################################################
cuda-8.0.44-Cuda_OpenMP-release build_time=423 run_time=252
cuda-8.0.44-Cuda_Serial-release build_time=385 run_time=246
cuda-9.0.103-Cuda_OpenMP-release build_time=370 run_time=245
cuda-9.0.103-Cuda_Serial-release build_time=351 run_time=235
