### PR TITLE
Suppress error messages for check with return value in KokkosConfigCommon

### DIFF
--- a/cmake/KokkosConfigCommon.cmake.in
+++ b/cmake/KokkosConfigCommon.cmake.in
@@ -73,6 +73,9 @@ function(kokkos_check)
     # use it to check that there are variables defined for all required
     # arguments. Success or failure messages will be displayed but we are
     # responsible for signaling failure and skip the build system generation.
+    if (KOKKOS_CHECK_RETURN_VALUE)
+      set(Kokkos_${arg}_FIND_QUIETLY ON)
+    endif()
     find_package_handle_standard_args("Kokkos_${arg}" DEFAULT_MSG
             ${KOKKOS_CHECK_${arg}})
     if(NOT Kokkos_${arg}_FOUND)


### PR DESCRIPTION
If `KOKKOS_CHECK` is being used as a query function rather than an error assertion, we probably shouldn't be cluttering the output with find error messages. This turns off CMake error messages with return values. It keeps them without return values.