### PR TITLE
Try to autodetect the number of devices

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -372,3 +372,13 @@ void hip_internal_error_throw(hipError_t e, const char *name, const char *file,
 }
 }  // namespace Impl
 }  // namespace Kokkos
+
+//----------------------------------------------------------------------------
+
+namespace Kokkos {
+namespace Experimental {
+HIP::size_type HIP::detect_device_count() {
+  return HIPInternalDevices::singleton().m_hipDevCount;
+}
+}  // namespace Experimental
+}  // namespace Kokkos

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -587,9 +587,6 @@ void* hip_resize_scratch_space(size_t bytes, bool force_shrink) {
 namespace Kokkos {
 namespace Experimental {
 
-// HIP::size_type HIP::detect_device_count()
-//{ return Impl::HIPInternalDevices::singleton().m_hipDevCount ; }
-
 int HIP::concurrency() {
   auto const& prop = hip_device_prop();
   return prop.maxThreadsPerMultiProcessor * prop.multiProcessorCount;

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -695,7 +695,7 @@ class HIP {
 
   //  static size_type device_arch();
 
-  //  static size_type detect_device_count();
+  static size_type detect_device_count();
 
   static int concurrency();
   static const char* name();

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -200,7 +200,8 @@ void initialize_backends(const InitArguments& args) {
 #if defined(KOKKOS_ENABLE_CUDA)
                                          Cuda::detect_device_count();
 #elif defined(KOKKOS_ENABLE_HIP)
-                                         1;  // FIXME_HIP
+                                         Experimental::HIP::
+                                             detect_device_count();
 #endif
 
   const int skip_device = args.skip_device;


### PR DESCRIPTION
Fixes #2975. After talking to @crtrott this is enough at a first step.
We might want to check that all the devices also satisfy the compute capability given or something similar.

So far, I checked that we arrive at the line changed in this pull request with `-1` by default.

While there, I also changed the type of the numerous `*_found` variables to `bool`. I can rip that out into a new pull request if preferred.