### PR TITLE
Enable algorithms unit tests for HIP

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -621,9 +621,8 @@ template <>
 struct Random_UniqueIndex<Kokkos::Cuda> {
   using locks_view_type = View<int*, Kokkos::Cuda>;
   KOKKOS_FUNCTION
-  static int get_state_idx(const locks_view_type&
+  static int get_state_idx(const locks_view_type& locks_) {
 #ifdef __CUDA_ARCH__
-                               locks_) {
     const int i_offset =
         (threadIdx.x * blockDim.y + threadIdx.y) * blockDim.z + threadIdx.z;
     int i = (((blockIdx.x * gridDim.y + blockIdx.y) * gridDim.z + blockIdx.z) *
@@ -637,12 +636,41 @@ struct Random_UniqueIndex<Kokkos::Cuda> {
       }
     }
     return i;
-  }
 #else
-  ) {
+    (void)locks_;
     return 0;
-  }
 #endif
+  }
+};
+#endif
+
+#ifdef KOKKOS_ENABLE_HIP
+template <>
+struct Random_UniqueIndex<Kokkos::Experimental::HIP> {
+  using locks_view_type = View<int*, Kokkos::Experimental::HIP>;
+  KOKKOS_FUNCTION
+  static int get_state_idx(const locks_view_type& locks_) {
+#ifdef __HIP_DEVICE_COMPILE__
+    const int i_offset =
+        (hipThreadIdx_x * hipBlockDim_y + hipThreadIdx_y) * hipBlockDim_z +
+        hipThreadIdx_z;
+    int i = (((hipBlockIdx_x * hipGridDim_y + hipBlockIdx_y) * hipGridDim_z +
+              hipBlockIdx_z) *
+                 hipBlockDim_x * hipBlockDim_y * hipBlockDim_z +
+             i_offset) %
+            locks_.extent(0);
+    while (Kokkos::atomic_compare_exchange(&locks_(i), 0, 1)) {
+      i += hipBlockDim_x * hipBlockDim_y * hipBlockDim_z;
+      if (i >= static_cast<int>(locks_.extent(0))) {
+        i = i_offset;
+      }
+    }
+    return i;
+#else
+    (void)locks_;
+    return 0;
+#endif
+  }
 };
 #endif
 

--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -43,6 +43,12 @@ IF(Kokkos_ENABLE_OPENMP)
   )
 ENDIF()
 
+IF(Kokkos_ENABLE_HIP)
+  LIST( APPEND SOURCES
+    TestHIP.cpp
+  )
+ENDIF()
+
 IF(Kokkos_ENABLE_CUDA)
   LIST( APPEND SOURCES
     TestCuda.cpp

--- a/algorithms/unit_tests/TestHIP.cpp
+++ b/algorithms/unit_tests/TestHIP.cpp
@@ -1,0 +1,83 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_HIP
+
+#include <cstdint>
+#include <iostream>
+#include <iomanip>
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+
+#include <TestRandom.hpp>
+#include <TestSort.hpp>
+
+namespace Test {
+
+void hip_test_random_xorshift64(size_t num_draws) {
+  Impl::test_random<Kokkos::Random_XorShift64_Pool<Kokkos::Experimental::HIP>>(
+      num_draws);
+  Impl::test_random<Kokkos::Random_XorShift64_Pool<Kokkos::Device<
+      Kokkos::Experimental::HIP, Kokkos::Experimental::HIPSpace>>>(num_draws);
+}
+
+void hip_test_random_xorshift1024(size_t num_draws) {
+  Impl::test_random<
+      Kokkos::Random_XorShift1024_Pool<Kokkos::Experimental::HIP>>(num_draws);
+  Impl::test_random<Kokkos::Random_XorShift1024_Pool<Kokkos::Device<
+      Kokkos::Experimental::HIP, Kokkos::Experimental::HIPSpace>>>(num_draws);
+}
+
+TEST(hip, Random_XorShift64) { hip_test_random_xorshift64(132141141); }
+TEST(hip, Random_XorShift1024_0) { hip_test_random_xorshift1024(52428813); }
+TEST(hip, SortUnsigned) {
+  Impl::test_sort<Kokkos::Experimental::HIP, unsigned>(171);
+}
+}  // namespace Test
+#else
+void KOKKOS_ALGORITHMS_UNITTESTS_TESTHIP_PREVENT_LINK_ERROR() {}
+#endif /* #ifdef KOKKOS_ENABLE_HIP */

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -575,7 +575,8 @@ namespace Experimental {
 
 int HIP::concurrency() {
   // FIXME_HIP
-  return 32 * 8 * 40;  // 81920 fiji and hawaii
+  // MI60: ThreadsPerComputeUnit*ComputeUnits/ShaderEngine*ShaderEngines)
+  return 2536 * 16 * 4;
 }
 int HIP::impl_is_initialized() {
   return Impl::HIPInternal::singleton().is_initialized();


### PR DESCRIPTION
With the current `concurrency` value we never get out of the `while` loop in `Random_UniqueIndex::get_state_idx`. The new value also looks closer to what was in the comments for `fiji` and `hawaii`.
@crtrott Do you recall why we chose that value as it currently is?