### PR TITLE
Unmanaged dual view

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -283,6 +283,7 @@ public:
     }
   }
 
+  // given a View in HostSpace, create another view in the Default space and wrap them with a DualView
   template<typename V>
   DualView (V view,
         typename std::enable_if< std::is_same<typename V::memory_space, HostSpace>::value, int>::type dummmy = 0)
@@ -293,6 +294,7 @@ public:
     {
 
     }
+  // given a View not in HostSpace, create another view in the Host space and wrap them with a DualView
   template<typename V>
    DualView (V view,
          typename std::enable_if< !std::is_same<typename V::memory_space, HostSpace>::value, int>::type dummmy = 0)

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -285,10 +285,10 @@ public:
 
   // given a View in HostSpace, create another view in the Default space and wrap them with a DualView
   template<typename V>
-  DualView (V view,
+  DualView (V aView,
         typename std::enable_if< std::is_same<typename V::memory_space, HostSpace>::value, int>::type dummmy = 0)
-      : d_view (create_mirror_view(DefaultExecutionSpace(), view))
-      , h_view (view)
+    : d_view (create_mirror_view(typename t_dev::memory_space(), aView))
+      , h_view (aView)
       , modified_device (View<unsigned int,LayoutLeft,typename t_host::execution_space> ("DualView::modified_device"))
       , modified_host (View<unsigned int,LayoutLeft,typename t_host::execution_space> ("DualView::modified_host"))
     {
@@ -296,10 +296,10 @@ public:
     }
   // given a View not in HostSpace, create another view in the Host space and wrap them with a DualView
   template<typename V>
-   DualView (V view,
+   DualView (V aView,
          typename std::enable_if< !std::is_same<typename V::memory_space, HostSpace>::value, int>::type dummmy = 0)
-       : d_view (view)
-       , h_view (create_mirror_view(view))
+       : d_view (aView)
+       , h_view (create_mirror_view(aView))
        , modified_device (View<unsigned int,LayoutLeft,typename t_host::execution_space> ("DualView::modified_device"))
        , modified_host (View<unsigned int,LayoutLeft,typename t_host::execution_space> ("DualView::modified_host"))
      {

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -283,6 +283,27 @@ public:
     }
   }
 
+  template<typename V>
+  DualView (V view,
+        typename std::enable_if< std::is_same<typename V::memory_space, HostSpace>::value, int>::type dummmy = 0)
+      : d_view (create_mirror_view(DefaultExecutionSpace(), view))
+      , h_view (view)
+      , modified_device (View<unsigned int,LayoutLeft,typename t_host::execution_space> ("DualView::modified_device"))
+      , modified_host (View<unsigned int,LayoutLeft,typename t_host::execution_space> ("DualView::modified_host"))
+    {
+
+    }
+  template<typename V>
+   DualView (V view,
+         typename std::enable_if< !std::is_same<typename V::memory_space, HostSpace>::value, int>::type dummmy = 0)
+       : d_view (view)
+       , h_view (create_mirror_view(view))
+       , modified_device (View<unsigned int,LayoutLeft,typename t_host::execution_space> ("DualView::modified_device"))
+       , modified_host (View<unsigned int,LayoutLeft,typename t_host::execution_space> ("DualView::modified_host"))
+     {
+
+     }
+
   //@}
   //! \name Methods for synchronizing, marking as modified, and getting Views.
   //@{

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -105,12 +105,13 @@ namespace Impl {
        Kokkos::DualView<Scalar**,Kokkos::LayoutLeft,Device> a("dView", size, size2);
        result = run_me(a);
 
-       Scalar data[size*size2];
+       Scalar * data = new Scalar[size*size2];
        typedef Kokkos::View<Scalar**, Kokkos::LayoutLeft, Kokkos::HostSpace> unmanaged_type;
        unmanaged_type unmanagedView(&data[0], size, size2);
-       Kokkos::DualView<Scalar**, typename unmanaged_type::array_layout,Device> b(unmanagedView);
+       Kokkos::DualView<Scalar**, typename unmanaged_type::array_layout, typename Device::memory_space> b(unmanagedView);
        result += run_me(b);
 
+       delete [] data;
 
     }
 

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -67,10 +67,13 @@ namespace Impl {
     Scalar result;
 
     template <typename ViewType>
-    Scalar run_me(unsigned int n,unsigned int m){
-      if(n<10) n = 10;
-      if(m<3) m = 3;
-      ViewType a("A",n,m);
+    Scalar run_me(ViewType a){
+      int n = a.extent(0);
+      int m = a.extent(1);
+      const bool tooSmall = n < 10 || m < 3;
+      if(tooSmall) {
+         a.resize(10,3);
+      }
 
       Kokkos::deep_copy( a.d_view , 1 );
 
@@ -98,7 +101,17 @@ namespace Impl {
 
     test_dualview_combinations(unsigned int size)
     {
-      result = run_me< Kokkos::DualView<Scalar**,Kokkos::LayoutLeft,Device> >(size,3);
+       const int size2 = 3;
+       Kokkos::DualView<Scalar**,Kokkos::LayoutLeft,Device> a("dView", size, size2);
+       result = run_me(a);
+
+       Scalar data[size*size2];
+       typedef Kokkos::View<Scalar**, Kokkos::LayoutLeft, Kokkos::HostSpace> unmanaged_type;
+       unmanaged_type unmanagedView(&data[0], size, size2);
+       Kokkos::DualView<Scalar**, typename unmanaged_type::array_layout,Device> b(unmanagedView);
+       result += run_me(b);
+
+
     }
 
    };


### PR DESCRIPTION
This addresses #1713.  

During the ORNL Workshop, there was a fair amount of interest in creating a DualView around a managed View: the idea is that during the code conversion process this would be a helpful concept.  
Whereas there is a pre-existing constructor that takes two Views, this change simplifies determining the space of the other view.

I created a new constructor for DualView that takes a single View.  If the given View is in the host space, it creates one in the DualView::t_dev::memory_space.  Otherwise, it creates one in the host space.

results of spot-check on kokkos-dev:

#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-hwloc-release build_time=183 run_time=294
clang-3.9.0-Pthread_Serial-release build_time=181 run_time=616
cuda-8.0.44-Cuda_OpenMP-release build_time=601 run_time=623
gcc-5.3.0-OpenMP-hwloc-release build_time=186 run_time=156
gcc-5.3.0-OpenMP-release build_time=190 run_time=183
gcc-6.1.0-Serial-hwloc-release build_time=179 run_time=384
gcc-6.1.0-Serial-release build_time=184 run_time=371
intel-17.0.1-OpenMP-hwloc-release build_time=493 run_time=238
intel-17.0.1-OpenMP-release build_time=527 run_time=285

