### PR TITLE
Bug fix for `atomic_load`

### DIFF
--- a/core/src/impl/Kokkos_Atomic_Load.hpp
+++ b/core/src/impl/Kokkos_Atomic_Load.hpp
@@ -159,13 +159,14 @@ T _relaxed_atomic_load_impl(
   T rv{};
   // TODO remove a copy operation here?
   Kokkos::atomic_oper_fetch(NoOpOper<T>{}, &rv, rv);
+  return rv;
 }
 
 template <class T>
 __device__ __inline__
 T _atomic_load(T* ptr, memory_order_seq_cst_t) {
   Kokkos::memory_fence();
-  auto rv = Impl::_relaxed_atomic_load_impl(ptr);
+  T rv = Impl::_relaxed_atomic_load_impl(ptr);
   Kokkos::memory_fence();
   return rv;
 }
@@ -173,7 +174,7 @@ T _atomic_load(T* ptr, memory_order_seq_cst_t) {
 template <class T>
 __device__ __inline__
 T _atomic_load(T* ptr, memory_order_acquire_t) {
-  auto rv = _relaxed_atomic_load_impl(ptr);
+  T rv = Impl::_relaxed_atomic_load_impl(ptr);
   Kokkos::memory_fence();
   return rv;
 }

--- a/core/src/impl/Kokkos_Atomic_Store.hpp
+++ b/core/src/impl/Kokkos_Atomic_Store.hpp
@@ -142,7 +142,7 @@ struct StoreOper {
 
 template <class T>
 __device__ __inline__
-T _relaxed_atomic_store_impl(
+void _relaxed_atomic_store_impl(
   T* ptr, T val,
   typename std::enable_if<
     !(
@@ -159,25 +159,24 @@ T _relaxed_atomic_store_impl(
 
 template <class T>
 __device__ __inline__
-T _atomic_store(T* ptr, T val, memory_order_seq_cst_t) {
+void _atomic_store(T* ptr, T val, memory_order_seq_cst_t) {
   Kokkos::memory_fence();
-  auto rv = Impl::_relaxed_atomic_store_impl(ptr, val);
+  Impl::_relaxed_atomic_store_impl(ptr, val);
   Kokkos::memory_fence();
   return rv;
 }
 
 template <class T>
 __device__ __inline__
-T _atomic_store(T* ptr, T val, memory_order_release_t) {
+void _atomic_store(T* ptr, T val, memory_order_release_t) {
   Kokkos::memory_fence();
-  auto rv = _relaxed_atomic_store_impl(ptr, val);
-  return rv;
+  _relaxed_atomic_store_impl(ptr, val);
 }
 
 template <class T>
 __device__ __inline__
-T _atomic_store(T* ptr, T val, memory_order_relaxed_t) {
-  return _relaxed_atomic_store_impl(ptr, val);
+void _atomic_store(T* ptr, T val, memory_order_relaxed_t) {
+  _relaxed_atomic_store_impl(ptr, val);
 }
 
 #elif defined(KOKKOS_ENABLE_OPENMP_ATOMICS)


### PR DESCRIPTION
The code was not property deducing `auto` in non-intrinsic versions of atomic_load and atomic_store