### PR TITLE
CudaParallelLaunch: More gcc/7 fixes

### DIFF
--- a/core/src/Cuda/Kokkos_CudaExec.hpp
+++ b/core/src/Cuda/Kokkos_CudaExec.hpp
@@ -208,7 +208,7 @@ struct CudaParallelLaunch< DriverType
                     , const int          shmem
                     , const cudaStream_t stream = 0 )
   {
-    if ( grid.x && ( block.x * block.y * block.z ) ) {
+    if ( (grid.x != 0) && ( ( block.x * block.y * block.z ) != 0 ) ) {
 
       if ( sizeof( Kokkos::Impl::CudaTraits::ConstantGlobalBufferType ) <
            sizeof( DriverType ) ) {
@@ -264,7 +264,7 @@ struct CudaParallelLaunch< DriverType
                     , const int          shmem
                     , const cudaStream_t stream = 0 )
   {
-    if ( grid.x && ( block.x * block.y * block.z ) ) {
+    if ( (grid.x != 0) && ( ( block.x * block.y * block.z ) != 0 ) ) {
 
       if ( sizeof( Kokkos::Impl::CudaTraits::ConstantGlobalBufferType ) <
            sizeof( DriverType ) ) {
@@ -321,7 +321,7 @@ struct CudaParallelLaunch< DriverType
                     , const int          shmem
                     , const cudaStream_t stream = 0 )
   {
-    if ( grid.x && ( block.x * block.y * block.z ) ) {
+    if ( (grid.x != 0) && ( ( block.x * block.y * block.z ) != 0 ) ) {
 
       if ( sizeof( Kokkos::Impl::CudaTraits::ConstantGlobalBufferType ) <
            sizeof( DriverType ) ) {


### PR DESCRIPTION
Addresses issue #1796
Repeat gcc/7 warning fix to other CudaParallelLaunch calls