### PR TITLE
Extract and use get_gpu() (kokkos/kokkos#3040, trilinos/Trilinos#6840)

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -166,6 +166,8 @@ int get_ctest_gpu(const char* local_rank_str) {
   return std::atoi(id.c_str());
 }
 
+namespace {
+
 int get_gpu(const InitArguments& args) {
   int use_gpu           = args.device_id;
   const int ndevices    = args.ndevices;
@@ -204,8 +206,6 @@ int get_gpu(const InitArguments& args) {
   }
   return use_gpu;
 }
-
-namespace {
 
 bool is_unsigned_int(const char* str) {
   const size_t len = strlen(str);

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -166,36 +166,7 @@ int get_ctest_gpu(const char* local_rank_str) {
   return std::atoi(id.c_str());
 }
 
-namespace {
-
-bool is_unsigned_int(const char* str) {
-  const size_t len = strlen(str);
-  for (size_t i = 0; i < len; ++i) {
-    if (!isdigit(str[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-void initialize_backends(const InitArguments& args) {
-// This is an experimental setting
-// For KNL in Flat mode this variable should be set, so that
-// memkind allocates high bandwidth memory correctly.
-#ifdef KOKKOS_ENABLE_HBWSPACE
-  setenv("MEMKIND_HBW_NODES", "1", 0);
-#endif
-
-  // Protect declarations, to prevent "unused variable" warnings.
-#if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS) || \
-    defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_HPX)
-  const int num_threads = args.num_threads;
-#endif
-#if defined(KOKKOS_ENABLE_THREADS) || defined(KOKKOS_ENABLE_OPENMPTARGET)
-  const int use_numa = args.num_numa;
-#endif
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_ROCM) || \
-    defined(KOKKOS_ENABLE_HIP)
+int get_gpu(const InitArguments& args) {
   int use_gpu           = args.device_id;
   const int ndevices    = args.ndevices;
   const int skip_device = args.skip_device;
@@ -231,6 +202,40 @@ void initialize_backends(const InitArguments& args) {
     // shift assignments over by one so no one is assigned to "skip_device"
     if (use_gpu >= skip_device) ++use_gpu;
   }
+  return use_gpu;
+}
+
+namespace {
+
+bool is_unsigned_int(const char* str) {
+  const size_t len = strlen(str);
+  for (size_t i = 0; i < len; ++i) {
+    if (!isdigit(str[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void initialize_backends(const InitArguments& args) {
+// This is an experimental setting
+// For KNL in Flat mode this variable should be set, so that
+// memkind allocates high bandwidth memory correctly.
+#ifdef KOKKOS_ENABLE_HBWSPACE
+  setenv("MEMKIND_HBW_NODES", "1", 0);
+#endif
+
+  // Protect declarations, to prevent "unused variable" warnings.
+#if defined(KOKKOS_ENABLE_OPENMP) || defined(KOKKOS_ENABLE_THREADS) || \
+    defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_HPX)
+  const int num_threads = args.num_threads;
+#endif
+#if defined(KOKKOS_ENABLE_THREADS) || defined(KOKKOS_ENABLE_OPENMPTARGET)
+  const int use_numa = args.num_numa;
+#endif
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_ROCM) || \
+    defined(KOKKOS_ENABLE_HIP)
+  int use_gpu = get_gpu(args);
 #endif  // defined( KOKKOS_ENABLE_CUDA )
 
 #if defined(KOKKOS_ENABLE_OPENMP)

--- a/core/unit_test/TestDefaultDeviceTypeInit.hpp
+++ b/core/unit_test/TestDefaultDeviceTypeInit.hpp
@@ -52,6 +52,14 @@
 
 #if !defined(KOKKOS_ENABLE_CUDA) || defined(__CUDACC__)
 
+namespace Kokkos {
+namespace Impl {
+
+int get_gpu(const InitArguments& args);
+
+}  // namespace Impl
+}  // namespace Kokkos
+
 namespace Test {
 
 namespace Impl {
@@ -273,7 +281,7 @@ void check_correct_initialization(const Kokkos::InitArguments& argstruct) {
 
     int expected_device = argstruct.device_id;
     if (argstruct.device_id < 0) {
-      expected_device = 0;
+      expected_device = Kokkos::Impl::get_gpu(argstruct);
     }
 
     ASSERT_EQ(expected_device, device);

--- a/core/unit_test/TestDefaultDeviceTypeInit.hpp
+++ b/core/unit_test/TestDefaultDeviceTypeInit.hpp
@@ -52,14 +52,6 @@
 
 #if !defined(KOKKOS_ENABLE_CUDA) || defined(__CUDACC__)
 
-namespace Kokkos {
-namespace Impl {
-
-int get_gpu(const InitArguments& args);
-
-}  // namespace Impl
-}  // namespace Kokkos
-
 namespace Test {
 
 namespace Impl {
@@ -281,7 +273,7 @@ void check_correct_initialization(const Kokkos::InitArguments& argstruct) {
 
     int expected_device = argstruct.device_id;
     if (argstruct.device_id < 0) {
-      expected_device = Kokkos::Impl::get_gpu(argstruct);
+      expected_device = Kokkos::Cuda().cuda_device();
     }
 
     ASSERT_EQ(expected_device, device);


### PR DESCRIPTION
This fixes the tests KokkosCore_UnitTest_DefaultInit_<x>_MPI_1 that fail when
running with ctest GPU allocation feature that fail becuase they don't run on
GPU device 0 (see kokkos/kokkos#3040).

Note: Since get_ctest_gpu() returns 0 if CTest has not provided anything, it
is safe to always call it.

This new function get_gpu() should really be unit tested on its own.