### PR TITLE
Implement parallel_scan for HIP

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -222,7 +222,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       }
     }
 
-    // Reduce with final value at hipblockDim_y - 1 location.
+    // Reduce with final value at hipBlockDim_y - 1 location.
     if (hip_single_inter_block_reduce_scan<false, ReducerTypeFwd, WorkTagFwd>(
             ReducerConditional::select(m_functor, m_reducer), hipBlockIdx_x,
             hipGridDim_x,
@@ -536,8 +536,8 @@ class ParallelScanHIPBase {
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    // blockDim.y must be power of two = 128 (2 warps) or 256 (4 warps) or 512
-    // (8 warps) gridDim.x <= blockDim.y * blockDim.y
+    // hipBlockDim_y must be power of two = 128 (2 warps) or 256 (4 warps) or 512
+    // (8 warps) hipGridDim_x <= hipBlockDim_y * hipBlockDim_y
     //
     // TODO check best option
 

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -356,6 +356,303 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
         m_scratch_space(0),
         m_scratch_flags(0) {}
 };
+
+template <class FunctorType, class... Traits>
+class ParallelScanHIPBase {
+ public:
+  using Policy = Kokkos::RangePolicy<Traits...>;
+
+ protected:
+  using Member       = typename Policy::member_type;
+  using WorkTag      = typename Policy::work_tag;
+  using WorkRange    = typename Policy::WorkRange;
+  using LaunchBounds = typename Policy::launch_bounds;
+
+  using ValueTraits = Kokkos::Impl::FunctorValueTraits<FunctorType, WorkTag>;
+  using ValueInit   = Kokkos::Impl::FunctorValueInit<FunctorType, WorkTag>;
+  using ValueOps    = Kokkos::Impl::FunctorValueOps<FunctorType, WorkTag>;
+
+ public:
+  using pointer_type   = typename ValueTraits::pointer_type;
+  using reference_type = typename ValueTraits::reference_type;
+  using functor_type   = FunctorType;
+  using size_type      = Kokkos::Experimental::HIP::size_type;
+  using index_type     = typename Policy::index_type;
+
+ protected:
+  // Algorithmic constraints:
+  //  (a) hipBlockDim_y is a power of two
+  //  (b) hipBlockDim_x == hipBlockDim_z == 1
+  //  (c) hipGridDim_x  <= hipBlockDim_y * hipBlockDim_y
+  //  (d) hipGridDim_y  == hipGridDim_z == 1
+
+  const FunctorType m_functor;
+  const Policy m_policy;
+  size_type* m_scratch_space;
+  size_type* m_scratch_flags;
+  size_type m_final;
+  int m_grid_x = 0;
+
+ private:
+  template <class TagType>
+  __device__ inline
+      typename std::enable_if<std::is_same<TagType, void>::value>::type
+      exec_range(const Member& i, reference_type update,
+                 const bool final_result) const {
+    m_functor(i, update, final_result);
+  }
+
+  template <class TagType>
+  __device__ inline
+      typename std::enable_if<!std::is_same<TagType, void>::value>::type
+      exec_range(const Member& i, reference_type update,
+                 const bool final_result) const {
+    m_functor(TagType(), i, update, final_result);
+  }
+
+  //----------------------------------------
+
+  __device__ inline void initial(void) const {
+    const integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /
+                                                   sizeof(size_type)>
+        word_count(ValueTraits::value_size(m_functor) / sizeof(size_type));
+
+    size_type* const shared_value =
+        Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>() +
+        word_count.value * hipThreadIdx_y;
+
+    ValueInit::init(m_functor, shared_value);
+
+    // Number of blocks is bounded so that the reduction can be limited to two
+    // passes. Each thread block is given an approximately equal amount of work
+    // to perform. Accumulate the values for this block. The accumulation
+    // ordering does not match the final pass, but is arithmetically equivalent.
+
+    const WorkRange range(m_policy, hipBlockIdx_x, hipGridDim_x);
+
+    for (Member iwork = range.begin() + hipThreadIdx_y, iwork_end = range.end();
+         iwork < iwork_end; iwork += hipBlockDim_y) {
+      this->template exec_range<WorkTag>(
+          iwork, ValueOps::reference(shared_value), false);
+    }
+
+    // Reduce and scan, writing out scan of blocks' totals and block-groups'
+    // totals. Blocks' scan values are written to 'hipBlockIdx_x' location.
+    // Block-groups' scan values are at: i = ( j * hipBlockDim_y - 1 ) for i <
+    // hipGridDim_x
+    hip_single_inter_block_reduce_scan<true, FunctorType, WorkTag>(
+        m_functor, hipBlockIdx_x, hipGridDim_x,
+        Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>(),
+        m_scratch_space, m_scratch_flags);
+  }
+
+  //----------------------------------------
+
+  __device__ inline void final(void) const {
+    const integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /
+                                                   sizeof(size_type)>
+        word_count(ValueTraits::value_size(m_functor) / sizeof(size_type));
+
+    // Use shared memory as an exclusive scan: { 0 , value[0] , value[1] ,
+    // value[2] , ... }
+    size_type* const shared_data =
+        Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>();
+    size_type* const shared_prefix =
+        shared_data + word_count.value * hipThreadIdx_y;
+    size_type* const shared_accum =
+        shared_data + word_count.value * (hipBlockDim_y + 1);
+
+    // Starting value for this thread block is the previous block's total.
+    if (hipBlockIdx_x) {
+      size_type* const block_total =
+          m_scratch_space + word_count.value * (hipBlockIdx_x - 1);
+      for (unsigned i = hipThreadIdx_y; i < word_count.value; ++i) {
+        shared_accum[i] = block_total[i];
+      }
+    } else if (0 == hipThreadIdx_y) {
+      ValueInit::init(m_functor, shared_accum);
+    }
+
+    const WorkRange range(m_policy, hipBlockIdx_x, hipGridDim_x);
+
+    for (typename Policy::member_type iwork_base = range.begin();
+         iwork_base < range.end(); iwork_base += hipBlockDim_y) {
+      const typename Policy::member_type iwork = iwork_base + hipThreadIdx_y;
+
+      __syncthreads();  // Don't overwrite previous iteration values until they
+                        // are used
+
+      ValueInit::init(m_functor, shared_prefix + word_count.value);
+
+      // Copy previous block's accumulation total into thread[0] prefix and
+      // inclusive scan value of this block
+      for (unsigned i = hipThreadIdx_y; i < word_count.value; ++i) {
+        shared_data[i + word_count.value] = shared_data[i] = shared_accum[i];
+      }
+
+      if (Experimental::Impl::HIPTraits::WarpSize < word_count.value) {
+        __syncthreads();
+      }  // Protect against large scan values.
+
+      // Call functor to accumulate inclusive scan value for this work item
+      const bool doWork = (iwork < range.end());
+      if (doWork) {
+        this->template exec_range<WorkTag>(
+            iwork, ValueOps::reference(shared_prefix + word_count.value),
+            false);
+      }
+
+      // Scan block values into locations shared_data[1..hipBlockDim_y]
+      hip_intra_block_reduce_scan<true, FunctorType, WorkTag>(
+          m_functor,
+          typename ValueTraits::pointer_type(shared_data + word_count.value));
+
+      {
+        size_type* const block_total =
+            shared_data + word_count.value * hipBlockDim_y;
+        for (unsigned i = hipThreadIdx_y; i < word_count.value; ++i) {
+          shared_accum[i] = block_total[i];
+        }
+      }
+
+      // Call functor with exclusive scan value
+      if (doWork) {
+        this->template exec_range<WorkTag>(
+            iwork, ValueOps::reference(shared_prefix), true);
+      }
+    }
+  }
+
+ public:
+  //----------------------------------------
+
+  __device__ inline void operator()(void) const {
+    if (!m_final) {
+      initial();
+    } else {
+      final();
+    }
+  }
+
+  // Determine block size constrained by shared memory:
+  inline unsigned local_block_size(const FunctorType& f) {
+    // blockDim.y must be power of two = 128 (2 warps) or 256 (4 warps) or 512
+    // (8 warps) gridDim.x <= blockDim.y * blockDim.y
+    //
+    // TODO check best option
+
+    unsigned n = Experimental::Impl::HIPTraits::WarpSize * 4;
+    while (n && unsigned(m_policy.space()
+                             .impl_internal_space_instance()
+                             ->m_maxShmemPerBlock) <
+                    hip_single_inter_block_reduce_scan_shmem<false, FunctorType,
+                                                             WorkTag>(f, n)) {
+      n >>= 1;
+    }
+    return n;
+  }
+
+  inline void impl_execute() {
+    const index_type nwork = m_policy.end() - m_policy.begin();
+    if (nwork) {
+      enum { GridMaxComputeCapability_2x = 0x0ffff };
+
+      const int block_size = local_block_size(m_functor);
+
+      const int grid_max =
+          (block_size * block_size) < GridMaxComputeCapability_2x
+              ? (block_size * block_size)
+              : GridMaxComputeCapability_2x;
+
+      // At most 'max_grid' blocks:
+      const int max_grid =
+          std::min(int(grid_max), int((nwork + block_size - 1) / block_size));
+
+      // How much work per block:
+      const int work_per_block = (nwork + max_grid - 1) / max_grid;
+
+      // How many block are really needed for this much work:
+      m_grid_x = (nwork + work_per_block - 1) / work_per_block;
+
+      m_scratch_space = Kokkos::Experimental::Impl::hip_internal_scratch_space(
+          ValueTraits::value_size(m_functor) * m_grid_x);
+      m_scratch_flags = Kokkos::Experimental::Impl::hip_internal_scratch_flags(
+          sizeof(size_type) * 1);
+
+      dim3 grid(m_grid_x, 1, 1);
+      dim3 block(1, block_size, 1);  // REQUIRED DIMENSIONS ( 1 , N , 1 )
+      const int shmem = ValueTraits::value_size(m_functor) * (block_size + 2);
+
+      m_final = false;
+      Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelScanHIPBase,
+                                                    LaunchBounds>(
+          *this, grid, block, shmem,
+          m_policy.space().impl_internal_space_instance(),
+          false);  // copy to device and execute
+
+      m_final = true;
+      Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelScanHIPBase,
+                                                    LaunchBounds>(
+          *this, grid, block, shmem,
+          m_policy.space().impl_internal_space_instance(),
+          false);  // copy to device and execute
+    }
+  }
+
+  ParallelScanHIPBase(const FunctorType& arg_functor, const Policy& arg_policy)
+      : m_functor(arg_functor),
+        m_policy(arg_policy),
+        m_scratch_space(0),
+        m_scratch_flags(0),
+        m_final(false) {}
+};
+
+template <class FunctorType, class... Traits>
+class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
+                   Kokkos::Experimental::HIP>
+    : private ParallelScanHIPBase<FunctorType, Traits...> {
+ public:
+  using Base = ParallelScanHIPBase<FunctorType, Traits...>;
+  using Base::operator();
+
+  inline void execute() { Base::impl_execute(); }
+
+  ParallelScan(const FunctorType& arg_functor,
+               const typename Base::Policy& arg_policy)
+      : Base(arg_functor, arg_policy) {}
+};
+
+//----------------------------------------------------------------------------
+
+template <class FunctorType, class ReturnType, class... Traits>
+class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
+                            ReturnType, Kokkos::Experimental::HIP>
+    : private ParallelScanHIPBase<FunctorType, Traits...> {
+ public:
+  using Base = ParallelScanHIPBase<FunctorType, Traits...>;
+  using Base::operator();
+
+  ReturnType& m_returnvalue;
+
+  inline void execute() {
+    Base::impl_execute();
+
+    const auto nwork = Base::m_policy.end() - Base::m_policy.begin();
+    if (nwork) {
+      const int size = Base::ValueTraits::value_size(Base::m_functor);
+      DeepCopy<HostSpace, Kokkos::Experimental::HIPSpace>(
+          &m_returnvalue,
+          Base::m_scratch_space + (Base::m_grid_x - 1) * size / sizeof(int),
+          size);
+    }
+  }
+
+  ParallelScanWithTotal(const FunctorType& arg_functor,
+                        const typename Base::Policy& arg_policy,
+                        ReturnType& arg_returnvalue)
+      : Base(arg_functor, arg_policy), m_returnvalue(arg_returnvalue) {}
+};
+
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -91,11 +91,11 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
   using functor_type = FunctorType;
 
   inline __device__ void operator()(void) const {
-    const Member work_stride = blockDim.y * gridDim.x;
+    const Member work_stride = hipBlockDim_y * hipGridDim_x;
     const Member work_end    = m_policy.end();
 
     for (Member iwork =
-             m_policy.begin() + threadIdx.y + blockDim.y * blockIdx.x;
+             m_policy.begin() + hipThreadIdx_y + hipBlockDim_y * hipBlockIdx_x;
          iwork < work_end;
          iwork = iwork < work_end - work_stride ? iwork + work_stride
                                                 : work_end) {

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -535,8 +535,8 @@ class ParallelScanHIPBase {
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    // hipBlockDim_y must be power of two = 128 (2 warps) or 256 (4 warps) or 512
-    // (8 warps) hipGridDim_x <= hipBlockDim_y * hipBlockDim_y
+    // hipBlockDim_y must be power of two = 128 (2 warps) or 256 (4 warps) or
+    // 512 (8 warps) hipGridDim_x <= hipBlockDim_y * hipBlockDim_y
     //
     // TODO check best option
 

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -193,7 +193,8 @@ __device__ void hip_intra_block_reduce_scan(
   // Must have power of two thread count
   if ((hipBlockDim_y - 1) & hipBlockDim_y) {
     Kokkos::abort(
-        "HIP::hip_intra_block_reduce_scan requires power-of-two y- blockDim\n");
+        "HIP::hip_intra_block_reduce_scan requires power-of-two "
+        "hipBlockDim_y\n");
   }
 
   auto block_reduce_step = [&functor, value_count, base_data](

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -370,7 +370,7 @@ __device__ bool hip_single_inter_block_reduce_scan2(
       for (size_type i = b; i < e; ++i) {
         size_type* const global_value = global_data + word_count.value * i;
         ValueJoin::join(functor, shared_value, global_value);
-        ValueOps ::copy(functor, global_value, shared_value);
+        ValueOps::copy(functor, global_value, shared_value);
       }
     }
   }

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -197,13 +197,12 @@ __device__ void hip_intra_block_reduce_scan(
         "hipBlockDim_y\n");
   }
 
-  auto block_reduce_step = [&functor, value_count, base_data](
-                               int const R, pointer_type const TD,
-                               int const S) {
-    if (R > ((1 << S) - 1)) {
-      ValueJoin::join(functor, TD, (TD - (value_count << S)));
-    }
-  };
+  auto block_reduce_step =
+      [&functor, value_count](int const R, pointer_type const TD, int const S) {
+        if (R > ((1 << S) - 1)) {
+          ValueJoin::join(functor, TD, (TD - (value_count << S)));
+        }
+      };
 
   {  // Intra-warp reduction:
     const unsigned rtid_intra      = hipThreadIdx_y & WarpMask;

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -641,10 +641,10 @@ struct SubviewExtents {
     error(buf + n, buf_len - n, domain_rank + 1, range_rank + 1, dim, args...);
   }
 
+#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
   template <size_t... DimArgs, class... Args>
   KOKKOS_FORCEINLINE_FUNCTION void error(const ViewDimension<DimArgs...>& dim,
                                          Args... args) const {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
     enum { LEN = 1024 };
     char buffer[LEN];
 
@@ -652,10 +652,14 @@ struct SubviewExtents {
     error(buffer + n, LEN - n, 0, 0, dim, args...);
 
     Kokkos::Impl::throw_runtime_exception(std::string(buffer));
-#else
-    Kokkos::abort("Kokkos::subview bounds error");
-#endif
   }
+#else
+  template <size_t... DimArgs, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION void error(const ViewDimension<DimArgs...>&,
+                                         Args...) const {
+    Kokkos::abort("Kokkos::subview bounds error");
+  }
+#endif
 
 #else
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -262,6 +262,7 @@ if(Kokkos_ENABLE_HIP)
       UnitTestMainInit.cpp
       hip/TestHIP_Init.cpp
       hip/TestHIP_RangePolicy.cpp
+      hip/TestHIP_RangePolicyRequire.cpp
       hip/TestHIP_Reductions.cpp
       hip/TestHIP_Reducers_a.cpp
       hip/TestHIP_Reducers_b.cpp

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -268,6 +268,7 @@ if(Kokkos_ENABLE_HIP)
       hip/TestHIP_Reducers_b.cpp
       hip/TestHIP_Reducers_c.cpp
       hip/TestHIP_Reducers_d.cpp
+      hip/TestHIP_Scan.cpp
       hip/TestHIP_MDRange_a.cpp
       hip/TestHIP_MDRange_b.cpp
       hip/TestHIP_MDRange_c.cpp

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -261,6 +261,7 @@ if(Kokkos_ENABLE_HIP)
   set(HIP_SOURCES
       UnitTestMainInit.cpp
       hip/TestHIP_Init.cpp
+      hip/TestHIP_RangePolicy.cpp
       hip/TestHIP_Reductions.cpp
       hip/TestHIP_Reducers_a.cpp
       hip/TestHIP_Reducers_b.cpp

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -269,6 +269,7 @@ if(Kokkos_ENABLE_HIP)
       hip/TestHIP_Reducers_c.cpp
       hip/TestHIP_Reducers_d.cpp
       hip/TestHIP_Scan.cpp
+      hip/TestHIP_ScanUnit.cpp
       hip/TestHIP_MDRange_a.cpp
       hip/TestHIP_MDRange_b.cpp
       hip/TestHIP_MDRange_c.cpp

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -436,7 +436,7 @@ TEST(TEST_CATEGORY, range_reduce) {
 #ifdef KOKKOS_ENABLE_HIP
 struct DummyFunctor {
   using value_type = int;
-  void operator()(const int i, value_type &update, bool final) const {}
+  void operator()(const int, value_type &, bool) const {}
 };
 
 template <int N>
@@ -481,6 +481,7 @@ TEST(TEST_CATEGORY, range_scan) {
     test_intra_block_scan<64>();
     test_intra_block_scan<128>();
     test_intra_block_scan<256>();
+    // FIXME_HIP block sizes larger than 256 give wrong results.
     // test_intra_block_scan<512>();
     // test_intra_block_scan<1024>();
   }

--- a/core/unit_test/TestRangeRequire.hpp
+++ b/core/unit_test/TestRangeRequire.hpp
@@ -465,7 +465,7 @@ TEST(TEST_CATEGORY, range_scan_require) {
         f(0);
     f.test_scan();
   }
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_ROCM)
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
   {
     TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
                      Property>
@@ -485,7 +485,7 @@ TEST(TEST_CATEGORY, range_scan_require) {
         f(3);
     f.test_scan();
   }
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_ROCM)
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
   {
     TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
                      Property>
@@ -505,7 +505,7 @@ TEST(TEST_CATEGORY, range_scan_require) {
         f(1001);
     f.test_scan();
   }
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_ROCM)
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
   {
     TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
                      Property>

--- a/core/unit_test/TestScan.hpp
+++ b/core/unit_test/TestScan.hpp
@@ -101,6 +101,8 @@ struct TestScan {
     int64_t total = 0;
     Kokkos::parallel_scan(N, *this, total);
 
+    // We can't return a value in a constructor so use a lambda as wrapper to
+    // ignore it.
     [&] { ASSERT_EQ(size_t((N + 1) * N / 2), size_t(total)); }();
     check_error();
   }

--- a/core/unit_test/TestScan.hpp
+++ b/core/unit_test/TestScan.hpp
@@ -101,7 +101,7 @@ struct TestScan {
     int64_t total = 0;
     Kokkos::parallel_scan(N, *this, total);
 
-    run_check(size_t((N + 1) * N / 2), size_t(total));
+    [&] { ASSERT_EQ(size_t((N + 1) * N / 2), size_t(total)); }();
     check_error();
   }
 
@@ -128,10 +128,6 @@ struct TestScan {
     for (WorkSpec i = begin; i < end; ++i) {
       (void)TestScan(i);
     }
-  }
-
-  void run_check(const size_t& expected, const size_t& actual) {
-    ASSERT_EQ(expected, actual);
   }
 };
 

--- a/core/unit_test/hip/TestHIP_RangePolicy.cpp
+++ b/core/unit_test/hip/TestHIP_RangePolicy.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestRange.hpp>

--- a/core/unit_test/hip/TestHIP_RangePolicyRequire.cpp
+++ b/core/unit_test/hip/TestHIP_RangePolicyRequire.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestRangeRequire.hpp>

--- a/core/unit_test/hip/TestHIP_Scan.cpp
+++ b/core/unit_test/hip/TestHIP_Scan.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestScan.hpp>

--- a/core/unit_test/hip/TestHIP_ScanUnit.cpp
+++ b/core/unit_test/hip/TestHIP_ScanUnit.cpp
@@ -1,0 +1,97 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+#include <hip/TestHIP_Category.hpp>
+
+struct DummyFunctor {
+  using value_type = int;
+  void operator()(const int, value_type &, bool) const {}
+};
+
+template <int N>
+__global__ void start_intra_block_scan() {
+  __shared__ DummyFunctor::value_type values[N];
+  const int i = hipThreadIdx_y;
+  values[i]   = i + 1;
+  __syncthreads();
+
+  DummyFunctor f;
+  Kokkos::Impl::hip_intra_block_reduce_scan<true, DummyFunctor, void>(f,
+                                                                      values);
+
+  __syncthreads();
+  if (values[i] != ((i + 2) * (i + 1)) / 2) {
+    printf("Value for %d should be %d but is %d\n", i, ((i + 2) * (i + 1)) / 2,
+           values[i]);
+    Kokkos::abort("Test for intra_block_reduce_scan failed!");
+  }
+}
+
+template <int N>
+void test_intra_block_scan() {
+  dim3 grid(1, 1, 1);
+  dim3 block(1, N, 1);
+  hipLaunchKernelGGL(start_intra_block_scan<N>, grid, block, 0, 0);
+}
+
+TEST(TEST_CATEGORY, scan_unit) {
+  if (std::is_same<
+          TEST_EXECSPACE,
+          typename Kokkos::Experimental::HIPSpace::execution_space>::value) {
+    test_intra_block_scan<1>();
+    test_intra_block_scan<2>();
+    test_intra_block_scan<4>();
+    test_intra_block_scan<8>();
+    test_intra_block_scan<16>();
+    test_intra_block_scan<32>();
+    test_intra_block_scan<64>();
+    test_intra_block_scan<128>();
+    test_intra_block_scan<256>();
+    // FIXME_HIP block sizes larger than 256 give wrong results.
+    // test_intra_block_scan<512>();
+    // test_intra_block_scan<1024>();
+  }
+}


### PR DESCRIPTION
I needed to modify `hip_intra_block_reduce_scan` a bit for this to work correctly. Apart from that, it is more or less the `CUDA` implementation, but I introduced a base class for `ParallelScan` and `ParallelScanWithResult` to avoid code duplication.