### PR TITLE
Fix issue with unused variable with warnings as errors enabled (Issue #2397)

### DIFF
--- a/cmake/compile_tests/clang_omp.cpp
+++ b/cmake/compile_tests/clang_omp.cpp
@@ -2,5 +2,8 @@
 
 int main(int argc, char** argv) {
   int thr = omp_get_num_threads();
-  return 0;
+  if ( thr > 0 )
+     return thr;
+  else
+     return 0;
 }


### PR DESCRIPTION
must use the thr variable or -Werror will cause it to fail

Issue #2397 