### PR TITLE
Fix issue #2410 max_team_size not compiling for reducers with scalar types without +=

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -209,9 +209,10 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     p2 /= 2;
     return p2 / vector_length();
   }
-  
+
   template <class FunctorType, class ReducerType>
-  int team_size_max(const FunctorType& f, const ReducerType& r, const ParallelReduceTag&) const {
+  int team_size_max(const FunctorType& f, const ReducerType& r,
+                    const ParallelReduceTag&) const {
     typedef Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                                  ReducerType>
         closure_type;
@@ -238,7 +239,6 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     p2 /= 2;
     return p2 / vector_length();
   }
-
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   template <class FunctorType>
@@ -306,7 +306,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     p2 /= 2;
     return p2 / vector_length();
   }
-  
+
   template <class FunctorType, class ReducerType>
   int team_size_recommended(const FunctorType& f, const ReducerType&,
                             const ParallelReduceTag&) const {
@@ -2030,7 +2030,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
           std::string("Kokkos::Impl::ParallelReduce< Cuda > bad team size"));
     }
     if (int(m_team_size) >
-        arg_policy.team_size_max(m_functor,m_reducer, ParallelReduceTag())) {
+        arg_policy.team_size_max(m_functor, m_reducer, ParallelReduceTag())) {
       Kokkos::Impl::throw_runtime_exception(
           std::string("Kokkos::Impl::ParallelReduce< Cuda > requested too "
                       "large team size."));

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -187,7 +187,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     typedef Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                                  reducer_type>
         closure_type;
-    return internal_team_size_max<closure_type>(f);
+    return internal_team_size_max<FunctorType, closure_type>(f);
   }
 
   template <class FunctorType, class ReducerType>
@@ -196,7 +196,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     typedef Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                                  ReducerType>
         closure_type;
-    return internal_team_size_max<closure_type>(f);
+    return internal_team_size_max<FunctorType, closure_type>(f);
   }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
@@ -243,7 +243,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     typedef Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                                  reducer_type>
         closure_type;
-    return team_size_recommeded_impl<closure_type>(f);
+    return internal_team_size_recommended<FunctorType, closure_type>(f);
   }
 
   template <class FunctorType, class ReducerType>
@@ -252,7 +252,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     typedef Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                                  ReducerType>
         closure_type;
-    return team_size_recommeded_impl<closure_type>(f);
+    return internal_team_size_recommended<FunctorType, closure_type>(f);
   }
 
   inline static int vector_length_max() { return Impl::CudaTraits::WarpSize; }
@@ -511,7 +511,8 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
 #endif
 
   template <class FunctorType, class ClosureType>
-  int internal_team_size_max<closure_type>(const FunctorType& f) {
+  int internal_team_size_max(const FunctorType& f) const {
+    using closure_type = ClosureType;
     typedef Impl::FunctorValueTraits<FunctorType, typename traits::work_tag>
         functor_value_traits;
 
@@ -537,7 +538,8 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
   }
 
   template <class FunctorType, class ClosureType>
-  int internal_team_size_recommended<closure_type>(const FunctorType& f) {
+  int internal_team_size_recommended(const FunctorType& f) const {
+    using closure_type = ClosureType;
     typedef Impl::FunctorValueTraits<FunctorType, typename traits::work_tag>
         functor_value_traits;
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -51,7 +51,6 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdint>
-#include <cassert>
 
 #include <utility>
 #include <Kokkos_Parallel.hpp>
@@ -521,15 +520,15 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     cudaFuncAttributes attr =
         CudaParallelLaunch<closure_type, typename traits::launch_bounds>::
             get_cuda_func_attributes();
-    const int block_size =
-        block_size_callable(space().impl_internal_space_instance(), attr, f,
-                            (size_t)vector_length(),
-                            (size_t)team_scratch_size(0) + 2 * sizeof(double),
-                            (size_t)thread_scratch_size(0) + sizeof(double) +
-                                ((functor_value_traits::StaticValueSize != 0)
-                                     ? 0
-                                     : functor_value_traits::value_size(f)));
-    assert(block_size > 0);
+    const int block_size = std::forward<BlockSizeCallable>(block_size_callable)(
+        space().impl_internal_space_instance(), attr, f,
+        (size_t)vector_length(),
+        (size_t)team_scratch_size(0) + 2 * sizeof(double),
+        (size_t)thread_scratch_size(0) + sizeof(double) +
+            ((functor_value_traits::StaticValueSize != 0)
+                 ? 0
+                 : functor_value_traits::value_size(f)));
+    KOKKOS_ASSERT(block_size > 0);
 
     // Currently we require Power-of-2 team size for reductions.
     int p2 = 1;

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -514,12 +514,26 @@ class TeamPolicyInternal<Kokkos::Experimental::HPX, Properties...>
   int team_size_max(const FunctorType &, const ParallelReduceTag &) const {
     return 1;
   }
+
+  template <class FunctorType, class ReducerType>
+  int team_size_max(const FunctorType &, const ReducerType &,
+                    const ParallelReduceTag &) const {
+    return 1;
+  }
+
   template <class FunctorType>
   int team_size_recommended(const FunctorType &, const ParallelForTag &) const {
     return 1;
   }
+
   template <class FunctorType>
   int team_size_recommended(const FunctorType &,
+                            const ParallelReduceTag &) const {
+    return 1;
+  }
+
+  template <class FunctorType, class ReducerType>
+  int team_size_recommended(const FunctorType &, const ReducerType &,
                             const ParallelReduceTag &) const {
     return 1;
   }

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -306,12 +306,22 @@ class TeamPolicyInternal<Kokkos::Serial, Properties...>
   int team_size_max(const FunctorType&, const ParallelReduceTag&) const {
     return 1;
   }
+  template <class FunctorType, class ReducerType>
+  int team_size_max(const FunctorType&, const ReducerType&,
+                    const ParallelReduceTag&) const {
+    return 1;
+  }
   template <class FunctorType>
   int team_size_recommended(const FunctorType&, const ParallelForTag&) const {
     return 1;
   }
   template <class FunctorType>
   int team_size_recommended(const FunctorType&,
+                            const ParallelReduceTag&) const {
+    return 1;
+  }
+  template <class FunctorType, class ReducerType>
+  int team_size_recommended(const FunctorType&, const ReducerType&,
                             const ParallelReduceTag&) const {
     return 1;
   }

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -131,6 +131,11 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
     int max_host_team_size = Impl::HostThreadTeamData::max_team_members;
     return pool_size < max_host_team_size ? pool_size : max_host_team_size;
   }
+  template <class FunctorType, class ReducerType>
+  inline int team_size_max(const FunctorType& f, const ReducerType&,
+                           const ParallelReduceTag& t) const {
+    return team_size_max(f, t);
+  }
   template <class FunctorType>
   int team_size_recommended(const FunctorType&, const ParallelForTag&) const {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
@@ -147,6 +152,11 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
 #else
     return traits::execution_space::impl_thread_pool_size(2);
 #endif
+  }
+  template <class FunctorType, class ReducerType>
+  inline int team_size_recommended(const FunctorType& f, const ReducerType&,
+                                   const ParallelReduceTag& t) const {
+    return team_size_recommended(f, t);
   }
 
   inline static int vector_length_max() {

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -677,6 +677,11 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
     int max_host_team_size = Impl::HostThreadTeamData::max_team_members;
     return pool_size < max_host_team_size ? pool_size : max_host_team_size;
   }
+  template <class FunctorType, class ReducerType>
+  inline int team_size_max(const FunctorType& f, const ReducerType&,
+                           const ParallelReduceTag& t) const {
+    return team_size_max(f, t);
+  }
   template <class FunctorType>
   int team_size_recommended(const FunctorType&, const ParallelForTag&) const {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
@@ -693,6 +698,11 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
 #else
     return traits::execution_space::impl_thread_pool_size(2);
 #endif
+  }
+  template <class FunctorType, class ReducerType>
+  inline int team_size_recommended(const FunctorType& f, const ReducerType&,
+                                   const ParallelReduceTag& t) const {
+    return team_size_recommended(f, t);
   }
 
   inline static int vector_length_max() {

--- a/core/unit_test/TestTeamTeamSize.hpp
+++ b/core/unit_test/TestTeamTeamSize.hpp
@@ -176,7 +176,7 @@ template <typename TeamHandleType, typename ReducerValueType>
 struct PrintFunctor1 {
   KOKKOS_INLINE_FUNCTION void operator()(const TeamHandleType& team,
                                          ReducerValueType&) const {
-    printf("Test %i %i\n", (int)team.league_rank(), (int)team.team_rank());
+    printf("Test %i %i\n", int(team.league_rank()), int(team.team_rank()));
   }
 };
 
@@ -184,7 +184,7 @@ template <typename TeamHandleType, typename ReducerValueType>
 struct PrintFunctor2 {
   KOKKOS_INLINE_FUNCTION void operator()(const TeamHandleType& team,
                                          ReducerValueType& teamVal) const {
-    printf("Test %i %i\n", (int)team.league_rank(), (int)team.team_rank());
+    printf("Test %i %i\n", int(team.league_rank()), int(team.team_rank()));
     teamVal += 1;
   }
 };


### PR DESCRIPTION
Tests are missing, and I couldn't apply clang format due to limited machines I can access. That said this fixes #2410 