### PR TITLE
Fixup CUDA algorithms unit test

### DIFF
--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -23,9 +23,14 @@ KOKKOS_ADD_TEST_LIBRARY(
 KOKKOS_TARGET_COMPILE_DEFINITIONS(kokkosalgorithms_gtest PUBLIC "-DGTEST_HAS_PTHREAD=0")
 
 SET(SOURCES
-  UnitTestMain.cpp 
-  TestCuda.cpp
+  UnitTestMain.cpp
+)
+
+IF(Kokkos_ENABLE_CUDA)
+  LIST( APPEND SOURCES
+    TestCuda.cpp
   )
+ENDIF()
 
 IF(Kokkos_ENABLE_OPENMP)
   LIST( APPEND SOURCES


### PR DESCRIPTION
Do not attempt to compile empty `.cpp` file when CUDA backend is not enabled.