### PR TITLE
Remove test fixtures (no HPX)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ script:
           -DKokkos_ENABLE_TESTS=On
           ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}} &&
     make VERBOSE=1 -j2 &&
-    travis_wait make test CTEST_OUTPUT_ON_FAILURE=1 &&
+    travis_wait 60 make test CTEST_OUTPUT_ON_FAILURE=1 &&
     make install DESTDIR=${PWD}/install && rm -rf ${PWD}/install/usr/local && rmdir ${PWD}/install/usr &&
     popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ script:
           -DKokkos_ENABLE_TESTS=On
           ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}} &&
     make VERBOSE=1 -j2 &&
-    travis_wait ctest --verbose &&
+    travis_wait 60 make test CTEST_OUTPUT_ON_FAILURE=1 &&
     make install DESTDIR=${PWD}/install && rm -rf ${PWD}/install/usr/local && rmdir ${PWD}/install/usr &&
     popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ script:
           -DKokkos_ENABLE_TESTS=On
           ${CMAKE_BUILD_TYPE:+-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}} &&
     make VERBOSE=1 -j2 &&
-    travis_wait 60 make test CTEST_OUTPUT_ON_FAILURE=1 &&
+    travis_wait ctest --verbose &&
     make install DESTDIR=${PWD}/install && rm -rf ${PWD}/install/usr/local && rmdir ${PWD}/install/usr &&
     popd
 

--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -14,6 +14,38 @@ SET(SOURCES
   PerfTestGramSchmidt.cpp
   PerfTestHexGrad.cpp
   PerfTest_CustomReduction.cpp
+  PerfTest_ExecSpacePartitioning.cpp
+  PerfTest_ViewCopy_a123.cpp
+  PerfTest_ViewCopy_b123.cpp
+  PerfTest_ViewCopy_c123.cpp
+  PerfTest_ViewCopy_d123.cpp
+  PerfTest_ViewCopy_a45.cpp
+  PerfTest_ViewCopy_b45.cpp
+  PerfTest_ViewCopy_c45.cpp
+  PerfTest_ViewCopy_d45.cpp
+  PerfTest_ViewCopy_a6.cpp
+  PerfTest_ViewCopy_b6.cpp
+  PerfTest_ViewCopy_c6.cpp
+  PerfTest_ViewCopy_d6.cpp
+  PerfTest_ViewCopy_a7.cpp
+  PerfTest_ViewCopy_b7.cpp
+  PerfTest_ViewCopy_c7.cpp
+  PerfTest_ViewCopy_d7.cpp
+  PerfTest_ViewCopy_a8.cpp
+  PerfTest_ViewCopy_b8.cpp
+  PerfTest_ViewCopy_c8.cpp
+  PerfTest_ViewCopy_d8.cpp
+  PerfTest_ViewAllocate.cpp
+  PerfTest_ViewFill_123.cpp
+  PerfTest_ViewFill_45.cpp
+  PerfTest_ViewFill_6.cpp
+  PerfTest_ViewFill_7.cpp
+  PerfTest_ViewFill_8.cpp
+  PerfTest_ViewResize_123.cpp
+  PerfTest_ViewResize_45.cpp
+  PerfTest_ViewResize_6.cpp
+  PerfTest_ViewResize_7.cpp
+  PerfTest_ViewResize_8.cpp
   )
 
 # Per #374, we always want to build this test, but we only want to run

--- a/core/perf_test/PerfTestGramSchmidt.cpp
+++ b/core/perf_test/PerfTestGramSchmidt.cpp
@@ -234,7 +234,7 @@ void run_test_gramschmidt(int exp_beg, int exp_end, int num_trials,
   }
 }
 
-TEST_F(default_exec, gramschmidt) {
+TEST(default_exec, gramschmidt) {
   int exp_beg    = 10;
   int exp_end    = 20;
   int num_trials = 5;

--- a/core/perf_test/PerfTestHexGrad.cpp
+++ b/core/perf_test/PerfTestHexGrad.cpp
@@ -283,7 +283,7 @@ void run_test_hexgrad(int exp_beg, int exp_end, int num_trials,
   }
 }
 
-TEST_F(default_exec, hexgrad) {
+TEST(default_exec, hexgrad) {
   int exp_beg    = 10;
   int exp_end    = 20;
   int num_trials = 5;

--- a/core/perf_test/PerfTest_Category.hpp
+++ b/core/perf_test/PerfTest_Category.hpp
@@ -51,13 +51,6 @@ namespace Test {
 extern int command_line_num_args(int n = 0);
 extern const char* command_line_arg(int k, char** input_args = NULL);
 
-class default_exec : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
 }  // namespace Test
 
 #define TEST_CATEGORY default_exec

--- a/core/perf_test/PerfTest_CustomReduction.cpp
+++ b/core/perf_test/PerfTest_CustomReduction.cpp
@@ -123,7 +123,7 @@ void custom_reduction_test(int N, int R, int num_trials) {
          max);
 }
 
-TEST_F(default_exec, custom_reduction) {
+TEST(default_exec, custom_reduction) {
   int N          = 100000;
   int R          = 1000;
   int num_trials = 1;

--- a/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
+++ b/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
@@ -127,7 +127,7 @@ struct FunctorTeamReduce {
   }
 };
 
-TEST_F(default_exec, overlap_range_policy) {
+TEST(default_exec, overlap_range_policy) {
   int N = 2000;
   int M = 10000;
   int R = 10;
@@ -288,7 +288,7 @@ TEST_F(default_exec, overlap_range_policy) {
   SpaceInstance<TEST_EXECSPACE>::destroy(space2);
 }
 
-TEST_F(default_exec, overlap_mdrange_policy) {
+TEST(default_exec, overlap_mdrange_policy) {
   int N = 200;
   int M = 10000;
   int R = 10;
@@ -467,7 +467,7 @@ TEST_F(default_exec, overlap_mdrange_policy) {
   SpaceInstance<TEST_EXECSPACE>::destroy(space1);
 }
 
-TEST_F(default_exec, overlap_team_policy) {
+TEST(default_exec, overlap_team_policy) {
   int N = 20;
   int M = 1000000;
   int R = 10;

--- a/core/perf_test/PerfTest_ViewAllocate.cpp
+++ b/core/perf_test/PerfTest_ViewAllocate.cpp
@@ -149,7 +149,7 @@ void run_allocateview_tests(int N, int R) {
          size / 1024 / time8);
 }
 
-TEST_F(default_exec, ViewCreate) {
+TEST(default_exec, ViewCreate) {
   printf("Create View Performance for LayoutLeft:\n");
   run_allocateview_tests<Kokkos::LayoutLeft>(10, 1);
   printf("Create View Performance for LayoutRight:\n");

--- a/core/perf_test/PerfTest_ViewCopy_a123.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_a123.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_LeftLeft_Rank123) {
+TEST(default_exec, ViewDeepCopy_LeftLeft_Rank123) {
   printf("DeepCopy Performance for LayoutLeft to LayoutLeft:\n");
   run_deepcopyview_tests123<Kokkos::LayoutLeft, Kokkos::LayoutLeft>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_a45.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_a45.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_LeftLeft_Rank45) {
+TEST(default_exec, ViewDeepCopy_LeftLeft_Rank45) {
   printf("DeepCopy Performance for LayoutLeft to LayoutLeft:\n");
   run_deepcopyview_tests45<Kokkos::LayoutLeft, Kokkos::LayoutLeft>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_a6.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_a6.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_LeftLeft_Rank6) {
+TEST(default_exec, ViewDeepCopy_LeftLeft_Rank6) {
   printf("DeepCopy Performance for LayoutLeft to LayoutLeft:\n");
   run_deepcopyview_tests6<Kokkos::LayoutLeft, Kokkos::LayoutLeft>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_a7.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_a7.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_LeftLeft_Rank7) {
+TEST(default_exec, ViewDeepCopy_LeftLeft_Rank7) {
   printf("DeepCopy Performance for LayoutLeft to LayoutLeft:\n");
   run_deepcopyview_tests7<Kokkos::LayoutLeft, Kokkos::LayoutLeft>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_a8.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_a8.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_LeftLeft_Rank8) {
+TEST(default_exec, ViewDeepCopy_LeftLeft_Rank8) {
   printf("DeepCopy Performance for LayoutLeft to LayoutLeft:\n");
   run_deepcopyview_tests8<Kokkos::LayoutLeft, Kokkos::LayoutLeft>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_b123.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_b123.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_RightRight_Rank123) {
+TEST(default_exec, ViewDeepCopy_RightRight_Rank123) {
   printf("DeepCopy Performance for LayoutRight to LayoutRight:\n");
   run_deepcopyview_tests123<Kokkos::LayoutRight, Kokkos::LayoutRight>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_b45.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_b45.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_RightRight_Rank45) {
+TEST(default_exec, ViewDeepCopy_RightRight_Rank45) {
   printf("DeepCopy Performance for LayoutRight to LayoutRight:\n");
   run_deepcopyview_tests45<Kokkos::LayoutRight, Kokkos::LayoutRight>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_b7.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_b7.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_RightRight_Rank7) {
+TEST(default_exec, ViewDeepCopy_RightRight_Rank7) {
   printf("DeepCopy Performance for LayoutRight to LayoutRight:\n");
   run_deepcopyview_tests7<Kokkos::LayoutRight, Kokkos::LayoutRight>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_b8.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_b8.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_RightRight_Rank8) {
+TEST(default_exec, ViewDeepCopy_RightRight_Rank8) {
   printf("DeepCopy Performance for LayoutRight to LayoutRight:\n");
   run_deepcopyview_tests8<Kokkos::LayoutRight, Kokkos::LayoutRight>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_c123.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_c123.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_LeftRight_Rank123) {
+TEST(default_exec, ViewDeepCopy_LeftRight_Rank123) {
   printf("DeepCopy Performance for LayoutLeft to LayoutRight:\n");
   run_deepcopyview_tests123<Kokkos::LayoutLeft, Kokkos::LayoutRight>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_c45.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_c45.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_LeftRight_Rank45) {
+TEST(default_exec, ViewDeepCopy_LeftRight_Rank45) {
   printf("DeepCopy Performance for LayoutLeft to LayoutRight:\n");
   run_deepcopyview_tests45<Kokkos::LayoutLeft, Kokkos::LayoutRight>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_c6.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_c6.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_LeftRight_Rank6) {
+TEST(default_exec, ViewDeepCopy_LeftRight_Rank6) {
   printf("DeepCopy Performance for LayoutLeft to LayoutRight:\n");
   run_deepcopyview_tests6<Kokkos::LayoutLeft, Kokkos::LayoutRight>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_c7.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_c7.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_LeftRight_Rank7) {
+TEST(default_exec, ViewDeepCopy_LeftRight_Rank7) {
   printf("DeepCopy Performance for LayoutLeft to LayoutRight:\n");
   run_deepcopyview_tests7<Kokkos::LayoutLeft, Kokkos::LayoutRight>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_c8.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_c8.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_LeftRight_Rank8) {
+TEST(default_exec, ViewDeepCopy_LeftRight_Rank8) {
   printf("DeepCopy Performance for LayoutLeft to LayoutRight:\n");
   run_deepcopyview_tests8<Kokkos::LayoutLeft, Kokkos::LayoutRight>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_d123.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_d123.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_RightLeft_Rank123) {
+TEST(default_exec, ViewDeepCopy_RightLeft_Rank123) {
   printf("DeepCopy Performance for LayoutRight to LayoutLeft:\n");
   run_deepcopyview_tests123<Kokkos::LayoutRight, Kokkos::LayoutLeft>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_d45.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_d45.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_RightLeft_Rank45) {
+TEST(default_exec, ViewDeepCopy_RightLeft_Rank45) {
   printf("DeepCopy Performance for LayoutRight to LayoutLeft:\n");
   run_deepcopyview_tests45<Kokkos::LayoutRight, Kokkos::LayoutLeft>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_d6.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_d6.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_RightLeft_Rank6) {
+TEST(default_exec, ViewDeepCopy_RightLeft_Rank6) {
   printf("DeepCopy Performance for LayoutRight to LayoutLeft:\n");
   run_deepcopyview_tests6<Kokkos::LayoutRight, Kokkos::LayoutLeft>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_d7.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_d7.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_RightLeft_Rank7) {
+TEST(default_exec, ViewDeepCopy_RightLeft_Rank7) {
   printf("DeepCopy Performance for LayoutRight to LayoutLeft:\n");
   run_deepcopyview_tests7<Kokkos::LayoutRight, Kokkos::LayoutLeft>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewCopy_d8.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_d8.cpp
@@ -43,7 +43,7 @@
 
 #include <PerfTest_ViewCopy.hpp>
 namespace Test {
-TEST_F(default_exec, ViewDeepCopy_RightLeft_Rank8) {
+TEST(default_exec, ViewDeepCopy_RightLeft_Rank8) {
   printf("DeepCopy Performance for LayoutRight to LayoutLeft:\n");
   run_deepcopyview_tests8<Kokkos::LayoutRight, Kokkos::LayoutLeft>(10, 1);
 }

--- a/core/perf_test/PerfTest_ViewFill_123.cpp
+++ b/core/perf_test/PerfTest_ViewFill_123.cpp
@@ -44,7 +44,7 @@
 #include <PerfTest_ViewFill.hpp>
 
 namespace Test {
-TEST_F(default_exec, ViewFill_Rank123) {
+TEST(default_exec, ViewFill_Rank123) {
   printf("ViewFill Performance for LayoutLeft:\n");
   run_fillview_tests123<Kokkos::LayoutLeft>(10, 1);
   printf("ViewFill Performance for LayoutRight:\n");

--- a/core/perf_test/PerfTest_ViewFill_45.cpp
+++ b/core/perf_test/PerfTest_ViewFill_45.cpp
@@ -44,7 +44,7 @@
 #include <PerfTest_ViewFill.hpp>
 
 namespace Test {
-TEST_F(default_exec, ViewFill_Rank45) {
+TEST(default_exec, ViewFill_Rank45) {
   printf("ViewFill Performance for LayoutLeft:\n");
   run_fillview_tests45<Kokkos::LayoutLeft>(10, 1);
   printf("ViewFill Performance for LayoutRight:\n");

--- a/core/perf_test/PerfTest_ViewFill_6.cpp
+++ b/core/perf_test/PerfTest_ViewFill_6.cpp
@@ -44,7 +44,7 @@
 #include <PerfTest_ViewFill.hpp>
 
 namespace Test {
-TEST_F(default_exec, ViewFill_Rank6) {
+TEST(default_exec, ViewFill_Rank6) {
   printf("ViewFill Performance for LayoutLeft:\n");
   run_fillview_tests6<Kokkos::LayoutLeft>(10, 1);
   printf("ViewFill Performance for LayoutRight:\n");

--- a/core/perf_test/PerfTest_ViewFill_7.cpp
+++ b/core/perf_test/PerfTest_ViewFill_7.cpp
@@ -44,7 +44,7 @@
 #include <PerfTest_ViewFill.hpp>
 
 namespace Test {
-TEST_F(default_exec, ViewFill_Rank7) {
+TEST(default_exec, ViewFill_Rank7) {
   printf("ViewFill Performance for LayoutLeft:\n");
   run_fillview_tests7<Kokkos::LayoutLeft>(10, 1);
   printf("ViewFill Performance for LayoutRight:\n");

--- a/core/perf_test/PerfTest_ViewFill_8.cpp
+++ b/core/perf_test/PerfTest_ViewFill_8.cpp
@@ -44,7 +44,7 @@
 #include <PerfTest_ViewFill.hpp>
 
 namespace Test {
-TEST_F(default_exec, ViewFill_Rank8) {
+TEST(default_exec, ViewFill_Rank8) {
   printf("ViewFill Performance for LayoutLeft:\n");
   run_fillview_tests8<Kokkos::LayoutLeft>(10, 1);
   printf("ViewFill Performance for LayoutRight:\n");

--- a/core/perf_test/PerfTest_ViewResize_123.cpp
+++ b/core/perf_test/PerfTest_ViewResize_123.cpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(default_exec, ViewResize_Rank123) {
+TEST(default_exec, ViewResize_Rank123) {
   printf("Resize View Performance for LayoutLeft:\n");
   run_resizeview_tests123<Kokkos::LayoutLeft>(10, 1);
   printf("Resize View Performance for LayoutRight:\n");

--- a/core/perf_test/PerfTest_ViewResize_45.cpp
+++ b/core/perf_test/PerfTest_ViewResize_45.cpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(default_exec, ViewResize_Rank_45) {
+TEST(default_exec, ViewResize_Rank_45) {
   printf("Resize View Performance for LayoutLeft:\n");
   run_resizeview_tests45<Kokkos::LayoutLeft>(10, 1);
   printf("Resize View Performance for LayoutRight:\n");

--- a/core/perf_test/PerfTest_ViewResize_6.cpp
+++ b/core/perf_test/PerfTest_ViewResize_6.cpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(default_exec, ViewResize_Rank6) {
+TEST(default_exec, ViewResize_Rank6) {
   printf("Resize View Performance for LayoutLeft:\n");
   run_resizeview_tests6<Kokkos::LayoutLeft>(10, 1);
   printf("Resize View Performance for LayoutRight:\n");

--- a/core/perf_test/PerfTest_ViewResize_7.cpp
+++ b/core/perf_test/PerfTest_ViewResize_7.cpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(default_exec, ViewResize_Rank7) {
+TEST(default_exec, ViewResize_Rank7) {
   printf("Resize View Performance for LayoutLeft:\n");
   run_resizeview_tests7<Kokkos::LayoutLeft>(10, 1);
   printf("Resize View Performance for LayoutRight:\n");

--- a/core/perf_test/PerfTest_ViewResize_8.cpp
+++ b/core/perf_test/PerfTest_ViewResize_8.cpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(default_exec, ViewResize_Rank8) {
+TEST(default_exec, ViewResize_Rank8) {
   printf("Resize View Performance for LayoutLeft:\n");
   run_resizeview_tests8<Kokkos::LayoutLeft>(10, 1);
   printf("Resize View Performance for LayoutRight:\n");

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -41,7 +41,10 @@ IF(KOKKOS_ENABLE_SERIAL)
       serial/TestSerial_AtomicViews.cpp
       serial/TestSerial_Atomics.cpp
       serial/TestSerial_Complex.cpp
+      serial/TestSerial_DeepCopyAlignment.cpp
+      serial/TestSerial_FunctorAnalysis.cpp
       serial/TestSerial_Init.cpp
+      serial/TestSerial_LocalDeepCopy.cpp
       serial/TestSerial_MDRange_a.cpp
       serial/TestSerial_MDRange_b.cpp
       serial/TestSerial_MDRange_c.cpp
@@ -54,6 +57,7 @@ IF(KOKKOS_ENABLE_SERIAL)
       serial/TestSerial_Reducers_b.cpp
       serial/TestSerial_Reducers_c.cpp
       serial/TestSerial_Reducers_d.cpp
+      serial/TestSerial_Reductions_DeviceView.cpp
       serial/TestSerial_Scan.cpp
       serial/TestSerial_SharedAlloc.cpp
       serial/TestSerial_SubView_a.cpp
@@ -75,17 +79,21 @@ IF(KOKKOS_ENABLE_SERIAL)
       serial/TestSerial_Team.cpp
       serial/TestSerial_TeamReductionScan.cpp
       serial/TestSerial_TeamScratch.cpp
+      serial/TestSerial_TeamTeamSize.cpp
+      serial/TestSerial_TeamVectorRange.cpp
       serial/TestSerial_ViewAPI_a.cpp
       serial/TestSerial_ViewAPI_b.cpp
       serial/TestSerial_ViewAPI_c.cpp
       serial/TestSerial_ViewAPI_d.cpp
       serial/TestSerial_ViewAPI_e.cpp
+      serial/TestSerial_ViewLayoutStrideAssignment.cpp
       serial/TestSerial_ViewMapping_a.cpp
       serial/TestSerial_ViewMapping_b.cpp
       serial/TestSerial_ViewMapping_subview.cpp
       serial/TestSerial_ViewOfClass.cpp
       serial/TestSerial_Crs.cpp
       serial/TestSerial_WorkGraph.cpp
+      serial/TestSerial_View_64bit.cpp
       serial/TestSerial_ViewResize.cpp
   )
 ENDIF()
@@ -107,7 +115,10 @@ IF(Kokkos_ENABLE_PTHREAD)
       threads/TestThreads_AtomicViews.cpp
       threads/TestThreads_Atomics.cpp
       threads/TestThreads_Complex.cpp
+      threads/TestThreads_DeepCopyAlignment.cpp
+      threads/TestThreads_FunctorAnalysis.cpp
       threads/TestThreads_Init.cpp
+      threads/TestThreads_LocalDeepCopy.cpp
       threads/TestThreads_MDRange_a.cpp
       threads/TestThreads_MDRange_b.cpp
       threads/TestThreads_MDRange_c.cpp
@@ -120,6 +131,7 @@ IF(Kokkos_ENABLE_PTHREAD)
       threads/TestThreads_Reducers_b.cpp
       threads/TestThreads_Reducers_c.cpp
       threads/TestThreads_Reducers_d.cpp
+      threads/TestThreads_Reductions_DeviceView.cpp
       threads/TestThreads_Scan.cpp
       threads/TestThreads_SharedAlloc.cpp
       threads/TestThreads_SubView_a.cpp
@@ -140,11 +152,15 @@ IF(Kokkos_ENABLE_PTHREAD)
       threads/TestThreads_Team.cpp
       threads/TestThreads_TeamReductionScan.cpp
       threads/TestThreads_TeamScratch.cpp
+      threads/TestThreads_TeamTeamSize.cpp
+      threads/TestThreads_TeamVectorRange.cpp
+      threads/TestThreads_View_64bit.cpp
       threads/TestThreads_ViewAPI_a.cpp
       threads/TestThreads_ViewAPI_b.cpp
       threads/TestThreads_ViewAPI_c.cpp
       threads/TestThreads_ViewAPI_d.cpp
       threads/TestThreads_ViewAPI_e.cpp
+      threads/TestThreads_ViewLayoutStrideAssignment.cpp
       threads/TestThreads_ViewMapping_a.cpp
       threads/TestThreads_ViewMapping_b.cpp
       threads/TestThreads_ViewMapping_subview.cpp
@@ -172,7 +188,10 @@ IF(Kokkos_ENABLE_OPENMP)
       openmp/TestOpenMP_AtomicViews.cpp
       openmp/TestOpenMP_Atomics.cpp
       openmp/TestOpenMP_Complex.cpp
+      openmp/TestOpenMP_DeepCopyAlignment.cpp
+      openmp/TestOpenMP_FunctorAnalysis.cpp
       openmp/TestOpenMP_Init.cpp
+      openmp/TestOpenMP_LocalDeepCopy.cpp
       openmp/TestOpenMP_MDRange_a.cpp
       openmp/TestOpenMP_MDRange_b.cpp
       openmp/TestOpenMP_MDRange_c.cpp
@@ -185,6 +204,7 @@ IF(Kokkos_ENABLE_OPENMP)
       openmp/TestOpenMP_Reducers_b.cpp
       openmp/TestOpenMP_Reducers_c.cpp
       openmp/TestOpenMP_Reducers_d.cpp
+      openmp/TestOpenMP_Reductions_DeviceView.cpp
       openmp/TestOpenMP_Scan.cpp
       openmp/TestOpenMP_SharedAlloc.cpp
       openmp/TestOpenMP_SubView_a.cpp
@@ -205,11 +225,15 @@ IF(Kokkos_ENABLE_OPENMP)
       openmp/TestOpenMP_Task.cpp
       openmp/TestOpenMP_Team.cpp
       openmp/TestOpenMP_TeamReductionScan.cpp
+      openmp/TestOpenMP_TeamTeamSize.cpp
+      openmp/TestOpenMP_TeamVectorRange.cpp
+      openmp/TestOpenMP_View_64bit.cpp
       openmp/TestOpenMP_ViewAPI_a.cpp
       openmp/TestOpenMP_ViewAPI_b.cpp
       openmp/TestOpenMP_ViewAPI_c.cpp
       openmp/TestOpenMP_ViewAPI_d.cpp
       openmp/TestOpenMP_ViewAPI_e.cpp
+      openmp/TestOpenMP_ViewLayoutStrideAssignment.cpp
       openmp/TestOpenMP_ViewMapping_a.cpp
       openmp/TestOpenMP_ViewMapping_b.cpp
       openmp/TestOpenMP_ViewMapping_subview.cpp
@@ -276,6 +300,8 @@ IF(Kokkos_ENABLE_HPX)
       hpx/TestHPX_Team.cpp
       hpx/TestHPX_TeamReductionScan.cpp
       hpx/TestHPX_TeamScratch.cpp
+      hpx/TestHPX_TeamVectorRange.cpp
+      hpx/TestHPX_View_64bit.cpp
       hpx/TestHPX_ViewAPI_a.cpp
       hpx/TestHPX_ViewAPI_b.cpp
       hpx/TestHPX_ViewAPI_c.cpp
@@ -305,6 +331,7 @@ IF(Kokkos_ENABLE_QTHREADS)
       UnitTestMainInit.cpp
       qthreads/TestQthreads_Atomics.cpp
       qthreads/TestQthreads_Complex.cpp
+      qthreads/TestQthreads_DeepCopyAlignment.cpp
       qthreads/TestQthreads_Other.cpp
       qthreads/TestQthreads_Reductions.cpp
       qthreads/TestQthreads_Reducers_a.cpp
@@ -327,6 +354,7 @@ IF(Kokkos_ENABLE_QTHREADS)
       qthreads/TestQthreads_SubView_c12.cpp
       qthreads/TestQthreads_SubView_c13.cpp
       qthreads/TestQthreads_Team.cpp
+      qthreads/TestQthreads_View_64bit.cpp
       qthreads/TestQthreads_ViewAPI_a.cpp
       qthreads/TestQthreads_ViewAPI_b.cpp
       qthreads/TestQthreads_ViewAPI_c.cpp
@@ -372,7 +400,10 @@ IF(Kokkos_ENABLE_CUDA)
       cuda/TestCuda_AtomicViews.cpp
       cuda/TestCuda_Atomics.cpp
       cuda/TestCuda_Complex.cpp
+      cuda/TestCuda_DeepCopyAlignment.cpp
       cuda/TestCuda_Init.cpp
+      cuda/TestCuda_FunctorAnalysis.cpp
+      cuda/TestCuda_LocalDeepCopy.cpp
       cuda/TestCuda_MDRange_a.cpp
       cuda/TestCuda_MDRange_b.cpp
       cuda/TestCuda_MDRange_c.cpp
@@ -385,6 +416,7 @@ IF(Kokkos_ENABLE_CUDA)
       cuda/TestCuda_Reducers_b.cpp
       cuda/TestCuda_Reducers_c.cpp
       cuda/TestCuda_Reducers_d.cpp
+      cuda/TestCuda_Reductions_DeviceView.cpp
       cuda/TestCuda_Scan.cpp
       cuda/TestCuda_SharedAlloc.cpp
       cuda/TestCuda_Spaces.cpp
@@ -407,11 +439,15 @@ IF(Kokkos_ENABLE_CUDA)
       cuda/TestCuda_Team.cpp
       cuda/TestCuda_TeamReductionScan.cpp
       cuda/TestCuda_TeamScratch.cpp
+      cuda/TestCuda_TeamTeamSize.cpp
+      cuda/TestCuda_TeamVectorRange.cpp
+      cuda/TestCuda_View_64bit.cpp
       cuda/TestCuda_ViewAPI_a.cpp
       cuda/TestCuda_ViewAPI_b.cpp
       cuda/TestCuda_ViewAPI_c.cpp
       cuda/TestCuda_ViewAPI_d.cpp
       cuda/TestCuda_ViewAPI_e.cpp
+      cuda/TestCuda_ViewLayoutStrideAssignment.cpp
       cuda/TestCuda_ViewMapping_a.cpp
       cuda/TestCuda_ViewMapping_b.cpp
       cuda/TestCuda_ViewMapping_subview.cpp

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -225,6 +225,7 @@ IF(Kokkos_ENABLE_OPENMP)
       openmp/TestOpenMP_Task.cpp
       openmp/TestOpenMP_Team.cpp
       openmp/TestOpenMP_TeamReductionScan.cpp
+      openmp/TestOpenMP_TeamScratch.cpp
       openmp/TestOpenMP_TeamTeamSize.cpp
       openmp/TestOpenMP_TeamVectorRange.cpp
       openmp/TestOpenMP_View_64bit.cpp

--- a/core/unit_test/TestAggregate.hpp
+++ b/core/unit_test/TestAggregate.hpp
@@ -139,7 +139,7 @@ void TestViewAggregate() {
   }
 }
 
-TEST_F(TEST_CATEGORY, view_aggregate) { TestViewAggregate<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, view_aggregate) { TestViewAggregate<TEST_EXECSPACE>(); }
 
 }  // namespace Test
 

--- a/core/unit_test/TestAtomic.hpp
+++ b/core/unit_test/TestAtomic.hpp
@@ -491,7 +491,7 @@ bool Loop(int loop, int test) {
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, atomics) {
+TEST(TEST_CATEGORY, atomics) {
   const int loop_count = 1e4;
 
   ASSERT_TRUE((TestAtomic::Loop<int, TEST_EXECSPACE>(loop_count, 1)));

--- a/core/unit_test/TestAtomicOperations_complexdouble.hpp
+++ b/core/unit_test/TestAtomicOperations_complexdouble.hpp
@@ -44,7 +44,7 @@
 #include <TestAtomicOperations.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, atomic_operations_complexdouble) {
+TEST(TEST_CATEGORY, atomic_operations_complexdouble) {
   const int start = 1;  // Avoid zero for division.
   const int end   = 11;
   for (int i = start; i < end; ++i) {

--- a/core/unit_test/TestAtomicOperations_complexfloat.hpp
+++ b/core/unit_test/TestAtomicOperations_complexfloat.hpp
@@ -44,7 +44,7 @@
 #include <TestAtomicOperations.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, atomic_operations_complexfloat) {
+TEST(TEST_CATEGORY, atomic_operations_complexfloat) {
   const int start = 1;  // Avoid zero for division.
   const int end   = 11;
   for (int i = start; i < end; ++i) {

--- a/core/unit_test/TestAtomicOperations_double.hpp
+++ b/core/unit_test/TestAtomicOperations_double.hpp
@@ -44,7 +44,7 @@
 #include <TestAtomicOperations.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, atomic_operations_double) {
+TEST(TEST_CATEGORY, atomic_operations_double) {
   const int start = 1;  // Avoid zero for division.
   const int end   = 11;
   for (int i = start; i < end; ++i) {

--- a/core/unit_test/TestAtomicOperations_float.hpp
+++ b/core/unit_test/TestAtomicOperations_float.hpp
@@ -44,7 +44,7 @@
 #include <TestAtomicOperations.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, atomic_operations_float) {
+TEST(TEST_CATEGORY, atomic_operations_float) {
   const int start = 1;  // Avoid zero for division.
   const int end   = 11;
   for (int i = start; i < end; ++i) {

--- a/core/unit_test/TestAtomicOperations_int.hpp
+++ b/core/unit_test/TestAtomicOperations_int.hpp
@@ -44,7 +44,7 @@
 #include <TestAtomicOperations.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, atomic_operations_int) {
+TEST(TEST_CATEGORY, atomic_operations_int) {
   const int start = 1;  // Avoid zero for division.
   const int end   = 11;
   for (int i = start; i < end; ++i) {

--- a/core/unit_test/TestAtomicOperations_longint.hpp
+++ b/core/unit_test/TestAtomicOperations_longint.hpp
@@ -44,7 +44,7 @@
 #include <TestAtomicOperations.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, atomic_operations_long) {
+TEST(TEST_CATEGORY, atomic_operations_long) {
   const int start = 1;  // Avoid zero for division.
   const int end   = 11;
   for (int i = start; i < end; ++i) {

--- a/core/unit_test/TestAtomicOperations_longlongint.hpp
+++ b/core/unit_test/TestAtomicOperations_longlongint.hpp
@@ -44,7 +44,7 @@
 #include <TestAtomicOperations.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, atomic_operations_longlong) {
+TEST(TEST_CATEGORY, atomic_operations_longlong) {
   const int start = 1;  // Avoid zero for division.
   const int end   = 11;
   for (int i = start; i < end; ++i) {

--- a/core/unit_test/TestAtomicOperations_unsignedint.hpp
+++ b/core/unit_test/TestAtomicOperations_unsignedint.hpp
@@ -44,7 +44,7 @@
 #include <TestAtomicOperations.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, atomic_operations_unsigned) {
+TEST(TEST_CATEGORY, atomic_operations_unsigned) {
   const int start = 1;  // Avoid zero for division.
   const int end   = 11;
   for (int i = start; i < end; ++i) {

--- a/core/unit_test/TestAtomicOperations_unsignedlongint.hpp
+++ b/core/unit_test/TestAtomicOperations_unsignedlongint.hpp
@@ -44,7 +44,7 @@
 #include <TestAtomicOperations.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, atomic_operations_unsignedlong) {
+TEST(TEST_CATEGORY, atomic_operations_unsignedlong) {
   const int start = 1;  // Avoid zero for division.
   const int end   = 11;
   for (int i = start; i < end; ++i) {

--- a/core/unit_test/TestAtomicViews.hpp
+++ b/core/unit_test/TestAtomicViews.hpp
@@ -1424,7 +1424,7 @@ bool AtomicViewsTestNonIntegralType(const int length, int test) {
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, atomic_views_integral) {
+TEST(TEST_CATEGORY, atomic_views_integral) {
   const long length = 1000000;
   {
     // Integral Types.
@@ -1455,7 +1455,7 @@ TEST_F(TEST_CATEGORY, atomic_views_integral) {
   }
 }
 
-TEST_F(TEST_CATEGORY, atomic_views_nonintegral) {
+TEST(TEST_CATEGORY, atomic_views_nonintegral) {
   const long length = 1000000;
   {
     // Non-Integral Types.
@@ -1474,7 +1474,7 @@ TEST_F(TEST_CATEGORY, atomic_views_nonintegral) {
   }
 }
 
-TEST_F(TEST_CATEGORY, atomic_view_api) {
+TEST(TEST_CATEGORY, atomic_view_api) {
   TestAtomicViews::TestAtomicViewAPI<int, TEST_EXECSPACE>();
 }
 }  // namespace Test

--- a/core/unit_test/TestCXX11.hpp
+++ b/core/unit_test/TestCXX11.hpp
@@ -367,7 +367,7 @@ bool Test(int test) {
 }  // namespace TestCXX11
 
 namespace Test {
-TEST_F(TEST_CATEGORY, cxx11) {
+TEST(TEST_CATEGORY, cxx11) {
   if (std::is_same<Kokkos::DefaultExecutionSpace, TEST_EXECSPACE>::value) {
     ASSERT_TRUE((TestCXX11::Test<TEST_EXECSPACE>(1)));
     ASSERT_TRUE((TestCXX11::Test<TEST_EXECSPACE>(2)));

--- a/core/unit_test/TestCXX11Deduction.hpp
+++ b/core/unit_test/TestCXX11Deduction.hpp
@@ -100,7 +100,7 @@ void test_reduction_deduction() {
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, reduction_deduction) {
+TEST(TEST_CATEGORY, reduction_deduction) {
   TestCXX11::test_reduction_deduction<TEST_EXECSPACE>();
 }
 }  // namespace Test

--- a/core/unit_test/TestCompilerMacros.hpp
+++ b/core/unit_test/TestCompilerMacros.hpp
@@ -110,7 +110,7 @@ bool Test() {
 }  // namespace TestCompilerMacros
 
 namespace Test {
-TEST_F(TEST_CATEGORY, compiler_macros) {
+TEST(TEST_CATEGORY, compiler_macros) {
   ASSERT_TRUE((TestCompilerMacros::Test<TEST_EXECSPACE>()));
 }
 }  // namespace Test

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -124,7 +124,7 @@ struct TestComplexConstruction {
   }
 };
 
-TEST_F(TEST_CATEGORY, complex_construction) {
+TEST(TEST_CATEGORY, complex_construction) {
   TestComplexConstruction<TEST_EXECSPACE> test;
   test.testit();
 }
@@ -274,7 +274,7 @@ struct TestComplexBasicMath {
   }
 };
 
-TEST_F(TEST_CATEGORY, complex_basic_math) {
+TEST(TEST_CATEGORY, complex_basic_math) {
   TestComplexBasicMath<TEST_EXECSPACE> test;
   test.testit();
 }
@@ -348,11 +348,11 @@ void testComplexIO() {
   ASSERT_EQ(z, (Kokkos::complex<double>{3, 4}));
 }
 
-TEST_F(TEST_CATEGORY, complex_special_funtions) {
+TEST(TEST_CATEGORY, complex_special_funtions) {
   TestComplexSpecialFunctions<TEST_EXECSPACE> test;
   test.testit();
 }
 
-TEST_F(TEST_CATEGORY, complex_io) { testComplexIO(); }
+TEST(TEST_CATEGORY, complex_io) { testComplexIO(); }
 
 }  // namespace Test

--- a/core/unit_test/TestCrs.hpp
+++ b/core/unit_test/TestCrs.hpp
@@ -200,7 +200,7 @@ void test_constructor(std::int32_t nrows) {
 
 }  // anonymous namespace
 
-TEST_F(TEST_CATEGORY, crs_count_fill) {
+TEST(TEST_CATEGORY, crs_count_fill) {
   test_count_fill<TEST_EXECSPACE>(0);
   test_count_fill<TEST_EXECSPACE>(1);
   test_count_fill<TEST_EXECSPACE>(2);
@@ -211,7 +211,7 @@ TEST_F(TEST_CATEGORY, crs_count_fill) {
   test_count_fill<TEST_EXECSPACE>(10000);
 }
 
-TEST_F(TEST_CATEGORY, crs_copy_constructor) {
+TEST(TEST_CATEGORY, crs_copy_constructor) {
   test_constructor<TEST_EXECSPACE>(0);
   test_constructor<TEST_EXECSPACE>(1);
   test_constructor<TEST_EXECSPACE>(2);

--- a/core/unit_test/TestDeepCopy.hpp
+++ b/core/unit_test/TestDeepCopy.hpp
@@ -196,7 +196,7 @@ struct TestDeepCopy {
 };
 }  // namespace Impl
 
-TEST_F(TEST_CATEGORY, deep_copy_alignment) {
+TEST(TEST_CATEGORY, deep_copy_alignment) {
   {
     Impl::TestDeepCopy<TEST_EXECSPACE::memory_space,
                        TEST_EXECSPACE::memory_space>::run_test(100000);

--- a/core/unit_test/TestDefaultDeviceTypeInit.hpp
+++ b/core/unit_test/TestDefaultDeviceTypeInit.hpp
@@ -302,19 +302,12 @@ void test_initstruct_args(const Kokkos::InitArguments& args) {
 
 }  // namespace Impl
 
-class defaultdevicetypeinit : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_01
-TEST_F(defaultdevicetypeinit, no_args) { Impl::test_no_arguments(); }
+TEST(defaultdevicetypeinit, no_args) { Impl::test_no_arguments(); }
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_02
-TEST_F(defaultdevicetypeinit, commandline_args_empty) {
+TEST(defaultdevicetypeinit, commandline_args_empty) {
   Kokkos::InitArguments argstruct;
   int nargs = 0;
   char** args =
@@ -329,7 +322,7 @@ TEST_F(defaultdevicetypeinit, commandline_args_empty) {
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_03
-TEST_F(defaultdevicetypeinit, commandline_args_other) {
+TEST(defaultdevicetypeinit, commandline_args_other) {
   Kokkos::InitArguments argstruct;
   int nargs = 0;
   char** args =
@@ -344,7 +337,7 @@ TEST_F(defaultdevicetypeinit, commandline_args_other) {
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_04
-TEST_F(defaultdevicetypeinit, commandline_args_nthreads) {
+TEST(defaultdevicetypeinit, commandline_args_nthreads) {
   Kokkos::InitArguments argstruct;
   int nargs = 0;
   char** args =
@@ -359,7 +352,7 @@ TEST_F(defaultdevicetypeinit, commandline_args_nthreads) {
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_05
-TEST_F(defaultdevicetypeinit, commandline_args_nthreads_numa) {
+TEST(defaultdevicetypeinit, commandline_args_nthreads_numa) {
   Kokkos::InitArguments argstruct;
   int nargs = 0;
   char** args =
@@ -374,7 +367,7 @@ TEST_F(defaultdevicetypeinit, commandline_args_nthreads_numa) {
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_06
-TEST_F(defaultdevicetypeinit, commandline_args_nthreads_numa_device) {
+TEST(defaultdevicetypeinit, commandline_args_nthreads_numa_device) {
   Kokkos::InitArguments argstruct;
   int nargs = 0;
   char** args =
@@ -389,7 +382,7 @@ TEST_F(defaultdevicetypeinit, commandline_args_nthreads_numa_device) {
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_07
-TEST_F(defaultdevicetypeinit, commandline_args_nthreads_device) {
+TEST(defaultdevicetypeinit, commandline_args_nthreads_device) {
   Kokkos::InitArguments argstruct;
   int nargs = 0;
   char** args =
@@ -404,7 +397,7 @@ TEST_F(defaultdevicetypeinit, commandline_args_nthreads_device) {
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_08
-TEST_F(defaultdevicetypeinit, commandline_args_numa_device) {
+TEST(defaultdevicetypeinit, commandline_args_numa_device) {
   Kokkos::InitArguments argstruct;
   int nargs = 0;
   char** args =
@@ -419,7 +412,7 @@ TEST_F(defaultdevicetypeinit, commandline_args_numa_device) {
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_09
-TEST_F(defaultdevicetypeinit, commandline_args_device) {
+TEST(defaultdevicetypeinit, commandline_args_device) {
   Kokkos::InitArguments argstruct;
   int nargs = 0;
   char** args =
@@ -434,7 +427,7 @@ TEST_F(defaultdevicetypeinit, commandline_args_device) {
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_10
-TEST_F(defaultdevicetypeinit, commandline_args_nthreads_numa_device_other) {
+TEST(defaultdevicetypeinit, commandline_args_nthreads_numa_device_other) {
   Kokkos::InitArguments argstruct;
   int nargs = 0;
   char** args =
@@ -449,42 +442,42 @@ TEST_F(defaultdevicetypeinit, commandline_args_nthreads_numa_device_other) {
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_11
-TEST_F(defaultdevicetypeinit, initstruct_default) {
+TEST(defaultdevicetypeinit, initstruct_default) {
   Kokkos::InitArguments args;
   Impl::test_initstruct_args(args);
 }
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_12
-TEST_F(defaultdevicetypeinit, initstruct_nthreads) {
+TEST(defaultdevicetypeinit, initstruct_nthreads) {
   Kokkos::InitArguments args = Impl::init_initstruct(true, false, false);
   Impl::test_initstruct_args(args);
 }
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_13
-TEST_F(defaultdevicetypeinit, initstruct_nthreads_numa) {
+TEST(defaultdevicetypeinit, initstruct_nthreads_numa) {
   Kokkos::InitArguments args = Impl::init_initstruct(true, true, false);
   Impl::test_initstruct_args(args);
 }
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_14
-TEST_F(defaultdevicetypeinit, initstruct_device) {
+TEST(defaultdevicetypeinit, initstruct_device) {
   Kokkos::InitArguments args = Impl::init_initstruct(false, false, true);
   Impl::test_initstruct_args(args);
 }
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_15
-TEST_F(defaultdevicetypeinit, initstruct_nthreads_device) {
+TEST(defaultdevicetypeinit, initstruct_nthreads_device) {
   Kokkos::InitArguments args = Impl::init_initstruct(true, false, true);
   Impl::test_initstruct_args(args);
 }
 #endif
 
 #ifdef KOKKOS_DEFAULTDEVICETYPE_INIT_TEST_16
-TEST_F(defaultdevicetypeinit, initstruct_nthreads_numa_device) {
+TEST(defaultdevicetypeinit, initstruct_nthreads_numa_device) {
   Kokkos::InitArguments args = Impl::init_initstruct(true, true, true);
   Impl::test_initstruct_args(args);
 }

--- a/core/unit_test/TestFunctorAnalysis.hpp
+++ b/core/unit_test/TestFunctorAnalysis.hpp
@@ -140,7 +140,7 @@ void test_functor_analysis() {
   //------------------------------
 }
 
-TEST_F(TEST_CATEGORY, functor_analysis) {
+TEST(TEST_CATEGORY, functor_analysis) {
   test_functor_analysis<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/TestHWLOC.cpp
+++ b/core/unit_test/TestHWLOC.cpp
@@ -49,14 +49,7 @@
 
 namespace Test {
 
-class hwloc : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-TEST_F(hwloc, query) {
+TEST(hwloc, query) {
   std::cout << " NUMA[" << Kokkos::hwloc::get_available_numa_count() << "]"
             << " CORE[" << Kokkos::hwloc::get_available_cores_per_numa() << "]"
             << " PU[" << Kokkos::hwloc::get_available_threads_per_core() << "]"

--- a/core/unit_test/TestHostBarrier.cpp
+++ b/core/unit_test/TestHostBarrier.cpp
@@ -2,12 +2,6 @@
 
 namespace Test {
 
-class host_barrier : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-  static void TearDownTestCase() {}
-};
-
-TEST_F(host_barrier, openmp) {}
+TEST(host_barrier, openmp) {}
 
 }  // namespace Test

--- a/core/unit_test/TestInit.hpp
+++ b/core/unit_test/TestInit.hpp
@@ -49,7 +49,7 @@
 #include <Kokkos_Core.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, init) { ; }
+TEST(TEST_CATEGORY, init) { ; }
 
 #ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
 
@@ -64,7 +64,7 @@ void test_dispatch() {
   }
 }
 
-TEST_F(TEST_CATEGORY, dispatch) { test_dispatch<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, dispatch) { test_dispatch<TEST_EXECSPACE>(); }
 #endif
 
 }  // namespace Test

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -934,7 +934,7 @@ void impl_test_local_deepcopy_rangepolicy_rank_7(const int N) {
 
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 #if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
-TEST_F(TEST_CATEGORY, local_deepcopy_teampolicy_layoutleft) {
+TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutleft) {
   typedef TEST_EXECSPACE ExecSpace;
   typedef Kokkos::View<double********, Kokkos::LayoutLeft, ExecSpace> ViewType;
 
@@ -961,7 +961,7 @@ TEST_F(TEST_CATEGORY, local_deepcopy_teampolicy_layoutleft) {
   }
 }
 //-------------------------------------------------------------------------------------------------------------
-TEST_F(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutleft) {
+TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutleft) {
   typedef TEST_EXECSPACE ExecSpace;
   typedef Kokkos::View<double********, Kokkos::LayoutLeft, ExecSpace> ViewType;
 
@@ -988,7 +988,7 @@ TEST_F(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutleft) {
   }
 }
 //-------------------------------------------------------------------------------------------------------------
-TEST_F(TEST_CATEGORY, local_deepcopy_teampolicy_layoutright) {
+TEST(TEST_CATEGORY, local_deepcopy_teampolicy_layoutright) {
   typedef TEST_EXECSPACE ExecSpace;
   typedef Kokkos::View<double********, Kokkos::LayoutRight, ExecSpace> ViewType;
 
@@ -1015,7 +1015,7 @@ TEST_F(TEST_CATEGORY, local_deepcopy_teampolicy_layoutright) {
   }
 }
 //-------------------------------------------------------------------------------------------------------------
-TEST_F(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutright) {
+TEST(TEST_CATEGORY, local_deepcopy_rangepolicy_layoutright) {
   typedef TEST_EXECSPACE ExecSpace;
   typedef Kokkos::View<double********, Kokkos::LayoutRight, ExecSpace> ViewType;
 

--- a/core/unit_test/TestMDRange_a.hpp
+++ b/core/unit_test/TestMDRange_a.hpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, mdrange_5d) {
+TEST(TEST_CATEGORY, mdrange_5d) {
 #if !defined(KOKKOS_ENABLE_ROCM)  // MDRange Reduce explicitly handled in its
                                   // own cpp file
   TestMDRange_5D<TEST_EXECSPACE>::test_reduce5(100, 10, 10, 10, 5);

--- a/core/unit_test/TestMDRange_b.hpp
+++ b/core/unit_test/TestMDRange_b.hpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, mdrange_6d) {
+TEST(TEST_CATEGORY, mdrange_6d) {
   TestMDRange_6D<TEST_EXECSPACE>::test_for6(10, 10, 10, 10, 5, 5);
 #if !defined(KOKKOS_ENABLE_ROCM)  // MDRange Reduce explicitly handled in its
                                   // own cpp file

--- a/core/unit_test/TestMDRange_c.hpp
+++ b/core/unit_test/TestMDRange_c.hpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, mdrange_2d) {
+TEST(TEST_CATEGORY, mdrange_2d) {
 #if !defined(KOKKOS_ENABLE_ROCM)  // MDRange Reduce explicitly handled in its
                                   // own cpp file
   TestMDRange_2D<TEST_EXECSPACE>::test_reduce2(100, 100);
@@ -53,7 +53,7 @@ TEST_F(TEST_CATEGORY, mdrange_2d) {
   TestMDRange_2D<TEST_EXECSPACE>::test_for2(100, 100);
 }
 
-TEST_F(TEST_CATEGORY, mdrange_array_reduce) {
+TEST(TEST_CATEGORY, mdrange_array_reduce) {
   TestMDRange_ReduceArray_2D<TEST_EXECSPACE>::test_arrayreduce2(4, 5);
   TestMDRange_ReduceArray_3D<TEST_EXECSPACE>::test_arrayreduce3(4, 5, 10);
 }

--- a/core/unit_test/TestMDRange_d.hpp
+++ b/core/unit_test/TestMDRange_d.hpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, mdrange_3d) {
+TEST(TEST_CATEGORY, mdrange_3d) {
   TestMDRange_3D<TEST_EXECSPACE>::test_for3(1, 10, 100);
   TestMDRange_3D<TEST_EXECSPACE>::test_for3(100, 10, 100);
 #if !defined(KOKKOS_ENABLE_ROCM)  // MDRange Reduced explicitly handled in its
@@ -55,7 +55,7 @@ TEST_F(TEST_CATEGORY, mdrange_3d) {
 #endif
 }
 
-TEST_F(TEST_CATEGORY, mdrange_neg_idx) {
+TEST(TEST_CATEGORY, mdrange_neg_idx) {
   TestMDRange_2D_NegIdx<TEST_EXECSPACE>::test_2D_negidx(128, 32);
   TestMDRange_3D_NegIdx<TEST_EXECSPACE>::test_3D_negidx(128, 32, 8);
   TestMDRange_4D_NegIdx<TEST_EXECSPACE>::test_4D_negidx(128, 32, 8, 8);

--- a/core/unit_test/TestMDRange_e.hpp
+++ b/core/unit_test/TestMDRange_e.hpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, mdrange_4d) {
+TEST(TEST_CATEGORY, mdrange_4d) {
 #if !defined(KOKKOS_ENABLE_ROCM)  // MDRange Reduce explicitly handled in its
                                   // own cpp file
   TestMDRange_4D<TEST_EXECSPACE>::test_reduce4(100, 10, 10, 10);

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -562,7 +562,7 @@ void test_memory_pool_huge() {
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, memory_pool) {
+TEST(TEST_CATEGORY, memory_pool) {
   TestMemoryPool::test_host_memory_pool_defaults<>();
   TestMemoryPool::test_host_memory_pool_stats<>();
   TestMemoryPool::test_memory_pool_v2<TEST_EXECSPACE>(false, false);

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -875,7 +875,7 @@ class TestTeamPolicyConstruction {
   }
 };
 
-TEST_F(TEST_CATEGORY, policy_construction) {
+TEST(TEST_CATEGORY, policy_construction) {
   TestRangePolicyConstruction<TEST_EXECSPACE>();
   TestTeamPolicyConstruction<TEST_EXECSPACE>();
 }

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -345,7 +345,7 @@ struct TestRange {
 
 }  // namespace
 
-TEST_F(TEST_CATEGORY, range_for) {
+TEST(TEST_CATEGORY, range_for) {
   {
     TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(0);
     f.test_for();
@@ -374,7 +374,7 @@ TEST_F(TEST_CATEGORY, range_for) {
   }
 }
 
-TEST_F(TEST_CATEGORY, range_reduce) {
+TEST(TEST_CATEGORY, range_reduce) {
   {
     TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(0);
     f.test_reduce();
@@ -404,7 +404,7 @@ TEST_F(TEST_CATEGORY, range_reduce) {
 }
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
-TEST_F(TEST_CATEGORY, range_scan) {
+TEST(TEST_CATEGORY, range_scan) {
   {
     TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> > f(0);
     f.test_scan();

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -434,27 +434,27 @@ class TestReduceDynamicView {
 
 }  // namespace
 
-TEST_F(TEST_CATEGORY, long_reduce) {
+TEST(TEST_CATEGORY, long_reduce) {
   TestReduce<long, TEST_EXECSPACE>(0);
   TestReduce<long, TEST_EXECSPACE>(1000000);
 }
 
-TEST_F(TEST_CATEGORY, double_reduce) {
+TEST(TEST_CATEGORY, double_reduce) {
   TestReduce<double, TEST_EXECSPACE>(0);
   TestReduce<double, TEST_EXECSPACE>(1000000);
 }
 
-TEST_F(TEST_CATEGORY, long_reduce_dynamic) {
+TEST(TEST_CATEGORY, long_reduce_dynamic) {
   TestReduceDynamic<long, TEST_EXECSPACE>(0);
   TestReduceDynamic<long, TEST_EXECSPACE>(1000000);
 }
 
-TEST_F(TEST_CATEGORY, double_reduce_dynamic) {
+TEST(TEST_CATEGORY, double_reduce_dynamic) {
   TestReduceDynamic<double, TEST_EXECSPACE>(0);
   TestReduceDynamic<double, TEST_EXECSPACE>(1000000);
 }
 
-TEST_F(TEST_CATEGORY, long_reduce_dynamic_view) {
+TEST(TEST_CATEGORY, long_reduce_dynamic_view) {
   TestReduceDynamicView<long, TEST_EXECSPACE>(0);
   TestReduceDynamicView<long, TEST_EXECSPACE>(1000000);
 }

--- a/core/unit_test/TestReduceDeviceView.hpp
+++ b/core/unit_test/TestReduceDeviceView.hpp
@@ -108,13 +108,13 @@ struct TeamPolicyFunctor {
 
 }  // namespace
 
-TEST_F(TEST_CATEGORY, reduce_device_view_range_policy) {
+TEST(TEST_CATEGORY, reduce_device_view_range_policy) {
   int N = 1000 * 1024 * 1024;
   test_reduce_device_view(N, Kokkos::RangePolicy<TEST_EXECSPACE>(0, N),
                           RangePolicyFunctor());
 }
 
-TEST_F(TEST_CATEGORY, reduce_device_view_mdrange_policy) {
+TEST(TEST_CATEGORY, reduce_device_view_mdrange_policy) {
   int N = 1000 * 1024 * 1024;
   test_reduce_device_view(
       N,
@@ -123,7 +123,7 @@ TEST_F(TEST_CATEGORY, reduce_device_view_mdrange_policy) {
       MDRangePolicyFunctor());
 }
 
-TEST_F(TEST_CATEGORY, reduce_device_view_team_policy) {
+TEST(TEST_CATEGORY, reduce_device_view_team_policy) {
   int N = 1000 * 1024 * 1024;
   test_reduce_device_view(
       N, Kokkos::TeamPolicy<TEST_EXECSPACE>(1000 * 1024, Kokkos::AUTO),

--- a/core/unit_test/TestReducers_a.hpp
+++ b/core/unit_test/TestReducers_a.hpp
@@ -44,7 +44,7 @@
 #include <TestReducers.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, reducers_int) {
+TEST(TEST_CATEGORY, reducers_int) {
   TestReducers<int, TEST_EXECSPACE>::execute_integer();
 }
 

--- a/core/unit_test/TestReducers_b.hpp
+++ b/core/unit_test/TestReducers_b.hpp
@@ -44,7 +44,7 @@
 #include <TestReducers.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, reducers_size_t) {
+TEST(TEST_CATEGORY, reducers_size_t) {
   TestReducers<size_t, TEST_EXECSPACE>::execute_integer();
 }
 }  // namespace Test

--- a/core/unit_test/TestReducers_c.hpp
+++ b/core/unit_test/TestReducers_c.hpp
@@ -44,7 +44,7 @@
 #include <TestReducers.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, reducers_double) {
+TEST(TEST_CATEGORY, reducers_double) {
   TestReducers<double, TEST_EXECSPACE>::execute_float();
 }
 }  // namespace Test

--- a/core/unit_test/TestReducers_d.hpp
+++ b/core/unit_test/TestReducers_d.hpp
@@ -44,7 +44,7 @@
 #include <TestReducers.hpp>
 
 namespace Test {
-TEST_F(TEST_CATEGORY, reducers_complex_double) {
+TEST(TEST_CATEGORY, reducers_complex_double) {
   TestReducers<Kokkos::complex<double>, TEST_EXECSPACE>::execute_basic();
 }
 

--- a/core/unit_test/TestScan.hpp
+++ b/core/unit_test/TestScan.hpp
@@ -142,7 +142,7 @@ TEST(TEST_CATEGORY, scan) {
   TEST_EXECSPACE().fence();
 }
 
-/*TEST_F( TEST_CATEGORY, scan_small )
+/*TEST( TEST_CATEGORY, scan_small )
 {
   typedef TestScan< TEST_EXECSPACE, Kokkos::Impl::ThreadsExecUseScanSmall >
 TestScanFunctor;

--- a/core/unit_test/TestScan.hpp
+++ b/core/unit_test/TestScan.hpp
@@ -134,7 +134,7 @@ struct TestScan {
   }
 };
 
-TEST_F(TEST_CATEGORY, scan) {
+TEST(TEST_CATEGORY, scan) {
   TestScan<TEST_EXECSPACE>::test_range(1, 1000);
   TestScan<TEST_EXECSPACE>(0);
   TestScan<TEST_EXECSPACE>(100000);

--- a/core/unit_test/TestTaskScheduler_single.hpp
+++ b/core/unit_test/TestTaskScheduler_single.hpp
@@ -43,8 +43,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY,
-       KOKKOS_TEST_WITH_SUFFIX(task_fib, TEST_SCHEDULER_SUFFIX)) {
+TEST(TEST_CATEGORY, KOKKOS_TEST_WITH_SUFFIX(task_fib, TEST_SCHEDULER_SUFFIX)) {
   const int N = 27;
   for (int i = 0; i < N; ++i) {
     TestTaskScheduler::TestFib<TEST_SCHEDULER>::run(i,
@@ -52,41 +51,40 @@ TEST_F(TEST_CATEGORY,
   }
 }
 
-TEST_F(TEST_CATEGORY,
-       KOKKOS_TEST_WITH_SUFFIX(task_depend, TEST_SCHEDULER_SUFFIX)) {
+TEST(TEST_CATEGORY,
+     KOKKOS_TEST_WITH_SUFFIX(task_depend, TEST_SCHEDULER_SUFFIX)) {
   for (int i = 0; i < 25; ++i) {
     TestTaskScheduler::TestTaskDependence<TEST_SCHEDULER>::run(i);
   }
 }
 
-TEST_F(TEST_CATEGORY,
-       KOKKOS_TEST_WITH_SUFFIX(task_team, TEST_SCHEDULER_SUFFIX)) {
+TEST(TEST_CATEGORY, KOKKOS_TEST_WITH_SUFFIX(task_team, TEST_SCHEDULER_SUFFIX)) {
   TestTaskScheduler::TestTaskTeam<TEST_SCHEDULER>::run(1000);
   // TestTaskScheduler::TestTaskTeamValue< TEST_EXECSPACE >::run( 1000 ); // Put
   // back after testing.
 }
 
-TEST_F(TEST_CATEGORY,
-       KOKKOS_TEST_WITH_SUFFIX(task_with_mempool, TEST_SCHEDULER_SUFFIX)) {
+TEST(TEST_CATEGORY,
+     KOKKOS_TEST_WITH_SUFFIX(task_with_mempool, TEST_SCHEDULER_SUFFIX)) {
   TestTaskScheduler::TestTaskSpawnWithPool<TEST_SCHEDULER>::run();
 }
 
-TEST_F(TEST_CATEGORY,
-       KOKKOS_TEST_WITH_SUFFIX(task_multiple_depend, TEST_SCHEDULER_SUFFIX)) {
+TEST(TEST_CATEGORY,
+     KOKKOS_TEST_WITH_SUFFIX(task_multiple_depend, TEST_SCHEDULER_SUFFIX)) {
   for (int i = 2; i < 6; ++i) {
     TestTaskScheduler::TestMultipleDependence<TEST_SCHEDULER>::run(i);
   }
 }
 
-TEST_F(TEST_CATEGORY,
-       KOKKOS_TEST_WITH_SUFFIX(task_scheduler_ctors, TEST_SCHEDULER_SUFFIX)) {
+TEST(TEST_CATEGORY,
+     KOKKOS_TEST_WITH_SUFFIX(task_scheduler_ctors, TEST_SCHEDULER_SUFFIX)) {
   TEST_SCHEDULER sched;
   TEST_SCHEDULER sched2 = sched;
   sched                 = sched2;
 }
 
-TEST_F(TEST_CATEGORY, KOKKOS_TEST_WITH_SUFFIX(task_scheduer_ctors_device,
-                                              TEST_SCHEDULER_SUFFIX)) {
+TEST(TEST_CATEGORY, KOKKOS_TEST_WITH_SUFFIX(task_scheduer_ctors_device,
+                                            TEST_SCHEDULER_SUFFIX)) {
   TestTaskScheduler::TestTaskCtorsDevice<TEST_SCHEDULER>::run();
 }
 

--- a/core/unit_test/TestTeamTeamSize.hpp
+++ b/core/unit_test/TestTeamTeamSize.hpp
@@ -139,7 +139,7 @@ void test_team_policy_max_recommended(int scratch_size) {
       scratch_size);
 }
 
-TEST_F(TEST_CATEGORY, team_policy_max_recommended) {
+TEST(TEST_CATEGORY, team_policy_max_recommended) {
   int max_scratch_size = policy_type::scratch_size_max(0);
   test_team_policy_max_recommended<double, 2, policy_type>(0);
   test_team_policy_max_recommended<double, 2, policy_type>(max_scratch_size /

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -1010,7 +1010,7 @@ class TestTripleNestedReduce {
 #endif
 
 #if !defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
-TEST_F(TEST_CATEGORY, team_vector) {
+TEST(TEST_CATEGORY, team_vector) {
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(0)));
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(1)));
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(2)));
@@ -1027,7 +1027,7 @@ TEST_F(TEST_CATEGORY, team_vector) {
 #endif
 
 #if !defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
-TEST_F(TEST_CATEGORY, triple_nested_parallelism) {
+TEST(TEST_CATEGORY, triple_nested_parallelism) {
 // With KOKKOS_DEBUG enabled, the functor uses too many registers to run
 // with a team size of 32 on GPUs, 16 is the max possible (at least on a K80
 // GPU) See https://github.com/kokkos/kokkos/issues/1513

--- a/core/unit_test/TestTeamVectorRange.hpp
+++ b/core/unit_test/TestTeamVectorRange.hpp
@@ -484,7 +484,7 @@ bool Test(int test) {
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_teamvector_range) {
+TEST(TEST_CATEGORY, team_teamvector_range) {
   ASSERT_TRUE((TestTeamVectorRange::Test<TEST_EXECSPACE>(0)));
   ASSERT_TRUE((TestTeamVectorRange::Test<TEST_EXECSPACE>(1)));
   ASSERT_TRUE((TestTeamVectorRange::Test<TEST_EXECSPACE>(2)));

--- a/core/unit_test/TestTemplateMetaFunctions.hpp
+++ b/core/unit_test/TestTemplateMetaFunctions.hpp
@@ -208,7 +208,7 @@ void TestTemplateMetaFunctions() {
 }  // namespace
 
 namespace Test {
-TEST_F(TEST_CATEGORY, template_meta_functions) {
+TEST(TEST_CATEGORY, template_meta_functions) {
   TestTemplateMetaFunctions<int, TEST_EXECSPACE>();
 }
 }  // namespace Test

--- a/core/unit_test/TestTile.hpp
+++ b/core/unit_test/TestTile.hpp
@@ -148,7 +148,7 @@ void test(const size_t dim0, const size_t dim1) {
 }  // namespace TestTile
 
 namespace Test {
-TEST_F(TEST_CATEGORY, tile_layout) {
+TEST(TEST_CATEGORY, tile_layout) {
   TestTile::test<TEST_EXECSPACE, 1, 1>(1, 1);
   TestTile::test<TEST_EXECSPACE, 1, 1>(2, 3);
   TestTile::test<TEST_EXECSPACE, 1, 1>(9, 10);

--- a/core/unit_test/TestUniqueToken.hpp
+++ b/core/unit_test/TestUniqueToken.hpp
@@ -128,6 +128,6 @@ class TestUniqueToken {
   }
 };
 
-TEST_F(TEST_CATEGORY, unique_token) { TestUniqueToken<TEST_EXECSPACE>::run(); }
+TEST(TEST_CATEGORY, unique_token) { TestUniqueToken<TEST_EXECSPACE>::run(); }
 
 }  // namespace Test

--- a/core/unit_test/TestViewAPI_a.hpp
+++ b/core/unit_test/TestViewAPI_a.hpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_api_a) {
+TEST(TEST_CATEGORY, view_api_a) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test();
 }
 

--- a/core/unit_test/TestViewAPI_b.hpp
+++ b/core/unit_test/TestViewAPI_b.hpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_api_b) {
+TEST(TEST_CATEGORY, view_api_b) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_view_operator_a();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_mirror();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_scalar();

--- a/core/unit_test/TestViewAPI_c.hpp
+++ b/core/unit_test/TestViewAPI_c.hpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_api_c) {
+TEST(TEST_CATEGORY, view_api_c) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_deep_copy_empty();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_view_operator_b();
 }

--- a/core/unit_test/TestViewAPI_d.hpp
+++ b/core/unit_test/TestViewAPI_d.hpp
@@ -53,7 +53,7 @@ TEST(TEST_CATEGORY, view_api_d) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_view_operator_c();
 }
 
-TEST_F(TEST_CATEGORY, view_allocation_error) {
+TEST(TEST_CATEGORY, view_allocation_error) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_error();
 }
 

--- a/core/unit_test/TestViewAPI_d.hpp
+++ b/core/unit_test/TestViewAPI_d.hpp
@@ -45,7 +45,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_api_d) {
+TEST(TEST_CATEGORY, view_api_d) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_const();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_subview();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_subview_strided();

--- a/core/unit_test/TestViewAPI_e.hpp
+++ b/core/unit_test/TestViewAPI_e.hpp
@@ -50,7 +50,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_remap) {
+TEST(TEST_CATEGORY, view_remap) {
   enum { N0 = 3, N1 = 2, N2 = 8, N3 = 9 };
 
 #ifdef KOKKOS_ENABLE_CUDA
@@ -111,7 +111,7 @@ TEST_F(TEST_CATEGORY, view_remap) {
         }
 }
 
-TEST_F(TEST_CATEGORY, view_mirror_nonconst) {
+TEST(TEST_CATEGORY, view_mirror_nonconst) {
   Kokkos::View<int*, TEST_EXECSPACE> d_view("d_view", 10);
   Kokkos::View<const int*, TEST_EXECSPACE> d_view_const = d_view;
   auto h_view = Kokkos::create_mirror(d_view_const);
@@ -157,7 +157,7 @@ void test_stride(Extents... extents) {
   test_left_stride<DataType>(extents...);
 }
 
-TEST_F(TEST_CATEGORY, view_stride_method) {
+TEST(TEST_CATEGORY, view_stride_method) {
   test_stride<double[3]>();
   test_stride<double*>(3);
   test_stride<double[3][7][13]>();
@@ -198,7 +198,7 @@ inline void test_anonymous_space() {
 #endif
 }
 
-TEST_F(TEST_CATEGORY, anonymous_space) { test_anonymous_space(); }
+TEST(TEST_CATEGORY, anonymous_space) { test_anonymous_space(); }
 
 template <class ExecSpace>
 struct TestViewOverloadResolution {
@@ -235,7 +235,7 @@ struct TestViewOverloadResolution {
   }
 };
 
-TEST_F(TEST_CATEGORY, view_overload_resolution) {
+TEST(TEST_CATEGORY, view_overload_resolution) {
   TestViewOverloadResolution<TEST_EXECSPACE>::test_function_overload();
 }
 }  // namespace Test

--- a/core/unit_test/TestViewCopy.hpp
+++ b/core/unit_test/TestViewCopy.hpp
@@ -150,13 +150,13 @@ struct TestViewCopy {
 
 }  // namespace
 
-TEST_F(TEST_CATEGORY, view_copy_tests) {
+TEST(TEST_CATEGORY, view_copy_tests) {
   // Only include this file to be compiled with CudaUVM and CudaHostPinned
   TestViewCopy<TEST_EXECSPACE>::test_view_copy(4, 2, 3);
   TestViewCopy<TEST_EXECSPACE>::test_view_copy(4, 2, 0);
 }
 
-TEST_F(TEST_CATEGORY, view_copy_degenerated) {
+TEST(TEST_CATEGORY, view_copy_degenerated) {
   // Only include this file to be compiled with CudaUVM and CudaHostPinned
   Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged>> v_um_def_1;
   Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged>> v_um_1(

--- a/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
+++ b/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
@@ -152,7 +152,7 @@ struct TestViewCtorProp_EmbeddedDim {
 
 }  // namespace
 
-TEST_F(TEST_CATEGORY, viewctorprop_embedded_dim) {
+TEST(TEST_CATEGORY, viewctorprop_embedded_dim) {
   TestViewCtorProp_EmbeddedDim<TEST_EXECSPACE>::test_vcpt(2, 3);
 }
 

--- a/core/unit_test/TestViewLayoutStrideAssignment.hpp
+++ b/core/unit_test/TestViewLayoutStrideAssignment.hpp
@@ -52,7 +52,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
+TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
   typedef TEST_EXECSPACE exec_space;
 
   auto t = time(0);
@@ -334,7 +334,7 @@ TEST_F(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
   }
 }
 
-TEST_F(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
+TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
   typedef TEST_EXECSPACE exec_space;
 
   auto t = time(0);
@@ -616,7 +616,7 @@ TEST_F(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
   }
 }
 
-TEST_F(TEST_CATEGORY, view_layoutstride_right_to_layoutleft_assignment) {
+TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutleft_assignment) {
   typedef TEST_EXECSPACE exec_space;
 
   auto t = time(0);
@@ -767,7 +767,7 @@ TEST_F(TEST_CATEGORY, view_layoutstride_right_to_layoutleft_assignment) {
   }
 }
 
-TEST_F(TEST_CATEGORY, view_layoutstride_left_to_layoutright_assignment) {
+TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutright_assignment) {
   typedef TEST_EXECSPACE exec_space;
 
   auto t = time(0);

--- a/core/unit_test/TestViewLayoutTiled.hpp
+++ b/core/unit_test/TestViewLayoutTiled.hpp
@@ -1757,7 +1757,7 @@ struct TestViewLayoutTiled {
 
 }  // namespace
 
-TEST_F(TEST_CATEGORY, view_layouttiled) {
+TEST(TEST_CATEGORY, view_layouttiled) {
   // These two examples are iterating by tile, then within a tile - not by
   // extents If N# is not a power of two, but want to iterate by tile then
   // within a tile, need to check that mapped index is within extent
@@ -1765,7 +1765,7 @@ TEST_F(TEST_CATEGORY, view_layouttiled) {
   TestViewLayoutTiled<TEST_EXECSPACE>::test_view_layout_tiled_3d(4, 12, 16);
   TestViewLayoutTiled<TEST_EXECSPACE>::test_view_layout_tiled_4d(4, 12, 16, 12);
 }
-TEST_F(TEST_CATEGORY, view_layouttiled_subtile) {
+TEST(TEST_CATEGORY, view_layouttiled_subtile) {
   // These two examples are iterating by tile, then within a tile - not by
   // extents If N# is not a power of two, but want to iterate by tile then
   // within a tile, need to check that mapped index is within extent

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -1090,7 +1090,7 @@ void test_view_mapping() {
   }
 }
 
-TEST_F(TEST_CATEGORY, view_mapping) { test_view_mapping<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, view_mapping) { test_view_mapping<TEST_EXECSPACE>(); }
 /*--------------------------------------------------------------------------*/
 
 template <class ViewType>
@@ -1335,11 +1335,11 @@ void test_view_mapping_operator() {
   }
 }
 
-TEST_F(TEST_CATEGORY, view_mapping_operator) {
+TEST(TEST_CATEGORY, view_mapping_operator) {
   test_view_mapping_operator<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, static_extent) {
+TEST(TEST_CATEGORY, static_extent) {
   using T = Kokkos::View<double * [2][3]>;
   ASSERT_EQ(T::static_extent(1), 2);
   ASSERT_EQ(T::static_extent(2), 3);

--- a/core/unit_test/TestViewMapping_b.hpp
+++ b/core/unit_test/TestViewMapping_b.hpp
@@ -125,7 +125,7 @@ struct TestViewMappingAtomic {
   }
 };
 
-TEST_F(TEST_CATEGORY, view_mapping_atomic) {
+TEST(TEST_CATEGORY, view_mapping_atomic) {
   TestViewMappingAtomic<TEST_EXECSPACE> f;
   f.run();
 }
@@ -175,7 +175,7 @@ void test_view_mapping_class_value() {
   ExecSpace().fence();
 }
 
-TEST_F(TEST_CATEGORY, view_mapping_class_value) {
+TEST(TEST_CATEGORY, view_mapping_class_value) {
   test_view_mapping_class_value<TEST_EXECSPACE>();
 }
 
@@ -185,7 +185,7 @@ TEST_F(TEST_CATEGORY, view_mapping_class_value) {
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_mapping_assignable) {
+TEST(TEST_CATEGORY, view_mapping_assignable) {
   typedef TEST_EXECSPACE exec_space;
 
   {  // Assignment of rank-0 Left = Right

--- a/core/unit_test/TestViewMapping_subview.hpp
+++ b/core/unit_test/TestViewMapping_subview.hpp
@@ -201,7 +201,7 @@ struct TestViewMappingSubview {
   }
 };
 
-TEST_F(TEST_CATEGORY, view_mapping_subview) {
+TEST(TEST_CATEGORY, view_mapping_subview) {
   TestViewMappingSubview<TEST_EXECSPACE> f;
   f.run();
 }

--- a/core/unit_test/TestViewOfClass.hpp
+++ b/core/unit_test/TestViewOfClass.hpp
@@ -113,6 +113,6 @@ void view_nested_view() {
   ASSERT_EQ(0, host_tracking(0));
 }
 
-TEST_F(TEST_CATEGORY, view_nested_view) { view_nested_view<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, view_nested_view) { view_nested_view<TEST_EXECSPACE>(); }
 
 }  // namespace Test

--- a/core/unit_test/TestViewResize.hpp
+++ b/core/unit_test/TestViewResize.hpp
@@ -48,7 +48,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_resize) {
+TEST(TEST_CATEGORY, view_resize) {
   typedef TEST_EXECSPACE ExecSpace;
   TestViewResize::testResize<ExecSpace>();
 }

--- a/core/unit_test/TestView_64bit.hpp
+++ b/core/unit_test/TestView_64bit.hpp
@@ -127,7 +127,7 @@ void test_64bit() {
 }
 
 #ifdef KOKKOS_ENABLE_LARGE_MEM_TESTS
-TEST_F(TEST_CATEGORY, view_64bit) { test_64bit<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, view_64bit) { test_64bit<TEST_EXECSPACE>(); }
 #endif
 
 }  // namespace Test

--- a/core/unit_test/TestWorkGraph.hpp
+++ b/core/unit_test/TestWorkGraph.hpp
@@ -157,7 +157,7 @@ struct TestWorkGraph {
 
 }  // anonymous namespace
 
-TEST_F(TEST_CATEGORY, workgraph_fib) {
+TEST(TEST_CATEGORY, workgraph_fib) {
   int limit = 27;
   for (int i = 0; i < limit; ++i) {
     TestWorkGraph<TEST_EXECSPACE> f(i);

--- a/core/unit_test/cuda/TestCudaHostPinned_Category.hpp
+++ b/core/unit_test/cuda/TestCudaHostPinned_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class cuda_hostpinned : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY cuda_hostpinned
 //#define TEST_EXECSPACE
 // Kokkos::Device<Kokkos::Cuda,Kokkos::CudaHostPinnedSpace>

--- a/core/unit_test/cuda/TestCudaHostPinned_SharedAlloc.cpp
+++ b/core/unit_test/cuda/TestCudaHostPinned_SharedAlloc.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, impl_shared_alloc) {
+TEST(TEST_CATEGORY, impl_shared_alloc) {
   test_shared_alloc<TEST_EXECSPACE, Kokkos::DefaultHostExecutionSpace>();
 }
 

--- a/core/unit_test/cuda/TestCudaUVM_Category.hpp
+++ b/core/unit_test/cuda/TestCudaUVM_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class cuda_uvm : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY cuda_uvm
 #define TEST_EXECSPACE Kokkos::CudaUVMSpace
 

--- a/core/unit_test/cuda/TestCudaUVM_SharedAlloc.cpp
+++ b/core/unit_test/cuda/TestCudaUVM_SharedAlloc.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, impl_shared_alloc) {
+TEST(TEST_CATEGORY, impl_shared_alloc) {
   test_shared_alloc<TEST_EXECSPACE, Kokkos::DefaultHostExecutionSpace>();
 }
 

--- a/core/unit_test/cuda/TestCuda_Category.hpp
+++ b/core/unit_test/cuda/TestCuda_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class cuda : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY cuda
 #define TEST_EXECSPACE Kokkos::Cuda
 

--- a/core/unit_test/cuda/TestCuda_FunctorAnalysis.cpp
+++ b/core/unit_test/cuda/TestCuda_FunctorAnalysis.cpp
@@ -1,3 +1,4 @@
+
 /*
 //@HEADER
 // ************************************************************************
@@ -41,10 +42,5 @@
 //@HEADER
 */
 
-#include <PerfTest_ViewCopy.hpp>
-namespace Test {
-TEST(default_exec, ViewDeepCopy_RightRight_Rank6) {
-  printf("DeepCopy Performance for LayoutRight to LayoutRight:\n");
-  run_deepcopyview_tests6<Kokkos::LayoutRight, Kokkos::LayoutRight>(10, 1);
-}
-}  // namespace Test
+#include <cuda/TestCuda_Category.hpp>
+#include <TestFunctorAnalysis.hpp>

--- a/core/unit_test/cuda/TestCuda_InterOp_Init.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Init.cpp
@@ -55,7 +55,7 @@ __global__ void offset(int* p) {
 
 // Test whether allocations survive Kokkos initialize/finalize if done via Raw
 // Cuda.
-TEST_F(cuda, raw_cuda_interop) {
+TEST(cuda, raw_cuda_interop) {
   int* p;
   cudaMalloc(&p, sizeof(int) * 100);
   Kokkos::InitArguments arguments{-1, -1, -1, false};

--- a/core/unit_test/cuda/TestCuda_InterOp_Streams.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Streams.cpp
@@ -139,7 +139,7 @@ struct FunctorTeamReduce {
 }  // namespace
 
 // Test Interoperability with Cuda Streams
-TEST_F(cuda, raw_cuda_streams) {
+TEST(cuda, raw_cuda_streams) {
   cudaStream_t stream;
   cudaStreamCreate(&stream);
   Kokkos::InitArguments arguments{-1, -1, -1, false};

--- a/core/unit_test/cuda/TestCuda_SharedAlloc.cpp
+++ b/core/unit_test/cuda/TestCuda_SharedAlloc.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, impl_shared_alloc) {
+TEST(TEST_CATEGORY, impl_shared_alloc) {
   test_shared_alloc<Kokkos::CudaSpace, Kokkos::DefaultHostExecutionSpace>();
 }
 

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -54,7 +54,7 @@ __global__ void test_cuda_spaces_int_value(int *ptr) {
   }
 }
 
-TEST_F(cuda, space_access) {
+TEST(cuda, space_access) {
   static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
                                                 Kokkos::HostSpace>::assignable,
                 "");
@@ -256,7 +256,7 @@ TEST_F(cuda, space_access) {
       "");
 }
 
-TEST_F(cuda, uvm) {
+TEST(cuda, uvm) {
   if (Kokkos::CudaUVMSpace::available()) {
     int *uvm_ptr = (int *)Kokkos::kokkos_malloc<Kokkos::CudaUVMSpace>(
         "uvm_ptr", sizeof(int));
@@ -277,7 +277,7 @@ TEST_F(cuda, uvm) {
  * The issue verified with this unit test appears to no longer be an
  * problem.  Refer to github issue 1880 for more details
  *
-TEST_F( cuda, uvm_num_allocs )
+TEST( cuda, uvm_num_allocs )
 {
   // The max number of UVM allocations allowed is 65536.
   #define MAX_NUM_ALLOCS 65536
@@ -376,7 +376,7 @@ struct TestViewCudaAccessible {
   }
 };
 
-TEST_F(cuda, impl_view_accessible) {
+TEST(cuda, impl_view_accessible) {
   TestViewCudaAccessible<Kokkos::CudaSpace, Kokkos::Cuda>::run();
 
   TestViewCudaAccessible<Kokkos::CudaUVMSpace, Kokkos::Cuda>::run();
@@ -431,7 +431,7 @@ struct TestViewCudaTexture {
   }
 };
 
-TEST_F(cuda, impl_view_texture) {
+TEST(cuda, impl_view_texture) {
   TestViewCudaTexture<Kokkos::CudaSpace>::run();
   TestViewCudaTexture<Kokkos::CudaUVMSpace>::run();
 }

--- a/core/unit_test/cuda/TestCuda_SubView_a.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_a.cpp
@@ -46,51 +46,51 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_left) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_left) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutLeft, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_right) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_right) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutRight, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_stride) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_stride) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutStride, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_assign_strided) {
+TEST(TEST_CATEGORY, view_subview_assign_strided) {
   TestViewSubview::test_1d_strided_assignment<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_0) {
+TEST(TEST_CATEGORY, view_subview_left_0) {
   TestViewSubview::test_left_0<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_1) {
+TEST(TEST_CATEGORY, view_subview_left_1) {
   TestViewSubview::test_left_1<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_2) {
+TEST(TEST_CATEGORY, view_subview_left_2) {
   TestViewSubview::test_left_2<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_3) {
+TEST(TEST_CATEGORY, view_subview_left_3) {
   TestViewSubview::test_left_3<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_0) {
+TEST(TEST_CATEGORY, view_subview_right_0) {
   TestViewSubview::test_right_0<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_1) {
+TEST(TEST_CATEGORY, view_subview_right_1) {
   TestViewSubview::test_right_1<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_3) {
+TEST(TEST_CATEGORY, view_subview_right_3) {
   TestViewSubview::test_right_3<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_static_tests) {
+TEST(TEST_CATEGORY, view_static_tests) {
   TestViewSubview::TestSubviewStaticSizes<TEST_EXECSPACE,
                                           Kokkos::LayoutLeft>()();
   TestViewSubview::TestSubviewStaticSizes<TEST_EXECSPACE,

--- a/core/unit_test/cuda/TestCuda_SubView_b.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_b.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
+TEST(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
   TestViewSubview::test_layoutleft_to_layoutleft<TEST_EXECSPACE>();
   TestViewSubview::test_layoutleft_to_layoutleft<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
@@ -54,7 +54,7 @@ TEST_F(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_layoutright_to_layoutright) {
+TEST(TEST_CATEGORY, view_subview_layoutright_to_layoutright) {
   TestViewSubview::test_layoutright_to_layoutright<TEST_EXECSPACE>();
   TestViewSubview::test_layoutright_to_layoutright<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();

--- a/core/unit_test/cuda/TestCuda_SubView_c01.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c01.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign) {
+TEST(TEST_CATEGORY, view_subview_1d_assign) {
   TestViewSubview::test_1d_assign<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/cuda/TestCuda_SubView_c02.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c02.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign_atomic) {
+TEST(TEST_CATEGORY, view_subview_1d_assign_atomic) {
   TestViewSubview::test_1d_assign<TEST_EXECSPACE,
                                   Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/cuda/TestCuda_SubView_c03.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c03.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_1d_assign_randomaccess) {
   TestViewSubview::test_1d_assign<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/cuda/TestCuda_SubView_c04.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c04.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_2d_from_3d) {
+TEST(TEST_CATEGORY, view_subview_2d_from_3d) {
   TestViewSubview::test_2d_subview_3d<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/cuda/TestCuda_SubView_c05.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c05.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_2d_from_3d_atomic) {
+TEST(TEST_CATEGORY, view_subview_2d_from_3d_atomic) {
   TestViewSubview::test_2d_subview_3d<TEST_EXECSPACE,
                                       Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/cuda/TestCuda_SubView_c06.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c06.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_2d_from_3d_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_2d_from_3d_randomaccess) {
   TestViewSubview::test_2d_subview_3d<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/cuda/TestCuda_SubView_c07.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c07.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left) {
   TestViewSubview::test_3d_subview_5d_left<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/cuda/TestCuda_SubView_c08.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c08.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left_atomic) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left_atomic) {
   TestViewSubview::test_3d_subview_5d_left<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/cuda/TestCuda_SubView_c09.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c09.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left_randomaccess) {
   TestViewSubview::test_3d_subview_5d_left<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/cuda/TestCuda_SubView_c10.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c10.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right) {
   TestViewSubview::test_3d_subview_5d_right<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/cuda/TestCuda_SubView_c11.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c11.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right_atomic) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right_atomic) {
   TestViewSubview::test_3d_subview_5d_right<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/cuda/TestCuda_SubView_c12.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c12.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right_randomaccess) {
   TestViewSubview::test_3d_subview_5d_right<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/cuda/TestCuda_SubView_c13.cpp
+++ b/core/unit_test/cuda/TestCuda_SubView_c13.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_test_unmanaged_subview_reset) {
+TEST(TEST_CATEGORY, view_test_unmanaged_subview_reset) {
   TestViewSubview::test_unmanaged_subview_reset<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/cuda/TestCuda_Team.cpp
+++ b/core/unit_test/cuda/TestCuda_Team.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_for) {
+TEST(TEST_CATEGORY, team_for) {
   TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::test_for(
       0);
   TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::test_for(
@@ -63,7 +63,7 @@ TEST_F(TEST_CATEGORY, team_for) {
       1000);
 }
 
-TEST_F(TEST_CATEGORY, team_reduce) {
+TEST(TEST_CATEGORY, team_reduce) {
   TestTeamPolicy<TEST_EXECSPACE,
                  Kokkos::Schedule<Kokkos::Static> >::test_reduce(0);
   TestTeamPolicy<TEST_EXECSPACE,
@@ -78,7 +78,7 @@ TEST_F(TEST_CATEGORY, team_reduce) {
                  Kokkos::Schedule<Kokkos::Dynamic> >::test_reduce(1000);
 }
 
-TEST_F(TEST_CATEGORY, team_broadcast) {
+TEST(TEST_CATEGORY, team_broadcast) {
   TestTeamBroadcast<TEST_EXECSPACE,
                     Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(0);
   TestTeamBroadcast<TEST_EXECSPACE,

--- a/core/unit_test/cuda/TestCuda_TeamReductionScan.cpp
+++ b/core/unit_test/cuda/TestCuda_TeamReductionScan.cpp
@@ -47,7 +47,7 @@
 namespace Test {
 
 #if !defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
-TEST_F(TEST_CATEGORY, team_scan) {
+TEST(TEST_CATEGORY, team_scan) {
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(10);
@@ -57,7 +57,7 @@ TEST_F(TEST_CATEGORY, team_scan) {
 }
 #endif
 
-TEST_F(TEST_CATEGORY, team_long_reduce) {
+TEST(TEST_CATEGORY, team_long_reduce) {
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);
@@ -68,7 +68,7 @@ TEST_F(TEST_CATEGORY, team_long_reduce) {
       100000);
 }
 
-TEST_F(TEST_CATEGORY, team_double_reduce) {
+TEST(TEST_CATEGORY, team_double_reduce) {
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);

--- a/core/unit_test/cuda/TestCuda_TeamScratch.cpp
+++ b/core/unit_test/cuda/TestCuda_TeamScratch.cpp
@@ -46,32 +46,32 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_shared_request) {
+TEST(TEST_CATEGORY, team_shared_request) {
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
-TEST_F(TEST_CATEGORY, team_scratch_request) {
+TEST(TEST_CATEGORY, team_scratch_request) {
   TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
   TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 #if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
-TEST_F(TEST_CATEGORY, team_lambda_shared_request) {
+TEST(TEST_CATEGORY, team_lambda_shared_request) {
   TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
                        Kokkos::Schedule<Kokkos::Static> >();
   TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
                        Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
-TEST_F(TEST_CATEGORY, scratch_align) { TestScratchAlignment<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, scratch_align) { TestScratchAlignment<TEST_EXECSPACE>(); }
 #endif
 #endif
 
-TEST_F(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
 
-TEST_F(TEST_CATEGORY, multi_level_scratch) {
+TEST(TEST_CATEGORY, multi_level_scratch) {
   TestMultiLevelScratchTeam<TEST_EXECSPACE,
                             Kokkos::Schedule<Kokkos::Static> >();
   TestMultiLevelScratchTeam<TEST_EXECSPACE,

--- a/core/unit_test/default/TestDefaultDeviceType.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType.cpp
@@ -50,7 +50,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, host_space_access) {
+TEST(TEST_CATEGORY, host_space_access) {
   typedef Kokkos::HostSpace::execution_space host_exec_space;
   typedef Kokkos::Device<host_exec_space, Kokkos::HostSpace> device_space;
   typedef Kokkos::Impl::HostMirror<Kokkos::DefaultExecutionSpace>::Space

--- a/core/unit_test/default/TestDefaultDeviceType_Category.hpp
+++ b/core/unit_test/default/TestDefaultDeviceType_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class defaultdevicetype : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY defaultdevicetype
 #define TEST_EXECSPACE Kokkos::DefaultExecutionSpace
 

--- a/core/unit_test/default/TestDefaultDeviceType_a1.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_a1.cpp
@@ -52,7 +52,7 @@
 
 namespace Test {
 
-TEST_F(defaultdevicetype, reduce_instantiation_a1) {
+TEST(defaultdevicetype, reduce_instantiation_a1) {
   TestReduceCombinatoricalInstantiation<>::execute_a1();
 }
 

--- a/core/unit_test/default/TestDefaultDeviceType_a2.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_a2.cpp
@@ -52,7 +52,7 @@
 
 namespace Test {
 
-TEST_F(defaultdevicetype, reduce_instantiation_a2) {
+TEST(defaultdevicetype, reduce_instantiation_a2) {
   TestReduceCombinatoricalInstantiation<>::execute_a2();
 }
 

--- a/core/unit_test/default/TestDefaultDeviceType_a3.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_a3.cpp
@@ -52,7 +52,7 @@
 
 namespace Test {
 
-TEST_F(defaultdevicetype, reduce_instantiation_a3) {
+TEST(defaultdevicetype, reduce_instantiation_a3) {
   TestReduceCombinatoricalInstantiation<>::execute_a3();
 }
 

--- a/core/unit_test/default/TestDefaultDeviceType_b1.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_b1.cpp
@@ -52,7 +52,7 @@
 
 namespace Test {
 
-TEST_F(defaultdevicetype, reduce_instantiation_b1) {
+TEST(defaultdevicetype, reduce_instantiation_b1) {
   TestReduceCombinatoricalInstantiation<>::execute_b1();
 }
 

--- a/core/unit_test/default/TestDefaultDeviceType_b2.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_b2.cpp
@@ -52,7 +52,7 @@
 
 namespace Test {
 
-TEST_F(defaultdevicetype, reduce_instantiation_b2) {
+TEST(defaultdevicetype, reduce_instantiation_b2) {
   TestReduceCombinatoricalInstantiation<>::execute_b2();
 }
 

--- a/core/unit_test/default/TestDefaultDeviceType_b3.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_b3.cpp
@@ -52,7 +52,7 @@
 
 namespace Test {
 
-TEST_F(defaultdevicetype, reduce_instantiation_b3) {
+TEST(defaultdevicetype, reduce_instantiation_b3) {
   TestReduceCombinatoricalInstantiation<>::execute_b3();
 }
 

--- a/core/unit_test/default/TestDefaultDeviceType_c1.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_c1.cpp
@@ -53,7 +53,7 @@
 
 namespace Test {
 
-TEST_F(defaultdevicetype, reduce_instantiation_c1) {
+TEST(defaultdevicetype, reduce_instantiation_c1) {
   TestReduceCombinatoricalInstantiation<>::execute_c1();
 }
 

--- a/core/unit_test/default/TestDefaultDeviceType_c2.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_c2.cpp
@@ -53,7 +53,7 @@
 
 namespace Test {
 
-TEST_F(defaultdevicetype, reduce_instantiation_c2) {
+TEST(defaultdevicetype, reduce_instantiation_c2) {
   TestReduceCombinatoricalInstantiation<>::execute_c2();
 }
 

--- a/core/unit_test/default/TestDefaultDeviceType_c3.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_c3.cpp
@@ -53,7 +53,7 @@
 
 namespace Test {
 
-TEST_F(defaultdevicetype, reduce_instantiation_c3) {
+TEST(defaultdevicetype, reduce_instantiation_c3) {
   TestReduceCombinatoricalInstantiation<>::execute_c3();
 }
 

--- a/core/unit_test/default/TestDefaultDeviceType_d.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_d.cpp
@@ -52,9 +52,9 @@
 
 namespace Test {
 
-TEST_F(defaultdevicetype, test_utilities) { test_utilities(); }
+TEST(defaultdevicetype, test_utilities) { test_utilities(); }
 
-TEST_F(defaultdevicetype, malloc) {
+TEST(defaultdevicetype, malloc) {
   int* data = (int*)Kokkos::kokkos_malloc(100 * sizeof(int));
   ASSERT_NO_THROW(data = (int*)Kokkos::kokkos_realloc(data, 120 * sizeof(int)));
   Kokkos::kokkos_free(data);

--- a/core/unit_test/openmp/TestOpenMP_Category.hpp
+++ b/core/unit_test/openmp/TestOpenMP_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class openmp : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY openmp
 #define TEST_EXECSPACE Kokkos::OpenMP
 

--- a/core/unit_test/openmp/TestOpenMP_FunctorAnalysis.cpp
+++ b/core/unit_test/openmp/TestOpenMP_FunctorAnalysis.cpp
@@ -1,3 +1,4 @@
+
 /*
 //@HEADER
 // ************************************************************************
@@ -41,10 +42,5 @@
 //@HEADER
 */
 
-#include <PerfTest_ViewCopy.hpp>
-namespace Test {
-TEST(default_exec, ViewDeepCopy_RightRight_Rank6) {
-  printf("DeepCopy Performance for LayoutRight to LayoutRight:\n");
-  run_deepcopyview_tests6<Kokkos::LayoutRight, Kokkos::LayoutRight>(10, 1);
-}
-}  // namespace Test
+#include <openmp/TestOpenMP_Category.hpp>
+#include <TestFunctorAnalysis.hpp>

--- a/core/unit_test/openmp/TestOpenMP_InterOp.cpp
+++ b/core/unit_test/openmp/TestOpenMP_InterOp.cpp
@@ -49,7 +49,7 @@ namespace Test {
 
 // Test whether allocations survive Kokkos initialize/finalize if done via Raw
 // Cuda.
-TEST_F(openmp, raw_openmp_interop) {
+TEST(openmp, raw_openmp_interop) {
   int count = 0;
   int num_threads, concurrency;
 #pragma omp parallel

--- a/core/unit_test/openmp/TestOpenMP_Other.cpp
+++ b/core/unit_test/openmp/TestOpenMP_Other.cpp
@@ -56,7 +56,7 @@
 
 namespace Test {
 
-TEST_F(openmp, partition_master) {
+TEST(openmp, partition_master) {
   using Mutex = Kokkos::Experimental::MasterLock<Kokkos::OpenMP>;
 
   Mutex mtx;

--- a/core/unit_test/openmp/TestOpenMP_SharedAlloc.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SharedAlloc.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, impl_shared_alloc) {
+TEST(TEST_CATEGORY, impl_shared_alloc) {
   test_shared_alloc<Kokkos::HostSpace, TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/openmp/TestOpenMP_SubView_a.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_a.cpp
@@ -46,51 +46,51 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_left) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_left) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutLeft, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_right) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_right) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutRight, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_stride) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_stride) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutStride, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_assign_strided) {
+TEST(TEST_CATEGORY, view_subview_assign_strided) {
   TestViewSubview::test_1d_strided_assignment<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_0) {
+TEST(TEST_CATEGORY, view_subview_left_0) {
   TestViewSubview::test_left_0<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_1) {
+TEST(TEST_CATEGORY, view_subview_left_1) {
   TestViewSubview::test_left_1<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_2) {
+TEST(TEST_CATEGORY, view_subview_left_2) {
   TestViewSubview::test_left_2<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_3) {
+TEST(TEST_CATEGORY, view_subview_left_3) {
   TestViewSubview::test_left_3<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_0) {
+TEST(TEST_CATEGORY, view_subview_right_0) {
   TestViewSubview::test_right_0<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_1) {
+TEST(TEST_CATEGORY, view_subview_right_1) {
   TestViewSubview::test_right_1<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_3) {
+TEST(TEST_CATEGORY, view_subview_right_3) {
   TestViewSubview::test_right_3<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_static_tests) {
+TEST(TEST_CATEGORY, view_static_tests) {
   TestViewSubview::TestSubviewStaticSizes<TEST_EXECSPACE,
                                           Kokkos::LayoutLeft>()();
   TestViewSubview::TestSubviewStaticSizes<TEST_EXECSPACE,

--- a/core/unit_test/openmp/TestOpenMP_SubView_b.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_b.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
+TEST(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
   TestViewSubview::test_layoutleft_to_layoutleft<TEST_EXECSPACE>();
   TestViewSubview::test_layoutleft_to_layoutleft<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
@@ -54,7 +54,7 @@ TEST_F(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_layoutright_to_layoutright) {
+TEST(TEST_CATEGORY, view_subview_layoutright_to_layoutright) {
   TestViewSubview::test_layoutright_to_layoutright<TEST_EXECSPACE>();
   TestViewSubview::test_layoutright_to_layoutright<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();

--- a/core/unit_test/openmp/TestOpenMP_SubView_c01.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c01.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign) {
+TEST(TEST_CATEGORY, view_subview_1d_assign) {
   TestViewSubview::test_1d_assign<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/openmp/TestOpenMP_SubView_c02.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c02.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign_atomic) {
+TEST(TEST_CATEGORY, view_subview_1d_assign_atomic) {
   TestViewSubview::test_1d_assign<TEST_EXECSPACE,
                                   Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/openmp/TestOpenMP_SubView_c03.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c03.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_1d_assign_randomaccess) {
   TestViewSubview::test_1d_assign<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/openmp/TestOpenMP_SubView_c04.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c04.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_2d_from_3d) {
+TEST(TEST_CATEGORY, view_subview_2d_from_3d) {
   TestViewSubview::test_2d_subview_3d<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/openmp/TestOpenMP_SubView_c05.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c05.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(openmp, view_subview_2d_from_3d_atomic) {
+TEST(openmp, view_subview_2d_from_3d_atomic) {
   TestViewSubview::test_2d_subview_3d<TEST_EXECSPACE,
                                       Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/openmp/TestOpenMP_SubView_c06.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c06.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_2d_from_3d_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_2d_from_3d_randomaccess) {
   TestViewSubview::test_2d_subview_3d<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/openmp/TestOpenMP_SubView_c07.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c07.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left) {
   TestViewSubview::test_3d_subview_5d_left<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/openmp/TestOpenMP_SubView_c08.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c08.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left_atomic) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left_atomic) {
   TestViewSubview::test_3d_subview_5d_left<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/openmp/TestOpenMP_SubView_c09.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c09.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left_randomaccess) {
   TestViewSubview::test_3d_subview_5d_left<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/openmp/TestOpenMP_SubView_c10.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c10.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right) {
   TestViewSubview::test_3d_subview_5d_right<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/openmp/TestOpenMP_SubView_c11.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c11.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right_atomic) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right_atomic) {
   TestViewSubview::test_3d_subview_5d_right<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/openmp/TestOpenMP_SubView_c12.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c12.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right_randomaccess) {
   TestViewSubview::test_3d_subview_5d_right<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/openmp/TestOpenMP_SubView_c13.cpp
+++ b/core/unit_test/openmp/TestOpenMP_SubView_c13.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_test_unmanaged_subview_reset) {
+TEST(TEST_CATEGORY, view_test_unmanaged_subview_reset) {
   TestViewSubview::test_unmanaged_subview_reset<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/openmp/TestOpenMP_Team.cpp
+++ b/core/unit_test/openmp/TestOpenMP_Team.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_for) {
+TEST(TEST_CATEGORY, team_for) {
   TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::test_for(
       0);
   TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::test_for(
@@ -63,7 +63,7 @@ TEST_F(TEST_CATEGORY, team_for) {
       1000);
 }
 
-TEST_F(TEST_CATEGORY, team_reduce) {
+TEST(TEST_CATEGORY, team_reduce) {
   TestTeamPolicy<TEST_EXECSPACE,
                  Kokkos::Schedule<Kokkos::Static> >::test_reduce(0);
   TestTeamPolicy<TEST_EXECSPACE,
@@ -78,7 +78,7 @@ TEST_F(TEST_CATEGORY, team_reduce) {
                  Kokkos::Schedule<Kokkos::Dynamic> >::test_reduce(1000);
 }
 
-TEST_F(TEST_CATEGORY, team_broadcast) {
+TEST(TEST_CATEGORY, team_broadcast) {
   TestTeamBroadcast<TEST_EXECSPACE,
                     Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(0);
   TestTeamBroadcast<TEST_EXECSPACE,

--- a/core/unit_test/openmp/TestOpenMP_TeamReductionScan.cpp
+++ b/core/unit_test/openmp/TestOpenMP_TeamReductionScan.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_scan) {
+TEST(TEST_CATEGORY, team_scan) {
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(10);
@@ -55,7 +55,7 @@ TEST_F(TEST_CATEGORY, team_scan) {
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(10000);
 }
 
-TEST_F(TEST_CATEGORY, team_long_reduce) {
+TEST(TEST_CATEGORY, team_long_reduce) {
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);
@@ -66,7 +66,7 @@ TEST_F(TEST_CATEGORY, team_long_reduce) {
       100000);
 }
 
-TEST_F(TEST_CATEGORY, team_double_reduce) {
+TEST(TEST_CATEGORY, team_double_reduce) {
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);

--- a/core/unit_test/openmp/TestOpenMP_TeamScratch.cpp
+++ b/core/unit_test/openmp/TestOpenMP_TeamScratch.cpp
@@ -46,31 +46,31 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_shared_request) {
+TEST(TEST_CATEGORY, team_shared_request) {
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
-TEST_F(TEST_CATEGORY, team_scratch_request) {
+TEST(TEST_CATEGORY, team_scratch_request) {
   TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
   TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 #if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
-TEST_F(TEST_CATEGORY, team_lambda_shared_request) {
+TEST(TEST_CATEGORY, team_lambda_shared_request) {
   TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
                        Kokkos::Schedule<Kokkos::Static> >();
   TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
                        Kokkos::Schedule<Kokkos::Dynamic> >();
 }
-TEST_F(TEST_CATEGORY, scratch_align) { TestScratchAlignment<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, scratch_align) { TestScratchAlignment<TEST_EXECSPACE>(); }
 #endif
 #endif
 
-TEST_F(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
 
-TEST_F(TEST_CATEGORY, multi_level_scratch) {
+TEST(TEST_CATEGORY, multi_level_scratch) {
   TestMultiLevelScratchTeam<TEST_EXECSPACE,
                             Kokkos::Schedule<Kokkos::Static> >();
   TestMultiLevelScratchTeam<TEST_EXECSPACE,

--- a/core/unit_test/openmptarget/TestOpenMPTarget_Category.hpp
+++ b/core/unit_test/openmptarget/TestOpenMPTarget_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class openmptarget : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY openmptarget
 #define TEST_EXECSPACE Kokkos::Experimental::OpenMPTarget
 

--- a/core/unit_test/qthreads/TestQthreads_Category.hpp
+++ b/core/unit_test/qthreads/TestQthreads_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class qthreads : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY qthreads
 #define TEST_EXECSPACE Kokkos::Qthreads
 

--- a/core/unit_test/rocm/TestROCmHostPinned_Category.hpp
+++ b/core/unit_test/rocm/TestROCmHostPinned_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class rocm_hostpinned : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY rocm_hostpinned
 #define TEST_EXECSPACE Kokkos::Experimental::ROCmHostPinnedSpace
 

--- a/core/unit_test/rocm/TestROCm_Category.hpp
+++ b/core/unit_test/rocm/TestROCm_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class rocm : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY rocm
 #define TEST_EXECSPACE Kokkos::Experimental::ROCm
 

--- a/core/unit_test/serial/TestSerial_Category.hpp
+++ b/core/unit_test/serial/TestSerial_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class serial : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY serial
 #define TEST_EXECSPACE Kokkos::Serial
 

--- a/core/unit_test/serial/TestSerial_FunctorAnalysis.cpp
+++ b/core/unit_test/serial/TestSerial_FunctorAnalysis.cpp
@@ -1,3 +1,4 @@
+
 /*
 //@HEADER
 // ************************************************************************
@@ -41,10 +42,5 @@
 //@HEADER
 */
 
-#include <PerfTest_ViewCopy.hpp>
-namespace Test {
-TEST(default_exec, ViewDeepCopy_RightRight_Rank6) {
-  printf("DeepCopy Performance for LayoutRight to LayoutRight:\n");
-  run_deepcopyview_tests6<Kokkos::LayoutRight, Kokkos::LayoutRight>(10, 1);
-}
-}  // namespace Test
+#include <serial/TestSerial_Category.hpp>
+#include <TestFunctorAnalysis.hpp>

--- a/core/unit_test/serial/TestSerial_SharedAlloc.cpp
+++ b/core/unit_test/serial/TestSerial_SharedAlloc.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, impl_shared_alloc) {
+TEST(TEST_CATEGORY, impl_shared_alloc) {
   test_shared_alloc<Kokkos::HostSpace, TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/serial/TestSerial_SubView_a.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_a.cpp
@@ -46,51 +46,51 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_left) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_left) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutLeft, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_right) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_right) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutRight, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_stride) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_stride) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutStride, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_assign_strided) {
+TEST(TEST_CATEGORY, view_subview_assign_strided) {
   TestViewSubview::test_1d_strided_assignment<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_0) {
+TEST(TEST_CATEGORY, view_subview_left_0) {
   TestViewSubview::test_left_0<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_1) {
+TEST(TEST_CATEGORY, view_subview_left_1) {
   TestViewSubview::test_left_1<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_2) {
+TEST(TEST_CATEGORY, view_subview_left_2) {
   TestViewSubview::test_left_2<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_3) {
+TEST(TEST_CATEGORY, view_subview_left_3) {
   TestViewSubview::test_left_3<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_0) {
+TEST(TEST_CATEGORY, view_subview_right_0) {
   TestViewSubview::test_right_0<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_1) {
+TEST(TEST_CATEGORY, view_subview_right_1) {
   TestViewSubview::test_right_1<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_3) {
+TEST(TEST_CATEGORY, view_subview_right_3) {
   TestViewSubview::test_right_3<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_static_tests) {
+TEST(TEST_CATEGORY, view_static_tests) {
   TestViewSubview::TestSubviewStaticSizes<TEST_EXECSPACE,
                                           Kokkos::LayoutLeft>()();
   TestViewSubview::TestSubviewStaticSizes<TEST_EXECSPACE,

--- a/core/unit_test/serial/TestSerial_SubView_b.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_b.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
+TEST(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
   TestViewSubview::test_layoutleft_to_layoutleft<TEST_EXECSPACE>();
   TestViewSubview::test_layoutleft_to_layoutleft<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
@@ -54,7 +54,7 @@ TEST_F(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_layoutright_to_layoutright) {
+TEST(TEST_CATEGORY, view_subview_layoutright_to_layoutright) {
   TestViewSubview::test_layoutright_to_layoutright<TEST_EXECSPACE>();
   TestViewSubview::test_layoutright_to_layoutright<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();

--- a/core/unit_test/serial/TestSerial_SubView_c01.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c01.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign) {
+TEST(TEST_CATEGORY, view_subview_1d_assign) {
   TestViewSubview::test_1d_assign<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/serial/TestSerial_SubView_c02.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c02.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign_atomic) {
+TEST(TEST_CATEGORY, view_subview_1d_assign_atomic) {
   TestViewSubview::test_1d_assign<TEST_EXECSPACE,
                                   Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/serial/TestSerial_SubView_c03.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c03.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_1d_assign_randomaccess) {
   TestViewSubview::test_1d_assign<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/serial/TestSerial_SubView_c04.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c04.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_2d_from_3d) {
+TEST(TEST_CATEGORY, view_subview_2d_from_3d) {
   TestViewSubview::test_2d_subview_3d<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/serial/TestSerial_SubView_c05.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c05.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(serial, view_subview_2d_from_3d_atomic) {
+TEST(serial, view_subview_2d_from_3d_atomic) {
   TestViewSubview::test_2d_subview_3d<TEST_EXECSPACE,
                                       Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/serial/TestSerial_SubView_c06.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c06.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_2d_from_3d_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_2d_from_3d_randomaccess) {
   TestViewSubview::test_2d_subview_3d<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/serial/TestSerial_SubView_c07.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c07.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left) {
   TestViewSubview::test_3d_subview_5d_left<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/serial/TestSerial_SubView_c08.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c08.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left_atomic) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left_atomic) {
   TestViewSubview::test_3d_subview_5d_left<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/serial/TestSerial_SubView_c09.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c09.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left_randomaccess) {
   TestViewSubview::test_3d_subview_5d_left<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/serial/TestSerial_SubView_c10.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c10.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right) {
   TestViewSubview::test_3d_subview_5d_right<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/serial/TestSerial_SubView_c11.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c11.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right_atomic) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right_atomic) {
   TestViewSubview::test_3d_subview_5d_right<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/serial/TestSerial_SubView_c12.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c12.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right_randomaccess) {
   TestViewSubview::test_3d_subview_5d_right<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/serial/TestSerial_SubView_c13.cpp
+++ b/core/unit_test/serial/TestSerial_SubView_c13.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_test_unmanaged_subview_reset) {
+TEST(TEST_CATEGORY, view_test_unmanaged_subview_reset) {
   TestViewSubview::test_unmanaged_subview_reset<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/serial/TestSerial_Team.cpp
+++ b/core/unit_test/serial/TestSerial_Team.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_for) {
+TEST(TEST_CATEGORY, team_for) {
   TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::test_for(
       0);
   TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::test_for(
@@ -63,7 +63,7 @@ TEST_F(TEST_CATEGORY, team_for) {
       1000);
 }
 
-TEST_F(TEST_CATEGORY, team_reduce) {
+TEST(TEST_CATEGORY, team_reduce) {
   TestTeamPolicy<TEST_EXECSPACE,
                  Kokkos::Schedule<Kokkos::Static> >::test_reduce(0);
   TestTeamPolicy<TEST_EXECSPACE,
@@ -78,7 +78,7 @@ TEST_F(TEST_CATEGORY, team_reduce) {
                  Kokkos::Schedule<Kokkos::Dynamic> >::test_reduce(1000);
 }
 
-TEST_F(TEST_CATEGORY, team_broadcast) {
+TEST(TEST_CATEGORY, team_broadcast) {
   TestTeamBroadcast<TEST_EXECSPACE,
                     Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(0);
   TestTeamBroadcast<TEST_EXECSPACE,

--- a/core/unit_test/serial/TestSerial_TeamReductionScan.cpp
+++ b/core/unit_test/serial/TestSerial_TeamReductionScan.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_scan) {
+TEST(TEST_CATEGORY, team_scan) {
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(10);
@@ -55,7 +55,7 @@ TEST_F(TEST_CATEGORY, team_scan) {
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(10000);
 }
 
-TEST_F(TEST_CATEGORY, team_long_reduce) {
+TEST(TEST_CATEGORY, team_long_reduce) {
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);
@@ -66,7 +66,7 @@ TEST_F(TEST_CATEGORY, team_long_reduce) {
       100000);
 }
 
-TEST_F(TEST_CATEGORY, team_double_reduce) {
+TEST(TEST_CATEGORY, team_double_reduce) {
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);

--- a/core/unit_test/serial/TestSerial_TeamScratch.cpp
+++ b/core/unit_test/serial/TestSerial_TeamScratch.cpp
@@ -46,32 +46,32 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_shared_request) {
+TEST(TEST_CATEGORY, team_shared_request) {
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
-TEST_F(TEST_CATEGORY, team_scratch_request) {
+TEST(TEST_CATEGORY, team_scratch_request) {
   TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
   TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 #if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
-TEST_F(TEST_CATEGORY, team_lambda_shared_request) {
+TEST(TEST_CATEGORY, team_lambda_shared_request) {
   TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
                        Kokkos::Schedule<Kokkos::Static> >();
   TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
                        Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
-TEST_F(TEST_CATEGORY, scratch_align) { TestScratchAlignment<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, scratch_align) { TestScratchAlignment<TEST_EXECSPACE>(); }
 #endif
 #endif
 
-TEST_F(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
 
-TEST_F(TEST_CATEGORY, multi_level_scratch) {
+TEST(TEST_CATEGORY, multi_level_scratch) {
   TestMultiLevelScratchTeam<TEST_EXECSPACE,
                             Kokkos::Schedule<Kokkos::Static> >();
   TestMultiLevelScratchTeam<TEST_EXECSPACE,

--- a/core/unit_test/threads/TestThreads_Category.hpp
+++ b/core/unit_test/threads/TestThreads_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class threads : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY threads
 #define TEST_EXECSPACE Kokkos::Threads
 

--- a/core/unit_test/threads/TestThreads_FunctorAnalysis.cpp
+++ b/core/unit_test/threads/TestThreads_FunctorAnalysis.cpp
@@ -1,3 +1,4 @@
+
 /*
 //@HEADER
 // ************************************************************************
@@ -41,10 +42,5 @@
 //@HEADER
 */
 
-#include <PerfTest_ViewCopy.hpp>
-namespace Test {
-TEST(default_exec, ViewDeepCopy_RightRight_Rank6) {
-  printf("DeepCopy Performance for LayoutRight to LayoutRight:\n");
-  run_deepcopyview_tests6<Kokkos::LayoutRight, Kokkos::LayoutRight>(10, 1);
-}
-}  // namespace Test
+#include <threads/TestThreads_Category.hpp>
+#include <TestFunctorAnalysis.hpp>

--- a/core/unit_test/threads/TestThreads_SharedAlloc.cpp
+++ b/core/unit_test/threads/TestThreads_SharedAlloc.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, impl_shared_alloc) {
+TEST(TEST_CATEGORY, impl_shared_alloc) {
   test_shared_alloc<Kokkos::HostSpace, TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/threads/TestThreads_SubView_a.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_a.cpp
@@ -46,51 +46,51 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_left) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_left) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutLeft, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_right) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_right) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutRight, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_stride) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_stride) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutStride, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_assign_strided) {
+TEST(TEST_CATEGORY, view_subview_assign_strided) {
   TestViewSubview::test_1d_strided_assignment<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_0) {
+TEST(TEST_CATEGORY, view_subview_left_0) {
   TestViewSubview::test_left_0<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_1) {
+TEST(TEST_CATEGORY, view_subview_left_1) {
   TestViewSubview::test_left_1<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_2) {
+TEST(TEST_CATEGORY, view_subview_left_2) {
   TestViewSubview::test_left_2<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_3) {
+TEST(TEST_CATEGORY, view_subview_left_3) {
   TestViewSubview::test_left_3<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_0) {
+TEST(TEST_CATEGORY, view_subview_right_0) {
   TestViewSubview::test_right_0<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_1) {
+TEST(TEST_CATEGORY, view_subview_right_1) {
   TestViewSubview::test_right_1<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_3) {
+TEST(TEST_CATEGORY, view_subview_right_3) {
   TestViewSubview::test_right_3<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_static_tests) {
+TEST(TEST_CATEGORY, view_static_tests) {
   TestViewSubview::TestSubviewStaticSizes<TEST_EXECSPACE,
                                           Kokkos::LayoutLeft>()();
   TestViewSubview::TestSubviewStaticSizes<TEST_EXECSPACE,

--- a/core/unit_test/threads/TestThreads_SubView_b.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_b.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
+TEST(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
   TestViewSubview::test_layoutleft_to_layoutleft<TEST_EXECSPACE>();
   TestViewSubview::test_layoutleft_to_layoutleft<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
@@ -54,7 +54,7 @@ TEST_F(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_layoutright_to_layoutright) {
+TEST(TEST_CATEGORY, view_subview_layoutright_to_layoutright) {
   TestViewSubview::test_layoutright_to_layoutright<TEST_EXECSPACE>();
   TestViewSubview::test_layoutright_to_layoutright<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();

--- a/core/unit_test/threads/TestThreads_SubView_c01.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c01.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign) {
+TEST(TEST_CATEGORY, view_subview_1d_assign) {
   TestViewSubview::test_1d_assign<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/threads/TestThreads_SubView_c02.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c02.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign_atomic) {
+TEST(TEST_CATEGORY, view_subview_1d_assign_atomic) {
   TestViewSubview::test_1d_assign<TEST_EXECSPACE,
                                   Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/threads/TestThreads_SubView_c03.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c03.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_1d_assign_randomaccess) {
   TestViewSubview::test_1d_assign<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/threads/TestThreads_SubView_c04.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c04.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_2d_from_3d) {
+TEST(TEST_CATEGORY, view_subview_2d_from_3d) {
   TestViewSubview::test_2d_subview_3d<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/threads/TestThreads_SubView_c05.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c05.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(threads, view_subview_2d_from_3d_atomic) {
+TEST(threads, view_subview_2d_from_3d_atomic) {
   TestViewSubview::test_2d_subview_3d<TEST_EXECSPACE,
                                       Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/threads/TestThreads_SubView_c06.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c06.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_2d_from_3d_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_2d_from_3d_randomaccess) {
   TestViewSubview::test_2d_subview_3d<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/threads/TestThreads_SubView_c07.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c07.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left) {
   TestViewSubview::test_3d_subview_5d_left<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/threads/TestThreads_SubView_c08.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c08.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left_atomic) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left_atomic) {
   TestViewSubview::test_3d_subview_5d_left<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/threads/TestThreads_SubView_c09.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c09.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left_randomaccess) {
   TestViewSubview::test_3d_subview_5d_left<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/threads/TestThreads_SubView_c10.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c10.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right) {
   TestViewSubview::test_3d_subview_5d_right<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/threads/TestThreads_SubView_c11.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c11.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right_atomic) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right_atomic) {
   TestViewSubview::test_3d_subview_5d_right<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/threads/TestThreads_SubView_c12.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c12.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right_randomaccess) {
   TestViewSubview::test_3d_subview_5d_right<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/threads/TestThreads_SubView_c13.cpp
+++ b/core/unit_test/threads/TestThreads_SubView_c13.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_test_unmanaged_subview_reset) {
+TEST(TEST_CATEGORY, view_test_unmanaged_subview_reset) {
   TestViewSubview::test_unmanaged_subview_reset<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/threads/TestThreads_Team.cpp
+++ b/core/unit_test/threads/TestThreads_Team.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_for) {
+TEST(TEST_CATEGORY, team_for) {
   TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::test_for(
       0);
   TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::test_for(
@@ -63,7 +63,7 @@ TEST_F(TEST_CATEGORY, team_for) {
       1000);
 }
 
-TEST_F(TEST_CATEGORY, team_reduce) {
+TEST(TEST_CATEGORY, team_reduce) {
   TestTeamPolicy<TEST_EXECSPACE,
                  Kokkos::Schedule<Kokkos::Static> >::test_reduce(0);
   TestTeamPolicy<TEST_EXECSPACE,
@@ -78,7 +78,7 @@ TEST_F(TEST_CATEGORY, team_reduce) {
                  Kokkos::Schedule<Kokkos::Dynamic> >::test_reduce(1000);
 }
 
-TEST_F(TEST_CATEGORY, team_broadcast) {
+TEST(TEST_CATEGORY, team_broadcast) {
   TestTeamBroadcast<TEST_EXECSPACE,
                     Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(0);
   TestTeamBroadcast<TEST_EXECSPACE,

--- a/core/unit_test/threads/TestThreads_TeamReductionScan.cpp
+++ b/core/unit_test/threads/TestThreads_TeamReductionScan.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_scan) {
+TEST(TEST_CATEGORY, team_scan) {
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(10);
@@ -55,7 +55,7 @@ TEST_F(TEST_CATEGORY, team_scan) {
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(10000);
 }
 
-TEST_F(TEST_CATEGORY, team_long_reduce) {
+TEST(TEST_CATEGORY, team_long_reduce) {
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);
@@ -66,7 +66,7 @@ TEST_F(TEST_CATEGORY, team_long_reduce) {
       100000);
 }
 
-TEST_F(TEST_CATEGORY, team_double_reduce) {
+TEST(TEST_CATEGORY, team_double_reduce) {
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);

--- a/core/unit_test/threads/TestThreads_TeamScratch.cpp
+++ b/core/unit_test/threads/TestThreads_TeamScratch.cpp
@@ -46,32 +46,32 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_shared_request) {
+TEST(TEST_CATEGORY, team_shared_request) {
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
-TEST_F(TEST_CATEGORY, team_scratch_request) {
+TEST(TEST_CATEGORY, team_scratch_request) {
   TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
   TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 #if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
-TEST_F(TEST_CATEGORY, team_lambda_shared_request) {
+TEST(TEST_CATEGORY, team_lambda_shared_request) {
   TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
                        Kokkos::Schedule<Kokkos::Static> >();
   TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
                        Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
-TEST_F(TEST_CATEGORY, scratch_align) { TestScratchAlignment<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, scratch_align) { TestScratchAlignment<TEST_EXECSPACE>(); }
 #endif
 #endif
 
-TEST_F(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
 
-TEST_F(TEST_CATEGORY, multi_level_scratch) {
+TEST(TEST_CATEGORY, multi_level_scratch) {
   TestMultiLevelScratchTeam<TEST_EXECSPACE,
                             Kokkos::Schedule<Kokkos::Static> >();
   TestMultiLevelScratchTeam<TEST_EXECSPACE,


### PR DESCRIPTION
Part of #2152. This pull requests removes all empty text fixtures for the backends I could easily check, i.e. `HPX`, `OpenMP Target`, `QThreads` and `ROCm` are missing.