### PR TITLE
cuda warnings: more syncwarp mask fixes

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -2026,9 +2026,8 @@ private:
     const WorkRange range( m_policy , blockIdx.x , gridDim.x );
 
     for ( typename Policy::member_type iwork_base = range.begin(); iwork_base < range.end() ; iwork_base += blockDim.y ) {
-      #ifdef __CUDA_ARCH__
+      #ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
       unsigned MASK=KOKKOS_IMPL_CUDA_ACTIVEMASK;
-      MASK=MASK; // Silence warning about unused variable (void) MASK did not work
       #endif
       const typename Policy::member_type iwork = iwork_base + threadIdx.y ;
 
@@ -2040,8 +2039,10 @@ private:
       for ( unsigned i = threadIdx.y ; i < word_count.value ; ++i ) {
         shared_data[i + word_count.value] = shared_data[i] = shared_accum[i] ;
       }
-      #ifdef __CUDA_ARCH__
+      #ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
       KOKKOS_IMPL_CUDA_SYNCWARP_MASK(MASK);
+      #else
+      KOKKOS_IMPL_CUDA_SYNCWARP_MASK;
       #endif
       if ( CudaTraits::WarpSize < word_count.value ) { __syncthreads(); } // Protect against large scan values.
 
@@ -2250,9 +2251,8 @@ private:
     const WorkRange range( m_policy , blockIdx.x , gridDim.x );
 
     for ( typename Policy::member_type iwork_base = range.begin(); iwork_base < range.end() ; iwork_base += blockDim.y ) {
-      #ifdef __CUDA_ARCH__
+      #ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
       unsigned MASK=KOKKOS_IMPL_CUDA_ACTIVEMASK;
-      MASK=MASK; // Silence warning about unused variable (void) MASK did not work
       #endif
 
       const typename Policy::member_type iwork = iwork_base + threadIdx.y ;
@@ -2266,8 +2266,10 @@ private:
         shared_data[i + word_count.value] = shared_data[i] = shared_accum[i] ;
       }
 
-      #ifdef __CUDA_ARCH__
+      #ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
       KOKKOS_IMPL_CUDA_SYNCWARP_MASK(MASK);
+      #else
+      KOKKOS_IMPL_CUDA_SYNCWARP_MASK;
       #endif
       if ( CudaTraits::WarpSize < word_count.value ) { __syncthreads(); } // Protect against large scan values.
 

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -739,7 +739,11 @@ void parallel_for
       ; i += blockDim.x ) {
     closure(i);
   }
+  #ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
   KOKKOS_IMPL_CUDA_SYNCWARP_MASK(blockDim.x==32?0xffffffff:((1<<blockDim.x)-1)<<(threadIdx.y%(32/blockDim.x))*blockDim.x);
+  #else
+  KOKKOS_IMPL_CUDA_SYNCWARP_MASK;
+  #endif
 #endif
 }
 
@@ -908,7 +912,11 @@ KOKKOS_INLINE_FUNCTION
 void single(const Impl::VectorSingleStruct<Impl::CudaTeamMember>& , const FunctorType& lambda) {
 #ifdef __CUDA_ARCH__
   if(threadIdx.x == 0) lambda();
+  #ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
   KOKKOS_IMPL_CUDA_SYNCWARP_MASK(blockDim.x==32?0xffffffff:((1<<blockDim.x)-1)<<(threadIdx.y%(32/blockDim.x))*blockDim.x);
+  #else
+  KOKKOS_IMPL_CUDA_SYNCWARP_MASK;
+  #endif
 #endif
 }
 
@@ -917,7 +925,11 @@ KOKKOS_INLINE_FUNCTION
 void single(const Impl::ThreadSingleStruct<Impl::CudaTeamMember>& , const FunctorType& lambda) {
 #ifdef __CUDA_ARCH__
   if(threadIdx.x == 0 && threadIdx.y == 0) lambda();
+  #ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
   KOKKOS_IMPL_CUDA_SYNCWARP_MASK(blockDim.x==32?0xffffffff:((1<<blockDim.x)-1)<<(threadIdx.y%(32/blockDim.x))*blockDim.x);
+  #else
+  KOKKOS_IMPL_CUDA_SYNCWARP_MASK;
+  #endif
 #endif
 }
 


### PR DESCRIPTION
This commit addresses issue #1802
Fix KOKKOS_IMPL_CUDA_SYNCWARP_MASK usage in files missed by PR #1799