### PR TITLE
Fixed signature of markEvent

### DIFF
--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -71,7 +71,7 @@ void startSection(const uint32_t secID);
 void stopSection(const uint32_t secID);
 void destroyProfileSection(const uint32_t secID);
 
-void markEvent(const std::string* evName);
+void markEvent(const std::string& evName);
 
 void allocateData(const SpaceHandle space, const std::string label,
                   const void* ptr, const uint64_t size);


### PR DESCRIPTION
In the process of developing unit tests for the Tools subsystem, I found that the signature of `markEvent` takes a `const std::string *` in the interface file, and a `const std::string &` in implementation. This has been true since its introduction. It looks like you'd want to call it with a `const std::string &`, so I'm changing the interface to match it.

...oops