### PR TITLE
(re)compile time fix for Kokkos on Darwin

### DIFF
--- a/core/src/Makefile
+++ b/core/src/Makefile
@@ -16,6 +16,7 @@ endif
 CXXFLAGS ?= -O3
 LINK ?= $(CXX)
 LDFLAGS ?=
+CP = cp
 
 include $(KOKKOS_PATH)/Makefile.kokkos
 include $(KOKKOS_PATH)/core/src/Makefile.generate_header_lists
@@ -50,7 +51,12 @@ ifeq ($(KOKKOS_OS),Linux)
   COPY_FLAG = -u
 endif
 ifeq ($(KOKKOS_OS),Darwin)
-  COPY_FLAG =
+  COPY_FLAG = 
+  # If Homebrew coreutils is installed, its cp will have the -u option
+  ifneq ("$(wildcard /usr/local/opt/coreutils/libexec/gnubin/cp)","")
+    CP = /usr/local/opt/coreutils/libexec/gnubin/cp
+    COPY_FLAG = -u
+  endif
 endif
 
 ifeq ($(KOKKOS_DEBUG),"no")
@@ -70,32 +76,32 @@ mkdir:
 
 copy-cuda: mkdir
 	mkdir -p $(PREFIX)/include/Cuda
-	cp $(COPY_FLAG) $(KOKKOS_HEADERS_CUDA) $(PREFIX)/include/Cuda
+	$(CP) $(COPY_FLAG) $(KOKKOS_HEADERS_CUDA) $(PREFIX)/include/Cuda
 
 copy-threads: mkdir
 	mkdir -p $(PREFIX)/include/Threads
-	cp $(COPY_FLAG) $(KOKKOS_HEADERS_THREADS) $(PREFIX)/include/Threads
+	$(CP) $(COPY_FLAG) $(KOKKOS_HEADERS_THREADS) $(PREFIX)/include/Threads
 
 copy-qthreads: mkdir
 	mkdir -p $(PREFIX)/include/Qthreads
-	cp $(COPY_FLAG) $(KOKKOS_HEADERS_QTHREADS) $(PREFIX)/include/Qthreads
+	$(CP) $(COPY_FLAG) $(KOKKOS_HEADERS_QTHREADS) $(PREFIX)/include/Qthreads
 
 copy-openmp: mkdir
 	mkdir -p $(PREFIX)/include/OpenMP
-	cp $(COPY_FLAG) $(KOKKOS_HEADERS_OPENMP) $(PREFIX)/include/OpenMP
+	$(CP) $(COPY_FLAG) $(KOKKOS_HEADERS_OPENMP) $(PREFIX)/include/OpenMP
 
 copy-rocm: mkdir
 	mkdir -p $(PREFIX)/include/ROCm
-	cp $(COPY_FLAG) $(KOKKOS_HEADERS_ROCM) $(PREFIX)/include/ROCm
+	$(CP) $(COPY_FLAG) $(KOKKOS_HEADERS_ROCM) $(PREFIX)/include/ROCm
 
 install: mkdir $(CONDITIONAL_COPIES) build-lib generate_build_settings
-	cp $(COPY_FLAG) $(NVCC_WRAPPER) $(PREFIX)/bin
-	cp $(COPY_FLAG) $(KOKKOS_HEADERS_INCLUDE) $(PREFIX)/include
-	cp $(COPY_FLAG) $(KOKKOS_HEADERS_INCLUDE_IMPL) $(PREFIX)/include/impl
-	cp $(COPY_FLAG) $(KOKKOS_MAKEFILE)  $(PREFIX)
-	cp $(COPY_FLAG) $(KOKKOS_CMAKEFILE)  $(PREFIX)
-	cp $(COPY_FLAG) libkokkos.a $(PREFIX)/lib
-	cp $(COPY_FLAG) $(KOKKOS_CONFIG_HEADER) $(PREFIX)/include
+	$(CP) $(COPY_FLAG) $(NVCC_WRAPPER) $(PREFIX)/bin
+	$(CP) $(COPY_FLAG) $(KOKKOS_HEADERS_INCLUDE) $(PREFIX)/include
+	$(CP) $(COPY_FLAG) $(KOKKOS_HEADERS_INCLUDE_IMPL) $(PREFIX)/include/impl
+	$(CP) $(COPY_FLAG) $(KOKKOS_MAKEFILE)  $(PREFIX)
+	$(CP) $(COPY_FLAG) $(KOKKOS_CMAKEFILE)  $(PREFIX)
+	$(CP) $(COPY_FLAG) libkokkos.a $(PREFIX)/lib
+	$(CP) $(COPY_FLAG) $(KOKKOS_CONFIG_HEADER) $(PREFIX)/include
 
 clean: kokkos-clean
 	rm -f $(KOKKOS_MAKEFILE) $(KOKKOS_CMAKEFILE) 


### PR DESCRIPTION
@ibaned 
Recompilation times on Darwin were very long when building kokkoskernels with kokkos because the `cp` command in the Makefile for Kokkos was copying all the files into the KK examples dir.  This updated the timestamps on the sources each time resulting in a full recompile every time.

In the makefile, Darwin (OSX) systems did not use the `-u` parameter to `cp` which makes `cp` only copy files over that are newer.  On vanilla OSX systems, this parameter does not exist but for OSX systems using homebrew to install the `coreutils` package, the -u option is there and can be used to keep recompilation times on darwin quick.

Resolves #1721 