### PR TITLE
Update Test for ThreadVectorRange with non-zero start

### DIFF
--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -532,7 +532,11 @@ struct functor_vec_single {
   typedef ExecutionSpace execution_space;
 
   Kokkos::View< int, Kokkos::LayoutLeft, ExecutionSpace > flag;
-  functor_vec_single( Kokkos::View< int, Kokkos::LayoutLeft, ExecutionSpace > flag_ ) : flag( flag_ ) {}
+  int nStart;
+  int nEnd;
+
+  functor_vec_single( Kokkos::View< int, Kokkos::LayoutLeft, ExecutionSpace > flag_, const int start_, const int end_ ) : 
+                           flag( flag_ ), nStart(start_), nEnd(end_) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()( typename policy_type::member_type team ) const {
@@ -541,7 +545,7 @@ struct functor_vec_single {
     // inside a parallel_for and write to it.
     Scalar value = 0;
 
-    Kokkos::parallel_for( Kokkos::ThreadVectorRange( team, 0, 13 ), [&] ( int i )
+    Kokkos::parallel_for( Kokkos::ThreadVectorRange( team, nStart, nEnd ), [&] ( int i )
     {
       value = i; // This write is violating Kokkos semantics for nested parallelism.
     });
@@ -552,12 +556,12 @@ struct functor_vec_single {
     }, value );
 
     Scalar value2 = 0;
-    Kokkos::parallel_reduce( Kokkos::ThreadVectorRange( team, 0, 13 ), [&] ( int i, Scalar & val )
+    Kokkos::parallel_reduce( Kokkos::ThreadVectorRange( team, nStart, nEnd ), [&] ( int i, Scalar & val )
     {
       val += value;
     }, value2 );
 
-    if ( value2 != ( value * 13 ) ) {
+    if ( value2 != ( value * (nEnd-nStart) ) ) {
       printf( "FAILED vector_single broadcast %i %i %f %f\n",
               team.league_rank(), team.team_rank(), (double) value2, (double) value );
 
@@ -765,7 +769,7 @@ bool test_scalar( int nteams, int team_size, int test ) {
   }
   else if ( test == 4 ) {
     Kokkos::parallel_for( "B", Kokkos::TeamPolicy< ExecutionSpace >( nteams, team_size, 8 ),
-                          functor_vec_single< Scalar, ExecutionSpace >( d_flag ) );
+                          functor_vec_single< Scalar, ExecutionSpace >( d_flag, 0, 13 ) );
   }
   else if ( test == 5 ) {
     Kokkos::parallel_for( Kokkos::TeamPolicy< ExecutionSpace >( nteams, team_size ),
@@ -790,6 +794,10 @@ bool test_scalar( int nteams, int team_size, int test ) {
   else if ( test == 10 ) {
     Kokkos::parallel_for( Kokkos::TeamPolicy< ExecutionSpace >( nteams, team_size, 8 ),
                           functor_team_vector_reduce_reducer< Scalar, ExecutionSpace >( d_flag ) );
+  }
+  else if ( test == 11 ) {
+    Kokkos::parallel_for( "B", Kokkos::TeamPolicy< ExecutionSpace >( nteams, team_size, 8 ),
+                          functor_vec_single< Scalar, ExecutionSpace >( d_flag, 4, 13 ) );
   }
 
   Kokkos::deep_copy( h_flag, d_flag );
@@ -938,6 +946,7 @@ TEST_F( TEST_CATEGORY, team_vector )
   ASSERT_TRUE( ( TestTeamVector::Test< TEST_EXECSPACE >( 8 ) ) );
   ASSERT_TRUE( ( TestTeamVector::Test< TEST_EXECSPACE >( 9 ) ) );
   ASSERT_TRUE( ( TestTeamVector::Test< TEST_EXECSPACE >( 10 ) ) );
+  ASSERT_TRUE( ( TestTeamVector::Test< TEST_EXECSPACE >( 11 ) ) );
 }
 #endif
 


### PR DESCRIPTION
 Update Test for ThreadVectorRange (functor_vec_single functor) to take start and end parameters,
   then add test using non-zero start value.

the no-begin test already exists in TestTripleNestedReduce and in functor_vec_scan

below is the result of the spot check:


Going to test compilers:  gcc/5.3.0 gcc/7.3.0 intel/17.0.1 clang/4.0.1 cuda/8.0.44
Testing compiler gcc/5.3.0
  Starting job gcc-5.3.0-OpenMP-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler gcc/7.3.0
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  Starting job gcc-7.3.0-Serial-release
  PASSED gcc-7.3.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-7.3.0-Serial-hwloc-release
  PASSED gcc-7.3.0-Serial-hwloc-release
  Starting job intel-17.0.1-OpenMP-release
  PASSED intel-17.0.1-OpenMP-release
Testing compiler clang/4.0.1
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  Starting job clang-4.0.1-Pthread_Serial-release
  PASSED clang-4.0.1-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-4.0.1-Pthread_Serial-hwloc-release
  PASSED clang-4.0.1-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=189 run_time=193
clang-4.0.1-Pthread_Serial-release build_time=185 run_time=414
cuda-8.0.44-Cuda_OpenMP-release build_time=545 run_time=531
gcc-5.3.0-OpenMP-hwloc-release build_time=177 run_time=102
gcc-5.3.0-OpenMP-release build_time=180 run_time=100
gcc-7.3.0-Serial-hwloc-release build_time=149 run_time=234
gcc-7.3.0-Serial-release build_time=149 run_time=164
intel-17.0.1-OpenMP-hwloc-release build_time=438 run_time=159
intel-17.0.1-OpenMP-release build_time=434 run_time=161