### PR TITLE
Avoid warnings in HIP backend

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Atomic.hpp
+++ b/core/src/HIP/Kokkos_HIP_Atomic.hpp
@@ -139,7 +139,7 @@ inline __device__ float atomic_exchange(float *dest, const float &val) {
 }
 
 template <class T>
-inline __device__ T atomic_exchange(T *dest, const T &val) {
+inline __device__ T atomic_exchange(T * /*dest*/, const T &val) {
   // FIXME
   return val;
 }
@@ -161,14 +161,15 @@ inline __device__ unsigned long long int atomic_compare_exchange(
 }
 
 template <typename T>
-inline __device__ T atomic_compare_exchange(T *dest, T compare, const T &val) {
+inline __device__ T atomic_compare_exchange(T * /*dest*/, T /*compare*/,
+                                            const T &val) {
   // FIXME
   return val;
 }
 
 template <typename T>
-inline __device__ T atomic_compare_exchange(volatile T *dest, T compare,
-                                            const T &val) {
+inline __device__ T atomic_compare_exchange(volatile T * /*dest*/,
+                                            T /*compare*/, const T &val) {
   // FIXME
   return val;
 }
@@ -263,7 +264,8 @@ inline __device__ unsigned long long atomic_fetch_add(
 }
 
 template <typename T>
-inline __device__ T atomic_fetch_add(volatile T *dest, const T &val) {
+inline __device__ T atomic_fetch_add(volatile T * /*dest*/, const T &val) {
+  // FIXME
   return val;
 }
 

--- a/core/src/HIP/Kokkos_HIP_Atomic.hpp
+++ b/core/src/HIP/Kokkos_HIP_Atomic.hpp
@@ -141,6 +141,7 @@ inline __device__ float atomic_exchange(float *dest, const float &val) {
 template <class T>
 inline __device__ T atomic_exchange(T * /*dest*/, const T &val) {
   // FIXME
+  Kokkos::abort("atomic_exchange not implemented!\n");
   return val;
 }
 
@@ -164,6 +165,7 @@ template <typename T>
 inline __device__ T atomic_compare_exchange(T * /*dest*/, T /*compare*/,
                                             const T &val) {
   // FIXME
+  Kokkos::abort("atomic_compare_exchange not implemented!\n");
   return val;
 }
 
@@ -171,6 +173,7 @@ template <typename T>
 inline __device__ T atomic_compare_exchange(volatile T * /*dest*/,
                                             T /*compare*/, const T &val) {
   // FIXME
+  Kokkos::abort("volatile atomic_compare_exchange not implemented!\n");
   return val;
 }
 
@@ -266,6 +269,7 @@ inline __device__ unsigned long long atomic_fetch_add(
 template <typename T>
 inline __device__ T atomic_fetch_add(volatile T * /*dest*/, const T &val) {
   // FIXME
+  Kokkos::abort("volatile atomic_fetch_add not implemented!\n");
   return val;
 }
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -104,7 +104,8 @@ int HIPInternal::was_initialized = 0;
 int HIPInternal::was_finalized   = 0;
 //----------------------------------------------------------------------------
 
-void HIPInternal::print_configuration(std::ostream &s) const {
+void HIPInternal::print_configuration(std::ostream & /*s*/) const {
+  // FIXME_HIP
   /*const HIPInternalDevices & dev_info = HIPInternalDevices::singleton();
 
 #if defined( KOKKOS_ENABLE_HIP )

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -106,6 +106,7 @@ int HIPInternal::was_finalized   = 0;
 
 void HIPInternal::print_configuration(std::ostream & /*s*/) const {
   // FIXME_HIP
+  Kokkos::abort("print_configuration not implemented!\n");
   /*const HIPInternalDevices & dev_info = HIPInternalDevices::singleton();
 
 #if defined( KOKKOS_ENABLE_HIP )

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -136,8 +136,9 @@ struct HIPParallelLaunch<
   inline HIPParallelLaunch(const DriverType &driver, const dim3 &grid,
                            const dim3 &block, const int shmem,
                            const HIPInternal *hip_instance,
-                           const bool prefer_shmem) {
+                           const bool /*prefer_shmem*/) {
     if ((grid.x != 0) && ((block.x * block.y * block.z) != 0)) {
+      // FIXME_HIP use prefer_shmem
       /*
             if ( hip_instance->m_maxShmemPerBlock < shmem ) {
               Kokkos::Impl::throw_runtime_exception(
@@ -194,8 +195,9 @@ struct HIPParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
   inline HIPParallelLaunch(const DriverType &driver, const dim3 &grid,
                            const dim3 &block, const int shmem,
                            const HIPInternal *hip_instance,
-                           const bool prefer_shmem) {
+                           const bool /*prefer_shmem*/) {
     if ((grid.x != 0) && ((block.x * block.y * block.z) != 0)) {
+      // FIXME_HIP use prefer_shmem
       /**
             if ( hip_instance->m_maxShmemPerBlock < shmem ) {
               Kokkos::Impl::throw_runtime_exception(

--- a/core/src/HIP/Kokkos_HIP_Parallel.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel.hpp
@@ -109,10 +109,9 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
 };
 
 template <class... Properties>
-TeamPolicyInternal<Kokkos::Experimental::HIP,
-                   Properties...>::TeamPolicyInternal(int league_size,
-                                                      int team_size_request,
-                                                      int vector_length_request)
+TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>::
+    TeamPolicyInternal(int league_size, int team_size_request,
+                       int /*vector_length_request*/)
     : m_space(typename traits::execution_space()),
       m_league_size(league_size),
       m_team_size(team_size_request),
@@ -121,13 +120,13 @@ TeamPolicyInternal<Kokkos::Experimental::HIP,
       m_chunk_size(32) {
   // FIXME add a check that the league size is permissible
   // FIXME add a check that the block size is permissible
+  // FIXME use vector_length_request
 }
 
 template <class... Properties>
-TeamPolicyInternal<Kokkos::Experimental::HIP,
-                   Properties...>::TeamPolicyInternal(int league_size,
-                                                      Kokkos::AUTO_t const &,
-                                                      int vector_length_request)
+TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>::
+    TeamPolicyInternal(int league_size, Kokkos::AUTO_t const &,
+                       int /*vector_length_request*/)
     : m_space(typename traits::execution_space()),
       m_league_size(league_size),
       m_team_size(-1),
@@ -135,6 +134,7 @@ TeamPolicyInternal<Kokkos::Experimental::HIP,
       m_thread_scratch_size{0, 0},
       m_chunk_size(32) {
   // FIXME add a check that the league size is permissible
+  // FIXME use vector_length_request
 }
 
 template <class... Properties>

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -83,7 +83,7 @@ struct HIPReductionsFunctor<FunctorType, ArgTag, false, false> {
 
   __device__ static inline void scalar_intra_block_reduction(
       FunctorType const& functor, Scalar value, bool const skip, Scalar* result,
-      int const shared_elements, Scalar* shared_team_buffer_element) {
+      int const /*shared_elements*/, Scalar* shared_team_buffer_element) {
     int const warp_id = (hipThreadIdx_y * hipBlockDim_x) /
                         ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
     Scalar* const my_shared_team_buffer_element =
@@ -115,7 +115,7 @@ struct HIPReductionsFunctor<FunctorType, ArgTag, false, false> {
 
   __device__ static inline bool scalar_inter_block_reduction(
       FunctorType const& functor,
-      ::Kokkos::Experimental::HIP::size_type const block_id,
+      ::Kokkos::Experimental::HIP::size_type const /*block_id*/,
       ::Kokkos::Experimental::HIP::size_type const block_count,
       ::Kokkos::Experimental::HIP::size_type* const shared_data,
       ::Kokkos::Experimental::HIP::size_type* const global_data,

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -89,21 +89,24 @@ DeepCopy<Kokkos::Experimental::HIPSpace, HostSpace,
 
 DeepCopy<Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPSpace,
          Kokkos::Experimental::HIP>::DeepCopy(const Kokkos::Experimental::HIP&
-                                                  instance,
+                                              /*instance*/,
                                               void* dst, const void* src,
                                               size_t n) {
+  // FIXME_HIP use instance
   hipMemcpy(dst, src, n, hipMemcpyDefault);
 }
 
 DeepCopy<HostSpace, Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIP>::
-    DeepCopy(const Kokkos::Experimental::HIP& instance, void* dst,
+    DeepCopy(const Kokkos::Experimental::HIP& /*instance*/, void* dst,
              const void* src, size_t n) {
+  // FIXME_HIP use instance
   hipMemcpy(dst, src, n, hipMemcpyDefault);
 }
 
 DeepCopy<Kokkos::Experimental::HIPSpace, HostSpace, Kokkos::Experimental::HIP>::
-    DeepCopy(const Kokkos::Experimental::HIP& instance, void* dst,
+    DeepCopy(const Kokkos::Experimental::HIP& /*instance*/, void* dst,
              const void* src, size_t n) {
+  // FIXME_HIP use instance
   hipMemcpy(dst, src, n, hipMemcpyDefault);
 }
 
@@ -128,24 +131,27 @@ DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace, HostSpace,
 
 DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace,
          Kokkos::Experimental::HIPHostPinnedSpace, Kokkos::Experimental::HIP>::
-    DeepCopy(const Kokkos::Experimental::HIP& instance, void* dst,
+    DeepCopy(const Kokkos::Experimental::HIP& /*instance*/, void* dst,
              const void* src, size_t n) {
+  // FIXME_HIP use instance
   hipMemcpy(dst, src, n, hipMemcpyDefault);
 }
 
 DeepCopy<HostSpace, Kokkos::Experimental::HIPHostPinnedSpace,
          Kokkos::Experimental::HIP>::DeepCopy(const Kokkos::Experimental::HIP&
-                                                  instance,
+                                              /*instance*/,
                                               void* dst, const void* src,
                                               size_t n) {
+  // FIXME_HIP use instance
   hipMemcpy(dst, src, n, hipMemcpyDefault);
 }
 
 DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace, HostSpace,
          Kokkos::Experimental::HIP>::DeepCopy(const Kokkos::Experimental::HIP&
-                                                  instance,
+                                              /*instance*/,
                                               void* dst, const void* src,
                                               size_t n) {
+  // FIXME_HIP use instance
   hipMemcpy(dst, src, n, hipMemcpyDefault);
 }
 
@@ -529,19 +535,17 @@ void SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::
     } while (r != &s_root_record);
   }
 #else
+  (void)s;
+  (void)space;
+  (void)detail;
   throw_runtime_exception(
       "Kokkos::Impl::SharedAllocationRecord<HIPSpace>::print_records"
       " only works with KOKKOS_DEBUG enabled");
 #endif
 }
 
-}  // namespace Impl
-}  // namespace Kokkos
-
 /*--------------------------------------------------------------------------*/
 /*--------------------------------------------------------------------------*/
-namespace Kokkos {
-namespace {
 
 void* hip_resize_scratch_space(size_t bytes, bool force_shrink) {
   static void* ptr           = NULL;
@@ -565,7 +569,7 @@ void* hip_resize_scratch_space(size_t bytes, bool force_shrink) {
   return ptr;
 }
 
-}  // namespace
+}  // namespace Impl
 }  // namespace Kokkos
 
 #endif  // KOKKOS_ENABLE_HIP

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -298,7 +298,7 @@ struct DeepCopy<Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPSpace,
   inline DeepCopy(const ExecutionSpace& /*exec*/, void* /*dst*/,
                   const void* /*src*/, size_t /*n*/) {
     // FIXME_HIP
-    Kokkos::abort("Not implemented!");
+    Kokkos::abort("DeepCopy with ExecutionSpace not implemented!");
 
     //    exec.fence();
     //    hc::completion_future fut = DeepCopyAsyncHIP (dst,src,n);
@@ -371,7 +371,7 @@ struct DeepCopy<Kokkos::Experimental::HIPSpace,
   inline DeepCopy(const ExecutionSpace& /*exec*/, void* /*dst*/,
                   const void* /*src*/, size_t /*n*/) {
     // FIXME_HIP
-    Kokkos::abort("Not implemented!");
+    Kokkos::abort("DeepCopy with ExecutionSpace not implemented!");
 
     //    exec.fence();
     //    hc::completion_future fut = DeepCopyAsyncHIP (dst,src,n);
@@ -391,7 +391,7 @@ struct DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace,
   inline DeepCopy(const ExecutionSpace& /*exec*/, void* /*dst*/,
                   const void* /*src*/, size_t /*n*/) {
     // FIXME_HIP
-    Kokkos::abort("Not implemented!");
+    Kokkos::abort("DeepCopy with ExecutionSpace not implemented!");
 
     //    exec.fence();
     //    hc::completion_future fut = DeepCopyAsyncHIP (dst,src,n);

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -295,8 +295,11 @@ struct DeepCopy<Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPSpace,
         dst, src, n);
   }
 
-  inline DeepCopy(const ExecutionSpace& exec, void* dst, const void* src,
-                  size_t n) {
+  inline DeepCopy(const ExecutionSpace& /*exec*/, void* /*dst*/,
+                  const void* /*src*/, size_t /*n*/) {
+    // FIXME_HIP
+    Kokkos::abort("Not implemented!");
+
     //    exec.fence();
     //    hc::completion_future fut = DeepCopyAsyncHIP (dst,src,n);
     //    fut.wait();
@@ -365,8 +368,11 @@ struct DeepCopy<Kokkos::Experimental::HIPSpace,
                    Kokkos::Experimental::HIP>(dst, src, n);
   }
 
-  inline DeepCopy(const ExecutionSpace& exec, void* dst, const void* src,
-                  size_t n) {
+  inline DeepCopy(const ExecutionSpace& /*exec*/, void* /*dst*/,
+                  const void* /*src*/, size_t /*n*/) {
+    // FIXME_HIP
+    Kokkos::abort("Not implemented!");
+
     //    exec.fence();
     //    hc::completion_future fut = DeepCopyAsyncHIP (dst,src,n);
     //    fut.wait();
@@ -382,8 +388,11 @@ struct DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace,
                    Kokkos::Experimental::HIP>(dst, src, n);
   }
 
-  inline DeepCopy(const ExecutionSpace& exec, void* dst, const void* src,
-                  size_t n) {
+  inline DeepCopy(const ExecutionSpace& /*exec*/, void* /*dst*/,
+                  const void* /*src*/, size_t /*n*/) {
+    // FIXME_HIP
+    Kokkos::abort("Not implemented!");
+
     //    exec.fence();
     //    hc::completion_future fut = DeepCopyAsyncHIP (dst,src,n);
     //    fut.wait();

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -282,6 +282,8 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
   }
   return return_val;
 #elif defined(__HIP_DEVICE_COMPILE__)  // FIXME_HIP
+  (void)op;
+  (void)dest;
   return val;
 #endif
 }
@@ -331,6 +333,10 @@ atomic_oper_fetch(const Oper& op, volatile T* const dest,
 #endif
   }
   return return_val;
+#elif defined(__HIP_DEVICE_COMPILE__)  // FIXME_HIP
+  (void)op;
+  (void)dest;
+  return val;
 #endif
 }
 


### PR DESCRIPTION
Marking places that need some TLC with `FIXME` or `FIXME_HIP`.
I don't see any warnings after using `-Wno-unused-command-line-argument -Wno-braced-scalar-init`.