### PR TITLE
conditionally remove uvm_num_alloc_test #1880

### DIFF
--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -34,6 +34,10 @@ include $(KOKKOS_PATH)/Makefile.kokkos
 
 KOKKOS_CXXFLAGS += -I$(GTEST_PATH) -I${KOKKOS_PATH}/core/unit_test
 
+ifeq ($(KOKKOS_INCLUDE_UVM_ALLOC_TEST),yes)
+ KOKKOS_CXXFLAGS += -DINCLUDE_UVM_ALLOC_TEST  
+endif
+
 TEST_TARGETS =
 TARGETS =
 

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -228,6 +228,7 @@ TEST_F( cuda, uvm )
   }
 }
 
+#ifdef INCLUDE_UVM_ALLOC_TEST
 TEST_F( cuda, uvm_num_allocs )
 {
   // The max number of UVM allocations allowed is 65536.
@@ -288,6 +289,7 @@ TEST_F( cuda, uvm_num_allocs )
 
   #undef MAX_NUM_ALLOCS
 }
+#endif
 
 template< class MemSpace, class ExecSpace >
 struct TestViewCudaAccessible {

--- a/core/unit_test/standalone/Makefile
+++ b/core/unit_test/standalone/Makefile
@@ -38,6 +38,10 @@ LIB =
 
 include $(KOKKOS_PATH)/Makefile.kokkos
 
+ifeq ($(KOKKOS_INCLUDE_UVM_ALLOC_TEST),yes)
+ KOKKOS_CXXFLAGS += -DINCLUDE_UVM_ALLOC_TEST  
+endif
+
 build: $(EXE)
 
 $(EXE): $(OBJ) $(KOKKOS_LINK_DEPENDS) gtest-all.o


### PR DESCRIPTION
   Issue #1880 :  wrap uvm_num_alloc test with ifdef on INCLUDE_UVM_ALLOC_TEST
   INCLUDE_UVM_ALLOC_TEST is enabled by setting environment(or build) variable
   KOKKOS_INCLUDE_UVM_ALLOC_TEST=yes

Here is the spot check result with the variable set:
Repository Status:  eece131eaf935e5a2894ad513aa8a9367651bd60 Issue 1880: wrap uvm_num_alloc test with ifdef on INCLUDE_UVM_ALLOC_TEST INCLUDE_UVM_ALLOC_TEST is enabled by setting environment(or build) variable KOKKOS_INCLUDE_UVM_ALLOC_TEST=yes


Going to test compilers:  gcc/5.3.0 gcc/7.3.0 intel/17.0.1 clang/4.0.1 cuda/8.0.44
Testing compiler gcc/5.3.0
  Starting job gcc-5.3.0-OpenMP-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler gcc/7.3.0
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  Starting job gcc-7.3.0-Serial-release
  PASSED gcc-7.3.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-7.3.0-Serial-hwloc-release
  PASSED gcc-7.3.0-Serial-hwloc-release
  Starting job intel-17.0.1-OpenMP-release
  PASSED intel-17.0.1-OpenMP-release
Testing compiler clang/4.0.1
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  Starting job clang-4.0.1-Pthread_Serial-release
  PASSED clang-4.0.1-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-4.0.1-Pthread_Serial-hwloc-release
  PASSED clang-4.0.1-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=197 run_time=199
clang-4.0.1-Pthread_Serial-release build_time=184 run_time=419
cuda-8.0.44-Cuda_OpenMP-release build_time=547 run_time=644
gcc-5.3.0-OpenMP-hwloc-release build_time=181 run_time=111
gcc-5.3.0-OpenMP-release build_time=179 run_time=110
gcc-7.3.0-Serial-hwloc-release build_time=151 run_time=238
gcc-7.3.0-Serial-release build_time=148 run_time=165
intel-17.0.1-OpenMP-hwloc-release build_time=478 run_time=192
intel-17.0.1-OpenMP-release build_time=435 run_time=166

Here is the spot-check result with the variable un-set:

Repository Status:  eece131eaf935e5a2894ad513aa8a9367651bd60 Issue 1880: wrap uvm_num_alloc test with ifdef on INCLUDE_UVM_ALLOC_TEST INCLUDE_UVM_ALLOC_TEST is enabled by setting environment(or build) variable KOKKOS_INCLUDE_UVM_ALLOC_TEST=yes


Going to test compilers:  gcc/5.3.0 gcc/7.3.0 intel/17.0.1 clang/4.0.1 cuda/8.0.44
Testing compiler gcc/5.3.0
  Starting job gcc-5.3.0-OpenMP-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler gcc/7.3.0
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  Starting job gcc-7.3.0-Serial-release
  PASSED gcc-7.3.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-7.3.0-Serial-hwloc-release
  PASSED gcc-7.3.0-Serial-hwloc-release
  Starting job intel-17.0.1-OpenMP-release
  PASSED intel-17.0.1-OpenMP-release
Testing compiler clang/4.0.1
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  Starting job clang-4.0.1-Pthread_Serial-release
  PASSED clang-4.0.1-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-4.0.1-Pthread_Serial-hwloc-release
  PASSED clang-4.0.1-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=210 run_time=215
clang-4.0.1-Pthread_Serial-release build_time=231 run_time=655
cuda-8.0.44-Cuda_OpenMP-release build_time=595 run_time=630
gcc-5.3.0-OpenMP-hwloc-release build_time=215 run_time=110
gcc-5.3.0-OpenMP-release build_time=209 run_time=109
gcc-7.3.0-Serial-hwloc-release build_time=158 run_time=168
gcc-7.3.0-Serial-release build_time=179 run_time=170
intel-17.0.1-OpenMP-hwloc-release build_time=482 run_time=174
intel-17.0.1-OpenMP-release build_time=526 run_time=169