### PR TITLE
Use CUDA_SAFE_CALL for cudaFuncGetAttributes

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -282,10 +282,10 @@ struct CudaParallelLaunch<
 
   static cudaFuncAttributes get_cuda_func_attributes() {
     cudaFuncAttributes attr;
-    cudaFuncGetAttributes(
+    CUDA_SAFE_CALL(cudaFuncGetAttributes(
         &attr,
         cuda_parallel_launch_constant_memory<DriverType, MaxThreadsPerBlock,
-                                             MinBlocksPerSM>);
+                                             MinBlocksPerSM>));
     return attr;
   }
 };
@@ -338,8 +338,8 @@ struct CudaParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
 
   static cudaFuncAttributes get_cuda_func_attributes() {
     cudaFuncAttributes attr;
-    cudaFuncGetAttributes(&attr,
-                          cuda_parallel_launch_constant_memory<DriverType>);
+    CUDA_SAFE_CALL(cudaFuncGetAttributes(
+        &attr, cuda_parallel_launch_constant_memory<DriverType>));
     return attr;
   }
 };
@@ -388,9 +388,9 @@ struct CudaParallelLaunch<
 
   static cudaFuncAttributes get_cuda_func_attributes() {
     cudaFuncAttributes attr;
-    cudaFuncGetAttributes(
+    CUDA_SAFE_CALL(cudaFuncGetAttributes(
         &attr, cuda_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
-                                                 MinBlocksPerSM>);
+                                                 MinBlocksPerSM>));
     return attr;
   }
 };
@@ -435,7 +435,8 @@ struct CudaParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
 
   static cudaFuncAttributes get_cuda_func_attributes() {
     cudaFuncAttributes attr;
-    cudaFuncGetAttributes(&attr, cuda_parallel_launch_local_memory<DriverType>);
+    CUDA_SAFE_CALL(cudaFuncGetAttributes(
+        &attr, cuda_parallel_launch_local_memory<DriverType>));
     return attr;
   }
 };
@@ -486,10 +487,10 @@ struct CudaParallelLaunch<
   }
   static cudaFuncAttributes get_cuda_func_attributes() {
     cudaFuncAttributes attr;
-    cudaFuncGetAttributes(
+    CUDA_SAFE_CALL(cudaFuncGetAttributes(
         &attr,
         cuda_parallel_launch_global_memory<DriverType, MaxThreadsPerBlock,
-                                           MinBlocksPerSM>);
+                                           MinBlocksPerSM>));
     return attr;
   }
 };
@@ -536,8 +537,8 @@ struct CudaParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
 
   static cudaFuncAttributes get_cuda_func_attributes() {
     cudaFuncAttributes attr;
-    cudaFuncGetAttributes(&attr,
-                          cuda_parallel_launch_global_memory<DriverType>);
+    CUDA_SAFE_CALL(cudaFuncGetAttributes(
+        &attr, cuda_parallel_launch_global_memory<DriverType>));
     return attr;
   }
 };


### PR DESCRIPTION
In respoense to https://github.com/kokkos/kokkos/pull/2499#discussion_r344857978.