### PR TITLE
Avoid warning about unused variable

### DIFF
--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -254,8 +254,8 @@ struct TestRange {
   }
 
   void test_dynamic_policy() {
-    auto const N_no_implicit_capture = N;
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+    auto const N_no_implicit_capture = N;
     typedef Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >
         policy_t;
 

--- a/core/unit_test/TestRangeRequire.hpp
+++ b/core/unit_test/TestRangeRequire.hpp
@@ -272,8 +272,8 @@ struct TestRangeRequire {
   }
 
   void test_dynamic_policy() {
-    auto const N_no_implicit_capture = N;
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+    auto const N_no_implicit_capture = N;
     typedef Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >
         policy_t;
 


### PR DESCRIPTION
I see this warning when not enabling lambda support for `CUDA`.