### PR TITLE
change TeamPolicyInternal to convert the vector_length (Issue #2020)

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -238,12 +238,6 @@ public:
          test_vector_length = test_pow2 >> 1;
       }
 
-      if ( Kokkos::show_warnings() && ( test_vector_length != requested_vector_length ) ) {
-           std::cerr << "Kokkos::Cuda::TeamPolicyInternal WARNING: requested vector length ( " 
-                     << requested_vector_length << " ) invalid.  using vector length = "
-                << test_vector_length << " instead." << std::endl ;
-      }
-
       return test_vector_length;
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -73,6 +73,9 @@
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
+
+extern bool show_warnings() noexcept;
+
 namespace Impl {
 
 template< class ... Properties >
@@ -220,6 +223,31 @@ public:
     { return Impl::CudaTraits::WarpSize; }
 
   inline static
+  int verify_requested_vector_length( int requested_vector_length ) {
+      int test_vector_length = std::min( requested_vector_length, vector_length_max() );
+
+      // Allow only power-of-two vector_length
+      if ( !(is_integral_power_of_two( test_vector_length ) ) ) {
+         int test_pow2 = 1;
+         for (int i = 0; i < 5; i++) {
+            test_pow2 = test_pow2 << 1;
+            if (test_pow2 > test_vector_length) {
+               break;
+            }
+         }
+         test_vector_length = test_pow2 >> 1;
+      }
+
+      if ( Kokkos::show_warnings() && ( test_vector_length != requested_vector_length ) ) {
+           std::cerr << "Kokkos::Cuda::TeamPolicyInternal WARNING: requested vector length ( " 
+                     << requested_vector_length << " ) invalid.  using vector length = "
+                << test_vector_length << " instead." << std::endl ;
+      }
+
+      return test_vector_length;
+  }
+
+  inline static
   int scratch_size_max(int level)
     { return (level==0?
         1024*40:             // 48kB is the max for CUDA, but we need some for team_member.reduce etc.
@@ -264,16 +292,11 @@ public:
     : m_space( space_ )
     , m_league_size( league_size_ )
     , m_team_size( team_size_request )
-    , m_vector_length( vector_length_request )
+    , m_vector_length( verify_requested_vector_length(vector_length_request) )
     , m_team_scratch_size {0,0}
     , m_thread_scratch_size {0,0}
     , m_chunk_size ( 32 )
     {
-      // Allow only power-of-two vector_length
-      if ( ! Kokkos::Impl::is_integral_power_of_two( vector_length_request ) ) {
-        Impl::throw_runtime_exception( "Requested non-power-of-two vector length for TeamPolicy.");
-      }
-
       // Make sure league size is permissable
       if(league_size_ >= int(Impl::cuda_internal_maximum_grid_count()))
         Impl::throw_runtime_exception( "Requested too large league_size for TeamPolicy on Cuda execution space.");
@@ -292,16 +315,11 @@ public:
     : m_space( space_ )
     , m_league_size( league_size_ )
     , m_team_size( -1 )
-    , m_vector_length( vector_length_request )
+    , m_vector_length( verify_requested_vector_length(vector_length_request) )
     , m_team_scratch_size {0,0}
     , m_thread_scratch_size {0,0}
     , m_chunk_size ( 32 )
     {
-      // Allow only power-of-two vector_length
-      if ( ! Kokkos::Impl::is_integral_power_of_two( vector_length_request ) ) {
-        Impl::throw_runtime_exception( "Requested non-power-of-two vector length for TeamPolicy.");
-      }
-
       // Make sure league size is permissable
       if(league_size_ >= int(Impl::cuda_internal_maximum_grid_count()))
         Impl::throw_runtime_exception( "Requested too large league_size for TeamPolicy on Cuda execution space.");
@@ -313,16 +331,11 @@ public:
     : m_space( typename traits::execution_space() )
     , m_league_size( league_size_ )
     , m_team_size( team_size_request )
-    , m_vector_length ( vector_length_request )
+    , m_vector_length ( verify_requested_vector_length(vector_length_request) )
     , m_team_scratch_size {0,0}
     , m_thread_scratch_size {0,0}
     , m_chunk_size ( 32 )
     {
-      // Allow only power-of-two vector_length
-      if ( ! Kokkos::Impl::is_integral_power_of_two( vector_length_request ) ) {
-        Impl::throw_runtime_exception( "Requested non-power-of-two vector length for TeamPolicy.");
-      }
-
       // Make sure league size is permissable
       if(league_size_ >= int(Impl::cuda_internal_maximum_grid_count()))
         Impl::throw_runtime_exception( "Requested too large league_size for TeamPolicy on Cuda execution space.");
@@ -339,16 +352,11 @@ public:
     : m_space( typename traits::execution_space() )
     , m_league_size( league_size_ )
     , m_team_size( -1 )
-    , m_vector_length ( vector_length_request )
+    , m_vector_length ( verify_requested_vector_length(vector_length_request) )
     , m_team_scratch_size {0,0}
     , m_thread_scratch_size {0,0}
     , m_chunk_size ( 32 )
     {
-      // Allow only power-of-two vector_length
-      if ( ! Kokkos::Impl::is_integral_power_of_two( vector_length_request ) ) {
-        Impl::throw_runtime_exception( "Requested non-power-of-two vector length for TeamPolicy.");
-      }
-
       // Make sure league size is permissable
       if(league_size_ >= int(Impl::cuda_internal_maximum_grid_count()))
         Impl::throw_runtime_exception( "Requested too large league_size for TeamPolicy on Cuda execution space.");

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -823,7 +823,6 @@ namespace Test {
 // ( modified from kokkos-tutorials/GTC2016/Exercises/ThreeLevelPar )
 
 #if ( ! defined( KOKKOS_ENABLE_CUDA ) ) || (defined( KOKKOS_ENABLE_CUDA_LAMBDA ) && (8000 <= CUDA_VERSION))
-
 template< typename ScalarType, class DeviceType >
 class TestTripleNestedReduce
 {
@@ -962,6 +961,8 @@ TEST_F( TEST_CATEGORY, triple_nested_parallelism )
   }
 #endif
   TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 16, 16 );
+  TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 16, 33 );
+  TestTripleNestedReduce< double, TEST_EXECSPACE >( 8192, 2048, 16, 19 );
 #ifdef KOKKOS_ENABLE_ROCM // ROCm doesn't support team sizes not powers of two
   if (!std::is_same<TEST_EXECSPACE, Kokkos::Experimental::ROCm>::value)
 #endif


### PR DESCRIPTION
Issue #2020 
Modify TeamPolicyInternal to convert requested vector length into a vector length that is <= to the warp_size and also a power of 2.  Print a warning (if warnings are enabled) if the final vector length is different than the requested vector length.  Spot check from apollo below.

========================================================================
Running on machine: apollo

Repository Status:  835f44be5e4943bfaa68e5a9e88d86687f39497c change TeamPolicyInternal to convert the vector_length into a number that is <= warp_size and is a power of 2.


Going to test compilers:  gcc/4.8.4 gcc/5.3.0 intel/16.0.1 clang/3.9.0 clang/6.0 cuda/9.1
Testing compiler gcc/4.8.4
  Starting job gcc-4.8.4-OpenMP-release
  PASSED gcc-4.8.4-OpenMP-release
Testing compiler gcc/5.3.0
  Starting job gcc-4.8.4-Pthread-release
  PASSED gcc-4.8.4-Pthread-release
Testing compiler intel/16.0.1
  Starting job gcc-5.3.0-Serial-release
  PASSED gcc-5.3.0-Serial-release
Testing compiler clang/3.9.0
  Starting job intel-16.0.1-OpenMP-release
  PASSED intel-16.0.1-OpenMP-release
Testing compiler clang/6.0
  Starting job clang-3.9.0-Pthread_Serial-release
  PASSED clang-3.9.0-Pthread_Serial-release
  Starting job clang-6.0-Cuda_Pthread-release
  PASSED clang-6.0-Cuda_Pthread-release
Testing compiler cuda/9.1
  Starting job clang-6.0-OpenMP-release
  PASSED clang-6.0-OpenMP-release
  Starting job cuda-9.1-Cuda_OpenMP-release
  PASSED cuda-9.1-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-3.9.0-Pthread_Serial-release build_time=136 run_time=483
clang-6.0-Cuda_Pthread-release build_time=238 run_time=331
clang-6.0-OpenMP-release build_time=117 run_time=93
cuda-9.1-Cuda_OpenMP-release build_time=323 run_time=182
gcc-4.8.4-OpenMP-release build_time=106 run_time=109
gcc-4.8.4-Pthread-release build_time=100 run_time=354
gcc-5.3.0-Serial-release build_time=114 run_time=200
intel-16.0.1-OpenMP-release build_time=358 run_time=156
~                                                                 