### PR TITLE
Fix issue #1850 failing test with UVM default

### DIFF
--- a/core/unit_test/TestCXX11.hpp
+++ b/core/unit_test/TestCXX11.hpp
@@ -216,7 +216,7 @@ template< class DeviceType, bool PWRTest >
 double ReduceTestFunctor() {
   typedef Kokkos::TeamPolicy< DeviceType > policy_type;
   typedef Kokkos::View< double**, DeviceType > view_type;
-  typedef Kokkos::View< double, typename view_type::host_mirror_space, Kokkos::MemoryUnmanaged > unmanaged_result;
+  typedef Kokkos::View< double, Kokkos::HostSpace, Kokkos::MemoryUnmanaged > unmanaged_result;
 
   view_type a( "A", 100, 5 );
   typename view_type::HostMirror h_a = Kokkos::create_mirror_view( a );
@@ -244,7 +244,7 @@ template< class DeviceType, bool PWRTest >
 double ReduceTestLambda() {
   typedef Kokkos::TeamPolicy< DeviceType > policy_type;
   typedef Kokkos::View< double**, DeviceType > view_type;
-  typedef Kokkos::View< double, typename view_type::host_mirror_space, Kokkos::MemoryUnmanaged > unmanaged_result;
+  typedef Kokkos::View< double, Kokkos::HostSpace, Kokkos::MemoryUnmanaged > unmanaged_result;
 
   view_type a( "A", 100, 5 );
   typename view_type::HostMirror h_a = Kokkos::create_mirror_view( a );

--- a/core/unit_test/standalone/Makefile
+++ b/core/unit_test/standalone/Makefile
@@ -10,6 +10,7 @@ endif
 
 SRC = $(wildcard $(MAKEFILE_PATH)*.cpp)
 HEADERS = $(wildcard $(MAKEFILE_PATH)*.hpp)
+HEADERS = $(wildcard $(MAKEFILE_PATH)/../*.hpp)
 
 vpath %.cpp $(sort $(dir $(SRC)))
 


### PR DESCRIPTION
The test was lying. It was creating an unmanaged UVM view
from a host pointer and using that as a result place for parallel_reduce.
With the recent changes to parallel_reduce this was causing a device
side access error.