### PR TITLE
Fix deprecated version of team_size_max

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -149,7 +149,7 @@ public:
           /* for team   reduce */ + ( n + 2 ) * sizeof(double)
           /* for team   shared */ + Impl::FunctorTeamShmemSize< FunctorType >::value( functor , n );
 
-        if ( shmem_size < traits::execution_space().impl_internal_space_instance()->m_maxShmemPerBlock ) break ;
+        if ( shmem_size < typename traits::execution_space().impl_internal_space_instance()->m_maxShmemPerBlock ) break ;
       }
 
       return n ;


### PR DESCRIPTION
Recent changes in PR #2133 broke KokkosKernels when compiling with Cuda
and deprecated code enabled, fixed with minor update in this PR.