### PR TITLE
Fix race condition in team_reduce for pthreads with other collective ops

### DIFF
--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -180,6 +180,7 @@ class ThreadsExecTeamMember {
 
     if (m_team_base) {
       type* const local_value = ((type*)m_team_base[0]->scratch_memory());
+      team_barrier();
       if (team_rank() == thread_id) *local_value = value;
       memory_fence();
       team_barrier();
@@ -204,6 +205,7 @@ class ThreadsExecTeamMember {
     f(value);
     if (m_team_base) {
       type* const local_value = ((type*)m_team_base[0]->scratch_memory());
+      team_barrier();
       if (team_rank() == thread_id) *local_value = value;
       memory_fence();
       team_barrier();

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -228,13 +228,15 @@ class ThreadsExecTeamMember {
 
     if (0 == m_exec) return value;
 
-    *((volatile type*)m_exec->scratch_memory()) = value;
+    if (team_rank() != team_size() - 1)
+      *((volatile type*)m_exec->scratch_memory()) = value;
 
     memory_fence();
 
     type& accum = *((type*)m_team_base[0]->scratch_memory());
 
     if (team_fan_in()) {
+      accum = value;
       for (int i = 1; i < m_team_size; ++i) {
         accum += *((type*)m_team_base[i]->scratch_memory());
       }
@@ -274,7 +276,7 @@ class ThreadsExecTeamMember {
     type* const local_value = ((type*)m_exec->scratch_memory());
 
     // Set this thread's contribution
-    *local_value = contribution;
+    if (team_rank() != team_size() - 1) *local_value = contribution;
 
     // Fence to make sure the base team member has access:
     memory_fence();
@@ -284,6 +286,7 @@ class ThreadsExecTeamMember {
       // team_fan_out()
       type* const team_value = ((type*)m_team_base[0]->scratch_memory());
 
+      *team_value = contribution;
       // Join to the team value:
       for (int i = 1; i < m_team_size; ++i) {
         reducer.join(*team_value, *((type*)m_team_base[i]->scratch_memory()));

--- a/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
@@ -87,9 +87,10 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
     }
   }
 
-  static inline void thread_main(ThreadsExec&, const void* arg) noexcept {
+  static inline void thread_main(ThreadsExec& exec, const void* arg) noexcept {
     const Self& self = *(static_cast<const Self*>(arg));
     self.exec_one_thread();
+    exec.fan_in();
   }
 
  public:


### PR DESCRIPTION
This in particular fixes a race condition of a team_broadcast followed by
team_reduce