### PR TITLE
LayoutTiled: Initial implementation

### DIFF
--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -46,7 +46,6 @@
 
 #include <initializer_list>
 
-// TODO Remove me once Iterate enum class finds a home...
 #include <Kokkos_Layout.hpp>
 
 #include<impl/KokkosExp_Host_IterateTile.hpp>
@@ -66,7 +65,7 @@
 namespace Kokkos {
 
 // ------------------------------------------------------------------ //
-// TODO Move me somewhere else for more general use
+// Moved to Kokkos_Layout.hpp for more general accessibility
 /*
 enum class Iterate
 {

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -46,6 +46,9 @@
 
 #include <initializer_list>
 
+// TODO Remove me once Iterate enum class finds a home...
+#include <Kokkos_Layout.hpp>
+
 #include<impl/KokkosExp_Host_IterateTile.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_Parallel.hpp>
@@ -63,13 +66,15 @@
 namespace Kokkos {
 
 // ------------------------------------------------------------------ //
-
+// TODO Move me somewhere else for more general use
+/*
 enum class Iterate
 {
   Default, // Default for the device
   Left,    // Left indices stride fastest
   Right,   // Right indices stride fastest
 };
+*/
 
 template <typename ExecSpace>
 struct default_outer_direction

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -655,30 +655,22 @@ void view_copy(const DstType& dst, const SrcType& src) {
   int64_t strides[DstType::Rank+1];
   dst.stride(strides);
   Kokkos::Iterate iterate;
-//  Kokkos::Iterate iterate_inner;
   if        ( Kokkos::is_layouttiled<typename DstType::array_layout>::value ) {
     iterate = Kokkos::layout_iterate_type_selector<typename DstType::array_layout>::outer_iteration_pattern;
-//    iterate_inner = Kokkos::layout_iterate_type_selector::inner_iteration_pattern;
   } else if        ( std::is_same<typename DstType::array_layout,Kokkos::LayoutRight>::value ) {
     iterate = Kokkos::Iterate::Right;
-//    iterate_inner = Kokkos::Iterate::Right;
   } else if ( std::is_same<typename DstType::array_layout,Kokkos::LayoutLeft>::value ) {
     iterate = Kokkos::Iterate::Left;
-//    iterate_inner = Kokkos::Iterate::Left;
   } else if ( std::is_same<typename DstType::array_layout,Kokkos::LayoutStride>::value ) {
     if( strides[0] > strides[DstType::Rank-1] )
       iterate = Kokkos::Iterate::Right;
-//      iterate_inner = Kokkos::Iterate::Right;
     else
       iterate = Kokkos::Iterate::Left;
-//      iterate_inner = Kokkos::Iterate::Left;
   } else {
     if( std::is_same<typename DstType::execution_space::array_layout, Kokkos::LayoutRight>::value )
       iterate = Kokkos::Iterate::Right;
-//      iterate_inner = Kokkos::Iterate::Right;
     else
       iterate = Kokkos::Iterate::Left;
-//      iterate_inner = Kokkos::Iterate::Left;
   }
 
   if( (dst.span() >= size_t(std::numeric_limits<int>::max())) ||

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -453,8 +453,9 @@ template<class ViewTypeA,class ViewTypeB, class Layout, class ExecSpace,typename
 struct ViewCopy<ViewTypeA,ViewTypeB,Layout,ExecSpace,2,iType,KOKKOS_IMPL_COMPILING_LIBRARY> {
   ViewTypeA a;
   ViewTypeB b;
-
-  typedef Kokkos::Rank<2,ViewFillLayoutSelector<Layout>::iterate,ViewFillLayoutSelector<Layout>::iterate> iterate_type;
+  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+  typedef Kokkos::Rank<2,outer_iteration_pattern,inner_iteration_pattern> iterate_type;
   typedef Kokkos::MDRangePolicy<ExecSpace,iterate_type,Kokkos::IndexType<iType>> policy_type;
 
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_):a(a_),b(b_) {
@@ -475,7 +476,9 @@ struct ViewCopy<ViewTypeA,ViewTypeB,Layout,ExecSpace,3,iType,KOKKOS_IMPL_COMPILI
   ViewTypeA a;
   ViewTypeB b;
 
-  typedef Kokkos::Rank<3,ViewFillLayoutSelector<Layout>::iterate,ViewFillLayoutSelector<Layout>::iterate> iterate_type;
+  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+  typedef Kokkos::Rank<3,outer_iteration_pattern,inner_iteration_pattern> iterate_type;
   typedef Kokkos::MDRangePolicy<ExecSpace,iterate_type,Kokkos::IndexType<iType>> policy_type;
 
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_):a(a_),b(b_) {
@@ -496,7 +499,9 @@ struct ViewCopy<ViewTypeA,ViewTypeB,Layout,ExecSpace,4,iType,KOKKOS_IMPL_COMPILI
   ViewTypeA a;
   ViewTypeB b;
 
-  typedef Kokkos::Rank<4,ViewFillLayoutSelector<Layout>::iterate,ViewFillLayoutSelector<Layout>::iterate> iterate_type;
+  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+  typedef Kokkos::Rank<4,outer_iteration_pattern,inner_iteration_pattern> iterate_type;
   typedef Kokkos::MDRangePolicy<ExecSpace,iterate_type,Kokkos::IndexType<iType>> policy_type;
 
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_):a(a_),b(b_) {
@@ -519,7 +524,9 @@ struct ViewCopy<ViewTypeA,ViewTypeB,Layout,ExecSpace,5,iType,KOKKOS_IMPL_COMPILI
   ViewTypeA a;
   ViewTypeB b;
 
-  typedef Kokkos::Rank<5,ViewFillLayoutSelector<Layout>::iterate,ViewFillLayoutSelector<Layout>::iterate> iterate_type;
+  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+  typedef Kokkos::Rank<5,outer_iteration_pattern,inner_iteration_pattern> iterate_type;
   typedef Kokkos::MDRangePolicy<ExecSpace,iterate_type,Kokkos::IndexType<iType>> policy_type;
 
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_):a(a_),b(b_) {
@@ -542,7 +549,9 @@ struct ViewCopy<ViewTypeA,ViewTypeB,Layout,ExecSpace,6,iType,KOKKOS_IMPL_COMPILI
   ViewTypeA a;
   ViewTypeB b;
 
-  typedef Kokkos::Rank<6,ViewFillLayoutSelector<Layout>::iterate,ViewFillLayoutSelector<Layout>::iterate> iterate_type;
+  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+  typedef Kokkos::Rank<6,outer_iteration_pattern,inner_iteration_pattern> iterate_type;
   typedef Kokkos::MDRangePolicy<ExecSpace,iterate_type,Kokkos::IndexType<iType>> policy_type;
 
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_):a(a_),b(b_) {
@@ -566,7 +575,9 @@ struct ViewCopy<ViewTypeA,ViewTypeB,Layout,ExecSpace,7,iType,KOKKOS_IMPL_COMPILI
   ViewTypeA a;
   ViewTypeB b;
 
-  typedef Kokkos::Rank<6,ViewFillLayoutSelector<Layout>::iterate,ViewFillLayoutSelector<Layout>::iterate> iterate_type;
+  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+  typedef Kokkos::Rank<6,outer_iteration_pattern,inner_iteration_pattern> iterate_type;
   typedef Kokkos::MDRangePolicy<ExecSpace,iterate_type,Kokkos::IndexType<iType>> policy_type;
 
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_):a(a_),b(b_) {
@@ -590,7 +601,9 @@ struct ViewCopy<ViewTypeA,ViewTypeB,Layout,ExecSpace,8,iType,KOKKOS_IMPL_COMPILI
   ViewTypeA a;
   ViewTypeB b;
 
-  typedef Kokkos::Rank<6,ViewFillLayoutSelector<Layout>::iterate,ViewFillLayoutSelector<Layout>::iterate> iterate_type;
+  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::outer_iteration_pattern;
+  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::layout_iterate_type_selector<Layout>::inner_iteration_pattern;
+  typedef Kokkos::Rank<6,outer_iteration_pattern,inner_iteration_pattern> iterate_type;
   typedef Kokkos::MDRangePolicy<ExecSpace,iterate_type,Kokkos::IndexType<iType>> policy_type;
 
   ViewCopy(const ViewTypeA& a_, const ViewTypeB& b_):a(a_),b(b_) {
@@ -642,20 +655,30 @@ void view_copy(const DstType& dst, const SrcType& src) {
   int64_t strides[DstType::Rank+1];
   dst.stride(strides);
   Kokkos::Iterate iterate;
-  if        ( std::is_same<typename DstType::array_layout,Kokkos::LayoutRight>::value ) {
+//  Kokkos::Iterate iterate_inner;
+  if        ( Kokkos::check_layout_is_tiled<typename DstType::array_layout>::value ) {
+    iterate = Kokkos::layout_iterate_type_selector<typename DstType::array_layout>::outer_iteration_pattern;
+//    iterate_inner = Kokkos::layout_iterate_type_selector::inner_iteration_pattern;
+  } else if        ( std::is_same<typename DstType::array_layout,Kokkos::LayoutRight>::value ) {
     iterate = Kokkos::Iterate::Right;
+//    iterate_inner = Kokkos::Iterate::Right;
   } else if ( std::is_same<typename DstType::array_layout,Kokkos::LayoutLeft>::value ) {
     iterate = Kokkos::Iterate::Left;
+//    iterate_inner = Kokkos::Iterate::Left;
   } else if ( std::is_same<typename DstType::array_layout,Kokkos::LayoutStride>::value ) {
     if( strides[0] > strides[DstType::Rank-1] )
       iterate = Kokkos::Iterate::Right;
+//      iterate_inner = Kokkos::Iterate::Right;
     else
       iterate = Kokkos::Iterate::Left;
+//      iterate_inner = Kokkos::Iterate::Left;
   } else {
     if( std::is_same<typename DstType::execution_space::array_layout, Kokkos::LayoutRight>::value )
       iterate = Kokkos::Iterate::Right;
+//      iterate_inner = Kokkos::Iterate::Right;
     else
       iterate = Kokkos::Iterate::Left;
+//      iterate_inner = Kokkos::Iterate::Left;
   }
 
   if( (dst.span() >= size_t(std::numeric_limits<int>::max())) ||

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -656,7 +656,7 @@ void view_copy(const DstType& dst, const SrcType& src) {
   dst.stride(strides);
   Kokkos::Iterate iterate;
 //  Kokkos::Iterate iterate_inner;
-  if        ( Kokkos::check_layout_is_tiled<typename DstType::array_layout>::value ) {
+  if        ( Kokkos::is_layouttiled<typename DstType::array_layout>::value ) {
     iterate = Kokkos::layout_iterate_type_selector<typename DstType::array_layout>::outer_iteration_pattern;
 //    iterate_inner = Kokkos::layout_iterate_type_selector::inner_iteration_pattern;
   } else if        ( std::is_same<typename DstType::array_layout,Kokkos::LayoutRight>::value ) {

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -243,6 +243,85 @@ struct LayoutTileLeft {
     : dimension { argN0 , argN1 , argN2 , argN3 , argN4 , argN5 , argN6 , argN7 } {}
 };
 
+
+/// LayoutTiled Specializations
+
+// TODO: Remove this enum class after resolving where to move the same class in MDRangePolicy to for reuse
+namespace Pattern {
+enum class Iterate
+{
+  Left,    // Left indices stride fastest
+  Right,   // Right indices stride fastest
+};
+} // end namespace Pattern
+
+// Must have Rank >= 2
+// TODO: Possibly specialize for each rank, allow for iterate pattern to default
+template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP,
+           unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 = 0,  unsigned ArgN3 = 0,  unsigned ArgN4 = 0,  unsigned ArgN5 = 0,  unsigned ArgN6 = 0,  unsigned ArgN7 = 0, 
+           bool IsPowerOfTwo = 
+#if 1
+           true
+#else
+           ( Impl::is_integral_power_of_two(ArgN0) &&
+                                 Impl::is_integral_power_of_two(ArgN1) &&
+                                 Impl::is_integral_power_of_two(ArgN2) &&
+                                 Impl::is_integral_power_of_two(ArgN3) &&
+                                 Impl::is_integral_power_of_two(ArgN4) &&
+                                 Impl::is_integral_power_of_two(ArgN5) &&
+                                 Impl::is_integral_power_of_two(ArgN6) &&
+                                 Impl::is_integral_power_of_two(ArgN7)
+                               )
+#endif
+         >
+struct LayoutTiled {
+
+#if 0
+  static_assert( Impl::is_integral_power_of_two(ArgN0) &&
+                 Impl::is_integral_power_of_two(ArgN1) &&
+                 Impl::is_integral_power_of_two(ArgN2) &&
+                 Impl::is_integral_power_of_two(ArgN3) &&
+                 Impl::is_integral_power_of_two(ArgN4) &&
+                 Impl::is_integral_power_of_two(ArgN5) &&
+                 Impl::is_integral_power_of_two(ArgN6) &&
+                 Impl::is_integral_power_of_two(ArgN7)
+               , "LayoutTiled must be given power-of-two tile dimensions" );
+#endif
+
+  //! Tag this class as a kokkos array_layout
+  typedef LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, IsPowerOfTwo> array_layout ;
+  static constexpr Pattern::Iterate outer_pattern = OuterP;
+  static constexpr Pattern::Iterate inner_pattern = InnerP;
+
+  enum { N0 = ArgN0 };
+  enum { N1 = ArgN1 };
+  enum { N2 = ArgN2 };
+  enum { N3 = ArgN3 };
+  enum { N4 = ArgN4 };
+  enum { N5 = ArgN5 };
+  enum { N6 = ArgN6 };
+  enum { N7 = ArgN7 };
+
+  size_t dimension[ ARRAY_LAYOUT_MAX_RANK ] ;
+
+  enum { is_extent_constructible = true };
+
+  LayoutTiled( LayoutTiled const & ) = default ;
+  LayoutTiled( LayoutTiled && ) = default ;
+  LayoutTiled & operator = ( LayoutTiled const & ) = default ;
+  LayoutTiled & operator = ( LayoutTiled && ) = default ;
+
+  KOKKOS_INLINE_FUNCTION
+  explicit constexpr
+  LayoutTiled( size_t argN0 = 0 , size_t argN1 = 0 , size_t argN2 = 0 , size_t argN3 = 0
+                , size_t argN4 = 0 , size_t argN5 = 0 , size_t argN6 = 0 , size_t argN7 = 0
+                )
+    : dimension { argN0 , argN1 , argN2 , argN3 , argN4 , argN5 , argN6 , argN7 } {}
+};
+
+
+
+
 } // namespace Kokkos
 
 #endif // #ifndef KOKKOS_LAYOUT_HPP

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -262,10 +262,10 @@ struct is_layouttiled : std::false_type {};
 template < typename LayoutTiledCheck >
 struct is_layouttiled< LayoutTiledCheck, typename std::enable_if<LayoutTiledCheck::is_array_layout_tiled>::type > : std::true_type {};
 
+namespace Experimental {
 
 /// LayoutTiled
 // Must have Rank >= 2
-// TODO: Possibly allow default iterate patterns by specializing for each rank
 template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP,
            unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 = 0,  unsigned ArgN3 = 0,  unsigned ArgN4 = 0,  unsigned ArgN5 = 0,  unsigned ArgN6 = 0,  unsigned ArgN7 = 0, 
            bool IsPowerOfTwo = 
@@ -325,6 +325,8 @@ struct LayoutTiled {
                 )
     : dimension { argN0 , argN1 , argN2 , argN3 , argN4 , argN5 , argN6 , argN7 } {}
 };
+
+} // namespace Experimental
 #endif
 
 
@@ -352,25 +354,25 @@ struct layout_iterate_type_selector< Kokkos::LayoutStride > {
 
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE
 template < unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 >
-struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
+struct layout_iterate_type_selector< Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
   static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Left ;
   static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Left ;
 };
 
 template < unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 >
-struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
+struct layout_iterate_type_selector< Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
   static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Right ;
   static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Left ;
 };
 
 template < unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 >
-struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
+struct layout_iterate_type_selector< Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
   static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Left ;
   static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Right ;
 };
 
 template < unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 >
-struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
+struct layout_iterate_type_selector< Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
   static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Right ;
   static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Right ;
 };

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -247,18 +247,6 @@ struct LayoutTileLeft {
 //////////////////////////////////////////////////////////////////////////////////////
 
 /// LayoutTiled Specializations
-
-// TODO: Remove this enum class after resolving where to move the same class in MDRangePolicy to for reuse
-namespace Pattern {
-enum class Iterate
-{
-  Left,    // Left indices stride fastest
-  Right   // Right indices stride fastest
-};
-} // end namespace Pattern
-
-// TODO: Find a home for me and delete from here, as well including this file in KokkosExp_MDRange
-// Copied here and commented out of KokkosExp_MDRangePolicy.hpp code (and this file is included as header there).
 enum class Iterate
 {
   Default,
@@ -277,7 +265,7 @@ struct check_layout_is_tiled< LayoutTiledCheck, typename std::enable_if<LayoutTi
 
 // Must have Rank >= 2
 // TODO: Possibly allow default iterate patterns by specializing for each rank
-template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP,
+template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP,
            unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 = 0,  unsigned ArgN3 = 0,  unsigned ArgN4 = 0,  unsigned ArgN5 = 0,  unsigned ArgN6 = 0,  unsigned ArgN7 = 0, 
            bool IsPowerOfTwo = 
 #if 1
@@ -312,8 +300,8 @@ struct LayoutTiled {
   enum { is_array_tiled_layout = true };
 
   typedef LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, IsPowerOfTwo> array_layout ;
-  static constexpr Pattern::Iterate outer_pattern = OuterP;
-  static constexpr Pattern::Iterate inner_pattern = InnerP;
+  static constexpr Iterate outer_pattern = OuterP;
+  static constexpr Iterate inner_pattern = InnerP;
 
   enum { N0 = ArgN0 };
   enum { N1 = ArgN1 };
@@ -370,25 +358,25 @@ struct layout_iterate_type_selector< Kokkos::LayoutStride > {
 };
 
 template < unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 >
-struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Left, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
+struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
   static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Left ;
   static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Left ;
 };
 
 template < unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 >
-struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Left, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
+struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
   static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Right ;
   static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Left ;
 };
 
 template < unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 >
-struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Right, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
+struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
   static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Left ;
   static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Right ;
 };
 
 template < unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 >
-struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Right, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
+struct layout_iterate_type_selector< Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > {
   static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Right ;
   static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Right ;
 };

--- a/core/src/impl/Kokkos_ViewLayoutTiled.hpp
+++ b/core/src/impl/Kokkos_ViewLayoutTiled.hpp
@@ -317,6 +317,22 @@ public:
   KOKKOS_INLINE_FUNCTION constexpr size_type stride_6() const { return 0 ; }
   KOKKOS_INLINE_FUNCTION constexpr size_type stride_7() const { return 0 ; }
 
+  // Stride with [ rank ] value is the total length
+  template< typename iType >
+  KOKKOS_INLINE_FUNCTION
+  void stride( iType * const s ) const
+    {
+      s[0] = 0 ;
+      if ( 0 < dimension_type::rank ) { s[1] = 0 ; }
+      if ( 1 < dimension_type::rank ) { s[2] = 0 ; }
+      if ( 2 < dimension_type::rank ) { s[3] = 0 ; }
+      if ( 3 < dimension_type::rank ) { s[4] = 0 ; }
+      if ( 4 < dimension_type::rank ) { s[5] = 0 ; }
+      if ( 5 < dimension_type::rank ) { s[6] = 0 ; }
+      if ( 6 < dimension_type::rank ) { s[7] = 0 ; }
+      if ( 7 < dimension_type::rank ) { s[8] = 0 ; }
+    }
+
   KOKKOS_INLINE_FUNCTION constexpr size_type span() const
     {
       // Rank2: ( NumTile0 * ( NumTile1 ) ) * TileSize, etc

--- a/core/src/impl/Kokkos_ViewLayoutTiled.hpp
+++ b/core/src/impl/Kokkos_ViewLayoutTiled.hpp
@@ -44,6 +44,8 @@
 #ifndef KOKKOS_EXPERIMENTAL_VIEWLAYOUTTILE_HPP
 #define KOKKOS_EXPERIMENTAL_VIEWLAYOUTTILE_HPP
 
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE
+
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_View.hpp>
 
@@ -53,9 +55,6 @@
 namespace Kokkos {
 
 // View offset and mapping for tiled view's
-
-//template< class L >
-//struct is_array_layout : public std::false_type {};
 
 template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 >
 struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, 0, 0, 0, 0, 0, 0, true> > : public std::true_type {};
@@ -82,8 +81,8 @@ struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2
 template< class L >
 struct is_array_layout_tiled : public std::false_type {};
 
-template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 > 
-struct is_array_layout_tiled < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > : public std::true_type {};
+template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 , unsigned ArgN7 , bool IsPowerTwo >
+struct is_array_layout_tiled < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, IsPowerTwo> > : public std::true_type {}; // Last template parameter "true" meaning this currently only supports powers-of-two
 
 
 namespace Impl {
@@ -945,7 +944,7 @@ tile_subview( const Kokkos::View<T********, Kokkos::LayoutTiled<OuterP,InnerP,N0
 }
 
 } /* namespace Kokkos */
-
+#endif //!defined(KOKKOS_ENABLE_DEPRECATED_CODE
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 

--- a/core/src/impl/Kokkos_ViewLayoutTiled.hpp
+++ b/core/src/impl/Kokkos_ViewLayoutTiled.hpp
@@ -1,0 +1,937 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_EXPERIMENTAL_VIEWLAYOUTTILE_HPP
+#define KOKKOS_EXPERIMENTAL_VIEWLAYOUTTILE_HPP
+
+#include <Kokkos_Layout.hpp>
+#include <Kokkos_View.hpp>
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace Kokkos {
+
+// View offset and mapping for tiled view's
+
+//template< class L >
+//struct is_array_layout : public std::false_type {};
+
+template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 >
+struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, 0, 0, 0, 0, 0, 0, true> > : public std::true_type {};
+
+template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 >
+struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, 0, 0, 0, 0, 0, true> > : public std::true_type {};
+
+template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 >
+struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, 0, 0, 0, 0, true> > : public std::true_type {};
+
+template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 >
+struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, 0, 0, 0, true> > : public std::true_type {};
+
+template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 >
+struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, 0, 0, true> > : public std::true_type {};
+
+template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 >
+struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, 0, true> > : public std::true_type {};
+
+template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 > 
+struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > : public std::true_type {};
+
+
+template< class L >
+struct is_array_layout_tiled : public std::false_type {};
+
+template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 > 
+struct is_array_layout_tiled < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > : public std::true_type {};
+
+
+namespace Impl {
+
+template< class Dimension , class Layout >
+struct ViewOffset< Dimension , Layout ,
+  typename std::enable_if<(
+    ( Dimension::rank <= 8 )
+    &&
+    ( Dimension::rank >= 2 )
+    &&
+    is_array_layout< Layout >::value
+    &&
+    is_array_layout_tiled< Layout >::value
+  )>::type >
+{
+public:
+
+//  enum { outer_pattern = Layout::outer_pattern };
+//  enum { inner_pattern = Layout::inner_pattern };
+  static constexpr Kokkos::Pattern::Iterate outer_pattern = Layout::outer_pattern;
+  static constexpr Kokkos::Pattern::Iterate inner_pattern = Layout::inner_pattern;
+
+  enum { VORank = Dimension::rank };
+
+  enum { SHIFT_0 = Kokkos::Impl::integral_power_of_two(Layout::N0) };
+  enum { SHIFT_1 = Kokkos::Impl::integral_power_of_two(Layout::N1) };
+  enum { SHIFT_2 = Kokkos::Impl::integral_power_of_two(Layout::N2) };
+  enum { SHIFT_3 = Kokkos::Impl::integral_power_of_two(Layout::N3) };
+  enum { SHIFT_4 = Kokkos::Impl::integral_power_of_two(Layout::N4) };
+  enum { SHIFT_5 = Kokkos::Impl::integral_power_of_two(Layout::N5) };
+  enum { SHIFT_6 = Kokkos::Impl::integral_power_of_two(Layout::N6) };
+  enum { SHIFT_7 = Kokkos::Impl::integral_power_of_two(Layout::N7) };
+  enum { MASK_0  = Layout::N0 - 1 };
+  enum { MASK_1  = Layout::N1 - 1 };
+  enum { MASK_2  = Layout::N2 - 1 };
+  enum { MASK_3  = Layout::N3 - 1 };
+  enum { MASK_4  = Layout::N4 - 1 };
+  enum { MASK_5  = Layout::N5 - 1 };
+  enum { MASK_6  = Layout::N6 - 1 };
+  enum { MASK_7  = Layout::N7 - 1 };
+
+  enum { SHIFT_2T = SHIFT_0 + SHIFT_1 };
+  enum { SHIFT_3T = SHIFT_0 + SHIFT_1 + SHIFT_2 };
+  enum { SHIFT_4T = SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 };
+  enum { SHIFT_5T = SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 + SHIFT_4 };
+  enum { SHIFT_6T = SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 + SHIFT_4 + SHIFT_5 };
+  enum { SHIFT_7T = SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 + SHIFT_4 + SHIFT_5 + SHIFT_6 };
+  enum { SHIFT_8T = SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 + SHIFT_4 + SHIFT_5 + SHIFT_6 + SHIFT_7 };
+
+  // Is an irregular layout that does not have uniform striding for each index.
+  using is_mapping_plugin = std::true_type ;
+  using is_regular        = std::false_type ;
+
+  typedef size_t     size_type ;
+  typedef Dimension  dimension_type ;
+  typedef Layout     array_layout ;
+
+  dimension_type m_dim ;
+  size_type      m_tile_N0 ; // Num tiles dim 0
+  size_type      m_tile_N1 ;
+  size_type      m_tile_N2 ;
+  size_type      m_tile_N3 ;
+  size_type      m_tile_N4 ;
+  size_type      m_tile_N5 ;
+  size_type      m_tile_N6 ;
+  size_type      m_tile_N7 ;
+
+  //----------------------------------------
+
+#define DEBUG_OUTPUT_CHECK 0
+
+  // Rank 2
+  template< typename I0 , typename I1 >
+  KOKKOS_INLINE_FUNCTION
+  size_type operator()( I0 const & i0 , I1 const & i1 ) const {
+    auto tile_offset = (outer_pattern == (Kokkos::Pattern::Iterate::Left)) 
+                     ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1)) ) << SHIFT_2T)
+                     : ( ( (m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) ) << SHIFT_2T) ;
+    //                     ( num_tiles[1] * ti0     +  ti1 ) * FTD
+
+    auto local_offset = (inner_pattern == (Kokkos::Pattern::Iterate::Left)) 
+                      ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) )
+                      : ( ((i0 & MASK_0) << SHIFT_1) + (i1 & MASK_1) ) ;
+    //                     ( tile_dim[1] * li0         +  li1 )
+
+#if DEBUG_OUTPUT_CHECK
+    std::cout << "Am I Outer Left? " << (outer_pattern == (Kokkos::Pattern::Iterate::Left)) << std::endl;
+    std::cout << "Am I Inner Left? " << (inner_pattern == (Kokkos::Pattern::Iterate::Left)) << std::endl;
+    std::cout << "i0 = " << i0
+      << " i1 = " << i1
+      << "\ntilei0 = " << (i0>>SHIFT_0)
+      << " tilei1 = " << (i1>>SHIFT_1)
+      << "locali0 = " << (i0 & MASK_0)
+      << "\nlocali1 = " << (i1 & MASK_1) 
+      << std::endl;
+#endif
+
+    return tile_offset + local_offset;
+  }
+
+  // Rank 3
+  template< typename I0 , typename I1 , typename I2 >
+  KOKKOS_INLINE_FUNCTION
+  size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 ) const {
+    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+                     ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*(i2>>SHIFT_2)) ) << SHIFT_3T)
+                     : ( ( m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2) ) << SHIFT_3T) ;
+
+    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+                      ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) )
+                      : ( ((i0 & MASK_0) << (SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_2)) + (i2 & MASK_2) ) ;
+
+#if DEBUG_OUTPUT_CHECK
+    std::cout << "Am I Outer Left? " << (outer_pattern == (Kokkos::Pattern::Iterate::Left)) << std::endl;
+    std::cout << "Am I Inner Left? " << (inner_pattern == (Kokkos::Pattern::Iterate::Left)) << std::endl;
+    std::cout << "i0 = " << i0
+      << " i1 = " << i1
+      << " i2 = " << i2
+      << "\ntilei0 = " << (i0>>SHIFT_0)
+      << " tilei1 = " << (i1>>SHIFT_1)
+      << " tilei2 = " << (i2>>SHIFT_2)
+      << "\nlocali0 = " << (i0 & MASK_0)
+      << "locali1 = " << (i1 & MASK_1)
+      << "locali2 = " << (i2 & MASK_2)
+      << std::endl;
+#endif
+
+    return tile_offset + local_offset;
+  }
+
+  // Rank 4
+  template< typename I0 , typename I1 , typename I2 , typename I3 >
+  KOKKOS_INLINE_FUNCTION
+  size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 , I3 const & i3 ) const {
+    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+                     ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*((i2>>SHIFT_2) + m_tile_N2*(i3>>SHIFT_3))) ) << SHIFT_4T)
+                     : ( ( m_tile_N3*(m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2)) + (i3>>SHIFT_3) ) << SHIFT_4T) ;
+
+    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+                      ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) + ((i3 & MASK_3)<<(SHIFT_0+SHIFT_1+SHIFT_2)) )
+                      : ( ((i0 & MASK_0) << (SHIFT_3+SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_3+SHIFT_2)) + ((i2 & MASK_2)<<(SHIFT_3)) + (i3 & MASK_3) ) ;
+
+    return tile_offset + local_offset;
+  }
+
+  // Rank 5
+  template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 >
+  KOKKOS_INLINE_FUNCTION
+  size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 , I3 const & i3 , I4 const & i4 ) const {
+    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+                     ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*((i2>>SHIFT_2) + m_tile_N2*((i3>>SHIFT_3) + m_tile_N3*(i4>>SHIFT_4)))) ) << SHIFT_5T)
+                     : ( ( m_tile_N4*(m_tile_N3*(m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2)) + (i3>>SHIFT_3)) + (i4>>SHIFT_4) ) << SHIFT_5T) ;
+
+    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+                      ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) + ((i3 & MASK_3)<<(SHIFT_0+SHIFT_1+SHIFT_2)) + ((i4 & MASK_4)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3)) )
+                      : ( ((i0 & MASK_0) << (SHIFT_4+SHIFT_3+SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_4+SHIFT_3+SHIFT_2)) + ((i2 & MASK_2)<<(SHIFT_4+SHIFT_3)) + ((i3 & MASK_3)<<(SHIFT_4)) + (i4 & MASK_4) ) ;
+
+    return tile_offset + local_offset;
+  }
+
+  // Rank 6
+  template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 , typename I5 >
+  KOKKOS_INLINE_FUNCTION
+  size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 , I3 const & i3 , I4 const & i4 , I5 const & i5 ) const {
+    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+                     ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*((i2>>SHIFT_2) + m_tile_N2*((i3>>SHIFT_3) + m_tile_N3*((i4>>SHIFT_4) + m_tile_N4*(i5>>SHIFT_5))))) ) << SHIFT_6T)
+                     : ( ( m_tile_N5*(m_tile_N4*(m_tile_N3*(m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2)) + (i3>>SHIFT_3)) + (i4>>SHIFT_4)) + (i5>>SHIFT_5) ) << SHIFT_6T) ;
+
+    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+                      ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) + ((i3 & MASK_3)<<(SHIFT_0+SHIFT_1+SHIFT_2)) + ((i4 & MASK_4)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3)) + ((i5 & MASK_5)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4)) )
+                      : ( ((i0 & MASK_0) << (SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2)) + ((i2 & MASK_2)<<(SHIFT_5+SHIFT_4+SHIFT_3)) + ((i3 & MASK_3)<<(SHIFT_5+SHIFT_4)) + ((i4 & MASK_4)<<(SHIFT_5)) + (i5 & MASK_5) ) ;
+
+    return tile_offset + local_offset;
+  }
+
+  // Rank 7
+  template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 , typename I5 , typename I6 >
+  KOKKOS_INLINE_FUNCTION
+  size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 , I3 const & i3 , I4 const & i4 , I5 const & i5 , I6 const & i6 ) const {
+    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+                     ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*((i2>>SHIFT_2) + m_tile_N2*((i3>>SHIFT_3) + m_tile_N3*((i4>>SHIFT_4) + m_tile_N4*((i5>>SHIFT_5) + m_tile_N5*(i6>>SHIFT_6)))))) ) << SHIFT_7T)
+                     : ( ( m_tile_N6*(m_tile_N5*(m_tile_N4*(m_tile_N3*(m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2)) + (i3>>SHIFT_3)) + (i4>>SHIFT_4)) + (i5>>SHIFT_5)) + (i6>>SHIFT_6) ) << SHIFT_7T) ;
+
+    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+                      ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) + ((i3 & MASK_3)<<(SHIFT_0+SHIFT_1+SHIFT_2)) + ((i4 & MASK_4)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3)) + ((i5 & MASK_5)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4)) + ((i6 & MASK_6)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4+SHIFT_5)) )
+                      : ( ((i0 & MASK_0) << (SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2)) + ((i2 & MASK_2)<<(SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3)) + ((i3 & MASK_3)<<(SHIFT_6+SHIFT_5+SHIFT_4)) + ((i4 & MASK_4)<<(SHIFT_6+SHIFT_5)) + ((i5 & MASK_5)<<(SHIFT_6)) + (i6 & MASK_6) ) ;
+
+    return tile_offset + local_offset;
+  }
+
+  // Rank 8
+  template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 , typename I5 , typename I6 , typename I7 >
+  KOKKOS_INLINE_FUNCTION
+  size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 , I3 const & i3 , I4 const & i4 , I5 const & i5 , I6 const & i6 , I7 const & i7 ) const {
+    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+                     ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*((i2>>SHIFT_2) + m_tile_N2*((i3>>SHIFT_3) + m_tile_N3*((i4>>SHIFT_4) + m_tile_N4*((i5>>SHIFT_5) + m_tile_N5*((i6>>SHIFT_6) + m_tile_N6*(i7>>SHIFT_7))))))) ) << SHIFT_8T)
+                     : ( ( m_tile_N7*(m_tile_N6*(m_tile_N5*(m_tile_N4*(m_tile_N3*(m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2)) + (i3>>SHIFT_3)) + (i4>>SHIFT_4)) + (i5>>SHIFT_5)) + (i6>>SHIFT_6)) + (i7>>SHIFT_7) ) << SHIFT_8T) ;
+
+    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+                      ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) + ((i3 & MASK_3)<<(SHIFT_0+SHIFT_1+SHIFT_2)) + ((i4 & MASK_4)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3)) + ((i5 & MASK_5)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4)) + ((i6 & MASK_6)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4+SHIFT_5)) + ((i7 & MASK_7)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4+SHIFT_5+SHIFT_6)) )
+                      : ( ((i0 & MASK_0) << (SHIFT_7+SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_7+SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2)) + ((i2 & MASK_2)<<(SHIFT_7+SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3)) + ((i3 & MASK_3)<<(SHIFT_7+SHIFT_6+SHIFT_5+SHIFT_4)) + ((i4 & MASK_4)<<(SHIFT_7+SHIFT_6+SHIFT_5)) + ((i5 & MASK_5)<<(SHIFT_7+SHIFT_6)) + ((i6 & MASK_6)<<(SHIFT_7)) + (i7 & MASK_7) ) ;
+
+    return tile_offset + local_offset;
+  }
+
+  //----------------------------------------
+
+  KOKKOS_INLINE_FUNCTION constexpr
+  array_layout layout() const
+    { return array_layout( m_dim.N0 , m_dim.N1 , m_dim.N2 , m_dim.N2  , m_dim.N3  , m_dim.N4  , m_dim.N5  , m_dim.N6  , m_dim.N7 ); }
+
+  KOKKOS_INLINE_FUNCTION constexpr size_type dimension_0() const { return m_dim.N0 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type dimension_1() const { return m_dim.N1 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type dimension_2() const { return m_dim.N2 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type dimension_3() const { return m_dim.N3 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type dimension_4() const { return m_dim.N4 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type dimension_5() const { return m_dim.N5 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type dimension_6() const { return m_dim.N6 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type dimension_7() const { return m_dim.N7 ; }
+
+  KOKKOS_INLINE_FUNCTION constexpr size_type size() const { return m_dim.N0 * m_dim.N1 * m_dim.N2 * m_dim.N3 * m_dim.N4 * m_dim.N5 * m_dim.N6 * m_dim.N7 ; }
+
+  // Strides are meaningless due to irregularity
+  KOKKOS_INLINE_FUNCTION constexpr size_type stride_0() const { return 0 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type stride_1() const { return 0 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type stride_2() const { return 0 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type stride_3() const { return 0 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type stride_4() const { return 0 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type stride_5() const { return 0 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type stride_6() const { return 0 ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type stride_7() const { return 0 ; }
+
+  KOKKOS_INLINE_FUNCTION constexpr size_type span() const
+    {
+      // Rank2: ( NumTile0 * ( NumTile1 ) ) * TileSize, etc
+      return   ( VORank == 2 ) ? ( m_tile_N0 * m_tile_N1 ) << SHIFT_2T
+             : ( VORank == 3 ) ? ( m_tile_N0 * m_tile_N1 * m_tile_N2 ) << SHIFT_3T
+             : ( VORank == 4 ) ? ( m_tile_N0 * m_tile_N1 * m_tile_N2 * m_tile_N3 ) << SHIFT_4T
+             : ( VORank == 5 ) ? ( m_tile_N0 * m_tile_N1 * m_tile_N2 * m_tile_N3 * m_tile_N4 ) << SHIFT_5T
+             : ( VORank == 6 ) ? ( m_tile_N0 * m_tile_N1 * m_tile_N2 * m_tile_N3 * m_tile_N4 * m_tile_N5 ) << SHIFT_6T
+             : ( VORank == 7 ) ? ( m_tile_N0 * m_tile_N1 * m_tile_N2 * m_tile_N3 * m_tile_N4 * m_tile_N5 * m_tile_N6 ) << SHIFT_7T
+             : ( m_tile_N0 * m_tile_N1 * m_tile_N2 * m_tile_N3 * m_tile_N4 * m_tile_N5 * m_tile_N6 * m_tile_N7 ) << SHIFT_8T ;
+    }
+
+  KOKKOS_INLINE_FUNCTION constexpr bool span_is_contiguous() const
+    {
+      // Only if dimensions align with tile size
+      return   ( VORank == 2 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0
+             : ( VORank == 3 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0
+             : ( VORank == 4 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0 && ( m_dim.N3 && MASK_3 ) == 0
+             : ( VORank == 5 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0 && ( m_dim.N3 && MASK_3 ) == 0 && ( m_dim.N4 && MASK_4 ) == 0
+             : ( VORank == 6 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0 && ( m_dim.N3 && MASK_3 ) == 0 && ( m_dim.N4 && MASK_4 ) == 0 && ( m_dim.N5 && MASK_5 ) == 0
+             : ( VORank == 7 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0 && ( m_dim.N3 && MASK_3 ) == 0 && ( m_dim.N4 && MASK_4 ) == 0 && ( m_dim.N5 && MASK_5 ) == 0 && ( m_dim.N6 && MASK_6 ) == 0
+             : ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0 && ( m_dim.N3 && MASK_3 ) == 0 && ( m_dim.N4 && MASK_4 ) == 0 && ( m_dim.N5 && MASK_5 ) == 0 && ( m_dim.N6 && MASK_6 ) == 0 && ( m_dim.N7 && MASK_7 ) ;
+    }
+
+  //----------------------------------------
+
+#ifdef KOKKOS_CUDA_9_DEFAULTED_BUG_WORKAROUND
+  KOKKOS_INLINE_FUNCTION ~ViewOffset() {}
+  KOKKOS_INLINE_FUNCTION ViewOffset() {}
+  KOKKOS_INLINE_FUNCTION ViewOffset( const ViewOffset & rhs )
+  : m_dim(rhs.m_dim)
+  , m_tile_N0(rhs.m_tile_N0)
+  , m_tile_N1(rhs.m_tile_N1)
+  , m_tile_N2(rhs.m_tile_N2)
+  , m_tile_N3(rhs.m_tile_N3)
+  , m_tile_N4(rhs.m_tile_N4)
+  , m_tile_N5(rhs.m_tile_N5)
+  , m_tile_N6(rhs.m_tile_N6)
+  , m_tile_N7(rhs.m_tile_N7)
+  {}
+
+  KOKKOS_INLINE_FUNCTION ViewOffset & operator = ( const ViewOffset & rhs ) {
+    m_dim = rhs.m_dim;
+    m_tile_N0 = rhs.m_tile_N0;
+    m_tile_N1 = rhs.m_tile_N1;
+    m_tile_N2 = rhs.m_tile_N2;
+    m_tile_N3 = rhs.m_tile_N3;
+    m_tile_N4 = rhs.m_tile_N4;
+    m_tile_N5 = rhs.m_tile_N5;
+    m_tile_N6 = rhs.m_tile_N6;
+    m_tile_N7 = rhs.m_tile_N7;
+    return *this;
+  }
+
+#else
+  KOKKOS_INLINE_FUNCTION ~ViewOffset() = default;
+  KOKKOS_INLINE_FUNCTION ViewOffset() = default;
+  KOKKOS_INLINE_FUNCTION ViewOffset( const ViewOffset & ) = default;
+  KOKKOS_INLINE_FUNCTION ViewOffset & operator = ( const ViewOffset & ) = default;
+#endif
+
+  template< unsigned TrivialScalarSize >
+  KOKKOS_INLINE_FUNCTION
+  constexpr ViewOffset( std::integral_constant<unsigned,TrivialScalarSize> const & ,
+                        array_layout const arg_layout )
+    : m_dim( arg_layout.dimension[0], arg_layout.dimension[1], arg_layout.dimension[2], arg_layout.dimension[3], arg_layout.dimension[4], arg_layout.dimension[5], arg_layout.dimension[6], arg_layout.dimension[7] )
+    , m_tile_N0( ( arg_layout.dimension[0] + MASK_0 ) >> SHIFT_0 /* number of tiles in first dimension */ )
+    , m_tile_N1( ( arg_layout.dimension[1] + MASK_1 ) >> SHIFT_1 )
+    , m_tile_N2( (VORank > 2 ) ? ( arg_layout.dimension[2] + MASK_2 ) >> SHIFT_2 : 0 )
+    , m_tile_N3( (VORank > 3 ) ? ( arg_layout.dimension[3] + MASK_3 ) >> SHIFT_3 : 0 )
+    , m_tile_N4( (VORank > 4 ) ? ( arg_layout.dimension[4] + MASK_4 ) >> SHIFT_4 : 0 )
+    , m_tile_N5( (VORank > 5 ) ? ( arg_layout.dimension[5] + MASK_5 ) >> SHIFT_5 : 0 )
+    , m_tile_N6( (VORank > 6 ) ? ( arg_layout.dimension[6] + MASK_6 ) >> SHIFT_6 : 0 )
+    , m_tile_N7( (VORank > 7 ) ? ( arg_layout.dimension[7] + MASK_7 ) >> SHIFT_7 : 0 )
+    {}
+
+};
+
+
+//----------------------------------------
+
+
+// ViewMapping assign method needed in order to return a 'subview' tile as a proper View
+// The outer iteration pattern determines the mapping of the pointer offset to the beginning of requested tile
+// The inner iteration pattern is needed for the layout of the tile's View to be returned
+// Rank 2
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+        , class ... P
+        , typename iType0 , typename iType1
+        >
+struct ViewMapping
+  < typename std::enable_if< (N2 == 0 && N3 == 0 && N4 == 0 && N5 == 0 && N6 == 0 && N7 == 0) >::type //void
+  , Kokkos::ViewTraits<T**,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , iType0
+  , iType1 >
+{
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::ViewTraits< T** , src_layout , P... > src_traits ;
+
+  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::ViewTraits< T[N0][N1] , array_layout , P ... > traits ;
+  typedef Kokkos::View< T[N0][N1] , array_layout , P ... > type ;
+
+  KOKKOS_INLINE_FUNCTION static
+  void assign( ViewMapping< traits , void > & dst
+             , const ViewMapping< src_traits , void > & src
+             , const src_layout &
+             , const iType0 i_tile0
+             , const iType1 i_tile1
+             )
+    {
+      typedef ViewMapping< traits , void >        dst_map_type ;
+      typedef ViewMapping< src_traits , void >    src_map_type ;
+      typedef typename dst_map_type::handle_type  dst_handle_type ;
+      typedef typename dst_map_type::offset_type  dst_offset_type ;
+      typedef typename src_map_type::offset_type  src_offset_type ;
+
+      dst = dst_map_type(
+         dst_handle_type( src.m_handle +
+                          ( is_outer_left ? ( (i_tile0 + src.m_offset.m_tile_N0 * i_tile1) << src_offset_type::SHIFT_2T )
+                                          : ( (src.m_offset.m_tile_N1 * i_tile0 + i_tile1) << src_offset_type::SHIFT_2T )
+                          ) // offset to start of the tile
+                        )
+       , dst_offset_type() );
+    }
+};
+
+// Rank 3
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+        , class ... P
+        , typename iType0 , typename iType1 , typename iType2
+        >
+struct ViewMapping
+  < typename std::enable_if< (N3 == 0 && N4 == 0 && N5 == 0 && N6 == 0 && N7 == 0) >::type //void
+  , Kokkos::ViewTraits<T***,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , iType0
+  , iType1
+  , iType2 >
+{
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::ViewTraits< T*** , src_layout , P... > src_traits ;
+
+  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::ViewTraits< T[N0][N1][N2] , array_layout , P ... > traits ;
+  typedef Kokkos::View< T[N0][N1][N2] , array_layout , P ... > type ;
+
+  KOKKOS_INLINE_FUNCTION static
+  void assign( ViewMapping< traits , void > & dst
+             , const ViewMapping< src_traits , void > & src
+             , const src_layout &
+             , const iType0 i_tile0
+             , const iType1 i_tile1
+             , const iType2 i_tile2
+             )
+    {
+      typedef ViewMapping< traits , void >        dst_map_type ;
+      typedef ViewMapping< src_traits , void >    src_map_type ;
+      typedef typename dst_map_type::handle_type  dst_handle_type ;
+      typedef typename dst_map_type::offset_type  dst_offset_type ;
+      typedef typename src_map_type::offset_type  src_offset_type ;
+
+      dst = dst_map_type(
+         dst_handle_type( src.m_handle +
+                          ( is_outer_left ? ( ( i_tile0 + src.m_offset.m_tile_N0 * ( i_tile1 + src.m_offset.m_tile_N1 * i_tile2 ) ) << src_offset_type::SHIFT_3T ) 
+                                          : ( ( src.m_offset.m_tile_N2 * ( src.m_offset.m_tile_N1 * i_tile0 + i_tile1 ) + i_tile2 ) << src_offset_type::SHIFT_3T )
+                          )
+                        ) // offset to start of the tile
+       , dst_offset_type() );
+    }
+};
+
+// Rank 4
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+        , class ... P
+        , typename iType0 , typename iType1 , typename iType2 , typename iType3
+        >
+struct ViewMapping
+  < typename std::enable_if< (N4 == 0 && N5 == 0 && N6 == 0 && N7 == 0) >::type //void
+  , Kokkos::ViewTraits<T****,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , iType0
+  , iType1
+  , iType2 
+  , iType3 >
+{
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::ViewTraits< T**** , src_layout , P... > src_traits ;
+
+  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::ViewTraits< T[N0][N1][N2][N3] , array_layout , P ... > traits ;
+  typedef Kokkos::View< T[N0][N1][N2][N3] , array_layout , P ... > type ;
+
+  KOKKOS_INLINE_FUNCTION static
+  void assign( ViewMapping< traits , void > & dst
+             , const ViewMapping< src_traits , void > & src
+             , const src_layout &
+             , const iType0 i_tile0
+             , const iType1 i_tile1
+             , const iType2 i_tile2
+             , const iType3 i_tile3
+             )
+    {
+      typedef ViewMapping< traits , void >        dst_map_type ;
+      typedef ViewMapping< src_traits , void >    src_map_type ;
+      typedef typename dst_map_type::handle_type  dst_handle_type ;
+      typedef typename dst_map_type::offset_type  dst_offset_type ;
+      typedef typename src_map_type::offset_type  src_offset_type ;
+
+      dst = dst_map_type(
+         dst_handle_type( src.m_handle +
+                          ( is_outer_left ? ( ( i_tile0 + src.m_offset.m_tile_N0 * ( i_tile1 + src.m_offset.m_tile_N1 * ( i_tile2 + src.m_offset.m_tile_N2 * i_tile3 ) ) ) << src_offset_type::SHIFT_4T ) 
+                                          : ( ( src.m_offset.m_tile_N3 * ( src.m_offset.m_tile_N2 * ( src.m_offset.m_tile_N1 * i_tile0 + i_tile1 ) + i_tile2 ) + i_tile3 ) << src_offset_type::SHIFT_4T )
+                          )
+                        ) // offset to start of the tile
+       , dst_offset_type() );
+    }
+};
+
+// Rank 5
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+        , class ... P
+        , typename iType0 , typename iType1 , typename iType2 , typename iType3 , typename iType4
+        >
+struct ViewMapping
+  < typename std::enable_if< (N5 == 0 && N6 == 0 && N7 == 0) >::type //void
+  , Kokkos::ViewTraits<T*****,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , iType0
+  , iType1
+  , iType2 
+  , iType3
+  , iType4 >
+{
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::ViewTraits< T***** , src_layout , P... > src_traits ;
+
+  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::ViewTraits< T[N0][N1][N2][N3][N4] , array_layout , P ... > traits ;
+  typedef Kokkos::View< T[N0][N1][N2][N3][N4] , array_layout , P ... > type ;
+
+  KOKKOS_INLINE_FUNCTION static
+  void assign( ViewMapping< traits , void > & dst
+             , const ViewMapping< src_traits , void > & src
+             , const src_layout &
+             , const iType0 i_tile0
+             , const iType1 i_tile1
+             , const iType2 i_tile2
+             , const iType3 i_tile3
+             , const iType4 i_tile4
+             )
+    {
+      typedef ViewMapping< traits , void >        dst_map_type ;
+      typedef ViewMapping< src_traits , void >    src_map_type ;
+      typedef typename dst_map_type::handle_type  dst_handle_type ;
+      typedef typename dst_map_type::offset_type  dst_offset_type ;
+      typedef typename src_map_type::offset_type  src_offset_type ;
+
+      dst = dst_map_type(
+         dst_handle_type( src.m_handle +
+                          ( is_outer_left ? ( ( i_tile0 + src.m_offset.m_tile_N0 * ( i_tile1 + src.m_offset.m_tile_N1 * ( i_tile2 + src.m_offset.m_tile_N2 * ( i_tile3 + src.m_offset.m_tile_N3 * i_tile4 ) ) ) ) << src_offset_type::SHIFT_5T ) 
+                                          : ( ( src.m_offset.m_tile_N4 * ( src.m_offset.m_tile_N3 * ( src.m_offset.m_tile_N2 * ( src.m_offset.m_tile_N1 * i_tile0 + i_tile1 ) + i_tile2 ) + i_tile3 ) + i_tile4 ) << src_offset_type::SHIFT_5T )
+                          )
+                        ) // offset to start of the tile
+       , dst_offset_type() );
+    }
+};
+
+// Rank 6
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+        , class ... P
+        , typename iType0 , typename iType1 , typename iType2 , typename iType3 , typename iType4 , typename iType5
+        >
+struct ViewMapping
+  < typename std::enable_if< (N6 == 0 && N7 == 0) >::type //void
+  , Kokkos::ViewTraits<T******,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , iType0
+  , iType1
+  , iType2 
+  , iType3
+  , iType4
+  , iType5 >
+{
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::ViewTraits< T****** , src_layout , P... > src_traits ;
+
+  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::ViewTraits< T[N0][N1][N2][N3][N4][N5] , array_layout , P ... > traits ;
+  typedef Kokkos::View< T[N0][N1][N2][N3][N4][N5] , array_layout , P ... > type ;
+
+  KOKKOS_INLINE_FUNCTION static
+  void assign( ViewMapping< traits , void > & dst
+             , const ViewMapping< src_traits , void > & src
+             , const src_layout &
+             , const iType0 i_tile0
+             , const iType1 i_tile1
+             , const iType2 i_tile2
+             , const iType3 i_tile3
+             , const iType4 i_tile4
+             , const iType5 i_tile5
+             )
+    {
+      typedef ViewMapping< traits , void >        dst_map_type ;
+      typedef ViewMapping< src_traits , void >    src_map_type ;
+      typedef typename dst_map_type::handle_type  dst_handle_type ;
+      typedef typename dst_map_type::offset_type  dst_offset_type ;
+      typedef typename src_map_type::offset_type  src_offset_type ;
+
+      dst = dst_map_type(
+         dst_handle_type( src.m_handle +
+                          ( is_outer_left ? ( ( i_tile0 + src.m_offset.m_tile_N0 * ( i_tile1 + src.m_offset.m_tile_N1 * ( i_tile2 + src.m_offset.m_tile_N2 * ( i_tile3 + src.m_offset.m_tile_N3 * ( i_tile4 + src.m_offset.m_tile_N4 * i_tile5 ) ) ) ) ) << src_offset_type::SHIFT_6T ) 
+                                          : ( ( src.m_offset.m_tile_N5 * ( src.m_offset.m_tile_N4 * ( src.m_offset.m_tile_N3 * ( src.m_offset.m_tile_N2 * ( src.m_offset.m_tile_N1 * i_tile0 + i_tile1 ) + i_tile2 ) + i_tile3 ) + i_tile4 ) + i_tile5 ) << src_offset_type::SHIFT_6T )
+                          )
+                        ) // offset to start of the tile
+       , dst_offset_type() );
+    }
+};
+
+// Rank 7
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+        , class ... P
+        , typename iType0 , typename iType1 , typename iType2 , typename iType3 , typename iType4 , typename iType5 , typename iType6
+        >
+struct ViewMapping
+  < typename std::enable_if< (N7 == 0) >::type //void
+  , Kokkos::ViewTraits<T*******,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , iType0
+  , iType1
+  , iType2 
+  , iType3
+  , iType4
+  , iType5 
+  , iType6 >
+{
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::ViewTraits< T******* , src_layout , P... > src_traits ;
+
+  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::ViewTraits< T[N0][N1][N2][N3][N4][N5][N6] , array_layout , P ... > traits ;
+  typedef Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6] , array_layout , P ... > type ;
+
+  KOKKOS_INLINE_FUNCTION static
+  void assign( ViewMapping< traits , void > & dst
+             , const ViewMapping< src_traits , void > & src
+             , const src_layout &
+             , const iType0 i_tile0
+             , const iType1 i_tile1
+             , const iType2 i_tile2
+             , const iType3 i_tile3
+             , const iType4 i_tile4
+             , const iType5 i_tile5
+             , const iType6 i_tile6
+             )
+    {
+      typedef ViewMapping< traits , void >        dst_map_type ;
+      typedef ViewMapping< src_traits , void >    src_map_type ;
+      typedef typename dst_map_type::handle_type  dst_handle_type ;
+      typedef typename dst_map_type::offset_type  dst_offset_type ;
+      typedef typename src_map_type::offset_type  src_offset_type ;
+
+      dst = dst_map_type(
+         dst_handle_type( src.m_handle +
+                          ( is_outer_left ? ( ( i_tile0 + src.m_offset.m_tile_N0 * ( i_tile1 + src.m_offset.m_tile_N1 * ( i_tile2 + src.m_offset.m_tile_N2 * ( i_tile3 + src.m_offset.m_tile_N3 * ( i_tile4 + src.m_offset.m_tile_N4 * ( i_tile5 + src.m_offset.m_tile_N5 * i_tile6 ) ) ) ) ) ) << src_offset_type::SHIFT_7T ) 
+                                          : ( ( src.m_offset.m_tile_N6 * ( src.m_offset.m_tile_N5 * ( src.m_offset.m_tile_N4 * ( src.m_offset.m_tile_N3 * ( src.m_offset.m_tile_N2 * ( src.m_offset.m_tile_N1 * i_tile0 + i_tile1 ) + i_tile2 ) + i_tile3 ) + i_tile4 ) + i_tile5 ) + i_tile6 ) << src_offset_type::SHIFT_7T )
+                          )
+                        ) // offset to start of the tile
+       , dst_offset_type() );
+    }
+};
+
+// Rank 8
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+        , class ... P
+        , typename iType0 , typename iType1 , typename iType2 , typename iType3 , typename iType4 , typename iType5 , typename iType6 , typename iType7
+        >
+struct ViewMapping
+  < typename std::enable_if< (N0 != 0 && N1 != 0 && N2 != 0 && N3 != 0 && N4 != 0 && N5 != 0 && N6 != 0 && N7 != 0) >::type //void
+  , Kokkos::ViewTraits<T********,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , iType0
+  , iType1
+  , iType2 
+  , iType3
+  , iType4
+  , iType5 
+  , iType6
+  , iType7 >
+{
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::ViewTraits< T******** , src_layout , P... > src_traits ;
+
+  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::ViewTraits< T[N0][N1][N2][N3][N4][N5][N6][N7] , array_layout , P ... > traits ;
+  typedef Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6][N7] , array_layout , P ... > type ;
+
+  KOKKOS_INLINE_FUNCTION static
+  void assign( ViewMapping< traits , void > & dst
+             , const ViewMapping< src_traits , void > & src
+             , const src_layout &
+             , const iType0 i_tile0
+             , const iType1 i_tile1
+             , const iType2 i_tile2
+             , const iType3 i_tile3
+             , const iType4 i_tile4
+             , const iType5 i_tile5
+             , const iType6 i_tile6
+             , const iType7 i_tile7
+             )
+    {
+      typedef ViewMapping< traits , void >        dst_map_type ;
+      typedef ViewMapping< src_traits , void >    src_map_type ;
+      typedef typename dst_map_type::handle_type  dst_handle_type ;
+      typedef typename dst_map_type::offset_type  dst_offset_type ;
+      typedef typename src_map_type::offset_type  src_offset_type ;
+
+      dst = dst_map_type(
+         dst_handle_type( src.m_handle +
+                          ( is_outer_left ? ( ( i_tile0 + src.m_offset.m_tile_N0 * ( i_tile1 + src.m_offset.m_tile_N1 * ( i_tile2 + src.m_offset.m_tile_N2 * ( i_tile3 + src.m_offset.m_tile_N3 * ( i_tile4 + src.m_offset.m_tile_N4 * ( i_tile5 + src.m_offset.m_tile_N5 * ( i_tile6 + src.m_offset.m_tile_N6 * i_tile7 ) ) ) ) ) ) ) << src_offset_type::SHIFT_8T ) 
+                                          : ( ( src.m_offset.m_tile_N7 * ( src.m_offset.m_tile_N6 * ( src.m_offset.m_tile_N5 * ( src.m_offset.m_tile_N4 * ( src.m_offset.m_tile_N3 * ( src.m_offset.m_tile_N2 * ( src.m_offset.m_tile_N1 * i_tile0 + i_tile1 ) + i_tile2 ) + i_tile3 ) + i_tile4 ) + i_tile5 ) + i_tile6 ) + i_tile7 ) << src_offset_type::SHIFT_8T )
+                          )
+                        ) // offset to start of the tile
+       , dst_offset_type() );
+    }
+};
+
+
+} /* namespace Impl */
+} /* namespace Kokkos */
+
+//----------------------------------------
+
+namespace Kokkos {
+
+// Rank 2
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+        , class ... P 
+        >
+KOKKOS_INLINE_FUNCTION
+Kokkos::View< T[N0][N1] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+tile_subview( const Kokkos::View<T**, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+            , const size_t i_tile0
+            , const size_t i_tile1
+            )
+{
+  // Force the specialized ViewMapping for extracting a tile
+  // by using the first subview argument as the layout.
+  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+
+  return Kokkos::View< T[N0][N1] , array_layout , P... >
+    ( src , SrcLayout() , i_tile0 , i_tile1 );
+}
+
+// Rank 3
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+        , class ... P 
+        >
+KOKKOS_INLINE_FUNCTION
+Kokkos::View< T[N0][N1][N2] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+tile_subview( const Kokkos::View<T***, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+            , const size_t i_tile0
+            , const size_t i_tile1
+            , const size_t i_tile2
+            )
+{
+  // Force the specialized ViewMapping for extracting a tile
+  // by using the first subview argument as the layout.
+  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+
+  return Kokkos::View< T[N0][N1][N2] , array_layout , P... >
+    ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 );
+}
+
+// Rank 4
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+        , class ... P 
+        >
+KOKKOS_INLINE_FUNCTION
+Kokkos::View< T[N0][N1][N2][N3] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+tile_subview( const Kokkos::View<T****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+            , const size_t i_tile0
+            , const size_t i_tile1
+            , const size_t i_tile2
+            , const size_t i_tile3
+            )
+{
+  // Force the specialized ViewMapping for extracting a tile
+  // by using the first subview argument as the layout.
+  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+
+  return Kokkos::View< T[N0][N1][N2][N3] , array_layout , P... >
+    ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 , i_tile3 );
+}
+
+// Rank 5
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+        , class ... P 
+        >
+KOKKOS_INLINE_FUNCTION
+Kokkos::View< T[N0][N1][N2][N3][N4] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+tile_subview( const Kokkos::View<T*****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+            , const size_t i_tile0
+            , const size_t i_tile1
+            , const size_t i_tile2
+            , const size_t i_tile3
+            , const size_t i_tile4
+            )
+{
+  // Force the specialized ViewMapping for extracting a tile
+  // by using the first subview argument as the layout.
+  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+
+  return Kokkos::View< T[N0][N1][N2][N3][N4] , array_layout , P... >
+    ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 , i_tile3 , i_tile4 );
+}
+
+// Rank 6
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+        , class ... P 
+        >
+KOKKOS_INLINE_FUNCTION
+Kokkos::View< T[N0][N1][N2][N3][N4][N5] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+tile_subview( const Kokkos::View<T******, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+            , const size_t i_tile0
+            , const size_t i_tile1
+            , const size_t i_tile2
+            , const size_t i_tile3
+            , const size_t i_tile4
+            , const size_t i_tile5
+            )
+{
+  // Force the specialized ViewMapping for extracting a tile
+  // by using the first subview argument as the layout.
+  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+
+  return Kokkos::View< T[N0][N1][N2][N3][N4][N5] , array_layout , P... >
+    ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 , i_tile3 , i_tile4 , i_tile5 );
+}
+
+// Rank 7
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+        , class ... P 
+        >
+KOKKOS_INLINE_FUNCTION
+Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+tile_subview( const Kokkos::View<T*******, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+            , const size_t i_tile0
+            , const size_t i_tile1
+            , const size_t i_tile2
+            , const size_t i_tile3
+            , const size_t i_tile4
+            , const size_t i_tile5
+            , const size_t i_tile6
+            )
+{
+  // Force the specialized ViewMapping for extracting a tile
+  // by using the first subview argument as the layout.
+  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+
+  return Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6] , array_layout , P... >
+    ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 , i_tile3 , i_tile4 , i_tile5 , i_tile6 );
+}
+
+// Rank 8
+template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+        , class ... P 
+        >
+KOKKOS_INLINE_FUNCTION
+Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6][N7] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+tile_subview( const Kokkos::View<T********, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+            , const size_t i_tile0
+            , const size_t i_tile1
+            , const size_t i_tile2
+            , const size_t i_tile3
+            , const size_t i_tile4
+            , const size_t i_tile5
+            , const size_t i_tile6
+            , const size_t i_tile7
+            )
+{
+  // Force the specialized ViewMapping for extracting a tile
+  // by using the first subview argument as the layout.
+  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+
+  return Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6][N7] , array_layout , P... >
+    ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 , i_tile3 , i_tile4 , i_tile5 , i_tile6 , i_tile7 );
+}
+
+} /* namespace Kokkos */
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+#endif /* #ifndef KOKKOS_EXPERIENTAL_VIEWLAYOUTTILE_HPP */
+

--- a/core/src/impl/Kokkos_ViewLayoutTiled.hpp
+++ b/core/src/impl/Kokkos_ViewLayoutTiled.hpp
@@ -57,32 +57,32 @@ namespace Kokkos {
 // View offset and mapping for tiled view's
 
 template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 >
-struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, 0, 0, 0, 0, 0, 0, true> > : public std::true_type {};
+struct is_array_layout < Kokkos::Experimental::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, 0, 0, 0, 0, 0, 0, true> > : public std::true_type {};
 
 template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 >
-struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, 0, 0, 0, 0, 0, true> > : public std::true_type {};
+struct is_array_layout < Kokkos::Experimental::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, 0, 0, 0, 0, 0, true> > : public std::true_type {};
 
 template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 >
-struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, 0, 0, 0, 0, true> > : public std::true_type {};
+struct is_array_layout < Kokkos::Experimental::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, 0, 0, 0, 0, true> > : public std::true_type {};
 
 template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 >
-struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, 0, 0, 0, true> > : public std::true_type {};
+struct is_array_layout < Kokkos::Experimental::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, 0, 0, 0, true> > : public std::true_type {};
 
 template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 >
-struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, 0, 0, true> > : public std::true_type {};
+struct is_array_layout < Kokkos::Experimental::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, 0, 0, true> > : public std::true_type {};
 
 template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 >
-struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, 0, true> > : public std::true_type {};
+struct is_array_layout < Kokkos::Experimental::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, 0, true> > : public std::true_type {};
 
 template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 > 
-struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > : public std::true_type {};
+struct is_array_layout < Kokkos::Experimental::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > : public std::true_type {};
 
 
 template< class L >
 struct is_array_layout_tiled : public std::false_type {};
 
 template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 , unsigned ArgN7 , bool IsPowerTwo >
-struct is_array_layout_tiled < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, IsPowerTwo> > : public std::true_type {}; // Last template parameter "true" meaning this currently only supports powers-of-two
+struct is_array_layout_tiled < Kokkos::Experimental::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, IsPowerTwo> > : public std::true_type {}; // Last template parameter "true" meaning this currently only supports powers-of-two
 
 
 namespace Impl {
@@ -346,14 +346,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION constexpr bool span_is_contiguous() const
     {
-      // Only if dimensions align with tile size
-      return   ( VORank == 2 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0
-             : ( VORank == 3 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0
-             : ( VORank == 4 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0 && ( m_dim.N3 && MASK_3 ) == 0
-             : ( VORank == 5 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0 && ( m_dim.N3 && MASK_3 ) == 0 && ( m_dim.N4 && MASK_4 ) == 0
-             : ( VORank == 6 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0 && ( m_dim.N3 && MASK_3 ) == 0 && ( m_dim.N4 && MASK_4 ) == 0 && ( m_dim.N5 && MASK_5 ) == 0
-             : ( VORank == 7 ) ? ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0 && ( m_dim.N3 && MASK_3 ) == 0 && ( m_dim.N4 && MASK_4 ) == 0 && ( m_dim.N5 && MASK_5 ) == 0 && ( m_dim.N6 && MASK_6 ) == 0
-             : ( m_dim.N0 & MASK_0 ) == 0 && ( m_dim.N1 & MASK_1 ) == 0 && ( m_dim.N2 && MASK_2 ) == 0 && ( m_dim.N3 && MASK_3 ) == 0 && ( m_dim.N4 && MASK_4 ) == 0 && ( m_dim.N5 && MASK_5 ) == 0 && ( m_dim.N6 && MASK_6 ) == 0 && ( m_dim.N7 && MASK_7 ) ;
+      return true;
     }
 
   //----------------------------------------
@@ -424,12 +417,12 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 struct ViewMapping
   < typename std::enable_if< (N2 == 0 && N3 == 0 && N4 == 0 && N5 == 0 && N6 == 0 && N7 == 0) >::type //void
-  , Kokkos::ViewTraits<T**,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
-  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , Kokkos::ViewTraits<T**,Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
   , iType0
   , iType1 >
 {
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T** , src_layout , P... > src_traits ;
 
   enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
@@ -469,13 +462,13 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 struct ViewMapping
   < typename std::enable_if< (N3 == 0 && N4 == 0 && N5 == 0 && N6 == 0 && N7 == 0) >::type //void
-  , Kokkos::ViewTraits<T***,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
-  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , Kokkos::ViewTraits<T***,Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
   , iType0
   , iType1
   , iType2 >
 {
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T*** , src_layout , P... > src_traits ;
 
   enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
@@ -516,14 +509,14 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 struct ViewMapping
   < typename std::enable_if< (N4 == 0 && N5 == 0 && N6 == 0 && N7 == 0) >::type //void
-  , Kokkos::ViewTraits<T****,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
-  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , Kokkos::ViewTraits<T****,Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
   , iType0
   , iType1
   , iType2 
   , iType3 >
 {
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T**** , src_layout , P... > src_traits ;
 
   enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
@@ -565,15 +558,15 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 struct ViewMapping
   < typename std::enable_if< (N5 == 0 && N6 == 0 && N7 == 0) >::type //void
-  , Kokkos::ViewTraits<T*****,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
-  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , Kokkos::ViewTraits<T*****,Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
   , iType0
   , iType1
   , iType2 
   , iType3
   , iType4 >
 {
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T***** , src_layout , P... > src_traits ;
 
   enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
@@ -616,8 +609,8 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 struct ViewMapping
   < typename std::enable_if< (N6 == 0 && N7 == 0) >::type //void
-  , Kokkos::ViewTraits<T******,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
-  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , Kokkos::ViewTraits<T******,Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
   , iType0
   , iType1
   , iType2 
@@ -625,7 +618,7 @@ struct ViewMapping
   , iType4
   , iType5 >
 {
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T****** , src_layout , P... > src_traits ;
 
   enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
@@ -669,8 +662,8 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 struct ViewMapping
   < typename std::enable_if< (N7 == 0) >::type //void
-  , Kokkos::ViewTraits<T*******,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
-  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , Kokkos::ViewTraits<T*******,Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
   , iType0
   , iType1
   , iType2 
@@ -679,7 +672,7 @@ struct ViewMapping
   , iType5 
   , iType6 >
 {
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T******* , src_layout , P... > src_traits ;
 
   enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
@@ -724,8 +717,8 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 struct ViewMapping
   < typename std::enable_if< (N0 != 0 && N1 != 0 && N2 != 0 && N3 != 0 && N4 != 0 && N5 != 0 && N6 != 0 && N7 != 0) >::type //void
-  , Kokkos::ViewTraits<T********,Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
-  , Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
+  , Kokkos::ViewTraits<T********,Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>,P...>
+  , Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>
   , iType0
   , iType1
   , iType2 
@@ -735,7 +728,7 @@ struct ViewMapping
   , iType6
   , iType7 >
 {
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T******** , src_layout , P... > src_traits ;
 
   enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
@@ -788,7 +781,7 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 KOKKOS_INLINE_FUNCTION
 Kokkos::View< T[N0][N1] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
-tile_subview( const Kokkos::View<T**, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+tile_subview( const Kokkos::View<T**, Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
             )
@@ -796,7 +789,7 @@ tile_subview( const Kokkos::View<T**, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1] , array_layout , P... >
     ( src , SrcLayout() , i_tile0 , i_tile1 );
@@ -808,7 +801,7 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 KOKKOS_INLINE_FUNCTION
 Kokkos::View< T[N0][N1][N2] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
-tile_subview( const Kokkos::View<T***, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+tile_subview( const Kokkos::View<T***, Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
             , const size_t i_tile2
@@ -817,7 +810,7 @@ tile_subview( const Kokkos::View<T***, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2] , array_layout , P... >
     ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 );
@@ -829,7 +822,7 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 KOKKOS_INLINE_FUNCTION
 Kokkos::View< T[N0][N1][N2][N3] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
-tile_subview( const Kokkos::View<T****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+tile_subview( const Kokkos::View<T****, Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
             , const size_t i_tile2
@@ -839,7 +832,7 @@ tile_subview( const Kokkos::View<T****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2][N3] , array_layout , P... >
     ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 , i_tile3 );
@@ -851,7 +844,7 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 KOKKOS_INLINE_FUNCTION
 Kokkos::View< T[N0][N1][N2][N3][N4] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
-tile_subview( const Kokkos::View<T*****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+tile_subview( const Kokkos::View<T*****, Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
             , const size_t i_tile2
@@ -862,7 +855,7 @@ tile_subview( const Kokkos::View<T*****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2][N3][N4] , array_layout , P... >
     ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 , i_tile3 , i_tile4 );
@@ -874,7 +867,7 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 KOKKOS_INLINE_FUNCTION
 Kokkos::View< T[N0][N1][N2][N3][N4][N5] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
-tile_subview( const Kokkos::View<T******, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+tile_subview( const Kokkos::View<T******, Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
             , const size_t i_tile2
@@ -886,7 +879,7 @@ tile_subview( const Kokkos::View<T******, Kokkos::LayoutTiled<OuterP,InnerP,N0,N
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2][N3][N4][N5] , array_layout , P... >
     ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 , i_tile3 , i_tile4 , i_tile5 );
@@ -898,7 +891,7 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 KOKKOS_INLINE_FUNCTION
 Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
-tile_subview( const Kokkos::View<T*******, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+tile_subview( const Kokkos::View<T*******, Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
             , const size_t i_tile2
@@ -911,7 +904,7 @@ tile_subview( const Kokkos::View<T*******, Kokkos::LayoutTiled<OuterP,InnerP,N0,
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6] , array_layout , P... >
     ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 , i_tile3 , i_tile4 , i_tile5 , i_tile6 );
@@ -923,7 +916,7 @@ template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigne
         >
 KOKKOS_INLINE_FUNCTION
 Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6][N7] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
-tile_subview( const Kokkos::View<T********, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
+tile_subview( const Kokkos::View<T********, Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
             , const size_t i_tile2
@@ -937,7 +930,7 @@ tile_subview( const Kokkos::View<T********, Kokkos::LayoutTiled<OuterP,InnerP,N0
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
-  typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
+  typedef Kokkos::Experimental::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6][N7] , array_layout , P... >
     ( src , SrcLayout() , i_tile0 , i_tile1 , i_tile2 , i_tile3 , i_tile4 , i_tile5 , i_tile6 , i_tile7 );

--- a/core/src/impl/Kokkos_ViewLayoutTiled.hpp
+++ b/core/src/impl/Kokkos_ViewLayoutTiled.hpp
@@ -57,32 +57,32 @@ namespace Kokkos {
 //template< class L >
 //struct is_array_layout : public std::false_type {};
 
-template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 >
+template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 >
 struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, 0, 0, 0, 0, 0, 0, true> > : public std::true_type {};
 
-template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 >
+template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 >
 struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, 0, 0, 0, 0, 0, true> > : public std::true_type {};
 
-template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 >
+template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 >
 struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, 0, 0, 0, 0, true> > : public std::true_type {};
 
-template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 >
+template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 >
 struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, 0, 0, 0, true> > : public std::true_type {};
 
-template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 >
+template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 >
 struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, 0, 0, true> > : public std::true_type {};
 
-template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 >
+template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 >
 struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, 0, true> > : public std::true_type {};
 
-template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 > 
+template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 > 
 struct is_array_layout < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > : public std::true_type {};
 
 
 template< class L >
 struct is_array_layout_tiled : public std::false_type {};
 
-template < Kokkos::Pattern::Iterate OuterP, Kokkos::Pattern::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 > 
+template < Kokkos::Iterate OuterP, Kokkos::Iterate InnerP, unsigned ArgN0 , unsigned ArgN1 , unsigned ArgN2 ,  unsigned ArgN3 ,  unsigned ArgN4 ,  unsigned ArgN5 ,  unsigned ArgN6 ,  unsigned ArgN7 > 
 struct is_array_layout_tiled < Kokkos::LayoutTiled<OuterP, InnerP, ArgN0, ArgN1, ArgN2, ArgN3, ArgN4, ArgN5, ArgN6, ArgN7, true> > : public std::true_type {};
 
 
@@ -104,8 +104,8 @@ public:
 
 //  enum { outer_pattern = Layout::outer_pattern };
 //  enum { inner_pattern = Layout::inner_pattern };
-  static constexpr Kokkos::Pattern::Iterate outer_pattern = Layout::outer_pattern;
-  static constexpr Kokkos::Pattern::Iterate inner_pattern = Layout::inner_pattern;
+  static constexpr Kokkos::Iterate outer_pattern = Layout::outer_pattern;
+  static constexpr Kokkos::Iterate inner_pattern = Layout::inner_pattern;
 
   enum { VORank = Dimension::rank };
 
@@ -160,19 +160,19 @@ public:
   template< typename I0 , typename I1 >
   KOKKOS_INLINE_FUNCTION
   size_type operator()( I0 const & i0 , I1 const & i1 ) const {
-    auto tile_offset = (outer_pattern == (Kokkos::Pattern::Iterate::Left)) 
+    auto tile_offset = (outer_pattern == (Kokkos::Iterate::Left)) 
                      ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1)) ) << SHIFT_2T)
                      : ( ( (m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) ) << SHIFT_2T) ;
     //                     ( num_tiles[1] * ti0     +  ti1 ) * FTD
 
-    auto local_offset = (inner_pattern == (Kokkos::Pattern::Iterate::Left)) 
+    auto local_offset = (inner_pattern == (Kokkos::Iterate::Left)) 
                       ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) )
                       : ( ((i0 & MASK_0) << SHIFT_1) + (i1 & MASK_1) ) ;
     //                     ( tile_dim[1] * li0         +  li1 )
 
 #if DEBUG_OUTPUT_CHECK
-    std::cout << "Am I Outer Left? " << (outer_pattern == (Kokkos::Pattern::Iterate::Left)) << std::endl;
-    std::cout << "Am I Inner Left? " << (inner_pattern == (Kokkos::Pattern::Iterate::Left)) << std::endl;
+    std::cout << "Am I Outer Left? " << (outer_pattern == (Kokkos::Iterate::Left)) << std::endl;
+    std::cout << "Am I Inner Left? " << (inner_pattern == (Kokkos::Iterate::Left)) << std::endl;
     std::cout << "i0 = " << i0
       << " i1 = " << i1
       << "\ntilei0 = " << (i0>>SHIFT_0)
@@ -189,17 +189,17 @@ public:
   template< typename I0 , typename I1 , typename I2 >
   KOKKOS_INLINE_FUNCTION
   size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 ) const {
-    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto tile_offset = (outer_pattern == Kokkos::Iterate::Left) 
                      ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*(i2>>SHIFT_2)) ) << SHIFT_3T)
                      : ( ( m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2) ) << SHIFT_3T) ;
 
-    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto local_offset = (inner_pattern == Kokkos::Iterate::Left) 
                       ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) )
                       : ( ((i0 & MASK_0) << (SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_2)) + (i2 & MASK_2) ) ;
 
 #if DEBUG_OUTPUT_CHECK
-    std::cout << "Am I Outer Left? " << (outer_pattern == (Kokkos::Pattern::Iterate::Left)) << std::endl;
-    std::cout << "Am I Inner Left? " << (inner_pattern == (Kokkos::Pattern::Iterate::Left)) << std::endl;
+    std::cout << "Am I Outer Left? " << (outer_pattern == (Kokkos::Iterate::Left)) << std::endl;
+    std::cout << "Am I Inner Left? " << (inner_pattern == (Kokkos::Iterate::Left)) << std::endl;
     std::cout << "i0 = " << i0
       << " i1 = " << i1
       << " i2 = " << i2
@@ -219,11 +219,11 @@ public:
   template< typename I0 , typename I1 , typename I2 , typename I3 >
   KOKKOS_INLINE_FUNCTION
   size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 , I3 const & i3 ) const {
-    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto tile_offset = (outer_pattern == Kokkos::Iterate::Left) 
                      ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*((i2>>SHIFT_2) + m_tile_N2*(i3>>SHIFT_3))) ) << SHIFT_4T)
                      : ( ( m_tile_N3*(m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2)) + (i3>>SHIFT_3) ) << SHIFT_4T) ;
 
-    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto local_offset = (inner_pattern == Kokkos::Iterate::Left) 
                       ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) + ((i3 & MASK_3)<<(SHIFT_0+SHIFT_1+SHIFT_2)) )
                       : ( ((i0 & MASK_0) << (SHIFT_3+SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_3+SHIFT_2)) + ((i2 & MASK_2)<<(SHIFT_3)) + (i3 & MASK_3) ) ;
 
@@ -234,11 +234,11 @@ public:
   template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 >
   KOKKOS_INLINE_FUNCTION
   size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 , I3 const & i3 , I4 const & i4 ) const {
-    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto tile_offset = (outer_pattern == Kokkos::Iterate::Left) 
                      ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*((i2>>SHIFT_2) + m_tile_N2*((i3>>SHIFT_3) + m_tile_N3*(i4>>SHIFT_4)))) ) << SHIFT_5T)
                      : ( ( m_tile_N4*(m_tile_N3*(m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2)) + (i3>>SHIFT_3)) + (i4>>SHIFT_4) ) << SHIFT_5T) ;
 
-    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto local_offset = (inner_pattern == Kokkos::Iterate::Left) 
                       ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) + ((i3 & MASK_3)<<(SHIFT_0+SHIFT_1+SHIFT_2)) + ((i4 & MASK_4)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3)) )
                       : ( ((i0 & MASK_0) << (SHIFT_4+SHIFT_3+SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_4+SHIFT_3+SHIFT_2)) + ((i2 & MASK_2)<<(SHIFT_4+SHIFT_3)) + ((i3 & MASK_3)<<(SHIFT_4)) + (i4 & MASK_4) ) ;
 
@@ -249,11 +249,11 @@ public:
   template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 , typename I5 >
   KOKKOS_INLINE_FUNCTION
   size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 , I3 const & i3 , I4 const & i4 , I5 const & i5 ) const {
-    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto tile_offset = (outer_pattern == Kokkos::Iterate::Left) 
                      ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*((i2>>SHIFT_2) + m_tile_N2*((i3>>SHIFT_3) + m_tile_N3*((i4>>SHIFT_4) + m_tile_N4*(i5>>SHIFT_5))))) ) << SHIFT_6T)
                      : ( ( m_tile_N5*(m_tile_N4*(m_tile_N3*(m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2)) + (i3>>SHIFT_3)) + (i4>>SHIFT_4)) + (i5>>SHIFT_5) ) << SHIFT_6T) ;
 
-    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto local_offset = (inner_pattern == Kokkos::Iterate::Left) 
                       ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) + ((i3 & MASK_3)<<(SHIFT_0+SHIFT_1+SHIFT_2)) + ((i4 & MASK_4)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3)) + ((i5 & MASK_5)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4)) )
                       : ( ((i0 & MASK_0) << (SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2)) + ((i2 & MASK_2)<<(SHIFT_5+SHIFT_4+SHIFT_3)) + ((i3 & MASK_3)<<(SHIFT_5+SHIFT_4)) + ((i4 & MASK_4)<<(SHIFT_5)) + (i5 & MASK_5) ) ;
 
@@ -264,11 +264,11 @@ public:
   template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 , typename I5 , typename I6 >
   KOKKOS_INLINE_FUNCTION
   size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 , I3 const & i3 , I4 const & i4 , I5 const & i5 , I6 const & i6 ) const {
-    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto tile_offset = (outer_pattern == Kokkos::Iterate::Left) 
                      ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*((i2>>SHIFT_2) + m_tile_N2*((i3>>SHIFT_3) + m_tile_N3*((i4>>SHIFT_4) + m_tile_N4*((i5>>SHIFT_5) + m_tile_N5*(i6>>SHIFT_6)))))) ) << SHIFT_7T)
                      : ( ( m_tile_N6*(m_tile_N5*(m_tile_N4*(m_tile_N3*(m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2)) + (i3>>SHIFT_3)) + (i4>>SHIFT_4)) + (i5>>SHIFT_5)) + (i6>>SHIFT_6) ) << SHIFT_7T) ;
 
-    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto local_offset = (inner_pattern == Kokkos::Iterate::Left) 
                       ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) + ((i3 & MASK_3)<<(SHIFT_0+SHIFT_1+SHIFT_2)) + ((i4 & MASK_4)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3)) + ((i5 & MASK_5)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4)) + ((i6 & MASK_6)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4+SHIFT_5)) )
                       : ( ((i0 & MASK_0) << (SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2)) + ((i2 & MASK_2)<<(SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3)) + ((i3 & MASK_3)<<(SHIFT_6+SHIFT_5+SHIFT_4)) + ((i4 & MASK_4)<<(SHIFT_6+SHIFT_5)) + ((i5 & MASK_5)<<(SHIFT_6)) + (i6 & MASK_6) ) ;
 
@@ -279,11 +279,11 @@ public:
   template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 , typename I5 , typename I6 , typename I7 >
   KOKKOS_INLINE_FUNCTION
   size_type operator()( I0 const & i0 , I1 const & i1 , I2 const & i2 , I3 const & i3 , I4 const & i4 , I5 const & i5 , I6 const & i6 , I7 const & i7 ) const {
-    auto tile_offset = (outer_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto tile_offset = (outer_pattern == Kokkos::Iterate::Left) 
                      ? ( ( (i0>>SHIFT_0) + m_tile_N0*((i1>>SHIFT_1) + m_tile_N1*((i2>>SHIFT_2) + m_tile_N2*((i3>>SHIFT_3) + m_tile_N3*((i4>>SHIFT_4) + m_tile_N4*((i5>>SHIFT_5) + m_tile_N5*((i6>>SHIFT_6) + m_tile_N6*(i7>>SHIFT_7))))))) ) << SHIFT_8T)
                      : ( ( m_tile_N7*(m_tile_N6*(m_tile_N5*(m_tile_N4*(m_tile_N3*(m_tile_N2*(m_tile_N1*(i0>>SHIFT_0) + (i1>>SHIFT_1)) + (i2>>SHIFT_2)) + (i3>>SHIFT_3)) + (i4>>SHIFT_4)) + (i5>>SHIFT_5)) + (i6>>SHIFT_6)) + (i7>>SHIFT_7) ) << SHIFT_8T) ;
 
-    auto local_offset = (inner_pattern == Kokkos::Pattern::Iterate::Left) 
+    auto local_offset = (inner_pattern == Kokkos::Iterate::Left) 
                       ? ( (i0 & MASK_0) + ((i1 & MASK_1)<<SHIFT_0) + ((i2 & MASK_2)<<(SHIFT_0+SHIFT_1)) + ((i3 & MASK_3)<<(SHIFT_0+SHIFT_1+SHIFT_2)) + ((i4 & MASK_4)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3)) + ((i5 & MASK_5)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4)) + ((i6 & MASK_6)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4+SHIFT_5)) + ((i7 & MASK_7)<<(SHIFT_0+SHIFT_1+SHIFT_2+SHIFT_3+SHIFT_4+SHIFT_5+SHIFT_6)) )
                       : ( ((i0 & MASK_0) << (SHIFT_7+SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2+SHIFT_1)) + ((i1 & MASK_1) << (SHIFT_7+SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3+SHIFT_2)) + ((i2 & MASK_2)<<(SHIFT_7+SHIFT_6+SHIFT_5+SHIFT_4+SHIFT_3)) + ((i3 & MASK_3)<<(SHIFT_7+SHIFT_6+SHIFT_5+SHIFT_4)) + ((i4 & MASK_4)<<(SHIFT_7+SHIFT_6+SHIFT_5)) + ((i5 & MASK_5)<<(SHIFT_7+SHIFT_6)) + ((i6 & MASK_6)<<(SHIFT_7)) + (i7 & MASK_7) ) ;
 
@@ -419,7 +419,7 @@ public:
 // The outer iteration pattern determines the mapping of the pointer offset to the beginning of requested tile
 // The inner iteration pattern is needed for the layout of the tile's View to be returned
 // Rank 2
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
         , class ... P
         , typename iType0 , typename iType1
         >
@@ -433,8 +433,8 @@ struct ViewMapping
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T** , src_layout , P... > src_traits ;
 
-  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
   typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::ViewTraits< T[N0][N1] , array_layout , P ... > traits ;
   typedef Kokkos::View< T[N0][N1] , array_layout , P ... > type ;
@@ -464,7 +464,7 @@ struct ViewMapping
 };
 
 // Rank 3
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
         , class ... P
         , typename iType0 , typename iType1 , typename iType2
         >
@@ -479,8 +479,8 @@ struct ViewMapping
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T*** , src_layout , P... > src_traits ;
 
-  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
   typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::ViewTraits< T[N0][N1][N2] , array_layout , P ... > traits ;
   typedef Kokkos::View< T[N0][N1][N2] , array_layout , P ... > type ;
@@ -511,7 +511,7 @@ struct ViewMapping
 };
 
 // Rank 4
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
         , class ... P
         , typename iType0 , typename iType1 , typename iType2 , typename iType3
         >
@@ -527,8 +527,8 @@ struct ViewMapping
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T**** , src_layout , P... > src_traits ;
 
-  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
   typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::ViewTraits< T[N0][N1][N2][N3] , array_layout , P ... > traits ;
   typedef Kokkos::View< T[N0][N1][N2][N3] , array_layout , P ... > type ;
@@ -560,7 +560,7 @@ struct ViewMapping
 };
 
 // Rank 5
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
         , class ... P
         , typename iType0 , typename iType1 , typename iType2 , typename iType3 , typename iType4
         >
@@ -577,8 +577,8 @@ struct ViewMapping
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T***** , src_layout , P... > src_traits ;
 
-  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
   typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::ViewTraits< T[N0][N1][N2][N3][N4] , array_layout , P ... > traits ;
   typedef Kokkos::View< T[N0][N1][N2][N3][N4] , array_layout , P ... > type ;
@@ -611,7 +611,7 @@ struct ViewMapping
 };
 
 // Rank 6
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
         , class ... P
         , typename iType0 , typename iType1 , typename iType2 , typename iType3 , typename iType4 , typename iType5
         >
@@ -629,8 +629,8 @@ struct ViewMapping
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T****** , src_layout , P... > src_traits ;
 
-  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
   typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::ViewTraits< T[N0][N1][N2][N3][N4][N5] , array_layout , P ... > traits ;
   typedef Kokkos::View< T[N0][N1][N2][N3][N4][N5] , array_layout , P ... > type ;
@@ -664,7 +664,7 @@ struct ViewMapping
 };
 
 // Rank 7
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
         , class ... P
         , typename iType0 , typename iType1 , typename iType2 , typename iType3 , typename iType4 , typename iType5 , typename iType6
         >
@@ -683,8 +683,8 @@ struct ViewMapping
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T******* , src_layout , P... > src_traits ;
 
-  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
   typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::ViewTraits< T[N0][N1][N2][N3][N4][N5][N6] , array_layout , P ... > traits ;
   typedef Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6] , array_layout , P ... > type ;
@@ -719,7 +719,7 @@ struct ViewMapping
 };
 
 // Rank 8
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7
         , class ... P
         , typename iType0 , typename iType1 , typename iType2 , typename iType3 , typename iType4 , typename iType5 , typename iType6 , typename iType7
         >
@@ -739,8 +739,8 @@ struct ViewMapping
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>  src_layout ;
   typedef Kokkos::ViewTraits< T******** , src_layout , P... > src_traits ;
 
-  enum { is_outer_left = (OuterP == Kokkos::Pattern::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Pattern::Iterate::Left) };
+  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
+  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
   typedef typename std::conditional< is_inner_left, Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::ViewTraits< T[N0][N1][N2][N3][N4][N5][N6][N7] , array_layout , P ... > traits ;
   typedef Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6][N7] , array_layout , P ... > type ;
@@ -784,11 +784,11 @@ struct ViewMapping
 namespace Kokkos {
 
 // Rank 2
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
         , class ... P 
         >
 KOKKOS_INLINE_FUNCTION
-Kokkos::View< T[N0][N1] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+Kokkos::View< T[N0][N1] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
 tile_subview( const Kokkos::View<T**, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
@@ -796,7 +796,7 @@ tile_subview( const Kokkos::View<T**, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2
 {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
-  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1] , array_layout , P... >
@@ -804,11 +804,11 @@ tile_subview( const Kokkos::View<T**, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2
 }
 
 // Rank 3
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
         , class ... P 
         >
 KOKKOS_INLINE_FUNCTION
-Kokkos::View< T[N0][N1][N2] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+Kokkos::View< T[N0][N1][N2] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
 tile_subview( const Kokkos::View<T***, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
@@ -817,7 +817,7 @@ tile_subview( const Kokkos::View<T***, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N
 {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
-  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2] , array_layout , P... >
@@ -825,11 +825,11 @@ tile_subview( const Kokkos::View<T***, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N
 }
 
 // Rank 4
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
         , class ... P 
         >
 KOKKOS_INLINE_FUNCTION
-Kokkos::View< T[N0][N1][N2][N3] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+Kokkos::View< T[N0][N1][N2][N3] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
 tile_subview( const Kokkos::View<T****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
@@ -839,7 +839,7 @@ tile_subview( const Kokkos::View<T****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,
 {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
-  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2][N3] , array_layout , P... >
@@ -847,11 +847,11 @@ tile_subview( const Kokkos::View<T****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,
 }
 
 // Rank 5
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
         , class ... P 
         >
 KOKKOS_INLINE_FUNCTION
-Kokkos::View< T[N0][N1][N2][N3][N4] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+Kokkos::View< T[N0][N1][N2][N3][N4] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
 tile_subview( const Kokkos::View<T*****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
@@ -862,7 +862,7 @@ tile_subview( const Kokkos::View<T*****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1
 {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
-  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2][N3][N4] , array_layout , P... >
@@ -870,11 +870,11 @@ tile_subview( const Kokkos::View<T*****, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1
 }
 
 // Rank 6
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
         , class ... P 
         >
 KOKKOS_INLINE_FUNCTION
-Kokkos::View< T[N0][N1][N2][N3][N4][N5] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+Kokkos::View< T[N0][N1][N2][N3][N4][N5] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
 tile_subview( const Kokkos::View<T******, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
@@ -886,7 +886,7 @@ tile_subview( const Kokkos::View<T******, Kokkos::LayoutTiled<OuterP,InnerP,N0,N
 {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
-  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2][N3][N4][N5] , array_layout , P... >
@@ -894,11 +894,11 @@ tile_subview( const Kokkos::View<T******, Kokkos::LayoutTiled<OuterP,InnerP,N0,N
 }
 
 // Rank 7
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
         , class ... P 
         >
 KOKKOS_INLINE_FUNCTION
-Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
 tile_subview( const Kokkos::View<T*******, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
@@ -911,7 +911,7 @@ tile_subview( const Kokkos::View<T*******, Kokkos::LayoutTiled<OuterP,InnerP,N0,
 {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
-  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6] , array_layout , P... >
@@ -919,11 +919,11 @@ tile_subview( const Kokkos::View<T*******, Kokkos::LayoutTiled<OuterP,InnerP,N0,
 }
 
 // Rank 8
-template< typename T , Kokkos::Pattern::Iterate OuterP , Kokkos::Pattern::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
+template< typename T , Kokkos::Iterate OuterP , Kokkos::Iterate InnerP , unsigned N0 , unsigned N1 , unsigned N2 , unsigned N3 , unsigned N4 , unsigned N5 , unsigned N6 , unsigned N7 
         , class ... P 
         >
 KOKKOS_INLINE_FUNCTION
-Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6][N7] , typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
+Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6][N7] , typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type , P... >
 tile_subview( const Kokkos::View<T********, Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true>, P...> & src
             , const size_t i_tile0
             , const size_t i_tile1
@@ -937,7 +937,7 @@ tile_subview( const Kokkos::View<T********, Kokkos::LayoutTiled<OuterP,InnerP,N0
 {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
-  typedef typename std::conditional< (InnerP == Kokkos::Pattern::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
+  typedef typename std::conditional< (InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft, Kokkos::LayoutRight >::type array_layout;
   typedef Kokkos::LayoutTiled<OuterP,InnerP,N0,N1,N2,N3,N4,N5,N6,N7,true> SrcLayout ;
 
   return Kokkos::View< T[N0][N1][N2][N3][N4][N5][N6][N7] , array_layout , P... >

--- a/core/unit_test/TestViewLayoutTiled.hpp
+++ b/core/unit_test/TestViewLayoutTiled.hpp
@@ -70,22 +70,22 @@ struct TestViewLayoutTiled {
   static constexpr int T7 = 4;
 
   // Rank 2
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Left, T0, T1>   LayoutLL_2D_2x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Left, T0, T1>  LayoutRL_2D_2x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Right, T0, T1>  LayoutLR_2D_2x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Right, T0, T1> LayoutRR_2D_2x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, T0, T1>   LayoutLL_2D_2x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, T0, T1>  LayoutRL_2D_2x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, T0, T1>  LayoutLR_2D_2x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, T0, T1> LayoutRR_2D_2x4;
 
   // Rank 3
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Left, T0, T1, T2>   LayoutLL_3D_2x4x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Left, T0, T1, T2>  LayoutRL_3D_2x4x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Right, T0, T1, T2>  LayoutLR_3D_2x4x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Right, T0, T1, T2> LayoutRR_3D_2x4x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, T0, T1, T2>   LayoutLL_3D_2x4x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, T0, T1, T2>  LayoutRL_3D_2x4x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, T0, T1, T2>  LayoutLR_3D_2x4x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, T0, T1, T2> LayoutRR_3D_2x4x4;
 
   // Rank 4
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Left, T0, T1, T2, T3>   LayoutLL_4D_2x4x4x2;
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Left, T0, T1, T2, T3>  LayoutRL_4D_2x4x4x2;
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Right, T0, T1, T2, T3>  LayoutLR_4D_2x4x4x2;
-  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Right, T0, T1, T2, T3> LayoutRR_4D_2x4x4x2;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, T0, T1, T2, T3>   LayoutLL_4D_2x4x4x2;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, T0, T1, T2, T3>  LayoutRL_4D_2x4x4x2;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, T0, T1, T2, T3>  LayoutLR_4D_2x4x4x2;
+  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, T0, T1, T2, T3> LayoutRR_4D_2x4x4x2;
 
 
 #define DEBUG_VERBOSE_OUTPUT 0

--- a/core/unit_test/TestViewLayoutTiled.hpp
+++ b/core/unit_test/TestViewLayoutTiled.hpp
@@ -1,0 +1,433 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <cstdio>
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+#include <impl/Kokkos_ViewLayoutTiled.hpp>
+
+#include <type_traits>
+#include <typeinfo>
+
+namespace Test {
+
+namespace {
+
+template <typename ExecSpace >
+struct TestViewLayoutTiled {
+
+  using ViewIntType     = typename Kokkos::View< int**, ExecSpace >;
+  using ViewDoubleType     = typename Kokkos::View< double*, ExecSpace >;
+
+
+  template < class ViewType >
+  struct Functor {
+
+    ViewType v;
+
+    Functor( const ViewType & v_ ) : v(v_) {}
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const int i ) const {
+      v(i) = i;
+    }
+
+  };
+
+  typedef double Scalar;
+
+  static constexpr int T0 = 2;
+  static constexpr int T1 = 4;
+  static constexpr int T2 = 4;
+  static constexpr int T3 = 4;
+  static constexpr int T4 = 4;
+  static constexpr int T5 = 4;
+  static constexpr int T6 = 4;
+  static constexpr int T7 = 4;
+
+  // Rank 2
+  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Left, T0, T1>   LayoutLL_2D_2x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Left, T0, T1>  LayoutRL_2D_2x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Right, T0, T1>  LayoutLR_2D_2x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Right, T0, T1> LayoutRR_2D_2x4;
+
+  // Rank 3
+  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Left, T0, T1, T2>   LayoutLL_3D_2x4x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Left, T0, T1, T2>  LayoutRL_3D_2x4x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Left, Kokkos::Pattern::Iterate::Right, T0, T1, T2>  LayoutLR_3D_2x4x4;
+  typedef Kokkos::LayoutTiled<Kokkos::Pattern::Iterate::Right, Kokkos::Pattern::Iterate::Right, T0, T1, T2> LayoutRR_3D_2x4x4;
+
+#define DEBUG_VERBOSE_OUTPUT 1
+#define DEBUG_SUMMARY_OUTPUT 1
+
+  // Rank 2 tests
+  // Create N0 x N1 view with tile dimensions of T0 x T1
+  static void test_view_layout_tiled_2d( const int N0, const int N1 )
+  {
+
+//    const int T0 = 2;
+//    const int T1 = 4;
+    const int FT = T0*T1;
+
+    const int NT0 = int( std::ceil( N0 / T0 ) );
+    const int NT1 = int( std::ceil( N1 / T1 ) );
+
+    // 4x12 view - 48 items
+    // tiledims 2x4
+    // full tile 8
+    // num tiles 2x3
+    std::cout << "Begin output \n N0 = " << N0 << " N1 = " << N1 << "\n T0 = " << T0 << " T1 = " << T1 << "  FTD = " << FT << "  NT0 = " << NT0 << "  NT1 = " << NT1 << std::endl;
+    long counter[4] = {0};
+    // Create LL View
+    {
+      std::cout << "Init LL View" << std::endl;
+      Kokkos::View< Scalar**, LayoutLL_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          v(ti*T0 + i, tj*T1+j) = ( ti + tj*NT0 )*FT + ( i + j*T0 );
+        } }
+      } }
+
+      std::cout << "\nOutput L-L pattern 2x4 tiles:" << std::endl;
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          auto tile_subview = Kokkos::tile_subview( v, ti, tj );
+          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[0]; }
+#if DEBUG_VERBOSE_OUTPUT
+          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
+          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti + tj*NT0 )*FT + ( i + j*T0 ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
+#endif
+        } }
+      } }
+    } // end scope
+
+    // Create RL View
+    {
+      std::cout << "\nInit RL View" << std::endl;
+      Kokkos::View< Scalar**, LayoutRL_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          v(ti*T0 + i, tj*T1+j) = ( ti*NT1 + tj )*FT + ( i + j*T0 );
+        } }
+      } }
+
+      std::cout << "\nOutput R-L pattern 2x4 tiles:" << std::endl;
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          auto tile_subview = Kokkos::tile_subview( v, ti, tj );
+          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[1]; }
+#if DEBUG_VERBOSE_OUTPUT
+          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
+          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti*NT1 + tj )*FT + ( i + j*T0 ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
+#endif
+        } }
+      } }
+    } // end scope
+
+    // Create LR View
+    {
+      std::cout << "\nInit LR View" << std::endl;
+      Kokkos::View< Scalar**, LayoutLR_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          v(ti*T0 + i, tj*T1+j) = ( ti + tj*NT0 )*FT + ( i*T1 + j );
+        } }
+      } }
+
+      std::cout << "\nOutput L-R pattern 2x4 tiles:" << std::endl;
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          auto tile_subview = Kokkos::tile_subview( v, ti, tj );
+          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[2]; }
+#if DEBUG_VERBOSE_OUTPUT
+          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
+          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti + tj*NT0 )*FT + ( i*T1 + j ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
+#endif
+        } }
+      } }
+    } // end scope
+
+    // Create RR View
+    {
+      std::cout << "\nInit RR View" << std::endl;
+      Kokkos::View< Scalar**, LayoutRR_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          v(ti*T0 + i, tj*T1+j) = ( ti*NT1 + tj )*FT + ( i*T1 + j );
+        } }
+      } }
+
+      std::cout << "\nOutput R-R pattern 2x4 tiles:" << std::endl;
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          auto tile_subview = Kokkos::tile_subview( v, ti, tj );
+          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[3]; }
+#if DEBUG_VERBOSE_OUTPUT
+          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
+          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti*NT1 + tj )*FT + ( i*T1 + j ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
+          std::cout << "subview tile rank = " << Kokkos::rank(tile_subview) << std::endl;
+#endif
+        } }
+      } }
+    } // end scope
+
+#if DEBUG_SUMMARY_OUTPUT
+    std::cout << "subview_tile vs view errors:\n"
+      << " LL: " << counter[0]
+      << " RL: " << counter[1]
+      << " LR: " << counter[2]
+      << " RR: " << counter[3] 
+      << std::endl;
+#endif
+
+    ASSERT_EQ(counter[0], long(0));
+    ASSERT_EQ(counter[1], long(0));
+    ASSERT_EQ(counter[2], long(0));
+    ASSERT_EQ(counter[3], long(0));
+
+  } // end test_view_layout_tiled_2d
+
+
+  static void test_view_layout_tiled_3d( const int N0, const int N1, const int N2 )
+  {
+
+    const int FT = T0*T1*T2;
+
+    const int NT0 = int( std::ceil( N0 / T0 ) );
+    const int NT1 = int( std::ceil( N1 / T1 ) );
+    const int NT2 = int( std::ceil( N2 / T2 ) );
+
+    // 4x12x16 view
+    // tiledims 2x4x4
+    // full tile 32
+    // num tiles 2x3x4
+    std::cout << "\nBegin output \n N0 = " << N0 << " N1 = " << N1 << " N2 = " << N2 << "\n T0 = " << T0 << " T1 = " << T1 << " T2 = " << T2 << "  FTD = " << FT << "  NT0 = " << NT0 << "  NT1 = " << NT1 << " NT2 = " << NT2 << std::endl;
+    long counter[4] = {0};
+    // Create LL View
+    {
+      std::cout << "Init LL View" << std::endl;
+      Kokkos::View< Scalar***, LayoutLL_3D_2x4x4, Kokkos::HostSpace > v("v", N0, N1, N2);
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k) = ( ti + tj*NT0 + tk*N0*N1 )*FT + ( i + j*T0 + k*T0*T1 );
+        } } }
+      } } }
+
+      std::cout << "\nOutput L-L pattern 2x4x4 tiles:" << std::endl;
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
+          if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter[0]; }
+#if DEBUG_VERBOSE_OUTPUT
+          std::cout << "idx0,idx1,idx2 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << std::endl;
+          std::cout << "ti,tj,tk,i,j,k: " << ti << "," << tj << "," << tk << "," << i << "," << j << "," << k << "  v = " << v(ti*T0 + i, tj*T1+j, tk*T2 + k) << "  flat idx = " << ( ti + tj*NT0 + tk*N0*N1 )*FT + ( i + j*T0 + k*T0*T1 ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j,k) << std::endl;
+          std::cout << "subview tile rank = " << Kokkos::rank(tile_subview) << std::endl;
+#endif
+        } } }
+      } } }
+    } // end scope
+
+    // Create RL View
+    {
+      std::cout << "\nInit RL View" << std::endl;
+      Kokkos::View< Scalar***, LayoutRL_3D_2x4x4, Kokkos::HostSpace > v("v", N0, N1, N2);
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k) = ( ti*NT1*NT2 + tj*NT2 + tk )*FT + ( i + j*T0 + k*T0*T1 );
+        } } }
+      } } }
+
+      std::cout << "\nOutput R-L pattern 2x4x4 tiles:" << std::endl;
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
+          if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter[1]; }
+#if DEBUG_VERBOSE_OUTPUT
+          std::cout << "idx0,idx1,idx2 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << std::endl;
+          std::cout << "ti,tj,tk,i,j,k: " << ti << "," << tj << "," << tk << "," << i << "," << j << "," << k << "  v = " << v(ti*T0 + i, tj*T1+j, tk*T2 + k) << "  flat idx = " << ( ti*NT1*NT2 + tj*NT2 + tk )*FT + ( i + j*T0 + k*T0*T1 ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j,k) << std::endl;
+#endif
+        } } }
+      } } }
+    } // end scope
+
+    // Create LR View
+    {
+      std::cout << "\nInit LR View" << std::endl;
+      Kokkos::View< Scalar***, LayoutLR_3D_2x4x4, Kokkos::HostSpace > v("v", N0, N1, N2);
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k) = ( ti + tj*NT0 + tk*NT0*NT1 )*FT + ( i*T1*T2 + j*T2 + k );
+        } } }
+      } } }
+
+      std::cout << "\nOutput L-R pattern 2x4x4 tiles:" << std::endl;
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
+          if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter[2]; }
+#if DEBUG_VERBOSE_OUTPUT
+          std::cout << "idx0,idx1,idx2 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << std::endl;
+          std::cout << "ti,tj,tk,i,j,k: " << ti << "," << tj << "," << tk << "," << i << "," << j << "," << k << "  v = " << v(ti*T0 + i, tj*T1+j, tk*T2 + k) << "  flat idx = " << ( ti + tj*NT0 + tk*NT0*NT1 )*FT + ( i*T1*T2 + j*T2 + k ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j,k) << std::endl;
+          std::cout << "subview tile rank = " << Kokkos::rank(tile_subview) << std::endl;
+#endif
+        } } }
+      } } }
+    } // end scope
+
+    // Create RR View
+    {
+      std::cout << "\nInit RR View" << std::endl;
+      Kokkos::View< Scalar***, LayoutRR_3D_2x4x4, Kokkos::HostSpace > v("v", N0, N1, N2);
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k) = ( ti*NT1*NT2 + tj*NT2 + tk )*FT + ( i*T1*T2 + j*T2 + k );
+        } } }
+      } } }
+
+      std::cout << "\nOutput R-R pattern 2x4x4 tiles:" << std::endl;
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
+          if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter[3]; }
+#if DEBUG_VERBOSE_OUTPUT
+          std::cout << "idx0,idx1,idx2 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << std::endl;
+          std::cout << "ti,tj,tk,i,j,k: " << ti << "," << tj << "," << tk << "," << i << "," << j << "," << k << "  v = " << v(ti*T0 + i, tj*T1+j, tk*T2 + k) << "  flat idx = " << ( ti*NT1*NT2 + tj*NT2 + tk )*FT + ( i*T1*T2 + j*T2 + k ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j,k) << std::endl;
+          std::cout << "subview tile rank = " << Kokkos::rank(tile_subview) << std::endl;
+#endif
+        } } }
+      } } }
+    } // end scope
+
+#if DEBUG_SUMMARY_OUTPUT
+    std::cout << "subview_tile vs view errors:\n"
+      << " LL: " << counter[0]
+      << " RL: " << counter[1]
+      << " LR: " << counter[2]
+      << " RR: " << counter[3] 
+      << std::endl;
+#endif
+
+    ASSERT_EQ(counter[0], long(0));
+    ASSERT_EQ(counter[1], long(0));
+    ASSERT_EQ(counter[2], long(0));
+    ASSERT_EQ(counter[3], long(0));
+
+  } // end test_view_layout_tiled_3d
+
+#ifdef DEBUG_VERBOSE_OUTPUT
+#undef DEBUG_VERBOSE_OUTPUT
+#endif
+#ifdef DEBUG_SUMMARY_OUTPUT
+#undef DEBUG_SUMMARY_OUTPUT
+#endif
+
+}; // end struct
+
+} // namespace
+
+TEST_F( TEST_CATEGORY , view_layouttiled) {
+  // These two examples are iterating by tile, then within a tile - not by extents
+  // If N# is not a power of two, but want to iterate by tile then within a tile, need to check that mapped index is within extent
+  TestViewLayoutTiled< TEST_EXECSPACE >::test_view_layout_tiled_2d( 4, 12 );
+  TestViewLayoutTiled< TEST_EXECSPACE >::test_view_layout_tiled_3d( 4, 12, 16 );
+}
+
+} // namespace Test

--- a/core/unit_test/TestViewLayoutTiled.hpp
+++ b/core/unit_test/TestViewLayoutTiled.hpp
@@ -65,10 +65,10 @@ struct TestViewLayoutTiled {
   static constexpr int T1 = 4;
   static constexpr int T2 = 4;
   static constexpr int T3 = 2;
-  static constexpr int T4 = 4;
-  static constexpr int T5 = 4;
-  static constexpr int T6 = 4;
-  static constexpr int T7 = 4;
+  static constexpr int T4 = 2;
+  static constexpr int T5 = 2;
+  static constexpr int T6 = 2;
+  static constexpr int T7 = 2;
 
   // Rank 2
   typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, T0, T1>   LayoutLL_2D_2x4;
@@ -89,164 +89,21 @@ struct TestViewLayoutTiled {
   typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, T0, T1, T2, T3> LayoutRR_4D_2x4x4x2;
 
 
-#define DEBUG_VERBOSE_OUTPUT 0
-
-  // Rank 2 tests
-  // Create N0 x N1 view with tile dimensions of T0 x T1
   static void test_view_layout_tiled_2d( const int N0, const int N1 )
   {
-
-//    const int T0 = 2;
-//    const int T1 = 4;
     const int FT = T0*T1;
 
     const int NT0 = int( std::ceil( N0 / T0 ) );
     const int NT1 = int( std::ceil( N1 / T1 ) );
-
-    // 4x12 view - 48 items
-    // tiledims 2x4
-    // full tile 8
-    // num tiles 2x3
-    std::cout << "Begin output \n N0 = " << N0 << " N1 = " << N1 << "\n T0 = " << T0 << " T1 = " << T1 << "  FTD = " << FT << "  NT0 = " << NT0 << "  NT1 = " << NT1 << std::endl;
-    long counter[4] = {0};
+    // Test create_mirror_view, deep_copy
     // Create LL View
     {
-      std::cout << "Init LL View" << std::endl;
-      Kokkos::View< Scalar**, LayoutLL_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
-      for ( int tj = 0; tj < NT1; ++tj ) {
-      for ( int ti = 0; ti < NT0; ++ti ) {
-        for ( int j = 0; j < T1; ++j ) {
-        for ( int i = 0; i < T0; ++i ) {
-          v(ti*T0 + i, tj*T1+j) = ( ti + tj*NT0 )*FT + ( i + j*T0 );
-        } }
-      } }
-
-      std::cout << "\nOutput L-L pattern 2x4 tiles:" << std::endl;
-      for ( int tj = 0; tj < NT1; ++tj ) {
-      for ( int ti = 0; ti < NT0; ++ti ) {
-        for ( int j = 0; j < T1; ++j ) {
-        for ( int i = 0; i < T0; ++i ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj );
-          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[0]; }
-#if DEBUG_VERBOSE_OUTPUT
-          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
-          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti + tj*NT0 )*FT + ( i + j*T0 ) << std::endl;
-          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
-#endif
-        } }
-      } }
-    } // end scope
-
-    // Create RL View
-    {
-      std::cout << "\nInit RL View" << std::endl;
-      Kokkos::View< Scalar**, LayoutRL_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
-      for ( int ti = 0; ti < NT0; ++ti ) {
-      for ( int tj = 0; tj < NT1; ++tj ) {
-        for ( int j = 0; j < T1; ++j ) {
-        for ( int i = 0; i < T0; ++i ) {
-          v(ti*T0 + i, tj*T1+j) = ( ti*NT1 + tj )*FT + ( i + j*T0 );
-        } }
-      } }
-
-      std::cout << "\nOutput R-L pattern 2x4 tiles:" << std::endl;
-      for ( int ti = 0; ti < NT0; ++ti ) {
-      for ( int tj = 0; tj < NT1; ++tj ) {
-        for ( int j = 0; j < T1; ++j ) {
-        for ( int i = 0; i < T0; ++i ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj );
-          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[1]; }
-#if DEBUG_VERBOSE_OUTPUT
-          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
-          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti*NT1 + tj )*FT + ( i + j*T0 ) << std::endl;
-          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
-#endif
-        } }
-      } }
-    } // end scope
-
-    // Create LR View
-    {
-      std::cout << "\nInit LR View" << std::endl;
-      Kokkos::View< Scalar**, LayoutLR_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
-      for ( int tj = 0; tj < NT1; ++tj ) {
-      for ( int ti = 0; ti < NT0; ++ti ) {
-        for ( int i = 0; i < T0; ++i ) {
-        for ( int j = 0; j < T1; ++j ) {
-          v(ti*T0 + i, tj*T1+j) = ( ti + tj*NT0 )*FT + ( i*T1 + j );
-        } }
-      } }
-
-      std::cout << "\nOutput L-R pattern 2x4 tiles:" << std::endl;
-      for ( int tj = 0; tj < NT1; ++tj ) {
-      for ( int ti = 0; ti < NT0; ++ti ) {
-        for ( int i = 0; i < T0; ++i ) {
-        for ( int j = 0; j < T1; ++j ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj );
-          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[2]; }
-#if DEBUG_VERBOSE_OUTPUT
-          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
-          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti + tj*NT0 )*FT + ( i*T1 + j ) << std::endl;
-          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
-#endif
-        } }
-      } }
-    } // end scope
-
-    // Create RR View
-    {
-      std::cout << "\nInit RR View" << std::endl;
-      Kokkos::View< Scalar**, LayoutRR_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
-      for ( int ti = 0; ti < NT0; ++ti ) {
-      for ( int tj = 0; tj < NT1; ++tj ) {
-        for ( int i = 0; i < T0; ++i ) {
-        for ( int j = 0; j < T1; ++j ) {
-          v(ti*T0 + i, tj*T1+j) = ( ti*NT1 + tj )*FT + ( i*T1 + j );
-        } }
-      } }
-
-      std::cout << "\nOutput R-R pattern 2x4 tiles:" << std::endl;
-      for ( int ti = 0; ti < NT0; ++ti ) {
-      for ( int tj = 0; tj < NT1; ++tj ) {
-        for ( int i = 0; i < T0; ++i ) {
-        for ( int j = 0; j < T1; ++j ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj );
-          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[3]; }
-#if DEBUG_VERBOSE_OUTPUT
-          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
-          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti*NT1 + tj )*FT + ( i*T1 + j ) << std::endl;
-          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
-          std::cout << "subview tile rank = " << Kokkos::rank(tile_subview) << std::endl;
-#endif
-        } }
-      } }
-    } // end scope
-
-#if DEBUG_SUMMARY_OUTPUT
-    std::cout << "subview_tile vs view errors:\n"
-      << " LL: " << counter[0]
-      << " RL: " << counter[1]
-      << " LR: " << counter[2]
-      << " RR: " << counter[3] 
-      << std::endl;
-#endif
-
-    ASSERT_EQ(counter[0], long(0));
-    ASSERT_EQ(counter[1], long(0));
-    ASSERT_EQ(counter[2], long(0));
-    ASSERT_EQ(counter[3], long(0));
-
-    // Test create_mirror_view, deep_copy
-    {
-      std::cout << "\nCreate LL View - test mirror view and deep_copy and use in parallel_for" << std::endl;
       typedef typename Kokkos::View< Scalar**, LayoutLL_2D_2x4, ExecSpace > ViewType;
       ViewType v("v", N0, N1);
 
       typename ViewType::HostMirror hv = Kokkos::create_mirror_view(v);
 
-      std::cout << "  ViewType: " << typeid(ViewType()).name() << "\n  HostMirror: " << typeid(typename ViewType::HostMirror() ).name() << std::endl;
-      std::cout << "  ViewType Layout: " << typeid(typename ViewType::array_layout()).name() << "\n  HostMirror Layout: " << typeid(typename ViewType::HostMirror::array_layout() ).name() << std::endl;
-
+      // Initialize host-view
       for ( int tj = 0; tj < NT1; ++tj ) {
       for ( int ti = 0; ti < NT0; ++ti ) {
         for ( int j = 0; j < T1; ++j ) {
@@ -254,12 +111,14 @@ struct TestViewLayoutTiled {
           hv(ti*T0 + i, tj*T1+j) = ( ti + tj*NT0 )*FT + ( i + j*T0 );
         } }
       } }
-#if 1
+
+      // copy to device
       Kokkos::deep_copy(v, hv);
 
       Kokkos::MDRangePolicy< Kokkos::Rank<2, Kokkos::Iterate::Left, Kokkos::Iterate::Left>, ExecSpace > mdrangepolicy( {0,0}, {NT0, NT1}, {T0,T1} );
 
-      Kokkos::parallel_for( "ViewTile rank 2 test 1", mdrangepolicy, 
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 2 LL", mdrangepolicy, 
         KOKKOS_LAMBDA (const int ti, const int tj) {
           for ( int j = 0; j < T1; ++j ) {
           for ( int i = 0; i < T0; ++i ) {
@@ -282,9 +141,151 @@ struct TestViewLayoutTiled {
       } }
       ASSERT_EQ(counter_subview, long(0));
       ASSERT_EQ(counter_inc, long(0));
-#endif    
     }
 
+    // Create RL View
+    {
+      typedef typename Kokkos::View< Scalar**, LayoutRL_2D_2x4, ExecSpace > ViewType;
+      Kokkos::View< Scalar**, LayoutRL_2D_2x4, ExecSpace > v("v", N0, N1);
+
+      typename ViewType::HostMirror hv = Kokkos::create_mirror_view(v);
+
+      // Initialize host-view
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          hv(ti*T0 + i, tj*T1+j) = ( ti*NT1 + tj )*FT + ( i + j*T0 );
+        } }
+      } }
+
+      // copy to device
+      Kokkos::deep_copy(v, hv);
+
+      Kokkos::MDRangePolicy< Kokkos::Rank<2, Kokkos::Iterate::Right, Kokkos::Iterate::Left>, ExecSpace > mdrangepolicy( {0,0}, {NT0, NT1}, {T0,T1} );
+
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 2 RL", mdrangepolicy, 
+        KOKKOS_LAMBDA (const int ti, const int tj) {
+          for ( int j = 0; j < T1; ++j ) {
+          for ( int i = 0; i < T0; ++i ) {
+            if ( (ti*T0 + i < N0) && (tj*T1 + j < N1) ) { v(ti*T0 + i, tj*T1+j) += 1; }
+          } }
+        });
+
+      Kokkos::deep_copy(hv, v);
+
+      long counter_subview = 0;
+      long counter_inc = 0;
+
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        auto tile_subview = Kokkos::tile_subview( hv, ti, tj );
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          if ( tile_subview(i,j) != hv(ti*T0+i, tj*T1+j) ) { ++counter_subview; }
+          if ( tile_subview(i,j) != (( ti*NT1 + tj )*FT + ( i + j*T0 ) + 1 )) { ++counter_inc; }
+        } }
+      } }
+      ASSERT_EQ(counter_subview, long(0));
+      ASSERT_EQ(counter_inc, long(0));
+    } // end scope
+
+    // Create LR View
+    {
+      typedef typename Kokkos::View< Scalar**, LayoutLR_2D_2x4, ExecSpace > ViewType;
+      Kokkos::View< Scalar**, LayoutLR_2D_2x4, ExecSpace > v("v", N0, N1);
+
+      typename ViewType::HostMirror hv = Kokkos::create_mirror_view(v);
+
+      // Initialize host-view
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          hv(ti*T0 + i, tj*T1+j) = ( ti + tj*NT0 )*FT + ( i*T1 + j );
+        } }
+      } }
+
+      // copy to device
+      Kokkos::deep_copy(v, hv);
+
+      Kokkos::MDRangePolicy< Kokkos::Rank<2, Kokkos::Iterate::Left, Kokkos::Iterate::Right>, ExecSpace > mdrangepolicy( {0,0}, {NT0, NT1}, {T0,T1} );
+
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 2 LR", mdrangepolicy, 
+        KOKKOS_LAMBDA (const int ti, const int tj) {
+          for ( int j = 0; j < T1; ++j ) {
+          for ( int i = 0; i < T0; ++i ) {
+            if ( (ti*T0 + i < N0) && (tj*T1 + j < N1) ) { v(ti*T0 + i, tj*T1+j) += 1; }
+          } }
+        });
+
+      Kokkos::deep_copy(hv, v);
+
+      long counter_subview = 0;
+      long counter_inc = 0;
+
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        auto tile_subview = Kokkos::tile_subview( hv, ti, tj );
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          if ( tile_subview(i,j) != hv(ti*T0+i, tj*T1+j) ) { ++counter_subview; }
+          if ( tile_subview(i,j) != ( ( ti + tj*NT0 )*FT + ( i*T1 + j ) + 1 ) ) { ++counter_inc; }
+        } }
+      } }
+      ASSERT_EQ(counter_subview, long(0));
+      ASSERT_EQ(counter_inc, long(0));
+    } // end scope
+
+    // Create RR View
+    {
+      typedef typename Kokkos::View< Scalar**, LayoutRR_2D_2x4, ExecSpace > ViewType;
+      Kokkos::View< Scalar**, LayoutRR_2D_2x4, ExecSpace > v("v", N0, N1);
+
+      typename ViewType::HostMirror hv = Kokkos::create_mirror_view(v);
+
+      // Initialize host-view
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          hv(ti*T0 + i, tj*T1+j) = ( ti*NT1 + tj )*FT + ( i*T1 + j );
+        } }
+      } }
+
+      // copy to device
+      Kokkos::deep_copy(v, hv);
+
+      Kokkos::MDRangePolicy< Kokkos::Rank<2, Kokkos::Iterate::Left, Kokkos::Iterate::Right>, ExecSpace > mdrangepolicy( {0,0}, {NT0, NT1}, {T0,T1} );
+
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 2 LR", mdrangepolicy, 
+        KOKKOS_LAMBDA (const int ti, const int tj) {
+          for ( int j = 0; j < T1; ++j ) {
+          for ( int i = 0; i < T0; ++i ) {
+            if ( (ti*T0 + i < N0) && (tj*T1 + j < N1) ) { v(ti*T0 + i, tj*T1+j) += 1; }
+          } }
+        });
+
+      Kokkos::deep_copy(hv, v);
+
+      long counter_subview = 0;
+      long counter_inc = 0;
+
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        auto tile_subview = Kokkos::tile_subview( hv, ti, tj );
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          if ( tile_subview(i,j) != hv(ti*T0+i, tj*T1+j) ) { ++counter_subview; }
+          if ( tile_subview(i,j) != ( ( ti*NT1 + tj )*FT + ( i*T1 + j ) + 1 ) ) { ++counter_inc; }
+        } }
+      } }
+      ASSERT_EQ(counter_subview, long(0));
+      ASSERT_EQ(counter_inc, long(0));
+    } // end scope
   } // end test_view_layout_tiled_2d
 
 
@@ -297,15 +298,572 @@ struct TestViewLayoutTiled {
     const int NT1 = int( std::ceil( N1 / T1 ) );
     const int NT2 = int( std::ceil( N2 / T2 ) );
 
-    // 4x12x16 view
-    // tiledims 2x4x4
-    // full tile 32
-    // num tiles 2x3x4
-    std::cout << "\nBegin output \n N0 = " << N0 << " N1 = " << N1 << " N2 = " << N2 << "\n T0 = " << T0 << " T1 = " << T1 << " T2 = " << T2 << "  FTD = " << FT << "  NT0 = " << NT0 << "  NT1 = " << NT1 << " NT2 = " << NT2 << std::endl;
+    // Create LL View
+    {
+      typedef Kokkos::View< Scalar***, LayoutLL_3D_2x4x4, ExecSpace > ViewType;
+      Kokkos::View< Scalar***, LayoutLL_3D_2x4x4, ExecSpace > dv("dv", N0, N1, N2);
+
+      typename ViewType::HostMirror v = Kokkos::create_mirror_view(dv);
+
+      // Initialize on host
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k) = ( ti + tj*NT0 + tk*N0*N1 )*FT + ( i + j*T0 + k*T0*T1 );
+        } } }
+      } } }
+
+      // copy to device
+      Kokkos::deep_copy(dv, v);
+
+      Kokkos::MDRangePolicy< Kokkos::Rank<3, Kokkos::Iterate::Left, Kokkos::Iterate::Left>, ExecSpace > mdrangepolicy( {0,0,0}, {N0,N1,N2}, {T0,T1,T2} );
+
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 3 LL", mdrangepolicy, 
+        KOKKOS_LAMBDA (const int i, const int j, const int k) {
+          dv(i,j,k) += 1;
+        });
+
+      Kokkos::deep_copy(v, dv);
+
+      long counter_subview = 0;
+      long counter_inc = 0;
+
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter_subview; }
+          if ( tile_subview(i,j,k) != ( ( ti + tj*NT0 + tk*N0*N1 )*FT + ( i + j*T0 + k*T0*T1 ) +  1 ) ) { ++counter_inc; }
+        } } }
+      } } }
+      ASSERT_EQ(counter_subview, long(0));
+      ASSERT_EQ(counter_inc, long(0));
+    } // end scope
+
+    // Create RL View
+    {
+      typedef Kokkos::View< Scalar***, LayoutRL_3D_2x4x4, ExecSpace > ViewType;
+      Kokkos::View< Scalar***, LayoutRL_3D_2x4x4, ExecSpace > dv("dv", N0, N1, N2);
+
+      typename ViewType::HostMirror v = Kokkos::create_mirror_view(dv);
+
+      // Initialize on host
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k) = ( ti*NT1*NT2 + tj*NT2 + tk )*FT + ( i + j*T0 + k*T0*T1 );
+        } } }
+      } } }
+
+      // copy to device
+      Kokkos::deep_copy(dv, v);
+
+      Kokkos::MDRangePolicy< Kokkos::Rank<3, Kokkos::Iterate::Right, Kokkos::Iterate::Left>, ExecSpace > mdrangepolicy( {0,0,0}, {N0,N1,N2}, {T0,T1,T2} );
+
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 3 RL", mdrangepolicy, 
+        KOKKOS_LAMBDA (const int i, const int j, const int k) {
+          dv(i,j,k) += 1;
+        });
+
+      Kokkos::deep_copy(v, dv);
+
+      long counter_subview = 0;
+      long counter_inc = 0;
+
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter_subview; }
+          if ( tile_subview(i,j,k) != ( ( ti*NT1*NT2 + tj*NT2 + tk )*FT + ( i + j*T0 + k*T0*T1 ) + 1 ) ) { ++counter_inc; }
+        } } }
+      } } }
+      ASSERT_EQ(counter_subview, long(0));
+      ASSERT_EQ(counter_inc, long(0));
+    } // end scope
+
+    // Create LR View
+    {
+      typedef Kokkos::View< Scalar***, LayoutLR_3D_2x4x4, ExecSpace > ViewType;
+      Kokkos::View< Scalar***, LayoutLR_3D_2x4x4, ExecSpace > dv("dv", N0, N1, N2);
+
+      typename ViewType::HostMirror v = Kokkos::create_mirror_view(dv);
+
+      // Initialize on host
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k) = ( ti + tj*NT0 + tk*NT0*NT1 )*FT + ( i*T1*T2 + j*T2 + k );
+        } } }
+      } } }
+
+      // copy to device
+      Kokkos::deep_copy(dv, v);
+
+      Kokkos::MDRangePolicy< Kokkos::Rank<3, Kokkos::Iterate::Left, Kokkos::Iterate::Right>, ExecSpace > mdrangepolicy( {0,0,0}, {N0,N1,N2}, {T0,T1,T2} );
+
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 3 LR", mdrangepolicy, 
+        KOKKOS_LAMBDA (const int i, const int j, const int k) {
+          dv(i,j,k) += 1;
+        });
+
+      Kokkos::deep_copy(v, dv);
+
+      long counter_subview = 0;
+      long counter_inc = 0;
+
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+          if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter_subview; }
+          if ( tile_subview(i,j,k) != ( ( ti + tj*NT0 + tk*NT0*NT1 )*FT + ( i*T1*T2 + j*T2 + k ) + 1 ) ) { ++counter_inc; }
+        } } }
+      } } }
+      ASSERT_EQ(counter_subview, long(0));
+      ASSERT_EQ(counter_inc, long(0));
+    } // end scope
+
+    // Create RR View
+    {
+      typedef Kokkos::View< Scalar***, LayoutRR_3D_2x4x4, ExecSpace > ViewType;
+      Kokkos::View< Scalar***, LayoutRR_3D_2x4x4, ExecSpace > dv("dv", N0, N1, N2);
+
+      typename ViewType::HostMirror v = Kokkos::create_mirror_view(dv);
+
+      // Initialize on host
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k) = ( ti*NT1*NT2 + tj*NT2 + tk )*FT + ( i*T1*T2 + j*T2 + k );
+        } } }
+      } } }
+
+      // copy to device
+      Kokkos::deep_copy(dv, v);
+
+      Kokkos::MDRangePolicy< Kokkos::Rank<3, Kokkos::Iterate::Right, Kokkos::Iterate::Right>, ExecSpace > mdrangepolicy( {0,0,0}, {N0,N1,N2}, {T0,T1,T2} );
+
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 3 RR", mdrangepolicy, 
+        KOKKOS_LAMBDA (const int i, const int j, const int k) {
+          dv(i,j,k) += 1;
+        });
+
+      Kokkos::deep_copy(v, dv);
+
+      long counter_subview = 0;
+      long counter_inc = 0;
+
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+          if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter_subview; }
+          if ( tile_subview(i,j,k) != ( ( ti*NT1*NT2 + tj*NT2 + tk )*FT + ( i*T1*T2 + j*T2 + k ) + 1 ) ) { ++counter_inc; }
+        } } }
+      } } }
+      ASSERT_EQ(counter_subview, long(0));
+      ASSERT_EQ(counter_inc, long(0));
+    } // end scope
+  } // end test_view_layout_tiled_3d
+
+
+  static void test_view_layout_tiled_4d( const int N0, const int N1, const int N2, const int N3 )
+  {
+    const int FT = T0*T1*T2*T3;
+
+    const int NT0 = int( std::ceil( N0 / T0 ) );
+    const int NT1 = int( std::ceil( N1 / T1 ) );
+    const int NT2 = int( std::ceil( N2 / T2 ) );
+    const int NT3 = int( std::ceil( N3 / T3 ) );
+
+    // Create LL View
+    {
+      typedef Kokkos::View< Scalar****, LayoutLL_4D_2x4x4x2, ExecSpace > ViewType;
+      Kokkos::View< Scalar****, LayoutLL_4D_2x4x4x2, ExecSpace > dv("dv", N0, N1, N2, N3);
+
+      typename ViewType::HostMirror v = Kokkos::create_mirror_view(dv);
+
+      // Initialize on host
+      for ( int tl = 0; tl < NT3; ++tl ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int l = 0; l < T3; ++l ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k, tl*T3 + l) = ( ti + tj*NT0 + tk*N0*N1 + tl*N0*N1*N2 )*FT + ( i + j*T0 + k*T0*T1 + l*T0*T1*T2 );
+        } } } }
+      } } } }
+
+      // copy to device
+      Kokkos::deep_copy(dv, v);
+
+      Kokkos::MDRangePolicy< Kokkos::Rank<4, Kokkos::Iterate::Left, Kokkos::Iterate::Left>, ExecSpace > mdrangepolicy( {0,0,0,0}, {N0,N1,N2,N3}, {T0,T1,T2,T3} );
+
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 4 LL", mdrangepolicy, 
+        KOKKOS_LAMBDA (const int i, const int j, const int k, const int l) {
+          dv(i,j,k,l) += 1;
+        });
+
+      Kokkos::deep_copy(v, dv);
+
+      long counter_subview = 0;
+      long counter_inc = 0;
+
+      for ( int tl = 0; tl < NT3; ++tl ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
+        for ( int l = 0; l < T3; ++l ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          if ( tile_subview(i,j,k,l) != v(ti*T0+i, tj*T1+j, tk*T2+k, tl*T3 + l) ) { ++counter_subview; }
+          if ( tile_subview(i,j,k,l) != ( ( ti + tj*NT0 + tk*N0*N1 + tl*N0*N1*N2 )*FT + ( i + j*T0 + k*T0*T1 + l*T0*T1*T2 ) + 1 ) ) { ++counter_inc; }
+        } } } }
+      } } } }
+      ASSERT_EQ(counter_subview, long(0));
+      ASSERT_EQ(counter_inc, long(0));
+    } // end scope
+
+    // Create RL View
+    {
+      typedef Kokkos::View< Scalar****, LayoutRL_4D_2x4x4x2, ExecSpace > ViewType;
+      Kokkos::View< Scalar****, LayoutRL_4D_2x4x4x2, ExecSpace > dv("dv", N0, N1, N2, N3);
+
+      typename ViewType::HostMirror v = Kokkos::create_mirror_view(dv);
+
+      // Initialize on host
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tl = 0; tl < NT3; ++tl ) {
+        for ( int l = 0; l < T3; ++l ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k, tl*T3 + l) = ( ti*NT1*NT2*N3 + tj*NT2*N3 + tk*N3 + tl )*FT + ( i + j*T0 + k*T0*T1 + l*T0*T1*T2 );
+        } } } }
+      } } } }
+
+      // copy to device
+      Kokkos::deep_copy(dv, v);
+
+      Kokkos::MDRangePolicy< Kokkos::Rank<4, Kokkos::Iterate::Right, Kokkos::Iterate::Left>, ExecSpace > mdrangepolicy( {0,0,0,0}, {N0,N1,N2,N3}, {T0,T1,T2,T3} );
+
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 4 RL", mdrangepolicy, 
+        KOKKOS_LAMBDA (const int i, const int j, const int k, const int l) {
+          dv(i,j,k,l) += 1;
+        });
+
+      Kokkos::deep_copy(v, dv);
+
+      long counter_subview = 0;
+      long counter_inc = 0;
+
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tl = 0; tl < NT3; ++tl ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
+        for ( int l = 0; l < T3; ++l ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          if ( tile_subview(i,j,k,l) != v(ti*T0+i, tj*T1+j, tk*T2+k, tl*T3 + l) ) { ++counter_subview; }
+          if ( tile_subview(i,j,k,l) != ( ( ti*NT1*NT2*N3 + tj*NT2*N3 + tk*N3 + tl )*FT + ( i + j*T0 + k*T0*T1 + l*T0*T1*T2 ) + 1 ) ) { ++counter_inc; }
+        } } } }
+      } } } }
+      ASSERT_EQ(counter_subview, long(0));
+      ASSERT_EQ(counter_inc, long(0));
+    } // end scope
+
+    // Create LR View
+    {
+      typedef Kokkos::View< Scalar****, LayoutLR_4D_2x4x4x2, ExecSpace > ViewType;
+      Kokkos::View< Scalar****, LayoutLR_4D_2x4x4x2, ExecSpace > dv("dv", N0, N1, N2, N3);
+
+      typename ViewType::HostMirror v = Kokkos::create_mirror_view(dv);
+
+      // Initialize on host
+      for ( int tl = 0; tl < NT3; ++tl ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int l = 0; l < T3; ++l ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k, tl*T3 + l) = ( ti + tj*NT0 + tk*NT0*NT1 + tl*NT0*NT1*NT2 )*FT + ( i*T1*T2*T3 + j*T2*T3 + k*T3 + l );
+        } } } }
+      } } } }
+
+      // copy to device
+      Kokkos::deep_copy(dv, v);
+
+      Kokkos::MDRangePolicy< Kokkos::Rank<4, Kokkos::Iterate::Left, Kokkos::Iterate::Right>, ExecSpace > mdrangepolicy( {0,0,0,0}, {N0,N1,N2,N3}, {T0,T1,T2,T3} );
+
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 4 LR", mdrangepolicy, 
+        KOKKOS_LAMBDA (const int i, const int j, const int k, const int l) {
+          dv(i,j,k,l) += 1;
+        });
+
+      Kokkos::deep_copy(v, dv);
+
+      long counter_subview = 0;
+      long counter_inc = 0;
+
+      for ( int tl = 0; tl < NT3; ++tl ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int l = 0; l < T3; ++l ) {
+          if ( tile_subview(i,j,k,l) != v(ti*T0+i, tj*T1+j, tk*T2+k, tl*T3 + l) ) { ++counter_subview; }
+          if ( tile_subview(i,j,k,l) != ( ( ti + tj*NT0 + tk*NT0*NT1 + tl*NT0*NT1*NT2 )*FT + ( i*T1*T2*T3 + j*T2*T3 + k*T3 + l ) + 1 ) ) { ++counter_inc; }
+        } } } }
+      } } } }
+      ASSERT_EQ(counter_subview, long(0));
+      ASSERT_EQ(counter_inc, long(0));
+    } // end scope
+
+    // Create RR View
+    {
+      typedef Kokkos::View< Scalar****, LayoutRR_4D_2x4x4x2, ExecSpace > ViewType;
+      Kokkos::View< Scalar****, LayoutRR_4D_2x4x4x2, ExecSpace > dv("dv", N0, N1, N2, N3);
+
+      typename ViewType::HostMirror v = Kokkos::create_mirror_view(dv);
+
+      // Initialize on host
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tl = 0; tl < NT3; ++tl ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int l = 0; l < T3; ++l ) {
+          v(ti*T0 + i, tj*T1+j, tk*T2 + k, tl*T3 + l) = ( ti*NT1*NT2*NT3 + tj*NT2*NT3 + tk*NT3 + tl )*FT + ( i*T1*T2*T3 + j*T2*T3 + k*T3 + l );
+        } } } }
+      } } } }
+
+      // copy to device
+      Kokkos::deep_copy(dv, v);
+
+      Kokkos::MDRangePolicy< Kokkos::Rank<4, Kokkos::Iterate::Right, Kokkos::Iterate::Right>, ExecSpace > mdrangepolicy( {0,0,0,0}, {N0,N1,N2,N3}, {T0,T1,T2,T3} );
+
+      // iterate by tile
+      Kokkos::parallel_for( "ViewTile rank 4 RR", mdrangepolicy, 
+        KOKKOS_LAMBDA (const int i, const int j, const int k, const int l) {
+          dv(i,j,k,l) += 1;
+        });
+
+      Kokkos::deep_copy(v, dv);
+
+      long counter_subview = 0;
+      long counter_inc = 0;
+
+
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int tk = 0; tk < NT2; ++tk ) {
+      for ( int tl = 0; tl < NT3; ++tl ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int k = 0; k < T2; ++k ) {
+        for ( int l = 0; l < T3; ++l ) {
+          if ( tile_subview(i,j,k,l) != v(ti*T0+i, tj*T1+j, tk*T2+k, tl*T3 + l) ) { ++counter_subview; }
+          if ( tile_subview(i,j,k,l) != ( ( ti*NT1*NT2*NT3 + tj*NT2*NT3 + tk*NT3 + tl )*FT + ( i*T1*T2*T3 + j*T2*T3 + k*T3 + l ) + 1 ) ) { ++counter_inc; }
+        } } } }
+      } } } }
+      ASSERT_EQ(counter_subview, long(0));
+      ASSERT_EQ(counter_inc, long(0));
+    } // end scope
+  } // end test_view_layout_tiled_4d
+
+
+  static void test_view_layout_tiled_subtile_2d( const int N0, const int N1 )
+  {
+    const int FT = T0*T1;
+
+    const int NT0 = int( std::ceil( N0 / T0 ) );
+    const int NT1 = int( std::ceil( N1 / T1 ) );
+
+    // Counter to check for errors at the end
+    long counter[4] = {0};
+
+    // Create LL View
+    {
+      Kokkos::View< Scalar**, LayoutLL_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          v(ti*T0 + i, tj*T1+j) = ( ti + tj*NT0 )*FT + ( i + j*T0 );
+        } }
+      } }
+
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj );
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[0]; }
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
+          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
+          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti + tj*NT0 )*FT + ( i + j*T0 ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
+#endif
+        } }
+      } }
+    } // end scope
+
+    // Create RL View
+    {
+      Kokkos::View< Scalar**, LayoutRL_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          v(ti*T0 + i, tj*T1+j) = ( ti*NT1 + tj )*FT + ( i + j*T0 );
+        } }
+      } }
+
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj );
+        for ( int j = 0; j < T1; ++j ) {
+        for ( int i = 0; i < T0; ++i ) {
+          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[1]; }
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
+          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
+          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti*NT1 + tj )*FT + ( i + j*T0 ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
+#endif
+        } }
+      } }
+    } // end scope
+
+    // Create LR View
+    {
+      Kokkos::View< Scalar**, LayoutLR_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          v(ti*T0 + i, tj*T1+j) = ( ti + tj*NT0 )*FT + ( i*T1 + j );
+        } }
+      } }
+
+      for ( int tj = 0; tj < NT1; ++tj ) {
+      for ( int ti = 0; ti < NT0; ++ti ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj );
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[2]; }
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
+          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
+          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti + tj*NT0 )*FT + ( i*T1 + j ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
+#endif
+        } }
+      } }
+    } // end scope
+
+    // Create RR View
+    {
+      Kokkos::View< Scalar**, LayoutRR_2D_2x4, Kokkos::HostSpace > v("v", N0, N1);
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          v(ti*T0 + i, tj*T1+j) = ( ti*NT1 + tj )*FT + ( i*T1 + j );
+        } }
+      } }
+
+      for ( int ti = 0; ti < NT0; ++ti ) {
+      for ( int tj = 0; tj < NT1; ++tj ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj );
+        for ( int i = 0; i < T0; ++i ) {
+        for ( int j = 0; j < T1; ++j ) {
+          if ( tile_subview(i,j) != v(ti*T0+i, tj*T1+j) ) { ++counter[3]; }
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
+          std::cout << "idx0,idx1 = " << ti*T0 + i << "," << tj*T1 + j << std::endl;
+          std::cout << "ti,tj,i,j: " << ti << "," << tj << "," << i << "," << j << "  v = " << v(ti*T0 + i, tj*T1+j) << "  flat idx = " << ( ti*NT1 + tj )*FT + ( i*T1 + j ) << std::endl;
+          std::cout << "subview_tile output = " << tile_subview(i,j) << std::endl;
+          std::cout << "subview tile rank = " << Kokkos::rank(tile_subview) << std::endl;
+#endif
+        } }
+      } }
+    } // end scope
+
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
+    std::cout << "subview_tile vs view errors:\n"
+      << " LL: " << counter[0]
+      << " RL: " << counter[1]
+      << " LR: " << counter[2]
+      << " RR: " << counter[3] 
+      << std::endl;
+#endif
+
+    ASSERT_EQ(counter[0], long(0));
+    ASSERT_EQ(counter[1], long(0));
+    ASSERT_EQ(counter[2], long(0));
+    ASSERT_EQ(counter[3], long(0));
+  } // end test_view_layout_tiled_subtile_2d
+
+
+  static void test_view_layout_tiled_subtile_3d( const int N0, const int N1, const int N2 )
+  {
+
+    const int FT = T0*T1*T2;
+
+    const int NT0 = int( std::ceil( N0 / T0 ) );
+    const int NT1 = int( std::ceil( N1 / T1 ) );
+    const int NT2 = int( std::ceil( N2 / T2 ) );
+
+    // Counter to check for errors at the end
     long counter[4] = {0};
     // Create LL View
     {
-      std::cout << "Init LL View" << std::endl;
       Kokkos::View< Scalar***, LayoutLL_3D_2x4x4, Kokkos::HostSpace > v("v", N0, N1, N2);
       for ( int tk = 0; tk < NT2; ++tk ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
@@ -317,16 +875,15 @@ struct TestViewLayoutTiled {
         } } }
       } } }
 
-      std::cout << "\nOutput L-L pattern 2x4x4 tiles:" << std::endl;
       for ( int tk = 0; tk < NT2; ++tk ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
       for ( int ti = 0; ti < NT0; ++ti ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
         for ( int k = 0; k < T2; ++k ) {
         for ( int j = 0; j < T1; ++j ) {
         for ( int i = 0; i < T0; ++i ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
           if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter[0]; }
-#if DEBUG_VERBOSE_OUTPUT
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
           std::cout << "idx0,idx1,idx2 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << std::endl;
           std::cout << "ti,tj,tk,i,j,k: " << ti << "," << tj << "," << tk << "," << i << "," << j << "," << k << "  v = " << v(ti*T0 + i, tj*T1+j, tk*T2 + k) << "  flat idx = " << ( ti + tj*NT0 + tk*N0*N1 )*FT + ( i + j*T0 + k*T0*T1 ) << std::endl;
           std::cout << "subview_tile output = " << tile_subview(i,j,k) << std::endl;
@@ -338,7 +895,6 @@ struct TestViewLayoutTiled {
 
     // Create RL View
     {
-      std::cout << "\nInit RL View" << std::endl;
       Kokkos::View< Scalar***, LayoutRL_3D_2x4x4, Kokkos::HostSpace > v("v", N0, N1, N2);
       for ( int ti = 0; ti < NT0; ++ti ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
@@ -350,16 +906,15 @@ struct TestViewLayoutTiled {
         } } }
       } } }
 
-      std::cout << "\nOutput R-L pattern 2x4x4 tiles:" << std::endl;
       for ( int ti = 0; ti < NT0; ++ti ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
       for ( int tk = 0; tk < NT2; ++tk ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
         for ( int k = 0; k < T2; ++k ) {
         for ( int j = 0; j < T1; ++j ) {
         for ( int i = 0; i < T0; ++i ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
           if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter[1]; }
-#if DEBUG_VERBOSE_OUTPUT
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
           std::cout << "idx0,idx1,idx2 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << std::endl;
           std::cout << "ti,tj,tk,i,j,k: " << ti << "," << tj << "," << tk << "," << i << "," << j << "," << k << "  v = " << v(ti*T0 + i, tj*T1+j, tk*T2 + k) << "  flat idx = " << ( ti*NT1*NT2 + tj*NT2 + tk )*FT + ( i + j*T0 + k*T0*T1 ) << std::endl;
           std::cout << "subview_tile output = " << tile_subview(i,j,k) << std::endl;
@@ -370,7 +925,6 @@ struct TestViewLayoutTiled {
 
     // Create LR View
     {
-      std::cout << "\nInit LR View" << std::endl;
       Kokkos::View< Scalar***, LayoutLR_3D_2x4x4, Kokkos::HostSpace > v("v", N0, N1, N2);
       for ( int tk = 0; tk < NT2; ++tk ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
@@ -382,16 +936,15 @@ struct TestViewLayoutTiled {
         } } }
       } } }
 
-      std::cout << "\nOutput L-R pattern 2x4x4 tiles:" << std::endl;
       for ( int tk = 0; tk < NT2; ++tk ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
       for ( int ti = 0; ti < NT0; ++ti ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
         for ( int i = 0; i < T0; ++i ) {
         for ( int j = 0; j < T1; ++j ) {
         for ( int k = 0; k < T2; ++k ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
           if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter[2]; }
-#if DEBUG_VERBOSE_OUTPUT
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
           std::cout << "idx0,idx1,idx2 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << std::endl;
           std::cout << "ti,tj,tk,i,j,k: " << ti << "," << tj << "," << tk << "," << i << "," << j << "," << k << "  v = " << v(ti*T0 + i, tj*T1+j, tk*T2 + k) << "  flat idx = " << ( ti + tj*NT0 + tk*NT0*NT1 )*FT + ( i*T1*T2 + j*T2 + k ) << std::endl;
           std::cout << "subview_tile output = " << tile_subview(i,j,k) << std::endl;
@@ -403,7 +956,6 @@ struct TestViewLayoutTiled {
 
     // Create RR View
     {
-      std::cout << "\nInit RR View" << std::endl;
       Kokkos::View< Scalar***, LayoutRR_3D_2x4x4, Kokkos::HostSpace > v("v", N0, N1, N2);
       for ( int ti = 0; ti < NT0; ++ti ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
@@ -415,16 +967,15 @@ struct TestViewLayoutTiled {
         } } }
       } } }
 
-      std::cout << "\nOutput R-R pattern 2x4x4 tiles:" << std::endl;
       for ( int ti = 0; ti < NT0; ++ti ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
       for ( int tk = 0; tk < NT2; ++tk ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
         for ( int i = 0; i < T0; ++i ) {
         for ( int j = 0; j < T1; ++j ) {
         for ( int k = 0; k < T2; ++k ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
           if ( tile_subview(i,j,k) != v(ti*T0+i, tj*T1+j, tk*T2+k) ) { ++counter[3]; }
-#if DEBUG_VERBOSE_OUTPUT
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
           std::cout << "idx0,idx1,idx2 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << std::endl;
           std::cout << "ti,tj,tk,i,j,k: " << ti << "," << tj << "," << tk << "," << i << "," << j << "," << k << "  v = " << v(ti*T0 + i, tj*T1+j, tk*T2 + k) << "  flat idx = " << ( ti*NT1*NT2 + tj*NT2 + tk )*FT + ( i*T1*T2 + j*T2 + k ) << std::endl;
           std::cout << "subview_tile output = " << tile_subview(i,j,k) << std::endl;
@@ -434,7 +985,7 @@ struct TestViewLayoutTiled {
       } } }
     } // end scope
 
-#if DEBUG_SUMMARY_OUTPUT
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
     std::cout << "subview_tile vs view errors:\n"
       << " LL: " << counter[0]
       << " RL: " << counter[1]
@@ -448,12 +999,11 @@ struct TestViewLayoutTiled {
     ASSERT_EQ(counter[2], long(0));
     ASSERT_EQ(counter[3], long(0));
 
-  } // end test_view_layout_tiled_3d
+  } // end test_view_layout_tiled_subtile_3d
 
 
-  static void test_view_layout_tiled_4d( const int N0, const int N1, const int N2, const int N3 )
+  static void test_view_layout_tiled_subtile_4d( const int N0, const int N1, const int N2, const int N3 )
   {
-
     const int FT = T0*T1*T2*T3;
 
     const int NT0 = int( std::ceil( N0 / T0 ) );
@@ -461,15 +1011,10 @@ struct TestViewLayoutTiled {
     const int NT2 = int( std::ceil( N2 / T2 ) );
     const int NT3 = int( std::ceil( N3 / T3 ) );
 
-    // 4x12x16x12 view
-    // tiledims 2x4x4x2
-    // full tile 64
-    // num tiles 2x3x4x6
-    std::cout << "\nBegin output \n N0 = " << N0 << " N1 = " << N1 << " N2 = " << N2  << " N3 = " << N3 << "\n T0 = " << T0 << " T1 = " << T1 << " T2 = " << T2 << " T3 = " << T3 << "  FTD = " << FT << "  NT0 = " << NT0 << "  NT1 = " << NT1 << " NT2 = " << NT2 << " NT3 = " << NT3 << std::endl;
+    // Counter to check for errors at the end
     long counter[4] = {0};
     // Create LL View
     {
-      std::cout << "Init LL View" << std::endl;
       Kokkos::View< Scalar****, LayoutLL_4D_2x4x4x2, Kokkos::HostSpace > v("v", N0, N1, N2, N3);
       for ( int tl = 0; tl < NT3; ++tl ) {
       for ( int tk = 0; tk < NT2; ++tk ) {
@@ -483,18 +1028,17 @@ struct TestViewLayoutTiled {
         } } } }
       } } } }
 
-      std::cout << "\nOutput L-L pattern 2x4x4x2 tiles:" << std::endl;
       for ( int tl = 0; tl < NT3; ++tl ) {
       for ( int tk = 0; tk < NT2; ++tk ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
       for ( int ti = 0; ti < NT0; ++ti ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
         for ( int l = 0; l < T3; ++l ) {
         for ( int k = 0; k < T2; ++k ) {
         for ( int j = 0; j < T1; ++j ) {
         for ( int i = 0; i < T0; ++i ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
           if ( tile_subview(i,j,k,l) != v(ti*T0+i, tj*T1+j, tk*T2+k, tl*T3 + l) ) { ++counter[0]; }
-#if DEBUG_VERBOSE_OUTPUT
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
           std::cout << "idx0,idx1,idx2,idx3 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << "," << tl*T3 + l<< std::endl;
           std::cout << "ti,tj,tk,tl: " << ti << "," << tj << "," << tk << "," << tl << ","
           << "  i,j,k,l: " <<  i << "," << j << "," << k << "," << l
@@ -509,7 +1053,6 @@ struct TestViewLayoutTiled {
 
     // Create RL View
     {
-      std::cout << "\nInit RL View" << std::endl;
       Kokkos::View< Scalar****, LayoutRL_4D_2x4x4x2, Kokkos::HostSpace > v("v", N0, N1, N2, N3);
       for ( int ti = 0; ti < NT0; ++ti ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
@@ -523,18 +1066,17 @@ struct TestViewLayoutTiled {
         } } } }
       } } } }
 
-      std::cout << "\nOutput R-L pattern 2x4x4x2 tiles:" << std::endl;
       for ( int ti = 0; ti < NT0; ++ti ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
       for ( int tk = 0; tk < NT2; ++tk ) {
       for ( int tl = 0; tl < NT3; ++tl ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
         for ( int l = 0; l < T3; ++l ) {
         for ( int k = 0; k < T2; ++k ) {
         for ( int j = 0; j < T1; ++j ) {
         for ( int i = 0; i < T0; ++i ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
           if ( tile_subview(i,j,k,l) != v(ti*T0+i, tj*T1+j, tk*T2+k, tl*T3 + l) ) { ++counter[1]; }
-#if DEBUG_VERBOSE_OUTPUT
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
           std::cout << "idx0,idx1,idx2,idx3 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << "," << tl*T3 + l<< std::endl;
           std::cout << "ti,tj,tk,tl: " << ti << "," << tj << "," << tk << "," << tl << ","
           << "  i,j,k,l: " <<  i << "," << j << "," << k << "," << l
@@ -549,7 +1091,6 @@ struct TestViewLayoutTiled {
 
     // Create LR View
     {
-      std::cout << "\nInit LR View" << std::endl;
       Kokkos::View< Scalar****, LayoutLR_4D_2x4x4x2, Kokkos::HostSpace > v("v", N0, N1, N2, N3);
       for ( int tl = 0; tl < NT3; ++tl ) {
       for ( int tk = 0; tk < NT2; ++tk ) {
@@ -563,18 +1104,17 @@ struct TestViewLayoutTiled {
         } } } }
       } } } }
 
-      std::cout << "\nOutput L-R pattern 2x4x4x2 tiles:" << std::endl;
       for ( int tl = 0; tl < NT3; ++tl ) {
       for ( int tk = 0; tk < NT2; ++tk ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
       for ( int ti = 0; ti < NT0; ++ti ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
         for ( int i = 0; i < T0; ++i ) {
         for ( int j = 0; j < T1; ++j ) {
         for ( int k = 0; k < T2; ++k ) {
         for ( int l = 0; l < T3; ++l ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
           if ( tile_subview(i,j,k,l) != v(ti*T0+i, tj*T1+j, tk*T2+k, tl*T3 + l) ) { ++counter[2]; }
-#if DEBUG_VERBOSE_OUTPUT
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
           std::cout << "idx0,idx1,idx2,idx3 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << "," << tl*T3 + l<< std::endl;
           std::cout << "ti,tj,tk,tl: " << ti << "," << tj << "," << tk << "," << tl << ","
           << "  i,j,k,l: " <<  i << "," << j << "," << k << "," << l
@@ -589,7 +1129,6 @@ struct TestViewLayoutTiled {
 
     // Create RR View
     {
-      std::cout << "\nInit RR View" << std::endl;
       Kokkos::View< Scalar****, LayoutRR_4D_2x4x4x2, Kokkos::HostSpace > v("v", N0, N1, N2, N3);
       for ( int ti = 0; ti < NT0; ++ti ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
@@ -603,18 +1142,17 @@ struct TestViewLayoutTiled {
         } } } }
       } } } }
 
-      std::cout << "\nOutput R-R pattern 2x4x4x2 tiles:" << std::endl;
       for ( int ti = 0; ti < NT0; ++ti ) {
       for ( int tj = 0; tj < NT1; ++tj ) {
       for ( int tk = 0; tk < NT2; ++tk ) {
       for ( int tl = 0; tl < NT3; ++tl ) {
+        auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
         for ( int i = 0; i < T0; ++i ) {
         for ( int j = 0; j < T1; ++j ) {
         for ( int k = 0; k < T2; ++k ) {
         for ( int l = 0; l < T3; ++l ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
           if ( tile_subview(i,j,k,l) != v(ti*T0+i, tj*T1+j, tk*T2+k, tl*T3 + l) ) { ++counter[3]; }
-#if DEBUG_VERBOSE_OUTPUT
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
           std::cout << "idx0,idx1,idx2,idx3 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << "," << tl*T3 + l<< std::endl;
           std::cout << "ti,tj,tk,tl: " << ti << "," << tj << "," << tk << "," << tl << ","
           << "  i,j,k,l: " <<  i << "," << j << "," << k << "," << l
@@ -627,7 +1165,7 @@ struct TestViewLayoutTiled {
       } } } }
     } // end scope
 
-#if DEBUG_SUMMARY_OUTPUT
+#ifdef KOKKOS_VERBOSE_LAYOUTTILED_OUTPUT
     std::cout << "subview_tile vs view errors:\n"
       << " LL: " << counter[0]
       << " RL: " << counter[1]
@@ -641,18 +1179,9 @@ struct TestViewLayoutTiled {
     ASSERT_EQ(counter[2], long(0));
     ASSERT_EQ(counter[3], long(0));
 
-  } // end test_view_layout_tiled_4d
+  } // end test_view_layout_tiled_subtile_4d
 
-
-
-#ifdef DEBUG_VERBOSE_OUTPUT
-#undef DEBUG_VERBOSE_OUTPUT
-#endif
-#ifdef DEBUG_SUMMARY_OUTPUT
-#undef DEBUG_SUMMARY_OUTPUT
-#endif
-
-}; // end struct
+}; // end TestViewLayoutTiled struct
 
 } // namespace
 
@@ -662,6 +1191,13 @@ TEST_F( TEST_CATEGORY , view_layouttiled) {
   TestViewLayoutTiled< TEST_EXECSPACE >::test_view_layout_tiled_2d( 4, 12 );
   TestViewLayoutTiled< TEST_EXECSPACE >::test_view_layout_tiled_3d( 4, 12, 16 );
   TestViewLayoutTiled< TEST_EXECSPACE >::test_view_layout_tiled_4d( 4, 12, 16, 12 );
+}
+TEST_F( TEST_CATEGORY , view_layouttiled_subtile) {
+  // These two examples are iterating by tile, then within a tile - not by extents
+  // If N# is not a power of two, but want to iterate by tile then within a tile, need to check that mapped index is within extent
+  TestViewLayoutTiled< TEST_EXECSPACE >::test_view_layout_tiled_subtile_2d( 4, 12 );
+  TestViewLayoutTiled< TEST_EXECSPACE >::test_view_layout_tiled_subtile_3d( 4, 12, 16 );
+  TestViewLayoutTiled< TEST_EXECSPACE >::test_view_layout_tiled_subtile_4d( 4, 12, 16, 12 );
 }
 #endif
 } // namespace Test

--- a/core/unit_test/TestViewLayoutTiled.hpp
+++ b/core/unit_test/TestViewLayoutTiled.hpp
@@ -541,7 +541,7 @@ struct TestViewLayoutTiled {
         for ( int j = 0; j < T1; ++j ) {
         for ( int k = 0; k < T2; ++k ) {
         for ( int l = 0; l < T3; ++l ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
+          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
           if ( tile_subview(i,j,k,l) != v(ti*T0+i, tj*T1+j, tk*T2+k, tl*T3 + l) ) { ++counter[2]; }
 #if DEBUG_VERBOSE_OUTPUT
           std::cout << "idx0,idx1,idx2,idx3 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << "," << tl*T3 + l<< std::endl;
@@ -581,7 +581,7 @@ struct TestViewLayoutTiled {
         for ( int j = 0; j < T1; ++j ) {
         for ( int k = 0; k < T2; ++k ) {
         for ( int l = 0; l < T3; ++l ) {
-          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk );
+          auto tile_subview = Kokkos::tile_subview( v, ti, tj, tk, tl );
           if ( tile_subview(i,j,k,l) != v(ti*T0+i, tj*T1+j, tk*T2+k, tl*T3 + l) ) { ++counter[3]; }
 #if DEBUG_VERBOSE_OUTPUT
           std::cout << "idx0,idx1,idx2,idx3 = " << ti*T0 + i << "," << tj*T1 + j << "," << tk*T2 + k << "," << tl*T3 + l<< std::endl;

--- a/core/unit_test/TestViewLayoutTiled.hpp
+++ b/core/unit_test/TestViewLayoutTiled.hpp
@@ -58,24 +58,6 @@ namespace {
 template <typename ExecSpace >
 struct TestViewLayoutTiled {
 
-  using ViewIntType     = typename Kokkos::View< int**, ExecSpace >;
-  using ViewDoubleType     = typename Kokkos::View< double*, ExecSpace >;
-
-
-  template < class ViewType >
-  struct Functor {
-
-    ViewType v;
-
-    Functor( const ViewType & v_ ) : v(v_) {}
-
-    KOKKOS_INLINE_FUNCTION
-    void operator()( const int i ) const {
-      v(i) = i;
-    }
-
-  };
-
   typedef double Scalar;
 
   static constexpr int T0 = 2;
@@ -107,7 +89,6 @@ struct TestViewLayoutTiled {
 
 
 #define DEBUG_VERBOSE_OUTPUT 0
-#define DEBUG_SUMMARY_OUTPUT 1
 
   // Rank 2 tests
   // Create N0 x N1 view with tile dimensions of T0 x T1
@@ -257,7 +238,7 @@ struct TestViewLayoutTiled {
     // Test create_mirror_view, deep_copy
     {
       std::cout << "\nCreate LL View - test mirror view and deep_copy and use in parallel_for" << std::endl;
-      typedef typename Kokkos::View< Scalar**, LayoutLL_2D_2x4 > ViewType;
+      typedef typename Kokkos::View< Scalar**, LayoutLL_2D_2x4, ExecSpace > ViewType;
       ViewType v("v", N0, N1);
 
       typename ViewType::HostMirror hv = Kokkos::create_mirror_view(v);

--- a/core/unit_test/TestViewLayoutTiled.hpp
+++ b/core/unit_test/TestViewLayoutTiled.hpp
@@ -71,22 +71,22 @@ struct TestViewLayoutTiled {
   static constexpr int T7 = 2;
 
   // Rank 2
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, T0, T1>   LayoutLL_2D_2x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, T0, T1>  LayoutRL_2D_2x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, T0, T1>  LayoutLR_2D_2x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, T0, T1> LayoutRR_2D_2x4;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, T0, T1>   LayoutLL_2D_2x4;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, T0, T1>  LayoutRL_2D_2x4;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, T0, T1>  LayoutLR_2D_2x4;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, T0, T1> LayoutRR_2D_2x4;
 
   // Rank 3
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, T0, T1, T2>   LayoutLL_3D_2x4x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, T0, T1, T2>  LayoutRL_3D_2x4x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, T0, T1, T2>  LayoutLR_3D_2x4x4;
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, T0, T1, T2> LayoutRR_3D_2x4x4;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, T0, T1, T2>   LayoutLL_3D_2x4x4;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, T0, T1, T2>  LayoutRL_3D_2x4x4;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, T0, T1, T2>  LayoutLR_3D_2x4x4;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, T0, T1, T2> LayoutRR_3D_2x4x4;
 
   // Rank 4
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, T0, T1, T2, T3>   LayoutLL_4D_2x4x4x2;
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, T0, T1, T2, T3>  LayoutRL_4D_2x4x4x2;
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, T0, T1, T2, T3>  LayoutLR_4D_2x4x4x2;
-  typedef Kokkos::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, T0, T1, T2, T3> LayoutRR_4D_2x4x4x2;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Left, T0, T1, T2, T3>   LayoutLL_4D_2x4x4x2;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Left, T0, T1, T2, T3>  LayoutRL_4D_2x4x4x2;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Left, Kokkos::Iterate::Right, T0, T1, T2, T3>  LayoutLR_4D_2x4x4x2;
+  typedef Kokkos::Experimental::LayoutTiled<Kokkos::Iterate::Right, Kokkos::Iterate::Right, T0, T1, T2, T3> LayoutRR_4D_2x4x4x2;
 
 
   static void test_view_layout_tiled_2d( const int N0, const int N1 )

--- a/core/unit_test/TestViewLayoutTiled.hpp
+++ b/core/unit_test/TestViewLayoutTiled.hpp
@@ -91,6 +91,8 @@ struct TestViewLayoutTiled {
 
   static void test_view_layout_tiled_2d( const int N0, const int N1 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     const int FT = T0*T1;
 
     const int NT0 = int( std::ceil( N0 / T0 ) );
@@ -286,11 +288,15 @@ struct TestViewLayoutTiled {
       ASSERT_EQ(counter_subview, long(0));
       ASSERT_EQ(counter_inc, long(0));
     } // end scope
+#endif
+#endif
   } // end test_view_layout_tiled_2d
 
 
   static void test_view_layout_tiled_3d( const int N0, const int N1, const int N2 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
 
     const int FT = T0*T1*T2;
 
@@ -493,11 +499,15 @@ struct TestViewLayoutTiled {
       ASSERT_EQ(counter_subview, long(0));
       ASSERT_EQ(counter_inc, long(0));
     } // end scope
+#endif
+#endif
   } // end test_view_layout_tiled_3d
 
 
   static void test_view_layout_tiled_4d( const int N0, const int N1, const int N2, const int N3 )
   {
+#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
+#if !defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION )
     const int FT = T0*T1*T2*T3;
 
     const int NT0 = int( std::ceil( N0 / T0 ) );
@@ -717,6 +727,8 @@ struct TestViewLayoutTiled {
       ASSERT_EQ(counter_subview, long(0));
       ASSERT_EQ(counter_inc, long(0));
     } // end scope
+#endif
+#endif
   } // end test_view_layout_tiled_4d
 
 

--- a/core/unit_test/TestViewLayoutTiled.hpp
+++ b/core/unit_test/TestViewLayoutTiled.hpp
@@ -53,6 +53,7 @@
 
 namespace Test {
 
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE
 namespace {
 
 template <typename ExecSpace >
@@ -662,5 +663,5 @@ TEST_F( TEST_CATEGORY , view_layouttiled) {
   TestViewLayoutTiled< TEST_EXECSPACE >::test_view_layout_tiled_3d( 4, 12, 16 );
   TestViewLayoutTiled< TEST_EXECSPACE >::test_view_layout_tiled_4d( 4, 12, 16, 12 );
 }
-
+#endif
 } // namespace Test

--- a/core/unit_test/cuda/TestCuda_Other.cpp
+++ b/core/unit_test/cuda/TestCuda_Other.cpp
@@ -50,3 +50,4 @@
 #include<TestTile.hpp>
 
 #include<TestViewCtorPropEmbeddedDim.hpp>
+#include<TestViewLayoutTiled.hpp>

--- a/core/unit_test/openmp/TestOpenMP_Other.cpp
+++ b/core/unit_test/openmp/TestOpenMP_Other.cpp
@@ -50,6 +50,7 @@
 #include<TestTile.hpp>
 
 #include<TestViewCtorPropEmbeddedDim.hpp>
+#include<TestViewLayoutTiled.hpp>
 
 #include <mutex>
 

--- a/core/unit_test/serial/TestSerial_Other.cpp
+++ b/core/unit_test/serial/TestSerial_Other.cpp
@@ -50,3 +50,4 @@
 #include<TestTile.hpp>
 
 #include<TestViewCtorPropEmbeddedDim.hpp>
+#include<TestViewLayoutTiled.hpp>

--- a/core/unit_test/threads/TestThreads_Other.cpp
+++ b/core/unit_test/threads/TestThreads_Other.cpp
@@ -50,3 +50,4 @@
 #include<TestTile.hpp>
 
 #include<TestViewCtorPropEmbeddedDim.hpp>
+#include<TestViewLayoutTiled.hpp>


### PR DESCRIPTION
Added LayoutTiled to Kokkos_Layouts;
ViewOffset for LayoutTiled with
operator(), ViewMapping overloads and
tile_subview functions for ranks 2-8.

Initial unit testing on host for ranks 2 and 3.

1. Add unit tests for remaining ranks
2. Add missing ExecSpace testing
3. Consider specializations of LayoutTiled to support default iterate
patterns - update ViewOffset, etc
4. Move Iterate enum type to common location
6. Decide what to name the ViewLayoutTiled file, or where contents go

 Changes to be committed:
	modified:   core/src/Kokkos_Layout.hpp
	new file:   core/src/impl/Kokkos_ViewLayoutTiled.hpp
	new file:   core/unit_test/TestViewLayoutTiled.hpp
	modified:   core/unit_test/serial/TestSerial_Other.cpp