### PR TITLE
Issue #2122 - Deprecate LayoutTileLeft.  Should use LayoutTiled instead

### DIFF
--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -193,6 +193,9 @@ struct LayoutStride {
     {}
 };
 
+// ==========================================================================
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+
 //----------------------------------------------------------------------------
 /// \struct LayoutTileLeft
 /// \brief Memory layout tag indicating left-to-right (Fortran scheme)
@@ -243,6 +246,8 @@ struct LayoutTileLeft {
     : dimension { argN0 , argN1 , argN2 , argN3 , argN4 , argN5 , argN6 , argN7 } {}
 };
 
+#endif   // KOKKOS_ENABLE_DEPRECATED_CODE
+// ===================================================================================
 
 //////////////////////////////////////////////////////////////////////////////////////
 

--- a/core/src/impl/Kokkos_ViewTile.hpp
+++ b/core/src/impl/Kokkos_ViewTile.hpp
@@ -50,6 +50,9 @@
 namespace Kokkos {
 namespace Impl {
 
+// ===========================================================================
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+
 // View mapping for rank two tiled array
 
 template< class L >
@@ -208,10 +211,16 @@ struct ViewMapping
     }
 };
 
+#endif // KOKKOS_ENABLE_DEPRECATED_CODE
+// ===============================================================================
+
 } /* namespace Impl */
 } /* namespace Kokkos */
 
 namespace Kokkos {
+
+// ==============================================================================
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 
 template< typename T , unsigned N0 , unsigned N1 , class ... P >
 KOKKOS_INLINE_FUNCTION
@@ -228,6 +237,9 @@ tile_subview( const Kokkos::View<T**,Kokkos::LayoutTileLeft<N0,N1,true>,P...> & 
   return Kokkos::View< T[N0][N1] , LayoutLeft , P... >
     ( src , SrcLayout() , i_tile0 , i_tile1 );
 }
+
+#endif // KOKKOS_ENABLE_DEPRECATED_CODE
+// ===============================================================================
 
 } /* namespace Kokkos */
 

--- a/core/unit_test/TestTile.hpp
+++ b/core/unit_test/TestTile.hpp
@@ -42,6 +42,9 @@
 #ifndef TEST_TILE_HPP
 #define TEST_TILE_HPP
 
+//========================================================================
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+
 #include <Kokkos_Core.hpp>
 #include <impl/Kokkos_ViewTile.hpp>
 
@@ -166,4 +169,8 @@ TEST_F( TEST_CATEGORY, tile_layout )
 }
 
 }
+
+#endif // KOKKOS_ENABLE_DEPRECATED_CODE
+//=====================================================================
+
 #endif //TEST_TILE_HPP


### PR DESCRIPTION
Issue #2122 
Wrapped all definitions, references and unit test with the #ifdef KOKKOS_ENABLE_DEPRECATED_CODE.

Here are the spot checks from kokkos-dev with and without deprecated code enabled 
---------------------------------------------------------------------------------------
With Deprecated code enabled...
---------------------------------------------------------------------------------------
Running on machine: kokkos-dev

Repository Status:  624e711771c96f3f4188b83b62a4db8b28d2c610 Issue 2122 - Deprecate LayoutTileLeft. Should use LayoutTiled instead


Going to test compilers:  gcc/5.3.0 gcc/7.3.0 intel/17.0.1 clang/4.0.1 cuda/8.0.44
Testing compiler gcc/5.3.0
  Starting job gcc-5.3.0-OpenMP-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler gcc/7.3.0
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  Starting job gcc-7.3.0-Serial-release
  PASSED gcc-7.3.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-7.3.0-Serial-hwloc-release
  PASSED gcc-7.3.0-Serial-hwloc-release
  Starting job intel-17.0.1-OpenMP-release
  PASSED intel-17.0.1-OpenMP-release
Testing compiler clang/4.0.1
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  Starting job clang-4.0.1-Pthread_Serial-release
  PASSED clang-4.0.1-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-4.0.1-Pthread_Serial-hwloc-release
  PASSED clang-4.0.1-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=204 run_time=127
clang-4.0.1-Pthread_Serial-release build_time=207 run_time=293
cuda-8.0.44-Cuda_OpenMP-release build_time=595 run_time=498
gcc-5.3.0-OpenMP-hwloc-release build_time=188 run_time=89
gcc-5.3.0-OpenMP-release build_time=187 run_time=87
gcc-7.3.0-Serial-hwloc-release build_time=157 run_time=156
gcc-7.3.0-Serial-release build_time=156 run_time=155
intel-17.0.1-OpenMP-hwloc-release build_time=508 run_time=164
intel-17.0.1-OpenMP-release build_time=502 run_time=205

------------------------------------------------------------------------------------------
Without deprecated code enabled
------------------------------------------------------------------------------------------
Running on machine: kokkos-dev

Repository Status:  624e711771c96f3f4188b83b62a4db8b28d2c610 Issue 2122 - Deprecate LayoutTileLeft. Should use LayoutTiled instead


Going to test compilers:  gcc/5.3.0 gcc/7.3.0 intel/17.0.1 clang/4.0.1 cuda/8.0.44
Testing compiler gcc/5.3.0
  Starting job gcc-5.3.0-OpenMP-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler gcc/7.3.0
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  Starting job gcc-7.3.0-Serial-release
  PASSED gcc-7.3.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-7.3.0-Serial-hwloc-release
  PASSED gcc-7.3.0-Serial-hwloc-release
  Starting job intel-17.0.1-OpenMP-release
  PASSED intel-17.0.1-OpenMP-release
Testing compiler clang/4.0.1
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  Starting job clang-4.0.1-Pthread_Serial-release
  PASSED clang-4.0.1-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-4.0.1-Pthread_Serial-hwloc-release
  PASSED clang-4.0.1-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=258 run_time=355
clang-4.0.1-Pthread_Serial-release build_time=206 run_time=340
cuda-8.0.44-Cuda_OpenMP-release build_time=683 run_time=585
gcc-5.3.0-OpenMP-hwloc-release build_time=206 run_time=164
gcc-5.3.0-OpenMP-release build_time=218 run_time=176
gcc-7.3.0-Serial-hwloc-release build_time=152 run_time=200
gcc-7.3.0-Serial-release build_time=176 run_time=187
intel-17.0.1-OpenMP-hwloc-release build_time=461 run_time=241
intel-17.0.1-OpenMP-release build_time=487 run_time=255