### PR TITLE
Fix warnigns for clang/cuda on Kepler

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -260,6 +260,8 @@ struct CudaParallelLaunch<
             (prefer_shmem ? cudaFuncCachePreferShared
                           : cudaFuncCachePreferL1)));
       }
+#else
+      (void)prefer_shmem;
 #endif
 
       // Copy functor to constant memory on the device
@@ -317,6 +319,8 @@ struct CudaParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
             (prefer_shmem ? cudaFuncCachePreferShared
                           : cudaFuncCachePreferL1)));
       }
+#else
+      (void)prefer_shmem;
 #endif
 
       // Copy functor to constant memory on the device
@@ -371,6 +375,8 @@ struct CudaParallelLaunch<
             (prefer_shmem ? cudaFuncCachePreferShared
                           : cudaFuncCachePreferL1)));
       }
+#else
+      (void)prefer_shmem;
 #endif
 
       KOKKOS_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
@@ -419,6 +425,8 @@ struct CudaParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
             (prefer_shmem ? cudaFuncCachePreferShared
                           : cudaFuncCachePreferL1)));
       }
+#else
+      (void)prefer_shmem;
 #endif
 
       KOKKOS_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
@@ -465,6 +473,8 @@ struct CudaParallelLaunch<
             (prefer_shmem ? cudaFuncCachePreferShared
                           : cudaFuncCachePreferL1)));
       }
+#else
+      (void)prefer_shmem;
 #endif
 
       KOKKOS_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();
@@ -516,6 +526,8 @@ struct CudaParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
             (prefer_shmem ? cudaFuncCachePreferShared
                           : cudaFuncCachePreferL1)));
       }
+#else
+      (void)prefer_shmem;
 #endif
 
       KOKKOS_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE();

--- a/core/src/impl/Kokkos_Atomic_Load.hpp
+++ b/core/src/impl/Kokkos_Atomic_Load.hpp
@@ -125,8 +125,7 @@ __device__ __inline__ T _relaxed_atomic_load_impl(
                                     void const**>::type = nullptr) {
   T rv{};
   // TODO remove a copy operation here?
-  Kokkos::Impl::atomic_oper_fetch(NoOpOper<T>{}, &rv, rv);
-  return rv;
+  return Kokkos::Impl::atomic_oper_fetch(NoOpOper<T>{}, ptr, rv);
 }
 
 template <class T>


### PR DESCRIPTION
One of the unused parameter issues was probably a real bug in atomics
for atomic_load of larger than 64bit on Volta. Apparently not used anywhere
(otherwise it would have shown since the return value was always defaulted
scalar type)

Fixes #2884 