### PR TITLE
Remove Unused Parameter Warnings

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -75,7 +75,7 @@ struct DynRankDimTraits {
                            , const size_t N4
                            , const size_t N5
                            , const size_t N6
-                           , const size_t N7 )
+                           , const size_t /* N7 */)
   {
     return
       (   (N6 == unspecified && N5 == unspecified && N4 == unspecified && N3 == unspecified && N2 == unspecified && N1 == unspecified && N0 == unspecified) ? 0
@@ -106,7 +106,7 @@ struct DynRankDimTraits {
   // Extra overload to match that for specialize types v2
   template <typename Layout, typename ... P>
   KOKKOS_INLINE_FUNCTION
-  static size_t computeRank( const Kokkos::Impl::ViewCtorProp<P...>& prop, const Layout& layout )
+  static size_t computeRank( const Kokkos::Impl::ViewCtorProp<P...>& /* prop */, const Layout& layout )
   {
     return computeRank(layout);
   }
@@ -155,7 +155,7 @@ struct DynRankDimTraits {
   // Extra overload to match that for specialize types
   template <typename Traits, typename ... P>
   KOKKOS_INLINE_FUNCTION
-  static typename std::enable_if< (std::is_same<typename Traits::array_layout , Kokkos::LayoutRight>::value || std::is_same<typename Traits::array_layout , Kokkos::LayoutLeft>::value || std::is_same<typename Traits::array_layout , Kokkos::LayoutStride>::value) , typename Traits::array_layout >::type createLayout( const Kokkos::Impl::ViewCtorProp<P...>& prop, const typename Traits::array_layout& layout )
+  static typename std::enable_if< (std::is_same<typename Traits::array_layout , Kokkos::LayoutRight>::value || std::is_same<typename Traits::array_layout , Kokkos::LayoutLeft>::value || std::is_same<typename Traits::array_layout , Kokkos::LayoutStride>::value) , typename Traits::array_layout >::type createLayout( const Kokkos::Impl::ViewCtorProp<P...>& /* prop */, const typename Traits::array_layout& layout )
   {
     return createLayout( layout );
   }

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -166,7 +166,7 @@ T atomic_fetch_oper( const Oper& op, volatile T * const dest ,
 
   do {
     assume.i = oldval.i ;
-    newval.t = Oper::apply(assume.t, val) ;
+    newval.t = op.apply(assume.t, val) ;
     oldval.i = Kokkos::atomic_compare_exchange( (unsigned long long int*)dest , assume.i , newval.i );
   } while ( assume.i != oldval.i );
 
@@ -211,7 +211,7 @@ T atomic_fetch_oper( const Oper& op, volatile T * const dest ,
 
   do {
     assume.i = oldval.i ;
-    newval.t = Oper::apply(assume.t, val) ;
+    newval.t = op.apply(assume.t, val) ;
     oldval.i = Kokkos::atomic_compare_exchange( (int*)dest , assume.i , newval.i );
   } while ( assume.i != oldval.i );
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -284,6 +284,8 @@ void finalize_internal( const bool all_spaces = false )
       Kokkos::Cuda::impl_finalize();
 #endif
   }
+#else
+  (void)all_spaces;
 #endif
 
 #if defined( KOKKOS_ENABLE_ROCM )

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -282,6 +282,7 @@ decrement( SharedAllocationRecord< void , void > * arg_record )
   return arg_record ;
 }
 
+#ifdef KOKKOS_DEBUG
 void
 SharedAllocationRecord< void , void >::
 print_host_accessible_records( std::ostream & s
@@ -289,7 +290,6 @@ print_host_accessible_records( std::ostream & s
                              , const SharedAllocationRecord * const root
                              , const bool detail )
 {
-#ifdef KOKKOS_DEBUG
   const SharedAllocationRecord< void , void > * r = root ;
 
   char buffer[256] ;
@@ -350,12 +350,20 @@ print_host_accessible_records( std::ostream & s
       r = r->m_next ;
     } while ( r != root );
   }
+}
 #else
+void
+SharedAllocationRecord< void , void >::
+print_host_accessible_records( std::ostream &
+                             , const char * const
+                             , const SharedAllocationRecord * const
+                             , const bool )
+{
   Kokkos::Impl::throw_runtime_exception(
       "Kokkos::Impl::SharedAllocationRecord::print_host_accessible_records"
       " only works with KOKKOS_DEBUG enabled");
-#endif
 }
+#endif
 
 } /* namespace Impl */
 } /* namespace Kokkos */


### PR DESCRIPTION
I've come across a number of unused parameter warnings in Kokkos in Trilinos using gcc-7.3.0 and compiling with `-Wall -Wextra -Wpedantic`.  It looks like a number of these have already been dealt with in the `develop` branch, but a number still remain.

Where possible, I've commented out parameter names in function definitions to avoid `-Wunused-parameter` warnings.  If you'd prefer to have the parameter names removed entirely, feel free to do so.  If the use of a given parameter is hidden behind an `#ifdef`, I've used an `#else` block to avoid the warning instead.

These changes build fine for me within Trilinos, but I haven't built/tested Kokkos by itself.  I don't expect any issues.