### PR TITLE
Fixup CUDA testing on Jenkins server

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -90,7 +90,7 @@ pipeline {
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \
                                 -DKokkos_DEVICES=CUDA \
                                 -DKokkos_ARCH=Volta70 \
-                                -DKokkos_OPTIONS=COMPILER_WARNINGS,CUDA_LAMBDA,RELOCATABLE_DEVICE_CODE,FORCE_UVM \
+                                -DKokkos_OPTIONS=COMPILER_WARNINGS,CUDA_LAMBDA,CUDA_RELOCATABLE_DEVICE_CODE,CUDA_UVM \
                                 -DKokkos_ENABLE_TESTS=ON \
                               .. && \
                               make -j8 && ctest --output-on-failure'''


### PR DESCRIPTION
This cannot wait for the resolution of #2289 

`FORCE_UVM` is not a valid option for CMake at the moment.  Changing it to `CUDA_UVM` is more straightforward than allowing the missing option.

Also note the missing `CUDA_` prefix on the RDC option.  I think this calls for us adding some mechanism of validation for the variable `Kokkos_OPTIONS` that is passed at configuration time.