### PR TITLE
fix cxxflags passed in before handing down to cmake

### DIFF
--- a/cm_generate_makefile.bash
+++ b/cm_generate_makefile.bash
@@ -239,6 +239,7 @@ do
       ;;
     --cxxflags*)
       KOKKOS_CXXFLAGS="${key#*=}"
+      KOKKOS_CXXFLAGS=${KOKKOS_CXXFLAGS//,/ }
       ;;
     --cxxstandard*)
       KOKKOS_CXX_STANDARD="${key#*=}"


### PR DESCRIPTION
convert ',' to ' ' in cxx flags because they need to be passed to nvcc_wrapper with spaces not commas

cm_test_all_sandia uses ',' but nvcc_wrapper needs them to be spaces