### PR TITLE
fix MacOS issue with unistd.h

### DIFF
--- a/core/src/impl/Kokkos_CPUDiscovery.cpp
+++ b/core/src/impl/Kokkos_CPUDiscovery.cpp
@@ -44,7 +44,7 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#else
+#elif !defined(__APPLE__)
 #include <unistd.h>
 #endif
 #include <cstdio>


### PR DESCRIPTION
```
/usr/local/bin/g++-9 -I./ -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/containers/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/algorithms/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src/eti --std=c++11 -fopenmp -I./ -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/containers/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/algorithms/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src/eti -I/Users/jrhammon/Work/DOE/KOKKOS/github/tpls/gtest -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/unit_test -O3 -c /Users/jrhammon/Work/DOE/KOKKOS/github/core/src/impl/Kokkos_CPUDiscovery.cpp
/usr/local/bin/g++-9 -I./ -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/containers/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/algorithms/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src/eti --std=c++11 -fopenmp -I./ -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/containers/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/algorithms/src -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/src/eti -I/Users/jrhammon/Work/DOE/KOKKOS/github/tpls/gtest -I/Users/jrhammon/Work/DOE/KOKKOS/github/core/unit_test -O3 -c /Users/jrhammon/Work/DOE/KOKKOS/github/core/src/impl/Kokkos_HostSpace.cpp
In file included from /usr/local/Cellar/gcc/9.2.0_1/include/c++/9.2.0/cstdio:42,
                 from /Users/jrhammon/Work/DOE/KOKKOS/github/core/src/impl/Kokkos_CPUDiscovery.cpp:50:
/usr/local/Cellar/gcc/9.2.0_1/lib/gcc/9/gcc/x86_64-apple-darwin18/9.2.0/include-fixed/stdio.h:222:7: error: conflicting declaration of 'char* ctermid(char*)' with 'C' linkage
  222 | char *ctermid(char *);
      |       ^~~~~~~
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:524,
                 from /Users/jrhammon/Work/DOE/KOKKOS/github/core/src/impl/Kokkos_CPUDiscovery.cpp:48:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_ctermid.h:26:10: note: previous declaration with 'C++' linkage
   26 | char    *ctermid(char *);
      |          ^~~~~~~
```