### PR TITLE
Test AtomicOperations for Kokkos::Complex

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -631,8 +631,10 @@ RealType real (const complex<RealType>& x) {
 template<class RealType>
 KOKKOS_INLINE_FUNCTION
 RealType abs (const complex<RealType>& x) {
-  // FIXME (mfh 31 Oct 2014) Scale to avoid unwarranted overflow.
-  return std::sqrt (real (x) * real (x) + imag (x) * imag (x));
+#ifndef __CUDA_ARCH__
+  using std::hypot;
+#endif
+  return hypot(x.real(),x.imag());
 }
 
 //! Power of a complex number

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -53,6 +53,8 @@ IF(Kokkos_ENABLE_Serial)
         serial/TestSerial_AtomicOperations_longlongint.cpp
         serial/TestSerial_AtomicOperations_double.cpp
         serial/TestSerial_AtomicOperations_float.cpp
+        serial/TestSerial_AtomicOperations_complexdouble.cpp
+        serial/TestSerial_AtomicOperations_complexfloat.cpp
         serial/TestSerial_AtomicViews.cpp
         serial/TestSerial_Atomics.cpp
       COMM serial mpi
@@ -189,6 +191,8 @@ IF(Kokkos_ENABLE_Serial)
         serial/TestSerial_AtomicOperations_longlongint.cpp
         serial/TestSerial_AtomicOperations_double.cpp
         serial/TestSerial_AtomicOperations_float.cpp
+        serial/TestSerial_AtomicOperations_complexdouble.cpp
+        serial/TestSerial_AtomicOperations_complexfloat.cpp
         serial/TestSerial_AtomicViews.cpp
         serial/TestSerial_Atomics.cpp
         serial/TestSerial_Complex.cpp
@@ -257,6 +261,8 @@ IF(Kokkos_ENABLE_Pthread)
       threads/TestThreads_AtomicOperations_longlongint.cpp
       threads/TestThreads_AtomicOperations_double.cpp
       threads/TestThreads_AtomicOperations_float.cpp
+      threads/TestThreads_AtomicOperations_complexdouble.cpp
+      threads/TestThreads_AtomicOperations_complexfloat.cpp
       threads/TestThreads_AtomicViews.cpp
       threads/TestThreads_Atomics.cpp
       threads/TestThreads_Complex.cpp
@@ -324,6 +330,8 @@ IF(Kokkos_ENABLE_OpenMP)
         openmp/TestOpenMP_AtomicOperations_longlongint.cpp
         openmp/TestOpenMP_AtomicOperations_double.cpp
         openmp/TestOpenMP_AtomicOperations_float.cpp
+        openmp/TestOpenMP_AtomicOperations_complexdouble.cpp
+        openmp/TestOpenMP_AtomicOperations_complexfloat.cpp
         openmp/TestOpenMP_AtomicViews.cpp
         openmp/TestOpenMP_Atomics.cpp
       COMM serial mpi
@@ -471,6 +479,8 @@ IF(Kokkos_ENABLE_OpenMP)
         openmp/TestOpenMP_AtomicOperations_longlongint.cpp
         openmp/TestOpenMP_AtomicOperations_double.cpp
         openmp/TestOpenMP_AtomicOperations_float.cpp
+        openmp/TestOpenMP_AtomicOperations_complexdouble.cpp
+        openmp/TestOpenMP_AtomicOperations_complexfloat.cpp
         openmp/TestOpenMP_AtomicViews.cpp
         openmp/TestOpenMP_Atomics.cpp
         openmp/TestOpenMP_Complex.cpp
@@ -687,6 +697,8 @@ IF(Kokkos_ENABLE_Cuda)
       cuda/TestCuda_AtomicOperations_longlongint.cpp
       cuda/TestCuda_AtomicOperations_double.cpp
       cuda/TestCuda_AtomicOperations_float.cpp
+      cuda/TestCuda_AtomicOperations_complexdouble.cpp
+      cuda/TestCuda_AtomicOperations_complexfloat.cpp
       cuda/TestCuda_AtomicViews.cpp
       cuda/TestCuda_Atomics.cpp
       cuda/TestCuda_Complex.cpp

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -39,225 +39,224 @@ TEST_TARGETS =
 TARGETS =
 
 ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
-	OBJ_CUDA = UnitTestMainInit.o gtest-all.o
-	OBJ_CUDA += TestCuda_Init.o
-	OBJ_CUDA += TestCuda_SharedAlloc.o TestCudaUVM_SharedAlloc.o TestCudaHostPinned_SharedAlloc.o
-	OBJ_CUDA += TestCuda_RangePolicy.o
-	OBJ_CUDA += TestCuda_ViewAPI_a.o TestCuda_ViewAPI_b.o TestCuda_ViewAPI_c.o TestCuda_ViewAPI_d.o TestCuda_ViewAPI_e.o
-	OBJ_CUDA += TestCuda_DeepCopyAlignment.o
-	OBJ_CUDA += TestCuda_ViewMapping_a.o TestCuda_ViewMapping_b.o TestCuda_ViewMapping_subview.o TestCuda_ViewLayoutStrideAssignment.o
-	OBJ_CUDA += TestCudaUVM_ViewCopy.o TestCudaUVM_ViewAPI_a.o TestCudaUVM_ViewAPI_b.o TestCudaUVM_ViewAPI_c.o TestCudaUVM_ViewAPI_d.o TestCudaUVM_ViewAPI_e.o
-	OBJ_CUDA += TestCudaUVM_ViewMapping_a.o TestCudaUVM_ViewMapping_b.o TestCudaUVM_ViewMapping_subview.o
-	OBJ_CUDA += TestCudaHostPinned_ViewCopy.o TestCudaHostPinned_ViewAPI_a.o TestCudaHostPinned_ViewAPI_b.o TestCudaHostPinned_ViewAPI_c.o TestCudaHostPinned_ViewAPI_d.o TestCudaHostPinned_ViewAPI_e.o
-	OBJ_CUDA += TestCudaHostPinned_ViewMapping_a.o TestCudaHostPinned_ViewMapping_b.o TestCudaHostPinned_ViewMapping_subview.o
-	OBJ_CUDA += TestCuda_View_64bit.o
-	OBJ_CUDA += TestCuda_ViewOfClass.o
-	OBJ_CUDA += TestCuda_SubView_a.o TestCuda_SubView_b.o
-	OBJ_CUDA += TestCuda_SubView_c01.o TestCuda_SubView_c02.o TestCuda_SubView_c03.o
-	OBJ_CUDA += TestCuda_SubView_c04.o TestCuda_SubView_c05.o TestCuda_SubView_c06.o
-	OBJ_CUDA += TestCuda_SubView_c07.o TestCuda_SubView_c08.o TestCuda_SubView_c09.o
-	OBJ_CUDA += TestCuda_SubView_c10.o TestCuda_SubView_c11.o TestCuda_SubView_c12.o
-	OBJ_CUDA += TestCuda_SubView_c13.o
-	OBJ_CUDA += TestCuda_Reductions.o TestCuda_Scan.o
-	OBJ_CUDA += TestCuda_Reductions_DeviceView.o
-	OBJ_CUDA += TestCuda_Reducers_a.o TestCuda_Reducers_b.o TestCuda_Reducers_c.o TestCuda_Reducers_d.o
-	OBJ_CUDA += TestCuda_Complex.o
-	OBJ_CUDA += TestCuda_AtomicOperations_int.o TestCuda_AtomicOperations_unsignedint.o TestCuda_AtomicOperations_longint.o 
-	OBJ_CUDA += TestCuda_AtomicOperations_unsignedlongint.o TestCuda_AtomicOperations_longlongint.o TestCuda_AtomicOperations_double.o TestCuda_AtomicOperations_float.o
-	OBJ_CUDA += TestCuda_AtomicViews.o TestCuda_Atomics.o
-	OBJ_CUDA += TestCuda_Team.o TestCuda_TeamScratch.o
-	OBJ_CUDA += TestCuda_TeamReductionScan.o TestCuda_TeamTeamSize.o
-	OBJ_CUDA += TestCuda_Other.o
-	OBJ_CUDA += TestCuda_MDRange_a.o TestCuda_MDRange_b.o TestCuda_MDRange_c.o TestCuda_MDRange_d.o TestCuda_MDRange_e.o
-	OBJ_CUDA += TestCuda_Crs.o
-	OBJ_CUDA += TestCuda_Task.o TestCuda_WorkGraph.o
-	OBJ_CUDA += TestCuda_Spaces.o
-	OBJ_CUDA += TestCuda_UniqueToken.o
-	OBJ_CUDA += TestCuda_LocalDeepCopy.o
-	
-	TARGETS += KokkosCore_UnitTest_Cuda
+    OBJ_CUDA = UnitTestMainInit.o gtest-all.o
+    OBJ_CUDA += TestCuda_Init.o
+    OBJ_CUDA += TestCuda_SharedAlloc.o TestCudaUVM_SharedAlloc.o TestCudaHostPinned_SharedAlloc.o
+    OBJ_CUDA += TestCuda_RangePolicy.o
+    OBJ_CUDA += TestCuda_ViewAPI_a.o TestCuda_ViewAPI_b.o TestCuda_ViewAPI_c.o TestCuda_ViewAPI_d.o TestCuda_ViewAPI_e.o
+    OBJ_CUDA += TestCuda_DeepCopyAlignment.o
+    OBJ_CUDA += TestCuda_ViewMapping_a.o TestCuda_ViewMapping_b.o TestCuda_ViewMapping_subview.o TestCuda_ViewLayoutStrideAssignment.o
+    OBJ_CUDA += TestCudaUVM_ViewCopy.o TestCudaUVM_ViewAPI_a.o TestCudaUVM_ViewAPI_b.o TestCudaUVM_ViewAPI_c.o TestCudaUVM_ViewAPI_d.o TestCudaUVM_ViewAPI_e.o
+    OBJ_CUDA += TestCudaUVM_ViewMapping_a.o TestCudaUVM_ViewMapping_b.o TestCudaUVM_ViewMapping_subview.o
+    OBJ_CUDA += TestCudaHostPinned_ViewCopy.o TestCudaHostPinned_ViewAPI_a.o TestCudaHostPinned_ViewAPI_b.o TestCudaHostPinned_ViewAPI_c.o TestCudaHostPinned_ViewAPI_d.o TestCudaHostPinned_ViewAPI_e.o
+    OBJ_CUDA += TestCudaHostPinned_ViewMapping_a.o TestCudaHostPinned_ViewMapping_b.o TestCudaHostPinned_ViewMapping_subview.o
+    OBJ_CUDA += TestCuda_View_64bit.o
+    OBJ_CUDA += TestCuda_ViewOfClass.o
+    OBJ_CUDA += TestCuda_SubView_a.o TestCuda_SubView_b.o
+    OBJ_CUDA += TestCuda_SubView_c01.o TestCuda_SubView_c02.o TestCuda_SubView_c03.o
+    OBJ_CUDA += TestCuda_SubView_c04.o TestCuda_SubView_c05.o TestCuda_SubView_c06.o
+    OBJ_CUDA += TestCuda_SubView_c07.o TestCuda_SubView_c08.o TestCuda_SubView_c09.o
+    OBJ_CUDA += TestCuda_SubView_c10.o TestCuda_SubView_c11.o TestCuda_SubView_c12.o
+    OBJ_CUDA += TestCuda_SubView_c13.o
+    OBJ_CUDA += TestCuda_Reductions.o TestCuda_Scan.o
+    OBJ_CUDA += TestCuda_Reductions_DeviceView.o
+    OBJ_CUDA += TestCuda_Reducers_a.o TestCuda_Reducers_b.o TestCuda_Reducers_c.o TestCuda_Reducers_d.o
+    OBJ_CUDA += TestCuda_Complex.o
+    OBJ_CUDA += TestCuda_AtomicOperations_int.o TestCuda_AtomicOperations_unsignedint.o TestCuda_AtomicOperations_longint.o
+    OBJ_CUDA += TestCuda_AtomicOperations_unsignedlongint.o TestCuda_AtomicOperations_longlongint.o TestCuda_AtomicOperations_double.o TestCuda_AtomicOperations_float.o
+    OBJ_CUDA += TestCuda_AtomicViews.o TestCuda_Atomics.o
+    OBJ_CUDA += TestCuda_Team.o TestCuda_TeamScratch.o
+    OBJ_CUDA += TestCuda_TeamReductionScan.o TestCuda_TeamTeamSize.o
+    OBJ_CUDA += TestCuda_Other.o
+    OBJ_CUDA += TestCuda_MDRange_a.o TestCuda_MDRange_b.o TestCuda_MDRange_c.o TestCuda_MDRange_d.o TestCuda_MDRange_e.o
+    OBJ_CUDA += TestCuda_Crs.o
+    OBJ_CUDA += TestCuda_Task.o TestCuda_WorkGraph.o
+    OBJ_CUDA += TestCuda_Spaces.o
+    OBJ_CUDA += TestCuda_UniqueToken.o
+    OBJ_CUDA += TestCuda_LocalDeepCopy.o
+
+    TARGETS += KokkosCore_UnitTest_Cuda
     TARGETS += KokkosCore_UnitTest_CudaInterOpInit
     TARGETS += KokkosCore_UnitTest_CudaInterOpStreams
-	TEST_TARGETS += test-cuda
+    TEST_TARGETS += test-cuda
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_ROCM), 1)
-        OBJ_ROCM = UnitTestMainInit.o gtest-all.o
-        OBJ_ROCM += TestROCm_Init.o
-        OBJ_ROCM += TestROCm_Complex.o
-        OBJ_ROCM += TestROCm_RangePolicy.o
-	OBJ_ROCM += TestROCm_AtomicOperations_int.o TestROCm_AtomicOperations_unsignedint.o TestROCm_AtomicOperations_longint.o 
-	OBJ_ROCM += TestROCm_AtomicOperations_unsignedlongint.o TestROCm_AtomicOperations_longlongint.o TestROCm_AtomicOperations_double.o TestROCm_AtomicOperations_float.o
-        OBJ_ROCM += TestROCm_Atomics.o
-        OBJ_ROCM += TestROCm_AtomicViews.o
-        OBJ_ROCM += TestROCm_Other.o
-        OBJ_ROCM += TestROCm_MDRange_a.o TestROCm_MDRange_b.o TestROCm_MDRange_c.o TestROCm_MDRange_d.o TestROCm_MDRange_e.o
-        OBJ_ROCM += TestROCm_MDRangeReduce_a.o TestROCm_MDRangeReduce_b.o TestROCm_MDRangeReduce_c.o TestROCm_MDRangeReduce_d.o TestROCm_MDRangeReduce_e.o
-	OBJ_ROCM += TestROCm_Reductions.o
-	OBJ_ROCM += TestROCm_Reducers_a.o TestROCm_Reducers_b.o TestROCm_Reducers_c.o TestROCm_Reducers_d.o
-        OBJ_ROCM += TestROCm_Scan.o
-        OBJ_ROCM += TestROCm_SharedAlloc.o
-        OBJ_ROCM += TestROCm_SubView_a.o
-        OBJ_ROCM += TestROCm_SubView_b.o
-        OBJ_ROCM += TestROCm_SubView_c01.o
-        OBJ_ROCM += TestROCm_SubView_c02.o
-        OBJ_ROCM += TestROCm_SubView_c03.o
-        OBJ_ROCM += TestROCm_SubView_c04.o
-        OBJ_ROCM += TestROCm_SubView_c05.o
-        OBJ_ROCM += TestROCm_SubView_c06.o
-        OBJ_ROCM += TestROCm_SubView_c07.o
-        OBJ_ROCM += TestROCm_SubView_c08.o
-        OBJ_ROCM += TestROCm_SubView_c09.o
-        OBJ_ROCM += TestROCm_SubView_c10.o
-        OBJ_ROCM += TestROCm_SubView_c11.o
-        OBJ_ROCM += TestROCm_SubView_c12.o
-        OBJ_ROCM += TestROCm_SubView_c13.o
-        OBJ_ROCM += TestROCm_Team.o
-        OBJ_ROCM += TestROCm_TeamReductionScan.o
-        OBJ_ROCM += TestROCm_TeamScratch.o TestROCm_TeamTeamSize.o
-        OBJ_ROCM += TestROCm_ViewAPI_a.o TestROCm_ViewAPI_b.o TestROCm_ViewAPI_c.o TestROCm_ViewAPI_d.o TestROCm_ViewAPI_e.o
-	OBJ_ROCM += TestROCm_DeepCopyAlignment.o
-        OBJ_ROCM += TestROCm_ViewMapping_a.o
-        OBJ_ROCM += TestROCm_ViewMapping_b.o
-        OBJ_ROCM += TestROCm_ViewMapping_subview.o
-        OBJ_ROCM += TestROCmHostPinned_ViewCopy.o TestROCmHostPinned_ViewAPI_a.o TestROCmHostPinned_ViewAPI_b.o TestROCmHostPinned_ViewAPI_c.o TestROCmHostPinned_ViewAPI_d.o TestROCmHostPinned_ViewAPI_e.o
-        OBJ_ROCM += TestROCmHostPinned_View_64bit.o
-        OBJ_ROCM += TestROCmHostPinned_ViewMapping_a.o 
-        OBJ_ROCM += TestROCmHostPinned_ViewMapping_b.o 
-        OBJ_ROCM += TestROCmHostPinned_ViewMapping_subview.o
-        OBJ_ROCM += TestROCm_ViewOfClass.o
-        OBJ_ROCM += TestROCm_Spaces.o
-        OBJ_ROCM += TestROCm_Crs.o
-     
-        TARGETS += KokkosCore_UnitTest_ROCm
-        TEST_TARGETS += test-rocm
+    OBJ_ROCM = UnitTestMainInit.o gtest-all.o
+    OBJ_ROCM += TestROCm_Init.o
+    OBJ_ROCM += TestROCm_Complex.o
+    OBJ_ROCM += TestROCm_RangePolicy.o
+    OBJ_ROCM += TestROCm_AtomicOperations_int.o TestROCm_AtomicOperations_unsignedint.o TestROCm_AtomicOperations_longint.o
+    OBJ_ROCM += TestROCm_AtomicOperations_unsignedlongint.o TestROCm_AtomicOperations_longlongint.o TestROCm_AtomicOperations_double.o TestROCm_AtomicOperations_float.o
+    OBJ_ROCM += TestROCm_Atomics.o
+    OBJ_ROCM += TestROCm_AtomicViews.o
+    OBJ_ROCM += TestROCm_Other.o
+    OBJ_ROCM += TestROCm_MDRange_a.o TestROCm_MDRange_b.o TestROCm_MDRange_c.o TestROCm_MDRange_d.o TestROCm_MDRange_e.o
+    OBJ_ROCM += TestROCm_MDRangeReduce_a.o TestROCm_MDRangeReduce_b.o TestROCm_MDRangeReduce_c.o TestROCm_MDRangeReduce_d.o TestROCm_MDRangeReduce_e.o
+    OBJ_ROCM += TestROCm_Reductions.o
+    OBJ_ROCM += TestROCm_Reducers_a.o TestROCm_Reducers_b.o TestROCm_Reducers_c.o TestROCm_Reducers_d.o
+    OBJ_ROCM += TestROCm_Scan.o
+    OBJ_ROCM += TestROCm_SharedAlloc.o
+    OBJ_ROCM += TestROCm_SubView_a.o
+    OBJ_ROCM += TestROCm_SubView_b.o
+    OBJ_ROCM += TestROCm_SubView_c01.o
+    OBJ_ROCM += TestROCm_SubView_c02.o
+    OBJ_ROCM += TestROCm_SubView_c03.o
+    OBJ_ROCM += TestROCm_SubView_c04.o
+    OBJ_ROCM += TestROCm_SubView_c05.o
+    OBJ_ROCM += TestROCm_SubView_c06.o
+    OBJ_ROCM += TestROCm_SubView_c07.o
+    OBJ_ROCM += TestROCm_SubView_c08.o
+    OBJ_ROCM += TestROCm_SubView_c09.o
+    OBJ_ROCM += TestROCm_SubView_c10.o
+    OBJ_ROCM += TestROCm_SubView_c11.o
+    OBJ_ROCM += TestROCm_SubView_c12.o
+    OBJ_ROCM += TestROCm_SubView_c13.o
+    OBJ_ROCM += TestROCm_Team.o
+    OBJ_ROCM += TestROCm_TeamReductionScan.o
+    OBJ_ROCM += TestROCm_TeamScratch.o TestROCm_TeamTeamSize.o
+    OBJ_ROCM += TestROCm_ViewAPI_a.o TestROCm_ViewAPI_b.o TestROCm_ViewAPI_c.o TestROCm_ViewAPI_d.o TestROCm_ViewAPI_e.o
+    OBJ_ROCM += TestROCm_DeepCopyAlignment.o
+    OBJ_ROCM += TestROCm_ViewMapping_a.o
+    OBJ_ROCM += TestROCm_ViewMapping_b.o
+    OBJ_ROCM += TestROCm_ViewMapping_subview.o
+    OBJ_ROCM += TestROCmHostPinned_ViewCopy.o TestROCmHostPinned_ViewAPI_a.o TestROCmHostPinned_ViewAPI_b.o TestROCmHostPinned_ViewAPI_c.o TestROCmHostPinned_ViewAPI_d.o TestROCmHostPinned_ViewAPI_e.o
+    OBJ_ROCM += TestROCmHostPinned_View_64bit.o
+    OBJ_ROCM += TestROCmHostPinned_ViewMapping_a.o
+    OBJ_ROCM += TestROCmHostPinned_ViewMapping_b.o
+    OBJ_ROCM += TestROCmHostPinned_ViewMapping_subview.o
+    OBJ_ROCM += TestROCm_ViewOfClass.o
+    OBJ_ROCM += TestROCm_Spaces.o
+    OBJ_ROCM += TestROCm_Crs.o
+
+    TARGETS += KokkosCore_UnitTest_ROCm
+    TEST_TARGETS += test-rocm
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_PTHREADS), 1)
+    OBJ_THREADS = UnitTestMainInit.o gtest-all.o
+    OBJ_THREADS += TestThreads_Init.o
+    OBJ_THREADS += TestThreads_SharedAlloc.o
+    OBJ_THREADS += TestThreads_RangePolicy.o
+    OBJ_THREADS += TestThreads_View_64bit.o
+    OBJ_THREADS += TestThreads_ViewAPI_a.o TestThreads_ViewAPI_b.o TestThreads_ViewAPI_c.o TestThreads_ViewAPI_d.o TestThreads_ViewAPI_e.o
+    OBJ_THREADS += TestThreads_DeepCopyAlignment.o
+    OBJ_THREADS += TestThreads_ViewMapping_a.o TestThreads_ViewMapping_b.o TestThreads_ViewMapping_subview.o TestThreads_ViewLayoutStrideAssignment.o
+    OBJ_THREADS += TestThreads_ViewOfClass.o
+    OBJ_THREADS += TestThreads_SubView_a.o TestThreads_SubView_b.o
+    OBJ_THREADS += TestThreads_SubView_c01.o TestThreads_SubView_c02.o TestThreads_SubView_c03.o
+    OBJ_THREADS += TestThreads_SubView_c04.o TestThreads_SubView_c05.o TestThreads_SubView_c06.o
+    OBJ_THREADS += TestThreads_SubView_c07.o TestThreads_SubView_c08.o TestThreads_SubView_c09.o
+    OBJ_THREADS += TestThreads_SubView_c10.o TestThreads_SubView_c11.o TestThreads_SubView_c12.o
+    OBJ_THREADS += TestThreads_Reductions.o TestThreads_Scan.o
+    OBJ_THREADS += TestThreads_Reductions_DeviceView.o
+    OBJ_THREADS += TestThreads_Reducers_a.o TestThreads_Reducers_b.o TestThreads_Reducers_c.o TestThreads_Reducers_d.o
+    OBJ_THREADS += TestThreads_Complex.o
+    OBJ_THREADS += TestThreads_AtomicOperations_int.o TestThreads_AtomicOperations_unsignedint.o TestThreads_AtomicOperations_longint.o
+    OBJ_THREADS += TestThreads_AtomicOperations_unsignedlongint.o TestThreads_AtomicOperations_longlongint.o TestThreads_AtomicOperations_double.o TestThreads_AtomicOperations_float.o
+    OBJ_THREADS += TestThreads_AtomicViews.o TestThreads_Atomics.o
+    OBJ_THREADS += TestThreads_Team.o TestThreads_TeamScratch.o TestThreads_TeamTeamSize.o
+    OBJ_THREADS += TestThreads_TeamReductionScan.o
+    OBJ_THREADS += TestThreads_Other.o
+    OBJ_THREADS += TestThreads_MDRange_a.o TestThreads_MDRange_b.o TestThreads_MDRange_c.o TestThreads_MDRange_d.o TestThreads_MDRange_e.o
+    OBJ_THREADS += TestThreads_LocalDeepCopy.o
 
-	OBJ_THREADS = UnitTestMainInit.o gtest-all.o
-	OBJ_THREADS += TestThreads_Init.o
-	OBJ_THREADS += TestThreads_SharedAlloc.o
-	OBJ_THREADS += TestThreads_RangePolicy.o
-	OBJ_THREADS += TestThreads_View_64bit.o
-	OBJ_THREADS += TestThreads_ViewAPI_a.o TestThreads_ViewAPI_b.o TestThreads_ViewAPI_c.o TestThreads_ViewAPI_d.o TestThreads_ViewAPI_e.o
-	OBJ_THREADS += TestThreads_DeepCopyAlignment.o
-	OBJ_THREADS += TestThreads_ViewMapping_a.o TestThreads_ViewMapping_b.o TestThreads_ViewMapping_subview.o TestThreads_ViewLayoutStrideAssignment.o
-	OBJ_THREADS += TestThreads_ViewOfClass.o
-	OBJ_THREADS += TestThreads_SubView_a.o TestThreads_SubView_b.o
-	OBJ_THREADS += TestThreads_SubView_c01.o TestThreads_SubView_c02.o TestThreads_SubView_c03.o
-	OBJ_THREADS += TestThreads_SubView_c04.o TestThreads_SubView_c05.o TestThreads_SubView_c06.o
-	OBJ_THREADS += TestThreads_SubView_c07.o TestThreads_SubView_c08.o TestThreads_SubView_c09.o
-	OBJ_THREADS += TestThreads_SubView_c10.o TestThreads_SubView_c11.o TestThreads_SubView_c12.o
-	OBJ_THREADS += TestThreads_Reductions.o TestThreads_Scan.o
-	OBJ_THREADS += TestThreads_Reductions_DeviceView.o
-	OBJ_THREADS += TestThreads_Reducers_a.o TestThreads_Reducers_b.o TestThreads_Reducers_c.o TestThreads_Reducers_d.o
-	OBJ_THREADS += TestThreads_Complex.o
-	OBJ_THREADS += TestThreads_AtomicOperations_int.o TestThreads_AtomicOperations_unsignedint.o TestThreads_AtomicOperations_longint.o 
-	OBJ_THREADS += TestThreads_AtomicOperations_unsignedlongint.o TestThreads_AtomicOperations_longlongint.o TestThreads_AtomicOperations_double.o TestThreads_AtomicOperations_float.o
-	OBJ_THREADS += TestThreads_AtomicViews.o TestThreads_Atomics.o
-	OBJ_THREADS += TestThreads_Team.o TestThreads_TeamScratch.o TestThreads_TeamTeamSize.o
-	OBJ_THREADS += TestThreads_TeamReductionScan.o
-	OBJ_THREADS += TestThreads_Other.o
-	OBJ_THREADS += TestThreads_MDRange_a.o TestThreads_MDRange_b.o TestThreads_MDRange_c.o TestThreads_MDRange_d.o TestThreads_MDRange_e.o
-	OBJ_THREADS += TestThreads_LocalDeepCopy.o
-	
-	TARGETS += KokkosCore_UnitTest_Threads
+    TARGETS += KokkosCore_UnitTest_Threads
 
-	TEST_TARGETS += test-threads
+    TEST_TARGETS += test-threads
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)
-	OBJ_OPENMP = UnitTestMainInit.o gtest-all.o
-	OBJ_OPENMP += TestOpenMP_Init.o
-	OBJ_OPENMP += TestOpenMP_SharedAlloc.o
-	OBJ_OPENMP += TestOpenMP_RangePolicy.o
-	OBJ_OPENMP += TestOpenMP_View_64bit.o
-	OBJ_OPENMP += TestOpenMP_ViewAPI_a.o TestOpenMP_ViewAPI_b.o TestOpenMP_ViewAPI_c.o TestOpenMP_ViewAPI_d.o TestOpenMP_ViewAPI_e.o
-	OBJ_OPENMP += TestOpenMP_DeepCopyAlignment.o
-	OBJ_OPENMP += TestOpenMP_ViewMapping_a.o TestOpenMP_ViewMapping_b.o TestOpenMP_ViewMapping_subview.o TestOpenMP_ViewLayoutStrideAssignment.o
-	OBJ_OPENMP += TestOpenMP_ViewOfClass.o
-	OBJ_OPENMP += TestOpenMP_SubView_a.o TestOpenMP_SubView_b.o
-	OBJ_OPENMP += TestOpenMP_SubView_c01.o TestOpenMP_SubView_c02.o TestOpenMP_SubView_c03.o
-	OBJ_OPENMP += TestOpenMP_SubView_c04.o TestOpenMP_SubView_c05.o TestOpenMP_SubView_c06.o
-	OBJ_OPENMP += TestOpenMP_SubView_c07.o TestOpenMP_SubView_c08.o TestOpenMP_SubView_c09.o
-	OBJ_OPENMP += TestOpenMP_SubView_c10.o TestOpenMP_SubView_c11.o TestOpenMP_SubView_c12.o
-	OBJ_OPENMP += TestOpenMP_SubView_c13.o
-	OBJ_OPENMP += TestOpenMP_Reductions.o TestOpenMP_Scan.o
-	OBJ_OPENMP += TestOpenMP_Reductions_DeviceView.o
-	OBJ_OPENMP += TestOpenMP_Reducers_a.o TestOpenMP_Reducers_b.o TestOpenMP_Reducers_c.o TestOpenMP_Reducers_d.o
-	OBJ_OPENMP += TestOpenMP_Complex.o
-	OBJ_OPENMP += TestOpenMP_AtomicOperations_int.o TestOpenMP_AtomicOperations_unsignedint.o TestOpenMP_AtomicOperations_longint.o 
-	OBJ_OPENMP += TestOpenMP_AtomicOperations_unsignedlongint.o TestOpenMP_AtomicOperations_longlongint.o TestOpenMP_AtomicOperations_double.o TestOpenMP_AtomicOperations_float.o
-	OBJ_OPENMP += TestOpenMP_AtomicViews.o TestOpenMP_Atomics.o
-	OBJ_OPENMP += TestOpenMP_Team.o TestOpenMP_TeamScratch.o
-	OBJ_OPENMP += TestOpenMP_TeamReductionScan.o TestOpenMP_TeamTeamSize.o
-	OBJ_OPENMP += TestOpenMP_Other.o
-	OBJ_OPENMP += TestOpenMP_MDRange_a.o TestOpenMP_MDRange_b.o TestOpenMP_MDRange_c.o TestOpenMP_MDRange_d.o TestOpenMP_MDRange_e.o
-	OBJ_OPENMP += TestOpenMP_Crs.o
-	OBJ_OPENMP += TestOpenMP_Task.o TestOpenMP_WorkGraph.o
-	OBJ_OPENMP += TestOpenMP_UniqueToken.o
-	OBJ_OPENMP += TestOpenMP_LocalDeepCopy.o
-	
-	TARGETS += KokkosCore_UnitTest_OpenMP
+    OBJ_OPENMP = UnitTestMainInit.o gtest-all.o
+    OBJ_OPENMP += TestOpenMP_Init.o
+    OBJ_OPENMP += TestOpenMP_SharedAlloc.o
+    OBJ_OPENMP += TestOpenMP_RangePolicy.o
+    OBJ_OPENMP += TestOpenMP_View_64bit.o
+    OBJ_OPENMP += TestOpenMP_ViewAPI_a.o TestOpenMP_ViewAPI_b.o TestOpenMP_ViewAPI_c.o TestOpenMP_ViewAPI_d.o TestOpenMP_ViewAPI_e.o
+    OBJ_OPENMP += TestOpenMP_DeepCopyAlignment.o
+    OBJ_OPENMP += TestOpenMP_ViewMapping_a.o TestOpenMP_ViewMapping_b.o TestOpenMP_ViewMapping_subview.o TestOpenMP_ViewLayoutStrideAssignment.o
+    OBJ_OPENMP += TestOpenMP_ViewOfClass.o
+    OBJ_OPENMP += TestOpenMP_SubView_a.o TestOpenMP_SubView_b.o
+    OBJ_OPENMP += TestOpenMP_SubView_c01.o TestOpenMP_SubView_c02.o TestOpenMP_SubView_c03.o
+    OBJ_OPENMP += TestOpenMP_SubView_c04.o TestOpenMP_SubView_c05.o TestOpenMP_SubView_c06.o
+    OBJ_OPENMP += TestOpenMP_SubView_c07.o TestOpenMP_SubView_c08.o TestOpenMP_SubView_c09.o
+    OBJ_OPENMP += TestOpenMP_SubView_c10.o TestOpenMP_SubView_c11.o TestOpenMP_SubView_c12.o
+    OBJ_OPENMP += TestOpenMP_SubView_c13.o
+    OBJ_OPENMP += TestOpenMP_Reductions.o TestOpenMP_Scan.o
+    OBJ_OPENMP += TestOpenMP_Reductions_DeviceView.o
+    OBJ_OPENMP += TestOpenMP_Reducers_a.o TestOpenMP_Reducers_b.o TestOpenMP_Reducers_c.o TestOpenMP_Reducers_d.o
+    OBJ_OPENMP += TestOpenMP_Complex.o
+    OBJ_OPENMP += TestOpenMP_AtomicOperations_int.o TestOpenMP_AtomicOperations_unsignedint.o TestOpenMP_AtomicOperations_longint.o
+    OBJ_OPENMP += TestOpenMP_AtomicOperations_unsignedlongint.o TestOpenMP_AtomicOperations_longlongint.o TestOpenMP_AtomicOperations_double.o TestOpenMP_AtomicOperations_float.o
+    OBJ_OPENMP += TestOpenMP_AtomicViews.o TestOpenMP_Atomics.o
+    OBJ_OPENMP += TestOpenMP_Team.o TestOpenMP_TeamScratch.o
+    OBJ_OPENMP += TestOpenMP_TeamReductionScan.o TestOpenMP_TeamTeamSize.o
+    OBJ_OPENMP += TestOpenMP_Other.o
+    OBJ_OPENMP += TestOpenMP_MDRange_a.o TestOpenMP_MDRange_b.o TestOpenMP_MDRange_c.o TestOpenMP_MDRange_d.o TestOpenMP_MDRange_e.o
+    OBJ_OPENMP += TestOpenMP_Crs.o
+    OBJ_OPENMP += TestOpenMP_Task.o TestOpenMP_WorkGraph.o
+    OBJ_OPENMP += TestOpenMP_UniqueToken.o
+    OBJ_OPENMP += TestOpenMP_LocalDeepCopy.o
+
+    TARGETS += KokkosCore_UnitTest_OpenMP
     TARGETS += KokkosCore_UnitTest_OpenMPInterOp
 
-	TEST_TARGETS += test-openmp
+    TEST_TARGETS += test-openmp
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_OPENMPTARGET), 1)
-	OBJ_OPENMPTARGET = UnitTestMainInit.o gtest-all.o
-	OBJ_OPENMPTARGET += TestOpenMPTarget_Init.o
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_SharedAlloc.o
-	OBJ_OPENMPTARGET += TestOpenMPTarget_RangePolicy.o
-	OBJ_OPENMPTARGET += TestOpenMPTarget_ViewAPI_a.o TestOpenMPTarget_ViewAPI_b.o TestOpenMPTarget_ViewAPI_c.o TestOpenMPTarget_ViewAPI_d.o TestOpenMPTarget_ViewAPI_e.o #Some commented out code
-	OBJ_OPENMPTARGET += TestOpenMPTarget_DeepCopyAlignment.o
-	OBJ_OPENMPTARGET += TestOpenMPTarget_ViewMapping_a.o 
-	OBJ_OPENMPTARGET += TestOpenMPTarget_ViewMapping_b.o 
-	OBJ_OPENMPTARGET += TestOpenMPTarget_ViewMapping_subview.o
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_ViewOfClass.o
-	OBJ_OPENMPTARGET += TestOpenMPTarget_SubView_a.o TestOpenMPTarget_SubView_b.o
-	#The following subview tests need something like UVM:
-        #OBJ_OPENMPTARGET += TestOpenMPTarget_SubView_c01.o TestOpenMPTarget_SubView_c02.o TestOpenMPTarget_SubView_c03.o
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_SubView_c04.o TestOpenMPTarget_SubView_c05.o TestOpenMPTarget_SubView_c06.o
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_SubView_c07.o TestOpenMPTarget_SubView_c08.o TestOpenMPTarget_SubView_c09.o
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_SubView_c10.o TestOpenMPTarget_SubView_c11.o TestOpenMPTarget_SubView_c12.o
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_Reductions.o # Need custom reductions
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_Reducers_a.o TestOpenMPTarget_Reducers_b.o TestOpenMPTarget_Reducers_c.o TestOpenMPTarget_Reducers_d.o
-        #OBJ_OPENMPTARGET += TestOpenMPTarget_Scan.o
-	OBJ_OPENMPTARGET += TestOpenMPTarget_Complex.o
-	OBJ_OPENMPTARGET += TestOpenMPTarget_AtomicOperations_int.o TestOpenMPTarget_AtomicOperations_unsignedint.o TestOpenMPTarget_AtomicOperations_longint.o 
-	OBJ_OPENMPTARGET += TestOpenMPTarget_AtomicOperations_unsignedlongint.o TestOpenMPTarget_AtomicOperations_longlongint.o TestOpenMPTarget_AtomicOperations_double.o TestOpenMPTarget_AtomicOperations_float.o
-        OBJ_OPENMPTARGET += TestOpenMPTarget_AtomicViews.o 
-        OBJ_OPENMPTARGET += TestOpenMPTarget_Atomics.o # Commented Out Arbitrary Type Atomics
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_Team.o # There is still a static function in this
-        #OBJ_OPENMPTARGET += TestOpenMPTarget_TeamScratch.o
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_TeamReductionScan.o
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_Other.o
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_MDRange_a.o TestOpenMPTarget_MDRange_b.o TestOpenMPTarget_MDRange_c.o TestOpenMPTarget_MDRange_d.o TestOpenMPTarget_MDRange_d.e
-	#OBJ_OPENMPTARGET += TestOpenMPTarget_Task.o
-	
-	TARGETS += KokkosCore_UnitTest_OpenMPTarget
+    OBJ_OPENMPTARGET = UnitTestMainInit.o gtest-all.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_Init.o
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_SharedAlloc.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_RangePolicy.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_ViewAPI_a.o TestOpenMPTarget_ViewAPI_b.o TestOpenMPTarget_ViewAPI_c.o TestOpenMPTarget_ViewAPI_d.o TestOpenMPTarget_ViewAPI_e.o #Some commented out code
+    OBJ_OPENMPTARGET += TestOpenMPTarget_DeepCopyAlignment.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_ViewMapping_a.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_ViewMapping_b.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_ViewMapping_subview.o
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_ViewOfClass.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_SubView_a.o TestOpenMPTarget_SubView_b.o
+    #The following subview tests need something like UVM:
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_SubView_c01.o TestOpenMPTarget_SubView_c02.o TestOpenMPTarget_SubView_c03.o
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_SubView_c04.o TestOpenMPTarget_SubView_c05.o TestOpenMPTarget_SubView_c06.o
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_SubView_c07.o TestOpenMPTarget_SubView_c08.o TestOpenMPTarget_SubView_c09.o
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_SubView_c10.o TestOpenMPTarget_SubView_c11.o TestOpenMPTarget_SubView_c12.o
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_Reductions.o # Need custom reductions
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_Reducers_a.o TestOpenMPTarget_Reducers_b.o TestOpenMPTarget_Reducers_c.o TestOpenMPTarget_Reducers_d.o
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_Scan.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_Complex.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_AtomicOperations_int.o TestOpenMPTarget_AtomicOperations_unsignedint.o TestOpenMPTarget_AtomicOperations_longint.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_AtomicOperations_unsignedlongint.o TestOpenMPTarget_AtomicOperations_longlongint.o TestOpenMPTarget_AtomicOperations_double.o TestOpenMPTarget_AtomicOperations_float.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_AtomicViews.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_Atomics.o # Commented Out Arbitrary Type Atomics
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_Team.o # There is still a static function in this
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_TeamScratch.o
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_TeamReductionScan.o
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_Other.o
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_MDRange_a.o TestOpenMPTarget_MDRange_b.o TestOpenMPTarget_MDRange_c.o TestOpenMPTarget_MDRange_d.o TestOpenMPTarget_MDRange_d.e
+    #OBJ_OPENMPTARGET += TestOpenMPTarget_Task.o
 
-	TEST_TARGETS += test-openmptarget
+    TARGETS += KokkosCore_UnitTest_OpenMPTarget
+
+    TEST_TARGETS += test-openmptarget
 
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_QTHREADS), 1)
-	OBJ_QTHREADS = TestQthreads_Other.o TestQthreads_Reductions.o TestQthreads_Atomics.o TestQthreads_Team.o
-	OBJ_QTHREADS += TestQthreads_SubView_a.o TestQthreads_SubView_b.o
-	OBJ_QTHREADS += TestQthreads_SubView_c01.o TestQthreads_SubView_c02.o TestQthreads_SubView_c03.o
-	OBJ_QTHREADS += TestQthreads_SubView_c04.o TestQthreads_SubView_c05.o TestQthreads_SubView_c06.o
-	OBJ_QTHREADS += TestQthreads_SubView_c07.o TestQthreads_SubView_c08.o TestQthreads_SubView_c09.o
-	OBJ_QTHREADS += TestQthreads_SubView_c10.o TestQthreads_SubView_c11.o TestQthreads_SubView_c12.o
-	OBJ_QTHREADS += TestQthreads_ViewAPI_a.o TestQthreads_ViewAPI_b.o TestQthreads_ViewAPI_c.o TestQthreads_ViewAPI_d.o TestQthreads_ViewAPI_e.o UnitTestMain.o gtest-all.o
-	TARGETS += KokkosCore_UnitTest_Qthreads
+    OBJ_QTHREADS = TestQthreads_Other.o TestQthreads_Reductions.o TestQthreads_Atomics.o TestQthreads_Team.o
+    OBJ_QTHREADS += TestQthreads_SubView_a.o TestQthreads_SubView_b.o
+    OBJ_QTHREADS += TestQthreads_SubView_c01.o TestQthreads_SubView_c02.o TestQthreads_SubView_c03.o
+    OBJ_QTHREADS += TestQthreads_SubView_c04.o TestQthreads_SubView_c05.o TestQthreads_SubView_c06.o
+    OBJ_QTHREADS += TestQthreads_SubView_c07.o TestQthreads_SubView_c08.o TestQthreads_SubView_c09.o
+    OBJ_QTHREADS += TestQthreads_SubView_c10.o TestQthreads_SubView_c11.o TestQthreads_SubView_c12.o
+    OBJ_QTHREADS += TestQthreads_ViewAPI_a.o TestQthreads_ViewAPI_b.o TestQthreads_ViewAPI_c.o TestQthreads_ViewAPI_d.o TestQthreads_ViewAPI_e.o UnitTestMain.o gtest-all.o
+    TARGETS += KokkosCore_UnitTest_Qthreads
 
-	OBJ_QTHREADS2 = UnitTestMainInit.o gtest-all.o
-	OBJ_QTHREADS2 += TestQthreads_Complex.o
-	TARGETS += KokkosCore_UnitTest_Qthreads2
+    OBJ_QTHREADS2 = UnitTestMainInit.o gtest-all.o
+    OBJ_QTHREADS2 += TestQthreads_Complex.o
+    TARGETS += KokkosCore_UnitTest_Qthreads2
 
-	TEST_TARGETS += test-qthreads
+    TEST_TARGETS += test-qthreads
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_HPX), 1)
@@ -299,42 +298,42 @@ ifeq ($(KOKKOS_INTERNAL_USE_HPX), 1)
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_SERIAL), 1)
-        OBJ_SERIAL = UnitTestMainInit.o gtest-all.o
-        OBJ_SERIAL += TestSerial_Init.o
-        OBJ_SERIAL += TestSerial_SharedAlloc.o
-        OBJ_SERIAL += TestSerial_RangePolicy.o
-        OBJ_SERIAL += TestSerial_View_64bit.o
-        OBJ_SERIAL += TestSerial_ViewAPI_a.o TestSerial_ViewAPI_b.o TestSerial_ViewAPI_c.o TestSerial_ViewAPI_d.o TestSerial_ViewAPI_e.o
-	OBJ_SERIAL += TestSerial_DeepCopyAlignment.o
-        OBJ_SERIAL += TestSerial_ViewMapping_a.o TestSerial_ViewMapping_b.o TestSerial_ViewMapping_subview.o TestSerial_ViewLayoutStrideAssignment.o
-        OBJ_SERIAL += TestSerial_ViewOfClass.o
-        OBJ_SERIAL += TestSerial_SubView_a.o TestSerial_SubView_b.o
-        OBJ_SERIAL += TestSerial_SubView_c01.o TestSerial_SubView_c02.o TestSerial_SubView_c03.o
-        OBJ_SERIAL += TestSerial_SubView_c04.o TestSerial_SubView_c05.o TestSerial_SubView_c06.o
-        OBJ_SERIAL += TestSerial_SubView_c07.o TestSerial_SubView_c08.o TestSerial_SubView_c09.o
-        OBJ_SERIAL += TestSerial_SubView_c10.o TestSerial_SubView_c11.o TestSerial_SubView_c12.o
-        OBJ_SERIAL += TestSerial_SubView_c13.o
-        OBJ_SERIAL += TestSerial_Reductions.o TestSerial_Scan.o
-	OBJ_SERIAL += TestSerial_Reductions_DeviceView.o
-    	OBJ_SERIAL += TestSerial_Reducers_a.o TestSerial_Reducers_b.o TestSerial_Reducers_c.o TestSerial_Reducers_d.o
-        OBJ_SERIAL += TestSerial_Complex.o
-	    OBJ_SERIAL += TestSerial_AtomicOperations_int.o TestSerial_AtomicOperations_unsignedint.o TestSerial_AtomicOperations_longint.o 
-	    OBJ_SERIAL += TestSerial_AtomicOperations_unsignedlongint.o TestSerial_AtomicOperations_longlongint.o TestSerial_AtomicOperations_double.o TestSerial_AtomicOperations_float.o
-	    OBJ_SERIAL += TestSerial_AtomicViews.o TestSerial_Atomics.o
-        OBJ_SERIAL += TestSerial_Team.o TestSerial_TeamScratch.o
-        OBJ_SERIAL += TestSerial_TeamReductionScan.o TestSerial_TeamTeamSize.o
-        OBJ_SERIAL += TestSerial_Other.o
-        #HCC_WORKAROUND
-        ifneq ($(KOKKOS_INTERNAL_COMPILER_HCC), 1)
+    OBJ_SERIAL = UnitTestMainInit.o gtest-all.o
+    OBJ_SERIAL += TestSerial_Init.o
+    OBJ_SERIAL += TestSerial_SharedAlloc.o
+    OBJ_SERIAL += TestSerial_RangePolicy.o
+    OBJ_SERIAL += TestSerial_View_64bit.o
+    OBJ_SERIAL += TestSerial_ViewAPI_a.o TestSerial_ViewAPI_b.o TestSerial_ViewAPI_c.o TestSerial_ViewAPI_d.o TestSerial_ViewAPI_e.o
+    OBJ_SERIAL += TestSerial_DeepCopyAlignment.o
+    OBJ_SERIAL += TestSerial_ViewMapping_a.o TestSerial_ViewMapping_b.o TestSerial_ViewMapping_subview.o TestSerial_ViewLayoutStrideAssignment.o
+    OBJ_SERIAL += TestSerial_ViewOfClass.o
+    OBJ_SERIAL += TestSerial_SubView_a.o TestSerial_SubView_b.o
+    OBJ_SERIAL += TestSerial_SubView_c01.o TestSerial_SubView_c02.o TestSerial_SubView_c03.o
+    OBJ_SERIAL += TestSerial_SubView_c04.o TestSerial_SubView_c05.o TestSerial_SubView_c06.o
+    OBJ_SERIAL += TestSerial_SubView_c07.o TestSerial_SubView_c08.o TestSerial_SubView_c09.o
+    OBJ_SERIAL += TestSerial_SubView_c10.o TestSerial_SubView_c11.o TestSerial_SubView_c12.o
+    OBJ_SERIAL += TestSerial_SubView_c13.o
+    OBJ_SERIAL += TestSerial_Reductions.o TestSerial_Scan.o
+    OBJ_SERIAL += TestSerial_Reductions_DeviceView.o
+    OBJ_SERIAL += TestSerial_Reducers_a.o TestSerial_Reducers_b.o TestSerial_Reducers_c.o TestSerial_Reducers_d.o
+    OBJ_SERIAL += TestSerial_Complex.o
+    OBJ_SERIAL += TestSerial_AtomicOperations_int.o TestSerial_AtomicOperations_unsignedint.o TestSerial_AtomicOperations_longint.o
+    OBJ_SERIAL += TestSerial_AtomicOperations_unsignedlongint.o TestSerial_AtomicOperations_longlongint.o TestSerial_AtomicOperations_double.o TestSerial_AtomicOperations_float.o
+    OBJ_SERIAL += TestSerial_AtomicViews.o TestSerial_Atomics.o
+    OBJ_SERIAL += TestSerial_Team.o TestSerial_TeamScratch.o
+    OBJ_SERIAL += TestSerial_TeamReductionScan.o TestSerial_TeamTeamSize.o
+    OBJ_SERIAL += TestSerial_Other.o
+    #HCC_WORKAROUND
+    ifneq ($(KOKKOS_INTERNAL_COMPILER_HCC), 1)
         OBJ_SERIAL += TestSerial_MDRange_a.o TestSerial_MDRange_b.o TestSerial_MDRange_c.o TestSerial_MDRange_d.o TestSerial_MDRange_e.o
-        endif
-        OBJ_SERIAL += TestSerial_Crs.o
-        OBJ_SERIAL += TestSerial_Task.o TestSerial_WorkGraph.o
-        OBJ_SERIAL += TestSerial_LocalDeepCopy.o
-		
-	TARGETS += KokkosCore_UnitTest_Serial
+    endif
+    OBJ_SERIAL += TestSerial_Crs.o
+    OBJ_SERIAL += TestSerial_Task.o TestSerial_WorkGraph.o
+    OBJ_SERIAL += TestSerial_LocalDeepCopy.o
 
-	TEST_TARGETS += test-serial
+    TARGETS += KokkosCore_UnitTest_Serial
+
+    TEST_TARGETS += test-serial
 endif
 
 OBJ_HWLOC = TestHWLOC.o UnitTestMain.o gtest-all.o
@@ -348,10 +347,10 @@ TEST_TARGETS += test-host-barrier
 OBJ_DEFAULT = UnitTestMainInit.o gtest-all.o
 ifneq ($(KOKKOS_INTERNAL_USE_OPENMPTARGET), 1)
 ifneq ($(KOKKOS_INTERNAL_COMPILER_HCC), 1)
-  OBJ_DEFAULT += TestDefaultDeviceType.o 
-  OBJ_DEFAULT += TestDefaultDeviceType_a1.o TestDefaultDeviceType_b1.o TestDefaultDeviceType_c1.o 
-  OBJ_DEFAULT += TestDefaultDeviceType_a2.o TestDefaultDeviceType_b2.o TestDefaultDeviceType_c2.o 
-  OBJ_DEFAULT += TestDefaultDeviceType_a3.o TestDefaultDeviceType_b3.o TestDefaultDeviceType_c3.o 
+  OBJ_DEFAULT += TestDefaultDeviceType.o
+  OBJ_DEFAULT += TestDefaultDeviceType_a1.o TestDefaultDeviceType_b1.o TestDefaultDeviceType_c1.o
+  OBJ_DEFAULT += TestDefaultDeviceType_a2.o TestDefaultDeviceType_b2.o TestDefaultDeviceType_c2.o
+  OBJ_DEFAULT += TestDefaultDeviceType_a3.o TestDefaultDeviceType_b3.o TestDefaultDeviceType_c3.o
   OBJ_DEFAULT += TestDefaultDeviceType_d.o
 endif
 endif
@@ -379,7 +378,7 @@ KokkosCore_UnitTest_CudaInterOpInit: UnitTestMain.o gtest-all.o TestCuda_InterOp
 	$(LINK) $(EXTRA_PATH) UnitTestMain.o gtest-all.o TestCuda_InterOp_Init.o $(KOKKOS_LIBS) $(LIB) $(KOKKOS_LDFLAGS) $(LDFLAGS) -o KokkosCore_UnitTest_CudaInterOpInit
 KokkosCore_UnitTest_CudaInterOpStreams: UnitTestMain.o gtest-all.o TestCuda_InterOp_Streams.o $(KOKKOS_LINK_DEPENDS)
 	$(LINK) $(EXTRA_PATH) UnitTestMain.o gtest-all.o TestCuda_InterOp_Streams.o $(KOKKOS_LIBS) $(LIB) $(KOKKOS_LDFLAGS) $(LDFLAGS) -o KokkosCore_UnitTest_CudaInterOpStreams
-	
+
 KokkosCore_UnitTest_ROCm: $(OBJ_ROCM) $(KOKKOS_LINK_DEPENDS)
 	$(LINK) $(EXTRA_PATH) $(OBJ_ROCM) $(KOKKOS_LIBS) $(LIB) $(KOKKOS_LDFLAGS) $(LDFLAGS) -o KokkosCore_UnitTest_ROCm
 

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -64,6 +64,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
     OBJ_CUDA += TestCuda_Complex.o
     OBJ_CUDA += TestCuda_AtomicOperations_int.o TestCuda_AtomicOperations_unsignedint.o TestCuda_AtomicOperations_longint.o
     OBJ_CUDA += TestCuda_AtomicOperations_unsignedlongint.o TestCuda_AtomicOperations_longlongint.o TestCuda_AtomicOperations_double.o TestCuda_AtomicOperations_float.o
+    OBJ_CUDA += TestCuda_AtomicOperations_complexfloat.o TestCuda_AtomicOperations_complexdouble.o
     OBJ_CUDA += TestCuda_AtomicViews.o TestCuda_Atomics.o
     OBJ_CUDA += TestCuda_Team.o TestCuda_TeamScratch.o
     OBJ_CUDA += TestCuda_TeamReductionScan.o TestCuda_TeamTeamSize.o
@@ -154,6 +155,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_PTHREADS), 1)
     OBJ_THREADS += TestThreads_Complex.o
     OBJ_THREADS += TestThreads_AtomicOperations_int.o TestThreads_AtomicOperations_unsignedint.o TestThreads_AtomicOperations_longint.o
     OBJ_THREADS += TestThreads_AtomicOperations_unsignedlongint.o TestThreads_AtomicOperations_longlongint.o TestThreads_AtomicOperations_double.o TestThreads_AtomicOperations_float.o
+    OBJ_THREADS += TestThreads_AtomicOperations_complexfloat.o TestThreads_AtomicOperations_complexdouble.o
     OBJ_THREADS += TestThreads_AtomicViews.o TestThreads_Atomics.o
     OBJ_THREADS += TestThreads_Team.o TestThreads_TeamScratch.o TestThreads_TeamTeamSize.o
     OBJ_THREADS += TestThreads_TeamReductionScan.o
@@ -188,6 +190,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)
     OBJ_OPENMP += TestOpenMP_Complex.o
     OBJ_OPENMP += TestOpenMP_AtomicOperations_int.o TestOpenMP_AtomicOperations_unsignedint.o TestOpenMP_AtomicOperations_longint.o
     OBJ_OPENMP += TestOpenMP_AtomicOperations_unsignedlongint.o TestOpenMP_AtomicOperations_longlongint.o TestOpenMP_AtomicOperations_double.o TestOpenMP_AtomicOperations_float.o
+    OBJ_OPENMP += TestOpenMP_AtomicOperations_complexfloat.o TestOpenMP_AtomicOperations_complexdouble.o
     OBJ_OPENMP += TestOpenMP_AtomicViews.o TestOpenMP_Atomics.o
     OBJ_OPENMP += TestOpenMP_Team.o TestOpenMP_TeamScratch.o
     OBJ_OPENMP += TestOpenMP_TeamReductionScan.o TestOpenMP_TeamTeamSize.o
@@ -227,6 +230,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENMPTARGET), 1)
     OBJ_OPENMPTARGET += TestOpenMPTarget_Complex.o
     OBJ_OPENMPTARGET += TestOpenMPTarget_AtomicOperations_int.o TestOpenMPTarget_AtomicOperations_unsignedint.o TestOpenMPTarget_AtomicOperations_longint.o
     OBJ_OPENMPTARGET += TestOpenMPTarget_AtomicOperations_unsignedlongint.o TestOpenMPTarget_AtomicOperations_longlongint.o TestOpenMPTarget_AtomicOperations_double.o TestOpenMPTarget_AtomicOperations_float.o
+    OBJ_OPENMPTARGET += TestOpenMPTarget_AtomicOperations_complexfloat.o TestOpenMPTarget_AtomicOperations_complexdouble.o
     OBJ_OPENMPTARGET += TestOpenMPTarget_AtomicViews.o
     OBJ_OPENMPTARGET += TestOpenMPTarget_Atomics.o # Commented Out Arbitrary Type Atomics
     #OBJ_OPENMPTARGET += TestOpenMPTarget_Team.o # There is still a static function in this
@@ -239,7 +243,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENMPTARGET), 1)
     TARGETS += KokkosCore_UnitTest_OpenMPTarget
 
     TEST_TARGETS += test-openmptarget
-
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_QTHREADS), 1)
@@ -319,6 +322,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_SERIAL), 1)
     OBJ_SERIAL += TestSerial_Complex.o
     OBJ_SERIAL += TestSerial_AtomicOperations_int.o TestSerial_AtomicOperations_unsignedint.o TestSerial_AtomicOperations_longint.o
     OBJ_SERIAL += TestSerial_AtomicOperations_unsignedlongint.o TestSerial_AtomicOperations_longlongint.o TestSerial_AtomicOperations_double.o TestSerial_AtomicOperations_float.o
+    OBJ_SERIAL += TestSerial_AtomicOperations_complexfloat.o TestSerial_AtomicOperations_complexdouble.o
     OBJ_SERIAL += TestSerial_AtomicViews.o TestSerial_Atomics.o
     OBJ_SERIAL += TestSerial_Team.o TestSerial_TeamScratch.o
     OBJ_SERIAL += TestSerial_TeamReductionScan.o TestSerial_TeamTeamSize.o

--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -536,6 +536,8 @@ bool DivAtomicTest( T i0, T i1 )
 
   bool passed = true;
 
+  using std::abs;
+  using Kokkos::abs;
   if ( abs( (resSerial-res) * 1.) > 1e-5 ) {
     passed = false;
 

--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -536,7 +536,7 @@ bool DivAtomicTest( T i0, T i1 )
 
   bool passed = true;
 
-  if ( (resSerial-res)*(resSerial-res) > 1e-10 ) {
+  if ( abs( (resSerial-res) * 1.) > 1e-5 ) {
     passed = false;
 
     std::cout << "Loop<"

--- a/core/unit_test/TestAtomicOperations_complexdouble.hpp
+++ b/core/unit_test/TestAtomicOperations_complexdouble.hpp
@@ -1,0 +1,57 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<TestAtomicOperations.hpp>
+
+namespace Test {
+TEST_F( TEST_CATEGORY , atomic_operations_complexdouble )
+{
+  const int start = 1; // Avoid zero for division.
+  const int end = 11;
+  for ( int i = start; i < end; ++i )
+  {
+    ASSERT_TRUE( ( TestAtomicOperations::MulAtomicTest< Kokkos::complex<double>, TEST_EXECSPACE >( start , end - i) ) );
+    ASSERT_TRUE( ( TestAtomicOperations::DivAtomicTest< Kokkos::complex<double>, TEST_EXECSPACE >( start , end - i) ) );
+  }
+}
+}

--- a/core/unit_test/TestAtomicOperations_complexfloat.hpp
+++ b/core/unit_test/TestAtomicOperations_complexfloat.hpp
@@ -1,0 +1,57 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<TestAtomicOperations.hpp>
+
+namespace Test {
+TEST_F( TEST_CATEGORY , atomic_operations_complexfloat )
+{
+  const int start = 1; // Avoid zero for division.
+  const int end = 11;
+  for ( int i = start; i < end; ++i )
+  {
+    ASSERT_TRUE( ( TestAtomicOperations::MulAtomicTest< Kokkos::complex<float>, TEST_EXECSPACE >( start , end - i) ) );
+    ASSERT_TRUE( ( TestAtomicOperations::DivAtomicTest< Kokkos::complex<float>, TEST_EXECSPACE >( start , end - i) ) );
+  }
+}
+}

--- a/core/unit_test/cuda/TestCuda_AtomicOperations_complexdouble.cpp
+++ b/core/unit_test/cuda/TestCuda_AtomicOperations_complexdouble.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<cuda/TestCuda_Category.hpp>
+#include<TestAtomicOperations_complexdouble.hpp>
+

--- a/core/unit_test/cuda/TestCuda_AtomicOperations_complexfloat.cpp
+++ b/core/unit_test/cuda/TestCuda_AtomicOperations_complexfloat.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<cuda/TestCuda_Category.hpp>
+#include<TestAtomicOperations_complexfloat.hpp>
+

--- a/core/unit_test/openmp/TestOpenMP_AtomicOperations_complexdouble.cpp
+++ b/core/unit_test/openmp/TestOpenMP_AtomicOperations_complexdouble.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<openmp/TestOpenMP_Category.hpp>
+#include<TestAtomicOperations_complexdouble.hpp>
+

--- a/core/unit_test/openmp/TestOpenMP_AtomicOperations_complexfloat.cpp
+++ b/core/unit_test/openmp/TestOpenMP_AtomicOperations_complexfloat.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<openmp/TestOpenMP_Category.hpp>
+#include<TestAtomicOperations_complexfloat.hpp>
+

--- a/core/unit_test/openmptarget/TestOpenMPTarget_AtomicOperations_complexdouble.cpp
+++ b/core/unit_test/openmptarget/TestOpenMPTarget_AtomicOperations_complexdouble.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<openmptarget/TestOpenMPTarget_Category.hpp>
+#include<TestAtomicOperations_complexdouble.hpp>
+

--- a/core/unit_test/openmptarget/TestOpenMPTarget_AtomicOperations_complexfloat.cpp
+++ b/core/unit_test/openmptarget/TestOpenMPTarget_AtomicOperations_complexfloat.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<openmptarget/TestOpenMPTarget_Category.hpp>
+#include<TestAtomicOperations_complexfloat.hpp>
+

--- a/core/unit_test/qthreads/TestQqthreads_AtomicOperations_complexdouble.cpp
+++ b/core/unit_test/qthreads/TestQqthreads_AtomicOperations_complexdouble.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<qthreads/TestQqthreads_Category.hpp>
+#include<TestAtomicOperations_complexdouble.hpp>
+

--- a/core/unit_test/qthreads/TestQqthreads_AtomicOperations_complexfloat.cpp
+++ b/core/unit_test/qthreads/TestQqthreads_AtomicOperations_complexfloat.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<qthreads/TestQqthreads_Category.hpp>
+#include<TestAtomicOperations_complexfloat.hpp>
+

--- a/core/unit_test/serial/TestSerial_AtomicOperations_complexdouble.cpp
+++ b/core/unit_test/serial/TestSerial_AtomicOperations_complexdouble.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<serial/TestSerial_Category.hpp>
+#include<TestAtomicOperations_complexdouble.hpp>
+

--- a/core/unit_test/serial/TestSerial_AtomicOperations_complexfloat.cpp
+++ b/core/unit_test/serial/TestSerial_AtomicOperations_complexfloat.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<serial/TestSerial_Category.hpp>
+#include<TestAtomicOperations_complexfloat.hpp>
+

--- a/core/unit_test/threads/TestThreads_AtomicOperations_complexdouble.cpp
+++ b/core/unit_test/threads/TestThreads_AtomicOperations_complexdouble.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<threads/TestThreads_Category.hpp>
+#include<TestAtomicOperations_complexdouble.hpp>
+

--- a/core/unit_test/threads/TestThreads_AtomicOperations_complexfloat.cpp
+++ b/core/unit_test/threads/TestThreads_AtomicOperations_complexfloat.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include<threads/TestThreads_Category.hpp>
+#include<TestAtomicOperations_complexfloat.hpp>
+


### PR DESCRIPTION
This pull request adds tests for #1964. More specifically, it adds the `MulAtomicTest` and `DivAtomicTest` for `Kokkos::complex<double>` and `Kokkos::complex<float>` for all backends except for `ROCm`.
While modifying the `Makefile` to include the additional tests also use uniform formatting avoiding tabulators.
The test required to test for the difference of `Kokkos::complex` objects to be small. Hence, I added a `std::abs` overload and used it in the tests.