### PR TITLE
Fix ARM CMake configuration for ThunderX2: Issue #2590

### DIFF
--- a/cmake/KokkosCore_config.h.in
+++ b/cmake/KokkosCore_config.h.in
@@ -58,7 +58,9 @@
 
 #cmakedefine KOKKOS_ARCH_SSE42
 #cmakedefine KOKKOS_ARCH_ARMV80
+#cmakedefine KOKKOS_ARCH_ARMV8_THUNDERX
 #cmakedefine KOKKOS_ARCH_ARMV81
+#cmakedefine KOKKOS_ARCH_ARMV8_THUNDERX2
 #cmakedefine KOKKOS_ARCH_AMD_AVX2
 #cmakedefine KOKKOS_ARCH_AVX
 #cmakedefine KOKKOS_ARCH_AVX2

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -75,7 +75,7 @@ KOKKOS_ARCH_OPTION(AMDAVX          HOST "AMD chip")
 KOKKOS_ARCH_OPTION(ARMV80          HOST "ARMv8.0 Compatible CPU")
 KOKKOS_ARCH_OPTION(ARMV81          HOST "ARMv8.1 Compatible CPU")
 KOKKOS_ARCH_OPTION(ARMV8_THUNDERX  HOST "ARMv8 Cavium ThunderX CPU")
-KOKKOS_ARCH_OPTION(ARMV8_TX2       HOST "ARMv8 Cavium ThunderX2 CPU")
+KOKKOS_ARCH_OPTION(ARMV8_THUNDERX2 HOST "ARMv8 Cavium ThunderX2 CPU")
 KOKKOS_ARCH_OPTION(WSM             HOST "Intel Westmere CPU")
 KOKKOS_ARCH_OPTION(SNB             HOST "Intel Sandy/Ivy Bridge CPUs")
 KOKKOS_ARCH_OPTION(HSW             HOST "Intel Haswell CPUs")
@@ -224,7 +224,7 @@ IF (KOKKOS_ARCH_ARMV8_THUNDERX2)
   ARCH_FLAGS(
     Cray NO-VALUE-SPECIFIED
     PGI  NO-VALUE-SPECIFIED
-    DEFAULT -march=thunderx2t99 -mtune=thunderx2t99
+    DEFAULT -mcpu=thunderx2t99 -mtune=thunderx2t99
   )
 ENDIF()
 

--- a/core/unit_test/configuration/test-code/test_config_arch_list.bash
+++ b/core/unit_test/configuration/test-code/test_config_arch_list.bash
@@ -4,7 +4,7 @@ HostArch=(SNB HSW SKX KNL)
 DeviceArch=(Kepler35 Kepler37 Pascal60 Pascal61 Volta70)
 if [ ! -z "$KOKKOS_HOST_ARCH_TEST" ]; then
   export KOKKOS_ARCH_TEST=1
-  HostArch=(WSM SNB HSW SKX WSM AMDAVX ARMv80 ARMv81 BDW KNC KNL BGQ Power7 Power8 Power9 Ryzen EPYC)
+  HostArch=(WSM SNB HSW SKX WSM AMDAVX ARMv80 ARMv81 BDW KNC KNL BGQ Power7 Power8 Power9 Ryzen EPYC ARMv8_ThunderX ARMv8_ThunderX2)
   DeviceArch=()
 fi
 
@@ -23,6 +23,12 @@ for harch in "${HostArch[@]}"
 do
   harch_up=`echo $harch | tr a-z A-Z`
   CMAKE_HARCH="-DKokkos_ARCH_${harch_up}=ON"
+
+  if [ "$harch" == "ARMv8_ThunderX2" ]; then
+    harch="ARMv8-TX2"
+  elif [ "$harch" == "ARMv8_ThunderX" ]; then
+    harch="ARMv8-ThunderX"
+  fi
 
   if [ ! -z "$DeviceArch" ]
   then


### PR DESCRIPTION
`Makefile.kokkos` still has the armclang identification issue: #2589 