### PR TITLE
Rename local variables to avoid shadowing class-level typedef

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1060,7 +1060,7 @@ public:
       }
 
       // Copy the input allocation properties with possibly defaulted properties
-      alloc_prop prop( arg_prop );
+      alloc_prop aprop( arg_prop );
 
 //------------------------------------------------------------
 #if defined( KOKKOS_ENABLE_CUDA )
@@ -1076,7 +1076,7 @@ public:
 //------------------------------------------------------------
 
       Kokkos::Impl::SharedAllocationRecord<> *
-        record = m_map.allocate_shared( prop , Impl::DynRankDimTraits<typename traits::specialize>::template createLayout<traits, P...>(arg_prop, arg_layout) );
+        record = m_map.allocate_shared( aprop , Impl::DynRankDimTraits<typename traits::specialize>::template createLayout<traits, P...>(arg_prop, arg_layout) );
 
 //------------------------------------------------------------
 #if defined( KOKKOS_ENABLE_CUDA )

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -2077,7 +2077,7 @@ public:
       }
 
       // Copy the input allocation properties with possibly defaulted properties
-      alloc_prop prop( arg_prop );
+      alloc_prop aprop( arg_prop );
 
 //------------------------------------------------------------
 #if defined( KOKKOS_ENABLE_CUDA )
@@ -2093,7 +2093,7 @@ public:
 //------------------------------------------------------------
 
       Kokkos::Impl::SharedAllocationRecord<> *
-        record = m_map.allocate_shared( prop , arg_layout );
+        record = m_map.allocate_shared( aprop , arg_layout );
 
 //------------------------------------------------------------
 #if defined( KOKKOS_ENABLE_CUDA )


### PR DESCRIPTION
These name conflicts were spewing warnings from GCC 8 with -Wshadow:

```
    /home/pbmille/repos/Trilinos-install/include/Kokkos_DynRankView.hpp:1063:18: warning: declaration of ‘prop’ shadows a previous local [-Wshadow]
           alloc_prop prop( arg_prop );
                      ^~~~
    In file included from /home/pbmille/repos/Trilinos-install/include/Kokkos_Parallel.hpp:52,
                     from /home/pbmille/repos/Trilinos-install/include/Kokkos_Serial.hpp:55,
                     from /home/pbmille/repos/Trilinos-install/include/Kokkos_Core.hpp:53,
    /home/pbmille/repos/Trilinos-install/include/Kokkos_View.hpp:273:48: note: shadowed declaration is here
       typedef ViewTraits< void , Properties ... >  prop ;
                                                    ^~~~

    /home/pbmille/repos/Trilinos-install/include/Kokkos_View.hpp:2080:18: warning: declaration of ‘prop’ shadows a previous local [-Wshadow]
           alloc_prop prop( arg_prop );
                      ^~~~
    In file included from /home/pbmille/repos/Trilinos-install/include/Kokkos_Parallel.hpp:52,
                     from /home/pbmille/repos/Trilinos-install/include/Kokkos_Serial.hpp:55,
                     from /home/pbmille/repos/Trilinos-install/include/Kokkos_Core.hpp:53,
    /home/pbmille/repos/Trilinos-install/include/Kokkos_View.hpp:273:48: note: shadowed declaration is here
       typedef ViewTraits< void , Properties ... >  prop ;
                                                    ^~~~
```