### PR TITLE
Issue 2137

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -128,11 +128,10 @@ public:
       OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_for");
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      const int pool_size = OpenMP::thread_pool_size();
+      #pragma omp parallel num_threads(OpenMP::thread_pool_size())
 #else
-      const int pool_size = OpenMP::impl_thread_pool_size();
+      #pragma omp parallel num_threads(OpenMP::impl_thread_pool_size())
 #endif
-      #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
 
@@ -228,11 +227,10 @@ public:
       OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_for");
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      const int pool_size = OpenMP::thread_pool_size();
+      #pragma omp parallel num_threads(OpenMP::thread_pool_size())
 #else
-      const int pool_size = OpenMP::impl_thread_pool_size();
+      #pragma omp parallel num_threads(OpenMP::impl_thread_pool_size())
 #endif
-      #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
 
@@ -703,11 +701,10 @@ public:
                                     );
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      const int pool_size = OpenMP::thread_pool_size();
+      #pragma omp parallel num_threads(OpenMP::thread_pool_size())
 #else
-      const int pool_size = OpenMP::impl_thread_pool_size();
+      #pragma omp parallel num_threads(OpenMP::impl_thread_pool_size())
 #endif
-      #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
 
@@ -840,11 +837,10 @@ public:
                                     );
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      const int pool_size = OpenMP::thread_pool_size();
+      #pragma omp parallel num_threads(OpenMP::thread_pool_size())
 #else
-      const int pool_size = OpenMP::impl_thread_pool_size();
+      #pragma omp parallel num_threads(OpenMP::impl_thread_pool_size())
 #endif
-      #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
 
@@ -1005,11 +1001,10 @@ public:
                                     , thread_local_size );
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      const int pool_size = OpenMP::thread_pool_size();
+      #pragma omp parallel num_threads(OpenMP::thread_pool_size())
 #else
-      const int pool_size = OpenMP::impl_thread_pool_size();
+      #pragma omp parallel num_threads(OpenMP::impl_thread_pool_size())
 #endif
-      #pragma omp parallel num_threads(pool_size)
       {
         HostThreadTeamData & data = *(m_instance->get_thread_data());
 

--- a/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
@@ -76,11 +76,10 @@ public:
   void execute()
   {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    const int pool_size = OpenMP::thread_pool_size();
+    #pragma omp parallel num_threads(OpenMP::thread_pool_size())
 #else
-    const int pool_size = OpenMP::impl_thread_pool_size();
+    #pragma omp parallel num_threads(OpenMP::impl_thread_pool_size())
 #endif
-    #pragma omp parallel num_threads(pool_size)
     {
       // Spin until COMPLETED_TOKEN.
       // END_TOKEN indicates no work is currently available.

--- a/core/src/impl/Kokkos_TaskQueueMultiple_impl.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMultiple_impl.hpp
@@ -57,7 +57,7 @@ namespace Impl {
 template <class ExecSpace, class MemorySpace>
 void TaskQueueMultiple<ExecSpace, MemorySpace>::Destroy::destroy_shared_allocation() {
 // KOKKOS WORKAROUND for CUDA 10.1 with GCC 7.3.0
-#if(KOKKOS_COMPILER_CUDA_VERSION==101) && defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_GNU==730)
+#if(KOKKOS_COMPILER_CUDA_VERSION==101) && defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_GNU>=730)
   (*m_queue).get_team_queue(0).~TaskQueueMultiple();
 #else
   m_queue->get_team_queue(0).~TaskQueueMultiple();

--- a/scripts/testing_scripts/test_all_sandia
+++ b/scripts/testing_scripts/test_all_sandia
@@ -450,7 +450,7 @@ elif [ "$MACHINE" = "kokkos-dev-2" ]; then
 
   BASE_MODULE_LIST="sems-env,kokkos-env,kokkos-hwloc/1.10.1/base,sems-<COMPILER_NAME>/<COMPILER_VERSION>"
   GCC91_MODULE_LIST="sems-env,kokkos-env,kokkos-hwloc/1.10.1/base,<COMPILER_NAME>/<COMPILER_VERSION>"
-  NVCC_MODULE_LIST="sems-env,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/7.3.0,kokkos-hwloc/1.10.1/base"
+  NVCC_MODULE_LIST="sems-env,kokkos-env,kokkos-hwloc/1.10.1/base,<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/7.3.0"
 
   CLANG_MODULE_LIST="sems-env,kokkos-env,sems-<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/6.1.0"
   CLANG8_MODULE_LIST="sems-env,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,cuda/10.0"


### PR DESCRIPTION
This fixes the compiler issue #2134 for GCC versions later than 7.3, fixes issue #2137 (unused variable warnings in clang 8) and adds another small update to the test script for kokkos-dev-2.