### PR TITLE
CMake test all sandia script updates.

### DIFF
--- a/cm_generate_makefile.bash
+++ b/cm_generate_makefile.bash
@@ -1,5 +1,80 @@
 #!/bin/bash
 
+update_kokkos_devices() {
+   SEARCH_TEXT="*$1*"
+   if [[ $KOKKOS_DEVICES == $SEARCH_TEXT ]]; then
+      echo kokkos devices already includes $SEARCH_TEXT
+   else
+      if [ "$KOKKOS_DEVICES" = "" ]; then
+         KOKKOS_DEVICES="$1"
+         echo reseting kokkos devices to $KOKKOS_DEVICES
+      else
+         KOKKOS_DEVICES="${KOKKOS_DEVICES},$1"
+         echo appending to kokkos devices $KOKKOS_DEVICES
+      fi
+   fi
+}
+
+get_kokkos_device_list() {
+  KOKKOS_DEVICE_CMD=
+  PARSE_DEVICES_LST=$(echo $KOKKOS_DEVICES | tr "," "\n")
+  for DEVICE_ in $PARSE_DEVICES_LST
+  do 
+     KOKKOS_DEVICE_CMD="-DKokkos_ENABLE_${DEVICE_^^}=ON ${KOKKOS_DEVICE_CMD}"
+  done
+}
+
+get_kokkos_arch_list() {
+  KOKKOS_ARCH_CMD=
+  PARSE_ARCH_LST=$(echo $KOKKOS_ARCH | tr "," "\n")
+  for ARCH_ in $PARSE_ARCH_LST
+  do 
+     KOKKOS_ARCH_CMD="-DKokkos_ARCH_${ARCH_^^}=ON ${KOKKOS_ARCH_CMD}"
+  done
+}
+
+get_kokkos_cuda_option_list() {
+  echo parsing KOKKOS_CUDA_OPTIONS=$KOKKOS_CUDA_OPTIONS
+  KOKKOS_CUDA_OPTION_CMD=
+  PARSE_CUDA_LST=$(echo $KOKKOS_CUDA_OPTIONS | tr "," "\n")
+  for CUDA_ in $PARSE_CUDA_LST
+  do 
+     CUDA_OPT_NAME=
+     if [ "${CUDA_}" == "enable_lambda"]; then
+        CUDA_OPT_NAME=CUDA_LAMBDA
+     elif  [ "${CUDA_}" == "rdc"]; then	
+        CUDA_OPT_NAME=CUDA_RELOCATABLE_DEVICE_CODE
+     elif  [ "${CUDA_}" == "force_uvm"]; then
+        CUDA_OPT_NAME=CUDA_UVM
+     elif  [ "${CUDA_}" == "use_ldg"]; then
+        CUDA_OPT_NAME=CUDA_LDG_INTRINSIC
+     else
+        echo "${CUDA_} is not a valid cuda options..."
+     fi
+     if [ "${CUDA_OPT_NAME}" != "" ]; then
+        KOKKOS_CUDA_OPTION_CMD="-DKokkos_ENABLE_${CUDA_OPT_NAME}=ON ${KOKKOS_CUDA_OPTION_CMD}"
+     fi
+  done
+}
+
+get_kokkos_option_list() {
+  echo parsing KOKKOS_OPTIONS=$KOKKOS_OPTIONS
+  KOKKOS_OPTION_CMD=
+  PARSE_OPTIONS_LST=$(echo $KOKKOS_OPTIONS | tr "," "\n")
+  for OPT_ in $PARSE_OPTIONS_LST
+  do 
+     UC_OPT_ = ${OPT_}
+     if [[ "$UC_OPT_" == *DISABLE* ]]; then
+        FLIP_OPT_ = ${UC_OPT_/DISABLE/ENABLE}
+        KOKKOS_OPTION_CMD="-DKokkos_${FLIP_OPT_}=OFF ${KOKKOS_OPTION_CMD}"
+     elif [[ "$UC_OPT_" == *ENABLE* ]]; then
+        KOKKOS_OPTION_CMD="-DKokkos_${UC_OPT_}=ON ${KOKKOS_OPTION_CMD}"
+     else
+        KOKKOS_OPTION_CMD="-DKokkos_ENABLE_${UC_OPT_}=ON ${KOKKOS_OPTION_CMD}"
+     fi
+  done
+}
+
 KOKKOS_DO_EXAMPLES=ON
 
 while [[ $# > 0 ]]
@@ -20,7 +95,7 @@ do
       PREFIX="${key#*=}"
       ;;
     --with-cuda)
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},Cuda"
+      update_kokkos_devices Cuda
       CUDA_PATH_NVCC=$(command -v nvcc)
       CUDA_PATH=${CUDA_PATH_NVCC%/bin/nvcc}
       ;;
@@ -29,23 +104,23 @@ do
       KOKKOS_CUDA_OPT="${key#*=}"
       ;;
     --with-cuda*)
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},Cuda"
+      update_kokkos_devices Cuda
       CUDA_PATH="${key#*=}"
       ;;
     --with-rocm)
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},ROCm"
+      update_kokkos_devices ROCm
       ;;
     --with-openmp)
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},OpenMP"
+      update_kokkos_devices OpenMP
       ;;
     --with-pthread)
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},Pthread"
+      update_kokkos_devices Pthread
       ;;
     --with-serial)
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},Serial"
+      update_kokkos_devices Serial
       ;;
     --with-qthreads*)
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},Qthreads"
+      update_kokkos_devices Qthreads
       if [ -z "$QTHREADS_PATH" ]; then
         QTHREADS_PATH="${key#*=}"
       fi
@@ -54,14 +129,18 @@ do
       KOKKOS_HPX_OPT="${key#*=}"
       ;;
     --with-hpx*)
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},HPX"
+      update_kokkos_devices HPX
       if [ -z "$HPX_PATH" ]; then
         HPX_PATH="${key#*=}"
       fi
       ;;
     --with-devices*)
       DEVICES="${key#*=}"
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},${DEVICES}"
+      PARSE_DEVICES=$(echo $DEVICES | tr "," "\n")
+      for DEVICE_ in $PARSE_DEVICES
+      do 
+         update_kokkos_devices $DEVICE_
+      done
       ;;
     --with-gtest*)
       GTEST_PATH="${key#*=}"
@@ -217,4 +296,10 @@ else
     COMPILER_CMD='-DCMAKE_CXX_COMPILER=$COMPILER'
 fi
 
-cmake $COMPILER_CMD -DCMAKE_INSTALL_PREFIX=${PREFIX} -DKOKKOS_DEVICES=$KOKKOS_DEVICES -DKOKKOS_ARCH=$KOKKOS_ARCH -DKOKKOS_ENABLE_TESTS=ON -DKOKKOS_ENABLE_EXAMPLES=${KOKKOS_DO_EXAMPLES} -DKOKKOS_OPTIONS=${KOKKOS_OPT} -DCMAKE_CXX_COMPILER=${COMPILER} -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_CXX_EXTENSIONS=OFF -DKOKKOS_CUDA_DIR=${CUDA_PATH} ${KOKKOS_PATH}
+get_kokkos_device_list
+get_kokkos_option_list
+get_kokkos_arch_list
+get_kokkos_cuda_option_list
+
+echo cmake $COMPILER_CMD  -DCMAKE_CXX_FLAGS="${CXXFLAGS}" -DCMAKE_INSTALL_PREFIX=${PREFIX} ${KOKKOS_DEVICE_CMD} ${KOKKOS_ARCH_CMD} -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_EXAMPLES=${KOKKOS_DO_EXAMPLES} ${KOKKOS_OPTION_CMD} ${KOKKOS_CUDA_OPTION_CMD} -DCMAKE_CXX_COMPILER=${COMPILER} -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_CUDA_DIR=${CUDA_PATH} -DKokkos_CXX_STANDARD=${KOKKOS_CXX_STANDARD} ${KOKKOS_PATH} 
+cmake $COMPILER_CMD  -DCMAKE_CXX_FLAGS="${CXXFLAGS}" -DCMAKE_INSTALL_PREFIX=${PREFIX} ${KOKKOS_DEVICE_CMD} ${KOKKOS_ARCH_CMD} -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_EXAMPLES=${KOKKOS_DO_EXAMPLES} ${KOKKOS_OPTION_CMD} ${KOKKOS_CUDA_OPTION_CMD} -DCMAKE_CXX_COMPILER=${COMPILER} -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_CXX_EXTENSIONS=OFF -DKokkos_CUDA_DIR=${CUDA_PATH} -DKokkos_CXX_STANDARD=${KOKKOS_CXX_STANDARD} ${KOKKOS_PATH} 

--- a/cm_generate_makefile.bash
+++ b/cm_generate_makefile.bash
@@ -40,13 +40,13 @@ get_kokkos_cuda_option_list() {
   for CUDA_ in $PARSE_CUDA_LST
   do 
      CUDA_OPT_NAME=
-     if [ "${CUDA_}" == "enable_lambda"]; then
+     if [ "${CUDA_}" == "enable_lambda" ]; then
         CUDA_OPT_NAME=CUDA_LAMBDA
-     elif  [ "${CUDA_}" == "rdc"]; then	
+     elif  [ "${CUDA_}" == "rdc" ]; then	
         CUDA_OPT_NAME=CUDA_RELOCATABLE_DEVICE_CODE
-     elif  [ "${CUDA_}" == "force_uvm"]; then
+     elif  [ "${CUDA_}" == "force_uvm" ]; then
         CUDA_OPT_NAME=CUDA_UVM
-     elif  [ "${CUDA_}" == "use_ldg"]; then
+     elif  [ "${CUDA_}" == "use_ldg" ]; then
         CUDA_OPT_NAME=CUDA_LDG_INTRINSIC
      else
         echo "${CUDA_} is not a valid cuda options..."
@@ -63,9 +63,9 @@ get_kokkos_option_list() {
   PARSE_OPTIONS_LST=$(echo $KOKKOS_OPTIONS | tr "," "\n")
   for OPT_ in $PARSE_OPTIONS_LST
   do 
-     UC_OPT_ = ${OPT_}
+     UC_OPT_=${OPT_^^}
      if [[ "$UC_OPT_" == *DISABLE* ]]; then
-        FLIP_OPT_ = ${UC_OPT_/DISABLE/ENABLE}
+        FLIP_OPT_=${UC_OPT_/DISABLE/ENABLE}
         KOKKOS_OPTION_CMD="-DKokkos_${FLIP_OPT_}=OFF ${KOKKOS_OPTION_CMD}"
      elif [[ "$UC_OPT_" == *ENABLE* ]]; then
         KOKKOS_OPTION_CMD="-DKokkos_${UC_OPT_}=ON ${KOKKOS_OPTION_CMD}"
@@ -101,7 +101,7 @@ do
       ;;
     # Catch this before '--with-cuda*'
     --with-cuda-options*)
-      KOKKOS_CUDA_OPT="${key#*=}"
+      KOKKOS_CUDA_OPTIONS="${key#*=}"
       ;;
     --with-cuda*)
       update_kokkos_devices Cuda
@@ -196,7 +196,7 @@ do
       COMPILER=${COMPDIR}/${COMPNAME}
       ;;
     --with-options*)
-      KOKKOS_OPT="${key#*=}"
+      KOKKOS_OPTIONS="${key#*=}"
       ;;
     --gcc-toolchain*)
       KOKKOS_GCC_TOOLCHAIN="${key#*=}"

--- a/scripts/testing_scripts/cm_test_all_sandia
+++ b/scripts/testing_scripts/cm_test_all_sandia
@@ -36,7 +36,7 @@ if [[ "$HOSTNAME" == kokkos-dev-2* ]]; then
   MACHINE=kokkos-dev-2
 fi
 
-if [[ "$HOSTNAME" == mayer\.* ]]; then
+if [[ "$HOSTNAME" == mayer* ]]; then
   MACHINE=mayer
 #  module load git
 fi
@@ -97,7 +97,7 @@ CXX_FLAGS_EXTRA=""
 LD_FLAGS_EXTRA=""
 KOKKOS_OPTIONS=""
 
-CXX_STANDARD="c++11"
+CXX_STANDARD="11"
 
 #
 # Handle arguments.
@@ -154,7 +154,12 @@ do
       CXX_FLAGS_EXTRA="${key#*=}"
       ;;
     --cxxstandard*)
-      CXX_STANDARD="${key#*=}"
+      FULL_CXX_STANDARD="${key#*=}"
+      if [[ ${FULL_CXX_STANDARD} == *++* ]]; then
+         CXX_STANDARD="${FULL_CXX_STANDARD#*++}"
+      else
+         CXX_STANDARD="${FULL_CXX_STANDARD}"
+      fi
       ;;
     --ldflags-extra*)
       LD_FLAGS_EXTRA="${key#*=}"
@@ -287,10 +292,10 @@ elif [ "$MACHINE" = "white" ]; then
   SKIP_HWLOC=True
   export SLURM_TASKS_PER_NODE=32
 
-  BASE_MODULE_LIST="<COMPILER_NAME>/<COMPILER_VERSION>"
-  IBM_MODULE_LIST="<COMPILER_NAME>/xl/<COMPILER_VERSION>,gcc/7.2.0"
-  CUDA_MODULE_LIST="<COMPILER_NAME>/<COMPILER_VERSION>,gcc/7.2.0,ibm/xl/16.1.0"
-  CUDA10_MODULE_LIST="<COMPILER_NAME>/<COMPILER_VERSION>,gcc/7.4.0,ibm/xl/16.1.0"
+  BASE_MODULE_LIST="cmake/3.12.3,<COMPILER_NAME>/<COMPILER_VERSION>"
+  IBM_MODULE_LIST="cmake/3.12.3,<COMPILER_NAME>/xl/<COMPILER_VERSION>,gcc/7.2.0"
+  CUDA_MODULE_LIST="cmake/3.12.3,<COMPILER_NAME>/<COMPILER_VERSION>,gcc/7.2.0,ibm/xl/16.1.0"
+  CUDA10_MODULE_LIST="cmake/3.12.3,<COMPILER_NAME>/<COMPILER_VERSION>,gcc/7.4.0,ibm/xl/16.1.0"
 
   # Don't do pthread on white.
   GCC_BUILD_LIST="OpenMP,Serial,OpenMP_Serial"
@@ -322,7 +327,7 @@ elif [ "$MACHINE" = "bowman" ]; then
   SKIP_HWLOC=True
   export SLURM_TASKS_PER_NODE=32
 
-  BASE_MODULE_LIST="<COMPILER_NAME>/compilers/<COMPILER_VERSION>"
+  BASE_MODULE_LIST="cmake/3.12.3,<COMPILER_NAME>/compilers/<COMPILER_VERSION>"
 
   OLD_INTEL_BUILD_LIST="Pthread,Serial,Pthread_Serial"
 
@@ -340,12 +345,12 @@ elif [ "$MACHINE" = "mayer" ]; then
   SKIP_HWLOC=True
   export SLURM_TASKS_PER_NODE=96
 
-  BASE_MODULE_LIST="<COMPILER_NAME>/<COMPILER_VERSION>"
-  ARM_MODULE_LIST="<COMPILER_NAME>/compilers/<COMPILER_VERSION>"
+  BASE_MODULE_LIST="cmake/3.12.2,<COMPILER_NAME>/<COMPILER_VERSION>"
+  ARM_MODULE_LIST="cmake/3.12.2,<COMPILER_NAME>/<COMPILER_VERSION>"
 
   # Format: (compiler module-list build-list exe-name warning-flag)
-  COMPILERS=("gnu/7.2.0 $BASE_MODULE_LIST $ARM_GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
-             "arm/19.0.0 $ARM_MODULE_LIST $ARM_GCC_BUILD_LIST armclang++ $CLANG_WARNING_FLAGS")
+  COMPILERS=("gnu7/7.2.0 $BASE_MODULE_LIST $ARM_GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+             "arm/19.0 $ARM_MODULE_LIST $ARM_GCC_BUILD_LIST armclang++ $CLANG_WARNING_FLAGS")
 
   if [ -z "$ARCH_FLAG" ]; then
     ARCH_FLAG="--arch=ARMv8-TX2"
@@ -388,21 +393,21 @@ elif [ "$MACHINE" = "apollo" ]; then
 
   module load sems-git
   module load sems-tex
-  module load sems-cmake/3.5.2
+  module load sems-cmake/3.12.2
   module load sems-gdb
   module load binutils
 
   SKIP_HWLOC=True
 
-  BASE_MODULE_LIST="sems-env,kokkos-env,kokkos-hwloc/1.10.1/base,sems-<COMPILER_NAME>/<COMPILER_VERSION>"
-  CUDA_MODULE_LIST="sems-env,kokkos-env,kokkos-<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/4.8.4,kokkos-hwloc/1.10.1/base"
-  CUDA8_MODULE_LIST="sems-env,kokkos-env,kokkos-<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/5.3.0,kokkos-hwloc/1.10.1/base"
-  CUDA10_MODULE_LIST="sems-env,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/5.3.0,kokkos-hwloc/1.10.1/base"
+  BASE_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,kokkos-hwloc/1.10.1/base,sems-<COMPILER_NAME>/<COMPILER_VERSION>"
+  CUDA_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,kokkos-<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/4.8.4,kokkos-hwloc/1.10.1/base"
+  CUDA8_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,kokkos-<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/5.3.0,kokkos-hwloc/1.10.1/base"
+  CUDA10_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/5.3.0,kokkos-hwloc/1.10.1/base"
 
-  CLANG_MODULE_LIST="sems-env,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,cuda/9.0.69"
-  CLANG7_MODULE_LIST="sems-env,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,cuda/9.1"
-  NVCC_MODULE_LIST="sems-env,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/5.3.0"
-  HPX_MODULE_LIST="sems-env,kokkos-env,hpx/1.2.1,sems-gcc/6.1.0,binutils"
+  CLANG_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,cuda/9.0.69"
+  CLANG7_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,sems-gcc/6.1.0,<COMPILER_NAME>/<COMPILER_VERSION>,cuda/9.1"
+  NVCC_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/5.3.0"
+  HPX_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,hpx/1.2.1,sems-gcc/6.1.0,binutils"
 
   BUILD_LIST_CUDA_NVCC="Cuda_Serial,Cuda_OpenMP"
   BUILD_LIST_CUDA_CLANG="Cuda_Serial,Cuda_Pthread"
@@ -455,12 +460,12 @@ elif [ "$MACHINE" = "kokkos-dev-2" ]; then
 
   SKIP_HWLOC=True
 
-  BASE_MODULE_LIST="sems-env,kokkos-env,kokkos-hwloc/1.10.1/base,sems-<COMPILER_NAME>/<COMPILER_VERSION>"
-  GCC91_MODULE_LIST="sems-env,kokkos-env,kokkos-hwloc/1.10.1/base,<COMPILER_NAME>/<COMPILER_VERSION>"
-  NVCC_MODULE_LIST="sems-env,kokkos-env,kokkos-hwloc/1.10.1/base,<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/7.3.0"
+  BASE_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,kokkos-hwloc/1.10.1/base,sems-<COMPILER_NAME>/<COMPILER_VERSION>"
+  GCC91_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,kokkos-hwloc/1.10.1/base,<COMPILER_NAME>/<COMPILER_VERSION>"
+  NVCC_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,kokkos-hwloc/1.10.1/base,<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/7.3.0"
 
-  CLANG_MODULE_LIST="sems-env,kokkos-env,sems-<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/6.1.0"
-  CLANG8_MODULE_LIST="sems-env,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,cuda/10.0"
+  CLANG_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,sems-<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/6.1.0"
+  CLANG8_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,cuda/10.0"
 
   BUILD_LIST_CUDA_NVCC="Cuda_Serial,Cuda_Pthread"
   BUILD_LIST_CUDA_CLANG="Cuda_Serial,Cuda_OpenMP"
@@ -719,6 +724,9 @@ setup_env() {
     module list 2>&1 | grep "$mod" >& /dev/null || return 1
   done
 
+  if [ -e ./update_lib.sh ]; then
+     source ./update_lib.sh $MACHINE
+  fi
   return 0
 }
 
@@ -792,6 +800,9 @@ single_build_and_test() {
     if [[ "$LOCAL_KOKKOS_DEVICES" = *Cuda* ]]; then
        CUDA_ENABLE_CMD="--with-cuda=$CUDA_ROOT"
     fi
+    echo "kokkos options: ${KOKKOS_OPTIONS}"
+    echo "kokkos devices: ${LOCAL_KOKKOS_DEVICES}"
+    echo "kokkos cxx: ${cxxflags}"
     run_cmd ${KOKKOS_PATH}/cm_generate_makefile.bash --with-devices=$LOCAL_KOKKOS_DEVICES $ARCH_FLAG --compiler=$(which $compiler_exe) --cxxflags=\"$cxxflags\" --cxxstandard=\"$cxx_standard\" --ldflags=\"$ldflags\" $CUDA_ENABLE_CMD --kokkos-path=${KOKKOS_PATH} --no-examples $extra_args &>> ${desc}.configure.log || { report_and_log_test_result 1 ${desc} configure && return 0; }
     local -i build_start_time=$(date +%s)
     run_cmd make -j 48 all >& ${desc}.build.log || { report_and_log_test_result 1 ${desc} build && return 0; }

--- a/scripts/testing_scripts/cm_test_all_sandia
+++ b/scripts/testing_scripts/cm_test_all_sandia
@@ -145,10 +145,12 @@ do
       OPT_FLAG="${key#*=}"
       ;;
     --with-cuda-options*)
-      KOKKOS_CUDA_OPTIONS="--with-cuda-options=${key#*=}"
+      KOKKOS_CUDA_OPTIONS="${key#*=}"
+      export KOKKOS_CUDA_OPTIONS
       ;;
     --with-options*)
-      KOKKOS_OPTIONS="--with-options=${key#*=}"
+      KOKKOS_OPTIONS="${key#*=}"
+      export KOKKOS_OPTIONS
       ;;
     --cxxflags-extra*)
       CXX_FLAGS_EXTRA="${key#*=}"


### PR DESCRIPTION
Script updates to convert 
   - Kokkos_OPTIONS to Kokkos_ENABLE_<OPT>
   - Kokkos_ARCH to Kokkos_ARCH_<ARCH>
   - Kokkos_CUDA_OPTIONS to Kokkos_ENABLE_<appropriate name>
   - Kokkos_DEVICES to Kokkos_ENABLE_<Device>

Also update setup information for white, mayer, apollo, and kokkos-dev2