### PR TITLE
Use tolerant comparison between functors and lambdas

### DIFF
--- a/core/unit_test/TestCXX11.hpp
+++ b/core/unit_test/TestCXX11.hpp
@@ -331,12 +331,14 @@ bool Test( int test ) {
   auto b = res_lambda;
   // use a tolerant comparison because functors and lambdas vectorize differently
   // https://github.com/trilinos/Trilinos/issues/3233
-  if ( (std::abs(b - a) / std::max(std::abs(a), std::abs(b))) > 1e-14) {
+  auto rel_err = (std::abs(b - a) / std::max(std::abs(a), std::abs(b)));
+  auto tol = 1e-14;
+  if (rel_err > tol) {
     passed = false;
 
     std::cout << "CXX11 ( test = '"
-              << testnames[test] << "' FAILED : "
-              << res_functor << " != " << res_lambda
+              << testnames[test] << "' FAILED : relative error "
+              << rel_err << " > tolerance " << tol
               << std::endl;
   }
 

--- a/core/unit_test/TestCXX11.hpp
+++ b/core/unit_test/TestCXX11.hpp
@@ -327,7 +327,11 @@ bool Test( int test ) {
                            };
   bool passed = true;
 
-  if ( res_functor != res_lambda ) {
+  auto a = res_functor;
+  auto b = res_lambda;
+  // use a tolerant comparison because functors and lambdas vectorize differently
+  // https://github.com/trilinos/Trilinos/issues/3233
+  if ( (std::abs(b - a) / std::max(std::abs(a), std::abs(b))) > 1e-14) {
     passed = false;
 
     std::cout << "CXX11 ( test = '"


### PR DESCRIPTION
trilinos/Trilinos#3233

In short, these two vectorized slightly differently, so we can't expect bitwise equality.
This test fails using Intel compiler vectorization, which is a bug in the test.

```
Running on machine: apollo
Repository Status:  e392a77389c73555640e755c7ac719ecf3e1e24f Output requested by @bartlettroscoe


Going to test compilers:  gcc/4.8.4 gcc/5.3.0 intel/16.0.1 clang/3.9.0 clang/6.0 cuda/9.1
Testing compiler gcc/4.8.4
  Starting job gcc-4.8.4-OpenMP-release
  PASSED gcc-4.8.4-OpenMP-release
Testing compiler gcc/5.3.0
  Starting job gcc-4.8.4-Pthread-release
  PASSED gcc-4.8.4-Pthread-release
Testing compiler intel/16.0.1
  Starting job gcc-5.3.0-Serial-release
  PASSED gcc-5.3.0-Serial-release
Testing compiler clang/3.9.0
  Starting job intel-16.0.1-OpenMP-release
  PASSED intel-16.0.1-OpenMP-release
Testing compiler clang/6.0
  Starting job clang-3.9.0-Pthread_Serial-release
  PASSED clang-3.9.0-Pthread_Serial-release
  Starting job clang-6.0-Cuda_Pthread-release
  PASSED clang-6.0-Cuda_Pthread-release
Testing compiler cuda/9.1
  Starting job clang-6.0-OpenMP-release
  PASSED clang-6.0-OpenMP-release
  Starting job cuda-9.1-Cuda_OpenMP-release
  PASSED cuda-9.1-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-release build_time=128 run_time=428
clang-6.0-Cuda_Pthread-release build_time=221 run_time=693
clang-6.0-OpenMP-release build_time=111 run_time=122
cuda-9.1-Cuda_OpenMP-release build_time=301 run_time=652
gcc-4.8.4-OpenMP-release build_time=105 run_time=153
gcc-4.8.4-Pthread-release build_time=96 run_time=300
gcc-5.3.0-Serial-release build_time=111 run_time=168
intel-16.0.1-OpenMP-release build_time=331 run_time=171
```