### PR TITLE
Always fence the execution space instead of globally

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -326,7 +326,7 @@ class BinSort {
                    Kokkos::RangePolicy<execution_space>(0, len), functor);
     }
 
-    Kokkos::fence();
+    execution_space().fence();
   }
 
   template <class ValuesViewType>

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1772,7 +1772,7 @@ struct DynRankViewRemap {
     const Kokkos::Impl::ParallelFor<DynRankViewRemap, Policy> closure(
         *this, Policy(0, n0));
     closure.execute();
-    // Kokkos::fence(); // ??
+    // ExecSpace().fence(); // ??
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -186,7 +186,7 @@ template <typename ReportType, typename DeviceType>
 void ErrorReporter<ReportType, DeviceType>::resize(const size_t new_size) {
   m_reports.resize(new_size);
   m_reporters.resize(new_size);
-  Kokkos::fence();
+  typename DeviceType::execution_space().fence();
 }
 
 }  // namespace Experimental

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -415,7 +415,7 @@ class StaticCrsGraph {
 
     Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(0, numRows()),
                          partitioner);
-    Kokkos::fence();
+    typename device_type::execution_space().fence();
 
     row_block_offsets = block_offsets;
   }

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -303,7 +303,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     return m_thread_scratch_size[level];
   }
 
-  inline typename traits::execution_space space() const { return m_space; }
+  const typename traits::execution_space& space() const { return m_space; }
 
   TeamPolicyInternal()
       : m_space(typename traits::execution_space()),

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -589,6 +589,11 @@ class TeamPolicyInternal<Kokkos::Experimental::HPX, Properties...>
   template <class ExecSpace, class... OtherProperties>
   friend class TeamPolicyInternal;
 
+  const typename traits::execution_space &space() const {
+    static typename traits::execution_space m_space;
+    return m_space;
+  }
+
   template <class... OtherProperties>
   TeamPolicyInternal(const TeamPolicyInternal<Kokkos::Experimental::HPX,
                                               OtherProperties...> &p) {

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -502,7 +502,7 @@ inline void parallel_scan(
     Kokkos::Profiling::endParallelScan(kpID);
   }
 #endif
-  Kokkos::fence();
+  policy.space().fence();
 }
 
 template <class FunctorType, class ReturnType>
@@ -534,7 +534,7 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
     Kokkos::Profiling::endParallelScan(kpID);
   }
 #endif
-  Kokkos::fence();
+  execution_space().fence();
 }
 
 template <class ExecutionPolicy, class FunctorType, class ReturnType>

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -918,18 +918,21 @@ struct ReducerHasTestReferenceFunction {
   };
 };
 
-template <class T, bool is_reducer = ReducerHasTestReferenceFunction<T>::value>
+template <class ExecutionSpace, class T,
+          bool is_reducer = ReducerHasTestReferenceFunction<T>::value>
 struct ParallelReduceFence {
-  static void fence(const T&) { Kokkos::fence(); }
+  static void fence(const ExecutionSpace& execution_space, const T&) {
+    execution_space.fence();
+  }
 };
-template <class... Args>
-struct ParallelReduceFence<View<Args...>, false> {
-  static void fence(const View<Args...>){};
+template <class ExecutionSpace, class... Args>
+struct ParallelReduceFence<ExecutionSpace, View<Args...>, false> {
+  static void fence(const ExecutionSpace&, const View<Args...>){};
 };
-template <class T>
-struct ParallelReduceFence<T, true> {
-  static void fence(const T& reducer) {
-    if (reducer.references_scalar()) Kokkos::fence();
+template <class ExecutionSpace, class T>
+struct ParallelReduceFence<ExecutionSpace, T, true> {
+  static void fence(const ExecutionSpace& execution_space, const T& reducer) {
+    if (reducer.references_scalar()) execution_space.fence();
   }
 };
 }  // namespace Impl
@@ -979,7 +982,8 @@ inline void parallel_reduce(
         Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       label, policy, functor, return_value);
-  Impl::ParallelReduceFence<ReturnType>::fence(return_value);
+  Impl::ParallelReduceFence<typename PolicyType::execution_space,
+                            ReturnType>::fence(policy.space(), return_value);
 }
 
 template <class PolicyType, class FunctorType, class ReturnType>
@@ -990,7 +994,8 @@ inline void parallel_reduce(
         Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       "", policy, functor, return_value);
-  Impl::ParallelReduceFence<ReturnType>::fence(return_value);
+  Impl::ParallelReduceFence<typename PolicyType::execution_space,
+                            ReturnType>::fence(policy.space(), return_value);
 }
 
 template <class FunctorType, class ReturnType>
@@ -1000,7 +1005,8 @@ inline void parallel_reduce(const size_t& policy, const FunctorType& functor,
       void, size_t, FunctorType>::policy_type policy_type;
   Impl::ParallelReduceAdaptor<policy_type, FunctorType, ReturnType>::execute(
       "", policy_type(0, policy), functor, return_value);
-  Impl::ParallelReduceFence<ReturnType>::fence(return_value);
+  Impl::ParallelReduceFence<typename policy_type::execution_space, ReturnType>::
+      fence(typename policy_type::execution_space(), return_value);
 }
 
 template <class FunctorType, class ReturnType>
@@ -1011,7 +1017,8 @@ inline void parallel_reduce(const std::string& label, const size_t& policy,
       void, size_t, FunctorType>::policy_type policy_type;
   Impl::ParallelReduceAdaptor<policy_type, FunctorType, ReturnType>::execute(
       label, policy_type(0, policy), functor, return_value);
-  Impl::ParallelReduceFence<ReturnType>::fence(return_value);
+  Impl::ParallelReduceFence<typename policy_type::execution_space, ReturnType>::
+      fence(typename policy_type::execution_space(), return_value);
 }
 
 // ReturnValue as View or Reducer: take by copy to allow for inline construction
@@ -1025,7 +1032,8 @@ inline void parallel_reduce(
   ReturnType return_value_impl = return_value;
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       label, policy, functor, return_value_impl);
-  Impl::ParallelReduceFence<ReturnType>::fence(return_value);
+  Impl::ParallelReduceFence<typename PolicyType::execution_space,
+                            ReturnType>::fence(policy.space(), return_value);
 }
 
 template <class PolicyType, class FunctorType, class ReturnType>
@@ -1037,7 +1045,8 @@ inline void parallel_reduce(
   ReturnType return_value_impl = return_value;
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       "", policy, functor, return_value_impl);
-  Impl::ParallelReduceFence<ReturnType>::fence(return_value);
+  Impl::ParallelReduceFence<typename PolicyType::execution_space,
+                            ReturnType>::fence(policy.space(), return_value);
 }
 
 template <class FunctorType, class ReturnType>
@@ -1048,7 +1057,8 @@ inline void parallel_reduce(const size_t& policy, const FunctorType& functor,
   ReturnType return_value_impl = return_value;
   Impl::ParallelReduceAdaptor<policy_type, FunctorType, ReturnType>::execute(
       "", policy_type(0, policy), functor, return_value_impl);
-  Impl::ParallelReduceFence<ReturnType>::fence(return_value);
+  Impl::ParallelReduceFence<typename policy_type::execution_space, ReturnType>::
+      fence(typename policy_type::execution_space(), return_value);
 }
 
 template <class FunctorType, class ReturnType>
@@ -1060,7 +1070,8 @@ inline void parallel_reduce(const std::string& label, const size_t& policy,
   ReturnType return_value_impl = return_value;
   Impl::ParallelReduceAdaptor<policy_type, FunctorType, ReturnType>::execute(
       label, policy_type(0, policy), functor, return_value_impl);
-  Impl::ParallelReduceFence<ReturnType>::fence(return_value);
+  Impl::ParallelReduceFence<typename policy_type::execution_space, ReturnType>::
+      fence(typename policy_type::execution_space(), return_value);
 }
 
 // No Return Argument

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -256,6 +256,11 @@ class TeamPolicyInternal<Kokkos::Serial, Properties...>
   //! Execution space of this execution policy:
   typedef Kokkos::Serial execution_space;
 
+  const typename traits::execution_space& space() const {
+    static typename traits::execution_space m_space;
+    return m_space;
+  }
+
   TeamPolicyInternal& operator=(const TeamPolicyInternal& p) {
     m_league_size            = p.m_league_size;
     m_team_scratch_size[0]   = p.m_team_scratch_size[0];

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1877,8 +1877,8 @@ class View : public ViewTraits<DataType, Properties...> {
     // If allocating in CudaUVMSpace must fence before and after
     // the allocation to protect against possible concurrent access
     // on the CPU and the GPU.
-    // Fence using the trait's executon space (which will be Kokkos::Cuda)
-    // to avoid incomplete type errors from usng Kokkos::Cuda directly.
+    // Fence using the trait's execution space (which will be Kokkos::Cuda)
+    // to avoid incomplete type errors from using Kokkos::Cuda directly.
     if (std::is_same<Kokkos::CudaUVMSpace,
                      typename traits::device_type::memory_space>::value) {
       typename traits::device_type::memory_space::execution_space().fence();

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -61,6 +61,11 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
 
   typedef PolicyTraits<Properties...> traits;
 
+  const typename traits::execution_space& space() const {
+    static typename traits::execution_space m_space;
+    return m_space;
+  }
+
   TeamPolicyInternal& operator=(const TeamPolicyInternal& p) {
     m_league_size            = p.m_league_size;
     m_team_size              = p.m_team_size;

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -606,6 +606,11 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
 
   typedef PolicyTraits<Properties...> traits;
 
+  const typename traits::execution_space& space() const {
+    static typename traits::execution_space m_space;
+    return m_space;
+  }
+
   TeamPolicyInternal& operator=(const TeamPolicyInternal& p) {
     m_league_size            = p.m_league_size;
     m_team_size              = p.m_team_size;


### PR DESCRIPTION
This pull request replaces all `Kokkos::fence` (except for the ones in `core/src/impl/Kokkos_Profiling_Interface.cpp`) by ones for the respective execution space.

Hence, it should address #2659.