### PR TITLE
CUDA: Rework the logic for maximum team size

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Internal.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Internal.hpp
@@ -67,7 +67,7 @@ struct CudaGetMaxBlockSize<DriverType,Kokkos::LaunchBounds<>,true> {
   static int get_block_size(const typename DriverType::functor_type & f, const size_t vector_length,
                             const size_t shmem_extra_block, const size_t shmem_extra_thread) {
     int numBlocks;
-    int blockSize=32;
+    int blockSize=1024;
     int sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
                     FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
     cudaOccupancyMaxActiveBlocksPerMultiprocessor(
@@ -76,8 +76,9 @@ struct CudaGetMaxBlockSize<DriverType,Kokkos::LaunchBounds<>,true> {
         blockSize,
         sharedmem);
 
-    while (blockSize<1024 && numBlocks>0) {
-      blockSize*=2;
+    if(numBlocks>0) return blockSize;
+    while (blockSize>32 && numBlocks==0) {
+      blockSize/=2;
       sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
                   FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
 
@@ -87,8 +88,19 @@ struct CudaGetMaxBlockSize<DriverType,Kokkos::LaunchBounds<>,true> {
           blockSize,
           sharedmem);
     }
-    if(numBlocks>0) return blockSize;
-    else return blockSize/2;
+    int blockSizeUpperBound = blockSize*2;
+    while (blockSize<blockSizeUpperBound && numBlocks>0) {
+      blockSize+=32;
+      sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
+                  FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
+
+      cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &numBlocks,
+            cuda_parallel_launch_constant_memory<DriverType>,
+            blockSize,
+            sharedmem);
+    }
+    return blockSize - 32;
   }
 };
 
@@ -98,7 +110,7 @@ struct CudaGetMaxBlockSize<DriverType,Kokkos::LaunchBounds<>,false> {
                             const size_t shmem_extra_block, const size_t shmem_extra_thread) {
     int numBlocks;
 
-    int blockSize=32;
+    int blockSize=1024;
     int sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
                     FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
     cudaOccupancyMaxActiveBlocksPerMultiprocessor(
@@ -107,8 +119,9 @@ struct CudaGetMaxBlockSize<DriverType,Kokkos::LaunchBounds<>,false> {
         blockSize,
         sharedmem);
 
-    while (blockSize<1024 && numBlocks>0) {
-      blockSize*=2;
+    if(numBlocks>0) return blockSize;
+    while (blockSize>32 && numBlocks==0) {
+      blockSize/=2;
       sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
                   FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
 
@@ -118,8 +131,19 @@ struct CudaGetMaxBlockSize<DriverType,Kokkos::LaunchBounds<>,false> {
           blockSize,
           sharedmem);
     }
-    if(numBlocks>0) return blockSize;
-    else return blockSize/2;
+    int blockSizeUpperBound = blockSize*2;
+    while (blockSize<blockSizeUpperBound && numBlocks>0) {
+      blockSize+=32;
+      sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
+                  FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
+
+      cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &numBlocks,
+            cuda_parallel_launch_local_memory<DriverType>,
+            blockSize,
+            sharedmem);
+    }
+    return blockSize - 32;
   }
 };
 
@@ -128,7 +152,7 @@ struct CudaGetMaxBlockSize<DriverType,Kokkos::LaunchBounds<MaxThreadsPerBlock,Mi
   static int get_block_size(const typename DriverType::functor_type & f, const size_t vector_length,
                             const size_t shmem_extra_block, const size_t shmem_extra_thread) {
     int numBlocks = 0, oldNumBlocks = 0;
-    int blockSize=32;
+    int blockSize=MaxThreadsPerBlock;
     int sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
                     FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
     cudaOccupancyMaxActiveBlocksPerMultiprocessor(
@@ -137,21 +161,32 @@ struct CudaGetMaxBlockSize<DriverType,Kokkos::LaunchBounds<MaxThreadsPerBlock,Mi
         blockSize,
         sharedmem);
 
-    while (blockSize*2<=int(MaxThreadsPerBlock) && numBlocks>0) {
-      blockSize*=2;
+    if(numBlocks>=MinBlocksPerSM) return blockSize;
+
+    while (blockSize>32 && numBlocks<MinBlocksPerSM) {
+      blockSize/=2;
       sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
                   FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
 
-      oldNumBlocks = numBlocks;
-
       cudaOccupancyMaxActiveBlocksPerMultiprocessor(
           &numBlocks,
-          cuda_parallel_launch_constant_memory<DriverType,MaxThreadsPerBlock,MinBlocksPerSM>,
+          cuda_parallel_launch_constant_memory<DriverType>,
           blockSize,
           sharedmem);
     }
-    if( numBlocks    >= int(MinBlocksPerSM) && blockSize   <= int(MaxThreadsPerBlock) ) return blockSize;
-    if( oldNumBlocks >= int(MinBlocksPerSM) && blockSize/2 <= int(MaxThreadsPerBlock) ) return blockSize/2;
+    int blockSizeUpperBound = (blockSize*2<MaxThreadsPerBlock?blockSize*2:MaxThreadsPerBlock);
+    while (blockSize<blockSizeUpperBound && numBlocks>MinBlocksPerSM) {
+      blockSize+=32;
+      sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
+                  FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
+      oldNumBlocks = numBlocks;
+      cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &numBlocks,
+            cuda_parallel_launch_constant_memory<DriverType>,
+            blockSize,
+            sharedmem);
+    }
+    if(oldNumBlocks>=MinBlocksPerSM) return blockSize - 32;
     return -1;
   }
 };
@@ -161,8 +196,7 @@ struct CudaGetMaxBlockSize<DriverType,Kokkos::LaunchBounds<MaxThreadsPerBlock,Mi
   static int get_block_size(const typename DriverType::functor_type & f, const size_t vector_length,
                             const size_t shmem_extra_block, const size_t shmem_extra_thread) {
     int numBlocks = 0, oldNumBlocks = 0;
-
-    int blockSize=32;
+    int blockSize=MaxThreadsPerBlock;
     int sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
                     FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
     cudaOccupancyMaxActiveBlocksPerMultiprocessor(
@@ -170,22 +204,32 @@ struct CudaGetMaxBlockSize<DriverType,Kokkos::LaunchBounds<MaxThreadsPerBlock,Mi
         cuda_parallel_launch_local_memory<DriverType,MaxThreadsPerBlock,MinBlocksPerSM>,
         blockSize,
         sharedmem);
+    if(numBlocks>=MinBlocksPerSM) return blockSize;
 
-    while (blockSize*2<=int(MaxThreadsPerBlock) && numBlocks>0) {
-      blockSize*=2;
+    while (blockSize>32 && numBlocks<MinBlocksPerSM) {
+      blockSize/=2;
       sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
                   FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
 
-      oldNumBlocks = numBlocks;
-
       cudaOccupancyMaxActiveBlocksPerMultiprocessor(
           &numBlocks,
-          cuda_parallel_launch_local_memory<DriverType,MaxThreadsPerBlock,MinBlocksPerSM>,
+          cuda_parallel_launch_local_memory<DriverType>,
           blockSize,
           sharedmem);
     }
-    if( numBlocks    >= int(MinBlocksPerSM) && blockSize   <= int(MaxThreadsPerBlock) ) return blockSize;
-    if( oldNumBlocks >= int(MinBlocksPerSM) && blockSize/2 <= int(MaxThreadsPerBlock) ) return blockSize/2;
+    int blockSizeUpperBound = (blockSize*2<MaxThreadsPerBlock?blockSize*2:MaxThreadsPerBlock);
+    while (blockSize<blockSizeUpperBound && numBlocks>=MinBlocksPerSM) {
+      blockSize+=32;
+      sharedmem = shmem_extra_block + shmem_extra_thread*(blockSize/vector_length) +
+                  FunctorTeamShmemSize< typename DriverType::functor_type  >::value( f , blockSize/vector_length );
+      oldNumBlocks = numBlocks;
+      cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &numBlocks,
+            cuda_parallel_launch_local_memory<DriverType>,
+            blockSize,
+            sharedmem);
+    }
+    if(oldNumBlocks>=MinBlocksPerSM) return blockSize - 32;
     return -1;
   }
 };

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -154,7 +154,12 @@ public:
     int block_size = Kokkos::Impl::cuda_get_max_block_size< closure_type, typename traits::launch_bounds >( f ,(size_t) vector_length(),
         (size_t) team_scratch_size(0) + 2*sizeof(double), (size_t) thread_scratch_size(0) + sizeof(double) +
                                                           (functor_value_traits::StaticValueSize?0:functor_value_traits::value_size( f )));
-    return block_size/vector_length();
+
+    // Currently we require Power-of-2 team size for reductions.
+    int p2 = 1;
+    while(p2<=block_size) p2*=2;
+    p2/=2;
+    return p2/vector_length();
   }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE


### PR DESCRIPTION
This now allows for teamsizes non-power of 2.
In KokkosKernels GEMM we want to run with team size 24 and vector length 16.
team_size_max came now back as 16 ....
But 24 works while 32 doesn't.