### PR TITLE
Fix another error in debug

### DIFF
--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -144,8 +144,8 @@ SharedAllocationRecord<void,void>::find( SharedAllocationRecord<void,void> * con
 {
   Kokkos::Impl::throw_runtime_exception("Kokkos::Impl::SharedAllocationRecord::find only works with KOKKOS_DEBUG enabled");
   return nullptr;
-#endif
 }
+#endif
 
 
 /**\brief  Construct and insert into 'arg_root' tracking set.


### PR DESCRIPTION
```
[crtrott@apollo KokkosBuild]$ cat nohup.issue-1984-b 
nohup: ignoring input
ModuleCmd_Load.c(213):ERROR:105: Unable to locate a modulefile for 'git'
Running on machine: apollo
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
?? patch_teamvectorrange

Repository Status:  a0361db8e83f24872ad459357780d8df8397887c Fix another error in debug


Going to test compilers:  gcc/4.8.4 gcc/5.3.0 intel/16.0.1 clang/3.9.0 clang/6.0 cuda/9.1
Testing compiler gcc/4.8.4
  Starting job gcc-4.8.4-OpenMP-release
  PASSED gcc-4.8.4-OpenMP-release
Testing compiler gcc/5.3.0
  Starting job gcc-4.8.4-Pthread-release
  PASSED gcc-4.8.4-Pthread-release
Testing compiler intel/16.0.1
  Starting job gcc-5.3.0-Serial-release
  PASSED gcc-5.3.0-Serial-release
Testing compiler clang/3.9.0
  Starting job intel-16.0.1-OpenMP-release
  PASSED intel-16.0.1-OpenMP-release
Testing compiler clang/6.0
  Starting job clang-3.9.0-Pthread_Serial-release
  PASSED clang-3.9.0-Pthread_Serial-release
  Starting job clang-6.0-Cuda_Pthread-release
  PASSED clang-6.0-Cuda_Pthread-release
Testing compiler cuda/9.1
  Starting job clang-6.0-OpenMP-release
  PASSED clang-6.0-OpenMP-release
  Starting job cuda-9.1-Cuda_OpenMP-release
  PASSED cuda-9.1-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-release build_time=134 run_time=484
clang-6.0-Cuda_Pthread-release build_time=236 run_time=325
clang-6.0-OpenMP-release build_time=117 run_time=93
cuda-9.1-Cuda_OpenMP-release build_time=319 run_time=173
gcc-4.8.4-OpenMP-release build_time=106 run_time=116
gcc-4.8.4-Pthread-release build_time=98 run_time=362
gcc-5.3.0-Serial-release build_time=114 run_time=180
intel-16.0.1-OpenMP-release build_time=334 run_time=145
[1]+  Done                    nohup ~/Kokkos/kokkos/scripts/testing_scripts/test_all_sandia --spot-check &>nohup.issue-1984-b
```