### PR TITLE
Add is_assignable and is_always_assignable

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -464,48 +464,31 @@ constexpr bool is_always_assignable(const Kokkos::View<ViewTDst...>&,
 }
 
 template <class... ViewTDst, class... ViewTSrc>
-constexpr bool is_assignable(const Kokkos::View<ViewTDst...>&,
+constexpr bool is_assignable(const Kokkos::View<ViewTDst...>& dst,
                              const Kokkos::View<ViewTSrc...>& src) {
   using DstTraits = typename Kokkos::View<ViewTDst...>::traits;
   using SrcTraits = typename Kokkos::View<ViewTSrc...>::traits;
-  using dst_dim   = typename DstTraits::dimension;
   using mapping_type =
       Kokkos::Impl::ViewMapping<DstTraits, SrcTraits,
                                 typename DstTraits::specialize>;
 
   return mapping_type::is_assignable &&
-         ((1 > DstTraits::dimension::rank_dynamic &&
-           1 <= SrcTraits::dimension::rank_dynamic)
-              ? dst_dim::ArgN0 == src.extent(0)
-              : true) &&
-         ((2 > DstTraits::dimension::rank_dynamic &&
-           2 <= SrcTraits::dimension::rank_dynamic)
-              ? dst_dim::ArgN1 == src.extent(1)
-              : true) &&
-         ((3 > DstTraits::dimension::rank_dynamic &&
-           3 <= SrcTraits::dimension::rank_dynamic)
-              ? dst_dim::ArgN2 == src.extent(2)
-              : true) &&
-         ((4 > DstTraits::dimension::rank_dynamic &&
-           4 <= SrcTraits::dimension::rank_dynamic)
-              ? dst_dim::ArgN3 == src.extent(3)
-              : true) &&
-         ((5 > DstTraits::dimension::rank_dynamic &&
-           5 <= SrcTraits::dimension::rank_dynamic)
-              ? dst_dim::ArgN4 == src.extent(4)
-              : true) &&
-         ((6 > DstTraits::dimension::rank_dynamic &&
-           6 <= SrcTraits::dimension::rank_dynamic)
-              ? dst_dim::ArgN5 == src.extent(5)
-              : true) &&
-         ((7 > DstTraits::dimension::rank_dynamic &&
-           7 <= SrcTraits::dimension::rank_dynamic)
-              ? dst_dim::ArgN6 == src.extent(6)
-              : true) &&
-         ((8 > DstTraits::dimension::rank_dynamic &&
-           8 <= SrcTraits::dimension::rank_dynamic)
-              ? dst_dim::ArgN7 == src.extent(7)
-              : true);
+         ((DstTraits::dimension::rank_dynamic >= 1) ||
+          (dst.static_extent(0) == src.extent(0))) &&
+         ((DstTraits::dimension::rank_dynamic >= 2) ||
+          (dst.static_extent(1) == src.extent(1))) &&
+         ((DstTraits::dimension::rank_dynamic >= 3) ||
+          (dst.static_extent(2) == src.extent(2))) &&
+         ((DstTraits::dimension::rank_dynamic >= 4) ||
+          (dst.static_extent(3) == src.extent(3))) &&
+         ((DstTraits::dimension::rank_dynamic >= 5) ||
+          (dst.static_extent(4) == src.extent(4))) &&
+         ((DstTraits::dimension::rank_dynamic >= 6) ||
+          (dst.static_extent(5) == src.extent(5))) &&
+         ((DstTraits::dimension::rank_dynamic >= 7) ||
+          (dst.static_extent(6) == src.extent(6))) &&
+         ((DstTraits::dimension::rank_dynamic >= 8) ||
+          (dst.static_extent(7) == src.extent(7)));
 }
 
 } /* namespace Kokkos */

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -464,7 +464,7 @@ constexpr bool is_always_assignable(const Kokkos::View<ViewTDst...>&,
 }
 
 template <class... ViewTDst, class... ViewTSrc>
-constexpr bool is_assignable(const Kokkos::View<ViewTDst...>& dst,
+constexpr bool is_assignable(const Kokkos::View<ViewTDst...>&,
                              const Kokkos::View<ViewTSrc...>& src) {
   using DstTraits = typename Kokkos::View<ViewTDst...>::traits;
   using SrcTraits = typename Kokkos::View<ViewTSrc...>::traits;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -451,7 +451,7 @@ template <class DataType, class... Properties>
 class View;
 
 template <class T1, class T2>
-struct is_always_assignable : public std::false_type {};
+struct is_always_assignable;
 
 template <class... ViewTDst, class... ViewTSrc>
 struct is_always_assignable<Kokkos::View<ViewTDst...>,

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -450,6 +450,64 @@ struct ViewTraits {
 template <class DataType, class... Properties>
 class View;
 
+template <class... ViewTDst, class... ViewTSrc>
+constexpr bool is_always_assignable(const Kokkos::View<ViewTDst...>&,
+                                    const Kokkos::View<ViewTSrc...>&) {
+  using mapping_type = Kokkos::Impl::ViewMapping<
+      typename Kokkos::View<ViewTDst...>::traits,
+      typename Kokkos::View<ViewTSrc...>::traits,
+      typename Kokkos::View<ViewTDst...>::traits::specialize>;
+
+  return mapping_type::is_assignable &&
+         static_cast<int>(Kokkos::View<ViewTDst...>::rank_dynamic) >=
+             static_cast<int>(Kokkos::View<ViewTSrc...>::rank_dynamic);
+}
+
+template <class... ViewTDst, class... ViewTSrc>
+constexpr bool is_assignable(const Kokkos::View<ViewTDst...>& dst,
+                             const Kokkos::View<ViewTSrc...>& src) {
+  using DstTraits = typename Kokkos::View<ViewTDst...>::traits;
+  using SrcTraits = typename Kokkos::View<ViewTSrc...>::traits;
+  using dst_dim   = typename DstTraits::dimension;
+  using mapping_type =
+      Kokkos::Impl::ViewMapping<DstTraits, SrcTraits,
+                                typename DstTraits::specialize>;
+
+  return mapping_type::is_assignable &&
+         ((1 > DstTraits::dimension::rank_dynamic &&
+           1 <= SrcTraits::dimension::rank_dynamic)
+              ? dst_dim::ArgN0 == src.extent(0)
+              : true) &&
+         ((2 > DstTraits::dimension::rank_dynamic &&
+           2 <= SrcTraits::dimension::rank_dynamic)
+              ? dst_dim::ArgN1 == src.extent(1)
+              : true) &&
+         ((3 > DstTraits::dimension::rank_dynamic &&
+           3 <= SrcTraits::dimension::rank_dynamic)
+              ? dst_dim::ArgN2 == src.extent(2)
+              : true) &&
+         ((4 > DstTraits::dimension::rank_dynamic &&
+           4 <= SrcTraits::dimension::rank_dynamic)
+              ? dst_dim::ArgN3 == src.extent(3)
+              : true) &&
+         ((5 > DstTraits::dimension::rank_dynamic &&
+           5 <= SrcTraits::dimension::rank_dynamic)
+              ? dst_dim::ArgN4 == src.extent(4)
+              : true) &&
+         ((6 > DstTraits::dimension::rank_dynamic &&
+           6 <= SrcTraits::dimension::rank_dynamic)
+              ? dst_dim::ArgN5 == src.extent(5)
+              : true) &&
+         ((7 > DstTraits::dimension::rank_dynamic &&
+           7 <= SrcTraits::dimension::rank_dynamic)
+              ? dst_dim::ArgN6 == src.extent(6)
+              : true) &&
+         ((8 > DstTraits::dimension::rank_dynamic &&
+           8 <= SrcTraits::dimension::rank_dynamic)
+              ? dst_dim::ArgN7 == src.extent(7)
+              : true);
+}
+
 } /* namespace Kokkos */
 
 //----------------------------------------------------------------------------

--- a/core/unit_test/TestViewIsAssignable.hpp
+++ b/core/unit_test/TestViewIsAssignable.hpp
@@ -19,7 +19,10 @@ struct TestAssignability {
   template <class MappingType>
   static void try_assign(
       ViewTypeDst&, ViewTypeSrc&,
-      typename std::enable_if<!MappingType::is_assignable>::type* = nullptr) {}
+      typename std::enable_if<!MappingType::is_assignable>::type* = nullptr) {
+    Kokkos::Impl::throw_runtime_exception(
+        "TestAssignability::try_assign: Unexpected call path");
+  }
 
   template <class... Dimensions>
   static void test(bool always, bool sometimes, Dimensions... dims) {

--- a/core/unit_test/TestViewIsAssignable.hpp
+++ b/core/unit_test/TestViewIsAssignable.hpp
@@ -28,8 +28,9 @@ struct TestAssignability {
 
     // bool is_always_assignable =
     // Kokkos::is_always_assignable<ViewTypeDst,ViewTypeSrc>::value;
-    bool is_always_assignable = Kokkos::is_always_assignable(dst, src);
-    bool is_assignable        = Kokkos::is_assignable(dst, src);
+    bool is_always_assignable =
+        Kokkos::is_always_assignable<ViewTypeDst, ViewTypeSrc>::value;
+    bool is_assignable = Kokkos::is_assignable(dst, src);
 
     // Print out if there is an error with typeid so you can just filter the
     // output with c++filt -t to see which assignment causes the error.

--- a/core/unit_test/TestViewIsAssignable.hpp
+++ b/core/unit_test/TestViewIsAssignable.hpp
@@ -1,0 +1,115 @@
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+namespace Impl {
+template <class ViewTypeDst, class ViewTypeSrc>
+struct TestAssignability {
+  using mapping_type =
+      Kokkos::Impl::ViewMapping<typename ViewTypeDst::traits,
+                                typename ViewTypeSrc::traits,
+                                typename ViewTypeDst::specialize>;
+
+  template <class MappingType>
+  static void try_assign(
+      ViewTypeDst& dst, ViewTypeSrc& src,
+      typename std::enable_if<MappingType::is_assignable>::type* = nullptr) {
+    dst = src;
+  }
+
+  template <class MappingType>
+  static void try_assign(
+      ViewTypeDst&, ViewTypeSrc&,
+      typename std::enable_if<!MappingType::is_assignable>::type* = nullptr) {}
+
+  template <class... Dimensions>
+  static void test(bool always, bool sometimes, Dimensions... dims) {
+    ViewTypeDst dst;
+    ViewTypeSrc src("SRC", dims...);
+
+    // bool is_always_assignable =
+    // Kokkos::is_always_assignable<ViewTypeDst,ViewTypeSrc>::value;
+    bool is_always_assignable = Kokkos::is_always_assignable(dst, src);
+    bool is_assignable        = Kokkos::is_assignable(dst, src);
+
+    // Print out if there is an error with typeid so you can just filter the
+    // output with c++filt -t to see which assignment causes the error.
+    if (is_always_assignable != always || is_assignable != sometimes)
+      printf(
+          "is_always_assignable: %i (%i), is_assignable: %i (%i) [ %s ] to [ "
+          "%s ]\n",
+          is_always_assignable ? 1 : 0, always ? 1 : 0, is_assignable ? 1 : 0,
+          sometimes ? 1 : 0, typeid(ViewTypeSrc).name(),
+          typeid(ViewTypeDst).name());
+    if (sometimes) try_assign<mapping_type>(dst, src);
+    ASSERT_EQ(always, is_always_assignable);
+    ASSERT_EQ(sometimes, is_assignable);
+  }
+};
+
+}  // namespace Impl
+
+TEST(TEST_CATEGORY, view_is_assignable) {
+  using namespace Kokkos;
+  using h_exec = typename DefaultHostExecutionSpace::memory_space;
+  using d_exec = typename TEST_EXECSPACE::memory_space;
+  using left   = LayoutLeft;
+  using right  = LayoutRight;
+  using stride = LayoutStride;
+  // Static/Dynamic Extents
+  Impl::TestAssignability<View<int*, left, d_exec>,
+                          View<int*, left, d_exec>>::test(true, true, 10);
+  Impl::TestAssignability<View<int[10], left, d_exec>,
+                          View<int*, left, d_exec>>::test(false, true, 10);
+  Impl::TestAssignability<View<int[5], left, d_exec>,
+                          View<int*, left, d_exec>>::test(false, false, 10);
+  Impl::TestAssignability<View<int*, left, d_exec>,
+                          View<int[10], left, d_exec>>::test(true, true);
+  Impl::TestAssignability<View<int[10], left, d_exec>,
+                          View<int[10], left, d_exec>>::test(true, true);
+  Impl::TestAssignability<View<int[5], left, d_exec>,
+                          View<int[10], left, d_exec>>::test(false, false);
+  Impl::TestAssignability<View<int**, left, d_exec>,
+                          View<int**, left, d_exec>>::test(true, true, 10, 10);
+  Impl::TestAssignability<View<int * [10], left, d_exec>,
+                          View<int**, left, d_exec>>::test(false, true, 10, 10);
+  Impl::TestAssignability<View<int * [5], left, d_exec>,
+                          View<int**, left, d_exec>>::test(false, false, 10,
+                                                           10);
+  Impl::TestAssignability<View<int**, left, d_exec>,
+                          View<int * [10], left, d_exec>>::test(true, true, 10);
+  Impl::TestAssignability<View<int * [10], left, d_exec>,
+                          View<int * [10], left, d_exec>>::test(true, true, 10);
+  Impl::TestAssignability<View<int * [5], left, d_exec>,
+                          View<int * [10], left, d_exec>>::test(false, false,
+                                                                10);
+
+  // Mismatch value_type
+  Impl::TestAssignability<View<int*, left, d_exec>,
+                          View<double*, left, d_exec>>::test(false, false, 10);
+
+  // Layout assignment
+  Impl::TestAssignability<View<int*, left, d_exec>,
+                          View<int*, right, d_exec>>::test(true, true, 10);
+
+  // This could be made possible (due to the degenerate nature of the views) but
+  // we do not allow this yet
+  // TestAssignability<View<int**,left,d_exec>,View<int**,right,d_exec>>::test(false,true,10,1);
+  Impl::TestAssignability<View<int**, left, d_exec>,
+                          View<int**, right, d_exec>>::test(false, false, 10,
+                                                            2);
+  Impl::TestAssignability<View<int**, stride, d_exec>,
+                          View<int**, right, d_exec>>::test(true, true, 10, 2);
+  Impl::TestAssignability<View<int**, stride, d_exec>,
+                          View<int**, left, d_exec>>::test(true, true, 10, 2);
+
+  // Space Assignment
+  bool expected = Kokkos::Impl::MemorySpaceAccess<d_exec, h_exec>::assignable;
+  Impl::TestAssignability<View<int*, left, d_exec>,
+                          View<int*, left, h_exec>>::test(expected, expected,
+                                                          10);
+  expected = Kokkos::Impl::MemorySpaceAccess<h_exec, d_exec>::assignable;
+  Impl::TestAssignability<View<int*, left, h_exec>,
+                          View<int*, left, d_exec>>::test(expected, expected,
+                                                          10);
+}
+}  // namespace Test

--- a/core/unit_test/TestViewIsAssignable.hpp
+++ b/core/unit_test/TestViewIsAssignable.hpp
@@ -26,8 +26,6 @@ struct TestAssignability {
     ViewTypeDst dst;
     ViewTypeSrc src("SRC", dims...);
 
-    // bool is_always_assignable =
-    // Kokkos::is_always_assignable<ViewTypeDst,ViewTypeSrc>::value;
     bool is_always_assignable =
         Kokkos::is_always_assignable<ViewTypeDst, ViewTypeSrc>::value;
     bool is_assignable = Kokkos::is_assignable(dst, src);
@@ -41,7 +39,7 @@ struct TestAssignability {
           is_always_assignable ? 1 : 0, always ? 1 : 0, is_assignable ? 1 : 0,
           sometimes ? 1 : 0, typeid(ViewTypeSrc).name(),
           typeid(ViewTypeDst).name());
-    if (sometimes) try_assign<mapping_type>(dst, src);
+    if (sometimes) ASSERT_NO_THROW(try_assign<mapping_type>(dst, src));
     ASSERT_EQ(always, is_always_assignable);
     ASSERT_EQ(sometimes, is_assignable);
   }

--- a/core/unit_test/TestViewLayoutStrideAssignment.hpp
+++ b/core/unit_test/TestViewLayoutStrideAssignment.hpp
@@ -51,6 +51,7 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <TestViewIsAssignable.hpp>
 namespace Test {
 
 TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {


### PR DESCRIPTION
This is an alternative (and fully working) variant to #2829 for the functions. Note in this case I decided to implement `is_always_assignable` also as a function instead of a trait like thing. @dhollman @dalg24 @jeffmiles63 any thoughts on that change?

