### PR TITLE
Tentative MinGW support

### DIFF
--- a/core/src/impl/Kokkos_Atomic_Windows.hpp
+++ b/core/src/impl/Kokkos_Atomic_Windows.hpp
@@ -45,13 +45,17 @@
 
 #ifdef _WIN32
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <winsock2.h>
-#include <Windows.h>
+#include <windows.h>
 
 namespace Kokkos {
   namespace Impl {
+#ifdef _MSC_VER
     _declspec(align(16))
+#endif
     struct cas128_t
     {
       LONGLONG lower;
@@ -60,7 +64,11 @@ namespace Kokkos {
         bool operator != (const cas128_t& a) const {
         return (lower != a.lower) || upper != a.upper;
       }
-    };
+    }
+#ifdef __GNUC__
+    __attribute__ ((aligned (16)))
+#endif
+    ;
   }
 
   template < typename T >


### PR DESCRIPTION
It seems MinGW is not supported, it needs at least these fixes.

But then I'm stuck compiling Kokkos_ExecPolicy.cpp with:
```
kokkos/core/src/impl/Kokkos_Atomic_View.hpp:133:20: error: ‘atomic_mul_fetch’ is not a member of ‘Kokkos’
     return Kokkos::atomic_mul_fetch(ptr,val);
```