### PR TITLE
Issue 1908

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -55,7 +55,7 @@ namespace Kokkos {
 namespace Impl {
 
 // Include all lanes
-constexpr unsigned shfl_all_mask = 0xffffffff;
+constexpr unsigned shfl_all_mask = 0xffffffffu;
 
 //----------------------------------------------------------------------------
 // Shuffle operations require input to be a register (stack) variable
@@ -71,16 +71,28 @@ struct in_place_shfl_op {
     return *static_cast<Derived const*>(this);
   }
 
-  // sizeof(Scalar) == sizeof(int) case
+  // sizeof(Scalar) <= sizeof(int) case
   template <class Scalar>
   // requires _assignable_from_bits<Scalar>
-  __device__ inline typename std::enable_if<sizeof(Scalar) == sizeof(int)>::type
+  __device__ inline typename std::enable_if<sizeof(Scalar) <= sizeof(int)>::type
   operator()(Scalar& out, Scalar const& in, int lane_or_delta, int width,
              unsigned mask = shfl_all_mask) const noexcept {
+    using shfl_type = int;
+    union conv_type {
+      Scalar orig;
+      shfl_type conv;
+    };
+    conv_type tmp_in;
+    tmp_in.orig = in;
+    conv_type tmp_out;
+    tmp_out.conv = tmp_in.conv;
+    conv_type res;
     //------------------------------------------------
-    reinterpret_cast<int&>(out) = self().do_shfl_op(
-        mask, reinterpret_cast<int const&>(in), lane_or_delta, width);
+    res.conv = self().do_shfl_op(
+        mask, reinterpret_cast<shfl_type const&>(tmp_out.conv), lane_or_delta,
+        width);
     //------------------------------------------------
+    out = res.orig;
   }
 
 // TODO: figure out why 64-bit shfl fails in Clang

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -178,9 +178,13 @@ struct FunctorValueTraits<FunctorType, ArgTag,
       value_type;
   typedef FunctorType functor_type;
 
-  static_assert(0 == (sizeof(value_type) % sizeof(int)),
-                "Reduction functor's declared value_type requires: 0 == "
-                "sizeof(value_type) % sizeof(int)");
+  // It seems that if you have redction_identities for unsigned char and short
+  // that the below static assert is contradictory.  I am commenting it out
+  // (JSM)
+  //
+  //  static_assert(0 == (sizeof(value_type) % sizeof(int)),
+  //                "Reduction functor's declared value_type requires: 0 == "
+  //                "sizeof(value_type) % sizeof(int)");
 
   /* this cast to bool is needed for correctness by NVCC */
   enum : bool {

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -178,9 +178,10 @@ struct FunctorValueTraits<FunctorType, ArgTag,
       value_type;
   typedef FunctorType functor_type;
 
-  static_assert((sizeof(value_type)<sizeof(int)) || 0 == (sizeof(value_type) % sizeof(int)),
-                 "Reduction functor's declared value_type requires: 0 == "
-                 "sizeof(value_type) % sizeof(int)");
+  static_assert((sizeof(value_type) < sizeof(int)) ||
+                    0 == (sizeof(value_type) % sizeof(int)),
+                "Reduction functor's declared value_type requires: 0 == "
+                "sizeof(value_type) % sizeof(int)");
 
   /* this cast to bool is needed for correctness by NVCC */
   enum : bool {

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -178,13 +178,9 @@ struct FunctorValueTraits<FunctorType, ArgTag,
       value_type;
   typedef FunctorType functor_type;
 
-  // It seems that if you have redction_identities for unsigned char and short
-  // that the below static assert is contradictory.  I am commenting it out
-  // (JSM)
-  //
-  //  static_assert(0 == (sizeof(value_type) % sizeof(int)),
-  //                "Reduction functor's declared value_type requires: 0 == "
-  //                "sizeof(value_type) % sizeof(int)");
+  static_assert((sizeof(value_type)<sizeof(int)) || 0 == (sizeof(value_type) % sizeof(int)),
+                 "Reduction functor's declared value_type requires: 0 == "
+                 "sizeof(value_type) % sizeof(int)");
 
   /* this cast to bool is needed for correctness by NVCC */
   enum : bool {

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -399,4 +399,3 @@ TEST(TEST_CATEGORY, complex_trivially_copyable) {
 }
 
 }  // namespace Test
-

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -399,3 +399,4 @@ TEST(TEST_CATEGORY, complex_trivially_copyable) {
 }
 
 }  // namespace Test
+

--- a/core/unit_test/cuda/TestCuda_Team.cpp
+++ b/core/unit_test/cuda/TestCuda_Team.cpp
@@ -103,6 +103,30 @@ TEST(TEST_CATEGORY, team_broadcast_long) {
   //      test_teambroadcast(1000, 1);
 }
 
+TEST(TEST_CATEGORY, team_broadcast_char) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    unsigned char>::test_teambroadcast(0, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    unsigned char>::test_teambroadcast(0, 1);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    unsigned char>::test_teambroadcast(2, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    unsigned char>::test_teambroadcast(2, 1);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    unsigned char>::test_teambroadcast(16, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    unsigned char>::test_teambroadcast(16, 1);
+
+  //  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, long
+  //  >::
+  //      test_teambroadcast(1000, 1);
+  //  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>, long
+  //  >::
+  //      test_teambroadcast(1000, 1);
+}
+
 TEST(TEST_CATEGORY, team_broadcast_float) {
   TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
                     float>::test_teambroadcast(0, 1.3);

--- a/core/unit_test/cuda/TestCuda_Team.cpp
+++ b/core/unit_test/cuda/TestCuda_Team.cpp
@@ -79,26 +79,76 @@ TEST(TEST_CATEGORY, team_reduce) {
                  Kokkos::Schedule<Kokkos::Dynamic> >::test_reduce(1000);
 }
 
-TEST(TEST_CATEGORY, team_broadcast) {
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(0);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(0);
+TEST(TEST_CATEGORY, team_broadcast_long) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(0, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(0, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(2);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(2);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(2, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(2, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(16);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(16);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(16, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(16, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::
-      test_teambroadcast(1000);
-  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::
-      test_teambroadcast(1000);
+  //  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, long
+  //  >::
+  //      test_teambroadcast(1000, 1);
+  //  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>, long
+  //  >::
+  //      test_teambroadcast(1000, 1);
+}
+
+TEST(TEST_CATEGORY, team_broadcast_float) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    float>::test_teambroadcast(0, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    float>::test_teambroadcast(0, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    float>::test_teambroadcast(2, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    float>::test_teambroadcast(2, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    float>::test_teambroadcast(16, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    float>::test_teambroadcast(16, 1.3);
+
+  //  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, float
+  //  >::
+  //      test_teambroadcast(1000, 1.3);
+  //  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>, float
+  //  >::
+  //      test_teambroadcast(1000, 1.3);
+}
+
+TEST(TEST_CATEGORY, team_broadcast_double) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    double>::test_teambroadcast(0, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    double>::test_teambroadcast(0, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    double>::test_teambroadcast(2, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    double>::test_teambroadcast(2, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    double>::test_teambroadcast(16, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    double>::test_teambroadcast(16, 1.3);
+
+  //  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>, double
+  //  >::
+  //      test_teambroadcast(1000, 1.3);
+  //  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+  //  double >::
+  //      test_teambroadcast(1000, 1.3);
 }
 
 }  // namespace Test

--- a/core/unit_test/openmp/TestOpenMP_Team.cpp
+++ b/core/unit_test/openmp/TestOpenMP_Team.cpp
@@ -80,25 +80,25 @@ TEST(TEST_CATEGORY, team_reduce) {
 }
 
 TEST(TEST_CATEGORY, team_broadcast) {
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(0);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(0);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(0, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(0, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(2);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(2);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(2, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(2, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(16);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(16);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(16, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(16, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::
-      test_teambroadcast(1000);
-  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::
-      test_teambroadcast(1000);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(1000, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(1000, 1);
 }
 }  // namespace Test
 

--- a/core/unit_test/serial/TestSerial_Team.cpp
+++ b/core/unit_test/serial/TestSerial_Team.cpp
@@ -79,26 +79,70 @@ TEST(TEST_CATEGORY, team_reduce) {
                  Kokkos::Schedule<Kokkos::Dynamic> >::test_reduce(1000);
 }
 
-TEST(TEST_CATEGORY, team_broadcast) {
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(0);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(0);
+TEST(TEST_CATEGORY, team_broadcast_long) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(0, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(0, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(2);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(2);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(2, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(2, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(16);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(16);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(16, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(16, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::
-      test_teambroadcast(1000);
-  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::
-      test_teambroadcast(1000);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(1000, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(1000, 1);
+}
+
+TEST(TEST_CATEGORY, team_broadcast_float) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    float>::test_teambroadcast(0, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    float>::test_teambroadcast(0, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    float>::test_teambroadcast(2, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    float>::test_teambroadcast(2, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    float>::test_teambroadcast(16, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    float>::test_teambroadcast(16, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    float>::test_teambroadcast(1000, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    float>::test_teambroadcast(1000, 1.3);
+}
+
+TEST(TEST_CATEGORY, team_broadcast_double) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    double>::test_teambroadcast(0, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    double>::test_teambroadcast(0, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    double>::test_teambroadcast(2, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    double>::test_teambroadcast(2, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    double>::test_teambroadcast(16, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    double>::test_teambroadcast(16, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    double>::test_teambroadcast(1000, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    double>::test_teambroadcast(1000, 1.3);
 }
 }  // namespace Test
 

--- a/core/unit_test/serial/TestSerial_Team.cpp
+++ b/core/unit_test/serial/TestSerial_Team.cpp
@@ -101,6 +101,23 @@ TEST(TEST_CATEGORY, team_broadcast_long) {
                     long>::test_teambroadcast(1000, 1);
 }
 
+TEST(TEST_CATEGORY, team_broadcast_char) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    unsigned char>::test_teambroadcast(0, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    unsigned char>::test_teambroadcast(0, 1);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    unsigned char>::test_teambroadcast(2, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    unsigned char>::test_teambroadcast(2, 1);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    unsigned char>::test_teambroadcast(16, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    unsigned char>::test_teambroadcast(16, 1);
+}
+
 TEST(TEST_CATEGORY, team_broadcast_float) {
   TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
                     float>::test_teambroadcast(0, 1.3);

--- a/core/unit_test/threads/TestThreads_Team.cpp
+++ b/core/unit_test/threads/TestThreads_Team.cpp
@@ -80,25 +80,25 @@ TEST(TEST_CATEGORY, team_reduce) {
 }
 
 TEST(TEST_CATEGORY, team_broadcast) {
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(0);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(0);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(0, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(0, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(2);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(2);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(2, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(2, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Static> >::test_teambroadcast(16);
-  TestTeamBroadcast<TEST_EXECSPACE,
-                    Kokkos::Schedule<Kokkos::Dynamic> >::test_teambroadcast(16);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(16, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(16, 1);
 
-  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::
-      test_teambroadcast(1000);
-  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::
-      test_teambroadcast(1000);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(1000, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(1000, 1);
 }
 }  // namespace Test
 


### PR DESCRIPTION
Moved the template logic for types smaller than sizeof(int) down into the Vectorization layer.  

The TestTeam.hpp changes are still in tact verifying team_broadcast of a boolean value.

While these changes address the issues described in 1908, I am tagging this WIP because I think we also need to add test cases for other operations that use Impl::in_place_shfl