### PR TITLE
Fix --cuda option in generate_makefile.bash

### DIFF
--- a/generate_makefile.bash
+++ b/generate_makefile.bash
@@ -20,7 +20,7 @@ do
       ;;
     --with-cuda)
       KOKKOS_DEVICES="${KOKKOS_DEVICES},Cuda"
-      CUDA_PATH_NVCC=`which nvcc`
+      CUDA_PATH_NVCC=$(command -v nvcc)
       CUDA_PATH=${CUDA_PATH_NVCC%/bin/nvcc}
       ;;
     # Catch this before '--with-cuda*'
@@ -86,7 +86,7 @@ do
       ;;
     --compiler*)
       COMPILER="${key#*=}"
-      CNUM=`which ${COMPILER} 2>&1 >/dev/null | grep "no ${COMPILER}" | wc -l`
+      CNUM=$(command -v ${COMPILER} 2>&1 >/dev/null | grep "no ${COMPILER}" | wc -l)
       if [ ${CNUM} -gt 0 ]; then
         echo "Invalid compiler by --compiler command: '${COMPILER}'"
         exit
@@ -95,15 +95,15 @@ do
         echo "Empty compiler specified by --compiler command."
         exit
       fi
-      CNUM=`which ${COMPILER} | grep ${COMPILER} | wc -l`
+      CNUM=$(command -v ${COMPILER} | grep ${COMPILER} | wc -l)
       if [ ${CNUM} -eq 0 ]; then
         echo "Invalid compiler by --compiler command: '${COMPILER}'"
         exit
       fi
       # ... valid compiler, ensure absolute path set 
-      WCOMPATH=`which $COMPILER`
-      COMPDIR=`dirname $WCOMPATH`
-      COMPNAME=`basename $WCOMPATH`
+      WCOMPATH=$(command -v $COMPILER)
+      COMPDIR=$(dirname $WCOMPATH)
+      COMPNAME=$(basename $WCOMPATH)
       COMPILER=${COMPDIR}/${COMPNAME}
       ;;
     --with-options*)


### PR DESCRIPTION
Without this pull request
```
 ./generate_makefile.bash --with-cuda
```
gives:
```
Generating Makefiles with options  KOKKOS_SRC_PATH=/export/home/darndt/Sources/kokkos CXX=/export/home/darndt/Sources/kokkos/bin/nvcc_wrapper KOKKOS_DEVICES=Cuda CUDA_PATH=/export/home/darndt/cuda-8.0/bin//nvcc GTEST_PATH=/export/home/darndt/Sources/kokkos/tpls/gtest KOKKOS_PATH=/export/home/darndt/Sources/kokkos
```
Note that `CUDA_PATH` points to the `nvcc` executable. Using 
```
CUDA_PATH_NVCC=$(command -v nvcc)
````
instead of
```
CUDA_PATH_NVCC=`which nvcc`
```
fixes this problem and the above command (correctly) gives:
```
Generating Makefiles with options  KOKKOS_SRC_PATH=/export/home/darndt/Sources/kokkos CXX=/export/home/darndt/Sources/kokkos/bin/nvcc_wrapper KOKKOS_DEVICES=Cuda CUDA_PATH=/export/home/darndt/cuda-8.0 GTEST_PATH=/export/home/darndt/Sources/kokkos/tpls/gtest KOKKOS_PATH=/export/home/darndt/Sources/kokkos
```
The pull request also replaces the other occurrences of the legacy 
```
`...`
```
syntax by `$(...)` and  `which` by `command -v`.