### PR TITLE
Add -Wextra flag

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -349,14 +349,14 @@ class BinSort {
 
  public:
   KOKKOS_INLINE_FUNCTION
-  void operator()(const bin_count_tag& tag, const int& i) const {
+  void operator()(const bin_count_tag& /*tag*/, const int& i) const {
     const int j = range_begin + i;
     bin_count_atomic(bin_op.bin(keys, j))++;
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const bin_offset_tag& tag, const int& i, value_type& offset,
-                  const bool& final) const {
+  void operator()(const bin_offset_tag& /*tag*/, const int& i,
+                  value_type& offset, const bool& final) const {
     if (final) {
       bin_offsets(i) = offset;
     }
@@ -364,7 +364,7 @@ class BinSort {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const bin_binning_tag& tag, const int& i) const {
+  void operator()(const bin_binning_tag& /*tag*/, const int& i) const {
     const int j     = range_begin + i;
     const int bin   = bin_op.bin(keys, j);
     const int count = bin_count_atomic(bin)++;
@@ -373,7 +373,7 @@ class BinSort {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const bin_sort_bins_tag& tag, const int& i) const {
+  void operator()(const bin_sort_bins_tag& /*tag*/, const int& i) const {
     auto bin_size = bin_count_const(i);
     if (bin_size <= 1) return;
     int upper_bound = bin_offsets(i) + bin_size;

--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -140,7 +140,7 @@ struct test_random_functor {
         density_3d(d3d) {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(int i, RandomProperties& prop) const {
+  void operator()(int /*i*/, RandomProperties& prop) const {
     using Kokkos::atomic_fetch_add;
 
     rnd_type rand_gen = rand_pool.get_state();

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -81,8 +81,9 @@ ENDIF()
 
 IF(KOKKOS_ENABLE_COMPILER_WARNINGS)
   SET(COMMON_WARNINGS
-    "-Wall" "-Wshadow" "-pedantic"
-    "-Wsign-compare" "-Wtype-limits" "-Wuninitialized")
+    "-Wall" "-Wextra" "-Wshadow" "-pedantic"
+    "-Wsign-compare" "-Wtype-limits" "-Wuninitialized"
+    "-Wno-implicit-fallthrough")
 
   SET(GNU_WARNINGS "-Wempty-body" "-Wclobbered" "-Wignored-qualifiers"
     ${COMMON_WARNINGS})

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -82,8 +82,7 @@ ENDIF()
 IF(KOKKOS_ENABLE_COMPILER_WARNINGS)
   SET(COMMON_WARNINGS
     "-Wall" "-Wextra" "-Wshadow" "-pedantic"
-    "-Wsign-compare" "-Wtype-limits" "-Wuninitialized"
-    "-Wno-implicit-fallthrough")
+    "-Wsign-compare" "-Wtype-limits" "-Wuninitialized")
 
   SET(GNU_WARNINGS "-Wempty-body" "-Wclobbered" "-Wignored-qualifiers"
     ${COMMON_WARNINGS})

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -293,6 +293,7 @@ KOKKOS_INLINE_FUNCTION void dyn_rank_view_verify_operator_bounds(
     dyn_rank_view_error_operator_bounds<0>(buffer + n, LEN - n, map, args...);
     Kokkos::Impl::throw_runtime_exception(std::string(buffer));
 #else
+    (void)tracker;
     Kokkos::abort("DynRankView bounds error");
 #endif
   }

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2143,7 +2143,7 @@ inline void resize(DynRankView<T, P...>& v,
   static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
                 "Can only resize managed views");
 
-  drview_type v_resized(v.label(), n0, n1, n2, n3, n4, n5, n6);
+  drview_type v_resized(v.label(), n0, n1, n2, n3, n4, n5, n6, n7);
 
   Kokkos::Impl::DynRankViewRemap<drview_type, drview_type>(v_resized, v);
 
@@ -2170,7 +2170,7 @@ inline void realloc(DynRankView<T, P...>& v,
   const std::string label = v.label();
 
   v = drview_type();  // Deallocate first, if the only view to allocation
-  v = drview_type(label, n0, n1, n2, n3, n4, n5, n6);
+  v = drview_type(label, n0, n1, n2, n3, n4, n5, n6, n7);
 }
 
 }  // namespace Kokkos

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -248,8 +248,8 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
   //----------------------------------------
 
   template <typename I0, class... Args>
-  KOKKOS_INLINE_FUNCTION reference_type operator()(const I0& i0,
-                                                   const Args&... args) const {
+  KOKKOS_INLINE_FUNCTION reference_type
+  operator()(const I0& i0, const Args&... /*args*/) const {
     static_assert(Kokkos::Impl::are_integral<I0, Args...>::value,
                   "Indices must be integral type");
 
@@ -528,7 +528,7 @@ struct CommonSubview<Kokkos::Experimental::DynamicView<DP...>,
   typedef SrcType src_subview_type;
   dst_subview_type dst_sub;
   src_subview_type src_sub;
-  CommonSubview(const DstType& dst, const SrcType& src, const Arg0& arg0)
+  CommonSubview(const DstType& dst, const SrcType& src, const Arg0& /*arg0*/)
       : dst_sub(dst), src_sub(src) {}
 };
 

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1317,7 +1317,7 @@ KOKKOS_INLINE_FUNCTION
 
 KOKKOS_INLINE_FUNCTION
 Kokkos::Impl::ALL_t shift_input(const Kokkos::Impl::ALL_t arg,
-                                const int64_t offset) {
+                                const int64_t /*offset*/) {
   return arg;
 }
 
@@ -1347,9 +1347,9 @@ KOKKOS_INLINE_FUNCTION void map_arg_to_new_begin(
 
 template <size_t N, class Arg, class A>
 KOKKOS_INLINE_FUNCTION void map_arg_to_new_begin(
-    const size_t i, Kokkos::Array<int64_t, N>& subviewBegins,
-    typename std::enable_if<N == 0, const Arg>::type shiftedArg, const Arg arg,
-    const A viewBegins, size_t& counter) {}
+    const size_t /*i*/, Kokkos::Array<int64_t, N>& /*subviewBegins*/,
+    typename std::enable_if<N == 0, const Arg>::type /*shiftedArg*/,
+    const Arg /*arg*/, const A /*viewBegins*/, size_t& /*counter*/) {}
 
 template <class D, class... P, class T>
 KOKKOS_INLINE_FUNCTION

--- a/containers/src/impl/Kokkos_Functional_impl.hpp
+++ b/containers/src/impl/Kokkos_Functional_impl.hpp
@@ -106,8 +106,8 @@ uint32_t MurmurHash3_x86_32(const void* key, int len, uint32_t seed) {
   uint32_t k1 = 0;
 
   switch (len & 3) {
-    case 3: k1 ^= tail[2] << 16;
-    case 2: k1 ^= tail[1] << 8;
+    case 3: k1 ^= tail[2] << 16; KOKKOS_FALLTHROUGH;
+    case 2: k1 ^= tail[1] << 8; KOKKOS_FALLTHROUGH;
     case 1:
       k1 ^= tail[0];
       k1 *= c1;

--- a/containers/src/impl/Kokkos_Functional_impl.hpp
+++ b/containers/src/impl/Kokkos_Functional_impl.hpp
@@ -105,16 +105,18 @@ uint32_t MurmurHash3_x86_32(const void* key, int len, uint32_t seed) {
 
   uint32_t k1 = 0;
 
-  switch (len & 3) {
-    case 3: k1 ^= tail[2] << 16;  // FALLTHROUGH
-    case 2: k1 ^= tail[1] << 8;   // FALLTHROUGH
-    case 1:
-      k1 ^= tail[0];
-      k1 *= c1;
-      k1 = rotl32(k1, 15);
-      k1 *= c2;
-      h1 ^= k1;
-  };
+  const int len_and_3 = len & 3;
+  if (len_and_3 >= 1) {
+    if (len_and_3 >= 2) {
+      if (len_and_3 == 3) k1 ^= tail[2] << 16;
+      k1 ^= tail[1] << 8;
+    }
+    k1 ^= tail[0];
+    k1 *= c1;
+    k1 = rotl32(k1, 15);
+    k1 *= c2;
+    h1 ^= k1;
+  }
 
   //----------
   // finalization

--- a/containers/src/impl/Kokkos_Functional_impl.hpp
+++ b/containers/src/impl/Kokkos_Functional_impl.hpp
@@ -106,8 +106,8 @@ uint32_t MurmurHash3_x86_32(const void* key, int len, uint32_t seed) {
   uint32_t k1 = 0;
 
   switch (len & 3) {
-    case 3: k1 ^= tail[2] << 16; KOKKOS_FALLTHROUGH;
-    case 2: k1 ^= tail[1] << 8; KOKKOS_FALLTHROUGH;
+    case 3: k1 ^= tail[2] << 16;  // FALLTHROUGH
+    case 2: k1 ^= tail[1] << 8;   // FALLTHROUGH
     case 1:
       k1 ^= tail[0];
       k1 *= c1;

--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -52,7 +52,7 @@
 
 namespace Test {
 
-// Just save the data in the report.  Informative text goies in the
+// Just save the data in the report.  Informative text goes in the
 // operator<<(..).
 template <typename DataType1, typename DataType2, typename DataType3>
 struct ThreeValReport {
@@ -85,7 +85,7 @@ struct ErrorReporterDriverBase {
       error_reporter_type;
   error_reporter_type m_errorReporter;
 
-  ErrorReporterDriverBase(int reporter_capacity, int test_size)
+  ErrorReporterDriverBase(int reporter_capacity, int /*test_size*/)
       : m_errorReporter(reporter_capacity) {}
 
   KOKKOS_INLINE_FUNCTION bool error_condition(const int work_idx) const {

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -127,7 +127,7 @@ void test_offsetview_construction() {
   typedef typename range_type::point_type point_type;
 
   range_type rangePolicy2D(point_type{{ovmin0, ovmin1}},
-                           point_type{{ovend0, ovend1}});
+                           point_type{{ovend0, ovend1}}, point_type{{0, 0}});
 
   const int constValue = 9;
   Kokkos::parallel_for(
@@ -195,7 +195,8 @@ void test_offsetview_construction() {
     typedef typename range3_type::point_type point3_type;
 
     range3_type rangePolicy3DZero(point3_type{{0, 0, 0}},
-                                  point3_type{{extent0, extent1, extent2}});
+                                  point3_type{{extent0, extent1, extent2}},
+                                  point3_type{{0, 0, 0}});
 
 #if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
     int view3DSum = 0;
@@ -209,7 +210,8 @@ void test_offsetview_construction() {
     range3_type rangePolicy3D(
         point3_type{{begins[0], begins[1], begins[2]}},
         point3_type{
-            {begins[0] + extent0, begins[1] + extent1, begins[2] + extent2}});
+            {begins[0] + extent0, begins[1] + extent1, begins[2] + extent2}},
+        point3_type{{0, 0, 0}});
     int offsetView3DSum = 0;
 
     Kokkos::parallel_reduce(
@@ -457,7 +459,8 @@ void test_offsetview_subview() {
       const int e0 = offsetSubview.end(0);
       const int e1 = offsetSubview.end(1);
 
-      range_type rangeP2D(point_type{{b0, b1}}, point_type{{e0, e1}});
+      range_type rangeP2D(point_type{{b0, b1}}, point_type{{e0, e1}},
+                          point_type{{0, 0}});
 
       Kokkos::parallel_for(
           rangeP2D,

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -60,7 +60,7 @@ using std::endl;
 namespace Test {
 
 template <typename Scalar, typename Device>
-void test_offsetview_construction(unsigned int size) {
+void test_offsetview_construction() {
   typedef Kokkos::Experimental::OffsetView<Scalar**, Device> offset_view_type;
   typedef Kokkos::View<Scalar**, Device> view_type;
 
@@ -388,7 +388,7 @@ void test_offsetview_unmanaged_construction() {
 }
 
 template <typename Scalar, typename Device>
-void test_offsetview_subview(unsigned int size) {
+void test_offsetview_subview() {
   {  // test subview 1
     Kokkos::Experimental::OffsetView<Scalar*, Device> sliceMe("offsetToSlice",
                                                               {-10, 20});
@@ -675,7 +675,7 @@ void test_offsetview_offsets_rank3() {
 #endif
 
 TEST(TEST_CATEGORY, offsetview_construction) {
-  test_offsetview_construction<int, TEST_EXECSPACE>(10);
+  test_offsetview_construction<int, TEST_EXECSPACE>();
 }
 
 TEST(TEST_CATEGORY, offsetview_unmanaged_construction) {
@@ -683,7 +683,7 @@ TEST(TEST_CATEGORY, offsetview_unmanaged_construction) {
 }
 
 TEST(TEST_CATEGORY, offsetview_subview) {
-  test_offsetview_subview<int, TEST_EXECSPACE>(10);
+  test_offsetview_subview<int, TEST_EXECSPACE>();
 }
 
 #if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)

--- a/core/perf_test/PerfTest_CustomReduction.cpp
+++ b/core/perf_test/PerfTest_CustomReduction.cpp
@@ -74,10 +74,10 @@ void custom_reduction_test(int N, int R, int num_trials) {
                 Scalar t_max = Scalar(0);
                 Kokkos::parallel_reduce(
                     Kokkos::ThreadVectorRange(team, 32),
-                    [&](const int& k, Scalar& /*max_*/) {
+                    [&](const int& k, Scalar& max_) {
                       const Scalar val = a((i * 32 + j) * 32 + k);
-                      if (val > lmax) lmax = val;
-                      if ((k == 11) && (j == 17) && (i == 2)) lmax = 11.5;
+                      if (val > max_) max_ = val;
+                      if ((k == 11) && (j == 17) && (i == 2)) max_ = 11.5;
                     },
                     Kokkos::Max<Scalar>(t_max));
                 if (t_max > thread_max) thread_max = t_max;

--- a/core/perf_test/PerfTest_CustomReduction.cpp
+++ b/core/perf_test/PerfTest_CustomReduction.cpp
@@ -104,10 +104,10 @@ void custom_reduction_test(int N, int R, int num_trials) {
                   Scalar t_max = Scalar(0);
                   Kokkos::parallel_reduce(
                       Kokkos::ThreadVectorRange(team, 32),
-                      [&](const int& k, Scalar& /*max_*/) {
+                      [&](const int& k, Scalar& max_) {
                         const Scalar val = a((i * 32 + j) * 32 + k);
-                        if (val > lmax) lmax = val;
-                        if ((k == 11) && (j == 17) && (i == 2)) lmax = 11.5;
+                        if (val > max_) max_ = val;
+                        if ((k == 11) && (j == 17) && (i == 2)) max_ = 11.5;
                       },
                       Kokkos::Max<Scalar>(t_max));
                   if (t_max > thread_max) thread_max = t_max;

--- a/core/perf_test/PerfTest_CustomReduction.cpp
+++ b/core/perf_test/PerfTest_CustomReduction.cpp
@@ -74,7 +74,7 @@ void custom_reduction_test(int N, int R, int num_trials) {
                 Scalar t_max = Scalar(0);
                 Kokkos::parallel_reduce(
                     Kokkos::ThreadVectorRange(team, 32),
-                    [&](const int& k, Scalar& max_) {
+                    [&](const int& k, Scalar& /*max_*/) {
                       const Scalar val = a((i * 32 + j) * 32 + k);
                       if (val > lmax) lmax = val;
                       if ((k == 11) && (j == 17) && (i == 2)) lmax = 11.5;
@@ -104,7 +104,7 @@ void custom_reduction_test(int N, int R, int num_trials) {
                   Scalar t_max = Scalar(0);
                   Kokkos::parallel_reduce(
                       Kokkos::ThreadVectorRange(team, 32),
-                      [&](const int& k, Scalar& max_) {
+                      [&](const int& k, Scalar& /*max_*/) {
                         const Scalar val = a((i * 32 + j) * 32 + k);
                         if (val > lmax) lmax = val;
                         if ((k == 11) && (j == 17) && (i == 2)) lmax = 11.5;

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -789,6 +789,8 @@ SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>
 // Iterate records to print orphaned memory ...
 void SharedAllocationRecord<Kokkos::CudaSpace, void>::print_records(
     std::ostream &s, const Kokkos::CudaSpace &, bool detail) {
+  (void)s;
+  (void)detail;
 #ifdef KOKKOS_DEBUG
   SharedAllocationRecord<void, void> *r = &s_root_record;
 
@@ -861,6 +863,8 @@ void SharedAllocationRecord<Kokkos::CudaSpace, void>::print_records(
 
 void SharedAllocationRecord<Kokkos::CudaUVMSpace, void>::print_records(
     std::ostream &s, const Kokkos::CudaUVMSpace &, bool detail) {
+  (void)s;
+  (void)detail;
 #ifdef KOKKOS_DEBUG
   SharedAllocationRecord<void, void>::print_host_accessible_records(
       s, "CudaUVM", &s_root_record, detail);
@@ -873,6 +877,8 @@ void SharedAllocationRecord<Kokkos::CudaUVMSpace, void>::print_records(
 
 void SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::print_records(
     std::ostream &s, const Kokkos::CudaHostPinnedSpace &, bool detail) {
+  (void)s;
+  (void)detail;
 #ifdef KOKKOS_DEBUG
   SharedAllocationRecord<void, void>::print_host_accessible_records(
       s, "CudaHostPinned", &s_root_record, detail);

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -742,7 +742,7 @@ int Cuda::impl_is_initialized()
 void Cuda::initialize(const Cuda::SelectDevice config, size_t num_instances)
 #else
 void Cuda::impl_initialize(const Cuda::SelectDevice config,
-                           size_t num_instances)
+                           size_t /*num_instances*/)
 #endif
 {
   Impl::CudaInternal::singleton().initialize(config.cuda_device_id, 0);

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -192,7 +192,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
   }
 
   template <class FunctorType, class ReducerType>
-  inline int team_size_max(const FunctorType& f, const ReducerType& r,
+  inline int team_size_max(const FunctorType& f, const ReducerType& /*r*/,
                            const ParallelReduceTag&) const {
     using closure_type =
         Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -133,7 +133,8 @@ __device__ bool cuda_inter_block_reduction(
     typename FunctorValueTraits<FunctorType, ArgTag>::reference_type value,
     typename FunctorValueTraits<FunctorType, ArgTag>::reference_type neutral,
     const JoinOp& join, Cuda::size_type* const m_scratch_space,
-    typename FunctorValueTraits<FunctorType, ArgTag>::pointer_type const result,
+    typename FunctorValueTraits<FunctorType,
+                                ArgTag>::pointer_type const /*result*/,
     Cuda::size_type* const m_scratch_flags,
     const int max_active_thread = blockDim.y) {
 #ifdef __CUDA_ARCH__
@@ -236,6 +237,12 @@ __device__ bool cuda_inter_block_reduction(
   // "value"
   return last_block;
 #else
+  (void)value;
+  (void)neutral;
+  (void)join;
+  (void)m_scratch_space;
+  (void)m_scratch_flags;
+  (void)max_active_thread;
   return true;
 #endif
 }
@@ -426,6 +433,10 @@ __device__ inline
   // "value"
   return last_block;
 #else
+  (void)reducer;
+  (void)m_scratch_space;
+  (void)m_scratch_flags;
+  (void)max_active_thread;
   return true;
 #endif
 }
@@ -500,7 +511,7 @@ struct CudaReductionsFunctor<FunctorType, ArgTag, false, true> {
   }
 
   __device__ static inline bool scalar_inter_block_reduction(
-      const FunctorType& functor, const Cuda::size_type block_id,
+      const FunctorType& functor, const Cuda::size_type /*block_id*/,
       const Cuda::size_type block_count, Cuda::size_type* const shared_data,
       Cuda::size_type* const global_data, Cuda::size_type* const global_flags) {
     Scalar* const global_team_buffer_element = ((Scalar*)global_data);
@@ -577,7 +588,7 @@ struct CudaReductionsFunctor<FunctorType, ArgTag, false, false> {
 
   __device__ static inline void scalar_intra_block_reduction(
       const FunctorType& functor, Scalar value, const bool skip, Scalar* result,
-      const int shared_elements, Scalar* shared_team_buffer_element) {
+      const int /*shared_elements*/, Scalar* shared_team_buffer_element) {
     const int warp_id = (threadIdx.y * blockDim.x) / 32;
     Scalar* const my_shared_team_buffer_element =
         shared_team_buffer_element + threadIdx.y * blockDim.x + threadIdx.x;
@@ -601,7 +612,7 @@ struct CudaReductionsFunctor<FunctorType, ArgTag, false, false> {
   }
 
   __device__ static inline bool scalar_inter_block_reduction(
-      const FunctorType& functor, const Cuda::size_type block_id,
+      const FunctorType& functor, const Cuda::size_type /*block_id*/,
       const Cuda::size_type block_count, Cuda::size_type* const shared_data,
       Cuda::size_type* const global_data, Cuda::size_type* const global_flags) {
     Scalar* const global_team_buffer_element = ((Scalar*)global_data);

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -164,6 +164,8 @@ class CudaTeamMember {
   template <class ValueType>
   KOKKOS_INLINE_FUNCTION void team_broadcast(ValueType& val,
                                              const int& thread_id) const {
+    (void)val;
+    (void)thread_id;
 #ifdef __CUDA_ARCH__
     if (1 == blockDim.z) {  // team == block
       __syncthreads();
@@ -184,6 +186,9 @@ class CudaTeamMember {
   template <class Closure, class ValueType>
   KOKKOS_INLINE_FUNCTION void team_broadcast(Closure const& f, ValueType& val,
                                              const int& thread_id) const {
+    (void)f;
+    (void)val;
+    (void)thread_id;
 #ifdef __CUDA_ARCH__
     f(val);
 
@@ -230,6 +235,8 @@ class CudaTeamMember {
       typename std::enable_if<is_reducer<ReducerType>::value>::type
       team_reduce(ReducerType const& reducer,
                   typename ReducerType::value_type& value) const noexcept {
+    (void)reducer;
+    (void)value;
 #ifdef __CUDA_ARCH__
     cuda_intra_block_reduction(reducer, value, blockDim.y);
 #endif /* #ifdef __CUDA_ARCH__ */
@@ -274,6 +281,8 @@ class CudaTeamMember {
 
     return base_data[threadIdx.y];
 #else
+    (void)value;
+    (void)global_accum;
     return Type();
 #endif
   }
@@ -302,6 +311,8 @@ class CudaTeamMember {
       typename std::enable_if<is_reducer<ReducerType>::value>::type
       vector_reduce(ReducerType const& reducer,
                     typename ReducerType::value_type& value) {
+    (void)reducer;
+    (void)value;
 #ifdef __CUDA_ARCH__
     if (blockDim.x == 1) return;
 
@@ -509,6 +520,11 @@ class CudaTeamMember {
     return 0;
 
 #else
+    (void)reducer;
+    (void)global_scratch_flags;
+    (void)global_scratch_space;
+    (void)shmem;
+    (void)shmem_size;
     return 0;
 #endif
   }
@@ -763,6 +779,8 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
     const Impl::TeamVectorRangeBoundariesStruct<iType, Impl::CudaTeamMember>&
         loop_boundaries,
     const Closure& closure) {
+  (void)loop_boundaries;
+  (void)closure;
 #ifdef __CUDA_ARCH__
   for (iType i = loop_boundaries.start + threadIdx.y * blockDim.x + threadIdx.x;
        i < loop_boundaries.end; i += blockDim.y * blockDim.x)
@@ -776,6 +794,9 @@ KOKKOS_INLINE_FUNCTION
     parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
                         iType, Impl::CudaTeamMember>& loop_boundaries,
                     const Closure& closure, const ReducerType& reducer) {
+  (void)loop_boundaries;
+  (void)closure;
+  (void)reducer;
 #ifdef __CUDA_ARCH__
   typename ReducerType::value_type value;
   reducer.init(value);
@@ -796,6 +817,9 @@ KOKKOS_INLINE_FUNCTION
     parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
                         iType, Impl::CudaTeamMember>& loop_boundaries,
                     const Closure& closure, ValueType& result) {
+  (void)loop_boundaries;
+  (void)closure;
+  (void)result;
 #ifdef __CUDA_ARCH__
   ValueType val;
   Kokkos::Sum<ValueType> reducer(val);
@@ -928,6 +952,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     const Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::CudaTeamMember>&
         loop_boundaries,
     const Closure& closure) {
+  (void)loop_boundaries;
+  (void)closure;
 #ifdef __CUDA_ARCH__
 
   // Extract value_type from closure
@@ -1038,6 +1064,8 @@ template <class FunctorType, class ValueType>
 KOKKOS_INLINE_FUNCTION void single(
     const Impl::VectorSingleStruct<Impl::CudaTeamMember>&,
     const FunctorType& lambda, ValueType& val) {
+  (void)lambda;
+  (void)val;
 #ifdef __CUDA_ARCH__
   if (threadIdx.x == 0) lambda(val);
   unsigned mask = blockDim.x == 32
@@ -1052,6 +1080,9 @@ template <class FunctorType, class ValueType>
 KOKKOS_INLINE_FUNCTION void single(
     const Impl::ThreadSingleStruct<Impl::CudaTeamMember>& single_struct,
     const FunctorType& lambda, ValueType& val) {
+  (void)single_struct;
+  (void)lambda;
+  (void)val;
 #ifdef __CUDA_ARCH__
   if (threadIdx.x == 0 && threadIdx.y == 0) {
     lambda(val);

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -683,6 +683,8 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
     const Impl::TeamThreadRangeBoundariesStruct<iType, Impl::CudaTeamMember>&
         loop_boundaries,
     const Closure& closure) {
+  (void)loop_boundaries;
+  (void)closure;
 #ifdef __CUDA_ARCH__
   for (iType i = loop_boundaries.start + threadIdx.y; i < loop_boundaries.end;
        i += blockDim.y)
@@ -706,6 +708,9 @@ KOKKOS_INLINE_FUNCTION
     parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                         iType, Impl::CudaTeamMember>& loop_boundaries,
                     const Closure& closure, const ReducerType& reducer) {
+  (void)loop_boundaries;
+  (void)closure;
+  (void)reducer;
 #ifdef __CUDA_ARCH__
   typename ReducerType::value_type value;
   reducer.init(value);
@@ -734,6 +739,9 @@ KOKKOS_INLINE_FUNCTION
     parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
                         iType, Impl::CudaTeamMember>& loop_boundaries,
                     const Closure& closure, ValueType& result) {
+  (void)loop_boundaries;
+  (void)closure;
+  (void)result;
 #ifdef __CUDA_ARCH__
   ValueType val;
   Kokkos::Sum<ValueType> reducer(val);
@@ -818,6 +826,8 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
     const Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::CudaTeamMember>&
         loop_boundaries,
     const Closure& closure) {
+  (void)loop_boundaries;
+  (void)closure;
 #ifdef __CUDA_ARCH__
   for (iType i = loop_boundaries.start + threadIdx.x; i < loop_boundaries.end;
        i += blockDim.x) {
@@ -853,6 +863,9 @@ KOKKOS_INLINE_FUNCTION
     parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
                         iType, Impl::CudaTeamMember> const& loop_boundaries,
                     Closure const& closure, ReducerType const& reducer) {
+  (void)loop_boundaries;
+  (void)closure;
+  (void)reducer;
 #ifdef __CUDA_ARCH__
 
   reducer.init(reducer.reference());
@@ -884,6 +897,9 @@ KOKKOS_INLINE_FUNCTION
     parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
                         iType, Impl::CudaTeamMember> const& loop_boundaries,
                     Closure const& closure, ValueType& result) {
+  (void)loop_boundaries;
+  (void)closure;
+  (void)result;
 #ifdef __CUDA_ARCH__
   result = ValueType();
 
@@ -986,6 +1002,7 @@ template <class FunctorType>
 KOKKOS_INLINE_FUNCTION void single(
     const Impl::VectorSingleStruct<Impl::CudaTeamMember>&,
     const FunctorType& lambda) {
+  (void)lambda;
 #ifdef __CUDA_ARCH__
   if (threadIdx.x == 0) lambda();
 #ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
@@ -1003,6 +1020,7 @@ template <class FunctorType>
 KOKKOS_INLINE_FUNCTION void single(
     const Impl::ThreadSingleStruct<Impl::CudaTeamMember>&,
     const FunctorType& lambda) {
+  (void)lambda;
 #ifdef __CUDA_ARCH__
   if (threadIdx.x == 0 && threadIdx.y == 0) lambda();
 #ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK

--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -140,6 +140,10 @@ struct in_place_shfl_fn : in_place_shfl_op<in_place_shfl_fn> {
   __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(unsigned mask, T& val,
                                                   int lane, int width) const
       noexcept {
+    (void)mask;
+    (void)val;
+    (void)lane;
+    (void)width;
     return KOKKOS_IMPL_CUDA_SHFL_MASK(mask, val, lane, width);
   }
 };
@@ -167,6 +171,10 @@ struct in_place_shfl_down_fn : in_place_shfl_op<in_place_shfl_down_fn> {
   __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(unsigned mask, T& val,
                                                   int lane, int width) const
       noexcept {
+    (void)mask;
+    (void)val;
+    (void)lane;
+    (void)width;
     return KOKKOS_IMPL_CUDA_SHFL_DOWN_MASK(mask, val, lane, width);
   }
 };

--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -273,6 +273,7 @@ class ViewDataHandle<
     return handle_type(arg_data_ptr, r);
 
 #else
+    (void)arg_tracker;
     Kokkos::Impl::cuda_abort(
         "Cannot create Cuda texture object from within a Cuda kernel");
     return handle_type();

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -193,6 +193,7 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   inline void set(const ChunkSize& chunksize, Args... args) {
     m_granularity      = chunksize.value;
     m_granularity_mask = m_granularity - 1;
+    set(args...);
   }
 
  public:

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -268,6 +268,9 @@ class SharedAllocationRecord<Kokkos::HostSpace, void>
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
     return new SharedAllocationRecord(arg_space, arg_label, arg_alloc_size);
 #else
+    (void)arg_space;
+    (void)arg_label;
+    (void)arg_alloc_size;
     return (SharedAllocationRecord*)0;
 #endif
   }

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -640,8 +640,12 @@
 #undef __CUDA_ARCH__
 #endif
 
-#if defined(__has_cpp_attribute) && __has_cpp_attribute(fallthrough) >= 201603
-#define KOKKOS_FALLTHROUGH [[fallthrough]]
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(fallthrough) >= 201603
+#define KOKKOS_FALLTHROUGH [[fallthrough]] 
+#else
+#define KOKKOS_FALLTHROUGH
+#endif
 #else
 #define KOKKOS_FALLTHROUGH
 #endif

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -639,4 +639,11 @@
     !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_CUDA)
 #undef __CUDA_ARCH__
 #endif
+
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(fallthrough) >= 201603
+#define KOKKOS_FALLTHROUGH [[fallthrough]]
+#else
+#define KOKKOS_FALLTHROUGH
+#endif
+
 #endif  // #ifndef KOKKOS_MACROS_HPP

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -640,14 +640,4 @@
 #undef __CUDA_ARCH__
 #endif
 
-#if defined(__has_cpp_attribute)
-#if __has_cpp_attribute(fallthrough) >= 201603
-#define KOKKOS_FALLTHROUGH [[fallthrough]] 
-#else
-#define KOKKOS_FALLTHROUGH
-#endif
-#else
-#define KOKKOS_FALLTHROUGH
-#endif
-
 #endif  // #ifndef KOKKOS_MACROS_HPP

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -639,5 +639,4 @@
     !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_CUDA)
 #undef __CUDA_ARCH__
 #endif
-
 #endif  // #ifndef KOKKOS_MACROS_HPP

--- a/core/src/Kokkos_TaskScheduler.hpp
+++ b/core/src/Kokkos_TaskScheduler.hpp
@@ -143,7 +143,7 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
       Kokkos::BasicFuture<typename FunctorType::value_type, scheduler_type>
       _spawn_impl(DepTaskType* arg_predecessor_task, TaskPriority arg_priority,
                   typename task_base::function_type arg_function,
-                  typename task_base::destroy_type arg_destroy,
+                  typename task_base::destroy_type /*arg_destroy*/,
                   FunctorType&& arg_functor) {
     using functor_future_type =
         future_type_for_functor<typename std::decay<FunctorType>::type>;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -830,10 +830,10 @@ class View : public ViewTraits<DataType, Properties...> {
 
 #else
 
-#define KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(ARG) \
-  View::template verify_space<                \
-      Kokkos::Impl::ActiveExecutionMemorySpace>::check();
-
+#define KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(ARG)             \
+  View::template verify_space<                            \
+      Kokkos::Impl::ActiveExecutionMemorySpace>::check(); \
+  [](...) {} ARG;
 #endif
 
  public:

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -821,20 +821,10 @@ class View : public ViewTraits<DataType, Properties...> {
     };
   };
 
-#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-
 #define KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(ARG)             \
   View::template verify_space<                            \
       Kokkos::Impl::ActiveExecutionMemorySpace>::check(); \
   Kokkos::Impl::view_verify_operator_bounds<typename traits::memory_space> ARG;
-
-#else
-
-#define KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(ARG)             \
-  View::template verify_space<                            \
-      Kokkos::Impl::ActiveExecutionMemorySpace>::check(); \
-  [](...) {} ARG;
-#endif
 
  public:
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
@@ -447,7 +447,7 @@ void OpenMP::impl_finalize()
 
 //----------------------------------------------------------------------------
 
-void OpenMP::print_configuration(std::ostream &s, const bool verbose) {
+void OpenMP::print_configuration(std::ostream &s, const bool /*verbose*/) {
   s << "Kokkos::OpenMP";
 
   const bool is_initialized = Impl::t_openmp_instance != nullptr;

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -174,13 +174,13 @@ int OpenMP::impl_thread_pool_rank() noexcept
 #endif
 }
 
-inline void OpenMP::impl_static_fence(OpenMP const& instance) noexcept {}
+inline void OpenMP::impl_static_fence(OpenMP const& /*instance*/) noexcept {}
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
 inline void OpenMP::fence(OpenMP const& instance) noexcept {}
 #endif
 
-inline bool OpenMP::is_asynchronous(OpenMP const& instance) noexcept {
+inline bool OpenMP::is_asynchronous(OpenMP const& /*instance*/) noexcept {
   return false;
 }
 

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -1172,7 +1172,8 @@ namespace Kokkos {
 
 template <class FunctorType>
 KOKKOS_INLINE_FUNCTION void single(
-    const Impl::VectorSingleStruct<Impl::ThreadsExecTeamMember>& single_struct,
+    const Impl::VectorSingleStruct<
+        Impl::ThreadsExecTeamMember>& /*single_struct*/,
     const FunctorType& lambda) {
   lambda();
 }
@@ -1186,7 +1187,8 @@ KOKKOS_INLINE_FUNCTION void single(
 
 template <class FunctorType, class ValueType>
 KOKKOS_INLINE_FUNCTION void single(
-    const Impl::VectorSingleStruct<Impl::ThreadsExecTeamMember>& single_struct,
+    const Impl::VectorSingleStruct<
+        Impl::ThreadsExecTeamMember>& /*single_struct*/,
     const FunctorType& lambda, ValueType& val) {
   lambda(val);
 }

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -178,7 +178,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
 
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
-    const Oper& op, volatile T* const dest,
+    const Oper& /*op*/, volatile T* const dest,
     typename std::enable_if<sizeof(T) != sizeof(int) &&
                                 sizeof(T) == sizeof(unsigned long long int),
                             const T>::type val) {
@@ -244,7 +244,7 @@ KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
 
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
-    const Oper& op, volatile T* const dest,
+    const Oper& /*op*/, volatile T* const dest,
     typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8), const T>::type
         val) {
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -178,7 +178,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
 
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
-    const Oper& /*op*/, volatile T* const dest,
+    const Oper& op, volatile T* const dest,
     typename std::enable_if<sizeof(T) != sizeof(int) &&
                                 sizeof(T) == sizeof(unsigned long long int),
                             const T>::type val) {
@@ -192,7 +192,7 @@ KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
 
   do {
     assume.i = oldval.i;
-    newval.t = Oper::apply(assume.t, val);
+    newval.t = op.apply(assume.t, val);
     oldval.i = Kokkos::atomic_compare_exchange((unsigned long long int*)dest,
                                                assume.i, newval.i);
   } while (assume.i != oldval.i);
@@ -223,7 +223,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
 
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
-    const Oper& /*op*/, volatile T* const dest,
+    const Oper& op, volatile T* const dest,
     typename std::enable_if<sizeof(T) == sizeof(int), const T>::type val) {
   union U {
     int i;
@@ -235,7 +235,7 @@ KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
 
   do {
     assume.i = oldval.i;
-    newval.t = Oper::apply(assume.t, val);
+    newval.t = op.apply(assume.t, val);
     oldval.i = Kokkos::atomic_compare_exchange((int*)dest, assume.i, newval.i);
   } while (assume.i != oldval.i);
 
@@ -244,14 +244,14 @@ KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
 
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
-    const Oper& /*op*/, volatile T* const dest,
+    const Oper& op, volatile T* const dest,
     typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8), const T>::type
         val) {
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
   while (!Impl::lock_address_host_space((void*)dest))
     ;
   T return_val = *dest;
-  *dest        = Oper::apply(return_val, val);
+  *dest        = op.apply(return_val, val);
   Impl::unlock_address_host_space((void*)dest);
   return return_val;
 #elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA)
@@ -269,7 +269,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
     if (!done) {
       if (Impl::lock_address_cuda_space((void*)dest)) {
         return_val = *dest;
-        *dest      = Oper::apply(return_val, val);
+        *dest      = op.apply(return_val, val);
         Impl::unlock_address_cuda_space((void*)dest);
         done = 1;
       }
@@ -288,7 +288,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
 
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T
-atomic_oper_fetch(const Oper& /*op*/, volatile T* const dest,
+atomic_oper_fetch(const Oper& op, volatile T* const dest,
                   typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
 #if defined(KOKKOS_ENABLE_ASM) && \
     defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
@@ -300,7 +300,7 @@ atomic_oper_fetch(const Oper& /*op*/, volatile T* const dest,
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
   while (!Impl::lock_address_host_space((void*)dest))
     ;
-  T return_val = Oper::apply(*dest, val);
+  T return_val = op.apply(*dest, val);
   *dest        = return_val;
   Impl::unlock_address_host_space((void*)dest);
   return return_val;
@@ -318,7 +318,7 @@ atomic_oper_fetch(const Oper& /*op*/, volatile T* const dest,
   while (active != done_active) {
     if (!done) {
       if (Impl::lock_address_cuda_space((void*)dest)) {
-        return_val = Oper::apply(*dest, val);
+        return_val = op.apply(*dest, val);
         *dest      = return_val;
         Impl::unlock_address_cuda_space((void*)dest);
         done = 1;

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -223,7 +223,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
 
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
-    const Oper& op, volatile T* const dest,
+    const Oper& /*op*/, volatile T* const dest,
     typename std::enable_if<sizeof(T) == sizeof(int), const T>::type val) {
   union U {
     int i;
@@ -288,7 +288,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
 
 template <class Oper, typename T>
 KOKKOS_INLINE_FUNCTION T
-atomic_oper_fetch(const Oper& op, volatile T* const dest,
+atomic_oper_fetch(const Oper& /*op*/, volatile T* const dest,
                   typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
 #if defined(KOKKOS_ENABLE_ASM) && \
     defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)

--- a/core/src/impl/Kokkos_Atomic_Load.hpp
+++ b/core/src/impl/Kokkos_Atomic_Load.hpp
@@ -189,7 +189,7 @@ KOKKOS_FORCEINLINE_FUNCTION T atomic_load(T* ptr,
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION T atomic_load(T* ptr,
+KOKKOS_FORCEINLINE_FUNCTION T atomic_load(T* /*ptr*/,
                                           Impl::memory_order_release_t) {
   static_assert(
       sizeof(T) == 0,  // just something that will always be false, but only on
@@ -198,7 +198,7 @@ KOKKOS_FORCEINLINE_FUNCTION T atomic_load(T* ptr,
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION T atomic_load(T* ptr,
+KOKKOS_FORCEINLINE_FUNCTION T atomic_load(T* /*ptr*/,
                                           Impl::memory_order_acq_rel_t) {
   static_assert(
       sizeof(T) == 0,  // just something that will always be false, but only on

--- a/core/src/impl/Kokkos_Atomic_Store.hpp
+++ b/core/src/impl/Kokkos_Atomic_Store.hpp
@@ -205,7 +205,7 @@ KOKKOS_FORCEINLINE_FUNCTION void atomic_store(T* /*ptr*/, T /*val*/,
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION void atomic_store(T* ptr, T val) {
   // relaxed by default!
-  _atomic_store(ptr, Impl::memory_order_relaxed);
+  _atomic_store(ptr, val, Impl::memory_order_relaxed);
 }
 
 }  // end namespace Impl

--- a/core/src/impl/Kokkos_Atomic_Store.hpp
+++ b/core/src/impl/Kokkos_Atomic_Store.hpp
@@ -185,7 +185,7 @@ KOKKOS_FORCEINLINE_FUNCTION void atomic_store(T* ptr, T val,
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION void atomic_store(T* ptr, T val,
+KOKKOS_FORCEINLINE_FUNCTION void atomic_store(T* /*ptr*/, T /*val*/,
                                               Impl::memory_order_acquire_t) {
   static_assert(
       sizeof(T) == 0,  // just something that will always be false, but only on
@@ -194,7 +194,7 @@ KOKKOS_FORCEINLINE_FUNCTION void atomic_store(T* ptr, T val,
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION void atomic_store(T* ptr, T val,
+KOKKOS_FORCEINLINE_FUNCTION void atomic_store(T* /*ptr*/, T /*val*/,
                                               Impl::memory_order_acq_rel_t) {
   static_assert(
       sizeof(T) == 0,  // just something that will always be false, but only on

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -362,7 +362,7 @@ void initialize_backends(const InitArguments& args) {
 #endif
 }
 
-void initialize_profiling(const InitArguments& args) {
+void initialize_profiling(const InitArguments&) {
 #if defined(KOKKOS_ENABLE_PROFILING)
   Kokkos::Profiling::initialize();
 #else

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -1525,7 +1525,7 @@ struct FunctorValueJoin<FunctorType, ArgTag, T&, Enable> {
   KOKKOS_FORCEINLINE_FUNCTION
   FunctorValueJoin(const FunctorType&) {}
 
-  KOKKOS_FORCEINLINE_FUNCTION static void join(const FunctorType& f,
+  KOKKOS_FORCEINLINE_FUNCTION static void join(const FunctorType& /*f*/,
                                                volatile void* const lhs,
                                                const volatile void* const rhs) {
     *((volatile T*)lhs) += *((const volatile T*)rhs);

--- a/core/src/impl/Kokkos_HostBarrier.hpp
+++ b/core/src/impl/Kokkos_HostBarrier.hpp
@@ -235,6 +235,7 @@ class HostBarrier {
       impl_backoff_wait_until_equal(ptr, v, active_wait);
     }
 #else
+    (void)active_wait;
     while (!test_equal(ptr, v)) {
     }
 #endif

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -538,6 +538,8 @@ class HostThreadTeamMember {
   }
 #else
   {
+    (void)value;
+    (void)source_team_rank;
     Kokkos::abort("HostThreadTeamMember team_broadcast\n");
   }
 #endif
@@ -574,6 +576,9 @@ class HostThreadTeamMember {
   }
 #else
   {
+    (void)f;
+    (void)value;
+    (void)source_team_rank;
     Kokkos::abort("HostThreadTeamMember team_broadcast\n");
   }
 #endif
@@ -640,6 +645,8 @@ class HostThreadTeamMember {
   }
 #else
   {
+    (void)reducer;
+    (void)contribution;
     Kokkos::abort("HostThreadTeamMember team_reduce\n");
   }
 #endif
@@ -751,6 +758,8 @@ class HostThreadTeamMember {
   }
 #else
   {
+    (void)value;
+    (void)global;
     Kokkos::abort("HostThreadTeamMember team_scan\n");
     return T();
   }

--- a/core/src/impl/Kokkos_MultipleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_MultipleTaskQueue.hpp
@@ -142,7 +142,7 @@ struct MultipleTaskQueueTeamEntry {
 
   template <class _always_void = void>
   KOKKOS_INLINE_FUNCTION OptionalRef<task_base_type> _pop_failed_insertion(
-      int priority, TaskType type,
+      int /*priority*/, TaskType /*type*/,
       typename std::enable_if<
           not task_queue_traits::ready_queue_insertion_may_fail and
               std::is_void<_always_void>::value,
@@ -217,7 +217,7 @@ struct MultipleTaskQueueTeamEntry {
 
   template <class _always_void = void>
   KOKKOS_INLINE_FUNCTION void do_handle_failed_insertion(
-      runnable_task_base_type&& task,
+      runnable_task_base_type&& /*task*/,
       typename std::enable_if<
           not task_queue_traits::ready_queue_insertion_may_fail and
               std::is_void<_always_void>::value,
@@ -484,32 +484,32 @@ class MultipleTaskQueue final
   // Provide a sensible default that can be overridden
   KOKKOS_INLINE_FUNCTION
   void update_scheduling_info_from_completed_predecessor(
-      runnable_task_base_type& ready_task,
-      runnable_task_base_type const& predecessor) const {
+      runnable_task_base_type& /*ready_task*/,
+      runnable_task_base_type const& /*predecessor*/) const {
     // Do nothing; we're using the extra storage for the failure linked list
   }
 
   // Provide a sensible default that can be overridden
   KOKKOS_INLINE_FUNCTION
   void update_scheduling_info_from_completed_predecessor(
-      aggregate_task_type& aggregate,
-      runnable_task_base_type const& predecessor) const {
+      aggregate_task_type& /*aggregate*/,
+      runnable_task_base_type const& /*predecessor*/) const {
     // Do nothing; we're using the extra storage for the failure linked list
   }
 
   // Provide a sensible default that can be overridden
   KOKKOS_INLINE_FUNCTION
   void update_scheduling_info_from_completed_predecessor(
-      aggregate_task_type& aggregate,
-      aggregate_task_type const& predecessor) const {
+      aggregate_task_type& /*aggregate*/,
+      aggregate_task_type const& /*predecessor*/) const {
     // Do nothing; we're using the extra storage for the failure linked list
   }
 
   // Provide a sensible default that can be overridden
   KOKKOS_INLINE_FUNCTION
   void update_scheduling_info_from_completed_predecessor(
-      runnable_task_base_type& ready_task,
-      aggregate_task_type const& predecessor) const {
+      runnable_task_base_type& /*ready_task*/,
+      aggregate_task_type const& /*predecessor*/) const {
     // Do nothing; we're using the extra storage for the failure linked list
   }
 

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -245,6 +245,9 @@ class SharedAllocationRecord
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
     return new SharedAllocationRecord(arg_space, arg_label, arg_alloc);
 #else
+    (void)arg_space;
+    (void)arg_label;
+    (void)arg_alloc;
     return (SharedAllocationRecord*)0;
 #endif
   }

--- a/core/src/impl/Kokkos_SimpleTaskScheduler.hpp
+++ b/core/src/impl/Kokkos_SimpleTaskScheduler.hpp
@@ -226,13 +226,13 @@ class SimpleTaskScheduler
   }
 
   template <int TaskEnum, class DepTaskType, class FunctorType>
-  KOKKOS_FUNCTION
-      future_type_for_functor<typename std::decay<FunctorType>::type>
-      _spawn_impl(
-          DepTaskType arg_predecessor_task, TaskPriority arg_priority,
-          typename runnable_task_base_type::function_type apply_function_ptr,
-          typename runnable_task_base_type::destroy_type destroy_function_ptr,
-          FunctorType&& functor) {
+  KOKKOS_FUNCTION future_type_for_functor<
+      typename std::decay<FunctorType>::type>
+  _spawn_impl(
+      DepTaskType arg_predecessor_task, TaskPriority arg_priority,
+      typename runnable_task_base_type::function_type apply_function_ptr,
+      typename runnable_task_base_type::destroy_type /*destroy_function_ptr*/,
+      FunctorType&& functor) {
     KOKKOS_EXPECTS(m_queue != nullptr);
 
     using functor_future_type =

--- a/core/src/impl/Kokkos_SingleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_SingleTaskQueue.hpp
@@ -154,7 +154,7 @@ class SingleTaskQueue
 
   KOKKOS_FUNCTION
   OptionalRef<task_base_type> pop_ready_task(
-      team_scheduler_info_type const& info) {
+      team_scheduler_info_type const& /*info*/) {
     OptionalRef<task_base_type> return_value;
     // always loop in order of priority first, then prefer team tasks over
     // single tasks

--- a/core/src/impl/Kokkos_TaskNode.hpp
+++ b/core/src/impl/Kokkos_TaskNode.hpp
@@ -620,7 +620,7 @@ class alignas(16) RunnableTask
   ~RunnableTask() = delete;
 
   KOKKOS_INLINE_FUNCTION
-  void update_scheduling_info(member_type& member) {
+  void update_scheduling_info(member_type& /*member*/) {
     // TODO @tasking @generalization DSH call a queue-specific hook here; for
     // now, this info is already updated elsewhere this->scheduling_info() =
     // member.scheduler().scheduling_info();
@@ -639,7 +639,7 @@ class alignas(16) RunnableTask
     this->functor_type::operator()(*member, *val);
   }
 
-  KOKKOS_FUNCTION static void destroy(task_base_type* root) {
+  KOKKOS_FUNCTION static void destroy(task_base_type* /*root*/) {
     // TaskResult<result_type>::destroy(root);
   }
 

--- a/core/src/impl/Kokkos_TaskQueue.hpp
+++ b/core/src/impl/Kokkos_TaskQueue.hpp
@@ -168,13 +168,13 @@ class TaskQueue : public TaskQueueBase {
   int allocation_count() const noexcept { return m_count_alloc; }
 
   KOKKOS_INLINE_FUNCTION
-  void initialize_team_queues(int pool_size) const noexcept {}
+  void initialize_team_queues(int /*pool_size*/) const noexcept {}
 
   KOKKOS_INLINE_FUNCTION
   task_root_type* attempt_to_steal_task() const noexcept { return nullptr; }
 
   KOKKOS_INLINE_FUNCTION
-  team_queue_type& get_team_queue(int team_rank) { return *this; }
+  team_queue_type& get_team_queue(int /*team_rank*/) { return *this; }
 
   // void execute() { specialization::execute( this ); }
 

--- a/core/src/impl/Kokkos_TaskQueueCommon.hpp
+++ b/core/src/impl/Kokkos_TaskQueueCommon.hpp
@@ -312,8 +312,8 @@ class TaskQueueCommonMixin {
   template <class TaskQueueTraits, class ReadyQueueType,
             class TeamSchedulerInfo>
   KOKKOS_INLINE_FUNCTION void handle_failed_ready_queue_insertion(
-      RunnableTaskBase<TaskQueueTraits>&& task, ReadyQueueType& ready_queue,
-      TeamSchedulerInfo const& info) {
+      RunnableTaskBase<TaskQueueTraits>&& /*task*/,
+      ReadyQueueType& /*ready_queue*/, TeamSchedulerInfo const& /*info*/) {
     Kokkos::abort("Unhandled failure of ready task queue insertion!\n");
   }
 
@@ -462,15 +462,16 @@ class TaskQueueCommonMixin {
 
   template <class TaskQueueTraits>
   KOKKOS_INLINE_FUNCTION void initialize_scheduling_info_from_predecessor(
-      TaskNode<TaskQueueTraits>& task,
-      TaskNode<TaskQueueTraits>& predecessor) const {
+      TaskNode<TaskQueueTraits>& /*task*/,
+      TaskNode<TaskQueueTraits>& /*predecessor*/) const {
     /* do nothing by default */
   }
 
   template <class TeamSchedulerInfo, class TaskQueueTraits>
   KOKKOS_INLINE_FUNCTION void
   initialize_scheduling_info_from_team_scheduler_info(
-      TaskNode<TaskQueueTraits>& task, TeamSchedulerInfo const& info) const {
+      TaskNode<TaskQueueTraits>& /*task*/,
+      TeamSchedulerInfo const& /*info*/) const {
     /* do nothing by default */
   }
 

--- a/core/src/impl/Kokkos_TaskResult.hpp
+++ b/core/src/impl/Kokkos_TaskResult.hpp
@@ -126,7 +126,7 @@ struct TaskResult<void> {
 
   KOKKOS_INLINE_FUNCTION static reference_type get(TaskBase*) {}
 
-  KOKKOS_INLINE_FUNCTION static void destroy(TaskBase* task) {}
+  KOKKOS_INLINE_FUNCTION static void destroy(TaskBase* /*task*/) {}
 
   // template <class TaskQueueTraits>
   // KOKKOS_INLINE_FUNCTION static

--- a/core/src/impl/Kokkos_ViewArray.hpp
+++ b/core/src/impl/Kokkos_ViewArray.hpp
@@ -468,7 +468,7 @@ class ViewMapping<
 
   KOKKOS_INLINE_FUNCTION
   static void assign(DstType &dst, const SrcType &src,
-                     const TrackType &src_track) {
+                     const TrackType & /*src_track*/) {
     static_assert(is_assignable, "Can only convert to array_type");
 
     typedef typename DstType::offset_type dst_offset_type;

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2113,7 +2113,8 @@ struct ViewStride;
 
 template <>
 struct ViewStride<0> {
-  enum { S0 = 0, S1 = 0, S2 = 0, S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0 };
+  static constexpr size_t S0 = 0, S1 = 0, S2 = 0, S3 = 0, S4 = 0, S5 = 0,
+                          S6 = 0, S7 = 0;
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2127,7 +2128,8 @@ struct ViewStride<0> {
 template <>
 struct ViewStride<1> {
   size_t S0;
-  enum { S1 = 0, S2 = 0, S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0 };
+  static constexpr size_t S1 = 0, S2 = 0, S3 = 0, S4 = 0, S5 = 0, S6 = 0,
+                          S7 = 0;
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2142,7 +2144,7 @@ struct ViewStride<1> {
 template <>
 struct ViewStride<2> {
   size_t S0, S1;
-  enum { S2 = 0, S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0 };
+  static constexpr size_t S2 = 0, S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0;
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2157,7 +2159,7 @@ struct ViewStride<2> {
 template <>
 struct ViewStride<3> {
   size_t S0, S1, S2;
-  enum { S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0 };
+  static constexpr size_t S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0;
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2172,7 +2174,7 @@ struct ViewStride<3> {
 template <>
 struct ViewStride<4> {
   size_t S0, S1, S2, S3;
-  enum { S4 = 0, S5 = 0, S6 = 0, S7 = 0 };
+  static constexpr size_t S4 = 0, S5 = 0, S6 = 0, S7 = 0;
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2187,7 +2189,7 @@ struct ViewStride<4> {
 template <>
 struct ViewStride<5> {
   size_t S0, S1, S2, S3, S4;
-  enum { S5 = 0, S6 = 0, S7 = 0 };
+  static constexpr size_t S5 = 0, S6 = 0, S7 = 0;
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2202,7 +2204,7 @@ struct ViewStride<5> {
 template <>
 struct ViewStride<6> {
   size_t S0, S1, S2, S3, S4, S5;
-  enum { S6 = 0, S7 = 0 };
+  static constexpr size_t S6 = 0, S7 = 0;
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2217,7 +2219,7 @@ struct ViewStride<6> {
 template <>
 struct ViewStride<7> {
   size_t S0, S1, S2, S3, S4, S5, S6;
-  enum { S7 = 0 };
+  static constexpr size_t S7 = 0;
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2043,19 +2043,23 @@ struct ViewOffset<
       : m_dim(rhs.m_dim.N0, rhs.m_dim.N1, rhs.m_dim.N2, rhs.m_dim.N3,
               rhs.m_dim.N4, rhs.m_dim.N5, rhs.m_dim.N6, rhs.m_dim.N7),
         m_stride(rhs.stride_0()) {
-    if (((dimension_type::rank == 2)
-             ? rhs.m_stride.S1
-             : ((dimension_type::rank == 3)
-                    ? rhs.m_stride.S2
-                    : ((dimension_type::rank == 4)
-                           ? rhs.m_stride.S3
-                           : ((dimension_type::rank == 5)
-                                  ? rhs.m_stride.S4
-                                  : ((dimension_type::rank == 6)
-                                         ? rhs.m_stride.S5
-                                         : ((dimension_type::rank == 7)
-                                                ? rhs.m_stride.S6
-                                                : rhs.m_stride.S7)))))) != 1) {
+    bool right_stride_is_1 = true;
+    if (dimension_type::rank == 2)
+      right_stride_is_1 = (rhs.m_stride.S1 == 1);
+    else if (dimension_type::rank == 3)
+      right_stride_is_1 = (rhs.m_stride.S2 == 1);
+    else if (dimension_type::rank == 4)
+      right_stride_is_1 = (rhs.m_stride.S3 == 1);
+    else if (dimension_type::rank == 5)
+      right_stride_is_1 = (rhs.m_stride.S4 == 1);
+    else if (dimension_type::rank == 6)
+      right_stride_is_1 = (rhs.m_stride.S5 == 1);
+    else if (dimension_type::rank == 7)
+      right_stride_is_1 = (rhs.m_stride.S6 == 1);
+    else if (dimension_type::rank == 8)
+      right_stride_is_1 = (rhs.m_stride.S7 == 1);
+
+    if (!right_stride_is_1) {
       Kokkos::abort(
           "Kokkos::Impl::ViewOffset assignment of LayoutRight from "
           "LayoutStride requires right-most stride == 1");
@@ -2113,8 +2117,7 @@ struct ViewStride;
 
 template <>
 struct ViewStride<0> {
-  static constexpr size_t S0 = 0, S1 = 0, S2 = 0, S3 = 0, S4 = 0, S5 = 0,
-                          S6 = 0, S7 = 0;
+  enum { S0 = 0, S1 = 0, S2 = 0, S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0 };
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2128,8 +2131,7 @@ struct ViewStride<0> {
 template <>
 struct ViewStride<1> {
   size_t S0;
-  static constexpr size_t S1 = 0, S2 = 0, S3 = 0, S4 = 0, S5 = 0, S6 = 0,
-                          S7 = 0;
+  enum { S1 = 0, S2 = 0, S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0 };
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2144,7 +2146,7 @@ struct ViewStride<1> {
 template <>
 struct ViewStride<2> {
   size_t S0, S1;
-  static constexpr size_t S2 = 0, S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0;
+  enum { S2 = 0, S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0 };
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2159,7 +2161,7 @@ struct ViewStride<2> {
 template <>
 struct ViewStride<3> {
   size_t S0, S1, S2;
-  static constexpr size_t S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0;
+  enum { S3 = 0, S4 = 0, S5 = 0, S6 = 0, S7 = 0 };
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2174,7 +2176,7 @@ struct ViewStride<3> {
 template <>
 struct ViewStride<4> {
   size_t S0, S1, S2, S3;
-  static constexpr size_t S4 = 0, S5 = 0, S6 = 0, S7 = 0;
+  enum { S4 = 0, S5 = 0, S6 = 0, S7 = 0 };
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2189,7 +2191,7 @@ struct ViewStride<4> {
 template <>
 struct ViewStride<5> {
   size_t S0, S1, S2, S3, S4;
-  static constexpr size_t S5 = 0, S6 = 0, S7 = 0;
+  enum { S5 = 0, S6 = 0, S7 = 0 };
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2204,7 +2206,7 @@ struct ViewStride<5> {
 template <>
 struct ViewStride<6> {
   size_t S0, S1, S2, S3, S4, S5;
-  static constexpr size_t S6 = 0, S7 = 0;
+  enum { S6 = 0, S7 = 0 };
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;
@@ -2219,7 +2221,7 @@ struct ViewStride<6> {
 template <>
 struct ViewStride<7> {
   size_t S0, S1, S2, S3, S4, S5, S6;
-  static constexpr size_t S7 = 0;
+  enum { S7 = 0 };
 
   ViewStride()                  = default;
   ViewStride(const ViewStride&) = default;

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3692,6 +3692,7 @@ struct ViewMapping<
 namespace Kokkos {
 namespace Impl {
 
+#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
 template <unsigned, class MapType>
 KOKKOS_INLINE_FUNCTION bool view_verify_operator_bounds(const MapType&) {
   return true;
@@ -3704,6 +3705,13 @@ KOKKOS_INLINE_FUNCTION bool view_verify_operator_bounds(const MapType& map,
   return (size_t(i) < map.extent(R)) &&
          view_verify_operator_bounds<R + 1>(map, args...);
 }
+#else
+template <unsigned R, class MapType, class... Args>
+KOKKOS_INLINE_FUNCTION bool view_verify_operator_bounds(const MapType& /*map*/,
+                                                        Args... /*args*/) {
+  return true;
+}
+#endif
 
 template <unsigned, class MapType>
 inline void view_error_operator_bounds(char*, int, const MapType&) {}

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -105,7 +105,7 @@ struct TestComplexConstruction {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const int &i) const {
+  void operator()(const int & /*i*/) const {
     Kokkos::complex<double> a(1.5, 2.5);
     d_results(0) = a;
     Kokkos::complex<double> b(a);
@@ -232,7 +232,7 @@ struct TestComplexBasicMath {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const int &i) const {
+  void operator()(const int & /*i*/) const {
     Kokkos::complex<double> a(1.5, 2.5);
     Kokkos::complex<double> b(3.25, 5.75);
     // Basic math complex / complex
@@ -325,7 +325,7 @@ struct TestComplexSpecialFunctions {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const int &i) const {
+  void operator()(const int & /*i*/) const {
     Kokkos::complex<double> a(1.5, 2.5);
     Kokkos::complex<double> b(3.25, 5.75);
     double c = 9.3;

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -268,7 +268,7 @@ struct TestMDRange_2D {
       double sum = 0.0;
       parallel_reduce(
           range,
-          KOKKOS_LAMBDA(const int i, const int j, double &lsum) {
+          KOKKOS_LAMBDA(const int /*i*/, const int /*j*/, double &lsum) {
             lsum += 1.0;
           },
           sum);
@@ -915,9 +915,8 @@ struct TestMDRange_3D {
       double sum = 0.0;
       parallel_reduce(
           range,
-          KOKKOS_LAMBDA(const int i, const int j, const int k, double &lsum) {
-            lsum += 1.0;
-          },
+          KOKKOS_LAMBDA(const int /*i*/, const int /*j*/, const int /*k*/,
+                        double &lsum) { lsum += 1.0; },
           sum);
       ASSERT_EQ(sum, N0 * N1 * N2);
     }
@@ -1549,8 +1548,8 @@ struct TestMDRange_4D {
       double sum = 0.0;
       parallel_reduce(
           range,
-          KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
-                        double &lsum) { lsum += 1.0; },
+          KOKKOS_LAMBDA(const int /*i*/, const int /*j*/, const int /*k*/,
+                        const int /*l*/, double &lsum) { lsum += 1.0; },
           sum);
       ASSERT_EQ(sum, N0 * N1 * N2 * N3);
     }
@@ -2201,8 +2200,9 @@ struct TestMDRange_5D {
       double sum = 0.0;
       parallel_reduce(
           range,
-          KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
-                        const int m, double &lsum) { lsum += 1.0; },
+          KOKKOS_LAMBDA(const int /*i*/, const int /*j*/, const int /*k*/,
+                        const int /*l*/, const int /*m*/,
+                        double &lsum) { lsum += 1.0; },
           sum);
       ASSERT_EQ(sum, N0 * N1 * N2 * N3 * N4);
     }
@@ -2787,8 +2787,8 @@ struct TestMDRange_6D {
       double sum = 0.0;
       parallel_reduce(
           range,
-          KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
-                        const int m, const int n,
+          KOKKOS_LAMBDA(const int /*i*/, const int /*j*/, const int /*k*/,
+                        const int /*l*/, const int /*m*/, const int /*n*/,
                         double &lsum) { lsum += 1.0; },
           sum);
       ASSERT_EQ(sum, N0 * N1 * N2 * N3 * N4 * N5);

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -644,7 +644,8 @@ struct TestMDRange_2D {
               range_type;
       typedef typename range_type::point_type point_type;
 
-      range_type range(point_type{{0, 0}}, point_type{{N0, N1}});
+      range_type range(point_type{{0, 0}}, point_type{{N0, N1}},
+                       point_type{{0, 0}});
       TestMDRange_2D functor(N0, N1);
 
       parallel_for(range, functor);
@@ -1231,7 +1232,8 @@ struct TestMDRange_3D {
           range_type;
       typedef typename range_type::point_type point_type;
 
-      range_type range(point_type{{0, 0, 0}}, point_type{{N0, N1, N2}});
+      range_type range(point_type{{0, 0, 0}}, point_type{{N0, N1, N2}},
+                       point_type{{0, 0, 0}});
       TestMDRange_3D functor(N0, N1, N2);
 
       parallel_for(range, functor);
@@ -1867,7 +1869,8 @@ struct TestMDRange_4D {
           range_type;
       typedef typename range_type::point_type point_type;
 
-      range_type range(point_type{{0, 0, 0, 0}}, point_type{{N0, N1, N2, N3}});
+      range_type range(point_type{{0, 0, 0, 0}}, point_type{{N0, N1, N2, N3}},
+                       point_type{{0, 0, 0, 0}});
       TestMDRange_4D functor(N0, N1, N2, N3);
 
       parallel_for(range, functor);
@@ -2437,7 +2440,8 @@ struct TestMDRange_5D {
       typedef typename range_type::point_type point_type;
 
       range_type range(point_type{{0, 0, 0, 0, 0}},
-                       point_type{{N0, N1, N2, N3, N4}});
+                       point_type{{N0, N1, N2, N3, N4}},
+                       point_type{{0, 0, 0, 0, 0}});
       TestMDRange_5D functor(N0, N1, N2, N3, N4);
 
       parallel_for(range, functor);
@@ -3030,7 +3034,8 @@ struct TestMDRange_6D {
       typedef typename range_type::point_type point_type;
 
       range_type range(point_type{{0, 0, 0, 0, 0, 0}},
-                       point_type{{N0, N1, N2, N3, N4, N5}});
+                       point_type{{N0, N1, N2, N3, N4, N5}},
+                       point_type{{0, 0, 0, 0, 0, 0}});
       TestMDRange_6D functor(N0, N1, N2, N3, N4, N5);
 
       parallel_for(range, functor);

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -480,10 +480,10 @@ struct TestMemoryPoolHuge {
   using value_type = long;
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(int i, long& err) const noexcept {}
+  void operator()(int /*i*/, long& /*err*/) const noexcept {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(int i) const noexcept {}
+  void operator()(int /*i*/) const noexcept {}
 };
 
 template <class DeviceType>

--- a/core/unit_test/TestReduceCombinatorical.hpp
+++ b/core/unit_test/TestReduceCombinatorical.hpp
@@ -467,10 +467,10 @@ struct TestReduceCombinatoricalInstantiation {
   }
 
   template <class... Args>
-  static void AddLambdaRange(Kokkos::InvalidType, Args... args) {}
+  static void AddLambdaRange(Kokkos::InvalidType, Args... /*args*/) {}
 
   template <class... Args>
-  static void AddLambdaTeam(Kokkos::InvalidType, Args... args) {}
+  static void AddLambdaTeam(Kokkos::InvalidType, Args... /*args*/) {}
 
   template <int ISTEAM, class... Args>
   static void AddFunctor(Args... args) {

--- a/core/unit_test/TestTaskScheduler.hpp
+++ b/core/unit_test/TestTaskScheduler.hpp
@@ -199,9 +199,9 @@ struct TestTaskDependence {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(typename sched_type::member_type& member) {
-    auto& sched = member.scheduler();
-    enum { CHUNK = 8 };
-    const int n = CHUNK < m_count ? CHUNK : m_count;
+    auto& sched     = member.scheduler();
+    const int CHUNK = 8;
+    const int n     = CHUNK < m_count ? CHUNK : m_count;
 
     if (1 < m_count) {
       const int increment = (m_count + n - 1) / n;

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -100,7 +100,7 @@ struct TestTeamPolicy {
   struct NoOpTag {};
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const NoOpTag &, const team_member &member) const {}
+  void operator()(const NoOpTag &, const team_member & /*member*/) const {}
 
   static void test_small_league_size() {
     int bs = 8;   // batch size (number of elements per batch)
@@ -445,7 +445,7 @@ struct SharedTeamFunctor {
       shared_int_array_type;
 
   // Tell how much shared memory will be required by this functor.
-  inline unsigned team_shmem_size(int team_size) const {
+  inline unsigned team_shmem_size(int /*team_size*/) const {
     return shared_int_array_type::shmem_size(SHARED_COUNT) +
            shared_int_array_type::shmem_size(SHARED_COUNT);
   }
@@ -1138,7 +1138,7 @@ struct TestTeamBroadcast {
   typedef typename Kokkos::TeamPolicy<ScheduleType, ExecSpace>::member_type
       team_member;
 
-  TestTeamBroadcast(const size_t league_size) {}
+  TestTeamBroadcast(const size_t /*league_size*/) {}
 
   struct BroadcastTag {};
 
@@ -1157,7 +1157,7 @@ struct TestTeamBroadcast {
 
     Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(teamMember, ts),
-        [&](const int j, value_type &teamUpdate) { teamUpdate += value; },
+        [&](const int /*j*/, value_type &teamUpdate) { teamUpdate += value; },
         parUpdate);
 
     if (teamMember.team_rank() == 0) update += parUpdate;
@@ -1178,7 +1178,7 @@ struct TestTeamBroadcast {
 
     Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(teamMember, ts),
-        [&](const int j, value_type &teamUpdate) { teamUpdate += value; },
+        [&](const int /*j*/, value_type &teamUpdate) { teamUpdate += value; },
         parUpdate);
 
     if (teamMember.team_rank() == 0) update += parUpdate;

--- a/core/unit_test/TestTeamTeamSize.hpp
+++ b/core/unit_test/TestTeamTeamSize.hpp
@@ -78,13 +78,13 @@ template <class T, int N, class PolicyType, int S>
 struct FunctorFor {
   double static_array[S];
   KOKKOS_INLINE_FUNCTION
-  void operator()(const typename PolicyType::member_type& team) const {}
+  void operator()(const typename PolicyType::member_type& /*team*/) const {}
 };
 template <class T, int N, class PolicyType, int S>
 struct FunctorReduce {
   double static_array[S];
   KOKKOS_INLINE_FUNCTION
-  void operator()(const typename PolicyType::member_type& team,
+  void operator()(const typename PolicyType::member_type& /*team*/,
                   MyArray<T, N>& lval) const {
     for (int j = 0; j < N; j++) lval.values[j] += 1 + lval.values[0];
   }

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -622,7 +622,7 @@ struct functor_vec_single {
     Scalar value2 = 0;
     Kokkos::parallel_reduce(
         Kokkos::ThreadVectorRange(team, nStart, nEnd),
-        [&](int i, Scalar &val) { val += value; }, value2);
+        [&](int /*i*/, Scalar &val) { val += value; }, value2);
 
     if (value2 != (value * (nEnd - nStart))) {
       printf("FAILED vector_single broadcast %i %i %f %f\n", team.league_rank(),

--- a/core/unit_test/TestTeamVectorRange.hpp
+++ b/core/unit_test/TestTeamVectorRange.hpp
@@ -233,7 +233,7 @@ struct functor_teamvector_for {
   typedef typename ExecutionSpace::scratch_memory_space shmem_space;
   typedef Kokkos::View<Scalar*, shmem_space, Kokkos::MemoryUnmanaged>
       shared_int;
-  unsigned team_shmem_size(int team_size) const {
+  unsigned team_shmem_size(int /*team_size*/) const {
     return shared_int::shmem_size(131);
   }
 

--- a/core/unit_test/TestTemplateMetaFunctions.hpp
+++ b/core/unit_test/TestTemplateMetaFunctions.hpp
@@ -58,7 +58,7 @@ struct SumPlain {
   SumPlain(type view_) : view(view_) {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(int i, Scalar& val) { val += Scalar(); }
+  void operator()(int /*i*/, Scalar& val) { val += Scalar(); }
 };
 
 template <class Scalar, class ExecutionSpace>
@@ -80,7 +80,7 @@ struct SumInitJoinFinalValueType {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(int i, value_type& val) const { val += value_type(); }
+  void operator()(int /*i*/, value_type& val) const { val += value_type(); }
 };
 
 template <class Scalar, class ExecutionSpace>
@@ -102,7 +102,7 @@ struct SumInitJoinFinalValueType2 {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(int i, value_type& val) const { val += value_type(); }
+  void operator()(int /*i*/, value_type& val) const { val += value_type(); }
 };
 
 template <class Scalar, class ExecutionSpace>
@@ -157,7 +157,7 @@ struct SumWrongInitJoinFinalValueType {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(int i, value_type& val) const { val += value_type(); }
+  void operator()(int /*i*/, value_type& val) const { val += value_type(); }
 };
 
 template <class Scalar, class ExecutionSpace>

--- a/core/unit_test/TestViewAPI_e.hpp
+++ b/core/unit_test/TestViewAPI_e.hpp
@@ -204,13 +204,13 @@ TEST(TEST_CATEGORY, anonymous_space) { test_anonymous_space(); }
 template <class ExecSpace>
 struct TestViewOverloadResolution {
   // Overload based on value_type and rank
-  static int foo(Kokkos::View<const double**, ExecSpace> a) { return 1; }
-  static int foo(Kokkos::View<const int**, ExecSpace> a) { return 2; }
-  static int foo(Kokkos::View<const double***, ExecSpace> a) { return 3; }
+  static int foo(Kokkos::View<const double**, ExecSpace> /*a*/) { return 1; }
+  static int foo(Kokkos::View<const int**, ExecSpace> /*a*/) { return 2; }
+  static int foo(Kokkos::View<const double***, ExecSpace> /*a*/) { return 3; }
 
   // Overload based on compile time dimensions
-  static int bar(Kokkos::View<double * [3], ExecSpace> a) { return 4; }
-  static int bar(Kokkos::View<double * [4], ExecSpace> a) { return 5; }
+  static int bar(Kokkos::View<double * [3], ExecSpace> /*a*/) { return 4; }
+  static int bar(Kokkos::View<double * [4], ExecSpace> /*a*/) { return 5; }
 
   static void test_function_overload() {
     Kokkos::View<double**, typename ExecSpace::execution_space::array_layout,

--- a/core/unit_test/TestViewCopy.hpp
+++ b/core/unit_test/TestViewCopy.hpp
@@ -50,6 +50,7 @@
 
 namespace Test {
 
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_ROCM)
 namespace {
 
 template <typename ExecSpace>
@@ -57,7 +58,6 @@ struct TestViewCopy {
   using InExecSpace = ExecSpace;
 
   static void test_view_copy(const int dim0, const int dim1, const int dim2) {
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_ROCM)
     // ExecSpace = CudaUVM, CudaHostPinned
     // This test will fail at runtime with an illegal memory access if something
     // goes wrong Test 1: deep_copy from host_mirror_space to ExecSpace and
@@ -144,7 +144,6 @@ struct TestViewCopy {
       Kokkos::deep_copy(srcView, dstView);
       Kokkos::fence();
     }
-#endif
   }  // end test_view_copy
 
 };  // end struct
@@ -156,6 +155,7 @@ TEST(TEST_CATEGORY, view_copy_tests) {
   TestViewCopy<TEST_EXECSPACE>::test_view_copy(4, 2, 3);
   TestViewCopy<TEST_EXECSPACE>::test_view_copy(4, 2, 0);
 }
+#endif
 
 TEST(TEST_CATEGORY, view_copy_degenerated) {
   // Only include this file to be compiled with CudaUVM and CudaHostPinned

--- a/core/unit_test/TestView_64bit.hpp
+++ b/core/unit_test/TestView_64bit.hpp
@@ -55,7 +55,7 @@ void test_64bit() {
     Kokkos::parallel_reduce(
         Kokkos::RangePolicy<typename Device::execution_space,
                             Kokkos::IndexType<int64_t>>(0, N),
-        KOKKOS_LAMBDA(const int64_t& i, int64_t& lsum) { lsum += 1; }, sum);
+        KOKKOS_LAMBDA(const int64_t& /*i*/, int64_t& lsum) { lsum += 1; }, sum);
     ASSERT_EQ(N, sum);
   }
   {

--- a/core/unit_test/openmp/TestOpenMP_Other.cpp
+++ b/core/unit_test/openmp/TestOpenMP_Other.cpp
@@ -63,7 +63,7 @@ TEST(openmp, partition_master) {
   Mutex mtx;
   int errors = 0;
 
-  auto master = [&errors, &mtx](int partition_id, int num_partitions) {
+  auto master = [&errors, &mtx](int /*partition_id*/, int /*num_partitions*/) {
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     const int pool_size = Kokkos::OpenMP::thread_pool_size();

--- a/example/query_device/query_device.cpp
+++ b/example/query_device/query_device.cpp
@@ -59,6 +59,8 @@
 int main(int argc, char** argv) {
   std::ostringstream msg;
 
+  (void)argc;
+  (void)argv;
 #if defined(KOKKOS_ENABLE_MPI)
 
   MPI_Init(&argc, &argv);


### PR DESCRIPTION
Addresses #2796. This works for me locally.
Some things still to address:
- add `-Wextra` to the documentation of flags used (and `Makefile`, `testing_scripts`)
- ~~deal with the `fallthrough` warning for `containers/src/impl/Kokkos_Functional_impl.hpp:109` (hopefully removing `-Wno-implicit-fallthrough`.~~
- ~~find a better workaround in `core/src/Kokkos_View.hpp`~~
- make sure ignoring all unused arguments is intended indeed