### PR TITLE
HPX backend fixes

### DIFF
--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -85,6 +85,9 @@ void HPX::impl_initialize(int thread_count) {
     char *argv_hpx[] = {name, nullptr};
     hpx::start(nullptr, argc_hpx, argv_hpx, config);
 
+#if HPX_VERSION_FULL < 0x010400
+    // This has been fixed in HPX 1.4.0.
+    //
     // NOTE: Wait for runtime to start. hpx::start returns as soon as
     // possible, meaning some operations are not allowed immediately
     // after hpx::start. Notably, hpx::stop needs state_running. This
@@ -94,6 +97,7 @@ void HPX::impl_initialize(int thread_count) {
     rt = hpx::get_runtime_ptr();
     hpx::util::yield_while(
         [rt]() { return rt->get_state() < hpx::state_running; });
+#endif
 
     m_hpx_initialized = true;
   }

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -83,6 +83,7 @@
 #include <hpx/runtime.hpp>
 #include <hpx/runtime/threads/run_as_hpx_thread.hpp>
 #include <hpx/runtime/threads/threadmanager.hpp>
+#include <hpx/runtime/thread_pool_helpers.hpp>
 
 #include <iostream>
 #include <memory>

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -230,8 +230,8 @@ class HPX {
   }
 
   template <typename F>
-  static void partition_master(F const &f, int requested_num_partitions = 0,
-                               int requested_partition_size = 0) {
+  static void partition_master(F const &, int requested_num_partitions = 0,
+                               int = 0) {
     if (requested_num_partitions > 1) {
       Kokkos::abort(
           "Kokkos::Experimental::HPX::partition_master: can't partition an "
@@ -473,7 +473,7 @@ struct HPXTeamMember {
   template <class ReducerType>
   KOKKOS_INLINE_FUNCTION
       typename std::enable_if<is_reducer<ReducerType>::value>::type
-      team_reduce(const ReducerType &reducer) const {}
+      team_reduce(const ReducerType &) const {}
 
   template <typename Type>
   KOKKOS_INLINE_FUNCTION Type
@@ -628,8 +628,7 @@ class TeamPolicyInternal<Kokkos::Experimental::HPX, Properties...>
   }
 
   TeamPolicyInternal(const typename traits::execution_space &,
-                     int league_size_request,
-                     const Kokkos::AUTO_t &team_size_request,
+                     int league_size_request, const Kokkos::AUTO_t &,
                      int /* vector_length_request */ = 1)
       : m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
@@ -645,8 +644,7 @@ class TeamPolicyInternal<Kokkos::Experimental::HPX, Properties...>
     init(league_size_request, team_size_request);
   }
 
-  TeamPolicyInternal(int league_size_request,
-                     const Kokkos::AUTO_t &team_size_request,
+  TeamPolicyInternal(int league_size_request, const Kokkos::AUTO_t &,
                      int /* vector_length_request */ = 1)
       : m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
@@ -2257,28 +2255,28 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
 
 template <class FunctorType>
 KOKKOS_INLINE_FUNCTION void single(
-    const Impl::VectorSingleStruct<Impl::HPXTeamMember> &single_struct,
+    const Impl::VectorSingleStruct<Impl::HPXTeamMember> &,
     const FunctorType &lambda) {
   lambda();
 }
 
 template <class FunctorType>
 KOKKOS_INLINE_FUNCTION void single(
-    const Impl::ThreadSingleStruct<Impl::HPXTeamMember> &single_struct,
+    const Impl::ThreadSingleStruct<Impl::HPXTeamMember> &,
     const FunctorType &lambda) {
   lambda();
 }
 
 template <class FunctorType, class ValueType>
 KOKKOS_INLINE_FUNCTION void single(
-    const Impl::VectorSingleStruct<Impl::HPXTeamMember> &single_struct,
+    const Impl::VectorSingleStruct<Impl::HPXTeamMember> &,
     const FunctorType &lambda, ValueType &val) {
   lambda(val);
 }
 
 template <class FunctorType, class ValueType>
 KOKKOS_INLINE_FUNCTION void single(
-    const Impl::ThreadSingleStruct<Impl::HPXTeamMember> &single_struct,
+    const Impl::ThreadSingleStruct<Impl::HPXTeamMember> &,
     const FunctorType &lambda, ValueType &val) {
   lambda(val);
 }

--- a/core/unit_test/incremental/Test10_HierarchicalBasics.hpp
+++ b/core/unit_test/incremental/Test10_HierarchicalBasics.hpp
@@ -60,9 +60,15 @@ struct HierarchicalBasics {
   void run(const int nP, int nT) {
     if (nT > ExecSpace::concurrency()) nT = ExecSpace::concurrency();
 
+    policy_t pol(nP, nT);
+
+    ASSERT_EQ(pol.league_size(), nP);
+    ASSERT_LE(pol.team_size(), nT);
+    nT = pol.team_size();
+
     Kokkos::View<int **, ExecSpace> v("Array_A", nP, nT);
     Kokkos::parallel_for(
-        "Teams", policy_t(nP, nT), KOKKOS_LAMBDA(const team_t &team) {
+        "Teams", pol, KOKKOS_LAMBDA(const team_t &team) {
           const int tR = team.team_rank();
           const int tS = team.team_size();
           const int lR = team.league_rank();


### PR DESCRIPTION
Fixes:

- A few tests with the asynchronous HPX backend. I've added a few fences for some of these tests but I expect their real place would be somewhere else.
- Warnings in the backend
- Missing header in the HPX backend (this is backwards compatible)