### PR TITLE
Remove syncs from Profiling push/pop region calls

### DIFF
--- a/core/src/impl/Kokkos_Profiling_Interface.cpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.cpp
@@ -131,14 +131,12 @@ void endParallelReduce(const uint64_t kernelID) {
 
 void pushRegion(const std::string& kName) {
   if (nullptr != pushRegionCallee) {
-    Kokkos::fence();
     (*pushRegionCallee)(kName.c_str());
   }
 }
 
 void popRegion() {
   if (nullptr != popRegionCallee) {
-    Kokkos::fence();
     (*popRegionCallee)();
   }
 }


### PR DESCRIPTION
Reported by @csiefer2 in #1631 , we apparently globally fence Kokkos inside of our push/pop region calls. Everybody who uses those calls wraps them or isolates them in one place, if they want a sync they can add one. They can't remove a sync from our implementation. I propose that we globally remove those fences.