### PR TITLE
StaticCrsGraph: Add template parameter for memory traits

### DIFF
--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -278,8 +278,13 @@ public:
 template< class DataType,
           class Arg1Type,
           class Arg2Type = void,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+          typename SizeType = typename ViewTraits<DataType*, Arg1Type, Arg2Type >::size_type,
+          class Arg3Type = void>
+#else
           class Arg3Type = void,
           typename SizeType = typename ViewTraits<DataType*, Arg1Type, Arg2Type, Arg3Type >::size_type>
+#endif
 class StaticCrsGraph {
 private:
   typedef ViewTraits<DataType*, Arg1Type, Arg2Type, Arg3Type> traits;
@@ -292,8 +297,13 @@ public:
   typedef typename traits::memory_traits                      memory_traits;
   typedef SizeType                                            size_type;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+  typedef StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType , Arg3Type > staticcrsgraph_type;
+  typedef StaticCrsGraph< data_type , array_layout , typename traits::host_mirror_space , size_type, memory_traits > HostMirror;
+#else
   typedef StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type, SizeType > staticcrsgraph_type;
   typedef StaticCrsGraph< data_type , array_layout , typename traits::host_mirror_space , memory_traits, size_type > HostMirror;
+#endif
 
   typedef View< const size_type* , array_layout, device_type , memory_traits >  row_map_type;
   typedef View<       data_type* , array_layout, device_type , memory_traits >  entries_type;
@@ -412,18 +422,32 @@ create_staticcrsgraph( const std::string & label ,
 template< class DataType ,
           class Arg1Type ,
           class Arg2Type ,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+          typename SizeType ,
+          class Arg3Type >
+typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType , Arg3Type >::HostMirror
+create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType,Arg3Type > & input );
+#else
           class Arg3Type ,
           typename SizeType >
 typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >::HostMirror
 create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType > & input );
+#endif
 
 template< class DataType ,
           class Arg1Type ,
           class Arg2Type ,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+          typename SizeType ,
+          class Arg3Type >
+typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType , Arg3Type >::HostMirror
+create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType,Arg3Type > & input );
+#else
           class Arg3Type ,
           typename SizeType >
 typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >::HostMirror
 create_mirror( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType > & input );
+#endif
 
 } // namespace Kokkos
 
@@ -464,10 +488,17 @@ struct StaticCrsGraphMaximumEntry {
 
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+template< class DataType, class Arg1Type, class Arg2Type, typename SizeType , class Arg3Type >
+DataType maximum_entry( const StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType , Arg3Type > & graph )
+{
+  typedef StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType,Arg3Type> GraphType ;
+#else
 template< class DataType, class Arg1Type, class Arg2Type, class Arg3Type, typename SizeType >
 DataType maximum_entry( const StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType > & graph )
 {
   typedef StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType> GraphType ;
+#endif
   typedef Impl::StaticCrsGraphMaximumEntry< GraphType > FunctorType ;
 
   DataType result = 0 ;

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -258,6 +258,9 @@ public:
 /// \tparam Arg2Type The third template parameter, which if provided
 ///   corresponds to the Device type.
 ///
+/// \tparam Arg3Type The third template parameter, which if provided
+///   corresponds to the MemoryTraits.
+///
 /// \tparam SizeType The type of row offsets.  Usually the default
 ///   parameter suffices.  However, setting a nondefault value is
 ///   necessary in some cases, for example, if you want to have a
@@ -275,23 +278,26 @@ public:
 template< class DataType,
           class Arg1Type,
           class Arg2Type = void,
-          typename SizeType = typename ViewTraits<DataType*, Arg1Type, Arg2Type, void >::size_type>
+          class Arg3Type = void,
+          typename SizeType = typename ViewTraits<DataType*, Arg1Type, Arg2Type, Arg3Type >::size_type>
 class StaticCrsGraph {
 private:
-  typedef ViewTraits<DataType*, Arg1Type, Arg2Type, void> traits;
+  typedef ViewTraits<DataType*, Arg1Type, Arg2Type, Arg3Type> traits;
 
 public:
   typedef DataType                                            data_type;
   typedef typename traits::array_layout                       array_layout;
   typedef typename traits::execution_space                    execution_space;
   typedef typename traits::device_type                        device_type;
+  typedef typename traits::memory_traits                      memory_traits;
   typedef SizeType                                            size_type;
 
-  typedef StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType > staticcrsgraph_type;
-  typedef StaticCrsGraph< DataType , array_layout , typename traits::host_mirror_space , SizeType > HostMirror;
-  typedef View< const size_type* , array_layout, device_type >  row_map_type;
-  typedef View<       DataType*  , array_layout, device_type >  entries_type;
-  typedef View< const size_type* , array_layout, device_type >  row_block_type;
+  typedef StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type, SizeType > staticcrsgraph_type;
+  typedef StaticCrsGraph< data_type , array_layout , typename traits::host_mirror_space , memory_traits, size_type > HostMirror;
+
+  typedef View< const size_type* , array_layout, device_type , memory_traits >  row_map_type;
+  typedef View<       data_type* , array_layout, device_type , memory_traits >  entries_type;
+  typedef View< const size_type* , array_layout, device_type , memory_traits >  row_block_type;
 
   entries_type entries;
   row_map_type row_map;
@@ -406,16 +412,18 @@ create_staticcrsgraph( const std::string & label ,
 template< class DataType ,
           class Arg1Type ,
           class Arg2Type ,
+          class Arg3Type ,
           typename SizeType >
-typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType >::HostMirror
-create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType > & input );
+typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >::HostMirror
+create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType > & input );
 
 template< class DataType ,
           class Arg1Type ,
           class Arg2Type ,
+          class Arg3Type ,
           typename SizeType >
-typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType >::HostMirror
-create_mirror( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType > & input );
+typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >::HostMirror
+create_mirror( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType > & input );
 
 } // namespace Kokkos
 

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -464,10 +464,10 @@ struct StaticCrsGraphMaximumEntry {
 
 }
 
-template< class DataType, class Arg1Type, class Arg2Type, typename SizeType >
-DataType maximum_entry( const StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType > & graph )
+template< class DataType, class Arg1Type, class Arg2Type, class Arg3Type, typename SizeType >
+DataType maximum_entry( const StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType > & graph )
 {
-  typedef StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType> GraphType ;
+  typedef StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType> GraphType ;
   typedef Impl::StaticCrsGraphMaximumEntry< GraphType > FunctorType ;
 
   DataType result = 0 ;

--- a/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
+++ b/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
@@ -49,23 +49,23 @@
 
 namespace Kokkos {
 
-template< class DataType , class Arg1Type , class Arg2Type , typename SizeType >
+template< class DataType , class Arg1Type , class Arg2Type , class Arg3Type, typename SizeType >
 inline
-typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType >::HostMirror
-create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType > & view ,
-                    typename Impl::enable_if< ViewTraits<DataType,Arg1Type,Arg2Type,void>::is_hostspace >::type * = 0 )
+typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >::HostMirror
+create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType > & view ,
+                    typename Impl::enable_if< ViewTraits<DataType,Arg1Type,Arg2Type,Arg3Type>::is_hostspace >::type * = 0 )
 {
   return view ;
 }
 
-template< class DataType , class Arg1Type , class Arg2Type , typename SizeType >
+template< class DataType , class Arg1Type , class Arg2Type , class Arg3Type, typename SizeType >
 inline
-typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType >::HostMirror
-create_mirror( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType > & view )
+typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >::HostMirror
+create_mirror( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType > & view )
 {
   // Force copy:
   //typedef Impl::ViewAssignment< Impl::ViewDefault > alloc ; // unused
-  typedef StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType >  staticcrsgraph_type ;
+  typedef StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >  staticcrsgraph_type ;
 
   typename staticcrsgraph_type::HostMirror               tmp ;
   typename staticcrsgraph_type::row_map_type::HostMirror tmp_row_map = create_mirror( view.row_map);
@@ -84,11 +84,11 @@ create_mirror( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType > & view
   return tmp ;
 }
 
-template< class DataType , class Arg1Type , class Arg2Type , typename SizeType >
+template< class DataType , class Arg1Type , class Arg2Type , class Arg3Type, typename SizeType >
 inline
-typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType >::HostMirror
-create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType > & view ,
-                    typename Impl::enable_if< ! ViewTraits<DataType,Arg1Type,Arg2Type,void>::is_hostspace >::type * = 0 )
+typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >::HostMirror
+create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType > & view ,
+                    typename Impl::enable_if< ! ViewTraits<DataType,Arg1Type,Arg2Type,Arg3Type>::is_hostspace >::type * = 0 )
 {
   return create_mirror( view );
 }
@@ -112,7 +112,8 @@ create_staticcrsgraph( const std::string & label ,
 
   typedef View< typename output_type::size_type [] ,
                 typename output_type::array_layout ,
-                typename output_type::execution_space > work_type ;
+                typename output_type::execution_space,
+                typename output_type::memory_traits > work_type ;
 
   output_type output ;
 
@@ -157,7 +158,8 @@ create_staticcrsgraph( const std::string & label ,
 
   typedef View< typename output_type::size_type [] ,
                 typename output_type::array_layout ,
-                typename output_type::execution_space > work_type ;
+                typename output_type::execution_space,
+                typename output_type::memory_traits > work_type ;
 
   output_type output ;
 

--- a/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
+++ b/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
@@ -49,6 +49,16 @@
 
 namespace Kokkos {
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+template< class DataType , class Arg1Type , class Arg2Type , typename SizeType , class Arg3Type>
+inline
+typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType , Arg3Type >::HostMirror
+create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType,Arg3Type > & view ,
+                    typename Impl::enable_if< ViewTraits<DataType,Arg1Type,Arg2Type,Arg3Type>::is_hostspace >::type * = 0 )
+{
+  return view ;
+}
+#else
 template< class DataType , class Arg1Type , class Arg2Type , class Arg3Type, typename SizeType >
 inline
 typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >::HostMirror
@@ -57,7 +67,18 @@ create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,Siz
 {
   return view ;
 }
+#endif
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+template< class DataType , class Arg1Type , class Arg2Type , typename SizeType , class Arg3Type>
+inline
+typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType , Arg3Type >::HostMirror
+create_mirror( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType,Arg3Type > & view )
+{
+  // Force copy:
+  //typedef Impl::ViewAssignment< Impl::ViewDefault > alloc ; // unused
+  typedef StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType , Arg3Type >  staticcrsgraph_type ;
+#else
 template< class DataType , class Arg1Type , class Arg2Type , class Arg3Type, typename SizeType >
 inline
 typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >::HostMirror
@@ -66,6 +87,7 @@ create_mirror( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType
   // Force copy:
   //typedef Impl::ViewAssignment< Impl::ViewDefault > alloc ; // unused
   typedef StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >  staticcrsgraph_type ;
+#endif
 
   typename staticcrsgraph_type::HostMirror               tmp ;
   typename staticcrsgraph_type::row_map_type::HostMirror tmp_row_map = create_mirror( view.row_map);
@@ -84,11 +106,19 @@ create_mirror( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType
   return tmp ;
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+template< class DataType , class Arg1Type , class Arg2Type , typename SizeType , class Arg3Type>
+inline
+typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , SizeType , Arg3Type >::HostMirror
+create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,SizeType,Arg3Type > & view ,
+                    typename Impl::enable_if< ! ViewTraits<DataType,Arg1Type,Arg2Type,Arg3Type>::is_hostspace >::type * = 0 )
+#else
 template< class DataType , class Arg1Type , class Arg2Type , class Arg3Type, typename SizeType >
 inline
 typename StaticCrsGraph< DataType , Arg1Type , Arg2Type , Arg3Type , SizeType >::HostMirror
 create_mirror_view( const StaticCrsGraph<DataType,Arg1Type,Arg2Type,Arg3Type,SizeType > & view ,
                     typename Impl::enable_if< ! ViewTraits<DataType,Arg1Type,Arg2Type,Arg3Type>::is_hostspace >::type * = 0 )
+#endif
 {
   return create_mirror( view );
 }

--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -200,7 +200,11 @@ void run_test_graph4()
   typedef Kokkos::LayoutRight layout_type;
   typedef Space space_type;
   typedef Kokkos::MemoryUnmanaged memory_traits_type;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+  typedef Kokkos::StaticCrsGraph< ordinal_type , layout_type , space_type , ordinal_type , memory_traits_type > dView ;
+#else
   typedef Kokkos::StaticCrsGraph< ordinal_type , layout_type , space_type , memory_traits_type > dView ;
+#endif
   typedef typename dView::HostMirror hView ;
 
   dView dx ;

--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -193,6 +193,69 @@ void run_test_graph3(size_t B, size_t N)
   }
 }
 
+template< class Space >
+void run_test_graph4()
+{
+  typedef unsigned ordinal_type;
+  typedef Kokkos::LayoutRight layout_type;
+  typedef Space space_type;
+  typedef Kokkos::MemoryUnmanaged memory_traits_type;
+  typedef Kokkos::StaticCrsGraph< ordinal_type , layout_type , space_type , memory_traits_type > dView ;
+  typedef typename dView::HostMirror hView ;
+
+  dView dx ;
+
+  // StaticCrsGraph with Unmanaged trait will contain row_map and entries members
+  // with the Unmanaged memory trait.
+  // Use of such a StaticCrsGraph requires an allocaton of memory for the unmanaged views
+  // to wrap.
+  //
+  // In this test, a graph (via raw arrays) resides on the host.
+  // The pointers are wrapped by unmanaged Views. 
+  // To make use of this on the device, managed device Views are created (allocation required),
+  // and data from the unmanaged host views is deep copied to the device Views
+  // Unmanaged views of the appropriate type wrap the device data and are assigned to
+  // their corresponding unmanaged view members of the unmanaged StaticCrsGraph
+
+  // Data types for raw pointers storing StaticCrsGraph info
+  typedef typename dView::size_type ptr_row_map_type;
+  typedef typename dView::data_type ptr_entries_type;
+
+  const ordinal_type numRows = 8;
+  const ordinal_type nnz = 24;
+  ptr_row_map_type ptrRaw[] = {0, 4, 8, 10, 12, 14, 16, 20, 24};
+  ptr_entries_type indRaw[] = {0, 1, 4, 5, 0, 1, 4, 5, 2, 3, 2, 3, 4, 5, 4, 5, 2, 3, 6, 7, 2, 3, 6, 7};
+
+  // Wrap pointers in unmanaged host views
+  typedef typename hView::row_map_type local_row_map_type ;
+  typedef typename hView::entries_type local_entries_type ;
+  local_row_map_type unman_row_map( &(ptrRaw[0]) , numRows+1 );
+  local_entries_type unman_entries( &(indRaw[0]) , nnz );
+
+  hView hx ;
+  hx = hView( unman_entries, unman_row_map );
+
+  // Create the device Views for copying the host arrays into
+  // An allocation is needed on the device for the unmanaged StaticCrsGraph to wrap the pointer
+  typedef typename Kokkos::View< ptr_row_map_type*, layout_type, space_type > d_row_map_view_type;
+  typedef typename Kokkos::View< ptr_entries_type*, layout_type, space_type > d_entries_view_type;
+
+  d_row_map_view_type tmp_row_map( "tmp_row_map", numRows+1 );
+  d_entries_view_type tmp_entries( "tmp_entries", nnz );
+
+  Kokkos::deep_copy (tmp_row_map, unman_row_map);
+  Kokkos::deep_copy (tmp_entries, unman_entries);
+
+  // Wrap the pointer in unmanaged View and assign to the corresponding StaticCrsGraph member
+  dx.row_map = typename dView::row_map_type(tmp_row_map.data(), numRows+1);
+  dx.entries = typename dView::entries_type(tmp_entries.data(), nnz);
+
+  ASSERT_TRUE((std::is_same< typename dView::row_map_type::memory_traits , Kokkos::MemoryUnmanaged >::value));
+  ASSERT_TRUE((std::is_same< typename dView::entries_type::memory_traits , Kokkos::MemoryUnmanaged >::value));
+  ASSERT_TRUE((std::is_same< typename hView::row_map_type::memory_traits , Kokkos::MemoryUnmanaged >::value));
+  ASSERT_TRUE((std::is_same< typename hView::entries_type::memory_traits , Kokkos::MemoryUnmanaged >::value));
+}
+
 } /* namespace TestStaticCrsGraph */
 
 TEST_F( TEST_CATEGORY , staticcrsgraph )
@@ -211,5 +274,6 @@ TEST_F( TEST_CATEGORY , staticcrsgraph )
   TestStaticCrsGraph::run_test_graph3< TEST_EXECSPACE >(75, 1000);
   TestStaticCrsGraph::run_test_graph3< TEST_EXECSPACE >(75, 10000);
   TestStaticCrsGraph::run_test_graph3< TEST_EXECSPACE >(75, 100000);
+  TestStaticCrsGraph::run_test_graph4< TEST_EXECSPACE >();
 }
 }

--- a/example/fenl/CGSolve.hpp
+++ b/example/fenl/CGSolve.hpp
@@ -59,7 +59,11 @@ namespace Example {
 
 template< typename ValueType , class Space >
 struct CrsMatrix {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+  typedef Kokkos::StaticCrsGraph< unsigned , Space , void , unsigned , void >  StaticCrsGraphType ;
+#else
   typedef Kokkos::StaticCrsGraph< unsigned , Space , void , void , unsigned >  StaticCrsGraphType ;
+#endif
   typedef View< ValueType * , Space > coeff_type ;
 
   StaticCrsGraphType  graph ;

--- a/example/fenl/CGSolve.hpp
+++ b/example/fenl/CGSolve.hpp
@@ -59,7 +59,7 @@ namespace Example {
 
 template< typename ValueType , class Space >
 struct CrsMatrix {
-  typedef Kokkos::StaticCrsGraph< unsigned , Space , void , unsigned >  StaticCrsGraphType ;
+  typedef Kokkos::StaticCrsGraph< unsigned , Space , void , void , unsigned >  StaticCrsGraphType ;
   typedef View< ValueType * , Space > coeff_type ;
 
   StaticCrsGraphType  graph ;

--- a/example/multi_fem/SparseLinearSystem.hpp
+++ b/example/multi_fem/SparseLinearSystem.hpp
@@ -59,7 +59,7 @@ struct CrsMatrix {
   typedef Device      execution_space ;
   typedef ScalarType  value_type ;
 
-  typedef StaticCrsGraph< int , execution_space , void , int >  graph_type ;
+  typedef StaticCrsGraph< int , execution_space , void , void , int >  graph_type ;
   typedef View< value_type* , execution_space >   coefficients_type ;
 
   graph_type         graph ;

--- a/example/multi_fem/SparseLinearSystem.hpp
+++ b/example/multi_fem/SparseLinearSystem.hpp
@@ -59,7 +59,11 @@ struct CrsMatrix {
   typedef Device      execution_space ;
   typedef ScalarType  value_type ;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+  typedef StaticCrsGraph< int , execution_space , void , int , void >  graph_type ;
+#else
   typedef StaticCrsGraph< int , execution_space , void , void , int >  graph_type ;
+#endif
   typedef View< value_type* , execution_space >   coefficients_type ;
 
   graph_type         graph ;


### PR DESCRIPTION
Partially address issue-1581.
A template parameter ArgType3 is added so MemoryTrait information can be
provided to the StaticCrsGraph.
This can break backward compatibility in cases where uses provide a
'SizeType' with the final template parameter.