### PR TITLE
Control Profiling hooks programmatically

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -96,8 +96,8 @@ void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
                       uint64_t* kernelID) {
   if (Experimental::current_callbacks.begin_parallel_for != nullptr) {
     Kokkos::fence();
-    (*Experimental::current_callbacks.begin_parallel_for)(kernelPrefix.c_str(), devID,
-                                            kernelID);
+    (*Experimental::current_callbacks.begin_parallel_for)(kernelPrefix.c_str(),
+                                                          devID, kernelID);
   }
 }
 
@@ -112,8 +112,8 @@ void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
                        uint64_t* kernelID) {
   if (Experimental::current_callbacks.begin_parallel_scan != nullptr) {
     Kokkos::fence();
-    (*Experimental::current_callbacks.begin_parallel_scan)(kernelPrefix.c_str(), devID,
-                                             kernelID);
+    (*Experimental::current_callbacks.begin_parallel_scan)(kernelPrefix.c_str(),
+                                                           devID, kernelID);
   }
 }
 
@@ -128,8 +128,8 @@ void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
                          uint64_t* kernelID) {
   if (Experimental::current_callbacks.begin_parallel_reduce != nullptr) {
     Kokkos::fence();
-    (*Experimental::current_callbacks.begin_parallel_reduce)(kernelPrefix.c_str(), devID,
-                                               kernelID);
+    (*Experimental::current_callbacks.begin_parallel_reduce)(
+        kernelPrefix.c_str(), devID, kernelID);
   }
 }
 
@@ -157,14 +157,16 @@ void popRegion() {
 void allocateData(const SpaceHandle space, const std::string label,
                   const void* ptr, const uint64_t size) {
   if (Experimental::current_callbacks.allocate_data != nullptr) {
-    (*Experimental::current_callbacks.allocate_data)(space, label.c_str(), ptr, size);
+    (*Experimental::current_callbacks.allocate_data)(space, label.c_str(), ptr,
+                                                     size);
   }
 }
 
 void deallocateData(const SpaceHandle space, const std::string label,
                     const void* ptr, const uint64_t size) {
   if (Experimental::current_callbacks.deallocate_data != nullptr) {
-    (*Experimental::current_callbacks.deallocate_data)(space, label.c_str(), ptr, size);
+    (*Experimental::current_callbacks.deallocate_data)(space, label.c_str(),
+                                                       ptr, size);
   }
 }
 
@@ -173,9 +175,9 @@ void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
                    const std::string src_label, const void* src_ptr,
                    const uint64_t size) {
   if (Experimental::current_callbacks.begin_deep_copy != nullptr) {
-    (*Experimental::current_callbacks.begin_deep_copy)(dst_space, dst_label.c_str(), dst_ptr,
-                                         src_space, src_label.c_str(), src_ptr,
-                                         size);
+    (*Experimental::current_callbacks.begin_deep_copy)(
+        dst_space, dst_label.c_str(), dst_ptr, src_space, src_label.c_str(),
+        src_ptr, size);
   }
 }
 
@@ -187,7 +189,8 @@ void endDeepCopy() {
 
 void createProfileSection(const std::string& sectionName, uint32_t* secID) {
   if (Experimental::current_callbacks.create_profile_section != nullptr) {
-    (*Experimental::current_callbacks.create_profile_section)(sectionName.c_str(), secID);
+    (*Experimental::current_callbacks.create_profile_section)(
+        sectionName.c_str(), secID);
   }
 }
 
@@ -267,29 +270,37 @@ void initialize() {
       // pointer to function A direct cast will give warnings hence, we have to
       // workaround the issue by casting pointer to pointers.
       auto p1 = dlsym(firstProfileLibrary, "kokkosp_begin_parallel_for");
-      Experimental::set_begin_parallel_for_callback(*reinterpret_cast<beginFunction*>(&p1));
+      Experimental::set_begin_parallel_for_callback(
+          *reinterpret_cast<beginFunction*>(&p1));
       auto p2 = dlsym(firstProfileLibrary, "kokkosp_begin_parallel_scan");
-      Experimental::set_begin_parallel_scan_callback(*reinterpret_cast<beginFunction*>(&p2));
+      Experimental::set_begin_parallel_scan_callback(
+          *reinterpret_cast<beginFunction*>(&p2));
       auto p3 = dlsym(firstProfileLibrary, "kokkosp_begin_parallel_reduce");
       Experimental::set_begin_parallel_reduce_callback(
           *reinterpret_cast<beginFunction*>(&p3));
 
       auto p4 = dlsym(firstProfileLibrary, "kokkosp_end_parallel_scan");
-      Experimental::set_end_parallel_scan_callback(*reinterpret_cast<endFunction*>(&p4));
+      Experimental::set_end_parallel_scan_callback(
+          *reinterpret_cast<endFunction*>(&p4));
       auto p5 = dlsym(firstProfileLibrary, "kokkosp_end_parallel_for");
-      Experimental::set_end_parallel_for_callback(*reinterpret_cast<endFunction*>(&p5));
+      Experimental::set_end_parallel_for_callback(
+          *reinterpret_cast<endFunction*>(&p5));
       auto p6 = dlsym(firstProfileLibrary, "kokkosp_end_parallel_reduce");
-      Experimental::set_end_parallel_reduce_callback(*reinterpret_cast<endFunction*>(&p6));
+      Experimental::set_end_parallel_reduce_callback(
+          *reinterpret_cast<endFunction*>(&p6));
 
       auto p7 = dlsym(firstProfileLibrary, "kokkosp_init_library");
       Experimental::set_init_callback(*reinterpret_cast<initFunction*>(&p7));
       auto p8 = dlsym(firstProfileLibrary, "kokkosp_finalize_library");
-      Experimental::set_finalize_callback(*reinterpret_cast<finalizeFunction*>(&p8));
+      Experimental::set_finalize_callback(
+          *reinterpret_cast<finalizeFunction*>(&p8));
 
       auto p9 = dlsym(firstProfileLibrary, "kokkosp_push_profile_region");
-      Experimental::set_push_region_callback(*reinterpret_cast<pushFunction*>(&p9));
+      Experimental::set_push_region_callback(
+          *reinterpret_cast<pushFunction*>(&p9));
       auto p10 = dlsym(firstProfileLibrary, "kokkosp_pop_profile_region");
-      Experimental::set_pop_region_callback(*reinterpret_cast<popFunction*>(&p10));
+      Experimental::set_pop_region_callback(
+          *reinterpret_cast<popFunction*>(&p10));
 
       auto p11 = dlsym(firstProfileLibrary, "kokkosp_allocate_data");
       Experimental::set_allocate_data_callback(
@@ -302,7 +313,8 @@ void initialize() {
       Experimental::set_begin_deep_copy_callback(
           *reinterpret_cast<beginDeepCopyFunction*>(&p13));
       auto p14 = dlsym(firstProfileLibrary, "kokkosp_end_deep_copy");
-      Experimental::set_end_deep_copy_callback(*reinterpret_cast<endDeepCopyFunction*>(&p14));
+      Experimental::set_end_deep_copy_callback(
+          *reinterpret_cast<endDeepCopyFunction*>(&p14));
 
       auto p15 = dlsym(firstProfileLibrary, "kokkosp_create_profile_section");
       Experimental::set_create_profile_section_callback(
@@ -324,8 +336,8 @@ void initialize() {
   }
 
   if (Experimental::current_callbacks.init != nullptr) {
-    (*Experimental::current_callbacks.init)(0, (uint64_t)KOKKOSP_INTERFACE_VERSION,
-                              (uint32_t)0, nullptr);
+    (*Experimental::current_callbacks.init)(
+        0, (uint64_t)KOKKOSP_INTERFACE_VERSION, (uint32_t)0, nullptr);
   }
 
   Experimental::no_profiling.init     = nullptr;
@@ -441,7 +453,7 @@ void resume_tools() { current_callbacks = backup_callbacks; }
 
 EventSet get_callbacks() { return current_callbacks; }
 void set_callbacks(EventSet new_events) { current_callbacks = new_events; }
-} // namespace Experimental
+}  // namespace Experimental
 }  // namespace Profiling
 
 }  // namespace Kokkos
@@ -486,7 +498,7 @@ void endDeepCopy() {}
 
 void initialize() {}
 void finalize() {}
-
+namespace Experimental {
 static EventSet current_callbacks;
 
 void set_init_callback(initFunction) {}
@@ -515,7 +527,7 @@ void resume_tools() {}
 
 EventSet get_callbacks() { return current_callbacks; }
 void set_callbacks(EventSet) {}
-
+}  // namespace Experimental
 }  // namespace Profiling
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -43,6 +43,8 @@
 */
 
 #include <Kokkos_Macros.hpp>
+#include <impl/Kokkos_Profiling.hpp>
+
 #if defined(KOKKOS_ENABLE_PROFILING)
 #include <dlfcn.h>
 #endif
@@ -52,7 +54,6 @@
 #include <chrono>
 
 #if defined(KOKKOS_ENABLE_PROFILING)
-#include <impl/Kokkos_Profiling.hpp>
 #include <cstring>
 #include <unordered_map>
 #include <unordered_set>
@@ -60,107 +61,84 @@
 namespace Kokkos {
 namespace Profiling {
 
-static initFunction initProfileLibrary         = nullptr;
-static finalizeFunction finalizeProfileLibrary = nullptr;
+static EventSet current_callbacks;
+static EventSet backup_callbacks;
 
-static beginFunction beginForCallback    = nullptr;
-static beginFunction beginScanCallback   = nullptr;
-static beginFunction beginReduceCallback = nullptr;
-static endFunction endForCallback        = nullptr;
-static endFunction endScanCallback       = nullptr;
-static endFunction endReduceCallback     = nullptr;
-
-static pushFunction pushRegionCallback = nullptr;
-static popFunction popRegionCallback   = nullptr;
-
-static allocateDataFunction allocateDataCallback     = nullptr;
-static deallocateDataFunction deallocateDataCallback = nullptr;
-
-static beginDeepCopyFunction beginDeepCopyCallback = nullptr;
-static endDeepCopyFunction endDeepCopyCallback     = nullptr;
-
-static createProfileSectionFunction createSectionCallback   = nullptr;
-static startProfileSectionFunction startSectionCallback     = nullptr;
-static stopProfileSectionFunction stopSectionCallback       = nullptr;
-static destroyProfileSectionFunction destroySectionCallback = nullptr;
-
-static profileEventFunction profileEventCallback = nullptr;
-}  // end namespace Profiling
-
-namespace Profiling {
-
-bool profileLibraryLoaded() { return (initProfileLibrary != nullptr); }
+bool profileLibraryLoaded() { return (current_callbacks.init != nullptr); }
 
 void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
                       uint64_t* kernelID) {
-  if (beginForCallback != nullptr) {
+  if (current_callbacks.begin_parallel_for != nullptr) {
     Kokkos::fence();
-    (*beginForCallback)(kernelPrefix.c_str(), devID, kernelID);
+    (*current_callbacks.begin_parallel_for)(kernelPrefix.c_str(), devID,
+                                            kernelID);
   }
 }
 
 void endParallelFor(const uint64_t kernelID) {
-  if (endForCallback != nullptr) {
+  if (current_callbacks.end_parallel_for != nullptr) {
     Kokkos::fence();
-    (*endForCallback)(kernelID);
+    (*current_callbacks.end_parallel_for)(kernelID);
   }
 }
 
 void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
                        uint64_t* kernelID) {
-  if (beginScanCallback != nullptr) {
+  if (current_callbacks.begin_parallel_scan != nullptr) {
     Kokkos::fence();
-    (*beginScanCallback)(kernelPrefix.c_str(), devID, kernelID);
+    (*current_callbacks.begin_parallel_scan)(kernelPrefix.c_str(), devID,
+                                             kernelID);
   }
 }
 
 void endParallelScan(const uint64_t kernelID) {
-  if (endScanCallback != nullptr) {
+  if (current_callbacks.end_parallel_scan != nullptr) {
     Kokkos::fence();
-    (*endScanCallback)(kernelID);
+    (*current_callbacks.end_parallel_scan)(kernelID);
   }
 }
 
 void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
                          uint64_t* kernelID) {
-  if (beginReduceCallback != nullptr) {
+  if (current_callbacks.begin_parallel_reduce != nullptr) {
     Kokkos::fence();
-    (*beginReduceCallback)(kernelPrefix.c_str(), devID, kernelID);
+    (*current_callbacks.begin_parallel_reduce)(kernelPrefix.c_str(), devID,
+                                               kernelID);
   }
 }
 
 void endParallelReduce(const uint64_t kernelID) {
-  if (endReduceCallback != nullptr) {
+  if (current_callbacks.end_parallel_reduce != nullptr) {
     Kokkos::fence();
-    (*endReduceCallback)(kernelID);
+    (*current_callbacks.end_parallel_reduce)(kernelID);
   }
 }
 
 void pushRegion(const std::string& kName) {
-  if (pushRegionCallback != nullptr) {
+  if (current_callbacks.push_region != nullptr) {
     Kokkos::fence();
-    (*pushRegionCallback)(kName.c_str());
+    (*current_callbacks.push_region)(kName.c_str());
   }
 }
 
 void popRegion() {
-  if (popRegionCallback != nullptr) {
+  if (current_callbacks.pop_region != nullptr) {
     Kokkos::fence();
-    (*popRegionCallback)();
+    (*current_callbacks.pop_region)();
   }
 }
 
 void allocateData(const SpaceHandle space, const std::string label,
                   const void* ptr, const uint64_t size) {
-  if (allocateDataCallback != nullptr) {
-    (*allocateDataCallback)(space, label.c_str(), ptr, size);
+  if (current_callbacks.allocate_data != nullptr) {
+    (*current_callbacks.allocate_data)(space, label.c_str(), ptr, size);
   }
 }
 
 void deallocateData(const SpaceHandle space, const std::string label,
                     const void* ptr, const uint64_t size) {
-  if (deallocateDataCallback != nullptr) {
-    (*deallocateDataCallback)(space, label.c_str(), ptr, size);
+  if (current_callbacks.deallocate_data != nullptr) {
+    (*current_callbacks.deallocate_data)(space, label.c_str(), ptr, size);
   }
 }
 
@@ -168,45 +146,46 @@ void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
                    const void* dst_ptr, const SpaceHandle src_space,
                    const std::string src_label, const void* src_ptr,
                    const uint64_t size) {
-  if (beginDeepCopyCallback != nullptr) {
-    (*beginDeepCopyCallback)(dst_space, dst_label.c_str(), dst_ptr, src_space,
-                             src_label.c_str(), src_ptr, size);
+  if (current_callbacks.begin_deep_copy != nullptr) {
+    (*current_callbacks.begin_deep_copy)(dst_space, dst_label.c_str(), dst_ptr,
+                                         src_space, src_label.c_str(), src_ptr,
+                                         size);
   }
 }
 
 void endDeepCopy() {
-  if (endDeepCopyCallback != nullptr) {
-    (*endDeepCopyCallback)();
+  if (current_callbacks.end_deep_copy != nullptr) {
+    (*current_callbacks.end_deep_copy)();
   }
 }
 
 void createProfileSection(const std::string& sectionName, uint32_t* secID) {
-  if (createSectionCallback != nullptr) {
-    (*createSectionCallback)(sectionName.c_str(), secID);
+  if (current_callbacks.create_profile_section != nullptr) {
+    (*current_callbacks.create_profile_section)(sectionName.c_str(), secID);
   }
 }
 
 void startSection(const uint32_t secID) {
-  if (startSectionCallback != nullptr) {
-    (*startSectionCallback)(secID);
+  if (current_callbacks.start_profile_section != nullptr) {
+    (*current_callbacks.start_profile_section)(secID);
   }
 }
 
 void stopSection(const uint32_t secID) {
-  if (stopSectionCallback != nullptr) {
-    (*stopSectionCallback)(secID);
+  if (current_callbacks.stop_profile_section != nullptr) {
+    (*current_callbacks.stop_profile_section)(secID);
   }
 }
 
 void destroyProfileSection(const uint32_t secID) {
-  if (destroySectionCallback != nullptr) {
-    (*destroySectionCallback)(secID);
+  if (current_callbacks.destroy_profile_section != nullptr) {
+    (*current_callbacks.destroy_profile_section)(secID);
   }
 }
 
 void markEvent(const std::string& eventName) {
-  if (profileEventCallback != nullptr) {
-    (*profileEventCallback)(eventName.c_str());
+  if (current_callbacks.profile_event != nullptr) {
+    (*current_callbacks.profile_event)(eventName.c_str());
   }
 }
 
@@ -219,6 +198,8 @@ SpaceHandle make_space_handle(const char* space_name) {
 }  // end namespace Profiling
 
 namespace Profiling {
+
+static EventSet no_profiling;
 
 void initialize() {
   // Make sure initialize calls happens only once
@@ -262,57 +243,91 @@ void initialize() {
       // pointer to function A direct cast will give warnings hence, we have to
       // workaround the issue by casting pointer to pointers.
       auto p1 = dlsym(firstProfileLibrary, "kokkosp_begin_parallel_for");
-      beginForCallback = *((beginFunction*)&p1);
+      set_begin_parallel_for_callback(*reinterpret_cast<beginFunction*>(&p1));
       auto p2 = dlsym(firstProfileLibrary, "kokkosp_begin_parallel_scan");
-      beginScanCallback = *((beginFunction*)&p2);
+      set_begin_parallel_scan_callback(*reinterpret_cast<beginFunction*>(&p2));
       auto p3 = dlsym(firstProfileLibrary, "kokkosp_begin_parallel_reduce");
-      beginReduceCallback = *((beginFunction*)&p3);
+      set_begin_parallel_reduce_callback(
+          *reinterpret_cast<beginFunction*>(&p3));
 
-      auto p4         = dlsym(firstProfileLibrary, "kokkosp_end_parallel_scan");
-      endScanCallback = *((endFunction*)&p4);
-      auto p5         = dlsym(firstProfileLibrary, "kokkosp_end_parallel_for");
-      endForCallback  = *((endFunction*)&p5);
+      auto p4 = dlsym(firstProfileLibrary, "kokkosp_end_parallel_scan");
+      set_end_parallel_scan_callback(*reinterpret_cast<endFunction*>(&p4));
+      auto p5 = dlsym(firstProfileLibrary, "kokkosp_end_parallel_for");
+      set_end_parallel_for_callback(*reinterpret_cast<endFunction*>(&p5));
       auto p6 = dlsym(firstProfileLibrary, "kokkosp_end_parallel_reduce");
-      endReduceCallback = *((endFunction*)&p6);
+      set_end_parallel_reduce_callback(*reinterpret_cast<endFunction*>(&p6));
 
-      auto p7            = dlsym(firstProfileLibrary, "kokkosp_init_library");
-      initProfileLibrary = *((initFunction*)&p7);
+      auto p7 = dlsym(firstProfileLibrary, "kokkosp_init_library");
+      set_init_callback(*reinterpret_cast<initFunction*>(&p7));
       auto p8 = dlsym(firstProfileLibrary, "kokkosp_finalize_library");
-      finalizeProfileLibrary = *((finalizeFunction*)&p8);
+      set_finalize_callback(*reinterpret_cast<finalizeFunction*>(&p8));
 
       auto p9 = dlsym(firstProfileLibrary, "kokkosp_push_profile_region");
-      pushRegionCallback = *((pushFunction*)&p9);
+      set_push_region_callback(*reinterpret_cast<pushFunction*>(&p9));
       auto p10 = dlsym(firstProfileLibrary, "kokkosp_pop_profile_region");
-      popRegionCallback = *((popFunction*)&p10);
+      set_pop_region_callback(*reinterpret_cast<popFunction*>(&p10));
 
       auto p11 = dlsym(firstProfileLibrary, "kokkosp_allocate_data");
-      allocateDataCallback = *((allocateDataFunction*)&p11);
+      set_allocate_data_callback(
+          *reinterpret_cast<allocateDataFunction*>(&p11));
       auto p12 = dlsym(firstProfileLibrary, "kokkosp_deallocate_data");
-      deallocateDataCallback = *((deallocateDataFunction*)&p12);
+      set_deallocate_data_callback(
+          *reinterpret_cast<deallocateDataFunction*>(&p12));
 
       auto p13 = dlsym(firstProfileLibrary, "kokkosp_begin_deep_copy");
-      beginDeepCopyCallback = *((beginDeepCopyFunction*)&p13);
-      auto p14            = dlsym(firstProfileLibrary, "kokkosp_end_deep_copy");
-      endDeepCopyCallback = *((endDeepCopyFunction*)&p14);
+      set_begin_deep_copy_callback(
+          *reinterpret_cast<beginDeepCopyFunction*>(&p13));
+      auto p14 = dlsym(firstProfileLibrary, "kokkosp_end_deep_copy");
+      set_end_deep_copy_callback(*reinterpret_cast<endDeepCopyFunction*>(&p14));
 
       auto p15 = dlsym(firstProfileLibrary, "kokkosp_create_profile_section");
-      createSectionCallback = *((createProfileSectionFunction*)&p15);
+      set_create_profile_section_callback(
+          *(reinterpret_cast<createProfileSectionFunction*>(&p15)));
       auto p16 = dlsym(firstProfileLibrary, "kokkosp_start_profile_section");
-      startSectionCallback = *((startProfileSectionFunction*)&p16);
+      set_start_profile_section_callback(
+          *reinterpret_cast<startProfileSectionFunction*>(&p16));
       auto p17 = dlsym(firstProfileLibrary, "kokkosp_stop_profile_section");
-      stopSectionCallback = *((stopProfileSectionFunction*)&p17);
+      set_stop_profile_section_callback(
+          *reinterpret_cast<stopProfileSectionFunction*>(&p17));
       auto p18 = dlsym(firstProfileLibrary, "kokkosp_destroy_profile_section");
-      destroySectionCallback = *((destroyProfileSectionFunction*)&p18);
+      set_destroy_profile_section_callback(
+          *(reinterpret_cast<destroyProfileSectionFunction*>(&p18)));
 
       auto p19 = dlsym(firstProfileLibrary, "kokkosp_profile_event");
-      profileEventCallback = *((profileEventFunction*)&p19);
+      set_profile_event_callback(
+          *reinterpret_cast<profileEventFunction*>(&p19));
     }
   }
 
-  if (initProfileLibrary != nullptr) {
-    (*initProfileLibrary)(0, (uint64_t)KOKKOSP_INTERFACE_VERSION, (uint32_t)0,
-                          nullptr);
+  if (current_callbacks.init != nullptr) {
+    (*current_callbacks.init)(0, (uint64_t)KOKKOSP_INTERFACE_VERSION,
+                              (uint32_t)0, nullptr);
   }
+
+  no_profiling.init     = nullptr;
+  no_profiling.finalize = nullptr;
+
+  no_profiling.begin_parallel_for    = nullptr;
+  no_profiling.begin_parallel_scan   = nullptr;
+  no_profiling.begin_parallel_reduce = nullptr;
+  no_profiling.end_parallel_scan     = nullptr;
+  no_profiling.end_parallel_for      = nullptr;
+  no_profiling.end_parallel_reduce   = nullptr;
+
+  no_profiling.push_region     = nullptr;
+  no_profiling.pop_region      = nullptr;
+  no_profiling.allocate_data   = nullptr;
+  no_profiling.deallocate_data = nullptr;
+
+  no_profiling.begin_deep_copy = nullptr;
+  no_profiling.end_deep_copy   = nullptr;
+
+  no_profiling.create_profile_section  = nullptr;
+  no_profiling.start_profile_section   = nullptr;
+  no_profiling.stop_profile_section    = nullptr;
+  no_profiling.destroy_profile_section = nullptr;
+
+  no_profiling.profile_event = nullptr;
 
   free(envProfileCopy);
 }
@@ -323,40 +338,86 @@ void finalize() {
   if (is_finalized) return;
   is_finalized = 1;
 
-  if (finalizeProfileLibrary != nullptr) {
-    (*finalizeProfileLibrary)();
+  if (current_callbacks.finalize != nullptr) {
+    (*current_callbacks.finalize)();
 
     // Set all profile hooks to nullptr to prevent
     // any additional calls. Once we are told to
     // finalize, we mean it
-    initProfileLibrary     = nullptr;
-    finalizeProfileLibrary = nullptr;
-
-    beginForCallback    = nullptr;
-    beginScanCallback   = nullptr;
-    beginReduceCallback = nullptr;
-    endScanCallback     = nullptr;
-    endForCallback      = nullptr;
-    endReduceCallback   = nullptr;
-
-    pushRegionCallback = nullptr;
-    popRegionCallback  = nullptr;
-
-    allocateDataCallback   = nullptr;
-    deallocateDataCallback = nullptr;
-
-    beginDeepCopyCallback = nullptr;
-    endDeepCopyCallback   = nullptr;
-
-    createSectionCallback  = nullptr;
-    startSectionCallback   = nullptr;
-    stopSectionCallback    = nullptr;
-    destroySectionCallback = nullptr;
-
-    profileEventCallback = nullptr;
-    // TODO DZP: move to its own section
+    pause_tools();
   }
 }
+
+void set_init_callback(initFunction callback) {
+  current_callbacks.init = callback;
+}
+void set_finalize_callback(finalizeFunction callback) {
+  current_callbacks.finalize = callback;
+}
+void set_begin_parallel_for_callback(beginFunction callback) {
+  current_callbacks.begin_parallel_for = callback;
+}
+void set_end_parallel_for_callback(endFunction callback) {
+  current_callbacks.end_parallel_for = callback;
+}
+void set_begin_parallel_reduce_callback(beginFunction callback) {
+  current_callbacks.begin_parallel_reduce = callback;
+}
+void set_end_parallel_reduce_callback(endFunction callback) {
+  current_callbacks.end_parallel_reduce = callback;
+}
+void set_begin_parallel_scan_callback(beginFunction callback) {
+  current_callbacks.begin_parallel_scan = callback;
+}
+void set_end_parallel_scan_callback(endFunction callback) {
+  current_callbacks.end_parallel_scan = callback;
+}
+void set_push_region_callback(pushFunction callback) {
+  current_callbacks.push_region = callback;
+}
+void set_pop_region_callback(popFunction callback) {
+  current_callbacks.pop_region = callback;
+}
+void set_allocate_data_callback(allocateDataFunction callback) {
+  current_callbacks.allocate_data = callback;
+}
+void set_deallocate_data_callback(deallocateDataFunction callback) {
+  current_callbacks.deallocate_data = callback;
+}
+void set_create_profile_section_callback(
+    createProfileSectionFunction callback) {
+  current_callbacks.create_profile_section = callback;
+}
+void set_start_profile_section_callback(startProfileSectionFunction callback) {
+  current_callbacks.start_profile_section = callback;
+}
+void set_stop_profile_section_callback(stopProfileSectionFunction callback) {
+  current_callbacks.stop_profile_section = callback;
+}
+void set_destroy_profile_section_callback(
+    destroyProfileSectionFunction callback) {
+  current_callbacks.destroy_profile_section = callback;
+}
+void set_profile_event_callback(profileEventFunction callback) {
+  current_callbacks.profile_event = callback;
+}
+void set_begin_deep_copy_callback(beginDeepCopyFunction callback) {
+  current_callbacks.begin_deep_copy = callback;
+}
+void set_end_deep_copy_callback(endDeepCopyFunction callback) {
+  current_callbacks.end_deep_copy = callback;
+}
+
+void pause_tools() {
+  backup_callbacks  = current_callbacks;
+  current_callbacks = no_profiling;
+}
+
+void resume_tools() { current_callbacks = backup_callbacks; }
+
+EventSet get_callbacks() { return current_callbacks; }
+void set_callbacks(EventSet new_events) { current_callbacks = new_events; }
+
 }  // namespace Profiling
 
 }  // namespace Kokkos
@@ -401,6 +462,35 @@ void endDeepCopy() {}
 
 void initialize() {}
 void finalize() {}
+
+static EventSet current_callbacks;
+
+void set_init_callback(initFunction) {}
+void set_finalize_callback(finalizeFunction) {}
+void set_begin_parallel_for_callback(beginFunction) {}
+void set_end_parallel_for_callback(endFunction) {}
+void set_begin_parallel_reduce_callback(beginFunction) {}
+void set_end_parallel_reduce_callback(endFunction) {}
+void set_begin_parallel_scan_callback(beginFunction) {}
+void set_end_parallel_scan_callback(endFunction) {}
+void set_push_region_callback(pushFunction) {}
+void set_pop_region_callback(popFunction) {}
+void set_allocate_data_callback(allocateDataFunction) {}
+void set_deallocate_data_callback(deallocateDataFunction) {}
+void set_create_profile_section_callback(createProfileSectionFunction) {}
+void set_start_profile_section_callback(startProfileSectionFunction) {}
+void set_stop_profile_section_callback(stopProfileSectionFunction) {}
+void set_destroy_profile_section_callback(destroyProfileSectionFunction) {}
+void set_profile_event_callback(profileEventFunction) {}
+void set_begin_deep_copy_callback(beginDeepCopyFunction) {}
+void set_end_deep_copy_callback(endDeepCopyFunction) {}
+
+void pause_tools() {}
+
+void resume_tools() {}
+
+EventSet get_callbacks() { return current_callbacks; }
+void set_callbacks(EventSet) {}
 
 }  // namespace Profiling
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -63,8 +63,31 @@ namespace Profiling {
 
 static EventSet current_callbacks;
 static EventSet backup_callbacks;
+static EventSet no_profiling;
 
-bool profileLibraryLoaded() { return (current_callbacks.init != nullptr); }
+bool eventSetsEqual(const EventSet& l, const EventSet& r) {
+  return l.init == r.init && l.finalize == r.finalize &&
+         l.begin_parallel_for == r.begin_parallel_for &&
+         l.end_parallel_for == r.end_parallel_for &&
+         l.begin_parallel_reduce == r.begin_parallel_reduce &&
+         l.end_parallel_reduce == r.end_parallel_reduce &&
+         l.begin_parallel_scan == r.begin_parallel_scan &&
+         l.end_parallel_scan == r.end_parallel_scan &&
+         l.push_region == r.push_region && l.pop_region == r.pop_region &&
+         l.allocate_data == r.allocate_data &&
+         l.deallocate_data == r.deallocate_data &&
+         l.create_profile_section == r.create_profile_section &&
+         l.start_profile_section == r.start_profile_section &&
+         l.stop_profile_section == r.stop_profile_section &&
+         l.destroy_profile_section == r.destroy_profile_section &&
+         l.profile_event == r.profile_event &&
+         l.begin_deep_copy == r.begin_deep_copy &&
+         l.end_deep_copy == r.end_deep_copy;
+}
+
+bool profileLibraryLoaded() {
+  return !eventSetsEqual(current_callbacks, no_profiling);
+}
 
 void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
                       uint64_t* kernelID) {
@@ -198,8 +221,6 @@ SpaceHandle make_space_handle(const char* space_name) {
 }  // end namespace Profiling
 
 namespace Profiling {
-
-static EventSet no_profiling;
 
 void initialize() {
   // Make sure initialize calls happens only once

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -61,6 +61,8 @@
 namespace Kokkos {
 namespace Profiling {
 
+namespace Experimental {
+
 static EventSet current_callbacks;
 static EventSet backup_callbacks;
 static EventSet no_profiling;
@@ -84,84 +86,85 @@ bool eventSetsEqual(const EventSet& l, const EventSet& r) {
          l.begin_deep_copy == r.begin_deep_copy &&
          l.end_deep_copy == r.end_deep_copy;
 }
-
+}  // namespace Experimental
 bool profileLibraryLoaded() {
-  return !eventSetsEqual(current_callbacks, no_profiling);
+  return !Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                       Experimental::no_profiling);
 }
 
 void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
                       uint64_t* kernelID) {
-  if (current_callbacks.begin_parallel_for != nullptr) {
+  if (Experimental::current_callbacks.begin_parallel_for != nullptr) {
     Kokkos::fence();
-    (*current_callbacks.begin_parallel_for)(kernelPrefix.c_str(), devID,
+    (*Experimental::current_callbacks.begin_parallel_for)(kernelPrefix.c_str(), devID,
                                             kernelID);
   }
 }
 
 void endParallelFor(const uint64_t kernelID) {
-  if (current_callbacks.end_parallel_for != nullptr) {
+  if (Experimental::current_callbacks.end_parallel_for != nullptr) {
     Kokkos::fence();
-    (*current_callbacks.end_parallel_for)(kernelID);
+    (*Experimental::current_callbacks.end_parallel_for)(kernelID);
   }
 }
 
 void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
                        uint64_t* kernelID) {
-  if (current_callbacks.begin_parallel_scan != nullptr) {
+  if (Experimental::current_callbacks.begin_parallel_scan != nullptr) {
     Kokkos::fence();
-    (*current_callbacks.begin_parallel_scan)(kernelPrefix.c_str(), devID,
+    (*Experimental::current_callbacks.begin_parallel_scan)(kernelPrefix.c_str(), devID,
                                              kernelID);
   }
 }
 
 void endParallelScan(const uint64_t kernelID) {
-  if (current_callbacks.end_parallel_scan != nullptr) {
+  if (Experimental::current_callbacks.end_parallel_scan != nullptr) {
     Kokkos::fence();
-    (*current_callbacks.end_parallel_scan)(kernelID);
+    (*Experimental::current_callbacks.end_parallel_scan)(kernelID);
   }
 }
 
 void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
                          uint64_t* kernelID) {
-  if (current_callbacks.begin_parallel_reduce != nullptr) {
+  if (Experimental::current_callbacks.begin_parallel_reduce != nullptr) {
     Kokkos::fence();
-    (*current_callbacks.begin_parallel_reduce)(kernelPrefix.c_str(), devID,
+    (*Experimental::current_callbacks.begin_parallel_reduce)(kernelPrefix.c_str(), devID,
                                                kernelID);
   }
 }
 
 void endParallelReduce(const uint64_t kernelID) {
-  if (current_callbacks.end_parallel_reduce != nullptr) {
+  if (Experimental::current_callbacks.end_parallel_reduce != nullptr) {
     Kokkos::fence();
-    (*current_callbacks.end_parallel_reduce)(kernelID);
+    (*Experimental::current_callbacks.end_parallel_reduce)(kernelID);
   }
 }
 
 void pushRegion(const std::string& kName) {
-  if (current_callbacks.push_region != nullptr) {
+  if (Experimental::current_callbacks.push_region != nullptr) {
     Kokkos::fence();
-    (*current_callbacks.push_region)(kName.c_str());
+    (*Experimental::current_callbacks.push_region)(kName.c_str());
   }
 }
 
 void popRegion() {
-  if (current_callbacks.pop_region != nullptr) {
+  if (Experimental::current_callbacks.pop_region != nullptr) {
     Kokkos::fence();
-    (*current_callbacks.pop_region)();
+    (*Experimental::current_callbacks.pop_region)();
   }
 }
 
 void allocateData(const SpaceHandle space, const std::string label,
                   const void* ptr, const uint64_t size) {
-  if (current_callbacks.allocate_data != nullptr) {
-    (*current_callbacks.allocate_data)(space, label.c_str(), ptr, size);
+  if (Experimental::current_callbacks.allocate_data != nullptr) {
+    (*Experimental::current_callbacks.allocate_data)(space, label.c_str(), ptr, size);
   }
 }
 
 void deallocateData(const SpaceHandle space, const std::string label,
                     const void* ptr, const uint64_t size) {
-  if (current_callbacks.deallocate_data != nullptr) {
-    (*current_callbacks.deallocate_data)(space, label.c_str(), ptr, size);
+  if (Experimental::current_callbacks.deallocate_data != nullptr) {
+    (*Experimental::current_callbacks.deallocate_data)(space, label.c_str(), ptr, size);
   }
 }
 
@@ -169,46 +172,46 @@ void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
                    const void* dst_ptr, const SpaceHandle src_space,
                    const std::string src_label, const void* src_ptr,
                    const uint64_t size) {
-  if (current_callbacks.begin_deep_copy != nullptr) {
-    (*current_callbacks.begin_deep_copy)(dst_space, dst_label.c_str(), dst_ptr,
+  if (Experimental::current_callbacks.begin_deep_copy != nullptr) {
+    (*Experimental::current_callbacks.begin_deep_copy)(dst_space, dst_label.c_str(), dst_ptr,
                                          src_space, src_label.c_str(), src_ptr,
                                          size);
   }
 }
 
 void endDeepCopy() {
-  if (current_callbacks.end_deep_copy != nullptr) {
-    (*current_callbacks.end_deep_copy)();
+  if (Experimental::current_callbacks.end_deep_copy != nullptr) {
+    (*Experimental::current_callbacks.end_deep_copy)();
   }
 }
 
 void createProfileSection(const std::string& sectionName, uint32_t* secID) {
-  if (current_callbacks.create_profile_section != nullptr) {
-    (*current_callbacks.create_profile_section)(sectionName.c_str(), secID);
+  if (Experimental::current_callbacks.create_profile_section != nullptr) {
+    (*Experimental::current_callbacks.create_profile_section)(sectionName.c_str(), secID);
   }
 }
 
 void startSection(const uint32_t secID) {
-  if (current_callbacks.start_profile_section != nullptr) {
-    (*current_callbacks.start_profile_section)(secID);
+  if (Experimental::current_callbacks.start_profile_section != nullptr) {
+    (*Experimental::current_callbacks.start_profile_section)(secID);
   }
 }
 
 void stopSection(const uint32_t secID) {
-  if (current_callbacks.stop_profile_section != nullptr) {
-    (*current_callbacks.stop_profile_section)(secID);
+  if (Experimental::current_callbacks.stop_profile_section != nullptr) {
+    (*Experimental::current_callbacks.stop_profile_section)(secID);
   }
 }
 
 void destroyProfileSection(const uint32_t secID) {
-  if (current_callbacks.destroy_profile_section != nullptr) {
-    (*current_callbacks.destroy_profile_section)(secID);
+  if (Experimental::current_callbacks.destroy_profile_section != nullptr) {
+    (*Experimental::current_callbacks.destroy_profile_section)(secID);
   }
 }
 
 void markEvent(const std::string& eventName) {
-  if (current_callbacks.profile_event != nullptr) {
-    (*current_callbacks.profile_event)(eventName.c_str());
+  if (Experimental::current_callbacks.profile_event != nullptr) {
+    (*Experimental::current_callbacks.profile_event)(eventName.c_str());
   }
 }
 
@@ -264,91 +267,91 @@ void initialize() {
       // pointer to function A direct cast will give warnings hence, we have to
       // workaround the issue by casting pointer to pointers.
       auto p1 = dlsym(firstProfileLibrary, "kokkosp_begin_parallel_for");
-      set_begin_parallel_for_callback(*reinterpret_cast<beginFunction*>(&p1));
+      Experimental::set_begin_parallel_for_callback(*reinterpret_cast<beginFunction*>(&p1));
       auto p2 = dlsym(firstProfileLibrary, "kokkosp_begin_parallel_scan");
-      set_begin_parallel_scan_callback(*reinterpret_cast<beginFunction*>(&p2));
+      Experimental::set_begin_parallel_scan_callback(*reinterpret_cast<beginFunction*>(&p2));
       auto p3 = dlsym(firstProfileLibrary, "kokkosp_begin_parallel_reduce");
-      set_begin_parallel_reduce_callback(
+      Experimental::set_begin_parallel_reduce_callback(
           *reinterpret_cast<beginFunction*>(&p3));
 
       auto p4 = dlsym(firstProfileLibrary, "kokkosp_end_parallel_scan");
-      set_end_parallel_scan_callback(*reinterpret_cast<endFunction*>(&p4));
+      Experimental::set_end_parallel_scan_callback(*reinterpret_cast<endFunction*>(&p4));
       auto p5 = dlsym(firstProfileLibrary, "kokkosp_end_parallel_for");
-      set_end_parallel_for_callback(*reinterpret_cast<endFunction*>(&p5));
+      Experimental::set_end_parallel_for_callback(*reinterpret_cast<endFunction*>(&p5));
       auto p6 = dlsym(firstProfileLibrary, "kokkosp_end_parallel_reduce");
-      set_end_parallel_reduce_callback(*reinterpret_cast<endFunction*>(&p6));
+      Experimental::set_end_parallel_reduce_callback(*reinterpret_cast<endFunction*>(&p6));
 
       auto p7 = dlsym(firstProfileLibrary, "kokkosp_init_library");
-      set_init_callback(*reinterpret_cast<initFunction*>(&p7));
+      Experimental::set_init_callback(*reinterpret_cast<initFunction*>(&p7));
       auto p8 = dlsym(firstProfileLibrary, "kokkosp_finalize_library");
-      set_finalize_callback(*reinterpret_cast<finalizeFunction*>(&p8));
+      Experimental::set_finalize_callback(*reinterpret_cast<finalizeFunction*>(&p8));
 
       auto p9 = dlsym(firstProfileLibrary, "kokkosp_push_profile_region");
-      set_push_region_callback(*reinterpret_cast<pushFunction*>(&p9));
+      Experimental::set_push_region_callback(*reinterpret_cast<pushFunction*>(&p9));
       auto p10 = dlsym(firstProfileLibrary, "kokkosp_pop_profile_region");
-      set_pop_region_callback(*reinterpret_cast<popFunction*>(&p10));
+      Experimental::set_pop_region_callback(*reinterpret_cast<popFunction*>(&p10));
 
       auto p11 = dlsym(firstProfileLibrary, "kokkosp_allocate_data");
-      set_allocate_data_callback(
+      Experimental::set_allocate_data_callback(
           *reinterpret_cast<allocateDataFunction*>(&p11));
       auto p12 = dlsym(firstProfileLibrary, "kokkosp_deallocate_data");
-      set_deallocate_data_callback(
+      Experimental::set_deallocate_data_callback(
           *reinterpret_cast<deallocateDataFunction*>(&p12));
 
       auto p13 = dlsym(firstProfileLibrary, "kokkosp_begin_deep_copy");
-      set_begin_deep_copy_callback(
+      Experimental::set_begin_deep_copy_callback(
           *reinterpret_cast<beginDeepCopyFunction*>(&p13));
       auto p14 = dlsym(firstProfileLibrary, "kokkosp_end_deep_copy");
-      set_end_deep_copy_callback(*reinterpret_cast<endDeepCopyFunction*>(&p14));
+      Experimental::set_end_deep_copy_callback(*reinterpret_cast<endDeepCopyFunction*>(&p14));
 
       auto p15 = dlsym(firstProfileLibrary, "kokkosp_create_profile_section");
-      set_create_profile_section_callback(
+      Experimental::set_create_profile_section_callback(
           *(reinterpret_cast<createProfileSectionFunction*>(&p15)));
       auto p16 = dlsym(firstProfileLibrary, "kokkosp_start_profile_section");
-      set_start_profile_section_callback(
+      Experimental::set_start_profile_section_callback(
           *reinterpret_cast<startProfileSectionFunction*>(&p16));
       auto p17 = dlsym(firstProfileLibrary, "kokkosp_stop_profile_section");
-      set_stop_profile_section_callback(
+      Experimental::set_stop_profile_section_callback(
           *reinterpret_cast<stopProfileSectionFunction*>(&p17));
       auto p18 = dlsym(firstProfileLibrary, "kokkosp_destroy_profile_section");
-      set_destroy_profile_section_callback(
+      Experimental::set_destroy_profile_section_callback(
           *(reinterpret_cast<destroyProfileSectionFunction*>(&p18)));
 
       auto p19 = dlsym(firstProfileLibrary, "kokkosp_profile_event");
-      set_profile_event_callback(
+      Experimental::set_profile_event_callback(
           *reinterpret_cast<profileEventFunction*>(&p19));
     }
   }
 
-  if (current_callbacks.init != nullptr) {
-    (*current_callbacks.init)(0, (uint64_t)KOKKOSP_INTERFACE_VERSION,
+  if (Experimental::current_callbacks.init != nullptr) {
+    (*Experimental::current_callbacks.init)(0, (uint64_t)KOKKOSP_INTERFACE_VERSION,
                               (uint32_t)0, nullptr);
   }
 
-  no_profiling.init     = nullptr;
-  no_profiling.finalize = nullptr;
+  Experimental::no_profiling.init     = nullptr;
+  Experimental::no_profiling.finalize = nullptr;
 
-  no_profiling.begin_parallel_for    = nullptr;
-  no_profiling.begin_parallel_scan   = nullptr;
-  no_profiling.begin_parallel_reduce = nullptr;
-  no_profiling.end_parallel_scan     = nullptr;
-  no_profiling.end_parallel_for      = nullptr;
-  no_profiling.end_parallel_reduce   = nullptr;
+  Experimental::no_profiling.begin_parallel_for    = nullptr;
+  Experimental::no_profiling.begin_parallel_scan   = nullptr;
+  Experimental::no_profiling.begin_parallel_reduce = nullptr;
+  Experimental::no_profiling.end_parallel_scan     = nullptr;
+  Experimental::no_profiling.end_parallel_for      = nullptr;
+  Experimental::no_profiling.end_parallel_reduce   = nullptr;
 
-  no_profiling.push_region     = nullptr;
-  no_profiling.pop_region      = nullptr;
-  no_profiling.allocate_data   = nullptr;
-  no_profiling.deallocate_data = nullptr;
+  Experimental::no_profiling.push_region     = nullptr;
+  Experimental::no_profiling.pop_region      = nullptr;
+  Experimental::no_profiling.allocate_data   = nullptr;
+  Experimental::no_profiling.deallocate_data = nullptr;
 
-  no_profiling.begin_deep_copy = nullptr;
-  no_profiling.end_deep_copy   = nullptr;
+  Experimental::no_profiling.begin_deep_copy = nullptr;
+  Experimental::no_profiling.end_deep_copy   = nullptr;
 
-  no_profiling.create_profile_section  = nullptr;
-  no_profiling.start_profile_section   = nullptr;
-  no_profiling.stop_profile_section    = nullptr;
-  no_profiling.destroy_profile_section = nullptr;
+  Experimental::no_profiling.create_profile_section  = nullptr;
+  Experimental::no_profiling.start_profile_section   = nullptr;
+  Experimental::no_profiling.stop_profile_section    = nullptr;
+  Experimental::no_profiling.destroy_profile_section = nullptr;
 
-  no_profiling.profile_event = nullptr;
+  Experimental::no_profiling.profile_event = nullptr;
 
   free(envProfileCopy);
 }
@@ -359,16 +362,16 @@ void finalize() {
   if (is_finalized) return;
   is_finalized = 1;
 
-  if (current_callbacks.finalize != nullptr) {
-    (*current_callbacks.finalize)();
+  if (Experimental::current_callbacks.finalize != nullptr) {
+    (*Experimental::current_callbacks.finalize)();
 
     // Set all profile hooks to nullptr to prevent
     // any additional calls. Once we are told to
     // finalize, we mean it
-    pause_tools();
+    Experimental::pause_tools();
   }
 }
-
+namespace Experimental {
 void set_init_callback(initFunction callback) {
   current_callbacks.init = callback;
 }
@@ -438,7 +441,7 @@ void resume_tools() { current_callbacks = backup_callbacks; }
 
 EventSet get_callbacks() { return current_callbacks; }
 void set_callbacks(EventSet new_events) { current_callbacks = new_events; }
-
+} // namespace Experimental
 }  // namespace Profiling
 
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -89,6 +89,8 @@ void finalize();
 
 Kokkos_Profiling_SpaceHandle make_space_handle(const char* space_name);
 
+namespace Experimental {
+
 void set_init_callback(initFunction callback);
 void set_finalize_callback(finalizeFunction callback);
 void set_begin_parallel_for_callback(beginFunction callback);
@@ -115,7 +117,7 @@ void resume_tools();
 
 EventSet get_callbacks();
 void set_callbacks(EventSet new_events);
-
+}  // namespace Experimental
 }  // namespace Profiling
 
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -88,6 +88,34 @@ void initialize();
 void finalize();
 
 Kokkos_Profiling_SpaceHandle make_space_handle(const char* space_name);
+
+void set_init_callback(initFunction callback);
+void set_finalize_callback(finalizeFunction callback);
+void set_begin_parallel_for_callback(beginFunction callback);
+void set_end_parallel_for_callback(endFunction callback);
+void set_begin_parallel_reduce_callback(beginFunction callback);
+void set_end_parallel_reduce_callback(endFunction callback);
+void set_begin_parallel_scan_callback(beginFunction callback);
+void set_end_parallel_scan_callback(endFunction callback);
+void set_push_region_callback(pushFunction callback);
+void set_pop_region_callback(popFunction callback);
+void set_allocate_data_callback(allocateDataFunction callback);
+void set_deallocate_data_callback(deallocateDataFunction callback);
+void set_create_profile_section_callback(createProfileSectionFunction callback);
+void set_start_profile_section_callback(startProfileSectionFunction callback);
+void set_stop_profile_section_callback(stopProfileSectionFunction callback);
+void set_destroy_profile_section_callback(
+    destroyProfileSectionFunction callback);
+void set_profile_event_callback(profileEventFunction callback);
+void set_begin_deep_copy_callback(beginDeepCopyFunction callback);
+void set_end_deep_copy_callback(endDeepCopyFunction callback);
+
+void pause_tools();
+void resume_tools();
+
+EventSet get_callbacks();
+void set_callbacks(EventSet new_events);
+
 }  // namespace Profiling
 
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -94,4 +94,26 @@ typedef void (*Kokkos_Profiling_beginDeepCopyFunction)(
     Kokkos_Profiling_SpaceHandle, const char*, const void*, uint64_t);
 typedef void (*Kokkos_Profiling_endDeepCopyFunction)();
 
+struct Kokkos_Profiling_EventSet {
+  Kokkos_Profiling_initFunction init;
+  Kokkos_Profiling_finalizeFunction finalize;
+  Kokkos_Profiling_beginFunction begin_parallel_for;
+  Kokkos_Profiling_endFunction end_parallel_for;
+  Kokkos_Profiling_beginFunction begin_parallel_reduce;
+  Kokkos_Profiling_endFunction end_parallel_reduce;
+  Kokkos_Profiling_beginFunction begin_parallel_scan;
+  Kokkos_Profiling_endFunction end_parallel_scan;
+  Kokkos_Profiling_pushFunction push_region;
+  Kokkos_Profiling_popFunction pop_region;
+  Kokkos_Profiling_allocateDataFunction allocate_data;
+  Kokkos_Profiling_deallocateDataFunction deallocate_data;
+  Kokkos_Profiling_createProfileSectionFunction create_profile_section;
+  Kokkos_Profiling_startProfileSectionFunction start_profile_section;
+  Kokkos_Profiling_stopProfileSectionFunction stop_profile_section;
+  Kokkos_Profiling_destroyProfileSectionFunction destroy_profile_section;
+  Kokkos_Profiling_profileEventFunction profile_event;
+  Kokkos_Profiling_beginDeepCopyFunction begin_deep_copy;
+  Kokkos_Profiling_endDeepCopyFunction end_deep_copy;
+};
+
 #endif  // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -114,6 +114,8 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_profileEventFunction profile_event;
   Kokkos_Profiling_beginDeepCopyFunction begin_deep_copy;
   Kokkos_Profiling_endDeepCopyFunction end_deep_copy;
+  char padding[2048];  // allows us to add another 256 events to the Tools
+                       // interface without changing struct layout
 };
 
 #endif  // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -98,6 +98,7 @@ using SpaceHandle = Kokkos_Profiling_SpaceHandle;
 
 namespace Profiling {
 
+using EventSet               = Kokkos_Profiling_EventSet;
 using initFunction           = Kokkos_Profiling_initFunction;
 using finalizeFunction       = Kokkos_Profiling_finalizeFunction;
 using beginFunction          = Kokkos_Profiling_beginFunction;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -98,7 +98,9 @@ using SpaceHandle = Kokkos_Profiling_SpaceHandle;
 
 namespace Profiling {
 
-using EventSet               = Kokkos_Profiling_EventSet;
+namespace Experimental {
+using EventSet = Kokkos_Profiling_EventSet;
+}  // namespace Experimental
 using initFunction           = Kokkos_Profiling_initFunction;
 using finalizeFunction       = Kokkos_Profiling_finalizeFunction;
 using beginFunction          = Kokkos_Profiling_beginFunction;


### PR DESCRIPTION
Per #2973 , this adds two features (though it doesn't close 2973, I need one more orthogonal PR for that).

This allows 

1. A code to set the profiling hooks via an API call
2. A code to pause/resume profiling

For each callback, there's an associated setter. When a profiling hook is set, it's recorded in a struct. On pause, every callback is null'd out. On resume, the callbacks are repopulated from that struct.