### PR TITLE
Run HIP CI with -Werror

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -26,7 +26,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=hipcc \
-                                -DCMAKE_CXX_FLAGS=-Werror -Wno-unused-command-line-argument -Wno-braced-scalar-init \
+                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -Wno-braced-scalar-init" \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_HIP=ON \

--- a/.jenkins
+++ b/.jenkins
@@ -26,6 +26,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=hipcc \
+                                -DCMAKE_CXX_FLAGS=-Werror -Wno-unused-command-line-argument -Wno-braced-scalar-init \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_HIP=ON \

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -558,6 +558,8 @@ struct ReduceDuplicatesBase {
       Kokkos::Profiling::beginParallelFor(std::string("reduce_") + name, 0,
                                           &kpID);
     }
+#else
+    (void)name;
 #endif
     typedef RangePolicy<ExecSpace, size_t> policy_type;
     typedef Kokkos::Impl::ParallelFor<Derived, policy_type> closure_type;
@@ -607,6 +609,8 @@ struct ResetDuplicatesBase {
       Kokkos::Profiling::beginParallelFor(std::string("reduce_") + name, 0,
                                           &kpID);
     }
+#else
+    (void)name;
 #endif
     typedef RangePolicy<ExecSpace, size_t> policy_type;
     typedef Kokkos::Impl::ParallelFor<Derived, policy_type> closure_type;

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -171,6 +171,8 @@ inline void parallel_for(
         name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
         &kpID);
   }
+#else
+  (void)str;
 #endif
 
   Kokkos::Impl::shared_allocation_tracking_disable();
@@ -201,6 +203,8 @@ inline void parallel_for(const size_t work_count, const FunctorType& functor,
         name.get(),
         Kokkos::Profiling::Experimental::device_id(policy().space()), &kpID);
   }
+#else
+  (void)str;
 #endif
 
   Kokkos::Impl::shared_allocation_tracking_disable();
@@ -421,6 +425,8 @@ inline void parallel_scan(
         name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
         &kpID);
   }
+#else
+  (void)str;
 #endif
 
   Kokkos::Impl::shared_allocation_tracking_disable();
@@ -452,6 +458,8 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
         name.get(),
         Kokkos::Profiling::Experimental::device_id(policy().space()), &kpID);
   }
+#else
+  (void)str;
 #endif
 
   Kokkos::Impl::shared_allocation_tracking_disable();
@@ -502,6 +510,8 @@ inline void parallel_scan(
         name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
         &kpID);
   }
+#else
+  (void)str;
 #endif
 
   Kokkos::Impl::shared_allocation_tracking_disable();
@@ -536,6 +546,8 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
         name.get(),
         Kokkos::Profiling::Experimental::device_id(policy().space()), &kpID);
   }
+#else
+  (void)str;
 #endif
 
   Kokkos::Impl::shared_allocation_tracking_disable();

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -862,6 +862,8 @@ struct ParallelReduceAdaptor {
           name(label);
       Kokkos::Profiling::beginParallelReduce(name.get(), 0, &kpID);
     }
+#else
+    (void)label;
 #endif
 
     Kokkos::Impl::shared_allocation_tracking_disable();

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -641,10 +641,10 @@ struct SubviewExtents {
     error(buf + n, buf_len - n, domain_rank + 1, range_rank + 1, dim, args...);
   }
 
+#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
   template <size_t... DimArgs, class... Args>
   KOKKOS_FORCEINLINE_FUNCTION void error(const ViewDimension<DimArgs...>& dim,
                                          Args... args) const {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
     enum { LEN = 1024 };
     char buffer[LEN];
 
@@ -652,10 +652,14 @@ struct SubviewExtents {
     error(buffer + n, LEN - n, 0, 0, dim, args...);
 
     Kokkos::Impl::throw_runtime_exception(std::string(buffer));
-#else
-    Kokkos::abort("Kokkos::subview bounds error");
-#endif
   }
+#else
+  template <size_t... DimArgs, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION void error(const ViewDimension<DimArgs...>&,
+                                         Args...) const {
+    Kokkos::abort("Kokkos::subview bounds error");
+  }
+#endif
 
 #else
 


### PR DESCRIPTION
With `-Wno-unused-command-line-argument` and `-Wno-braced-scalar-init` we should be able to also check for warnings in the HIP CI tester.