### PR TITLE
Temporarily drop CUDA relocatable device code testing on Jenkins

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -90,7 +90,7 @@ pipeline {
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \
                                 -DKokkos_ENABLE_CUDA=ON \
                                 -DKokkos_ARCH=Volta70 \
-                                -DKokkos_OPTIONS=COMPILER_WARNINGS,CUDA_LAMBDA,CUDA_RELOCATABLE_DEVICE_CODE,CUDA_UVM \
+                                -DKokkos_OPTIONS=COMPILER_WARNINGS,CUDA_LAMBDA,CUDA_UVM \
                                 -DKokkos_ENABLE_TESTS=ON \
                               .. && \
                               make -j8 && ctest --output-on-failure'''


### PR DESCRIPTION
Rational:
* `-DKokkos_DEVICES=FOO,BAR` still has some surprising behavior at the moment
*  I don't think RDC has actually ever worked with CMake and this blocks other efforts because they now have to fix several loosely related issued at the same time
