### PR TITLE
Remove memory space generalization from SharedAlloc.hpp

### DIFF
--- a/core/src/Kokkos_AnonymousSpace.hpp
+++ b/core/src/Kokkos_AnonymousSpace.hpp
@@ -82,6 +82,10 @@ namespace Kokkos {
 
 namespace Impl {
 
+template <>
+class SharedAllocationRecord<Kokkos::AnonymousSpace, void>
+    : public SharedAllocationRecord<void, void> {};
+
 template <typename OtherSpace>
 struct MemorySpaceAccess<Kokkos::AnonymousSpace, OtherSpace> {
   enum { assignable = true };

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -210,8 +210,8 @@ class ScratchMemorySpace {
 
 namespace Impl {
 
-// specialize SharedAllocationRecord -- note: it is never used so it doesn't need
-// an implementation.
+// specialize SharedAllocationRecord -- note: it is never used so it doesn't
+// need an implementation.
 template <class ExecSpace>
 class SharedAllocationRecord<Kokkos::ScratchMemorySpace<ExecSpace>, void>
     : public SharedAllocationRecord<void, void> {};

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -208,6 +208,16 @@ class ScratchMemorySpace {
   }
 };
 
+namespace Impl {
+
+// specialize SharedAllocationRecord -- not it is never used so it doen't need
+// an implementation.
+template <class ExecSpace>
+class SharedAllocationRecord<Kokkos::ScratchMemorySpace<ExecSpace>, void>
+    : public SharedAllocationRecord<void, void> {};
+
+}  // namespace Impl
+
 }  // namespace Kokkos
 
 #endif /* #ifndef KOKKOS_SCRATCHSPACE_HPP */

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -210,7 +210,7 @@ class ScratchMemorySpace {
 
 namespace Impl {
 
-// specialize SharedAllocationRecord -- not it is never used so it doen't need
+// specialize SharedAllocationRecord -- note: it is never used so it doesn't need
 // an implementation.
 template <class ExecSpace>
 class SharedAllocationRecord<Kokkos::ScratchMemorySpace<ExecSpace>, void>

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -249,10 +249,6 @@ class SharedAllocationRecord
   }
 };
 
-template <class MemorySpace>
-class SharedAllocationRecord<MemorySpace, void>
-    : public SharedAllocationRecord<void, void> {};
-
 union SharedAllocationTracker {
  private:
   typedef SharedAllocationRecord<void, void> Record;


### PR DESCRIPTION
While working on the Umpire memory space, I discovered an idiosyncrasy in the template for `SharedAllocationRecord<MemorySpace, void>`.  

There was a generic implementation that was empty in Kokkos_SharedAlloc.hpp which was predominantly used by AnonymousSpace and ScratchMemorySpace.  The problem with this is that if the specialization of the SharedAllocationRecord used anything other that a direct reference to a memory space (i.e. SharedAllocationRecord<Kokkos::SomeMemorySpace, void>) then the compiler would complain about having two specializations....

My example used something like this: 

```
template<MemorySpace>
class SharedAllocationRecord<MemorySpace, std::enable_if< 
                                         is_my_space_special<MemorySpace>::value, void>::type > { };
``` 

So the fix is to remove the template from Kokkos_SharedAlloc.hpp and to add specializations for Anonymous and ScratchMemorySpace.