### PR TITLE
Properly deprecate Execution Space APIs

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -702,7 +702,11 @@ namespace Kokkos {
     }
     Random_XorShift64_Pool(uint64_t seed) {
       num_states_ = 0;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       init(seed,DeviceType::max_hardware_threads());
+#else
+      init(seed,DeviceType::impl_max_hardware_threads());
+#endif
     }
 
     Random_XorShift64_Pool(const Random_XorShift64_Pool& src):
@@ -751,7 +755,11 @@ namespace Kokkos {
 
     KOKKOS_INLINE_FUNCTION
     Random_XorShift64<DeviceType> get_state() const {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       const int i = DeviceType::hardware_thread_id();;
+#else
+      const int i = DeviceType::impl_hardware_thread_id();;
+#endif
       return Random_XorShift64<DeviceType>(state_(i),i);
     }
 
@@ -957,7 +965,11 @@ namespace Kokkos {
     inline
     Random_XorShift1024_Pool(uint64_t seed){
       num_states_ = 0;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       init(seed,DeviceType::max_hardware_threads());
+#else
+      init(seed,DeviceType::impl_max_hardware_threads());
+#endif
     }
 
     Random_XorShift1024_Pool(const Random_XorShift1024_Pool& src):
@@ -1012,7 +1024,11 @@ namespace Kokkos {
 
     KOKKOS_INLINE_FUNCTION
     Random_XorShift1024<DeviceType> get_state() const {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       const int i = DeviceType::hardware_thread_id();
+#else
+      const int i = DeviceType::impl_hardware_thread_id();
+#endif
       return Random_XorShift1024<DeviceType>(state_,p_(i),i);
     };
 

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1044,7 +1044,12 @@ public:
                    , "View allocation constructor requires managed memory" );
 
       if ( alloc_prop::initialize &&
-           ! alloc_prop::execution_space::is_initialized() ) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+           ! alloc_prop::execution_space::is_initialized()
+#else
+           ! alloc_prop::execution_space::impl_is_initialized()
+#endif
+           ) {
         // If initializing view data then
         // the execution space must be initialized.
         Kokkos::Impl::throw_runtime_exception("Constructing DynRankView and initializing data with uninitialized execution space");

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -781,7 +781,6 @@ public:
     ASSERT_EQ( a.rank() , am.rank() );
     ASSERT_EQ( ax.rank() , am.rank() );
 
-    if (Kokkos::HostSpace::execution_space::is_initialized() )
     {
       Kokkos::DynRankView<double, Kokkos::LayoutLeft, Kokkos::HostSpace> a_h("A",1000);
       auto a_h2 = Kokkos::create_mirror(Kokkos::HostSpace(),a_h);
@@ -801,7 +800,6 @@ public:
       ASSERT_EQ(a_h.rank(),a_h2.rank());
       ASSERT_EQ(a_h.rank(),a_d.rank());
     }
-    if (Kokkos::HostSpace::execution_space::is_initialized() )
     {
       Kokkos::DynRankView<double, Kokkos::LayoutRight, Kokkos::HostSpace> a_h("A",1000);
       auto a_h2 = Kokkos::create_mirror(Kokkos::HostSpace(),a_h);
@@ -822,7 +820,6 @@ public:
       ASSERT_EQ(a_h.rank(),a_d.rank());
     }
 
-    if (Kokkos::HostSpace::execution_space::is_initialized() )
     {
       Kokkos::DynRankView<double, Kokkos::LayoutLeft, Kokkos::HostSpace> a_h("A",1000);
       auto a_h2 = Kokkos::create_mirror_view(Kokkos::HostSpace(),a_h);
@@ -843,7 +840,6 @@ public:
       ASSERT_EQ(a_h.rank(),a_h2.rank());
       ASSERT_EQ(a_h.rank(),a_d.rank());
     }
-    if (Kokkos::HostSpace::execution_space::is_initialized() )
     {
       Kokkos::DynRankView<double, Kokkos::LayoutRight, Kokkos::HostSpace> a_h("A",1000);
       auto a_h2 = Kokkos::create_mirror_view(Kokkos::HostSpace(),a_h);
@@ -865,7 +861,6 @@ public:
       ASSERT_EQ(a_h.rank(),a_h2.rank());
       ASSERT_EQ(a_h.rank(),a_d.rank());
     }
-    if (Kokkos::HostSpace::execution_space::is_initialized() )
     {
       typedef Kokkos::DynRankView< int , Kokkos::LayoutStride , Kokkos::HostSpace > view_stride_type ;
       unsigned order[] = { 6,5,4,3,2,1,0 }, dimen[] = { N0, N1, N2, 2, 2, 2, 2 }; //LayoutRight equivalent

--- a/core/src/Cuda/Kokkos_Cuda_Impl.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Impl.cpp
@@ -375,7 +375,11 @@ void CudaInternal::initialize( int cuda_device_id , int stream_count )
 
   enum { WordSize = sizeof(size_type) };
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   if ( ! HostSpace::execution_space::is_initialized() ) {
+#else
+  if ( ! HostSpace::execution_space::impl_is_initialized() ) {
+#endif
     const std::string msg("Cuda::initialize ERROR : HostSpace::execution_space is not initialized");
     throw_runtime_exception( msg );
   }
@@ -724,10 +728,18 @@ Cuda::size_type Cuda::detect_device_count()
 int Cuda::concurrency()
 { return Impl::CudaInternal::singleton().m_maxConcurrency ; }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 int Cuda::is_initialized()
+#else
+int Cuda::impl_is_initialized()
+#endif
 { return Impl::CudaInternal::singleton().is_initialized(); }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 void Cuda::initialize( const Cuda::SelectDevice config , size_t num_instances )
+#else
+void Cuda::impl_initialize( const Cuda::SelectDevice config , size_t num_instances )
+#endif
 {
   Impl::CudaInternal::singleton().initialize( config.cuda_device_id , num_instances );
 
@@ -766,7 +778,11 @@ Cuda::size_type Cuda::device_arch()
   return dev_arch ;
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 void Cuda::finalize()
+#else
+void Cuda::impl_finalize()
+#endif
 {
   Impl::CudaInternal::singleton().finalize();
 
@@ -793,9 +809,11 @@ Cuda::Cuda( const int instance_id )
 void Cuda::print_configuration( std::ostream & s , const bool )
 { Impl::CudaInternal::singleton().print_configuration( s ); }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 bool Cuda::sleep() { return false ; }
 
 bool Cuda::wake() { return true ; }
+#endif
 
 void Cuda::fence()
 {

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -155,12 +155,6 @@ public:
   /// device have completed.
   static void fence();
 
-  //! Free any resources being consumed by the device.
-  static void finalize();
-
-  //! Has been initialized
-  static int is_initialized();
-
   /** \brief  Return the maximum amount of concurrency.  */
   static int concurrency();
 
@@ -190,9 +184,27 @@ public:
     explicit SelectDevice( int id ) : cuda_device_id( id ) {}
   };
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+  //! Free any resources being consumed by the device.
+  static void finalize();
+
+  //! Has been initialized
+  static int is_initialized();
+
   //! Initialize, telling the CUDA run-time library which device to use.
   static void initialize( const SelectDevice = SelectDevice()
                         , const size_t num_instances = 1 );
+#else
+  //! Free any resources being consumed by the device.
+  static void impl_finalize();
+
+  //! Has been initialized
+  static int impl_is_initialized();
+
+  //! Initialize, telling the CUDA run-time library which device to use.
+  static void impl_initialize( const SelectDevice = SelectDevice()
+                        , const size_t num_instances = 1 );
+#endif
 
   /// \brief Cuda device architecture of the selected device.
   ///

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -224,6 +224,8 @@ public:
   // use UniqueToken
   KOKKOS_INLINE_FUNCTION
   static int impl_hardware_thread_id() noexcept;
+
+  static int impl_get_current_max_threads() noexcept;
 #endif
 
   static constexpr const char* name() noexcept { return "OpenMP"; }

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -97,34 +97,6 @@ public:
   inline
   OpenMP() noexcept;
 
-  // Using omp_get_max_threads(); is problematic
-  // On Intel (essentially an initial call to the OpenMP runtime
-  // without a parallel region before will set a process mask for a single core
-  // The runtime will than bind threads for a parallel region to other cores on the
-  // entering the first parallel region and make the process mask the aggregate of
-  // the thread masks. The intend seems to be to make serial code run fast, if you
-  // compile with OpenMP enabled but don't actually use parallel regions or so
-  // static int omp_max_threads = omp_get_max_threads();
-  static int get_current_max_threads() noexcept;
-
-  /// \brief Initialize the default execution space
-  ///
-  /// if ( thread_count == -1 )
-  ///   then use the number of threads that openmp defaults to
-  /// if ( thread_count == 0 && Kokkos::hwlow_available() )
-  ///   then use hwloc to choose the number of threads and change
-  ///   the default number of threads
-  /// if ( thread_count > 0 )
-  ///   then force openmp to use the given number of threads and change
-  ///   the default number of threads
-  static void initialize( int thread_count = -1 );
-
-  /// \brief Free any resources being consumed by the default execution space
-  static void finalize();
-
-  /// \brief is the default execution space initialized for current 'master' thread
-  static bool is_initialized() noexcept;
-
   /// \brief Print configuration information to the given output stream.
   static void print_configuration( std::ostream & , const bool verbose = false );
 
@@ -169,12 +141,8 @@ public:
                               , int requested_partition_size = 0
                               );
 
-  inline
-  static int thread_pool_size() noexcept;
-
-  /** \brief  The rank of the executing thread in this thread pool */
-  KOKKOS_INLINE_FUNCTION
-  static int thread_pool_rank() noexcept;
+  // use UniqueToken
+  static int concurrency();
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   /// \brief Initialize the default execution space
@@ -182,14 +150,46 @@ public:
                           int use_numa_count,
                           int use_cores_per_numa = 0);
 
+  /// \brief Initialize the default execution space
+  ///
+  /// if ( thread_count == -1 )
+  ///   then use the number of threads that openmp defaults to
+  /// if ( thread_count == 0 && Kokkos::hwlow_available() )
+  ///   then use hwloc to choose the number of threads and change
+  ///   the default number of threads
+  /// if ( thread_count > 0 )
+  ///   then force openmp to use the given number of threads and change
+  ///   the default number of threads
+  static void initialize( int thread_count = -1 );
+
+  /// \brief is the default execution space initialized for current 'master' thread
+  static bool is_initialized() noexcept;
+
+  /// \brief Free any resources being consumed by the default execution space
+  static void finalize();
+
+  inline
+  static int thread_pool_size() noexcept;
+
+  /** \brief  The rank of the executing thread in this thread pool */
+  KOKKOS_INLINE_FUNCTION
+  static int thread_pool_rank() noexcept;
+
   inline
   static int thread_pool_size( int depth );
 
   static void sleep() {};
   static void wake() {};
 
-  // use UniqueToken
-  static int concurrency();
+  // Using omp_get_max_threads(); is problematic
+  // On Intel (essentially an initial call to the OpenMP runtime
+  // without a parallel region before will set a process mask for a single core
+  // The runtime will than bind threads for a parallel region to other cores on the
+  // entering the first parallel region and make the process mask the aggregate of
+  // the thread masks. The intend seems to be to make serial code run fast, if you
+  // compile with OpenMP enabled but don't actually use parallel regions or so
+  // static int omp_max_threads = omp_get_max_threads();
+  static int get_current_max_threads() noexcept;
 
   // use UniqueToken
   inline
@@ -198,6 +198,32 @@ public:
   // use UniqueToken
   KOKKOS_INLINE_FUNCTION
   static int hardware_thread_id() noexcept;
+#else
+  static void impl_initialize( int thread_count = -1 );
+
+  /// \brief is the default execution space initialized for current 'master' thread
+  static bool impl_is_initialized() noexcept;
+
+  /// \brief Free any resources being consumed by the default execution space
+  static void impl_finalize();
+
+  inline
+  static int impl_thread_pool_size() noexcept;
+
+  /** \brief  The rank of the executing thread in this thread pool */
+  KOKKOS_INLINE_FUNCTION
+  static int impl_thread_pool_rank() noexcept;
+
+  inline
+  static int impl_thread_pool_size( int depth );
+
+  // use UniqueToken
+  inline
+  static int impl_max_hardware_threads() noexcept;
+
+  // use UniqueToken
+  KOKKOS_INLINE_FUNCTION
+  static int impl_hardware_thread_id() noexcept;
 #endif
 
   static constexpr const char* name() noexcept { return "OpenMP"; }

--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -96,25 +96,8 @@ public:
   ///   thread-parallel function.
   static int in_parallel();
 
-  /** \brief  Set the device in a "sleep" state.
-   *
-   * This function sets the device in a "sleep" state in which it is
-   * not ready for work.  This may consume less resources than if the
-   * device were in an "awake" state, but it may also take time to
-   * bring the device from a sleep state to be ready for work.
-   *
-   * \return True if the device is in the "sleep" state, else false if
-   *   the device is actively working and could not enter the "sleep"
-   *   state.
-   */
-  static bool sleep();
-
-  /// \brief Wake the device from the 'sleep' state so it is ready for work.
-  ///
-  /// \return True if the device is in the "ready" state, else "false"
-  ///  if the device is actively working (which also means that it's
-  ///  awake).
-  static bool wake();
+  /// \brief Print configuration information to the given output stream.
+  static void print_configuration( std::ostream & , const bool detail = false );
 
   /// \brief Wait until all dispatched functors complete.
   ///
@@ -124,13 +107,41 @@ public:
   /// device have completed.
   static void fence();
 
+  /** \brief  Return the maximum amount of concurrency.  */
+  static int concurrency();
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+  static bool sleep();
+
+  static bool wake();
+
+  static void finalize();
+
+  static void initialize( unsigned threads_count = 0 ,
+                          unsigned use_numa_count = 0 ,
+                          unsigned use_cores_per_numa = 0 ,
+                          bool allow_asynchronous_threadpool = false );
+
+  static int is_initialized();
+
+  static Threads & instance( int = 0 );
+
+  //----------------------------------------
+
+  static int thread_pool_size( int depth = 0 );
+#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+  static int thread_pool_rank();
+#else
+  KOKKOS_INLINE_FUNCTION static int thread_pool_rank() { return 0 ; }
+#endif
+
+  inline static unsigned max_hardware_threads() { return thread_pool_size(0); }
+  KOKKOS_INLINE_FUNCTION static unsigned hardware_thread_id() { return thread_pool_rank(); }
+#else
   /// \brief Free any resources being consumed by the device.
   ///
   /// For the Threads device, this terminates spawned worker threads.
-  static void finalize();
-
-  /// \brief Print configuration information to the given output stream.
-  static void print_configuration( std::ostream & , const bool detail = false );
+  static void impl_finalize();
 
   //@}
   /*------------------------------------------------------------------------*/
@@ -155,29 +166,27 @@ public:
    *  If the 'use_' arguments are not supplied the hwloc is queried
    *  to use all available cores.
    */
-  static void initialize( unsigned threads_count = 0 ,
+  static void impl_initialize( unsigned threads_count = 0 ,
                           unsigned use_numa_count = 0 ,
                           unsigned use_cores_per_numa = 0 ,
                           bool allow_asynchronous_threadpool = false );
 
-  static int is_initialized();
+  static int impl_is_initialized();
 
-  /** \brief  Return the maximum amount of concurrency.  */
-  static int concurrency();
-
-  static Threads & instance( int = 0 );
+  static Threads & impl_instance( int = 0 );
 
   //----------------------------------------
 
-  static int thread_pool_size( int depth = 0 );
+  static int impl_thread_pool_size( int depth = 0 );
 #if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
-  static int thread_pool_rank();
+  static int impl_thread_pool_rank();
 #else
-  KOKKOS_INLINE_FUNCTION static int thread_pool_rank() { return 0 ; }
+  KOKKOS_INLINE_FUNCTION static int impl_thread_pool_rank() { return 0 ; }
 #endif
 
-  inline static unsigned max_hardware_threads() { return thread_pool_size(0); }
-  KOKKOS_INLINE_FUNCTION static unsigned hardware_thread_id() { return thread_pool_rank(); }
+  inline static unsigned impl_max_hardware_threads() { return impl_thread_pool_size(0); }
+  KOKKOS_INLINE_FUNCTION static unsigned impl_hardware_thread_id() { return impl_thread_pool_rank(); }
+#endif
 
   static const char* name();
   //@}

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -2014,7 +2014,12 @@ public:
                    , "View allocation constructor requires managed memory" );
 
       if ( alloc_prop::initialize &&
-           ! alloc_prop::execution_space::is_initialized() ) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+           ! alloc_prop::execution_space::is_initialized()
+#else
+           ! alloc_prop::execution_space::impl_is_initialized()
+#endif
+           ) {
         // If initializing view data then
         // the execution space must be initialized.
         Kokkos::Impl::throw_runtime_exception("Constructing View and initializing data with uninitialized execution space");

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
@@ -260,7 +260,11 @@ namespace Kokkos {
 
 //----------------------------------------------------------------------------
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 int OpenMP::get_current_max_threads() noexcept
+#else
+int OpenMP::impl_get_current_max_threads() noexcept
+#endif
 {
   // Using omp_get_max_threads(); is problematic in conjunction with
   // Hwloc on Intel (essentially an initial call to the OpenMP runtime
@@ -309,7 +313,11 @@ void OpenMP::impl_initialize( int thread_count )
     // Before any other call to OMP query the maximum number of threads
     // and save the value for re-initialization unit testing.
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     Impl::g_openmp_hardware_max_threads = get_current_max_threads();
+#else
+    Impl::g_openmp_hardware_max_threads = impl_get_current_max_threads();
+#endif
 
     int process_num_threads = Impl::g_openmp_hardware_max_threads;
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
@@ -280,8 +280,11 @@ int OpenMP::get_current_max_threads() noexcept
   return count;
 }
 
-
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 void OpenMP::initialize( int thread_count )
+#else
+void OpenMP::impl_initialize( int thread_count )
+#endif
 {
   if ( omp_in_parallel() ) {
     std::string msg("Kokkos::OpenMP::initialize ERROR : in parallel");
@@ -373,14 +376,18 @@ void OpenMP::initialize( int thread_count )
   // Init the array for used for arbitrarily sized atomics
   Impl::init_lock_array_host_space();
 
-  #if defined(KOKKOS_ENABLE_PROFILING)
-    Kokkos::Profiling::initialize();
+  #if defined(KOKKOS_ENABLE_DEPRECATED_CODE) && defined(KOKKOS_ENABLE_PROFILING)
+  Kokkos::Profiling::initialize();
   #endif
 }
 
 //----------------------------------------------------------------------------
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 void OpenMP::finalize()
+#else
+void OpenMP::impl_finalize()
+#endif
 {
   if ( omp_in_parallel() )
   {
@@ -453,12 +460,11 @@ std::vector<OpenMP> OpenMP::partition(...)
 
 OpenMP OpenMP::create_instance(...) { return OpenMP(); }
 
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-
 int OpenMP::concurrency() {
   return Impl::g_openmp_hardware_max_threads;
 }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 
 void OpenMP::initialize( int thread_count , int, int )
 {

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -141,7 +141,11 @@ inline OpenMP::OpenMP() noexcept
 {}
 
 inline
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 bool OpenMP::is_initialized() noexcept
+#else
+bool OpenMP::impl_is_initialized() noexcept
+#endif
 { return Impl::t_openmp_instance != nullptr; }
 
 inline

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -158,7 +158,11 @@ bool OpenMP::in_parallel( OpenMP const& ) noexcept
 }
 
 inline
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 int OpenMP::thread_pool_size() noexcept
+#else
+int OpenMP::impl_thread_pool_size() noexcept
+#endif
 {
   return   OpenMP::in_parallel()
          ? omp_get_num_threads()
@@ -167,7 +171,11 @@ int OpenMP::thread_pool_size() noexcept
 }
 
 KOKKOS_INLINE_FUNCTION
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 int OpenMP::thread_pool_rank() noexcept
+#else
+int OpenMP::impl_thread_pool_rank() noexcept
+#endif
 {
 #if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
   return Impl::t_openmp_instance ? 0 : omp_get_thread_num();
@@ -271,22 +279,30 @@ public:
   KOKKOS_INLINE_FUNCTION
   int size() const noexcept
     {
-      #if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+#if defined( KOKKOS_ENABLE_DEPRECATED_CODE )
       return Kokkos::OpenMP::thread_pool_size();
-      #else
+#else
+      return Kokkos::OpenMP::impl_thread_pool_size();
+#endif
+#else
       return 0 ;
-      #endif
+#endif
     }
 
   /// \brief acquire value such that 0 <= value < size()
   KOKKOS_INLINE_FUNCTION
   int acquire() const  noexcept
     {
-      #if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+#if defined( KOKKOS_ENABLE_DEPRECATED_CODE )
       return Kokkos::OpenMP::thread_pool_rank();
-      #else
+#else
+      return Kokkos::OpenMP::impl_thread_pool_rank();
+#endif
+#else
       return 0 ;
-      #endif
+#endif
     }
 
   /// \brief release a value acquired by generate
@@ -335,19 +351,28 @@ public:
 
 } // namespace Experimental
 
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-
 inline
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 int OpenMP::thread_pool_size( int depth )
+#else
+int OpenMP::impl_thread_pool_size( int depth )
+#endif
 {
   return depth < 2
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
          ? thread_pool_size()
+#else
+         ? impl_thread_pool_size()
+#endif
          : 1;
 }
 
 KOKKOS_INLINE_FUNCTION
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 int OpenMP::hardware_thread_id() noexcept
+#else
+int OpenMP::impl_hardware_thread_id() noexcept
+#endif
 {
 #if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
   return Impl::t_openmp_hardware_id;
@@ -357,12 +382,14 @@ int OpenMP::hardware_thread_id() noexcept
 }
 
 inline
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 int OpenMP::max_hardware_threads() noexcept
+#else
+int OpenMP::impl_max_hardware_threads() noexcept
+#endif
 {
   return Impl::g_openmp_hardware_max_threads;
 }
-
-#endif
 
 } // namespace Kokkos
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -127,7 +127,11 @@ public:
 
       OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_for");
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       const int pool_size = OpenMP::thread_pool_size();
+#else
+      const int pool_size = OpenMP::impl_thread_pool_size();
+#endif
       #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
@@ -223,7 +227,11 @@ public:
 
       OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_for");
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       const int pool_size = OpenMP::thread_pool_size();
+#else
+      const int pool_size = OpenMP::impl_thread_pool_size();
+#endif
       #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
@@ -351,7 +359,11 @@ public:
                                     , 0 // thread_local_bytes
                                     );
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       const int pool_size = OpenMP::thread_pool_size();
+#else
+      const int pool_size = OpenMP::impl_thread_pool_size();
+#endif
       #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
@@ -516,7 +528,11 @@ public:
                                     , 0 // thread_local_bytes
                                     );
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       const int pool_size = OpenMP::thread_pool_size();
+#else
+      const int pool_size = OpenMP::impl_thread_pool_size();
+#endif
       #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
@@ -686,7 +702,11 @@ public:
                                     , 0 // thread_local_bytes
                                     );
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       const int pool_size = OpenMP::thread_pool_size();
+#else
+      const int pool_size = OpenMP::impl_thread_pool_size();
+#endif
       #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
@@ -842,7 +862,11 @@ public:
                                     , team_shared_size
                                     , thread_local_size );
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       const int pool_size = OpenMP::thread_pool_size();
+#else
+      const int pool_size = OpenMP::impl_thread_pool_size();
+#endif
       #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
@@ -1004,7 +1028,11 @@ public:
                                     , team_shared_size
                                     , thread_local_size );
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       const int pool_size = OpenMP::thread_pool_size();
+#else
+      const int pool_size = OpenMP::impl_thread_pool_size();
+#endif
       #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
@@ -1093,7 +1121,7 @@ public:
     , m_functor( arg_functor )
     , m_policy(  arg_policy )
     , m_reducer( InvalidType() )
-    , m_result_ptr( arg_result.ptr_on_device() )
+    , m_result_ptr( arg_result.data() )
     , m_shmem_size( arg_policy.scratch_size(0) +
                     arg_policy.scratch_size(1) +
                     FunctorTeamShmemSize< FunctorType >

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
@@ -116,7 +116,11 @@ void TaskQueueSpecialization< Kokkos::OpenMP >::execute
     HostThreadTeamDataSingleton::singleton();
 
   Impl::OpenMPExec * instance = t_openmp_instance;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   const int pool_size = OpenMP::thread_pool_size();
+#else
+  const int pool_size = OpenMP::impl_thread_pool_size();
+#endif
 
   const int team_size = 1;  // Threads per core
   instance->resize_thread_data( 0 /* global reduce buffer */
@@ -214,7 +218,12 @@ void TaskQueueSpecialization< Kokkos::OpenMP >::
   using task_root_type  = TaskBase< void , void , void > ;
   using Member          = Impl::HostThreadTeamMember< execution_space > ;
 
-  if ( 1 == OpenMP::thread_pool_size() ) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+  if ( 1 == OpenMP::thread_pool_size() )
+#else
+  if ( 1 == OpenMP::impl_thread_pool_size() )
+#endif
+  {
 
     task_root_type * const end = (task_root_type *) task_root_type::EndTag ;
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -79,20 +79,36 @@ public:
   template< class FunctorType >
   inline static
   int team_size_max( const FunctorType & ) {
-      int pool_size = traits::execution_space::thread_pool_size(1);
-      int max_host_team_size =  Impl::HostThreadTeamData::max_team_members;
-      return pool_size<max_host_team_size?pool_size:max_host_team_size;
-    }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+    int pool_size = traits::execution_space::thread_pool_size(1);
+#else
+    int pool_size = traits::execution_space::impl_thread_pool_size(1);
+#endif
+    int max_host_team_size =  Impl::HostThreadTeamData::max_team_members;
+    return pool_size<max_host_team_size?pool_size:max_host_team_size;
+  }
 
   template< class FunctorType >
   inline static
   int team_size_recommended( const FunctorType & )
-    { return traits::execution_space::thread_pool_size(2); }
+  {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+    return traits::execution_space::thread_pool_size(2);
+#else
+    return traits::execution_space::impl_thread_pool_size(2);
+#endif
+  }
 
   template< class FunctorType >
   inline static
   int team_size_recommended( const FunctorType &, const int& )
-    { return traits::execution_space::thread_pool_size(2); }
+  {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+    return traits::execution_space::thread_pool_size(2);
+#else
+    return traits::execution_space::impl_thread_pool_size(2);
+#endif
+  }
 
   //----------------------------------------
 
@@ -111,10 +127,15 @@ private:
   inline void init( const int league_size_request
                   , const int team_size_request )
     {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       const int pool_size  = traits::execution_space::thread_pool_size(0);
-      const int max_host_team_size =  Impl::HostThreadTeamData::max_team_members;
-      const int team_max   = pool_size<max_host_team_size?pool_size:max_host_team_size;
       const int team_grain = traits::execution_space::thread_pool_size(2);
+#else
+      const int pool_size  = traits::execution_space::impl_thread_pool_size(0);
+      const int team_grain = traits::execution_space::impl_thread_pool_size(2);
+#endif
+      const int max_host_team_size =  Impl::HostThreadTeamData::max_team_members;
+      const int team_max   = ((pool_size < max_host_team_size) ? pool_size : max_host_team_size);
 
       m_league_size = league_size_request ;
 
@@ -177,7 +198,15 @@ public:
             : m_team_scratch_size { 0 , 0 }
             , m_thread_scratch_size { 0 , 0 }
             , m_chunk_size(0)
-    { init( league_size_request , traits::execution_space::thread_pool_size(2) ); }
+  {
+    init( league_size_request ,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+        traits::execution_space::thread_pool_size(2)
+#else
+        traits::execution_space::impl_thread_pool_size(2)
+#endif
+        );
+  }
 
   inline int team_alloc() const { return m_team_alloc ; }
   inline int team_iter()  const { return m_team_iter ; }
@@ -240,7 +269,11 @@ private:
   /** \brief finalize chunk_size if it was set to AUTO*/
   inline void set_auto_chunk_size() {
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     int concurrency = traits::execution_space::thread_pool_size(0)/m_team_alloc;
+#else
+    int concurrency = traits::execution_space::impl_thread_pool_size(0)/m_team_alloc;
+#endif
     if( concurrency==0 ) concurrency=1;
 
     if(m_chunk_size > 0) {

--- a/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
@@ -75,8 +75,11 @@ public:
   inline
   void execute()
   {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     const int pool_size = OpenMP::thread_pool_size();
-
+#else
+    const int pool_size = OpenMP::impl_thread_pool_size();
+#endif
     #pragma omp parallel num_threads(pool_size)
     {
       // Spin until COMPLETED_TOKEN.

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -92,7 +92,7 @@ struct Sentinel {
          s_current_function ||
          s_current_function_arg ||
          s_threads_exec[0] ) {
-      std::cerr << "ERROR : Process exiting without calling Kokkos::Threads::terminate()" << std::endl ;
+      std::cerr << "ERROR : Process exiting while Kokkos::Threads is still initialized" << std::endl ;
     }
   }
 };
@@ -567,13 +567,22 @@ void ThreadsExec::print_configuration( std::ostream & s , const bool detail )
 
 //----------------------------------------------------------------------------
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 int ThreadsExec::is_initialized()
+#else
+int ThreadsExec::impl_is_initialized()
+#endif
 { return 0 != s_threads_exec[0] ; }
 
-void ThreadsExec::initialize( unsigned thread_count ,
-                              unsigned use_numa_count ,
-                              unsigned use_cores_per_numa ,
-                              bool allow_asynchronous_threadpool )
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+void ThreadsExec::initialize
+#else
+void ThreadsExec::impl_initialize
+#endif
+( unsigned thread_count ,
+  unsigned use_numa_count ,
+  unsigned use_cores_per_numa ,
+  bool allow_asynchronous_threadpool )
 {
   static const Sentinel sentinel ;
 
@@ -728,7 +737,7 @@ void ThreadsExec::initialize( unsigned thread_count ,
 
   Impl::SharedAllocationRecord< void, void >::tracking_enable();
 
-  #if defined(KOKKOS_ENABLE_PROFILING)
+  #if defined(KOKKOS_ENABLE_DEPRECATED_CODE) && defined(KOKKOS_ENABLE_PROFILING)
     Kokkos::Profiling::initialize();
   #endif
 }

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -113,12 +113,7 @@ setenv("MEMKIND_HBW_NODES", "1", 0);
 #if defined( KOKKOS_ENABLE_OPENMP )
   if( std::is_same< Kokkos::OpenMP , Kokkos::DefaultExecutionSpace >::value ||
       std::is_same< Kokkos::OpenMP , Kokkos::HostSpace::execution_space >::value ) {
-    if(use_numa>0) {
-      Kokkos::OpenMP::initialize(num_threads,use_numa);
-    }
-    else {
-      Kokkos::OpenMP::initialize(num_threads);
-    }
+    Kokkos::OpenMP::impl_initialize(num_threads);
   }
   else {
     //std::cout << "Kokkos::initialize() fyi: OpenMP enabled but not initialized" << std::endl ;
@@ -152,7 +147,11 @@ setenv("MEMKIND_HBW_NODES", "1", 0);
   (void) args;
 
   // Always initialize Serial if it is configure time enabled
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   Kokkos::Serial::initialize();
+#else
+  Kokkos::Serial::impl_initialize();
+#endif
 #endif
 
 #if defined( KOKKOS_ENABLE_OPENMPTARGET )
@@ -177,10 +176,18 @@ setenv("MEMKIND_HBW_NODES", "1", 0);
 #if defined( KOKKOS_ENABLE_CUDA )
   if( std::is_same< Kokkos::Cuda , Kokkos::DefaultExecutionSpace >::value || 0 < use_gpu ) {
     if (use_gpu > -1) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       Kokkos::Cuda::initialize( Kokkos::Cuda::SelectDevice( use_gpu ) );
+#else
+      Kokkos::Cuda::impl_initialize( Kokkos::Cuda::SelectDevice( use_gpu ) );
+#endif
     }
     else {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
       Kokkos::Cuda::initialize();
+#else
+      Kokkos::Cuda::impl_initialize();
+#endif
     }
     //std::cout << "Kokkos::initialize() fyi: Cuda enabled and initialized" << std::endl ;
   }
@@ -233,8 +240,13 @@ void finalize_internal( const bool all_spaces = false )
 
 #if defined( KOKKOS_ENABLE_CUDA )
   if( std::is_same< Kokkos::Cuda , Kokkos::DefaultExecutionSpace >::value || all_spaces ) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     if(Kokkos::Cuda::is_initialized())
       Kokkos::Cuda::finalize();
+#else
+    if(Kokkos::Cuda::impl_is_initialized())
+      Kokkos::Cuda::impl_finalize();
+#endif
   }
 #endif
 
@@ -256,8 +268,8 @@ void finalize_internal( const bool all_spaces = false )
   if( std::is_same< Kokkos::OpenMP , Kokkos::DefaultExecutionSpace >::value ||
       std::is_same< Kokkos::OpenMP , Kokkos::HostSpace::execution_space >::value ||
       all_spaces ) {
-    if(Kokkos::OpenMP::is_initialized())
-      Kokkos::OpenMP::finalize();
+    if(Kokkos::OpenMP::impl_is_initialized())
+      Kokkos::OpenMP::impl_finalize();
   }
 #endif
 
@@ -271,8 +283,13 @@ void finalize_internal( const bool all_spaces = false )
 #endif
 
 #if defined( KOKKOS_ENABLE_SERIAL )
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   if(Kokkos::Serial::is_initialized())
     Kokkos::Serial::finalize();
+#else
+  if(Kokkos::Serial::impl_is_initialized())
+    Kokkos::Serial::impl_finalize();
+#endif
 #endif
 
   g_is_initialized = false;

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -115,7 +115,11 @@ setenv("MEMKIND_HBW_NODES", "1", 0);
 #if defined( KOKKOS_ENABLE_OPENMP )
   if( std::is_same< Kokkos::OpenMP , Kokkos::DefaultExecutionSpace >::value ||
       std::is_same< Kokkos::OpenMP , Kokkos::HostSpace::execution_space >::value ) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+    Kokkos::OpenMP::initialize(num_threads);
+#else
     Kokkos::OpenMP::impl_initialize(num_threads);
+#endif
   }
   else {
     //std::cout << "Kokkos::initialize() fyi: OpenMP enabled but not initialized" << std::endl ;
@@ -270,8 +274,13 @@ void finalize_internal( const bool all_spaces = false )
   if( std::is_same< Kokkos::OpenMP , Kokkos::DefaultExecutionSpace >::value ||
       std::is_same< Kokkos::OpenMP , Kokkos::HostSpace::execution_space >::value ||
       all_spaces ) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+    if(Kokkos::OpenMP::is_initialized())
+      Kokkos::OpenMP::finalize();
+#else
     if(Kokkos::OpenMP::impl_is_initialized())
       Kokkos::OpenMP::impl_finalize();
+#endif
   }
 #endif
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -87,8 +87,10 @@ setenv("MEMKIND_HBW_NODES", "1", 0);
   // Protect declarations, to prevent "unused variable" warnings.
 #if defined( KOKKOS_ENABLE_OPENMP ) || defined( KOKKOS_ENABLE_THREADS ) || defined( KOKKOS_ENABLE_OPENMPTARGET )
   const int num_threads = args.num_threads;
+#endif
+#if defined( KOKKOS_ENABLE_THREADS ) || defined( KOKKOS_ENABLE_OPENMPTARGET )
   const int use_numa = args.num_numa;
-#endif // defined( KOKKOS_ENABLE_OPENMP ) || defined( KOKKOS_ENABLE_THREADS )
+#endif
 #if defined( KOKKOS_ENABLE_CUDA ) || defined( KOKKOS_ENABLE_ROCM )
   int use_gpu = args.device_id;
   const int ndevices = args.ndevices;

--- a/core/src/impl/Kokkos_Serial.cpp
+++ b/core/src/impl/Kokkos_Serial.cpp
@@ -138,11 +138,16 @@ HostThreadTeamData * serial_get_thread_team_data()
 
 namespace Kokkos {
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 bool Serial::is_initialized()
+#else
+bool Serial::impl_is_initialized()
+#endif
 {
   return Impl::g_serial_is_initialized ;
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 void Serial::initialize( unsigned threads_count
                        , unsigned use_numa_count
                        , unsigned use_cores_per_numa
@@ -152,19 +157,27 @@ void Serial::initialize( unsigned threads_count
   (void) use_numa_count;
   (void) use_cores_per_numa;
   (void) allow_asynchronous_threadpool;
+#else
+void Serial::impl_initialize()
+{
+#endif
 
   Impl::SharedAllocationRecord< void, void >::tracking_enable();
 
   // Init the array of locks used for arbitrarily sized atomics
   Impl::init_lock_array_host_space();
-  #if defined(KOKKOS_ENABLE_PROFILING)
+  #if defined(KOKKOS_ENABLE_DEPRECATED_CODE) && defined(KOKKOS_ENABLE_PROFILING)
     Kokkos::Profiling::initialize();
   #endif
 
   Impl::g_serial_is_initialized = true;
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 void Serial::finalize()
+#else
+void Serial::impl_finalize()
+#endif
 {
   if ( Impl::g_serial_thread_team_data.scratch_buffer() ) {
     Impl::g_serial_thread_team_data.disband_team();

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -33,7 +33,13 @@ IF(Kokkos_ENABLE_Serial)
     UnitTest_Serial
     SOURCES
       UnitTestMainInit.cpp
-      serial/TestSerial_AtomicOperations.cpp
+      serial/TestSerial_AtomicOperations_int.cpp
+      serial/TestSerial_AtomicOperations_unsignedint.cpp
+      serial/TestSerial_AtomicOperations_longint.cpp
+      serial/TestSerial_AtomicOperations_unsignedlongint.cpp
+      serial/TestSerial_AtomicOperations_longlongint.cpp
+      serial/TestSerial_AtomicOperations_double.cpp
+      serial/TestSerial_AtomicOperations_float.cpp
       serial/TestSerial_AtomicViews.cpp
       serial/TestSerial_Atomics.cpp
       serial/TestSerial_Complex.cpp
@@ -93,7 +99,13 @@ IF(Kokkos_ENABLE_Pthread)
     UnitTest_Threads
     SOURCES
       UnitTestMainInit.cpp
-      threads/TestThreads_AtomicOperations.cpp
+      threads/TestThreads_AtomicOperations_int.cpp
+      threads/TestThreads_AtomicOperations_unsignedint.cpp
+      threads/TestThreads_AtomicOperations_longint.cpp
+      threads/TestThreads_AtomicOperations_unsignedlongint.cpp
+      threads/TestThreads_AtomicOperations_longlongint.cpp
+      threads/TestThreads_AtomicOperations_double.cpp
+      threads/TestThreads_AtomicOperations_float.cpp
       threads/TestThreads_AtomicViews.cpp
       threads/TestThreads_Atomics.cpp
       threads/TestThreads_Complex.cpp
@@ -153,7 +165,13 @@ IF(Kokkos_ENABLE_OpenMP)
     UnitTest_OpenMP
     SOURCES
       UnitTestMainInit.cpp
-      openmp/TestOpenMP_AtomicOperations.cpp
+      openmp/TestOpenMP_AtomicOperations_int.cpp
+      openmp/TestOpenMP_AtomicOperations_unsignedint.cpp
+      openmp/TestOpenMP_AtomicOperations_longint.cpp
+      openmp/TestOpenMP_AtomicOperations_unsignedlongint.cpp
+      openmp/TestOpenMP_AtomicOperations_longlongint.cpp
+      openmp/TestOpenMP_AtomicOperations_double.cpp
+      openmp/TestOpenMP_AtomicOperations_float.cpp
       openmp/TestOpenMP_AtomicViews.cpp
       openmp/TestOpenMP_Atomics.cpp
       openmp/TestOpenMP_Complex.cpp
@@ -283,7 +301,13 @@ IF(Kokkos_ENABLE_Cuda)
       cuda/TestCudaUVM_ViewMapping_a.cpp
       cuda/TestCudaUVM_ViewMapping_b.cpp
       cuda/TestCudaUVM_ViewMapping_subview.cpp
-      cuda/TestCuda_AtomicOperations.cpp
+      cuda/TestCuda_AtomicOperations_int.cpp
+      cuda/TestCuda_AtomicOperations_unsignedint.cpp
+      cuda/TestCuda_AtomicOperations_longint.cpp
+      cuda/TestCuda_AtomicOperations_unsignedlongint.cpp
+      cuda/TestCuda_AtomicOperations_longlongint.cpp
+      cuda/TestCuda_AtomicOperations_double.cpp
+      cuda/TestCuda_AtomicOperations_float.cpp
       cuda/TestCuda_AtomicViews.cpp
       cuda/TestCuda_Atomics.cpp
       cuda/TestCuda_Complex.cpp

--- a/core/unit_test/TestDefaultDeviceTypeInit.hpp
+++ b/core/unit_test/TestDefaultDeviceTypeInit.hpp
@@ -180,8 +180,13 @@ Kokkos::InitArguments init_initstruct( bool do_threads, bool do_numa, bool do_de
 }
 
 void check_correct_initialization( const Kokkos::InitArguments & argstruct ) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   ASSERT_EQ( Kokkos::DefaultExecutionSpace::is_initialized(), 1 );
   ASSERT_EQ( Kokkos::HostSpace::execution_space::is_initialized(), 1 );
+#else
+  ASSERT_EQ( Kokkos::DefaultExecutionSpace::impl_is_initialized(), 1 );
+  ASSERT_EQ( Kokkos::HostSpace::execution_space::impl_is_initialized(), 1 );
+#endif
 
   // Figure out the number of threads the HostSpace ExecutionSpace should have initialized to.
   int expected_nthreads = argstruct.num_threads;
@@ -236,8 +241,11 @@ void check_correct_initialization( const Kokkos::InitArguments & argstruct ) {
 #endif
   }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   ASSERT_EQ( Kokkos::HostSpace::execution_space::thread_pool_size(), expected_nthreads );
-
+#else
+  ASSERT_EQ( Kokkos::HostSpace::execution_space::impl_thread_pool_size(), expected_nthreads );
+#endif
 
 #ifdef KOKKOS_ENABLE_CUDA
   if ( std::is_same< Kokkos::DefaultExecutionSpace, Kokkos::Cuda >::value ) {

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -207,7 +207,11 @@ struct TestRange {
         for ( int k = 0; k < ( i < N / 2 ? 1 : 10000 ); k++ ) {
           a( i )++;
         }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
         count( ExecSpace::hardware_thread_id() )++;
+#else
+        count( ExecSpace::impl_hardware_thread_id() )++;
+#endif
       });
 
       int error = 0;
@@ -240,7 +244,11 @@ struct TestRange {
         for ( int k = 0; k < ( i < N / 2 ? 1 : 10000 ); k++ ) {
           a( i )++;
         }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
         count( ExecSpace::hardware_thread_id() )++;
+#else
+        count( ExecSpace::impl_hardware_thread_id() )++;
+#endif
         lsum++;
       }, sum );
       ASSERT_EQ( sum, N );

--- a/core/unit_test/openmp/TestOpenMP_Other.cpp
+++ b/core/unit_test/openmp/TestOpenMP_Other.cpp
@@ -64,14 +64,23 @@ TEST_F( openmp, partition_master )
 
   auto master = [&errors, &mtx](int partition_id, int num_partitions) {
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     const int pool_size = Kokkos::OpenMP::thread_pool_size();
+#else
+    const int pool_size = Kokkos::OpenMP::impl_thread_pool_size();
+#endif
 
     {
       std::unique_lock<Mutex> lock(mtx);
       if ( Kokkos::OpenMP::in_parallel() ) {
         ++errors;
       }
-      if ( Kokkos::OpenMP::thread_pool_rank() != 0 ) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+      if ( Kokkos::OpenMP::thread_pool_rank() != 0 )
+#else
+      if ( Kokkos::OpenMP::impl_thread_pool_rank() != 0 )
+#endif
+      {
         ++errors;
       }
     }
@@ -80,7 +89,12 @@ TEST_F( openmp, partition_master )
       int local_errors = 0;
       Kokkos::parallel_reduce( Kokkos::RangePolicy<Kokkos::OpenMP>(0,1000)
                            , [pool_size]( const int , int & errs ) {
-          if ( Kokkos::OpenMP::thread_pool_size() != pool_size ) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+          if ( Kokkos::OpenMP::thread_pool_size() != pool_size )
+#else
+          if ( Kokkos::OpenMP::impl_thread_pool_size() != pool_size )
+#endif
+          {
             ++errs;
           }
         }


### PR DESCRIPTION
This un-deprecates `OpenMP::concurrency` and deprecates the following APIs for `Cuda`, `OpenMP`, `Threads`, and `Serial`:
 - `initialize`
 - `finalize`
 - `is_initialized`
 - `thread_pool_size`
 - `thread_pool_rank`
 - `max_hardware_threads`
 - `hardware_thread_id`
 - `sleep`
 - `wake`