### PR TITLE
WIP: Fix for Teams in HIP-Clang

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Abort.hpp
+++ b/core/src/HIP/Kokkos_HIP_Abort.hpp
@@ -66,12 +66,12 @@ __device__ __attribute__((noinline)) void __hip_abort(char const *msg,
   abort();
 }
 
-} // namespace Impl
-} // namespace Kokkos
+}  // namespace Impl
+}  // namespace Kokkos
 
-#define HIP_ABORT(msg)                                                         \
-  do {                                                                         \
-    Kokkos::Impl::__hip_abort(msg, __FILE__, __LINE__, __FUNCTION__);          \
+#define HIP_ABORT(msg)                                                \
+  do {                                                                \
+    Kokkos::Impl::__hip_abort(msg, __FILE__, __LINE__, __FUNCTION__); \
   } while (0)
 
 #endif

--- a/core/src/HIP/Kokkos_HIP_Abort.hpp
+++ b/core/src/HIP/Kokkos_HIP_Abort.hpp
@@ -53,26 +53,17 @@
 namespace Kokkos {
 namespace Impl {
 
-__device__ __attribute__((noinline)) void __hip_abort(char const *msg,
-                                                      const char *__file,
-                                                      unsigned int __line,
-                                                      const char *__function) {
+__device__ __attribute__((noinline)) void hip_abort(char const *msg) {
 #ifndef NDEBUG
   // disable printf on release builds, as it has a non-trivial performance
   // impact
-  printf("%s:%u: %s: Aborting with message `%s'.\n", __file, __line, __function,
-         msg);
+  printf("Aborting with message `%s'.\n", msg);
 #endif
   abort();
 }
 
 }  // namespace Impl
 }  // namespace Kokkos
-
-#define HIP_ABORT(msg)                                                \
-  do {                                                                \
-    Kokkos::Impl::__hip_abort(msg, __FILE__, __LINE__, __FUNCTION__); \
-  } while (0)
 
 #endif
 #endif

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -231,13 +231,15 @@ int hip_get_opt_block_size(typename DriverType::functor_type const &f,
                                             shmem_extra_thread);
 }
 
+template<class T> void ignore( const T& ) { }
+
 template <typename FunctorType, typename LaunchBounds>
 int hip_get_opt_block_size(HIPInternal const *hip_instance,
                            hipFuncAttributes const &attr, FunctorType const &f,
                            size_t const vector_length, size_t const shmem_block,
                            size_t const shmem_thread) {
   return hip_internal_get_block_size<FunctorType, LaunchBounds>(
-      [](int x) { return true; }, hip_instance, attr, f, vector_length,
+      [](int x) { ignore(x); return true; }, hip_instance, attr, f, vector_length,
       shmem_block, shmem_thread);
 }
 

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -68,7 +68,7 @@ int hip_get_max_block_size(typename DriverType::functor_type const &f,
 }
 
 template <class FunctorType, class LaunchBounds, typename F>
-int hip_internal_get_block_size(const F& condition_check,
+int hip_internal_get_block_size(const F &condition_check,
                                 const HIPInternal *hip_instance,
                                 const hipFuncAttributes &attr,
                                 const FunctorType &f,
@@ -89,7 +89,8 @@ int hip_internal_get_block_size(const F& condition_check,
   const int max_threads_per_sm  = hip_instance->m_maxThreadsPerSM;
 
 // FIXME_HIP this is broken in 3.5, but should be in 3.6
-#if (HIP_VERSION_MAJOR > 3 || HIP_VERSION_MINOR > 5 || HIP_VERSION_PATCH >= 20226)
+#if (HIP_VERSION_MAJOR > 3 || HIP_VERSION_MINOR > 5 || \
+     HIP_VERSION_PATCH >= 20226)
   int block_size = std::min(attr.maxThreadsPerBlock, max_threads_per_block);
 #else
   int block_size = max_threads_per_block;
@@ -231,13 +232,11 @@ int hip_get_opt_block_size(typename DriverType::functor_type const &f,
 }
 
 template <typename FunctorType, typename LaunchBounds>
-int hip_get_opt_block_size(HIPInternal const * hip_instance,
-                           hipFuncAttributes const &attr,
-                           FunctorType const & f,
-                           size_t const vector_length,
-                           size_t const shmem_block,
+int hip_get_opt_block_size(HIPInternal const *hip_instance,
+                           hipFuncAttributes const &attr, FunctorType const &f,
+                           size_t const vector_length, size_t const shmem_block,
                            size_t const shmem_thread) {
- return hip_internal_get_block_size<FunctorType, LaunchBounds>(
+  return hip_internal_get_block_size<FunctorType, LaunchBounds>(
       [](int x) { return true; }, hip_instance, attr, f, vector_length,
       shmem_block, shmem_thread);
 }

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -231,15 +231,13 @@ int hip_get_opt_block_size(typename DriverType::functor_type const &f,
                                             shmem_extra_thread);
 }
 
-template<class T> void ignore( const T& ) { }
-
 template <typename FunctorType, typename LaunchBounds>
 int hip_get_opt_block_size(HIPInternal const *hip_instance,
                            hipFuncAttributes const &attr, FunctorType const &f,
                            size_t const vector_length, size_t const shmem_block,
                            size_t const shmem_thread) {
   return hip_internal_get_block_size<FunctorType, LaunchBounds>(
-      [](int x) { ignore(x); return true; }, hip_instance, attr, f, vector_length,
+      [](int) { return true; }, hip_instance, attr, f, vector_length,
       shmem_block, shmem_thread);
 }
 

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -67,26 +67,101 @@ int hip_get_max_block_size(typename DriverType::functor_type const &f,
       f, vector_length, shmem_extra_block, shmem_extra_thread);
 }
 
-template <class FunctorType, class LaunchBounds>
-int hip_get_max_block_size(const HIPInternal * /*hip_instance*/,
-                           const hipFuncAttributes &attr,
-                           const FunctorType & /*f*/,
-                           const size_t /*vector_length*/,
-                           const size_t /*shmem_block*/,
-                           const size_t /*shmem_thread*/) {
-  // FIXME_HIP find a better algorithm. Be aware that
-  // maxThreadsPerMultiProcessor, regsPerBlock, and l2CacheSize are bugged and
-  // always return zero
-  // https://github.com/ROCm-Developer-Tools/HIP/blob/6c5fa32815650cc20a4f783d09b013610348a4d5/include/hip/hcc_detail/hip_runtime_api.h#L438-L440
-  // and we don't have access to the same information than we do for CUDA
-
-  int const max_threads_per_block_mi60 = 1024;
-  int const max_threads_per_block      = LaunchBounds::maxTperB == 0
-                                        ? max_threads_per_block_mi60
+template <class FunctorType, class LaunchBounds, typename F>
+int hip_internal_get_block_size(const F& condition_check,
+                                const HIPInternal *hip_instance,
+                                const hipFuncAttributes &attr,
+                                const FunctorType &f,
+                                const size_t vector_length,
+                                const size_t shmem_block,
+                                const size_t shmem_thread) {
+  const int min_blocks_per_sm =
+      LaunchBounds::minBperSM == 0 ? 1 : LaunchBounds::minBperSM;
+  const int max_threads_per_block = LaunchBounds::maxTperB == 0
+                                        ? hip_instance->m_maxThreadsPerBlock
                                         : LaunchBounds::maxTperB;
-  return std::min(attr.maxThreadsPerBlock, max_threads_per_block);
+
+  const int regs_per_wavefront  = attr.numRegs;
+  const int regs_per_sm         = hip_instance->m_regsPerSM;
+  const int shmem_per_sm        = hip_instance->m_shmemPerSM;
+  const int max_shmem_per_block = hip_instance->m_maxShmemPerBlock;
+  const int max_blocks_per_sm   = hip_instance->m_maxBlocksPerSM;
+  const int max_threads_per_sm  = hip_instance->m_maxThreadsPerSM;
+
+// FIXME_HIP this is broken in 3.5, but should be in 3.6
+#if (HIP_VERSION_MAJOR > 3 || HIP_VERSION_MINOR > 5 || HIP_VERSION_PATCH >= 20226)
+  int block_size = std::min(attr.maxThreadsPerBlock, max_threads_per_block);
+#else
+  int block_size = max_threads_per_block;
+#endif
+  KOKKOS_ASSERT(block_size > 0);
+
+  int functor_shmem = ::Kokkos::Impl::FunctorTeamShmemSize<FunctorType>::value(
+      f, block_size / vector_length);
+  int total_shmem = shmem_block + shmem_thread * (block_size / vector_length) +
+                    functor_shmem + attr.sharedSizeBytes;
+  int max_blocks_regs =
+      regs_per_sm / (regs_per_wavefront * (block_size / HIPTraits::WarpSize));
+  int max_blocks_shmem =
+      (total_shmem < max_shmem_per_block)
+          ? (total_shmem > 0 ? shmem_per_sm / total_shmem : max_blocks_regs)
+          : 0;
+  int blocks_per_sm  = std::min(max_blocks_regs, max_blocks_shmem);
+  int threads_per_sm = blocks_per_sm * block_size;
+  if (threads_per_sm > max_threads_per_sm) {
+    blocks_per_sm  = max_threads_per_sm / block_size;
+    threads_per_sm = blocks_per_sm * block_size;
+  }
+  int opt_block_size = (blocks_per_sm >= min_blocks_per_sm) ? block_size : 0;
+  int opt_threads_per_sm = threads_per_sm;
+  // printf("BlockSizeMax: %i Shmem: %i %i %i %i Regs: %i %i Blocks: %i %i
+  // Achieved: %i %i Opt: %i %i\n",block_size,
+  //   shmem_per_sm,max_shmem_per_block,functor_shmem,total_shmem,
+  //   regs_per_sm,regs_per_wavefront,max_blocks_shmem,max_blocks_regs,blocks_per_sm,threads_per_sm,opt_block_size,opt_threads_per_sm);
+  block_size -= HIPTraits::WarpSize;
+  while (condition_check(blocks_per_sm) &&
+         (block_size >= HIPTraits::WarpSize)) {
+    functor_shmem = ::Kokkos::Impl::FunctorTeamShmemSize<FunctorType>::value(
+        f, block_size / vector_length);
+    total_shmem = shmem_block + shmem_thread * (block_size / vector_length) +
+                  functor_shmem + attr.sharedSizeBytes;
+    max_blocks_regs =
+        regs_per_sm / (regs_per_wavefront * (block_size / HIPTraits::WarpSize));
+    max_blocks_shmem =
+        (total_shmem < max_shmem_per_block)
+            ? (total_shmem > 0 ? shmem_per_sm / total_shmem : max_blocks_regs)
+            : 0;
+    blocks_per_sm  = std::min(max_blocks_regs, max_blocks_shmem);
+    threads_per_sm = blocks_per_sm * block_size;
+    if (threads_per_sm > max_threads_per_sm) {
+      blocks_per_sm  = max_threads_per_sm / block_size;
+      threads_per_sm = blocks_per_sm * block_size;
+    }
+    if ((blocks_per_sm >= min_blocks_per_sm) &&
+        (blocks_per_sm <= max_blocks_per_sm)) {
+      if (threads_per_sm >= opt_threads_per_sm) {
+        opt_block_size     = block_size;
+        opt_threads_per_sm = threads_per_sm;
+      }
+    }
+    // printf("BlockSizeMax: %i Shmem: %i %i %i %i Regs: %i %i Blocks: %i %i
+    // Achieved: %i %i Opt: %i %i\n",block_size,
+    //   shmem_per_sm,max_shmem_per_block,functor_shmem,total_shmem,
+    //   regs_per_sm,regs_per_wavefront,max_blocks_shmem,max_blocks_regs,blocks_per_sm,threads_per_sm,opt_block_size,opt_threads_per_sm);
+    block_size -= HIPTraits::WarpSize;
+  }
+  return opt_block_size;
 }
 
+template <class FunctorType, class LaunchBounds>
+int hip_get_max_block_size(const HIPInternal *hip_instance,
+                           const hipFuncAttributes &attr, const FunctorType &f,
+                           const size_t vector_length, const size_t shmem_block,
+                           const size_t shmem_thread) {
+  return hip_internal_get_block_size<FunctorType, LaunchBounds>(
+      [](int x) { return x == 0; }, hip_instance, attr, f, vector_length,
+      shmem_block, shmem_thread);
+}
 template <typename DriverType>
 struct HIPGetMaxBlockSize<DriverType, Kokkos::LaunchBounds<>, true> {
   static int get_block_size(typename DriverType::functor_type const &f,
@@ -156,23 +231,15 @@ int hip_get_opt_block_size(typename DriverType::functor_type const &f,
 }
 
 template <typename FunctorType, typename LaunchBounds>
-int hip_get_opt_block_size(HIPInternal const * /*hip_instance*/,
+int hip_get_opt_block_size(HIPInternal const * hip_instance,
                            hipFuncAttributes const &attr,
-                           FunctorType const & /*f*/,
-                           size_t const /*vector_length*/,
-                           size_t const /*shmem_block*/,
-                           size_t const /*shmem_thread*/) {
-  // FIXME_HIP find a better algorithm. Be aware that
-  // maxThreadsPerMultiProcessor, regsPerBlock, and l2CacheSize are bugged and
-  // always return zero
-  // https://github.com/ROCm-Developer-Tools/HIP/blob/6c5fa32815650cc20a4f783d09b013610348a4d5/include/hip/hcc_detail/hip_runtime_api.h#L438-L440
-  // and we don't have access to the same information than we do for CUDA
-
-  int const max_threads_per_block_mi60 = 1024;
-  int const max_threads_per_block      = LaunchBounds::maxTperB == 0
-                                        ? max_threads_per_block_mi60
-                                        : LaunchBounds::maxTperB;
-  return std::min(attr.maxThreadsPerBlock, max_threads_per_block);
+                           FunctorType const & f,
+                           size_t const vector_length,
+                           size_t const shmem_block,
+                           size_t const shmem_thread) {
+ return hip_internal_get_block_size<FunctorType, LaunchBounds>(
+      [](int x) { return true; }, hip_instance, attr, f, vector_length,
+      shmem_block, shmem_thread);
 }
 
 // FIXME_HIP the code is identical to the false struct except for

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -213,9 +213,13 @@ void HIPInternal::initialize(int hip_device_id) {
     // Maximum number of blocks
     m_maxBlock = hipProp.maxGridSize[0];
 
+    // theoretically, we can get 40 WF's / CU, but only can sustain 32
+    m_maxBlocksPerSM = 32;
+    // FIXME_HIP - Nick to implement this upstream
+    m_regsPerSM          = 262144 / 32;
     m_shmemPerSM         = hipProp.maxSharedMemoryPerMultiProcessor;
     m_maxShmemPerBlock   = hipProp.sharedMemPerBlock;
-    m_maxThreadsPerSM    = hipProp.maxThreadsPerMultiProcessor;
+    m_maxThreadsPerSM    = m_maxBlocksPerSM * HIPTraits::WarpSize;
     m_maxThreadsPerBlock = hipProp.maxThreadsPerBlock;
 
     //----------------------------------

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -85,7 +85,9 @@ class HIPInternal {
   unsigned m_multiProcCount;
   unsigned m_maxWarpCount;
   unsigned m_maxBlock;
+  unsigned m_maxBlocksPerSM;
   unsigned m_maxSharedWords;
+  int m_regsPerSM;
   int m_shmemPerSM;
   int m_maxShmemPerBlock;
   int m_maxThreadsPerSM;

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -207,7 +207,7 @@ struct HIPParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
       HIP_SAFE_CALL(hipMemcpyAsync(d_driver, &driver, sizeof(DriverType),
                                    hipMemcpyHostToDevice,
                                    hip_instance->m_stream));
-      hip_parallel_launch_local_memory<DriverType>
+      hip_parallel_launch_local_memory<DriverType, 1024, 1>
           <<<grid, block, shmem, hip_instance->m_stream>>>(d_driver);
 
       Kokkos::Experimental::HIP().fence();
@@ -221,9 +221,9 @@ struct HIPParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
 
   static hipFuncAttributes get_hip_func_attributes() {
     hipFuncAttributes attr;
-    hipFuncGetAttributes(&attr,
-                         reinterpret_cast<void *>(
-                             &hip_parallel_launch_local_memory<DriverType>));
+    hipFuncGetAttributes(
+        &attr, reinterpret_cast<void *>(
+                   &hip_parallel_launch_local_memory<DriverType, 1024, 1>));
     return attr;
   }
 };

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -553,10 +553,8 @@ class ParallelScanHIPBase {
       // correctly, the unit tests fail with wrong results
       const int gridMaxComputeCapability_2x = 0x01fff;
 
-      // FIXME_HIP block sizes greater than 256 don't work correctly,
-      // the unit tests fail with wrong results
       const int block_size =
-          std::min(static_cast<int>(local_block_size(m_functor)), 256);
+          std::min(static_cast<int>(local_block_size(m_functor)), 1024);
       KOKKOS_ASSERT(block_size > 0);
 
       const int grid_max =

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -553,8 +553,7 @@ class ParallelScanHIPBase {
       // correctly, the unit tests fail with wrong results
       const int gridMaxComputeCapability_2x = 0x01fff;
 
-      const int block_size =
-          std::min(static_cast<int>(local_block_size(m_functor)), 1024);
+      const int block_size = static_cast<int>(local_block_size(m_functor));
       KOKKOS_ASSERT(block_size > 0);
 
       const int grid_max =

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -160,7 +160,7 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
         static_cast<size_t>(vector_length()),
         static_cast<size_t>(team_scratch_size(0)) + 2 * sizeof(double),
         static_cast<size_t>(thread_scratch_size(0)) + sizeof(double));
-    return std::min(block_size / vector_length(), 1024);
+    return block_size / vector_length();
   }
 
   template <typename FunctorType>

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -478,7 +478,7 @@ void* SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::
     allocate_tracked(const Kokkos::Experimental::HIPSpace& arg_space,
                      const std::string& arg_alloc_label,
                      const size_t arg_alloc_size) {
-  if (!arg_alloc_size) return (void*)0;
+  if (!arg_alloc_size) return nullptr;
 
   SharedAllocationRecord* const r =
       allocate(arg_space, arg_alloc_label, arg_alloc_size);
@@ -518,7 +518,7 @@ void* SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>::
     allocate_tracked(const Kokkos::Experimental::HIPHostPinnedSpace& arg_space,
                      const std::string& arg_alloc_label,
                      const size_t arg_alloc_size) {
-  if (!arg_alloc_size) return (void*)0;
+  if (!arg_alloc_size) return nullptr;
 
   SharedAllocationRecord* const r =
       allocate(arg_space, arg_alloc_label, arg_alloc_size);
@@ -531,7 +531,7 @@ void* SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>::
 void SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace,
                             void>::deallocate_tracked(void* const
                                                           arg_alloc_ptr) {
-  if (arg_alloc_ptr != 0) {
+  if (arg_alloc_ptr) {
     SharedAllocationRecord* const r = get_record(arg_alloc_ptr);
 
     RecordBase::decrement(r);
@@ -594,7 +594,7 @@ SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace,
       SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>;
 
   Header* const h =
-      alloc_ptr ? reinterpret_cast<Header*>(alloc_ptr) - 1 : (Header*)0;
+      alloc_ptr ? reinterpret_cast<Header*>(alloc_ptr) - 1 : nullptr;
 
   if (!alloc_ptr || h->m_record->m_alloc_ptr != h) {
     Kokkos::Impl::throw_runtime_exception(std::string(

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -514,14 +514,13 @@ void* SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::
   return r_new->data();
 }
 
-void *SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>::
-    allocate_tracked(const Kokkos::Experimental::HIPHostPinnedSpace &arg_space,
-                     const std::string &arg_alloc_label,
+void* SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>::
+    allocate_tracked(const Kokkos::Experimental::HIPHostPinnedSpace& arg_space,
+                     const std::string& arg_alloc_label,
                      const size_t arg_alloc_size) {
-  if (!arg_alloc_size)
-    return (void *)0;
+  if (!arg_alloc_size) return (void*)0;
 
-  SharedAllocationRecord *const r =
+  SharedAllocationRecord* const r =
       allocate(arg_space, arg_alloc_label, arg_alloc_size);
 
   RecordBase::increment(r);
@@ -530,21 +529,19 @@ void *SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>::
 }
 
 void SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace,
-                            void>::deallocate_tracked(void *const
+                            void>::deallocate_tracked(void* const
                                                           arg_alloc_ptr) {
   if (arg_alloc_ptr != 0) {
-    SharedAllocationRecord *const r = get_record(arg_alloc_ptr);
+    SharedAllocationRecord* const r = get_record(arg_alloc_ptr);
 
     RecordBase::decrement(r);
   }
 }
 
-void *
-SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace,
-                       void>::reallocate_tracked(void *const arg_alloc_ptr,
-                                                 const size_t arg_alloc_size) {
-  SharedAllocationRecord *const r_old = get_record(arg_alloc_ptr);
-  SharedAllocationRecord *const r_new =
+void* SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>::
+    reallocate_tracked(void* const arg_alloc_ptr, const size_t arg_alloc_size) {
+  SharedAllocationRecord* const r_old = get_record(arg_alloc_ptr);
+  SharedAllocationRecord* const r_new =
       allocate(r_old->m_space, r_old->get_label(), arg_alloc_size);
 
   using HIPHostPinnedSpace = Kokkos::Experimental::HIPHostPinnedSpace;
@@ -589,15 +586,15 @@ SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::get_record(
   return record;
 }
 
-SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void> *
+SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>*
 SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace,
-                       void>::get_record(void *alloc_ptr) {
+                       void>::get_record(void* alloc_ptr) {
   using Header = SharedAllocationHeader;
   using RecordHIP =
       SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>;
 
-  Header *const h =
-      alloc_ptr ? reinterpret_cast<Header *>(alloc_ptr) - 1 : (Header *)0;
+  Header* const h =
+      alloc_ptr ? reinterpret_cast<Header*>(alloc_ptr) - 1 : (Header*)0;
 
   if (!alloc_ptr || h->m_record->m_alloc_ptr != h) {
     Kokkos::Impl::throw_runtime_exception(std::string(
@@ -605,7 +602,7 @@ SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace,
         "Kokkos::Experimental::HIPHostPinnedSpace , void >::get_record ERROR"));
   }
 
-  return static_cast<RecordHIP *>(h->m_record);
+  return static_cast<RecordHIP*>(h->m_record);
 }
 
 // Iterate records to print orphaned memory ...

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -170,7 +170,7 @@ void abort(const char *const message) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
   Kokkos::Impl::cuda_abort(message);
 #elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
-  HIP_ABORT(message);
+  Kokkos::Impl::hip_abort(message);
 #elif !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__)
   Kokkos::Impl::host_abort(message);
 #endif

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -170,7 +170,7 @@ void abort(const char *const message) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
   Kokkos::Impl::cuda_abort(message);
 #elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
-  Kokkos::Impl::hip_abort(message);
+  HIP_ABORT(message);
 #elif !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__)
   Kokkos::Impl::host_abort(message);
 #endif

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -850,7 +850,7 @@ class TestTripleNestedReduce {
 
 #endif
 
-#if !(defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND))
+#if !(defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND) || defined(KOKKOS_ENABLE_HIP))
 TEST(TEST_CATEGORY, team_vector) {
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(0)));
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(1)));

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -850,8 +850,7 @@ class TestTripleNestedReduce {
 
 #endif
 
-// FIXME_HIP check if HIP needs CUDA-clang workaround
-#if !(defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND) || defined(KOKKOS_ENABLE_HIP))
+#if !(defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND))
 TEST(TEST_CATEGORY, team_vector) {
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(0)));
   ASSERT_TRUE((TestTeamVector::Test<TEST_EXECSPACE>(1)));
@@ -868,7 +867,6 @@ TEST(TEST_CATEGORY, team_vector) {
 }
 #endif
 
-// FIXME_HIP
 #if !defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
 TEST(TEST_CATEGORY, triple_nested_parallelism) {
 // With KOKKOS_DEBUG enabled, the functor uses too many registers to run

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -869,7 +869,7 @@ TEST(TEST_CATEGORY, team_vector) {
 #endif
 
 // FIXME_HIP
-#if !defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND) && !defined(KOKKOS_ENABLE_HIP)
+#if !defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
 TEST(TEST_CATEGORY, triple_nested_parallelism) {
 // With KOKKOS_DEBUG enabled, the functor uses too many registers to run
 // with a team size of 32 on GPUs, 16 is the max possible (at least on a K80


### PR DESCRIPTION
This PR does the following:

- Adds a few missing HIPHostPinnedSpace methods that LAMMPS complains about (largely copy-pasted from the CUDA equivalents)  
- Implements a similar algorithm for `hip_get_max_block_size` and `hip_get_opt_block_size`, with some workarounds for bugs in 3.5 (notably in the `maxThreadsPerBlock` attribute), and some (currently) hardcoded values for the max waves / CU (to match the [Occupancy API's, which are more correct](https://github.com/ROCm-Developer-Tools/HIP/blob/a0b5dfd625d99af7e288629747b40dd057183173/vdi/hip_platform.cpp#L741)).
- Defaults all kernels w/o a launch bounds attributes to `__launch_bounds__(1024, 1)` to ensure we always generate correct code.
- Places `abort` behind a no-inline wrapper such that we minimize the impact of the generated printf code (which is rather hefty, and will inline everywhere by default).  Also, we manually implement the NDEBUG behaviour, as `assert` is ... spotty... in respecting this in 3.5

This fixes the triply nested parallelism test, which has been re-enabled.  I have one test that appears to be failing on my system (`HIP.IncrTest_12a_ThreadScratch`).  I believe this is related to the `1024` block-size assumption I made in `hip_internal_get_block_size`, but need to dig further.