### PR TITLE
Fix compile error in OpenMP_Exec with clang 8.0

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
@@ -219,19 +219,11 @@ void OpenMPExec::resize_thread_data(size_t pool_reduce_bytes,
       void *ptr = nullptr;
       try {
         ptr = space.allocate(alloc_bytes);
-      }
-#ifndef __NVCC__
-      catch (Experimental::RawMemoryAllocationFailure const &failure) {
+      } catch (
+          Kokkos::Experimental::RawMemoryAllocationFailure const &failure) {
         // For now, just rethrow the error message the existing way
         Kokkos::Impl::throw_runtime_exception(failure.get_error_message());
       }
-#else
-      // For some reason, NVCC with OpenMP chokes on custom exception classes
-      catch (std::bad_alloc const &failure) {
-        // For now, just rethrow the error message the existing way
-        Kokkos::Impl::throw_runtime_exception(failure.what());
-      }
-#endif
 
       m_pool[rank] = new (ptr) HostThreadTeamData();
 
@@ -360,7 +352,7 @@ void OpenMP::impl_initialize(int thread_count)
     void *ptr = nullptr;
     try {
       ptr = space.allocate(sizeof(Impl::OpenMPExec));
-    } catch (Experimental::RawMemoryAllocationFailure const &f) {
+    } catch (Kokkos::Experimental::RawMemoryAllocationFailure const &f) {
       // For now, just rethrow the error message the existing way
       Kokkos::Impl::throw_runtime_exception(f.get_error_message());
     }

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -203,7 +203,8 @@ void OpenMP::partition_master(F const& f, int num_partitions,
       void* ptr = nullptr;
       try {
         ptr = space.allocate(sizeof(Exec));
-      } catch (Experimental::RawMemoryAllocationFailure const& failure) {
+      } catch (
+          Kokkos::Experimental::RawMemoryAllocationFailure const& failure) {
         // For now, just rethrow the error message the existing way
         Kokkos::Impl::throw_runtime_exception(failure.get_error_message());
       }

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
@@ -78,9 +78,7 @@ HostThreadTeamDataSingleton::HostThreadTeamDataSingleton()
   void* ptr = nullptr;
   try {
     ptr = space.allocate(alloc_bytes);
-  }
-#if !(defined(__NVCC__) && defined(KOKKOS_ENABLE_OPENMP))
-  catch (Experimental::RawMemoryAllocationFailure const& f) {
+  } catch (Kokkos::Experimental::RawMemoryAllocationFailure const& f) {
     // For now, just rethrow the error message with a note
     // Note that this could, in turn, trigger an out of memory exception,
     // but it's pretty unlikely, so we won't worry about it for now.
@@ -89,13 +87,6 @@ HostThreadTeamDataSingleton::HostThreadTeamDataSingleton()
         std::string("Failure to allocate scratch memory:  ") +
         f.get_error_message());
   }
-#else
-  // For some reason, NVCC with OpenMP chokes on custom exception classes
-  catch (std::bad_alloc const& failure) {
-    // For now, just rethrow the error message the existing way
-    Kokkos::Impl::throw_runtime_exception(failure.what());
-  }
-#endif
 
   HostThreadTeamData::scratch_assign(
       ptr, alloc_bytes, num_pool_reduce_bytes, num_team_reduce_bytes,


### PR DESCRIPTION
In response to the comment in the source 
`For some reason, NVCC with OpenMP chokes on custom exception classes`
it turns out that this was a problem with clang as well...

the problem seems to go away if we use the fully qualified namespace, so removing the ifdef and adding the Kokkos:: to the namespace 