### PR TITLE
[WIP] Fix bug in deep_copy() overload that take an execution space

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2858,6 +2858,18 @@ inline void deep_copy(
   dst_value_type* dst_end   = dst.data() + dst.span();
   src_value_type* src_start = src.data();
   src_value_type* src_end   = src.data() + src.span();
+  if (((std::ptrdiff_t)dst_start == (std::ptrdiff_t)src_start) &&
+      ((std::ptrdiff_t)dst_end == (std::ptrdiff_t)src_end) &&
+      (dst.span_is_contiguous() && src.span_is_contiguous())) {
+    Kokkos::fence();
+#if defined(KOKKOS_ENABLE_PROFILING)
+    if (Kokkos::Profiling::profileLibraryLoaded()) {
+      Kokkos::Profiling::endDeepCopy();
+    }
+#endif
+    return;
+  }
+
   if ((((std::ptrdiff_t)dst_start < (std::ptrdiff_t)src_end) &&
        ((std::ptrdiff_t)dst_end > (std::ptrdiff_t)src_start)) &&
       ((dst.span_is_contiguous() && src.span_is_contiguous()))) {

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -785,6 +785,9 @@ struct TestViewMirror {
 
     ASSERT_EQ(a_h.extent(0), a_h2.extent(0));
     ASSERT_EQ(a_h.extent(0), a_d.extent(0));
+
+    ASSERT_NO_THROW(
+        Kokkos::deep_copy(Kokkos::DefaultHostExecutionSpace{}, a_h, a_org));
   }
 
   template <class MemoryTraits>


### PR DESCRIPTION
Probably not the most appropriate place to add the test but that will get my point across