### PR TITLE
DualView: update static_assert in .view() method

### DIFF
--- a/core/unit_test/TestReduceDeviceView.hpp
+++ b/core/unit_test/TestReduceDeviceView.hpp
@@ -71,11 +71,13 @@ void test_reduce_device_view(int64_t N, PolicyType policy, ReduceFunctor functor
      double time_fence3 = timer.seconds();
 
      ASSERT_EQ(N,scalar_result); 
-     if(is_async)
+     if(is_async) {
        ASSERT_TRUE(time1<time_fence1);
-     if(is_async)
+     }
+     if(is_async) {
        ASSERT_TRUE(time2<time_fence2);
-     ASSERT_TRUE(time3>time_fence3);
+       ASSERT_TRUE(time3>time_fence3);
+     }
   }
 
 struct RangePolicyFunctor {


### PR DESCRIPTION
Address issue #1834 by pattern matching the memory spaces as done in PR #1741.