### PR TITLE
cmake options: Remove librt as tpl if using Mac OSX

### DIFF
--- a/cmake/kokkos_options.cmake
+++ b/cmake/kokkos_options.cmake
@@ -121,11 +121,18 @@ list(APPEND KOKKOS_DEVICES_LIST
 # List of possible TPLs for Kokkos
 # From Makefile.kokkos: Options: hwloc,librt,experimental_memkind
 set(KOKKOS_USE_TPLS_LIST)
+if(APPLE)
+list(APPEND KOKKOS_USE_TPLS_LIST
+    HWLOC          # hwloc
+    MEMKIND        # experimental_memkind
+    )
+else()
 list(APPEND KOKKOS_USE_TPLS_LIST
     HWLOC          # hwloc
     LIBRT          # librt
     MEMKIND        # experimental_memkind
     )
+endif()
 # Map of cmake variables to Makefile variables
 set(KOKKOS_INTERNAL_HWLOC hwloc)
 set(KOKKOS_INTERNAL_LIBRT librt)


### PR DESCRIPTION
This commit to address issue #1698 reported by @mfdeakin-sandia
librt does not exist on Mac OSX (thanks @nmhamster for info)
Remove it from list of TPLs in the cmake options.