### PR TITLE
Add hpx/1.3.0 support to apollo and replace spot check version

### DIFF
--- a/cm_generate_makefile.bash
+++ b/cm_generate_makefile.bash
@@ -284,11 +284,6 @@ do
   shift
 done
 
-if [ "$KOKKOS_CXX_STANDARD" == "" ]; then
-    STANDARD_CMD=
-else
-    STANDARD_CMD=-DKokkos_CXX_STANDARD=${KOKKOS_CXX_STANDARD}
-fi
 
 if [ "$COMPILER" == "" ]; then
     COMPILER_CMD=
@@ -318,10 +313,16 @@ get_kokkos_cuda_option_list
 
 ## if HPX is enabled, we need to enforce cxx standard = 14
 if [[ ${KOKKOS_DEVICE_CMD} == *Kokkos_ENABLE_HPX* ]]; then
-   if [ ${#KOKKOS_CXX_STANDARD} -lt 14 ]; then
+   if [ "${KOKKOS_CXX_STANDARD}" == "" ] || [ ${#KOKKOS_CXX_STANDARD} -lt 14 ]; then
       echo CXX Standard must be 14 or higher for HPX to work.
       KOKKOS_CXX_STANDARD=14
    fi
+fi
+
+if [ "$KOKKOS_CXX_STANDARD" == "" ]; then
+    STANDARD_CMD=
+else
+    STANDARD_CMD=-DKokkos_CXX_STANDARD=${KOKKOS_CXX_STANDARD}
 fi
 
 if [[ ${COMPILER} == *clang* ]]; then

--- a/scripts/testing_scripts/cm_test_all_sandia
+++ b/scripts/testing_scripts/cm_test_all_sandia
@@ -447,6 +447,7 @@ elif [ "$MACHINE" = "apollo" ]; then
   CLANG7_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,sems-gcc/6.1.0,<COMPILER_NAME>/<COMPILER_VERSION>,cuda/9.1"
   NVCC_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/5.3.0"
   HPX_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,hpx/1.2.1,sems-gcc/6.1.0,binutils"
+  HPX3_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,compilers/hpx/1.3.0,sems-gcc/6.1.0,binutils"
 
   BUILD_LIST_CUDA_NVCC="Cuda_Serial,Cuda_OpenMP"
   BUILD_LIST_CUDA_CLANG="Cuda_Serial,Cuda_Pthread"
@@ -460,7 +461,7 @@ elif [ "$MACHINE" = "apollo" ]; then
                "clang/3.9.0 $BASE_MODULE_LIST "Pthread_Serial" clang++ $CLANG_WARNING_FLAGS"
                "clang/6.0 $CLANG_MODULE_LIST "Cuda_Pthread,OpenMP" clang++ $CUDA_WARNING_FLAGS"
                "cuda/9.1 $CUDA_MODULE_LIST "Cuda_OpenMP" $KOKKOS_PATH/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
-               "hpx/1.2.1 $HPX_MODULE_LIST "HPX" g++ $PGI_WARNING_FLAGS"
+               "hpx/1.3.0 $HPX3_MODULE_LIST "HPX" g++ $PGI_WARNING_FLAGS"
     )
   else
     # Format: (compiler module-list build-list exe-name warning-flag)
@@ -479,6 +480,7 @@ elif [ "$MACHINE" = "apollo" ]; then
                "clang/3.5.2 $BASE_MODULE_LIST $CLANG_BUILD_LIST clang++ $CLANG_WARNING_FLAGS"
                "clang/3.6.1 $BASE_MODULE_LIST $CLANG_BUILD_LIST clang++ $CLANG_WARNING_FLAGS"
                "hpx/1.2.1 $HPX_MODULE_LIST "HPX" g++ $PGI_WARNING_FLAGS"
+               "hpx/1.3.0 $HPX3_MODULE_LIST "HPX" g++ $PGI_WARNING_FLAGS"
     )
   fi
 


### PR DESCRIPTION
Added hpx/1.3.0 to Apollo

Also had to fix issue with HPX CXXSTANDARD check in cm_generate_makefile.bash: the STANDARD_CMD was being set before the logic to ensure that hpx was set to cxx14.  