### PR TITLE
get multi-FEM example to compile

### DIFF
--- a/example/multi_fem/ExplicitFunctors.hpp
+++ b/example/multi_fem/ExplicitFunctors.hpp
@@ -526,7 +526,7 @@ struct grad
     const int X = 0 ;
     const int Y = 1 ;
     const int Z = 2 ;
-    const Scalar dt_scale = -0.5 * *dt;
+    const Scalar dt_scale = -0.5 * dt();
 
     //  declare and reuse local data for frequently accessed data to
     //  reduce global memory reads and writes.
@@ -674,7 +674,7 @@ struct decomp_rotate
   KOKKOS_INLINE_FUNCTION
   void polar_decomp(int ielem, Scalar * v_gr, Scalar * str_ten, Scalar * str, Scalar * vort, Scalar * rot_old, Scalar * rot_new)const
   {
-    const Scalar dt = *dt_value;
+    const Scalar dt = dt_value();
     const Scalar dt_half = 0.5 * dt;
 
     //  Skew Symmetric part
@@ -958,8 +958,8 @@ struct internal_force
   KOKKOS_INLINE_FUNCTION
   void final( value_type & result ) const
   {
-    *prev_dt = *dt ;
-    *dt = result ;
+    prev_dt() = dt() ;
+    dt() = result ;
   };
 
   //--------------------------------------------------------------------------
@@ -1121,13 +1121,13 @@ struct internal_force
 
       const Scalar e = (rot_stretch(ielem,kxx)+rot_stretch(ielem,kyy)+rot_stretch(ielem,kzz))/3.0;
 
-      s_n[kxx] = stress_new(ielem,kxx) += *dt * (two_mu * (rot_stretch(ielem,kxx)-e)+3*bulk_modulus*e);
-      s_n[kyy] = stress_new(ielem,kyy) += *dt * (two_mu * (rot_stretch(ielem,kyy)-e)+3*bulk_modulus*e);
-      s_n[kzz] = stress_new(ielem,kzz) += *dt * (two_mu * (rot_stretch(ielem,kzz)-e)+3*bulk_modulus*e);
+      s_n[kxx] = stress_new(ielem,kxx) += dt() * (two_mu * (rot_stretch(ielem,kxx)-e)+3*bulk_modulus*e);
+      s_n[kyy] = stress_new(ielem,kyy) += dt() * (two_mu * (rot_stretch(ielem,kyy)-e)+3*bulk_modulus*e);
+      s_n[kzz] = stress_new(ielem,kzz) += dt() * (two_mu * (rot_stretch(ielem,kzz)-e)+3*bulk_modulus*e);
 
-      s_n[kxy] = stress_new(ielem,kxy) += *dt * two_mu * rot_stretch(ielem,kxy);
-      s_n[kyz] = stress_new(ielem,kyz) += *dt * two_mu * rot_stretch(ielem,kyz);
-      s_n[kzx] = stress_new(ielem,kzx) += *dt * two_mu * rot_stretch(ielem,kzx);
+      s_n[kxy] = stress_new(ielem,kxy) += dt() * two_mu * rot_stretch(ielem,kxy);
+      s_n[kyz] = stress_new(ielem,kyz) += dt() * two_mu * rot_stretch(ielem,kyz);
+      s_n[kzx] = stress_new(ielem,kzx) += dt() * two_mu * rot_stretch(ielem,kzx);
     }
 
   //----------------------------------------------------------------------------
@@ -1325,8 +1325,8 @@ struct nodal_step
 
       // Central difference time integration:
 
-      const Scalar dt_disp = *dt ;
-      const Scalar dt_vel = ( *dt + *prev_dt ) / 2.0 ;
+      const Scalar dt_disp = dt() ;
+      const Scalar dt_vel = ( dt() + prev_dt() ) / 2.0 ;
 
       velocity(inode,0,next_state) = v_new[0] =
         velocity(inode,0,current_state) + dt_vel * a_current[0];

--- a/example/multi_fem/Implicit.hpp
+++ b/example/multi_fem/Implicit.hpp
@@ -175,6 +175,7 @@ PerformanceData run( const typename FixtureType::FEMeshType & mesh ,
 
   linsys_rhs      = vector_type( "rhs" , local_owned_length );
   linsys_solution = vector_type( "solution" , local_owned_length );
+  fprintf(stderr, "created \"solution\", linsys_solution.use_count() %d\n", linsys_solution.use_count());
 
   //------------------------------------
   // Fill linear system
@@ -254,6 +255,8 @@ PerformanceData run( const typename FixtureType::FEMeshType & mesh ,
       }
     }
   }
+
+  fprintf(stderr, "at end of run(), linsys_solution.use_count() %d\n", linsys_solution.use_count());
 
   return perf_data ;
 }

--- a/example/multi_fem/Implicit.hpp
+++ b/example/multi_fem/Implicit.hpp
@@ -175,7 +175,6 @@ PerformanceData run( const typename FixtureType::FEMeshType & mesh ,
 
   linsys_rhs      = vector_type( "rhs" , local_owned_length );
   linsys_solution = vector_type( "solution" , local_owned_length );
-  fprintf(stderr, "created \"solution\", linsys_solution.use_count() %d\n", linsys_solution.use_count());
 
   //------------------------------------
   // Fill linear system
@@ -255,8 +254,6 @@ PerformanceData run( const typename FixtureType::FEMeshType & mesh ,
       }
     }
   }
-
-  fprintf(stderr, "at end of run(), linsys_solution.use_count() %d\n", linsys_solution.use_count());
 
   return perf_data ;
 }

--- a/example/multi_fem/LinAlgBLAS.hpp
+++ b/example/multi_fem/LinAlgBLAS.hpp
@@ -103,17 +103,17 @@ namespace Kokkos {
 
 template< typename ScalarX /* Allow mix of const and non-const */ ,
           typename ScalarY /* Allow mix of const and non-const */ ,
-          class L , class D ,
-          class MX /* Allow any management type */ ,
-          class MY /* Allow any management type */ >
+          class D>
 inline
 double dot( const size_t n ,
-            const View< ScalarX * , L , D , MX > & x ,
-            const View< ScalarY * , L , D , MY > & y ,
+            const View< ScalarX * , D > & x ,
+            const View< ScalarY * , D > & y ,
             comm::Machine machine )
 {
   double global_result = 0 ;
   double local_result = 0 ;
+  using x_type = View<ScalarX*, D>;
+  using L = typename x_type::array_layout;
 
   Impl::Dot< ScalarX , L , D >( n , x , y , local_result );
 
@@ -127,16 +127,16 @@ double dot( const size_t n ,
 
 template< typename ScalarX /* Allow mix of const and non-const */ ,
           typename ScalarY /* Allow mix of const and non-const */ ,
-          class L , class D ,
-          class MX /* Allow any management type */ ,
-          class MY /* Allow any management type */ >
+          class D >
 inline
 double dot( const size_t n ,
-            const View< ScalarX * , L , D , MX > & x ,
-            const View< ScalarY * , L , D , MY > & y ,
+            const View< ScalarX * , D > & x ,
+            const View< ScalarY * , D > & y ,
             comm::Machine )
 {
   double global_result = 0 ;
+  using x_type = View<ScalarX*, D>;
+  using L = typename x_type::array_layout;
 
   Impl::Dot< ScalarX , L , D >( n , x , y , global_result );
 
@@ -171,14 +171,15 @@ double dot( const size_t n ,
 #else
 
 template< typename ScalarX /* Allow mix of const and non-const */ ,
-          class L , class D ,
-          class MX /* Allow any management type */ >
+          class D>
 inline
 double dot( const size_t n ,
-            const View< ScalarX * , L , D , MX > & x ,
+            const View< ScalarX * , D> & x ,
             comm::Machine )
 {
   double global_result = 0 ;
+  using x_type = View<ScalarX*, D>;
+  using L = typename x_type::array_layout;
 
   Impl::Dot1< ScalarX , L , D >( n , x , global_result );
 
@@ -190,11 +191,10 @@ double dot( const size_t n ,
 //----------------------------------------------------------------------------
 
 template< typename ScalarX /* Allow mix of const and non-const */ ,
-          class L , class D ,
-          class MX /* Allow any management type */ >
+          class D >
 inline
 double norm2( const size_t n ,
-              const View< ScalarX * , L , D , MX > & x ,
+              const View< ScalarX * , D > & x ,
               comm::Machine machine )
 {
   return std::sqrt( dot( n , x , machine ) );
@@ -216,13 +216,13 @@ void scale( const size_t n ,
 
 template< typename ScalarA ,
           typename ScalarX ,
-          class L ,
-          class D ,
-          class MX >
+          class D >
 void fill( const size_t n ,
            const ScalarA & alpha ,
-           const View< ScalarX * , L , D , MX > & x )
+           const View< ScalarX * , D > & x )
 {
+  using x_type = View<ScalarX*, D>;
+  using L = typename x_type::array_layout;
   Impl::Fill< ScalarA , ScalarX , L , D >( n , alpha , x );
 }
 
@@ -231,15 +231,14 @@ void fill( const size_t n ,
 template< typename ScalarA ,
           typename ScalarX ,
           typename ScalarY ,
-          class L ,
-          class D ,
-          class MX ,
-          class MY >
+          class D >
 void axpy( const size_t n ,
            const ScalarA & alpha ,
-           const View< ScalarX *, L , D , MX > & x ,
-           const View< ScalarY *, L , D , MY > & y )
+           const View< ScalarX *, D > & x ,
+           const View< ScalarY *, D > & y )
 {
+  using x_type = View<ScalarX*, D>;
+  using L = typename x_type::array_layout;
   Impl::AXPY< ScalarA, ScalarX, ScalarY , L , D >( n, alpha, x, y );
 }
 
@@ -248,15 +247,14 @@ void axpy( const size_t n ,
 template< typename ScalarX ,
           typename ScalarB ,
           typename ScalarY ,
-          class L ,
-          class D ,
-          class MX ,
-          class MY >
+          class D >
 void xpby( const size_t n ,
-           const View< ScalarX *, L , D , MX > & x ,
+           const View< ScalarX *, D > & x ,
            const ScalarB & beta ,
-           const View< ScalarY *, L , D , MY > & y )
+           const View< ScalarY *, D > & y )
 {
+  using x_type = View<ScalarX*, D>;
+  using L = typename x_type::array_layout;
   Impl::XPBY< ScalarX, ScalarB, ScalarY , L , D >( n, x, beta, y );
 }
 
@@ -268,15 +266,17 @@ template< typename ScalarA ,
           typename ScalarB ,
           typename ScalarY ,
           typename ScalarW ,
-          class L , class D ,
-          class MX , class MY , class MW >
+          class D
+          >
 void waxpby( const size_t n ,
              const ScalarA & alpha ,
-             const View< ScalarX * , L , D , MX > & x ,
+             const View< ScalarX * , D > & x ,
              const ScalarB & beta ,
-             const View< ScalarY * , L , D , MY > & y ,
-             const View< ScalarW * , L , D , MW > & w )
+             const View< ScalarY * , D > & y ,
+             const View< ScalarW * , D > & w )
 {
+  using x_type = typename std::decay<decltype(x)>::type;
+  using L = typename x_type::array_layout;
   Impl::WAXPBY<ScalarA,ScalarX,ScalarB,ScalarY,ScalarW,L,D>
     ( n , alpha , x , beta , y , w );
 }

--- a/example/multi_fem/TestCuda.cpp
+++ b/example/multi_fem/TestCuda.cpp
@@ -86,12 +86,12 @@ void test_cuda_fixture( comm::Machine machine ,
     dev_count && dev_count <= comm_size ? comm_rank % dev_count : 0 ;
   const size_t gang_count = 0 ;
 
-  Kokkos::HostSpace::execution_space::initialize();
-  Kokkos::Cuda::SelectDevice select_device( dev_rank );
-  Kokkos::Cuda::initialize( select_device );
+  Kokkos::InitArguments args;
+  args.device_id = dev_rank;
+  Kokkos::initialize(args);
+
   test_box_fixture<Kokkos::Cuda>( machine , gang_count , nx , ny , nz );
-  Kokkos::Cuda::finalize();
-  Kokkos::HostSpace::execution_space::finalize();
+  Kokkos::finalize();
 }
 
 //----------------------------------------------------------------------------
@@ -108,12 +108,11 @@ void test_cuda_implicit( comm::Machine machine ,
     dev_count && dev_count <= comm_size ? comm_rank % dev_count : 0 ;
   const size_t gang_count = 0 ;
 
-  Kokkos::HostSpace::execution_space::initialize();
-  Kokkos::Cuda::SelectDevice select_device( dev_rank );
-  Kokkos::Cuda::initialize( select_device );
+  Kokkos::InitArguments args;
+  args.device_id = dev_rank;
+  Kokkos::initialize(args);
   HybridFEM::Implicit::driver<double,Kokkos::Cuda>( "Cuda" , machine , gang_count , elem_count_begin , elem_count_end , count_run );
-  Kokkos::Cuda::finalize();
-  Kokkos::HostSpace::execution_space::finalize();
+  Kokkos::finalize();
 }
 
 //----------------------------------------------------------------------------
@@ -130,12 +129,11 @@ void test_cuda_explicit( comm::Machine machine ,
     dev_count && dev_count <= comm_size ? comm_rank % dev_count : 0 ;
   const size_t gang_count = 0 ;
 
-  Kokkos::HostSpace::execution_space::initialize();
-  Kokkos::Cuda::SelectDevice select_device( dev_rank );
-  Kokkos::Cuda::initialize( select_device );
+  Kokkos::InitArguments args;
+  args.device_id = dev_rank;
+  Kokkos::initialize(args);
   Explicit::driver<double,Kokkos::Cuda>( "Cuda" , machine , gang_count , elem_count_begin , elem_count_end , count_run );
-  Kokkos::Cuda::finalize();
-  Kokkos::HostSpace::execution_space::finalize();
+  Kokkos::finalize();
 }
 
 //----------------------------------------------------------------------------
@@ -152,15 +150,14 @@ void test_cuda_nonlinear( comm::Machine machine ,
     dev_count && dev_count <= comm_size ? comm_rank % dev_count : 0 ;
   const size_t gang_count = 0 ;
 
-  Kokkos::HostSpace::execution_space::initialize();
-  Kokkos::Cuda::SelectDevice select_device( dev_rank );
-  Kokkos::Cuda::initialize( select_device );
+  Kokkos::InitArguments args;
+  args.device_id = dev_rank;
+  Kokkos::initialize(args);
 
   typedef Kokkos::Cuda device ;
   typedef FixtureElementHex8 hex8 ;
   HybridFEM::Nonlinear::driver<double,device,hex8>( "Cuda" , machine , gang_count , elem_count_begin , elem_count_end , count_run );
-  Kokkos::Cuda::finalize();
-  Kokkos::HostSpace::execution_space::finalize();
+  Kokkos::finalize();
 }
 
 void test_cuda_nonlinear_quadratic( comm::Machine machine , 
@@ -175,15 +172,14 @@ void test_cuda_nonlinear_quadratic( comm::Machine machine ,
     dev_count && dev_count <= comm_size ? comm_rank % dev_count : 0 ;
   const size_t gang_count = 0 ;
 
-  Kokkos::HostSpace::execution_space::initialize();
-  Kokkos::Cuda::SelectDevice select_device( dev_rank );
-  Kokkos::Cuda::initialize( select_device );
+  Kokkos::InitArguments args;
+  args.device_id = dev_rank;
+  Kokkos::initialize(args);
 
   typedef Kokkos::Cuda device ;
   typedef FixtureElementHex27 hex27 ;
   HybridFEM::Nonlinear::driver<double,device,hex27>( "Cuda" , machine , gang_count , elem_count_begin , elem_count_end , count_run );
-  Kokkos::Cuda::finalize();
-  Kokkos::HostSpace::execution_space::finalize();
+  Kokkos::finalize();
 }
 
 //----------------------------------------------------------------------------

--- a/example/multi_fem/TestHost.cpp
+++ b/example/multi_fem/TestHost.cpp
@@ -68,9 +68,10 @@ void test_host_fixture( comm::Machine machine ,
                         size_t gang_worker_count ,
                         size_t nx , size_t ny , size_t nz )
 {
-  Kokkos::HostSpace::execution_space::initialize( gang_count * gang_worker_count );
+  Kokkos::InitArguments args(gang_count * gang_worker_count);
+  Kokkos::initialize( args );
   test_box_fixture<Kokkos::HostSpace::execution_space>( machine , gang_count , nx , ny , nz );
-  Kokkos::HostSpace::execution_space::finalize();
+  Kokkos::finalize();
 }
 
 //----------------------------------------------------------------------------
@@ -82,9 +83,10 @@ void test_host_implicit( comm::Machine machine ,
                          size_t elem_count_end ,
                          size_t count_run )
 {
-  Kokkos::HostSpace::execution_space::initialize( gang_count * gang_worker_count );
+  Kokkos::InitArguments args(gang_count * gang_worker_count);
+  Kokkos::initialize( args );
   HybridFEM::Implicit::driver<double,Kokkos::HostSpace::execution_space>( "Threads" , machine , gang_count , elem_count_begin , elem_count_end , count_run );
-  Kokkos::HostSpace::execution_space::finalize();
+  Kokkos::finalize();
 }
 
 //----------------------------------------------------------------------------
@@ -96,9 +98,10 @@ void test_host_explicit( comm::Machine machine ,
                          size_t elem_count_end ,
                          size_t count_run )
 {
-  Kokkos::HostSpace::execution_space::initialize( gang_count * gang_worker_count );
+  Kokkos::InitArguments args(gang_count * gang_worker_count);
+  Kokkos::initialize( args );
   Explicit::driver<double,Kokkos::HostSpace::execution_space>( "Threads" , machine , gang_count , elem_count_begin , elem_count_end , count_run );
-  Kokkos::HostSpace::execution_space::finalize();
+  Kokkos::finalize();
 }
 
 //----------------------------------------------------------------------------
@@ -111,11 +114,12 @@ void test_host_nonlinear( comm::Machine machine ,
                           size_t elem_count_end ,
                           size_t count_run )
 {
-  Kokkos::HostSpace::execution_space::initialize( gang_count * gang_worker_count );
+  Kokkos::InitArguments args(gang_count * gang_worker_count);
+  Kokkos::initialize( args );
   typedef FixtureElementHex8 hex8 ;
   typedef Kokkos::HostSpace::execution_space             device ;
   HybridFEM::Nonlinear::driver<double,device,hex8>( "Threads" , machine , gang_count , elem_count_begin , elem_count_end , count_run );
-  Kokkos::HostSpace::execution_space::finalize();
+  Kokkos::finalize();
 }
 
 void test_host_nonlinear_quadratic( comm::Machine machine ,
@@ -125,11 +129,12 @@ void test_host_nonlinear_quadratic( comm::Machine machine ,
                                     size_t elem_count_end ,
                                     size_t count_run )
 {
-  Kokkos::HostSpace::execution_space::initialize( gang_count * gang_worker_count );
+  Kokkos::InitArguments args(gang_count * gang_worker_count);
+  Kokkos::initialize( args );
   typedef FixtureElementHex27 hex27 ;
   typedef Kokkos::HostSpace::execution_space              device ;
   HybridFEM::Nonlinear::driver<double,device,hex27>( "Threads" , machine , gang_count , elem_count_begin , elem_count_end , count_run );
-  Kokkos::HostSpace::execution_space::finalize();
+  Kokkos::finalize();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
spot check:
```
Running on machine: kokkos-dev
Repository Status:  ba0ae7a3c5bbc1615e4eee42b5f86bf57d6134ca Removing debug prints


Going to test compilers:  gcc/5.3.0 gcc/7.3.0 intel/17.0.1 clang/4.0.1 cuda/8.0.44
Testing compiler gcc/5.3.0
  Starting job gcc-5.3.0-OpenMP-release
  PASSED gcc-5.3.0-OpenMP-release
Testing compiler gcc/7.3.0
  Starting job gcc-5.3.0-OpenMP-hwloc-release
  PASSED gcc-5.3.0-OpenMP-hwloc-release
  Starting job gcc-7.3.0-Serial-release
  PASSED gcc-7.3.0-Serial-release
Testing compiler intel/17.0.1
  Starting job gcc-7.3.0-Serial-hwloc-release
  PASSED gcc-7.3.0-Serial-hwloc-release
  Starting job intel-17.0.1-OpenMP-release
  PASSED intel-17.0.1-OpenMP-release
Testing compiler clang/4.0.1
  Starting job intel-17.0.1-OpenMP-hwloc-release
  PASSED intel-17.0.1-OpenMP-hwloc-release
  Starting job clang-4.0.1-Pthread_Serial-release
  PASSED clang-4.0.1-Pthread_Serial-release
Testing compiler cuda/8.0.44
  Starting job clang-4.0.1-Pthread_Serial-hwloc-release
  PASSED clang-4.0.1-Pthread_Serial-hwloc-release
  Starting job cuda-8.0.44-Cuda_OpenMP-release
  PASSED cuda-8.0.44-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=214 run_time=462
clang-4.0.1-Pthread_Serial-release build_time=212 run_time=564
cuda-8.0.44-Cuda_OpenMP-release build_time=586 run_time=536
gcc-5.3.0-OpenMP-hwloc-release build_time=188 run_time=134
gcc-5.3.0-OpenMP-release build_time=207 run_time=142
gcc-7.3.0-Serial-hwloc-release build_time=163 run_time=247
gcc-7.3.0-Serial-release build_time=160 run_time=283
intel-17.0.1-OpenMP-hwloc-release build_time=458 run_time=199
intel-17.0.1-OpenMP-release build_time=462 run_time=204
```