### PR TITLE
Enable Cross-Compiling without Device Driver

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -67,7 +67,7 @@ Note that all of these use `PUBLIC`! Almost every Kokkos flag is not private to 
 
 
 ### Compiler Features and Compiler Options
-Compiler options are flags like `-fopenmp` that do not need to be "resolved." 
+Compiler options are flags like `-fopenmp` that do not need to be "resolved."
 The flag is either on or off.
 Compiler features are more fine-grained and require conflicting requests to be resolved.
 Suppose I have
@@ -145,11 +145,11 @@ If Kokkos depends on, e.g. `hwloc` the downstream project will also need to link
 There are three stages in adding a new third-party library (TPL):
 * Finding: find the desired library on the system and verify the installation is correct
 * Importing: create a CMake target, if necessary, that is compatible with `target_link_libraries`. This is mostly relevant for TPLs not installed with CMake.
-* Exporting: make the desired library visible to downstream projects 
+* Exporting: make the desired library visible to downstream projects
 
 TPLs are somewhat complicated by whether the library was installed with CMake or some other build system.
 If CMake, our lives are greatly simplified. We simply use `find_package` to locate the installed CMake project then call `target_link_libraries(kokkoscore PUBLIC/PRIVATE TPL)`. For libaries not installed with CMake, the process is a bit more complex.
-It is up to the Kokkos developers to "convert" the library into a CMake target as if it had been installed as a valid modern CMake target with properties.  
+It is up to the Kokkos developers to "convert" the library into a CMake target as if it had been installed as a valid modern CMake target with properties.
 There are helper functions for simplifying the process of importing TPLs in Kokkos, but we walk through the process in detail to clearly illustrate the steps involved.
 
 #### TPL Search Order
@@ -166,8 +166,9 @@ There are 3 possibilities that could be used:
 The following is the search order that Kokkos follows. Note: This differs from the default search order used by CMake `find_library` and `find_header`. CMake prefers default system paths over user-provided paths.
 For Kokkos (and package managers in general), it is better to prefer user-provided paths since this usually indicates a specific version we want.
 
-1. `<NAME>_ROOT`
-1. `Kokkos_<NAME>_DIR`
+1. `<NAME>_ROOT` command line option
+1. `<NAME>_ROOT` environment variable
+1. `Kokkos_<NAME>_DIR` command line option
 1.  Paths added by Kokkos CMake logic
 1.  Default system paths (if allowed)
 

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -391,37 +391,26 @@ MACRO(kokkos_find_header VAR_NAME HEADER TPL_NAME)
   SET(${VAR_NAME} "${VARNAME}-NOTFOUND")
   SET(HAVE_CUSTOM_PATHS FALSE)
 
-  IF(NOT ${VAR_NAME} AND DEFINED ${TPL_NAME}_ROOT)
-    #ONLY look in the root directory
-    FIND_PATH(${VAR_NAME} ${HEADER} PATHS ${${TPL_NAME}_ROOT}/include NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND DEFINED ENV{${TPL_NAME}_ROOT})
-    #ONLY look in the root directory (via environent variable)
-    FIND_PATH(${VAR_NAME} ${HEADER} PATHS $ENV{${TPL_NAME}_ROOT}/include NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND DEFINED KOKKOS_${TPL_NAME}_DIR)
-    #ONLY look in the Kokkos_*_DIR directory
-    FIND_PATH(${VAR_NAME} ${HEADER} PATHS ${KOKKOS_${TPL_NAME}_DIR}/include NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND TPL_PATHS)
-    #we got custom paths
-    #ONLY look in these paths and nowhere else
-    FIND_PATH(${VAR_NAME} ${HEADER} PATHS ${TPL_PATHS} NO_DEFAULT_PATH)
+  IF(DEFINED ${TPL_NAME}_ROOT OR
+     DEFINED ENV{${TPL_NAME}_ROOT} OR
+     DEFINED KOKKOS_${TPL_NAME}_DIR OR
+     TPL_PATHS)
+    FIND_PATH(${VAR_NAME} ${HEADER}
+      PATHS
+        ${${TPL_NAME}_ROOT}
+        $ENV{${TPL_NAME}_ROOT}
+        ${KOKKOS_${TPL_NAME}_DIR}
+        ${TPL_PATHS}
+      PATH_SUFFIXES include
+      NO_DEFAULT_PATH)
     SET(HAVE_CUSTOM_PATHS TRUE)
   ENDIF()
 
   IF(NOT HAVE_CUSTOM_PATHS OR TPL_ALLOW_SYSTEM_PATH_FALLBACK)
-    #Now go ahead and look in system paths
-    IF(NOT ${VAR_NAME})
-      FIND_PATH(${VAR_NAME} ${HEADER})
-    ENDIF()
+    #No-op if ${VAR_NAME} set by previous call
+    FIND_PATH(${VAR_NAME} ${HEADER})
   ENDIF()
+
 ENDMACRO()
 
 #
@@ -479,52 +468,33 @@ MACRO(kokkos_find_library VAR_NAME LIB TPL_NAME)
    "PATHS"
    ${ARGN})
 
-  # Appended to user- and system-provided location candidates.
-  # The "stubs" directory supports cross-compiling CUDA when the
-  # libcuda device driver is not present on the host machine.
+  #Appended to user- and system-provided path candidates.
+  #The "stubs" directory supports cross-compiling CUDA when the
+  #libcuda device driver is not present on the host machine.
   SET(SUFFIXES lib lib64 lib/stubs lib64/stubs)
-  SET(${VAR_NAME} "${VAR_NAME}-NOTFOUND")
+
+  SET(${VAR_NAME} "${VARNAME}-NOTFOUND")
   SET(HAVE_CUSTOM_PATHS FALSE)
 
-  IF(NOT ${VAR_NAME} AND DEFINED ${TPL_NAME}_ROOT)
+  IF(DEFINED ${TPL_NAME}_ROOT OR
+     DEFINED ENV{${TPL_NAME}_ROOT} OR
+     DEFINED KOKKOS_${TPL_NAME}_DIR OR
+     TPL_PATHS)
     FIND_LIBRARY(${VAR_NAME} ${LIB}
-      PATHS ${${TPL_NAME}_ROOT}
-      PATH_SUFFIXES ${SUFFIXES}
-      NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND DEFINED ENV{${TPL_NAME}_ROOT})
-    FIND_LIBRARY(${VAR_NAME} ${LIB}
-      PATHS $ENV{${TPL_NAME}_ROOT}
-      PATH_SUFFIXES ${SUFFIXES}
-      NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND DEFINED KOKKOS_${TPL_NAME}_DIR)
-    #we got root paths, only look in these paths and nowhere else
-    FIND_LIBRARY(${VAR_NAME} ${LIB}
-      PATHS ${KOKKOS_${TPL_NAME}_DIR}
-      PATH_SUFFIXES ${SUFFIXES}
-      NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND TPL_PATHS)
-    #we got custom paths, only look in these paths and nowhere else
-    FIND_LIBRARY(${VAR_NAME} ${LIB}
-      PATHS ${TPL_PATHS}
-      PATH_SUFFIXES ${SUFFIXES}
+      PATHS
+        ${${TPL_NAME}_ROOT}
+        $ENV{${TPL_NAME}_ROOT}
+        ${KOKKOS_${TPL_NAME}_DIR}
+        ${TPL_PATHS}
+      PATH_SUFFIXES
+        ${SUFFIXES}
       NO_DEFAULT_PATH)
     SET(HAVE_CUSTOM_PATHS TRUE)
   ENDIF()
 
   IF(NOT HAVE_CUSTOM_PATHS OR TPL_ALLOW_SYSTEM_PATH_FALLBACK)
-    IF(NOT ${VAR_NAME})
-      #Now go ahead and look in system paths
-      FIND_LIBRARY(${VAR_NAME} ${LIB} PATH_SUFFIXES ${SUFFIXES})
-    ENDIF()
+    #No-op if ${VAR_NAME} set by previous call
+    FIND_LIBRARY(${VAR_NAME} ${LIB} PATH_SUFFIXES ${SUFFIXES})
   ENDIF()
 
 ENDMACRO()

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -3,9 +3,9 @@
 #   kokkos_option
 
 # Validate options are given with correct case and define an internal
-# upper-case version for use within 
+# upper-case version for use within
 
-# 
+#
 #
 # @FUNCTION: kokkos_deprecated_list
 #
@@ -62,7 +62,7 @@ FUNCTION(kokkos_option CAMEL_SUFFIX DEFAULT TYPE DOCSTRING)
           UNSET(${opt} CACHE)
         ELSE()
           MESSAGE(FATAL_ERROR "Matching option found for ${CAMEL_NAME} with the wrong case ${opt}. Please delete your CMakeCache.txt and change option to -D${CAMEL_NAME}=${${opt}}. This is now enforced to avoid hard-to-debug CMake cache inconsistencies.")
-	ENDIF()
+        ENDIF()
       ENDIF()
     ENDIF()
   ENDFOREACH()
@@ -125,7 +125,7 @@ MACRO(kokkos_export_imported_tpl NAME)
       KOKKOS_APPEND_CONFIG_LINE("IF(NOT TARGET ${NAME})")
       KOKKOS_APPEND_CONFIG_LINE("ADD_LIBRARY(${NAME} UNKNOWN IMPORTED)")
       KOKKOS_APPEND_CONFIG_LINE("SET_TARGET_PROPERTIES(${NAME} PROPERTIES")
-      
+
       GET_TARGET_PROPERTY(TPL_LIBRARY ${NAME} IMPORTED_LOCATION)
       IF(TPL_LIBRARY)
         KOKKOS_APPEND_CONFIG_LINE("IMPORTED_LOCATION ${TPL_LIBRARY}")
@@ -198,7 +198,7 @@ MACRO(kokkos_import_tpl NAME)
   # I have still been getting errors about ROOT variables being ignored
   # I'm not sure if this is a scope issue - but make sure
   # the policy is set before we do any find_package calls
-  IF(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0") 
+  IF(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
     CMAKE_POLICY(SET CMP0074 NEW)
   ENDIF()
 
@@ -341,11 +341,12 @@ ENDMACRO()
 # default, custom paths are prioritized over system paths. The searched
 # order is:
 # 1. <NAME>_ROOT variable
-# 2. Kokkos_<NAME>_DIR variable
-# 3. Locations in the PATHS option
-# 4. Default system paths, if allowed.
+# 2. <NAME>_ROOT environment variable
+# 3. Kokkos_<NAME>_DIR variable
+# 4. Locations in the PATHS option
+# 5. Default system paths, if allowed.
 #
-# Default system paths are allowed if none of options (1)-(3) are specified
+# Default system paths are allowed if none of options (1)-(4) are specified
 # or if default paths are specifically allowed via ALLOW_SYSTEM_PATH_FALLBACK
 #
 # Usage::
@@ -387,30 +388,37 @@ MACRO(kokkos_find_header VAR_NAME HEADER TPL_NAME)
    "PATHS"
    ${ARGN})
 
-  SET(${HEADER}_FOUND FALSE)
+  SET(${VAR_NAME} "${VARNAME}-NOTFOUND")
   SET(HAVE_CUSTOM_PATHS FALSE)
-  IF(NOT ${HEADER}_FOUND AND DEFINED ${TPL_NAME}_ROOT)
+
+  IF(NOT ${VAR_NAME} AND DEFINED ${TPL_NAME}_ROOT)
     #ONLY look in the root directory
     FIND_PATH(${VAR_NAME} ${HEADER} PATHS ${${TPL_NAME}_ROOT}/include NO_DEFAULT_PATH)
     SET(HAVE_CUSTOM_PATHS TRUE)
   ENDIF()
 
-  IF(NOT ${HEADER}_FOUND AND DEFINED KOKKOS_${TPL_NAME}_DIR)
-    #ONLY look in the root directory
+  IF(NOT ${VAR_NAME} AND DEFINED ENV{${TPL_NAME}_ROOT})
+    #ONLY look in the root directory (via environent variable)
+    FIND_PATH(${VAR_NAME} ${HEADER} PATHS $ENV{${TPL_NAME}_ROOT}/include NO_DEFAULT_PATH)
+    SET(HAVE_CUSTOM_PATHS TRUE)
+  ENDIF()
+
+  IF(NOT ${VAR_NAME} AND DEFINED KOKKOS_${TPL_NAME}_DIR)
+    #ONLY look in the Kokkos_*_DIR directory
     FIND_PATH(${VAR_NAME} ${HEADER} PATHS ${KOKKOS_${TPL_NAME}_DIR}/include NO_DEFAULT_PATH)
     SET(HAVE_CUSTOM_PATHS TRUE)
   ENDIF()
 
-  IF (NOT ${HEADER}_FOUND AND TPL_PATHS)
+  IF(NOT ${VAR_NAME} AND TPL_PATHS)
     #we got custom paths
     #ONLY look in these paths and nowhere else
     FIND_PATH(${VAR_NAME} ${HEADER} PATHS ${TPL_PATHS} NO_DEFAULT_PATH)
     SET(HAVE_CUSTOM_PATHS TRUE)
   ENDIF()
 
-  IF (NOT HAVE_CUSTOM_PATHS OR TPL_ALLOW_SYSTEM_PATH_FALLBACK)
+  IF(NOT HAVE_CUSTOM_PATHS OR TPL_ALLOW_SYSTEM_PATH_FALLBACK)
     #Now go ahead and look in system paths
-    IF (NOT ${HEADER}_FOUND)
+    IF(NOT ${VAR_NAME})
       FIND_PATH(${VAR_NAME} ${HEADER})
     ENDIF()
   ENDIF()
@@ -424,9 +432,10 @@ ENDMACRO()
 # default, custom paths are prioritized over system paths. The search
 # order is:
 # 1. <NAME>_ROOT variable
-# 2. Kokkos_<NAME>_DIR variable
-# 3. Locations in the PATHS option
-# 4. Default system paths, if allowed.
+# 2. <NAME>_ROOT environment variable
+# 3. Kokkos_<NAME>_DIR variable
+# 4. Locations in the PATHS option
+# 5. Default system paths, if allowed.
 #
 # Default system paths are allowed if none of options (1)-(3) are specified
 # or if default paths are specifically allowed via ALLOW_SYSTEM_PATH_FALLBACK
@@ -470,32 +479,54 @@ MACRO(kokkos_find_library VAR_NAME LIB TPL_NAME)
    "PATHS"
    ${ARGN})
 
-  SET(${LIB}_FOUND FALSE)
+  # Appended to user- and system-provided location candidates.
+  # The "stubs" directory supports cross-compiling CUDA when the
+  # libcuda device driver is not present on the host machine.
+  SET(SUFFIXES lib lib64 lib/stubs lib64/stubs)
+  SET(${VAR_NAME} "${VAR_NAME}-NOTFOUND")
   SET(HAVE_CUSTOM_PATHS FALSE)
-  IF(NOT ${LIB}_FOUND AND DEFINED ${TPL_NAME}_ROOT)
-    FIND_LIBRARY(${VAR_NAME} ${LIB} PATHS ${${TPL_NAME}_ROOT}/lib ${${TPL_NAME}_ROOT}/lib64 NO_DEFAULT_PATH)
+
+  IF(NOT ${VAR_NAME} AND DEFINED ${TPL_NAME}_ROOT)
+    FIND_LIBRARY(${VAR_NAME} ${LIB}
+      PATHS ${${TPL_NAME}_ROOT}
+      PATH_SUFFIXES ${SUFFIXES}
+      NO_DEFAULT_PATH)
     SET(HAVE_CUSTOM_PATHS TRUE)
   ENDIF()
 
-  IF(NOT ${LIB}_FOUND AND DEFINED KOKKOS_${TPL_NAME}_DIR)
+  IF(NOT ${VAR_NAME} AND DEFINED ENV{${TPL_NAME}_ROOT})
+    FIND_LIBRARY(${VAR_NAME} ${LIB}
+      PATHS $ENV{${TPL_NAME}_ROOT}
+      PATH_SUFFIXES ${SUFFIXES}
+      NO_DEFAULT_PATH)
+    SET(HAVE_CUSTOM_PATHS TRUE)
+  ENDIF()
+
+  IF(NOT ${VAR_NAME} AND DEFINED KOKKOS_${TPL_NAME}_DIR)
     #we got root paths, only look in these paths and nowhere else
-    FIND_LIBRARY(${VAR_NAME} ${LIB} PATHS ${KOKKOS_${TPL_NAME}_DIR}/lib ${KOKKOS_${TPL_NAME}_DIR}/lib64 NO_DEFAULT_PATH)
+    FIND_LIBRARY(${VAR_NAME} ${LIB}
+      PATHS ${KOKKOS_${TPL_NAME}_DIR}
+      PATH_SUFFIXES ${SUFFIXES}
+      NO_DEFAULT_PATH)
     SET(HAVE_CUSTOM_PATHS TRUE)
   ENDIF()
 
-  IF (NOT ${LIB}_FOUND AND TPL_PATHS)
+  IF(NOT ${VAR_NAME} AND TPL_PATHS)
     #we got custom paths, only look in these paths and nowhere else
-    FIND_LIBRARY(${VAR_NAME} ${LIB} PATHS ${TPL_PATHS} NO_DEFAULT_PATH)
+    FIND_LIBRARY(${VAR_NAME} ${LIB}
+      PATHS ${TPL_PATHS}
+      PATH_SUFFIXES ${SUFFIXES}
+      NO_DEFAULT_PATH)
     SET(HAVE_CUSTOM_PATHS TRUE)
   ENDIF()
 
-
-  IF (NOT HAVE_CUSTOM_PATHS OR TPL_ALLOW_SYSTEM_PATH_FALLBACK)
-    IF (NOT ${LIB}_FOUND)
+  IF(NOT HAVE_CUSTOM_PATHS OR TPL_ALLOW_SYSTEM_PATH_FALLBACK)
+    IF(NOT ${VAR_NAME})
       #Now go ahead and look in system paths
-      FIND_LIBRARY(${VAR_NAME} ${LIB})
+      FIND_LIBRARY(${VAR_NAME} ${LIB} PATH_SUFFIXES ${SUFFIXES})
     ENDIF()
   ENDIF()
+
 ENDMACRO()
 
 #
@@ -607,7 +638,7 @@ MACRO(kokkos_find_imported NAME)
     IF(${LIB}_LOCATION)
       LIST(APPEND ${NAME}_FOUND_LIBRARIES ${${LIB}_LOCATION})
     ELSE()
-      SET(${NAME}_FOUND_LIBRARIES ${${LIB}_LOCATION}) 
+      SET(${NAME}_FOUND_LIBRARIES ${${LIB}_LOCATION})
       BREAK()
     ENDIF()
   ENDFOREACH()


### PR DESCRIPTION
Hello,

I recently built an application on NASA's Pleiades supercomputer using Kokkos with Clang 7.5 and Cuda 9.2. I ran into a few issues with the current CMake scripts related to finding Cuda libraries. See the commit messages for additional details. 

The most critical fix was adding `lib64/stubs` to the suffix list in `kokkos_find_library`. This allows CMake to find the dummy `libcuda.so` provided by CUDA Toolkit when a proper device driver is not available elsewhere on the system. This enables compiling on machines without a GPU (e.g. cluster head node) and then deploying to machines that do (the compute nodes).

This has been tested in Pleiades. No impact is expected to current test builds since "lib64/stubs" is at the end of suffix list; it should only enable builds that would have otherwise failed due to an inability to find "libcuda.so". 


