### PR TITLE
Fix logic for nested omp in partition_master

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -165,7 +165,7 @@ void OpenMP::partition_master(F const& f, int num_partitions,
 #if _OPENMP >= 201811
   if (omp_get_max_active_levels() > 1) {
 #else
-  if (omp_get_nested() > 1) {
+  if (omp_get_nested()) {
 #endif
     using Exec = Impl::OpenMPExec;
 


### PR DESCRIPTION
Reverting the old API call logic changed in a70dcf83a as `omp_get_nested()`may just return 1 if nested parallelism is activated independent of the OMP `max-active-levels-var`.