### PR TITLE
Add gcc toolchain to compiler and linker options if compiler is clang (Issue #2364)

### DIFF
--- a/cmake/kokkos_test_cxx_std.cmake
+++ b/cmake/kokkos_test_cxx_std.cmake
@@ -106,6 +106,25 @@ IF(KOKKOS_ENABLE_CUDA)
   ENDIF()
 ENDIF()
 
+IF(KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+    execute_process(
+      COMMAND "which"
+      g++
+      OUTPUT_VARIABLE gcc_exec_path ERROR_VARIABLE gcc_exec_path
+      RESULT_VARIABLE gcc_result
+      TIMEOUT 10
+      )
+    if (gcc_exec_path MATCHES "/bin/g")
+      STRING(REPLACE "/bin/g++\n" "" GCC_PATH "${gcc_exec_path}")
+      MESSAGE(STATUS "Clang using gcc toolchain ${GCC_PATH}")
+      GLOBAL_APPEND(KOKKOS_COMPILE_OPTIONS --gcc-toolchain=${GCC_PATH})
+
+      LIST(APPEND CLANG_LINK_OPTIONS ${KOKKOS_LINK_OPTIONS})
+      LIST(APPEND CLANG_LINK_OPTIONS --gcc-toolchain=${GCC_PATH})
+      GLOBAL_SET(KOKKOS_LINK_OPTIONS ${CLANG_LINK_OPTIONS})
+    endif()
+ENDIF()
+
 IF (NOT KOKKOS_CXX_STANDARD_FEATURE)
   #we need to pick the C++ flags ourselves
   UNSET(CMAKE_CXX_STANDARD)


### PR DESCRIPTION
Issue #2364 