### PR TITLE
Make sure semicolons are not deleted in KokkosConfig_install.cmake

### DIFF
--- a/cmake/kokkos_install.cmake
+++ b/cmake/kokkos_install.cmake
@@ -31,7 +31,7 @@ IF (NOT KOKKOS_HAS_TRILINOS)
 ELSE()
   CONFIGURE_FILE(cmake/KokkosConfigCommon.cmake.in ${Kokkos_BINARY_DIR}/KokkosConfigCommon.cmake @ONLY)
   file(READ ${Kokkos_BINARY_DIR}/KokkosConfigCommon.cmake KOKKOS_CONFIG_COMMON)
-  file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/KokkosConfig_install.cmake" ${KOKKOS_CONFIG_COMMON})
+  file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/KokkosConfig_install.cmake" "${KOKKOS_CONFIG_COMMON}")
 ENDIF()
 
 # build and install pkgconfig file


### PR DESCRIPTION
Without this, e.g. devices are not separated by semicolons.