### PR TITLE
MacOSX fix __has_builtin

### DIFF
--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -41,6 +41,7 @@
 //@HEADER
 */
 
+#include <cstdio>
 #include <algorithm>
 #include <Kokkos_Macros.hpp>
 #include <impl/Kokkos_Error.hpp>


### PR DESCRIPTION
background: https://github.com/jeffhammond/HPCInfo/tree/master/bugs/macosx/theworst

```
/usr/local/bin/g++-9 -I./ -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/containers/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/algorithms/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src/eti --std=c++11 -fopenmp -I./ -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/containers/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/algorithms/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src/eti -I/Users/jrhammon/Work/DOE/KOKKOS/github/tpls/gtest -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/unit_test -O3 -c /Users/jrhammon/Work/DOE/KOKKOS/github/core/src/impl/Kokkos_CPUDiscovery.cpp
/usr/local/bin/g++-9 -I./ -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/containers/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/algorithms/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src/eti --std=c++11 -fopenmp -I./ -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/containers/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/algorithms/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src/eti -I/Users/jrhammon/Work/DOE/KOKKOS/github/tpls/gtest -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/unit_test -O3 -c /Users/jrhammon/Work/DOE/KOKKOS/github/core/src/impl/Kokkos_HostSpace.cpp
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdlib.h:61,
                 from /usr/local/Cellar/gcc/9.2.0_1/include/c++/9.2.0/cstdlib:75,
                 from /usr/local/Cellar/gcc/9.2.0_1/include/c++/9.2.0/bits/stl_algo.h:59,
                 from /usr/local/Cellar/gcc/9.2.0_1/include/c++/9.2.0/algorithm:62,
                 from /Users/jrhammon/Work/DOE/KOKKOS/github/core/src/impl/Kokkos_HostSpace.cpp:44:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/Availability.h:257:22: error: missing binary operator before token "("
  257 |     #if __has_builtin(__is_target_arch)
      |                      ^
In file included from /usr/local/Cellar/gcc/9.2.0_1/include/c++/9.2.0/cstdio:42,
                 from /Users/jrhammon/Work/DOE/KOKKOS/github/core/src/impl/Kokkos_CPUDiscovery.cpp:50:
```