### PR TITLE
Make is_always_assignable work with const-qualified types and references

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -451,11 +451,11 @@ template <class DataType, class... Properties>
 class View;
 
 template <class T1, class T2>
-struct is_always_assignable;
+struct is_always_assignable_impl;
 
 template <class... ViewTDst, class... ViewTSrc>
-struct is_always_assignable<Kokkos::View<ViewTDst...>,
-                            Kokkos::View<ViewTSrc...>> {
+struct is_always_assignable_impl<Kokkos::View<ViewTDst...>,
+                                 Kokkos::View<ViewTSrc...>> {
   using mapping_type = Kokkos::Impl::ViewMapping<
       typename Kokkos::View<ViewTDst...>::traits,
       typename Kokkos::View<ViewTSrc...>::traits,
@@ -466,6 +466,12 @@ struct is_always_assignable<Kokkos::View<ViewTDst...>,
       static_cast<int>(Kokkos::View<ViewTDst...>::rank_dynamic) >=
           static_cast<int>(Kokkos::View<ViewTSrc...>::rank_dynamic);
 };
+
+template <class View1, class View2>
+using is_always_assignable = is_always_assignable_impl<
+    typename std::remove_reference<View1>::type,
+    typename std::remove_const<
+        typename std::remove_reference<View2>::type>::type>;
 
 #ifdef KOKKOS_ENABLE_CXX17
 template <class T1, class T2>

--- a/core/unit_test/TestViewIsAssignable.hpp
+++ b/core/unit_test/TestViewIsAssignable.hpp
@@ -113,5 +113,31 @@ TEST(TEST_CATEGORY, view_is_assignable) {
   Impl::TestAssignability<View<int*, left, h_exec>,
                           View<int*, left, d_exec>>::test(expected, expected,
                                                           10);
+
+  // reference type and const-qualified types
+  using SomeViewType = View<int*, left, d_exec>;
+#if defined(KOKKOS_ENABLE_CXX17)
+  static_assert(is_always_assignable_v<SomeViewType, SomeViewType>);
+  static_assert(is_always_assignable_v<SomeViewType, SomeViewType&>);
+  static_assert(is_always_assignable_v<SomeViewType, SomeViewType const>);
+  static_assert(is_always_assignable_v<SomeViewType, SomeViewType const&>);
+  static_assert(is_always_assignable_v<SomeViewType&, SomeViewType>);
+  static_assert(is_always_assignable_v<SomeViewType&, SomeViewType&>);
+  static_assert(is_always_assignable_v<SomeViewType&, SomeViewType const>);
+  static_assert(is_always_assignable_v<SomeViewType&, SomeViewType const&>);
+#else
+  static_assert(is_always_assignable<SomeViewType, SomeViewType>::value, "");
+  static_assert(is_always_assignable<SomeViewType, SomeViewType&>::value, "");
+  static_assert(is_always_assignable<SomeViewType, SomeViewType const>::value,
+                "");
+  static_assert(is_always_assignable<SomeViewType, SomeViewType const&>::value,
+                "");
+  static_assert(is_always_assignable<SomeViewType&, SomeViewType>::value, "");
+  static_assert(is_always_assignable<SomeViewType&, SomeViewType&>::value, "");
+  static_assert(is_always_assignable<SomeViewType&, SomeViewType const>::value,
+                "");
+  static_assert(is_always_assignable<SomeViewType&, SomeViewType const&>::value,
+                "");
+#endif
 }
 }  // namespace Test


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/2874#discussion_r394638992

Deliberately chose to ignore volatile-qualified views