### PR TITLE
core/unit_test/CMakeLists.txt: Remove changes breaking Trilinos

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -21,14 +21,6 @@ TRIBITS_ADD_LIBRARY(
   SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
   TESTONLY
   )
-target_compile_options(
-  kokkos_gtest
-  PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${KOKKOS_CXX_FLAGS}>
-)
-target_link_libraries(
-  kokkos_gtest
-  PUBLIC ${KOKKOS_LD_FLAGS}
-)
 
 #
 # Define the tests
@@ -754,40 +746,4 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   FAIL_REGULAR_EXPRESSION "  FAILED  "
     TESTONLYLIBS kokkos_gtest ${TEST_LINK_TARGETS}
 )
-
-#
-# Compile-only tests
-#
-FUNCTION(KOKKOS_ADD_COMPILE_TEST TEST_NAME)
-
-  SET(options LINK_KOKKOS)
-  SET(oneValueArgs)
-  SET(multiValueArgs)
-
-  CMAKE_PARSE_ARGUMENTS(PARSE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
-  IF(PARSE_LINK_KOKKOS)
-    SET(libs ${TEST_LINK_TARGETS})
-  ELSE()
-    SET(libs)
-  ENDIF()
-
-  TRIBITS_ADD_EXECUTABLE(
-    ${TEST_NAME}
-    TESTONLY
-    COMM serial
-    TESTONLYLIBS ${libs}
-    ${PARSE_UNPARSED_ARGUMENTS}
-  )
-
-  target_compile_options(
-    ${PACKAGE_NAME}_${TEST_NAME}
-    PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${KOKKOS_CXX_FLAGS}>
-  )
-  target_link_libraries(
-    ${PACKAGE_NAME}_${TEST_NAME}
-    PUBLIC ${KOKKOS_LD_FLAGS}
-  )
-
-ENDFUNCTION()
 


### PR DESCRIPTION
Address #2069 remove some recent modification that prevent Trilinos from
configuring. Temporary workaround until those changes can be revisited.