### PR TITLE
core/src/impl: Conditionally define get_gpu in Kokkos_Core

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -168,8 +168,7 @@ int get_ctest_gpu(const char* local_rank_str) {
 
 namespace {
 
-#if defined(KOKKOS_ENABLE_CUDA) || \
-    defined(KOKKOS_ENABLE_ROCM) || \
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_ROCM) || \
     defined(KOKKOS_ENABLE_HIP)
 int get_gpu(const InitArguments& args) {
   int use_gpu           = args.device_id;
@@ -210,7 +209,7 @@ int get_gpu(const InitArguments& args) {
   }
   return use_gpu;
 }
-#endif // KOKKOS_ENABLE_CUDA || KOKKOS_ENABLE_ROCM || KOKKOS_ENABLE_HIP
+#endif  // KOKKOS_ENABLE_CUDA || KOKKOS_ENABLE_ROCM || KOKKOS_ENABLE_HIP
 
 bool is_unsigned_int(const char* str) {
   const size_t len = strlen(str);

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -168,6 +168,9 @@ int get_ctest_gpu(const char* local_rank_str) {
 
 namespace {
 
+#if defined(KOKKOS_ENABLE_CUDA) || \
+    defined(KOKKOS_ENABLE_ROCM) || \
+    defined(KOKKOS_ENABLE_HIP)
 int get_gpu(const InitArguments& args) {
   int use_gpu           = args.device_id;
   const int ndevices    = args.ndevices;
@@ -207,6 +210,7 @@ int get_gpu(const InitArguments& args) {
   }
   return use_gpu;
 }
+#endif // KOKKOS_ENABLE_CUDA || KOKKOS_ENABLE_ROCM || KOKKOS_ENABLE_HIP
 
 bool is_unsigned_int(const char* str) {
   const size_t len = strlen(str);


### PR DESCRIPTION
This PR conditionally defines `get_gpu` since a subset of the kokkos-kernels nightly tests do not enable `CUDA`, `ROCM`, or `HIP` and fail to build due to `get_gpu` being defined but not used.

This was tested by running spot-checks from kokkos-kernels:
```
KokkosKernels Repository Status:  190629e7ce8bd49a8cf5f42cccae260672171251 Merge pull request #728 from e10harvey/issue-727

Kokkos Repository Status:  cb9727fae308ce7ae2248dbb8168c430d958bc32 core/src/impl: Conditionally define get_gpu in Kokkos_Core


Going to test compilers:  gcc/7.2.0
Testing compiler gcc/7.2.0
  Starting job gcc-7.2.0-OpenMP-release
kokkos devices: OpenMP
kokkos arch: Power8
kokkos options: 
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED gcc-7.2.0-OpenMP-release
#######################################################
PASSED TESTS
#######################################################
gcc-7.2.0-OpenMP-release build_time=153 run_time=75
```

```
KokkosKernels Repository Status:  11c83504a722cd84e68bdbacdfc61ad30b4d79f8 Merge pull request #723 from jjwilke/install-testing

Kokkos Repository Status:  cb9727fae308ce7ae2248dbb8168c430d958bc32 core/src/impl: Conditionally define get_gpu in Kokkos_Core


Going to test compilers:  gcc/7.3.0
Testing compiler gcc/7.3.0
  Starting job gcc-7.3.0-OpenMP-release
kokkos devices: OpenMP
kokkos arch: SNB,Volta70
kokkos options: 
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED gcc-7.3.0-OpenMP-release
  Starting job gcc-7.3.0-Pthread-release
kokkos devices: Pthread
kokkos arch: SNB,Volta70
kokkos options: 
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED gcc-7.3.0-Pthread-release
#######################################################
PASSED TESTS
#######################################################
gcc-7.3.0-OpenMP-release build_time=138 run_time=60
gcc-7.3.0-Pthread-release build_time=123 run_time=53
```

Unable to select reviewers: @crtrott, @bartlettroscoe.