### PR TITLE
Fix atomic issues

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -428,10 +428,10 @@
 #define KOKKOS_ENABLE_ASM 1
 #endif
 
-#if KOKKOS_COMPILER_GNU < 500
-#define KOKKOS_IMPL_YOLO_ASSUME_TRIVIALLY_COPYABLE_TO_WORK_AROUND_BUG 1
 #endif
 
+#if (__GNUC__ < 5)
+#define KOKKOS_IMPL_YOLO_ASSUME_TRIVIALLY_COPYABLE_TO_WORK_AROUND_BUG 1
 #endif
 
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -430,6 +430,8 @@
 
 #endif
 
+// Every compiler which uses GCC headers from before GCC 5.0 needs this
+// Since they won't have trivially_copyable available
 #if (__GNUC__ < 5)
 #define KOKKOS_IMPL_YOLO_ASSUME_TRIVIALLY_COPYABLE_TO_WORK_AROUND_BUG 1
 #endif

--- a/core/src/impl/Kokkos_Atomic_Load.hpp
+++ b/core/src/impl/Kokkos_Atomic_Load.hpp
@@ -230,7 +230,7 @@ __device__ __inline__ T _relaxed_atomic_load_impl(
 
 template <class T>
 struct NoOpOper {
-  __device__ __inline__ static constexpr T apply(T const& t,
+  __device__ __inline__ static constexpr T apply(T const volatile& t,
                                                  T const&) noexcept {
     return t;
   }

--- a/core/src/impl/Kokkos_Atomic_Load.hpp
+++ b/core/src/impl/Kokkos_Atomic_Load.hpp
@@ -96,7 +96,7 @@ KOKKOS_INTERNAL_INLINE_DEVICE_IF_CUDA_ARCH T _atomic_load(
 #ifndef KOKKOS_IMPL_YOLO_ASSUME_TRIVIALLY_COPYABLE_TO_WORK_AROUND_BUG
               std::is_trivially_copyable<T>::value
 #else
-              true
+              false
 #endif
               ) ||
              ((sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
@@ -136,7 +136,7 @@ KOKKOS_INTERNAL_INLINE_DEVICE_IF_CUDA_ARCH T _relaxed_atomic_load_impl(
 #ifndef KOKKOS_IMPL_YOLO_ASSUME_TRIVIALLY_COPYABLE_TO_WORK_AROUND_BUG
                                         !std::is_trivially_copyable<T>::value
 #else
-                                        false
+                                        true
 #endif
                                     ,
                                     void const**>::type = nullptr) {
@@ -152,7 +152,7 @@ _atomic_load(T* ptr, memory_order_seq_cst_t,
 #ifndef KOKKOS_IMPL_YOLO_ASSUME_TRIVIALLY_COPYABLE_TO_WORK_AROUND_BUG
                                       !std::is_trivially_copyable<T>::value
 #else
-                                      false
+                                      true
 #endif
                                       ) ||
                                          ((sizeof(T) == 1 || sizeof(T) == 2 ||
@@ -177,7 +177,7 @@ _atomic_load(T* ptr, memory_order_acquire_t,
 #ifndef KOKKOS_IMPL_YOLO_ASSUME_TRIVIALLY_COPYABLE_TO_WORK_AROUND_BUG
                                       !std::is_trivially_copyable<T>::value
 #else
-                                      false
+                                      true
 #endif
                                       ) ||
                                          ((sizeof(T) == 1 || sizeof(T) == 2 ||
@@ -201,7 +201,7 @@ _atomic_load(T* ptr, memory_order_relaxed_t,
 #ifndef KOKKOS_IMPL_YOLO_ASSUME_TRIVIALLY_COPYABLE_TO_WORK_AROUND_BUG
                                       !std::is_trivially_copyable<T>::value
 #else
-                                      false
+                                      true
 #endif
                                       ) ||
                                          ((sizeof(T) == 1 || sizeof(T) == 2 ||


### PR DESCRIPTION
This fixes to issues with atomics introduced with the thread-sanitizer pull request #2375 

```
Kokkos_develop_white_cuda_92_gcc_720_kepler_uvm/ws/kokkos/core/src/impl/Kokkos_Atomic_Generic.hpp(358)>: error: qualifiers dropped in binding reference of type "const Kokkos::complex<double> &" to initializer of type "volatile Kokkos::complex<double>"
          detected during:
            instantiation of "T Kokkos::Impl::atomic_oper_fetch(const Oper &, volatile T *, Kokkos::Impl::enable_if<<expression>, const T>::type &) [with Oper=Kokkos::Impl::NoOpOper<Kokkos::complex<double>>, T=Kokkos::complex<double>]
```

```
Kokkos_develop_white_xl_16.1/ws/kokkos/core/src/impl/Kokkos_Atomic_Load.hpp>:153:45: error: no member named 'is_trivially_copyable' in namespace 'std'
                                      !std::is_trivially_copyable<T>::value
                                       ~~~~~^
```