### PR TITLE
update layout_iterate_type_selector to support defaults

### DIFF
--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -332,7 +332,10 @@ struct LayoutTiled {
 
 // For use with view_copy
 template < typename ... Layout >
-struct layout_iterate_type_selector;
+struct layout_iterate_type_selector {
+  static const Kokkos::Iterate outer_iteration_pattern = Kokkos::Iterate::Default ;
+  static const Kokkos::Iterate inner_iteration_pattern = Kokkos::Iterate::Default ;
+};
 
 template <>
 struct layout_iterate_type_selector< Kokkos::LayoutRight > {


### PR DESCRIPTION
layout_iterate_type_selector must support default types for non-standard
layouts created outside of Kokkos (e.g. LayoutContiguous, etc).
This better replicates the behavior of ViewFillLayoutSelector.