### PR TITLE
Move reducers

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -516,7 +516,7 @@ bool try_std_sort(ViewType view) {
 
 template<class ViewType>
 struct min_max_functor {
-  typedef Kokkos::Experimental::MinMaxScalar<typename ViewType::non_const_value_type> minmax_scalar;
+  typedef Kokkos::MinMaxScalar<typename ViewType::non_const_value_type> minmax_scalar;
 
   ViewType view;
   min_max_functor(const ViewType& view_):view(view_) {}
@@ -538,8 +538,8 @@ void sort( ViewType const & view , bool const always_use_kokkos_sort = false)
   }
   typedef BinOp1D<ViewType> CompType;
 
-  Kokkos::Experimental::MinMaxScalar<typename ViewType::non_const_value_type> result;
-  Kokkos::Experimental::MinMax<typename ViewType::non_const_value_type> reducer(result);
+  Kokkos::MinMaxScalar<typename ViewType::non_const_value_type> result;
+  Kokkos::MinMax<typename ViewType::non_const_value_type> reducer(result);
   parallel_reduce("Kokkos::Sort::FindExtent",Kokkos::RangePolicy<typename ViewType::execution_space>(0,view.extent(0)),
                   Impl::min_max_functor<ViewType>(view),reducer);
   if(result.min_val == result.max_val) return;
@@ -557,8 +557,8 @@ void sort( ViewType view
   typedef Kokkos::RangePolicy<typename ViewType::execution_space> range_policy ;
   typedef BinOp1D<ViewType> CompType;
 
-  Kokkos::Experimental::MinMaxScalar<typename ViewType::non_const_value_type> result;
-  Kokkos::Experimental::MinMax<typename ViewType::non_const_value_type> reducer(result);
+  Kokkos::MinMaxScalar<typename ViewType::non_const_value_type> result;
+  Kokkos::MinMax<typename ViewType::non_const_value_type> reducer(result);
 
   parallel_reduce("Kokkos::Sort::FindExtent", range_policy( begin , end )
                  , Impl::min_max_functor<ViewType>(view),reducer );

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -540,7 +540,7 @@ struct ViewCopy<Kokkos::Experimental::DynamicView<DP...>,ViewTypeB,Layout,ExecSp
   typedef Kokkos::RangePolicy<ExecSpace,Kokkos::IndexType<iType>> policy_type;
 
   ViewCopy(const Kokkos::Experimental::DynamicView<DP...>& a_, const ViewTypeB& b_):a(a_),b(b_) {
-    Kokkos::parallel_for("Kokkos::ViewCopy-2D",
+    Kokkos::parallel_for("Kokkos::ViewCopy-1D",
        policy_type(0,b.extent(0)),*this);
   }
 
@@ -561,7 +561,7 @@ struct ViewCopy<Kokkos::Experimental::DynamicView<DP...>,
   ViewCopy(const Kokkos::Experimental::DynamicView<DP...>& a_,
            const Kokkos::Experimental::DynamicView<SP...>& b_):a(a_),b(b_) {
     const iType n = std::min(a.extent(0),b.extent(0));
-    Kokkos::parallel_for("Kokkos::ViewCopy-2D",
+    Kokkos::parallel_for("Kokkos::ViewCopy-1D",
        policy_type(0,n),*this);
   }
 

--- a/core/perf_test/PerfTest_CustomReduction.cpp
+++ b/core/perf_test/PerfTest_CustomReduction.cpp
@@ -67,12 +67,12 @@ void custom_reduction_test(int N, int R, int num_trials) {
         const Scalar val =  a((i*32 + j)*32 + k);
         if(val>lmax) lmax = val;
         if((k == 11) && (j==17) && (i==2)) lmax = 11.5;
-      },Kokkos::Experimental::Max<Scalar>(t_max));
+      },Kokkos::Max<Scalar>(t_max));
       if(t_max>thread_max) thread_max = t_max;
-    },Kokkos::Experimental::Max<Scalar>(team_max));
+    },Kokkos::Max<Scalar>(team_max));
     }
     if(team_max>lmax) lmax = team_max;
-  },Kokkos::Experimental::Max<Scalar>(max));
+  },Kokkos::Max<Scalar>(max));
 
   // Timing
   Kokkos::Timer timer;
@@ -87,12 +87,12 @@ void custom_reduction_test(int N, int R, int num_trials) {
           const Scalar val =  a((i*32 + j)*32 + k);
           if(val>lmax) lmax = val;
           if((k == 11) && (j==17) && (i==2)) lmax = 11.5;
-        },Kokkos::Experimental::Max<Scalar>(t_max));
+        },Kokkos::Max<Scalar>(t_max));
         if(t_max>thread_max) thread_max = t_max;
-      },Kokkos::Experimental::Max<Scalar>(team_max));
+      },Kokkos::Max<Scalar>(team_max));
       }
       if(team_max>lmax) lmax = team_max;
-    },Kokkos::Experimental::Max<Scalar>(max));
+    },Kokkos::Max<Scalar>(max));
   }
   double time = timer.seconds();
   printf("%e %e %e\n",time,1.0*N*R*num_trials*sizeof(Scalar)/time/1024/1024/1024,max);

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -284,7 +284,6 @@ template< class FunctorType, class ExecPolicy, class ExecutionSapce =
 
 } // namespace Impl
 
-namespace Experimental {
 template<class ScalarType , class Space = HostSpace> struct Sum;
 template<class ScalarType , class Space = HostSpace> struct Prod;
 template<class ScalarType , class Space = HostSpace> struct Min;
@@ -297,8 +296,34 @@ template<class ScalarType , class Space = HostSpace> struct BAnd;
 template<class ScalarType , class Space = HostSpace> struct BOr;
 template<class ScalarType , class Space = HostSpace> struct LAnd;
 template<class ScalarType , class Space = HostSpace> struct LOr;
-}
+
+
 } // namespace Kokkos
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+namespace Kokkos{
+  template<class ScalarType> struct MinMaxScalar;
+  template<class ScalarType, class Index> struct MinMaxLocScalar;
+  template<class ScalarType, class Index> struct ValLocScalar;
+
+  namespace Experimental {
+    using Kokkos::Sum;
+    using Kokkos::Prod;
+    using Kokkos::Min;
+    using Kokkos::Max;
+    using Kokkos::MinMax;
+    using Kokkos::MinLoc;
+    using Kokkos::MaxLoc;
+    using Kokkos::MinMaxLoc;
+    using Kokkos::BAnd;
+    using Kokkos::BOr;
+    using Kokkos::LAnd;
+    using Kokkos::LOr;
+    using Kokkos::MinMaxScalar;
+    using Kokkos::MinMaxLocScalar;
+    using Kokkos::ValLocScalar;
+  }
+}
+#endif
 
 #endif /* #ifndef KOKKOS_CORE_FWD_HPP */
 

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -62,9 +62,6 @@ struct is_reducer_type<T,typename std::enable_if<
   enum { value = 1 };
 };
 
-namespace Experimental {
-
-
 template<class Scalar, class Space>
 struct Sum {
 public:
@@ -740,10 +737,7 @@ public:
   }
 };
 }
-}
-
-
-namespace Kokkos {
+namespace Kokkos{
 namespace Impl {
 
 template< class T, class ReturnType , class ValueTraits>
@@ -823,9 +817,7 @@ struct ParallelReduceReturnValue<typename std::enable_if<
     return return_val;
   }
 };
-}
 
-namespace Impl {
 template< class T, class ReturnType , class FunctorType>
 struct ParallelReducePolicyType;
 
@@ -851,9 +843,7 @@ struct ParallelReducePolicyType<typename std::enable_if<std::is_integral<PolicyT
   }
 };
 
-}
 
-namespace Impl {
   template< class FunctorType, class ExecPolicy, class ValueType, class ExecutionSpace>
   struct ParallelReduceFunctorType {
     typedef FunctorType functor_type;
@@ -861,9 +851,6 @@ namespace Impl {
       return functor;
     }
   };
-}
-
-namespace Impl {
 
   template< class PolicyType, class FunctorType, class ReturnType >
   struct ParallelReduceAdaptor {
@@ -1140,6 +1127,8 @@ void parallel_reduce(const std::string& label,
 }
 
 } //namespace Kokkos
+
+
 
 #endif // KOKKOS_PARALLEL_REDUCE_HPP
 

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -876,7 +876,7 @@ parallel_reduce
   , ValueType      & result
   )
 {
-  Kokkos::Experimental::Sum<ValueType> reducer( result );
+  Sum<ValueType> reducer( result );
 
   reducer.init( result );
 

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -312,7 +312,7 @@ struct TestMDRange_2D {
       parallel_for( range, functor );
 
       value_type sum = 0.0;
-      Kokkos::Experimental::Sum< value_type > reducer_scalar( sum );
+      Kokkos::Sum< value_type > reducer_scalar( sum );
 
       parallel_reduce( range, functor, reducer_scalar );
 
@@ -330,7 +330,7 @@ struct TestMDRange_2D {
       value_type sum = 0.0;
       Kokkos::View< value_type, Kokkos::HostSpace > sum_view("sum_view");
       sum_view() = sum;
-      Kokkos::Experimental::Sum< value_type > reducer_view( sum_view );
+      Kokkos::Sum< value_type > reducer_view( sum_view );
 
       parallel_reduce( range, functor, reducer_view);
       sum = sum_view();
@@ -852,7 +852,7 @@ struct TestMDRange_3D {
       parallel_for( range, functor );
 
       value_type sum = 0.0;
-      Kokkos::Experimental::Sum< value_type > reducer_scalar( sum );
+      Kokkos::Sum< value_type > reducer_scalar( sum );
 
       parallel_reduce( range, functor, reducer_scalar );
 
@@ -870,7 +870,7 @@ struct TestMDRange_3D {
       value_type sum = 0.0;
       Kokkos::View< value_type, Kokkos::HostSpace > sum_view("sum_view");
       sum_view() = sum;
-      Kokkos::Experimental::Sum< value_type > reducer_view( sum_view );
+      Kokkos::Sum< value_type > reducer_view( sum_view );
 
       parallel_reduce( range, functor, reducer_view);
       sum = sum_view();
@@ -1375,7 +1375,7 @@ struct TestMDRange_4D {
       parallel_for( range, functor );
 
       value_type sum = 0.0;
-      Kokkos::Experimental::Sum< value_type > reducer_scalar( sum );
+      Kokkos::Sum< value_type > reducer_scalar( sum );
 
       parallel_reduce( range, functor, reducer_scalar );
 
@@ -1394,7 +1394,7 @@ struct TestMDRange_4D {
       value_type sum = 0.0;
       Kokkos::View< value_type, Kokkos::HostSpace > sum_view("sum_view");
       sum_view() = sum;
-      Kokkos::Experimental::Sum< value_type > reducer_view( sum_view );
+      Kokkos::Sum< value_type > reducer_view( sum_view );
 
       parallel_reduce( range, functor, reducer_view);
       sum = sum_view();
@@ -1919,7 +1919,7 @@ struct TestMDRange_5D {
       parallel_for( range, functor );
 
       value_type sum = 0.0;
-      Kokkos::Experimental::Sum< value_type > reducer_scalar( sum );
+      Kokkos::Sum< value_type > reducer_scalar( sum );
 
       parallel_reduce( range, functor, reducer_scalar );
 
@@ -1938,7 +1938,7 @@ struct TestMDRange_5D {
       value_type sum = 0.0;
       Kokkos::View< value_type, Kokkos::HostSpace > sum_view("sum_view");
       sum_view() = sum;
-      Kokkos::Experimental::Sum< value_type > reducer_view( sum_view );
+      Kokkos::Sum< value_type > reducer_view( sum_view );
 
       parallel_reduce( range, functor, reducer_view);
       sum = sum_view();
@@ -2394,7 +2394,7 @@ struct TestMDRange_6D {
       parallel_for( range, functor );
 
       value_type sum = 0.0;
-      Kokkos::Experimental::Sum< value_type > reducer_scalar( sum );
+      Kokkos::Sum< value_type > reducer_scalar( sum );
 
       parallel_reduce( range, functor, reducer_scalar );
 
@@ -2413,7 +2413,7 @@ struct TestMDRange_6D {
       value_type sum = 0.0;
       Kokkos::View< value_type, Kokkos::HostSpace > sum_view("sum_view");
       sum_view() = sum;
-      Kokkos::Experimental::Sum< value_type > reducer_view( sum_view );
+      Kokkos::Sum< value_type > reducer_view( sum_view );
 
       parallel_reduce( range, functor, reducer_view);
       sum = sum_view();

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -97,7 +97,7 @@ struct TestReducers {
     Kokkos::View< const Scalar*, ExecSpace > values;
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const int & i, typename Kokkos::Experimental::MinLoc< Scalar, int >::value_type & value ) const {
+    void operator()( const int & i, typename Kokkos::MinLoc< Scalar, int >::value_type & value ) const {
       if ( values( i ) < value.val ) {
         value.val = values( i );
         value.loc = i;
@@ -109,7 +109,7 @@ struct TestReducers {
     Kokkos::View< const Scalar*, ExecSpace > values;
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const int & i, typename Kokkos::Experimental::MaxLoc< Scalar, int >::value_type & value ) const {
+    void operator()( const int & i, typename Kokkos::MaxLoc< Scalar, int >::value_type & value ) const {
       if ( values( i ) > value.val ) {
         value.val = values( i );
         value.loc = i;
@@ -121,7 +121,7 @@ struct TestReducers {
     Kokkos::View< const Scalar*, ExecSpace > values;
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const int & i, typename Kokkos::Experimental::MinMaxLoc< Scalar, int >::value_type & value ) const {
+    void operator()( const int & i, typename Kokkos::MinMaxLoc< Scalar, int >::value_type & value ) const {
       if ( values( i ) > value.max_val ) {
         value.max_val = values( i );
         value.max_loc = i;
@@ -210,7 +210,7 @@ struct TestReducers {
     Kokkos::View< const Scalar*, ExecSpace > values;
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const ReducerTag, const int & i, typename Kokkos::Experimental::MinLoc< Scalar, int >::value_type & value ) const {
+    void operator()( const ReducerTag, const int & i, typename Kokkos::MinLoc< Scalar, int >::value_type & value ) const {
       if ( values( i ) < value.val ) {
         value.val = values( i );
         value.loc = i;
@@ -222,7 +222,7 @@ struct TestReducers {
     Kokkos::View< const Scalar*, ExecSpace > values;
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const ReducerTag, const int & i, typename Kokkos::Experimental::MaxLoc< Scalar, int >::value_type & value ) const {
+    void operator()( const ReducerTag, const int & i, typename Kokkos::MaxLoc< Scalar, int >::value_type & value ) const {
       if ( values( i ) > value.val ) {
         value.val = values( i );
         value.loc = i;
@@ -234,7 +234,7 @@ struct TestReducers {
     Kokkos::View< const Scalar*, ExecSpace > values;
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const ReducerTag, const int & i, typename Kokkos::Experimental::MinMaxLoc< Scalar, int >::value_type & value ) const {
+    void operator()( const ReducerTag, const int & i, typename Kokkos::MinMaxLoc< Scalar, int >::value_type & value ) const {
       if ( values( i ) > value.max_val ) {
         value.max_val = values( i );
         value.max_loc = i;
@@ -301,7 +301,7 @@ struct TestReducers {
 
     {
       Scalar sum_scalar = init;
-      Kokkos::Experimental::Sum< Scalar > reducer_scalar( sum_scalar );
+      Kokkos::Sum< Scalar > reducer_scalar( sum_scalar );
       
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_scalar );
       ASSERT_EQ( sum_scalar, reference_sum );
@@ -317,7 +317,7 @@ struct TestReducers {
     {
       Kokkos::View< Scalar, Kokkos::HostSpace> sum_view( "View" );
       sum_view() = init;
-      Kokkos::Experimental::Sum< Scalar > reducer_view( sum_view );
+      Kokkos::Sum< Scalar > reducer_view( sum_view );
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_view );
 
       Scalar sum_view_scalar = sum_view();
@@ -347,7 +347,7 @@ struct TestReducers {
 
     {
       Scalar prod_scalar = init;
-      Kokkos::Experimental::Prod< Scalar > reducer_scalar( prod_scalar );
+      Kokkos::Prod< Scalar > reducer_scalar( prod_scalar );
    
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_scalar );
       ASSERT_EQ( prod_scalar, reference_prod );
@@ -363,7 +363,7 @@ struct TestReducers {
     {
       Kokkos::View< Scalar, Kokkos::HostSpace > prod_view( "View" );
       prod_view() = init;
-      Kokkos::Experimental::Prod< Scalar > reducer_view( prod_view );
+      Kokkos::Prod< Scalar > reducer_view( prod_view );
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_view );
 
       Scalar prod_view_scalar = prod_view();
@@ -394,7 +394,7 @@ struct TestReducers {
 
     {
       Scalar min_scalar = init;
-      Kokkos::Experimental::Min< Scalar > reducer_scalar( min_scalar );
+      Kokkos::Min< Scalar > reducer_scalar( min_scalar );
      
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_scalar );
       ASSERT_EQ( min_scalar, reference_min );
@@ -410,7 +410,7 @@ struct TestReducers {
     {
       Kokkos::View< Scalar, Kokkos::HostSpace > min_view( "View" );
       min_view() = init;
-      Kokkos::Experimental::Min< Scalar > reducer_view( min_view );
+      Kokkos::Min< Scalar > reducer_view( min_view );
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_view );
 
       Scalar min_view_scalar = min_view();
@@ -441,7 +441,7 @@ struct TestReducers {
 
     {
       Scalar max_scalar = init;
-      Kokkos::Experimental::Max< Scalar > reducer_scalar( max_scalar );
+      Kokkos::Max< Scalar > reducer_scalar( max_scalar );
 
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_scalar );
       ASSERT_EQ( max_scalar, reference_max );
@@ -457,7 +457,7 @@ struct TestReducers {
     {
       Kokkos::View< Scalar, Kokkos::HostSpace > max_view( "View" );
       max_view() = init;
-      Kokkos::Experimental::Max< Scalar > reducer_view( max_view );
+      Kokkos::Max< Scalar > reducer_view( max_view );
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_view );
 
       Scalar max_view_scalar = max_view();
@@ -469,7 +469,7 @@ struct TestReducers {
   }
 
   static void test_minloc( int N ) {
-    typedef typename Kokkos::Experimental::MinLoc< Scalar, int >::value_type value_type;
+    typedef typename Kokkos::MinLoc< Scalar, int >::value_type value_type;
 
     Kokkos::View< Scalar*, ExecSpace > values( "Values", N );
     auto h_values = Kokkos::create_mirror_view( values );
@@ -497,7 +497,7 @@ struct TestReducers {
 
     {
       value_type min_scalar;
-      Kokkos::Experimental::MinLoc< Scalar, int > reducer_scalar( min_scalar );
+      Kokkos::MinLoc< Scalar, int > reducer_scalar( min_scalar );
 
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_scalar );
       ASSERT_EQ( min_scalar.val, reference_min );
@@ -515,7 +515,7 @@ struct TestReducers {
 
     {
       Kokkos::View< value_type, Kokkos::HostSpace > min_view( "View" );
-      Kokkos::Experimental::MinLoc< Scalar, int > reducer_view( min_view );
+      Kokkos::MinLoc< Scalar, int > reducer_view( min_view );
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_view );
 
       value_type min_view_scalar = min_view();
@@ -529,7 +529,7 @@ struct TestReducers {
   }
 
   static void test_maxloc( int N ) {
-    typedef typename Kokkos::Experimental::MaxLoc< Scalar, int >::value_type value_type;
+    typedef typename Kokkos::MaxLoc< Scalar, int >::value_type value_type;
 
     Kokkos::View< Scalar*, ExecSpace > values( "Values", N );
     auto h_values = Kokkos::create_mirror_view( values );
@@ -557,7 +557,7 @@ struct TestReducers {
 
     {
       value_type max_scalar;
-      Kokkos::Experimental::MaxLoc< Scalar, int > reducer_scalar( max_scalar );
+      Kokkos::MaxLoc< Scalar, int > reducer_scalar( max_scalar );
 
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_scalar );
       ASSERT_EQ( max_scalar.val, reference_max );
@@ -575,7 +575,7 @@ struct TestReducers {
 
     {
       Kokkos::View< value_type, Kokkos::HostSpace > max_view( "View" );
-      Kokkos::Experimental::MaxLoc< Scalar, int > reducer_view( max_view );
+      Kokkos::MaxLoc< Scalar, int > reducer_view( max_view );
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_view );
 
       value_type max_view_scalar = max_view();
@@ -589,7 +589,7 @@ struct TestReducers {
   }
 
   static void test_minmaxloc( int N ) {
-     typedef typename Kokkos::Experimental::MinMaxLoc< Scalar, int >::value_type value_type;
+     typedef typename Kokkos::MinMaxLoc< Scalar, int >::value_type value_type;
 
      Kokkos::View< Scalar*, ExecSpace > values( "Values", N );
      auto h_values = Kokkos::create_mirror_view( values );
@@ -633,7 +633,7 @@ struct TestReducers {
 
      {
        value_type minmax_scalar;
-       Kokkos::Experimental::MinMaxLoc< Scalar, int > reducer_scalar( minmax_scalar );
+       Kokkos::MinMaxLoc< Scalar, int > reducer_scalar( minmax_scalar );
 
        Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_scalar );
        ASSERT_EQ( minmax_scalar.min_val, reference_min );
@@ -685,7 +685,7 @@ struct TestReducers {
 
      {
        Kokkos::View< value_type, Kokkos::HostSpace > minmax_view( "View" );
-       Kokkos::Experimental::MinMaxLoc< Scalar, int > reducer_view( minmax_view );
+       Kokkos::MinMaxLoc< Scalar, int > reducer_view( minmax_view );
        Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_view );
 
        value_type minmax_view_scalar = minmax_view();
@@ -721,7 +721,7 @@ struct TestReducers {
 
     {
       Scalar band_scalar = init;
-      Kokkos::Experimental::BAnd< Scalar > reducer_scalar( band_scalar );
+      Kokkos::BAnd< Scalar > reducer_scalar( band_scalar );
 
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_scalar );
       ASSERT_EQ( band_scalar, reference_band );
@@ -738,7 +738,7 @@ struct TestReducers {
     {
       Kokkos::View< Scalar, Kokkos::HostSpace > band_view( "View" );
       band_view() = init;
-      Kokkos::Experimental::BAnd< Scalar > reducer_view( band_view );
+      Kokkos::BAnd< Scalar > reducer_view( band_view );
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_view );
 
       Scalar band_view_scalar = band_view();
@@ -768,7 +768,7 @@ struct TestReducers {
 
     {
       Scalar bor_scalar = init;
-      Kokkos::Experimental::BOr< Scalar > reducer_scalar( bor_scalar );
+      Kokkos::BOr< Scalar > reducer_scalar( bor_scalar );
 
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_scalar );
       ASSERT_EQ( bor_scalar, reference_bor );
@@ -784,7 +784,7 @@ struct TestReducers {
     {
       Kokkos::View< Scalar, Kokkos::HostSpace > bor_view( "View" );
       bor_view() = init;
-      Kokkos::Experimental::BOr< Scalar > reducer_view( bor_view );
+      Kokkos::BOr< Scalar > reducer_view( bor_view );
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_view );
 
       Scalar bor_view_scalar = bor_view();
@@ -814,7 +814,7 @@ struct TestReducers {
 
     {
       Scalar land_scalar = init;
-      Kokkos::Experimental::LAnd< Scalar > reducer_scalar( land_scalar );
+      Kokkos::LAnd< Scalar > reducer_scalar( land_scalar );
 
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_scalar );
       ASSERT_EQ( land_scalar, reference_land );
@@ -830,7 +830,7 @@ struct TestReducers {
     {
       Kokkos::View< Scalar, Kokkos::HostSpace > land_view( "View" );
       land_view() = init;
-      Kokkos::Experimental::LAnd< Scalar > reducer_view( land_view );
+      Kokkos::LAnd< Scalar > reducer_view( land_view );
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_view );
 
       Scalar land_view_scalar = land_view();
@@ -860,7 +860,7 @@ struct TestReducers {
 
     {
       Scalar lor_scalar = init;
-      Kokkos::Experimental::LOr< Scalar > reducer_scalar( lor_scalar );
+      Kokkos::LOr< Scalar > reducer_scalar( lor_scalar );
 
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_scalar );
       ASSERT_EQ( lor_scalar, reference_lor );
@@ -876,7 +876,7 @@ struct TestReducers {
     {
       Kokkos::View< Scalar, Kokkos::HostSpace > lor_view( "View" );
       lor_view() = init;
-      Kokkos::Experimental::LOr< Scalar > reducer_view( lor_view );
+      Kokkos::LOr< Scalar > reducer_view( lor_view );
       Kokkos::parallel_reduce( Kokkos::RangePolicy< ExecSpace >( 0, N ), f, reducer_view );
 
       Scalar lor_view_scalar = lor_view();

--- a/core/unit_test/TestTaskScheduler.hpp
+++ b/core/unit_test/TestTaskScheduler.hpp
@@ -345,7 +345,7 @@ struct TestTaskTeam {
     tot = 0;
     Kokkos::parallel_reduce( Kokkos::TeamThreadRange( member, begin, end )
                            , [&] ( int i, long & res ) { res += parfor_result[i]; }
-                           , Kokkos::Experimental::Sum<long>( tot )
+                           , Kokkos::Sum<long>( tot )
                            );
 
     Kokkos::parallel_for( Kokkos::TeamThreadRange( member, begin, end )

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -309,7 +309,7 @@ public:
 
     // Team max:
     int long m = (long int) ( ind.league_rank() + ind.team_rank() );
-    ind.team_reduce(  Kokkos::Experimental::Max<int long>(m) );
+    ind.team_reduce(  Kokkos::Max<int long>(m) );
 
     if ( m != ind.league_rank() + ( ind.team_size() - 1 ) ) {
       printf( "ScanTeamFunctor[%d.%d of %d.%d] reduce_max_answer(%ld) != reduce_max(%ld)\n",

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -343,7 +343,7 @@ struct functor_team_reduce_reducer {
     {
       val += i - team.league_rank() + team.league_size() + team.team_size();
     },
-      Kokkos::Experimental::Sum<Scalar>(value)
+      Kokkos::Sum<Scalar>(value)
     );
 
     team.team_barrier();
@@ -495,7 +495,7 @@ struct functor_team_vector_reduce_reducer {
     {
       val += i - team.league_rank() + team.league_size() + team.team_size();
     },
-      Kokkos::Experimental::Sum<Scalar>(value)
+      Kokkos::Sum<Scalar>(value)
     );
 
     team.team_barrier();
@@ -664,7 +664,7 @@ struct functor_vec_red_reducer {
     Kokkos::parallel_reduce( Kokkos::ThreadVectorRange( team, 13 ), [&] ( int i, Scalar & val )
     {
       val *= ( i % 5 + 1 );
-    }, Kokkos::Experimental::Prod<Scalar>(value)
+    }, Kokkos::Prod<Scalar>(value)
     );
 
     Kokkos::single( Kokkos::PerThread( team ), [&] ()

--- a/example/fixture/Main.cpp
+++ b/example/fixture/Main.cpp
@@ -285,9 +285,17 @@ int main()
 
   {
     std::cout << "test_fixture< Host >" << std::endl ;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     Kokkos::HostSpace::execution_space::initialize( 1 );
+#else
+    Kokkos::HostSpace::execution_space::impl_initialize();
+#endif
     Kokkos::Example::test_fixture< Kokkos::HostSpace::execution_space >();
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     Kokkos::HostSpace::execution_space::finalize();
+#else
+    Kokkos::HostSpace::execution_space::impl_finalize();
+#endif
   }
 
 #if defined( KOKKOS_ENABLE_CUDA )

--- a/example/tutorial/Hierarchical_Parallelism/04_team_scan/team_scan.cpp
+++ b/example/tutorial/Hierarchical_Parallelism/04_team_scan/team_scan.cpp
@@ -112,7 +112,7 @@ int main(int narg, char* args[]) {
 
   srand(1231093);
 
-  for(int i = 0; i < (int) data.dimension_0(); i++) {
+  for(int i = 0; i < (int) data.extent(0); i++) {
     data.h_view(i) = rand()%TEAM_SIZE;
   }
   data.modify<Host>();


### PR DESCRIPTION
this addresses #1487 and #1494.  I usually wouldn't conflate multiple issues into one task, but did so here because #1487 is trivial.

spot check on ride timed out before finishing:


Going to test compilers:  gcc/5.4.0 ibm/13.1.6 cuda/8.0.44 cuda/9.0.103
Testing compiler gcc/5.4.0
  Starting job gcc-5.4.0-OpenMP-release
  PASSED gcc-5.4.0-OpenMP-release
  Starting job gcc-5.4.0-Serial-release
  PASSED gcc-5.4.0-Serial-release
Testing compiler ibm/13.1.6
  Starting job gcc-5.4.0-OpenMP_Serial-release
  PASSED gcc-5.4.0-OpenMP_Serial-release
  Starting job ibm-13.1.6-OpenMP-release
  PASSED ibm-13.1.6-OpenMP-release
  Starting job ibm-13.1.6-Serial-release
  PASSED ibm-13.1.6-Serial-release
Testing compiler cuda/8.0.44
  Starting job ibm-13.1.6-OpenMP_Serial-release
  PASSED ibm-13.1.6-OpenMP_Serial-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
