### PR TITLE
Use nullptr

### DIFF
--- a/benchmarks/gups/gups-kokkos.cc
+++ b/benchmarks/gups/gups-kokkos.cc
@@ -60,7 +60,7 @@ typedef int GUPSIndex;
 
 double now() {
 	struct timeval now;
-	gettimeofday(&now, NULL);
+	gettimeofday(&now, nullptr);
 
 	return (double) now.tv_sec + ((double) now.tv_usec * 1.0e-6);
 }

--- a/benchmarks/stream/stream-kokkos.cc
+++ b/benchmarks/stream/stream-kokkos.cc
@@ -63,7 +63,7 @@ typedef int StreamIndex;
 
 double now() {
 	struct timeval now;
-	gettimeofday(&now, NULL);
+	gettimeofday(&now, nullptr);
 
 	return (double) now.tv_sec + ((double) now.tv_usec * 1.0e-6);
 }

--- a/cmake/compile_tests/pthread.cpp
+++ b/cmake/compile_tests/pthread.cpp
@@ -4,7 +4,7 @@ void* kokkos_test(void* args) { return args; }
 
 int main(void) {
   pthread_t thread;
-  pthread_create(&thread, NULL, kokkos_test, NULL);
-  pthread_join(thread, NULL);
+  pthread_create(&thread, nullptr, kokkos_test, nullptr);
+  pthread_join(thread, nullptr);
   return 0;
 }

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -474,7 +474,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                               typename traits::non_const_data_type>::value) ||
                     (std::is_same<Device, int>::value),
                 int>::type& = 0) {
-    if (modified_flags.data() == NULL) return;
+    if (modified_flags.data() == nullptr) return;
 
     int dev = get_device_side<Device>();
 
@@ -503,7 +503,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                                typename traits::non_const_data_type>::value) ||
                     (std::is_same<Device, int>::value),
                 int>::type& = 0) {
-    if (modified_flags.data() == NULL) return;
+    if (modified_flags.data() == nullptr) return;
 
     int dev = get_device_side<Device>();
 
@@ -526,7 +526,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                       typename traits::non_const_data_type>::value)
       Impl::throw_runtime_exception(
           "Calling sync_host on a DualView with a const datatype.");
-    if (modified_flags.data() == NULL) return;
+    if (modified_flags.data() == nullptr) return;
     if (modified_flags(1) > modified_flags(0)) {
       deep_copy(h_view, d_view);
       modified_flags(1) = modified_flags(0) = 0;
@@ -538,7 +538,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                       typename traits::non_const_data_type>::value)
       Impl::throw_runtime_exception(
           "Calling sync_device on a DualView with a const datatype.");
-    if (modified_flags.data() == NULL) return;
+    if (modified_flags.data() == nullptr) return;
     if (modified_flags(0) > modified_flags(1)) {
       deep_copy(d_view, h_view);
       modified_flags(1) = modified_flags(0) = 0;
@@ -547,7 +547,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
 
   template <class Device>
   bool need_sync() const {
-    if (modified_flags.data() == NULL) return false;
+    if (modified_flags.data() == nullptr) return false;
     int dev = get_device_side<Device>();
 
     if (dev == 1) {  // if Device is the same as DualView's device type
@@ -564,12 +564,12 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   }
 
   inline bool need_sync_host() const {
-    if (modified_flags.data() == NULL) return false;
+    if (modified_flags.data() == nullptr) return false;
     return modified_flags(0) < modified_flags(1);
   }
 
   inline bool need_sync_device() const {
-    if (modified_flags.data() == NULL) return false;
+    if (modified_flags.data() == nullptr) return false;
     return modified_flags(1) < modified_flags(0);
   }
 
@@ -580,7 +580,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   /// data as modified.
   template <class Device>
   void modify() {
-    if (modified_flags.data() == NULL) return;
+    if (modified_flags.data() == nullptr) return;
     int dev = get_device_side<Device>();
 
     if (dev == 1) {  // if Device is the same as DualView's device type
@@ -611,7 +611,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   }
 
   inline void modify_host() {
-    if (modified_flags.data() != NULL) {
+    if (modified_flags.data() != nullptr) {
       modified_flags(0) =
           (modified_flags(1) > modified_flags(0) ? modified_flags(1)
                                                  : modified_flags(0)) +
@@ -630,7 +630,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   }
 
   inline void modify_device() {
-    if (modified_flags.data() != NULL) {
+    if (modified_flags.data() != nullptr) {
       modified_flags(1) =
           (modified_flags(1) > modified_flags(0) ? modified_flags(1)
                                                  : modified_flags(0)) +
@@ -649,7 +649,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   }
 
   inline void clear_sync_state() {
-    if (modified_flags.data() != NULL)
+    if (modified_flags.data() != nullptr)
       modified_flags(1) = modified_flags(0) = 0;
   }
 
@@ -674,7 +674,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     h_view = create_mirror_view(d_view);
 
     /* Reset dirty flags */
-    if (modified_flags.data() == NULL) {
+    if (modified_flags.data() == nullptr) {
       modified_flags = t_modified_flags("DualView::modified_flags");
     } else
       modified_flags(1) = modified_flags(0) = 0;
@@ -692,7 +692,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
               const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
               const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
               const size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG) {
-    if (modified_flags.data() == NULL) {
+    if (modified_flags.data() == nullptr) {
       modified_flags = t_modified_flags("DualView::modified_flags");
     }
     if (modified_flags(1) >= modified_flags(0)) {

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1805,7 +1805,8 @@ inline void deep_copy(
     const DynRankView<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<std::is_same<
-        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* = 0) {
+        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* =
+        nullptr) {
   static_assert(
       std::is_same<typename ViewTraits<DT, DP...>::non_const_value_type,
                    typename ViewTraits<DT, DP...>::value_type>::value,
@@ -1842,7 +1843,7 @@ inline void deep_copy(
         (std::is_same<typename DstType::traits::specialize, void>::value &&
          std::is_same<typename SrcType::traits::specialize, void>::value &&
          (Kokkos::is_dyn_rank_view<DstType>::value ||
-          Kokkos::is_dyn_rank_view<SrcType>::value))>::type* = 0) {
+          Kokkos::is_dyn_rank_view<SrcType>::value))>::type* = nullptr) {
   static_assert(
       std::is_same<typename DstType::traits::value_type,
                    typename DstType::traits::non_const_value_type>::value,
@@ -2008,7 +2009,7 @@ inline typename DynRankView<T, P...>::HostMirror create_mirror(
     typename std::enable_if<
         std::is_same<typename ViewTraits<T, P...>::specialize, void>::value &&
         !std::is_same<typename Kokkos::ViewTraits<T, P...>::array_layout,
-                      Kokkos::LayoutStride>::value>::type* = 0) {
+                      Kokkos::LayoutStride>::value>::type* = nullptr) {
   typedef DynRankView<T, P...> src_type;
   typedef typename src_type::HostMirror dst_type;
 
@@ -2035,7 +2036,8 @@ template <class Space, class T, class... P>
 typename Impl::MirrorDRVType<Space, T, P...>::view_type create_mirror(
     const Space&, const Kokkos::DynRankView<T, P...>& src,
     typename std::enable_if<std::is_same<
-        typename ViewTraits<T, P...>::specialize, void>::value>::type* = 0) {
+        typename ViewTraits<T, P...>::specialize, void>::value>::type* =
+        nullptr) {
   return typename Impl::MirrorDRVType<Space, T, P...>::view_type(
       src.label(), Impl::reconstructLayout(src.layout(), src.rank()));
 }
@@ -2049,7 +2051,7 @@ inline typename DynRankView<T, P...>::HostMirror create_mirror_view(
              typename DynRankView<T, P...>::HostMirror::memory_space>::value &&
          std::is_same<typename DynRankView<T, P...>::data_type,
                       typename DynRankView<T, P...>::HostMirror::data_type>::
-             value)>::type* = 0) {
+             value)>::type* = nullptr) {
   return src;
 }
 
@@ -2071,7 +2073,8 @@ template <class Space, class T, class... P>
 typename Impl::MirrorDRViewType<Space, T, P...>::view_type create_mirror_view(
     const Space&, const Kokkos::DynRankView<T, P...>& src,
     typename std::enable_if<
-        Impl::MirrorDRViewType<Space, T, P...>::is_same_memspace>::type* = 0) {
+        Impl::MirrorDRViewType<Space, T, P...>::is_same_memspace>::type* =
+        nullptr) {
   return src;
 }
 
@@ -2093,7 +2096,8 @@ create_mirror_view_and_copy(
     const Space&, const Kokkos::DynRankView<T, P...>& src,
     std::string const& name = "",
     typename std::enable_if<
-        Impl::MirrorDRViewType<Space, T, P...>::is_same_memspace>::type* = 0) {
+        Impl::MirrorDRViewType<Space, T, P...>::is_same_memspace>::type* =
+        nullptr) {
   (void)name;
   return src;
 }

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -264,7 +264,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
     // If not bounds checking then we assume a non-zero pointer is valid.
 
 #if !defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-    if (0 == *ch)
+    if (nullptr == *ch)
 #endif
     {
       // Verify that allocation of the requested chunk in in progress.
@@ -279,7 +279,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
 
       // Allocation of this chunk is in progress
       // so wait for allocation to complete.
-      while (0 == *ch)
+      while (nullptr == *ch)
         ;
     }
 
@@ -324,7 +324,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
         --*pc;
         typename traits::memory_space().deallocate(
             m_chunks[*pc], sizeof(local_value_type) << m_chunk_shift);
-        m_chunks[*pc] = 0;
+        m_chunks[*pc] = nullptr;
       }
     }
     // *m_chunks[m_chunk_max+1] stores the 'extent' requested by resize
@@ -365,10 +365,10 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
     // Initialize or destroy array of chunk pointers.
     // Two entries beyond the max chunks are allocation counters.
     inline void operator()(unsigned i) const {
-      if (m_destroy && i < m_chunk_max && 0 != m_chunks[i]) {
+      if (m_destroy && i < m_chunk_max && nullptr != m_chunks[i]) {
         typename traits::memory_space().deallocate(m_chunks[i], m_chunk_size);
       }
-      m_chunks[i] = 0;
+      m_chunks[i] = nullptr;
     }
 
     void execute(bool arg_destroy) {
@@ -418,7 +418,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
                               const unsigned min_chunk_size,
                               const unsigned max_extent)
       : m_track(),
-        m_chunks(0)
+        m_chunks(nullptr)
         // The chunk size is guaranteed to be a power of two
         ,
         m_chunk_shift(Kokkos::Impl::integral_power_of_two_that_contains(

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1832,7 +1832,8 @@ inline void deep_copy(
     const OffsetView<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<std::is_same<
-        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* = 0) {
+        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* =
+        nullptr) {
   static_assert(
       std::is_same<typename ViewTraits<DT, DP...>::non_const_value_type,
                    typename ViewTraits<DT, DP...>::value_type>::value,
@@ -1846,7 +1847,8 @@ template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const OffsetView<DT, DP...>& dst, const OffsetView<ST, SP...>& value,
     typename std::enable_if<std::is_same<
-        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* = 0) {
+        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* =
+        nullptr) {
   static_assert(
       std::is_same<typename ViewTraits<DT, DP...>::value_type,
                    typename ViewTraits<ST, SP...>::non_const_value_type>::value,
@@ -1859,7 +1861,8 @@ template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const OffsetView<DT, DP...>& dst, const View<ST, SP...>& value,
     typename std::enable_if<std::is_same<
-        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* = 0) {
+        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* =
+        nullptr) {
   static_assert(
       std::is_same<typename ViewTraits<DT, DP...>::value_type,
                    typename ViewTraits<ST, SP...>::non_const_value_type>::value,
@@ -1873,7 +1876,8 @@ template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
     const View<DT, DP...>& dst, const OffsetView<ST, SP...>& value,
     typename std::enable_if<std::is_same<
-        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* = 0) {
+        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* =
+        nullptr) {
   static_assert(
       std::is_same<typename ViewTraits<DT, DP...>::value_type,
                    typename ViewTraits<ST, SP...>::non_const_value_type>::value,
@@ -2011,7 +2015,7 @@ create_mirror_view(
          std::is_same<
              typename Kokkos::Experimental::OffsetView<T, P...>::data_type,
              typename Kokkos::Experimental::OffsetView<
-                 T, P...>::HostMirror::data_type>::value)>::type* = 0) {
+                 T, P...>::HostMirror::data_type>::value)>::type* = nullptr) {
   return src;
 }
 

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -395,7 +395,7 @@ class StaticCrsGraph {
     const data_type count = static_cast<data_type>(row_map(i + 1) - start);
 
     if (count == 0) {
-      return GraphRowViewConst<StaticCrsGraph>(NULL, 1, 0);
+      return GraphRowViewConst<StaticCrsGraph>(nullptr, 1, 0);
     } else {
       return GraphRowViewConst<StaticCrsGraph>(entries, 1, count, start);
     }

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -1077,12 +1077,12 @@ class TestDynViewAPI {
     ASSERT_TRUE(Kokkos::is_dyn_rank_view<dView0>::value);
     ASSERT_FALSE(Kokkos::is_dyn_rank_view<Kokkos::View<double> >::value);
 
-    ASSERT_TRUE(dx.data() == 0);  // Okay with UVM
-    ASSERT_TRUE(dy.data() == 0);  // Okay with UVM
-    ASSERT_TRUE(dz.data() == 0);  // Okay with UVM
-    ASSERT_TRUE(hx.data() == 0);
-    ASSERT_TRUE(hy.data() == 0);
-    ASSERT_TRUE(hz.data() == 0);
+    ASSERT_TRUE(dx.data() == nullptr);  // Okay with UVM
+    ASSERT_TRUE(dy.data() == nullptr);  // Okay with UVM
+    ASSERT_TRUE(dz.data() == nullptr);  // Okay with UVM
+    ASSERT_TRUE(hx.data() == nullptr);
+    ASSERT_TRUE(hy.data() == nullptr);
+    ASSERT_TRUE(hz.data() == nullptr);
     ASSERT_EQ(dx.extent(0), 0u);  // Okay with UVM
     ASSERT_EQ(dy.extent(0), 0u);  // Okay with UVM
     ASSERT_EQ(dz.extent(0), 0u);  // Okay with UVM
@@ -1153,11 +1153,11 @@ class TestDynViewAPI {
 
     ASSERT_EQ(dx.use_count(), size_t(2));
 
-    ASSERT_FALSE(dx.data() == 0);
-    ASSERT_FALSE(const_dx.data() == 0);
-    ASSERT_FALSE(unmanaged_dx.data() == 0);
-    ASSERT_FALSE(unmanaged_from_ptr_dx.data() == 0);
-    ASSERT_FALSE(dy.data() == 0);
+    ASSERT_FALSE(dx.data() == nullptr);
+    ASSERT_FALSE(const_dx.data() == nullptr);
+    ASSERT_FALSE(unmanaged_dx.data() == nullptr);
+    ASSERT_FALSE(unmanaged_from_ptr_dx.data() == nullptr);
+    ASSERT_FALSE(dy.data() == nullptr);
     ASSERT_NE(dx, dy);
 
     ASSERT_EQ(dx.extent(0), unsigned(N0));
@@ -1317,17 +1317,17 @@ class TestDynViewAPI {
     ASSERT_NE(dx, dz);
 
     dx = dView0();
-    ASSERT_TRUE(dx.data() == 0);
-    ASSERT_FALSE(dy.data() == 0);
-    ASSERT_FALSE(dz.data() == 0);
+    ASSERT_TRUE(dx.data() == nullptr);
+    ASSERT_FALSE(dy.data() == nullptr);
+    ASSERT_FALSE(dz.data() == nullptr);
     dy = dView0();
-    ASSERT_TRUE(dx.data() == 0);
-    ASSERT_TRUE(dy.data() == 0);
-    ASSERT_FALSE(dz.data() == 0);
+    ASSERT_TRUE(dx.data() == nullptr);
+    ASSERT_TRUE(dy.data() == nullptr);
+    ASSERT_FALSE(dz.data() == nullptr);
     dz = dView0();
-    ASSERT_TRUE(dx.data() == 0);
-    ASSERT_TRUE(dy.data() == 0);
-    ASSERT_TRUE(dz.data() == 0);
+    ASSERT_TRUE(dx.data() == nullptr);
+    ASSERT_TRUE(dy.data() == nullptr);
+    ASSERT_TRUE(dz.data() == nullptr);
 
     // View - DynRankView Interoperability tests
     // deep_copy from view to dynrankview

--- a/core/perf_test/PerfTestMain.cpp
+++ b/core/perf_test/PerfTestMain.cpp
@@ -53,13 +53,13 @@ int command_line_num_args(int n = 0) {
   return n_args;
 }
 
-const char* command_line_arg(int k, char** input_args = NULL) {
+const char* command_line_arg(int k, char** input_args = nullptr) {
   static char** args;
-  if (input_args != NULL) args = input_args;
+  if (input_args != nullptr) args = input_args;
   if (command_line_num_args() > k)
     return args[k];
   else
-    return NULL;
+    return nullptr;
 }
 
 }  // namespace Test

--- a/core/perf_test/PerfTest_Category.hpp
+++ b/core/perf_test/PerfTest_Category.hpp
@@ -49,7 +49,7 @@
 namespace Test {
 
 extern int command_line_num_args(int n = 0);
-extern const char* command_line_arg(int k, char** input_args = NULL);
+extern const char* command_line_arg(int k, char** input_args = nullptr);
 
 }  // namespace Test
 

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -359,7 +359,8 @@ SharedAllocationRecord<Kokkos::CudaSpace, void>::attach_texture_object(
   resDesc.res.linear.sizeInBytes = alloc_size;
   resDesc.res.linear.devPtr      = alloc_ptr;
 
-  CUDA_SAFE_CALL(cudaCreateTextureObject(&tex_obj, &resDesc, &texDesc, NULL));
+  CUDA_SAFE_CALL(
+      cudaCreateTextureObject(&tex_obj, &resDesc, &texDesc, nullptr));
 
   return tex_obj;
 }
@@ -894,7 +895,7 @@ void SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::print_records(
 //==============================================================================
 
 void *cuda_resize_scratch_space(std::int64_t bytes, bool force_shrink) {
-  static void *ptr                 = NULL;
+  static void *ptr                 = nullptr;
   static std::int64_t current_size = 0;
   if (current_size == 0) {
     current_size = bytes;

--- a/core/src/Cuda/Kokkos_Cuda_Error.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Error.hpp
@@ -57,10 +57,10 @@ namespace Impl {
 void cuda_device_synchronize();
 
 void cuda_internal_error_throw(cudaError e, const char* name,
-                               const char* file = NULL, const int line = 0);
+                               const char* file = nullptr, const int line = 0);
 
 inline void cuda_internal_safe_call(cudaError e, const char* name,
-                                    const char* file = NULL,
+                                    const char* file = nullptr,
                                     const int line   = 0) {
   if (cudaSuccess != e) {
     cuda_internal_error_throw(e, name, file, line);

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -149,7 +149,7 @@ template <class DriverType>
 __global__ static void cuda_parallel_launch_constant_or_global_memory(
     const DriverType* driver_ptr) {
   const DriverType& driver =
-      driver_ptr != NULL
+      driver_ptr != nullptr
           ? *driver_ptr
           : *((const DriverType*)kokkos_impl_cuda_constant_memory_buffer);
 
@@ -161,7 +161,7 @@ __global__
 __launch_bounds__(maxTperB, minBperSM) static void cuda_parallel_launch_constant_or_global_memory(
     const DriverType* driver_ptr) {
   const DriverType& driver =
-      driver_ptr != NULL
+      driver_ptr != nullptr
           ? *driver_ptr
           : *((const DriverType*)kokkos_impl_cuda_constant_memory_buffer);
 
@@ -468,7 +468,7 @@ struct CudaParallelLaunch<
 
       KOKKOS_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
 
-      DriverType* driver_ptr = NULL;
+      DriverType* driver_ptr = nullptr;
       driver_ptr             = reinterpret_cast<DriverType*>(
           cuda_instance->scratch_functor(sizeof(DriverType)));
       cudaMemcpyAsync(driver_ptr, &driver, sizeof(DriverType),
@@ -519,7 +519,7 @@ struct CudaParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
 
       KOKKOS_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
 
-      DriverType* driver_ptr = NULL;
+      DriverType* driver_ptr = nullptr;
       driver_ptr             = reinterpret_cast<DriverType*>(
           cuda_instance->scratch_functor(sizeof(DriverType)));
       cudaMemcpyAsync(driver_ptr, &driver, sizeof(DriverType),

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -894,10 +894,10 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
     // Functor's reduce memory, team scan memory, and team shared memory depend
     // upon team size.
-    m_scratch_ptr[0] = NULL;
+    m_scratch_ptr[0] = nullptr;
     m_scratch_ptr[1] =
         m_team_size <= 0
-            ? NULL
+            ? nullptr
             : cuda_resize_scratch_space(
                   static_cast<ptrdiff_t>(m_scratch_size[1]) *
                   static_cast<ptrdiff_t>(Cuda::concurrency() /
@@ -1206,7 +1206,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
                  const ViewType& arg_result,
                  typename std::enable_if<Kokkos::is_view<ViewType>::value,
-                                         void*>::type = NULL)
+                                         void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),
@@ -1498,7 +1498,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
                  const ViewType& arg_result,
                  typename std::enable_if<Kokkos::is_view<ViewType>::value,
-                                         void*>::type = NULL)
+                                         void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),
@@ -1809,7 +1809,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
                  const ViewType& arg_result,
                  typename std::enable_if<Kokkos::is_view<ViewType>::value,
-                                         void*>::type = NULL)
+                                         void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),
@@ -1823,7 +1823,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         m_team_begin(0),
         m_shmem_begin(0),
         m_shmem_size(0),
-        m_scratch_ptr{NULL, NULL},
+        m_scratch_ptr{nullptr, nullptr},
         m_league_size(arg_policy.league_size()),
         m_team_size(arg_policy.team_size()),
         m_vector_size(arg_policy.vector_length()) {
@@ -1860,7 +1860,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     m_scratch_size[1] = m_policy.scratch_size(1, m_team_size);
     m_scratch_ptr[1] =
         m_team_size <= 0
-            ? NULL
+            ? nullptr
             : cuda_resize_scratch_space(
                   static_cast<std::int64_t>(m_scratch_size[1]) *
                   (static_cast<std::int64_t>(Cuda::concurrency() /
@@ -1922,7 +1922,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         m_team_begin(0),
         m_shmem_begin(0),
         m_shmem_size(0),
-        m_scratch_ptr{NULL, NULL},
+        m_scratch_ptr{nullptr, nullptr},
         m_league_size(arg_policy.league_size()),
         m_team_size(arg_policy.team_size()),
         m_vector_size(arg_policy.vector_length()) {
@@ -1959,7 +1959,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     m_scratch_size[1] = m_policy.scratch_size(1, m_team_size);
     m_scratch_ptr[1] =
         m_team_size <= 0
-            ? NULL
+            ? nullptr
             : cuda_resize_scratch_space(
                   static_cast<ptrdiff_t>(m_scratch_size[1]) *
                   static_cast<ptrdiff_t>(Cuda::concurrency() /

--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -249,7 +249,7 @@ class ViewDataHandle<
   KOKKOS_INLINE_FUNCTION
   static handle_type assign(value_type* arg_data_ptr,
                             track_type const& arg_tracker) {
-    if (arg_data_ptr == NULL) return handle_type();
+    if (arg_data_ptr == nullptr) return handle_type();
 
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
     // Assignment of texture = non-texture requires creation of a texture object

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1434,7 +1434,7 @@ inline void deep_copy(
   }
 #endif
 
-  if (dst.data() == NULL) {
+  if (dst.data() == nullptr) {
     Kokkos::fence();
 #if defined(KOKKOS_ENABLE_PROFILING)
     if (Kokkos::Profiling::profileLibraryLoaded()) {
@@ -1558,7 +1558,7 @@ inline void deep_copy(
   }
 #endif
 
-  if (src.data() == NULL) {
+  if (src.data() == nullptr) {
     Kokkos::fence();
 #if defined(KOKKOS_ENABLE_PROFILING)
     if (Kokkos::Profiling::profileLibraryLoaded()) {
@@ -1608,7 +1608,7 @@ inline void deep_copy(
   }
 #endif
 
-  if (dst.data() == NULL && src.data() == NULL) {
+  if (dst.data() == nullptr && src.data() == nullptr) {
     Kokkos::fence();
 #if defined(KOKKOS_ENABLE_PROFILING)
     if (Kokkos::Profiling::profileLibraryLoaded()) {
@@ -1669,7 +1669,7 @@ inline void deep_copy(
   }
 #endif
 
-  if (dst.data() == NULL || src.data() == NULL) {
+  if (dst.data() == nullptr || src.data() == nullptr) {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     // do nothing
 #else
@@ -2677,7 +2677,7 @@ inline void deep_copy(
   }
 #endif
 
-  if (src.data() == NULL) {
+  if (src.data() == nullptr) {
     exec_space.fence();
 #if defined(KOKKOS_ENABLE_PROFILING)
     if (Kokkos::Profiling::profileLibraryLoaded()) {
@@ -2726,7 +2726,7 @@ inline void deep_copy(
   }
 #endif
 
-  if (dst.data() == NULL && src.data() == NULL) {
+  if (dst.data() == nullptr && src.data() == nullptr) {
     exec_space.fence();
 #if defined(KOKKOS_ENABLE_PROFILING)
     if (Kokkos::Profiling::profileLibraryLoaded()) {
@@ -2790,7 +2790,7 @@ inline void deep_copy(
   }
 #endif
 
-  if (dst.data() == NULL || src.data() == NULL) {
+  if (dst.data() == nullptr || src.data() == nullptr) {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     // do nothing
 #else

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1420,7 +1420,8 @@ inline void deep_copy(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<std::is_same<
-        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* = 0) {
+        typename ViewTraits<DT, DP...>::specialize, void>::value>::type* =
+        nullptr) {
   typedef View<DT, DP...> ViewType;
 
 #if defined(KOKKOS_ENABLE_PROFILING)
@@ -1541,7 +1542,8 @@ inline void deep_copy(
     typename ViewTraits<ST, SP...>::non_const_value_type& dst,
     const View<ST, SP...>& src,
     typename std::enable_if<std::is_same<
-        typename ViewTraits<ST, SP...>::specialize, void>::value>::type* = 0) {
+        typename ViewTraits<ST, SP...>::specialize, void>::value>::type* =
+        nullptr) {
   typedef ViewTraits<ST, SP...> src_traits;
   typedef typename src_traits::memory_space src_memory_space;
 
@@ -1586,7 +1588,8 @@ inline void deep_copy(
         std::is_same<typename ViewTraits<DT, DP...>::specialize, void>::value &&
         std::is_same<typename ViewTraits<ST, SP...>::specialize, void>::value &&
         (unsigned(ViewTraits<DT, DP...>::rank) == unsigned(0) &&
-         unsigned(ViewTraits<ST, SP...>::rank) == unsigned(0)))>::type* = 0) {
+         unsigned(ViewTraits<ST, SP...>::rank) == unsigned(0)))>::type* =
+        nullptr) {
   typedef View<DT, DP...> dst_type;
   typedef View<ST, SP...> src_type;
 
@@ -1642,7 +1645,7 @@ inline void deep_copy(
         std::is_same<typename ViewTraits<DT, DP...>::specialize, void>::value &&
         std::is_same<typename ViewTraits<ST, SP...>::specialize, void>::value &&
         (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
-         unsigned(ViewTraits<ST, SP...>::rank) != 0))>::type* = 0) {
+         unsigned(ViewTraits<ST, SP...>::rank) != 0))>::type* = nullptr) {
   typedef View<DT, DP...> dst_type;
   typedef View<ST, SP...> src_type;
   typedef typename dst_type::execution_space dst_execution_space;
@@ -1873,7 +1876,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 1 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 1)>::type* = 0) {
+                                 1)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -1892,7 +1895,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 2 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 2)>::type* = 0) {
+                                 2)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -1920,7 +1923,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 3 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 3)>::type* = 0) {
+                                 3)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -1950,7 +1953,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 4 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 4)>::type* = 0) {
+                                 4)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -1983,7 +1986,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 5 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 5)>::type* = 0) {
+                                 5)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2018,7 +2021,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 6 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 6)>::type* = 0) {
+                                 6)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2055,7 +2058,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 7 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 7)>::type* = 0) {
+                                 7)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2094,7 +2097,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 1 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 1)>::type* = 0) {
+                                 1)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2111,7 +2114,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 2 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 2)>::type* = 0) {
+                                 2)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2129,7 +2132,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 3 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 3)>::type* = 0) {
+                                 3)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2149,7 +2152,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 4 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 4)>::type* = 0) {
+                                 4)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2170,7 +2173,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 5 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 5)>::type* = 0) {
+                                 5)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2192,7 +2195,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 6 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 6)>::type* = 0) {
+                                 6)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2215,7 +2218,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst, const View<ST, SP...>& src,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) == 7 &&
                              unsigned(ViewTraits<ST, SP...>::rank) ==
-                                 7)>::type* = 0) {
+                                 7)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2259,7 +2262,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const TeamType& team, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             1)>::type* = 0) {
+                             1)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2277,7 +2280,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const TeamType& team, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             2)>::type* = 0) {
+                             2)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2304,7 +2307,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const TeamType& team, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             3)>::type* = 0) {
+                             3)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2333,7 +2336,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const TeamType& team, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             4)>::type* = 0) {
+                             4)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2365,7 +2368,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const TeamType& team, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             5)>::type* = 0) {
+                             5)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2399,7 +2402,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const TeamType& team, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             6)>::type* = 0) {
+                             6)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2435,7 +2438,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const TeamType& team, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             7)>::type* = 0) {
+                             7)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2474,7 +2477,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             1)>::type* = 0) {
+                             1)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2491,7 +2494,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             2)>::type* = 0) {
+                             2)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2509,7 +2512,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             3)>::type* = 0) {
+                             3)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2528,7 +2531,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             4)>::type* = 0) {
+                             4)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2549,7 +2552,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             5)>::type* = 0) {
+                             5)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2571,7 +2574,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             6)>::type* = 0) {
+                             6)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2594,7 +2597,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<(unsigned(ViewTraits<DT, DP...>::rank) ==
-                             7)>::type* = 0) {
+                             7)>::type* = nullptr) {
   if (dst.data() == nullptr) {
     return;
   }
@@ -2628,7 +2631,7 @@ inline void deep_copy(
     typename std::enable_if<
         Kokkos::Impl::is_execution_space<ExecSpace>::value &&
         std::is_same<typename ViewTraits<DT, DP...>::specialize,
-                     void>::value>::type* = 0) {
+                     void>::value>::type* = nullptr) {
   typedef ViewTraits<DT, DP...> dst_traits;
   typedef typename dst_traits::memory_space dst_memory_space;
   static_assert(std::is_same<typename dst_traits::non_const_value_type,
@@ -2763,7 +2766,7 @@ inline void deep_copy(
         std::is_same<typename ViewTraits<DT, DP...>::specialize, void>::value &&
         std::is_same<typename ViewTraits<ST, SP...>::specialize, void>::value &&
         (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
-         unsigned(ViewTraits<ST, SP...>::rank) != 0))>::type* = 0) {
+         unsigned(ViewTraits<ST, SP...>::rank) != 0))>::type* = nullptr) {
   typedef View<DT, DP...> dst_type;
   typedef View<ST, SP...> src_type;
 
@@ -3284,7 +3287,7 @@ inline typename Kokkos::View<T, P...>::HostMirror create_mirror(
     typename std::enable_if<
         std::is_same<typename ViewTraits<T, P...>::specialize, void>::value &&
         !std::is_same<typename Kokkos::ViewTraits<T, P...>::array_layout,
-                      Kokkos::LayoutStride>::value>::type* = 0) {
+                      Kokkos::LayoutStride>::value>::type* = nullptr) {
   typedef View<T, P...> src_type;
   typedef typename src_type::HostMirror dst_type;
 
@@ -3320,7 +3323,7 @@ inline typename Kokkos::View<T, P...>::HostMirror create_mirror(
     typename std::enable_if<
         std::is_same<typename ViewTraits<T, P...>::specialize, void>::value &&
         std::is_same<typename Kokkos::ViewTraits<T, P...>::array_layout,
-                     Kokkos::LayoutStride>::value>::type* = 0) {
+                     Kokkos::LayoutStride>::value>::type* = nullptr) {
   typedef View<T, P...> src_type;
   typedef typename src_type::HostMirror dst_type;
 
@@ -3352,7 +3355,8 @@ template <class Space, class T, class... P>
 typename Impl::MirrorType<Space, T, P...>::view_type create_mirror(
     const Space&, const Kokkos::View<T, P...>& src,
     typename std::enable_if<std::is_same<
-        typename ViewTraits<T, P...>::specialize, void>::value>::type* = 0) {
+        typename ViewTraits<T, P...>::specialize, void>::value>::type* =
+        nullptr) {
   return typename Impl::MirrorType<Space, T, P...>::view_type(src.label(),
                                                               src.layout());
 }
@@ -3366,7 +3370,7 @@ inline typename Kokkos::View<T, P...>::HostMirror create_mirror_view(
              typename Kokkos::View<T, P...>::HostMirror::memory_space>::value &&
          std::is_same<typename Kokkos::View<T, P...>::data_type,
                       typename Kokkos::View<T, P...>::HostMirror::data_type>::
-             value)>::type* = 0) {
+             value)>::type* = nullptr) {
   return src;
 }
 
@@ -3388,7 +3392,8 @@ template <class Space, class T, class... P>
 typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
     const Space&, const Kokkos::View<T, P...>& src,
     typename std::enable_if<
-        Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* = 0) {
+        Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* =
+        nullptr) {
   return src;
 }
 
@@ -3410,7 +3415,8 @@ create_mirror_view_and_copy(
     const Space&, const Kokkos::View<T, P...>& src,
     std::string const& name = "",
     typename std::enable_if<
-        Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* = 0) {
+        Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* =
+        nullptr) {
   (void)name;
   return src;
 }
@@ -3438,7 +3444,8 @@ typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
     const Space&, const Kokkos::View<T, P...>& src,
     Kokkos::Impl::WithoutInitializing_t,
     typename std::enable_if<
-        Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* = 0) {
+        Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* =
+        nullptr) {
   return src;
 }
 

--- a/core/src/Kokkos_Future.hpp
+++ b/core/src/Kokkos_Future.hpp
@@ -295,7 +295,8 @@ class BasicFuture {
 
   task_base* m_task;
 
-  KOKKOS_INLINE_FUNCTION explicit BasicFuture(task_base* task) : m_task(0) {
+  KOKKOS_INLINE_FUNCTION explicit BasicFuture(task_base* task)
+      : m_task(nullptr) {
     if (task) queue_type::assign(&m_task, task);
   }
 
@@ -305,7 +306,7 @@ class BasicFuture {
   //----------------------------------------
 
   KOKKOS_INLINE_FUNCTION
-  bool is_null() const { return 0 == m_task; }
+  bool is_null() const { return nullptr == m_task; }
 
   KOKKOS_INLINE_FUNCTION
   int reference_count() const {
@@ -316,7 +317,7 @@ class BasicFuture {
 
   KOKKOS_INLINE_FUNCTION
   void clear() {
-    if (m_task) queue_type::assign(&m_task, (task_base*)0);
+    if (m_task) queue_type::assign(&m_task, nullptr);
   }
 
   //----------------------------------------
@@ -331,11 +332,11 @@ class BasicFuture {
 
   KOKKOS_INLINE_FUNCTION
   BasicFuture(BasicFuture&& rhs) noexcept : m_task(rhs.m_task) {
-    rhs.m_task = 0;
+    rhs.m_task = nullptr;
   }
 
   KOKKOS_INLINE_FUNCTION
-  BasicFuture(const BasicFuture& rhs) : m_task(0) {
+  BasicFuture(const BasicFuture& rhs) : m_task(nullptr) {
     if (rhs.m_task) queue_type::assign(&m_task, rhs.m_task);
   }
 
@@ -343,7 +344,7 @@ class BasicFuture {
   BasicFuture& operator=(BasicFuture&& rhs) noexcept {
     clear();
     m_task     = rhs.m_task;
-    rhs.m_task = 0;
+    rhs.m_task = nullptr;
     return *this;
   }
 
@@ -419,13 +420,13 @@ class BasicFuture {
 
   KOKKOS_INLINE_FUNCTION
   int is_ready() const noexcept {
-    return (0 == m_task) ||
+    return (nullptr == m_task) ||
            (((task_base*)task_base::LockTag) == m_task->m_wait);
   }
 
   KOKKOS_INLINE_FUNCTION
   const typename Impl::TaskResult<ValueType>::reference_type get() const {
-    if (0 == m_task) {
+    if (nullptr == m_task) {
       Kokkos::abort("Kokkos:::Future::get ERROR: is_null()");
     }
     return Impl::TaskResult<ValueType>::get(m_task);

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -1168,7 +1168,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const ViewType &arg_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void *>::type = NULL)
+                              void *>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),
@@ -1358,7 +1358,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       const ViewType &arg_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void *>::type = NULL)
+                              void *>::type = nullptr)
       : m_functor(arg_functor),
         m_mdr_policy(arg_policy),
         m_policy(Policy(0, m_mdr_policy.m_num_tiles).set_chunk_size(1)),
@@ -1989,7 +1989,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       const ViewType &arg_result,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void *>::type = NULL)
+                              void *>::type = nullptr)
       : m_functor(arg_functor),
         m_league(arg_policy.league_size()),
         m_policy(arg_policy),

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -263,7 +263,7 @@ class MemoryPool {
 
   KOKKOS_INLINE_FUNCTION MemoryPool()
       : m_tracker(),
-        m_sb_state_array(0),
+        m_sb_state_array(nullptr),
         m_sb_state_size(0),
         m_sb_size_lg2(0),
         m_max_block_size_lg2(0),
@@ -291,7 +291,7 @@ class MemoryPool {
              const size_t min_total_alloc_size, size_t min_block_alloc_size = 0,
              size_t max_block_alloc_size = 0, size_t min_superblock_size = 0)
       : m_tracker(),
-        m_sb_state_array(0),
+        m_sb_state_array(nullptr),
         m_sb_state_size(0),
         m_sb_size_lg2(0),
         m_max_block_size_lg2(0),
@@ -499,9 +499,9 @@ class MemoryPool {
           "allocation size");
     }
 
-    if (0 == alloc_size) return (void *)0;
+    if (0 == alloc_size) return nullptr;
 
-    void *p = 0;
+    void *p = nullptr;
 
     const uint32_t block_size_lg2 = get_block_size_lg2(alloc_size);
 
@@ -542,7 +542,7 @@ class MemoryPool {
 
     int32_t sb_id = -1;
 
-    volatile uint32_t *sb_state_array = 0;
+    volatile uint32_t *sb_state_array = nullptr;
 
     while (attempt_limit) {
       int32_t hint_sb_id = -1;
@@ -736,7 +736,7 @@ class MemoryPool {
    */
   KOKKOS_INLINE_FUNCTION
   void deallocate(void *p, size_t /* alloc_size */) const noexcept {
-    if (0 == p) return;
+    if (nullptr == p) return;
 
     // Determine which superblock and block
     const ptrdiff_t d =

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -158,7 +158,8 @@ inline void parallel_for(
     const ExecPolicy& policy, const FunctorType& functor,
     const std::string& str = "",
     typename std::enable_if<
-        Kokkos::Impl::is_execution_policy<ExecPolicy>::value>::type* = 0) {
+        Kokkos::Impl::is_execution_policy<ExecPolicy>::value>::type* =
+        nullptr) {
 #if defined(KOKKOS_ENABLE_PROFILING)
   uint64_t kpID = 0;
   if (Kokkos::Profiling::profileLibraryLoaded()) {
@@ -403,7 +404,8 @@ inline void parallel_scan(
     const ExecutionPolicy& policy, const FunctorType& functor,
     const std::string& str = "",
     typename std::enable_if<
-        Kokkos::Impl::is_execution_policy<ExecutionPolicy>::value>::type* = 0) {
+        Kokkos::Impl::is_execution_policy<ExecutionPolicy>::value>::type* =
+        nullptr) {
 #if defined(KOKKOS_ENABLE_PROFILING)
   uint64_t kpID = 0;
   if (Kokkos::Profiling::profileLibraryLoaded()) {
@@ -479,7 +481,8 @@ inline void parallel_scan(
     const ExecutionPolicy& policy, const FunctorType& functor,
     ReturnType& return_value, const std::string& str = "",
     typename std::enable_if<
-        Kokkos::Impl::is_execution_policy<ExecutionPolicy>::value>::type* = 0) {
+        Kokkos::Impl::is_execution_policy<ExecutionPolicy>::value>::type* =
+        nullptr) {
 #if defined(KOKKOS_ENABLE_PROFILING)
   uint64_t kpID = 0;
   if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -914,7 +914,7 @@ struct ReducerHasTestReferenceFunction {
   static std::false_type test_func(...);
 
   enum {
-    value = std::is_same<std::true_type, decltype(test_func<T>(0))>::value
+    value = std::is_same<std::true_type, decltype(test_func<T>(nullptr))>::value
   };
 };
 
@@ -976,7 +976,8 @@ inline void parallel_reduce(
     const std::string& label, const PolicyType& policy,
     const FunctorType& functor, ReturnType& return_value,
     typename std::enable_if<
-        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
+        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* =
+        nullptr) {
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       label, policy, functor, return_value);
   Impl::ParallelReduceFence<ReturnType>::fence(return_value);
@@ -987,7 +988,8 @@ inline void parallel_reduce(
     const PolicyType& policy, const FunctorType& functor,
     ReturnType& return_value,
     typename std::enable_if<
-        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
+        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* =
+        nullptr) {
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       "", policy, functor, return_value);
   Impl::ParallelReduceFence<ReturnType>::fence(return_value);
@@ -1021,7 +1023,8 @@ inline void parallel_reduce(
     const std::string& label, const PolicyType& policy,
     const FunctorType& functor, const ReturnType& return_value,
     typename std::enable_if<
-        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
+        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* =
+        nullptr) {
   ReturnType return_value_impl = return_value;
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       label, policy, functor, return_value_impl);
@@ -1033,7 +1036,8 @@ inline void parallel_reduce(
     const PolicyType& policy, const FunctorType& functor,
     const ReturnType& return_value,
     typename std::enable_if<
-        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
+        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* =
+        nullptr) {
   ReturnType return_value_impl = return_value;
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       "", policy, functor, return_value_impl);
@@ -1070,7 +1074,8 @@ inline void parallel_reduce(
     const std::string& label, const PolicyType& policy,
     const FunctorType& functor,
     typename std::enable_if<
-        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
+        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* =
+        nullptr) {
   typedef Kokkos::Impl::FunctorValueTraits<FunctorType, void> ValueTraits;
   typedef typename Kokkos::Impl::if_c<
       (ValueTraits::StaticValueSize != 0), typename ValueTraits::value_type,
@@ -1094,7 +1099,8 @@ template <class PolicyType, class FunctorType>
 inline void parallel_reduce(
     const PolicyType& policy, const FunctorType& functor,
     typename std::enable_if<
-        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* = 0) {
+        Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* =
+        nullptr) {
   typedef Kokkos::Impl::FunctorValueTraits<FunctorType, void> ValueTraits;
   typedef typename Kokkos::Impl::if_c<
       (ValueTraits::StaticValueSize != 0), typename ValueTraits::value_type,

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -107,13 +107,13 @@ class ScratchMemorySpace {
 #ifdef KOKKOS_DEBUG
         // mfh 23 Jun 2015: printf call consumes 25 registers
         // in a CUDA build, so only print in debug mode.  The
-        // function still returns NULL if not enough memory.
+        // function still returns nullptr if not enough memory.
         printf(
             "ScratchMemorySpace<...>::get_shmem: Failed to allocate "
             "%ld byte(s); remaining capacity is %ld byte(s)\n",
             long(size), long(m_end_L0 - m_iter_L0));
 #endif  // KOKKOS_DEBUG
-        tmp = 0;
+        tmp = nullptr;
       }
       return tmp;
     } else {
@@ -123,13 +123,13 @@ class ScratchMemorySpace {
 #ifdef KOKKOS_DEBUG
         // mfh 23 Jun 2015: printf call consumes 25 registers
         // in a CUDA build, so only print in debug mode.  The
-        // function still returns NULL if not enough memory.
+        // function still returns nullptr if not enough memory.
         printf(
             "ScratchMemorySpace<...>::get_shmem: Failed to allocate "
             "%ld byte(s); remaining capacity is %ld byte(s)\n",
             long(size), long(m_end_L1 - m_iter_L1));
 #endif  // KOKKOS_DEBUG
-        tmp = 0;
+        tmp = nullptr;
       }
       return tmp;
     }
@@ -150,13 +150,13 @@ class ScratchMemorySpace {
 #ifdef KOKKOS_DEBUG
         // mfh 23 Jun 2015: printf call consumes 25 registers
         // in a CUDA build, so only print in debug mode.  The
-        // function still returns NULL if not enough memory.
+        // function still returns nullptr if not enough memory.
         printf(
             "ScratchMemorySpace<...>::get_shmem: Failed to allocate "
             "%ld byte(s); remaining capacity is %ld byte(s)\n",
             long(size), long(m_end_L0 - m_iter_L0));
 #endif  // KOKKOS_DEBUG
-        tmp = 0;
+        tmp = nullptr;
       }
       return tmp;
     } else {
@@ -170,13 +170,13 @@ class ScratchMemorySpace {
 #ifdef KOKKOS_DEBUG
         // mfh 23 Jun 2015: printf call consumes 25 registers
         // in a CUDA build, so only print in debug mode.  The
-        // function still returns NULL if not enough memory.
+        // function still returns nullptr if not enough memory.
         printf(
             "ScratchMemorySpace<...>::get_shmem: Failed to allocate "
             "%ld byte(s); remaining capacity is %ld byte(s)\n",
             long(size), long(m_end_L1 - m_iter_L1));
 #endif  // KOKKOS_DEBUG
-        tmp = 0;
+        tmp = nullptr;
       }
       return tmp;
     }
@@ -185,7 +185,7 @@ class ScratchMemorySpace {
   template <typename IntType>
   KOKKOS_INLINE_FUNCTION ScratchMemorySpace(void* ptr_L0,
                                             const IntType& size_L0,
-                                            void* ptr_L1           = NULL,
+                                            void* ptr_L1           = nullptr,
                                             const IntType& size_L1 = 0)
       : m_iter_L0((char*)ptr_L0),
         m_end_L0(m_iter_L0 + size_L0),

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -640,7 +640,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const HostViewType& arg_result_view,
       typename std::enable_if<Kokkos::is_view<HostViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL)
+                              void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),
@@ -911,7 +911,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       const HostViewType& arg_result_view,
       typename std::enable_if<Kokkos::is_view<HostViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL)
+                              void*>::type = nullptr)
       : m_functor(arg_functor),
         m_mdr_policy(arg_policy),
         m_policy(Policy(0, m_mdr_policy.m_num_tiles).set_chunk_size(1)),
@@ -1086,7 +1086,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       const ViewType& arg_result,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL)
+                              void*>::type = nullptr)
       : m_functor(arg_functor),
         m_league(arg_policy.league_size()),
         m_reducer(InvalidType()),

--- a/core/src/Kokkos_TaskScheduler.hpp
+++ b/core/src/Kokkos_TaskScheduler.hpp
@@ -202,7 +202,7 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
 
  public:
   KOKKOS_INLINE_FUNCTION
-  BasicTaskScheduler() : m_track(), m_queue(0) {}
+  BasicTaskScheduler() : m_track(), m_queue(nullptr) {}
 
   KOKKOS_INLINE_FUNCTION
   BasicTaskScheduler(BasicTaskScheduler&& rhs) noexcept
@@ -230,7 +230,7 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
   }
 
   explicit BasicTaskScheduler(memory_pool const& arg_memory_pool) noexcept
-      : m_track(), m_queue(0) {
+      : m_track(), m_queue(nullptr) {
     typedef Kokkos::Impl::SharedAllocationRecord<memory_space,
                                                  typename queue_type::Destroy>
         record_type;
@@ -348,7 +348,7 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
 
     task->m_priority = static_cast<int>(arg_priority);
 
-    task->add_dependence((task_base*)0);
+    task->add_dependence(nullptr);
 
     // Postcondition: task is in Executing-Respawn state
   }
@@ -379,8 +379,8 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
         }
       }
 
-      if (q != 0) {  // this should probably handle the queue == 0 case, but
-                     // this is deprecated code anyway
+      if (q != nullptr) {  // this should probably handle the queue == 0 case,
+                           // but this is deprecated code anyway
 
         size_t const alloc_size = q->when_all_allocation_size(narg);
 
@@ -458,7 +458,7 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
 
       for (int i = 0; i < narg; ++i) {
         const input_type arg_f = func(i);
-        if (0 != arg_f.m_task) {
+        if (nullptr != arg_f.m_task) {
           // Not scheduled, so task scheduler is not yet set
           // if ( m_queue != static_cast< BasicTaskScheduler const * >(
           // arg_f.m_task->m_scheduler )->m_queue ) {

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1758,7 +1758,8 @@ class View : public ViewTraits<DataType, Properties...> {
       const View<RT, RP...>& rhs,
       typename std::enable_if<Kokkos::Impl::ViewMapping<
           traits, typename View<RT, RP...>::traits,
-          typename traits::specialize>::is_assignable_data_type>::type* = 0)
+          typename traits::specialize>::is_assignable_data_type>::type* =
+          nullptr)
       : m_track(rhs.m_track, traits::is_managed), m_map() {
     typedef typename View<RT, RP...>::traits SrcTraits;
     typedef Kokkos::Impl::ViewMapping<traits, SrcTraits,

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
@@ -148,12 +148,12 @@ void OpenMPExec::clear_thread_data() {
   {
     const int rank = omp_get_thread_num();
 
-    if (0 != m_pool[rank]) {
+    if (nullptr != m_pool[rank]) {
       m_pool[rank]->disband_pool();
 
       space.deallocate(m_pool[rank], old_alloc_bytes);
 
-      m_pool[rank] = 0;
+      m_pool[rank] = nullptr;
     }
   }
   /* END #pragma omp parallel */
@@ -210,7 +210,7 @@ void OpenMPExec::resize_thread_data(size_t pool_reduce_bytes,
     {
       const int rank = omp_get_thread_num();
 
-      if (0 != m_pool[rank]) {
+      if (nullptr != m_pool[rank]) {
         m_pool[rank]->disband_pool();
 
         space.deallocate(m_pool[rank], old_alloc_bytes);

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -388,7 +388,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const ViewType& arg_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL)
+                              void*>::type = nullptr)
       : m_instance(t_openmp_instance),
         m_functor(arg_functor),
         m_policy(arg_policy),
@@ -550,7 +550,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       const ViewType& arg_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL)
+                              void*>::type = nullptr)
       : m_instance(t_openmp_instance),
         m_functor(arg_functor),
         m_mdr_policy(arg_policy),
@@ -1145,7 +1145,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       const ViewType& arg_result,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL)
+                              void*>::type = nullptr)
       : m_instance(t_openmp_instance),
         m_functor(arg_functor),
         m_policy(arg_policy),

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
@@ -118,14 +118,14 @@ void OpenMPTargetExec::verify_initialized(const char* const label) {
   }
 }
 
-void* OpenMPTargetExec::m_scratch_ptr    = NULL;
+void* OpenMPTargetExec::m_scratch_ptr    = nullptr;
 int64_t OpenMPTargetExec::m_scratch_size = 0;
 
 void OpenMPTargetExec::clear_scratch() {
   Kokkos::Experimental::OpenMPTargetSpace space;
   space.deallocate(m_scratch_ptr, m_scratch_size);
-  m_scratch_ptr  = NULL;
-  m_scratch_size = NULL;
+  m_scratch_ptr  = nullptr;
+  m_scratch_size = nullptr;
 }
 
 void* OpenMPTargetExec::get_scratch_ptr() { return m_scratch_ptr; }

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -282,7 +282,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const ViewType& arg_result_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL)
+                              void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),
@@ -671,7 +671,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       const ViewType& arg_result,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL)
+                              void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Task.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Task.hpp
@@ -112,7 +112,7 @@ class TaskExec<Kokkos::Experimental::OpenMPTarget> {
  public:
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
   void* team_shared() const {
-    return m_team_exec ? m_team_exec->scratch_thread() : (void*)0;
+    return m_team_exec ? m_team_exec->scratch_thread() : nullptr;
   }
 
   int team_shared_size() const {

--- a/core/src/Qthreads/Kokkos_QthreadsExec.cpp
+++ b/core/src/Qthreads/Kokkos_QthreadsExec.cpp
@@ -85,7 +85,7 @@ int s_number_workers              = 0;
 inline QthreadsExec **worker_exec() {
   return s_exec + s_number_workers -
          (qthread_shep() * s_number_workers_per_shepherd +
-          qthread_worker_local(NULL) + 1);
+          qthread_worker_local(nullptr) + 1);
 }
 
 const int s_base_size = QthreadsExec::align_alloc(sizeof(QthreadsExec));
@@ -298,7 +298,7 @@ aligned_t driver_resize_worker_scratch(void *arg) {
 
 void verify_is_process(const char *const label, bool not_active = false) {
   const bool not_process =
-      0 != qthread_shep() || 0 != qthread_worker_local(NULL);
+      0 != qthread_shep() || 0 != qthread_worker_local(nullptr);
   const bool is_active =
       not_active && (s_active_function || s_active_function_arg);
 
@@ -319,7 +319,7 @@ int QthreadsExec::worker_per_shepherd() {
 
 QthreadsExec::QthreadsExec() {
   const int shepherd_rank        = qthread_shep();
-  const int shepherd_worker_rank = qthread_worker_local(NULL);
+  const int shepherd_worker_rank = qthread_worker_local(nullptr);
   const int worker_rank =
       shepherd_rank * s_number_workers_per_shepherd + shepherd_worker_rank;
 
@@ -382,7 +382,7 @@ void QthreadsExec::resize_worker_scratch(const int reduce_size,
 #if 0
     for ( int jshep = 0; jshep < s_number_shepherds; ++jshep ) {
       for ( int i = jshep != main_shep ? 0 : 1; i < s_number_workers_per_shepherd; ++i ) {
-        qthread_fork_to( driver_resize_worker_scratch, NULL, NULL, jshep );
+        qthread_fork_to( driver_resize_worker_scratch, nullptr, nullptr, jshep );
       }
     }
 #else
@@ -398,9 +398,9 @@ void QthreadsExec::resize_worker_scratch(const int reduce_size,
         const int ret = qthread_fork_clones_to_local_priority(
             driver_resize_worker_scratch  // Function
             ,
-            NULL  // Function data block
+            nullptr  // Function data block
             ,
-            NULL  // Pointer to return value feb
+            nullptr  // Pointer to return value feb
             ,
             jshep  // Shepherd number
             ,
@@ -412,7 +412,7 @@ void QthreadsExec::resize_worker_scratch(const int reduce_size,
     }
 #endif
 
-    driver_resize_worker_scratch(NULL);
+    driver_resize_worker_scratch(nullptr);
 
     // Verify all workers allocated.
 
@@ -454,7 +454,7 @@ void QthreadsExec::exec_all(Qthreads &, QthreadsExecFunctionPointer func,
 #if 0
   for ( int jshep = 0, iwork = 0; jshep < s_number_shepherds; ++jshep ) {
     for ( int i = jshep != main_shep ? 0 : 1; i < s_number_workers_per_shepherd; ++i, ++iwork ) {
-      qthread_fork_to( driver_exec_all, NULL, NULL, jshep );
+      qthread_fork_to( driver_exec_all, nullptr, nullptr, jshep );
     }
   }
 #else
@@ -470,9 +470,9 @@ void QthreadsExec::exec_all(Qthreads &, QthreadsExecFunctionPointer func,
       const int ret = qthread_fork_clones_to_local_priority(
           driver_exec_all  // Function
           ,
-          NULL  // Function data block
+          nullptr  // Function data block
           ,
-          NULL  // Pointer to return value feb
+          nullptr  // Pointer to return value feb
           ,
           jshep  // Shepherd number
           ,
@@ -484,7 +484,7 @@ void QthreadsExec::exec_all(Qthreads &, QthreadsExecFunctionPointer func,
   }
 #endif
 
-  driver_exec_all(NULL);
+  driver_exec_all(nullptr);
 
   s_active_function     = 0;
   s_active_function_arg = 0;

--- a/core/src/Qthreads/Kokkos_Qthreads_Parallel.hpp
+++ b/core/src/Qthreads/Kokkos_Qthreads_Parallel.hpp
@@ -221,7 +221,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const ViewType& arg_result_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL)
+                              void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),
@@ -396,7 +396,7 @@ class ParallelReduce<FunctorType, TeamPolicy<Properties...>, ReducerType,
       const ViewType& arg_result,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL)
+                              void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),

--- a/core/src/Qthreads/Kokkos_Qthreads_Task.hpp
+++ b/core/src/Qthreads/Kokkos_Qthreads_Task.hpp
@@ -110,7 +110,7 @@ class TaskExec<Kokkos::Qthreads> {
  public:
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
   void* team_shared() const {
-    return m_team_exec ? m_team_exec->scratch_thread() : (void*)0;
+    return m_team_exec ? m_team_exec->scratch_thread() : nullptr;
   }
 
   int team_shared_size() const {

--- a/core/src/Qthreads/Kokkos_Qthreads_TaskPolicy.cpp.old
+++ b/core/src/Qthreads/Kokkos_Qthreads_TaskPolicy.cpp.old
@@ -266,7 +266,7 @@ void Task::closeout()
 fprintf( stdout
        , "worker(%d.%d) task 0x%.12lx %s\n"
        , qthread_shep()
-       , qthread_worker_local(NULL)
+       , qthread_worker_local(nullptr)
        , reinterpret_cast<unsigned long>(this)
        , ( m_state == RESPAWN ? "respawn" : "complete" )
        );
@@ -330,7 +330,7 @@ aligned_t Task::qthread_func( void * arg )
 fprintf( stdout
        , "worker(%d.%d) task 0x%.12lx executed by member(%d:%d)\n"
        , qthread_shep()
-       , qthread_worker_local(NULL)
+       , qthread_worker_local(nullptr)
        , reinterpret_cast<unsigned long>(task)
        , member.team_rank()
        , member.team_size()
@@ -357,7 +357,7 @@ fflush(stdout);
 fprintf( stdout
        , "worker(%d.%d) task 0x%.12lx return\n"
        , qthread_shep()
-       , qthread_worker_local(NULL)
+       , qthread_worker_local(nullptr)
        , reinterpret_cast<unsigned long>(task)
        );
 fflush(stdout);
@@ -408,7 +408,7 @@ void Task::schedule()
 fprintf( stdout
        , "worker(%d.%d) task 0x%.12lx spawning on shepherd(%d) clone(%d)\n"
        , qthread_shep()
-       , qthread_worker_local(NULL)
+       , qthread_worker_local(nullptr)
        , reinterpret_cast<unsigned long>(this)
        , spawn_shepherd
        , num_worker_per_shepherd - 1
@@ -420,7 +420,7 @@ fflush(stdout);
       ( & Task::qthread_func
       , this
       , 0
-      , NULL
+      , nullptr
       , m_dep_size , qprecon /* dependences */
       , spawn_shepherd
       , unsigned( QTHREAD_SPAWN_SIMPLE | QTHREAD_SPAWN_LOCAL_PRIORITY )
@@ -431,7 +431,7 @@ fflush(stdout);
     qthread_spawn( & Task::qthread_func /* function */
                  , this                 /* function argument */
                  , 0
-                 , NULL
+                 , nullptr
                  , m_dep_size , qprecon /* dependences */
                  , NO_SHEPHERD
                  , QTHREAD_SPAWN_SIMPLE /* allows optimization for non-blocking task */

--- a/core/src/Qthreads/Kokkos_Qthreads_TaskQueue_impl.hpp
+++ b/core/src/Qthreads/Kokkos_Qthreads_TaskQueue_impl.hpp
@@ -149,7 +149,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace>::schedule(
         fprintf( stdout,
                  "worker(%d.%d) task 0x%.12lx spawning on shepherd(%d) clone(%d)\n",
                  qthread_shep(),
-                 qthread_worker_local(NULL),
+                 qthread_worker_local(nullptr),
                  reinterpret_cast<unsigned long>(this),
                  spawn_shepherd,
                  m_team_size - 1
@@ -158,7 +158,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace>::schedule(
 #endif
 
         qthread_spawn_cloneable(
-            &task_root_type::qthread_func, task, 0, NULL,
+            &task_root_type::qthread_func, task, 0, nullptr,
             0,  // no depenedences
             0,  // dependences array
             spawn_shepherd,
@@ -166,7 +166,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace>::schedule(
             m_team_size - 1);
       } else {
         qthread_spawn(
-            &task_root_type::qthread_func, task, 0, NULL,
+            &task_root_type::qthread_func, task, 0, nullptr,
             0,  // no depenedences
             0,  // dependences array
             NO_SHEPHERD,
@@ -194,7 +194,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace>::schedule(
   fprintf( stdout,
            "worker(%d.%d) task 0x%.12lx spawning on shepherd(%d) clone(%d)\n",
            qthread_shep(),
-           qthread_worker_local(NULL),
+           qthread_worker_local(nullptr),
            reinterpret_cast<unsigned long>(this),
            spawn_shepherd,
            m_team_size - 1
@@ -203,16 +203,16 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace>::schedule(
 #endif
 
       qthread_spawn_cloneable(
-          &Task::qthread_func, this, 0, NULL, m_dep_size,
+          &Task::qthread_func, this, 0, nullptr, m_dep_size,
           qprecon, /* dependences */
           spawn_shepherd,
           unsigned(QTHREAD_SPAWN_SIMPLE | QTHREAD_SPAWN_LOCAL_PRIORITY),
           m_team_size - 1);
     } else {
       qthread_spawn(
-          &Task::qthread_func,          /* function */
-          this,                         /* function argument */
-          0, NULL, m_dep_size, qprecon, /* dependences */
+          &Task::qthread_func,             /* function */
+          this,                            /* function argument */
+          0, nullptr, m_dep_size, qprecon, /* dependences */
           NO_SHEPHERD,
           QTHREAD_SPAWN_SIMPLE /* allows optimization for non-blocking task */
       );
@@ -355,7 +355,7 @@ aligned_t TaskBase<Kokkos::Qthreads, void, void>::qthread_func(void *arg) {
       fprintf( stdout,
               "worker(%d.%d) task 0x%.12lx executed by member(%d:%d)\n",
               qthread_shep(),
-              qthread_worker_local(NULL),
+              qthread_worker_local(nullptr),
               reinterpret_cast<unsigned long>(task),
               member.team_rank(),
               member.team_size()
@@ -381,7 +381,7 @@ aligned_t TaskBase<Kokkos::Qthreads, void, void>::qthread_func(void *arg) {
 fprintf( stdout
        , "worker(%d.%d) task 0x%.12lx return\n"
        , qthread_shep()
-       , qthread_worker_local(NULL)
+       , qthread_worker_local(nullptr)
        , reinterpret_cast<unsigned long>(task)
        );
 fflush(stdout);

--- a/core/src/ROCm/Kokkos_ROCm_Parallel.hpp
+++ b/core/src/ROCm/Kokkos_ROCm_Parallel.hpp
@@ -836,7 +836,7 @@ class ParallelFor<F, Kokkos::TeamPolicy<Traits...>,
     if (total_size == 0) return;
 
     const auto shared_size = FunctorTeamShmemSize<F>::value(f, team_size);
-    char* scratch          = NULL;
+    char* scratch          = nullptr;
     char* shared = (char*)rocm_device_allocate(shared_size * league_size +
                                                scratch_size0 * league_size);
     if (0 < scratch_size1)
@@ -888,7 +888,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const FunctorType& f, const Policy& policy, const ViewType& result_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL) {
+                              void*>::type = nullptr) {
     typedef typename Policy::work_tag Tag;
     typedef Kokkos::Impl::FunctorValueTraits<FunctorType, Tag> ValueTraits;
     typedef Kokkos::Impl::FunctorValueInit<FunctorType, Tag> ValueInit;
@@ -1105,7 +1105,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
                  const HostViewType& arg_result,
                  typename std::enable_if<Kokkos::is_view<HostViewType>::value,
-                                         void*>::type = NULL)
+                                         void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),
@@ -1148,7 +1148,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Traits...>, ReducerType,
       const FunctorType& f, const Policy& policy, const ViewType& result_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void*>::type = NULL) {
+                              void*>::type = nullptr) {
     const int league_size   = policy.league_size();
     const int team_size     = policy.team_size(f);
     const int vector_length = policy.vector_length();
@@ -1171,7 +1171,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Traits...>, ReducerType,
         FunctorTeamShmemSize<FunctorType>::value(f, team_size);
 
     char* shared;
-    char* scratch = NULL;
+    char* scratch = nullptr;
 
     shared = (char*)rocm_device_allocate(league_size *
                                          (shared_size + scratch_size0));
@@ -1222,7 +1222,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Traits...>, ReducerType,
     const int scratch_size1 = policy.scratch_size(1, team_size);
 
     char* shared;
-    char* scratch = NULL;
+    char* scratch = nullptr;
     shared        = (char*)rocm_device_allocate((shared_size + scratch_size0) *
                                          league_size);
     if (0 < scratch_size1)

--- a/core/src/ROCm/Kokkos_ROCm_Space.cpp
+++ b/core/src/ROCm/Kokkos_ROCm_Space.cpp
@@ -408,7 +408,7 @@ void* SharedAllocationRecord<Kokkos::Experimental::ROCmSpace, void>::
     allocate_tracked(const Kokkos::Experimental::ROCmSpace& arg_space,
                      const std::string& arg_alloc_label,
                      const size_t arg_alloc_size) {
-  if (!arg_alloc_size) return (void*)0;
+  if (!arg_alloc_size) return nullptr;
 
   SharedAllocationRecord* const r =
       allocate(arg_space, arg_alloc_label, arg_alloc_size);
@@ -620,7 +620,7 @@ namespace Kokkos {
 namespace {
 
 void* rocm_resize_scratch_space(size_t bytes, bool force_shrink) {
-  static void* ptr           = NULL;
+  static void* ptr           = nullptr;
   static size_t current_size = 0;
   if (current_size == 0) {
     current_size = bytes;

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -64,7 +64,7 @@ namespace Impl {
 namespace {
 
 ThreadsExec s_threads_process;
-ThreadsExec *s_threads_exec[ThreadsExec::MAX_THREAD_COUNT] = {0};
+ThreadsExec *s_threads_exec[ThreadsExec::MAX_THREAD_COUNT] = {nullptr};
 pthread_t s_threads_pid[ThreadsExec::MAX_THREAD_COUNT]     = {0};
 std::pair<unsigned, unsigned> s_threads_coord[ThreadsExec::MAX_THREAD_COUNT];
 
@@ -74,7 +74,7 @@ unsigned s_current_reduce_size = 0;
 unsigned s_current_shared_size = 0;
 
 void (*volatile s_current_function)(ThreadsExec &, const void *);
-const void *volatile s_current_function_arg = 0;
+const void *volatile s_current_function_arg = nullptr;
 
 struct Sentinel {
   Sentinel() {}
@@ -128,8 +128,8 @@ void ThreadsExec::driver(void) {
 }
 
 ThreadsExec::ThreadsExec()
-    : m_pool_base(0),
-      m_scratch(0),
+    : m_pool_base(nullptr),
+      m_scratch(nullptr),
       m_scratch_reduce_end(0),
       m_scratch_thread_end(0),
       m_numa_rank(0),
@@ -141,7 +141,7 @@ ThreadsExec::ThreadsExec()
   if (&s_threads_process != this) {
     // A spawned thread
 
-    ThreadsExec *const nil = 0;
+    ThreadsExec *const nil = nullptr;
 
     // Which entry in 's_threads_exec', possibly determined from hwloc binding
     const int entry =
@@ -191,12 +191,12 @@ ThreadsExec::~ThreadsExec() {
   if (m_scratch) {
     Record *const r = Record::get_record(m_scratch);
 
-    m_scratch = 0;
+    m_scratch = nullptr;
 
     Record::decrement(r);
   }
 
-  m_pool_base          = 0;
+  m_pool_base          = nullptr;
   m_scratch_reduce_end = 0;
   m_scratch_thread_end = 0;
   m_numa_rank          = 0;
@@ -208,7 +208,7 @@ ThreadsExec::~ThreadsExec() {
   m_pool_state = ThreadsExec::Terminating;
 
   if (&s_threads_process != this && entry < MAX_THREAD_COUNT) {
-    ThreadsExec *const nil = 0;
+    ThreadsExec *const nil = nullptr;
 
     atomic_compare_exchange(s_threads_exec + entry, this, nil);
 
@@ -222,13 +222,13 @@ ThreadsExec *ThreadsExec::get_thread(const int init_thread_rank) {
   ThreadsExec *const th =
       init_thread_rank < s_thread_pool_size[0]
           ? s_threads_exec[s_thread_pool_size[0] - (init_thread_rank + 1)]
-          : 0;
+          : nullptr;
 
-  if (0 == th || th->m_pool_rank != init_thread_rank) {
+  if (nullptr == th || th->m_pool_rank != init_thread_rank) {
     std::ostringstream msg;
     msg << "Kokkos::Impl::ThreadsExec::get_thread ERROR : "
         << "thread " << init_thread_rank << " of " << s_thread_pool_size[0];
-    if (0 == th) {
+    if (nullptr == th) {
       msg << " does not exist";
     } else {
       msg << " has wrong thread_rank " << th->m_pool_rank;
@@ -298,8 +298,8 @@ void ThreadsExec::fence() {
                                     ThreadsExec::Active);
   }
 
-  s_current_function     = 0;
-  s_current_function_arg = 0;
+  s_current_function     = nullptr;
+  s_current_function_arg = nullptr;
 
   // Make sure function and arguments are cleared before
   // potentially re-activating threads with a subsequent launch.
@@ -363,7 +363,7 @@ bool ThreadsExec::wake() {
   ThreadsExec::global_unlock();
 
   if (s_threads_process.m_pool_base) {
-    execute_sleep(s_threads_process, 0);
+    execute_sleep(s_threads_process, nullptr);
     s_threads_process.m_pool_state = ThreadsExec::Inactive;
   }
 
@@ -393,12 +393,12 @@ void ThreadsExec::execute_serial(void (*func)(ThreadsExec &, const void *)) {
 
   if (s_threads_process.m_pool_base) {
     s_threads_process.m_pool_state = ThreadsExec::Active;
-    (*func)(s_threads_process, 0);
+    (*func)(s_threads_process, nullptr);
     s_threads_process.m_pool_state = ThreadsExec::Inactive;
   }
 
-  s_current_function_arg = 0;
-  s_current_function     = 0;
+  s_current_function_arg = nullptr;
+  s_current_function     = nullptr;
 
   // Make sure function and arguments are cleared before proceeding.
   memory_fence();
@@ -416,7 +416,7 @@ void ThreadsExec::execute_resize_scratch(ThreadsExec &exec, const void *) {
   if (exec.m_scratch) {
     Record *const r = Record::get_record(exec.m_scratch);
 
-    exec.m_scratch = 0;
+    exec.m_scratch = nullptr;
 
     Record::decrement(r);
   }
@@ -507,7 +507,7 @@ void ThreadsExec::print_configuration(std::ostream &s, const bool detail) {
     s << " threads[" << s_thread_pool_size[0] << "]"
       << " threads_per_numa[" << s_thread_pool_size[1] << "]"
       << " threads_per_core[" << s_thread_pool_size[2] << "]";
-    if (0 == s_threads_process.m_pool_base) {
+    if (nullptr == s_threads_process.m_pool_base) {
       s << " Asynchronous";
     }
     s << " ReduceScratch[" << s_current_reduce_size << "]"
@@ -546,7 +546,7 @@ void ThreadsExec::print_configuration(std::ostream &s, const bool detail) {
 
 //----------------------------------------------------------------------------
 
-int ThreadsExec::is_initialized() { return 0 != s_threads_exec[0]; }
+int ThreadsExec::is_initialized() { return nullptr != s_threads_exec[0]; }
 
 void ThreadsExec::initialize(unsigned thread_count, unsigned use_numa_count,
                              unsigned use_cores_per_numa,
@@ -558,7 +558,7 @@ void ThreadsExec::initialize(unsigned thread_count, unsigned use_numa_count,
   unsigned thread_spawn_failed = 0;
 
   for (int i = 0; i < ThreadsExec::MAX_THREAD_COUNT; i++)
-    s_threads_exec[i] = NULL;
+    s_threads_exec[i] = nullptr;
 
   if (!is_initialized) {
     // If thread_count, use_numa_count, or use_cores_per_numa are zero
@@ -630,8 +630,8 @@ void ThreadsExec::initialize(unsigned thread_count, unsigned use_numa_count,
       }
     }
 
-    s_current_function             = 0;
-    s_current_function_arg         = 0;
+    s_current_function             = nullptr;
+    s_current_function_arg         = nullptr;
     s_threads_process.m_pool_state = ThreadsExec::Inactive;
 
     memory_fence();
@@ -658,7 +658,7 @@ void ThreadsExec::initialize(unsigned thread_count, unsigned use_numa_count,
             s_threads_process.m_pool_rank, s_threads_process.m_pool_size);
         s_threads_pid[s_threads_process.m_pool_rank] = pthread_self();
       } else {
-        s_threads_process.m_pool_base     = 0;
+        s_threads_process.m_pool_base     = nullptr;
         s_threads_process.m_pool_rank     = 0;
         s_threads_process.m_pool_size     = 0;
         s_threads_process.m_pool_fan_size = 0;
@@ -739,7 +739,7 @@ void ThreadsExec::finalize() {
 
   if (s_threads_process.m_pool_base) {
     (&s_threads_process)->~ThreadsExec();
-    s_threads_exec[0] = 0;
+    s_threads_exec[0] = nullptr;
   }
 
   if (Kokkos::hwloc::can_bind_threads()) {
@@ -753,7 +753,7 @@ void ThreadsExec::finalize() {
   // Reset master thread to run solo.
   s_threads_process.m_numa_rank      = 0;
   s_threads_process.m_numa_core_rank = 0;
-  s_threads_process.m_pool_base      = 0;
+  s_threads_process.m_pool_base      = nullptr;
   s_threads_process.m_pool_rank      = 0;
   s_threads_process.m_pool_size      = 1;
   s_threads_process.m_pool_fan_size  = 0;

--- a/core/src/Threads/Kokkos_ThreadsExec_base.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec_base.cpp
@@ -86,7 +86,7 @@ void* internal_pthread_driver(void*) {
     std::cerr.flush();
     std::abort();
   }
-  return NULL;
+  return nullptr;
 }
 
 }  // namespace
@@ -104,7 +104,7 @@ bool ThreadsExec::spawn() {
       0 == pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED)) {
     pthread_t pt;
 
-    result = 0 == pthread_create(&pt, &attr, internal_pthread_driver, 0);
+    result = 0 == pthread_create(&pt, &attr, internal_pthread_driver, nullptr);
   }
 
   pthread_attr_destroy(&attr);

--- a/core/src/Threads/Kokkos_Threads_Parallel.hpp
+++ b/core/src/Threads/Kokkos_Threads_Parallel.hpp
@@ -491,7 +491,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const HostViewType &arg_result_view,
       typename std::enable_if<Kokkos::is_view<HostViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void *>::type = NULL)
+                              void *>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),
@@ -649,7 +649,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       const HostViewType &arg_result_view,
       typename std::enable_if<Kokkos::is_view<HostViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void *>::type = NULL)
+                              void *>::type = nullptr)
       : m_functor(arg_functor),
         m_mdr_policy(arg_policy),
         m_policy(Policy(0, m_mdr_policy.m_num_tiles).set_chunk_size(1)),
@@ -773,7 +773,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       const ViewType &arg_result,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
                                   !Kokkos::is_reducer_type<ReducerType>::value,
-                              void *>::type = NULL)
+                              void *>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),

--- a/core/src/impl/Kokkos_Atomic_View.hpp
+++ b/core/src/impl/Kokkos_Atomic_View.hpp
@@ -346,7 +346,7 @@ class AtomicViewDataHandle {
   typename ViewTraits::value_type* ptr;
 
   KOKKOS_INLINE_FUNCTION
-  AtomicViewDataHandle() : ptr(NULL) {}
+  AtomicViewDataHandle() : ptr(nullptr) {}
 
   KOKKOS_INLINE_FUNCTION
   AtomicViewDataHandle(typename ViewTraits::value_type* ptr_) : ptr(ptr_) {}

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -517,7 +517,7 @@ void initialize(int& narg, char* arg[]) {
 
       char* num1      = strchr(arg[iarg], '=') + 1;
       char* num2      = strpbrk(num1, ",");
-      int num1_len    = num2 == NULL ? strlen(num1) : num2 - num1;
+      int num1_len    = num2 == nullptr ? strlen(num1) : num2 - num1;
       char* num1_only = new char[num1_len + 1];
       strncpy(num1_only, num1, num1_len);
       num1_only[num1_len] = 0;
@@ -533,7 +533,7 @@ void initialize(int& narg, char* arg[]) {
         ndevices = atoi(num1_only);
       delete[] num1_only;
 
-      if (num2 != NULL) {
+      if (num2 != nullptr) {
         if ((!Impl::is_unsigned_int(num2 + 1)) || (strlen(num2) == 1))
           Impl::throw_runtime_exception(
               "Error: expecting an integer number after command line argument "

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -796,7 +796,7 @@ struct FunctorAnalysis {
     using rebind = Reducer<S>;
 
     KOKKOS_INLINE_FUNCTION explicit constexpr Reducer(
-        Functor const* arg_functor = 0, ValueType* arg_value = 0) noexcept
+        Functor const* arg_functor = 0, ValueType* arg_value = nullptr) noexcept
         : m_functor(arg_functor), m_result(arg_value) {}
   };
 };

--- a/core/src/impl/Kokkos_HBWSpace.cpp
+++ b/core/src/impl/Kokkos_HBWSpace.cpp
@@ -135,8 +135,8 @@ void *HBWSpace::allocate(const size_t arg_alloc_size) const {
       case STD_MALLOC: msg << "STD_MALLOC"; break;
     }
     msg << " ]( " << arg_alloc_size << " ) FAILED";
-    if (ptr == NULL) {
-      msg << " NULL";
+    if (ptr == nullptr) {
+      msg << " nullptr";
     } else {
       msg << " NOT ALIGNED " << ptr;
     }

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -220,18 +220,19 @@ void *HostSpace::allocate(const size_t arg_alloc_size) const {
 
       // read write access to private memory
 
-      ptr = mmap(NULL /* address hint, if NULL OS kernel chooses address */
-                 ,
-                 arg_alloc_size /* size in bytes */
-                 ,
-                 prot /* memory protection */
-                 ,
-                 flags /* visibility of updates */
-                 ,
-                 -1 /* file descriptor */
-                 ,
-                 0 /* offset */
-      );
+      ptr =
+          mmap(nullptr /* address hint, if nullptr OS kernel chooses address */
+               ,
+               arg_alloc_size /* size in bytes */
+               ,
+               prot /* memory protection */
+               ,
+               flags /* visibility of updates */
+               ,
+               -1 /* file descriptor */
+               ,
+               0 /* offset */
+          );
 
       /* Associated reallocation:
              ptr = mremap( old_ptr , old_size , new_size , MREMAP_MAYMOVE );
@@ -408,7 +409,7 @@ void *SharedAllocationRecord<Kokkos::HostSpace, void>::allocate_tracked(
 
 void SharedAllocationRecord<Kokkos::HostSpace, void>::deallocate_tracked(
     void *const arg_alloc_ptr) {
-  if (arg_alloc_ptr != 0) {
+  if (arg_alloc_ptr != nullptr) {
     SharedAllocationRecord *const r = get_record(arg_alloc_ptr);
 
     RecordBase::decrement(r);
@@ -436,9 +437,10 @@ SharedAllocationRecord<Kokkos::HostSpace, void>::get_record(void *alloc_ptr) {
   typedef SharedAllocationRecord<Kokkos::HostSpace, void> RecordHost;
 
   SharedAllocationHeader const *const head =
-      alloc_ptr ? Header::get_header(alloc_ptr) : (SharedAllocationHeader *)0;
+      alloc_ptr ? Header::get_header(alloc_ptr)
+                : (SharedAllocationHeader *)nullptr;
   RecordHost *const record =
-      head ? static_cast<RecordHost *>(head->m_record) : (RecordHost *)0;
+      head ? static_cast<RecordHost *>(head->m_record) : (RecordHost *)nullptr;
 
   if (!alloc_ptr || record->m_alloc_ptr != head) {
     Kokkos::Impl::throw_runtime_exception(

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -397,7 +397,7 @@ SharedAllocationRecord<Kokkos::HostSpace, void>::SharedAllocationRecord(
 void *SharedAllocationRecord<Kokkos::HostSpace, void>::allocate_tracked(
     const Kokkos::HostSpace &arg_space, const std::string &arg_alloc_label,
     const size_t arg_alloc_size) {
-  if (!arg_alloc_size) return (void *)nullptr;
+  if (!arg_alloc_size) return nullptr;
 
   SharedAllocationRecord *const r =
       allocate(arg_space, arg_alloc_label, arg_alloc_size);
@@ -437,10 +437,9 @@ SharedAllocationRecord<Kokkos::HostSpace, void>::get_record(void *alloc_ptr) {
   typedef SharedAllocationRecord<Kokkos::HostSpace, void> RecordHost;
 
   SharedAllocationHeader const *const head =
-      alloc_ptr ? Header::get_header(alloc_ptr)
-                : (SharedAllocationHeader *)nullptr;
+      alloc_ptr ? Header::get_header(alloc_ptr) : nullptr;
   RecordHost *const record =
-      head ? static_cast<RecordHost *>(head->m_record) : (RecordHost *)nullptr;
+      head ? static_cast<RecordHost *>(head->m_record) : nullptr;
 
   if (!alloc_ptr || record->m_alloc_ptr != head) {
     Kokkos::Impl::throw_runtime_exception(

--- a/core/src/impl/Kokkos_HostThreadTeam.cpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.cpp
@@ -61,7 +61,8 @@ void HostThreadTeamData::organize_pool(HostThreadTeamData *members[],
 
   // Verify not already a member of a pool:
   for (int rank = 0; rank < size && ok; ++rank) {
-    ok = (nullptr != members[rank]) && (0 == members[rank]->m_pool_scratch);
+    ok = (nullptr != members[rank]) &&
+         (nullptr == members[rank]->m_pool_scratch);
   }
 
   if (ok) {
@@ -105,8 +106,8 @@ void HostThreadTeamData::organize_pool(HostThreadTeamData *members[],
 void HostThreadTeamData::disband_pool() {
   m_work_range.first     = -1;
   m_work_range.second    = -1;
-  m_pool_scratch         = 0;
-  m_team_scratch         = 0;
+  m_pool_scratch         = nullptr;
+  m_team_scratch         = nullptr;
   m_pool_rank            = 0;
   m_pool_size            = 1;
   m_team_base            = 0;
@@ -120,7 +121,7 @@ void HostThreadTeamData::disband_pool() {
 
 int HostThreadTeamData::organize_team(const int team_size) {
   // Pool is initialized
-  const bool ok_pool = 0 != m_pool_scratch;
+  const bool ok_pool = nullptr != m_pool_scratch;
 
   // Team is not set
   const bool ok_team =

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -187,9 +187,9 @@ class HostThreadTeamData {
   constexpr HostThreadTeamData() noexcept
       : m_work_range(-1, -1),
         m_work_end(0),
-        m_scratch(0),
-        m_pool_scratch(0),
-        m_team_scratch(0),
+        m_scratch(nullptr),
+        m_pool_scratch(nullptr),
+        m_team_scratch(nullptr),
         m_pool_rank(0),
         m_pool_size(1),
         m_team_reduce(0),
@@ -692,8 +692,8 @@ class HostThreadTeamMember {
 #endif*/
 
   template <typename T>
-  KOKKOS_INLINE_FUNCTION T team_scan(T const& value, T* const global = 0) const
-      noexcept
+  KOKKOS_INLINE_FUNCTION T team_scan(T const& value,
+                                     T* const global = nullptr) const noexcept
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
   {
     if (0 != m_data.m_team_rank) {

--- a/core/src/impl/Kokkos_Serial.cpp
+++ b/core/src/impl/Kokkos_Serial.cpp
@@ -191,7 +191,7 @@ void Serial::impl_finalize()
     space.deallocate(Impl::g_serial_thread_team_data.scratch_buffer(),
                      Impl::g_serial_thread_team_data.scratch_bytes());
 
-    Impl::g_serial_thread_team_data.scratch_assign((void*)0, 0, 0, 0, 0, 0);
+    Impl::g_serial_thread_team_data.scratch_assign(nullptr, 0, 0, 0, 0, 0);
   }
 
 #if defined(KOKKOS_ENABLE_PROFILING)

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -99,7 +99,7 @@ bool SharedAllocationRecord<void, void>::is_sane(
                 reinterpret_cast<uintptr_t>(rec->m_next),
                 reinterpret_cast<uintptr_t>(rec->m_prev),
                 reinterpret_cast<uintptr_t>(
-                    rec->m_next != NULL ? rec->m_next->m_prev : NULL),
+                    rec->m_next != nullptr ? rec->m_next->m_prev : nullptr),
                 reinterpret_cast<uintptr_t>(rec->m_prev != rec->m_root
                                                 ? rec->m_prev->m_next
                                                 : root_next));
@@ -185,7 +185,7 @@ SharedAllocationRecord<void, void>::SharedAllocationRecord(
 #endif
       ,
       m_count(0) {
-  if (0 != arg_alloc_ptr) {
+  if (nullptr != arg_alloc_ptr) {
 #ifdef KOKKOS_DEBUG
     // Insert into the root double-linked list for tracking
     //
@@ -196,7 +196,7 @@ SharedAllocationRecord<void, void>::SharedAllocationRecord(
     m_prev                                        = m_root;
     static constexpr SharedAllocationRecord* zero = nullptr;
 
-    // Read root->m_next and lock by setting to NULL
+    // Read root->m_next and lock by setting to nullptr
     while ((m_next = Kokkos::atomic_exchange(&m_root->m_next, zero)) == nullptr)
       ;
 
@@ -213,7 +213,7 @@ SharedAllocationRecord<void, void>::SharedAllocationRecord(
 
   } else {
     Kokkos::Impl::throw_runtime_exception(
-        "Kokkos::Impl::SharedAllocationRecord given NULL allocation");
+        "Kokkos::Impl::SharedAllocationRecord given nullptr allocation");
   }
 }
 
@@ -287,7 +287,7 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<
 
     function_type d = arg_record->m_dealloc;
     (*d)(arg_record);
-    arg_record = 0;
+    arg_record = nullptr;
   } else if (old_count < 1) {  // Error
     fprintf(stderr,
             "Kokkos::Impl::SharedAllocationRecord '%s' failed decrement count "

--- a/core/src/impl/Kokkos_Stacktrace.cpp
+++ b/core/src/impl/Kokkos_Stacktrace.cpp
@@ -18,7 +18,7 @@ namespace Kokkos {
 namespace Impl {
 #ifndef KOKKOS_IMPL_ENABLE_STACKTRACE
 int backtrace(void**, int) { return 0; }
-char** backtrace_symbols(void* const*, int) { return NULL; }
+char** backtrace_symbols(void* const*, int) { return nullptr; }
 #endif
 
 std::string demangle(const std::string& name) {

--- a/core/src/impl/Kokkos_TaskBase.hpp
+++ b/core/src/impl/Kokkos_TaskBase.hpp
@@ -206,7 +206,7 @@ class TaskBase {
       Kokkos::abort("TaskScheduler ERROR: resetting task dependence");
     }
 
-    if (0 != dep) {
+    if (nullptr != dep) {
       // The future may be destroyed upon returning from this call
       // so increment reference count to track this assignment.
       Kokkos::atomic_increment(&(dep->m_ref_count));

--- a/core/src/impl/Kokkos_TaskQueue_impl.hpp
+++ b/core/src/impl/Kokkos_TaskQueue_impl.hpp
@@ -180,7 +180,7 @@ KOKKOS_FUNCTION bool TaskQueue<ExecSpace, MemorySpace>::push_task(
          task->m_priority, task->m_ref_count);
 #endif
 
-  task_root_type *const zero = (task_root_type *)0;
+  task_root_type *const zero = nullptr;
   task_root_type *const lock = (task_root_type *)task_root_type::LockTag;
 
   task_root_type *volatile &next = task->m_next;
@@ -253,7 +253,7 @@ TaskQueue<ExecSpace, MemorySpace>::pop_ready_task(
     //
     // If queue is locked then just read by guaranteeing the CAS will fail.
 
-    if (lock == task) task = 0;
+    if (lock == task) task = nullptr;
 
     task_root_type *const x = task;
 
@@ -333,7 +333,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::schedule_runnable(
          task->m_priority, task->m_ref_count);
 #endif
 
-  task_root_type *const zero = (task_root_type *)0;
+  task_root_type *const zero = nullptr;
   task_root_type *const lock = (task_root_type *)task_root_type::LockTag;
   task_root_type *const end  = (task_root_type *)task_root_type::EndTag;
 
@@ -381,16 +381,16 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::schedule_runnable(
   // If we don't have a dependency, or if pushing onto the wait queue of that
   // dependency failed (since the only time that queue should be locked is when
   // the task is transitioning to complete??!?)
-  const bool is_ready = (0 == dep) || (!push_task(&dep->m_wait, task));
+  const bool is_ready = (nullptr == dep) || (!push_task(&dep->m_wait, task));
 
-  if ((0 != dep) && respawn) {
+  if ((nullptr != dep) && respawn) {
     // Reference count for dep was incremented when
     // respawn assigned dependency to task->m_next
     // so that if dep completed prior to the
     // above push_task dep would not be destroyed.
     // dep reference count can now be decremented,
     // which may deallocate the task.
-    TaskQueue::assign(&dep, (task_root_type *)0);
+    TaskQueue::assign(&dep, nullptr);
   }
 
   if (is_ready) {
@@ -451,7 +451,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::schedule_aggregate(
          task->m_ref_count);
 #endif
 
-  task_root_type *const zero = (task_root_type *)0;
+  task_root_type *const zero = nullptr;
   task_root_type *const lock = (task_root_type *)task_root_type::LockTag;
   task_root_type *const end  = (task_root_type *)task_root_type::EndTag;
 
@@ -550,7 +550,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::reschedule(
   //   task is in Executing-Respawn state
   //   task->m_next == 0 (no dependence)
 
-  task_root_type *const zero = (task_root_type *)0;
+  task_root_type *const zero = nullptr;
   task_root_type *const lock = (task_root_type *)task_root_type::LockTag;
 
   if (lock != Kokkos::atomic_exchange(&task->m_next, zero)) {
@@ -566,7 +566,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::complete(
   // Complete a runnable task that has finished executing
   // or a when_all task when all of its dependeneces are complete.
 
-  task_root_type *const zero = (task_root_type *)0;
+  task_root_type *const zero = nullptr;
   task_root_type *const lock = (task_root_type *)task_root_type::LockTag;
   task_root_type *const end  = (task_root_type *)task_root_type::EndTag;
 
@@ -623,7 +623,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::complete(
         task_root_type volatile &vx = *x;
 
         task_root_type *const next = vx.m_next;
-        vx.m_next                  = 0;
+        vx.m_next                  = nullptr;
 
         Kokkos::memory_fence();
 

--- a/core/src/impl/Kokkos_TaskResult.hpp
+++ b/core/src/impl/Kokkos_TaskResult.hpp
@@ -116,7 +116,7 @@ struct TaskResult<void> {
     return nullptr;
   }
 
-  KOKKOS_INLINE_FUNCTION static void* ptr(TaskBase*) { return (void*)nullptr; }
+  KOKKOS_INLINE_FUNCTION static void* ptr(TaskBase*) { return nullptr; }
 
   template <class TaskQueueTraits>
   KOKKOS_INLINE_FUNCTION static reference_type get(

--- a/core/unit_test/TestAtomicViews.hpp
+++ b/core/unit_test/TestAtomicViews.hpp
@@ -254,11 +254,11 @@ class TestAtomicViewAPI {
     ASSERT_EQ(ax.use_count(), size_t(4));
     ASSERT_EQ(const_ax.use_count(), ax.use_count());
 
-    ASSERT_FALSE(ax.data() == 0);
-    ASSERT_FALSE(const_ax.data() == 0);  // referenceable ptr
-    ASSERT_FALSE(unmanaged_ax.data() == 0);
-    ASSERT_FALSE(unmanaged_ax_from_ptr_dx.data() == 0);
-    ASSERT_FALSE(ay.data() == 0);
+    ASSERT_FALSE(ax.data() == nullptr);
+    ASSERT_FALSE(const_ax.data() == nullptr);  // referenceable ptr
+    ASSERT_FALSE(unmanaged_ax.data() == nullptr);
+    ASSERT_FALSE(unmanaged_ax_from_ptr_dx.data() == nullptr);
+    ASSERT_FALSE(ay.data() == nullptr);
     //    ASSERT_NE( ax, ay );
     //    Above test results in following runtime error from gtest:
     //    Expected: (ax) != (ay), actual: 32-byte object <30-01 D0-A0 D8-7F

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -161,10 +161,10 @@ void test_host_memory_pool_stats() {
   // Aborts because exceeds max block size:
   // void * p2048 = pool.allocate(2048);
 
-  ASSERT_NE(p0064, (void*)0);
-  ASSERT_NE(p0128, (void*)0);
-  ASSERT_NE(p0256, (void*)0);
-  ASSERT_NE(p1024, (void*)0);
+  ASSERT_NE(p0064, nullptr);
+  ASSERT_NE(p0128, nullptr);
+  ASSERT_NE(p0256, nullptr);
+  ASSERT_NE(p1024, nullptr);
 
   pool.deallocate(p0064, 64);
   pool.deallocate(p0128, 128);

--- a/core/unit_test/TestResize.hpp
+++ b/core/unit_test/TestResize.hpp
@@ -70,7 +70,7 @@ void impl_testResize() {
     typedef Kokkos::View<int*, DeviceType> view_type;
     view_type view_1d("view_1d", sizes[0]);
     const int* oldPointer = view_1d.data();
-    EXPECT_TRUE(oldPointer != NULL);
+    EXPECT_TRUE(oldPointer != nullptr);
     resize_dispatch(Tag{}, view_1d, sizes[0]);
     const int* newPointer = view_1d.data();
     EXPECT_TRUE(oldPointer == newPointer);
@@ -79,7 +79,7 @@ void impl_testResize() {
     typedef Kokkos::View<int**, DeviceType> view_type;
     view_type view_2d("view_2d", sizes[0], sizes[1]);
     const int* oldPointer = view_2d.data();
-    EXPECT_TRUE(oldPointer != NULL);
+    EXPECT_TRUE(oldPointer != nullptr);
     resize_dispatch(Tag{}, view_2d, sizes[0], sizes[1]);
     const int* newPointer = view_2d.data();
     EXPECT_TRUE(oldPointer == newPointer);
@@ -88,7 +88,7 @@ void impl_testResize() {
     typedef Kokkos::View<int***, DeviceType> view_type;
     view_type view_3d("view_3d", sizes[0], sizes[1], sizes[2]);
     const int* oldPointer = view_3d.data();
-    EXPECT_TRUE(oldPointer != NULL);
+    EXPECT_TRUE(oldPointer != nullptr);
     resize_dispatch(Tag{}, view_3d, sizes[0], sizes[1], sizes[2]);
     const int* newPointer = view_3d.data();
     EXPECT_TRUE(oldPointer == newPointer);
@@ -97,7 +97,7 @@ void impl_testResize() {
     typedef Kokkos::View<int****, DeviceType> view_type;
     view_type view_4d("view_4d", sizes[0], sizes[1], sizes[2], sizes[3]);
     const int* oldPointer = view_4d.data();
-    EXPECT_TRUE(oldPointer != NULL);
+    EXPECT_TRUE(oldPointer != nullptr);
     resize_dispatch(Tag{}, view_4d, sizes[0], sizes[1], sizes[2], sizes[3]);
     const int* newPointer = view_4d.data();
     EXPECT_TRUE(oldPointer == newPointer);
@@ -107,7 +107,7 @@ void impl_testResize() {
     view_type view_5d("view_5d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4]);
     const int* oldPointer = view_5d.data();
-    EXPECT_TRUE(oldPointer != NULL);
+    EXPECT_TRUE(oldPointer != nullptr);
     resize_dispatch(Tag{}, view_5d, sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4]);
     const int* newPointer = view_5d.data();
@@ -118,7 +118,7 @@ void impl_testResize() {
     view_type view_6d("view_6d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5]);
     const int* oldPointer = view_6d.data();
-    EXPECT_TRUE(oldPointer != NULL);
+    EXPECT_TRUE(oldPointer != nullptr);
     resize_dispatch(Tag{}, view_6d, sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5]);
     const int* newPointer = view_6d.data();
@@ -129,7 +129,7 @@ void impl_testResize() {
     view_type view_7d("view_7d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5], sizes[6]);
     const int* oldPointer = view_7d.data();
-    EXPECT_TRUE(oldPointer != NULL);
+    EXPECT_TRUE(oldPointer != nullptr);
     resize_dispatch(Tag{}, view_7d, sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5], sizes[6]);
     const int* newPointer = view_7d.data();
@@ -140,7 +140,7 @@ void impl_testResize() {
     view_type view_8d("view_8d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5], sizes[6], sizes[7]);
     const int* oldPointer = view_8d.data();
-    EXPECT_TRUE(oldPointer != NULL);
+    EXPECT_TRUE(oldPointer != nullptr);
     resize_dispatch(Tag{}, view_8d, sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5], sizes[6], sizes[7]);
     const int* newPointer = view_8d.data();

--- a/core/unit_test/TestSharedAlloc.hpp
+++ b/core/unit_test/TestSharedAlloc.hpp
@@ -115,7 +115,7 @@ void test_shared_alloc() {
 #endif
 
     Kokkos::parallel_for(range, [=](size_t i) {
-      while (0 !=
+      while (nullptr !=
              (r[i] = static_cast<RecordMemS*>(RecordBase::decrement(r[i])))) {
 #ifdef KOKKOS_DEBUG
         if (r[i]->use_count() == 1) RecordBase::is_sane(r[i]);
@@ -156,7 +156,7 @@ void test_shared_alloc() {
 #endif
 
     Kokkos::parallel_for(range, [=](size_t i) {
-      while (0 !=
+      while (nullptr !=
              (r[i] = static_cast<RecordMemS*>(RecordBase::decrement(r[i])))) {
 #ifdef KOKKOS_DEBUG
         if (r[i]->use_count() == 1) RecordBase::is_sane(r[i]);

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1033,12 +1033,12 @@ class TestViewAPI {
     dView4 dx, dy, dz;
     hView4 hx, hy, hz;
 
-    ASSERT_TRUE(dx.data() == 0);
-    ASSERT_TRUE(dy.data() == 0);
-    ASSERT_TRUE(dz.data() == 0);
-    ASSERT_TRUE(hx.data() == 0);
-    ASSERT_TRUE(hy.data() == 0);
-    ASSERT_TRUE(hz.data() == 0);
+    ASSERT_TRUE(dx.data() == nullptr);
+    ASSERT_TRUE(dy.data() == nullptr);
+    ASSERT_TRUE(dz.data() == nullptr);
+    ASSERT_TRUE(hx.data() == nullptr);
+    ASSERT_TRUE(hy.data() == nullptr);
+    ASSERT_TRUE(hz.data() == nullptr);
     ASSERT_EQ(dx.extent(0), 0u);
     ASSERT_EQ(dy.extent(0), 0u);
     ASSERT_EQ(dz.extent(0), 0u);
@@ -1095,11 +1095,11 @@ class TestViewAPI {
 
     ASSERT_EQ(dx.use_count(), size_t(2));
 
-    ASSERT_FALSE(dx.data() == 0);
-    ASSERT_FALSE(const_dx.data() == 0);
-    ASSERT_FALSE(unmanaged_dx.data() == 0);
-    ASSERT_FALSE(unmanaged_from_ptr_dx.data() == 0);
-    ASSERT_FALSE(dy.data() == 0);
+    ASSERT_FALSE(dx.data() == nullptr);
+    ASSERT_FALSE(const_dx.data() == nullptr);
+    ASSERT_FALSE(unmanaged_dx.data() == nullptr);
+    ASSERT_FALSE(unmanaged_from_ptr_dx.data() == nullptr);
+    ASSERT_FALSE(dy.data() == nullptr);
     ASSERT_NE(dx, dy);
 
     ASSERT_EQ(dx.extent(0), unsigned(N0));
@@ -1232,19 +1232,19 @@ class TestViewAPI {
     ASSERT_NE(dx, dz);
 
     dx = dView4();
-    ASSERT_TRUE(dx.data() == 0);
-    ASSERT_FALSE(dy.data() == 0);
-    ASSERT_FALSE(dz.data() == 0);
+    ASSERT_TRUE(dx.data() == nullptr);
+    ASSERT_FALSE(dy.data() == nullptr);
+    ASSERT_FALSE(dz.data() == nullptr);
 
     dy = dView4();
-    ASSERT_TRUE(dx.data() == 0);
-    ASSERT_TRUE(dy.data() == 0);
-    ASSERT_FALSE(dz.data() == 0);
+    ASSERT_TRUE(dx.data() == nullptr);
+    ASSERT_TRUE(dy.data() == nullptr);
+    ASSERT_FALSE(dz.data() == nullptr);
 
     dz = dView4();
-    ASSERT_TRUE(dx.data() == 0);
-    ASSERT_TRUE(dy.data() == 0);
-    ASSERT_TRUE(dz.data() == 0);
+    ASSERT_TRUE(dx.data() == nullptr);
+    ASSERT_TRUE(dy.data() == nullptr);
+    ASSERT_TRUE(dz.data() == nullptr);
   }
 
   static void run_test_deep_copy_empty() {

--- a/core/unit_test/TestViewLayoutStrideAssignment.hpp
+++ b/core/unit_test/TestViewLayoutStrideAssignment.hpp
@@ -55,7 +55,7 @@ namespace Test {
 TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
   typedef TEST_EXECSPACE exec_space;
 
-  auto t = time(0);
+  auto t = time(nullptr);
   srand(t);  // Use current time as seed for random generator
   printf("view_layoutstride_left_to_layoutleft_assignment: srand(%lu)\n",
          size_t(t));
@@ -337,7 +337,7 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
 TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
   typedef TEST_EXECSPACE exec_space;
 
-  auto t = time(0);
+  auto t = time(nullptr);
   srand(t);  // Use current time as seed for random generator
   printf("view_layoutstride_right_to_layoutright_assignment: srand(%lu)\n",
          size_t(t));
@@ -619,7 +619,7 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
 TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
   typedef TEST_EXECSPACE exec_space;
 
-  auto t = time(0);
+  auto t = time(nullptr);
   srand(t);  // Use current time as seed for random generator
   printf("view_layoutstride_right_to_layoutleft_assignment: srand(%lu)\n",
          size_t(t));
@@ -770,7 +770,7 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
 TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
   typedef TEST_EXECSPACE exec_space;
 
-  auto t = time(0);
+  auto t = time(nullptr);
   srand(t);  // Use current time as seed for random generator
   printf("view_layoutstride_left_to_layoutright_assignment: srand(%lu)\n",
          size_t(t));

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -899,7 +899,7 @@ void test_view_mapping() {
     ASSERT_TRUE(offset.span_is_contiguous());
 
     Kokkos::Impl::ViewMapping<traits_t, void> v(
-        Kokkos::Impl::ViewCtorProp<int*>((int*)0), stride);
+        Kokkos::Impl::ViewCtorProp<int*>(nullptr), stride);
   }
 
   {

--- a/core/unit_test/default/TestDefaultDeviceType_d.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_d.cpp
@@ -60,7 +60,7 @@ TEST(defaultdevicetype, malloc) {
   Kokkos::kokkos_free(data);
 
   int* data2 = (int*)Kokkos::kokkos_malloc(0);
-  ASSERT_TRUE(data2 == NULL);
+  ASSERT_TRUE(data2 == nullptr);
   Kokkos::kokkos_free(data2);
 }
 

--- a/example/build_cmake_in_tree/cmake_example.cpp
+++ b/example/build_cmake_in_tree/cmake_example.cpp
@@ -56,7 +56,7 @@ int main(int argc, char* argv[]) {
     exit(1);
   }
 
-  const long n = strtol(argv[1], NULL, 10);
+  const long n = strtol(argv[1], nullptr, 10);
 
   printf("Number of even integers from 0 to %ld\n", n - 1);
 

--- a/example/build_cmake_installed/cmake_example.cpp
+++ b/example/build_cmake_installed/cmake_example.cpp
@@ -56,7 +56,7 @@ int main(int argc, char* argv[]) {
     exit(1);
   }
 
-  const long n = strtol(argv[1], NULL, 10);
+  const long n = strtol(argv[1], nullptr, 10);
 
   printf("Number of even integers from 0 to %ld\n", n - 1);
 


### PR DESCRIPTION
I see no reason still to use `NULL`, `0`, `(void*)0`, etc., instead of `nullptr`.