### PR TITLE
Drop unnecessary exported CMake variables

### DIFF
--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -12,9 +12,6 @@ INCLUDE(CMakeFindDependencyMacro)
 
 INCLUDE("${Kokkos_CMAKE_DIR}/KokkosTargets.cmake")
 
-# These are IMPORTED targets created by KokkosTargets.cmake
-SET(Kokkos_LIBRARIES       @KOKKOS_EXT_LIBRARIES@)
-
 SET(Kokkos_DEVICES @KOKKOS_ENABLED_DEVICES@)
 SET(Kokkos_OPTIONS @KOKKOS_ENABLED_OPTIONS@)
 SET(Kokkos_TPLS @KOKKOS_ENABLED_TPLS@)

--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -1,8 +1,6 @@
 # Compute paths
 @PACKAGE_INIT@
 
-GET_FILENAME_COMPONENT(Kokkos_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-
 #Find dependencies
 INCLUDE(CMakeFindDependencyMacro)
 
@@ -10,7 +8,9 @@ INCLUDE(CMakeFindDependencyMacro)
 #the Kokkos targets depend in some way on the TPL imports
 @KOKKOS_TPL_EXPORTS@
 
+GET_FILENAME_COMPONENT(Kokkos_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 INCLUDE("${Kokkos_CMAKE_DIR}/KokkosTargets.cmake")
+UNSET(Kokkos_CMAKE_DIR)
 
 SET(Kokkos_DEVICES @KOKKOS_ENABLED_DEVICES@)
 SET(Kokkos_OPTIONS @KOKKOS_ENABLED_OPTIONS@)

--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -2,7 +2,6 @@
 @PACKAGE_INIT@
 
 GET_FILENAME_COMPONENT(Kokkos_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-SET(Kokkos_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 
 #Find dependencies
 INCLUDE(CMakeFindDependencyMacro)
@@ -14,7 +13,6 @@ INCLUDE(CMakeFindDependencyMacro)
 INCLUDE("${Kokkos_CMAKE_DIR}/KokkosTargets.cmake")
 
 # These are IMPORTED targets created by KokkosTargets.cmake
-SET(Kokkos_LIBRARY_DIRS    @INSTALL_LIB_DIR@)
 SET(Kokkos_LIBRARIES       @KOKKOS_EXT_LIBRARIES@)
 
 SET(Kokkos_DEVICES @KOKKOS_ENABLED_DEVICES@)


### PR DESCRIPTION
* `Kokkos_CMAKE_DIR`: cannot think of any good reason to have it.
* `Kokkos_INCLUDE_DIRS` and `Kokkos_LIBRARY_DIRS`: currently broken.  If really needed these can be queried as a properties of the Kokkos target.
* `Kokkos_LIBRARIES`:  inconsistent with the CMake standard convention that expect a comma separated list with full path to the libraries to link against.  Also something that can be queried from the target.  Deemed unnecessary since we dropped the `SEPARATE_LIBS` option.
