### PR TITLE
Fix travis build to have O3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
     fi
   - mkdir build
   - cd build
-  - ../generate_makefile.bash --compiler=$CXX --with-$THREADING --with-options=compiler_warnings --cxxflags=-Werror ${GENERATE_OPTS}
+  - ../generate_makefile.bash --compiler=$CXX --with-$THREADING --with-options=compiler_warnings --cxxflags="-O3 -Werror" ${GENERATE_OPTS}
   - make
   - make test
 


### PR DESCRIPTION
we eliminated the optimization flag by setting cxxflags to Werror. This makes the builds time out on OSX.