### PR TITLE
Enable containers tests for HIP

### DIFF
--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -70,10 +70,10 @@ struct ChunkArraySpace<Kokkos::CudaSpace> {
   using memory_space = typename Kokkos::CudaUVMSpace;
 };
 #endif
-#ifdef KOKKOS_ENABLE_ROCM
+#ifdef KOKKOS_ENABLE_HIP
 template <>
-struct ChunkArraySpace<Kokkos::Experimental::ROCmSpace> {
-  using memory_space = typename Kokkos::Experimental::ROCmHostPinnedSpace;
+struct ChunkArraySpace<Kokkos::Experimental::HIPSpace> {
+  using memory_space = typename Kokkos::Experimental::HIPHostPinnedSpace;
 };
 #endif
 }  // end namespace Impl

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -171,6 +171,23 @@ struct DefaultContribution<Kokkos::Cuda,
 };
 #endif
 
+#ifdef KOKKOS_ENABLE_HIP
+template <>
+struct DefaultDuplication<Kokkos::Experimental::HIP> {
+  enum : int { value = Kokkos::Experimental::ScatterNonDuplicated };
+};
+template <>
+struct DefaultContribution<Kokkos::Experimental::HIP,
+                           Kokkos::Experimental::ScatterNonDuplicated> {
+  enum : int { value = Kokkos::Experimental::ScatterAtomic };
+};
+template <>
+struct DefaultContribution<Kokkos::Experimental::HIP,
+                           Kokkos::Experimental::ScatterDuplicated> {
+  enum : int { value = Kokkos::Experimental::ScatterAtomic };
+};
+#endif
+
 /* ScatterValue <Op=ScatterSum, contribution=ScatterNonAtomic> is the object
    returned by the access operator() of ScatterAccess, This class inherits from
    the Sum<> reducer and it wraps join(dest, src) with convenient operator+=,

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -3,7 +3,7 @@ KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 KOKKOS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
 KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../src )
 
-foreach(Tag Threads;Serial;OpenMP;HPX;Cuda)
+foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP)
   # Because there is always an exception to the rule
   if(Tag STREQUAL "Threads")
     set(DEVICE "PTHREAD")

--- a/containers/unit_tests/TestBitset.hpp
+++ b/containers/unit_tests/TestBitset.hpp
@@ -253,8 +253,10 @@ void test_bitset() {
   }
 }
 
+// FIXME_HIP deadlock
+#ifndef KOKKOS_ENABLE_HIP
 TEST(TEST_CATEGORY, bitset) { test_bitset<TEST_EXECSPACE>(); }
-
+#endif
 }  // namespace Test
 
 #endif  // KOKKOS_TEST_BITSET_HPP

--- a/containers/unit_tests/TestDynViewAPI_generic.hpp
+++ b/containers/unit_tests/TestDynViewAPI_generic.hpp
@@ -44,7 +44,10 @@
 
 #include <TestDynViewAPI.hpp>
 namespace Test {
+// FIXME_HIP attempt to access inaccessible memory space
+#ifndef KOKKOS_ENABLE_HIP
 TEST(TEST_CATEGORY, dyn_rank_view_api_generic) {
   TestDynViewAPI<double, TEST_EXECSPACE>::run_tests();
 }
+#endif
 }  // namespace Test

--- a/containers/unit_tests/TestHIP_Category.hpp
+++ b/containers/unit_tests/TestHIP_Category.hpp
@@ -42,13 +42,10 @@
 //@HEADER
 */
 
-#include <TestDynViewAPI.hpp>
+#ifndef KOKKOS_TEST_HIP_HPP
+#define KOKKOS_TEST_HIP_HPP
 
-namespace Test {
-// FIXME_HIP failing with wrong value
-#ifndef KOKKOS_ENABLE_HIP
-TEST(TEST_CATEGORY, dyn_rank_view_api_operator_rank12345) {
-  TestDynViewAPI<double, TEST_EXECSPACE>::run_operator_test_rank12345();
-}
+#define TEST_CATEGORY hip
+#define TEST_EXECSPACE Kokkos::Experimental::HIP
+
 #endif
-}  // namespace Test

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -492,6 +492,8 @@ void test_scatter_view(int n) {
   TestDuplicatedScatterView<DeviceType, ScatterType> duptest(n);
 }
 
+// FIXME_HIP ScatterView requires UniqueToken
+#ifndef KOKKOS_ENABLE_HIP
 TEST(TEST_CATEGORY, scatterview) {
   test_scatter_view<TEST_EXECSPACE, Kokkos::Experimental::ScatterSum>(10);
   test_scatter_view<TEST_EXECSPACE, Kokkos::Experimental::ScatterProd>(10);
@@ -545,6 +547,7 @@ TEST(TEST_CATEGORY, scatterview_devicetype) {
   }
 #endif
 }
+#endif
 
 }  // namespace Test
 

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -295,6 +295,8 @@ void test_deep_copy(uint32_t num_nodes) {
   }
 }
 
+// FIXME_HIP deadlock
+#ifndef KOKKOS_ENABLE_HIP
 // WORKAROUND MSVC
 #ifndef _WIN32
 TEST(TEST_CATEGORY, UnorderedMap_insert) {
@@ -312,6 +314,7 @@ TEST(TEST_CATEGORY, UnorderedMap_failed_insert) {
 TEST(TEST_CATEGORY, UnorderedMap_deep_copy) {
   for (int i = 0; i < 2; ++i) test_deep_copy<TEST_EXECSPACE>(10000);
 }
+#endif
 
 TEST(TEST_CATEGORY, UnorderedMap_valid_empty) {
   using Key   = int;


### PR DESCRIPTION
It appears that most of the `containers` tests already work.
Should not be conflicting with #2919 too much.