### PR TITLE
Fix the first part of #1607

### DIFF
--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -72,7 +72,7 @@ std::string human_memory_size(size_t arg_bytes);
 namespace Kokkos {
 KOKKOS_INLINE_FUNCTION
 void abort( const char * const message ) {
-#ifdef __CUDA_ARCH__
+#if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
   Kokkos::Impl::cuda_abort(message);
 #else
   #if !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__)


### PR DESCRIPTION
This is a rare use case that deal.II runs into: they compile Trilinos without CUDA support, then include Kokkos headers in code that is compiled by NVCC. This PR fixes one of many issues that result from that.