### PR TITLE
Fix #1661: REGEX for old cmake

### DIFF
--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -47,7 +47,7 @@ function(set_kokkos_cxx_compiler)
                     OUTPUT_VARIABLE INTERNAL_CXX_COMPILER_VERSION
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-    string(REGEX MATCH "[0-9]+\.[0-9]+\.[0-9]+$"
+    string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+$"
            INTERNAL_CXX_COMPILER_VERSION ${INTERNAL_CXX_COMPILER_VERSION})
   endif()
 


### PR DESCRIPTION
Invalid escape sequence \. in kokkos_functions.cmake for old cmake, so added another backslash. See: https://github.com/kokkos/kokkos/issues/1661#issuecomment-395325290