### PR TITLE
Remove Kokkos::Impl::condition and Kokkos::Impl::enable_if

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -469,7 +469,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   ///   as modified, by calling the modify() method with the
   ///   appropriate template parameter.
   template <class Device>
-  void sync(const typename Impl::enable_if<
+  void sync(const typename std::enable_if<
                 (std::is_same<typename traits::data_type,
                               typename traits::non_const_data_type>::value) ||
                     (std::is_same<Device, int>::value),
@@ -498,7 +498,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   }
 
   template <class Device>
-  void sync(const typename Impl::enable_if<
+  void sync(const typename std::enable_if<
                 (!std::is_same<typename traits::data_type,
                                typename traits::non_const_data_type>::value) ||
                     (std::is_same<Device, int>::value),

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -688,7 +688,7 @@ class UnorderedMap {
   template <typename SKey, typename SValue>
   UnorderedMap(
       UnorderedMap<SKey, SValue, Device, Hasher, EqualTo> const &src,
-      typename Impl::enable_if<
+      typename std::enable_if<
           Impl::UnorderedMapCanAssign<declared_key_type, declared_value_type,
                                       SKey, SValue>::value,
           int>::type = 0)
@@ -704,7 +704,7 @@ class UnorderedMap {
         m_scalars(src.m_scalars) {}
 
   template <typename SKey, typename SValue>
-  typename Impl::enable_if<
+  typename std::enable_if<
       Impl::UnorderedMapCanAssign<declared_key_type, declared_value_type, SKey,
                                   SValue>::value,
       declared_map_type &>::type
@@ -723,7 +723,7 @@ class UnorderedMap {
   }
 
   template <typename SKey, typename SValue, typename SDevice>
-  typename Impl::enable_if<
+  typename std::enable_if<
       std::is_same<typename Impl::remove_const<SKey>::type, key_type>::value &&
       std::is_same<typename Impl::remove_const<SValue>::type,
                    value_type>::value>::type

--- a/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
+++ b/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
@@ -57,8 +57,8 @@ inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, SizeType,
 create_mirror_view(
     const StaticCrsGraph<DataType, Arg1Type, Arg2Type, SizeType, Arg3Type>&
         view,
-    typename Impl::enable_if<ViewTraits<DataType, Arg1Type, Arg2Type,
-                                        Arg3Type>::is_hostspace>::type* = 0) {
+    typename std::enable_if<ViewTraits<DataType, Arg1Type, Arg2Type,
+                                       Arg3Type>::is_hostspace>::type* = 0) {
   return view;
 }
 #else
@@ -69,8 +69,8 @@ inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 create_mirror_view(
     const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>&
         view,
-    typename Impl::enable_if<ViewTraits<DataType, Arg1Type, Arg2Type,
-                                        Arg3Type>::is_hostspace>::type* = 0) {
+    typename std::enable_if<ViewTraits<DataType, Arg1Type, Arg2Type,
+                                       Arg3Type>::is_hostspace>::type* = 0) {
   return view;
 }
 #endif
@@ -127,8 +127,8 @@ inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, SizeType,
 create_mirror_view(
     const StaticCrsGraph<DataType, Arg1Type, Arg2Type, SizeType, Arg3Type>&
         view,
-    typename Impl::enable_if<!ViewTraits<DataType, Arg1Type, Arg2Type,
-                                         Arg3Type>::is_hostspace>::type* = 0)
+    typename std::enable_if<!ViewTraits<DataType, Arg1Type, Arg2Type,
+                                        Arg3Type>::is_hostspace>::type* = 0)
 #else
 template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type,
           typename SizeType>
@@ -137,8 +137,8 @@ inline typename StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type,
 create_mirror_view(
     const StaticCrsGraph<DataType, Arg1Type, Arg2Type, Arg3Type, SizeType>&
         view,
-    typename Impl::enable_if<!ViewTraits<DataType, Arg1Type, Arg2Type,
-                                         Arg3Type>::is_hostspace>::type* = 0)
+    typename std::enable_if<!ViewTraits<DataType, Arg1Type, Arg2Type,
+                                        Arg3Type>::is_hostspace>::type* = 0)
 #endif
 {
   return create_mirror(view);

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -639,8 +639,8 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
 /** Running in CudaSpace attempting to access an unknown space: error */
 template <class OtherSpace>
 struct VerifyExecutionCanAccessMemorySpace<
-    typename enable_if<!is_same<Kokkos::CudaSpace, OtherSpace>::value,
-                       Kokkos::CudaSpace>::type,
+    typename std::enable_if<!is_same<Kokkos::CudaSpace, OtherSpace>::value,
+                            Kokkos::CudaSpace>::type,
     OtherSpace> {
   enum { value = false };
   KOKKOS_INLINE_FUNCTION static void verify(void) {

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -157,7 +157,7 @@ template <class ExecPolicy, class FunctorType>
 inline void parallel_for(
     const ExecPolicy& policy, const FunctorType& functor,
     const std::string& str = "",
-    typename Impl::enable_if<
+    typename std::enable_if<
         Kokkos::Impl::is_execution_policy<ExecPolicy>::value>::type* = 0) {
 #if defined(KOKKOS_ENABLE_PROFILING)
   uint64_t kpID = 0;
@@ -402,7 +402,7 @@ template <class ExecutionPolicy, class FunctorType>
 inline void parallel_scan(
     const ExecutionPolicy& policy, const FunctorType& functor,
     const std::string& str = "",
-    typename Impl::enable_if<
+    typename std::enable_if<
         Kokkos::Impl::is_execution_policy<ExecutionPolicy>::value>::type* = 0) {
 #if defined(KOKKOS_ENABLE_PROFILING)
   uint64_t kpID = 0;
@@ -478,7 +478,7 @@ template <class ExecutionPolicy, class FunctorType, class ReturnType>
 inline void parallel_scan(
     const ExecutionPolicy& policy, const FunctorType& functor,
     ReturnType& return_value, const std::string& str = "",
-    typename Impl::enable_if<
+    typename std::enable_if<
         Kokkos::Impl::is_execution_policy<ExecutionPolicy>::value>::type* = 0) {
 #if defined(KOKKOS_ENABLE_PROFILING)
   uint64_t kpID = 0;
@@ -573,7 +573,7 @@ struct FunctorTeamShmemSize {
 template <class FunctorType>
 struct FunctorTeamShmemSize<
     FunctorType,
-    typename Impl::enable_if<0 < sizeof(&FunctorType::team_shmem_size)>::type> {
+    typename std::enable_if<0 < sizeof(&FunctorType::team_shmem_size)>::type> {
   static inline size_t value(const FunctorType& f, int team_size) {
     return f.team_shmem_size(team_size);
   }
@@ -582,7 +582,7 @@ struct FunctorTeamShmemSize<
 template <class FunctorType>
 struct FunctorTeamShmemSize<
     FunctorType,
-    typename Impl::enable_if<0 < sizeof(&FunctorType::shmem_size)>::type> {
+    typename std::enable_if<0 < sizeof(&FunctorType::shmem_size)>::type> {
   static inline size_t value(const FunctorType& f, int team_size) {
     return f.shmem_size(team_size);
   }

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -975,7 +975,7 @@ template <class PolicyType, class FunctorType, class ReturnType>
 inline void parallel_reduce(
     const std::string& label, const PolicyType& policy,
     const FunctorType& functor, ReturnType& return_value,
-    typename Impl::enable_if<
+    typename std::enable_if<
         Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       label, policy, functor, return_value);
@@ -986,7 +986,7 @@ template <class PolicyType, class FunctorType, class ReturnType>
 inline void parallel_reduce(
     const PolicyType& policy, const FunctorType& functor,
     ReturnType& return_value,
-    typename Impl::enable_if<
+    typename std::enable_if<
         Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       "", policy, functor, return_value);
@@ -1020,7 +1020,7 @@ template <class PolicyType, class FunctorType, class ReturnType>
 inline void parallel_reduce(
     const std::string& label, const PolicyType& policy,
     const FunctorType& functor, const ReturnType& return_value,
-    typename Impl::enable_if<
+    typename std::enable_if<
         Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
   ReturnType return_value_impl = return_value;
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
@@ -1032,7 +1032,7 @@ template <class PolicyType, class FunctorType, class ReturnType>
 inline void parallel_reduce(
     const PolicyType& policy, const FunctorType& functor,
     const ReturnType& return_value,
-    typename Impl::enable_if<
+    typename std::enable_if<
         Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
   ReturnType return_value_impl = return_value;
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
@@ -1069,7 +1069,7 @@ template <class PolicyType, class FunctorType>
 inline void parallel_reduce(
     const std::string& label, const PolicyType& policy,
     const FunctorType& functor,
-    typename Impl::enable_if<
+    typename std::enable_if<
         Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
   typedef Kokkos::Impl::FunctorValueTraits<FunctorType, void> ValueTraits;
   typedef typename Kokkos::Impl::if_c<
@@ -1093,7 +1093,7 @@ inline void parallel_reduce(
 template <class PolicyType, class FunctorType>
 inline void parallel_reduce(
     const PolicyType& policy, const FunctorType& functor,
-    typename Impl::enable_if<
+    typename std::enable_if<
         Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
   typedef Kokkos::Impl::FunctorValueTraits<FunctorType, void> ValueTraits;
   typedef typename Kokkos::Impl::if_c<

--- a/core/src/Kokkos_ROCmSpace.hpp
+++ b/core/src/Kokkos_ROCmSpace.hpp
@@ -480,7 +480,7 @@ struct VerifyExecutionCanAccessMemorySpace<
 /** Running in ROCmSpace attempting to access an unknown space: error */
 template <class OtherSpace>
 struct VerifyExecutionCanAccessMemorySpace<
-    typename enable_if<
+    typename std::enable_if<
         !is_same<Kokkos::Experimental::ROCmSpace, OtherSpace>::value,
         Kokkos::Experimental::ROCmSpace>::type,
     OtherSpace> {

--- a/core/src/ROCm/Kokkos_ROCm_Tile.hpp
+++ b/core/src/ROCm/Kokkos_ROCm_Tile.hpp
@@ -292,8 +292,9 @@ struct tile_buffer<T[]> {
   }
 
   template <class Action, class Q = T>
-  typename Impl::enable_if<(sizeof(Q) <= 8), void>::type action_at(
-      std::size_t i, Action a) [[hc]] {
+  typename std::enable_if<(sizeof(Q) <= 8), void>::type action_at(std::size_t i,
+                                                                  Action a)
+      [[hc]] {
     element_type* value = (*this)[i];
 #if defined(ROCM15)
     a(value);
@@ -315,7 +316,7 @@ struct tile_buffer<T[]> {
   }
 
   template <class Action, class Q = T>
-  typename Impl::enable_if<!(sizeof(Q) <= 8), void>::type action_at(
+  typename std::enable_if<!(sizeof(Q) <= 8), void>::type action_at(
       std::size_t i, Action a) [[hc]] {
     element_type* value = (*this)[i];
 #if defined(ROCM15)

--- a/core/src/ROCm/Kokkos_ROCm_Vectorization.hpp
+++ b/core/src/ROCm/Kokkos_ROCm_Vectorization.hpp
@@ -162,7 +162,7 @@ float shfl(const float& val, const int& srcLane, const int& width) {
 template <typename Scalar>
 KOKKOS_INLINE_FUNCTION Scalar
 shfl(const Scalar& val, const int& srcLane,
-     const typename Impl::enable_if<(sizeof(Scalar) == 4), int>::type& width) {
+     const typename std::enable_if<(sizeof(Scalar) == 4), int>::type& width) {
   Scalar tmp1 = val;
   float tmp   = *reinterpret_cast<float*>(&tmp1);
   tmp         = __shfl(tmp, srcLane, width);
@@ -181,7 +181,7 @@ double shfl(const double& val, const int& srcLane, const int& width) {
 template <typename Scalar>
 KOKKOS_INLINE_FUNCTION Scalar
 shfl(const Scalar& val, const int& srcLane,
-     const typename Impl::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
+     const typename std::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
   int lo           = __double2loint(*reinterpret_cast<const double*>(&val));
   int hi           = __double2hiint(*reinterpret_cast<const double*>(&val));
   lo               = __shfl(lo, srcLane, width);
@@ -193,7 +193,7 @@ shfl(const Scalar& val, const int& srcLane,
 template <typename Scalar>
 KOKKOS_INLINE_FUNCTION Scalar
 shfl(const Scalar& val, const int& srcLane,
-     const typename Impl::enable_if<(sizeof(Scalar) > 8), int>::type& width) {
+     const typename std::enable_if<(sizeof(Scalar) > 8), int>::type& width) {
   Impl::shfl_union<Scalar> s_val;
   Impl::shfl_union<Scalar> r_val;
   s_val = val;
@@ -216,7 +216,7 @@ float shfl_down(const float& val, const int& delta, const int& width) {
 template <typename Scalar>
 KOKKOS_INLINE_FUNCTION Scalar shfl_down(
     const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) == 4), int>::type& width) {
+    const typename std::enable_if<(sizeof(Scalar) == 4), int>::type& width) {
   Scalar tmp1 = val;
   float tmp   = *reinterpret_cast<float*>(&tmp1);
   tmp         = __shfl_down(tmp, delta, width);
@@ -244,7 +244,7 @@ double shfl_down(const double& val, const int& delta, const int& width) {
 template <typename Scalar>
 KOKKOS_INLINE_FUNCTION Scalar shfl_down(
     const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
+    const typename std::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
   int lo           = __double2loint(*reinterpret_cast<const double*>(&val));
   int hi           = __double2hiint(*reinterpret_cast<const double*>(&val));
   lo               = __shfl_down(lo, delta, width);
@@ -256,7 +256,7 @@ KOKKOS_INLINE_FUNCTION Scalar shfl_down(
 template <typename Scalar>
 KOKKOS_INLINE_FUNCTION Scalar shfl_down(
     const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) > 8), int>::type& width) {
+    const typename std::enable_if<(sizeof(Scalar) > 8), int>::type& width) {
   Impl::shfl_union<Scalar> s_val;
   Impl::shfl_union<Scalar> r_val;
   s_val = val;
@@ -279,7 +279,7 @@ float shfl_up(const float& val, const int& delta, const int& width) {
 template <typename Scalar>
 KOKKOS_INLINE_FUNCTION Scalar shfl_up(
     const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) == 4), int>::type& width) {
+    const typename std::enable_if<(sizeof(Scalar) == 4), int>::type& width) {
   Scalar tmp1 = val;
   float tmp   = *reinterpret_cast<float*>(&tmp1);
   tmp         = __shfl_up(tmp, delta, width);
@@ -298,7 +298,7 @@ double shfl_up(const double& val, const int& delta, const int& width) {
 template <typename Scalar>
 KOKKOS_INLINE_FUNCTION Scalar shfl_up(
     const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
+    const typename std::enable_if<(sizeof(Scalar) == 8), int>::type& width) {
   int lo           = __double2loint(*reinterpret_cast<const double*>(&val));
   int hi           = __double2hiint(*reinterpret_cast<const double*>(&val));
   lo               = __shfl_up(lo, delta, width);
@@ -308,9 +308,9 @@ KOKKOS_INLINE_FUNCTION Scalar shfl_up(
 }
 
 template <typename Scalar>
-KOKKOS_INLINE_FUNCTION Scalar shfl_up(
-    const Scalar& val, const int& delta,
-    const typename Impl::enable_if<(sizeof(Scalar) > 8), int>::type& width) {
+KOKKOS_INLINE_FUNCTION Scalar
+shfl_up(const Scalar& val, const int& delta,
+        const typename std::enable_if<(sizeof(Scalar) > 8), int>::type& width) {
   Impl::shfl_union<Scalar> s_val;
   Impl::shfl_union<Scalar> r_val;
   s_val = val;

--- a/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
+++ b/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
@@ -91,8 +91,7 @@ __inline__ __device__ unsigned long long int atomic_compare_exchange(
 template <typename T>
 __inline__ __device__ T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int), const T&>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(int), const T&>::type val) {
   const int tmp = atomicCAS((int*)dest, *((int*)&compare), *((int*)&val));
   return *((T*)&tmp);
 }
@@ -100,9 +99,9 @@ __inline__ __device__ T atomic_compare_exchange(
 template <typename T>
 __inline__ __device__ T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<
-        sizeof(T) != sizeof(int) && sizeof(T) == sizeof(unsigned long long int),
-        const T&>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) == sizeof(unsigned long long int),
+                            const T&>::type val) {
   typedef unsigned long long int type;
   const type tmp = atomicCAS((type*)dest, *((type*)&compare), *((type*)&val));
   return *((T*)&tmp);
@@ -111,8 +110,8 @@ __inline__ __device__ T atomic_compare_exchange(
 template <typename T>
 __inline__ __device__ T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8),
-                                     const T>::type& val) {
+    typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8),
+                            const T>::type& val) {
   T return_val;
   // This is a way to (hopefully) avoid dead lock in a warp
   int done = 0;
@@ -187,8 +186,7 @@ inline unsigned long atomic_compare_exchange(volatile unsigned long* const dest,
 template <typename T>
 inline T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int), const T&>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(int), const T&>::type val) {
   union U {
     int i;
     T t;
@@ -207,9 +205,9 @@ inline T atomic_compare_exchange(
 template <typename T>
 inline T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<sizeof(T) != sizeof(int) &&
-                                         sizeof(T) == sizeof(long),
-                                     const T&>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) == sizeof(long),
+                            const T&>::type val) {
   union U {
     long i;
     T t;
@@ -229,10 +227,10 @@ inline T atomic_compare_exchange(
 template <typename T>
 inline T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<sizeof(T) != sizeof(int) &&
-                                         sizeof(T) != sizeof(long) &&
-                                         sizeof(T) == sizeof(Impl::cas128_t),
-                                     const T&>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) != sizeof(long) &&
+                                sizeof(T) == sizeof(Impl::cas128_t),
+                            const T&>::type val) {
   union U {
     Impl::cas128_t i;
     T t;
@@ -252,12 +250,12 @@ inline T atomic_compare_exchange(
 template <typename T>
 inline T atomic_compare_exchange(
     volatile T* const dest, const T compare,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
+    typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
 #if defined(KOKKOS_ENABLE_ASM) && defined(KOKKOS_ENABLE_ISA_X86_64)
-                                         && (sizeof(T) != 16)
+                                && (sizeof(T) != 16)
 #endif
-                                         ,
-                                     const T>::type& val) {
+                                ,
+                            const T>::type& val) {
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);
 #endif

--- a/core/src/impl/Kokkos_Atomic_Compare_Exchange_Weak.hpp
+++ b/core/src/impl/Kokkos_Atomic_Compare_Exchange_Weak.hpp
@@ -266,8 +266,7 @@ inline unsigned long atomic_compare_exchange(volatile unsigned long* const dest,
 template <typename T>
 inline T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int), const T&>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(int), const T&>::type val) {
   union U {
     int i;
     T t;
@@ -286,9 +285,9 @@ inline T atomic_compare_exchange(
 template <typename T>
 inline T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<sizeof(T) != sizeof(int) &&
-                                         sizeof(T) == sizeof(long),
-                                     const T&>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) == sizeof(long),
+                            const T&>::type val) {
   union U {
     long i;
     T t;
@@ -308,10 +307,10 @@ inline T atomic_compare_exchange(
 template <typename T>
 inline T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<sizeof(T) != sizeof(int) &&
-                                         sizeof(T) != sizeof(long) &&
-                                         sizeof(T) == sizeof(Impl::cas128_t),
-                                     const T&>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) != sizeof(long) &&
+                                sizeof(T) == sizeof(Impl::cas128_t),
+                            const T&>::type val) {
   union U {
     Impl::cas128_t i;
     T t;
@@ -331,12 +330,12 @@ inline T atomic_compare_exchange(
 template <typename T>
 inline T atomic_compare_exchange(
     volatile T* const dest, const T compare,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
+    typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
 #if defined(KOKKOS_ENABLE_ASM) && defined(KOKKOS_ENABLE_ISA_X86_64)
-                                         && (sizeof(T) != 16)
+                                && (sizeof(T) != 16)
 #endif
-                                         ,
-                                     const T>::type& val) {
+                                ,
+                            const T>::type& val) {
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);
 #endif

--- a/core/src/impl/Kokkos_Atomic_Exchange.hpp
+++ b/core/src/impl/Kokkos_Atomic_Exchange.hpp
@@ -83,8 +83,7 @@ __inline__ __device__ unsigned long long int atomic_exchange(
 template <typename T>
 __inline__ __device__ T atomic_exchange(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int), const T&>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(int), const T&>::type val) {
   // int tmp = __ullAtomicExch( (int*) dest , *((int*)&val) );
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);
@@ -97,9 +96,9 @@ __inline__ __device__ T atomic_exchange(
 template <typename T>
 __inline__ __device__ T atomic_exchange(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<
-        sizeof(T) != sizeof(int) && sizeof(T) == sizeof(unsigned long long int),
-        const T&>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) == sizeof(unsigned long long int),
+                            const T&>::type val) {
   typedef unsigned long long int type;
 
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
@@ -112,10 +111,10 @@ __inline__ __device__ T atomic_exchange(
 }
 
 template <typename T>
-__inline__ __device__ T atomic_exchange(
-    volatile T* const dest,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8),
-                                     const T>::type& val) {
+__inline__ __device__ T
+atomic_exchange(volatile T* const dest,
+                typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8),
+                                        const T>::type& val) {
   T return_val;
   // This is a way to (hopefully) avoid dead lock in a warp
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
@@ -151,8 +150,7 @@ __inline__ __device__ T atomic_exchange(
 template <typename T>
 __inline__ __device__ void atomic_assign(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int), const T&>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(int), const T&>::type val) {
   // (void) __ullAtomicExch( (int*) dest , *((int*)&val) );
   (void)atomicExch(((int*)dest), *((int*)&val));
 }
@@ -160,9 +158,9 @@ __inline__ __device__ void atomic_assign(
 template <typename T>
 __inline__ __device__ void atomic_assign(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<
-        sizeof(T) != sizeof(int) && sizeof(T) == sizeof(unsigned long long int),
-        const T&>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) == sizeof(unsigned long long int),
+                            const T&>::type val) {
   typedef unsigned long long int type;
   // (void) __ullAtomicExch( (type*) dest , *((type*)&val) );
   (void)atomicExch(((type*)dest), *((type*)&val));
@@ -171,9 +169,9 @@ __inline__ __device__ void atomic_assign(
 template <typename T>
 __inline__ __device__ void atomic_assign(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<
-        sizeof(T) != sizeof(int) && sizeof(T) != sizeof(unsigned long long int),
-        const T&>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) != sizeof(unsigned long long int),
+                            const T&>::type val) {
   (void)atomic_exchange(dest, val);
 }
 
@@ -186,11 +184,10 @@ __inline__ __device__ void atomic_assign(
 #if defined(KOKKOS_ENABLE_GNU_ATOMICS) || defined(KOKKOS_ENABLE_INTEL_ATOMICS)
 
 template <typename T>
-inline T atomic_exchange(
-    volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int) ||
-                                         sizeof(T) == sizeof(long),
-                                     const T&>::type val) {
+inline T atomic_exchange(volatile T* const dest,
+                         typename std::enable_if<sizeof(T) == sizeof(int) ||
+                                                     sizeof(T) == sizeof(long),
+                                                 const T&>::type val) {
   typedef typename Kokkos::Impl::if_c<sizeof(T) == sizeof(int), int, long>::type
       type;
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
@@ -222,8 +219,8 @@ inline T atomic_exchange(
 template <typename T>
 inline T atomic_exchange(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(Impl::cas128_t),
-                                     const T&>::type val) {
+    typename std::enable_if<sizeof(T) == sizeof(Impl::cas128_t), const T&>::type
+        val) {
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);
 #endif
@@ -251,12 +248,12 @@ inline T atomic_exchange(
 template <typename T>
 inline T atomic_exchange(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
+    typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
 #if defined(KOKKOS_ENABLE_ASM) && defined(KOKKOS_ENABLE_ISA_X86_64)
-                                         && (sizeof(T) != 16)
+                                && (sizeof(T) != 16)
 #endif
-                                         ,
-                                     const T>::type& val) {
+                                ,
+                            const T>::type& val) {
   while (!Impl::lock_address_host_space((void*)dest))
     ;
   T return_val = *dest;
@@ -279,11 +276,10 @@ inline T atomic_exchange(
 }
 
 template <typename T>
-inline void atomic_assign(
-    volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int) ||
-                                         sizeof(T) == sizeof(long),
-                                     const T&>::type val) {
+inline void atomic_assign(volatile T* const dest,
+                          typename std::enable_if<sizeof(T) == sizeof(int) ||
+                                                      sizeof(T) == sizeof(long),
+                                                  const T&>::type val) {
   typedef typename Kokkos::Impl::if_c<sizeof(T) == sizeof(int), int, long>::type
       type;
 
@@ -314,8 +310,8 @@ inline void atomic_assign(
 template <typename T>
 inline void atomic_assign(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(Impl::cas128_t),
-                                     const T&>::type val) {
+    typename std::enable_if<sizeof(T) == sizeof(Impl::cas128_t), const T&>::type
+        val) {
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);
 #endif
@@ -338,12 +334,12 @@ inline void atomic_assign(
 template <typename T>
 inline void atomic_assign(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
+    typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
 #if defined(KOKKOS_ENABLE_ASM) && defined(KOKKOS_ENABLE_ISA_X86_64)
-                                         && (sizeof(T) != 16)
+                                && (sizeof(T) != 16)
 #endif
-                                         ,
-                                     const T>::type& val) {
+                                ,
+                            const T>::type& val) {
   while (!Impl::lock_address_host_space((void*)dest))
     ;
   // This is likely an aggregate type with a defined

--- a/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
@@ -93,8 +93,7 @@ __inline__ __device__ double atomic_fetch_add(volatile double* const dest,
 template <typename T>
 __inline__ __device__ T atomic_fetch_add(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int), const T>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(int), const T>::type val) {
   // to work around a bug in the clang cuda compiler, the name here needs to be
   // different from the one internal to the other overloads
   union U1 {
@@ -117,9 +116,9 @@ __inline__ __device__ T atomic_fetch_add(
 template <typename T>
 __inline__ __device__ T atomic_fetch_add(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<
-        sizeof(T) != sizeof(int) && sizeof(T) == sizeof(unsigned long long int),
-        const T>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) == sizeof(unsigned long long int),
+                            const T>::type val) {
   // to work around a bug in the clang cuda compiler, the name here needs to be
   // different from the one internal to the other overloads
   union U2 {
@@ -142,10 +141,10 @@ __inline__ __device__ T atomic_fetch_add(
 //----------------------------------------------------------------------------
 
 template <typename T>
-__inline__ __device__ T atomic_fetch_add(
-    volatile T* const dest,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8),
-                                     const T>::type& val) {
+__inline__ __device__ T
+atomic_fetch_add(volatile T* const dest,
+                 typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8),
+                                         const T>::type& val) {
   T return_val;
   // This is a way to (hopefully) avoid dead lock in a warp
   int done = 0;
@@ -238,8 +237,7 @@ inline unsigned long int atomic_fetch_add(
 template <typename T>
 inline T atomic_fetch_add(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int), const T>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(int), const T>::type val) {
   union U {
     int i;
     T t;
@@ -262,11 +260,10 @@ inline T atomic_fetch_add(
 }
 
 template <typename T>
-inline T atomic_fetch_add(
-    volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) != sizeof(int) &&
-                                         sizeof(T) == sizeof(long),
-                                     const T>::type val) {
+inline T atomic_fetch_add(volatile T* const dest,
+                          typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                                      sizeof(T) == sizeof(long),
+                                                  const T>::type val) {
   union U {
     long i;
     T t;
@@ -292,10 +289,10 @@ inline T atomic_fetch_add(
 template <typename T>
 inline T atomic_fetch_add(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) != sizeof(int) &&
-                                         sizeof(T) != sizeof(long) &&
-                                         sizeof(T) == sizeof(Impl::cas128_t),
-                                     const T>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) != sizeof(long) &&
+                                sizeof(T) == sizeof(Impl::cas128_t),
+                            const T>::type val) {
   union U {
     Impl::cas128_t i;
     T t;
@@ -323,12 +320,12 @@ inline T atomic_fetch_add(
 template <typename T>
 inline T atomic_fetch_add(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
+    typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
 #if defined(KOKKOS_ENABLE_ASM) && defined(KOKKOS_ENABLE_ISA_X86_64)
-                                         && (sizeof(T) != 16)
+                                && (sizeof(T) != 16)
 #endif
-                                         ,
-                                     const T>::type& val) {
+                                ,
+                            const T>::type& val) {
   while (!Impl::lock_address_host_space((void*)dest))
     ;
   T return_val = *dest;

--- a/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
@@ -92,8 +92,7 @@ __inline__ __device__ unsigned int atomic_fetch_sub(volatile double* const dest,
 template <typename T>
 __inline__ __device__ T atomic_fetch_sub(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int), const T>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(int), const T>::type val) {
   union U {
     int i;
     T t;
@@ -114,9 +113,9 @@ __inline__ __device__ T atomic_fetch_sub(
 template <typename T>
 __inline__ __device__ T atomic_fetch_sub(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<
-        sizeof(T) != sizeof(int) && sizeof(T) == sizeof(unsigned long long int),
-        const T>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) == sizeof(unsigned long long int),
+                            const T>::type val) {
   union U {
     unsigned long long int i;
     T t;
@@ -137,10 +136,10 @@ __inline__ __device__ T atomic_fetch_sub(
 //----------------------------------------------------------------------------
 
 template <typename T>
-__inline__ __device__ T atomic_fetch_sub(
-    volatile T* const dest,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8),
-                                     const T>::type& val) {
+__inline__ __device__ T
+atomic_fetch_sub(volatile T* const dest,
+                 typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8),
+                                         const T>::type& val) {
   T return_val;
   // This is a way to (hopefully) avoid dead lock in a warp
   int done = 0;
@@ -213,8 +212,7 @@ inline unsigned long int atomic_fetch_sub(
 template <typename T>
 inline T atomic_fetch_sub(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int), const T>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(int), const T>::type val) {
   union U {
     int i;
     T t;
@@ -237,11 +235,10 @@ inline T atomic_fetch_sub(
 }
 
 template <typename T>
-inline T atomic_fetch_sub(
-    volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) != sizeof(int) &&
-                                         sizeof(T) == sizeof(long),
-                                     const T>::type val) {
+inline T atomic_fetch_sub(volatile T* const dest,
+                          typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                                      sizeof(T) == sizeof(long),
+                                                  const T>::type val) {
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);
 #endif
@@ -268,8 +265,8 @@ inline T atomic_fetch_sub(
 template <typename T>
 inline T atomic_fetch_sub(
     volatile T* const dest,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8),
-                                     const T>::type& val) {
+    typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8),
+                            const T>::type& val) {
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);
 #endif

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -154,9 +154,9 @@ struct RShiftOper {
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
     const Oper& op, volatile T* const dest,
-    typename Kokkos::Impl::enable_if<
-        sizeof(T) != sizeof(int) && sizeof(T) == sizeof(unsigned long long int),
-        const T>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) == sizeof(unsigned long long int),
+                            const T>::type val) {
   union U {
     unsigned long long int i;
     T t;
@@ -178,9 +178,9 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
     const Oper& op, volatile T* const dest,
-    typename Kokkos::Impl::enable_if<
-        sizeof(T) != sizeof(int) && sizeof(T) == sizeof(unsigned long long int),
-        const T>::type val) {
+    typename std::enable_if<sizeof(T) != sizeof(int) &&
+                                sizeof(T) == sizeof(unsigned long long int),
+                            const T>::type val) {
   union U {
     unsigned long long int i;
     T t;
@@ -202,8 +202,7 @@ KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
     const Oper& op, volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int), const T>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(int), const T>::type val) {
   union U {
     int i;
     T t;
@@ -224,8 +223,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
     const Oper& op, volatile T* const dest,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(int), const T>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(int), const T>::type val) {
   union U {
     int i;
     T t;
@@ -246,8 +244,8 @@ KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
     const Oper& op, volatile T* const dest,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8),
-                                     const T>::type val) {
+    typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8), const T>::type
+        val) {
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
   while (!Impl::lock_address_host_space((void*)dest))
     ;
@@ -287,15 +285,15 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
 }
 
 template <class Oper, typename T>
-KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
-    const Oper& op, volatile T* const dest,
-    typename Kokkos::Impl::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
+KOKKOS_INLINE_FUNCTION T
+atomic_oper_fetch(const Oper& op, volatile T* const dest,
+                  typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
 #if defined(KOKKOS_ENABLE_ASM) && \
     defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-                                         && (sizeof(T) != 16)
+                                              && (sizeof(T) != 16)
 #endif
-                                         ,
-                                     const T>::type& val) {
+                                              ,
+                                          const T>::type& val) {
 
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
   while (!Impl::lock_address_host_space((void*)dest))

--- a/core/src/impl/Kokkos_Atomic_Windows.hpp
+++ b/core/src/impl/Kokkos_Atomic_Windows.hpp
@@ -73,8 +73,7 @@ __attribute__((aligned(16)))
 template <typename T>
 KOKKOS_INLINE_FUNCTION T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(LONG), const T&>::type
-        val) {
+    typename std::enable_if<sizeof(T) == sizeof(LONG), const T&>::type val) {
   union U {
     LONG i;
     T t;
@@ -89,8 +88,8 @@ KOKKOS_INLINE_FUNCTION T atomic_compare_exchange(
 template <typename T>
 KOKKOS_INLINE_FUNCTION T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(LONGLONG),
-                                     const T&>::type val) {
+    typename std::enable_if<sizeof(T) == sizeof(LONGLONG), const T&>::type
+        val) {
   union U {
     LONGLONG i;
     T t;
@@ -105,8 +104,8 @@ KOKKOS_INLINE_FUNCTION T atomic_compare_exchange(
 template <typename T>
 KOKKOS_INLINE_FUNCTION T atomic_compare_exchange(
     volatile T* const dest, const T& compare,
-    typename Kokkos::Impl::enable_if<sizeof(T) == sizeof(Impl::cas128_t),
-                                     const T&>::type val) {
+    typename std::enable_if<sizeof(T) == sizeof(Impl::cas128_t), const T&>::type
+        val) {
   union U {
     Impl::cas128_t i;
     T t;

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -63,7 +63,7 @@ struct ReduceFunctorHasInit {
 template <class FunctorType>
 struct ReduceFunctorHasInit<
     FunctorType,
-    typename Impl::enable_if<0 < sizeof(&FunctorType::init)>::type> {
+    typename std::enable_if<0 < sizeof(&FunctorType::init)>::type> {
   enum { value = true };
 };
 
@@ -75,7 +75,7 @@ struct ReduceFunctorHasJoin {
 template <class FunctorType>
 struct ReduceFunctorHasJoin<
     FunctorType,
-    typename Impl::enable_if<0 < sizeof(&FunctorType::join)>::type> {
+    typename std::enable_if<0 < sizeof(&FunctorType::join)>::type> {
   enum { value = true };
 };
 
@@ -87,7 +87,7 @@ struct ReduceFunctorHasFinal {
 template <class FunctorType>
 struct ReduceFunctorHasFinal<
     FunctorType,
-    typename Impl::enable_if<0 < sizeof(&FunctorType::final)>::type> {
+    typename std::enable_if<0 < sizeof(&FunctorType::final)>::type> {
   enum { value = true };
 };
 
@@ -99,7 +99,7 @@ struct ReduceFunctorHasShmemSize {
 template <class FunctorType>
 struct ReduceFunctorHasShmemSize<
     FunctorType,
-    typename Impl::enable_if<0 < sizeof(&FunctorType::team_shmem_size)>::type> {
+    typename std::enable_if<0 < sizeof(&FunctorType::team_shmem_size)>::type> {
   enum { value = true };
 };
 
@@ -201,8 +201,8 @@ struct FunctorValueTraits<FunctorType, ArgTag,
   // Number of values if single value
   template <class F>
   KOKKOS_FORCEINLINE_FUNCTION static
-      typename Impl::enable_if<std::is_same<F, FunctorType>::value && !IsArray,
-                               unsigned>::type
+      typename std::enable_if<std::is_same<F, FunctorType>::value && !IsArray,
+                              unsigned>::type
       value_count(const F&) {
     return 1;
   }
@@ -212,8 +212,8 @@ struct FunctorValueTraits<FunctorType, ArgTag,
   // be an array.
   template <class F>
   KOKKOS_FORCEINLINE_FUNCTION static
-      typename Impl::enable_if<std::is_same<F, FunctorType>::value && IsArray,
-                               unsigned>::type
+      typename std::enable_if<std::is_same<F, FunctorType>::value && IsArray,
+                              unsigned>::type
       value_count(const F& f) {
     return f.value_count;
   }

--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -240,27 +240,6 @@ struct remove_extent<T[N]> {
 };
 
 //----------------------------------------------------------------------------
-// C++11 Other type generators:
-
-template <bool, class T, class F>
-struct condition {
-  typedef F type;
-};
-
-template <class T, class F>
-struct condition<true, T, F> {
-  typedef T type;
-};
-
-template <bool, class = void>
-struct enable_if;
-
-template <class T>
-struct enable_if<true, T> {
-  typedef T type;
-};
-
-//----------------------------------------------------------------------------
 
 }  // namespace Impl
 }  // namespace Kokkos


### PR DESCRIPTION
There seems to be no good reason to use a custom `enable_if` or `conditional` struct.

Note that there still is `enable_if_type` struct (in `core/src/Kokkos_Parallel.hpp`) and an `enable_if` function (in `core/src/impl/Kokkos_FunctorAnalysis.hpp`).