### PR TITLE
[HIP] clean up

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -195,7 +195,7 @@ void HIPInternal::initialize(int hip_device_id) {
 
     hipSetDevice(m_hipDev);
 
-    // TODO for now always uses default stream
+    // FIXME_HIP for now always uses default stream
     m_stream = 0;
 
     // number of multiprocessors

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -53,7 +53,7 @@
 #include <HIP/Kokkos_HIP_Error.hpp>
 #include <HIP/Kokkos_HIP_Instance.hpp>
 
-// TODO cannot use global variable on the device with ROCm 2.9
+// FIXME_HIP cannot use global variable on the device with ROCm 2.9
 //__device__ __constant__ unsigned long kokkos_impl_hip_constant_memory_buffer
 //    [Kokkos::Experimental::Impl::HIPTraits::ConstantMemoryUsage /
 //     sizeof(unsigned long)];

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -257,7 +257,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    // TODO I don't know where 8 comes from
+    // FIXME_HIP I don't know where 8 comes from
     unsigned int n = ::Kokkos::Experimental::Impl::HIPTraits::WarpSize * 8;
     int shmem_size =
         hip_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag>(

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -163,8 +163,9 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
   }
 
   static int scratch_size_max(int level) {
-    return (level == 0 ? 1024 * 40 :  // TODO arbitrarily setting this to 48kB
-                20 * 1024 * 1024);    // TODO arbitrarily setting this to 20MB
+    return (
+        level == 0 ? 1024 * 40 :  // FIXME_HIP arbitrarily setting this to 48kB
+            20 * 1024 * 1024);    // FIXME_HIP arbitrarily setting this to 20MB
   }
 
   int vector_length() const { return m_vector_length; }

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -146,7 +146,7 @@ struct HIPReductionsFunctor<FunctorType, ArgTag, false, false> {
       num_teams_done = Kokkos::atomic_fetch_add(global_flags, 1) + 1;
     }
     bool is_last_block = false;
-    // TODO HIP does not support syncthreads_or. That's why we need to make
+    // FIXME_HIP HIP does not support syncthreads_or. That's why we need to make
     // num_teams_done __shared__
     // if (__syncthreads_or(num_teams_done == hipGridDim_x)) {*/
     __syncthreads();
@@ -321,7 +321,7 @@ __device__ bool hip_single_inter_block_reduce_scan2(
   // Contributing blocks note that their contribution has been completed via an
   // atomic-increment flag If this block is not the last block to contribute to
   // this group then the block is done.
-  // TODO __syncthreads_or is not supported by HIP yet.
+  // FIXME_HIP __syncthreads_or is not supported by HIP yet.
   // const bool is_last_block = !__syncthreads_or(
   //    threadIdx.y
   //        ? 0
@@ -388,7 +388,7 @@ __device__ bool hip_single_inter_block_reduce_scan(
     ::Kokkos::Experimental::HIP::size_type* const global_flags) {
   using ValueTraits = FunctorValueTraits<FunctorType, ArgTag>;
   if (!DoScan && /*FIXME*/ (bool)ValueTraits::StaticValueSize)
-    // TODO For now we don't use shuffle
+    // FIXME_HIP For now we don't use shuffle
     // return Kokkos::Impl::HIPReductionsFunctor<
     //    FunctorType, ArgTag, false, (ValueTraits::StaticValueSize > 16)>::
     //    scalar_inter_block_reduction(functor, block_id, block_count,

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -65,19 +65,19 @@ namespace Impl {
 DeepCopy<Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPSpace,
          Kokkos::Experimental::HIP>::DeepCopy(void* dst, const void* src,
                                               size_t n) {
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 DeepCopy<HostSpace, Kokkos::Experimental::HIPSpace,
          Kokkos::Experimental::HIP>::DeepCopy(void* dst, const void* src,
                                               size_t n) {
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 DeepCopy<Kokkos::Experimental::HIPSpace, HostSpace,
          Kokkos::Experimental::HIP>::DeepCopy(void* dst, const void* src,
                                               size_t n) {
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 DeepCopy<Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPSpace,
@@ -86,40 +86,40 @@ DeepCopy<Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPSpace,
                                               void* dst, const void* src,
                                               size_t n) {
   // FIXME_HIP use instance
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 DeepCopy<HostSpace, Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIP>::
     DeepCopy(const Kokkos::Experimental::HIP& /*instance*/, void* dst,
              const void* src, size_t n) {
   // FIXME_HIP use instance
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 DeepCopy<Kokkos::Experimental::HIPSpace, HostSpace, Kokkos::Experimental::HIP>::
     DeepCopy(const Kokkos::Experimental::HIP& /*instance*/, void* dst,
              const void* src, size_t n) {
   // FIXME_HIP use instance
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace,
          Kokkos::Experimental::HIPHostPinnedSpace,
          Kokkos::Experimental::HIP>::DeepCopy(void* dst, const void* src,
                                               size_t n) {
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 DeepCopy<HostSpace, Kokkos::Experimental::HIPHostPinnedSpace,
          Kokkos::Experimental::HIP>::DeepCopy(void* dst, const void* src,
                                               size_t n) {
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace, HostSpace,
          Kokkos::Experimental::HIP>::DeepCopy(void* dst, const void* src,
                                               size_t n) {
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace,
@@ -127,7 +127,7 @@ DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace,
     DeepCopy(const Kokkos::Experimental::HIP& /*instance*/, void* dst,
              const void* src, size_t n) {
   // FIXME_HIP use instance
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 DeepCopy<HostSpace, Kokkos::Experimental::HIPHostPinnedSpace,
@@ -136,7 +136,7 @@ DeepCopy<HostSpace, Kokkos::Experimental::HIPHostPinnedSpace,
                                               void* dst, const void* src,
                                               size_t n) {
   // FIXME_HIP use instance
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace, HostSpace,
@@ -145,7 +145,7 @@ DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace, HostSpace,
                                               void* dst, const void* src,
                                               size_t n) {
   // FIXME_HIP use instance
-  hipMemcpy(dst, src, n, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(dst, src, n, hipMemcpyDefault));
 }
 
 }  // namespace Impl
@@ -216,12 +216,12 @@ void* HIPHostPinnedSpace::allocate(const size_t arg_alloc_size) const {
 
 void HIPSpace::deallocate(void* const arg_alloc_ptr,
                           const size_t /* arg_alloc_size */) const {
-  hipFree(arg_alloc_ptr);
+  HIP_SAFE_CALL(hipFree(arg_alloc_ptr));
 }
 
 void HIPHostPinnedSpace::deallocate(void* const arg_alloc_ptr,
                                     const size_t /* arg_alloc_size */) const {
-  hipHostFree(arg_alloc_ptr);
+  HIP_SAFE_CALL(hipHostFree(arg_alloc_ptr));
 }
 
 }  // namespace Experimental

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -265,8 +265,7 @@ struct MemorySpaceAccess<Kokkos::Experimental::HIPHostPinnedSpace,
 namespace Kokkos {
 namespace Impl {
 
-// hc::completion_future DeepCopyAsyncHIP( void * dst , const void * src ,
-// size_t n);
+void DeepCopyAsyncHIP(void* dst, const void* src, size_t n);
 
 template <>
 struct DeepCopy<Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPSpace,
@@ -301,14 +300,10 @@ struct DeepCopy<Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPSpace,
         dst, src, n);
   }
 
-  inline DeepCopy(const ExecutionSpace& /*exec*/, void* /*dst*/,
-                  const void* /*src*/, size_t /*n*/) {
-    // FIXME_HIP
-    Kokkos::abort("DeepCopy with ExecutionSpace not implemented!");
-    //    exec.fence();
-    //    hc::completion_future fut = DeepCopyAsyncHIP (dst,src,n);
-    //    fut.wait();
-    //    DeepCopy (dst,src,n);
+  inline DeepCopy(const ExecutionSpace& exec, void* dst, const void* src,
+                  size_t n) {
+    exec.fence();
+    DeepCopyAsyncHIP(dst, src, n);
   }
 };
 
@@ -322,7 +317,7 @@ struct DeepCopy<Kokkos::Experimental::HIPSpace, HostSpace, ExecutionSpace> {
   inline DeepCopy(const ExecutionSpace& exec, void* dst, const void* src,
                   size_t n) {
     exec.fence();
-    DeepCopy(dst, src, n);
+    DeepCopyAsyncHIP(dst, src, n);
   }
 };
 
@@ -336,7 +331,7 @@ struct DeepCopy<HostSpace, Kokkos::Experimental::HIPSpace, ExecutionSpace> {
   inline DeepCopy(const ExecutionSpace& exec, void* dst, const void* src,
                   size_t n) {
     exec.fence();
-    DeepCopy(dst, src, n);
+    DeepCopyAsyncHIP(dst, src, n);
   }
 };
 
@@ -373,14 +368,10 @@ struct DeepCopy<Kokkos::Experimental::HIPSpace,
                    Kokkos::Experimental::HIP>(dst, src, n);
   }
 
-  inline DeepCopy(const ExecutionSpace& /*exec*/, void* /*dst*/,
-                  const void* /*src*/, size_t /*n*/) {
-    // FIXME_HIP
-    Kokkos::abort("DeepCopy with ExecutionSpace not implemented!");
-    //    exec.fence();
-    //    hc::completion_future fut = DeepCopyAsyncHIP (dst,src,n);
-    //    fut.wait();
-    //    DeepCopyHIP (dst,src,n);
+  inline DeepCopy(const ExecutionSpace& exec, void* dst, const void* src,
+                  size_t n) {
+    exec.fence();
+    DeepCopyAsyncHIP(dst, src, n);
   }
 };
 
@@ -392,14 +383,10 @@ struct DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace,
                    Kokkos::Experimental::HIP>(dst, src, n);
   }
 
-  inline DeepCopy(const ExecutionSpace& /*exec*/, void* /*dst*/,
-                  const void* /*src*/, size_t /*n*/) {
-    // FIXME_HIP
-    Kokkos::abort("DeepCopy with ExecutionSpace not implemented!");
-    //    exec.fence();
-    //    hc::completion_future fut = DeepCopyAsyncHIP (dst,src,n);
-    //    fut.wait();
-    //    DeepCopyHIP (dst,src,n);
+  inline DeepCopy(const ExecutionSpace& exec, void* dst, const void* src,
+                  size_t n) {
+    exec.fence();
+    DeepCopyAsyncHIP(dst, src, n);
   }
 };
 
@@ -415,10 +402,7 @@ struct DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace,
   inline DeepCopy(const ExecutionSpace& exec, void* dst, const void* src,
                   size_t n) {
     exec.fence();
-    //    hc::completion_future fut = DeepCopyAsyncHIP (dst,src,n);
-    //    fut.wait();
-    //    DeepCopyAsyncHIP (dst,src,n);
-    DeepCopy(dst, src, n);
+    DeepCopyAsyncHIP(dst, src, n);
   }
 };
 
@@ -433,7 +417,7 @@ struct DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace, HostSpace,
   inline DeepCopy(const ExecutionSpace& exec, void* dst, const void* src,
                   size_t n) {
     exec.fence();
-    DeepCopy(dst, src, n);
+    DeepCopyAsyncHIP(dst, src, n);
   }
 };
 
@@ -448,7 +432,7 @@ struct DeepCopy<HostSpace, Kokkos::Experimental::HIPHostPinnedSpace,
   inline DeepCopy(const ExecutionSpace& exec, void* dst, const void* src,
                   size_t n) {
     exec.fence();
-    DeepCopy(dst, src, n);
+    DeepCopyAsyncHIP(dst, src, n);
   }
 };
 }  // namespace Impl

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -71,11 +71,11 @@ namespace Experimental {
 class HIPSpace {
  public:
   //! Tag this class as a kokkos memory space
-  typedef HIPSpace memory_space;
-  typedef Kokkos::Experimental::HIP execution_space;
-  typedef Kokkos::Device<execution_space, memory_space> device_type;
+  using memory_space    = HIPSpace;
+  using execution_space = Kokkos::Experimental::HIP;
+  using device_type     = Kokkos::Device<execution_space, memory_space>;
 
-  typedef unsigned int size_type;
+  using size_type = unsigned int;
 
   /*--------------------------------*/
 
@@ -159,10 +159,10 @@ class HIPHostPinnedSpace {
  public:
   //! Tag this class as a kokkos memory space
   /** \brief  Memory is in HostSpace so use the HostSpace::execution_space */
-  typedef HostSpace::execution_space execution_space;
-  typedef HIPHostPinnedSpace memory_space;
-  typedef Kokkos::Device<execution_space, memory_space> device_type;
-  typedef unsigned int size_type;
+  using execution_space = HostSpace::execution_space;
+  using memory_space    = HIPHostPinnedSpace;
+  using device_type     = Kokkos::Device<execution_space, memory_space>;
+  using size_type       = unsigned int;
 
   /*--------------------------------*/
 


### PR DESCRIPTION
This PR:
 - replaces `TODO` with `FIXME_HIP`
 - adds missing `HIP_SAFE_CALL`
 - adds asynchronous deep copy since all the necessary functions have been implemented