### PR TITLE
PGI Compiler fix

### DIFF
--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -99,7 +99,7 @@
 #include <impl/Kokkos_Error.hpp>
 #include <Kokkos_Atomic.hpp>
 
-#if ( defined( KOKKOS_ENABLE_ASM ) || defined ( KOKKOS_ENABLE_TM ) ) && defined ( KOKKOS_ENABLE_ISA_X86_64 )
+#if ( defined( KOKKOS_ENABLE_ASM ) || defined ( KOKKOS_ENABLE_TM ) ) && defined ( KOKKOS_ENABLE_ISA_X86_64 ) && !defined ( KOKKOS_COMPILER_PGI )
 #include <immintrin.h>
 #endif
 
@@ -456,7 +456,7 @@ void init_lock_array_host_space() {
 }
 
 bool lock_address_host_space(void* ptr) {
-#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM )
+#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM ) && !defined ( KOKKOS_COMPILER_PGI )
   const unsigned status = _xbegin();
 
   if( _XBEGIN_STARTED == status ) {
@@ -478,13 +478,13 @@ bool lock_address_host_space(void* ptr) {
   return 0 == atomic_compare_exchange( &HOST_SPACE_ATOMIC_LOCKS[
       (( size_t(ptr) >> 2 ) & HOST_SPACE_ATOMIC_MASK) ^ HOST_SPACE_ATOMIC_XOR_MASK] ,
                                   0 , 1);
-#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM )
+#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM ) && !defined ( KOKKOS_COMPILER_PGI )
   }
 #endif
 }
 
 void unlock_address_host_space(void* ptr) {
-#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM )
+#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM ) && !defined ( KOKKOS_COMPILER_PGI )
   const unsigned status = _xbegin();
 
   if( _XBEGIN_STARTED == status ) {
@@ -495,7 +495,7 @@ void unlock_address_host_space(void* ptr) {
    atomic_exchange( &HOST_SPACE_ATOMIC_LOCKS[
       (( size_t(ptr) >> 2 ) & HOST_SPACE_ATOMIC_MASK) ^ HOST_SPACE_ATOMIC_XOR_MASK] ,
                     0);
-#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM )
+#if defined( KOKKOS_ENABLE_ISA_X86_64 ) && defined ( KOKKOS_ENABLE_TM ) && !defined ( KOKKOS_COMPILER_PGI )
   }
 #endif
 }


### PR DESCRIPTION
This PR is an attempt to fix build errors on SKX arch with
PGI 17.10 and 18.7 compilers due to problems with intrisics.