### PR TITLE
Change default SERIAL backend behavior for Trilinos 

### DIFF
--- a/cmake/kokkos_enable_devices.cmake
+++ b/cmake/kokkos_enable_devices.cmake
@@ -45,7 +45,10 @@ ENDIF()
 
 # We want this to default to OFF for cache reasons, but if no
 # host space is given, then activate serial
-IF (KOKKOS_HAS_HOST)
+IF (KOKKOS_HAS_TRILINOS)
+  #However, Trilinos always wants Serial ON
+  SET(SERIAL_DEFAULT ON)
+ELSEIF (KOKKOS_HAS_HOST)
   SET(SERIAL_DEFAULT OFF)
 ELSE()
   SET(SERIAL_DEFAULT ON)


### PR DESCRIPTION
Trilinos currently relies on SERIAL being enabled. This restores the original behavior where SERIAL always defaults to ON, even if other host backends are enabled.