### PR TITLE
Redux: Enable Cross-Compiling without Device Driver

### DIFF
--- a/cmake/Modules/FindTPLCUDA.cmake
+++ b/cmake/Modules/FindTPLCUDA.cmake
@@ -1,8 +1,12 @@
 
 IF (KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+   # Note: "stubs" suffix allows CMake to find the dummy
+   # libcuda.so provided by the nVidia CUDA Toolkit for
+   # cross-compiling CUDA on a host without a GPU.
    KOKKOS_FIND_IMPORTED(CUDA INTERFACE
     LIBRARIES cudart cuda
     LIBRARY_PATHS ENV LD_LIBRARY_PATH ENV CUDA_PATH
+    LIBRARY_SUFFIXES lib lib64 lib/stubs lib64/stubs
     ALLOW_SYSTEM_PATH_FALLBACK
    )
 ELSE()

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -166,8 +166,9 @@ There are 3 possibilities that could be used:
 The following is the search order that Kokkos follows. Note: This differs from the default search order used by CMake `find_library` and `find_header`. CMake prefers default system paths over user-provided paths.
 For Kokkos (and package managers in general), it is better to prefer user-provided paths since this usually indicates a specific version we want.
 
-1. `<NAME>_ROOT`
-1. `Kokkos_<NAME>_DIR`
+1. `<NAME>_ROOT` command line option
+1. `<NAME>_ROOT` environment variable
+1. `Kokkos_<NAME>_DIR` command line option
 1.  Paths added by Kokkos CMake logic
 1.  Default system paths (if allowed)
 

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -391,37 +391,26 @@ MACRO(kokkos_find_header VAR_NAME HEADER TPL_NAME)
   SET(${VAR_NAME} "${VARNAME}-NOTFOUND")
   SET(HAVE_CUSTOM_PATHS FALSE)
 
-  IF(NOT ${VAR_NAME} AND DEFINED ${TPL_NAME}_ROOT)
-    #ONLY look in the root directory
-    FIND_PATH(${VAR_NAME} ${HEADER} PATHS ${${TPL_NAME}_ROOT}/include NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND DEFINED ENV{${TPL_NAME}_ROOT})
-    #ONLY look in the root directory (via environent variable)
-    FIND_PATH(${VAR_NAME} ${HEADER} PATHS $ENV{${TPL_NAME}_ROOT}/include NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND DEFINED KOKKOS_${TPL_NAME}_DIR)
-    #ONLY look in the Kokkos_*_DIR directory
-    FIND_PATH(${VAR_NAME} ${HEADER} PATHS ${KOKKOS_${TPL_NAME}_DIR}/include NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND TPL_PATHS)
-    #we got custom paths
-    #ONLY look in these paths and nowhere else
-    FIND_PATH(${VAR_NAME} ${HEADER} PATHS ${TPL_PATHS} NO_DEFAULT_PATH)
+  IF(DEFINED ${TPL_NAME}_ROOT OR
+     DEFINED ENV{${TPL_NAME}_ROOT} OR
+     DEFINED KOKKOS_${TPL_NAME}_DIR OR
+     TPL_PATHS)
+    FIND_PATH(${VAR_NAME} ${HEADER}
+      PATHS
+        ${${TPL_NAME}_ROOT}
+        $ENV{${TPL_NAME}_ROOT}
+        ${KOKKOS_${TPL_NAME}_DIR}
+        ${TPL_PATHS}
+      PATH_SUFFIXES include
+      NO_DEFAULT_PATH)
     SET(HAVE_CUSTOM_PATHS TRUE)
   ENDIF()
 
   IF(NOT HAVE_CUSTOM_PATHS OR TPL_ALLOW_SYSTEM_PATH_FALLBACK)
-    #Now go ahead and look in system paths
-    IF(NOT ${VAR_NAME})
-      FIND_PATH(${VAR_NAME} ${HEADER})
-    ENDIF()
+    #No-op if ${VAR_NAME} set by previous call
+    FIND_PATH(${VAR_NAME} ${HEADER})
   ENDIF()
+
 ENDMACRO()
 
 #
@@ -479,52 +468,33 @@ MACRO(kokkos_find_library VAR_NAME LIB TPL_NAME)
    "PATHS"
    ${ARGN})
 
-  # Appended to user- and system-provided location candidates.
-  # The "stubs" directory supports cross-compiling CUDA when the
-  # libcuda device driver is not present on the host machine.
+  #Appended to user- and system-provided path candidates.
+  #The "stubs" directory supports cross-compiling CUDA when the
+  #libcuda device driver is not present on the host machine.
   SET(SUFFIXES lib lib64 lib/stubs lib64/stubs)
-  SET(${VAR_NAME} "${VAR_NAME}-NOTFOUND")
+
+  SET(${VAR_NAME} "${VARNAME}-NOTFOUND")
   SET(HAVE_CUSTOM_PATHS FALSE)
 
-  IF(NOT ${VAR_NAME} AND DEFINED ${TPL_NAME}_ROOT)
+  IF(DEFINED ${TPL_NAME}_ROOT OR
+     DEFINED ENV{${TPL_NAME}_ROOT} OR
+     DEFINED KOKKOS_${TPL_NAME}_DIR OR
+     TPL_PATHS)
     FIND_LIBRARY(${VAR_NAME} ${LIB}
-      PATHS ${${TPL_NAME}_ROOT}
-      PATH_SUFFIXES ${SUFFIXES}
-      NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND DEFINED ENV{${TPL_NAME}_ROOT})
-    FIND_LIBRARY(${VAR_NAME} ${LIB}
-      PATHS $ENV{${TPL_NAME}_ROOT}
-      PATH_SUFFIXES ${SUFFIXES}
-      NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND DEFINED KOKKOS_${TPL_NAME}_DIR)
-    #we got root paths, only look in these paths and nowhere else
-    FIND_LIBRARY(${VAR_NAME} ${LIB}
-      PATHS ${KOKKOS_${TPL_NAME}_DIR}
-      PATH_SUFFIXES ${SUFFIXES}
-      NO_DEFAULT_PATH)
-    SET(HAVE_CUSTOM_PATHS TRUE)
-  ENDIF()
-
-  IF(NOT ${VAR_NAME} AND TPL_PATHS)
-    #we got custom paths, only look in these paths and nowhere else
-    FIND_LIBRARY(${VAR_NAME} ${LIB}
-      PATHS ${TPL_PATHS}
-      PATH_SUFFIXES ${SUFFIXES}
+      PATHS
+        ${${TPL_NAME}_ROOT}
+        $ENV{${TPL_NAME}_ROOT}
+        ${KOKKOS_${TPL_NAME}_DIR}
+        ${TPL_PATHS}
+      PATH_SUFFIXES
+        ${SUFFIXES}
       NO_DEFAULT_PATH)
     SET(HAVE_CUSTOM_PATHS TRUE)
   ENDIF()
 
   IF(NOT HAVE_CUSTOM_PATHS OR TPL_ALLOW_SYSTEM_PATH_FALLBACK)
-    IF(NOT ${VAR_NAME})
-      #Now go ahead and look in system paths
-      FIND_LIBRARY(${VAR_NAME} ${LIB} PATH_SUFFIXES ${SUFFIXES})
-    ENDIF()
+    #No-op if ${VAR_NAME} set by previous call
+    FIND_LIBRARY(${VAR_NAME} ${LIB} PATH_SUFFIXES ${SUFFIXES})
   ENDIF()
 
 ENDMACRO()


### PR DESCRIPTION
2nd attempt... apologies for not reviewing the contribution instructions...

----

Hello,

I recently built an application on NASA's Pleiades supercomputer using Kokkos with Clang 7.5 and Cuda 9.2. I ran into a few issues with the current CMake scripts related to finding Cuda libraries. See the commit messages for additional details.

The most critical fix was adding lib64/stubs to the suffix list in kokkos_find_library. This allows CMake to find the dummy libcuda.so provided by CUDA Toolkit when a proper device driver is not available elsewhere on the system. This enables compiling on machines without a GPU (e.g. cluster head node) and then deploying to machines that do (the compute nodes).

This has been tested in Pleiades. No impact is expected to current test builds since "lib64/stubs" is at the end of suffix list; it should only enable builds that would have otherwise failed due to an inability to find "libcuda.so".