### PR TITLE
Set OMP_PROC_BIND=false in unit testing on Jenkins

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -117,7 +117,8 @@ pipeline {
                     }
                     environment {
                         OMP_NUM_THREADS = 8
-                        OMP_PROC_BIND = 'false'
+                        OMP_PLACES = 'threads'
+                        OMP_PROC_BIND = 'spread'
                     }
                     steps {
                         sh 'ccache --zero-stats'
@@ -187,7 +188,7 @@ pipeline {
                     }
                     environment {
                         OMP_NUM_THREADS = 8
-                        OMP_PROC_BIND = 'false'
+                        OMP_PROC_BIND = 'true'
                     }
                     steps {
                         sh '''rm -rf build && mkdir -p build && cd build && \

--- a/.jenkins
+++ b/.jenkins
@@ -117,8 +117,7 @@ pipeline {
                     }
                     environment {
                         OMP_NUM_THREADS = 8
-                        OMP_PLACES = 'threads'
-                        OMP_PROC_BIND = 'spread'
+                        OMP_PROC_BIND = 'false'
                     }
                     steps {
                         sh 'ccache --zero-stats'
@@ -188,8 +187,7 @@ pipeline {
                     }
                     environment {
                         OMP_NUM_THREADS = 8
-                        OMP_PLACES = 'threads'
-                        OMP_PROC_BIND = 'spread'
+                        OMP_PROC_BIND = 'false'
                     }
                     steps {
                         sh '''rm -rf build && mkdir -p build && cd build && \


### PR DESCRIPTION
Saw warning in failing test [log](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/Kokkos/detail/Kokkos/1795/pipeline#step-121-log-412) on another build which led me to https://github.com/kokkos/kokkos/blob/5c9808489fd0f7b5534e403bcf8630e6c951bcff/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp#L293-L302