### PR TITLE
Fix some clang-10 warnings

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -751,7 +751,9 @@ class Random_XorShift64 {
   float frand() { return urand64() / static_cast<float>(MAX_URAND64); }
 
   KOKKOS_INLINE_FUNCTION
-  float frand(const float& range) { return range * urand64() / MAX_URAND64; }
+  float frand(const float& range) {
+    return range * urand64() / static_cast<float>(MAX_URAND64);
+  }
 
   KOKKOS_INLINE_FUNCTION
   float frand(const float& start, const float& end) {
@@ -762,7 +764,9 @@ class Random_XorShift64 {
   double drand() { return urand64() / static_cast<double>(MAX_URAND64); }
 
   KOKKOS_INLINE_FUNCTION
-  double drand(const double& range) { return range * urand64() / MAX_URAND64; }
+  double drand(const double& range) {
+    return range * urand64() / static_cast<double>(MAX_URAND64);
+  }
 
   KOKKOS_INLINE_FUNCTION
   double drand(const double& start, const double& end) {
@@ -988,7 +992,9 @@ class Random_XorShift1024 {
   float frand() { return urand64() / static_cast<float>(MAX_URAND64); }
 
   KOKKOS_INLINE_FUNCTION
-  float frand(const float& range) { return range * urand64() / MAX_URAND64; }
+  float frand(const float& range) {
+    return range * urand64() / static_cast<float>(MAX_URAND64);
+  }
 
   KOKKOS_INLINE_FUNCTION
   float frand(const float& start, const float& end) {
@@ -999,7 +1005,9 @@ class Random_XorShift1024 {
   double drand() { return urand64() / static_cast<double>(MAX_URAND64); }
 
   KOKKOS_INLINE_FUNCTION
-  double drand(const double& range) { return range * urand64() / MAX_URAND64; }
+  double drand(const double& range) {
+    return range * urand64() / static_cast<double>(MAX_URAND64);
+  }
 
   KOKKOS_INLINE_FUNCTION
   double drand(const double& start, const double& end) {


### PR DESCRIPTION
`clang` complained that the implicit conversion would change the value. We don't really care about that so just cast and silence the warning.