### PR TITLE
Fix DeathTest failure on travis on master by not running DeathTests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ env:
   - 
   - BACKEND="OPENMP"
 #  - BACKEND="PTHREAD"
-  - CMAKE_BUILD_TYPE=Debug COVERAGE=yes
-  - CMAKE_BUILD_TYPE=Debug BACKEND="OPENMP" COVERAGE=yes
+  - CMAKE_BUILD_TYPE=Debug COVERAGE=yes GTEST_FILTER="-*DeathTest*"
+  - CMAKE_BUILD_TYPE=Debug BACKEND="OPENMP" COVERAGE=yes GTEST_FILTER="-*DeathTest*"
 #  - CMAKE_BUILD_TYPE=Debug BACKEND="PTHREAD" COVERAGE=yes
   - CMAKE_BUILD_TYPE=Release
   - CMAKE_BUILD_TYPE=Release BACKEND="OPENMP"
@@ -51,7 +51,7 @@ matrix:
       env: BACKEND="OPENMP"
     - os: osx
       compiler: clang
-      env: CMAKE_BUILD_TYPE=Debug BACKEND="OPENMP" COVERAGE=yes
+      env: CMAKE_BUILD_TYPE=Debug BACKEND="OPENMP" COVERAGE=yes GTEST_FILTER="-*DeathTest*"
     - os: osx
       compiler: clang
       env: CMAKE_BUILD_TYPE=Release BACKEND="OPENMP"

--- a/core/unit_test/TestStackTrace.hpp
+++ b/core/unit_test/TestStackTrace.hpp
@@ -155,14 +155,12 @@ void test_stacktrace(bool bTerminate, bool bCustom = true) {
 
 TEST(defaultdevicetype, stacktrace_normal) { test_stacktrace(false); }
 
-#define DECLARE_DEATH_TEST(NAME) NAME##DeathTest
-
-TEST(DECLARE_DEATH_TEST(defaultdevicetype), stacktrace_terminate) {
+TEST(defaultdevicetype_DeathTest, stacktrace_terminate) {
   ASSERT_DEATH({ test_stacktrace(true); },
                "I am the custom std::terminate handler.");
 }
 
-TEST(DECLARE_DEATH_TEST(defaultdevicetype), stacktrace_generic_term) {
+TEST(defaultdevicetype_DeathTest, stacktrace_generic_term) {
   ASSERT_DEATH({ test_stacktrace(true, false); },
                "Kokkos observes that std::terminate has been called");
 }

--- a/core/unit_test/TestViewLayoutStrideAssignment.hpp
+++ b/core/unit_test/TestViewLayoutStrideAssignment.hpp
@@ -616,9 +616,7 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
   }
 }
 
-#define DECLARE_DEATH_TEST(NAME) NAME##DeathTest
-TEST(DECLARE_DEATH_TEST(TEST_CATEGORY),
-     view_layoutstride_right_to_layoutleft_assignment) {
+TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
   typedef TEST_EXECSPACE exec_space;
 
   auto t = time(0);
@@ -769,7 +767,7 @@ TEST(DECLARE_DEATH_TEST(TEST_CATEGORY),
   }
 }
 
-TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutright_assignment) {
+TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
   typedef TEST_EXECSPACE exec_space;
 
   auto t = time(0);

--- a/core/unit_test/cuda/TestCudaHostPinned_Category.hpp
+++ b/core/unit_test/cuda/TestCudaHostPinned_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY cuda_hostpinned
+#define TEST_CATEGORY_DEATH cuda_hostpinned_DeathTest
 //#define TEST_EXECSPACE
 // Kokkos::Device<Kokkos::Cuda,Kokkos::CudaHostPinnedSpace>
 #define TEST_EXECSPACE Kokkos::CudaHostPinnedSpace

--- a/core/unit_test/cuda/TestCudaUVM_Category.hpp
+++ b/core/unit_test/cuda/TestCudaUVM_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY cuda_uvm
+#define TEST_CATEGORY_DEATH cuda_uvm_DeathTest
 #define TEST_EXECSPACE Kokkos::CudaUVMSpace
 
 #endif

--- a/core/unit_test/cuda/TestCuda_Category.hpp
+++ b/core/unit_test/cuda/TestCuda_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY cuda
+#define TEST_CATEGORY_DEATH cuda_DeathTest
 #define TEST_EXECSPACE Kokkos::Cuda
 
 #endif

--- a/core/unit_test/default/TestDefaultDeviceType_Category.hpp
+++ b/core/unit_test/default/TestDefaultDeviceType_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY defaultdevicetype
+#define TEST_CATEGORY_DEATH defaultdevicetype_DeathTest
 #define TEST_EXECSPACE Kokkos::DefaultExecutionSpace
 
 #endif

--- a/core/unit_test/hpx/TestHPX_Category.hpp
+++ b/core/unit_test/hpx/TestHPX_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY hpx
+#define TEST_CATEGORY_DEATH hpx_DeathTest
 #define TEST_EXECSPACE Kokkos::Experimental::HPX
 
 #endif

--- a/core/unit_test/openmp/TestOpenMP_Category.hpp
+++ b/core/unit_test/openmp/TestOpenMP_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY openmp
+#define TEST_CATEGORY_DEATH openmp_DeathTest
 #define TEST_EXECSPACE Kokkos::OpenMP
 
 #endif

--- a/core/unit_test/openmptarget/TestOpenMPTarget_Category.hpp
+++ b/core/unit_test/openmptarget/TestOpenMPTarget_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY openmptarget
+#define TEST_CATEGORY_DEATH openmptarget_DeathTest
 #define TEST_EXECSPACE Kokkos::Experimental::OpenMPTarget
 
 #endif

--- a/core/unit_test/qthreads/TestQthreads_Category.hpp
+++ b/core/unit_test/qthreads/TestQthreads_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY qthreads
+#define TEST_CATEGORY_DEATH qthreads_DeathTest
 #define TEST_EXECSPACE Kokkos::Qthreads
 
 #endif

--- a/core/unit_test/rocm/TestROCmHostPinned_Category.hpp
+++ b/core/unit_test/rocm/TestROCmHostPinned_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY rocm_hostpinned
+#define TEST_CATEGORY_DEATH rocm_hostpinned_DeathTest
 #define TEST_EXECSPACE Kokkos::Experimental::ROCmHostPinnedSpace
 
 #endif

--- a/core/unit_test/rocm/TestROCm_Category.hpp
+++ b/core/unit_test/rocm/TestROCm_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY rocm
+#define TEST_CATEGORY_DEATH rocm_DeathTest
 #define TEST_EXECSPACE Kokkos::Experimental::ROCm
 
 #endif

--- a/core/unit_test/serial/TestSerial_Category.hpp
+++ b/core/unit_test/serial/TestSerial_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY serial
+#define TEST_CATEGORY_DEATH serial_DeathTest
 #define TEST_EXECSPACE Kokkos::Serial
 
 #endif

--- a/core/unit_test/threads/TestThreads_Category.hpp
+++ b/core/unit_test/threads/TestThreads_Category.hpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #define TEST_CATEGORY threads
+#define TEST_CATEGORY_DEATH threads_DeathTest
 #define TEST_EXECSPACE Kokkos::Threads
 
 #endif


### PR DESCRIPTION
I don't think it's good if people see `master` failing. Hence, disable death tests in Travis there as well by cherry-picking #2671.