### PR TITLE
Support Additional reductions in ScatterView #1674

### DIFF
--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -216,10 +216,10 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
   Prod<ValueType,Kokkos::DefaultExecutionSpace> {
   public:
     KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in) : 
-       Sum<ValueType,Kokkos::DefaultExecutionSpace>(value_in)
+       Prod<ValueType,Kokkos::DefaultExecutionSpace>(value_in)
     {}
     KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ScatterValue&& other) : 
-       Sum<ValueType,Kokkos::DefaultExecutionSpace>(other.reference())
+       Prod<ValueType,Kokkos::DefaultExecutionSpace>(other.reference())
     {}
     KOKKOS_FORCEINLINE_FUNCTION void operator*=(ValueType const& rhs) {
       this->join( this->reference(), rhs );
@@ -234,10 +234,10 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
 
 template <typename ValueType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experimental::ScatterAtomic> :
-  Sum<ValueType,Kokkos::DefaultExecutionSpace> {
+  Prod<ValueType,Kokkos::DefaultExecutionSpace> {
   public:
     KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in) : 
-       Sum<ValueType,Kokkos::DefaultExecutionSpace>(value_in)
+       Prod<ValueType,Kokkos::DefaultExecutionSpace>(value_in)
     {}
 
     KOKKOS_FORCEINLINE_FUNCTION void operator*=(ValueType const& rhs) {
@@ -248,13 +248,13 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
     }
 
     KOKKOS_FORCEINLINE_FUNCTION 
-    void atomic_prod(ValueType & dest, const ValueType& src) {
+    void atomic_prod(ValueType & dest, const ValueType& src) const {
 
         bool success = false;
         ValueType & dest_old = dest;
         while(!success) {
-            ValueType & dest_new = dest_old * src;
-            dest_new = Kokkos::atomic_compare_exchange(&dest,dest_old,dest_new);
+            ValueType dest_new = dest_old * src;
+            dest_new = Kokkos::atomic_compare_exchange<ValueType>(&dest,dest_old,dest_new);
             success = (dest_new == dest_old);
             dest_old = dest_new;
         }
@@ -262,12 +262,12 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
     
     KOKKOS_INLINE_FUNCTION
     void join(ValueType& dest, const ValueType& src)  const {
-      atomic_prod(&dest, src);
+      atomic_prod(dest, src);
     }
 
     KOKKOS_INLINE_FUNCTION
     void join(volatile ValueType& dest, const volatile ValueType& src) const {
-      atomic_prod(&dest, src);
+      atomic_prod(dest, src);
     } 
 
     KOKKOS_FORCEINLINE_FUNCTION void upd(ValueType const& rhs) {
@@ -416,6 +416,21 @@ struct ReduceDuplicates<ExecSpace, ValueType, Kokkos::Experimental::ScatterSum> 
   }
 };
 
+template <typename ExecSpace, typename ValueType>
+struct ReduceDuplicates<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd> :
+  public ReduceDuplicatesBase<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd>
+{
+  typedef ReduceDuplicatesBase<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd> Base;
+  ReduceDuplicates(ValueType const* src_in, ValueType* dst_in, size_t stride_in, size_t start_in, size_t n_in, std::string const& name):
+    Base(src_in, dst_in, stride_in, start_in, n_in, name)
+  {}
+  KOKKOS_FORCEINLINE_FUNCTION void operator()(size_t i) const {
+    for (size_t j = Base::start; j < Base::n; ++j) {
+      Base::dst[i] *= Base::src[i + Base::stride * j];
+    }
+  }
+};
+
 template <typename ExecSpace, typename ValueType, int Op>
 struct ResetDuplicates;
 
@@ -454,6 +469,19 @@ struct ResetDuplicates<ExecSpace, ValueType, Kokkos::Experimental::ScatterSum> :
   {}
   KOKKOS_FORCEINLINE_FUNCTION void operator()(size_t i) const {
     Base::data[i] = Kokkos::reduction_identity<ValueType>::sum();
+  }
+};
+
+template <typename ExecSpace, typename ValueType>
+struct ResetDuplicates<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd> :
+  public ResetDuplicatesBase<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd>
+{
+  typedef ResetDuplicatesBase<ExecSpace, ValueType, Kokkos::Experimental::ScatterProd> Base;
+  ResetDuplicates(ValueType* data_in, size_t size_in, std::string const& name):
+    Base(data_in, size_in, name)
+  {}
+  KOKKOS_FORCEINLINE_FUNCTION void operator()(size_t i) const {
+    Base::data[i] = Kokkos::reduction_identity<ValueType>::prod();
   }
 };
 

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -251,15 +251,11 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
     void atomic_prod(ValueType & dest, const ValueType& src) const {
 
         bool success = false;
-        ValueType orig_val = dest;
-        //ValueType expectedResult = orig_val * src;
         while(!success) {
             ValueType dest_old = dest;
             ValueType dest_new = dest_old * src;
             dest_new = Kokkos::atomic_compare_exchange<ValueType>(&dest,dest_old,dest_new);
             success = ( (dest_new - dest_old)/dest_old <= 1e-15 );
-//            printf("Compare_exchange: (%s), %le, %le, %le\n",
-//                 success ? "true" : "false", dest_new, expectedResult, dest);
         }
     }
     

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -251,12 +251,15 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
     void atomic_prod(ValueType & dest, const ValueType& src) const {
 
         bool success = false;
-        ValueType & dest_old = dest;
+        ValueType orig_val = dest;
+        //ValueType expectedResult = orig_val * src;
         while(!success) {
+            ValueType dest_old = dest;
             ValueType dest_new = dest_old * src;
             dest_new = Kokkos::atomic_compare_exchange<ValueType>(&dest,dest_old,dest_new);
-            success = (dest_new == dest_old);
-            dest_old = dest_new;
+            success = ( (dest_new - dest_old)/dest_old <= 1e-15 );
+//            printf("Compare_exchange: (%s), %le, %le, %le\n",
+//                 success ? "true" : "false", dest_new, expectedResult, dest);
         }
     }
     

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -153,7 +153,7 @@ struct DefaultContribution<Kokkos::Cuda, Kokkos::Experimental::ScatterDuplicated
 
 /* ScatterValue <Op=ScatterSum, contribution=ScatterNonAtomic> is the object returned by the access operator() of ScatterAccess,
    This class inherits from the Sum<> reducer and it wraps join(dest, src) with convenient operator+=, etc. 
-   Note the addition of upd(ValueType const& rhs) and reset()  so that all reducers can have common functions
+   Note the addition of update(ValueType const& rhs) and reset()  so that all reducers can have common functions
    See ReduceDuplicates and ResetDuplicates ) */
 template <typename ValueType, int Op, int contribution>
 struct ScatterValue;
@@ -174,7 +174,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, Kokkos::Experim
     KOKKOS_FORCEINLINE_FUNCTION void operator-=(ValueType const& rhs) {
       this->join( this->reference(), -rhs );
     }
-    KOKKOS_FORCEINLINE_FUNCTION void upd(ValueType const& rhs) {
+    KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
       this->join( this->reference(), rhs );
     }
     KOKKOS_FORCEINLINE_FUNCTION void reset() {
@@ -184,7 +184,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, Kokkos::Experim
 
 /* ScatterValue <Op=ScatterSum, contribution=ScatterAtomic> is the object returned by the access operator() 
  * of ScatterAccess, similar to that returned by an Atomic View, it wraps Kokkos::atomic_add with convenient
-   operator+=, etc. This version also has the upd(rhs) and reset() functions. */
+   operator+=, etc. This version also has the update(rhs) and reset() functions. */
 template <typename ValueType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterAtomic> :
   Sum<ValueType,Kokkos::DefaultExecutionSpace> {
@@ -210,7 +210,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, Kokkos::Experim
       Kokkos::atomic_add(&dest, src);
     } 
 
-    KOKKOS_FORCEINLINE_FUNCTION void upd(ValueType const& rhs) {
+    KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
       this->join( this->reference(), rhs );
     }
 
@@ -221,7 +221,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, Kokkos::Experim
 
 /* ScatterValue <Op=ScatterProd, contribution=ScatterNonAtomic> is the object returned by the access operator() of ScatterAccess,
    This class inherits from the Prod<> reducer and it wraps join(dest, src) with convenient operator*=, etc. 
-   Note the addition of upd(ValueType const& rhs) and reset()  so that all reducers can have common functions
+   Note the addition of update(ValueType const& rhs) and reset()  so that all reducers can have common functions
    See ReduceDuplicates and ResetDuplicates ) */
 template <typename ValueType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experimental::ScatterNonAtomic> :
@@ -239,7 +239,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
     KOKKOS_FORCEINLINE_FUNCTION void operator/=(ValueType const& rhs) {
       this->join( this->reference(), static_cast<ValueType>(1)/rhs );
     }
-    KOKKOS_FORCEINLINE_FUNCTION void upd(ValueType const& rhs) {
+    KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
       this->join( this->reference(), rhs );
     }
     KOKKOS_FORCEINLINE_FUNCTION void reset() {
@@ -249,7 +249,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
 
 /* ScatterValue <Op=ScatterProd, contribution=ScatterAtomic> is the object returned by the access operator() 
  * of ScatterAccess, similar to that returned by an Atomic View, it wraps and atomic_prod with convenient
-   operator*=, etc. atomic_prod uses the atomic_compare_exchange. This version also has the upd(rhs) and reset() functions. */
+   operator*=, etc. atomic_prod uses the atomic_compare_exchange. This version also has the update(rhs) and reset() functions. */
 template <typename ValueType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experimental::ScatterAtomic> :
   Prod<ValueType,Kokkos::DefaultExecutionSpace> {
@@ -287,7 +287,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
       atomic_prod(dest, src);
     } 
 
-    KOKKOS_FORCEINLINE_FUNCTION void upd(ValueType const& rhs) {
+    KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
       this->join( this->reference(), rhs );
     }
     KOKKOS_FORCEINLINE_FUNCTION void reset() {
@@ -297,8 +297,8 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, Kokkos::Experi
 };
 
 /* ScatterValue <Op=ScatterMin, contribution=ScatterNonAtomic> is the object returned by the access operator() of ScatterAccess,
-   This class inherits from the Min<> reducer and it wraps join(dest, src) with convenient upd(rhs). 
-   Note the addition of upd(ValueType const& rhs) and reset() are so that all reducers can have a common update function
+   This class inherits from the Min<> reducer and it wraps join(dest, src) with convenient update(rhs). 
+   Note the addition of update(ValueType const& rhs) and reset() are so that all reducers can have a common update function
    See ReduceDuplicates and ResetDuplicates ) */
 template <typename ValueType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, Kokkos::Experimental::ScatterNonAtomic> :
@@ -310,7 +310,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, Kokkos::Experim
     KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ScatterValue&& other) : 
        Min<ValueType,Kokkos::DefaultExecutionSpace>(other.reference())
     {}
-    KOKKOS_FORCEINLINE_FUNCTION void upd(ValueType const& rhs) {
+    KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
       this->join( this->reference(), rhs );
     }
     KOKKOS_FORCEINLINE_FUNCTION void reset() {
@@ -319,7 +319,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, Kokkos::Experim
 };
 
 /* ScatterValue <Op=ScatterMin, contribution=ScatterAtomic> is the object returned by the access operator() 
- * of ScatterAccess, similar to that returned by an Atomic View, it wraps and atomic_min with the upd(rhs)
+ * of ScatterAccess, similar to that returned by an Atomic View, it wraps and atomic_min with the update(rhs)
    function. atomic_min uses the atomic_compare_exchange. This version also has the reset() function */
 template <typename ValueType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, Kokkos::Experimental::ScatterAtomic> :
@@ -351,7 +351,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, Kokkos::Experim
       atomic_min(dest, src);
     } 
 
-    KOKKOS_FORCEINLINE_FUNCTION void upd(ValueType const& rhs) {
+    KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
       this->join( this->reference(), rhs );
     }
     KOKKOS_FORCEINLINE_FUNCTION void reset() {
@@ -360,9 +360,9 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, Kokkos::Experim
 
 };
 
-/* ScatterValue <Op=ScatterMax, contribution=ScatterNonAtomic> is the object returned by the access operator() of ScatterAccess,
-   This class inherits from the Max<> reducer and it wraps join(dest, src) with convenient upd(rhs). 
-   Note the addition of upd(ValueType const& rhs) and reset() are so that all reducers can have a common update function
+/* ScatterValue <Op=ScatterMax, contribution=ScatterNonAtomic> is the object returned by the access operataor() of ScatterAccess,
+   This class inherits from the Max<> reducer and it wraps join(dest, src) with convenient update(rhs). 
+   Note the addition of update(ValueType const& rhs) and reset() are so that all reducers can have a common update function
    See ReduceDuplicates and ResetDuplicates ) */
 template <typename ValueType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, Kokkos::Experimental::ScatterNonAtomic> :
@@ -374,7 +374,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, Kokkos::Experim
     KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ScatterValue&& other) : 
        Max<ValueType,Kokkos::DefaultExecutionSpace>(other.reference())
     {}
-    KOKKOS_FORCEINLINE_FUNCTION void upd(ValueType const& rhs) {
+    KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
       this->join( this->reference(), rhs );
     }
     KOKKOS_FORCEINLINE_FUNCTION void reset() {
@@ -383,7 +383,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, Kokkos::Experim
 };
 
 /* ScatterValue <Op=ScatterMax, contribution=ScatterAtomic> is the object returned by the access operator() 
- * of ScatterAccess, similar to that returned by an Atomic View, it wraps and atomic_max with the upd(rhs)
+ * of ScatterAccess, similar to that returned by an Atomic View, it wraps and atomic_max with the update(rhs)
    function. atomic_max uses the atomic_compare_exchange. This version also has the reset() function  */
 template <typename ValueType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, Kokkos::Experimental::ScatterAtomic> :
@@ -415,7 +415,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, Kokkos::Experim
       atomic_max(dest, src);
     } 
 
-    KOKKOS_FORCEINLINE_FUNCTION void upd(ValueType const& rhs) {
+    KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
       this->join( this->reference(), rhs );
     }
     KOKKOS_FORCEINLINE_FUNCTION void reset() {
@@ -551,7 +551,7 @@ struct ReduceDuplicatesBase {
 
 /* ReduceDuplicates -- Perform reduction on destination array using strided source 
  *    Use ScatterValue<> specific to operation to wrap destination array so that
- *    the reduction operation can be accessed via the upd(rhs) function */
+ *    the reduction operation can be accessed via the update(rhs) function */
 template <typename ExecSpace, typename ValueType, int Op>
 struct ReduceDuplicates :
   public ReduceDuplicatesBase<ExecSpace, ValueType, Op>
@@ -563,7 +563,7 @@ struct ReduceDuplicates :
   KOKKOS_FORCEINLINE_FUNCTION void operator()(size_t i) const {
     for (size_t j = Base::start; j < Base::n; ++j) {
       ScatterValue<ValueType, Op, Kokkos::Experimental::ScatterNonAtomic> sv(Base::dst[i]);
-      sv.upd( Base::src[i + Base::stride * j] );
+      sv.update( Base::src[i + Base::stride * j] );
     }
   }
 };

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -241,9 +241,9 @@ public:
       auto scatter_access_atomic = scatter_view.template access<Kokkos::Experimental::ScatterAtomic>();
       for (int j = 0; j < 4; ++j) {
         auto k = (i + j) % scatterSize;
-        scatter_access(k, 0).upd((double)(j+1)*4);
-        scatter_access_atomic(k, 1).upd((double)(j+1)*2.0);
-        scatter_access(k, 2).upd((double)(j+1)*1.0);
+        scatter_access(k, 0).update((double)(j+1)*4);
+        scatter_access_atomic(k, 1).update((double)(j+1)*2.0);
+        scatter_access(k, 2).update((double)(j+1)*1.0);
       }
     }
 
@@ -312,9 +312,9 @@ public:
       auto scatter_access_atomic = scatter_view.template access<Kokkos::Experimental::ScatterAtomic>();
       for (int j = 0; j < 4; ++j) {
         auto k = (i + j) % scatterSize;
-        scatter_access(k, 0).upd((double)(j+1)*4);
-        scatter_access_atomic(k, 1).upd((double)(j+1)*2.0);
-        scatter_access(k, 2).upd((double)(j+1)*1.0);
+        scatter_access(k, 0).update((double)(j+1)*4);
+        scatter_access_atomic(k, 1).update((double)(j+1)*2.0);
+        scatter_access(k, 2).update((double)(j+1)*1.0);
       }
     }
 

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -48,71 +48,120 @@
 
 namespace Test {
 
+template <typename ExecSpace, typename Layout, int duplication, int contribution, int op>
+struct test_scatter_view_impl_cls;
+
 template <typename ExecSpace, typename Layout, int duplication, int contribution>
-void test_scatter_view_config(int n)
+struct test_scatter_view_impl_cls<ExecSpace, Layout, duplication, contribution, Kokkos::Experimental::ScatterSum>   
 {
-  Kokkos::View<double *[3], Layout, ExecSpace> original_view("original_view", n);
-  {
-    auto scatter_view = Kokkos::Experimental::create_scatter_view
-      < Kokkos::Experimental::ScatterSum
-      , duplication
-      , contribution
-      > (original_view);
-#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
-    auto policy = Kokkos::RangePolicy<ExecSpace, int>(0, n);
-    auto f = KOKKOS_LAMBDA(int i) {
+public:   
+
+   typedef Kokkos::Experimental::ScatterView
+       < double*[3]
+       , Layout
+       , ExecSpace
+       , Kokkos::Experimental::ScatterSum
+       , duplication
+       , contribution
+        > scatter_view_type;
+
+   typedef Kokkos::View<double *[3], Layout, ExecSpace> orig_view_type; 
+
+
+   scatter_view_type scatter_view;
+   int scatterSize;
+
+   test_scatter_view_impl_cls(const scatter_view_type& view){
+      scatter_view = view;
+      scatterSize = 0;
+   }
+
+   void run_parallel(int n) {
+        scatterSize = n;
+        auto policy = Kokkos::RangePolicy<ExecSpace, int>(0, n);
+        Kokkos::parallel_for(policy, *this, "scatter_view_test: Sum");
+   }
+
+   KOKKOS_INLINE_FUNCTION
+   void operator()(int i) const {
       auto scatter_access = scatter_view.access();
       auto scatter_access_atomic = scatter_view.template access<Kokkos::Experimental::ScatterAtomic>();
       for (int j = 0; j < 10; ++j) {
-        auto k = (i + j) % n;
+        auto k = (i + j) % scatterSize;
         scatter_access(k, 0) += 4.2;
         scatter_access_atomic(k, 1) += 2.0;
         scatter_access(k, 2) += 1.0;
       }
-    };
-    Kokkos::parallel_for(policy, f, "scatter_view_test");
-#endif
-    Kokkos::Experimental::contribute(original_view, scatter_view);
-    scatter_view.reset_except(original_view);
-#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
-    Kokkos::parallel_for(policy, f, "scatter_view_test");
-#endif
-    Kokkos::Experimental::contribute(original_view, scatter_view);
-  }
-#if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA )
-  Kokkos::fence();
-  auto host_view = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), original_view);
-  Kokkos::fence();
-  for (typename decltype(host_view)::size_type i = 0; i < host_view.extent(0); ++i) {
-    auto val0 = host_view(i, 0);
-    auto val1 = host_view(i, 1);
-    auto val2 = host_view(i, 2);
-    EXPECT_TRUE(std::fabs((val0 - 84.0) / 84.0) < 1e-15);
-    EXPECT_TRUE(std::fabs((val1 - 40.0) / 40.0) < 1e-15);
-    EXPECT_TRUE(std::fabs((val2 - 20.0) / 20.0) < 1e-15);
-  }
-#endif
-  {
-    Kokkos::Experimental::ScatterView
-      < double*[3]
-      , Layout
-      , ExecSpace
-      , Kokkos::Experimental::ScatterSum
-      , duplication
-      , contribution
-      >
-      persistent_view("persistent", n);
-    auto result_view = persistent_view.subview();
-    contribute(result_view, persistent_view);
-  }
-}
+    }
+
+    void validateResults(orig_view_type orig) {
+      auto host_view = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), orig);
+      Kokkos::fence();
+      for (typename decltype(host_view)::size_type i = 0; i < host_view.extent(0); ++i) {
+        auto val0 = host_view(i, 0);
+        auto val1 = host_view(i, 1);
+        auto val2 = host_view(i, 2);
+        EXPECT_TRUE(std::fabs((val0 - 84.0) / 84.0) < 1e-15);
+        EXPECT_TRUE(std::fabs((val1 - 40.0) / 40.0) < 1e-15);
+        EXPECT_TRUE(std::fabs((val2 - 20.0) / 20.0) < 1e-15);
+      }
+    }
+};
+template <typename ExecSpace, typename Layout, int duplication, int contribution, int op>
+struct test_scatter_view_config
+{
+ public:
+   typedef typename test_scatter_view_impl_cls<ExecSpace, Layout, 
+         duplication, contribution, op>::scatter_view_type scatter_view_def;
+   typedef typename test_scatter_view_impl_cls<ExecSpace, Layout, 
+         duplication, contribution, op>::orig_view_type orig_view_def;
+   scatter_view_def scatter_view;
+
+   test_scatter_view_config() {
+   }
+
+   void run_test(int n)
+   {
+
+     orig_view_def original_view("original_view", n);
+     scatter_view = Kokkos::Experimental::create_scatter_view
+       < op
+       , duplication
+       , contribution
+       > (original_view);
+
+     test_scatter_view_impl_cls<ExecSpace, Layout, duplication, contribution, op> scatter_view_test_impl(scatter_view);
+     scatter_view_test_impl.run_parallel(n);
+
+     Kokkos::Experimental::contribute(original_view, scatter_view);
+     scatter_view.reset_except(original_view);
+
+     scatter_view_test_impl.run_parallel(n);
+
+     Kokkos::Experimental::contribute(original_view, scatter_view);
+     Kokkos::fence();
+
+     scatter_view_test_impl.validateResults(original_view);
+
+     {
+        scatter_view_def persistent_view("persistent", n);
+        auto result_view = persistent_view.subview();
+        contribute(result_view, persistent_view);
+     }
+   }
+
+};
+
 
 template <typename ExecSpace>
 struct TestDuplicatedScatterView {
   TestDuplicatedScatterView(int n) {
+    // ScatterSum test
     test_scatter_view_config<ExecSpace, Kokkos::LayoutRight,
       Kokkos::Experimental::ScatterDuplicated,
-      Kokkos::Experimental::ScatterNonAtomic>(n);
+      Kokkos::Experimental::ScatterNonAtomic, 
+      Kokkos::Experimental::ScatterSum> test_sv_config;
+    test_sv_config.run_test(n);
   }
 };
 
@@ -149,14 +198,18 @@ void test_scatter_view(int n)
   if (unique_token.size() == 1) {
     test_scatter_view_config<ExecSpace, Kokkos::LayoutRight,
       Kokkos::Experimental::ScatterNonDuplicated,
-      Kokkos::Experimental::ScatterNonAtomic>(n);
+      Kokkos::Experimental::ScatterNonAtomic,
+      Kokkos::Experimental::ScatterSum> test_sv_config;
+    test_sv_config.run_test(n);
   }
 #ifdef KOKKOS_ENABLE_SERIAL
   if (!std::is_same<ExecSpace, Kokkos::Serial>::value) {
 #endif
   test_scatter_view_config<ExecSpace, Kokkos::LayoutRight,
     Kokkos::Experimental::ScatterNonDuplicated,
-    Kokkos::Experimental::ScatterAtomic>(n);
+    Kokkos::Experimental::ScatterAtomic,
+    Kokkos::Experimental::ScatterSum> test_sv_config;
+  test_sv_config.run_test(n);
 #ifdef KOKKOS_ENABLE_SERIAL
   }
 #endif


### PR DESCRIPTION
Issue #1674 :  Support additional reductions in scatter view.

Follow on pull request to #1896 which includes changing upd() to update().  Still waiting on response from @stanmoore1 to see if LAMMPS performance is okay.

below is the result from the latest spot-check:
Repository Status:  639c550d001beecdf35257a43ac7029f53bea63d Issue 1674: change upd to update


Going to test compilers:  gcc/5.3.0 gcc/7.3.0 intel/17.0.1 clang/4.0.1 cuda/8.0.44
Testing compiler gcc/5.3.0
  Starting job gcc-5.3.0-OpenMP-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler gcc/7.3.0
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  Starting job gcc-7.3.0-Serial-release
  PASSED gcc-7.3.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-7.3.0-Serial-hwloc-release
  PASSED gcc-7.3.0-Serial-hwloc-release
  Starting job intel-17.0.1-OpenMP-release
  PASSED intel-17.0.1-OpenMP-release
Testing compiler clang/4.0.1
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  Starting job clang-4.0.1-Pthread_Serial-release
  PASSED clang-4.0.1-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-4.0.1-Pthread_Serial-hwloc-release
  PASSED clang-4.0.1-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=192 run_time=235
clang-4.0.1-Pthread_Serial-release build_time=199 run_time=459
cuda-8.0.44-Cuda_OpenMP-release build_time=723 run_time=608
gcc-5.3.0-OpenMP-hwloc-release build_time=181 run_time=116
gcc-5.3.0-OpenMP-release build_time=178 run_time=114
gcc-7.3.0-Serial-hwloc-release build_time=159 run_time=224
gcc-7.3.0-Serial-release build_time=174 run_time=197
intel-17.0.1-OpenMP-hwloc-release build_time=466 run_time=211
intel-17.0.1-OpenMP-release build_time=481 run_time=284