### PR TITLE
Make nvcc_wrapper forward the last flag instead of the first

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -85,8 +85,8 @@ first_xcompiler_arg=1
 
 temp_dir=${TMPDIR:-/tmp}
 
-# Check if we have an optimization argument already
-optimization_applied=0
+# optimization flag added as a command-line argument
+optimization_flag=""
 
 # std standard flag added as a command-line argument
 std_flag=""
@@ -134,16 +134,16 @@ do
     ;;
    # Ensure we only have one optimization flag because NVCC doesn't allow muliple
   -O*)
-    if [ $optimization_applied -eq 1 ]; then
-       echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-O*), only the first is used because nvcc can only accept a single optimization setting."
-    else
-       if [ "$1" = "-O" ]; then
-         shared_args="$shared_args -O2"
-       else
-         shared_args="$shared_args $1"
-       fi
-       optimization_applied=1
+    if [ -n "$optimization_flag" ]; then
+       echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-O*), only the last is used because nvcc can only accept a single optimization setting."
+       shared_args=${shared_args/ $optimization_flag/}
     fi
+    if [ "$1" = "-O" ]; then
+      optimization_flag="-O2"
+    else
+      optimization_flag=$1
+    fi
+    shared_args="$shared_args $optimization_flag"
     ;;
   #Handle shared args (valid for both nvcc and the host compiler)
   -D*)

--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -88,8 +88,8 @@ temp_dir=${TMPDIR:-/tmp}
 # Check if we have an optimization argument already
 optimization_applied=0
 
-# Check if we have -std=c++X  or --std=c++X already
-stdcxx_applied=0
+# std standard flag added as a command-line argument
+std_flag=""
 
 # Run nvcc a second time to generate dependencies if needed
 depfile_separate=0
@@ -100,7 +100,7 @@ depfile_target_arg=""
 remove_duplicate_link_files=0
 
 function warn_std_flag() {
-  echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-std=c++1* or --std=c++1*), only the first is used because nvcc can only accept a single std setting"
+  echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-std=c++1* or --std=c++1*), only the last is used because nvcc can only accept a single std setting"
 }
 
 #echo "Arguments: $# $@"
@@ -196,33 +196,34 @@ do
     ;;
   #Handle c++11
   --std=c++1y|-std=c++1y|--std=c++1z|-std=c++1z|--std=gnu++1y|-std=gnu++1y|--std=gnu++1z|-std=gnu++1z)
-    if [ $stdcxx_applied -eq 1 ]; then
+    fallback_std_flag="-std=c++14"
+    # this is hopefully just occurring in a downstream project during CMake feature tests
+    # we really have no choice here but to accept the flag and "promote" to the corresponding C++ standard
+    echo "nvcc_wrapper does not accept intermediate standard flag $1, but it will use $fallback_std_flag instead. It is undefined behavior to use this flag. This should only be occurring during CMake configuration."
+    if [ -n "$std_flag" ]; then
        warn_std_flag
-    else
-       # this is hopefully just occurring in a downstream project during CMake feature tests
-       # we really have no choice here but to accept the flag and "promote" to the corresponding C++ standard
-       echo "nvcc_wrapper does not accept intermediate standard flag $1, but I will use -std=c++14 instead. It is undefined behavior to use this flag. This should only be occurring during CMake configuration."
-       shared_args="$shared_args -std=c++14"
-       stdcxx_applied=1
+       shared_args=${shared_args/ $std_flag/}
     fi
+    std_flag=$fallback_std_flag
+    shared_args="$shared_args $std_flag"
     ;;
   -std=gnu*)
-    if [ $stdcxx_applied -eq 1 ]; then
+    corrected_std_flag=${1/gnu/c}
+    echo "nvcc_wrapper has been given GNU extension standard flag $1 - reverting flag to $corrected_std_flag"
+    if [ -n "$std_flag" ]; then
        warn_std_flag
-    else
-       stdFlag=${1/gnu/c}
-       echo "nvcc_wrapper has been given GNU extension standard flag $1 - reverting flag to $stdFlag"
-       shared_args="$shared_args $stdFlag"
-       stdcxx_applied=1
+       shared_args=${shared_args/ $std_flag/}
     fi
+    std_flag=$corrected_std_flag
+    shared_args="$shared_args $std_flag"
   ;;
   --std=c++11|-std=c++11|--std=c++14|-std=c++14|--std=c++17|-std=c++17)
-    if [ $stdcxx_applied -eq 1 ]; then
+    if [ -n "$std_flag" ]; then
        warn_std_flag
-    else
-       shared_args="$shared_args $1"
-       stdcxx_applied=1
+       shared_args=${shared_args/ $std_flag/}
     fi
+    std_flag=$1
+    shared_args="$shared_args $std_flag"
     ;;
 
   #strip of -std=c++98 due to nvcc warnings and Tribits will place both -std=c++11 and -std=c++98


### PR DESCRIPTION
Address #2553 
Instead of using the first flags parsed in `nvcc_wrapper`, the last ones are forwarded to NVCC.