### PR TITLE
Fix compiler warnings when kokkos lambda not enabled

### DIFF
--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -80,12 +80,12 @@ void test_offsetview_construction(unsigned int size) {
   ASSERT_EQ(ov.extent(0), 5);
   ASSERT_EQ(ov.extent(1), 5);
 
+
+#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
   const int ovmin0 = ov.begin(0);
   const int ovend0 = ov.end(0);
   const int ovmin1 = ov.begin(1);
   const int ovend1 = ov.end(1);
-
-#if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
   {
     Kokkos::Experimental::OffsetView<Scalar*, Device> offsetV1("OneDOffsetView",
                                                                range0);

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -80,7 +80,6 @@ void test_offsetview_construction(unsigned int size) {
   ASSERT_EQ(ov.extent(0), 5);
   ASSERT_EQ(ov.extent(1), 5);
 
-
 #if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
   const int ovmin0 = ov.begin(0);
   const int ovend0 = ov.end(0);


### PR DESCRIPTION
Issue #2367 

Need to move ov variables to inside the ifdef (as they are used later)