### PR TITLE
Provide Array::max_size()

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -200,6 +200,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION static constexpr size_type size()  { return 0 ; }
   KOKKOS_INLINE_FUNCTION static constexpr bool      empty() { return true ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type max_size() const { return 0 ; }
 
   template< typename iType >
   KOKKOS_INLINE_FUNCTION
@@ -264,6 +265,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION constexpr size_type size()  const { return m_size ; }
   KOKKOS_INLINE_FUNCTION constexpr bool      empty() const { return 0 != m_size ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type max_size() const { return m_size ; }
 
   template< typename iType >
   KOKKOS_INLINE_FUNCTION
@@ -339,6 +341,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION constexpr size_type size()  const { return m_size ; }
   KOKKOS_INLINE_FUNCTION constexpr bool      empty() const { return 0 != m_size ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type max_size() const { return m_size ; }
 
   template< typename iType >
   KOKKOS_INLINE_FUNCTION

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -134,6 +134,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION static constexpr size_type size() { return N ; }
   KOKKOS_INLINE_FUNCTION static constexpr bool      empty(){ return false ; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type max_size() const { return N ; }
 
   template< typename iType >
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
Note that I chose to declare `Array<T, N>::max_size()` with a const qualifier for consistency with `std::array` but I can change it and make it a static member function if you prefer.