### PR TITLE
Issue 2577 - Making Kokkos::complex a trivially copyable class

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -294,7 +294,7 @@ class alignas(2 * sizeof(RealType)) complex {
   /// explanation.  In practice, this means that you should not chain
   /// assignments with volatile lvalues.
   //
-  // Templated, so as not to be a copy assignment operator (Kokkos issue #1173)
+  // Templated, so as not to be a copy assignment operator (Kokkos issue #2577)
   // Intended to behave as
   //    void operator=(const complex&) volatile noexcept
   //
@@ -317,7 +317,7 @@ class alignas(2 * sizeof(RealType)) complex {
   //! Assignment operator, volatile LHS and volatile RHS
   // TODO Should this return void like the other volatile assignment operators?
   //
-  // Templated, so as not to be a copy assignment operator (Kokkos issue #1173)
+  // Templated, so as not to be a copy assignment operator (Kokkos issue #2577)
   // Intended to behave as
   //    volatile complex& operator=(const volatile complex&) volatile noexcept
   //
@@ -339,7 +339,7 @@ class alignas(2 * sizeof(RealType)) complex {
 
   //! Assignment operator, volatile RHS and non-volatile LHS
   //
-  // Templated, so as not to be a copy assignment operator (Kokkos issue #1173)
+  // Templated, so as not to be a copy assignment operator (Kokkos issue #2577)
   // Intended to behave as
   //    complex& operator=(const volatile complex&) noexcept
   //

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -293,8 +293,21 @@ class alignas(2 * sizeof(RealType)) complex {
   /// complex& </tt>.  See Kokkos Issue #177 for the
   /// explanation.  In practice, this means that you should not chain
   /// assignments with volatile lvalues.
-  KOKKOS_INLINE_FUNCTION void operator=(
-      const complex<RealType>& src) volatile noexcept {
+  //
+  // Templated, so as not to be a copy assignment operator (Kokkos issue #1173)
+  // Intended to behave as
+  //    void operator=(const complex&) volatile noexcept
+  //
+  // Use cases:
+  //    complex r;
+  //    const complex cr;
+  //    volatile complex vl;
+  //    vl = r;
+  //    vl = cr;
+  template <class Complex,
+            typename std::enable_if<std::is_same<Complex, complex>::value,
+                                    int>::type = 0>
+  KOKKOS_INLINE_FUNCTION void operator=(const Complex& src) volatile noexcept {
     re_ = src.re_;
     im_ = src.im_;
     // We deliberately do not return anything here.  See explanation
@@ -303,16 +316,45 @@ class alignas(2 * sizeof(RealType)) complex {
 
   //! Assignment operator, volatile LHS and volatile RHS
   // TODO Should this return void like the other volatile assignment operators?
+  //
+  // Templated, so as not to be a copy assignment operator (Kokkos issue #1173)
+  // Intended to behave as
+  //    volatile complex& operator=(const volatile complex&) volatile noexcept
+  //
+  // Use cases:
+  //    volatile complex vr;
+  //    const volatile complex cvr;
+  //    volatile complex vl;
+  //    vl = vr;
+  //    vl = cvr;
+  template <class Complex,
+            typename std::enable_if<std::is_same<Complex, complex>::value,
+                                    int>::type = 0>
   KOKKOS_INLINE_FUNCTION volatile complex& operator=(
-      const volatile complex<RealType>& src) volatile noexcept {
+      const volatile Complex& src) volatile noexcept {
     re_ = src.re_;
     im_ = src.im_;
     return *this;
   }
 
   //! Assignment operator, volatile RHS and non-volatile LHS
+  //
+  // Templated, so as not to be a copy assignment operator (Kokkos issue #1173)
+  // Intended to behave as
+  //    complex& operator=(const volatile complex&) noexcept
+  //
+  // Use cases:
+  //    volatile complex vr;
+  //    const volatile complex cvr;
+  //    complex l;
+  //    l = vr;
+  //    l = cvr;
+  //
+  template <class Complex,
+            typename std::enable_if<std::is_same<Complex, complex>::value,
+                                    int>::type = 0>
   KOKKOS_INLINE_FUNCTION complex& operator=(
-      const volatile complex<RealType>& src) noexcept {
+      const volatile Complex& src) noexcept {
     re_ = src.re_;
     im_ = src.im_;
     return *this;

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -363,8 +363,12 @@ TEST(TEST_CATEGORY, complex_trivially_copyable) {
 
 #if defined(KOKKOS_COMPILER_GNU) && KOKKOS_COMPILER_GNU < 500
   ASSERT_TRUE(
-      std::has_trivial_copy_constructor<Kokkos::complex<RealType>>::value ||
-      !std::has_trivial_copy_constructor<RealType>::value);
+      (std::has_trivial_copy_constructor<Kokkos::complex<RealType>>::value &&
+       std::has_trivial_copy_assign<Kokkos::complex<RealType>>::value &&
+       std::is_trivially_destructible<Kokkos::complex<RealType>>::value) ||
+      !(std::has_trivial_copy_constructor<RealType>::value &&
+        std::has_trivial_copy_assign<RealType>::value &&
+        std::is_trivially_destructible<RealType>::value));
 #else
   ASSERT_TRUE(std::is_trivially_copyable<Kokkos::complex<RealType>>::value ||
               !std::is_trivially_copyable<RealType>::value);

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -361,9 +361,14 @@ TEST(TEST_CATEGORY, complex_trivially_copyable) {
   // Kokkos::complex<RealType> is trivially copyable when RealType is trivially
   // copyable
 
+#if defined(KOKKOS_COMPILER_GNU) && KOKKOS_COMPILER_GNU < 500
+  ASSERT_TRUE(
+      std::has_trivial_copy_constructor<Kokkos::complex<RealType>>::value ||
+      !std::has_trivial_copy_constructor<RealType>::value);
+#else
   ASSERT_TRUE(std::is_trivially_copyable<Kokkos::complex<RealType>>::value ||
               !std::is_trivially_copyable<RealType>::value);
+#endif
 }
 
 }  // namespace Test
-

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -361,7 +361,14 @@ TEST(TEST_CATEGORY, complex_trivially_copyable) {
   // Kokkos::complex<RealType> is trivially copyable when RealType is trivially
   // copyable
 
-#if defined(KOKKOS_COMPILER_GNU) && KOKKOS_COMPILER_GNU < 500
+#if !defined(__clang__)
+#define KOKKOS_COMPILER_GNU_VERSION \
+  __GNUC__ * 100 + __GNUC_MINOR__ * 10 + __GNUC_PATCHLEVEL__
+#endif
+#if KOKKOS_COMPILER_GNU_VERSION == 0 || KOKKOS_COMPILER_GNU_VERSION > 500
+  ASSERT_TRUE(std::is_trivially_copyable<Kokkos::complex<RealType>>::value ||
+              !std::is_trivially_copyable<RealType>::value);
+#elif KOKKOS_COMPILER_GNU_VERSION > 480
   ASSERT_TRUE(
       (std::has_trivial_copy_constructor<Kokkos::complex<RealType>>::value &&
        std::has_trivial_copy_assign<Kokkos::complex<RealType>>::value &&
@@ -370,8 +377,13 @@ TEST(TEST_CATEGORY, complex_trivially_copyable) {
         std::has_trivial_copy_assign<RealType>::value &&
         std::is_trivially_destructible<RealType>::value));
 #else
-  ASSERT_TRUE(std::is_trivially_copyable<Kokkos::complex<RealType>>::value ||
-              !std::is_trivially_copyable<RealType>::value);
+  ASSERT_TRUE(
+      (std::has_trivial_copy_constructor<Kokkos::complex<RealType>>::value &&
+       std::has_trivial_copy_assign<Kokkos::complex<RealType>>::value &&
+       std::has_trivial_destructor<Kokkos::complex<RealType>>::value) ||
+      !(std::has_trivial_copy_constructor<RealType>::value &&
+        std::has_trivial_copy_assign<RealType>::value &&
+        std::has_trivial_destructor<RealType>::value));
 #endif
 }
 

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -355,4 +355,15 @@ TEST(TEST_CATEGORY, complex_special_funtions) {
 
 TEST(TEST_CATEGORY, complex_io) { testComplexIO(); }
 
+TEST(TEST_CATEGORY, complex_trivially_copyable) {
+  using RealType = double;
+
+  // Kokkos::complex<RealType> is trivially copyable when RealType is trivially
+  // copyable
+
+  ASSERT_TRUE(std::is_trivially_copyable<Kokkos::complex<RealType>>::value ||
+              !std::is_trivially_copyable<RealType>::value);
+}
+
 }  // namespace Test
+


### PR DESCRIPTION
Changed the three "volatile" copy assignment operators into templated functions (constrained on is_same) so that they are no longer copy assignment operators, and now Kokkos::complex is a trivially copyable class.