### PR TITLE
fix nvcc_wrapper to not consider -o as a single -Xcompiler flag

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -58,7 +58,7 @@ object_files_xlinker=""
 shared_versioned_libraries_host=""
 shared_versioned_libraries=""
 
-# Does the User set the architecture 
+# Does the User set the architecture
 arch_set=0
 
 # Does the user overwrite the host compiler
@@ -77,7 +77,7 @@ host_only_args=""
 # Just run version on host compiler
 get_host_version=0
 
-# Enable workaround for CUDA 6.5 for pragma ident 
+# Enable workaround for CUDA 6.5 for pragma ident
 replace_pragma_ident=0
 
 # Mark first host compiler argument
@@ -237,13 +237,17 @@ do
     ;;
   #strip -Xcompiler because we add it
   -Xcompiler)
-    if [ $first_xcompiler_arg -eq 1 ]; then
-      xcompiler_args="$2"
-      first_xcompiler_arg=0
-    else
-      xcompiler_args="$xcompiler_args,$2"
+    if [[ $2 != "-o" ]]; then
+      if [ $first_xcompiler_arg -eq 1 ]; then
+        xcompiler_args="$2"
+        first_xcompiler_arg=0
+      else
+        xcompiler_args="$xcompiler_args,$2"
+      fi
+      shift
     fi
-    shift
+    # else this we have -Xcompiler -o <filename>, in this case just drop -Xcompiler and process
+    # the -o flag with the filename (done above)
     ;;
   #strip of "-x cu" because we add that
   -x)
@@ -329,7 +333,7 @@ do
     if [ $first_xcompiler_arg -eq 1 ]; then
       xcompiler_args=$1
       first_xcompiler_arg=0
-    else 
+    else
       xcompiler_args="$xcompiler_args,$1"
     fi
     ;;


### PR DESCRIPTION
This fixes #2993 

If we get `-o` after `-Xcompiler`, we simply ignore that `-Xcompiler` flag without processing the `-o` flag and then `-o out.o` will be processed as usual, instead of processing `-Xcompiler -o` and leaving the output file `out.o` hanging, which would then be interpreted as an object to link against.