### PR TITLE
Fix Sullivan issue #1538

### DIFF
--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -309,9 +309,10 @@ void test_deep_copy( uint32_t num_nodes )
 }
 
 TEST_F( TEST_CATEGORY, UnorderedMap_insert) {
-  for (int i=0; i<500; ++i)
+  for (int i=0; i<500; ++i) {
     test_insert<TEST_EXECSPACE>(100000, 90000, 100, true);
     test_insert<TEST_EXECSPACE>(100000, 90000, 100, false);
+  }
 }
 
 TEST_F( TEST_CATEGORY, UnorderedMap_failed_insert) {


### PR DESCRIPTION
Trivial fix. Here is spot-check on sullivan:
```
Running on machine: sullivan
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
?? benchmarks/bytes_and_flops/main.o
?? example/cmake_build/build/

Repository Status:  d67e7eb1db14a7675fb649da0dbcbfe460df28bc Fix Sullivan issue #1538


Going to test compilers:  gcc/6.1.0
Testing compiler gcc/6.1.0
  Starting job gcc-6.1.0-Serial-release
  Starting job gcc-6.1.0-OpenMP-release
  PASSED gcc-6.1.0-Serial-release
  Starting job gcc-6.1.0-OpenMP_Serial-release
  PASSED gcc-6.1.0-OpenMP-release
  PASSED gcc-6.1.0-OpenMP_Serial-release
#######################################################
PASSED TESTS
#######################################################
gcc-6.1.0-OpenMP-release build_time=397 run_time=546
gcc-6.1.0-OpenMP_Serial-release build_time=428 run_time=793
gcc-6.1.0-Serial-release build_time=287 run_time=548
```