### PR TITLE
Get rid of fixtures in containers unit tests

### DIFF
--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -6,12 +6,12 @@ KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../src )
 foreach(Tag Threads;Serial;OpenMP;HPX;Cuda)
   # Because there is always an exception to the rule
   if(Tag STREQUAL "Threads")
-    set(ARCH "PTHREAD")
+    set(DEVICE "PTHREAD")
   else()
-    string(TOUPPER ${Tag} ARCH)
+    string(TOUPPER ${Tag} DEVICE)
   endif()
   # Add test for that backend if it is enabled
-  if(Kokkos_ENABLE_${ARCH})
+  if(Kokkos_ENABLE_${DEVICE})
     KOKKOS_ADD_EXECUTABLE_AND_TEST(
       UnitTest_${Tag}
       SOURCES

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -3,108 +3,32 @@ KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 KOKKOS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
 KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../src )
 
-IF(Kokkos_ENABLE_PTHREAD)
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  UnitTest_Threads
-  SOURCES
-    UnitTestMain.cpp
-    threads/TestThreads_BitSet.cpp
-    threads/TestThreads_DualView.cpp
-    threads/TestThreads_DynamicView.cpp
-    threads/TestThreads_DynRankViewAPI_generic.cpp
-    threads/TestThreads_DynRankViewAPI_rank12345.cpp
-    threads/TestThreads_DynRankViewAPI_rank67.cpp
-    threads/TestThreads_ErrorReporter.cpp
-    threads/TestThreads_OffsetView.cpp
-    threads/TestThreads_ScatterView.cpp
-    threads/TestThreads_StaticCrsGraph.cpp
-    threads/TestThreads_UnorderedMap.cpp
-    threads/TestThreads_Vector.cpp
-    threads/TestThreads_ViewCtorPropEmbeddedDim.cpp
-  )
-ENDIF()
-
-IF(Kokkos_ENABLE_SERIAL)
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  UnitTest_Serial
-  SOURCES
-    UnitTestMain.cpp
-    serial/TestSerial_BitSet.cpp
-    serial/TestSerial_DualView.cpp
-    serial/TestSerial_DynamicView.cpp
-    serial/TestSerial_DynRankViewAPI_generic.cpp
-    serial/TestSerial_DynRankViewAPI_rank12345.cpp
-    serial/TestSerial_DynRankViewAPI_rank67.cpp
-    serial/TestSerial_ErrorReporter.cpp
-    serial/TestSerial_OffsetView.cpp
-    serial/TestSerial_ScatterView.cpp
-    serial/TestSerial_StaticCrsGraph.cpp
-    serial/TestSerial_UnorderedMap.cpp
-    serial/TestSerial_Vector.cpp
-    serial/TestSerial_ViewCtorPropEmbeddedDim.cpp
-  )
-ENDIF()
-
-IF(Kokkos_ENABLE_OPENMP)
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  UnitTest_OpenMP
-  SOURCES
-    UnitTestMain.cpp
-    openmp/TestOpenMP_BitSet.cpp
-    openmp/TestOpenMP_DualView.cpp
-    openmp/TestOpenMP_DynamicView.cpp
-    openmp/TestOpenMP_DynRankViewAPI_generic.cpp
-    openmp/TestOpenMP_DynRankViewAPI_rank12345.cpp
-    openmp/TestOpenMP_DynRankViewAPI_rank67.cpp
-    openmp/TestOpenMP_ErrorReporter.cpp
-    openmp/TestOpenMP_OffsetView.cpp
-    openmp/TestOpenMP_ScatterView.cpp
-    openmp/TestOpenMP_StaticCrsGraph.cpp
-    openmp/TestOpenMP_UnorderedMap.cpp
-    openmp/TestOpenMP_Vector.cpp
-    openmp/TestOpenMP_ViewCtorPropEmbeddedDim.cpp
-  )
-ENDIF()
-
-IF(Kokkos_ENABLE_HPX)
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  UnitTest_HPX
-  SOURCES
-    UnitTestMain.cpp
-    hpx/TestHPX_BitSet.cpp
-    hpx/TestHPX_DualView.cpp
-    hpx/TestHPX_DynamicView.cpp
-    hpx/TestHPX_DynRankViewAPI_generic.cpp
-    hpx/TestHPX_DynRankViewAPI_rank12345.cpp
-    hpx/TestHPX_DynRankViewAPI_rank67.cpp
-    hpx/TestHPX_ErrorReporter.cpp
-    hpx/TestHPX_OffsetView.cpp
-    hpx/TestHPX_ScatterView.cpp
-    hpx/TestHPX_StaticCrsGraph.cpp
-    hpx/TestHPX_UnorderedMap.cpp
-    hpx/TestHPX_Vector.cpp
-    hpx/TestHPX_ViewCtorPropEmbeddedDim.cpp
-  )
-ENDIF()
-
-IF(Kokkos_ENABLE_CUDA)
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  UnitTest_Cuda
-  SOURCES
-    UnitTestMain.cpp
-    cuda/TestCuda_BitSet.cpp
-    cuda/TestCuda_DualView.cpp
-    cuda/TestCuda_DynamicView.cpp
-    cuda/TestCuda_DynRankViewAPI_generic.cpp
-    cuda/TestCuda_DynRankViewAPI_rank12345.cpp
-    cuda/TestCuda_DynRankViewAPI_rank67.cpp
-    cuda/TestCuda_ErrorReporter.cpp
-    cuda/TestCuda_OffsetView.cpp
-    cuda/TestCuda_ScatterView.cpp
-    cuda/TestCuda_StaticCrsGraph.cpp
-    cuda/TestCuda_UnorderedMap.cpp
-    cuda/TestCuda_Vector.cpp
-    cuda/TestCuda_ViewCtorPropEmbeddedDim.cpp
-  )
-ENDIF()
-
+foreach(Tag Threads;Serial;OpenMP;HPX;Cuda)
+  # Because there is always an exception to the rule
+  if(Tag STREQUAL "Threads")
+    set(ARCH "PTHREAD")
+  else()
+    string(TOUPPER ${Tag} ARCH)
+  endif()
+  # Add test for that backend if it is enabled
+  if(Kokkos_ENABLE_${ARCH})
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+      UnitTest_${Tag}
+      SOURCES
+        UnitTestMain.cpp
+        ${Tag}/Test${Tag}_BitSet.cpp
+        ${Tag}/Test${Tag}_DualView.cpp
+        ${Tag}/Test${Tag}_DynamicView.cpp
+        ${Tag}/Test${Tag}_DynRankViewAPI_generic.cpp
+        ${Tag}/Test${Tag}_DynRankViewAPI_rank12345.cpp
+        ${Tag}/Test${Tag}_DynRankViewAPI_rank67.cpp
+        ${Tag}/Test${Tag}_ErrorReporter.cpp
+        ${Tag}/Test${Tag}_OffsetView.cpp
+        ${Tag}/Test${Tag}_ScatterView.cpp
+        ${Tag}/Test${Tag}_StaticCrsGraph.cpp
+        ${Tag}/Test${Tag}_UnorderedMap.cpp
+        ${Tag}/Test${Tag}_Vector.cpp
+        ${Tag}/Test${Tag}_ViewCtorPropEmbeddedDim.cpp
+      )
+  endif()
+endforeach()

--- a/containers/unit_tests/TestBitset.hpp
+++ b/containers/unit_tests/TestBitset.hpp
@@ -252,7 +252,7 @@ void test_bitset() {
   }
 }
 
-TEST_F(TEST_CATEGORY, bitset) { test_bitset<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, bitset) { test_bitset<TEST_EXECSPACE>(); }
 
 }  // namespace Test
 

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -199,11 +199,11 @@ void test_dualview_deep_copy() {
   Impl::test_dual_view_deep_copy<Scalar, Device>();
 }
 
-TEST_F(TEST_CATEGORY, dualview_combination) {
+TEST(TEST_CATEGORY, dualview_combination) {
   test_dualview_combinations<int, TEST_EXECSPACE>(10);
 }
 
-TEST_F(TEST_CATEGORY, dualview_deep_copy) {
+TEST(TEST_CATEGORY, dualview_deep_copy) {
   test_dualview_deep_copy<int, TEST_EXECSPACE>();
   test_dualview_deep_copy<double, TEST_EXECSPACE>();
 }

--- a/containers/unit_tests/TestDynViewAPI_generic.hpp
+++ b/containers/unit_tests/TestDynViewAPI_generic.hpp
@@ -43,7 +43,7 @@
 
 #include <TestDynViewAPI.hpp>
 namespace Test {
-TEST_F(TEST_CATEGORY, dyn_rank_view_api_generic) {
+TEST(TEST_CATEGORY, dyn_rank_view_api_generic) {
   TestDynViewAPI<double, TEST_EXECSPACE>::run_tests();
 }
 }  // namespace Test

--- a/containers/unit_tests/TestDynViewAPI_rank12345.hpp
+++ b/containers/unit_tests/TestDynViewAPI_rank12345.hpp
@@ -44,7 +44,7 @@
 #include <TestDynViewAPI.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, dyn_rank_view_api_operator_rank12345) {
+TEST(TEST_CATEGORY, dyn_rank_view_api_operator_rank12345) {
   TestDynViewAPI<double, TEST_EXECSPACE>::run_operator_test_rank12345();
 }
 }  // namespace Test

--- a/containers/unit_tests/TestDynViewAPI_rank67.hpp
+++ b/containers/unit_tests/TestDynViewAPI_rank67.hpp
@@ -43,7 +43,7 @@
 
 #include <TestDynViewAPI.hpp>
 namespace Test {
-TEST_F(TEST_CATEGORY, dyn_rank_view_api_operator_rank67) {
+TEST(TEST_CATEGORY, dyn_rank_view_api_operator_rank67) {
   TestDynViewAPI<double, TEST_EXECSPACE>::run_operator_test_rank67();
 }
 }  // namespace Test

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -233,7 +233,7 @@ struct TestDynamicView {
   }
 };
 
-TEST_F(TEST_CATEGORY, dynamic_view) {
+TEST(TEST_CATEGORY, dynamic_view) {
   typedef TestDynamicView<double, TEST_EXECSPACE> TestDynView;
 
   for (int i = 0; i < 10; ++i) {

--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -225,12 +225,12 @@ struct ErrorReporterDriverNativeOpenMP
 #endif
 
 #if defined(KOKKOS_CLASS_LAMBDA)
-TEST_F(TEST_CATEGORY, ErrorReporterViaLambda) {
+TEST(TEST_CATEGORY, ErrorReporterViaLambda) {
   TestErrorReporter<ErrorReporterDriverUseLambda<TEST_EXECSPACE>>();
 }
 #endif
 
-TEST_F(TEST_CATEGORY, ErrorReporter) {
+TEST(TEST_CATEGORY, ErrorReporter) {
   TestErrorReporter<ErrorReporterDriver<TEST_EXECSPACE>>();
 }
 

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -460,10 +460,10 @@ void test_offsetview_subview(unsigned int size) {
   }
 }
 
-TEST_F(TEST_CATEGORY, offsetview_construction) {
+TEST(TEST_CATEGORY, offsetview_construction) {
   test_offsetview_construction<int, TEST_EXECSPACE>(10);
 }
-TEST_F(TEST_CATEGORY, offsetview_subview) {
+TEST(TEST_CATEGORY, offsetview_subview) {
   test_offsetview_subview<int, TEST_EXECSPACE>(10);
 }
 

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -479,7 +479,7 @@ void test_scatter_view(int n) {
   TestDuplicatedScatterView<ExecSpace, ScatterType> duptest(n);
 }
 
-TEST_F(TEST_CATEGORY, scatterview) {
+TEST(TEST_CATEGORY, scatterview) {
 #ifndef KOKKOS_ENABLE_ROCM
   test_scatter_view<TEST_EXECSPACE, Kokkos::Experimental::ScatterSum>(10);
   test_scatter_view<TEST_EXECSPACE, Kokkos::Experimental::ScatterProd>(10);

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -45,6 +45,7 @@
 #define KOKKOS_TEST_SCATTER_VIEW_HPP
 
 #include <Kokkos_ScatterView.hpp>
+#include <gtest/gtest.h>
 
 namespace Test {
 

--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -275,7 +275,7 @@ void run_test_graph4() {
 
 } /* namespace TestStaticCrsGraph */
 
-TEST_F(TEST_CATEGORY, staticcrsgraph) {
+TEST(TEST_CATEGORY, staticcrsgraph) {
   TestStaticCrsGraph::run_test_graph<TEST_EXECSPACE>();
   TestStaticCrsGraph::run_test_graph2<TEST_EXECSPACE>();
   TestStaticCrsGraph::run_test_graph3<TEST_EXECSPACE>(1, 0);

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -290,18 +290,18 @@ void test_deep_copy(uint32_t num_nodes) {
   }
 }
 
-TEST_F(TEST_CATEGORY, UnorderedMap_insert) {
+TEST(TEST_CATEGORY, UnorderedMap_insert) {
   for (int i = 0; i < 500; ++i) {
     test_insert<TEST_EXECSPACE>(100000, 90000, 100, true);
     test_insert<TEST_EXECSPACE>(100000, 90000, 100, false);
   }
 }
 
-TEST_F(TEST_CATEGORY, UnorderedMap_failed_insert) {
+TEST(TEST_CATEGORY, UnorderedMap_failed_insert) {
   for (int i = 0; i < 1000; ++i) test_failed_insert<TEST_EXECSPACE>(10000);
 }
 
-TEST_F(TEST_CATEGORY, UnorderedMap_deep_copy) {
+TEST(TEST_CATEGORY, UnorderedMap_deep_copy) {
   for (int i = 0; i < 2; ++i) test_deep_copy<TEST_EXECSPACE>(10000);
 }
 

--- a/containers/unit_tests/TestVector.hpp
+++ b/containers/unit_tests/TestVector.hpp
@@ -111,7 +111,7 @@ void test_vector_combinations(unsigned int size) {
   ASSERT_EQ(test.reference, test.result);
 }
 
-TEST_F(TEST_CATEGORY, vector_combination) {
+TEST(TEST_CATEGORY, vector_combination) {
   test_vector_combinations<int, TEST_EXECSPACE>(10);
   test_vector_combinations<int, TEST_EXECSPACE>(3057);
 }

--- a/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
+++ b/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
@@ -206,7 +206,7 @@ struct TestViewCtorProp_EmbeddedDim {
 
 }  // namespace
 
-TEST_F(TEST_CATEGORY, viewctorprop_embedded_dim) {
+TEST(TEST_CATEGORY, viewctorprop_embedded_dim) {
   TestViewCtorProp_EmbeddedDim<TEST_EXECSPACE>::test_vcpt(2, 3);
 }
 }  // namespace Test

--- a/containers/unit_tests/UnitTestMain.cpp
+++ b/containers/unit_tests/UnitTestMain.cpp
@@ -42,7 +42,6 @@
 */
 
 #include <gtest/gtest.h>
-#include <cstdlib>
 #include <Kokkos_Core.hpp>
 
 int main(int argc, char *argv[]) {

--- a/containers/unit_tests/cuda/TestCuda_Category.hpp
+++ b/containers/unit_tests/cuda/TestCuda_Category.hpp
@@ -44,19 +44,6 @@
 #ifndef KOKKOS_TEST_CUDA_HPP
 #define KOKKOS_TEST_CUDA_HPP
 
-#include <gtest/gtest.h>
-
-namespace Test {
-
-class cuda : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY cuda
 #define TEST_EXECSPACE Kokkos::Cuda
 

--- a/containers/unit_tests/hpx/TestHPX_Category.hpp
+++ b/containers/unit_tests/hpx/TestHPX_Category.hpp
@@ -44,19 +44,6 @@
 #ifndef KOKKOS_TEST_HPX_HPP
 #define KOKKOS_TEST_HPX_HPP
 
-#include <gtest/gtest.h>
-
-namespace Test {
-
-class hpx : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY hpx
 #define TEST_EXECSPACE Kokkos::Experimental::HPX
 

--- a/containers/unit_tests/openmp/TestOpenMP_Category.hpp
+++ b/containers/unit_tests/openmp/TestOpenMP_Category.hpp
@@ -44,19 +44,6 @@
 #ifndef KOKKOS_TEST_OPENMP_HPP
 #define KOKKOS_TEST_OPENMP_HPP
 
-#include <gtest/gtest.h>
-
-namespace Test {
-
-class openmp : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY openmp
 #define TEST_EXECSPACE Kokkos::OpenMP
 

--- a/containers/unit_tests/rocm/TestROCm_Category.hpp
+++ b/containers/unit_tests/rocm/TestROCm_Category.hpp
@@ -44,19 +44,6 @@
 #ifndef KOKKOS_TEST_ROCM_HPP
 #define KOKKOS_TEST_ROCM_HPP
 
-#include <gtest/gtest.h>
-
-namespace Test {
-
-class rocm : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY rocm
 #define TEST_EXECSPACE Kokkos::Experimental::ROCm
 

--- a/containers/unit_tests/serial/TestSerial_Category.hpp
+++ b/containers/unit_tests/serial/TestSerial_Category.hpp
@@ -44,19 +44,6 @@
 #ifndef KOKKOS_TEST_SERIAL_HPP
 #define KOKKOS_TEST_SERIAL_HPP
 
-#include <gtest/gtest.h>
-
-namespace Test {
-
-class serial : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY serial
 #define TEST_EXECSPACE Kokkos::Serial
 

--- a/containers/unit_tests/threads/TestThreads_Category.hpp
+++ b/containers/unit_tests/threads/TestThreads_Category.hpp
@@ -44,19 +44,6 @@
 #ifndef KOKKOS_TEST_THREADS_HPP
 #define KOKKOS_TEST_THREADS_HPP
 
-#include <gtest/gtest.h>
-
-namespace Test {
-
-class threads : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY threads
 #define TEST_EXECSPACE Kokkos::Threads
 


### PR DESCRIPTION
Partially addressing #2152 