### PR TITLE
Test that headers are self-contained

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -47,6 +47,7 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
 
+#include <type_traits>
 #include <Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp>
 
 namespace Kokkos {

--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -47,7 +47,6 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
 
-#include <Kokkos_Cuda.hpp>
 #include <Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp>
 
 namespace Kokkos {

--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -45,6 +45,8 @@
 #ifndef KOKKOS_CUDA_WORKGRAPHPOLICY_HPP
 #define KOKKOS_CUDA_WORKGRAPHPOLICY_HPP
 
+#include <Cuda/Kokkos_Cuda_Instance.hpp>
+
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -45,7 +45,7 @@
 #ifndef KOKKOS_CUDA_WORKGRAPHPOLICY_HPP
 #define KOKKOS_CUDA_WORKGRAPHPOLICY_HPP
 
-#include <Cuda/Kokkos_Cuda_Instance.hpp>
+#include <Kokkos_Cuda.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/HIP/Kokkos_HIP_Vectorization.hpp
+++ b/core/src/HIP/Kokkos_HIP_Vectorization.hpp
@@ -46,7 +46,6 @@
 #define KOKKOS_HIP_VECTORIZATION_HPP
 
 #include <Kokkos_Macros.hpp>
-#include <Kokkos_HIP.hpp>
 
 namespace Kokkos {
 namespace Experimental {

--- a/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
+++ b/core/src/HPX/Kokkos_HPX_WorkGraphPolicy.hpp
@@ -45,7 +45,7 @@
 #ifndef KOKKOS_HPX_WORKGRAPHPOLICY_HPP
 #define KOKKOS_HPX_WORKGRAPHPOLICY_HPP
 
-#include <HPX/Kokkos_HPX_ChunkedRoundRobinExecutor.hpp>
+#include <Kokkos_HPX.hpp>
 
 #include <hpx/apply.hpp>
 #include <hpx/lcos/local/latch.hpp>

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -45,6 +45,8 @@
 #ifndef KOKKOS_COPYVIEWS_HPP_
 #define KOKKOS_COPYVIEWS_HPP_
 #include <string>
+#include <Kokkos_Parallel.hpp>
+#include <KokkosExp_MDRangePolicy.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_Crs.hpp
+++ b/core/src/Kokkos_Crs.hpp
@@ -45,6 +45,9 @@
 #ifndef KOKKOS_CRS_HPP
 #define KOKKOS_CRS_HPP
 
+#include <Kokkos_View.hpp>
+#include <Kokkos_CopyViews.hpp>
+
 namespace Kokkos {
 
 /// \class Crs

--- a/core/src/Kokkos_Extents.hpp
+++ b/core/src/Kokkos_Extents.hpp
@@ -45,6 +45,8 @@
 #define KOKKOS_KOKKOS_EXTENTS_HPP
 
 #include <cstddef>
+#include <type_traits>
+#include <Kokkos_Macros.hpp>
 
 namespace Kokkos {
 namespace Experimental {

--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -45,6 +45,7 @@
 #ifndef KOKKOS_NUMERICTRAITS_HPP
 #define KOKKOS_NUMERICTRAITS_HPP
 
+#include <Kokkos_Macros.hpp>
 #include <climits>
 #include <cfloat>
 

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -46,6 +46,10 @@
 #define KOKKOS_PARALLEL_REDUCE_HPP
 
 #include <Kokkos_NumericTraits.hpp>
+#include <Kokkos_View.hpp>
+#include <impl/Kokkos_FunctorAnalysis.hpp>
+#include <impl/Kokkos_FunctorAdapter.hpp>
+#include <type_traits>
 
 namespace Kokkos {
 

--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -47,6 +47,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
+#include <impl/Kokkos_Profiling.hpp>
 
 #include <string>
 

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -46,6 +46,7 @@
 #define KOKKOS_SCRATCHSPACE_HPP
 
 #include <cstdio>
+#include <cstddef>
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Concepts.hpp>
 

--- a/core/src/Kokkos_TaskScheduler_fwd.hpp
+++ b/core/src/Kokkos_TaskScheduler_fwd.hpp
@@ -47,6 +47,7 @@
 
 //----------------------------------------------------------------------------
 
+#include <cstddef>
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_TASKDAG)
 

--- a/core/src/Kokkos_Timer.hpp
+++ b/core/src/Kokkos_Timer.hpp
@@ -45,6 +45,7 @@
 #ifndef KOKKOS_TIMER_HPP
 #define KOKKOS_TIMER_HPP
 
+#include <Kokkos_Macros.hpp>
 #include <chrono>
 
 namespace Kokkos {

--- a/core/src/Kokkos_Vectorization.hpp
+++ b/core/src/Kokkos_Vectorization.hpp
@@ -47,6 +47,8 @@
 #ifndef KOKKOS_VECTORIZATION_HPP
 #define KOKKOS_VECTORIZATION_HPP
 
+#include <Kokkos_Macros.hpp>
+
 #if defined(KOKKOS_ENABLE_CUDA)
 #include <Cuda/Kokkos_Cuda_Vectorization.hpp>
 #elif defined(KOKKOS_ENABLE_HIP)

--- a/core/src/Kokkos_WorkGraphPolicy.hpp
+++ b/core/src/Kokkos_WorkGraphPolicy.hpp
@@ -45,6 +45,9 @@
 #ifndef KOKKOS_WORKGRAPHPOLICY_HPP
 #define KOKKOS_WORKGRAPHPOLICY_HPP
 
+#include <impl/Kokkos_AnalyzePolicy.hpp>
+#include <Kokkos_Crs.hpp>
+
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/Kokkos_hwloc.hpp
+++ b/core/src/Kokkos_hwloc.hpp
@@ -45,6 +45,8 @@
 #ifndef KOKKOS_HWLOC_HPP
 #define KOKKOS_HWLOC_HPP
 
+#include <Kokkos_Macros.hpp>
+
 #include <utility>
 
 namespace Kokkos {

--- a/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
@@ -45,6 +45,8 @@
 #ifndef KOKKOS_OPENMP_WORKGRAPHPOLICY_HPP
 #define KOKKOS_OPENMP_WORKGRAPHPOLICY_HPP
 
+#include <Kokkos_OpenMP.hpp>
+
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/Threads/Kokkos_Threads_ViewCopyETIDecl.hpp
+++ b/core/src/Threads/Kokkos_Threads_ViewCopyETIDecl.hpp
@@ -45,6 +45,8 @@
 #ifndef KOKKOS_THREADS_VIEWETIDECL_HPP
 #define KOKKOS_THREADS_VIEWETIDECL_HPP
 
+#include <Kokkos_Macros.hpp>
+
 namespace Kokkos {
 namespace Impl {
 #define KOKKOS_IMPL_VIEWCOPY_ETI_AVAIL_EXECSPACE Kokkos::Threads

--- a/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
@@ -46,6 +46,7 @@
 #define KOKKOS_THREADS_WORKGRAPHPOLICY_HPP
 
 #include <Kokkos_Core_fwd.hpp>
+#include <Kokkos_Threads.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
@@ -45,6 +45,8 @@
 #ifndef KOKKOS_THREADS_WORKGRAPHPOLICY_HPP
 #define KOKKOS_THREADS_WORKGRAPHPOLICY_HPP
 
+#include <Kokkos_Core_fwd.hpp>
+
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/impl/Kokkos_ViewUniformType.hpp
+++ b/core/src/impl/Kokkos_ViewUniformType.hpp
@@ -45,6 +45,8 @@
 #ifndef KOKKOS_EXPERIMENTAL_VIEWUNIFORMTYPE_HPP
 #define KOKKOS_EXPERIMENTAL_VIEWUNIFORMTYPE_HPP
 
+#include <Kokkos_Macros.hpp>
+
 namespace Kokkos {
 namespace Impl {
 template <class ScalarType, int Rank>

--- a/core/src/impl/Kokkos_Volatile_Load.hpp
+++ b/core/src/impl/Kokkos_Volatile_Load.hpp
@@ -42,6 +42,8 @@
 //@HEADER
 */
 
+#include <Kokkos_Macros.hpp>
+
 #if defined(KOKKOS_ATOMIC_HPP) && !defined(KOKKOS_VOLATILE_LOAD_HPP)
 #define KOKKOS_VOLATILE_LOAD_HPP
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -427,3 +427,5 @@ KOKKOS_ADD_EXECUTABLE_AND_TEST(
   UnitTest_CTestDevice
   SOURCES UnitTestMain.cpp  TestCTestDevice.cpp
 )
+
+add_subdirectory(headers_self_contained)

--- a/core/unit_test/headers_self_contained/CMakeLists.txt
+++ b/core/unit_test/headers_self_contained/CMakeLists.txt
@@ -1,13 +1,14 @@
 # Create tests that contain each header separately. We do not  run these tests
 # but we just try to compile them.
 
- # Globbing all the header filenames to test for self-containment and presence of header guards
-file(GLOB KOKKOS_CORE_HEADERS RELATIVE ${CMAKE_SOURCE_DIR}/core/src
-     ${CMAKE_SOURCE_DIR}/core/src/*.hpp ${CMAKE_SOURCE_DIR}/core/src/*.h)
-file(GLOB KOKKOS_CONTAINERS_HEADERS RELATIVE ${CMAKE_SOURCE_DIR}/containers/src
-     ${CMAKE_SOURCE_DIR}/containers/src/*.hpp)
-file(GLOB KOKKOS_ALGORITHMS_HEADERS RELATIVE  ${CMAKE_SOURCE_DIR}/algorithms/src
-     ${CMAKE_SOURCE_DIR}/algorithms/src/*.hpp)
+# Globbing all the header filenames to test for self-containment and presence of header guards
+SET(BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../")
+file(GLOB KOKKOS_CORE_HEADERS RELATIVE ${BASE_DIR}/core/src
+     ${BASE_DIR}/core/src/*.hpp ${BASE_DIR}/core/src/*.h)
+file(GLOB KOKKOS_CONTAINERS_HEADERS RELATIVE ${BASE_DIR}/containers/src
+     ${BASE_DIR}/containers/src/*.hpp)
+file(GLOB KOKKOS_ALGORITHMS_HEADERS RELATIVE  ${BASE_DIR}/algorithms/src
+     ${BASE_DIR}/algorithms/src/*.hpp)
 
 foreach (_header ${KOKKOS_CORE_HEADERS} ${KOKKOS_CONTAINERS_HEADERS} ${KOKKOS_ALGORITHMS_HEADERS})
   string(REGEX REPLACE "[\./]" "_" header_test_name ${_header})

--- a/core/unit_test/headers_self_contained/CMakeLists.txt
+++ b/core/unit_test/headers_self_contained/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Create tests that contain each header separately. We do not  run these tests
+# but we just try to compile them.
+
+ # Globbing all the header filenames to test for self-containment and presence of header guards
+file(GLOB KOKKOS_CORE_HEADERS RELATIVE ${CMAKE_SOURCE_DIR}/core/src
+     ${CMAKE_SOURCE_DIR}/core/src/*.hpp ${CMAKE_SOURCE_DIR}/core/src/*.h)
+file(GLOB KOKKOS_CONTAINERS_HEADERS RELATIVE ${CMAKE_SOURCE_DIR}/containers/src
+     ${CMAKE_SOURCE_DIR}/containers/src/*.hpp)
+file(GLOB KOKKOS_ALGORITHMS_HEADERS RELATIVE  ${CMAKE_SOURCE_DIR}/algorithms/src
+     ${CMAKE_SOURCE_DIR}/algorithms/src/*.hpp)
+
+foreach (_header ${KOKKOS_CORE_HEADERS} ${KOKKOS_CONTAINERS_HEADERS} ${KOKKOS_ALGORITHMS_HEADERS})
+  string(REGEX REPLACE "[\./]" "_" header_test_name ${_header})
+  set(header_test_name Kokkos_HeaderSelfContained_${header_test_name})
+  add_executable(${header_test_name} tstHeader.cpp)
+  target_link_libraries(${header_test_name} PRIVATE kokkos)
+  target_compile_definitions(${header_test_name} PRIVATE KOKKOS_HEADER_TEST_NAME=${_header})
+endforeach()

--- a/core/unit_test/headers_self_contained/tstHeader.cpp
+++ b/core/unit_test/headers_self_contained/tstHeader.cpp
@@ -1,0 +1,15 @@
+#define KOKKOS_HEADER_TEST_STRINGIZE_IMPL(x) #x
+#define KOKKOS_HEADER_TEST_STRINGIZE(x) KOKKOS_HEADER_TEST_STRINGIZE_IMPL(x)
+
+#define KOKKOS_HEADER_TO_TEST \
+  KOKKOS_HEADER_TEST_STRINGIZE(KOKKOS_HEADER_TEST_NAME)
+
+// include header twice to see if the include guards are set correctly
+#include KOKKOS_HEADER_TO_TEST
+#include KOKKOS_HEADER_TO_TEST
+
+#if !defined(KOKKOS_MACROS_HPP)
+#error "This header does not include Kokkos_Macros.hpp"
+#endif
+
+int main() { return 0; }


### PR DESCRIPTION
As requested by @DavidPoliakoff, this pull request checks that all the headers in `containers`, `core` and `algorithms` (not in subdirectories) are self-contained, define include guards correctly (by including them twice) and can access `Kokkos_Macros.hpp`.
We applied this kind of check successfully in other projects.

Currently, the check lives in `core/unit_tests` and does all the checks but I am happy to copy it to `algorithms` and `containers` if that's preferred.