### PR TITLE
Improve atomic support using HIP

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Atomic.hpp
+++ b/core/src/HIP/Kokkos_HIP_Atomic.hpp
@@ -184,7 +184,6 @@ __inline__ __device__ T atomic_compare_exchange(
     T f;
     __inline__ __device__ U() {}
   } idest, icompare, ival;
-  idest.f    = *dest;
   icompare.f = compare;
   ival.f     = val;
   idest.i    = atomicCAS(reinterpret_cast<int *>(const_cast<T *>(dest)),
@@ -203,7 +202,6 @@ __inline__ __device__ T atomic_compare_exchange(
     T f;
     __inline__ __device__ U() {}
   } idest, icompare, ival;
-  idest.f    = *dest;
   icompare.f = compare;
   ival.f     = val;
   idest.i    = atomicCAS(

--- a/core/src/HIP/Kokkos_HIP_Atomic.hpp
+++ b/core/src/HIP/Kokkos_HIP_Atomic.hpp
@@ -104,6 +104,7 @@ atomic_exchange(volatile T *const dest,
                 typename std::enable_if<sizeof(T) != sizeof(int) &&
                                             sizeof(T) != sizeof(long long),
                                         const T>::type &val) {
+  // FIXME_HIP
   Kokkos::abort("atomic_exchange not implemented for large types.\n");
   T return_val;
   int done                 = 0;
@@ -215,6 +216,7 @@ __inline__ __device__ T atomic_compare_exchange(
     typename std::enable_if<sizeof(T) != sizeof(int) &&
                                 sizeof(T) != sizeof(long long),
                             const T>::type &val) {
+  // FIXME_HIP
   Kokkos::abort("atomic_compare_exchange not implemented for large types.\n");
   T return_val;
   int done                 = 0;
@@ -347,6 +349,7 @@ atomic_fetch_add(volatile T *dest,
                  typename std::enable_if<sizeof(T) != sizeof(int) &&
                                              sizeof(T) != sizeof(long long),
                                          const T &>::type val) {
+  // FIXME_HIP
   Kokkos::abort("atomic_fetch_add not implemented for large types.\n");
   T return_val;
   int done                 = 0;
@@ -507,6 +510,7 @@ atomic_fetch_sub(volatile T *const dest,
                  typename std::enable_if<sizeof(T) != sizeof(int) &&
                                              sizeof(T) != sizeof(long long),
                                          const T>::type &val) {
+  // FIXME_HIP
   Kokkos::abort("atomic_fetch_sub not implemented for large types.\n");
   T return_val;
   int done                 = 0;

--- a/core/src/HIP/Kokkos_HIP_Atomic.hpp
+++ b/core/src/HIP/Kokkos_HIP_Atomic.hpp
@@ -178,6 +178,7 @@ template <class T>
 __inline__ __device__ T atomic_compare_exchange(
     volatile T *dest, T compare,
     typename std::enable_if<sizeof(T) == sizeof(int), const T &>::type val) {
+  // FIXME_HIP UB
   union U {
     int i;
     T f;
@@ -196,6 +197,7 @@ __inline__ __device__ T atomic_compare_exchange(
     volatile T *dest, T compare,
     typename std::enable_if<sizeof(T) == sizeof(unsigned long long int),
                             const T &>::type val) {
+  // FIXME_HIP UB
   union U {
     unsigned long long int i;
     T f;
@@ -262,6 +264,7 @@ template <typename T>
 inline __device__ T atomic_fetch_add(
     volatile T *const dest,
     typename std::enable_if<sizeof(T) == sizeof(int), const T>::type val) {
+  // FIXME_HIP UB
   union U {
     int i;
     T t;
@@ -285,6 +288,7 @@ inline __device__ T atomic_fetch_add(
     volatile T *const dest,
     typename std::enable_if<sizeof(T) == sizeof(long long), const T>::type
         val) {
+  // FIXME_HIP UB
   union U {
     unsigned long long i;
     T t;
@@ -430,6 +434,7 @@ template <class T>
 __inline__ __device__ T atomic_fetch_sub(
     volatile T *dest,
     typename std::enable_if<sizeof(T) == sizeof(int), T>::type val) {
+  // FIXME_HIP UB
   union U {
     int i;
     T t;
@@ -453,6 +458,7 @@ inline __device__ T atomic_fetch_sub(
     volatile T *const dest,
     typename std::enable_if<sizeof(T) == sizeof(long long), const T>::type
         val) {
+  // FIXME_HIP UB
   union U {
     unsigned long long i;
     T t;

--- a/core/src/impl/Kokkos_Atomic_Decrement.hpp
+++ b/core/src/impl/Kokkos_Atomic_Decrement.hpp
@@ -54,7 +54,7 @@
 
 namespace Kokkos {
 
-// Atomic increment
+// Atomic decrement
 template <>
 KOKKOS_INLINE_FUNCTION void atomic_decrement<char>(volatile char* a) {
 #if defined(KOKKOS_ENABLE_ASM) && defined(KOKKOS_ENABLE_ISA_X86_64) && \

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -282,6 +282,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
   }
   return return_val;
 #elif defined(__HIP_DEVICE_COMPILE__)
+  // FIXME_HIP
   Kokkos::abort("atomic_fetch_oper not implemented for large types.");
   T return_val             = *dest;
   int done                 = 0;
@@ -289,7 +290,6 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
   unsigned int done_active = 0;
   while (active != done_active) {
     if (!done) {
-      // FIXME_HIP
       // if (Impl::lock_address_hip_space((void*)dest))
       {
         return_val = *dest;
@@ -350,6 +350,7 @@ atomic_oper_fetch(const Oper& op, volatile T* const dest,
   }
   return return_val;
 #elif defined(__HIP_DEVICE_COMPILE__)
+  // FIXME_HIP
   Kokkos::abort("atomic_oper_fetch not implemented for large types.");
   T return_val;
   int done                 = 0;
@@ -357,7 +358,6 @@ atomic_oper_fetch(const Oper& op, volatile T* const dest,
   unsigned int done_active = 0;
   while (active != done_active) {
     if (!done) {
-      // FIXME_HIP
       // if (Impl::lock_address_hip_space((void*)dest))
       {
         return_val = op.apply(*dest, val);

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -260,39 +260,47 @@ endif()
 if(Kokkos_ENABLE_HIP)
   set(HIP_SOURCES
       UnitTestMainInit.cpp
+      #hip/TestHIP_AtomicOperations_complexdouble.cpp
+      hip/TestHIP_AtomicOperations_complexfloat.cpp
+      hip/TestHIP_AtomicOperations_double.cpp
+      hip/TestHIP_AtomicOperations_int.cpp
+      hip/TestHIP_AtomicOperations_float.cpp
+      hip/TestHIP_AtomicOperations_longint.cpp
+      hip/TestHIP_AtomicOperations_longlongint.cpp
+      hip/TestHIP_AtomicOperations_unsignedint.cpp
+      hip/TestHIP_AtomicOperations_unsignedlongint.cpp
+      hip/TestHIP_Atomics.cpp
+      hip/TestHIP_AtomicViews.cpp
+      hip/TestHIP_DeepCopyAlignment.cpp
       hip/TestHIP_Init.cpp
-      hip/TestHIP_RangePolicy.cpp
-      hip/TestHIP_RangePolicyRequire.cpp
-      hip/TestHIP_Reductions.cpp
-      hip/TestHIP_Reducers_a.cpp
-      hip/TestHIP_Reducers_b.cpp
-      hip/TestHIP_Reducers_c.cpp
-      hip/TestHIP_Reducers_d.cpp
-      hip/TestHIP_Scan.cpp
-      hip/TestHIP_ScanUnit.cpp
+      hip/TestHIP_LocalDeepCopy.cpp
       hip/TestHIP_MDRange_a.cpp
       hip/TestHIP_MDRange_b.cpp
       hip/TestHIP_MDRange_c.cpp
       hip/TestHIP_MDRange_d.cpp
       hip/TestHIP_MDRange_e.cpp
+      hip/TestHIP_RangePolicy.cpp
+      hip/TestHIP_RangePolicyRequire.cpp
+      hip/TestHIP_Reducers_a.cpp
+      hip/TestHIP_Reducers_b.cpp
+      hip/TestHIP_Reducers_c.cpp
+      hip/TestHIP_Reducers_d.cpp
+      hip/TestHIP_Reductions.cpp
+      hip/TestHIP_Scan.cpp
+      hip/TestHIP_ScanUnit.cpp
       hip/TestHIP_Spaces.cpp
-      hip/TestHIPHostPinned_ViewCopy.cpp
+      hip/TestHIP_SubView_a.cpp
+      hip/TestHIP_SubView_b.cpp
+      hip/TestHIP_View_64bit.cpp
       hip/TestHIPHostPinned_ViewAPI_a.cpp
       hip/TestHIPHostPinned_ViewAPI_b.cpp
       hip/TestHIPHostPinned_ViewAPI_c.cpp
       hip/TestHIPHostPinned_ViewAPI_d.cpp
       hip/TestHIPHostPinned_ViewAPI_e.cpp
+      hip/TestHIPHostPinned_ViewCopy.cpp
       hip/TestHIPHostPinned_ViewMapping_a.cpp
       hip/TestHIPHostPinned_ViewMapping_b.cpp
       hip/TestHIPHostPinned_ViewMapping_subview.cpp
-      hip/TestHIP_AtomicOperations_int.cpp
-      hip/TestHIP_AtomicOperations_unsignedint.cpp
-      hip/TestHIP_AtomicOperations_longlongint.cpp
-      hip/TestHIP_DeepCopyAlignment.cpp
-      hip/TestHIP_SubView_a.cpp
-      hip/TestHIP_SubView_b.cpp
-      hip/TestHIP_View_64bit.cpp
-      hip/TestHIP_LocalDeepCopy.cpp
   )
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_HIP

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -260,6 +260,7 @@ endif()
 if(Kokkos_ENABLE_HIP)
   set(HIP_SOURCES
       UnitTestMainInit.cpp
+      #FIXME_HIP
       #hip/TestHIP_AtomicOperations_complexdouble.cpp
       hip/TestHIP_AtomicOperations_complexfloat.cpp
       hip/TestHIP_AtomicOperations_double.cpp

--- a/core/unit_test/TestAtomic.hpp
+++ b/core/unit_test/TestAtomic.hpp
@@ -538,7 +538,7 @@ TEST(TEST_CATEGORY, atomics) {
   ASSERT_TRUE(
       (TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 3)));
 
-  // HIP doesn't yet support atomics for >64bit types properly
+  // FIXME_HIP HIP doesn't yet support atomics for >64bit types properly
 #ifndef KOKKOS_ENABLE_HIP
   ASSERT_TRUE(
       (TestAtomic::Loop<Kokkos::complex<double>, TEST_EXECSPACE>(1, 1)));

--- a/core/unit_test/TestAtomic.hpp
+++ b/core/unit_test/TestAtomic.hpp
@@ -527,7 +527,19 @@ TEST(TEST_CATEGORY, atomics) {
   ASSERT_TRUE((TestAtomic::Loop<float, TEST_EXECSPACE>(100, 3)));
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
-#ifndef KOKKOS_ENABLE_ROCM  // ROCM doesn't yet support atomics for >64bit types
+  ASSERT_TRUE((TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 1)));
+  ASSERT_TRUE((TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 2)));
+  ASSERT_TRUE((TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 3)));
+
+  ASSERT_TRUE(
+      (TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 1)));
+  ASSERT_TRUE(
+      (TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 2)));
+  ASSERT_TRUE(
+      (TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 3)));
+
+  // HIP doesn't yet support atomics for >64bit types properly
+#ifndef KOKKOS_ENABLE_HIP
   ASSERT_TRUE(
       (TestAtomic::Loop<Kokkos::complex<double>, TEST_EXECSPACE>(1, 1)));
   ASSERT_TRUE(
@@ -541,17 +553,6 @@ TEST(TEST_CATEGORY, atomics) {
       (TestAtomic::Loop<Kokkos::complex<double>, TEST_EXECSPACE>(100, 2)));
   ASSERT_TRUE(
       (TestAtomic::Loop<Kokkos::complex<double>, TEST_EXECSPACE>(100, 3)));
-
-  ASSERT_TRUE((TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 1)));
-  ASSERT_TRUE((TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 2)));
-  ASSERT_TRUE((TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(1, 3)));
-
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 1)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 2)));
-  ASSERT_TRUE(
-      (TestAtomic::Loop<Kokkos::complex<float>, TEST_EXECSPACE>(100, 3)));
 
 // WORKAROUND MSVC
 #ifndef _WIN32

--- a/core/unit_test/hip/TestHIP_AtomicOperations_complexdouble.cpp
+++ b/core/unit_test/hip/TestHIP_AtomicOperations_complexdouble.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestAtomicOperations_complexdouble.hpp>

--- a/core/unit_test/hip/TestHIP_AtomicOperations_complexfloat.cpp
+++ b/core/unit_test/hip/TestHIP_AtomicOperations_complexfloat.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestAtomicOperations_complexfloat.hpp>

--- a/core/unit_test/hip/TestHIP_AtomicOperations_double.cpp
+++ b/core/unit_test/hip/TestHIP_AtomicOperations_double.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestAtomicOperations_double.hpp>

--- a/core/unit_test/hip/TestHIP_AtomicOperations_float.cpp
+++ b/core/unit_test/hip/TestHIP_AtomicOperations_float.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestAtomicOperations_float.hpp>

--- a/core/unit_test/hip/TestHIP_AtomicOperations_longint.cpp
+++ b/core/unit_test/hip/TestHIP_AtomicOperations_longint.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestAtomicOperations_longint.hpp>

--- a/core/unit_test/hip/TestHIP_AtomicOperations_unsignedlongint.cpp
+++ b/core/unit_test/hip/TestHIP_AtomicOperations_unsignedlongint.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestAtomicOperations_unsignedlongint.hpp>

--- a/core/unit_test/hip/TestHIP_AtomicViews.cpp
+++ b/core/unit_test/hip/TestHIP_AtomicViews.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestAtomicViews.hpp>

--- a/core/unit_test/hip/TestHIP_Atomics.cpp
+++ b/core/unit_test/hip/TestHIP_Atomics.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestAtomic.hpp>


### PR DESCRIPTION
This pull requests enables almost all of the atomic tests for HIP.
Only the >64bit overloads are not working, yet. In particular, `Impl::lock_address_hip_space` and `Impl::unlock_address_hip_space` need f4904ee but doesn't seem to be quite enough to make that work immediately.