### PR TITLE
Avoid HIP warning

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -26,7 +26,6 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=hipcc \
-                                -DCMAKE_CXX_FLAGS=-Werror \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_HIP=ON \

--- a/.jenkins
+++ b/.jenkins
@@ -26,6 +26,8 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=hipcc \
+                                -DCMAKE_CXX_FLAGS=-Werror \
+                                -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_HIP=ON \
                                 -DKokkos_ENABLE_LIBDL=OFF \

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -287,8 +287,8 @@ void test_offsetview_unmanaged_construction() {
 
   {
     // Constructing an OffsetView directly around our preallocated memory
-    Kokkos::Array<int64_t, 1> begins1{{2}};
-    Kokkos::Array<int64_t, 1> ends1{{3}};
+    Kokkos::Array<int64_t, 1> begins1{2};
+    Kokkos::Array<int64_t, 1> ends1{3};
     Kokkos::Experimental::OffsetView<Scalar*, Device> ov1(&s, begins1, ends1);
 
     // Constructing an OffsetView around an unmanaged View of our preallocated
@@ -302,8 +302,8 @@ void test_offsetview_unmanaged_construction() {
   }
 
   {
-    Kokkos::Array<int64_t, 2> begins2{{-2, -7}};
-    Kokkos::Array<int64_t, 2> ends2{{5, -3}};
+    Kokkos::Array<int64_t, 2> begins2{-2, -7};
+    Kokkos::Array<int64_t, 2> ends2{5, -3};
     Kokkos::Experimental::OffsetView<Scalar**, Device> ov2(&s, begins2, ends2);
 
     Kokkos::View<Scalar**, Device> v2(&s, ends2[0] - begins2[0],
@@ -332,8 +332,8 @@ void test_offsetview_unmanaged_construction() {
   {
     // Test all four public constructor overloads (begins_type x
     // index_list_type)
-    Kokkos::Array<int64_t, 1> begins{{-3}};
-    Kokkos::Array<int64_t, 1> ends{{2}};
+    Kokkos::Array<int64_t, 1> begins{-3};
+    Kokkos::Array<int64_t, 1> ends{2};
 
     Kokkos::Experimental::OffsetView<Scalar*, Device> bb(&s, begins, ends);
     Kokkos::Experimental::OffsetView<Scalar*, Device> bi(&s, begins, {2});

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2633,11 +2633,11 @@ inline void deep_copy(
         std::is_same<typename ViewTraits<DT, DP...>::specialize,
                      void>::value>::type* = nullptr) {
   typedef ViewTraits<DT, DP...> dst_traits;
-  typedef typename dst_traits::memory_space dst_memory_space;
   static_assert(std::is_same<typename dst_traits::non_const_value_type,
                              typename dst_traits::value_type>::value,
                 "deep_copy requires non-const type");
 #if defined(KOKKOS_ENABLE_PROFILING)
+  typedef typename dst_traits::memory_space dst_memory_space;
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     Kokkos::Profiling::beginDeepCopy(
         Kokkos::Profiling::SpaceHandle(dst_memory_space::name()), dst.label(),


### PR DESCRIPTION
This allows compiling using `hipcc` with `-Werror`.