### PR TITLE
Fix issue #1663: reduce without final member or return value compiles

### DIFF
--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1054,6 +1054,9 @@ void parallel_reduce(const std::string& label,
                                      , typename ValueTraits::pointer_type
                                      >::type value_type ;
 
+  static_assert(Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,PolicyType,FunctorType>::
+                 has_final_member_function,"Calling parallel_reduce without either return value or final function.");
+
   typedef Kokkos::View< value_type
               , Kokkos::HostSpace
               , Kokkos::MemoryUnmanaged
@@ -1076,6 +1079,9 @@ void parallel_reduce(const PolicyType& policy,
                                      , typename ValueTraits::pointer_type
                                      >::type value_type ;
 
+  static_assert(Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,PolicyType,FunctorType>::
+                 has_final_member_function,"Calling parallel_reduce without either return value or final function.");
+
   typedef Kokkos::View< value_type
               , Kokkos::HostSpace
               , Kokkos::MemoryUnmanaged
@@ -1095,6 +1101,9 @@ void parallel_reduce(const size_t& policy,
                                      , typename ValueTraits::value_type
                                      , typename ValueTraits::pointer_type
                                      >::type value_type ;
+
+  static_assert(Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,RangePolicy<>,FunctorType>::
+                 has_final_member_function,"Calling parallel_reduce without either return value or final function.");
 
   typedef Kokkos::View< value_type
               , Kokkos::HostSpace
@@ -1116,6 +1125,9 @@ void parallel_reduce(const std::string& label,
                                      , typename ValueTraits::value_type
                                      , typename ValueTraits::pointer_type
                                      >::type value_type ;
+
+  static_assert(Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,RangePolicy<>,FunctorType>::
+                 has_final_member_function,"Calling parallel_reduce without either return value or final function.");
 
   typedef Kokkos::View< value_type
               , Kokkos::HostSpace

--- a/core/unit_test/TestAtomic.hpp
+++ b/core/unit_test/TestAtomic.hpp
@@ -224,7 +224,8 @@ T AddLoop( int loop ) {
 
   struct AddFunctorReduce< T, execution_space > f_add_red;
   f_add_red.data = data;
-  Kokkos::parallel_reduce( loop, f_add_red );
+  int dummy_result;
+  Kokkos::parallel_reduce( loop, f_add_red , dummy_result );
   execution_space::fence();
 
   return val;
@@ -309,7 +310,8 @@ T CASLoop( int loop ) {
 
   struct CASFunctorReduce< T, execution_space > f_cas_red;
   f_cas_red.data = data;
-  Kokkos::parallel_reduce( loop, f_cas_red );
+  int dummy_result;
+  Kokkos::parallel_reduce( loop, f_cas_red , dummy_result );
   execution_space::fence();
 
   return val;
@@ -401,7 +403,8 @@ T ExchLoop( int loop ) {
   struct ExchFunctorReduce< T, execution_space > f_exch_red;
   f_exch_red.data = data;
   f_exch_red.data2 = data2;
-  Kokkos::parallel_reduce( loop, f_exch_red );
+  int dummy_result;
+  Kokkos::parallel_reduce( loop, f_exch_red , dummy_result );
   execution_space::fence();
 
   return val;


### PR DESCRIPTION
This addresses issue #1663 