### PR TITLE
Fix issue 2155

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -241,7 +241,7 @@
   #endif
 #endif
 
-#if defined( __PGIC__ ) 
+#if defined( __PGIC__ )
   #define KOKKOS_COMPILER_PGI __PGIC__*100+__PGIC_MINOR__*10+__PGIC_PATCHLEVEL__
 
   #if ( 1540 > KOKKOS_COMPILER_PGI )
@@ -565,6 +565,12 @@
   #define KOKKOS_CONSTEXPR_14
 #endif
 
+
+// DJS 05/28/2019: Bugfix: Issue 2155
+// Use KOKKOS_ENABLE_CUDA_LDG_INTRINSIC to avoid memory leak in RandomAccess View
+#if defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_CUDA_LDG_INTRINSIC)
+ #define KOKKOS_ENABLE_CUDA_LDG_INTRINSIC
+#endif
 
 #endif // #ifndef KOKKOS_MACROS_HPP
 


### PR DESCRIPTION
Cuda RandomAccess views never deleted the texture object resulting
in a memory leak.  This patch always defines KOKKOS_ENABLE_CUDA_LDG_INTRINSIC
to avoid creating texture objects.

I am currently running tests in the benchmark suite (miniMD) and will create a new pull request if there is a 5% slow down or greater in the relevant kernels on V100.  Most of our performance tests appear to be unaffected.