### PR TITLE
Fixup for operator[] in zero-sized array specialization

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -201,6 +201,7 @@ struct Array<T, 0, Proxy> {
         (std::is_integral<iType>::value || std::is_enum<iType>::value),
         "Must be integer argument");
     Kokkos::abort("Unreachable code");
+    return value_type();
   }
 
   template <typename iType>
@@ -209,6 +210,7 @@ struct Array<T, 0, Proxy> {
         (std::is_integral<iType>::value || std::is_enum<iType>::value),
         "Must be integer argument");
     Kokkos::abort("Unreachable code");
+    return value_type();
   }
 
   KOKKOS_INLINE_FUNCTION pointer data() { return pointer(0); }

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -183,12 +183,12 @@ struct Array {
 template <class T, class Proxy>
 struct Array<T, 0, Proxy> {
  public:
-  typedef typename std::add_const<T>::type& reference;
+  typedef T& reference;
   typedef typename std::add_const<T>::type& const_reference;
   typedef size_t size_type;
   typedef ptrdiff_t difference_type;
-  typedef typename std::add_const<T>::type value_type;
-  typedef typename std::add_const<T>::type* pointer;
+  typedef T value_type;
+  typedef T* pointer;
   typedef typename std::add_const<T>::type* const_pointer;
 
   KOKKOS_INLINE_FUNCTION static constexpr size_type size() { return 0; }

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -200,6 +200,7 @@ struct Array<T, 0, Proxy> {
     static_assert(
         (std::is_integral<iType>::value || std::is_enum<iType>::value),
         "Must be integer argument");
+    Kokkos::abort("Unreachable code");
   }
 
   template <typename iType>
@@ -207,6 +208,7 @@ struct Array<T, 0, Proxy> {
     static_assert(
         (std::is_integral<iType>::value || std::is_enum<iType>::value),
         "Must be integer argument");
+    Kokkos::abort("Unreachable code");
   }
 
   KOKKOS_INLINE_FUNCTION pointer data() { return pointer(0); }

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -196,19 +196,17 @@ struct Array<T, 0, Proxy> {
   KOKKOS_INLINE_FUNCTION constexpr size_type max_size() const { return 0; }
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION value_type operator[](const iType&) {
+  KOKKOS_INLINE_FUNCTION reference operator[](const iType&) {
     static_assert(
         (std::is_integral<iType>::value || std::is_enum<iType>::value),
         "Must be integer argument");
-    return value_type();
   }
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION value_type operator[](const iType&) const {
+  KOKKOS_INLINE_FUNCTION const_reference operator[](const iType&) const {
     static_assert(
         (std::is_integral<iType>::value || std::is_enum<iType>::value),
         "Must be integer argument");
-    return value_type();
   }
 
   KOKKOS_INLINE_FUNCTION pointer data() { return pointer(0); }

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -201,7 +201,7 @@ struct Array<T, 0, Proxy> {
         (std::is_integral<iType>::value || std::is_enum<iType>::value),
         "Must be integer argument");
     Kokkos::abort("Unreachable code");
-    return value_type();
+    return *reinterpret_cast<pointer>(-1);
   }
 
   template <typename iType>
@@ -210,7 +210,7 @@ struct Array<T, 0, Proxy> {
         (std::is_integral<iType>::value || std::is_enum<iType>::value),
         "Must be integer argument");
     Kokkos::abort("Unreachable code");
-    return value_type();
+    return *reinterpret_cast<const_pointer>(-1);
   }
 
   KOKKOS_INLINE_FUNCTION pointer data() { return pointer(0); }

--- a/core/unit_test/TestAggregate.hpp
+++ b/core/unit_test/TestAggregate.hpp
@@ -128,6 +128,15 @@ void TestViewAggregate() {
   }
   // But the following line would not compile
   //  Kokkos::Array< double, 3 > initialized_with_too_many{ { 1, 2, 3, 4 } };
+
+  // The code below must compile for zero-sized arrays.
+  using T = float;
+
+  constexpr std::size_t N = 0;
+  Kokkos::Array<T, N> a;
+  for (std::size_t i = 0; i < N; ++i) {
+    a[i] = T();
+  }
 }
 
 TEST_F(TEST_CATEGORY, view_aggregate) { TestViewAggregate<TEST_EXECSPACE>(); }

--- a/core/unit_test/TestAggregate.hpp
+++ b/core/unit_test/TestAggregate.hpp
@@ -132,9 +132,9 @@ void TestViewAggregate() {
   // The code below must compile for zero-sized arrays.
   using T = float;
 
-  constexpr std::size_t N = 0;
+  constexpr int N = 0;
   Kokkos::Array<T, N> a;
-  for (std::size_t i = 0; i < N; ++i) {
+  for (int i = 0; i < N; ++i) {
     a[i] = T();
   }
 }


### PR DESCRIPTION
Consider
```C++
template <typename T, std::size_t N>
KOKKOS_FUNCTION void test() {
  Kokkos::Array<double, N> a;
  for (int i = 0; i < N; ++i)
    a[i] = T();
}
```
Without these changes, this code would not compile if attempting to instantiate `test` for `N == 0`.