### PR TITLE
workaround for PGI stack smashing bug related to EBO and/or aggregates

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -1159,4 +1159,13 @@ bool is_initialized() noexcept { return g_is_initialized; }
 
 bool show_warnings() noexcept { return g_show_warnings; }
 
+#ifdef KOKKOS_COMPILER_PGI
+namespace Impl {
+// Bizzarely, an extra jump instruction forces the PGI compiler to not have a
+// bug related to (probably?) empty base optimization and/or aggregate
+// construction.
+void _kokkos_pgi_compiler_bug_workaround() {}
+}  // end namespace Impl
+#endif
+
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_TaskNode.hpp
+++ b/core/src/impl/Kokkos_TaskNode.hpp
@@ -70,6 +70,14 @@
 namespace Kokkos {
 namespace Impl {
 
+#ifdef KOKKOS_COMPILER_PGI
+// Bizzarely, an extra jump instruction forces the PGI compiler to not have a
+// bug related to (probably?) empty base optimization and/or aggregate
+// construction.  This must be defined out-of-line to generate a jump
+// jump instruction
+void _kokkos_pgi_compiler_bug_workaround();
+#endif
+
 enum TaskType : int16_t {
   TaskTeam    = 0,
   TaskSingle  = 1,
@@ -121,11 +129,17 @@ class ReferenceCountedBase {
 
  public:
   KOKKOS_INLINE_FUNCTION
-  constexpr explicit ReferenceCountedBase(
-      reference_count_size_type initial_reference_count)
+#ifndef KOKKOS_COMPILER_PGI
+  constexpr
+#endif
+      explicit ReferenceCountedBase(
+          reference_count_size_type initial_reference_count)
       : m_ref_count(initial_reference_count) {
     // This can't be here because it breaks constexpr
     // KOKKOS_EXPECTS(initial_reference_count > 0);
+#ifdef KOKKOS_COMPILER_PGI
+    Impl::_kokkos_pgi_compiler_bug_workaround();
+#endif
   }
 
   /** Decrement the reference count,


### PR DESCRIPTION
Not sure why this fixes the problem (I have guesses...), but I guess it's better than just disabling the test?