### PR TITLE
Fixup for no discard attribute

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -609,9 +609,12 @@ define KOKKOS_FORCEINLINE_FUNCTION inline
 #define KOKKOS_ENABLE_CUDA_LDG_INTRINSIC
 #endif
 
-#if defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(nodiscard) >= 201603L
 #define KOKKOS_ATTRIBUTE_NODISCARD [[nodiscard]]
-#else
+#endif
+#endif
+#if !defined(KOKKOS_ATTRIBUTE_NODISCARD)
 #define KOKKOS_ATTRIBUTE_NODISCARD
 #endif
 

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -609,19 +609,9 @@ define KOKKOS_FORCEINLINE_FUNCTION inline
 #define KOKKOS_ENABLE_CUDA_LDG_INTRINSIC
 #endif
 
-#if defined(__has_cpp_attribute)
-#if __has_cpp_attribute(nodiscard)
+#if defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)
 #define KOKKOS_ATTRIBUTE_NODISCARD [[nodiscard]]
-#endif
-#endif
-#ifndef KOKKOS_ATTRIBUTE_NODISCARD
-// C++17 should have it no matter what
-#if KOKKOS_ENABLE_CXX17
-#define KOKKOS_ATTRIBUTE_NODISCARD [[nodiscard]]
-#endif
-#endif
-#ifndef KOKKOS_ATTRIBUTE_NODISCARD
-// Otherwise, not yet available
+#else
 #define KOKKOS_ATTRIBUTE_NODISCARD
 #endif
 


### PR DESCRIPTION
Develop branch is "broken" at the moment.
```
error: use of the 'nodiscard' attribute is a C++17 extension [-Werror,-Wc++17-extensions]
```

I cherry-picked the fix I pushed to #2462 and implemented https://github.com/kokkos/kokkos/pull/2462#issuecomment-542012234 afterwards.

This need to be fixed ASAP.