### PR TITLE
Fix CMake behavior for -std flags for newer versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,16 @@ IF(NOT KOKKOS_HAS_TRILINOS)
   ENDIF()
 ENDIF()
 
+IF (Kokkos_ENABLE_CUDA AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14.0")
+  #If we are building CUDA, we have tricked CMake because we declare a CXX project
+  #If the default C++ standard for a given compiler matches the requested
+  #standard, then CMake just omits the -std flag in later versions of CMake
+  #This breaks CUDA compilation (CUDA compiler can have a different default
+  #-std then the underlying host compiler by itself). Setting this variable
+  #forces CMake to always add the -std flag even if it thinks it doesn't need it
+  GLOBAL_SET(CMAKE_CXX_STANDARD_DEFAULT 98)
+ENDIF()
+
 IF (NOT CMAKE_SIZEOF_VOID_P)
   STRING(FIND ${CMAKE_CXX_COMPILER} nvcc_wrapper FIND_IDX)
   IF (NOT FIND_IDX STREQUAL -1)

--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -30,6 +30,16 @@ IF(NOT Kokkos_FIND_QUIETLY)
   MESSAGE(STATUS "Enabled Kokkos devices: ${Kokkos_DEVICES}")
 ENDIF()
 
+IF (Kokkos_ENABLE_CUDA AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14.0")
+  #If we are building CUDA, we have tricked CMake because we declare a CXX project
+  #If the default C++ standard for a given compiler matches the requested
+  #standard, then CMake just omits the -std flag in later versions of CMake
+  #This breaks CUDA compilation (CUDA compiler can have a different default
+  #-std then the underlying host compiler by itself). Setting this variable
+  #forces CMake to always add the -std flag even if it thinks it doesn't need it
+  SET(CMAKE_CXX_STANDARD_DEFAULT 98 CACHE INTERNAL "" FORCE)
+ENDIF()
+
 include(FindPackageHandleStandardArgs)
 
 #   This function makes sure that Kokkos was built with the requested backends


### PR DESCRIPTION
CMake omits -std flags if they are the default for a given host compiler. This can cause CUDA issues because the default -std flag for CUDA mode can different for host mode.  The changes here (in a somewhat hacky way) forces CMake to always add the -std flags.