### PR TITLE
[DO NOT MERGE] Kokkos CUDA Debugging and Sanitizer Integration

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -551,20 +551,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_LIBRT), 1)
   KOKKOS_TPL_LIBRARY_NAMES += rt
 endif
 
-ifeq ($(KOKKOS_INTERNAL_USE_MEMKIND), 1)
-  ifneq ($(MEMKIND_PATH),)
-    ifneq ($(KOKKOS_CMAKE), yes)
-      KOKKOS_CXXFLAGS += -I$(MEMKIND_PATH)/include
-    endif
-    KOKKOS_LDFLAGS += -L$(MEMKIND_PATH)/lib
-    KOKKOS_CXXLDFLAGS += -L$(MEMKIND_PATH)/lib
-    KOKKOS_TPL_INCLUDE_DIRS += $(MEMKIND_PATH)/include
-    KOKKOS_TPL_LIBRARY_DIRS += $(MEMKIND_PATH)/lib
-  endif
-  KOKKOS_LIBS += -lmemkind -lnuma
-  KOKKOS_TPL_LIBRARY_NAMES += memkind numa
-  tmp := $(call kokkos_append_header,"\#define KOKKOS_ENABLE_HBWSPACE")
-endif
+tmp := $(call kokkos_append_header,"\#define KOKKOS_ENABLE_HBWSPACE")
 
 ifeq ($(KOKKOS_INTERNAL_DISABLE_PROFILING), 0)
   tmp := $(call kokkos_append_header,"\#define KOKKOS_ENABLE_PROFILING")
@@ -1193,11 +1180,6 @@ ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
   KOKKOS_INTERNAL_GCC_TOOLCHAIN = $(KOKKOS_INTERNAL_GCC_PATH:/bin/g++=)
   KOKKOS_CXXFLAGS += --gcc-toolchain=$(KOKKOS_INTERNAL_GCC_TOOLCHAIN)
   KOKKOS_LDFLAGS += --gcc-toolchain=$(KOKKOS_INTERNAL_GCC_TOOLCHAIN)
-endif
-
-# Don't include Kokkos_HBWSpace.cpp if not using MEMKIND to avoid a link warning.
-ifneq ($(KOKKOS_INTERNAL_USE_MEMKIND), 1)
-  KOKKOS_SRC := $(filter-out $(KOKKOS_PATH)/core/src/impl/Kokkos_HBWSpace.cpp,$(KOKKOS_SRC))
 endif
 
 # Don't include Kokkos_Serial.cpp or Kokkos_Serial_Task.cpp if not using Serial

--- a/core/src/Kokkos_HBWSpace.hpp
+++ b/core/src/Kokkos_HBWSpace.hpp
@@ -276,7 +276,7 @@ namespace Kokkos {
 namespace Impl {
 
 template< class ExecutionSpace >
-struct DeepCopy< Experimental::HBWSpace, Experimental::HBWSpace, ExecutionSpace > {
+struct DeepCopy< Kokkos::Experimental::HBWSpace, Kokkos::Experimental::HBWSpace, ExecutionSpace > {
   DeepCopy( void * dst, const void * src, size_t n ) {
     memcpy( dst, src, n );
   }
@@ -288,7 +288,7 @@ struct DeepCopy< Experimental::HBWSpace, Experimental::HBWSpace, ExecutionSpace 
 };
 
 template< class ExecutionSpace >
-struct DeepCopy< HostSpace, Experimental::HBWSpace, ExecutionSpace > {
+struct DeepCopy< HostSpace, Kokkos::Experimental::HBWSpace, ExecutionSpace > {
   DeepCopy( void * dst, const void * src, size_t n ) {
     memcpy( dst, src, n );
   }
@@ -300,7 +300,7 @@ struct DeepCopy< HostSpace, Experimental::HBWSpace, ExecutionSpace > {
 };
 
 template< class ExecutionSpace >
-struct DeepCopy< Experimental::HBWSpace, HostSpace, ExecutionSpace > {
+struct DeepCopy< Kokkos::Experimental::HBWSpace, HostSpace, ExecutionSpace > {
   DeepCopy( void * dst, const void * src, size_t n ) {
     memcpy( dst, src, n );
   }

--- a/core/src/impl/Kokkos_HBWSpace.cpp
+++ b/core/src/impl/Kokkos_HBWSpace.cpp
@@ -131,6 +131,10 @@ void * HBWSpace::allocate( const size_t arg_alloc_size ) const
     msg << "Kokkos::Experimental::HBWSpace::allocate[ " ;
     switch( m_alloc_mech ) {
     case STD_MALLOC: msg << "STD_MALLOC" ; break ;
+    case POSIX_MEMALIGN: msg << "POSIX_MEMALIGN" ; break ;
+    case POSIX_MMAP: msg << "POSIX_MMAP" ; break ;
+    case INTEL_MM_ALLOC: msg << "INTEL_MM_ALLOC" ; break ;
+   
     }
     msg << " ]( " << arg_alloc_size << " ) FAILED" ;
     if ( ptr == NULL ) { msg << " NULL" ; }

--- a/core/src/impl/Kokkos_HBWSpace.cpp
+++ b/core/src/impl/Kokkos_HBWSpace.cpp
@@ -57,9 +57,6 @@
 #include <Kokkos_HBWSpace.hpp>
 #include <impl/Kokkos_Error.hpp>
 #include <Kokkos_Atomic.hpp>
-#ifdef KOKKOS_ENABLE_HBWSPACE
-#include <memkind.h>
-#endif
 
 #if defined(KOKKOS_ENABLE_PROFILING)
 #include <impl/Kokkos_Profiling_Interface.hpp>
@@ -90,12 +87,7 @@ HBWSpace::HBWSpace( const HBWSpace::AllocationMechanism & arg_alloc_mech )
   : m_alloc_mech( HBWSpace::STD_MALLOC )
 {
 printf("Init2\n");
-setenv("MEMKIND_HBW_NODES", "1", 0);
-  if ( arg_alloc_mech == STD_MALLOC ) {
-    m_alloc_mech = HBWSpace::STD_MALLOC ;
-  }
 }
-
 void * HBWSpace::allocate( const size_t arg_alloc_size ) const
 {
   static_assert( sizeof(void*) == sizeof(uintptr_t)
@@ -115,7 +107,7 @@ void * HBWSpace::allocate( const size_t arg_alloc_size ) const
       // Over-allocate to and round up to guarantee proper alignment.
       size_t size_padded = arg_alloc_size + sizeof(void*) + alignment ;
 
-      void * alloc_ptr = memkind_malloc(MEMKIND_TYPE, size_padded );
+      void * alloc_ptr = malloc( size_padded );
 
       if (alloc_ptr) {
         uintptr_t address = reinterpret_cast<uintptr_t>(alloc_ptr);
@@ -160,7 +152,7 @@ void HBWSpace::deallocate( void * const arg_alloc_ptr , const size_t arg_alloc_s
 
     if ( m_alloc_mech == STD_MALLOC ) {
       void * alloc_ptr = *(reinterpret_cast<void **>(arg_alloc_ptr) -1);
-      memkind_free(MEMKIND_TYPE, alloc_ptr );
+      free(alloc_ptr );
     }
 
   }


### PR DESCRIPTION
Hey folks,

Over at https://github.com/kokkos/kokkos/issues/783 two years ago @ibaned and @mhoemmen were talking about a magical CUDA debug space which would be like CUDA, but not require a GPU, and be a little less rough than real CUDA development. @crtrott and @dsunder realized that you could cheat a little bit and use the "HBW" space as mockup for your "CUDA" space.

In my view, the goal of an effort like this is to turn the development loop of a multiphysics app Kokkos developer who is just starting a GPU port from

1. Compile (wait N hours)
2. Run and get a segfault
3. Fix that single segfault
4. See (1)

Into a workflow where they hit every mistake at once and get a warning. My implementation is as follows

1) Make HBW into something that just malloc's (this PR)
2) Make a Kokkos Tool which tracks allocations and poisons the HBW space on "Host" kernels, and poisons the "Host" space on "Device" kernels (https://github.com/kokkos/kokkos-tools/pull/63 that PR)

I'm not very adept at Kokkos Core, so I didn't want to make a "CudaDebug" ExecutionSpace, instead my tool just looks at the names of kernels, kernel names prefixed with "Host" are host kernels, those prefixed with "Device" are device ones. A real implementation might include such an ExecutionSpace so that people can properly mark their ExecutionPolicies and such.

The workflow is rather simple, you just compile with -fsanitize=address -fsanitize-recover=address , load the tool, and you get most of the functionality I've described. Optionally, if you add `ASAN_OPTIONS=halt_on_error=0` as an environment variable, you don't die on an error.

TODOS

- [ ] On an error, automatically do some migration (this way consecutive kernels don't warn on the same field)
- [ ] Migrate this functionality from HBWSpace to a new CudaDebugSpace
- [ ] Make a "CudaSimulation" ExecutionSpace

This PR is intended as a discussion for what a solid implementation of this would look like. If somebody was feeling charitable, implementing bullet point three is likely to be the thing I'm most held up by, if somebody knows how to make something which is precisely the "Serial" execution space except it can only see the (HBWSpace/CudaSimulationSpace) memory space, that would be a huge help.