### PR TITLE
More reduction ops for ScatterView

### DIFF
--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -216,10 +216,10 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
   Prod<ValueType,Kokkos::DefaultExecutionSpace> {
   public:
     KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in) : 
-       Sum<ValueType,Kokkos::DefaultExecutionSpace>(value_in)
+       Prod<ValueType,Kokkos::DefaultExecutionSpace>(value_in)
     {}
     KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ScatterValue&& other) : 
-       Sum<ValueType,Kokkos::DefaultExecutionSpace>(other.reference())
+       Prod<ValueType,Kokkos::DefaultExecutionSpace>(other.reference())
     {}
     KOKKOS_FORCEINLINE_FUNCTION void operator*=(ValueType const& rhs) {
       this->join( this->reference(), rhs );
@@ -234,10 +234,10 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
 
 template <typename ValueType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experimental::ScatterAtomic> :
-  Sum<ValueType,Kokkos::DefaultExecutionSpace> {
+  Prod<ValueType,Kokkos::DefaultExecutionSpace> {
   public:
     KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in) : 
-       Sum<ValueType,Kokkos::DefaultExecutionSpace>(value_in)
+       Prod<ValueType,Kokkos::DefaultExecutionSpace>(value_in)
     {}
 
     KOKKOS_FORCEINLINE_FUNCTION void operator*=(ValueType const& rhs) {
@@ -248,13 +248,13 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
     }
 
     KOKKOS_FORCEINLINE_FUNCTION 
-    void atomic_prod(ValueType & dest, const ValueType& src) {
+    void atomic_prod(ValueType & dest, const ValueType& src) const {
 
         bool success = false;
         ValueType & dest_old = dest;
         while(!success) {
-            ValueType & dest_new = dest_old * src;
-            dest_new = Kokkos::atomic_compare_exchange(&dest,dest_old,dest_new);
+            ValueType dest_new = dest_old * src;
+            dest_new = Kokkos::atomic_compare_exchange<ValueType>(&dest,dest_old,dest_new);
             success = (dest_new == dest_old);
             dest_old = dest_new;
         }
@@ -262,12 +262,12 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
     
     KOKKOS_INLINE_FUNCTION
     void join(ValueType& dest, const ValueType& src)  const {
-      atomic_prod(&dest, src);
+      atomic_prod(dest, src);
     }
 
     KOKKOS_INLINE_FUNCTION
     void join(volatile ValueType& dest, const volatile ValueType& src) const {
-      atomic_prod(&dest, src);
+      atomic_prod(dest, src);
     } 
 
     KOKKOS_FORCEINLINE_FUNCTION void upd(ValueType const& rhs) {
@@ -416,6 +416,21 @@ struct ReduceDuplicates<ExecSpace, ValueType, Kokkos::Experimental::ScatterSum> 
   }
 };
 
+template <typename ExecSpace, typename ValueType>
+struct ReduceDuplicates<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd> :
+  public ReduceDuplicatesBase<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd>
+{
+  typedef ReduceDuplicatesBase<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd> Base;
+  ReduceDuplicates(ValueType const* src_in, ValueType* dst_in, size_t stride_in, size_t start_in, size_t n_in, std::string const& name):
+    Base(src_in, dst_in, stride_in, start_in, n_in, name)
+  {}
+  KOKKOS_FORCEINLINE_FUNCTION void operator()(size_t i) const {
+    for (size_t j = Base::start; j < Base::n; ++j) {
+      Base::dst[i] *= Base::src[i + Base::stride * j];
+    }
+  }
+};
+
 template <typename ExecSpace, typename ValueType, int Op>
 struct ResetDuplicates;
 
@@ -454,6 +469,19 @@ struct ResetDuplicates<ExecSpace, ValueType, Kokkos::Experimental::ScatterSum> :
   {}
   KOKKOS_FORCEINLINE_FUNCTION void operator()(size_t i) const {
     Base::data[i] = Kokkos::reduction_identity<ValueType>::sum();
+  }
+};
+
+template <typename ExecSpace, typename ValueType>
+struct ResetDuplicates<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd> :
+  public ResetDuplicatesBase<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd>
+{
+  typedef ResetDuplicatesBase<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd> Base;
+  ResetDuplicates(ValueType* data_in, size_t size_in, std::string const& name):
+    Base(data_in, size_in, name)
+  {}
+  KOKKOS_FORCEINLINE_FUNCTION void operator()(size_t i) const {
+    Base::data[i] = Kokkos::reduction_identity<ValueType>::prod();
   }
 };
 

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -48,71 +48,120 @@
 
 namespace Test {
 
+template <typename ExecSpace, typename Layout, int duplication, int contribution, int op>
+struct test_scatter_view_impl_cls;
+
 template <typename ExecSpace, typename Layout, int duplication, int contribution>
-void test_scatter_view_config(int n)
+struct test_scatter_view_impl_cls<ExecSpace, Layout, duplication, contribution, Kokkos::Experimental::ScatterSum>   
 {
-  Kokkos::View<double *[3], Layout, ExecSpace> original_view("original_view", n);
-  {
-    auto scatter_view = Kokkos::Experimental::create_scatter_view
-      < Kokkos::Experimental::ScatterSum
-      , duplication
-      , contribution
-      > (original_view);
-#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
-    auto policy = Kokkos::RangePolicy<ExecSpace, int>(0, n);
-    auto f = KOKKOS_LAMBDA(int i) {
+public:   
+
+   typedef Kokkos::Experimental::ScatterView
+       < double*[3]
+       , Layout
+       , ExecSpace
+       , Kokkos::Experimental::ScatterSum
+       , duplication
+       , contribution
+        > scatter_view_type;
+
+   typedef Kokkos::View<double *[3], Layout, ExecSpace> orig_view_type; 
+
+
+   scatter_view_type scatter_view;
+   int scatterSize;
+
+   test_scatter_view_impl_cls(const scatter_view_type& view){
+      scatter_view = view;
+      scatterSize = 0;
+   }
+
+   void run_parallel(int n) {
+        scatterSize = n;
+        auto policy = Kokkos::RangePolicy<ExecSpace, int>(0, n);
+        Kokkos::parallel_for(policy, *this, "scatter_view_test: Sum");
+   }
+
+   KOKKOS_INLINE_FUNCTION
+   void operator()(int i) const {
       auto scatter_access = scatter_view.access();
       auto scatter_access_atomic = scatter_view.template access<Kokkos::Experimental::ScatterAtomic>();
       for (int j = 0; j < 10; ++j) {
-        auto k = (i + j) % n;
+        auto k = (i + j) % scatterSize;
         scatter_access(k, 0) += 4.2;
         scatter_access_atomic(k, 1) += 2.0;
         scatter_access(k, 2) += 1.0;
       }
-    };
-    Kokkos::parallel_for(policy, f, "scatter_view_test");
-#endif
-    Kokkos::Experimental::contribute(original_view, scatter_view);
-    scatter_view.reset_except(original_view);
-#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
-    Kokkos::parallel_for(policy, f, "scatter_view_test");
-#endif
-    Kokkos::Experimental::contribute(original_view, scatter_view);
-  }
-#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
-  Kokkos::fence();
-  auto host_view = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), original_view);
-  Kokkos::fence();
-  for (typename decltype(host_view)::size_type i = 0; i < host_view.extent(0); ++i) {
-    auto val0 = host_view(i, 0);
-    auto val1 = host_view(i, 1);
-    auto val2 = host_view(i, 2);
-    EXPECT_TRUE(std::fabs((val0 - 84.0) / 84.0) < 1e-15);
-    EXPECT_TRUE(std::fabs((val1 - 40.0) / 40.0) < 1e-15);
-    EXPECT_TRUE(std::fabs((val2 - 20.0) / 20.0) < 1e-15);
-  }
-#endif
-  {
-    Kokkos::Experimental::ScatterView
-      < double*[3]
-      , Layout
-      , ExecSpace
-      , Kokkos::Experimental::ScatterSum
-      , duplication
-      , contribution
-      >
-      persistent_view("persistent", n);
-    auto result_view = persistent_view.subview();
-    contribute(result_view, persistent_view);
-  }
-}
+    }
+
+    void validateResults(orig_view_type orig) {
+      auto host_view = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), orig);
+      Kokkos::fence();
+      for (typename decltype(host_view)::size_type i = 0; i < host_view.extent(0); ++i) {
+        auto val0 = host_view(i, 0);
+        auto val1 = host_view(i, 1);
+        auto val2 = host_view(i, 2);
+        EXPECT_TRUE(std::fabs((val0 - 84.0) / 84.0) < 1e-15);
+        EXPECT_TRUE(std::fabs((val1 - 40.0) / 40.0) < 1e-15);
+        EXPECT_TRUE(std::fabs((val2 - 20.0) / 20.0) < 1e-15);
+      }
+    }
+};
+template <typename ExecSpace, typename Layout, int duplication, int contribution, int op>
+struct test_scatter_view_config
+{
+ public:
+   typedef typename test_scatter_view_impl_cls<ExecSpace, Layout, 
+         duplication, contribution, op>::scatter_view_type scatter_view_def;
+   typedef typename test_scatter_view_impl_cls<ExecSpace, Layout, 
+         duplication, contribution, op>::orig_view_type orig_view_def;
+   scatter_view_def scatter_view;
+
+   test_scatter_view_config() {
+   }
+
+   void run_test(int n)
+   {
+
+     orig_view_def original_view("original_view", n);
+     scatter_view = Kokkos::Experimental::create_scatter_view
+       < op
+       , duplication
+       , contribution
+       > (original_view);
+
+     test_scatter_view_impl_cls<ExecSpace, Layout, duplication, contribution, op> scatter_view_test_impl(scatter_view);
+     scatter_view_test_impl.run_parallel(n);
+
+     Kokkos::Experimental::contribute(original_view, scatter_view);
+     scatter_view.reset_except(original_view);
+
+     scatter_view_test_impl.run_parallel(n);
+
+     Kokkos::Experimental::contribute(original_view, scatter_view);
+     Kokkos::fence();
+
+     scatter_view_test_impl.validateResults(original_view);
+
+     {
+        scatter_view_def persistent_view("persistent", n);
+        auto result_view = persistent_view.subview();
+        contribute(result_view, persistent_view);
+     }
+   }
+
+};
+
 
 template <typename ExecSpace>
 struct TestDuplicatedScatterView {
   TestDuplicatedScatterView(int n) {
+    // ScatterSum test
     test_scatter_view_config<ExecSpace, Kokkos::LayoutRight,
       Kokkos::Experimental::ScatterDuplicated,
-      Kokkos::Experimental::ScatterNonAtomic>(n);
+      Kokkos::Experimental::ScatterNonAtomic, 
+      Kokkos::Experimental::ScatterSum> test_sv_config;
+    test_sv_config.run_test(n);
   }
 };
 
@@ -149,14 +198,18 @@ void test_scatter_view(int n)
   if (unique_token.size() == 1) {
     test_scatter_view_config<ExecSpace, Kokkos::LayoutRight,
       Kokkos::Experimental::ScatterNonDuplicated,
-      Kokkos::Experimental::ScatterNonAtomic>(n);
+      Kokkos::Experimental::ScatterNonAtomic,
+      Kokkos::Experimental::ScatterSum> test_sv_config;
+    test_sv_config.run_test(n);
   }
 #ifdef KOKKOS_ENABLE_SERIAL
   if (!std::is_same<ExecSpace, Kokkos::Serial>::value) {
 #endif
   test_scatter_view_config<ExecSpace, Kokkos::LayoutRight,
     Kokkos::Experimental::ScatterNonDuplicated,
-    Kokkos::Experimental::ScatterAtomic>(n);
+    Kokkos::Experimental::ScatterAtomic,
+    Kokkos::Experimental::ScatterSum> test_sv_config;
+  test_sv_config.run_test(n);
 #ifdef KOKKOS_ENABLE_SERIAL
   }
 #endif


### PR DESCRIPTION
I think this is ready for an initial review.  

I added 3 ScatterValue reducers (Prod, Min, Max) each having both a non-atomic and an atomic version.  All of the ScatterValue reducers (including Sum) derive from the corresponding reducers found in Parallel_Reduce.  I kept the += and -= operators in the Sum reducer, and also added *= and /= in the Prod reducer for consistency.  All of the reducers implement an upd(rhs) and reset() function which are used by the ReduceDuplicates and ResetDuplicates respectively.

In the unit test, I separated the implementation details out from the test_scatter_view_config.  This way the += and -= operators could still be tested.  Also, the initializers and test scenarios (including verification) are different for each of the reducer types.  Those are implemented in the test_scatter_view_impl_cls templates which correspond to each reducer type.

Here is the output from the last spot-check:
Repository Status:  4050335b58ce1a652fe084ddd169a4763c2ca383 Issue 1674 - update comments for ScatterValue classes


Going to test compilers:  gcc/4.8.4 gcc/5.3.0 intel/16.0.1 clang/3.9.0 clang/6.0 cuda/9.1
Testing compiler gcc/4.8.4
  Starting job gcc-4.8.4-OpenMP-release
  PASSED gcc-4.8.4-OpenMP-release
Testing compiler gcc/5.3.0
  Starting job gcc-4.8.4-Pthread-release
  PASSED gcc-4.8.4-Pthread-release
Testing compiler intel/16.0.1
  Starting job gcc-5.3.0-Serial-release
  PASSED gcc-5.3.0-Serial-release
Testing compiler clang/3.9.0
  Starting job intel-16.0.1-OpenMP-release
  PASSED intel-16.0.1-OpenMP-release
Testing compiler clang/6.0
  Starting job clang-3.9.0-Pthread_Serial-release
  PASSED clang-3.9.0-Pthread_Serial-release
  Starting job clang-6.0-Cuda_Pthread-release
  PASSED clang-6.0-Cuda_Pthread-release
Testing compiler cuda/9.1
  Starting job clang-6.0-OpenMP-release
  PASSED clang-6.0-OpenMP-release
  Starting job cuda-9.1-Cuda_OpenMP-release
  PASSED cuda-9.1-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-release build_time=130 run_time=452
clang-6.0-Cuda_Pthread-release build_time=225 run_time=323
clang-6.0-OpenMP-release build_time=112 run_time=86
cuda-9.1-Cuda_OpenMP-release build_time=304 run_time=189
gcc-4.8.4-OpenMP-release build_time=105 run_time=101
gcc-4.8.4-Pthread-release build_time=97 run_time=345
gcc-5.3.0-Serial-release build_time=109 run_time=168
intel-16.0.1-OpenMP-release build_time=329 run_time=137