### PR TITLE
Fix compiling with Kokkos_ENABLE_PTHREADS=ON

### DIFF
--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -56,6 +56,7 @@
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_MemoryTraits.hpp>
+#include <impl/Kokkos_Profiling_Interface.hpp>
 #include <impl/Kokkos_Tags.hpp>
 
 /*--------------------------------------------------------------------------*/
@@ -132,8 +133,6 @@ class Threads {
 
   static Threads& instance(int = 0);
 
-  uint32_t impl_instance_id() noexcept const { return 0; }
-
   //----------------------------------------
 
   static int thread_pool_size(int depth = 0);
@@ -193,6 +192,8 @@ class Threads {
 #else
   KOKKOS_INLINE_FUNCTION static int impl_thread_pool_rank() { return 0; }
 #endif
+
+  uint32_t impl_instance_id() const noexcept { return 0; }
 
   inline static unsigned impl_max_hardware_threads() {
     return impl_thread_pool_size(0);


### PR DESCRIPTION
Without this, I get
```
core/src/impl/Kokkos_Profiling_Interface.hpp:80:47: error: ‘const class Kokkos::Threads’ has no member named ‘impl_instance_id’; did you mean ‘impl_instance’?
   return (device_id << instance_bits) + space.impl_instance_id();
                                         ~~~~~~^~~~~~~~~~~~~~~~
                                         impl_instance
core/src/CMakeFiles/kokkoscore.dir/build.make:206: recipe for target 'core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_HostSpace_deepcopy.cpp.o' failed
make[2]: *** [core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_HostSpace_deepcopy.cpp.o] Error 1
[  3%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_Stacktrace.cpp.o
[  4%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_hwloc.cpp.o
[  4%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/Threads/Kokkos_ThreadsExec.cpp.o
[  4%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/Threads/Kokkos_ThreadsExec_base.cpp.o
In file included from core/src/Threads/Kokkos_ThreadsExec_base.cpp:62:0:
core/src/Kokkos_Threads.hpp:213:8: error: ‘DeviceTypeTraits’ is not a class template
 struct DeviceTypeTraits<Threads> {
        ^~~~~~~~~~~~~~~~
core/src/Kokkos_Threads.hpp:213:34: error: explicit specialization of non-template ‘Kokkos::Profiling::Experimental::DeviceTypeTraits’
 struct DeviceTypeTraits<Threads> {
                                  ^
core/src/Kokkos_Threads.hpp:214:20: error: ‘DeviceType’ does not name a type; did you mean ‘Device’?
   static constexpr DeviceType id = DeviceType::Threads;
                    ^~~~~~~~~~
                    Device
[...]
```