### PR TITLE
Run Travis checks with -Werror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
     fi
   - mkdir build
   - cd build
-  - ../generate_makefile.bash --compiler=$CXX --with-$THREADING --with-options=compiler_warnings ${GENERATE_OPTS}
+  - ../generate_makefile.bash --compiler=$CXX --with-$THREADING --with-options=compiler_warnings --cxxflags=-Werror ${GENERATE_OPTS}
   - make
   - make test
 


### PR DESCRIPTION
The README says: "Primary tested compiler are passing in release mode with warnings as errors". Hence, it seems to be sensible to also run the Travis CI check with `-Werror`.