### PR TITLE
dual_view: fix for deep_copy overloads

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -832,16 +832,14 @@ void
 deep_copy (DualView<DT,DL,DD,DM> dst, // trust me, this must not be a reference
            const DualView<ST,SL,SD,SM>& src )
 {
-  if(src.modified_flags.data()==NULL || dst.modified_flags.data()==NULL) {
-    return deep_copy(dst.d_view, src.d_view);
-  }
-  if (src.modified_flags(1) >= src.modified_flags(0)) {
-    deep_copy (dst.d_view, src.d_view);
-    dst.template modify<typename DualView<DT,DL,DD,DM>::device_type> ();
-  } else {
+  if ( src.need_sync_device() ) {
     deep_copy (dst.h_view, src.h_view);
-    dst.template modify<typename DualView<DT,DL,DD,DM>::host_mirror_space> ();
+    dst.modify_host();
   }
+  else {
+    deep_copy (dst.d_view, src.d_view);
+    dst.modify_device();
+  } 
 }
 
 template< class ExecutionSpace ,
@@ -852,15 +850,12 @@ deep_copy (const ExecutionSpace& exec ,
            DualView<DT,DL,DD,DM> dst, // trust me, this must not be a reference
            const DualView<ST,SL,SD,SM>& src )
 {
-  if(src.modified_flags.data()==NULL || dst.modified_flags.data()==NULL) {
-    return deep_copy(exec, dst.d_view, src.d_view);
-  }
-  if (src.modified_flags(1) >= src.modified_flags(0)) {
-    deep_copy (exec, dst.d_view, src.d_view);
-    dst.template modify<typename DualView<DT,DL,DD,DM>::device_type> ();
-  } else {
+  if ( src.need_sync_device() ) {
     deep_copy (exec, dst.h_view, src.h_view);
-    dst.template modify<typename DualView<DT,DL,DD,DM>::host_mirror_space> ();
+    dst.modify_host();
+  } else {
+    deep_copy (exec, dst.d_view, src.d_view);
+    dst.modify_device();
   }
 }
 

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -101,10 +101,94 @@ namespace Impl {
       result = run_me< Kokkos::DualView<Scalar**,Kokkos::LayoutLeft,Device> >(size,3);
     }
 
-   };
+  };
+
+  template < typename Scalar, class ViewType >
+  struct SumViewEntriesFunctor {
+
+    typedef Scalar value_type;
+
+    ViewType fv;
+
+    SumViewEntriesFunctor ( const ViewType & fv_ ) : fv(fv_) {}
+
+    KOKKOS_INLINE_FUNCTION
+    void operator() ( const int i , value_type & total ) const {
+      for ( size_t j = 0; j < fv.extent(1); ++j ) {
+        total += fv(i,j);
+      }
+    }
+
+  };
+  
+
+  template <typename Scalar, class Device>
+  struct test_dual_view_deep_copy
+  {
+    typedef Scalar scalar_type;
+    typedef Device execution_space;
+
+    template <typename ViewType>
+    void run_me() {
+
+      const unsigned int n = 10;
+      const unsigned int m = 5;
+      const unsigned int sum_total = n * m;
+
+      ViewType a("A",n,m);
+      ViewType b("B",n,m);
+
+      Kokkos::deep_copy( a.d_view , 1 );
+
+      a.template modify<typename ViewType::execution_space>();
+      a.template sync<typename ViewType::host_mirror_space>();
+
+      // Check device view is initialized as expected
+      scalar_type a_d_sum = 0;
+      // Execute on the execution_space associated with t_dev's memory space
+      typedef typename ViewType::t_dev::memory_space::execution_space t_dev_exec_space;
+      Kokkos::parallel_reduce( Kokkos::RangePolicy<t_dev_exec_space>(0,n), SumViewEntriesFunctor<scalar_type, typename ViewType::t_dev>(a.d_view), a_d_sum );
+      ASSERT_EQ(a_d_sum, sum_total);
+
+      // Check host view is synced as expected
+      scalar_type a_h_sum = 0;
+      for ( size_t i = 0; i < a.h_view.extent(0); ++i )
+        for ( size_t j = 0; j < a.h_view.extent(1); ++j ) {
+          a_h_sum += a.h_view(i,j);
+        }
+
+      ASSERT_EQ(a_h_sum, sum_total);
+
+
+      // Test deep_copy
+      Kokkos::deep_copy( b, a );
+
+      // Perform same checks on b as done on a
+      // Check device view is initialized as expected
+      scalar_type b_d_sum = 0;
+      // Execute on the execution_space associated with t_dev's memory space
+      Kokkos::parallel_reduce( Kokkos::RangePolicy<t_dev_exec_space>(0,n), SumViewEntriesFunctor<scalar_type, typename ViewType::t_dev>(b.d_view), b_d_sum );
+      ASSERT_EQ(b_d_sum, sum_total);
+
+      // Check host view is synced as expected
+      scalar_type b_h_sum = 0;
+      for ( size_t i = 0; i < b.h_view.extent(0); ++i )
+        for ( size_t j = 0; j < b.h_view.extent(1); ++j ) {
+          b_h_sum += b.h_view(i,j);
+        }
+
+      ASSERT_EQ(b_h_sum, sum_total);
+
+    } // end run_me
+
+    test_dual_view_deep_copy()
+    {
+      run_me< Kokkos::DualView<Scalar**,Kokkos::LayoutLeft,Device> >();
+    }
+
+  };
 
 } // namespace Impl
-
 
 
 
@@ -116,8 +200,19 @@ void test_dualview_combinations(unsigned int size)
 
 }
 
+template <typename Scalar, typename Device>
+void test_dualview_deep_copy()
+{
+  Impl::test_dual_view_deep_copy<Scalar,Device> ();
+}
+
 TEST_F( TEST_CATEGORY, dualview_combination) {
     test_dualview_combinations<int,TEST_EXECSPACE>(10);
+}
+
+TEST_F( TEST_CATEGORY, dualview_deep_copy) {
+    test_dualview_deep_copy<int,TEST_EXECSPACE>();
+    test_dualview_deep_copy<double,TEST_EXECSPACE>();
 }
 
 

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -162,6 +162,7 @@ namespace Impl {
 
       // Test deep_copy
       Kokkos::deep_copy( b, a );
+      b.template sync<typename ViewType::host_mirror_space>();
 
       // Perform same checks on b as done on a
       // Check device view is initialized as expected


### PR DESCRIPTION
Potential fix for issue #1952
Added a modified_flags_data method.
Changed the modified_flags checks in `deep_copy` to avoid <= check in order to use
need_sync_device()