### PR TITLE
Remove fixtures (HPX)

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -275,6 +275,7 @@ IF(Kokkos_ENABLE_HPX)
       hpx/TestHPX_Task.cpp
       hpx/TestHPX_Team.cpp
       hpx/TestHPX_TeamReductionScan.cpp
+      hpx/TestHPX_TeamScratch.cpp
       hpx/TestHPX_ViewAPI_a.cpp
       hpx/TestHPX_ViewAPI_b.cpp
       hpx/TestHPX_ViewAPI_c.cpp

--- a/core/unit_test/hpx/TestHPX_Category.hpp
+++ b/core/unit_test/hpx/TestHPX_Category.hpp
@@ -46,17 +46,6 @@
 
 #include <gtest/gtest.h>
 
-namespace Test {
-
-class hpx : public ::testing::Test {
- protected:
-  static void SetUpTestCase() {}
-
-  static void TearDownTestCase() {}
-};
-
-}  // namespace Test
-
 #define TEST_CATEGORY hpx
 #define TEST_EXECSPACE Kokkos::Experimental::HPX
 

--- a/core/unit_test/hpx/TestHPX_InterOp.cpp
+++ b/core/unit_test/hpx/TestHPX_InterOp.cpp
@@ -48,7 +48,7 @@ namespace Test {
 
 // Test whether allocations survive Kokkos initialize/finalize if done via Raw
 // Cuda.
-TEST_F(hpx, raw_hpx_interop) {
+TEST(hpx, raw_hpx_interop) {
   Kokkos::InitArguments arguments{-1, -1, -1, false};
   Kokkos::initialize(arguments);
   Kokkos::finalize();

--- a/core/unit_test/hpx/TestHPX_SharedAlloc.cpp
+++ b/core/unit_test/hpx/TestHPX_SharedAlloc.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, impl_shared_alloc) {
+TEST(TEST_CATEGORY, impl_shared_alloc) {
   test_shared_alloc<Kokkos::HostSpace, TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/hpx/TestHPX_SubView_a.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_a.cpp
@@ -46,47 +46,47 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_left) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_left) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutLeft, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_right) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_right) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutRight, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_auto_1d_stride) {
+TEST(TEST_CATEGORY, view_subview_auto_1d_stride) {
   TestViewSubview::test_auto_1d<Kokkos::LayoutStride, TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_assign_strided) {
+TEST(TEST_CATEGORY, view_subview_assign_strided) {
   TestViewSubview::test_1d_strided_assignment<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_0) {
+TEST(TEST_CATEGORY, view_subview_left_0) {
   TestViewSubview::test_left_0<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_1) {
+TEST(TEST_CATEGORY, view_subview_left_1) {
   TestViewSubview::test_left_1<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_2) {
+TEST(TEST_CATEGORY, view_subview_left_2) {
   TestViewSubview::test_left_2<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_left_3) {
+TEST(TEST_CATEGORY, view_subview_left_3) {
   TestViewSubview::test_left_3<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_0) {
+TEST(TEST_CATEGORY, view_subview_right_0) {
   TestViewSubview::test_right_0<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_1) {
+TEST(TEST_CATEGORY, view_subview_right_1) {
   TestViewSubview::test_right_1<TEST_EXECSPACE>();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_right_3) {
+TEST(TEST_CATEGORY, view_subview_right_3) {
   TestViewSubview::test_right_3<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/hpx/TestHPX_SubView_b.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_b.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
+TEST(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
   TestViewSubview::test_layoutleft_to_layoutleft<TEST_EXECSPACE>();
   TestViewSubview::test_layoutleft_to_layoutleft<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
@@ -54,7 +54,7 @@ TEST_F(TEST_CATEGORY, view_subview_layoutleft_to_layoutleft) {
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }
 
-TEST_F(TEST_CATEGORY, view_subview_layoutright_to_layoutright) {
+TEST(TEST_CATEGORY, view_subview_layoutright_to_layoutright) {
   TestViewSubview::test_layoutright_to_layoutright<TEST_EXECSPACE>();
   TestViewSubview::test_layoutright_to_layoutright<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();

--- a/core/unit_test/hpx/TestHPX_SubView_c01.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c01.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign) {
+TEST(TEST_CATEGORY, view_subview_1d_assign) {
   TestViewSubview::test_1d_assign<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/hpx/TestHPX_SubView_c02.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c02.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign_atomic) {
+TEST(TEST_CATEGORY, view_subview_1d_assign_atomic) {
   TestViewSubview::test_1d_assign<TEST_EXECSPACE,
                                   Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/hpx/TestHPX_SubView_c03.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c03.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_1d_assign_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_1d_assign_randomaccess) {
   TestViewSubview::test_1d_assign<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/hpx/TestHPX_SubView_c04.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c04.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_2d_from_3d) {
+TEST(TEST_CATEGORY, view_subview_2d_from_3d) {
   TestViewSubview::test_2d_subview_3d<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/hpx/TestHPX_SubView_c05.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c05.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(hpx, view_subview_2d_from_3d_atomic) {
+TEST(hpx, view_subview_2d_from_3d_atomic) {
   TestViewSubview::test_2d_subview_3d<TEST_EXECSPACE,
                                       Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/hpx/TestHPX_SubView_c06.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c06.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_2d_from_3d_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_2d_from_3d_randomaccess) {
   TestViewSubview::test_2d_subview_3d<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/hpx/TestHPX_SubView_c07.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c07.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left) {
   TestViewSubview::test_3d_subview_5d_left<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/hpx/TestHPX_SubView_c08.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c08.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left_atomic) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left_atomic) {
   TestViewSubview::test_3d_subview_5d_left<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/hpx/TestHPX_SubView_c09.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c09.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_left_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_left_randomaccess) {
   TestViewSubview::test_3d_subview_5d_left<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/hpx/TestHPX_SubView_c10.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c10.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right) {
   TestViewSubview::test_3d_subview_5d_right<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/hpx/TestHPX_SubView_c11.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c11.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right_atomic) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right_atomic) {
   TestViewSubview::test_3d_subview_5d_right<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic> >();
 }

--- a/core/unit_test/hpx/TestHPX_SubView_c12.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c12.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_subview_3d_from_5d_right_randomaccess) {
+TEST(TEST_CATEGORY, view_subview_3d_from_5d_right_randomaccess) {
   TestViewSubview::test_3d_subview_5d_right<
       TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::RandomAccess> >();
 }

--- a/core/unit_test/hpx/TestHPX_SubView_c13.cpp
+++ b/core/unit_test/hpx/TestHPX_SubView_c13.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, view_test_unmanaged_subview_reset) {
+TEST(TEST_CATEGORY, view_test_unmanaged_subview_reset) {
   TestViewSubview::test_unmanaged_subview_reset<TEST_EXECSPACE>();
 }
 

--- a/core/unit_test/hpx/TestHPX_Team.cpp
+++ b/core/unit_test/hpx/TestHPX_Team.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_for) {
+TEST(TEST_CATEGORY, team_for) {
   TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::test_for(
       0);
   TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::test_for(
@@ -63,7 +63,7 @@ TEST_F(TEST_CATEGORY, team_for) {
       1000);
 }
 
-TEST_F(TEST_CATEGORY, team_reduce) {
+TEST(TEST_CATEGORY, team_reduce) {
   TestTeamPolicy<TEST_EXECSPACE,
                  Kokkos::Schedule<Kokkos::Static> >::test_reduce(0);
   TestTeamPolicy<TEST_EXECSPACE,

--- a/core/unit_test/hpx/TestHPX_TeamReductionScan.cpp
+++ b/core/unit_test/hpx/TestHPX_TeamReductionScan.cpp
@@ -46,7 +46,7 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_scan) {
+TEST(TEST_CATEGORY, team_scan) {
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(10);
@@ -55,7 +55,7 @@ TEST_F(TEST_CATEGORY, team_scan) {
   TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(10000);
 }
 
-TEST_F(TEST_CATEGORY, team_long_reduce) {
+TEST(TEST_CATEGORY, team_long_reduce) {
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);
@@ -66,7 +66,7 @@ TEST_F(TEST_CATEGORY, team_long_reduce) {
       100000);
 }
 
-TEST_F(TEST_CATEGORY, team_double_reduce) {
+TEST(TEST_CATEGORY, team_double_reduce) {
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
   TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);

--- a/core/unit_test/hpx/TestHPX_TeamScratch.cpp
+++ b/core/unit_test/hpx/TestHPX_TeamScratch.cpp
@@ -46,19 +46,19 @@
 
 namespace Test {
 
-TEST_F(TEST_CATEGORY, team_shared_request) {
+TEST(TEST_CATEGORY, team_shared_request) {
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
-TEST_F(TEST_CATEGORY, team_scratch_request) {
+TEST(TEST_CATEGORY, team_scratch_request) {
   TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
   TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
 }
 
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 #if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
-TEST_F(TEST_CATEGORY, team_lambda_shared_request) {
+TEST(TEST_CATEGORY, team_lambda_shared_request) {
   TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
                        Kokkos::Schedule<Kokkos::Static> >();
   TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
@@ -67,9 +67,9 @@ TEST_F(TEST_CATEGORY, team_lambda_shared_request) {
 #endif
 #endif
 
-TEST_F(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
+TEST(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
 
-TEST_F(TEST_CATEGORY, multi_level_scratch) {
+TEST(TEST_CATEGORY, multi_level_scratch) {
   TestMultiLevelScratchTeam<TEST_EXECSPACE,
                             Kokkos::Schedule<Kokkos::Static> >();
   TestMultiLevelScratchTeam<TEST_EXECSPACE,


### PR DESCRIPTION
Part of #2152. This removes the empty test fixtures for all the `HPX` tests (and makes sure "TestHPX_TeamScratch.cpp" is actually used).