### PR TITLE
Fix CUDA compiler warnings

### DIFF
--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -1095,7 +1095,8 @@ class ScatterView<DataType, Kokkos::LayoutLeft, ExecSpace, Op,
 
  protected:
   template <typename... Args>
-  inline original_reference_type at(int thread_id, Args... args) const {
+  KOKKOS_FORCEINLINE_FUNCTION original_reference_type at(int thread_id,
+                                                         Args... args) const {
     return internal_view(args..., thread_id);
   }
 


### PR DESCRIPTION
This fixes the remaining CUDA compiler warnings similar to
```
/tmp/ArborX/my_docker/kokkos/containers/unit_tests/../src/Kokkos_ScatterView.hpp(1145): warning: calling a __host__ function from a __host__ __device__ function is not allowed
          detected during:
            instantiation of "Kokkos::Experimental::ScatterAccess<DataType, Op, ExecSpace, Layout, 1, contribution, override_contribution>::value_type Kokkos::Experimental::ScatterAccess<DataType, Op, ExecSpace, Layout, 1, contribution, override_contribution>::operator()(Args...) const [with DataType=double *[3], Op=0, ExecSpace=Kokkos::Serial, Layout=Kokkos::LayoutLeft, contribution=0, override_contribution=0, Args=<int, int>]"
/tmp/ArborX/my_docker/kokkos/containers/unit_tests/TestScatterView.hpp(103): here
            instantiation of "void Test::test_scatter_view_impl_cls<ExecSpace, Layout, duplication, contribution, 0>::operator()(int) const [with ExecSpace=Kokkos::Serial, Layout=Kokkos::LayoutLeft, duplication=1, contribution=0]"
/tmp/ArborX/my_docker/kokkos/core/src/Kokkos_Serial.hpp(538): here
            instantiation of "std::enable_if<std::is_same<TagType, void>::value, void>::type Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Serial>::exec<TagType>() const [with FunctorType=Test::test_scatter_view_impl_cls<Kokkos::Serial, Kokkos::LayoutLeft, 1, 0, 0>, Traits=<Kokkos::Serial, int>, TagType=void]"
/tmp/ArborX/my_docker/kokkos/core/src/Kokkos_Serial.hpp(554): here
            instantiation of "void Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Serial>::execute() const [with FunctorType=Test::test_scatter_view_impl_cls<Kokkos::Serial, Kokkos::LayoutLeft, 1, 0, 0>, Traits=<Kokkos::Serial, int>]"
/tmp/ArborX/my_docker/kokkos/core/src/Kokkos_Parallel.hpp(176): here
            instantiation of "void Kokkos::parallel_for(const ExecPolicy &, const FunctorType &, const std::__cxx11::string &, Kokkos::Impl::enable_if<Kokkos::is_execution_policy<ExecPolicy>::value, void>::type *) [with ExecPolicy=Kokkos::RangePolicy<Kokkos::Serial, int>, FunctorType=Test::test_scatter_view_impl_cls<Kokkos::Serial, Kokkos::LayoutLeft, 1, 0, 0>]"
/tmp/ArborX/my_docker/kokkos/containers/unit_tests/TestScatterView.hpp(93): here
            instantiation of "void Test::test_scatter_view_impl_cls<ExecSpace, Layout, duplication, contribution, 0>::run_parallel(int) [with ExecSpace=Kokkos::Serial, Layout=Kokkos::LayoutLeft, duplication=1, contribution=0]"
/tmp/ArborX/my_docker/kokkos/containers/unit_tests/TestScatterView.hpp(357): here
            instantiation of "void Test::test_scatter_view_config<ExecSpace, Layout, duplication, contribution, op>::run_test(int) [with ExecSpace=Kokkos::Serial, Layout=Kokkos::LayoutLeft, duplication=1, contribution=0, op=0]"
/tmp/ArborX/my_docker/kokkos/containers/unit_tests/TestScatterView.hpp(420): here
            instantiation of "Test::TestDuplicatedScatterView<ExecSpace, ScatterType>::TestDuplicatedScatterView(int) [with ExecSpace=Kokkos::Serial, ScatterType=0]"
/tmp/ArborX/my_docker/kokkos/containers/unit_tests/TestScatterView.hpp(480): here
            instantiation of "void Test::test_scatter_view<ExecSpace,ScatterType>(int) [with ExecSpace=Kokkos::Serial, ScatterType=0]"
/tmp/ArborX/my_docker/kokkos/containers/unit_tests/TestScatterView.hpp(485): here
```

Also, see https://github.com/kokkos/kokkos/pull/2385#discussion_r331283548.