### PR TITLE
Move round-robin GPU logic to InitArguments

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -102,6 +102,8 @@ struct InitArguments {
   int num_threads;
   int num_numa;
   int device_id;
+  int ndevices;
+  int skip_device;
   bool disable_warnings;
 
   InitArguments( int nt = -1
@@ -112,6 +114,8 @@ struct InitArguments {
     : num_threads{ nt }
     , num_numa{ nn }
     , device_id{ dv }
+    , ndevices{ -1 }
+    , skip_device{ 9999 }
     , disable_warnings{ dw }
   {}
 };


### PR DESCRIPTION
This implements request #1318.

I just did some light testing of this on Ride, the current `--kokkos-ndevices` system still works even though it is now going through `InitArguments`, so in principle going directly through `InitArguments` also works.