### PR TITLE
Adding device ID's to execution space instances

### DIFF
--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -266,11 +266,21 @@ class Cuda {
   inline Impl::CudaInternal* impl_internal_space_instance() const {
     return m_space_instance;
   }
+  uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
   Impl::CudaInternal* m_space_instance;
 };
 
+namespace Profiling {
+namespace Experimental {
+template <>
+struct DeviceTypeTraits<Cuda> {
+  /// \brief An ID to differentiate (for example) Serial from OpenMP in Tooling
+  static constexpr DeviceType id = DeviceType::Cuda;
+};
+}  // namespace Experimental
+}  // namespace Profiling
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/Kokkos_HIP.hpp
+++ b/core/src/Kokkos_HIP.hpp
@@ -147,10 +147,20 @@ class HIP {
     return m_space_instance;
   }
 
+  uint32_t impl_instance_id() const noexcept { return 0; }
+
  private:
   Impl::HIPInternal *m_space_instance;
 };
 }  // namespace Experimental
+namespace Profiling {
+namespace Experimental {
+template <>
+struct DeviceTypeTraits<Kokkos::Experimental::HIP> {
+  static constexpr DeviceType id = DeviceType::HIP;
+};
+}  // namespace Experimental
+}  // namespace Profiling
 }  // namespace Kokkos
 
 namespace Kokkos {

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -194,6 +194,7 @@ class HPX {
                                   const bool /* verbose */ = false) {
     std::cout << "HPX backend" << std::endl;
   }
+  uint32_t impl_instance_id() const noexcept { return 0 }
 
   static bool in_parallel(HPX const & = HPX()) noexcept { return false; }
   static void impl_static_fence(HPX const & = HPX())
@@ -296,6 +297,15 @@ class HPX {
   static constexpr const char *name() noexcept { return "HPX"; }
 };
 }  // namespace Experimental
+
+namespace Profiling {
+namespace Experimental {
+template <>
+struct DeviceTypeTraits<Experimental::HPX> {
+  constexpr DeviceType id = DeviceType::HPX;
+};
+}  // namespace Experimental
+}  // namespace Profiling
 
 namespace Impl {
 template <typename Closure>

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -222,8 +222,17 @@ class OpenMP {
 #endif
 
   static constexpr const char* name() noexcept { return "OpenMP"; }
+  uint32_t impl_instance_id() const noexcept { return 0; }
 };
 
+namespace Profiling {
+namespace Experimental {
+template <>
+struct DeviceTypeTraits<OpenMP> {
+  static constexpr DeviceType id = DeviceType::OpenMP;
+};
+}  // namespace Experimental
+}  // namespace Profiling
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/Kokkos_OpenMPTarget.hpp
+++ b/core/src/Kokkos_OpenMPTarget.hpp
@@ -114,11 +114,21 @@ class OpenMPTarget {
   }
 
   OpenMPTarget();
+  uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
   Impl::OpenMPTargetInternal* m_space_instance;
 };
 }  // namespace Experimental
+
+namespace Profiling {
+namespace Experimental {
+template <>
+struct DeviceTypeTraits<Experimental::OpenMPTarget> {
+  static constexpr DeviceType id = DeviceType::OpenMPTarget;
+};
+}  // namespace Experimental
+}  // namespace Profiling
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -167,7 +167,9 @@ inline void parallel_for(
     Kokkos::Impl::ParallelConstructName<FunctorType,
                                         typename ExecPolicy::work_tag>
         name(str);
-    Kokkos::Profiling::beginParallelFor(name.get(), 0, &kpID);
+    Kokkos::Profiling::beginParallelFor(
+        name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
+        &kpID);
   }
 #endif
 
@@ -195,7 +197,9 @@ inline void parallel_for(const size_t work_count, const FunctorType& functor,
   uint64_t kpID = 0;
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     Kokkos::Impl::ParallelConstructName<FunctorType, void> name(str);
-    Kokkos::Profiling::beginParallelFor(name.get(), 0, &kpID);
+    Kokkos::Profiling::beginParallelFor(
+        name.get(),
+        Kokkos::Profiling::Experimental::device_id(policy().space()), &kpID);
   }
 #endif
 
@@ -413,7 +417,9 @@ inline void parallel_scan(
     Kokkos::Impl::ParallelConstructName<FunctorType,
                                         typename ExecutionPolicy::work_tag>
         name(str);
-    Kokkos::Profiling::beginParallelScan(name.get(), 0, &kpID);
+    Kokkos::Profiling::beginParallelScan(
+        name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
+        &kpID);
   }
 #endif
 
@@ -442,7 +448,9 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
   uint64_t kpID = 0;
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     Kokkos::Impl::ParallelConstructName<FunctorType, void> name(str);
-    Kokkos::Profiling::beginParallelScan(name.get(), 0, &kpID);
+    Kokkos::Profiling::beginParallelScan(
+        name.get(),
+        Kokkos::Profiling::Experimental::device_id(policy().space()), &kpID);
   }
 #endif
 
@@ -490,7 +498,9 @@ inline void parallel_scan(
     Kokkos::Impl::ParallelConstructName<FunctorType,
                                         typename ExecutionPolicy::work_tag>
         name(str);
-    Kokkos::Profiling::beginParallelScan(name.get(), 0, &kpID);
+    Kokkos::Profiling::beginParallelScan(
+        name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
+        &kpID);
   }
 #endif
 
@@ -522,7 +532,9 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
   uint64_t kpID = 0;
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     Kokkos::Impl::ParallelConstructName<FunctorType, void> name(str);
-    Kokkos::Profiling::beginParallelScan(name.get(), 0, &kpID);
+    Kokkos::Profiling::beginParallelScan(
+        name.get(),
+        Kokkos::Profiling::Experimental::device_id(policy().space()), &kpID);
   }
 #endif
 

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -181,11 +181,20 @@ class Serial {
     return impl_thread_pool_size(0);
   }
 #endif
+  uint32_t impl_instance_id() const noexcept { return 0; }
 
   static const char* name();
   //--------------------------------------------------------------------------
 };
 
+namespace Profiling {
+namespace Experimental {
+template <>
+struct DeviceTypeTraits<Serial> {
+  static constexpr DeviceType id = DeviceType::Serial;
+};
+}  // namespace Experimental
+}  // namespace Profiling
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -132,6 +132,8 @@ class Threads {
 
   static Threads& instance(int = 0);
 
+  uint32_t impl_instance_id() noexcept const { return 0; }
+
   //----------------------------------------
 
   static int thread_pool_size(int depth = 0);
@@ -205,6 +207,14 @@ class Threads {
   //----------------------------------------
 };
 
+namespace Profiling {
+namespace Experimental {
+template <>
+struct DeviceTypeTraits<Threads> {
+  static constexpr DeviceType id = DeviceType::Threads;
+};
+}  // namespace Experimental
+}  // namespace Profiling
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/Kokkos_WorkGraphPolicy.hpp
+++ b/core/src/Kokkos_WorkGraphPolicy.hpp
@@ -199,6 +199,8 @@ class WorkGraphPolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
     if (0 == count_queue[w]) push_work(w);
   }
 
+  execution_space space() const { return execution_space(); }
+
   WorkGraphPolicy(const graph_type& arg_graph)
       : m_graph(arg_graph),
         m_queue(view_alloc("queue", WithoutInitializing),

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -54,6 +54,35 @@
 #include <iostream>
 #include <cstdlib>
 
+// NOTE: in this Kokkos::Profiling block, do not define anything that shouldn't
+// exist should Profiling be disabled
+
+namespace Kokkos {
+namespace Profiling {
+namespace Experimental {
+enum struct DeviceType {
+  Serial,
+  OpenMP,
+  Cuda,
+  HIP,
+  OpenMPTarget,
+  HPX,
+  Threads
+};
+template <typename ExecutionSpace>
+struct DeviceTypeTraits;
+
+constexpr const size_t device_type_bits = 8;
+constexpr const size_t instance_bits    = 24;
+template <typename ExecutionSpace>
+inline uint32_t device_id(ExecutionSpace const& space) noexcept {
+  auto device_id = static_cast<uint32_t>(DeviceTypeTraits<ExecutionSpace>::id);
+  return (device_id << instance_bits) + space.impl_instance_id();
+}
+}  // namespace Experimental
+}  // namespace Profiling
+}  // end namespace Kokkos
+
 #if defined(KOKKOS_ENABLE_PROFILING)
 // We check at configure time that libdl is available.
 #include <dlfcn.h>


### PR DESCRIPTION
This adds some meaning to the device ID passed in the Profiling Tools (currently it means "0," a philosophical comment on the essential sameness of all devices under Kokkos)

8 bits encode the type of Device, where "Device" here really means "Execution Space", and then there are 24 bits for instances. A default instance has instance ID 0, but an instance can be created with a custom instance ID, a capability we can leverage later if we start playing around more with instances