### PR TITLE
Allow device views as result location for reductions

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -1262,6 +1262,7 @@ private:
   const FunctorType   m_functor ;
   const ReducerType   m_reducer ;
   const pointer_type  m_result_ptr ;
+  const bool          m_result_ptr_device_accessible ;
   size_type *         m_scratch_space ;
   size_type *         m_scratch_flags ;
   size_type *         m_unified_space ;
@@ -1350,7 +1351,8 @@ public:
       // This is the final block with the final result at the final threads' location
 
       size_type * const shared = kokkos_impl_cuda_shared_memory<size_type>() + ( blockDim.y - 1 ) * word_count.value ;
-      size_type * const global = m_unified_space ? m_unified_space : m_scratch_space ;
+      size_type * const global = m_result_ptr_device_accessible? reinterpret_cast<size_type*>(m_result_ptr) :
+                                 ( m_unified_space ? m_unified_space : m_scratch_space );
 
       if ( threadIdx.y == 0 ) {
         Kokkos::Impl::FunctorFinal< ReducerTypeFwd , WorkTagFwd >::final( ReducerConditional::select(m_functor , m_reducer) , shared );
@@ -1383,7 +1385,8 @@ public:
         , value );
     }
 
-    pointer_type const result = (pointer_type) (m_unified_space ? m_unified_space : m_scratch_space) ;
+    pointer_type const result = m_result_ptr_device_accessible? m_result_ptr :
+                                (pointer_type) ( m_unified_space ? m_unified_space : m_scratch_space );
 
     value_type init;
     ValueInit::init( ReducerConditional::select(m_functor , m_reducer) , &init);
@@ -1420,16 +1423,18 @@ public:
 
         CudaParallelLaunch< ParallelReduce, LaunchBounds >( *this, grid, block, shmem_size_total ); // copy to device and execute
 
-        Cuda::fence();
+        if(!m_result_ptr_device_accessible) {
+          Cuda::fence();
 
-        if ( m_result_ptr ) {
-          if ( m_unified_space ) {
-            const int count = ValueTraits::value_count( ReducerConditional::select(m_functor , m_reducer) );
-            for ( int i = 0 ; i < count ; ++i ) { m_result_ptr[i] = pointer_type(m_unified_space)[i] ; }
-          }
-          else {
-            const int size = ValueTraits::value_size( ReducerConditional::select(m_functor , m_reducer) );
-            DeepCopy<HostSpace,CudaSpace>( m_result_ptr, m_scratch_space, size );
+          if ( m_result_ptr ) {
+            if ( m_unified_space ) {
+              const int count = ValueTraits::value_count( ReducerConditional::select(m_functor , m_reducer) );
+              for ( int i = 0 ; i < count ; ++i ) { m_result_ptr[i] = pointer_type(m_unified_space)[i] ; }
+            }
+            else {
+              const int size = ValueTraits::value_size( ReducerConditional::select(m_functor , m_reducer) );
+              DeepCopy<HostSpace,CudaSpace>( m_result_ptr, m_scratch_space, size );
+            }
           }
         }
       }
@@ -1440,16 +1445,17 @@ public:
       }
     }
 
-  template< class HostViewType >
+  template< class ViewType >
   ParallelReduce( const FunctorType  & arg_functor
                 , const Policy       & arg_policy
-                , const HostViewType & arg_result
+                , const ViewType & arg_result
                 , typename std::enable_if<
-                                   Kokkos::is_view< HostViewType >::value
+                                   Kokkos::is_view< ViewType >::value
                                 ,void*>::type = NULL)
   : m_functor( arg_functor )
   , m_reducer( InvalidType() )
   , m_result_ptr( arg_result.data() )
+  , m_result_ptr_device_accessible(MemorySpaceAccess< Kokkos::CudaSpace , typename ViewType::memory_space>::accessible )
   , m_scratch_space( 0 )
   , m_scratch_flags( 0 )
   , m_unified_space( 0 )
@@ -1518,6 +1524,7 @@ public:
   : m_functor( arg_functor )
   , m_reducer( reducer )
   , m_result_ptr( reducer.view().data() )
+  , m_result_ptr_device_accessible(MemorySpaceAccess< Kokkos::CudaSpace , typename ReducerType::result_view_type::memory_space>::accessible )
   , m_scratch_space( 0 )
   , m_scratch_flags( 0 )
   , m_unified_space( 0 )

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -48,7 +48,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
 	OBJ_CUDA += TestCudaUVM_ViewMapping_a.o TestCudaUVM_ViewMapping_b.o TestCudaUVM_ViewMapping_subview.o
 	OBJ_CUDA += TestCudaHostPinned_ViewCopy.o TestCudaHostPinned_ViewAPI_a.o TestCudaHostPinned_ViewAPI_b.o TestCudaHostPinned_ViewAPI_c.o TestCudaHostPinned_ViewAPI_d.o TestCudaHostPinned_ViewAPI_e.o
 	OBJ_CUDA += TestCudaHostPinned_ViewMapping_a.o TestCudaHostPinned_ViewMapping_b.o TestCudaHostPinned_ViewMapping_subview.o
-    OBJ_CUDA += TestCuda_View_64bit.o
+	OBJ_CUDA += TestCuda_View_64bit.o
 	OBJ_CUDA += TestCuda_ViewOfClass.o
 	OBJ_CUDA += TestCuda_SubView_a.o TestCuda_SubView_b.o
 	OBJ_CUDA += TestCuda_SubView_c01.o TestCuda_SubView_c02.o TestCuda_SubView_c03.o
@@ -57,6 +57,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
 	OBJ_CUDA += TestCuda_SubView_c10.o TestCuda_SubView_c11.o TestCuda_SubView_c12.o
 	OBJ_CUDA += TestCuda_SubView_c13.o
 	OBJ_CUDA += TestCuda_Reductions.o TestCuda_Scan.o
+	OBJ_CUDA += TestCuda_Reductions_DeviceView.o
 	OBJ_CUDA += TestCuda_Reducers_a.o TestCuda_Reducers_b.o TestCuda_Reducers_c.o TestCuda_Reducers_d.o
 	OBJ_CUDA += TestCuda_Complex.o
 	OBJ_CUDA += TestCuda_AtomicOperations_int.o TestCuda_AtomicOperations_unsignedint.o TestCuda_AtomicOperations_longint.o 
@@ -143,6 +144,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_PTHREADS), 1)
 	OBJ_THREADS += TestThreads_SubView_c07.o TestThreads_SubView_c08.o TestThreads_SubView_c09.o
 	OBJ_THREADS += TestThreads_SubView_c10.o TestThreads_SubView_c11.o TestThreads_SubView_c12.o
 	OBJ_THREADS += TestThreads_Reductions.o TestThreads_Scan.o
+	OBJ_THREADS += TestThreads_Reductions_DeviceView.o
 	OBJ_THREADS += TestThreads_Reducers_a.o TestThreads_Reducers_b.o TestThreads_Reducers_c.o TestThreads_Reducers_d.o
 	OBJ_THREADS += TestThreads_Complex.o
 	OBJ_THREADS += TestThreads_AtomicOperations_int.o TestThreads_AtomicOperations_unsignedint.o TestThreads_AtomicOperations_longint.o 
@@ -174,6 +176,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)
 	OBJ_OPENMP += TestOpenMP_SubView_c10.o TestOpenMP_SubView_c11.o TestOpenMP_SubView_c12.o
 	OBJ_OPENMP += TestOpenMP_SubView_c13.o
 	OBJ_OPENMP += TestOpenMP_Reductions.o TestOpenMP_Scan.o
+	OBJ_OPENMP += TestOpenMP_Reductions_DeviceView.o
 	OBJ_OPENMP += TestOpenMP_Reducers_a.o TestOpenMP_Reducers_b.o TestOpenMP_Reducers_c.o TestOpenMP_Reducers_d.o
 	OBJ_OPENMP += TestOpenMP_Complex.o
 	OBJ_OPENMP += TestOpenMP_AtomicOperations_int.o TestOpenMP_AtomicOperations_unsignedint.o TestOpenMP_AtomicOperations_longint.o 
@@ -263,6 +266,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_SERIAL), 1)
         OBJ_SERIAL += TestSerial_SubView_c10.o TestSerial_SubView_c11.o TestSerial_SubView_c12.o
         OBJ_SERIAL += TestSerial_SubView_c13.o
         OBJ_SERIAL += TestSerial_Reductions.o TestSerial_Scan.o
+	OBJ_SERIAL += TestSerial_Reductions_DeviceView.o
     	OBJ_SERIAL += TestSerial_Reducers_a.o TestSerial_Reducers_b.o TestSerial_Reducers_c.o TestSerial_Reducers_d.o
         OBJ_SERIAL += TestSerial_Complex.o
 	    OBJ_SERIAL += TestSerial_AtomicOperations_int.o TestSerial_AtomicOperations_unsignedint.o TestSerial_AtomicOperations_longint.o 

--- a/core/unit_test/TestReduceDeviceView.hpp
+++ b/core/unit_test/TestReduceDeviceView.hpp
@@ -1,0 +1,114 @@
+#include<Kokkos_Core.hpp>
+
+namespace Test {
+template<class PolicyType, class ReduceFunctor>
+void test_reduce_device_view(int64_t N, PolicyType policy, ReduceFunctor functor) {
+     
+     Kokkos::View<int64_t,TEST_EXECSPACE> result("Result");
+     Kokkos::View<double,TEST_EXECSPACE> atomic_test("Atomic");
+     int64_t reducer_result, view_result, scalar_result;
+
+     
+     Kokkos::Timer timer;     
+
+     // Establish whether execspace is asynchronous
+     Kokkos::parallel_for("Test::ReduceDeviceView::TestIsAsynch",Kokkos::RangePolicy<TEST_EXECSPACE>(0,1000000), KOKKOS_LAMBDA (const int) {
+       Kokkos::atomic_add(&atomic_test(),1.0);
+     });
+     double time0 = timer.seconds();
+     timer.reset();
+     Kokkos::fence();
+     double time_fence0 = timer.seconds(); 
+     Kokkos::deep_copy(result,0);
+     timer.reset();
+     bool is_async = time0<time_fence0;
+
+     // Test Reducer 
+
+     Kokkos::parallel_reduce("Test::ReduceDeviceView::TestReducer",policy, functor, Kokkos::Sum<int64_t,TEST_EXECSPACE>(result));
+     double time1 = timer.seconds();
+     // Check whether it was asyncronous
+     timer.reset();
+     Kokkos::fence();
+     double time_fence1 = timer.seconds();    
+     Kokkos::deep_copy(reducer_result,result);    
+     Kokkos::deep_copy(result,0);
+     ASSERT_EQ(N,reducer_result); 
+     timer.reset();
+     
+     
+     // Test View 
+     Kokkos::parallel_reduce("Test::ReduceDeviceView::TestView",policy, functor, result);
+     double time2 = timer.seconds();
+     // Check whether it was asyncronous
+     timer.reset();
+     Kokkos::fence();
+     double time_fence2 = timer.seconds();    
+     Kokkos::deep_copy(view_result,result);    
+     Kokkos::deep_copy(result,0);
+     ASSERT_EQ(N,view_result); 
+     timer.reset();
+     
+     
+     // Test Scalar
+     Kokkos::parallel_reduce("Test::ReduceDeviceView::TestScalar",policy, functor, scalar_result);
+     double time3 = timer.seconds();
+
+     // Check whether it was asyncronous
+     timer.reset();
+     Kokkos::fence();
+     double time_fence3 = timer.seconds();
+
+     ASSERT_EQ(N,scalar_result); 
+     if(is_async)
+       ASSERT_TRUE(time1<time_fence1);
+     if(is_async)
+       ASSERT_TRUE(time2<time_fence2);
+     ASSERT_TRUE(time3>time_fence3);
+  }
+
+struct RangePolicyFunctor {
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const int, int64_t& lsum) const {
+    lsum += 1;
+  }
+};
+
+TEST_F( TEST_CATEGORY, reduce_device_view_range_policy )
+{
+  int N=1000*1024*1024;
+  test_reduce_device_view(N,Kokkos::RangePolicy<TEST_EXECSPACE>(0,N),RangePolicyFunctor());
+}
+
+struct MDRangePolicyFunctor {
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const int, const int, const int, int64_t& lsum) const {
+    lsum += 1;
+  }
+};
+
+TEST_F( TEST_CATEGORY, reduce_device_view_mdrange_policy )
+{
+  int N=1000*1024*1024;
+  test_reduce_device_view(N,Kokkos::MDRangePolicy<TEST_EXECSPACE,Kokkos::Rank<3>>({0,0,0},{1000,1024,1024}),MDRangePolicyFunctor());
+}
+
+struct TeamPolicyFunctor {
+  int M;
+  TeamPolicyFunctor(int M_):M(M_){}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type& team, int64_t& lsum) const {
+    for(int i=team.team_rank(); i<M; i+=team.team_size())
+      lsum += 1;
+  }
+};
+
+TEST_F( TEST_CATEGORY, reduce_device_view_team_policy )
+{
+  int N=1000*1024*1024;
+  test_reduce_device_view(N,Kokkos::TeamPolicy<TEST_EXECSPACE>(1000*1024,Kokkos::AUTO),TeamPolicyFunctor(1024));
+}
+
+}
+

--- a/core/unit_test/cuda/TestCuda_Reductions_DeviceView.cpp
+++ b/core/unit_test/cuda/TestCuda_Reductions_DeviceView.cpp
@@ -41,27 +41,5 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
-#include <cstdlib>
-
-#include <Kokkos_Core.hpp>
-
-#ifdef KOKKOS_ENABLE_ROCM
-#include <rocm/TestROCm_Category.hpp>
-#endif
-#ifdef KOKKOS_ENABLE_CUDA
 #include <cuda/TestCuda_Category.hpp>
-#endif
-#ifdef KOKKOS_ENABLE_OPENMP
-#include <openmp/TestOpenMP_Category.hpp>
-#endif
 #include <TestReduceDeviceView.hpp>
-
-int main( int argc, char *argv[] ) {
-  Kokkos::initialize(argc,argv);
-  ::testing::InitGoogleTest( &argc, argv );
-
-  int result =  RUN_ALL_TESTS();
-  Kokkos::finalize();
-  return result;
-}

--- a/core/unit_test/openmp/TestOpenMP_Reductions_DeviceView.cpp
+++ b/core/unit_test/openmp/TestOpenMP_Reductions_DeviceView.cpp
@@ -41,27 +41,5 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
-#include <cstdlib>
-
-#include <Kokkos_Core.hpp>
-
-#ifdef KOKKOS_ENABLE_ROCM
-#include <rocm/TestROCm_Category.hpp>
-#endif
-#ifdef KOKKOS_ENABLE_CUDA
-#include <cuda/TestCuda_Category.hpp>
-#endif
-#ifdef KOKKOS_ENABLE_OPENMP
 #include <openmp/TestOpenMP_Category.hpp>
-#endif
 #include <TestReduceDeviceView.hpp>
-
-int main( int argc, char *argv[] ) {
-  Kokkos::initialize(argc,argv);
-  ::testing::InitGoogleTest( &argc, argv );
-
-  int result =  RUN_ALL_TESTS();
-  Kokkos::finalize();
-  return result;
-}

--- a/core/unit_test/serial/TestSerial_Reductions_DeviceView.cpp
+++ b/core/unit_test/serial/TestSerial_Reductions_DeviceView.cpp
@@ -43,4 +43,3 @@
 
 #include <serial/TestSerial_Category.hpp>
 #include <TestReduceDeviceView.hpp>
-#include <TestCXX11Deduction.hpp>

--- a/core/unit_test/serial/TestSerial_Reductions_DeviceView.cpp
+++ b/core/unit_test/serial/TestSerial_Reductions_DeviceView.cpp
@@ -41,27 +41,6 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
-#include <cstdlib>
-
-#include <Kokkos_Core.hpp>
-
-#ifdef KOKKOS_ENABLE_ROCM
-#include <rocm/TestROCm_Category.hpp>
-#endif
-#ifdef KOKKOS_ENABLE_CUDA
-#include <cuda/TestCuda_Category.hpp>
-#endif
-#ifdef KOKKOS_ENABLE_OPENMP
-#include <openmp/TestOpenMP_Category.hpp>
-#endif
+#include <serial/TestSerial_Category.hpp>
 #include <TestReduceDeviceView.hpp>
-
-int main( int argc, char *argv[] ) {
-  Kokkos::initialize(argc,argv);
-  ::testing::InitGoogleTest( &argc, argv );
-
-  int result =  RUN_ALL_TESTS();
-  Kokkos::finalize();
-  return result;
-}
+#include <TestCXX11Deduction.hpp>

--- a/core/unit_test/threads/TestThreads_Reductions_DeviceView.cpp
+++ b/core/unit_test/threads/TestThreads_Reductions_DeviceView.cpp
@@ -41,27 +41,5 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
-#include <cstdlib>
-
-#include <Kokkos_Core.hpp>
-
-#ifdef KOKKOS_ENABLE_ROCM
-#include <rocm/TestROCm_Category.hpp>
-#endif
-#ifdef KOKKOS_ENABLE_CUDA
-#include <cuda/TestCuda_Category.hpp>
-#endif
-#ifdef KOKKOS_ENABLE_OPENMP
-#include <openmp/TestOpenMP_Category.hpp>
-#endif
+#include <threads/TestThreads_Category.hpp>
 #include <TestReduceDeviceView.hpp>
-
-int main( int argc, char *argv[] ) {
-  Kokkos::initialize(argc,argv);
-  ::testing::InitGoogleTest( &argc, argv );
-
-  int result =  RUN_ALL_TESTS();
-  Kokkos::finalize();
-  return result;
-}


### PR DESCRIPTION
This will make CUDA Reductions asynchronous if you give it a device accessible view type. 

CAUTION:
This changes behavior for reductions where you give it a CudaUVMSpace or CudaHostPinnedSpace view. Those DID work before, but were synchronous, now they still work but are asynchronous. 

Note: This does not change official Kokkos semantics! Reductions were always allowed to be asynchronous, if you give it a Kokkos::View or a Reducer. 