### PR TITLE
DualView: Guard behavior change with deprecated code macros

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -404,7 +404,11 @@ public:
         "Template parameter to .sync() must exactly match one of the DualView's device types or one of the execution or memory spaces");
     #endif
 
+    #ifndef KOKKOS_ENABLE_DEPRECATED_CODE
     int dev = -1;
+    #else
+    int dev = 0;
+    #endif
     if(device_is_t_dev_device) dev = 1;
     else if(device_is_t_host_device) dev = 0;
     else {


### PR DESCRIPTION
The default setting in get_device_side for int dev was changed
from 0 to -1. This change of behavior breaks Tpetra, discovered during
Trilinos integration testing and should be guarded in deprecated macros
since it changed behavior.

Debugged and solution by @crtrott