### PR TITLE
Print devices that have been enabled when Kokkos is found downstream

### DIFF
--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -23,8 +23,12 @@ SET(Kokkos_ARCH                         @KOKKOS_ENABLED_ARCH_LIST@)
 
 # These are needed by KokkosKernels
 FOREACH(DEV ${Kokkos_DEVICES})
-SET(Kokkos_ENABLE_${DEV} ON)
+  SET(Kokkos_ENABLE_${DEV} ON)
 ENDFOREACH()
+
+IF(NOT Kokkos_FIND_QUIETLY)
+  MESSAGE(STATUS "Enabled Kokkos devices: ${Kokkos_DEVICES}")
+ENDIF()
 
 include(FindPackageHandleStandardArgs)
 


### PR DESCRIPTION
c.f. documentation for [`<PackageName>_FIND_QUIETLY`](https://cmake.org/cmake/help/latest/command/find_package.html#package-file-interface-variables)