### PR TITLE
Update testing scripts

### DIFF
--- a/scripts/testing_scripts/test_all_sandia
+++ b/scripts/testing_scripts/test_all_sandia
@@ -63,7 +63,7 @@ CUDA_BUILD_LIST="Cuda_OpenMP,Cuda_Pthread,Cuda_Serial"
 CUDA_IBM_BUILD_LIST="Cuda_OpenMP,Cuda_Serial"
 
 GCC_WARNING_FLAGS="-Wall,-Wshadow,-pedantic,-Werror,-Wsign-compare,-Wtype-limits,-Wignored-qualifiers,-Wempty-body,-Wclobbered,-Wuninitialized"
-IBM_WARNING_FLAGS="-Wall,-Wshadow,-pedantic,-Werror,-Wsign-compare,-Wtype-limits,-Wuninitialized"
+IBM_WARNING_FLAGS="-Wall,-Wshadow,-pedantic,-Wsign-compare,-Wtype-limits,-Wuninitialized"
 CLANG_WARNING_FLAGS="-Wall,-Wshadow,-pedantic,-Werror,-Wsign-compare,-Wtype-limits,-Wuninitialized"
 INTEL_WARNING_FLAGS="-Wall,-Wshadow,-pedantic,-Werror,-Wsign-compare,-Wtype-limits,-Wuninitialized"
 CUDA_WARNING_FLAGS="-Wall,-Wshadow,-pedantic,-Werror,-Wsign-compare,-Wtype-limits,-Wuninitialized"

--- a/scripts/trilinos-integration/blake_jenkins_run_script_pthread_intel
+++ b/scripts/trilinos-integration/blake_jenkins_run_script_pthread_intel
@@ -1,6 +1,8 @@
 #!/bin/bash -el
 ulimit -c 0
 module load devpack/20171203/openmpi/2.1.2/intel/18.1.163
+# Trilinos now requires cmake version >= 3.10.0
+module swap cmake/3.9.0 cmake/3.10.2
 
 KOKKOS_BRANCH=$1
 TRILINOS_UPDATE_BRANCH=$2

--- a/scripts/trilinos-integration/blake_jenkins_run_script_serial_intel
+++ b/scripts/trilinos-integration/blake_jenkins_run_script_serial_intel
@@ -1,6 +1,8 @@
 #!/bin/bash -el
 ulimit -c 0
 module load devpack/20171203/openmpi/2.1.2/intel/18.1.163
+# Trilinos now requires cmake version >= 3.10.0
+module swap cmake/3.9.0 cmake/3.10.2
 
 KOKKOS_BRANCH=$1
 TRILINOS_UPDATE_BRANCH=$2

--- a/scripts/trilinos-integration/white_run_jenkins_script_cuda
+++ b/scripts/trilinos-integration/white_run_jenkins_script_cuda
@@ -22,6 +22,8 @@ fi
 
 module load devpack/20180521/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88
 module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
+# Trilinos now requires cmake version >= 3.10.0
+module swap cmake/3.9.6 cmake/3.12.3
 export OMP_NUM_THREADS=8
 export JENKINS_DO_CUDA=ON
 export JENKINS_DO_OPENMP=OFF

--- a/scripts/trilinos-integration/white_run_jenkins_script_omp
+++ b/scripts/trilinos-integration/white_run_jenkins_script_omp
@@ -22,6 +22,8 @@ fi
 
 module load devpack/20180521/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88
 module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
+# Trilinos now requires cmake version >= 3.10.0
+module swap cmake/3.9.6 cmake/3.12.3
 export OMP_NUM_THREADS=8
 export JENKINS_DO_CUDA=OFF
 export JENKINS_DO_OPENMP=ON


### PR DESCRIPTION
test_all_sandia: Remove -Werror from XL testing until issue #1842 is
resolved.
trilinons integration scripts: Add module swap to load a cmake version
>= 3.10.0, to match Trilinos' recently updated minimum support requirements.