### PR TITLE
Issue 1753 (clang/cuda reduction problem) + test_all_sandia

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -809,12 +809,12 @@ public:
 
   __device__ inline
   void operator() () const {
-    run(Kokkos::Impl::if_c<UseShflReduction, DummyShflReductionType, DummySHMEMReductionType>::select(1,1.0) );
+/*    run(Kokkos::Impl::if_c<UseShflReduction, DummyShflReductionType, DummySHMEMReductionType>::select(1,1.0) );
   }
 
   __device__ inline
   void run(const DummySHMEMReductionType& ) const
-  {
+  {*/
     const integral_nonzero_constant< size_type , ValueTraits::StaticValueSize / sizeof(size_type) >
       word_count( ValueTraits::value_size( ReducerConditional::select(m_functor , m_reducer) ) / sizeof(size_type) );
 
@@ -855,10 +855,9 @@ public:
     }
   }
 
-  __device__ inline
+/*  __device__ inline
    void run(const DummyShflReductionType&) const
    {
-
      value_type value;
      ValueInit::init( ReducerConditional::select(m_functor , m_reducer) , &value);
      // Number of blocks is bounded so that the reduction can be limited to two passes.
@@ -889,7 +888,7 @@ public:
          *result = value;
        }
      }
-   }
+   }*/
 
   // Determine block size constrained by shared memory:
   static inline
@@ -1035,12 +1034,12 @@ public:
   inline
   __device__
   void operator() (void) const {
-    run(Kokkos::Impl::if_c<UseShflReduction, DummyShflReductionType, DummySHMEMReductionType>::select(1,1.0) );
+/*    run(Kokkos::Impl::if_c<UseShflReduction, DummyShflReductionType, DummySHMEMReductionType>::select(1,1.0) );
   }
 
   __device__ inline
   void run(const DummySHMEMReductionType& ) const
-  {
+  {*/
     const integral_nonzero_constant< size_type , ValueTraits::StaticValueSize / sizeof(size_type) >
       word_count( ValueTraits::value_size( ReducerConditional::select(m_functor , m_reducer) ) / sizeof(size_type) );
 
@@ -1076,7 +1075,7 @@ public:
     }
   }
 
-  __device__ inline
+/*  __device__ inline
    void run(const DummyShflReductionType&) const
    {
 
@@ -1108,7 +1107,7 @@ public:
        }
      }
    }
-
+*/
   // Determine block size constrained by shared memory:
   static inline
   unsigned local_block_size( const FunctorType & f )
@@ -1373,8 +1372,13 @@ public:
 
     value_type init;
     ValueInit::init( ReducerConditional::select(m_functor , m_reducer) , &init);
-    if(Impl::cuda_inter_block_reduction<FunctorType,ValueJoin,WorkTag>
-           (value,init,ValueJoin(ReducerConditional::select(m_functor , m_reducer)),m_scratch_space,result,m_scratch_flags,blockDim.y)) {
+    if(
+        Impl::cuda_inter_block_reduction<FunctorType,ValueJoin,WorkTag>
+           (value,init,ValueJoin(ReducerConditional::select(m_functor , m_reducer)),m_scratch_space,result,m_scratch_flags,blockDim.y)
+        //This breaks a test
+        //   Kokkos::Impl::CudaReductionsFunctor<FunctorType,WorkTag,false,true>::scalar_inter_block_reduction(ReducerConditional::select(m_functor , m_reducer) , blockIdx.x , gridDim.x ,
+        //              kokkos_impl_cuda_shared_memory<size_type>() , m_scratch_space , m_scratch_flags)
+    ) {
       const unsigned id = threadIdx.y*blockDim.x + threadIdx.x;
       if(id==0) {
         Kokkos::Impl::FunctorFinal< ReducerTypeFwd , WorkTagFwd >::final( ReducerConditional::select(m_functor , m_reducer) , (void*) &value );

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -787,7 +787,7 @@ public:
   size_type *         m_unified_space ;
 
   // Shall we use the shfl based reduction or not (only use it for static sized types of more than 128bit
-  enum { UseShflReduction = ((sizeof(value_type)>2*sizeof(double)) && ValueTraits::StaticValueSize) };
+  enum { UseShflReduction = false };//((sizeof(value_type)>2*sizeof(double)) && ValueTraits::StaticValueSize) };
   // Some crutch to do function overloading
 private:
   typedef double DummyShflReductionType;

--- a/core/src/Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp
@@ -33,8 +33,10 @@
 #define KOKKOS_IMPL_CUDA_BALLOT(x) 0
 #define KOKKOS_IMPL_CUDA_BALLOT_MASK(m,x) 0
 #define KOKKOS_IMPL_CUDA_SHFL(x,y,z) 0
+#define KOKKOS_IMPL_CUDA_SHFL_MASK(m,x,y,z) 0
 #define KOKKOS_IMPL_CUDA_SHFL_UP(x,y,z) 0
 #define KOKKOS_IMPL_CUDA_SHFL_DOWN(x,y,z) 0
+#define KOKKOS_IMPL_CUDA_SHFL_DOWN_MASK(m,x,y,z) 0
 #endif 
 
 #if ( CUDA_VERSION >= 9000 ) && (!defined(KOKKOS_COMPILER_CLANG))

--- a/core/unit_test/standalone/UnitTestMainInit.cpp
+++ b/core/unit_test/standalone/UnitTestMainInit.cpp
@@ -56,7 +56,7 @@
 #include <openmp/TestOpenMP_Category.hpp>
 #endif
 //#include <TestReduce.hpp>
-#include <TestMDRange_a.hpp>
+#include <TestMemoryPool.hpp>
 //#include <TestMDRange_b.hpp>
 //#include <TestMDRange_c.hpp>
 //#include <TestMDRange_d.hpp>

--- a/scripts/testing_scripts/test_all_sandia
+++ b/scripts/testing_scripts/test_all_sandia
@@ -256,8 +256,6 @@ elif [ "$MACHINE" = "white" ]; then
     ARCH_FLAG="--arch=Power8,Kepler37"
   fi
 
-  NUM_JOBS_TO_RUN_IN_PARALLEL=1
-
 elif [ "$MACHINE" = "bowman" ]; then
   source /etc/profile.d/modules.sh
   SKIP_HWLOC=True
@@ -277,40 +275,20 @@ elif [ "$MACHINE" = "bowman" ]; then
     ARCH_FLAG="--arch=KNL"
   fi
 
-  NUM_JOBS_TO_RUN_IN_PARALLEL=1
-
-elif [ "$MACHINE" = "sullivan" ]; then
-  source /etc/profile.d/modules.sh
-  SKIP_HWLOC=True
-  export SLURM_TASKS_PER_NODE=96
-
-  BASE_MODULE_LIST="<COMPILER_NAME>/<COMPILER_VERSION>"
-
-  # Format: (compiler module-list build-list exe-name warning-flag)
-  COMPILERS=("gcc/6.1.0 $BASE_MODULE_LIST $ARM_GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS")
-
-  if [ -z "$ARCH_FLAG" ]; then
-    ARCH_FLAG="--arch=ARMv8-ThunderX"
-  fi
-
-  NUM_JOBS_TO_RUN_IN_PARALLEL=1
-
 elif [ "$MACHINE" = "mayer" ]; then
   SKIP_HWLOC=True
   export SLURM_TASKS_PER_NODE=96
 
   BASE_MODULE_LIST="<COMPILER_NAME>/<COMPILER_VERSION>"
-  ARM_MODULE_LIST="<COMPILER_NAME>/<COMPILER_VERSION>"
+  ARM_MODULE_LIST="<COMPILER_NAME>/compilers/<COMPILER_VERSION>"
 
   # Format: (compiler module-list build-list exe-name warning-flag)
   COMPILERS=("gcc/7.2.0 $BASE_MODULE_LIST $ARM_GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
-             "arm/1.4.0 $ARM_MODULE_LIST $ARM_GCC_BUILD_LIST armclang++ $CLANG_WARNING_FLAGS")
+             "arm/18.4.0 $ARM_MODULE_LIST $ARM_GCC_BUILD_LIST armclang++ $CLANG_WARNING_FLAGS")
 
   if [ -z "$ARCH_FLAG" ]; then
     ARCH_FLAG="--arch=ARMv8-TX2"
   fi
-
-  NUM_JOBS_TO_RUN_IN_PARALLEL=1
 
 elif [ "$MACHINE" = "blake" ]; then
   source /etc/profile.d/modules.sh
@@ -341,7 +319,6 @@ elif [ "$MACHINE" = "blake" ]; then
   if [ -z "$ARCH_FLAG" ]; then
     ARCH_FLAG="--arch=SKX"
   fi
-  NUM_JOBS_TO_RUN_IN_PARALLEL=1
 
 elif [ "$MACHINE" = "apollo" ]; then
   source /projects/sems/modulefiles/utils/sems-modules-init.sh
@@ -360,6 +337,7 @@ elif [ "$MACHINE" = "apollo" ]; then
   CUDA8_MODULE_LIST="sems-env,kokkos-env,kokkos-<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/5.3.0,kokkos-hwloc/1.10.1/base"
 
   CLANG_MODULE_LIST="sems-env,kokkos-env,sems-git,sems-cmake/3.5.2,<COMPILER_NAME>/<COMPILER_VERSION>,cuda/9.0.69"
+  CLANG7_MODULE_LIST="sems-env,kokkos-env,sems-git,sems-cmake/3.5.2,<COMPILER_NAME>/<COMPILER_VERSION>,cuda/9.1"
   NVCC_MODULE_LIST="sems-env,kokkos-env,sems-git,sems-cmake/3.5.2,<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/5.3.0"
 
   BUILD_LIST_CUDA_NVCC="Cuda_Serial,Cuda_OpenMP"
@@ -379,6 +357,7 @@ elif [ "$MACHINE" = "apollo" ]; then
     # Format: (compiler module-list build-list exe-name warning-flag)
     COMPILERS=("cuda/9.1 $CUDA8_MODULE_LIST $BUILD_LIST_CUDA_NVCC $KOKKOS_PATH/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
                "clang/6.0 $CLANG_MODULE_LIST $BUILD_LIST_CUDA_CLANG clang++ $CUDA_WARNING_FLAGS"
+               "clang/7.0 $CLANG7_MODULE_LIST $BUILD_LIST_CUDA_CLANG clang++ $CUDA_WARNING_FLAGS"
                "clang/3.9.0 $CLANG_MODULE_LIST $BUILD_LIST_CLANG clang++ $CLANG_WARNING_FLAGS"
                "gcc/4.8.4 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
                "gcc/4.9.3 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
@@ -395,8 +374,6 @@ elif [ "$MACHINE" = "apollo" ]; then
   if [ -z "$ARCH_FLAG" ]; then
     ARCH_FLAG="--arch=SNB,Volta70"
   fi
-
-  NUM_JOBS_TO_RUN_IN_PARALLEL=1
 
 else
   echo "Unhandled machine $MACHINE" >&2


### PR DESCRIPTION
Third time is the charm. This passes both nvcc as well as clang/cuda tests.

```
Running on machine: apollo
Repository Status:  04d4f10c7704c31d0aa6fb6bd0794d267d02e6c3 CUDA Rewrite of reduction code for non-reducer interface static length


Going to test compilers:  cuda/9.1 clang/6.0
Testing compiler cuda/9.1
Testing compiler clang/6.0
  Starting job cuda-9.1-Cuda_OpenMP-release
  PASSED cuda-9.1-Cuda_OpenMP-release
  Starting job clang-6.0-Cuda_Pthread-release
  PASSED clang-6.0-Cuda_Pthread-release
  Starting job clang-6.0-OpenMP-release
  PASSED clang-6.0-OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-6.0-Cuda_Pthread-release build_time=221 run_time=347
clang-6.0-OpenMP-release build_time=112 run_time=82
cuda-9.1-Cuda_OpenMP-release build_time=303 run_time=207
```
I also added an update to the test_all_sandia