### PR TITLE
send --cudart to nvcc instead of host compiler

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -194,7 +194,7 @@ do
     cuda_args="$cuda_args $1"
     ;;
   #Handle known nvcc args that have an argument
-  -rdc|-maxrregcount|--default-stream|-Xnvlink|--fmad)
+  -rdc|-maxrregcount|--default-stream|-Xnvlink|--fmad|-cudart|--cudart)
     cuda_args="$cuda_args $1 $2"
     shift
     ;;


### PR DESCRIPTION
nvcc supports `--cudart {none|shared|static}`, while host compilers have no idea what to do with it...