### PR TITLE
Deprecate CudaUVMSpace::number_of_allocations()

### DIFF
--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -165,7 +165,7 @@ class CudaUVMSpace {
 
   /*--------------------------------*/
   /** \brief  CudaUVMSpace specific routine */
-  static int number_of_allocations();
+  KOKKOS_DEPRECATED static int number_of_allocations();
 
   /*--------------------------------*/
 


### PR DESCRIPTION
Follow-up to #2707.