### PR TITLE
Add support for new types shfl in CUDA 9

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -63,6 +63,8 @@ namespace Impl {
 //----------------------------------------------------------------------------
 // Shuffle operations require input to be a register (stack) variable
 
+// TODO: reconcile these implementations with those in Kokkos_Cuda_Vectorization.hpp
+
 template< typename T >
 __device__ inline
 void cuda_shfl( T & out , T const & in , int lane ,
@@ -73,11 +75,25 @@ void cuda_shfl( T & out , T const & in , int lane ,
     KOKKOS_IMPL_CUDA_SHFL_MASK( mask , *reinterpret_cast<int const *>(&in) , lane , width );
 }
 
+#if ( CUDA_VERSION >= 9000 )
+
+template< typename T >
+__device__ inline
+void cuda_shfl( T & out , T const & in , int lane ,
+  typename std::enable_if< sizeof(long long) == sizeof(T) , int >::type width
+  , unsigned mask = 0xffffffff )
+{
+  *reinterpret_cast<long long*>(&out) =
+    KOKKOS_IMPL_CUDA_SHFL_MASK( mask , *reinterpret_cast<long long const *>(&in) , lane , width );
+}
+
+#endif
+
 template< typename T >
 __device__ inline
 void cuda_shfl( T & out , T const & in , int lane ,
   typename std::enable_if
-    < ( sizeof(int) < sizeof(T) ) && ( 0 == ( sizeof(T) % sizeof(int) ) )
+    < ( KOKKOS_IMPL_CUDA_MAX_SHFL_SIZEOF < sizeof(T) ) && ( 0 == ( sizeof(T) % sizeof(int) ) )
     , int >::type width, unsigned mask = 0xffffffff )
 {
   enum : int { N = sizeof(T) / sizeof(int) };
@@ -99,11 +115,24 @@ void cuda_shfl_down( T & out , T const & in , int delta ,
     KOKKOS_IMPL_CUDA_SHFL_DOWN_MASK( mask , *reinterpret_cast<int const *>(&in) , delta , width );
 }
 
+#if ( CUDA_VERSION >= 9000 )
+
+template< typename T >
+__device__ inline
+void cuda_shfl_down( T & out , T const & in , int delta ,
+  typename std::enable_if< sizeof(long long) == sizeof(T) , int >::type width , unsigned mask = 0xffffffff )
+{
+  *reinterpret_cast<long long*>(&out) =
+    KOKKOS_IMPL_CUDA_SHFL_DOWN_MASK( mask , *reinterpret_cast<long long const *>(&in) , delta , width );
+}
+
+#endif
+
 template< typename T >
 __device__ inline
 void cuda_shfl_down( T & out , T const & in , int delta ,
   typename std::enable_if
-    < ( sizeof(int) < sizeof(T) ) && ( 0 == ( sizeof(T) % sizeof(int) ) )
+    < ( KOKKOS_IMPL_CUDA_MAX_SHFL_SIZEOF < sizeof(T) ) && ( 0 == ( sizeof(T) % sizeof(int) ) )
     , int >::type width , unsigned mask = 0xffffffff )
 {
   enum : int { N = sizeof(T) / sizeof(int) };
@@ -125,11 +154,24 @@ void cuda_shfl_up( T & out , T const & in , int delta ,
     KOKKOS_IMPL_CUDA_SHFL_UP_MASK( mask , *reinterpret_cast<int const *>(&in) , delta , width );
 }
 
+#if ( CUDA_VERSION >= 9000 )
+
+template< typename T >
+__device__ inline
+void cuda_shfl_up( T & out , T const & in , int delta ,
+  typename std::enable_if< sizeof(long long) == sizeof(T) , int >::type width , unsigned mask = 0xffffffff )
+{
+  *reinterpret_cast<long long*>(&out) =
+    KOKKOS_IMPL_CUDA_SHFL_UP_MASK( mask , *reinterpret_cast<long long const *>(&in) , delta , width );
+}
+
+#endif
+
 template< typename T >
 __device__ inline
 void cuda_shfl_up( T & out , T const & in , int delta ,
   typename std::enable_if
-    < ( sizeof(int) < sizeof(T) ) && ( 0 == ( sizeof(T) % sizeof(int) ) )
+    < ( KOKKOS_IMPL_CUDA_MAX_SHFL_SIZEOF < sizeof(T) ) && ( 0 == ( sizeof(T) % sizeof(int) ) )
     , int >::type width , unsigned mask = 0xffffffff )
 {
   enum : int { N = sizeof(T) / sizeof(int) };

--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -87,7 +87,7 @@ namespace Impl {
 }
 
 #ifdef __CUDA_ARCH__
-  #if (__CUDA_ARCH__ >= 300)
+#if (__CUDA_ARCH__ >= 300)
 
     KOKKOS_INLINE_FUNCTION
     int shfl(const int &val, const int& srcLane, const int& width ) {
@@ -99,15 +99,34 @@ namespace Impl {
       return KOKKOS_IMPL_CUDA_SHFL(val,srcLane,width);
     }
 
+#if ( CUDA_VERSION >= 9000 )
+
+    KOKKOS_INLINE_FUNCTION
+    long shfl(const long &val, const int& srcLane, const int& width ) {
+      return KOKKOS_IMPL_CUDA_SHFL(val,srcLane,width);
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    long long shfl(const long long &val, const int& srcLane, const int& width ) {
+      return KOKKOS_IMPL_CUDA_SHFL(val,srcLane,width);
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    double shfl(const double &val, const int& srcLane, const int& width ) {
+      return KOKKOS_IMPL_CUDA_SHFL(val,srcLane,width);
+    }
+
     template<typename Scalar>
     KOKKOS_INLINE_FUNCTION
-    Scalar shfl(const Scalar &val, const int& srcLane, const typename Impl::enable_if< (sizeof(Scalar) == 4) , int >::type& width
+    Scalar shfl(const Scalar &val, const int& srcLane, const typename Impl::enable_if< (sizeof(Scalar) == 8) , int >::type& width
         ) {
       Scalar tmp1 = val;
-      float tmp = *reinterpret_cast<float*>(&tmp1);
+      double tmp = *reinterpret_cast<double*>(&tmp1);
       tmp = KOKKOS_IMPL_CUDA_SHFL(tmp,srcLane,width);
       return *reinterpret_cast<Scalar*>(&tmp);
     }
+
+#else // ( CUDA_VERSION < 9000 )
 
     KOKKOS_INLINE_FUNCTION
     double shfl(const double &val, const int& srcLane, const int& width) {
@@ -127,6 +146,18 @@ namespace Impl {
       hi = KOKKOS_IMPL_CUDA_SHFL(hi,srcLane,width);
       const double tmp = __hiloint2double(hi,lo);
       return *(reinterpret_cast<const Scalar*>(&tmp));
+    }
+
+#endif // ( CUDA_VERSION < 9000 )
+
+    template<typename Scalar>
+    KOKKOS_INLINE_FUNCTION
+    Scalar shfl(const Scalar &val, const int& srcLane, const typename Impl::enable_if< (sizeof(Scalar) == 4) , int >::type& width
+        ) {
+      Scalar tmp1 = val;
+      float tmp = *reinterpret_cast<float*>(&tmp1);
+      tmp = KOKKOS_IMPL_CUDA_SHFL(tmp,srcLane,width);
+      return *reinterpret_cast<Scalar*>(&tmp);
     }
 
     template<typename Scalar>
@@ -151,14 +182,33 @@ namespace Impl {
       return KOKKOS_IMPL_CUDA_SHFL_DOWN(val,delta,width);
     }
 
+#if ( CUDA_VERSION >= 9000 )
+
+    KOKKOS_INLINE_FUNCTION
+    long shfl_down(const long &val, const int& delta, const int& width) {
+      return KOKKOS_IMPL_CUDA_SHFL_DOWN(val,delta,width);
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    long long shfl_down(const long long &val, const int& delta, const int& width) {
+      return KOKKOS_IMPL_CUDA_SHFL_DOWN(val,delta,width);
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    double shfl_down(const double &val, const int& delta, const int& width) {
+      return KOKKOS_IMPL_CUDA_SHFL_DOWN(val,delta,width);
+    }
+
     template<typename Scalar>
     KOKKOS_INLINE_FUNCTION
-    Scalar shfl_down(const Scalar &val, const int& delta, const typename Impl::enable_if< (sizeof(Scalar) == 4) , int >::type & width) {
+    Scalar shfl_down(const Scalar &val, const int& delta, const typename Impl::enable_if< (sizeof(Scalar) == 8) , int >::type & width) {
       Scalar tmp1 = val;
-      float tmp = *reinterpret_cast<float*>(&tmp1);
+      double tmp = *reinterpret_cast<double*>(&tmp1);
       tmp = KOKKOS_IMPL_CUDA_SHFL_DOWN(tmp,delta,width);
       return *reinterpret_cast<Scalar*>(&tmp);
     }
+
+#else // ( CUDA_VERSION < 9000 )
 
     KOKKOS_INLINE_FUNCTION
     double shfl_down(const double &val, const int& delta, const int& width) {
@@ -178,6 +228,17 @@ namespace Impl {
       hi = KOKKOS_IMPL_CUDA_SHFL_DOWN(hi,delta,width);
       const double tmp = __hiloint2double(hi,lo);
       return *(reinterpret_cast<const Scalar*>(&tmp));
+    }
+
+#endif // ( CUDA_VERSION < 9000 )
+
+    template<typename Scalar>
+    KOKKOS_INLINE_FUNCTION
+    Scalar shfl_down(const Scalar &val, const int& delta, const typename Impl::enable_if< (sizeof(Scalar) == 4) , int >::type & width) {
+      Scalar tmp1 = val;
+      float tmp = *reinterpret_cast<float*>(&tmp1);
+      tmp = KOKKOS_IMPL_CUDA_SHFL_DOWN(tmp,delta,width);
+      return *reinterpret_cast<Scalar*>(&tmp);
     }
 
     template<typename Scalar>
@@ -202,14 +263,33 @@ namespace Impl {
       return KOKKOS_IMPL_CUDA_SHFL_UP(val,delta,width);
     }
 
+#if ( CUDA_VERSION >= 9000 )
+
+    KOKKOS_INLINE_FUNCTION
+    long shfl_up(const long &val, const int& delta, const int& width ) {
+      return KOKKOS_IMPL_CUDA_SHFL_UP(val,delta,width);
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    long long shfl_up(const long long &val, const int& delta, const int& width ) {
+      return KOKKOS_IMPL_CUDA_SHFL_UP(val,delta,width);
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    double shfl_up(const double &val, const int& delta, const int& width ) {
+      return KOKKOS_IMPL_CUDA_SHFL_UP(val,delta,width);
+    }
+
     template<typename Scalar>
     KOKKOS_INLINE_FUNCTION
-    Scalar shfl_up(const Scalar &val, const int& delta, const typename Impl::enable_if< (sizeof(Scalar) == 4) , int >::type & width) {
+    Scalar shfl_up(const Scalar &val, const int& delta, const typename Impl::enable_if< (sizeof(Scalar) == 8) , int >::type & width) {
       Scalar tmp1 = val;
-      float tmp = *reinterpret_cast<float*>(&tmp1);
+      double tmp = *reinterpret_cast<double*>(&tmp1);
       tmp = KOKKOS_IMPL_CUDA_SHFL_UP(tmp,delta,width);
       return *reinterpret_cast<Scalar*>(&tmp);
     }
+
+#else // ( CUDA_VERSION < 9000 )
 
     KOKKOS_INLINE_FUNCTION
     double shfl_up(const double &val, const int& delta, const int& width ) {
@@ -231,6 +311,17 @@ namespace Impl {
       return *(reinterpret_cast<const Scalar*>(&tmp));
     }
 
+#endif // ( CUDA_VERSION < 9000 )
+
+    template<typename Scalar>
+    KOKKOS_INLINE_FUNCTION
+    Scalar shfl_up(const Scalar &val, const int& delta, const typename Impl::enable_if< (sizeof(Scalar) == 4) , int >::type & width) {
+      Scalar tmp1 = val;
+      float tmp = *reinterpret_cast<float*>(&tmp1);
+      tmp = KOKKOS_IMPL_CUDA_SHFL_UP(tmp,delta,width);
+      return *reinterpret_cast<Scalar*>(&tmp);
+    }
+
     template<typename Scalar>
     KOKKOS_INLINE_FUNCTION
     Scalar shfl_up(const Scalar &val, const int& delta, const typename Impl::enable_if< (sizeof(Scalar) > 8) , int >::type & width) {
@@ -243,7 +334,7 @@ namespace Impl {
       return r_val.value();
     }
 
-  #else
+#else // (__CUDA_ARCH__ < 300)
     template<typename Scalar>
     KOKKOS_INLINE_FUNCTION
     Scalar shfl(const Scalar &val, const int& srcLane, const int& width) {
@@ -264,34 +355,32 @@ namespace Impl {
       if(width > 1) Kokkos::abort("Error: calling shfl_down from a device with CC<3.0.");
       return val;
     }
-  #endif
-#else
+#endif // (__CUDA_ARCH__ < 300)
+#else // !defined( __CUDA_ARCH__ )
     template<typename Scalar>
     inline
     Scalar shfl(const Scalar &val, const int& srcLane, const int& width) {
-      if(width > 1) Kokkos::abort("Error: calling shfl from a device with CC<3.0.");
+      if(width > 1) Kokkos::abort("Error: calling shfl outside __CUDA_ARCH__.");
       return val;
     }
 
     template<typename Scalar>
     inline
     Scalar shfl_down(const Scalar &val, const int& delta, const int& width) {
-      if(width > 1) Kokkos::abort("Error: calling shfl_down from a device with CC<3.0.");
+      if(width > 1) Kokkos::abort("Error: calling shfl_down outside __CUDA_ARCH__.");
       return val;
     }
 
     template<typename Scalar>
     inline
     Scalar shfl_up(const Scalar &val, const int& delta, const int& width) {
-      if(width > 1) Kokkos::abort("Error: calling shfl_down from a device with CC<3.0.");
+      if(width > 1) Kokkos::abort("Error: calling shfl_down outside __CUDA_ARCH__.");
       return val;
     }
-#endif
+#endif // !defined( __CUDA_ARCH__ )
 
+} // end namespace Kokkos
 
-
-}
-
-#endif // KOKKOS_ENABLE_CUDA
-#endif
+#endif // defined( KOKKOS_ENABLE_CUDA )
+#endif // !defined( KOKKOS_CUDA_VECTORIZATION_HPP )
 

--- a/core/src/Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp
@@ -29,6 +29,12 @@
 #define KOKKOS_IMPL_CUDA_SHFL_DOWN(x,y,z) 0
 #endif 
 
+#if ( CUDA_VERSION < 9000 )
+#define KOKKOS_IMPL_CUDA_MAX_SHFL_SIZEOF sizeof(int)
+#else
+#define KOKKOS_IMPL_CUDA_MAX_SHFL_SIZEOF sizeof(long long)
+#endif
+
 #if defined( __CUDA_ARCH__ )
 #if ( CUDA_VERSION < 9000 )
 #define KOKKOS_IMPL_CUDA_SYNCWARP_OR_RETURN( MSG ) { \


### PR DESCRIPTION
This fulfills request #361.

CUDA 9's `__shfl_sync` and friends support more types like `long long` and `double`. Added the right overloads under the right `#ifdef`s so that we use those intrinsics instead of the workarounds when CUDA 9 is available.

So far, a TriBITS build of Kokkos under CUDA 9 passed all unit tests. Going to do a spot check next.