### PR TITLE
Reduce memory consumption ScatterView test

### DIFF
--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -520,9 +520,9 @@ void test_scatter_view(int n) {
   }
 #endif
   // with hundreds of threads we were running out of memory.
-  // limit (n) so that duplication doesn't exceed 8GB
+  // limit (n) so that duplication doesn't exceed 4GB
   constexpr std::size_t maximum_allowed_total_bytes =
-      8ull * 1024ull * 1024ull * 1024ull;
+      4ull * 1024ull * 1024ull * 1024ull;
   std::size_t const maximum_allowed_copy_bytes =
       maximum_allowed_total_bytes /
       std::size_t(execution_space().concurrency());


### PR DESCRIPTION
Lately, we have some of the CI running out of RAM. Reducing the consumption to a half should help and still keep the test meaningful. 