### PR TITLE
`parallel_reduce` cleanup, phase 1

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -453,7 +453,7 @@ struct CudaReductionsFunctor<FunctorType, ArgTag, false, true> {
             : ((1 << width) - 1)
                   << ((threadIdx.y * blockDim.x + threadIdx.x) / width) * width;
     for (int delta = skip_vector ? blockDim.x : 1; delta < width; delta *= 2) {
-      Scalar tmp = Impl::shfl_down(value, delta, width, mask);
+      Scalar tmp = Kokkos::shfl_down(value, delta, width, mask);
       ValueJoin::join(functor, &value, &tmp);
     }
 

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -453,7 +453,7 @@ struct CudaReductionsFunctor<FunctorType, ArgTag, false, true> {
             : ((1 << width) - 1)
                   << ((threadIdx.y * blockDim.x + threadIdx.x) / width) * width;
     for (int delta = skip_vector ? blockDim.x : 1; delta < width; delta *= 2) {
-      Scalar tmp = shfl_down(value, delta, width, mask);
+      Scalar tmp = Impl::shfl_down(value, delta, width, mask);
       ValueJoin::join(functor, &value, &tmp);
     }
 

--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -618,7 +618,7 @@ class TaskExec<Kokkos::Cuda, Scheduler> {
       // WarpSize = blockDim.X * blockDim.y
       // thread_id < blockDim.y
       ValueType tmp(val);  // input might not be register variable
-      cuda_shfl(val, tmp, blockDim.x * thread_id, WarpSize);
+      Impl::in_place_shfl(val, tmp, blockDim.x * thread_id, WarpSize);
     }
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -174,7 +174,8 @@ class CudaTeamMember {
       val = *((ValueType*)m_team_reduce);
     } else {               // team <= warp
       ValueType tmp(val);  // input might not be a register variable
-      Impl::in_place_shfl(val, tmp, blockDim.x * thread_id, blockDim.x * blockDim.y);
+      Impl::in_place_shfl(val, tmp, blockDim.x * thread_id,
+                          blockDim.x * blockDim.y);
     }
 #endif
   }
@@ -195,7 +196,8 @@ class CudaTeamMember {
       val = *((ValueType*)m_team_reduce);
     } else {               // team <= warp
       ValueType tmp(val);  // input might not be a register variable
-      Impl::in_place_shfl(val, tmp, blockDim.x * thread_id, blockDim.x * blockDim.y);
+      Impl::in_place_shfl(val, tmp, blockDim.x * thread_id,
+                          blockDim.x * blockDim.y);
     }
 #endif
   }
@@ -372,7 +374,8 @@ class CudaTeamMember {
       value_type tmp(reducer.reference());
 
       for (int i = CudaTraits::WarpSize; (int)blockDim.x <= (i >>= 1);) {
-        Impl::in_place_shfl_down(reducer.reference(), tmp, i, CudaTraits::WarpSize);
+        Impl::in_place_shfl_down(reducer.reference(), tmp, i,
+                                 CudaTraits::WarpSize);
 
         // Root of each vector lane reduces "thread" contribution
         if (0 == threadIdx.x && wx < i) {

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -174,7 +174,7 @@ class CudaTeamMember {
       val = *((ValueType*)m_team_reduce);
     } else {               // team <= warp
       ValueType tmp(val);  // input might not be a register variable
-      cuda_shfl(val, tmp, blockDim.x * thread_id, blockDim.x * blockDim.y);
+      Impl::in_place_shfl(val, tmp, blockDim.x * thread_id, blockDim.x * blockDim.y);
     }
 #endif
   }
@@ -195,7 +195,7 @@ class CudaTeamMember {
       val = *((ValueType*)m_team_reduce);
     } else {               // team <= warp
       ValueType tmp(val);  // input might not be a register variable
-      cuda_shfl(val, tmp, blockDim.x * thread_id, blockDim.x * blockDim.y);
+      Impl::in_place_shfl(val, tmp, blockDim.x * thread_id, blockDim.x * blockDim.y);
     }
 #endif
   }
@@ -313,7 +313,7 @@ class CudaTeamMember {
                   << ((threadIdx.y % (32 / blockDim.x)) * blockDim.x);
 
     for (int i = blockDim.x; (i >>= 1);) {
-      cuda_shfl_down(tmp2, tmp, i, blockDim.x, mask);
+      Impl::in_place_shfl_down(tmp2, tmp, i, blockDim.x, mask);
       if ((int)threadIdx.x < i) {
         reducer.join(tmp, tmp2);
       }
@@ -324,7 +324,7 @@ class CudaTeamMember {
     // because floating point summation is not associative
     // and thus different threads could have different results.
 
-    cuda_shfl(tmp2, tmp, 0, blockDim.x, mask);
+    Impl::in_place_shfl(tmp2, tmp, 0, blockDim.x, mask);
     value               = tmp2;
     reducer.reference() = tmp2;
 #endif
@@ -372,7 +372,7 @@ class CudaTeamMember {
       value_type tmp(reducer.reference());
 
       for (int i = CudaTraits::WarpSize; (int)blockDim.x <= (i >>= 1);) {
-        cuda_shfl_down(reducer.reference(), tmp, i, CudaTraits::WarpSize);
+        Impl::in_place_shfl_down(reducer.reference(), tmp, i, CudaTraits::WarpSize);
 
         // Root of each vector lane reduces "thread" contribution
         if (0 == threadIdx.x && wx < i) {
@@ -953,7 +953,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
 
     for (int j = 1; j < (int)blockDim.x; j <<= 1) {
       value_type tmp = 0;
-      Impl::cuda_shfl_up(tmp, sval, j, blockDim.x, active_mask);
+      Impl::in_place_shfl_up(tmp, sval, j, blockDim.x, active_mask);
       if (j <= (int)threadIdx.x) {
         sval += tmp;
       }
@@ -966,7 +966,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     if (i < loop_boundaries.end) closure(i, val, true);
 
     // Accumulate the last value in the inclusive scan:
-    Impl::cuda_shfl(sval, sval, mask, blockDim.x, active_mask);
+    Impl::in_place_shfl(sval, sval, mask, blockDim.x, active_mask);
 
     accum += sval;
   }
@@ -1022,7 +1022,7 @@ KOKKOS_INLINE_FUNCTION void single(
                       ? 0xffffffff
                       : ((1 << blockDim.x) - 1)
                             << ((threadIdx.y % (32 / blockDim.x)) * blockDim.x);
-  Impl::cuda_shfl(val, val, 0, blockDim.x, mask);
+  Impl::in_place_shfl(val, val, 0, blockDim.x, mask);
 #endif
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -82,7 +82,7 @@ struct in_place_shfl_op {
              unsigned mask = shfl_all_mask) const noexcept {
     //------------------------------------------------
     reinterpret_cast<int&>(out) = self().do_shfl_op(
-        mask, *reinterpret_cast<int const*>(&in), lane_or_delta, width);
+        mask, reinterpret_cast<int const&>(in), lane_or_delta, width);
     //------------------------------------------------
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -56,10 +56,9 @@ namespace Impl {
 // Include all lanes
 constexpr unsigned shfl_all_mask = 0xffffffff;
 
-} // end namespace Impl
+}  // end namespace Impl
 
 namespace Impl {
-
 
 //----------------------------------------------------------------------------
 // Shuffle operations require input to be a register (stack) variable

--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -50,10 +50,16 @@
 #include <Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp>
 
 namespace Kokkos {
+
 namespace Impl {
 
 // Include all lanes
 constexpr unsigned shfl_all_mask = 0xffffffff;
+
+} // end namespace Impl
+
+namespace Impl {
+
 
 //----------------------------------------------------------------------------
 // Shuffle operations require input to be a register (stack) variable
@@ -175,12 +181,6 @@ __device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl_down(
 }
 
 }  // namespace Impl
-}  // namespace Kokkos
-
-namespace Kokkos {
-
-#ifdef __CUDA_ARCH__
-#if (__CUDA_ARCH__ >= 300)
 
 template <class T>
 // requires default_constructible<T> && _assignable_from_bits<T>
@@ -208,56 +208,6 @@ __device__ inline T shfl_up(const T& val, int delta, int width,
   Impl::in_place_shfl_up(rv, val, delta, width, mask);
   return rv;
 }
-
-#else   // (__CUDA_ARCH__ < 300)
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl(const Scalar& val, int srcLane, int width,
-                                   unsigned mask = Impl::shfl_all_mask) {
-  if (width > 1)
-    Kokkos::abort("Error: calling shfl from a device with CC<3.0.");
-  return val;
-}
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_down(const Scalar& val, int delta, int width,
-                                        unsigned mask = Impl::shfl_all_mask) {
-  if (width > 1)
-    Kokkos::abort("Error: calling shfl_down from a device with CC<3.0.");
-  return val;
-}
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_up(const Scalar& val, int delta, int width,
-                                      unsigned mask = Impl::shfl_all_mask) {
-  if (width > 1)
-    Kokkos::abort("Error: calling shfl_down from a device with CC<3.0.");
-  return val;
-}
-#endif  // (__CUDA_ARCH__ < 300)
-#else   // !defined( __CUDA_ARCH__ )
-template <typename Scalar>
-inline Scalar shfl(const Scalar& val, int srcLane, int width,
-                   unsigned mask = Impl::shfl_all_mask) {
-  if (width > 1) Kokkos::abort("Error: calling shfl outside __CUDA_ARCH__.");
-  return val;
-}
-
-template <typename Scalar>
-inline Scalar shfl_down(const Scalar& val, int delta, int width,
-                        unsigned mask = Impl::shfl_all_mask) {
-  if (width > 1)
-    Kokkos::abort("Error: calling shfl_down outside __CUDA_ARCH__.");
-  return val;
-}
-
-template <typename Scalar>
-inline Scalar shfl_up(const Scalar& val, int delta, int width,
-                      unsigned mask = Impl::shfl_all_mask) {
-  if (width > 1)
-    Kokkos::abort("Error: calling shfl_down outside __CUDA_ARCH__.");
-  return val;
-}
-#endif  // !defined( __CUDA_ARCH__ )
 
 }  // end namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -56,10 +56,6 @@ namespace Impl {
 // Include all lanes
 constexpr unsigned shfl_all_mask = 0xffffffff;
 
-}  // end namespace Impl
-
-namespace Impl {
-
 //----------------------------------------------------------------------------
 // Shuffle operations require input to be a register (stack) variable
 
@@ -70,7 +66,7 @@ namespace Impl {
 template <class Derived>
 struct in_place_shfl_op {
   // CRTP boilerplate
-  __device__ __inline__ const Derived& self() const noexcept {
+  __device__ KOKKOS_IMPL_FORCEINLINE const Derived& self() const noexcept {
     return *static_cast<Derived const*>(this);
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -114,7 +114,7 @@ struct in_place_shfl_op {
     lo       = self().do_shfl_op(mask, lo, lane_or_delta, width);
     hi       = self().do_shfl_op(mask, hi, lane_or_delta, width);
     auto tmp = __hiloint2double(hi, lo);
-    out      = *(reinterpret_cast<const Scalar*>(&tmp));
+    out      = reinterpret_cast<Scalar&>(tmp);
     //------------------------------------------------
   }
 #endif

--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -48,321 +48,187 @@
 
 #include <Kokkos_Cuda.hpp>
 #include <Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp>
-namespace Kokkos {
 
-// Shuffle only makes sense on >= Kepler GPUs; it doesn't work on CPUs
-// or other GPUs.  We provide a generic definition (which is trivial
-// and doesn't do what it claims to do) because we don't actually use
-// this function unless we are on a suitable GPU, with a suitable
-// Scalar type.  (For example, in the mat-vec, the "ThreadsPerRow"
-// internal parameter depends both on the ExecutionSpace and the Scalar type,
-// and it controls whether shfl_down() gets called.)
+namespace Kokkos {
 namespace Impl {
 
-template <typename Scalar>
-struct shfl_union {
-  enum { n = sizeof(Scalar) / 4 };
-  float fval[n];
-  KOKKOS_INLINE_FUNCTION
-  Scalar value() { return *(Scalar*)fval; }
-  KOKKOS_INLINE_FUNCTION
-  void operator=(Scalar& value_) {
-    float* const val_ptr = (float*)&value_;
-    for (int i = 0; i < n; i++) {
-      fval[i] = val_ptr[i];
-    }
+// Include all lanes
+constexpr unsigned shfl_all_mask = 0xffffffff;
+
+//----------------------------------------------------------------------------
+// Shuffle operations require input to be a register (stack) variable
+
+// Derived implements do_shfl_op(unsigned mask, T& in, int lane, int width),
+// which turns in to one of KOKKOS_IMPL_CUDA_SHFL(_UP_|_DOWN_|_)MASK
+// Since the logic with respect to value sizes, etc., is the same everywhere,
+// put it all in one place.
+template <class Derived>
+struct in_place_shfl_op {
+  // CRTP boilerplate
+  __device__ __inline__ const Derived& self() const noexcept {
+    return *static_cast<Derived const*>(this);
   }
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const Scalar& value_) {
-    float* const val_ptr = (float*)&value_;
-    for (int i = 0; i < n; i++) {
-      fval[i] = val_ptr[i];
+
+  // sizeof(Scalar) == sizeof(int) case
+  template <class Scalar>
+  // requires _assignable_from_bits<Scalar>
+  __device__ inline typename std::enable_if<sizeof(Scalar) == sizeof(int)>::type
+  operator()(Scalar& out, Scalar const& in, int lane_or_delta, int width,
+             unsigned mask = shfl_all_mask) const noexcept {
+    //------------------------------------------------
+    reinterpret_cast<int&>(out) = self().do_shfl_op(
+        mask, *reinterpret_cast<int const*>(&in), lane_or_delta, width);
+    //------------------------------------------------
+  }
+
+// TODO: figure out why 64-bit shfl fails in Clang
+#if (CUDA_VERSION >= 9000) && (!defined(KOKKOS_COMPILER_CLANG))
+  // sizeof(Scalar) == sizeof(double) case
+  // requires _assignable_from_bits<Scalar>
+  template <class Scalar>
+  __device__ inline
+      typename std::enable_if<sizeof(Scalar) == sizeof(double)>::type
+      operator()(Scalar& out, Scalar const& in, int lane_or_delta, int width,
+                 unsigned mask = shfl_all_mask) const noexcept {
+    //------------------------------------------------
+    reinterpret_cast<double&>(out) = self().do_shfl_op(
+        mask, *reinterpret_cast<double const*>(&in), lane_or_delta, width);
+    //------------------------------------------------
+  }
+#else
+  // sizeof(Scalar) == sizeof(double) case
+  // requires _assignable_from_bits<Scalar>
+  template <typename Scalar>
+  __device__ inline
+      typename std::enable_if<sizeof(Scalar) == sizeof(double)>::type
+      operator()(Scalar& out, const Scalar& val, int lane_or_delta, int width,
+                 unsigned mask = shfl_all_mask) const noexcept {
+    //------------------------------------------------
+    int lo   = __double2loint(*reinterpret_cast<const double*>(&val));
+    int hi   = __double2hiint(*reinterpret_cast<const double*>(&val));
+    lo       = self().do_shfl_op(mask, lo, lane_or_delta, width);
+    hi       = self().do_shfl_op(mask, hi, lane_or_delta, width);
+    auto tmp = __hiloint2double(hi, lo);
+    out      = *(reinterpret_cast<const Scalar*>(&tmp));
+    //------------------------------------------------
+  }
+#endif
+
+  // sizeof(Scalar) > sizeof(double) case
+  template <typename Scalar>
+  __device__ inline
+      typename std::enable_if<(sizeof(Scalar) > sizeof(double))>::type
+      operator()(Scalar& out, const Scalar& val, int lane_or_delta, int width,
+                 unsigned mask = shfl_all_mask) const noexcept {
+    // TODO DSH shouldn't this be KOKKOS_IMPL_CUDA_MAX_SHFL_SIZEOF instead of
+    //      sizeof(int)? (Need benchmarks to decide which is faster)
+    using shuffle_as_t = int;
+    enum : int { N = sizeof(Scalar) / sizeof(shuffle_as_t) };
+
+    for (int i = 0; i < N; ++i) {
+      reinterpret_cast<shuffle_as_t*>(&out)[i] = self().do_shfl_op(
+          mask, reinterpret_cast<shuffle_as_t const*>(&val)[i], lane_or_delta,
+          width);
     }
   }
 };
+
+struct in_place_shfl_fn : in_place_shfl_op<in_place_shfl_fn> {
+  template <class T>
+  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(unsigned mask, T& val,
+                                                  int lane, int width) const
+      noexcept {
+    return KOKKOS_IMPL_CUDA_SHFL_MASK(mask, val, lane, width);
+  }
+};
+template <class... Args>
+__device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl(Args&&... args) noexcept {
+  in_place_shfl_fn{}((Args &&) args...);
+}
+
+struct in_place_shfl_up_fn : in_place_shfl_op<in_place_shfl_up_fn> {
+  template <class T>
+  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(unsigned mask, T& val,
+                                                  int lane, int width) const
+      noexcept {
+    return KOKKOS_IMPL_CUDA_SHFL_UP_MASK(mask, val, lane, width);
+  }
+};
+template <class... Args>
+__device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl_up(
+    Args&&... args) noexcept {
+  in_place_shfl_up_fn{}((Args &&) args...);
+}
+
+struct in_place_shfl_down_fn : in_place_shfl_op<in_place_shfl_down_fn> {
+  template <class T>
+  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(unsigned mask, T& val,
+                                                  int lane, int width) const
+      noexcept {
+    return KOKKOS_IMPL_CUDA_SHFL_DOWN_MASK(mask, val, lane, width);
+  }
+};
+template <class... Args>
+__device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl_down(
+    Args&&... args) noexcept {
+  in_place_shfl_down_fn{}((Args &&) args...);
+}
+
 }  // namespace Impl
+}  // namespace Kokkos
+
+namespace Kokkos {
 
 #ifdef __CUDA_ARCH__
 #if (__CUDA_ARCH__ >= 300)
 
-KOKKOS_INLINE_FUNCTION
-int shfl(const int& val, const int& srcLane, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL(val, srcLane, width);
+template <class T>
+// requires default_constructible<T> && _assignable_from_bits<T>
+__device__ inline T shfl(const T& val, const int& srcLane, const int& width,
+                         unsigned mask = Impl::shfl_all_mask) {
+  T rv = {};
+  Impl::in_place_shfl(rv, val, srcLane, width, mask);
+  return rv;
 }
 
-KOKKOS_INLINE_FUNCTION
-float shfl(const float& val, const int& srcLane, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL(val, srcLane, width);
+template <class T>
+// requires default_constructible<T> && _assignable_from_bits<T>
+__device__ inline T shfl_down(const T& val, int delta, int width,
+                              unsigned mask = Impl::shfl_all_mask) {
+  T rv = {};
+  Impl::in_place_shfl_down(rv, val, delta, width, mask);
+  return rv;
 }
 
-// TODO: figure out why 64-bit shfl fails with Clang
-#if (CUDA_VERSION >= 9000) && (!defined(KOKKOS_COMPILER_CLANG))
-
-KOKKOS_INLINE_FUNCTION
-long shfl(const long& val, const int& srcLane, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL(val, srcLane, width);
-}
-
-KOKKOS_INLINE_FUNCTION
-long long shfl(const long long& val, const int& srcLane, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL(val, srcLane, width);
-}
-
-KOKKOS_INLINE_FUNCTION
-double shfl(const double& val, const int& srcLane, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL(val, srcLane, width);
-}
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar
-shfl(const Scalar& val, const int& srcLane,
-     const typename Impl::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
-  Scalar tmp1 = val;
-  double tmp  = *reinterpret_cast<double*>(&tmp1);
-  tmp         = KOKKOS_IMPL_CUDA_SHFL(tmp, srcLane, width);
-  return *reinterpret_cast<Scalar*>(&tmp);
-}
-
-#else  // ( CUDA_VERSION < 9000 )
-
-KOKKOS_INLINE_FUNCTION
-double shfl(const double& val, const int& srcLane, const int& width) {
-  int lo = __double2loint(val);
-  int hi = __double2hiint(val);
-  lo     = KOKKOS_IMPL_CUDA_SHFL(lo, srcLane, width);
-  hi     = KOKKOS_IMPL_CUDA_SHFL(hi, srcLane, width);
-  return __hiloint2double(hi, lo);
-}
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar
-shfl(const Scalar& val, const int& srcLane,
-     const typename Impl::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
-  int lo           = __double2loint(*reinterpret_cast<const double*>(&val));
-  int hi           = __double2hiint(*reinterpret_cast<const double*>(&val));
-  lo               = KOKKOS_IMPL_CUDA_SHFL(lo, srcLane, width);
-  hi               = KOKKOS_IMPL_CUDA_SHFL(hi, srcLane, width);
-  const double tmp = __hiloint2double(hi, lo);
-  return *(reinterpret_cast<const Scalar*>(&tmp));
-}
-
-#endif  // ( CUDA_VERSION < 9000 )
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar
-shfl(const Scalar& val, const int& srcLane,
-     const typename Impl::enable_if<(sizeof(Scalar) == 4), int>::type& width) {
-  Scalar tmp1 = val;
-  float tmp   = *reinterpret_cast<float*>(&tmp1);
-  tmp         = KOKKOS_IMPL_CUDA_SHFL(tmp, srcLane, width);
-  return *reinterpret_cast<Scalar*>(&tmp);
-}
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar
-shfl(const Scalar& val, const int& srcLane,
-     const typename Impl::enable_if<(sizeof(Scalar) > 8), int>::type& width) {
-  Impl::shfl_union<Scalar> s_val;
-  Impl::shfl_union<Scalar> r_val;
-  s_val = val;
-
-  for (int i = 0; i < s_val.n; i++)
-    r_val.fval[i] = KOKKOS_IMPL_CUDA_SHFL(s_val.fval[i], srcLane, width);
-  return r_val.value();
-}
-
-KOKKOS_INLINE_FUNCTION
-int shfl_down(const int& val, const int& delta, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL_DOWN(val, delta, width);
-}
-
-KOKKOS_INLINE_FUNCTION
-float shfl_down(const float& val, const int& delta, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL_DOWN(val, delta, width);
-}
-
-// TODO: figure out why 64-bit shfl fails with Clang
-#if (CUDA_VERSION >= 9000) && (!defined(KOKKOS_COMPILER_CLANG))
-
-KOKKOS_INLINE_FUNCTION
-long shfl_down(const long& val, const int& delta, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL_DOWN(val, delta, width);
-}
-
-KOKKOS_INLINE_FUNCTION
-long long shfl_down(const long long& val, const int& delta, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL_DOWN(val, delta, width);
-}
-
-KOKKOS_INLINE_FUNCTION
-double shfl_down(const double& val, const int& delta, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL_DOWN(val, delta, width);
-}
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_down(
-    const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
-  Scalar tmp1 = val;
-  double tmp  = *reinterpret_cast<double*>(&tmp1);
-  tmp         = KOKKOS_IMPL_CUDA_SHFL_DOWN(tmp, delta, width);
-  return *reinterpret_cast<Scalar*>(&tmp);
-}
-
-#else  // ( CUDA_VERSION < 9000 )
-
-KOKKOS_INLINE_FUNCTION
-double shfl_down(const double& val, const int& delta, const int& width) {
-  int lo = __double2loint(val);
-  int hi = __double2hiint(val);
-  lo     = KOKKOS_IMPL_CUDA_SHFL_DOWN(lo, delta, width);
-  hi     = KOKKOS_IMPL_CUDA_SHFL_DOWN(hi, delta, width);
-  return __hiloint2double(hi, lo);
-}
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_down(
-    const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
-  int lo           = __double2loint(*reinterpret_cast<const double*>(&val));
-  int hi           = __double2hiint(*reinterpret_cast<const double*>(&val));
-  lo               = KOKKOS_IMPL_CUDA_SHFL_DOWN(lo, delta, width);
-  hi               = KOKKOS_IMPL_CUDA_SHFL_DOWN(hi, delta, width);
-  const double tmp = __hiloint2double(hi, lo);
-  return *(reinterpret_cast<const Scalar*>(&tmp));
-}
-
-#endif  // ( CUDA_VERSION < 9000 )
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_down(
-    const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) == 4), int>::type& width) {
-  Scalar tmp1 = val;
-  float tmp   = *reinterpret_cast<float*>(&tmp1);
-  tmp         = KOKKOS_IMPL_CUDA_SHFL_DOWN(tmp, delta, width);
-  return *reinterpret_cast<Scalar*>(&tmp);
-}
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_down(
-    const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) > 8), int>::type& width) {
-  Impl::shfl_union<Scalar> s_val;
-  Impl::shfl_union<Scalar> r_val;
-  s_val = val;
-
-  for (int i = 0; i < s_val.n; i++)
-    r_val.fval[i] = KOKKOS_IMPL_CUDA_SHFL_DOWN(s_val.fval[i], delta, width);
-  return r_val.value();
-}
-
-KOKKOS_INLINE_FUNCTION
-int shfl_up(const int& val, const int& delta, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL_UP(val, delta, width);
-}
-
-KOKKOS_INLINE_FUNCTION
-float shfl_up(const float& val, const int& delta, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL_UP(val, delta, width);
-}
-
-// TODO: figure out why 64-bit shfl fails with Clang
-#if (CUDA_VERSION >= 9000) && (!defined(KOKKOS_COMPILER_CLANG))
-
-KOKKOS_INLINE_FUNCTION
-long shfl_up(const long& val, const int& delta, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL_UP(val, delta, width);
-}
-
-KOKKOS_INLINE_FUNCTION
-long long shfl_up(const long long& val, const int& delta, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL_UP(val, delta, width);
-}
-
-KOKKOS_INLINE_FUNCTION
-double shfl_up(const double& val, const int& delta, const int& width) {
-  return KOKKOS_IMPL_CUDA_SHFL_UP(val, delta, width);
-}
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_up(
-    const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
-  Scalar tmp1 = val;
-  double tmp  = *reinterpret_cast<double*>(&tmp1);
-  tmp         = KOKKOS_IMPL_CUDA_SHFL_UP(tmp, delta, width);
-  return *reinterpret_cast<Scalar*>(&tmp);
-}
-
-#else  // ( CUDA_VERSION < 9000 )
-
-KOKKOS_INLINE_FUNCTION
-double shfl_up(const double& val, const int& delta, const int& width) {
-  int lo = __double2loint(val);
-  int hi = __double2hiint(val);
-  lo     = KOKKOS_IMPL_CUDA_SHFL_UP(lo, delta, width);
-  hi     = KOKKOS_IMPL_CUDA_SHFL_UP(hi, delta, width);
-  return __hiloint2double(hi, lo);
-}
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_up(
-    const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
-  int lo           = __double2loint(*reinterpret_cast<const double*>(&val));
-  int hi           = __double2hiint(*reinterpret_cast<const double*>(&val));
-  lo               = KOKKOS_IMPL_CUDA_SHFL_UP(lo, delta, width);
-  hi               = KOKKOS_IMPL_CUDA_SHFL_UP(hi, delta, width);
-  const double tmp = __hiloint2double(hi, lo);
-  return *(reinterpret_cast<const Scalar*>(&tmp));
-}
-
-#endif  // ( CUDA_VERSION < 9000 )
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_up(
-    const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) == 4), int>::type& width) {
-  Scalar tmp1 = val;
-  float tmp   = *reinterpret_cast<float*>(&tmp1);
-  tmp         = KOKKOS_IMPL_CUDA_SHFL_UP(tmp, delta, width);
-  return *reinterpret_cast<Scalar*>(&tmp);
-}
-
-template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_up(
-    const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) > 8), int>::type& width) {
-  Impl::shfl_union<Scalar> s_val;
-  Impl::shfl_union<Scalar> r_val;
-  s_val = val;
-
-  for (int i = 0; i < s_val.n; i++)
-    r_val.fval[i] = KOKKOS_IMPL_CUDA_SHFL_UP(s_val.fval[i], delta, width);
-  return r_val.value();
+template <class T>
+// requires default_constructible<T> && _assignable_from_bits<T>
+__device__ inline T shfl_up(const T& val, int delta, int width,
+                            unsigned mask = Impl::shfl_all_mask) {
+  T rv = {};
+  Impl::in_place_shfl_up(rv, val, delta, width, mask);
+  return rv;
 }
 
 #else   // (__CUDA_ARCH__ < 300)
 template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl(const Scalar& val, const int& srcLane,
-                                   const int& width) {
+KOKKOS_INLINE_FUNCTION Scalar shfl(const Scalar& val, int srcLane, int width,
+                                   unsigned mask = Impl::shfl_all_mask) {
   if (width > 1)
     Kokkos::abort("Error: calling shfl from a device with CC<3.0.");
   return val;
 }
 
 template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_down(const Scalar& val, const int& delta,
-                                        const int& width) {
+KOKKOS_INLINE_FUNCTION Scalar shfl_down(const Scalar& val, int delta, int width,
+                                        unsigned mask = Impl::shfl_all_mask) {
   if (width > 1)
     Kokkos::abort("Error: calling shfl_down from a device with CC<3.0.");
   return val;
 }
 
 template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_up(const Scalar& val, const int& delta,
-                                      const int& width) {
+KOKKOS_INLINE_FUNCTION Scalar shfl_up(const Scalar& val, int delta, int width,
+                                      unsigned mask = Impl::shfl_all_mask) {
   if (width > 1)
     Kokkos::abort("Error: calling shfl_down from a device with CC<3.0.");
   return val;
@@ -370,20 +236,23 @@ KOKKOS_INLINE_FUNCTION Scalar shfl_up(const Scalar& val, const int& delta,
 #endif  // (__CUDA_ARCH__ < 300)
 #else   // !defined( __CUDA_ARCH__ )
 template <typename Scalar>
-inline Scalar shfl(const Scalar& val, const int& srcLane, const int& width) {
+inline Scalar shfl(const Scalar& val, int srcLane, int width,
+                   unsigned mask = Impl::shfl_all_mask) {
   if (width > 1) Kokkos::abort("Error: calling shfl outside __CUDA_ARCH__.");
   return val;
 }
 
 template <typename Scalar>
-inline Scalar shfl_down(const Scalar& val, const int& delta, const int& width) {
+inline Scalar shfl_down(const Scalar& val, int delta, int width,
+                        unsigned mask = Impl::shfl_all_mask) {
   if (width > 1)
     Kokkos::abort("Error: calling shfl_down outside __CUDA_ARCH__.");
   return val;
 }
 
 template <typename Scalar>
-inline Scalar shfl_up(const Scalar& val, const int& delta, const int& width) {
+inline Scalar shfl_up(const Scalar& val, int delta, int width,
+                      unsigned mask = Impl::shfl_all_mask) {
   if (width > 1)
     Kokkos::abort("Error: calling shfl_down outside __CUDA_ARCH__.");
   return val;

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -274,6 +274,7 @@
 // Compiling Cuda code to 'ptx'
 
 #define KOKKOS_FORCEINLINE_FUNCTION __device__ __host__ __forceinline__
+#define KOKKOS_IMPL_FORCEINLINE __forceinline__
 #define KOKKOS_INLINE_FUNCTION __device__ __host__ inline
 #define KOKKOS_FUNCTION __device__ __host__
 #if defined(KOKKOS_COMPILER_NVCC)
@@ -340,6 +341,7 @@
 #if !defined(KOKKOS_FORCEINLINE_FUNCTION)
 #if !defined(_WIN32)
 #define KOKKOS_FORCEINLINE_FUNCTION inline __attribute__((always_inline))
+#define KOKKOS_IMPL_FORCEINLINE __attribute__((always_inline))
 #else
 #define KOKKOS_FORCEINLINE_FUNCTION inline
 #endif
@@ -390,6 +392,7 @@
 
 #if !defined(KOKKOS_FORCEINLINE_FUNCTION)
 #define KOKKOS_FORCEINLINE_FUNCTION inline __attribute__((always_inline))
+#define KOKKOS_IMPL_FORCEINLINE __attribute__((always_inline))
 #endif
 
 #if !defined(KOKKOS_IMPL_ALIGN_PTR)
@@ -414,6 +417,7 @@
 
 #if !defined(KOKKOS_FORCEINLINE_FUNCTION)
 #define KOKKOS_FORCEINLINE_FUNCTION inline __attribute__((always_inline))
+#define KOKKOS_IMPL_FORCEINLINE __attribute__((always_inline))
 #endif
 
 #define KOKKOS_RESTRICT __restrict__
@@ -448,6 +452,10 @@
 
 #if !defined(KOKKOS_FORCEINLINE_FUNCTION)
 define KOKKOS_FORCEINLINE_FUNCTION inline
+#endif
+
+#if !defined(KOKKOS_IMPL_FORCEINLINE)
+define KOKKOS_IMPL_FORCEINLINE inline
 #endif
 
 #if !defined(KOKKOS_INLINE_FUNCTION)

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -455,7 +455,7 @@ define KOKKOS_FORCEINLINE_FUNCTION inline
 #endif
 
 #if !defined(KOKKOS_IMPL_FORCEINLINE)
-define KOKKOS_IMPL_FORCEINLINE inline
+    define KOKKOS_IMPL_FORCEINLINE inline
 #endif
 
 #if !defined(KOKKOS_INLINE_FUNCTION)


### PR DESCRIPTION
* Reconciled `Kokkos_Cuda_Vectorization.hpp` shuffles with
`Kokkos_Cuda_ReduceScan.hpp` versions.
* Cleaned up a lot of copy-pasted logic