### PR TITLE
Parallel reduce team

### DIFF
--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -164,8 +164,10 @@ struct HIPParallelLaunch<
   static hipFuncAttributes get_hip_func_attributes() {
     hipFuncAttributes attr;
     hipFuncGetAttributes(
-        &attr, hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
-                                                MinBlocksPerSM>);
+        &attr,
+        reinterpret_cast<void const *>(
+            hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
+                                             MinBlocksPerSM>));
     return attr;
   }
 };

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -120,13 +120,42 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
         static_cast<size_t>(vector_length()),
         static_cast<size_t>(team_scratch_size(0)) + 2 * sizeof(double),
         static_cast<size_t>(thread_scratch_size(0)) + sizeof(double));
-    return block_size / vector_length();
+    // FIXME_HIP if the team size is larger than 256, the test hip.team_for
+    // fails with Memory access fault by GPU. Reason: Page not present or
+    // supervisor privilege
+    return std::min(block_size / vector_length(), 256);
+  }
+
+  template <class FunctorType>
+  inline int team_size_max(const FunctorType& f,
+                           const ParallelReduceTag&) const {
+    typedef Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                                  TeamPolicyInternal, FunctorType>
+        functor_analysis_type;
+    typedef typename Impl::ParallelReduceReturnValue<
+        void, typename functor_analysis_type::value_type,
+        FunctorType>::reducer_type reducer_type;
+    typedef Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
+                                 reducer_type>
+        closure_type;
+    // FIXME_HIP
+    return std::min(internal_team_size_max<closure_type>(f), 256);
+  }
+
+  template <class FunctorType, class ReducerType>
+  inline int team_size_max(const FunctorType& f, const ReducerType& /*r*/,
+                           const ParallelReduceTag&) const {
+    using closure_type =
+        Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
+                             ReducerType>;
+    // FIXME_HIP
+    return std::min(internal_team_size_max<closure_type>(f), 256);
   }
 
   template <typename FunctorType>
   int team_size_recommended(FunctorType const& f, ParallelForTag const&) const {
-    typedef Impl::ParallelFor<FunctorType, TeamPolicy<Properties...> >
-        closure_type;
+    using closure_type =
+        Impl::ParallelFor<FunctorType, TeamPolicy<Properties...> >;
     hipFuncAttributes attr = ::Kokkos::Experimental::Impl::HIPParallelLaunch<
         closure_type,
         typename traits::launch_bounds>::get_hip_func_attributes();
@@ -136,7 +165,32 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
         static_cast<size_t>(vector_length()),
         static_cast<size_t>(team_scratch_size(0)) + 2 * sizeof(double),
         static_cast<size_t>(thread_scratch_size(0)) + sizeof(double));
-    return block_size / vector_length();
+    // FIXME_HIP
+    return std::min(block_size / vector_length(), 256);
+  }
+
+  template <typename FunctorType>
+  inline int team_size_recommended(FunctorType const& f,
+                                   ParallelReduceTag const&) const {
+    using functor_analysis_type =
+        Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                              TeamPolicyInternal, FunctorType>;
+    using reducer_type = typename Impl::ParallelReduceReturnValue<
+        void, typename functor_analysis_type::value_type,
+        FunctorType>::reducer_type;
+    using closure_type =
+        Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
+                             reducer_type>;
+    return internal_team_size_recommended<closure_type>(f);
+  }
+
+  template <class FunctorType, class ReducerType>
+  int team_size_recommended(FunctorType const& f, ReducerType const&,
+                            ParallelReduceTag const&) const {
+    using closure_type =
+        Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
+                             ReducerType>;
+    return internal_team_size_recommended<closure_type>(f);
   }
 
   static int vector_length_max() {
@@ -351,16 +405,22 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
 
   template <class ClosureType, class FunctorType>
   int internal_team_size_max(const FunctorType& f) const {
-    return internal_team_size_common<ClosureType>(
-        f, ::Kokkos::Experimental::Impl::hip_get_max_block_size<
-               FunctorType, typename traits::launch_bounds>);
+    // FIXME_HIP if the team size is larger than 256, there is seems to be a
+    // problem in Kokkos_HIP_ReduceScan.cc::hip_inter_warp_reduction:120
+    return std::min(internal_team_size_common<ClosureType>(
+                        f, ::Kokkos::Experimental::Impl::hip_get_max_block_size<
+                               FunctorType, typename traits::launch_bounds>),
+                    256);
   }
 
   template <class ClosureType, class FunctorType>
   int internal_team_size_recommended(const FunctorType& f) const {
-    return internal_team_size_common<ClosureType>(
-        f, ::Kokkos::Experimental::Impl::hip_get_opt_block_size<
-               FunctorType, typename traits::launch_bounds>);
+    // FIXME_HIP if the team size is larger than 256, there is seems to be a
+    // problem in Kokkos_HIP_ReduceScan.cc::hip_inter_warp_reduction:120
+    return std::min(internal_team_size_common<ClosureType>(
+                        f, ::Kokkos::Experimental::Impl::hip_get_opt_block_size<
+                               FunctorType, typename traits::launch_bounds>),
+                    256);
   }
 };
 
@@ -551,6 +611,473 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
             arg_policy.vector_length())) {
       Kokkos::Impl::throw_runtime_exception(std::string(
           "Kokkos::Impl::ParallelFor< HIP > requested too large team size."));
+    }
+  }
+};
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+template <class FunctorType, class ReducerType, class... Properties>
+class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
+                     ReducerType, Kokkos::Experimental::HIP> {
+ public:
+  using Policy = TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>;
+
+ private:
+  using Member       = typename Policy::member_type;
+  using WorkTag      = typename Policy::work_tag;
+  using LaunchBounds = typename Policy::launch_bounds;
+
+  using ReducerConditional =
+      Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
+                         FunctorType, ReducerType>;
+  using ReducerTypeFwd = typename ReducerConditional::type;
+  using WorkTagFwd =
+      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
+                                  WorkTag, void>::type;
+
+  using ValueTraits =
+      Kokkos::Impl::FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>;
+  using ValueInit = Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd>;
+  using ValueJoin = Kokkos::Impl::FunctorValueJoin<ReducerTypeFwd, WorkTagFwd>;
+
+  using pointer_type   = typename ValueTraits::pointer_type;
+  using reference_type = typename ValueTraits::reference_type;
+  using value_type     = typename ValueTraits::value_type;
+
+ public:
+  using functor_type = FunctorType;
+  using size_type    = Kokkos::Experimental::HIP::size_type;
+
+  static int constexpr UseShflReduction = (ValueTraits::StaticValueSize != 0);
+
+ private:
+  typedef double DummyShflReductionType;
+  typedef int DummySHMEMReductionType;
+
+  // Algorithmic constraints: hipBlockDim_y is a power of two AND hipBlockDim_y
+  // == hipBlockDim_z == 1 shared memory utilization:
+  //
+  //  [ global reduce space ]
+  //  [ team   reduce space ]
+  //  [ team   shared space ]
+  //
+
+  const FunctorType m_functor;
+  const Policy m_policy;
+  const ReducerType m_reducer;
+  const pointer_type m_result_ptr;
+  const bool m_result_ptr_device_accessible;
+  size_type* m_scratch_space;
+  size_type* m_scratch_flags;
+  size_type m_team_begin;
+  size_type m_shmem_begin;
+  size_type m_shmem_size;
+  void* m_scratch_ptr[2];
+  int m_scratch_size[2];
+  const size_type m_league_size;
+  int m_team_size;
+  const size_type m_vector_size;
+
+  template <class TagType>
+  __device__ inline
+      typename std::enable_if<std::is_same<TagType, void>::value>::type
+      exec_team(Member const& member, reference_type update) const {
+    m_functor(member, update);
+  }
+
+  template <class TagType>
+  __device__ inline
+      typename std::enable_if<!std::is_same<TagType, void>::value>::type
+      exec_team(Member const& member, reference_type update) const {
+    m_functor(TagType(), member, update);
+  }
+
+ public:
+  __device__ inline void operator()() const {
+    int64_t threadid = 0;
+    if (m_scratch_size[1] > 0) {
+      __shared__ int64_t base_thread_id;
+      // FIXME Using global value
+      if (hipThreadIdx_x == 0 && hipThreadIdx_y == 0) {
+        Impl::hip_abort("Error should not be here\n");
+        threadid =
+            (hipBlockIdx_x * hipBlockDim_z + hipThreadIdx_z) %
+            (g_device_hip_lock_arrays.n / (hipBlockDim_x * hipBlockDim_y));
+        threadid *= hipBlockDim_x * hipBlockDim_y;
+        int done = 0;
+        while (!done) {
+          done = (0 ==
+                  atomicCAS(&g_device_hip_lock_arrays.scratch[threadid], 0, 1));
+          if (!done) {
+            threadid += hipBlockDim_x * hipBlockDim_y;
+            if (static_cast<int64_t>(threadid +
+                                     hipBlockDim_x * hipBlockDim_y) >=
+                static_cast<int64_t>(g_device_hip_lock_arrays.n))
+              threadid = 0;
+          }
+        }
+        base_thread_id = threadid;
+      }
+      __syncthreads();
+      threadid = base_thread_id;
+    }
+
+    run(Kokkos::Impl::if_c<UseShflReduction, DummyShflReductionType,
+                           DummySHMEMReductionType>::select(1, 1.0),
+        threadid);
+    if (m_scratch_size[1] > 0) {
+      __syncthreads();
+      if (hipThreadIdx_x == 0 && hipThreadIdx_y == 0) {
+        Impl::hip_abort("Error should not be here\n");
+        g_device_hip_lock_arrays.scratch[threadid] = 0;
+      }
+    }
+  }
+
+  __device__ inline void run(DummySHMEMReductionType const&,
+                             int const& threadid) const {
+    integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /
+                                             sizeof(size_type)> const
+        word_count(ValueTraits::value_size(
+                       ReducerConditional::select(m_functor, m_reducer)) /
+                   sizeof(size_type));
+
+    reference_type value = ValueInit::init(
+        ReducerConditional::select(m_functor, m_reducer),
+        Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>() +
+            hipThreadIdx_y * word_count.value);
+
+    // Iterate this block through the league
+    int const int_league_size = static_cast<int>(m_league_size);
+    for (int league_rank = hipBlockIdx_x; league_rank < int_league_size;
+         league_rank += hipGridDim_x) {
+      this->template exec_team<WorkTag>(
+          Member(Kokkos::Experimental::kokkos_impl_hip_shared_memory<char>() +
+                     m_team_begin,
+                 m_shmem_begin, m_shmem_size,
+                 reinterpret_cast<void*>(
+                     reinterpret_cast<char*>(m_scratch_ptr[1]) +
+                     static_cast<ptrdiff_t>(threadid /
+                                            (hipBlockDim_x * hipBlockDim_y)) *
+                         m_scratch_size[1]),
+                 m_scratch_size[1], league_rank, m_league_size),
+          value);
+    }
+
+    // Reduce with final value at blockDim.y - 1 location.
+    if (hip_single_inter_block_reduce_scan<false, FunctorType, WorkTag>(
+            ReducerConditional::select(m_functor, m_reducer), hipBlockIdx_x,
+            hipGridDim_x,
+            Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>(),
+            m_scratch_space, m_scratch_flags)) {
+      // This is the final block with the final result at the final threads'
+      // location
+
+      size_type* const shared =
+          Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>() +
+          (hipBlockDim_y - 1) * word_count.value;
+      size_type* const global = m_result_ptr_device_accessible
+                                    ? reinterpret_cast<size_type*>(m_result_ptr)
+                                    : m_scratch_space;
+
+      if (hipThreadIdx_y == 0) {
+        Kokkos::Impl::FunctorFinal<ReducerTypeFwd, WorkTagFwd>::final(
+            ReducerConditional::select(m_functor, m_reducer), shared);
+      }
+
+      if (Kokkos::Experimental::Impl::HIPTraits::WarpSize < word_count.value) {
+        __syncthreads();
+      }
+
+      for (unsigned i = hipThreadIdx_y; i < word_count.value;
+           i += hipBlockDim_y) {
+        global[i] = shared[i];
+      }
+    }
+  }
+
+  __device__ inline void run(DummyShflReductionType const&,
+                             int const& threadid) const {
+    value_type value;
+    ValueInit::init(ReducerConditional::select(m_functor, m_reducer), &value);
+
+    // Iterate this block through the league
+    int const int_league_size = static_cast<int>(m_league_size);
+    for (int league_rank = hipBlockIdx_x; league_rank < int_league_size;
+         league_rank += hipGridDim_x) {
+      this->template exec_team<WorkTag>(
+          Member(Kokkos::Experimental::kokkos_impl_hip_shared_memory<char>() +
+                     m_team_begin,
+                 m_shmem_begin, m_shmem_size,
+                 reinterpret_cast<void*>(
+                     reinterpret_cast<char*>(m_scratch_ptr[1]) +
+                     static_cast<ptrdiff_t>(threadid /
+                                            (hipBlockDim_x * hipBlockDim_y)) *
+                         m_scratch_size[1]),
+                 m_scratch_size[1], league_rank, m_league_size),
+          value);
+    }
+
+    pointer_type const result =
+        m_result_ptr_device_accessible
+            ? m_result_ptr
+            : reinterpret_cast<pointer_type>(m_scratch_space);
+
+    value_type init;
+    ValueInit::init(ReducerConditional::select(m_functor, m_reducer), &init);
+    if (Impl::hip_inter_block_reduction<FunctorType, ValueJoin, WorkTag>(
+            value, init,
+            ValueJoin(ReducerConditional::select(m_functor, m_reducer)),
+            m_scratch_space, result, m_scratch_flags, hipBlockDim_y)) {
+      unsigned int const id = hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x;
+      if (id == 0) {
+        Kokkos::Impl::FunctorFinal<ReducerTypeFwd, WorkTagFwd>::final(
+            ReducerConditional::select(m_functor, m_reducer),
+            reinterpret_cast<void*>(&value));
+        *result = value;
+      }
+    }
+  }
+
+  inline void execute() {
+    const int nwork = m_league_size * m_team_size;
+    if (nwork) {
+      const int block_count =
+          UseShflReduction
+              ? std::min(
+                    m_league_size,
+                    size_type(1024 *
+                              Kokkos::Experimental::Impl::HIPTraits::WarpSize))
+              : std::min(static_cast<int>(m_league_size), m_team_size);
+
+      m_scratch_space = Kokkos::Experimental::Impl::hip_internal_scratch_space(
+          ValueTraits::value_size(
+              ReducerConditional::select(m_functor, m_reducer)) *
+          block_count);
+      m_scratch_flags = Kokkos::Experimental::Impl::hip_internal_scratch_flags(
+          sizeof(size_type));
+
+      dim3 block(m_vector_size, m_team_size, 1);
+      dim3 grid(block_count, 1, 1);
+      const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
+
+      Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelReduce,
+                                                    LaunchBounds>(
+          *this, grid, block, shmem_size_total,
+          m_policy.space().impl_internal_space_instance(),
+          true);  // copy to device and execute
+
+      if (!m_result_ptr_device_accessible) {
+        Kokkos::Experimental::HIP().fence();
+
+        if (m_result_ptr) {
+          const int size = ValueTraits::value_size(
+              ReducerConditional::select(m_functor, m_reducer));
+          DeepCopy<HostSpace, Kokkos::Experimental::HIPSpace>(
+              m_result_ptr, m_scratch_space, size);
+        }
+      }
+    } else {
+      if (m_result_ptr) {
+        ValueInit::init(ReducerConditional::select(m_functor, m_reducer),
+                        m_result_ptr);
+      }
+    }
+  }
+
+  template <class ViewType>
+  ParallelReduce(FunctorType const& arg_functor, Policy const& arg_policy,
+                 ViewType const& arg_result,
+                 typename std::enable_if<Kokkos::is_view<ViewType>::value,
+                                         void*>::type = nullptr)
+      : m_functor(arg_functor),
+        m_policy(arg_policy),
+        m_reducer(InvalidType()),
+        m_result_ptr(arg_result.data()),
+        m_result_ptr_device_accessible(
+            MemorySpaceAccess<Kokkos::Experimental::HIPSpace,
+                              typename ViewType::memory_space>::accessible),
+        m_scratch_space(0),
+        m_scratch_flags(0),
+        m_team_begin(0),
+        m_shmem_begin(0),
+        m_shmem_size(0),
+        m_scratch_ptr{nullptr, nullptr},
+        m_league_size(arg_policy.league_size()),
+        m_team_size(arg_policy.team_size()),
+        m_vector_size(arg_policy.vector_length()) {
+    hipFuncAttributes attr = Kokkos::Experimental::Impl::HIPParallelLaunch<
+        ParallelReduce, LaunchBounds>::get_hip_func_attributes();
+    m_team_size =
+        m_team_size >= 0
+            ? m_team_size
+            : Kokkos::Experimental::Impl::hip_get_opt_block_size<FunctorType,
+                                                                 LaunchBounds>(
+                  m_policy.space().impl_internal_space_instance(), attr,
+                  m_functor, m_vector_size, m_policy.team_scratch_size(0),
+                  m_policy.thread_scratch_size(0)) /
+                  m_vector_size;
+
+    // Return Init value if the number of worksets is zero
+    if (m_league_size * m_team_size == 0) {
+      ValueInit::init(ReducerConditional::select(m_functor, m_reducer),
+                      arg_result.data());
+      return;
+    }
+
+    m_team_begin =
+        UseShflReduction
+            ? 0
+            : hip_single_inter_block_reduce_scan_shmem<false, FunctorType,
+                                                       WorkTag>(arg_functor,
+                                                                m_team_size);
+    m_shmem_begin = sizeof(double) * (m_team_size + 2);
+    m_shmem_size =
+        m_policy.scratch_size(0, m_team_size) +
+        FunctorTeamShmemSize<FunctorType>::value(arg_functor, m_team_size);
+    m_scratch_size[0] = m_shmem_size;
+    m_scratch_size[1] = m_policy.scratch_size(1, m_team_size);
+    m_scratch_ptr[1] =
+        m_team_size <= 0 ? nullptr
+                         : Kokkos::Experimental::Impl::hip_resize_scratch_space(
+                               static_cast<std::int64_t>(m_scratch_size[1]) *
+                               (static_cast<std::int64_t>(
+                                   Kokkos::Experimental::HIP::concurrency() /
+                                   (m_team_size * m_vector_size))));
+
+    // The global parallel_reduce does not support vector_length other than 1 at
+    // the moment
+    if ((arg_policy.vector_length() > 1) && !UseShflReduction)
+      Impl::throw_runtime_exception(
+          "Kokkos::parallel_reduce with a TeamPolicy using a vector length of "
+          "greater than 1 is not currently supported for HIP for dynamic "
+          "sized reduction types.");
+
+    if ((m_team_size < Kokkos::Experimental::Impl::HIPTraits::WarpSize) &&
+        !UseShflReduction)
+      Impl::throw_runtime_exception(
+          "Kokkos::parallel_reduce with a TeamPolicy using a team_size smaller "
+          "than 64 is not currently supported with HIP for dynamic sized "
+          "reduction types.");
+
+    // Functor's reduce memory, team scan memory, and team shared memory depend
+    // upon team size.
+
+    const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
+
+    if (!Kokkos::Impl::is_integral_power_of_two(m_team_size) &&
+        !UseShflReduction) {
+      Kokkos::Impl::throw_runtime_exception(
+          std::string("Kokkos::Impl::ParallelReduce< HIP > bad team size"));
+    }
+
+    if (m_policy.space().impl_internal_space_instance()->m_maxShmemPerBlock <
+        shmem_size_total) {
+      Kokkos::Impl::throw_runtime_exception(
+          std::string("Kokkos::Impl::ParallelReduce< HIP > requested too much "
+                      "L0 scratch memory"));
+    }
+
+    if (static_cast<int>(m_team_size) >
+        arg_policy.team_size_max(m_functor, m_reducer, ParallelReduceTag())) {
+      Kokkos::Impl::throw_runtime_exception(
+          std::string("Kokkos::Impl::ParallelReduce< HIP > requested too "
+                      "large team size."));
+    }
+  }
+
+  ParallelReduce(FunctorType const& arg_functor, Policy const& arg_policy,
+                 ReducerType const& reducer)
+      : m_functor(arg_functor),
+        m_policy(arg_policy),
+        m_reducer(reducer),
+        m_result_ptr(reducer.view().data()),
+        m_result_ptr_device_accessible(
+            MemorySpaceAccess<Kokkos::Experimental::HIPSpace,
+                              typename ReducerType::result_view_type::
+                                  memory_space>::accessible),
+        m_scratch_space(0),
+        m_scratch_flags(0),
+        m_team_begin(0),
+        m_shmem_begin(0),
+        m_shmem_size(0),
+        m_scratch_ptr{nullptr, nullptr},
+        m_league_size(arg_policy.league_size()),
+        m_team_size(arg_policy.team_size()),
+        m_vector_size(arg_policy.vector_length()) {
+    hipFuncAttributes attr = Kokkos::Experimental::Impl::HIPParallelLaunch<
+        ParallelReduce, LaunchBounds>::get_hip_func_attributes();
+    m_team_size =
+        m_team_size >= 0
+            ? m_team_size
+            : Kokkos::Experimental::Impl::hip_get_opt_block_size<FunctorType,
+                                                                 LaunchBounds>(
+                  m_policy.space().impl_internal_space_instance(), attr,
+                  m_functor, m_vector_size, m_policy.team_scratch_size(0),
+                  m_policy.thread_scratch_size(0)) /
+                  m_vector_size;
+
+    // Return Init value if the number of worksets is zero
+    if (arg_policy.league_size() == 0) {
+      ValueInit::init(ReducerConditional::select(m_functor, m_reducer),
+                      m_result_ptr);
+      return;
+    }
+
+    m_team_begin =
+        UseShflReduction
+            ? 0
+            : hip_single_inter_block_reduce_scan_shmem<false, FunctorType,
+                                                       WorkTag>(arg_functor,
+                                                                m_team_size);
+    m_shmem_begin = sizeof(double) * (m_team_size + 2);
+    m_shmem_size =
+        m_policy.scratch_size(0, m_team_size) +
+        FunctorTeamShmemSize<FunctorType>::value(arg_functor, m_team_size);
+    m_scratch_size[0] = m_shmem_size;
+    m_scratch_size[1] = m_policy.scratch_size(1, m_team_size);
+    m_scratch_ptr[1] =
+        m_team_size <= 0 ? nullptr
+                         : Kokkos::Experimental::Impl::hip_resize_scratch_space(
+                               static_cast<ptrdiff_t>(m_scratch_size[1]) *
+                               static_cast<ptrdiff_t>(
+                                   Kokkos::Experimental::HIP::concurrency() /
+                                   (m_team_size * m_vector_size)));
+
+    // The global parallel_reduce does not support vector_length other than 1 at
+    // the moment
+    if ((arg_policy.vector_length() > 1) && !UseShflReduction)
+      Impl::throw_runtime_exception(
+          "Kokkos::parallel_reduce with a TeamPolicy using a vector length of "
+          "greater than 1 is not currently supported for HIP for dynamic "
+          "sized reduction types.");
+
+    if ((m_team_size < Kokkos::Experimental::Impl::HIPTraits::WarpSize) &&
+        !UseShflReduction)
+      Impl::throw_runtime_exception(
+          "Kokkos::parallel_reduce with a TeamPolicy using a team_size smaller "
+          "than 64 is not currently supported with HIP for dynamic sized "
+          "reduction types.");
+
+    // Functor's reduce memory, team scan memory, and team shared memory depend
+    // upon team size.
+
+    const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
+
+    if ((!Kokkos::Impl::is_integral_power_of_two(m_team_size) &&
+         !UseShflReduction) ||
+        m_policy.space().impl_internal_space_instance()->m_maxShmemPerBlock <
+            shmem_size_total) {
+      Kokkos::Impl::throw_runtime_exception(
+          std::string("Kokkos::Impl::ParallelReduce< HIP > bad team size"));
+    }
+    if (static_cast<int>(m_team_size) >
+        arg_policy.team_size_max(m_functor, m_reducer, ParallelReduceTag())) {
+      Kokkos::Impl::throw_runtime_exception(
+          std::string("Kokkos::Impl::ParallelReduce< HIP > requested too "
+                      "large team size."));
     }
   }
 };

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -49,8 +49,326 @@
 
 #if defined(__HIPCC__)
 
+#include <HIP/Kokkos_HIP_Vectorization.hpp>
+
 namespace Kokkos {
 namespace Impl {
+
+/* Algorithmic constraints:
+ *   (a) threads with the same hipThreadIdx_x have same value
+ *   (b) hipBlockDim_x == power of two
+ *   (x) hipBlockDim_z == 1
+ */
+template <typename ValueType, typename JoinOp,
+          typename std::enable_if<!Kokkos::is_reducer<ValueType>::value,
+                                  int>::type = 0>
+__device__ inline void hip_intra_warp_reduction(
+    ValueType& result, JoinOp const& join,
+    uint32_t const max_active_thread = hipBlockDim_y) {
+  unsigned int shift = 1;
+
+  // Reduce over values from threads with different hipThreadIdx_y
+  unsigned int constexpr warp_size =
+      Kokkos::Experimental::Impl::HIPTraits::WarpSize;
+  while (hipBlockDim_x * shift < warp_size) {
+    ValueType const tmp = Kokkos::Experimental::shfl_down(
+        result, hipBlockDim_x * shift, warp_size);
+    // Only join the if upper thread is active (this allows non power of two for
+    // hipBlockDim_y)
+    if (hipThreadIdx_y + shift < max_active_thread) join(result, tmp);
+    shift *= 2;
+  }
+
+  // Broadcast the result to all the threads in the warp
+  result = Kokkos::Experimental::shfl(result, 0, warp_size);
+}
+
+template <typename ValueType, typename JoinOp,
+          typename std::enable_if<!Kokkos::is_reducer<ValueType>::value,
+                                  int>::type = 0>
+__device__ inline void hip_inter_warp_reduction(
+    ValueType& value, const JoinOp& join,
+    const int max_active_thread = hipBlockDim_y) {
+  unsigned int constexpr warp_size =
+      Kokkos::Experimental::Impl::HIPTraits::WarpSize;
+  int constexpr step_width = 8;
+  // Depending on the ValueType __shared__ memory must be aligned up to 8 byte
+  // boundaries. The reason not to use ValueType directly is that for types with
+  // constructors it could lead to race conditions.
+  __shared__ double sh_result[(sizeof(ValueType) + 7) / 8 * step_width];
+  ValueType* result = reinterpret_cast<ValueType*>(&sh_result);
+  int const step    = warp_size / hipBlockDim_x;
+  int shift         = step_width;
+  int const id = hipThreadIdx_y % step == 0 ? hipThreadIdx_y / step : 65000;
+  if (id < step_width) {
+    result[id] = value;
+  }
+  __syncthreads();
+  while (shift <= max_active_thread / step) {
+    if (shift <= id && shift + step_width > id && hipThreadIdx_x == 0) {
+      join(result[id % step_width], value);
+    }
+    __syncthreads();
+    shift += step_width;
+  }
+
+  value = result[0];
+  for (int i = 1; (i * step < max_active_thread) && (i < step_width); ++i)
+    join(value, result[i]);
+}
+
+template <typename ValueType, typename JoinOp,
+          typename std::enable_if<!Kokkos::is_reducer<ValueType>::value,
+                                  int>::type = 0>
+__device__ inline void hip_intra_block_reduction(
+    ValueType& value, JoinOp const& join,
+    int const max_active_thread = hipBlockDim_y) {
+  hip_intra_warp_reduction(value, join, max_active_thread);
+  hip_inter_warp_reduction(value, join, max_active_thread);
+}
+
+template <class FunctorType, class JoinOp, class ArgTag = void>
+__device__ bool hip_inter_block_reduction(
+    typename FunctorValueTraits<FunctorType, ArgTag>::reference_type value,
+    typename FunctorValueTraits<FunctorType, ArgTag>::reference_type neutral,
+    JoinOp const& join,
+    Kokkos::Experimental::HIP::size_type* const m_scratch_space,
+    typename FunctorValueTraits<FunctorType,
+                                ArgTag>::pointer_type const /*result*/,
+    Kokkos::Experimental::HIP::size_type* const m_scratch_flags,
+    int const max_active_thread = hipBlockDim_y) {
+  typedef typename FunctorValueTraits<FunctorType, ArgTag>::pointer_type
+      pointer_type;
+  typedef
+      typename FunctorValueTraits<FunctorType, ArgTag>::value_type value_type;
+
+  // Do the intra-block reduction with shfl operations and static shared memory
+  hip_intra_block_reduction(value, join, max_active_thread);
+
+  int const id = hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x;
+
+  // One thread in the block writes block result to global scratch_memory
+  if (id == 0) {
+    pointer_type global =
+        reinterpret_cast<pointer_type>(m_scratch_space) + hipBlockIdx_x;
+    *global = value;
+  }
+
+  // One warp of last block performs inter block reduction through loading the
+  // block values from global scratch_memory
+  bool last_block = false;
+  __threadfence();
+  __syncthreads();
+  int constexpr warp_size = Kokkos::Experimental::Impl::HIPTraits::WarpSize;
+  if (id < warp_size) {
+    Kokkos::Experimental::HIP::size_type count;
+
+    // Figure out whether this is the last block
+    if (id == 0) count = Kokkos::atomic_fetch_add(m_scratch_flags, 1);
+    count = Kokkos::Experimental::shfl(count, 0, warp_size);
+
+    // Last block does the inter block reduction
+    if (count == hipGridDim_x - 1) {
+      // set flag back to zero
+      if (id == 0) *m_scratch_flags = 0;
+      last_block = true;
+      value      = neutral;
+
+      pointer_type const volatile global =
+          reinterpret_cast<pointer_type>(m_scratch_space);
+
+      // Reduce all global values with splitting work over threads in one warp
+      const int step_size = hipBlockDim_x * hipBlockDim_y < warp_size
+                                ? hipBlockDim_x * hipBlockDim_y
+                                : warp_size;
+      for (int i = id; i < static_cast<int>(hipGridDim_x); i += step_size) {
+        value_type tmp = global[i];
+        join(value, tmp);
+      }
+
+      // Perform shfl reductions within the warp only join if contribution is
+      // valid (allows hipGridDim_x non power of two and <warp_size)
+      if (static_cast<int>(hipBlockDim_x * hipBlockDim_y) > 1) {
+        value_type tmp = Kokkos::Experimental::shfl_down(value, 1, warp_size);
+        if (id + 1 < static_cast<int>(hipGridDim_x)) join(value, tmp);
+      }
+      // FIXME_HIP check that the ballot is necessary. Also active is not read.
+      int active = __ballot(1);
+      for (unsigned int i = 2; i < warp_size; i *= 2) {
+        if ((hipBlockDim_x * hipBlockDim_y) > i) {
+          value_type tmp = Kokkos::Experimental::shfl_down(value, i, warp_size);
+          if (id + i < hipGridDim_x) join(value, tmp);
+        }
+        active += __ballot(1);
+      }
+    }
+  }
+  // The last block has in its thread=0 the global reduction value through
+  // "value"
+  return last_block;
+}
+
+template <typename ReducerType,
+          typename std::enable_if<Kokkos::is_reducer<ReducerType>::value,
+                                  int>::type = 0>
+__device__ inline void hip_intra_warp_reduction(
+    const ReducerType& reducer, typename ReducerType::value_type& result,
+    const uint32_t max_active_thread = hipBlockDim_y) {
+  typedef typename ReducerType::value_type ValueType;
+
+  unsigned int shift = 1;
+
+  // Reduce over values from threads with different hipThreadIdx_y
+  unsigned int constexpr warp_size =
+      Kokkos::Experimental::Impl::HIPTraits::WarpSize;
+  while (hipBlockDim_x * shift < warp_size) {
+    const ValueType tmp = Kokkos::Experimental::shfl_down(
+        result, hipBlockDim_x * shift, warp_size);
+    // Only join if upper thread is active (this allows non power of two for
+    // hipBlockDim_y)
+    if (hipThreadIdx_y + shift < max_active_thread) reducer.join(result, tmp);
+    shift *= 2;
+  }
+
+  result              = ::Kokkos::Experimental::shfl(result, 0, warp_size);
+  reducer.reference() = result;
+}
+
+template <typename ReducerType,
+          typename std::enable_if<Kokkos::is_reducer<ReducerType>::value,
+                                  int>::type = 0>
+__device__ inline void hip_inter_warp_reduction(
+    ReducerType const& reducer, typename ReducerType::value_type value,
+    int const max_active_thread = hipBlockDim_y) {
+  using ValueType          = typename ReducerType::value_type;
+  int constexpr step_width = 8;
+  // Depending on the ValueType __shared__ memory must be aligned up to 8 byte
+  // boundaries. The reason not to use ValueType directly is that for types
+  // with constructors it could lead to race conditions.
+  __shared__ double sh_result[(sizeof(ValueType) + 7) / 8 * step_width];
+  ValueType* result = reinterpret_cast<ValueType*>(&sh_result);
+  int const step =
+      Kokkos::Experimental::Impl::HIPTraits::WarpSize / hipBlockDim_x;
+  int shift    = step_width;
+  int const id = hipThreadIdx_y % step == 0 ? hipThreadIdx_y / step : 65000;
+  if (id < step_width) {
+    result[id] = value;
+  }
+  __syncthreads();
+  while (shift <= max_active_thread / step) {
+    if (shift <= id && shift + step_width > id && hipThreadIdx_x == 0) {
+      reducer.join(result[id % step_width], value);
+    }
+    __syncthreads();
+    shift += step_width;
+  }
+
+  value = result[0];
+  for (int i = 1; (i * step < max_active_thread) && i < step_width; ++i)
+    reducer.join(value, result[i]);
+
+  reducer.reference() = value;
+}
+
+template <typename ReducerType,
+          typename std::enable_if<Kokkos::is_reducer<ReducerType>::value,
+                                  int>::type = 0>
+__device__ inline void hip_intra_block_reduction(
+    ReducerType const& reducer, typename ReducerType::value_type value,
+    int const max_active_thread = hipBlockDim_y) {
+  hip_intra_warp_reduction(reducer, value, max_active_thread);
+  hip_inter_warp_reduction(reducer, value, max_active_thread);
+}
+
+template <typename ReducerType,
+          typename std::enable_if<Kokkos::is_reducer<ReducerType>::value,
+                                  int>::type = 0>
+__device__ inline void hip_intra_block_reduction(
+    ReducerType const& reducer, int const max_active_thread = hipBlockDim_y) {
+  hip_intra_block_reduction(reducer, reducer.reference(), max_active_thread);
+}
+
+template <typename ReducerType,
+          typename std::enable_if<Kokkos::is_reducer<ReducerType>::value,
+                                  int>::type = 0>
+__device__ inline bool hip_inter_block_reduction(
+    ReducerType const& reducer,
+    Kokkos::Experimental::HIP::size_type* const m_scratch_space,
+    Kokkos::Experimental::HIP::size_type* const m_scratch_flags,
+    int const max_active_thread = hipBlockDim_y) {
+  using pointer_type = typename ReducerType::value_type*;
+  using value_type   = typename ReducerType::value_type;
+
+  // Do the intra-block reduction with shfl operations and static shared memory
+  hip_intra_block_reduction(reducer, max_active_thread);
+
+  value_type value = reducer.reference();
+
+  int const id = hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x;
+
+  // One thread in the block writes block result to global scratch_memory
+  if (id == 0) {
+    pointer_type global =
+        reinterpret_cast<pointer_type>(m_scratch_space) + hipBlockIdx_x;
+    *global = value;
+  }
+
+  // One warp of last block performs inter block reduction through loading the
+  // block values from global scratch_memory
+  bool last_block = false;
+
+  __threadfence();
+  __syncthreads();
+  int constexpr warp_size = Kokkos::Experimental::Impl::HIPTraits::WarpSize;
+  if (id < warp_size) {
+    Kokkos::Experimental::HIP::size_type count;
+
+    // Figure out whether this is the last block
+    if (id == 0) count = Kokkos::atomic_fetch_add(m_scratch_flags, 1);
+    count = Kokkos::Experimental::shfl(count, 0, warp_size);
+
+    // Last block does the inter block reduction
+    if (count == hipGridDim_x - 1) {
+      // Set flag back to zero
+      if (id == 0) *m_scratch_flags = 0;
+      last_block = true;
+      reducer.init(value);
+
+      pointer_type const volatile global =
+          reinterpret_cast<pointer_type>(m_scratch_space);
+
+      // Reduce all global values with splitting work over threads in one warp
+      int const step_size = hipBlockDim_x * hipBlockDim_y < warp_size
+                                ? hipBlockDim_x * hipBlockDim_y
+                                : warp_size;
+      for (int i = id; i < static_cast<int>(hipGridDim_x); i += step_size) {
+        value_type tmp = global[i];
+        reducer.join(value, tmp);
+      }
+
+      // Perform shfl reductions within the warp only join if contribution is
+      // valid (allows hipGridDim_x non power of two and <warp_size)
+      if (static_cast<int>(hipBlockDim_x * hipBlockDim_y) > 1) {
+        value_type tmp = Kokkos::Experimental::shfl_down(value, 1, warp_size);
+        if (id + 1 < static_cast<int>(hipGridDim_x)) reducer.join(value, tmp);
+      }
+      // FIXME_HIP check that the ballot is necessary. Also active is not read.
+      int active = __ballot(1);
+      for (unsigned int i = 2; i < 64; i *= 2) {
+        if ((hipBlockDim_x * hipBlockDim_y) > i) {
+          value_type tmp = Kokkos::Experimental::shfl_down(value, i, warp_size);
+          if (id + i < hipGridDim_x) reducer.join(value, tmp);
+        }
+        active += __ballot(1);
+      }
+    }
+  }
+
+  // The last block has in its thread = 0 the global reduction value through
+  // "value"
+  return last_block;
+}
+
 template <class FunctorType, class ArgTag, bool DoScan, bool UseShfl>
 struct HIPReductionsFunctor;
 

--- a/core/src/HIP/Kokkos_HIP_Vectorization.hpp
+++ b/core/src/HIP/Kokkos_HIP_Vectorization.hpp
@@ -52,14 +52,11 @@ namespace Kokkos {
 namespace Experimental {
 namespace Impl {
 
-// Include all lanes
-constexpr unsigned shfl_all_mask = 0xffffffff;
-
 //----------------------------------------------------------------------------
 // Shuffle operations require input to be a register (stack) variable
 
-// Derived implements do_shfl_op(unsigned mask, T& in, int lane, int width),
-// which turns in to one of KOKKOS_IMPL_HIP_SHFL(_UP_|_DOWN_|_)MASK
+// Derived implements do_shfl_op( T& in, int lane, int width),
+// which turns in to one of __shfl_XXX
 // Since the logic with respect to value sizes, etc., is the same everywhere,
 // put it all in one place.
 template <class Derived>
@@ -69,52 +66,70 @@ struct in_place_shfl_op {
     return *static_cast<Derived const*>(this);
   }
 
+  // FIXME_HIP depends on UB
+  // sizeof(Scalar) < sizeof(int) case
+  template <class Scalar>
+  // requires _assignable_from_bits<Scalar>
+  __device__ inline typename std::enable_if<sizeof(Scalar) < sizeof(int)>::type
+  operator()(Scalar& out, Scalar const& in, int lane_or_delta,
+             int width) const noexcept {
+    using shfl_type = int;
+    union conv_type {
+      Scalar orig;
+      shfl_type conv;
+    };
+    conv_type tmp_in;
+    tmp_in.orig = in;
+    conv_type tmp_out;
+    tmp_out.conv = tmp_in.conv;
+    conv_type res;
+    //------------------------------------------------
+    res.conv = self().do_shfl_op(
+        reinterpret_cast<shfl_type const&>(tmp_out.conv), lane_or_delta, width);
+    //------------------------------------------------
+    out = res.orig;
+  }
+
   // sizeof(Scalar) == sizeof(int) case
   template <class Scalar>
   // requires _assignable_from_bits<Scalar>
   __device__ inline typename std::enable_if<sizeof(Scalar) == sizeof(int)>::type
-  operator()(Scalar& out, Scalar const& in, int lane_or_delta, int width,
-             unsigned mask = shfl_all_mask) const noexcept {
-    //------------------------------------------------
+  operator()(Scalar& out, Scalar const& in, int lane_or_delta,
+             int width) const noexcept {
     reinterpret_cast<int&>(out) = self().do_shfl_op(
-        mask, reinterpret_cast<int const&>(in), lane_or_delta, width);
-    //------------------------------------------------
+        reinterpret_cast<int const&>(in), lane_or_delta, width);
   }
 
   template <class Scalar>
   __device__ inline
       typename std::enable_if<sizeof(Scalar) == sizeof(double)>::type
-      operator()(Scalar& out, Scalar const& in, int lane_or_delta, int width,
-                 unsigned mask = shfl_all_mask) const noexcept {
-    //------------------------------------------------
+      operator()(Scalar& out, Scalar const& in, int lane_or_delta,
+                 int width) const noexcept {
     reinterpret_cast<double&>(out) = self().do_shfl_op(
-        mask, *reinterpret_cast<double const*>(&in), lane_or_delta, width);
-    //------------------------------------------------
+        *reinterpret_cast<double const*>(&in), lane_or_delta, width);
   }
 
   // sizeof(Scalar) > sizeof(double) case
   template <typename Scalar>
   __device__ inline
       typename std::enable_if<(sizeof(Scalar) > sizeof(double))>::type
-      operator()(Scalar& out, const Scalar& val, int lane_or_delta, int width,
-                 unsigned mask = shfl_all_mask) const noexcept {
+      operator()(Scalar& out, const Scalar& val, int lane_or_delta,
+                 int width) const noexcept {
     using shuffle_as_t = int;
-    enum : int { N = sizeof(Scalar) / sizeof(shuffle_as_t) };
+    int constexpr N    = sizeof(Scalar) / sizeof(shuffle_as_t);
 
     for (int i = 0; i < N; ++i) {
       reinterpret_cast<shuffle_as_t*>(&out)[i] = self().do_shfl_op(
-          mask, reinterpret_cast<shuffle_as_t const*>(&val)[i], lane_or_delta,
-          width);
+          reinterpret_cast<shuffle_as_t const*>(&val)[i], lane_or_delta, width);
     }
   }
 };
 
 struct in_place_shfl_fn : in_place_shfl_op<in_place_shfl_fn> {
   template <class T>
-  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(unsigned mask, T& val,
-                                                  int lane, int width) const
-      noexcept {
-    return KOKKOS_IMPL_HIP_SHFL_MASK(mask, val, lane, width);
+  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
+                                                  int width) const noexcept {
+    return __shfl(val, lane, width);
   }
 };
 
@@ -125,10 +140,9 @@ __device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl(Args&&... args) noexcept {
 
 struct in_place_shfl_up_fn : in_place_shfl_op<in_place_shfl_up_fn> {
   template <class T>
-  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(unsigned mask, T& val,
-                                                  int lane, int width) const
-      noexcept {
-    return KOKKOS_IMPL_HIP_SHFL_UP_MASK(mask, val, lane, width);
+  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
+                                                  int width) const noexcept {
+    return __shfl_up(val, lane, width);
   }
 };
 
@@ -140,10 +154,9 @@ __device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl_up(
 
 struct in_place_shfl_down_fn : in_place_shfl_op<in_place_shfl_down_fn> {
   template <class T>
-  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(unsigned mask, T& val,
-                                                  int lane, int width) const
-      noexcept {
-    return KOKKOS_IMPL_HIP_SHFL_DOWN_MASK(mask, val, lane, width);
+  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
+                                                  int width) const noexcept {
+    return __shfl_down(val, lane, width);
   }
 };
 
@@ -154,6 +167,31 @@ __device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl_down(
 }
 
 }  // namespace Impl
+
+template <class T>
+// requires default_constructible<T> && _assignable_from_bits<T>
+__device__ inline T shfl(const T& val, const int& srcLane, const int& width) {
+  T rv = {};
+  Impl::in_place_shfl(rv, val, srcLane, width);
+  return rv;
+}
+
+template <class T>
+// requires default_constructible<T> && _assignable_from_bits<T>
+__device__ inline T shfl_down(const T& val, int delta, int width) {
+  T rv = {};
+  Impl::in_place_shfl_down(rv, val, delta, width);
+  return rv;
+}
+
+template <class T>
+// requires default_constructible<T> && _assignable_from_bits<T>
+__device__ inline T shfl_up(const T& val, int delta, int width) {
+  T rv = {};
+  Impl::in_place_shfl_up(rv, val, delta, width);
+  return rv;
+}
+
 }  // namespace Experimental
 }  // namespace Kokkos
 

--- a/core/src/HIP/Kokkos_HIP_Vectorization.hpp
+++ b/core/src/HIP/Kokkos_HIP_Vectorization.hpp
@@ -71,8 +71,8 @@ struct in_place_shfl_op {
   template <class Scalar>
   // requires _assignable_from_bits<Scalar>
   __device__ inline typename std::enable_if<sizeof(Scalar) < sizeof(int)>::type
-  operator()(Scalar& out, Scalar const& in, int lane_or_delta,
-             int width) const noexcept {
+  operator()(Scalar& out, Scalar const& in, int lane_or_delta, int width) const
+      noexcept {
     using shfl_type = int;
     union conv_type {
       Scalar orig;
@@ -94,8 +94,8 @@ struct in_place_shfl_op {
   template <class Scalar>
   // requires _assignable_from_bits<Scalar>
   __device__ inline typename std::enable_if<sizeof(Scalar) == sizeof(int)>::type
-  operator()(Scalar& out, Scalar const& in, int lane_or_delta,
-             int width) const noexcept {
+  operator()(Scalar& out, Scalar const& in, int lane_or_delta, int width) const
+      noexcept {
     reinterpret_cast<int&>(out) = self().do_shfl_op(
         reinterpret_cast<int const&>(in), lane_or_delta, width);
   }

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -262,9 +262,6 @@ if(Kokkos_ENABLE_HIP)
   # FIXME_HIP
   LIST(REMOVE_ITEM HIP_SOURCES
     hip/TestHIP_AtomicOperations_complexdouble.cpp
-    hip/TestHIP_Team.cpp
-    hip/TestHIP_TeamReductionScan.cpp
-    hip/TestHIP_TeamScratch.cpp
     hip/TestHIP_TeamTeamSize.cpp
     hip/TestHIP_TeamVectorRange.cpp
     hip/TestHIP_UniqueToken.cpp

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -1009,7 +1009,8 @@ class TestTripleNestedReduce {
 
 #endif
 
-#if !defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
+// FIXME_HIP check if HIP needs CUDA-clang workaround
+#if !(defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND) || defined(KOKKOS_ENABLE_HIP))
 TEST(TEST_CATEGORY, team_vector) {
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(0)));
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(1)));

--- a/core/unit_test/hip/TestHIP_Team.cpp
+++ b/core/unit_test/hip/TestHIP_Team.cpp
@@ -1,0 +1,152 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestTeam.hpp>
+
+namespace Test {
+
+TEST(TEST_CATEGORY, team_for) {
+  TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::test_for(
+      0);
+  TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::test_for(
+      0);
+
+  TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::test_for(
+      2);
+  TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::test_for(
+      2);
+
+  TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >::test_for(
+      1000);
+  TestTeamPolicy<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >::test_for(
+      1000);
+}
+
+TEST(TEST_CATEGORY, team_reduce) {
+  TestTeamPolicy<TEST_EXECSPACE,
+                 Kokkos::Schedule<Kokkos::Static> >::test_reduce(0);
+  TestTeamPolicy<TEST_EXECSPACE,
+                 Kokkos::Schedule<Kokkos::Dynamic> >::test_reduce(0);
+  TestTeamPolicy<TEST_EXECSPACE,
+                 Kokkos::Schedule<Kokkos::Static> >::test_reduce(2);
+  TestTeamPolicy<TEST_EXECSPACE,
+                 Kokkos::Schedule<Kokkos::Dynamic> >::test_reduce(2);
+  TestTeamPolicy<TEST_EXECSPACE,
+                 Kokkos::Schedule<Kokkos::Static> >::test_reduce(1000);
+  TestTeamPolicy<TEST_EXECSPACE,
+                 Kokkos::Schedule<Kokkos::Dynamic> >::test_reduce(1000);
+}
+
+TEST(TEST_CATEGORY, team_broadcast_long) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(0, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(0, 1);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(2, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(2, 1);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    long>::test_teambroadcast(16, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    long>::test_teambroadcast(16, 1);
+}
+
+TEST(TEST_CATEGORY, team_broadcast_char) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    unsigned char>::test_teambroadcast(0, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    unsigned char>::test_teambroadcast(0, 1);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    unsigned char>::test_teambroadcast(2, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    unsigned char>::test_teambroadcast(2, 1);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    unsigned char>::test_teambroadcast(16, 1);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    unsigned char>::test_teambroadcast(16, 1);
+}
+
+TEST(TEST_CATEGORY, team_broadcast_float) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    float>::test_teambroadcast(0, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    float>::test_teambroadcast(0, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    float>::test_teambroadcast(2, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    float>::test_teambroadcast(2, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    float>::test_teambroadcast(16, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    float>::test_teambroadcast(16, 1.3);
+}
+
+TEST(TEST_CATEGORY, team_broadcast_double) {
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    double>::test_teambroadcast(0, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    double>::test_teambroadcast(0, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    double>::test_teambroadcast(2, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    double>::test_teambroadcast(2, 1.3);
+
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
+                    double>::test_teambroadcast(16, 1.3);
+  TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,
+                    double>::test_teambroadcast(16, 1.3);
+}
+
+}  // namespace Test
+
+#include <TestTeamVector.hpp>

--- a/core/unit_test/hip/TestHIP_TeamReductionScan.cpp
+++ b/core/unit_test/hip/TestHIP_TeamReductionScan.cpp
@@ -1,0 +1,84 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestTeam.hpp>
+
+namespace Test {
+
+// FIXME_HIP
+//#if !defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
+// TEST(TEST_CATEGORY, team_scan) {
+//  TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
+//  TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
+//  TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(10);
+//  TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(10);
+//  TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(10000);
+//  TestScanTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(10000);
+//}
+//#endif
+
+TEST(TEST_CATEGORY, team_long_reduce) {
+  TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
+  TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
+  TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);
+  TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(3);
+  TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(
+      100000);
+  TestReduceTeam<long, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(
+      100000);
+}
+
+TEST(TEST_CATEGORY, team_double_reduce) {
+  TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(0);
+  TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(0);
+  TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(3);
+  TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(3);
+  TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >(
+      100000);
+  TestReduceTeam<double, TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >(
+      100000);
+}
+
+}  // namespace Test

--- a/core/unit_test/hip/TestHIP_TeamScratch.cpp
+++ b/core/unit_test/hip/TestHIP_TeamScratch.cpp
@@ -1,0 +1,82 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestTeam.hpp>
+
+namespace Test {
+
+TEST(TEST_CATEGORY, team_shared_request) {
+  TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
+  TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
+}
+
+// FIXME_HIP the parallel_reduce in this test requires a team size larger than
+// 256
+// TEST(TEST_CATEGORY, team_scratch_request) {
+//  TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
+//  TestScratchTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic> >();
+//}
+
+TEST(TEST_CATEGORY, team_lambda_shared_request) {
+  TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
+                       Kokkos::Schedule<Kokkos::Static> >();
+  TestLambdaSharedTeam<Kokkos::HostSpace, TEST_EXECSPACE,
+                       Kokkos::Schedule<Kokkos::Dynamic> >();
+}
+
+TEST(TEST_CATEGORY, scratch_align) { TestScratchAlignment<TEST_EXECSPACE>(); }
+
+TEST(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
+
+// FIXME_HIP the parallel_for and the parallel_reduce in this test requires a
+// team size larger than 256
+// TEST(TEST_CATEGORY, multi_level_scratch) {
+//  TestMultiLevelScratchTeam<TEST_EXECSPACE,
+//                            Kokkos::Schedule<Kokkos::Static> >();
+//  TestMultiLevelScratchTeam<TEST_EXECSPACE,
+//                            Kokkos::Schedule<Kokkos::Dynamic> >();
+//}
+
+}  // namespace Test


### PR DESCRIPTION
This add `parallel_reduce` for `Teams`. There are still a few problems with `parallel_reduce`, the main ones are that it doesn't work with `Vector` and there is a limit on the size of the `Team`. The `Team` cannot be bigger than 256 which is the same limit that we have in the `parallel_scan`. I would like this to be merged because it is an improvement compared to what we have and the PR is already pretty big. I plan to keep working on the `FIXME_HIP`