### PR TITLE
Add alias targets to simplify out-of-tree vs in-tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,9 @@ KOKKOS_PACKAGE_POSTPROCESS()
 
 IF (NOT KOKKOS_HAS_TRILINOS)
   ADD_LIBRARY(kokkos INTERFACE)
+  #Make sure in-tree projects can reference this as Kokkos::
+  #to match the installed target names
+  ADD_LIBRARY(Kokkos::kokkos ALIAS kokkos)
   TARGET_LINK_LIBRARIES(kokkos INTERFACE kokkoscore kokkoscontainers kokkosalgorithms)
   KOKKOS_INTERNAL_ADD_LIBRARY_INSTALL(kokkos)
   include(${KOKKOS_SRC_PATH}/cmake/kokkos_install.cmake)

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -298,6 +298,9 @@ FUNCTION(KOKKOS_INTERNAL_ADD_LIBRARY LIBRARY_NAME)
     COMPONENT ${PACKAGE_NAME}
   )
 
+  #In case we are building in-tree, add an alias name
+  #that matches the install Kokkos:: name
+  ADD_LIBRARY(Kokkos::${LIBRARY_NAME} ALIAS ${LIBRARY_NAME})
 ENDFUNCTION()
 
 FUNCTION(KOKKOS_ADD_LIBRARY LIBRARY_NAME)


### PR DESCRIPTION
Can always link to `Kokkos::kokkos`