### PR TITLE
Use UVM for tasking memory pool even if it isn't the default

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Task.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.cpp
@@ -54,8 +54,8 @@
 namespace Kokkos {
 namespace Impl {
 
-template class TaskQueue< Kokkos::Cuda > ;
-template class TaskQueueMultiple< Kokkos::Cuda > ;
+template class TaskQueue< Kokkos::Cuda, Impl::default_tasking_memory_space_for_execution_space_t<Kokkos::Cuda> > ;
+template class TaskQueueMultiple< Kokkos::Cuda, Impl::default_tasking_memory_space_for_execution_space_t<Kokkos::Cuda> > ;
 
 }} /* namespace Kokkos::Impl */
 

--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -533,7 +533,7 @@ public:
     }
 };
 
-extern template class TaskQueue< Kokkos::Cuda > ;
+extern template class TaskQueue< Kokkos::Cuda, default_tasking_memory_space_for_execution_space_t<Kokkos::Cuda> > ;
 
 }} /* namespace Kokkos::Impl */
 
@@ -577,7 +577,7 @@ private:
   TaskExec & operator = ( TaskExec && ) = delete ;
   TaskExec & operator = ( TaskExec const & ) = delete ;
 
-  friend class Kokkos::Impl::TaskQueue< Kokkos::Cuda > ;
+  friend class Kokkos::Impl::TaskQueue< Kokkos::Cuda, default_tasking_memory_space_for_execution_space_t<Kokkos::Cuda> > ;
   template <class, class>
   friend class Kokkos::Impl::TaskQueueSpecializationConstrained;
   template <class>

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -87,6 +87,7 @@
 #include <Kokkos_Atomic.hpp>
 #include <Kokkos_hwloc.hpp>
 #include <Kokkos_Timer.hpp>
+#include <Kokkos_TaskScheduler.hpp>
 
 #include <Kokkos_Complex.hpp>
 

--- a/core/src/Kokkos_TaskScheduler_fwd.hpp
+++ b/core/src/Kokkos_TaskScheduler_fwd.hpp
@@ -111,11 +111,11 @@ class Task;
 
 class TaskQueueBase;
 
-template< typename Space, typename MemorySpace = typename Space::memory_space >
+template< typename Space, typename MemorySpace>
 class TaskQueue;
 
-template< typename ExecSpace, typename MemSpace = typename ExecSpace::memory_space >
-class TaskQueueMultiple ;
+template< typename ExecSpace, typename MemorySpace>
+class TaskQueueMultiple;
 
 template< typename ExecSpace, typename MemSpace, typename TaskQueueTraits>
 class SingleTaskQueue;
@@ -159,10 +159,16 @@ using default_tasking_memory_space_for_execution_space_t =
 namespace Kokkos {
 
 template< typename Space >
-using DeprecatedTaskScheduler = BasicTaskScheduler<Space, Impl::TaskQueue<Space>> ;
+using DeprecatedTaskScheduler = BasicTaskScheduler<
+  Space,
+  Impl::TaskQueue<Space, Impl::default_tasking_memory_space_for_execution_space_t<Space>>
+>;
 
 template< typename Space >
-using DeprecatedTaskSchedulerMultiple = BasicTaskScheduler<Space, Impl::TaskQueueMultiple<Space>> ;
+using DeprecatedTaskSchedulerMultiple = BasicTaskScheduler<
+  Space,
+  Impl::TaskQueueMultiple<Space, Impl::default_tasking_memory_space_for_execution_space_t<Space>>
+>;
 
 template< typename Space >
 using TaskScheduler = SimpleTaskScheduler<

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
@@ -57,7 +57,7 @@
 namespace Kokkos {
 namespace Impl {
 
-template class TaskQueue< Kokkos::OpenMP > ;
+template class TaskQueue< Kokkos::OpenMP, typename Kokkos::OpenMP::memory_space > ;
 
 HostThreadTeamData& HostThreadTeamDataSingleton::singleton()
 {

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -428,7 +428,7 @@ public:
   }
 };
 
-extern template class TaskQueue< Kokkos::OpenMP > ;
+extern template class TaskQueue< Kokkos::OpenMP, typename Kokkos::OpenMP::memory_space > ;
 
 }} /* namespace Kokkos::Impl */
 

--- a/core/src/impl/Kokkos_Serial_Task.cpp
+++ b/core/src/impl/Kokkos_Serial_Task.cpp
@@ -55,7 +55,7 @@
 namespace Kokkos {
 namespace Impl {
 
-template class TaskQueue<Kokkos::Serial>;
+template class TaskQueue<Kokkos::Serial, typename Kokkos::Serial::memory_space>;
 
 }} /* namespace Kokkos::Impl */
 

--- a/core/src/impl/Kokkos_Serial_Task.hpp
+++ b/core/src/impl/Kokkos_Serial_Task.hpp
@@ -269,7 +269,7 @@ public:
   }
 };
 
-extern template class TaskQueue< Kokkos::Serial > ;
+extern template class TaskQueue< Kokkos::Serial, typename Kokkos::Serial::memory_space > ;
 
 }} /* namespace Kokkos::Impl */
 

--- a/core/unit_test/TestTaskScheduler.hpp
+++ b/core/unit_test/TestTaskScheduler.hpp
@@ -663,6 +663,7 @@ struct TestMultipleDependence {
   enum : int { NFanout = 3 };
 
   // xlC doesn't like incomplete aggregate constructors, so we have do do this manually:
+  KOKKOS_INLINE_FUNCTION
   TestMultipleDependence(int depth, int max_depth)
     : m_depth(depth),
       m_max_depth(max_depth),
@@ -675,6 +676,7 @@ struct TestMultipleDependence {
   }
 
   // xlC doesn't like incomplete aggregate constructors, so we have do do this manually:
+  KOKKOS_INLINE_FUNCTION
   TestMultipleDependence(int depth, int max_depth, future_int dep)
     : m_depth(depth),
       m_max_depth(max_depth),


### PR DESCRIPTION
This was a bug; the old code (e.g., the code on `master`) was manually setting `CudaUVMSpace` even if it wasn't the default, whereas the new code was querying the execution space.  Since the current implementation (and the old implementation) requires the memory pool to be in unified memory, I put back in the manual setting (for now, at least; until I can get around to making this work in non-unified memory)