### PR TITLE
Cleanup KOKKOS_IMPL_IS_CONCEPT() macro

### DIFF
--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -153,19 +153,18 @@ namespace Kokkos {
     template <typename, typename = std::true_type>                             \
     struct have : std::false_type {};                                          \
     template <typename U>                                                      \
-    struct have<U, typename std::is_base_of<                                   \
-                       typename std::remove_cv<typename U::CONCEPT>::type,     \
-                       typename std::remove_cv<U>::type>::type>                \
+    struct have<U, typename std::is_base_of<typename U::CONCEPT, U>::type>     \
         : std::true_type {};                                                   \
     template <typename U>                                                      \
     struct have<U,                                                             \
-                typename std::is_base_of<                                      \
-                    typename std::remove_cv<typename U::CONCEPT##_type>::type, \
-                    typename std::remove_cv<U>::type>::type>                   \
+                typename std::is_base_of<typename U::CONCEPT##_type, U>::type> \
         : std::true_type {};                                                   \
                                                                                \
    public:                                                                     \
-    enum { value = is_##CONCEPT::template have<T>::value };                    \
+    enum {                                                                     \
+      value =                                                                  \
+          is_##CONCEPT::template have<typename std::remove_cv<T>::type>::value \
+    };                                                                         \
   };
 
 // Public concept:

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -163,6 +163,7 @@ namespace Kokkos {
    public:                                                                     \
     static constexpr bool value =                                              \
         is_##CONCEPT::template have<typename std::remove_cv<T>::type>::value;  \
+    constexpr operator bool() const noexcept { return value; }                 \
   };
 
 // Public concept:

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -161,10 +161,8 @@ namespace Kokkos {
         : std::true_type {};                                                   \
                                                                                \
    public:                                                                     \
-    enum {                                                                     \
-      value =                                                                  \
-          is_##CONCEPT::template have<typename std::remove_cv<T>::type>::value \
-    };                                                                         \
+    static constexpr bool value =                                              \
+        is_##CONCEPT::template have<typename std::remove_cv<T>::type>::value;  \
   };
 
 // Public concept:


### PR DESCRIPTION
Per https://github.com/kokkos/kokkos/pull/2909#issuecomment-603989272

Also added implicit conversion to bool so we can write
```diff
-  static_assert(Kokkos::is_memory_space<MemorySpace>::value, "");
+  static_assert(Kokkos::is_memory_space<MemorySpace>{}, "");
```
(This is not something that I made up, it is how `std::integral_constant` works)