### PR TITLE
Issue 2608 tags with require

### DIFF
--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -120,6 +120,17 @@ struct SetWorkTag {
                                 typename PolicyBase::work_item_property>;
 };
 
+// Partial specialization to drop void arguments
+template <typename PolicyBase>
+struct SetWorkTag<PolicyBase, void> {
+  using type = PolicyTraitsBase<
+      typename PolicyBase::execution_space, typename PolicyBase::schedule_type,
+      typename PolicyBase::work_tag, typename PolicyBase::index_type,
+      typename PolicyBase::iteration_pattern,
+      typename PolicyBase::launch_bounds,
+      typename PolicyBase::work_item_property>;
+};
+
 template <typename PolicyBase, typename IndexType>
 struct SetIndexType {
   static_assert(is_void<typename PolicyBase::index_type>::value,

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -120,17 +120,6 @@ struct SetWorkTag {
                                 typename PolicyBase::work_item_property>;
 };
 
-// Partial specialization to drop void arguments
-template <typename PolicyBase>
-struct SetWorkTag<PolicyBase, void> {
-  using type = PolicyTraitsBase<
-      typename PolicyBase::execution_space, typename PolicyBase::schedule_type,
-      typename PolicyBase::work_tag, typename PolicyBase::index_type,
-      typename PolicyBase::iteration_pattern,
-      typename PolicyBase::launch_bounds,
-      typename PolicyBase::work_item_property>;
-};
-
 template <typename PolicyBase, typename IndexType>
 struct SetIndexType {
   static_assert(is_void<typename PolicyBase::index_type>::value,
@@ -190,8 +179,11 @@ struct AnalyzePolicy<Base, T, Traits...>
                                       Experimental::is_work_item_property<
                                           T>::value,
                                       SetWorkItemProperty<Base, T>,
-                                      SetWorkTag<Base, T> >::type>::type>::
-                              type>::type>::type>::type>::type::type,
+                                      typename std::conditional<
+                                          !std::is_void<T>::value,
+                                          SetWorkTag<Base, T>, Base>::type>::
+                                      type>::type>::type>::type>::type>::type>::
+              type::type,
           Traits...> {};
 
 template <typename Base>

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -59,6 +59,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX)
       ${dir}/Test${Tag}_MDRange_e.cpp
       ${dir}/Test${Tag}_Other.cpp
       ${dir}/Test${Tag}_RangePolicy.cpp
+      ${dir}/Test${Tag}_RangePolicyRequire.cpp
       ${dir}/Test${Tag}_Reductions.cpp
       ${dir}/Test${Tag}_Reducers_a.cpp
       ${dir}/Test${Tag}_Reducers_b.cpp

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -67,7 +67,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
     OBJ_CUDA = UnitTestMainInit.o gtest-all.o
     OBJ_CUDA += TestCuda_Init.o
     OBJ_CUDA += TestCuda_SharedAlloc.o TestCudaUVM_SharedAlloc.o TestCudaHostPinned_SharedAlloc.o
-    OBJ_CUDA += TestCuda_RangePolicy.o
+    OBJ_CUDA += TestCuda_RangePolicy.o TestCuda_RangePolicyRequire.o
     OBJ_CUDA += TestCuda_ViewAPI_a.o TestCuda_ViewAPI_b.o TestCuda_ViewAPI_c.o TestCuda_ViewAPI_d.o TestCuda_ViewAPI_e.o
     OBJ_CUDA += TestCuda_DeepCopyAlignment.o
     OBJ_CUDA += TestCuda_ViewMapping_a.o TestCuda_ViewMapping_b.o TestCuda_ViewMapping_subview.o TestCuda_ViewResize.o TestCuda_ViewLayoutStrideAssignment.o
@@ -166,7 +166,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_PTHREADS), 1)
     OBJ_THREADS = UnitTestMainInit.o gtest-all.o
     OBJ_THREADS += TestThreads_Init.o
     OBJ_THREADS += TestThreads_SharedAlloc.o
-    OBJ_THREADS += TestThreads_RangePolicy.o
+    OBJ_THREADS += TestThreads_RangePolicy.o TestThreads_RangePolicyRequire.o
     OBJ_THREADS += TestThreads_View_64bit.o
     OBJ_THREADS += TestThreads_ViewAPI_a.o TestThreads_ViewAPI_b.o TestThreads_ViewAPI_c.o TestThreads_ViewAPI_d.o TestThreads_ViewAPI_e.o
     OBJ_THREADS += TestThreads_DeepCopyAlignment.o
@@ -201,7 +201,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)
     OBJ_OPENMP = UnitTestMainInit.o gtest-all.o
     OBJ_OPENMP += TestOpenMP_Init.o
     OBJ_OPENMP += TestOpenMP_SharedAlloc.o
-    OBJ_OPENMP += TestOpenMP_RangePolicy.o
+    OBJ_OPENMP += TestOpenMP_RangePolicy.o TestOpenMP_RangePolicyRequire.o
     OBJ_OPENMP += TestOpenMP_View_64bit.o
     OBJ_OPENMP += TestOpenMP_ViewAPI_a.o TestOpenMP_ViewAPI_b.o TestOpenMP_ViewAPI_c.o TestOpenMP_ViewAPI_d.o TestOpenMP_ViewAPI_e.o
     OBJ_OPENMP += TestOpenMP_DeepCopyAlignment.o
@@ -296,7 +296,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_HPX), 1)
 	OBJ_HPX = UnitTestMainInit.o gtest-all.o
 	OBJ_HPX += TestHPX_Init.o
 	OBJ_HPX += TestHPX_SharedAlloc.o
-	OBJ_HPX += TestHPX_RangePolicy.o
+	OBJ_HPX += TestHPX_RangePolicy.o TestHPX_RangePolicyRequire.o
 	OBJ_HPX += TestHPX_View_64bit.o
 	OBJ_HPX += TestHPX_ViewAPI_a.o TestHPX_ViewAPI_b.o TestHPX_ViewAPI_c.o TestHPX_ViewAPI_d.o TestHPX_ViewAPI_e.o
 	OBJ_HPX += TestHPX_ViewMapping_a.o TestHPX_ViewMapping_b.o TestHPX_ViewMapping_subview.o TestHPX_ViewResize.o
@@ -335,7 +335,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_SERIAL), 1)
     OBJ_SERIAL = UnitTestMainInit.o gtest-all.o
     OBJ_SERIAL += TestSerial_Init.o
     OBJ_SERIAL += TestSerial_SharedAlloc.o
-    OBJ_SERIAL += TestSerial_RangePolicy.o
+    OBJ_SERIAL += TestSerial_RangePolicy.o TestSerial_RangePolicyRequire.o
     OBJ_SERIAL += TestSerial_View_64bit.o
     OBJ_SERIAL += TestSerial_ViewAPI_a.o TestSerial_ViewAPI_b.o TestSerial_ViewAPI_c.o TestSerial_ViewAPI_d.o TestSerial_ViewAPI_e.o
     OBJ_SERIAL += TestSerial_DeepCopyAlignment.o

--- a/core/unit_test/TestRangeRequire.hpp
+++ b/core/unit_test/TestRangeRequire.hpp
@@ -1,0 +1,515 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <cstdio>
+
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+
+namespace {
+
+template <class ExecSpace, class ScheduleType, class Property>
+struct TestRangeRequire {
+  typedef int value_type;  ///< typedef required for the parallel_reduce
+
+  typedef Kokkos::View<int *, ExecSpace> view_type;
+
+  view_type m_flags;
+
+  struct VerifyInitTag {};
+  struct ResetTag {};
+  struct VerifyResetTag {};
+  struct OffsetTag {};
+  struct VerifyOffsetTag {};
+
+  int N;
+  static const int offset = 13;
+  TestRangeRequire(const size_t N_)
+      : m_flags(Kokkos::ViewAllocateWithoutInitializing("flags"), N_), N(N_) {}
+
+  void test_for() {
+    typename view_type::HostMirror host_flags =
+        Kokkos::create_mirror_view(m_flags);
+
+    Kokkos::parallel_for(
+        Kokkos::Experimental::require(
+            Kokkos::RangePolicy<ExecSpace, ScheduleType>(0, N), Property()),
+        *this);
+
+#if defined(KOKKOS_ENABLE_PROFILING)
+    {
+      typedef TestRangeRequire<ExecSpace, ScheduleType, Property> ThisType;
+      std::string label("parallel_for");
+      Kokkos::Impl::ParallelConstructName<ThisType, void> pcn(label);
+      ASSERT_EQ(pcn.get(), label);
+      std::string empty_label("");
+      Kokkos::Impl::ParallelConstructName<ThisType, void> empty_pcn(
+          empty_label);
+      ASSERT_EQ(empty_pcn.get(), typeid(ThisType).name());
+    }
+#endif
+
+    Kokkos::parallel_for(
+        Kokkos::Experimental::require(
+            Kokkos::RangePolicy<ExecSpace, ScheduleType, VerifyInitTag>(0, N),
+            Property()),
+        *this);
+
+#if defined(KOKKOS_ENABLE_PROFILING)
+    {
+      typedef TestRangeRequire<ExecSpace, ScheduleType, Property> ThisType;
+      std::string label("parallel_for");
+      Kokkos::Impl::ParallelConstructName<ThisType, VerifyInitTag> pcn(label);
+      ASSERT_EQ(pcn.get(), label);
+      std::string empty_label("");
+      Kokkos::Impl::ParallelConstructName<ThisType, VerifyInitTag> empty_pcn(
+          empty_label);
+      ASSERT_EQ(empty_pcn.get(), std::string(typeid(ThisType).name()) + "/" +
+                                     typeid(VerifyInitTag).name());
+    }
+#endif
+
+    Kokkos::deep_copy(host_flags, m_flags);
+
+    int error_count = 0;
+    for (int i = 0; i < N; ++i) {
+      if (int(i) != host_flags(i)) ++error_count;
+    }
+    ASSERT_EQ(error_count, int(0));
+
+    Kokkos::parallel_for(
+        Kokkos::Experimental::require(
+            Kokkos::RangePolicy<ExecSpace, ScheduleType, ResetTag>(0, N),
+            Property()),
+        *this);
+    Kokkos::parallel_for(
+        std::string("TestKernelFor"),
+        Kokkos::Experimental::require(
+            Kokkos::RangePolicy<ExecSpace, ScheduleType, VerifyResetTag>(0, N),
+            Property()),
+        *this);
+
+    Kokkos::deep_copy(host_flags, m_flags);
+
+    error_count = 0;
+    for (int i = 0; i < N; ++i) {
+      if (int(2 * i) != host_flags(i)) ++error_count;
+    }
+    ASSERT_EQ(error_count, int(0));
+
+    Kokkos::parallel_for(
+        Kokkos::Experimental::require(
+            Kokkos::RangePolicy<ExecSpace, ScheduleType, OffsetTag>(offset,
+                                                                    N + offset),
+            Property()),
+        *this);
+    Kokkos::parallel_for(
+        std::string("TestKernelFor"),
+        Kokkos::Experimental::require(
+            Kokkos::RangePolicy<ExecSpace, ScheduleType,
+                                Kokkos::IndexType<unsigned int>,
+                                VerifyOffsetTag>(0, N),
+            Property()),
+        *this);
+
+    Kokkos::deep_copy(host_flags, m_flags);
+
+    error_count = 0;
+    for (int i = 0; i < N; ++i) {
+      if (i + offset != host_flags(i)) ++error_count;
+    }
+    ASSERT_EQ(error_count, int(0));
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i) const { m_flags(i) = i; }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const VerifyInitTag &, const int i) const {
+    if (i != m_flags(i)) {
+      printf("TestRangeRequire::test_for error at %d != %d\n", i, m_flags(i));
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const ResetTag &, const int i) const {
+    m_flags(i) = 2 * m_flags(i);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const VerifyResetTag &, const int i) const {
+    if (2 * i != m_flags(i)) {
+      printf("TestRangeRequire::test_for error at %d != %d\n", i, m_flags(i));
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const OffsetTag &, const int i) const {
+    m_flags(i - offset) = i;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const VerifyOffsetTag &, const int i) const {
+    if (i + offset != m_flags(i)) {
+      printf("TestRangeRequire::test_for error at %d != %d\n", i + offset,
+             m_flags(i));
+    }
+  }
+
+  //----------------------------------------
+
+  void test_reduce() {
+    int total = 0;
+
+    Kokkos::parallel_for(
+        Kokkos::Experimental::require(
+            Kokkos::RangePolicy<ExecSpace, ScheduleType>(0, N), Property()),
+        *this);
+
+    Kokkos::parallel_reduce(
+        "TestKernelReduce",
+        Kokkos::Experimental::require(
+            Kokkos::RangePolicy<ExecSpace, ScheduleType>(0, N), Property()),
+        *this, total);
+    // sum( 0 .. N-1 )
+    ASSERT_EQ(size_t((N - 1) * (N) / 2), size_t(total));
+
+    Kokkos::parallel_reduce(
+        Kokkos::Experimental::require(
+            Kokkos::RangePolicy<ExecSpace, ScheduleType, OffsetTag>(offset,
+                                                                    N + offset),
+            Property()),
+        *this, total);
+    // sum( 1 .. N )
+    ASSERT_EQ(size_t((N) * (N + 1) / 2), size_t(total));
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i, value_type &update) const {
+    update += m_flags(i);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const OffsetTag &, const int i, value_type &update) const {
+    update += 1 + m_flags(i - offset);
+  }
+
+  //----------------------------------------
+
+  void test_scan() {
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, ScheduleType>(0, N),
+                         *this);
+
+    Kokkos::parallel_scan(
+        "TestKernelScan",
+        Kokkos::RangePolicy<ExecSpace, ScheduleType, OffsetTag>(0, N), *this);
+
+    int total = 0;
+    Kokkos::parallel_scan(
+        "TestKernelScanWithTotal",
+        Kokkos::RangePolicy<ExecSpace, ScheduleType, OffsetTag>(0, N), *this,
+        total);
+    ASSERT_EQ(size_t((N - 1) * (N) / 2), size_t(total));  // sum( 0 .. N-1 )
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const OffsetTag &, const int i, value_type &update,
+                  bool final) const {
+    update += m_flags(i);
+
+    if (final) {
+      if (update != (i * (i + 1)) / 2) {
+        printf("TestRangeRequire::test_scan error %d : %d != %d\n", i,
+               (i * (i + 1)) / 2, m_flags(i));
+      }
+    }
+  }
+
+  void test_dynamic_policy() {
+    auto const N_no_implicit_capture = N;
+#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+#if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
+    typedef Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >
+        policy_t;
+
+    {
+      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
+          count("Count", ExecSpace::concurrency());
+      Kokkos::View<int *, ExecSpace> a("A", N);
+
+      Kokkos::parallel_for(
+          policy_t(0, N), KOKKOS_LAMBDA(const int &i) {
+            for (int k = 0; k < (i < N_no_implicit_capture / 2 ? 1 : 10000);
+                 k++) {
+              a(i)++;
+            }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+            count(ExecSpace::hardware_thread_id())++;
+#else
+        count( ExecSpace::impl_hardware_thread_id() )++;
+#endif
+          });
+
+      int error = 0;
+      Kokkos::parallel_reduce(
+          Kokkos::RangePolicy<ExecSpace>(0, N),
+          KOKKOS_LAMBDA(const int &i, int &lsum) {
+            lsum += (a(i) != (i < N_no_implicit_capture / 2 ? 1 : 10000));
+          },
+          error);
+      ASSERT_EQ(error, 0);
+
+      if ((ExecSpace::concurrency() > (int)1) &&
+          (N > static_cast<int>(4 * ExecSpace::concurrency()))) {
+        size_t min = N;
+        size_t max = 0;
+        for (int t = 0; t < ExecSpace::concurrency(); t++) {
+          if (count(t) < min) min = count(t);
+          if (count(t) > max) max = count(t);
+        }
+        ASSERT_TRUE(min < max);
+
+        // if ( ExecSpace::concurrency() > 2 ) {
+        //  ASSERT_TRUE( 2 * min < max );
+        //}
+      }
+    }
+
+    {
+      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
+          count("Count", ExecSpace::concurrency());
+      Kokkos::View<int *, ExecSpace> a("A", N);
+
+      int sum = 0;
+      Kokkos::parallel_reduce(
+          policy_t(0, N),
+          KOKKOS_LAMBDA(const int &i, int &lsum) {
+            for (int k = 0; k < (i < N_no_implicit_capture / 2 ? 1 : 10000);
+                 k++) {
+              a(i)++;
+            }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+            count(ExecSpace::hardware_thread_id())++;
+#else
+            count(ExecSpace::impl_hardware_thread_id())++;
+#endif
+            lsum++;
+          },
+          sum);
+      ASSERT_EQ(sum, N);
+
+      int error = 0;
+      Kokkos::parallel_reduce(
+          Kokkos::RangePolicy<ExecSpace>(0, N),
+          KOKKOS_LAMBDA(const int &i, int &lsum) {
+            lsum += (a(i) != (i < N_no_implicit_capture / 2 ? 1 : 10000));
+          },
+          error);
+      ASSERT_EQ(error, 0);
+
+      if ((ExecSpace::concurrency() > (int)1) &&
+          (N > static_cast<int>(4 * ExecSpace::concurrency()))) {
+        size_t min = N;
+        size_t max = 0;
+        for (int t = 0; t < ExecSpace::concurrency(); t++) {
+          if (count(t) < min) min = count(t);
+          if (count(t) > max) max = count(t);
+        }
+        ASSERT_TRUE(min < max);
+
+        // if ( ExecSpace::concurrency() > 2 ) {
+        //  ASSERT_TRUE( 2 * min < max );
+        //}
+      }
+    }
+#endif
+#endif
+  }
+};
+
+}  // namespace
+
+TEST(TEST_CATEGORY, range_for_require) {
+  using Property = Kokkos::Experimental::WorkItemProperty::HintLightWeight_t;
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, Property>
+        f(0);
+    f.test_for();
+  }
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(0);
+    f.test_for();
+  }
+
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, Property>
+        f(2);
+    f.test_for();
+  }
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(3);
+    f.test_for();
+  }
+
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, Property>
+        f(1000);
+    f.test_for();
+  }
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(1001);
+    f.test_for();
+  }
+}
+
+TEST(TEST_CATEGORY, range_reduce_require) {
+  using Property = Kokkos::Experimental::WorkItemProperty::HintLightWeight_t;
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, Property>
+        f(0);
+    f.test_reduce();
+  }
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(0);
+    f.test_reduce();
+  }
+
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, Property>
+        f(2);
+    f.test_reduce();
+  }
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(3);
+    f.test_reduce();
+  }
+
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, Property>
+        f(1000);
+    f.test_reduce();
+  }
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(1001);
+    f.test_reduce();
+  }
+}
+
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
+TEST(TEST_CATEGORY, range_scan_require) {
+  using Property = Kokkos::Experimental::WorkItemProperty::HintLightWeight_t;
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, Property>
+        f(0);
+    f.test_scan();
+  }
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(0);
+    f.test_scan();
+  }
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_ROCM)
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(0);
+    f.test_dynamic_policy();
+  }
+#endif
+
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, Property>
+        f(2);
+    f.test_scan();
+  }
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(3);
+    f.test_scan();
+  }
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_ROCM)
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(3);
+    f.test_dynamic_policy();
+  }
+#endif
+
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, Property>
+        f(1000);
+    f.test_scan();
+  }
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(1001);
+    f.test_scan();
+  }
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_ROCM)
+  {
+    TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                     Property>
+        f(1001);
+    f.test_dynamic_policy();
+  }
+#endif
+}
+#endif
+}  // namespace Test

--- a/core/unit_test/TestRangeRequire.hpp
+++ b/core/unit_test/TestRangeRequire.hpp
@@ -45,6 +45,10 @@
 
 #include <Kokkos_Core.hpp>
 
+// This file is largely duplicating TestRange.hpp but it applies
+// Kokkos::Experimental require at every place where a parallel
+// operation is executed.
+
 namespace Test {
 
 namespace {

--- a/core/unit_test/cuda/TestCuda_RangePolicyRequire.cpp
+++ b/core/unit_test/cuda/TestCuda_RangePolicyRequire.cpp
@@ -1,0 +1,46 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <cuda/TestCuda_Category.hpp>
+#include <TestRangeRequire.hpp>

--- a/core/unit_test/hpx/TestHPX_RangePolicyRequire.cpp
+++ b/core/unit_test/hpx/TestHPX_RangePolicyRequire.cpp
@@ -1,0 +1,46 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hpx/TestHPX_Category.hpp>
+#include <TestRangeRequire.hpp>

--- a/core/unit_test/openmp/TestOpenMP_RangePolicyRequire.cpp
+++ b/core/unit_test/openmp/TestOpenMP_RangePolicyRequire.cpp
@@ -1,0 +1,46 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <openmp/TestOpenMP_Category.hpp>
+#include <TestRangeRequire.hpp>

--- a/core/unit_test/serial/TestSerial_RangePolicyRequire.cpp
+++ b/core/unit_test/serial/TestSerial_RangePolicyRequire.cpp
@@ -1,0 +1,46 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <serial/TestSerial_Category.hpp>
+#include <TestRangeRequire.hpp>

--- a/core/unit_test/standalone/Makefile
+++ b/core/unit_test/standalone/Makefile
@@ -9,7 +9,6 @@ ifndef KOKKOS_PATH
 endif
 
 SRC = $(wildcard $(MAKEFILE_PATH)*.cpp)
-SRC += $(MAKEFILE_PATH)/../TestStackTrace.cpp
 HEADERS = $(wildcard $(MAKEFILE_PATH)*.hpp)
 HEADERS = $(wildcard $(MAKEFILE_PATH)/../*.hpp)
 

--- a/core/unit_test/threads/TestThreads_RangePolicyRequire.cpp
+++ b/core/unit_test/threads/TestThreads_RangePolicyRequire.cpp
@@ -1,0 +1,46 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2014) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <threads/TestThreads_Category.hpp>
+#include <TestRangeRequire.hpp>


### PR DESCRIPTION
This fixes issue #2608. Essentially the last argument checkup in the argument list for policies will always be interpreted as "WorkTag" but if there gets an extra void inserted everything falls apart. This change just removes voids from the list. 