### PR TITLE
Fix duplicated standard flags

### DIFF
--- a/cmake/kokkos_cxx_std.cmake
+++ b/cmake/kokkos_cxx_std.cmake
@@ -133,7 +133,7 @@ ELSE()
   ENDIF()
   #okay, this is funky - kill this variable
   #this value is not really valid as a cmake variable
-  UNSET(CMAKE_CXX_STANDARD CACHE)
+  UNSET(CMAKE_CXX_STANDARD)
   IF     (KOKKOS_CXX_STANDARD STREQUAL "1Y")
     GLOBAL_SET(KOKKOS_ENABLE_CXX14 ON)
   ELSEIF (KOKKOS_CXX_STANDARD STREQUAL "1Z")

--- a/cmake/kokkos_cxx_std.cmake
+++ b/cmake/kokkos_cxx_std.cmake
@@ -178,7 +178,7 @@ IF(KOKKOS_ENABLE_CUDA)
 ENDIF()
 
 IF (NOT KOKKOS_CXX_STANDARD_FEATURE)
-  UNSET(CMAKE_CXX_STANDARD CACHE) #don't let cmake do this as a feature either
+  UNSET(CMAKE_CXX_STANDARD) #don't let cmake do this as a feature either
   #we need to pick the C++ flags ourselves
   IF(KOKKOS_CXX_COMPILER_ID STREQUAL Cray)
     INCLUDE(${KOKKOS_SRC_PATH}/cmake/cray.cmake)

--- a/cmake/kokkos_cxx_std.cmake
+++ b/cmake/kokkos_cxx_std.cmake
@@ -179,7 +179,6 @@ IF(KOKKOS_ENABLE_CUDA)
 ENDIF()
 
 IF (NOT KOKKOS_CXX_STANDARD_FEATURE)
-  #don't let cmake do this as a feature either
   #we need to pick the C++ flags ourselves
   UNSET(CMAKE_CXX_STANDARD)
   UNSET(CMAKE_CXX_STANDARD CACHE)

--- a/cmake/kokkos_cxx_std.cmake
+++ b/cmake/kokkos_cxx_std.cmake
@@ -134,6 +134,7 @@ ELSE()
   #okay, this is funky - kill this variable
   #this value is not really valid as a cmake variable
   UNSET(CMAKE_CXX_STANDARD)
+  UNSET(CMAKE_CXX_STANDARD CACHE)
   IF     (KOKKOS_CXX_STANDARD STREQUAL "1Y")
     GLOBAL_SET(KOKKOS_ENABLE_CXX14 ON)
   ELSEIF (KOKKOS_CXX_STANDARD STREQUAL "1Z")
@@ -178,8 +179,10 @@ IF(KOKKOS_ENABLE_CUDA)
 ENDIF()
 
 IF (NOT KOKKOS_CXX_STANDARD_FEATURE)
-  UNSET(CMAKE_CXX_STANDARD) #don't let cmake do this as a feature either
+  #don't let cmake do this as a feature either
   #we need to pick the C++ flags ourselves
+  UNSET(CMAKE_CXX_STANDARD)
+  UNSET(CMAKE_CXX_STANDARD CACHE)
   IF(KOKKOS_CXX_COMPILER_ID STREQUAL Cray)
     INCLUDE(${KOKKOS_SRC_PATH}/cmake/cray.cmake)
     kokkos_set_cray_flags(${KOKKOS_CXX_STANDARD})


### PR DESCRIPTION
Without this change we currently get
```
cd /scratch/my_docker/kokkos/build/core/src && /scratch/my_docker/kokkos/bin/nvcc_wrapper   -I/scratch/my_docker/kokkos/build/core/src -I/scratch/my_docker/kokkos/core/src -I/scratch/my_docker/kokkos/build  -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored -std=c++11 -std=c++11 -o CMakeFiles/kokkoscore.dir/impl/Kokkos_CPUDiscovery.cpp.o -c /scratch/my_docker/kokkos/core/src/impl/Kokkos_CPUDiscovery.cpp
nvcc_wrapper - *warning* you have set multiple optimization flags (-std=c++1* or --std=c++1*), only the first is used because nvcc can only accept a single std setting
```
In particular, the standard flag is always duplicated.