### PR TITLE
Array: Cast i to size_t to fix signed comparison warning/error

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -76,7 +76,7 @@ struct ArrayBoundsCheck<Integral, true> {
 template <typename Integral>
 struct ArrayBoundsCheck<Integral, false> {
   ArrayBoundsCheck(Integral i, size_t N) {
-    if (i >= N) {
+    if ( size_t(i) >= N) {
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
       std::string s = "Kokkos::Array: index ";
       s += std::to_string(i);


### PR DESCRIPTION
Fix Jenkins failure in debug mode with flags -Werror -Wsign-compare