### PR TITLE
fixed a missing memory fence in several tasking backends

### DIFF
--- a/core/src/impl/Kokkos_LIFO.hpp
+++ b/core/src/impl/Kokkos_LIFO.hpp
@@ -359,6 +359,7 @@ public:
 
     // (local variable used for assertion only)
     // TODO @tasking @memory_order DSH this should have memory order release, I think
+    Kokkos::memory_fence();
     auto old_head = Kokkos::atomic_exchange(&(this->m_head), consumed_tag);
 
     // Assert that the queue wasn't consumed before this


### PR DESCRIPTION
The missing fence was causing a race condition that *mostly* only showed up with some of the improvements to tasking that I'm working on. (It showed up in `develop` also, but only about every 10-100 runs or so of pure overhead tests.)