### PR TITLE
Let type traits work with reference types

### DIFF
--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -146,6 +146,19 @@ struct LaunchBounds {
 
 namespace Kokkos {
 
+namespace Impl {
+
+template <class T>
+struct remove_cvref {
+  using type =
+      typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+};
+
+template <class T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+
+}  // namespace Impl
+
 #define KOKKOS_IMPL_IS_CONCEPT(CONCEPT)                                        \
   template <typename T>                                                        \
   struct is_##CONCEPT {                                                        \

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -348,7 +348,7 @@ struct is_space {
   typedef typename std::conditional<
       std::is_same<execution_space, host_execution_space>::value &&
           std::is_same<memory_space, host_memory_space>::value,
-      T, Kokkos::Device<host_execution_space, host_memory_space> >::type
+      T, Kokkos::Device<host_execution_space, host_memory_space>>::type
       host_mirror_space;
 };
 
@@ -474,7 +474,7 @@ struct SpaceAccessibility {
       std::is_same<typename AccessSpace::memory_space, MemorySpace>::value ||
           !exe_access::accessible,
       AccessSpace,
-      Kokkos::Device<typename AccessSpace::execution_space, MemorySpace> >::type
+      Kokkos::Device<typename AccessSpace::execution_space, MemorySpace>>::type
       space;
 };
 

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -166,19 +166,17 @@ using remove_cvref_t = typename remove_cvref<T>::type;
     template <typename, typename = std::true_type>                             \
     struct have : std::false_type {};                                          \
     template <typename U>                                                      \
-    struct have<U, typename std::is_base_of<                                   \
-                       typename std::remove_cv<typename U::CONCEPT>::type,     \
-                       typename std::remove_cv<U>::type>::type>                \
+    struct have<U, typename std::is_base_of<typename U::CONCEPT, U>::type>     \
         : std::true_type {};                                                   \
     template <typename U>                                                      \
     struct have<U,                                                             \
-                typename std::is_base_of<                                      \
-                    typename std::remove_cv<typename U::CONCEPT##_type>::type, \
-                    typename std::remove_cv<U>::type>::type>                   \
+                typename std::is_base_of<typename U::CONCEPT##_type, U>::type> \
         : std::true_type {};                                                   \
                                                                                \
    public:                                                                     \
-    enum { value = is_##CONCEPT::template have<T>::value };                    \
+    enum {                                                                     \
+      value = is_##CONCEPT::template have<Impl::remove_cvref_t<T>>::value      \
+    };                                                                         \
   };
 
 // Public concept:


### PR DESCRIPTION
Without this patch the assertions below are failing
```C++
using ExecustionSpace = Kokkos::Serial;
static_assert(Kokkos::is_execution_space<ExecutionSpace &>::value);
static_assert(Kokkos::is_execution_space<ExecutionSpace const &>::value);
```