### PR TITLE
WorkGraphPolicy for HIP

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -357,6 +357,10 @@ void HIPInternal::finalize() {
 
 //----------------------------------------------------------------------------
 
+Kokkos::Experimental::HIP::size_type hip_internal_multiprocessor_count() {
+  return HIPInternal::singleton().m_multiProcCount;
+}
+
 Kokkos::Experimental::HIP::size_type hip_internal_maximum_warp_count() {
   return HIPInternal::singleton().m_maxWarpCount;
 }

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -65,6 +65,7 @@ struct HIPTraits {
 
 HIP::size_type hip_internal_maximum_warp_count();
 HIP::size_type hip_internal_maximum_grid_count();
+HIP::size_type hip_internal_multiprocessor_count();
 
 HIP::size_type *hip_internal_scratch_space(const HIP::size_type size);
 HIP::size_type *hip_internal_scratch_flags(const HIP::size_type size);

--- a/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
@@ -1,0 +1,115 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_HIP_WORKGRAPHPOLICY_HPP
+#define KOKKOS_HIP_WORKGRAPHPOLICY_HPP
+
+#include <Kokkos_HIP.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+template <class FunctorType, class... Traits>
+class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
+                  Kokkos::Experimental::HIP> {
+ public:
+  typedef Kokkos::WorkGraphPolicy<Traits...> Policy;
+  typedef ParallelFor<FunctorType, Policy, Kokkos::Experimental::HIP> Self;
+
+ private:
+  Policy m_policy;
+  FunctorType m_functor;
+
+  template <class TagType>
+  __device__ inline
+      typename std::enable_if<std::is_same<TagType, void>::value>::type
+      exec_one(const std::int32_t w) const noexcept {
+    m_functor(w);
+  }
+
+  template <class TagType>
+  __device__ inline
+      typename std::enable_if<!std::is_same<TagType, void>::value>::type
+      exec_one(const std::int32_t w) const noexcept {
+    const TagType t{};
+    m_functor(t, w);
+  }
+
+ public:
+  __device__ inline void operator()() const noexcept {
+    if (0 == (threadIdx.y % 16)) {
+      // Spin until COMPLETED_TOKEN.
+      // END_TOKEN indicates no work is currently available.
+
+      for (std::int32_t w = Policy::END_TOKEN;
+           Policy::COMPLETED_TOKEN != (w = m_policy.pop_work());) {
+        if (Policy::END_TOKEN != w) {
+          exec_one<typename Policy::work_tag>(w);
+          m_policy.completed_work(w);
+        }
+      }
+    }
+  }
+
+  inline void execute() {
+    const int warps_per_block = 4;
+    const dim3 grid(
+        Kokkos::Experimental::Impl::hip_internal_multiprocessor_count(), 1, 1);
+    const dim3 block(1, Kokkos::Experimental::Impl::HIPTraits::WarpSize,
+                     warps_per_block);
+    const int shared = 0;
+
+    Kokkos::Experimental::Impl::HIPParallelLaunch<Self>(
+        *this, grid, block, shared,
+        Experimental::HIP().impl_internal_space_instance(), false);
+  }
+
+  inline ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
+      : m_policy(arg_policy), m_functor(arg_functor) {}
+};
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif /* #define KOKKOS_HIP_WORKGRAPHPOLICY_HPP */

--- a/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
@@ -78,7 +78,11 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
 
  public:
   __device__ inline void operator()() const noexcept {
-    if (0 == (threadIdx.y % 16)) {
+    constexpr int active_threads_per_warp = 2;
+    constexpr int filter_value =
+        Kokkos::Experimental::Impl::HIPTraits::WarpSize /
+        active_threads_per_warp;
+    if (0 == (hipThreadIdx_y % filter_value)) {
       // Spin until COMPLETED_TOKEN.
       // END_TOKEN indicates no work is currently available.
 

--- a/core/src/Kokkos_WorkGraphPolicy.hpp
+++ b/core/src/Kokkos_WorkGraphPolicy.hpp
@@ -248,6 +248,10 @@ class WorkGraphPolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
 #include "Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp"
 #endif
 
+#ifdef KOKKOS_ENABLE_HIP
+#include "HIP/Kokkos_HIP_WorkGraphPolicy.hpp"
+#endif
+
 #ifdef KOKKOS_ENABLE_THREADS
 #include "Threads/Kokkos_Threads_WorkGraphPolicy.hpp"
 #endif

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -327,7 +327,6 @@ if(Kokkos_ENABLE_HIP)
     hip/TestHIP_AtomicOperations_complexdouble.cpp
     hip/TestHIP_TeamTeamSize.cpp
     hip/TestHIP_TeamVectorRange.cpp
-    hip/TestHIP_WorkGraph.cpp
     hip/TestHIP_LocalDeepCopy.cpp
   )
 

--- a/core/unit_test/hip/TestHIP_WorkGraph.cpp
+++ b/core/unit_test/hip/TestHIP_WorkGraph.cpp
@@ -1,0 +1,46 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestWorkGraph.hpp>


### PR DESCRIPTION
More or less verbatim copied from the `CUDA` implementation.
The test was failing with HIP 3.3 but works with 3.5.