### PR TITLE
Add UVM Prefetching to View Initialization and DualView

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -915,13 +915,12 @@ void *cuda_resize_scratch_space(std::int64_t bytes, bool force_shrink) {
   return ptr;
 }
 
-void cuda_prefetch_pointer(const Cuda &space, void *const ptr, size_t bytes,
+void cuda_prefetch_pointer(const Cuda &space, const void *ptr, size_t bytes,
                            bool to_device) {
   cudaPointerAttributes attr;
   cudaPointerGetAttributes(&attr, ptr);
-  int direction = to_device ? space.cuda_device() : cudaCpuDeviceId;
-
-  if (attr.isManaged && space.cuda_device_prop().concurrentManagedAccess) {
+  if (to_device && (attr.type == cudaMemoryTypeManaged) &&
+      space.cuda_device_prop().concurrentManagedAccess) {
     cudaMemPrefetchAsync(ptr, bytes, space.cuda_device(), space.cuda_stream());
   }
 }

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -919,7 +919,11 @@ void cuda_prefetch_pointer(const Cuda &space, const void *ptr, size_t bytes,
                            bool to_device) {
   cudaPointerAttributes attr;
   cudaPointerGetAttributes(&attr, ptr);
+#if CUDA_VERSION < 10000
+  if (to_device && attr.isManaged &&
+#else
   if (to_device && (attr.type == cudaMemoryTypeManaged) &&
+#endif
       space.cuda_device_prop().concurrentManagedAccess) {
     cudaMemPrefetchAsync(ptr, bytes, space.cuda_device(), space.cuda_stream());
   }

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -919,6 +919,10 @@ void cuda_prefetch_pointer(const Cuda &space, const void *ptr, size_t bytes,
                            bool to_device) {
   cudaPointerAttributes attr;
   cudaPointerGetAttributes(&attr, ptr);
+  // I measured this and it turns out prefetching towards the host slows
+  // DualView syncs down. Probably because the latency is not too bad in the
+  // first place for the pull down. If we want to change that provde
+  // cudaCpuDeviceId as the device if to_device is false
 #if CUDA_VERSION < 10000
   if (to_device && attr.isManaged &&
 #else

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -915,6 +915,17 @@ void *cuda_resize_scratch_space(std::int64_t bytes, bool force_shrink) {
   return ptr;
 }
 
+void cuda_prefetch_pointer(const Cuda &space, void *const ptr, size_t bytes,
+                           bool to_device) {
+  cudaPointerAttributes attr;
+  cudaPointerGetAttributes(&attr, ptr);
+  int direction = to_device ? space.cuda_device() : cudaCpuDeviceId;
+
+  if (attr.isManaged && space.cuda_device_prop().concurrentManagedAccess) {
+    cudaMemPrefetchAsync(ptr, bytes, space.cuda_device(), space.cuda_stream());
+  }
+}
+
 }  // namespace Impl
 }  // namespace Kokkos
 #else

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -346,7 +346,8 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream) {
   if (ok_init && ok_dev) {
     const struct cudaDeviceProp &cudaProp = dev_info.m_cudaProp[cuda_device_id];
 
-    m_cudaDev = cuda_device_id;
+    m_cudaDev    = cuda_device_id;
+    m_deviceProp = cudaProp;
 
     CUDA_SAFE_CALL(cudaSetDevice(m_cudaDev));
     Kokkos::Impl::cuda_device_synchronize();
@@ -839,6 +840,9 @@ const char *Cuda::name() { return "Cuda"; }
 
 cudaStream_t Cuda::cuda_stream() const { return m_space_instance->m_stream; }
 int Cuda::cuda_device() const { return m_space_instance->m_cudaDev; }
+cudaDeviceProp &Cuda::cuda_device_prop() const {
+  return m_space_instance->m_deviceProp;
+}
 
 }  // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -840,7 +840,7 @@ const char *Cuda::name() { return "Cuda"; }
 
 cudaStream_t Cuda::cuda_stream() const { return m_space_instance->m_stream; }
 int Cuda::cuda_device() const { return m_space_instance->m_cudaDev; }
-cudaDeviceProp &Cuda::cuda_device_prop() const {
+const cudaDeviceProp &Cuda::cuda_device_prop() const {
   return m_space_instance->m_deviceProp;
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -97,6 +97,8 @@ class CudaInternal {
   int m_maxThreadsPerSM;
   int m_maxThreadsPerBlock;
 
+  cudaDeviceProp m_deviceProp;
+
   mutable size_type m_scratchSpaceCount;
   mutable size_type m_scratchFlagsCount;
   mutable size_type m_scratchUnifiedCount;

--- a/core/src/Cuda/Kokkos_Cuda_fwd.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_fwd.hpp
@@ -55,10 +55,10 @@ class Cuda;                 ///< Execution space for Cuda GPU
 namespace Impl {
 
 template <class ExecSpace>
-void cuda_prefetch_pointer(const ExecSpace& /*space*/, void* const /*ptr*/,
+void cuda_prefetch_pointer(const ExecSpace& /*space*/, const void* /*ptr*/,
                            size_t /*bytes*/, bool /*to_device*/) {}
 
-void cuda_prefetch_pointer(const Cuda& space, void* const ptr, size_t bytes,
+void cuda_prefetch_pointer(const Cuda& space, const void* ptr, size_t bytes,
                            bool to_device);
 
 }  // namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda_fwd.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_fwd.hpp
@@ -1,0 +1,67 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_CUDA_FWD_HPP_
+#define KOKKOS_CUDA_FWD_HPP_
+#if defined(KOKKOS_ENABLE_CUDA)
+namespace Kokkos {
+
+class CudaSpace;            ///< Memory space on Cuda GPU
+class CudaUVMSpace;         ///< Memory space on Cuda GPU with UVM
+class CudaHostPinnedSpace;  ///< Memory space on Host accessible to Cuda GPU
+class Cuda;                 ///< Execution space for Cuda GPU
+
+namespace Impl {
+
+template <class ExecSpace>
+void cuda_prefetch_pointer(const ExecSpace& /*space*/, void* const /*ptr*/,
+                           size_t /*bytes*/, bool /*to_device*/) {}
+
+void cuda_prefetch_pointer(const Cuda& space, void* const ptr, size_t bytes,
+                           bool to_device);
+
+}  // namespace Impl
+}  // namespace Kokkos
+#endif
+#endif

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -120,13 +120,6 @@ class OpenMPTargetSpace;
 }  // namespace Experimental
 #endif
 
-#if defined(KOKKOS_ENABLE_CUDA)
-class CudaSpace;            ///< Memory space on Cuda GPU
-class CudaUVMSpace;         ///< Memory space on Cuda GPU with UVM
-class CudaHostPinnedSpace;  ///< Memory space on Host accessible to Cuda GPU
-class Cuda;                 ///< Execution space for Cuda GPU
-#endif
-
 #if defined(KOKKOS_ENABLE_ROCM)
 namespace Experimental {
 class ROCmSpace;  ///< Memory space on ROCm GPU
@@ -145,6 +138,8 @@ template <class ExecutionSpace, class MemorySpace>
 struct Device;
 
 }  // namespace Kokkos
+
+#include "Cuda/Kokkos_Cuda_fwd.hpp"
 
 //----------------------------------------------------------------------------
 // Set the default execution space.

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -257,6 +257,7 @@ class Cuda {
 
   cudaStream_t cuda_stream() const;
   int cuda_device() const;
+  cudaDeviceProp& cuda_device_prop() const;
 
   //@}
   //--------------------------------------------------------------------------

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -257,7 +257,7 @@ class Cuda {
 
   cudaStream_t cuda_stream() const;
   int cuda_device() const;
-  cudaDeviceProp& cuda_device_prop() const;
+  const cudaDeviceProp& cuda_device_prop() const;
 
   //@}
   //--------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2783,6 +2783,12 @@ struct ViewValueFunctor<ExecSpace, ValueType, false /* is_scalar */> {
             0, &kpID);
       }
 #endif
+#ifdef KOKKOS_ENABLE_CUDA
+      if (std::is_same<ExecSpace, Kokkos::Cuda>::value) {
+        Kokkos::Impl::cuda_prefetch_pointer(space, ptr, sizeof(ValueType) * n,
+                                            true);
+      }
+#endif
       const Kokkos::Impl::ParallelFor<ViewValueFunctor, PolicyType> closure(
           *this, PolicyType(0, n));
       closure.execute();
@@ -2828,6 +2834,12 @@ struct ViewValueFunctor<ExecSpace, ValueType, true /* is_scalar */> {
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::beginParallelFor("Kokkos::View::initialization", 0,
                                             &kpID);
+      }
+#endif
+#ifdef KOKKOS_ENABLE_CUDA
+      if (std::is_same<ExecSpace, Kokkos::Cuda>::value) {
+        Kokkos::Impl::cuda_prefetch_pointer(space, ptr, sizeof(ValueType) * n,
+                                            true);
       }
 #endif
       const Kokkos::Impl::ParallelFor<ViewValueFunctor, PolicyType> closure(


### PR DESCRIPTION
This add prefetching to initialization and dual view synching for UVM ptrs. This make `Kokkos::View<double*> a("A",10000000)` go from 12ms down to 1.6ms and a sync_device() followed by touching every element for DualView go from 25ms to 7ms. 