### PR TITLE
cmake/Dependencies.cmake: remove examples as optional dependency

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -6,5 +6,4 @@ TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
     Core                  core              PS       REQUIRED
     Containers            containers        PS       OPTIONAL
     Algorithms            algorithms        PS       OPTIONAL
-    Example               example           EX       OPTIONAL
   )


### PR DESCRIPTION
Addresses issue #2731