### PR TITLE
Fix cmake testing issues for bowman

### DIFF
--- a/scripts/testing_scripts/cm_test_all_sandia
+++ b/scripts/testing_scripts/cm_test_all_sandia
@@ -707,8 +707,9 @@ setup_env() {
     module list 2>&1 | grep "$mod" >& /dev/null || return 1
   done
 
-  if [ -e ./update_lib.sh ]; then
-     source ./update_lib.sh $MACHINE
+  if [ -e ${CM_ALL_SCRIPT_PATH}/update_lib.sh ]; then
+     echo calling ${CM_ALL_SCRIPT_PATH}/update_lib.sh $MACHINE
+     source ${CM_ALL_SCRIPT_PATH}/update_lib.sh $MACHINE
   fi
   return 0
 }
@@ -895,6 +896,10 @@ wait_summarize_and_exit() {
 #
 # Main.
 #
+
+CM_ALL_SCRIPT=$0
+CM_ALL_SCRIPT_PATH=`pwd`
+CM_ALL_SCRIPT_PATH=${CM_ALL_SCRIPT_PATH}/`dirname $CM_ALL_SCRIPT`
 
 ROOT_DIR=$(get_test_root_dir)
 mkdir -p $ROOT_DIR

--- a/scripts/testing_scripts/update_lib.sh
+++ b/scripts/testing_scripts/update_lib.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ "$1" = bowman ]; then
+   export LIBRARY_PATH=/home/projects/x86-64-knl/gcc/6.2.0/lib/gcc/x86_64-pc-linux-gnu/6.2.0:/home/projects/x86-64-knl/cloog/0.18.4/lib:/home/projects/x86-64-knl/isl/0.16.1/lib:/home/projects/x86-64-knl/gmp/6.1.0/lib:/home/projects/x86-64-knl/mpfr/3.1.3/lib:/home/projects/x86-64-knl/mpc/1.0.3/lib:/home/projects/x86-64-knl/binutils/2.26.0/lib:/usr/lib/gcc/x86_64-redhat-linux/4.8.3:$LIBRARY_PATH
+   export LD_LIBRARY_PATH=/home/projects/x86-64-knl/gcc/6.2.0/lib64:/home/projects/x86-64-knl/gcc/6.2.0/lib:/home/projects/x86-64-knl/cloog/0.18.4/lib:/home/projects/x86-64-knl/isl/0.16.1/lib:/home/projects/x86-64-knl/gmp/6.1.0/lib:/home/projects/x86-64-knl/mpfr/3.1.3/lib:/home/projects/x86-64-knl/mpc/1.0.3/lib:/home/projects/x86-64-knl/binutils/2.26.0/lib:/usr/lib/gcc/x86_64-redhat-linux/4.8.3:$LD_LIBRARY_PATH
+fi


### PR DESCRIPTION
The need for this is because bowman has some weird interdependency with glibc and cmake 3.12

The cm_test_all_sandia logic was sortof there, but forgot to add the update_lib.sh file.

Also had to fix cm_test_all_sandia logic to properly find and launch update_lib.sh
