### PR TITLE
 Error on non-all-caps KOKKOS_ARCH in CMake

### DIFF
--- a/cmake/kokkos_options.cmake
+++ b/cmake/kokkos_options.cmake
@@ -61,14 +61,11 @@ foreach(opt ${KOKKOS_INTERNAL_ENABLE_OPTIONS_LIST})
   ENDIF()
 endforeach()
 
+IF(DEFINED Kokkos_ARCH)
+  MESSAGE(FATAL_ERROR "Defined Kokkos_ARCH, use KOKKOS_ARCH instead!")
+ENDIF()
 IF(DEFINED Kokkos_Arch)
-  IF(DEFINED KOKKOS_ARCH)
-    IF(NOT (${KOKKOS_ARCH} STREQUAL "${Kokkos_Arch}"))
-      MESSAGE(FATAL_ERROR "Defined both Kokkos_Arch and KOKKOS_ARCH and they differ!")
-    ENDIF()
-  ELSE()
-    SET(KOKKOS_ARCH ${Kokkos_Arch})
-  ENDIF()
+  MESSAGE(FATAL_ERROR "Defined Kokkos_Arch, use KOKKOS_ARCH instead!")
 ENDIF()
   
 #-------------------------------------------------------------------------------

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -33,7 +33,13 @@ IF(Kokkos_ENABLE_Serial)
     UnitTest_Serial
     SOURCES
       UnitTestMainInit.cpp
-      serial/TestSerial_AtomicOperations.cpp
+      serial/TestSerial_AtomicOperations_int.cpp
+      serial/TestSerial_AtomicOperations_unsignedint.cpp
+      serial/TestSerial_AtomicOperations_longint.cpp
+      serial/TestSerial_AtomicOperations_unsignedlongint.cpp
+      serial/TestSerial_AtomicOperations_longlongint.cpp
+      serial/TestSerial_AtomicOperations_double.cpp
+      serial/TestSerial_AtomicOperations_float.cpp
       serial/TestSerial_AtomicViews.cpp
       serial/TestSerial_Atomics.cpp
       serial/TestSerial_Complex.cpp
@@ -93,7 +99,13 @@ IF(Kokkos_ENABLE_Pthread)
     UnitTest_Threads
     SOURCES
       UnitTestMainInit.cpp
-      threads/TestThreads_AtomicOperations.cpp
+      threads/TestThreads_AtomicOperations_int.cpp
+      threads/TestThreads_AtomicOperations_unsignedint.cpp
+      threads/TestThreads_AtomicOperations_longint.cpp
+      threads/TestThreads_AtomicOperations_unsignedlongint.cpp
+      threads/TestThreads_AtomicOperations_longlongint.cpp
+      threads/TestThreads_AtomicOperations_double.cpp
+      threads/TestThreads_AtomicOperations_float.cpp
       threads/TestThreads_AtomicViews.cpp
       threads/TestThreads_Atomics.cpp
       threads/TestThreads_Complex.cpp
@@ -153,7 +165,13 @@ IF(Kokkos_ENABLE_OpenMP)
     UnitTest_OpenMP
     SOURCES
       UnitTestMainInit.cpp
-      openmp/TestOpenMP_AtomicOperations.cpp
+      openmp/TestOpenMP_AtomicOperations_int.cpp
+      openmp/TestOpenMP_AtomicOperations_unsignedint.cpp
+      openmp/TestOpenMP_AtomicOperations_longint.cpp
+      openmp/TestOpenMP_AtomicOperations_unsignedlongint.cpp
+      openmp/TestOpenMP_AtomicOperations_longlongint.cpp
+      openmp/TestOpenMP_AtomicOperations_double.cpp
+      openmp/TestOpenMP_AtomicOperations_float.cpp
       openmp/TestOpenMP_AtomicViews.cpp
       openmp/TestOpenMP_Atomics.cpp
       openmp/TestOpenMP_Complex.cpp
@@ -283,7 +301,13 @@ IF(Kokkos_ENABLE_Cuda)
       cuda/TestCudaUVM_ViewMapping_a.cpp
       cuda/TestCudaUVM_ViewMapping_b.cpp
       cuda/TestCudaUVM_ViewMapping_subview.cpp
-      cuda/TestCuda_AtomicOperations.cpp
+      cuda/TestCuda_AtomicOperations_int.cpp
+      cuda/TestCuda_AtomicOperations_unsignedint.cpp
+      cuda/TestCuda_AtomicOperations_longint.cpp
+      cuda/TestCuda_AtomicOperations_unsignedlongint.cpp
+      cuda/TestCuda_AtomicOperations_longlongint.cpp
+      cuda/TestCuda_AtomicOperations_double.cpp
+      cuda/TestCuda_AtomicOperations_float.cpp
       cuda/TestCuda_AtomicViews.cpp
       cuda/TestCuda_Atomics.cpp
       cuda/TestCuda_Complex.cpp


### PR DESCRIPTION
We were checking `Kokkos_Arch` but not `Kokkos_ARCH`. This addresses #1555 