### PR TITLE
Address issue #2989: complex double misalignment

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -97,7 +97,9 @@ __device__ inline
   // Depending on the ValueType _shared__ memory must be aligned up to 8byte
   // boundaries The reason not to use ValueType directly is that for types with
   // constructors it could lead to race conditions
-  __shared__ double sh_result[(sizeof(ValueType) + 7) / 8 * STEP_WIDTH];
+  alignas(alignof(ValueType) > alignof(double) ? alignof(ValueType)
+                                               : alignof(double))
+      __shared__ double sh_result[(sizeof(ValueType) + 7) / 8 * STEP_WIDTH];
   ValueType* result = (ValueType*)&sh_result;
   const int step    = 32 / blockDim.x;
   int shift         = STEP_WIDTH;
@@ -282,7 +284,9 @@ __device__ inline
   // Depending on the ValueType _shared__ memory must be aligned up to 8byte
   // boundaries The reason not to use ValueType directly is that for types with
   // constructors it could lead to race conditions
-  __shared__ double sh_result[(sizeof(ValueType) + 7) / 8 * STEP_WIDTH];
+  alignas(alignof(ValueType) > alignof(double) ? alignof(ValueType)
+                                               : alignof(double))
+      __shared__ double sh_result[(sizeof(ValueType) + 7) / 8 * STEP_WIDTH];
   ValueType* result = (ValueType*)&sh_result;
   const int step    = 32 / blockDim.x;
   int shift         = STEP_WIDTH;


### PR DESCRIPTION
Also probably fixes kokkos/kokkos-kernels#645 and kokkos/kokkos-kernels#704.

The reproducer in #2989 now passes with no errors. We were unable to reproduce the error in Kokkos unit tests, and that needs to be in a separate pull request anyway (since this is pull request is targeting the 3.1.1 release), so no tests were included in this particular pull request.