### PR TITLE
Use defaulted constructors and destructors

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -200,7 +200,7 @@ class BinSort {
   bool sort_within_bins;
 
  public:
-  BinSort() {}
+  BinSort() = default;
 
   //----------------------------------------
   // Constructor: takes the keys, the binning_operator and optionally whether to
@@ -445,7 +445,7 @@ struct BinOp3D {
   typename KeyViewType::non_const_value_type range_[3];
   typename KeyViewType::non_const_value_type min_[3];
 
-  BinOp3D() {}
+  BinOp3D() = default;
 
   BinOp3D(int max_bins__[], typename KeyViewType::const_value_type min[],
           typename KeyViewType::const_value_type max[]) {

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1064,8 +1064,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   //----------------------------------------
   // Standard constructor, destructor, and assignment operators...
 
-  KOKKOS_INLINE_FUNCTION
-  ~DynRankView() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  ~DynRankView() = default;
 
   KOKKOS_INLINE_FUNCTION
   DynRankView() : m_track(), m_map(), m_rank() {}  // Default ctor

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -804,8 +804,8 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   //----------------------------------------
   // Standard destructor, constructors, and assignment operators
 
-  KOKKOS_INLINE_FUNCTION
-  ~OffsetView() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  ~OffsetView() = default;
 
   KOKKOS_INLINE_FUNCTION
   OffsetView() : m_track(), m_map() {

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -671,7 +671,7 @@ class ScatterView<DataType, Layout, ExecSpace, Op, ScatterNonDuplicated,
   friend class ScatterAccess<DataType, Op, ExecSpace, Layout,
                              ScatterNonDuplicated, contribution, ScatterAtomic>;
 
-  ScatterView() {}
+  ScatterView() = default;
 
   template <typename RT, typename... RP>
   ScatterView(View<RT, RP...> const& original_view)
@@ -760,8 +760,8 @@ class ScatterAccess<DataType, Op, ExecSpace, Layout, ScatterNonDuplicated,
   KOKKOS_INLINE_FUNCTION
   ScatterAccess(view_type const& view_in) : view(view_in) {}
 
-  KOKKOS_INLINE_FUNCTION
-  ~ScatterAccess() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  ~ScatterAccess() = default;
 
   template <typename... Args>
   KOKKOS_FORCEINLINE_FUNCTION value_type operator()(Args... args) const {
@@ -804,7 +804,7 @@ class ScatterView<DataType, Kokkos::LayoutRight, ExecSpace, Op,
   typedef Kokkos::View<internal_data_type, Kokkos::LayoutRight, ExecSpace>
       internal_view_type;
 
-  ScatterView() {}
+  ScatterView() = default;
 
   template <typename RT, typename... RP>
   ScatterView(View<RT, RP...> const& original_view)
@@ -956,7 +956,7 @@ class ScatterView<DataType, Kokkos::LayoutLeft, ExecSpace, Op,
   typedef Kokkos::View<internal_data_type, Kokkos::LayoutLeft, ExecSpace>
       internal_view_type;
 
-  ScatterView() {}
+  ScatterView() = default;
 
   template <typename RT, typename... RP>
   ScatterView(View<RT, RP...> const& original_view) : unique_token() {

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -357,8 +357,8 @@ class StaticCrsGraph {
   /**  \brief  Destroy this view of the array.
    *           If the last view then allocated memory is deallocated.
    */
-  KOKKOS_INLINE_FUNCTION
-  ~StaticCrsGraph() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  ~StaticCrsGraph() = default;
 
   /**  \brief  Return number of rows in the graph
    */

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -705,7 +705,7 @@ class TestDynViewAPI {
 
   typedef typename View0::host_mirror_space host_view_space;
 
-  TestDynViewAPI() {}
+  TestDynViewAPI() = default;
 
   static void run_tests() {
     run_test_resize_realloc();

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -705,8 +705,6 @@ class TestDynViewAPI {
 
   typedef typename View0::host_mirror_space host_view_space;
 
-  TestDynViewAPI() = default;
-
   static void run_tests() {
     run_test_resize_realloc();
     run_test_mirror();

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -341,7 +341,7 @@ struct test_scatter_view_config {
                                               contribution, op>::orig_view_type
       orig_view_def;
 
-  test_scatter_view_config() {}
+  test_scatter_view_config() = default;
 
   void run_test(int n) {
     // Test creation via create_scatter_view

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -341,8 +341,6 @@ struct test_scatter_view_config {
                                               contribution, op>::orig_view_type
       orig_view_def;
 
-  test_scatter_view_config() = default;
-
   void run_test(int n) {
     // Test creation via create_scatter_view
     {

--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -83,8 +83,8 @@ struct CudaTextureFetch {
   KOKKOS_INLINE_FUNCTION
   CudaTextureFetch() : m_obj(), m_ptr(), m_offset() {}
 
-  KOKKOS_INLINE_FUNCTION
-  ~CudaTextureFetch() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  ~CudaTextureFetch() = default;
 
   KOKKOS_INLINE_FUNCTION
   CudaTextureFetch(const CudaTextureFetch& rhs)
@@ -152,8 +152,8 @@ struct CudaLDGFetch {
   KOKKOS_INLINE_FUNCTION
   CudaLDGFetch() : m_ptr() {}
 
-  KOKKOS_INLINE_FUNCTION
-  ~CudaLDGFetch() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  ~CudaLDGFetch() = default;
 
   KOKKOS_INLINE_FUNCTION
   CudaLDGFetch(const CudaLDGFetch& rhs) : m_ptr(rhs.m_ptr) {}

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -198,7 +198,6 @@ class Cuda {
   //--------------------------------------------------
   //! \name  Cuda space instances
 
-  KOKKOS_DEFAULTED_FUNCTION
   ~Cuda() = default;
 
   Cuda();

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -198,8 +198,8 @@ class Cuda {
   //--------------------------------------------------
   //! \name  Cuda space instances
 
-  KOKKOS_INLINE_FUNCTION
-  ~Cuda() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  ~Cuda() = default;
 
   Cuda();
 

--- a/core/src/Kokkos_HIP.hpp
+++ b/core/src/Kokkos_HIP.hpp
@@ -88,7 +88,7 @@ class HIP {
 
   using scratch_memory_space = ScratchMemorySpace<HIP>;
 
-  ~HIP() {}
+  ~HIP() = default;
   HIP();
   //  explicit HIP( const int instance_id );
 

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -93,9 +93,6 @@ class OpenMP {
   using size_type            = memory_space::size_type;
   using scratch_memory_space = ScratchMemorySpace<OpenMP>;
 
-  /// \brief Get a handle to the default execution space instance
-  inline OpenMP() noexcept;
-
   /// \brief Print configuration information to the given output stream.
   static void print_configuration(std::ostream&, const bool verbose = false);
 

--- a/core/src/Kokkos_Timer.hpp
+++ b/core/src/Kokkos_Timer.hpp
@@ -59,7 +59,7 @@ class Timer {
  public:
   inline void reset() { m_old = std::chrono::high_resolution_clock::now(); }
 
-  inline ~Timer() {}
+  inline ~Timer() = default;
 
   inline Timer() { reset(); }
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1721,8 +1721,8 @@ class View : public ViewTraits<DataType, Properties...> {
   //----------------------------------------
   // Standard destructor, constructors, and assignment operators
 
-  KOKKOS_INLINE_FUNCTION
-  ~View() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  ~View() = default;
 
   KOKKOS_INLINE_FUNCTION
   View() : m_track(), m_map() {}

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -128,7 +128,7 @@ class OpenMPExec {
 
 namespace Kokkos {
 
-inline OpenMP::OpenMP() noexcept {}
+inline OpenMP::OpenMP() noexcept = default;
 
 inline
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -128,8 +128,6 @@ class OpenMPExec {
 
 namespace Kokkos {
 
-inline OpenMP::OpenMP() noexcept = default;
-
 inline
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     bool

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -77,8 +77,6 @@ void (*volatile s_current_function)(ThreadsExec &, const void *);
 const void *volatile s_current_function_arg = nullptr;
 
 struct Sentinel {
-  Sentinel() = default;
-
   ~Sentinel() {
     if (s_thread_pool_size[0] || s_thread_pool_size[1] ||
         s_thread_pool_size[2] || s_current_reduce_size ||

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -77,7 +77,7 @@ void (*volatile s_current_function)(ThreadsExec &, const void *);
 const void *volatile s_current_function_arg = nullptr;
 
 struct Sentinel {
-  Sentinel() {}
+  Sentinel() = default;
 
   ~Sentinel() {
     if (s_thread_pool_size[0] || s_thread_pool_size[1] ||

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -1759,8 +1759,8 @@ template <typename ValueType>
 struct JoinAdd {
   typedef ValueType value_type;
 
-  KOKKOS_INLINE_FUNCTION
-  JoinAdd() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  JoinAdd() = default;
 
   KOKKOS_INLINE_FUNCTION
   void join(volatile value_type& dst, const volatile value_type& src) const {

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -131,7 +131,7 @@ class SharedAllocationRecord<void, void> {
    */
   static void tracking_enable() { t_tracking_enabled = 1; }
 
-  virtual ~SharedAllocationRecord() {}
+  virtual ~SharedAllocationRecord() = default;
 
   SharedAllocationRecord()
       : m_alloc_ptr(nullptr),

--- a/core/src/impl/Kokkos_ViewArray.hpp
+++ b/core/src/impl/Kokkos_ViewArray.hpp
@@ -337,7 +337,7 @@ class ViewMapping<Traits, Kokkos::Array<> > {
 
   //----------------------------------------
 
-  KOKKOS_INLINE_FUNCTION ~ViewMapping() {}
+  KOKKOS_DEFAULTED_FUNCTION ~ViewMapping() = default;
   KOKKOS_INLINE_FUNCTION ViewMapping()
       : m_impl_handle(), m_impl_offset(), m_stride(0) {}
   KOKKOS_INLINE_FUNCTION ViewMapping(const ViewMapping &rhs)

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3068,7 +3068,7 @@ class ViewMapping<
 
   //----------------------------------------
 
-  KOKKOS_INLINE_FUNCTION ~ViewMapping() {}
+  KOKKOS_DEFAULTED_FUNCTION ~ViewMapping() = default;
   KOKKOS_INLINE_FUNCTION ViewMapping() : m_impl_handle(), m_impl_offset() {}
   KOKKOS_INLINE_FUNCTION ViewMapping(const ViewMapping& rhs)
       : m_impl_handle(rhs.m_impl_handle), m_impl_offset(rhs.m_impl_offset) {}

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -474,7 +474,7 @@ void test_memory_pool_corners(const bool print_statistics,
 
 template <class DeviceType, class Enable = void>
 struct TestMemoryPoolHuge {
-  TestMemoryPoolHuge() {}
+  TestMemoryPoolHuge() = default;
 
   enum : size_t { num_superblock = 0 };
 

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -474,8 +474,6 @@ void test_memory_pool_corners(const bool print_statistics,
 
 template <class DeviceType, class Enable = void>
 struct TestMemoryPoolHuge {
-  TestMemoryPoolHuge() = default;
-
   enum : size_t { num_superblock = 0 };
 
   using value_type = long;

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -919,7 +919,7 @@ class TestViewAPI {
       dView4_unmanaged;
   typedef typename dView0::host_mirror_space host;
 
-  TestViewAPI() {}
+  TestViewAPI() = default;
 
   static void run_test_view_operator_a() {
     {

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -919,8 +919,6 @@ class TestViewAPI {
       dView4_unmanaged;
   typedef typename dView0::host_mirror_space host;
 
-  TestViewAPI() = default;
-
   static void run_test_view_operator_a() {
     {
       TestViewOperator<T, device> f;


### PR DESCRIPTION
This should look a bit cleaner (and generate less assembly).