### PR TITLE
Remove ROCm and Qthreads from scripts 

### DIFF
--- a/cm_generate_makefile.bash
+++ b/cm_generate_makefile.bash
@@ -80,15 +80,12 @@ display_help_text() {
       echo "Kokkos configure options:"
       echo ""
       echo "--kokkos-path=/Path/To/Kokkos:        Path to the Kokkos root directory."
-      echo "--qthreads-path=/Path/To/Qthreads:    Path to Qthreads install directory."
-      echo "                                        Overrides path given by --with-qthreads."
       echo "--prefix=/Install/Path:               Path to install the Kokkos library."
       echo ""
       echo "--with-cuda[=/Path/To/Cuda]:          Enable Cuda and set path to Cuda Toolkit."
       echo "--with-openmp:                        Enable OpenMP backend."
       echo "--with-pthread:                       Enable Pthreads backend."
       echo "--with-serial:                        Enable Serial backend."
-      echo "--with-qthreads[=/Path/To/Qthreads]:  Enable Qthreads backend."
       echo "--with-devices:                       Explicitly add a set of backends."
       echo ""
       echo "--arch=[OPT]:  Set target architectures. Options are:"
@@ -168,9 +165,6 @@ do
     --kokkos-path*)
       KOKKOS_PATH="${key#*=}"
       ;;
-    --qthreads-path*)
-      QTHREADS_PATH="${key#*=}"
-      ;;
     --hpx-path*)
       HPX_PATH="${key#*=}"
       ;;
@@ -190,9 +184,6 @@ do
       update_kokkos_devices Cuda
       CUDA_PATH="${key#*=}"
       ;;
-    --with-rocm)
-      update_kokkos_devices ROCm
-      ;;
     --with-openmp)
       update_kokkos_devices OpenMP
       ;;
@@ -201,12 +192,6 @@ do
       ;;
     --with-serial)
       update_kokkos_devices Serial
-      ;;
-    --with-qthreads*)
-      update_kokkos_devices Qthreads
-      if [ -z "$QTHREADS_PATH" ]; then
-        QTHREADS_PATH="${key#*=}"
-      fi
       ;;
     --with-hpx-options*)
       KOKKOS_HPX_OPT="${key#*=}"

--- a/scripts/testing_scripts/cm_test_all_sandia
+++ b/scripts/testing_scripts/cm_test_all_sandia
@@ -28,8 +28,8 @@ print_help() {
   echo "--build-list=BUILD,BUILD,BUILD..."
   echo "    Provide a comma-separated list of builds instead of running all builds"
   echo "    Valid items:"
-  echo "      OpenMP, Pthread, Qthreads, Serial, OpenMP_Serial, Pthread_Serial"
-  echo "      Qthreads_Serial, Cuda_OpenMP, Cuda_Pthread, Cuda_Serial"
+  echo "      OpenMP, Pthread, Serial, OpenMP_Serial, Pthread_Serial"
+  echo "      Cuda_OpenMP, Cuda_Pthread, Cuda_Serial"
   echo ""
 
   echo "ARGS: list of expressions matching compilers to test"
@@ -138,7 +138,6 @@ PGI_WARNING_FLAGS=""
 DEBUG=False
 ARGS=""
 CUSTOM_BUILD_LIST=""
-QTHREADS_PATH=""
 DRYRUN=False
 BUILD_ONLY=False
 declare -i NUM_JOBS_TO_RUN_IN_PARALLEL=1
@@ -165,9 +164,6 @@ do
   case $key in
     --kokkos-path*)
       KOKKOS_PATH="${key#*=}"
-      ;;
-    --qthreads-path*)
-      QTHREADS_PATH="${key#*=}"
       ;;
     --build-list*)
       CUSTOM_BUILD_LIST="${key#*=}"
@@ -620,33 +616,6 @@ if [ "$COMPILERS_TO_TEST" == "" ]; then
    exit 0
 fi
 
-# Check if Qthreads build requested.
-HAVE_QTHREADS_BUILD="False"
-if [ -n "$CUSTOM_BUILD_LIST" ]; then
-  if [[ "$CUSTOM_BUILD_LIST" = *Qthreads* ]]; then
-    HAVE_QTHREADS_BUILD="True"
-  fi
-else
-  for COMPILER_DATA in "${COMPILERS[@]}"; do
-    ARR=($COMPILER_DATA)
-    BUILD_LIST=${ARR[2]}
-    if [[ "$BUILD_LIST" = *Qthreads* ]]; then
-      HAVE_QTHREADS_BUILD="True"
-    fi
-  done
-fi
-
-# Ensure Qthreads path is set if Qthreads build is requested.
-if [ "$HAVE_QTHREADS_BUILD" = "True" ]; then
-  if [ -z "$QTHREADS_PATH" ]; then
-    echo "Need to supply Qthreads path (--qthreads-path) when testing Qthreads backend." >&2
-    exit 1
-  else
-    # Strip trailing slashes from path.
-    QTHREADS_PATH=$(echo $QTHREADS_PATH | sed 's/\/*$//')
-  fi
-fi
-
 #
 # Functions.
 #
@@ -771,14 +740,6 @@ single_build_and_test() {
 
   if [[ "$build_type" = hwloc* ]]; then
     local extra_args="$extra_args --with-hwloc=$(dirname $(dirname $(which hwloc-info)))"
-  fi
-
-  if [[ "$build" = *Qthreads* ]]; then
-    if [[ "$build_type" = hwloc* ]]; then
-      local extra_args="$extra_args --qthreads-path=${QTHREADS_PATH}_hwloc"
-    else
-      local extra_args="$extra_args --qthreads-path=$QTHREADS_PATH"
-    fi
   fi
 
   if [[ "$OPT_FLAG" = "" ]]; then

--- a/scripts/testing_scripts/generate_makefile.bash
+++ b/scripts/testing_scripts/generate_makefile.bash
@@ -12,9 +12,6 @@ do
     --kokkos-path*)
       KOKKOS_PATH="${key#*=}"
       ;;
-    --qthreads-path*)
-      QTHREADS_PATH="${key#*=}"
-      ;;
     --hpx-path*)
       HPX_PATH="${key#*=}"
       ;;
@@ -34,9 +31,6 @@ do
       KOKKOS_DEVICES="${KOKKOS_DEVICES},Cuda"
       CUDA_PATH="${key#*=}"
       ;;
-    --with-rocm)
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},ROCm"
-      ;;
     --with-openmp)
       KOKKOS_DEVICES="${KOKKOS_DEVICES},OpenMP"
       ;;
@@ -45,12 +39,6 @@ do
       ;;
     --with-serial)
       KOKKOS_DEVICES="${KOKKOS_DEVICES},Serial"
-      ;;
-    --with-qthreads*)
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},Qthreads"
-      if [ -z "$QTHREADS_PATH" ]; then
-        QTHREADS_PATH="${key#*=}"
-      fi
       ;;
     --with-hpx-options*)
       KOKKOS_HPX_OPT="${key#*=}"
@@ -128,15 +116,12 @@ do
       echo "Kokkos configure options:"
       echo ""
       echo "--kokkos-path=/Path/To/Kokkos:        Path to the Kokkos root directory."
-      echo "--qthreads-path=/Path/To/Qthreads:    Path to Qthreads install directory."
-      echo "                                        Overrides path given by --with-qthreads."
       echo "--prefix=/Install/Path:               Path to install the Kokkos library."
       echo ""
       echo "--with-cuda[=/Path/To/Cuda]:          Enable Cuda and set path to Cuda Toolkit."
       echo "--with-openmp:                        Enable OpenMP backend."
       echo "--with-pthread:                       Enable Pthreads backend."
       echo "--with-serial:                        Enable Serial backend."
-      echo "--with-qthreads[=/Path/To/Qthreads]:  Enable Qthreads backend."
       echo "--with-devices:                       Explicitly add a set of backends."
       echo ""
       echo "--arch=[OPT]:  Set target architectures. Options are:"

--- a/scripts/testing_scripts/test_all_sandia
+++ b/scripts/testing_scripts/test_all_sandia
@@ -82,7 +82,6 @@ PGI_WARNING_FLAGS=""
 DEBUG=False
 ARGS=""
 CUSTOM_BUILD_LIST=""
-QTHREADS_PATH=""
 DRYRUN=False
 BUILD_ONLY=False
 declare -i NUM_JOBS_TO_RUN_IN_PARALLEL=1
@@ -109,9 +108,6 @@ do
   case $key in
     --kokkos-path*)
       KOKKOS_PATH="${key#*=}"
-      ;;
-    --qthreads-path*)
-      QTHREADS_PATH="${key#*=}"
       ;;
     --build-list*)
       CUSTOM_BUILD_LIST="${key#*=}"
@@ -525,8 +521,8 @@ if [ "$PRINT_HELP" = "True" ]; then
   echo "--build-list=BUILD,BUILD,BUILD..."
   echo "    Provide a comma-separated list of builds instead of running all builds"
   echo "    Valid items:"
-  echo "      OpenMP, Pthread, Qthreads, Serial, OpenMP_Serial, Pthread_Serial"
-  echo "      Qthreads_Serial, Cuda_OpenMP, Cuda_Pthread, Cuda_Serial"
+  echo "      OpenMP, Pthread, Serial, OpenMP_Serial, Pthread_Serial"
+  echo "      Cuda_OpenMP, Cuda_Pthread, Cuda_Serial"
   echo ""
 
   echo "ARGS: list of expressions matching compilers to test"
@@ -590,33 +586,6 @@ for ARG in $ARGS; do
     fi
   done
 done
-
-# Check if Qthreads build requested.
-HAVE_QTHREADS_BUILD="False"
-if [ -n "$CUSTOM_BUILD_LIST" ]; then
-  if [[ "$CUSTOM_BUILD_LIST" = *Qthreads* ]]; then
-    HAVE_QTHREADS_BUILD="True"
-  fi
-else
-  for COMPILER_DATA in "${COMPILERS[@]}"; do
-    ARR=($COMPILER_DATA)
-    BUILD_LIST=${ARR[2]}
-    if [[ "$BUILD_LIST" = *Qthreads* ]]; then
-      HAVE_QTHREADS_BUILD="True"
-    fi
-  done
-fi
-
-# Ensure Qthreads path is set if Qthreads build is requested.
-if [ "$HAVE_QTHREADS_BUILD" = "True" ]; then
-  if [ -z "$QTHREADS_PATH" ]; then
-    echo "Need to supply Qthreads path (--qthreads-path) when testing Qthreads backend." >&2
-    exit 1
-  else
-    # Strip trailing slashes from path.
-    QTHREADS_PATH=$(echo $QTHREADS_PATH | sed 's/\/*$//')
-  fi
-fi
 
 #
 # Functions.
@@ -733,14 +702,6 @@ single_build_and_test() {
 
   if [[ "$build_type" = hwloc* ]]; then
     local extra_args=--with-hwloc=$(dirname $(dirname $(which hwloc-info)))
-  fi
-
-  if [[ "$build" = *Qthreads* ]]; then
-    if [[ "$build_type" = hwloc* ]]; then
-      local extra_args="$extra_args --qthreads-path=${QTHREADS_PATH}_hwloc"
-    else
-      local extra_args="$extra_args --qthreads-path=$QTHREADS_PATH"
-    fi
   fi
 
   if [[ "$OPT_FLAG" = "" ]]; then


### PR DESCRIPTION
This should be combined with #2470 

Remove references to ROCm and Qthreads in the Build doc as well as the testing scripts.

Note that these were already removed from the README.md