### PR TITLE
Terminate process execution when abort() is called from HIP kernel

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Abort.hpp
+++ b/core/src/HIP/Kokkos_HIP_Abort.hpp
@@ -1,0 +1,66 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_HIP_ABORT_HPP
+#define KOKKOS_HIP_ABORT_HPP
+
+#include <Kokkos_Macros.hpp>
+#if defined(KOKKOS_ENABLE_HIP)
+
+#include <hip/hip_runtime.h>
+
+namespace Kokkos {
+namespace Impl {
+
+__device__ inline void hip_abort(char const *msg) {
+  // FIXME_HIP
+  printf("%s", msg);
+  abort();
+}
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif
+#endif

--- a/core/src/HIP/Kokkos_HIP_Abort.hpp
+++ b/core/src/HIP/Kokkos_HIP_Abort.hpp
@@ -55,7 +55,7 @@ namespace Impl {
 
 __device__ inline void hip_abort(char const *msg) {
   printf("%s", msg);
-  // FIXME_HIP both abort and the __assertfail system call are curretly
+  // FIXME_HIP both abort and the __assertfail system call are currently
   // implemented with __builtin_trap which causes the program to exit abnormally
   // without printing the error message.
   // abort();

--- a/core/src/HIP/Kokkos_HIP_Abort.hpp
+++ b/core/src/HIP/Kokkos_HIP_Abort.hpp
@@ -54,9 +54,11 @@ namespace Kokkos {
 namespace Impl {
 
 __device__ inline void hip_abort(char const *msg) {
-  // FIXME_HIP
   printf("%s", msg);
-  abort();
+  // FIXME_HIP both abort and the __assertfail system call are curretly
+  // implemented with __builtin_trap which causes the program to exit abnormally
+  // without printing the error message.
+  // abort();
 }
 
 }  // namespace Impl

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -59,12 +59,6 @@
 #define KOKKOS_ABORT_MESSAGE_BUFFER_SIZE 2048
 #endif  // ifndef KOKKOS_ABORT_MESSAGE_BUFFER_SIZE
 
-// HIP defines a macro abort() when using nvcc, thus we get a collision with the
-// abort function defined here
-#ifdef KOKKOS_ENABLE_HIP
-#undef abort
-#endif
-
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -51,6 +51,9 @@
 #ifdef KOKKOS_ENABLE_CUDA
 #include <Cuda/Kokkos_Cuda_abort.hpp>
 #endif
+#ifdef KOKKOS_ENABLE_HIP
+#include <HIP/Kokkos_HIP_Abort.hpp>
+#endif
 
 #ifndef KOKKOS_ABORT_MESSAGE_BUFFER_SIZE
 #define KOKKOS_ABORT_MESSAGE_BUFFER_SIZE 2048
@@ -173,8 +176,7 @@ void abort(const char *const message) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
   Kokkos::Impl::cuda_abort(message);
 #elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
-  // FIXME_HIP improve this once HIP supports asserting in a kernel properly
-  printf("%s", message);
+  Kokkos::Impl::hip_abort(message);
 #elif !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__)
   Kokkos::Impl::host_abort(message);
 #endif


### PR DESCRIPTION
Amendment to #2877

https://github.com/ROCm-Developer-Tools/HIP/blob/7d27247814d5eae33892ec508ff62fc6e8d8e160/docs/markdown/hip_kernel_language.md#assert