### PR TITLE
Remove branch for old CMake version

### DIFF
--- a/cmake/tpls/FindTPLCUSPARSE.cmake
+++ b/cmake/tpls/FindTPLCUSPARSE.cmake
@@ -58,16 +58,6 @@
 IF (NOT TPL_ENABLE_CUDA OR CUDA_VERSION VERSION_LESS "4.1")
   MESSAGE(FATAL_ERROR "\nCUSPARSE: did not find acceptable version of CUDA libraries (4.1 or greater)")
 ELSE()
-  IF(CMAKE_VERSION VERSION_LESS "2.8.8")
-    # FindCUDA before CMake 2.8.8 does not find cusparse library; therefore, we must
-    find_library(CUDA_cusparse_LIBRARY
-      cusparse
-      HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib
-      )
-    IF(CUDA_cusparse_LIBRARY STREQUAL "CUDA_cusparse_LIBRARY-NOTFOUND") 
-      MESSAGE(FATAL_ERROR "\nCUSPARSE: could not find cuspasre library.")
-    ENDIF()
-  ENDIF()
   GLOBAL_SET(TPL_CUSPARSE_LIBRARY_DIRS)
   GLOBAL_SET(TPL_CUSPARSE_INCLUDE_DIRS ${TPL_CUDA_INCLUDE_DIRS})
   GLOBAL_SET(TPL_CUSPARSE_LIBRARIES    ${CUDA_cusparse_LIBRARY})


### PR DESCRIPTION
Addressing https://github.com/kokkos/kokkos/pull/2644/files/4d48475bd02a8d22980360d9dd5f8d3803aacf13#diff-b47bb82036a97011593eb9fdcc23bceb. This was the only place where we check for a `CMake` version prior to 3.10.