### PR TITLE
Fix ICC warning about unused parameter

### DIFF
--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -238,7 +238,10 @@ struct ViewCtorProp : public ViewCtorProp<void, P>... {
   /* Copy from a matching property subset */
   template <typename... Args>
   ViewCtorProp(ViewCtorProp<Args...> const &arg)
-      : ViewCtorProp<void, Args>(((ViewCtorProp<void, Args> const &)arg))... {}
+      : ViewCtorProp<void, Args>(
+            static_cast<ViewCtorProp<void, Args> const &>(arg))... {
+    (void)arg;
+  }
 };
 
 } /* namespace Impl */


### PR DESCRIPTION
Fixes #2867. The Intel compiler complains if `sizeof...(P)==0` that `arg` is not used (because there is no base class).