### PR TITLE
core/unit_test/CMakeLists.txt: Fix for Trilinos

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -21,6 +21,8 @@ TRIBITS_ADD_LIBRARY(
   SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
   TESTONLY
   )
+
+IF(NOT KOKKOS_HAS_TRILINOS)
 target_compile_options(
   kokkos_gtest
   PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${KOKKOS_CXX_FLAGS}>
@@ -29,6 +31,7 @@ target_link_libraries(
   kokkos_gtest
   PUBLIC ${KOKKOS_LD_FLAGS}
 )
+ENDIF()
 
 #
 # Define the tests


### PR DESCRIPTION
Addresses #2069 allowing Trilinos to configure.