### PR TITLE
Make Kokkos::fence() fence all execution spaces

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -394,30 +394,19 @@ void finalize_internal(const bool all_spaces = false) {
 
 void fence_internal() {
 #if defined(KOKKOS_ENABLE_CUDA)
-  if (std::is_same<Kokkos::Cuda, Kokkos::DefaultExecutionSpace>::value) {
-    Kokkos::Cuda::impl_static_fence();
-  }
+  Kokkos::Cuda::impl_static_fence();
 #endif
 
 #if defined(KOKKOS_ENABLE_ROCM)
-  if (std::is_same<Kokkos::Experimental::ROCm,
-                   Kokkos::DefaultExecutionSpace>::value) {
-    Kokkos::Experimental::ROCm().fence();
-  }
+  Kokkos::Experimental::ROCm().fence();
 #endif
 
 #if defined(KOKKOS_ENABLE_HIP)
-  if (std::is_same<Kokkos::Experimental::HIP,
-                   Kokkos::DefaultExecutionSpace>::value) {
-    Kokkos::Experimental::HIP().fence();
-  }
+  Kokkos::Experimental::HIP().fence();
 #endif
 
 #if defined(KOKKOS_ENABLE_OPENMP)
-  if (std::is_same<Kokkos::OpenMP, Kokkos::DefaultExecutionSpace>::value ||
-      std::is_same<Kokkos::OpenMP, Kokkos::HostSpace::execution_space>::value) {
-    Kokkos::OpenMP::impl_static_fence();
-  }
+  Kokkos::OpenMP::impl_static_fence();
 #endif
 
 #if defined(KOKKOS_ENABLE_HPX)
@@ -425,18 +414,11 @@ void fence_internal() {
 #endif
 
 #if defined(KOKKOS_ENABLE_THREADS)
-  if (std::is_same<Kokkos::Threads, Kokkos::DefaultExecutionSpace>::value ||
-      std::is_same<Kokkos::Threads,
-                   Kokkos::HostSpace::execution_space>::value) {
-    Kokkos::Threads::impl_static_fence();
-  }
+  Kokkos::Threads::impl_static_fence();
 #endif
 
 #if defined(KOKKOS_ENABLE_SERIAL)
-  if (std::is_same<Kokkos::Serial, Kokkos::DefaultExecutionSpace>::value ||
-      std::is_same<Kokkos::Serial, Kokkos::HostSpace::execution_space>::value) {
-    Kokkos::Serial::impl_static_fence();
-  }
+  Kokkos::Serial::impl_static_fence();
 #endif
 }
 


### PR DESCRIPTION
Fixes #2659.
In the end, only `CUDA`, `HIP`, `HPX`, `Threads` do anything anyway. Since neither `CUDA` and `HIP` nor `HPX` and `Threads` can be enabled simultaneously, there is no change in functionality.