### PR TITLE
Error messsaging for profiling

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -255,8 +255,10 @@ void initialize_internal(const InitArguments& args) {
 #if defined(KOKKOS_ENABLE_PROFILING)
   Kokkos::Profiling::initialize();
 #else
-  if(getenv("KOKKOS_PROFILE_LIBRARY")!=nullptr){
-    std::cerr << "Kokkos::initialize() warning: Requested Kokkos Profiling, but Kokkos was built without Profiling support" << std::endl;
+  if (getenv("KOKKOS_PROFILE_LIBRARY") != nullptr) {
+    std::cerr << "Kokkos::initialize() warning: Requested Kokkos Profiling, "
+                 "but Kokkos was built without Profiling support"
+              << std::endl;
   }
 #endif
   g_is_initialized = true;

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -254,6 +254,10 @@ void initialize_internal(const InitArguments& args) {
 
 #if defined(KOKKOS_ENABLE_PROFILING)
   Kokkos::Profiling::initialize();
+#else
+  if(getenv("KOKKOS_PROFILE_LIBRARY")!=nullptr){
+    std::cerr << "Kokkos::initialize() warning: Requested Kokkos Profiling, but Kokkos was built without Profiling support" << std::endl;
+  }
 #endif
   g_is_initialized = true;
 }


### PR DESCRIPTION
I was working with a code team this morning, people were wondering why Kokkos Tools don't work. It turns out that somewhere in a build script from a TPL sitting over Kokkos, the flag for profiling was switched off. 

This PR prints a message if somebody asks for profiling (by setting the environment variable) if the build doesn't support profiling (as determined by the preprocessor macros).