### PR TITLE
Fix Pthread module issues: C++11 and failure checks

### DIFF
--- a/cmake/Modules/FindTPLPTHREAD.cmake
+++ b/cmake/Modules/FindTPLPTHREAD.cmake
@@ -3,15 +3,18 @@ TRY_COMPILE(KOKKOS_HAS_PTHREAD_ARG
   ${KOKKOS_TOP_BUILD_DIR}/tpl_tests
   ${KOKKOS_SOURCE_DIR}/cmake/compile_tests/pthread.cpp
   LINK_LIBRARIES -pthread
-  COMPILE_DEFINITIONS -pthread)
+  COMPILE_DEFINITIONS -pthread
+)
+# The test no longer requires C++11
+# if we did needed C++ standard support, then we should add option
+# ${CMAKE_CXX${KOKKOS_CXX_STANDARD}_STANDARD_COMPILE_OPTION}
 
 INCLUDE(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(PTHREAD DEFAULT_MSG KOKKOS_HAS_PTHREAD_ARG)
-
-KOKKOS_CREATE_IMPORTED_TPL(PTHREAD
-  INTERFACE   #this is not a real library with a real location
-  COMPILE_OPTIONS -pthread
-  LINK_OPTIONS    -pthread)
-
-
-
+#Only create the TPL if we succeed
+IF (KOKKOS_HAS_PTHREAD_ARG)
+  KOKKOS_CREATE_IMPORTED_TPL(PTHREAD
+    INTERFACE   #this is not a real library with a real location
+    COMPILE_OPTIONS -pthread
+    LINK_OPTIONS    -pthread)
+ENDIF()

--- a/cmake/compile_tests/pthread.cpp
+++ b/cmake/compile_tests/pthread.cpp
@@ -4,7 +4,11 @@ void* kokkos_test(void* args) { return args; }
 
 int main(void) {
   pthread_t thread;
-  pthread_create(&thread, nullptr, kokkos_test, nullptr);
-  pthread_join(thread, nullptr);
+  /* Use NULL to avoid C++11. Some compilers
+     do not have C++11 by default.  Forcing C++11
+     in the compile tests can be done, but is unnecessary
+  */
+  pthread_create(&thread, NULL, kokkos_test, NULL);
+  pthread_join(thread, NULL);
   return 0;
 }


### PR DESCRIPTION
Pthread tests required C++11, which then broke compilers without C++11 default.
Even if the compile test failed, the imported Pthread target still got created.