### PR TITLE
TeamVectorRange: Fix mismarkings

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -901,7 +901,7 @@ TeamThreadRange( const TeamMemberType&, const iType1& begin, const iType2& end )
  *  with the TeamPolicy. This variant expects a single count. So the range is (0,count].
  */
 template<typename iType, class TeamMemberType, class _never_use_this_overload>
-KOKKOS_INLINE_FUNCTION
+KOKKOS_INLINE_FUNCTION_DELETED
 Impl::TeamThreadRangeBoundariesStruct<iType,TeamMemberType>
 TeamVectorRange( const TeamMemberType&, const iType& count ) = delete;
 
@@ -912,7 +912,7 @@ TeamVectorRange( const TeamMemberType&, const iType& count ) = delete;
  *  with the TeamPolicy. This variant expects a begin and end. So the range is (begin,end].
  */
 template<typename iType1, typename iType2, class TeamMemberType, class _never_use_this_overload>
-KOKKOS_INLINE_FUNCTION
+KOKKOS_INLINE_FUNCTION_DELETED
 Impl::TeamThreadRangeBoundariesStruct<typename std::common_type<iType1, iType2>::type, TeamMemberType>
 TeamVectorRange( const TeamMemberType&, const iType1& begin, const iType2& end ) = delete;
 


### PR DESCRIPTION
Update KOKKOS_INLINE_FUNCTION to KOKKOS_INLINE_FUNCTION_DELETED on
mismarked ctors.
Address issue #2113