### PR TITLE
Make CMake warn on builds with object files in core/src directory

### DIFF
--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -191,6 +191,11 @@ MACRO(KOKKOS_SETUP_BUILD_ENVIRONMENT)
   INCLUDE(${KOKKOS_SRC_PATH}/cmake/kokkos_cxx_std.cmake)
   INCLUDE(${KOKKOS_SRC_PATH}/cmake/kokkos_tpls.cmake)
   INCLUDE(${KOKKOS_SRC_PATH}/cmake/kokkos_arch.cmake)
+
+  FILE(GLOB OBJECT_FILES_IN_SOURCE_DIRECTORY ${KOKKOS_SRC_PATH}/core/src/*.o)
+  IF(OBJECT_FILES_IN_SOURCE_DIRECTORY)
+    MESSAGE(WARNING "Running cmake with object files in the core/src directory, build may behave unexpectedly")
+  ENDIF()
  ENDIF()
 ENDMACRO()
 


### PR DESCRIPTION
Fixes #2298 

If we have object files in the `core/src/` directory, all CMake builds in some way seem to defer to those object files, leading to unexpected results (see the linked bug).

This way we at least give a warning when that behavior happens.

Ideally, we would just stop whatever influences the core/src object files have on CMake builds, but if that has to happen for legacy reasons, this at least warns people.