### PR TITLE
Add a suffix to unit tests that contains a death test

### DIFF
--- a/core/unit_test/TestViewLayoutStrideAssignment.hpp
+++ b/core/unit_test/TestViewLayoutStrideAssignment.hpp
@@ -616,7 +616,9 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
   }
 }
 
-TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutleft_assignment) {
+#define DECLARE_DEATH_TEST(NAME) NAME##DeathTest
+TEST(DECLARE_DEATH_TEST(TEST_CATEGORY),
+     view_layoutstride_right_to_layoutleft_assignment) {
   typedef TEST_EXECSPACE exec_space;
 
   auto t = time(0);


### PR DESCRIPTION
Related to #2471 and #2500 

This PR implements https://github.com/kokkos/kokkos/issues/2471#issuecomment-542957421 except that I chose to use a suffix instead of a prefix to follow the [naming convention suggested by googletest](https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-test-naming).