### PR TITLE
Disable check for IBM XL

### DIFF
--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -358,10 +358,13 @@ TEST(TEST_CATEGORY, complex_io) { testComplexIO(); }
 TEST(TEST_CATEGORY, complex_trivially_copyable) {
   using RealType = double;
 
-  // Kokkos::complex<RealType> is trivially copyable when RealType is trivially
-  // copyable
-
+  // Kokkos::complex<RealType> is trivially copyable when RealType is
+  // trivially copyable
+  // Simply disable the check for IBM's XL compiler since we can't reliably
+  // check for a version that defines relevant functions.
 #if !defined(__ibmxl__)
+  // clang claims compatibility with gcc 4.2.1 but all versions tested know
+  // about std::is_trivially_copyable.
 #if !defined(__clang__)
 #define KOKKOS_COMPILER_GNU_VERSION \
   __GNUC__ * 100 + __GNUC_MINOR__ * 10 + __GNUC_PATCHLEVEL__

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -361,6 +361,7 @@ TEST(TEST_CATEGORY, complex_trivially_copyable) {
   // Kokkos::complex<RealType> is trivially copyable when RealType is trivially
   // copyable
 
+#if !defined(__ibmxl__)
 #if !defined(__clang__)
 #define KOKKOS_COMPILER_GNU_VERSION \
   __GNUC__ * 100 + __GNUC_MINOR__ * 10 + __GNUC_PATCHLEVEL__
@@ -384,6 +385,7 @@ TEST(TEST_CATEGORY, complex_trivially_copyable) {
       !(std::has_trivial_copy_constructor<RealType>::value &&
         std::has_trivial_copy_assign<RealType>::value &&
         std::has_trivial_destructor<RealType>::value));
+#endif
 #endif
 }
 


### PR DESCRIPTION
Fixes #2601. We could in principle test with `has_trivial_copy_constructor` instead but that is not forward-compatible (and I didn't find any compatibility information that would help). Just as `clang` it reports compatibility with gnu 4.2.1 but gcc 4.2.1 needs `has_trivial_destructor` instead of `is_trivially_destructible`.

I also checked that the current version works with `pgi 19.9` and `pgi 18.10`.