### PR TITLE
Revert "Fix C++20 KOKKOS_LAMBDA deprecation warning"

### DIFF
--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -175,7 +175,7 @@ struct ErrorReporterDriver : public ErrorReporterDriverBase<DeviceType> {
   }
 };
 
-#if defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)
+#if defined(KOKKOS_CLASS_LAMBDA)
 template <typename DeviceType>
 struct ErrorReporterDriverUseLambda
     : public ErrorReporterDriverBase<DeviceType> {
@@ -224,7 +224,7 @@ struct ErrorReporterDriverNativeOpenMP
 };
 #endif
 
-#if defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)
+#if defined(KOKKOS_CLASS_LAMBDA)
 TEST(TEST_CATEGORY, ErrorReporterViaLambda) {
   TestErrorReporter<ErrorReporterDriverUseLambda<TEST_EXECSPACE>>();
 }

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -159,8 +159,6 @@
 
 #if defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)
 #define KOKKOS_CLASS_LAMBDA [ =, *this ] __host__ __device__
-#else
-#define KOKKOS_CLASS_LAMBDA [=] __host__ __device__
 #endif
 #endif
 
@@ -210,12 +208,9 @@
 #define KOKKOS_LAMBDA [=]
 #endif
 
-#if !defined(KOKKOS_CLASS_LAMBDA)
-#if (defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20))
+#if (defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)) && \
+    !defined(KOKKOS_CLASS_LAMBDA)
 #define KOKKOS_CLASS_LAMBDA [ =, *this ]
-#else
-#define KOKKOS_CLASS_LAMBDA [=]
-#endif
 #endif
 
 //#if !defined( __CUDA_ARCH__ ) // Not compiling Cuda code to 'ptx'.

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -245,6 +245,7 @@ struct TestRange {
   }
 
   void test_dynamic_policy() {
+    auto const N_no_implicit_capture = N;
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 #if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
     typedef Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >
@@ -257,7 +258,8 @@ struct TestRange {
 
       Kokkos::parallel_for(
           policy_t(0, N), KOKKOS_LAMBDA(const int &i) {
-            for (int k = 0; k < (i < N / 2 ? 1 : 10000); k++) {
+            for (int k = 0; k < (i < N_no_implicit_capture / 2 ? 1 : 10000);
+                 k++) {
               a(i)++;
             }
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
@@ -271,7 +273,7 @@ struct TestRange {
       Kokkos::parallel_reduce(
           Kokkos::RangePolicy<ExecSpace>(0, N),
           KOKKOS_LAMBDA(const int &i, int &lsum) {
-            lsum += (a(i) != (i < N / 2 ? 1 : 10000));
+            lsum += (a(i) != (i < N_no_implicit_capture / 2 ? 1 : 10000));
           },
           error);
       ASSERT_EQ(error, 0);
@@ -301,7 +303,8 @@ struct TestRange {
       Kokkos::parallel_reduce(
           policy_t(0, N),
           KOKKOS_LAMBDA(const int &i, int &lsum) {
-            for (int k = 0; k < (i < N / 2 ? 1 : 10000); k++) {
+            for (int k = 0; k < (i < N_no_implicit_capture / 2 ? 1 : 10000);
+                 k++) {
               a(i)++;
             }
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
@@ -318,7 +321,7 @@ struct TestRange {
       Kokkos::parallel_reduce(
           Kokkos::RangePolicy<ExecSpace>(0, N),
           KOKKOS_LAMBDA(const int &i, int &lsum) {
-            lsum += (a(i) != (i < N / 2 ? 1 : 10000));
+            lsum += (a(i) != (i < N_no_implicit_capture / 2 ? 1 : 10000));
           },
           error);
       ASSERT_EQ(error, 0);

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -256,7 +256,7 @@ struct TestRange {
       Kokkos::View<int *, ExecSpace> a("A", N);
 
       Kokkos::parallel_for(
-          policy_t(0, N), KOKKOS_CLASS_LAMBDA(const int &i) {
+          policy_t(0, N), KOKKOS_LAMBDA(const int &i) {
             for (int k = 0; k < (i < N / 2 ? 1 : 10000); k++) {
               a(i)++;
             }
@@ -270,7 +270,7 @@ struct TestRange {
       int error = 0;
       Kokkos::parallel_reduce(
           Kokkos::RangePolicy<ExecSpace>(0, N),
-          KOKKOS_CLASS_LAMBDA(const int &i, int &lsum) {
+          KOKKOS_LAMBDA(const int &i, int &lsum) {
             lsum += (a(i) != (i < N / 2 ? 1 : 10000));
           },
           error);
@@ -300,7 +300,7 @@ struct TestRange {
       int sum = 0;
       Kokkos::parallel_reduce(
           policy_t(0, N),
-          KOKKOS_CLASS_LAMBDA(const int &i, int &lsum) {
+          KOKKOS_LAMBDA(const int &i, int &lsum) {
             for (int k = 0; k < (i < N / 2 ? 1 : 10000); k++) {
               a(i)++;
             }
@@ -317,7 +317,7 @@ struct TestRange {
       int error = 0;
       Kokkos::parallel_reduce(
           Kokkos::RangePolicy<ExecSpace>(0, N),
-          KOKKOS_CLASS_LAMBDA(const int &i, int &lsum) {
+          KOKKOS_LAMBDA(const int &i, int &lsum) {
             lsum += (a(i) != (i < N / 2 ? 1 : 10000));
           },
           error);


### PR DESCRIPTION
Reverts kokkos/kokkos#2494 and instead just get rid of the implicit capture of `*this` by reference (5cb86b4).

See https://github.com/kokkos/kokkos/pull/2494#issuecomment-546633593 and https://github.com/kokkos/kokkos/issues/2454#issuecomment-546650801
