### PR TITLE
Print error message when calling abort in HIP kernel

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -173,9 +173,7 @@
 #define KOKKOS_IMPL_HIP_CLANG_WORKAROUND
 
 #define HIP_ENABLE_PRINTF
-#define HCC_ENABLE_PRINTF
 #include <hip/hip_runtime.h>
-#include <hc_printf.hpp>
 #include <hip/hip_runtime_api.h>
 
 #define KOKKOS_LAMBDA [=] __host__ __device__

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -172,7 +172,10 @@
 
 #define KOKKOS_IMPL_HIP_CLANG_WORKAROUND
 
+#define HIP_ENABLE_PRINTF
+#define HCC_ENABLE_PRINTF
 #include <hip/hip_runtime.h>
+#include <hc_printf.hpp>
 #include <hip/hip_runtime_api.h>
 
 #define KOKKOS_LAMBDA [=] __host__ __device__

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -173,7 +173,7 @@ void abort(const char *const message) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
   Kokkos::Impl::cuda_abort(message);
 #elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
-  // TODO improve this once HIP supports asserting in a kernel properly
+  // FIXME_HIP improve this once HIP supports asserting in a kernel properly
   printf("%s", message);
 #elif !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__)
   Kokkos::Impl::host_abort(message);

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -172,10 +172,11 @@ KOKKOS_INLINE_FUNCTION
 void abort(const char *const message) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
   Kokkos::Impl::cuda_abort(message);
-#else
-#if !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__)
+#elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
+  // TODO improve this once HIP supports asserting in a kernel properly
+  printf("%s", message);
+#elif !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__)
   Kokkos::Impl::host_abort(message);
-#endif
 #endif
 }
 


### PR DESCRIPTION
This allows printing from a HIP kernel, but I still need to set `HCC_ENABLE_PRINTF` as an environment variable via
```
export HCC_ENABLE_PRINTF=1
```
or similar.
Furthermore, we just print the error message for `Kokkos::abort()` if called from a `HIP` kernel. I also tried to call `abort()` afterward but wasn't able to see the error message then.