### PR TITLE
Set architecture when cross-compiling with hipcc

### DIFF
--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -5,7 +5,9 @@ SET(KOKKOS_CXX_COMPILER_ID ${CMAKE_CXX_COMPILER_ID})
 SET(KOKKOS_CXX_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION})
 
 # Check if the compiler is nvcc (which really means nvcc_wrapper).
-EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} --version
+# When hipcc is used to cross compile, we need to be able to set the
+# architecture before calling --version
+EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} ${Kokkos_HIP_ARCH_FLAG} --version
                 COMMAND grep nvcc
                 COMMAND wc -l
                 OUTPUT_VARIABLE INTERNAL_HAVE_COMPILER_NVCC


### PR DESCRIPTION
When cross-compiling with `hipcc` from a node without any GPU, we need to add the flag `--amdgpu-target=` to select the architecture for every call of `hipcc`. Adding the flag in `CMAKE_CXX_FLAGS` works but during configuration we get the message `Died at /opt/rocm/bin/hipcc line 773.` from [here](https://github.com/kokkos/kokkos/blob/master/cmake/kokkos_compiler_id.cmake#L8). The code compiles fine but it's still a strange message to see. 

This PR add `CMAKE_CXX_FLAGS` before `--version`.