### PR TITLE
Fix #2115 (add missing typeinfo header)

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -52,6 +52,9 @@
 #include <impl/Kokkos_AnalyzePolicy.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <iostream>
+#if defined(KOKKOS_ENABLE_PROFILING)
+#include <typeinfo>
+#endif // KOKKOS_ENABLE_PROFILING
 
 //----------------------------------------------------------------------------
 


### PR DESCRIPTION
Fix #2115 by adding missing typeinfo header include to Kokkos_ExecPolicy.hpp.