### PR TITLE
[HIP] parallel scan with more than 256 threads

### DIFF
--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -75,7 +75,8 @@ namespace Impl {
 void *hip_resize_scratch_space(std::int64_t bytes, bool force_shrink = false);
 
 template <typename DriverType>
-__global__ static void hip_parallel_launch_constant_memory() {
+__global__ static void hip_parallel_launch_constant_memory()
+    __attribute__((amdgpu_flat_work_group_size(1, 1024))) {
   __device__ __constant__ unsigned long kokkos_impl_hip_constant_memory_buffer
       [Kokkos::Experimental::Impl::HIPTraits::ConstantMemoryUsage /
        sizeof(unsigned long)];
@@ -87,8 +88,8 @@ __global__ static void hip_parallel_launch_constant_memory() {
 }
 
 template <class DriverType>
-__global__ static void hip_parallel_launch_local_memory(
-    const DriverType driver) {
+__global__ static void hip_parallel_launch_local_memory(const DriverType driver)
+    __attribute__((amdgpu_flat_work_group_size(1, 1024))) {
   driver();
 }
 
@@ -96,7 +97,8 @@ template <class DriverType, unsigned int maxTperB, unsigned int minBperSM>
 __global__ __launch_bounds__(
     maxTperB,
     minBperSM) static void hip_parallel_launch_local_memory(const DriverType
-                                                                driver) {
+                                                                driver)
+    __attribute__((amdgpu_flat_work_group_size(1, 1024))) {
   driver();
 }
 

--- a/core/src/HIP/Kokkos_HIP_Locks.cpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.cpp
@@ -61,14 +61,16 @@ namespace Kokkos {
 
 namespace {
 
-__global__ void init_lock_array_kernel_atomic() {
+__global__ void init_lock_array_kernel_atomic()
+    __attribute__((amdgpu_flat_work_group_size(1, 1024))) {
   unsigned i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
   if (i < KOKKOS_IMPL_HIP_SPACE_ATOMIC_MASK + 1) {
     g_device_hip_lock_arrays.atomic[i] = 0;
   }
 }
 
-__global__ void init_lock_array_kernel_threadid(int N) {
+__global__ void init_lock_array_kernel_threadid(int N)
+    __attribute__((amdgpu_flat_work_group_size(1, 1024))) {
   unsigned i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
   if (i < static_cast<unsigned>(N)) {
     g_device_hip_lock_arrays.scratch[i] = 0;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -550,14 +550,9 @@ class ParallelScanHIPBase {
   inline void impl_execute() {
     const index_type nwork = m_policy.end() - m_policy.begin();
     if (nwork) {
-      // FIXME_HIP we cannot choose it larger for large work sizes to work
-      // correctly, the unit tests fail with wrong results
-      const int gridMaxComputeCapability_2x = 0x01fff;
+      const int gridMaxComputeCapability_2x = 0x0ffff;
 
-      // FIXME_HIP block sizes greater than 256 don't work correctly,
-      // the unit tests fail with wrong results
-      const int block_size =
-          std::min(static_cast<int>(local_block_size(m_functor)), 256);
+      const int block_size = (local_block_size(m_functor));
 
       const int grid_max =
           std::min(block_size * block_size, gridMaxComputeCapability_2x);

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -275,6 +275,7 @@ if(Kokkos_ENABLE_HIP)
     UnitTest_HIP
     SOURCES
       ${HIP_SOURCES}
+      hip/TestHIP_ScanUnit.cpp
       hip/TestHIPHostPinned_ViewAPI_a.cpp
       hip/TestHIPHostPinned_ViewAPI_b.cpp
       hip/TestHIPHostPinned_ViewAPI_c.cpp

--- a/core/unit_test/hip/TestHIP_ScanUnit.cpp
+++ b/core/unit_test/hip/TestHIP_ScanUnit.cpp
@@ -52,7 +52,8 @@ struct DummyFunctor {
 };
 
 template <int N>
-__global__ void start_intra_block_scan() {
+__global__ void start_intra_block_scan()
+    __attribute__((amdgpu_flat_work_group_size(1, 1024))) {
   __shared__ DummyFunctor::value_type values[N];
   const int i = hipThreadIdx_y;
   values[i]   = i + 1;
@@ -90,8 +91,7 @@ TEST(TEST_CATEGORY, scan_unit) {
     test_intra_block_scan<64>();
     test_intra_block_scan<128>();
     test_intra_block_scan<256>();
-    // FIXME_HIP block sizes larger than 256 give wrong results.
-    // test_intra_block_scan<512>();
-    // test_intra_block_scan<1024>();
+    test_intra_block_scan<512>();
+    test_intra_block_scan<1024>();
   }
 }


### PR DESCRIPTION
This PR allows to use work groups of more than 256 for parallel scan (this should also fix the same problem in #2948 but I haven't tried yet). However with this PR, the test `hip.atomic_operations_int` fails with 
`C++ exception with description "Missing metadata for __global__ function: _ZN6Kokkos12Experimental4ImplL32hip_parallel_launch_local_memoryINS_4Impl11ParallelForIN20TestAtomicOperations11InitFunctorIiNS0_3HIPEEENS_11RangePolicyIJS7_EEES7_EEEEvT_" thrown in the test body.`
Before I spend more time to debug the problem, I was wondering: @arghdos is this a good idea to allow work groups of 1024 or should we keep the size as is?