### PR TITLE
Replace atoi by std::stoi

### DIFF
--- a/benchmarks/atomic/main.cpp
+++ b/benchmarks/atomic/main.cpp
@@ -69,13 +69,13 @@ int main(int argc, char* argv[]) {
       return 0;
     }
 
-    int L    = atoi(argv[1]);
-    int N    = atoi(argv[2]);
-    int M    = atoi(argv[3]);
-    int D    = atoi(argv[4]);
-    int K    = atoi(argv[5]);
-    int R    = atoi(argv[6]);
-    int type = atoi(argv[7]);
+    int L    = std::stoi(argv[1]);
+    int N    = std::stoi(argv[2]);
+    int M    = std::stoi(argv[3]);
+    int D    = std::stoi(argv[4]);
+    int K    = std::stoi(argv[5]);
+    int R    = std::stoi(argv[6]);
+    int type = std::stoi(argv[7]);
 
     Kokkos::View<int*> offsets("Offsets", L, M);
     Kokkos::Random_XorShift64_Pool<> pool(12371);

--- a/benchmarks/bytes_and_flops/main.cpp
+++ b/benchmarks/bytes_and_flops/main.cpp
@@ -73,15 +73,15 @@ int main(int argc, char* argv[]) {
     return 0;
   }
 
-  int P = atoi(argv[1]);
-  int N = atoi(argv[2]);
-  int K = atoi(argv[3]);
-  int R = atoi(argv[4]);
-  int D = atoi(argv[5]);
-  int U = atoi(argv[6]);
-  int F = atoi(argv[7]);
-  int T = atoi(argv[8]);
-  int S = atoi(argv[9]);
+  int P = std::stoi(argv[1]);
+  int N = std::stoi(argv[2]);
+  int K = std::stoi(argv[3]);
+  int R = std::stoi(argv[4]);
+  int D = std::stoi(argv[5]);
+  int U = std::stoi(argv[6]);
+  int F = std::stoi(argv[7]);
+  int T = std::stoi(argv[8]);
+  int S = std::stoi(argv[9]);
 
   if (U > 8) {
     printf("U must be 1-8\n");

--- a/benchmarks/gather/main.cpp
+++ b/benchmarks/gather/main.cpp
@@ -72,13 +72,13 @@ int main(int argc, char* argv[]) {
     return 0;
   }
 
-  int S = atoi(argv[1]);
-  int N = atoi(argv[2]);
-  int K = atoi(argv[3]);
-  int D = atoi(argv[4]);
-  int R = atoi(argv[5]);
-  int U = atoi(argv[6]);
-  int F = atoi(argv[7]);
+  int S = std::stoi(argv[1]);
+  int N = std::stoi(argv[2]);
+  int K = std::stoi(argv[3]);
+  int D = std::stoi(argv[4]);
+  int R = std::stoi(argv[5]);
+  int U = std::stoi(argv[6]);
+  int F = std::stoi(argv[7]);
 
   if ((S != 1) && (S != 2) && (S != 4)) {
     printf("S must be one of 1,2,4\n");

--- a/benchmarks/policy_performance/main.cpp
+++ b/benchmarks/policy_performance/main.cpp
@@ -94,22 +94,22 @@ int main(int argc, char* argv[]) {
     return 0;
   }
 
-  int team_range   = atoi(argv[1]);
-  int thread_range = atoi(argv[2]);
-  int vector_range = atoi(argv[3]);
+  int team_range   = std::stoi(argv[1]);
+  int thread_range = std::stoi(argv[2]);
+  int vector_range = std::stoi(argv[3]);
 
-  int outer_repeat  = atoi(argv[4]);
-  int thread_repeat = atoi(argv[5]);
-  int vector_repeat = atoi(argv[6]);
+  int outer_repeat  = std::stoi(argv[4]);
+  int thread_repeat = std::stoi(argv[5]);
+  int vector_repeat = std::stoi(argv[6]);
 
-  int team_size   = atoi(argv[7]);
-  int vector_size = atoi(argv[8]);
-  int schedule    = atoi(argv[9]);
-  int test_type   = atoi(argv[10]);
+  int team_size   = std::stoi(argv[7]);
+  int vector_size = std::stoi(argv[8]);
+  int schedule    = std::stoi(argv[9]);
+  int test_type   = std::stoi(argv[10]);
 
   int disable_verbose_output = 0;
   if (argc > 11) {
-    disable_verbose_output = atoi(argv[11]);
+    disable_verbose_output = std::stoi(argv[11]);
   }
 
   if (schedule != 1 && schedule != 2) {

--- a/core/perf_test/PerfTestGramSchmidt.cpp
+++ b/core/perf_test/PerfTestGramSchmidt.cpp
@@ -243,9 +243,9 @@ TEST(default_exec, gramschmidt) {
   int exp_end    = 20;
   int num_trials = 5;
 
-  if (command_line_num_args() > 1) exp_beg = atoi(command_line_arg(1));
-  if (command_line_num_args() > 2) exp_end = atoi(command_line_arg(2));
-  if (command_line_num_args() > 3) num_trials = atoi(command_line_arg(3));
+  if (command_line_num_args() > 1) exp_beg = std::stoi(command_line_arg(1));
+  if (command_line_num_args() > 2) exp_end = std::stoi(command_line_arg(2));
+  if (command_line_num_args() > 3) num_trials = std::stoi(command_line_arg(3));
 
   EXPECT_NO_THROW(run_test_gramschmidt<Kokkos::DefaultExecutionSpace>(
       exp_beg, exp_end, num_trials, Kokkos::DefaultExecutionSpace::name()));

--- a/core/perf_test/PerfTestHexGrad.cpp
+++ b/core/perf_test/PerfTestHexGrad.cpp
@@ -289,9 +289,9 @@ TEST(default_exec, hexgrad) {
   int exp_end    = 20;
   int num_trials = 5;
 
-  if (command_line_num_args() > 1) exp_beg = atoi(command_line_arg(1));
-  if (command_line_num_args() > 2) exp_end = atoi(command_line_arg(2));
-  if (command_line_num_args() > 3) num_trials = atoi(command_line_arg(3));
+  if (command_line_num_args() > 1) exp_beg = std::stoi(command_line_arg(1));
+  if (command_line_num_args() > 2) exp_end = std::stoi(command_line_arg(2));
+  if (command_line_num_args() > 3) num_trials = std::stoi(command_line_arg(3));
 
   EXPECT_NO_THROW(run_test_hexgrad<Kokkos::DefaultExecutionSpace>(
       exp_beg, exp_end, num_trials, Kokkos::DefaultExecutionSpace::name()));

--- a/core/perf_test/PerfTest_CustomReduction.cpp
+++ b/core/perf_test/PerfTest_CustomReduction.cpp
@@ -129,9 +129,9 @@ TEST(default_exec, custom_reduction) {
   int R          = 1000;
   int num_trials = 1;
 
-  if (command_line_num_args() > 1) N = atoi(command_line_arg(1));
-  if (command_line_num_args() > 2) R = atoi(command_line_arg(2));
-  if (command_line_num_args() > 3) num_trials = atoi(command_line_arg(3));
+  if (command_line_num_args() > 1) N = std::stoi(command_line_arg(1));
+  if (command_line_num_args() > 2) R = std::stoi(command_line_arg(2));
+  if (command_line_num_args() > 3) num_trials = std::stoi(command_line_arg(3));
   custom_reduction_test<double>(N, R, num_trials);
 }
 }  // namespace Test

--- a/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
+++ b/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
@@ -29,7 +29,7 @@ struct SpaceInstance<Kokkos::Cuda> {
     bool value          = true;
     auto local_rank_str = std::getenv("CUDA_LAUNCH_BLOCKING");
     if (local_rank_str) {
-      value = (std::atoi(local_rank_str) == 0);
+      value = (std::stoi(local_rank_str) == 0);
     }
     return value;
   }

--- a/core/perf_test/test_atomic.cpp
+++ b/core/perf_test/test_atomic.cpp
@@ -448,15 +448,15 @@ int main(int argc, char* argv[]) {
 
   for (int i = 0; i < argc; i++) {
     if ((strcmp(argv[i], "--test") == 0)) {
-      test = atoi(argv[++i]);
+      test = std::stoi(argv[++i]);
       continue;
     }
     if ((strcmp(argv[i], "--type") == 0)) {
-      type = atoi(argv[++i]);
+      type = std::stoi(argv[++i]);
       continue;
     }
     if ((strcmp(argv[i], "-l") == 0) || (strcmp(argv[i], "--loop") == 0)) {
-      loop = atoi(argv[++i]);
+      loop = std::stoi(argv[++i]);
       continue;
     }
   }

--- a/core/perf_test/test_mempool.cpp
+++ b/core/perf_test/test_mempool.cpp
@@ -203,22 +203,22 @@ int main(int argc, char* argv[]) {
       total_alloc_size = atol(a + strlen(alloc_size_flag));
 
     if (!strncmp(a, super_size_flag, strlen(super_size_flag)))
-      min_superblock_size = atoi(a + strlen(super_size_flag));
+      min_superblock_size = std::stoi(a + strlen(super_size_flag));
 
     if (!strncmp(a, fill_stride_flag, strlen(fill_stride_flag)))
-      fill_stride = atoi(a + strlen(fill_stride_flag));
+      fill_stride = std::stoi(a + strlen(fill_stride_flag));
 
     if (!strncmp(a, fill_level_flag, strlen(fill_level_flag)))
-      fill_level = atoi(a + strlen(fill_level_flag));
+      fill_level = std::stoi(a + strlen(fill_level_flag));
 
     if (!strncmp(a, chunk_span_flag, strlen(chunk_span_flag)))
-      chunk_span = atoi(a + strlen(chunk_span_flag));
+      chunk_span = std::stoi(a + strlen(chunk_span_flag));
 
     if (!strncmp(a, repeat_outer_flag, strlen(repeat_outer_flag)))
-      repeat_outer = atoi(a + strlen(repeat_outer_flag));
+      repeat_outer = std::stoi(a + strlen(repeat_outer_flag));
 
     if (!strncmp(a, repeat_inner_flag, strlen(repeat_inner_flag)))
-      repeat_inner = atoi(a + strlen(repeat_inner_flag));
+      repeat_inner = std::stoi(a + strlen(repeat_inner_flag));
   }
 
   int chunk_span_bytes = 0;

--- a/core/perf_test/test_taskdag.cpp
+++ b/core/perf_test/test_taskdag.cpp
@@ -152,13 +152,13 @@ int main(int argc, char* argv[]) {
       total_alloc_size = atol(a + strlen(alloc_size));
 
     if (!strncmp(a, super_size, strlen(super_size)))
-      min_superblock_size = atoi(a + strlen(super_size));
+      min_superblock_size = std::stoi(a + strlen(super_size));
 
     if (!strncmp(a, repeat_outer, strlen(repeat_outer)))
-      test_repeat_outer = atoi(a + strlen(repeat_outer));
+      test_repeat_outer = std::stoi(a + strlen(repeat_outer));
 
     if (!strncmp(a, input_value, strlen(input_value)))
-      fib_input = atoi(a + strlen(input_value));
+      fib_input = std::stoi(a + strlen(input_value));
   }
 
   const long fib_output   = eval_fib(fib_input);

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -134,7 +134,7 @@ bool cuda_launch_blocking() {
 
   if (env == 0) return false;
 
-  return atoi(env);
+  return std::stoi(env);
 }
 #endif
 
@@ -510,7 +510,7 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream) {
   if (env_force_device_alloc == 0)
     force_device_alloc = false;
   else
-    force_device_alloc = atoi(env_force_device_alloc) != 0;
+    force_device_alloc = std::stoi(env_force_device_alloc) != 0;
 
   const char *env_visible_devices = getenv("CUDA_VISIBLE_DEVICES");
   bool visible_devices_one        = true;

--- a/core/src/ROCm/Kokkos_ROCm_Impl.cpp
+++ b/core/src/ROCm/Kokkos_ROCm_Impl.cpp
@@ -101,7 +101,7 @@ bool rocm_launch_blocking()
 
   if (env == 0) return false;
 
-  return atoi(env);
+  return std::stoi(env);
 }
 
 }

--- a/core/src/impl/Kokkos_CPUDiscovery.cpp
+++ b/core/src/impl/Kokkos_CPUDiscovery.cpp
@@ -52,6 +52,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
+#include <string>
 
 namespace Kokkos {
 namespace Impl {
@@ -73,15 +74,15 @@ int mpi_ranks_per_node() {
   char *str;
   int ppn = 1;
   // if ((str = getenv("SLURM_TASKS_PER_NODE"))) {
-  //  ppn = atoi(str);
+  //  ppn = std::stoi(str);
   //  if(ppn<=0) ppn = 1;
   //}
   if ((str = getenv("MV2_COMM_WORLD_LOCAL_SIZE"))) {
-    ppn = atoi(str);
+    ppn = std::stoi(str);
     if (ppn <= 0) ppn = 1;
   }
   if ((str = getenv("OMPI_COMM_WORLD_LOCAL_SIZE"))) {
-    ppn = atoi(str);
+    ppn = std::stoi(str);
     if (ppn <= 0) ppn = 1;
   }
   return ppn;
@@ -91,13 +92,13 @@ int mpi_local_rank_on_node() {
   char *str;
   int local_rank = 0;
   // if ((str = getenv("SLURM_LOCALID"))) {
-  //  local_rank = atoi(str);
+  //  local_rank = std::stoi(str);
   //}
   if ((str = getenv("MV2_COMM_WORLD_LOCAL_RANK"))) {
-    local_rank = atoi(str);
+    local_rank = std::stoi(str);
   }
   if ((str = getenv("OMPI_COMM_WORLD_LOCAL_RANK"))) {
-    local_rank = atoi(str);
+    local_rank = std::stoi(str);
   }
   return local_rank;
 }

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -91,8 +91,8 @@ int get_ctest_gpu(const char* local_rank_str) {
   }
 
   // Make sure rank is within bounds of resource groups specified by CTest
-  auto resource_group_count = std::atoi(ctest_resource_group_count_str);
-  auto local_rank           = std::atoi(local_rank_str);
+  auto resource_group_count = std::stoi(ctest_resource_group_count_str);
+  auto local_rank           = std::stoi(local_rank_str);
   if (local_rank >= resource_group_count) {
     std::ostringstream ss;
     ss << "Error: local rank " << local_rank
@@ -163,7 +163,7 @@ int get_ctest_gpu(const char* local_rank_str) {
   }
 
   std::string id(resource_str + 3, comma - resource_str - 3);
-  return std::atoi(id.c_str());
+  return std::stoi(id.c_str());
 }
 
 namespace {
@@ -220,7 +220,7 @@ void initialize_backends(const InitArguments& args) {
     } else if (ndevices >= 0) {
       // Use the device assigned by the rank
       if (local_rank_str) {
-        auto local_rank = std::atoi(local_rank_str);
+        auto local_rank = std::stoi(local_rank_str);
         use_gpu         = local_rank % ndevices;
       } else {
         // user only gave use ndevices, but the MPI environment variable wasn't
@@ -577,7 +577,7 @@ bool check_int_arg(char const* arg, char const* expected, int* value) {
   if (arg_len == exp_len || arg[exp_len] != '=') okay = false;
   char const* number = arg + exp_len + 1;
   if (!Impl::is_unsigned_int(number) || strlen(number) == 0) okay = false;
-  *value = std::atoi(number);
+  *value = std::stoi(number);
   if (!okay) {
     std::ostringstream ss;
     ss << "Error: expecting an '=INT' after command line argument '" << expected
@@ -694,7 +694,7 @@ void parse_command_line_arguments(int& narg, char* arg[],
       }
       if (check_arg(arg[iarg], "--kokkos-num-devices") ||
           check_arg(arg[iarg], "--kokkos-ndevices") || !kokkos_ndevices_found)
-        ndevices = atoi(num1_only);
+        ndevices = std::stoi(num1_only);
       delete[] num1_only;
 
       if (num2 != nullptr) {
@@ -706,7 +706,7 @@ void parse_command_line_arguments(int& narg, char* arg[],
 
         if (check_arg(arg[iarg], "--kokkos-num-devices") ||
             check_arg(arg[iarg], "--kokkos-ndevices") || !kokkos_ndevices_found)
-          skip_device = atoi(num2 + 1);
+          skip_device = std::stoi(num2 + 1);
       }
 
       // Remove the --kokkos-num-devices argument from the list but leave

--- a/example/make_buildlink/main.cpp
+++ b/example/make_buildlink/main.cpp
@@ -3,9 +3,9 @@
 int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);
   {
-    int N = (argc > 1) ? atoi(argv[1]) : 10000;
-    int M = (argc > 2) ? atoi(argv[2]) : 10000;
-    int R = (argc > 3) ? atoi(argv[3]) : 10;
+    int N = (argc > 1) ? std::stoi(argv[1]) : 10000;
+    int M = (argc > 2) ? std::stoi(argv[2]) : 10000;
+    int R = (argc > 3) ? std::stoi(argv[3]) : 10;
 
     printf("Called with: %i %i %i\n", N, M, R);
   }

--- a/example/tutorial/Advanced_Views/07_Overlapping_DeepCopy/overlapping_deepcopy.cpp
+++ b/example/tutorial/Advanced_Views/07_Overlapping_DeepCopy/overlapping_deepcopy.cpp
@@ -106,7 +106,7 @@ struct MergeDevice {
 int main(int argc, char* argv[]) {
   int size = 100000000;
   Kokkos::initialize();
-  int synch = atoi(argv[1]);
+  int synch = std::stoi(argv[1]);
   Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::CudaSpace> d_a("Device A",
                                                                    size);
   Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::CudaSpace> d_b("Device B",

--- a/example/tutorial/Algorithms/01_random_numbers/random_numbers.cpp
+++ b/example/tutorial/Algorithms/01_random_numbers/random_numbers.cpp
@@ -108,8 +108,8 @@ int main(int argc, char* args[]) {
   } else {
     // Initialize Kokkos
     Kokkos::initialize(argc, args);
-    int size    = atoi(args[1]);
-    int samples = atoi(args[2]);
+    int size    = std::stoi(args[1]);
+    int samples = std::stoi(args[2]);
 
     // Create two random number generator pools one for 64bit states and one for
     // 1024 bit states Both take an 64 bit unsigned integer seed to initialize a


### PR DESCRIPTION
AFAICT, we really don't rely on `atoi` to return 0 for invalid input.