### PR TITLE
Workaround for gcc-4.9 bug

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -356,9 +356,9 @@ struct ViewTraits {
 
   typedef typename MemorySpace::size_type size_type;
 
-  enum { is_hostspace = std::is_same<MemorySpace, HostSpace>::value };
-  enum { is_managed = MemoryTraits::is_unmanaged == 0 };
-  enum { is_random_access = MemoryTraits::is_random_access == 1 };
+  enum : bool { is_hostspace = std::is_same<MemorySpace, HostSpace>::value };
+  enum : bool { is_managed = !MemoryTraits::is_unmanaged };
+  enum : bool { is_random_access = MemoryTraits::is_random_access };
 
   //------------------------------------
 };


### PR DESCRIPTION
Partial fix for #2419. I still see
```
kokkos/core/src/Kokkos_View.hpp:603:8: error: ‘Rank’ is not a member of ‘Kokkos::View<int*, Kokkos::Serial>::map_type {aka Kokkos::Impl::ViewMapping<Kokkos::ViewTraits<int*, Kokkos::Serial>, void>}’
   enum { Rank = map_type::Rank };
```
and similar errors.