### PR TITLE
Force nvcc_wrapper and link libraries to obey CUDA_ROOT

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -19,6 +19,13 @@ default_arch="sm_35"
 # The default C++ compiler.
 #
 host_compiler=${NVCC_WRAPPER_DEFAULT_COMPILER:-"g++"}
+
+# Default to whatever is in the path
+nvcc_compiler=nvcc
+if [ ! -z $CUDA_ROOT ]; then
+  nvcc_compiler="$CUDA_ROOT/bin/nvcc"
+fi
+
 #host_compiler="icpc"
 #host_compiler="/usr/local/gcc/4.8.3/bin/g++"
 #host_compiler="/usr/local/gcc/4.9.1/bin/g++"
@@ -387,7 +394,7 @@ if [ $arch_set -ne 1 ]; then
 fi
 
 #Compose compilation command
-nvcc_command="nvcc $cuda_args $shared_args $xlinker_args $shared_versioned_libraries"
+nvcc_command="$nvcc_compiler $cuda_args $shared_args $xlinker_args $shared_versioned_libraries"
 if [ $first_xcompiler_arg -eq 0 ]; then
   nvcc_command="$nvcc_command -Xcompiler $xcompiler_args"
 fi

--- a/cmake/Modules/FindTPLCUDA.cmake
+++ b/cmake/Modules/FindTPLCUDA.cmake
@@ -1,11 +1,17 @@
 
+SET(CUDA_ROOT_PATH /usr/local/cuda)
+SET(CUDA_ROOT_ENV $ENV{CUDA_ROOT})
+IF(CUDA_ROOT_ENV)
+  SET(CUDA_ROOT_PATH ${CUDA_ROOT_ENV})
+ENDIF()
+
 IF (KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
    # Note: "stubs" suffix allows CMake to find the dummy
    # libcuda.so provided by the NVIDIA CUDA Toolkit for
    # cross-compiling CUDA on a host without a GPU.
    KOKKOS_FIND_IMPORTED(CUDA INTERFACE
     LIBRARIES cudart cuda
-    LIBRARY_PATHS ENV LD_LIBRARY_PATH ENV CUDA_PATH /usr/local/cuda
+    LIBRARY_PATHS ENV LD_LIBRARY_PATH ENV CUDA_PATH ${CUDA_ROOT_PATH}
     LIBRARY_SUFFIXES lib lib64 lib/stubs lib64/stubs
     ALLOW_SYSTEM_PATH_FALLBACK
    )


### PR DESCRIPTION
A proposal to simplify CUDA and nvcc_wrapper configuration rather than just relying on whichever `nvcc` is in the user path. 