### PR TITLE
Include Profiling header for OpenMP with disabled profiling

### DIFF
--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -63,6 +63,7 @@
 #include <Kokkos_TaskScheduler.hpp>
 #include <Kokkos_Layout.hpp>
 #include <impl/Kokkos_Tags.hpp>
+#include <impl/Kokkos_Profiling_Interface.hpp>
 
 #include <vector>
 


### PR DESCRIPTION
Fixes #3003.