### PR TITLE
Fix HIPInternal::print_configuration

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -101,30 +101,29 @@ int HIPInternal::was_initialized = 0;
 int HIPInternal::was_finalized   = 0;
 //----------------------------------------------------------------------------
 
-void HIPInternal::print_configuration(std::ostream & /*s*/) const {
-  // FIXME_HIP
-  Kokkos::abort("print_configuration not implemented!\n");
-  /*const HIPInternalDevices & dev_info = HIPInternalDevices::singleton();
+void HIPInternal::print_configuration(std::ostream &s) const {
+  const HIPInternalDevices &dev_info = HIPInternalDevices::singleton();
 
-#if defined( KOKKOS_ENABLE_HIP )
-    s << "macro  KOKKOS_ENABLE_HIP      : defined" << std::endl ;
+#if defined(KOKKOS_ENABLE_HIP)
+  s << "macro  KOKKOS_ENABLE_HIP : defined" << std::endl;
 #endif
-#if defined( __hcc_version__ )
-    s << "macro  __hcc_version__          = " << __hcc_version__
-      << std::endl ;
+#if defined(HIP_VERSION)
+  s << "macro  HIP_VERSION = " << HIP_VERSION << " = version "
+    << HIP_VERSION / 100 << "." << HIP_VERSION % 100 << std::endl;
 #endif
 
-  for ( int i = 0 ; i < dev_info.m_hipDevCount ; ++i ) {
+  for (int i = 0; i < dev_info.m_hipDevCount; ++i) {
     s << "Kokkos::Experimental::HIP[ " << i << " ] "
-      << dev_info.m_hipProp[i].name
-      << " version " << (dev_info.m_hipProp[i].major) << "." <<
-dev_info.m_hipProp[i].minor
-      << ", Total Global Memory: " <<
-human_memory_size(dev_info.m_hipProp[i].totalGlobalMem)
-      << ", Shared Memory per Wavefront: " <<
-human_memory_size(dev_info.m_hipProp[i].sharedMemPerWavefront); if ( m_hipDev ==
-i ) s << " : Selected" ; s << std::endl ;
-  }*/
+      << dev_info.m_hipProp[i].name << " version "
+      << (dev_info.m_hipProp[i].major) << "." << dev_info.m_hipProp[i].minor
+      << ", Total Global Memory: "
+      << ::Kokkos::Impl::human_memory_size(dev_info.m_hipProp[i].totalGlobalMem)
+      << ", Shared Memory per Wavefront: "
+      << ::Kokkos::Impl::human_memory_size(
+             dev_info.m_hipProp[i].sharedMemPerBlock);
+    if (m_hipDev == i) s << " : Selected";
+    s << std::endl;
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -104,12 +104,10 @@ int HIPInternal::was_finalized   = 0;
 void HIPInternal::print_configuration(std::ostream &s) const {
   const HIPInternalDevices &dev_info = HIPInternalDevices::singleton();
 
-#if defined(KOKKOS_ENABLE_HIP)
-  s << "macro  KOKKOS_ENABLE_HIP : defined" << std::endl;
-#endif
+  s << "macro  KOKKOS_ENABLE_HIP : defined" << '\n';
 #if defined(HIP_VERSION)
   s << "macro  HIP_VERSION = " << HIP_VERSION << " = version "
-    << HIP_VERSION / 100 << "." << HIP_VERSION % 100 << std::endl;
+    << HIP_VERSION / 100 << "." << HIP_VERSION % 100 << '\n';
 #endif
 
   for (int i = 0; i < dev_info.m_hipDevCount; ++i) {
@@ -122,7 +120,7 @@ void HIPInternal::print_configuration(std::ostream &s) const {
       << ::Kokkos::Impl::human_memory_size(
              dev_info.m_hipProp[i].sharedMemPerBlock);
     if (m_hipDev == i) s << " : Selected";
-    s << std::endl;
+    s << '\n';
   }
 }
 


### PR DESCRIPTION
Sample output:
```
macro  KOKKOS_ENABLE_HIP : defined
macro  HIP_VERSION = 303 = version 3.3
Kokkos::Experimental::HIP[ 0 ] Vega 20 version 3.0, Total Global Memory: 31.98 G, Shared Memory per Wavefront: 64 K
Kokkos::Experimental::HIP[ 1 ] Vega 20 version 3.0, Total Global Memory: 31.98 G, Shared Memory per Wavefront: 64 K
Kokkos::Experimental::HIP[ 2 ] Vega 20 version 3.0, Total Global Memory: 31.98 G, Shared Memory per Wavefront: 64 K
Kokkos::Experimental::HIP[ 3 ] Vega 20 version 3.0, Total Global Memory: 31.98 G, Shared Memory per Wavefront: 64 K
Selected: 0
```