### PR TITLE
Work around some XL issues in CUDA/OpenMP build

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -349,13 +349,13 @@ class BinSort {
 
  public:
   KOKKOS_INLINE_FUNCTION
-  void operator()(const bin_count_tag& /*tag*/, const int& i) const {
+  void operator()(const bin_count_tag& /*tag*/, const int i) const {
     const int j = range_begin + i;
     bin_count_atomic(bin_op.bin(keys, j))++;
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const bin_offset_tag& /*tag*/, const int& i,
+  void operator()(const bin_offset_tag& /*tag*/, const int i,
                   value_type& offset, const bool& final) const {
     if (final) {
       bin_offsets(i) = offset;
@@ -364,7 +364,7 @@ class BinSort {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const bin_binning_tag& /*tag*/, const int& i) const {
+  void operator()(const bin_binning_tag& /*tag*/, const int i) const {
     const int j     = range_begin + i;
     const int bin   = bin_op.bin(keys, j);
     const int count = bin_count_atomic(bin)++;
@@ -373,7 +373,7 @@ class BinSort {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const bin_sort_bins_tag& /*tag*/, const int& i) const {
+  void operator()(const bin_sort_bins_tag& /*tag*/, const int i) const {
     auto bin_size = bin_count_const(i);
     if (bin_size <= 1) return;
     int upper_bound = bin_offsets(i) + bin_size;
@@ -381,7 +381,7 @@ class BinSort {
     while (!sorted) {
       sorted      = true;
       int old_idx = sort_order(bin_offsets(i));
-      int new_idx;
+      int new_idx = 0;
       for (int k = bin_offsets(i) + 1; k < upper_bound; k++) {
         new_idx = sort_order(k);
 

--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -33,15 +33,19 @@ SET(SOURCES
   UnitTestMain.cpp
 )
 
-IF(Kokkos_ENABLE_CUDA)
-  LIST( APPEND SOURCES
-    TestCuda.cpp
-  )
-ENDIF()
-
 IF(Kokkos_ENABLE_OPENMP)
   LIST( APPEND SOURCES
     TestOpenMP.cpp
+    TestOpenMP_Sort1D.cpp
+    TestOpenMP_Sort3D.cpp
+    TestOpenMP_SortDynamicView.cpp
+    TestOpenMP_Random.cpp
+  )
+ENDIF()
+
+IF(Kokkos_ENABLE_CUDA)
+  LIST( APPEND SOURCES
+    TestCuda.cpp
   )
 ENDIF()
 

--- a/algorithms/unit_tests/Makefile
+++ b/algorithms/unit_tests/Makefile
@@ -44,7 +44,7 @@ ifeq ($(KOKKOS_INTERNAL_USE_PTHREADS), 1)
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)
-	OBJ_OPENMP = TestOpenMP.o UnitTestMain.o gtest-all.o
+	OBJ_OPENMP = TestOpenMP.o TestOpenMP_Random.o TestOpenMP_Sort1D.o TestOpenMP_Sort3D.o TestOpenMP_SortDynamicView.o UnitTestMain.o gtest-all.o
 	TARGETS += KokkosAlgorithms_UnitTest_OpenMP
 	TEST_TARGETS += test-openmp
 endif

--- a/algorithms/unit_tests/TestOpenMP_Random.cpp
+++ b/algorithms/unit_tests/TestOpenMP_Random.cpp
@@ -50,13 +50,27 @@
 
 //----------------------------------------------------------------------------
 #include <TestRandom.hpp>
-#include <TestSort.hpp>
 #include <iomanip>
 
 namespace Test {
 
-TEST(openmp, SortIssue1160) { Impl::test_issue_1160_sort<Kokkos::OpenMP>(); }
+#define OPENMP_RANDOM_XORSHIFT64(num_draws)                             \
+  TEST(openmp, Random_XorShift64) {                                     \
+    Impl::test_random<Kokkos::Random_XorShift64_Pool<Kokkos::OpenMP> >( \
+        num_draws);                                                     \
+  }
 
+#define OPENMP_RANDOM_XORSHIFT1024(num_draws)                             \
+  TEST(openmp, Random_XorShift1024) {                                     \
+    Impl::test_random<Kokkos::Random_XorShift1024_Pool<Kokkos::OpenMP> >( \
+        num_draws);                                                       \
+  }
+
+OPENMP_RANDOM_XORSHIFT64(10240000)
+OPENMP_RANDOM_XORSHIFT1024(10130144)
+
+#undef OPENMP_RANDOM_XORSHIFT64
+#undef OPENMP_RANDOM_XORSHIFT1024
 }  // namespace Test
 #else
 void KOKKOS_ALGORITHMS_UNITTESTS_TESTOPENMP_PREVENT_LINK_ERROR() {}

--- a/algorithms/unit_tests/TestOpenMP_Sort1D.cpp
+++ b/algorithms/unit_tests/TestOpenMP_Sort1D.cpp
@@ -55,7 +55,9 @@
 
 namespace Test {
 
-TEST(openmp, SortIssue1160) { Impl::test_issue_1160_sort<Kokkos::OpenMP>(); }
+TEST(openmp, SortUnsigned1D) {
+  Impl::test_1D_sort<Kokkos::OpenMP, unsigned>(171);
+}
 
 }  // namespace Test
 #else

--- a/algorithms/unit_tests/TestOpenMP_Sort3D.cpp
+++ b/algorithms/unit_tests/TestOpenMP_Sort3D.cpp
@@ -55,7 +55,9 @@
 
 namespace Test {
 
-TEST(openmp, SortIssue1160) { Impl::test_issue_1160_sort<Kokkos::OpenMP>(); }
+TEST(openmp, SortUnsigned3D) {
+  Impl::test_3D_sort<Kokkos::OpenMP, unsigned>(171);
+}
 
 }  // namespace Test
 #else

--- a/algorithms/unit_tests/TestOpenMP_SortDynamicView.cpp
+++ b/algorithms/unit_tests/TestOpenMP_SortDynamicView.cpp
@@ -55,7 +55,9 @@
 
 namespace Test {
 
-TEST(openmp, SortIssue1160) { Impl::test_issue_1160_sort<Kokkos::OpenMP>(); }
+TEST(openmp, SortUnsignedDynamicView) {
+  Impl::test_dynamic_view_sort<Kokkos::OpenMP, unsigned>(171);
+}
 
 }  // namespace Test
 #else

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -130,7 +130,7 @@ struct sum3D {
 };
 
 template <class ExecutionSpace, typename KeyType>
-void test_1D_sort(unsigned int n, bool force_kokkos) {
+void test_1D_sort_impl(unsigned int n, bool force_kokkos) {
   typedef Kokkos::View<KeyType*, ExecutionSpace> KeyViewType;
   KeyViewType keys("Keys", n);
 
@@ -165,7 +165,7 @@ void test_1D_sort(unsigned int n, bool force_kokkos) {
 }
 
 template <class ExecutionSpace, typename KeyType>
-void test_3D_sort(unsigned int n) {
+void test_3D_sort_impl(unsigned int n) {
   typedef Kokkos::View<KeyType * [3], ExecutionSpace> KeyViewType;
 
   KeyViewType keys("Keys", n * n * n);
@@ -214,7 +214,7 @@ void test_3D_sort(unsigned int n) {
 //----------------------------------------------------------------------------
 
 template <class ExecutionSpace, typename KeyType>
-void test_dynamic_view_sort(unsigned int n) {
+void test_dynamic_view_sort_impl(unsigned int n) {
   typedef Kokkos::Experimental::DynamicView<KeyType*, ExecutionSpace>
       KeyDynamicViewType;
   typedef Kokkos::View<KeyType*, ExecutionSpace> KeyViewType;
@@ -278,7 +278,7 @@ void test_dynamic_view_sort(unsigned int n) {
 //----------------------------------------------------------------------------
 
 template <class ExecutionSpace>
-void test_issue_1160() {
+void test_issue_1160_impl() {
   Kokkos::View<int*, ExecutionSpace> element_("element", 10);
   Kokkos::View<double*, ExecutionSpace> x_("x", 10);
   Kokkos::View<double*, ExecutionSpace> v_("y", 10);
@@ -346,16 +346,33 @@ void test_issue_1160() {
 //----------------------------------------------------------------------------
 
 template <class ExecutionSpace, typename KeyType>
-void test_sort(unsigned int N) {
-  test_1D_sort<ExecutionSpace, KeyType>(N * N * N, true);
-  test_1D_sort<ExecutionSpace, KeyType>(N * N * N, false);
-#if !defined(KOKKOS_ENABLE_ROCM)
-  test_3D_sort<ExecutionSpace, KeyType>(N);
-  test_dynamic_view_sort<ExecutionSpace, KeyType>(N * N);
-#endif
-  test_issue_1160<ExecutionSpace>();
+void test_1D_sort(unsigned int N) {
+  test_1D_sort_impl<ExecutionSpace, KeyType>(N * N * N, true);
+  test_1D_sort_impl<ExecutionSpace, KeyType>(N * N * N, false);
 }
 
+template <class ExecutionSpace, typename KeyType>
+void test_3D_sort(unsigned int N) {
+  test_3D_sort_impl<ExecutionSpace, KeyType>(N);
+}
+
+template <class ExecutionSpace, typename KeyType>
+void test_dynamic_view_sort(unsigned int N) {
+  test_dynamic_view_sort_impl<ExecutionSpace, KeyType>(N * N);
+}
+
+template <class ExecutionSpace>
+void test_issue_1160_sort() {
+  test_issue_1160_impl<ExecutionSpace>();
+}
+
+template <class ExecutionSpace, typename KeyType>
+void test_sort(unsigned int N) {
+  test_1D_sort<ExecutionSpace, KeyType>(N);
+  test_3D_sort<ExecutionSpace, KeyType>(N);
+  test_dynamic_view_sort<ExecutionSpace, KeyType>(N);
+  test_issue_1160_sort<ExecutionSpace>();
+}
 }  // namespace Impl
 }  // namespace Test
 #endif /* KOKKOS_ALGORITHMS_UNITTESTS_TESTSORT_HPP */

--- a/core/unit_test/TestViewAPI_e.hpp
+++ b/core/unit_test/TestViewAPI_e.hpp
@@ -240,3 +240,5 @@ TEST(TEST_CATEGORY, view_overload_resolution) {
   TestViewOverloadResolution<TEST_EXECSPACE>::test_function_overload();
 }
 }  // namespace Test
+
+#include <TestViewIsAssignable.hpp>

--- a/core/unit_test/TestViewLayoutStrideAssignment.hpp
+++ b/core/unit_test/TestViewLayoutStrideAssignment.hpp
@@ -51,7 +51,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <TestViewIsAssignable.hpp>
 namespace Test {
 
 TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {


### PR DESCRIPTION
Errors go away by effectively chaning link order via various means (splitting CPP files, reordering how source files are added in CMake)