### PR TITLE
Fix C++20 KOKKOS_LAMBDA deprecation warning

### DIFF
--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -175,7 +175,7 @@ struct ErrorReporterDriver : public ErrorReporterDriverBase<DeviceType> {
   }
 };
 
-#if defined(KOKKOS_CLASS_LAMBDA)
+#if defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)
 template <typename DeviceType>
 struct ErrorReporterDriverUseLambda
     : public ErrorReporterDriverBase<DeviceType> {
@@ -224,7 +224,7 @@ struct ErrorReporterDriverNativeOpenMP
 };
 #endif
 
-#if defined(KOKKOS_CLASS_LAMBDA)
+#if defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)
 TEST(TEST_CATEGORY, ErrorReporterViaLambda) {
   TestErrorReporter<ErrorReporterDriverUseLambda<TEST_EXECSPACE>>();
 }

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -159,6 +159,8 @@
 
 #if defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)
 #define KOKKOS_CLASS_LAMBDA [ =, *this ] __host__ __device__
+#else
+#define KOKKOS_CLASS_LAMBDA [=] __host__ __device__
 #endif
 #endif
 
@@ -208,9 +210,12 @@
 #define KOKKOS_LAMBDA [=]
 #endif
 
-#if (defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)) && \
-    !defined(KOKKOS_CLASS_LAMBDA)
+#if !defined(KOKKOS_CLASS_LAMBDA)
+#if (defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20))
 #define KOKKOS_CLASS_LAMBDA [ =, *this ]
+#else
+#define KOKKOS_CLASS_LAMBDA [=]
+#endif
 #endif
 
 //#if !defined( __CUDA_ARCH__ ) // Not compiling Cuda code to 'ptx'.

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -256,7 +256,7 @@ struct TestRange {
       Kokkos::View<int *, ExecSpace> a("A", N);
 
       Kokkos::parallel_for(
-          policy_t(0, N), KOKKOS_LAMBDA(const int &i) {
+          policy_t(0, N), KOKKOS_CLASS_LAMBDA(const int &i) {
             for (int k = 0; k < (i < N / 2 ? 1 : 10000); k++) {
               a(i)++;
             }
@@ -270,7 +270,7 @@ struct TestRange {
       int error = 0;
       Kokkos::parallel_reduce(
           Kokkos::RangePolicy<ExecSpace>(0, N),
-          KOKKOS_LAMBDA(const int &i, int &lsum) {
+          KOKKOS_CLASS_LAMBDA(const int &i, int &lsum) {
             lsum += (a(i) != (i < N / 2 ? 1 : 10000));
           },
           error);
@@ -300,7 +300,7 @@ struct TestRange {
       int sum = 0;
       Kokkos::parallel_reduce(
           policy_t(0, N),
-          KOKKOS_LAMBDA(const int &i, int &lsum) {
+          KOKKOS_CLASS_LAMBDA(const int &i, int &lsum) {
             for (int k = 0; k < (i < N / 2 ? 1 : 10000); k++) {
               a(i)++;
             }
@@ -317,7 +317,7 @@ struct TestRange {
       int error = 0;
       Kokkos::parallel_reduce(
           Kokkos::RangePolicy<ExecSpace>(0, N),
-          KOKKOS_LAMBDA(const int &i, int &lsum) {
+          KOKKOS_CLASS_LAMBDA(const int &i, int &lsum) {
             lsum += (a(i) != (i < N / 2 ? 1 : 10000));
           },
           error);


### PR DESCRIPTION
Fixes #2454. `KOKKOS_CLASS_LAMBDA` should be used instead of `KOKKOS_LAMBDA` in places where `this` is implicitly captured. Unfortunately, we can only do this for `C++17` and later. To be able to write code that both avoids this warning for C++17 and later and still works for C++14 and below, this pull requests defines `KOKKOS_CLASS_LAMBDA` the same as `KOKKOS_LAMBDA` as this is the closest we can (easily) get.