### PR TITLE
Travis enhancements 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,8 @@ env:
 
 # Apple GCC does not support OpenMP.  GCC with OpenMP requires Homebrew.
 # Apple Clang does not support OpenMP.  Clang with OpenMP requires Homebrew.
-# Clang OpenMP support is not always available.
 matrix:
   exclude:
-    - compiler: clang
-      env: THREADING="openmp"
     - os: osx
       env: THREADING="openmp"
     - os: osx
@@ -42,6 +39,8 @@ script:
   - export OMP_NUM_THREADS=2
   - export OMP_PLACES=threads
   - export OMP_PROC_BIND=spread
+  # LD_LIBRARY_PATH workaround to find clang's libomp: https://github.com/travis-ci/travis-ci/issues/8613 
+  - if [[ ${CC} = clang ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH; fi 
   - mkdir build
   - cd build
   - ../generate_makefile.bash --compiler=$CXX --with-$THREADING --with-options=compiler_warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,5 @@ script:
   - mkdir build
   - cd build
   - ../generate_makefile.bash --compiler=$CXX --with-$THREADING --with-options=compiler_warnings
-  - make
-  - make test
+  - make KOKKOS_INTERNAL_GCC_TOOLCHAIN=/usr
+  - make test KOKKOS_INTERNAL_GCC_TOOLCHAIN=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,12 @@ script:
   - export OMP_PLACES=threads
   - export OMP_PROC_BIND=spread
   # LD_LIBRARY_PATH workaround to find clang's libomp: https://github.com/travis-ci/travis-ci/issues/8613 
-  - if [[ ${CC} = clang ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH; fi 
-  - if [[ ${TRAVIS_OS_NAME} = linux ]]; then ln -s /usr/bin/ccache $HOME/bin/clang++; fi 
+  - if [[ ${CC} = clang ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH; fi
+  # enable ccache for clang on linux and add CCACHE_CPP2 to avoid 'Argument unused during compilation -I...' warning
+  - if [[ ${TRAVIS_OS_NAME} = linux && ${CC} = clang ]]; then
+      ln -s /usr/bin/ccache $HOME/bin/clang++;
+      export CCACHE_CPP2=yes;
+    fi
   - mkdir build
   - cd build
   - ../generate_makefile.bash --compiler=$CXX --with-$THREADING --with-options=compiler_warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
   - export OMP_PROC_BIND=spread
   # LD_LIBRARY_PATH workaround to find clang's libomp: https://github.com/travis-ci/travis-ci/issues/8613 
   - if [[ ${CC} = clang ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH; fi 
+  - if [[ ${TRAVIS_OS_NAME} = linux ]]; then ln -s /usr/bin/ccache $HOME/bin/clang++; fi 
   - mkdir build
   - cd build
   - ../generate_makefile.bash --compiler=$CXX --with-$THREADING --with-options=compiler_warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ compiler:
   - gcc
   - clang
 
+cache:
+  - ccache
+
 env:
   - THREADING="serial"
   - THREADING="openmp"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,15 @@ matrix:
     - os: osx
       compiler: gcc
 
+before_script:
+  - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
+      brew update;
+      export HOMEBREW_NO_AUTO_UPDATE=1;
+      brew ls --versions ccache   > /dev/null || brew install ccache;
+      export PATH=/usr/local/opt/ccache/libexec:$PATH;
+    fi
+  - ccache -z
+
 script:
   - export OMP_NUM_THREADS=2
   - export OMP_PLACES=threads
@@ -38,3 +47,6 @@ script:
   - ../generate_makefile.bash --compiler=$CXX --with-$THREADING --with-options=compiler_warnings
   - make KOKKOS_INTERNAL_GCC_TOOLCHAIN=/usr
   - make test KOKKOS_INTERNAL_GCC_TOOLCHAIN=/usr
+
+after_success:
+  - ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,6 @@ os:
   - linux
   - osx
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - cmake
-      - clang
-
 compiler:
   - gcc
   - clang


### PR DESCRIPTION
Travis enhancements:

- Enable `ccache` for `gcc`, `clang` on Linux and OSX
- Remove unneeded package install step
- Enable openmp build with clang on Linux