### PR TITLE
Fix StackTrace test using shared libraries

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -286,12 +286,14 @@ KOKKOS_ADD_TEST_EXECUTABLE(
     TestStackTrace_f3.cpp
     TestStackTrace_f4.cpp
 )
+# We need -rdynamic on GNU platforms for the stacktrace functionality
+# to work correctly with shared libraries
+SET_PROPERTY(TARGET StackTraceTestExec PROPERTY ENABLE_EXPORTS 1)
 
 KOKKOS_ADD_TEST( NAME UnitTest_StackTraceTest_normal
                  EXE  StackTraceTestExec
                  FAIL_REGULAR_EXPRESSION "FAILED"
                )
-
 
 KOKKOS_ADD_TEST( NAME UnitTest_StackTraceTest_terminate
                  EXE  StackTraceTestExec


### PR DESCRIPTION
Fixes #2613 and supersedes #2673.
Admittedly, this is a minimalistic fix just intended for the test to work. Users might still need to add `-rdynamic` or similar themselves for the functionality to work in their projects.
