### PR TITLE
Fixup for OpenMP build on Jenkins

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -115,6 +115,11 @@ pipeline {
                             args '-v /tmp/ccache.kokkos:/tmp/ccache'
                         }
                     }
+                    environment {
+                        OMP_NUM_THREADS = 8
+                        OMP_PLACES = 'threads'
+                        OMP_PROC_BIND = 'spread'
+                    }
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''rm -rf build && mkdir -p build && cd build && \


### PR DESCRIPTION
Saw the warnings when looking at the build failing on another PR
https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/Kokkos/detail/Kokkos/1779/pipeline