### PR TITLE
kokkos-promotion.txt: Add comments, step 6.2

### DIFF
--- a/doc/kokkos-promotion.txt
+++ b/doc/kokkos-promotion.txt
@@ -175,16 +175,7 @@ Step 5: This step can be done on any SEMS machine (e.g. kokkos-dev). Actually, t
 
        ## KokkosKernels Changelog
 
-  5.4. Run checkin-test to push to trilinos using the CI build modules (gcc/4.9.3)
-
-     * This step is optional, the Github auto-tester is now the favored method for testing.
-
-       cd $TRILINOS_PATH
-       mkdir CHECKIN
-       cd CHECKIN
-       nohup ../cmake/std/sems/checkin-test-sems.sh --do-all --push &
-
-       Although Trilinos has experimental Pull Request testing, it is not good enough to replace the checkin script yet.
+  5.4. Wait for Trilinos Autotester results
 
   5.5. If there are failures, fix and backtrack. Otherwise, go to next step
 

--- a/doc/kokkos-promotion.txt
+++ b/doc/kokkos-promotion.txt
@@ -149,7 +149,9 @@ Step 5: This step can be done on any SEMS machine (e.g. kokkos-dev). Actually, t
         git clone -b kokkos-develop git@github.com:trilinos/Trilinos.git
         TRILINOS_PATH=$PWD/Trilinos
 
-  5.2. Snapshot Kokkos into Trilinos - this requires python/2.7.9 and that both Trilinos and Kokkos be clean - no untracked or modified files. Run the following outside of the Kokkos and Trilinos source trees.
+  5.2. Snapshot Kokkos into Trilinos - this requires python/2.7.9 and that both Trilinos and Kokkos be clean - no untracked or modified files. Run the following outside of the Kokkos and Trilinos source trees. 
+
+      * Use the master branch of Kokkos for this.
 
         module load sems-python/2.7.9
         python $KOKKOS_PATH/scripts/snapshot.py $KOKKOS_PATH $TRILINOS_PATH/packages
@@ -175,6 +177,8 @@ Step 5: This step can be done on any SEMS machine (e.g. kokkos-dev). Actually, t
 
   5.4. Run checkin-test to push to trilinos using the CI build modules (gcc/4.9.3)
 
+     * This step is optional, the Github auto-tester is now the favored method for testing.
+
        cd $TRILINOS_PATH
        mkdir CHECKIN
        cd CHECKIN
@@ -186,7 +190,16 @@ Step 5: This step can be done on any SEMS machine (e.g. kokkos-dev). Actually, t
 
 // -------------------------------------------------------------------------------- //
 
-Step 6: Push Kokkos master to GitHub (requires Owner permission).
+Step 6: Push Kokkos master and develop to GitHub (requires Owner permission).
       
+  6.1. Master branch:
        cd KOKKOS_PATH
+       git checkout master
        git push --follow-tags origin master 
+
+  6.2. Develop branch: First merge (--no-ff) master back into develop
+       cd KOKKOS_PATH
+       git checkout develop
+       git merge --no-ff maseter
+       git push origin develop 
+


### PR DESCRIPTION
Add reminder comment to use the master branches of kokkos and
kokkos-kernels during snapshot into Trilinos.
Break step 6 into parts 6.1 (master branch) and 6.2 (develop branch),
      step 6.2 added to avoid forgetting merge of master back into
      develop branch so the master_history and tags carry over.