### PR TITLE
Use CUDA notation in HIP

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -25,7 +25,7 @@ pipeline {
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER=hipcc \
-                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -Wno-braced-scalar-init -Wno-gnu-zero-variadic-macro-arguments" \
+                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -Wno-braced-scalar-init" \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_HIP=ON \

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -648,15 +648,13 @@ struct Random_UniqueIndex<Kokkos::Experimental::HIP> {
   static int get_state_idx(const locks_view_type& locks_) {
 #ifdef __HIP_DEVICE_COMPILE__
     const int i_offset =
-        (hipThreadIdx_x * hipBlockDim_y + hipThreadIdx_y) * hipBlockDim_z +
-        hipThreadIdx_z;
-    int i = (((hipBlockIdx_x * hipGridDim_y + hipBlockIdx_y) * hipGridDim_z +
-              hipBlockIdx_z) *
-                 hipBlockDim_x * hipBlockDim_y * hipBlockDim_z +
+        (threadIdx.x * blockDim.y + threadIdx.y) * blockDim.z + threadIdx.z;
+    int i = (((blockIdx.x * gridDim.y + blockIdx.y) * gridDim.z + blockIdx.z) *
+                 blockDim.x * blockDim.y * blockDim.z +
              i_offset) %
             locks_.extent(0);
     while (Kokkos::atomic_compare_exchange(&locks_(i), 0, 1)) {
-      i += hipBlockDim_x * hipBlockDim_y * hipBlockDim_z;
+      i += blockDim.x * blockDim.y * blockDim.z;
       if (i >= static_cast<int>(locks_.extent(0))) {
         i = i_offset;
       }

--- a/core/src/HIP/KokkosExp_HIP_IterateTile.hpp
+++ b/core/src/HIP/KokkosExp_HIP_IterateTile.hpp
@@ -80,22 +80,22 @@ struct DeviceIterateTile<2, PolicyType, Functor, void> {
   void exec_range() const {
     // LL
     if (PolicyType::inner_direction == PolicyType::Left) {
-      for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
-           tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+      for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
+           tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
         const index_type offset_1 =
             tile_id1 * m_policy.m_tile[1] +
-            static_cast<index_type>(hipThreadIdx_y) +
+            static_cast<index_type>(threadIdx.y) +
             static_cast<index_type>(m_policy.m_lower[1]);
         if (offset_1 < m_policy.m_upper[1] &&
-            static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
-          for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
-               tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+            static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
+          for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
+               tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
             const index_type offset_0 =
                 tile_id0 * m_policy.m_tile[0] +
-                static_cast<index_type>(hipThreadIdx_x) +
+                static_cast<index_type>(threadIdx.x) +
                 static_cast<index_type>(m_policy.m_lower[0]);
             if (offset_0 < m_policy.m_upper[0] &&
-                static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
+                static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
               m_func(offset_0, offset_1);
             }
           }
@@ -104,22 +104,22 @@ struct DeviceIterateTile<2, PolicyType, Functor, void> {
     }
     // LR
     else {
-      for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
-           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+      for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
+           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
         const index_type offset_0 =
             tile_id0 * m_policy.m_tile[0] +
-            static_cast<index_type>(hipThreadIdx_x) +
+            static_cast<index_type>(threadIdx.x) +
             static_cast<index_type>(m_policy.m_lower[0]);
         if (offset_0 < m_policy.m_upper[0] &&
-            static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
-          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
-               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
+          for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
             const index_type offset_1 =
                 tile_id1 * m_policy.m_tile[1] +
-                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[1]);
             if (offset_1 < m_policy.m_upper[1] &&
-                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
+                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
               m_func(offset_0, offset_1);
             }
           }
@@ -146,44 +146,44 @@ struct DeviceIterateTile<2, PolicyType, Functor, Tag> {
   void exec_range() const {
     if (PolicyType::inner_direction == PolicyType::Left) {
       // Loop over size maxnumblocks until full range covered
-      for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
-           tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+      for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
+           tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
         const index_type offset_1 =
             tile_id1 * m_policy.m_tile[1] +
-            static_cast<index_type>(hipThreadIdx_y) +
+            static_cast<index_type>(threadIdx.y) +
             static_cast<index_type>(m_policy.m_lower[1]);
         if (offset_1 < m_policy.m_upper[1] &&
-            static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
-          for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
-               tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+            static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
+          for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
+               tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
             const index_type offset_0 =
                 tile_id0 * m_policy.m_tile[0] +
-                static_cast<index_type>(hipThreadIdx_x) +
+                static_cast<index_type>(threadIdx.x) +
                 static_cast<index_type>(m_policy.m_lower[0]);
             if (offset_0 < m_policy.m_upper[0] &&
-                static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
+                static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
               m_func(Tag(), offset_0, offset_1);
             }
           }
         }
       }
     } else {
-      for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
-           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+      for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
+           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
         const index_type offset_0 =
             tile_id0 * m_policy.m_tile[0] +
-            static_cast<index_type>(hipThreadIdx_x) +
+            static_cast<index_type>(threadIdx.x) +
             static_cast<index_type>(m_policy.m_lower[0]);
         if (offset_0 < m_policy.m_upper[0] &&
-            static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
-          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
-               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
+          for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
             const index_type offset_1 =
                 tile_id1 * m_policy.m_tile[1] +
-                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[1]);
             if (offset_1 < m_policy.m_upper[1] &&
-                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
+                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
               m_func(Tag(), offset_0, offset_1);
             }
           }
@@ -210,32 +210,30 @@ struct DeviceIterateTile<3, PolicyType, Functor, void> {
   void exec_range() const {
     // LL
     if (PolicyType::inner_direction == PolicyType::Left) {
-      for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_z);
-           tile_id2 < m_policy.m_tile_end[2]; tile_id2 += hipGridDim_z) {
+      for (index_type tile_id2 = static_cast<index_type>(blockIdx.z);
+           tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.z) {
         const index_type offset_2 =
             tile_id2 * m_policy.m_tile[2] +
-            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(threadIdx.z) +
             static_cast<index_type>(m_policy.m_lower[2]);
         if (offset_2 < m_policy.m_upper[2] &&
-            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[2]) {
-          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
-               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            static_cast<index_type>(threadIdx.z) < m_policy.m_tile[2]) {
+          for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
             const index_type offset_1 =
                 tile_id1 * m_policy.m_tile[1] +
-                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[1]);
             if (offset_1 < m_policy.m_upper[1] &&
-                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
-              for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
-                   tile_id0 < m_policy.m_tile_end[0];
-                   tile_id0 += hipGridDim_x) {
+                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
+              for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
+                   tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
                 const index_type offset_0 =
                     tile_id0 * m_policy.m_tile[0] +
-                    static_cast<index_type>(hipThreadIdx_x) +
+                    static_cast<index_type>(threadIdx.x) +
                     static_cast<index_type>(m_policy.m_lower[0]);
                 if (offset_0 < m_policy.m_upper[0] &&
-                    static_cast<index_type>(hipThreadIdx_x) <
-                        m_policy.m_tile[0]) {
+                    static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
                   m_func(offset_0, offset_1, offset_2);
                 }
               }
@@ -246,32 +244,30 @@ struct DeviceIterateTile<3, PolicyType, Functor, void> {
     }
     // LR
     else {
-      for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
-           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+      for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
+           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
         const index_type offset_0 =
             tile_id0 * m_policy.m_tile[0] +
-            static_cast<index_type>(hipThreadIdx_x) +
+            static_cast<index_type>(threadIdx.x) +
             static_cast<index_type>(m_policy.m_lower[0]);
         if (offset_0 < m_policy.m_upper[0] &&
-            static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
-          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
-               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
+          for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
             const index_type offset_1 =
                 tile_id1 * m_policy.m_tile[1] +
-                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[1]);
             if (offset_1 < m_policy.m_upper[1] &&
-                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
-              for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_z);
-                   tile_id2 < m_policy.m_tile_end[2];
-                   tile_id2 += hipGridDim_z) {
+                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
+              for (index_type tile_id2 = static_cast<index_type>(blockIdx.z);
+                   tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.z) {
                 const index_type offset_2 =
                     tile_id2 * m_policy.m_tile[2] +
-                    static_cast<index_type>(hipThreadIdx_z) +
+                    static_cast<index_type>(threadIdx.z) +
                     static_cast<index_type>(m_policy.m_lower[2]);
                 if (offset_2 < m_policy.m_upper[2] &&
-                    static_cast<index_type>(hipThreadIdx_z) <
-                        m_policy.m_tile[2]) {
+                    static_cast<index_type>(threadIdx.z) < m_policy.m_tile[2]) {
                   m_func(offset_0, offset_1, offset_2);
                 }
               }
@@ -299,32 +295,30 @@ struct DeviceIterateTile<3, PolicyType, Functor, Tag> {
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
     if (PolicyType::inner_direction == PolicyType::Left) {
-      for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_z);
-           tile_id2 < m_policy.m_tile_end[2]; tile_id2 += hipGridDim_z) {
+      for (index_type tile_id2 = static_cast<index_type>(blockIdx.z);
+           tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.z) {
         const index_type offset_2 =
             tile_id2 * m_policy.m_tile[2] +
-            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(threadIdx.z) +
             static_cast<index_type>(m_policy.m_lower[2]);
         if (offset_2 < m_policy.m_upper[2] &&
-            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[2]) {
-          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
-               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            static_cast<index_type>(threadIdx.z) < m_policy.m_tile[2]) {
+          for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
             const index_type offset_1 =
                 tile_id1 * m_policy.m_tile[1] +
-                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[1]);
             if (offset_1 < m_policy.m_upper[1] &&
-                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
-              for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
-                   tile_id0 < m_policy.m_tile_end[0];
-                   tile_id0 += hipGridDim_x) {
+                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
+              for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
+                   tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
                 const index_type offset_0 =
                     tile_id0 * m_policy.m_tile[0] +
-                    static_cast<index_type>(hipThreadIdx_x) +
+                    static_cast<index_type>(threadIdx.x) +
                     static_cast<index_type>(m_policy.m_lower[0]);
                 if (offset_0 < m_policy.m_upper[0] &&
-                    static_cast<index_type>(hipThreadIdx_x) <
-                        m_policy.m_tile[0]) {
+                    static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
                   m_func(Tag(), offset_0, offset_1, offset_2);
                 }
               }
@@ -333,32 +327,30 @@ struct DeviceIterateTile<3, PolicyType, Functor, Tag> {
         }
       }
     } else {
-      for (index_type tile_id0 = static_cast<index_type>(hipBlockIdx_x);
-           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += hipGridDim_x) {
+      for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
+           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
         const index_type offset_0 =
             tile_id0 * m_policy.m_tile[0] +
-            static_cast<index_type>(hipThreadIdx_x) +
+            static_cast<index_type>(threadIdx.x) +
             static_cast<index_type>(m_policy.m_lower[0]);
         if (offset_0 < m_policy.m_upper[0] &&
-            static_cast<index_type>(hipThreadIdx_x) < m_policy.m_tile[0]) {
-          for (index_type tile_id1 = static_cast<index_type>(hipBlockIdx_y);
-               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += hipGridDim_y) {
+            static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
+          for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
+               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
             const index_type offset_1 =
                 tile_id1 * m_policy.m_tile[1] +
-                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[1]);
             if (offset_1 < m_policy.m_upper[1] &&
-                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[1]) {
-              for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_z);
-                   tile_id2 < m_policy.m_tile_end[2];
-                   tile_id2 += hipGridDim_z) {
+                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
+              for (index_type tile_id2 = static_cast<index_type>(blockIdx.z);
+                   tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.z) {
                 const index_type offset_2 =
                     tile_id2 * m_policy.m_tile[2] +
-                    static_cast<index_type>(hipThreadIdx_z) +
+                    static_cast<index_type>(threadIdx.z) +
                     static_cast<index_type>(m_policy.m_lower[2]);
                 if (offset_2 < m_policy.m_upper[2] &&
-                    static_cast<index_type>(hipThreadIdx_z) <
-                        m_policy.m_tile[2]) {
+                    static_cast<index_type>(threadIdx.z) < m_policy.m_tile[2]) {
                   m_func(Tag(), offset_0, offset_1, offset_2);
                 }
               }
@@ -397,31 +389,29 @@ struct DeviceIterateTile<4, PolicyType, Functor, void> {
                ? index_type(max_blocks / numbl0)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl0;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
 
-      for (index_type tile_id3 = static_cast<index_type>(hipBlockIdx_z);
-           tile_id3 < m_policy.m_tile_end[3]; tile_id3 += hipGridDim_z) {
+      for (index_type tile_id3 = static_cast<index_type>(blockIdx.z);
+           tile_id3 < m_policy.m_tile_end[3]; tile_id3 += gridDim.z) {
         const index_type offset_3 =
             tile_id3 * m_policy.m_tile[3] +
-            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(threadIdx.z) +
             static_cast<index_type>(m_policy.m_lower[3]);
         if (offset_3 < m_policy.m_upper[3] &&
-            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[3]) {
-          for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_y);
-               tile_id2 < m_policy.m_tile_end[2]; tile_id2 += hipGridDim_y) {
+            static_cast<index_type>(threadIdx.z) < m_policy.m_tile[3]) {
+          for (index_type tile_id2 = static_cast<index_type>(blockIdx.y);
+               tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.y) {
             const index_type offset_2 =
                 tile_id2 * m_policy.m_tile[2] +
-                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[2]);
             if (offset_2 < m_policy.m_upper[2] &&
-                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[2]) {
+                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[2]) {
               for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
                    j += numbl1) {
                 const index_type offset_1 =
@@ -456,14 +446,12 @@ struct DeviceIterateTile<4, PolicyType, Functor, void> {
                ? index_type(max_blocks / numbl1)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl1;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
 
       for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
         const index_type offset_0 =
@@ -477,26 +465,24 @@ struct DeviceIterateTile<4, PolicyType, Functor, void> {
                 static_cast<index_type>(m_policy.m_lower[1]);
             if (offset_1 < m_policy.m_upper[1] &&
                 thr_id1 < m_policy.m_tile[1]) {
-              for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_y);
-                   tile_id2 < m_policy.m_tile_end[2];
-                   tile_id2 += hipGridDim_y) {
+              for (index_type tile_id2 = static_cast<index_type>(blockIdx.y);
+                   tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.y) {
                 const index_type offset_2 =
                     tile_id2 * m_policy.m_tile[2] +
-                    static_cast<index_type>(hipThreadIdx_y) +
+                    static_cast<index_type>(threadIdx.y) +
                     static_cast<index_type>(m_policy.m_lower[2]);
                 if (offset_2 < m_policy.m_upper[2] &&
-                    static_cast<index_type>(hipThreadIdx_y) <
-                        m_policy.m_tile[2]) {
+                    static_cast<index_type>(threadIdx.y) < m_policy.m_tile[2]) {
                   for (index_type tile_id3 =
-                           static_cast<index_type>(hipBlockIdx_z);
+                           static_cast<index_type>(blockIdx.z);
                        tile_id3 < m_policy.m_tile_end[3];
-                       tile_id3 += hipGridDim_z) {
+                       tile_id3 += gridDim.z) {
                     const index_type offset_3 =
                         tile_id3 * m_policy.m_tile[3] +
-                        static_cast<index_type>(hipThreadIdx_z) +
+                        static_cast<index_type>(threadIdx.z) +
                         static_cast<index_type>(m_policy.m_lower[3]);
                     if (offset_3 < m_policy.m_upper[3] &&
-                        static_cast<index_type>(hipThreadIdx_z) <
+                        static_cast<index_type>(threadIdx.z) <
                             m_policy.m_tile[3]) {
                       m_func(offset_0, offset_1, offset_2, offset_3);
                     }
@@ -537,31 +523,29 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
                ? static_cast<index_type>(max_blocks / numbl0)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl0;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
 
-      for (index_type tile_id3 = static_cast<index_type>(hipBlockIdx_z);
-           tile_id3 < m_policy.m_tile_end[3]; tile_id3 += hipGridDim_z) {
+      for (index_type tile_id3 = static_cast<index_type>(blockIdx.z);
+           tile_id3 < m_policy.m_tile_end[3]; tile_id3 += gridDim.z) {
         const index_type offset_3 =
             tile_id3 * m_policy.m_tile[3] +
-            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(threadIdx.z) +
             static_cast<index_type>(m_policy.m_lower[3]);
         if (offset_3 < m_policy.m_upper[3] &&
-            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[3]) {
-          for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_y);
-               tile_id2 < m_policy.m_tile_end[2]; tile_id2 += hipGridDim_y) {
+            static_cast<index_type>(threadIdx.z) < m_policy.m_tile[3]) {
+          for (index_type tile_id2 = static_cast<index_type>(blockIdx.y);
+               tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.y) {
             const index_type offset_2 =
                 tile_id2 * m_policy.m_tile[2] +
-                static_cast<index_type>(hipThreadIdx_y) +
+                static_cast<index_type>(threadIdx.y) +
                 static_cast<index_type>(m_policy.m_lower[2]);
             if (offset_2 < m_policy.m_upper[2] &&
-                static_cast<index_type>(hipThreadIdx_y) < m_policy.m_tile[2]) {
+                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[2]) {
               for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
                    j += numbl1) {
                 const index_type offset_1 =
@@ -594,14 +578,12 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
                ? index_type(max_blocks / numbl1)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl1;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
 
       for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
         const index_type offset_0 =
@@ -615,26 +597,24 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
                 static_cast<index_type>(m_policy.m_lower[1]);
             if (offset_1 < m_policy.m_upper[1] &&
                 thr_id1 < m_policy.m_tile[1]) {
-              for (index_type tile_id2 = static_cast<index_type>(hipBlockIdx_y);
-                   tile_id2 < m_policy.m_tile_end[2];
-                   tile_id2 += hipGridDim_y) {
+              for (index_type tile_id2 = static_cast<index_type>(blockIdx.y);
+                   tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.y) {
                 const index_type offset_2 =
                     tile_id2 * m_policy.m_tile[2] +
-                    static_cast<index_type>(hipThreadIdx_y) +
+                    static_cast<index_type>(threadIdx.y) +
                     static_cast<index_type>(m_policy.m_lower[2]);
                 if (offset_2 < m_policy.m_upper[2] &&
-                    static_cast<index_type>(hipThreadIdx_y) <
-                        m_policy.m_tile[2]) {
+                    static_cast<index_type>(threadIdx.y) < m_policy.m_tile[2]) {
                   for (index_type tile_id3 =
-                           static_cast<index_type>(hipBlockIdx_z);
+                           static_cast<index_type>(blockIdx.z);
                        tile_id3 < m_policy.m_tile_end[3];
-                       tile_id3 += hipGridDim_z) {
+                       tile_id3 += gridDim.z) {
                     const index_type offset_3 =
                         tile_id3 * m_policy.m_tile[3] +
-                        static_cast<index_type>(hipThreadIdx_z) +
+                        static_cast<index_type>(threadIdx.z) +
                         static_cast<index_type>(m_policy.m_lower[3]);
                     if (offset_3 < m_policy.m_upper[3] &&
-                        static_cast<index_type>(hipThreadIdx_z) <
+                        static_cast<index_type>(threadIdx.z) <
                             m_policy.m_tile[3]) {
                       m_func(Tag(), offset_0, offset_1, offset_2, offset_3);
                     }
@@ -676,14 +656,12 @@ struct DeviceIterateTile<5, PolicyType, Functor, void> {
                ? index_type(max_blocks / numbl0)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl0;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
 
       temp0                   = m_policy.m_tile_end[2];
       temp1                   = m_policy.m_tile_end[3];
@@ -693,23 +671,21 @@ struct DeviceIterateTile<5, PolicyType, Functor, void> {
                ? index_type(max_blocks / numbl2)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id2 =
-          static_cast<index_type>(hipBlockIdx_y) % numbl2;
-      const index_type tile_id3 =
-          static_cast<index_type>(hipBlockIdx_y) / numbl2;
+      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
+      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) / numbl2;
       const index_type thr_id2 =
-          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[2];
+          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[2];
       const index_type thr_id3 =
-          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[2];
+          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[2];
 
-      for (index_type tile_id4 = static_cast<index_type>(hipBlockIdx_z);
-           tile_id4 < m_policy.m_tile_end[4]; tile_id4 += hipGridDim_z) {
+      for (index_type tile_id4 = static_cast<index_type>(blockIdx.z);
+           tile_id4 < m_policy.m_tile_end[4]; tile_id4 += gridDim.z) {
         const index_type offset_4 =
             tile_id4 * m_policy.m_tile[4] +
-            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(threadIdx.z) +
             static_cast<index_type>(m_policy.m_lower[4]);
         if (offset_4 < m_policy.m_upper[4] &&
-            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[4]) {
+            static_cast<index_type>(threadIdx.z) < m_policy.m_tile[4]) {
           for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
                l += numbl3) {
             const index_type offset_3 =
@@ -761,14 +737,12 @@ struct DeviceIterateTile<5, PolicyType, Functor, void> {
                ? index_type(max_blocks / numbl1)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl1;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
 
       temp0                   = m_policy.m_tile_end[2];
       temp1                   = m_policy.m_tile_end[3];
@@ -778,14 +752,12 @@ struct DeviceIterateTile<5, PolicyType, Functor, void> {
                ? index_type(max_blocks / numbl3)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id2 =
-          static_cast<index_type>(hipBlockIdx_y) / numbl3;
-      const index_type tile_id3 =
-          static_cast<index_type>(hipBlockIdx_y) % numbl3;
+      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
+      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) % numbl3;
       const index_type thr_id2 =
-          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[3];
+          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[3];
       const index_type thr_id3 =
-          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[3];
+          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[3];
 
       for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
         const index_type offset_0 =
@@ -814,15 +786,15 @@ struct DeviceIterateTile<5, PolicyType, Functor, void> {
                     if (offset_3 < m_policy.m_upper[3] &&
                         thr_id3 < m_policy.m_tile[3]) {
                       for (index_type tile_id4 =
-                               static_cast<index_type>(hipBlockIdx_z);
+                               static_cast<index_type>(blockIdx.z);
                            tile_id4 < m_policy.m_tile_end[4];
-                           tile_id4 += hipGridDim_z) {
+                           tile_id4 += gridDim.z) {
                         const index_type offset_4 =
                             tile_id4 * m_policy.m_tile[4] +
-                            static_cast<index_type>(hipThreadIdx_z) +
+                            static_cast<index_type>(threadIdx.z) +
                             static_cast<index_type>(m_policy.m_lower[4]);
                         if (offset_4 < m_policy.m_upper[4] &&
-                            static_cast<index_type>(hipThreadIdx_z) <
+                            static_cast<index_type>(threadIdx.z) <
                                 m_policy.m_tile[4]) {
                           m_func(offset_0, offset_1, offset_2, offset_3,
                                  offset_4);
@@ -867,14 +839,12 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
                ? index_type(max_blocks / numbl0)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl0;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
 
       temp0                   = m_policy.m_tile_end[2];
       temp1                   = m_policy.m_tile_end[3];
@@ -884,23 +854,21 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
                ? index_type(max_blocks / numbl2)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id2 =
-          static_cast<index_type>(hipBlockIdx_y) % numbl2;
-      const index_type tile_id3 =
-          static_cast<index_type>(hipBlockIdx_y) / numbl2;
+      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
+      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) / numbl2;
       const index_type thr_id2 =
-          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[2];
+          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[2];
       const index_type thr_id3 =
-          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[2];
+          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[2];
 
-      for (index_type tile_id4 = static_cast<index_type>(hipBlockIdx_z);
-           tile_id4 < m_policy.m_tile_end[4]; tile_id4 += hipGridDim_z) {
+      for (index_type tile_id4 = static_cast<index_type>(blockIdx.z);
+           tile_id4 < m_policy.m_tile_end[4]; tile_id4 += gridDim.z) {
         const index_type offset_4 =
             tile_id4 * m_policy.m_tile[4] +
-            static_cast<index_type>(hipThreadIdx_z) +
+            static_cast<index_type>(threadIdx.z) +
             static_cast<index_type>(m_policy.m_lower[4]);
         if (offset_4 < m_policy.m_upper[4] &&
-            static_cast<index_type>(hipThreadIdx_z) < m_policy.m_tile[4]) {
+            static_cast<index_type>(threadIdx.z) < m_policy.m_tile[4]) {
           for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
                l += numbl3) {
             const index_type offset_3 =
@@ -952,14 +920,12 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
                ? static_cast<index_type>(max_blocks / numbl1)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl1;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
 
       temp0                   = m_policy.m_tile_end[2];
       temp1                   = m_policy.m_tile_end[3];
@@ -969,14 +935,12 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
                ? index_type(max_blocks / numbl3)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id2 =
-          static_cast<index_type>(hipBlockIdx_y) / numbl3;
-      const index_type tile_id3 =
-          static_cast<index_type>(hipBlockIdx_y) % numbl3;
+      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
+      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) % numbl3;
       const index_type thr_id2 =
-          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[3];
+          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[3];
       const index_type thr_id3 =
-          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[3];
+          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[3];
 
       for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
         const index_type offset_0 =
@@ -1005,15 +969,15 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
                     if (offset_3 < m_policy.m_upper[3] &&
                         thr_id3 < m_policy.m_tile[3]) {
                       for (index_type tile_id4 =
-                               static_cast<index_type>(hipBlockIdx_z);
+                               static_cast<index_type>(blockIdx.z);
                            tile_id4 < m_policy.m_tile_end[4];
-                           tile_id4 += hipGridDim_z) {
+                           tile_id4 += gridDim.z) {
                         const index_type offset_4 =
                             tile_id4 * m_policy.m_tile[4] +
-                            static_cast<index_type>(hipThreadIdx_z) +
+                            static_cast<index_type>(threadIdx.z) +
                             static_cast<index_type>(m_policy.m_lower[4]);
                         if (offset_4 < m_policy.m_upper[4] &&
-                            static_cast<index_type>(hipThreadIdx_z) <
+                            static_cast<index_type>(threadIdx.z) <
                                 m_policy.m_tile[4]) {
                           m_func(Tag(), offset_0, offset_1, offset_2, offset_3,
                                  offset_4);
@@ -1058,14 +1022,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, void> {
                ? static_cast<index_type>(max_blocks / numbl0)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl0;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
 
       temp0                   = m_policy.m_tile_end[2];
       temp1                   = m_policy.m_tile_end[3];
@@ -1075,14 +1037,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, void> {
                ? index_type(max_blocks / numbl2)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id2 =
-          static_cast<index_type>(hipBlockIdx_y) % numbl2;
-      const index_type tile_id3 =
-          static_cast<index_type>(hipBlockIdx_y) / numbl2;
+      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
+      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) / numbl2;
       const index_type thr_id2 =
-          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[2];
+          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[2];
       const index_type thr_id3 =
-          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[2];
+          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[2];
 
       temp0                   = m_policy.m_tile_end[4];
       temp1                   = m_policy.m_tile_end[5];
@@ -1092,14 +1052,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, void> {
                ? static_cast<index_type>(max_blocks / numbl4)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id4 =
-          static_cast<index_type>(hipBlockIdx_z) % numbl4;
-      const index_type tile_id5 =
-          static_cast<index_type>(hipBlockIdx_z) / numbl4;
+      const index_type tile_id4 = static_cast<index_type>(blockIdx.z) % numbl4;
+      const index_type tile_id5 = static_cast<index_type>(blockIdx.z) / numbl4;
       const index_type thr_id4 =
-          static_cast<index_type>(hipThreadIdx_z) % m_policy.m_tile[4];
+          static_cast<index_type>(threadIdx.z) % m_policy.m_tile[4];
       const index_type thr_id5 =
-          static_cast<index_type>(hipThreadIdx_z) / m_policy.m_tile[4];
+          static_cast<index_type>(threadIdx.z) / m_policy.m_tile[4];
 
       for (index_type n = tile_id5; n < m_policy.m_tile_end[5]; n += numbl5) {
         const index_type offset_5 =
@@ -1166,14 +1124,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, void> {
                ? static_cast<index_type>(max_blocks / numbl1)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl1;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
 
       temp0                   = m_policy.m_tile_end[2];
       temp1                   = m_policy.m_tile_end[3];
@@ -1183,14 +1139,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, void> {
                ? index_type(max_blocks / numbl3)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id2 =
-          static_cast<index_type>(hipBlockIdx_y) / numbl3;
-      const index_type tile_id3 =
-          static_cast<index_type>(hipBlockIdx_y) % numbl3;
+      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
+      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) % numbl3;
       const index_type thr_id2 =
-          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[3];
+          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[3];
       const index_type thr_id3 =
-          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[3];
+          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[3];
 
       temp0                   = m_policy.m_tile_end[4];
       temp1                   = m_policy.m_tile_end[5];
@@ -1200,14 +1154,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, void> {
                ? index_type(max_blocks / numbl5)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id4 =
-          static_cast<index_type>(hipBlockIdx_z) / numbl5;
-      const index_type tile_id5 =
-          static_cast<index_type>(hipBlockIdx_z) % numbl5;
+      const index_type tile_id4 = static_cast<index_type>(blockIdx.z) / numbl5;
+      const index_type tile_id5 = static_cast<index_type>(blockIdx.z) % numbl5;
       const index_type thr_id4 =
-          static_cast<index_type>(hipThreadIdx_z) / m_policy.m_tile[5];
+          static_cast<index_type>(threadIdx.z) / m_policy.m_tile[5];
       const index_type thr_id5 =
-          static_cast<index_type>(hipThreadIdx_z) % m_policy.m_tile[5];
+          static_cast<index_type>(threadIdx.z) % m_policy.m_tile[5];
 
       for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
         const index_type offset_0 =
@@ -1294,14 +1246,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
                ? static_cast<index_type>(max_blocks / numbl0)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl0;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl0;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[0];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
 
       temp0                   = m_policy.m_tile_end[2];
       temp1                   = m_policy.m_tile_end[3];
@@ -1311,14 +1261,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
                ? static_cast<index_type>(max_blocks / numbl2)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id2 =
-          static_cast<index_type>(hipBlockIdx_y) % numbl2;
-      const index_type tile_id3 =
-          static_cast<index_type>(hipBlockIdx_y) / numbl2;
+      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
+      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) / numbl2;
       const index_type thr_id2 =
-          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[2];
+          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[2];
       const index_type thr_id3 =
-          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[2];
+          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[2];
 
       temp0                   = m_policy.m_tile_end[4];
       temp1                   = m_policy.m_tile_end[5];
@@ -1328,14 +1276,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
                ? static_cast<index_type>(max_blocks / numbl4)
                : (temp1 <= max_blocks ? temp1 : max_blocks));
 
-      const index_type tile_id4 =
-          static_cast<index_type>(hipBlockIdx_z) % numbl4;
-      const index_type tile_id5 =
-          static_cast<index_type>(hipBlockIdx_z) / numbl4;
+      const index_type tile_id4 = static_cast<index_type>(blockIdx.z) % numbl4;
+      const index_type tile_id5 = static_cast<index_type>(blockIdx.z) / numbl4;
       const index_type thr_id4 =
-          static_cast<index_type>(hipThreadIdx_z) % m_policy.m_tile[4];
+          static_cast<index_type>(threadIdx.z) % m_policy.m_tile[4];
       const index_type thr_id5 =
-          static_cast<index_type>(hipThreadIdx_z) / m_policy.m_tile[4];
+          static_cast<index_type>(threadIdx.z) / m_policy.m_tile[4];
 
       for (index_type n = tile_id5; n < m_policy.m_tile_end[5]; n += numbl5) {
         const index_type offset_5 =
@@ -1402,14 +1348,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
                ? static_cast<index_type>(max_blocks / numbl1)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id0 =
-          static_cast<index_type>(hipBlockIdx_x) / numbl1;
-      const index_type tile_id1 =
-          static_cast<index_type>(hipBlockIdx_x) % numbl1;
+      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
+      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
       const index_type thr_id0 =
-          static_cast<index_type>(hipThreadIdx_x) / m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
       const index_type thr_id1 =
-          static_cast<index_type>(hipThreadIdx_x) % m_policy.m_tile[1];
+          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
 
       temp0                   = m_policy.m_tile_end[2];
       temp1                   = m_policy.m_tile_end[3];
@@ -1419,14 +1363,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
                ? static_cast<index_type>(max_blocks / numbl3)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id2 =
-          static_cast<index_type>(hipBlockIdx_y) / numbl3;
-      const index_type tile_id3 =
-          static_cast<index_type>(hipBlockIdx_y) % numbl3;
+      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
+      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) % numbl3;
       const index_type thr_id2 =
-          static_cast<index_type>(hipThreadIdx_y) / m_policy.m_tile[3];
+          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[3];
       const index_type thr_id3 =
-          static_cast<index_type>(hipThreadIdx_y) % m_policy.m_tile[3];
+          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[3];
 
       temp0                   = m_policy.m_tile_end[4];
       temp1                   = m_policy.m_tile_end[5];
@@ -1436,14 +1378,12 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
                ? static_cast<index_type>(max_blocks / numbl5)
                : (temp0 <= max_blocks ? temp0 : max_blocks));
 
-      const index_type tile_id4 =
-          static_cast<index_type>(hipBlockIdx_z) / numbl5;
-      const index_type tile_id5 =
-          static_cast<index_type>(hipBlockIdx_z) % numbl5;
+      const index_type tile_id4 = static_cast<index_type>(blockIdx.z) / numbl5;
+      const index_type tile_id5 = static_cast<index_type>(blockIdx.z) % numbl5;
       const index_type thr_id4 =
-          static_cast<index_type>(hipThreadIdx_z) / m_policy.m_tile[5];
+          static_cast<index_type>(threadIdx.z) / m_policy.m_tile[5];
       const index_type thr_id5 =
-          static_cast<index_type>(hipThreadIdx_z) % m_policy.m_tile[5];
+          static_cast<index_type>(threadIdx.z) % m_policy.m_tile[5];
 
       for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
         const index_type offset_0 =
@@ -1573,18 +1513,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -1656,18 +1596,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -1741,18 +1681,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -1827,18 +1767,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -1914,18 +1854,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -1936,7 +1876,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with (index_type)hipThreadIdx_y
+            // tile-local indices identified with (index_type)threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -1999,18 +1939,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2021,7 +1961,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -2044,7 +1984,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -2085,18 +2025,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2130,7 +2070,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -2172,18 +2112,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2194,7 +2134,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -2217,7 +2157,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -2258,18 +2198,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2280,7 +2220,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -2303,7 +2243,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -2345,18 +2285,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2431,18 +2371,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2517,18 +2457,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2601,18 +2541,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2692,18 +2632,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2714,7 +2654,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -2778,18 +2718,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2800,7 +2740,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -2822,7 +2762,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -2865,18 +2805,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2953,18 +2893,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -2975,7 +2915,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -2998,7 +2938,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -3042,18 +2982,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -3064,7 +3004,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -3087,7 +3027,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -3130,18 +3070,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -3152,7 +3092,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -3175,7 +3115,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -3219,18 +3159,18 @@ struct DeviceIterateTile<
 
   KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(hipBlockIdx_x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(hipThreadIdx_y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
-      for (index_type tileidx = static_cast<index_type>(hipBlockIdx_x);
-           tileidx < m_policy.m_num_tiles; tileidx += hipGridDim_x) {
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(hipThreadIdx_y);
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
         bool in_bounds      = true;
 
         // LL
@@ -3241,7 +3181,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 
@@ -3264,7 +3204,7 @@ struct DeviceIterateTile<
                 m_policy.m_lower[i];
             tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with hipThreadIdx_y
+            // tile-local indices identified with threadIdx.y
             m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
             thrd_idx /= m_policy.m_tile[i];
 

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -161,10 +161,9 @@ struct HIPParallelLaunch<
       HIP_SAFE_CALL(hipMemcpyAsync(d_driver, &driver, sizeof(DriverType),
                                    hipMemcpyHostToDevice,
                                    hip_instance->m_stream));
-      hipLaunchKernelGGL(
-          (hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
-                                            MinBlocksPerSM>),
-          grid, block, shmem, hip_instance->m_stream, d_driver);
+      hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
+                                       MinBlocksPerSM>
+          <<<grid, block, shmem, hip_instance->m_stream>>>(d_driver);
 
       Kokkos::Experimental::HIP().fence();
       printf("Post Launch Error: %s\n", hipGetErrorName(hipGetLastError()));
@@ -208,8 +207,8 @@ struct HIPParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
       HIP_SAFE_CALL(hipMemcpyAsync(d_driver, &driver, sizeof(DriverType),
                                    hipMemcpyHostToDevice,
                                    hip_instance->m_stream));
-      hipLaunchKernelGGL(hip_parallel_launch_local_memory<DriverType>, grid,
-                         block, shmem, hip_instance->m_stream, d_driver);
+      hip_parallel_launch_local_memory<DriverType>
+          <<<grid, block, shmem, hip_instance->m_stream>>>(d_driver);
 
       Kokkos::Experimental::HIP().fence();
       HIP_SAFE_CALL(hipFree(d_driver));

--- a/core/src/HIP/Kokkos_HIP_Locks.cpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.cpp
@@ -62,14 +62,14 @@ namespace Kokkos {
 namespace {
 
 __global__ void init_lock_array_kernel_atomic() {
-  unsigned i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+  unsigned i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < KOKKOS_IMPL_HIP_SPACE_ATOMIC_MASK + 1) {
     g_device_hip_lock_arrays.atomic[i] = 0;
   }
 }
 
 __global__ void init_lock_array_kernel_threadid(int N) {
-  unsigned i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+  unsigned i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < static_cast<unsigned>(N)) {
     g_device_hip_lock_arrays.scratch[i] = 0;
   }

--- a/core/src/HIP/Kokkos_HIP_Locks.cpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.cpp
@@ -93,12 +93,11 @@ void initialize_host_hip_lock_arrays() {
   g_host_hip_lock_arrays.n = ::Kokkos::Experimental::HIP::concurrency();
 
   KOKKOS_COPY_HIP_LOCK_ARRAYS_TO_DEVICE();
-  hipLaunchKernelGGL(init_lock_array_kernel_atomic,
-                     (KOKKOS_IMPL_HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256,
-                     0, 0);
-  hipLaunchKernelGGL(init_lock_array_kernel_threadid,
-                     (::Kokkos::Experimental::HIP::concurrency() + 255) / 256,
-                     256, 0, 0, ::Kokkos::Experimental::HIP::concurrency());
+  init_lock_array_kernel_atomic<<<
+      (KOKKOS_IMPL_HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256, 0, 0>>>();
+  init_lock_array_kernel_threadid<<<
+      (::Kokkos::Experimental::HIP::concurrency() + 255) / 256, 256, 0, 0>>>(
+      ::Kokkos::Experimental::HIP::concurrency());
 }
 
 void finalize_host_hip_lock_arrays() {

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -57,27 +57,27 @@ namespace Kokkos {
 namespace Impl {
 
 /* Algorithmic constraints:
- *   (a) threads with the same hipThreadIdx_x have same value
- *   (b) hipBlockDim_x == power of two
- *   (x) hipBlockDim_z == 1
+ *   (a) threads with the same threadIdx.x have same value
+ *   (b) blockDim.x == power of two
+ *   (x) blockDim.z == 1
  */
 template <typename ValueType, typename JoinOp,
           typename std::enable_if<!Kokkos::is_reducer<ValueType>::value,
                                   int>::type = 0>
 __device__ inline void hip_intra_warp_reduction(
     ValueType& result, JoinOp const& join,
-    uint32_t const max_active_thread = hipBlockDim_y) {
+    uint32_t const max_active_thread = blockDim.y) {
   unsigned int shift = 1;
 
-  // Reduce over values from threads with different hipThreadIdx_y
+  // Reduce over values from threads with different threadIdx.y
   unsigned int constexpr warp_size =
       Kokkos::Experimental::Impl::HIPTraits::WarpSize;
-  while (hipBlockDim_x * shift < warp_size) {
-    ValueType const tmp = Kokkos::Experimental::shfl_down(
-        result, hipBlockDim_x * shift, warp_size);
+  while (blockDim.x * shift < warp_size) {
+    ValueType const tmp =
+        Kokkos::Experimental::shfl_down(result, blockDim.x * shift, warp_size);
     // Only join if upper thread is active (this allows non power of two for
-    // hipBlockDim_y)
-    if (hipThreadIdx_y + shift < max_active_thread) join(result, tmp);
+    // blockDim.y)
+    if (threadIdx.y + shift < max_active_thread) join(result, tmp);
     shift *= 2;
   }
 
@@ -90,7 +90,7 @@ template <typename ValueType, typename JoinOp,
                                   int>::type = 0>
 __device__ inline void hip_inter_warp_reduction(
     ValueType& value, const JoinOp& join,
-    const int max_active_thread = hipBlockDim_y) {
+    const int max_active_thread = blockDim.y) {
   unsigned int constexpr warp_size =
       Kokkos::Experimental::Impl::HIPTraits::WarpSize;
   int constexpr step_width = 8;
@@ -99,16 +99,16 @@ __device__ inline void hip_inter_warp_reduction(
   // constructors it could lead to race conditions.
   __shared__ double sh_result[(sizeof(ValueType) + 7) / 8 * step_width];
   ValueType* result = reinterpret_cast<ValueType*>(&sh_result);
-  int const step    = warp_size / hipBlockDim_x;
+  int const step    = warp_size / blockDim.x;
   int shift         = step_width;
-  // Skip the code below if  hipThreadIdx_y % step != 0
-  int const id = hipThreadIdx_y % step == 0 ? hipThreadIdx_y / step : INT_MAX;
+  // Skip the code below if  threadIdx.y % step != 0
+  int const id = threadIdx.y % step == 0 ? threadIdx.y / step : INT_MAX;
   if (id < step_width) {
     result[id] = value;
   }
   __syncthreads();
   while (shift <= max_active_thread / step) {
-    if (shift <= id && shift + step_width > id && hipThreadIdx_x == 0) {
+    if (shift <= id && shift + step_width > id && threadIdx.x == 0) {
       join(result[id % step_width], value);
     }
     __syncthreads();
@@ -125,7 +125,7 @@ template <typename ValueType, typename JoinOp,
                                   int>::type = 0>
 __device__ inline void hip_intra_block_reduction(
     ValueType& value, JoinOp const& join,
-    int const max_active_thread = hipBlockDim_y) {
+    int const max_active_thread = blockDim.y) {
   hip_intra_warp_reduction(value, join, max_active_thread);
   hip_inter_warp_reduction(value, join, max_active_thread);
 }
@@ -139,7 +139,7 @@ __device__ bool hip_inter_block_reduction(
     typename FunctorValueTraits<FunctorType,
                                 ArgTag>::pointer_type const /*result*/,
     Kokkos::Experimental::HIP::size_type* const m_scratch_flags,
-    int const max_active_thread = hipBlockDim_y) {
+    int const max_active_thread = blockDim.y) {
   typedef typename FunctorValueTraits<FunctorType, ArgTag>::pointer_type
       pointer_type;
   typedef
@@ -148,12 +148,12 @@ __device__ bool hip_inter_block_reduction(
   // Do the intra-block reduction with shfl operations and static shared memory
   hip_intra_block_reduction(value, join, max_active_thread);
 
-  int const id = hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x;
+  int const id = threadIdx.y * blockDim.x + threadIdx.x;
 
   // One thread in the block writes block result to global scratch_memory
   if (id == 0) {
     pointer_type global =
-        reinterpret_cast<pointer_type>(m_scratch_space) + hipBlockIdx_x;
+        reinterpret_cast<pointer_type>(m_scratch_space) + blockIdx.x;
     *global = value;
   }
 
@@ -171,7 +171,7 @@ __device__ bool hip_inter_block_reduction(
     count = Kokkos::Experimental::shfl(count, 0, warp_size);
 
     // Last block does the inter block reduction
-    if (count == hipGridDim_x - 1) {
+    if (count == gridDim.x - 1) {
       // set flag back to zero
       if (id == 0) *m_scratch_flags = 0;
       last_block = true;
@@ -181,26 +181,26 @@ __device__ bool hip_inter_block_reduction(
           reinterpret_cast<pointer_type>(m_scratch_space);
 
       // Reduce all global values with splitting work over threads in one warp
-      const int step_size = hipBlockDim_x * hipBlockDim_y < warp_size
-                                ? hipBlockDim_x * hipBlockDim_y
+      const int step_size = blockDim.x * blockDim.y < warp_size
+                                ? blockDim.x * blockDim.y
                                 : warp_size;
-      for (int i = id; i < static_cast<int>(hipGridDim_x); i += step_size) {
+      for (int i = id; i < static_cast<int>(gridDim.x); i += step_size) {
         value_type tmp = global[i];
         join(value, tmp);
       }
 
       // Perform shfl reductions within the warp only join if contribution is
-      // valid (allows hipGridDim_x non power of two and <warp_size)
-      if (static_cast<int>(hipBlockDim_x * hipBlockDim_y) > 1) {
+      // valid (allows gridDim.x non power of two and <warp_size)
+      if (static_cast<int>(blockDim.x * blockDim.y) > 1) {
         value_type tmp = Kokkos::Experimental::shfl_down(value, 1, warp_size);
-        if (id + 1 < static_cast<int>(hipGridDim_x)) join(value, tmp);
+        if (id + 1 < static_cast<int>(gridDim.x)) join(value, tmp);
       }
       // FIXME_HIP check that the ballot is necessary. Also active is not read.
       int active = __ballot(1);
       for (unsigned int i = 2; i < warp_size; i *= 2) {
-        if ((hipBlockDim_x * hipBlockDim_y) > i) {
+        if ((blockDim.x * blockDim.y) > i) {
           value_type tmp = Kokkos::Experimental::shfl_down(value, i, warp_size);
-          if (id + i < hipGridDim_x) join(value, tmp);
+          if (id + i < gridDim.x) join(value, tmp);
         }
         active += __ballot(1);
       }
@@ -216,20 +216,20 @@ template <typename ReducerType,
                                   int>::type = 0>
 __device__ inline void hip_intra_warp_reduction(
     const ReducerType& reducer, typename ReducerType::value_type& result,
-    const uint32_t max_active_thread = hipBlockDim_y) {
+    const uint32_t max_active_thread = blockDim.y) {
   typedef typename ReducerType::value_type ValueType;
 
   unsigned int shift = 1;
 
-  // Reduce over values from threads with different hipThreadIdx_y
+  // Reduce over values from threads with different threadIdx.y
   unsigned int constexpr warp_size =
       Kokkos::Experimental::Impl::HIPTraits::WarpSize;
-  while (hipBlockDim_x * shift < warp_size) {
-    const ValueType tmp = Kokkos::Experimental::shfl_down(
-        result, hipBlockDim_x * shift, warp_size);
+  while (blockDim.x * shift < warp_size) {
+    const ValueType tmp =
+        Kokkos::Experimental::shfl_down(result, blockDim.x * shift, warp_size);
     // Only join if upper thread is active (this allows non power of two for
-    // hipBlockDim_y)
-    if (hipThreadIdx_y + shift < max_active_thread) reducer.join(result, tmp);
+    // blockDim.y)
+    if (threadIdx.y + shift < max_active_thread) reducer.join(result, tmp);
     shift *= 2;
   }
 
@@ -242,7 +242,7 @@ template <typename ReducerType,
                                   int>::type = 0>
 __device__ inline void hip_inter_warp_reduction(
     ReducerType const& reducer, typename ReducerType::value_type value,
-    int const max_active_thread = hipBlockDim_y) {
+    int const max_active_thread = blockDim.y) {
   using ValueType          = typename ReducerType::value_type;
   int constexpr step_width = 8;
   // Depending on the ValueType __shared__ memory must be aligned up to 8 byte
@@ -250,17 +250,16 @@ __device__ inline void hip_inter_warp_reduction(
   // with constructors it could lead to race conditions.
   __shared__ double sh_result[(sizeof(ValueType) + 7) / 8 * step_width];
   ValueType* result = reinterpret_cast<ValueType*>(&sh_result);
-  int const step =
-      Kokkos::Experimental::Impl::HIPTraits::WarpSize / hipBlockDim_x;
-  int shift = step_width;
-  // Skip the code below if  hipThreadIdx_y % step != 0
-  int const id = hipThreadIdx_y % step == 0 ? hipThreadIdx_y / step : INT_MAX;
+  int const step = Kokkos::Experimental::Impl::HIPTraits::WarpSize / blockDim.x;
+  int shift      = step_width;
+  // Skip the code below if  threadIdx.y % step != 0
+  int const id = threadIdx.y % step == 0 ? threadIdx.y / step : INT_MAX;
   if (id < step_width) {
     result[id] = value;
   }
   __syncthreads();
   while (shift <= max_active_thread / step) {
-    if (shift <= id && shift + step_width > id && hipThreadIdx_x == 0) {
+    if (shift <= id && shift + step_width > id && threadIdx.x == 0) {
       reducer.join(result[id % step_width], value);
     }
     __syncthreads();
@@ -279,7 +278,7 @@ template <typename ReducerType,
                                   int>::type = 0>
 __device__ inline void hip_intra_block_reduction(
     ReducerType const& reducer, typename ReducerType::value_type value,
-    int const max_active_thread = hipBlockDim_y) {
+    int const max_active_thread = blockDim.y) {
   hip_intra_warp_reduction(reducer, value, max_active_thread);
   hip_inter_warp_reduction(reducer, value, max_active_thread);
 }
@@ -288,7 +287,7 @@ template <typename ReducerType,
           typename std::enable_if<Kokkos::is_reducer<ReducerType>::value,
                                   int>::type = 0>
 __device__ inline void hip_intra_block_reduction(
-    ReducerType const& reducer, int const max_active_thread = hipBlockDim_y) {
+    ReducerType const& reducer, int const max_active_thread = blockDim.y) {
   hip_intra_block_reduction(reducer, reducer.reference(), max_active_thread);
 }
 
@@ -299,7 +298,7 @@ __device__ inline bool hip_inter_block_reduction(
     ReducerType const& reducer,
     Kokkos::Experimental::HIP::size_type* const m_scratch_space,
     Kokkos::Experimental::HIP::size_type* const m_scratch_flags,
-    int const max_active_thread = hipBlockDim_y) {
+    int const max_active_thread = blockDim.y) {
   using pointer_type = typename ReducerType::value_type*;
   using value_type   = typename ReducerType::value_type;
 
@@ -308,12 +307,12 @@ __device__ inline bool hip_inter_block_reduction(
 
   value_type value = reducer.reference();
 
-  int const id = hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x;
+  int const id = threadIdx.y * blockDim.x + threadIdx.x;
 
   // One thread in the block writes block result to global scratch_memory
   if (id == 0) {
     pointer_type global =
-        reinterpret_cast<pointer_type>(m_scratch_space) + hipBlockIdx_x;
+        reinterpret_cast<pointer_type>(m_scratch_space) + blockIdx.x;
     *global = value;
   }
 
@@ -332,7 +331,7 @@ __device__ inline bool hip_inter_block_reduction(
     count = Kokkos::Experimental::shfl(count, 0, warp_size);
 
     // Last block does the inter block reduction
-    if (count == hipGridDim_x - 1) {
+    if (count == gridDim.x - 1) {
       // Set flag back to zero
       if (id == 0) *m_scratch_flags = 0;
       last_block = true;
@@ -342,26 +341,26 @@ __device__ inline bool hip_inter_block_reduction(
           reinterpret_cast<pointer_type>(m_scratch_space);
 
       // Reduce all global values with splitting work over threads in one warp
-      int const step_size = hipBlockDim_x * hipBlockDim_y < warp_size
-                                ? hipBlockDim_x * hipBlockDim_y
+      int const step_size = blockDim.x * blockDim.y < warp_size
+                                ? blockDim.x * blockDim.y
                                 : warp_size;
-      for (int i = id; i < static_cast<int>(hipGridDim_x); i += step_size) {
+      for (int i = id; i < static_cast<int>(gridDim.x); i += step_size) {
         value_type tmp = global[i];
         reducer.join(value, tmp);
       }
 
       // Perform shfl reductions within the warp only join if contribution is
-      // valid (allows hipGridDim_x non power of two and <warp_size)
-      if (static_cast<int>(hipBlockDim_x * hipBlockDim_y) > 1) {
+      // valid (allows gridDim.x non power of two and <warp_size)
+      if (static_cast<int>(blockDim.x * blockDim.y) > 1) {
         value_type tmp = Kokkos::Experimental::shfl_down(value, 1, warp_size);
-        if (id + 1 < static_cast<int>(hipGridDim_x)) reducer.join(value, tmp);
+        if (id + 1 < static_cast<int>(gridDim.x)) reducer.join(value, tmp);
       }
       // FIXME_HIP check that the ballot is necessary. Also active is not read.
       int active = __ballot(1);
       for (unsigned int i = 2; i < 64; i *= 2) {
-        if ((hipBlockDim_x * hipBlockDim_y) > i) {
+        if ((blockDim.x * blockDim.y) > i) {
           value_type tmp = Kokkos::Experimental::shfl_down(value, i, warp_size);
-          if (id + i < hipGridDim_x) reducer.join(value, tmp);
+          if (id + i < gridDim.x) reducer.join(value, tmp);
         }
         active += __ballot(1);
       }
@@ -392,10 +391,9 @@ struct HIPReductionsFunctor<FunctorType, ArgTag, false, false> {
                                // part of the reduction
       int const width)         // How much of the warp participates
   {
-    int const lane_id = (hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x) %
+    int const lane_id = (threadIdx.y * blockDim.x + threadIdx.x) %
                         ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
-    for (int delta = skip_vector ? hipBlockDim_x : 1; delta < width;
-         delta *= 2) {
+    for (int delta = skip_vector ? blockDim.x : 1; delta < width; delta *= 2) {
       if (lane_id + delta < ::Kokkos::Experimental::Impl::HIPTraits::WarpSize) {
         ValueJoin::join(functor, value, value + delta);
       }
@@ -406,11 +404,10 @@ struct HIPReductionsFunctor<FunctorType, ArgTag, false, false> {
   __device__ static inline void scalar_intra_block_reduction(
       FunctorType const& functor, Scalar value, bool const skip, Scalar* result,
       int const /*shared_elements*/, Scalar* shared_team_buffer_element) {
-    int const warp_id = (hipThreadIdx_y * hipBlockDim_x) /
+    int const warp_id = (threadIdx.y * blockDim.x) /
                         ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
     Scalar* const my_shared_team_buffer_element =
-        shared_team_buffer_element + hipThreadIdx_y * hipBlockDim_x +
-        hipThreadIdx_x;
+        shared_team_buffer_element + threadIdx.y * blockDim.x + threadIdx.x;
     *my_shared_team_buffer_element = value;
     // Warp Level Reduction, ignoring Kokkos vector entries
     scalar_intra_warp_reduction(
@@ -422,16 +419,15 @@ struct HIPReductionsFunctor<FunctorType, ArgTag, false, false> {
 
     if (warp_id == 0) {
       const unsigned int delta =
-          (hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x) *
+          (threadIdx.y * blockDim.x + threadIdx.x) *
           ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
-      if (delta < hipBlockDim_x * hipBlockDim_y)
+      if (delta < blockDim.x * blockDim.y)
         *my_shared_team_buffer_element = shared_team_buffer_element[delta];
       scalar_intra_warp_reduction(
           functor, my_shared_team_buffer_element, false,
-          hipBlockDim_x * hipBlockDim_y /
+          blockDim.x * blockDim.y /
               ::Kokkos::Experimental::Impl::HIPTraits::WarpSize);
-      if (hipThreadIdx_x + hipThreadIdx_y == 0)
-        *result = *shared_team_buffer_element;
+      if (threadIdx.x + threadIdx.y == 0) *result = *shared_team_buffer_element;
     }
   }
 
@@ -445,11 +441,11 @@ struct HIPReductionsFunctor<FunctorType, ArgTag, false, false> {
     Scalar* const global_team_buffer_element =
         reinterpret_cast<Scalar*>(global_data);
     Scalar* const my_global_team_buffer_element =
-        global_team_buffer_element + hipBlockIdx_x;
+        global_team_buffer_element + blockIdx.x;
     Scalar* shared_team_buffer_elements =
         reinterpret_cast<Scalar*>(shared_data);
-    Scalar value        = shared_team_buffer_elements[hipThreadIdx_y];
-    int shared_elements = (hipBlockDim_x * hipBlockDim_y) /
+    Scalar value        = shared_team_buffer_elements[threadIdx.y];
+    int shared_elements = (blockDim.x * blockDim.y) /
                           ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
     int global_elements = block_count;
     __syncthreads();
@@ -463,27 +459,26 @@ struct HIPReductionsFunctor<FunctorType, ArgTag, false, false> {
     // Use the last block that is done to do the do the reduction across the
     // block
     __shared__ unsigned int num_teams_done;
-    if (hipThreadIdx_x + hipThreadIdx_y == 0) {
+    if (threadIdx.x + threadIdx.y == 0) {
       __threadfence();
       num_teams_done = Kokkos::atomic_fetch_add(global_flags, 1) + 1;
     }
     bool is_last_block = false;
     // FIXME_HIP HIP does not support syncthreads_or. That's why we need to make
     // num_teams_done __shared__
-    // if (__syncthreads_or(num_teams_done == hipGridDim_x)) {*/
+    // if (__syncthreads_or(num_teams_done == gridDim.x)) {*/
     __syncthreads();
-    if (num_teams_done == hipGridDim_x) {
+    if (num_teams_done == gridDim.x) {
       is_last_block = true;
       *global_flags = 0;
       ValueInit::init(functor, &value);
-      for (int i = hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x;
-           i < global_elements; i += hipBlockDim_x * hipBlockDim_y) {
+      for (int i = threadIdx.y * blockDim.x + threadIdx.x; i < global_elements;
+           i += blockDim.x * blockDim.y) {
         ValueJoin::join(functor, &value, &global_team_buffer_element[i]);
       }
       scalar_intra_block_reduction(
-          functor, value, false,
-          shared_team_buffer_elements + (hipBlockDim_y - 1), shared_elements,
-          shared_team_buffer_elements);
+          functor, value, false, shared_team_buffer_elements + (blockDim.y - 1),
+          shared_elements, shared_team_buffer_elements);
     }
 
     return is_last_block;
@@ -493,9 +488,9 @@ struct HIPReductionsFunctor<FunctorType, ArgTag, false, false> {
 //----------------------------------------------------------------------------
 /*
  *  Algorithmic constraints:
- *   (a) hipBlockDim_y is a power of two
- *   (b) hipBlockDim_y <= 1024
- *   (c) hipBlockDim_x == hipBlockDim_z == 1
+ *   (a) blockDim.y is a power of two
+ *   (b) blockDim.y <= 1024
+ *   (c) blockDim.x == blockDim.z == 1
  */
 
 template <bool DoScan, class FunctorType, class ArgTag>
@@ -509,14 +504,14 @@ __device__ void hip_intra_block_reduce_scan(
   using pointer_type = typename ValueTraits::pointer_type;
 
   unsigned int const value_count   = ValueTraits::value_count(functor);
-  unsigned int const BlockSizeMask = hipBlockDim_y - 1;
+  unsigned int const BlockSizeMask = blockDim.y - 1;
   int const WarpMask = Experimental::Impl::HIPTraits::WarpSize - 1;
 
   // Must have power of two thread count
-  if ((hipBlockDim_y - 1) & hipBlockDim_y) {
+  if ((blockDim.y - 1) & blockDim.y) {
     Kokkos::abort(
         "HIP::hip_intra_block_reduce_scan requires power-of-two "
-        "hipBlockDim_y\n");
+        "blockDim.y\n");
   }
 
   auto block_reduce_step =
@@ -527,8 +522,8 @@ __device__ void hip_intra_block_reduce_scan(
       };
 
   {  // Intra-warp reduction:
-    const unsigned rtid_intra      = hipThreadIdx_y & WarpMask;
-    const pointer_type tdata_intra = base_data + value_count * hipThreadIdx_y;
+    const unsigned rtid_intra      = threadIdx.y & WarpMask;
+    const pointer_type tdata_intra = base_data + value_count * threadIdx.y;
 
     block_reduce_step(rtid_intra, tdata_intra, 0);
     block_reduce_step(rtid_intra, tdata_intra, 1);
@@ -542,11 +537,10 @@ __device__ void hip_intra_block_reduce_scan(
 
   {  // Inter-warp reduce-scan by a single warp to avoid extra synchronizations
     unsigned int const rtid_inter =
-        ((hipThreadIdx_y + 1)
-         << Experimental::Impl::HIPTraits::WarpIndexShift) -
+        ((threadIdx.y + 1) << Experimental::Impl::HIPTraits::WarpIndexShift) -
         1;
 
-    if (rtid_inter < hipBlockDim_y) {
+    if (rtid_inter < blockDim.y) {
       pointer_type const tdata_inter = base_data + value_count * rtid_inter;
 
       if ((1 << 6) < BlockSizeMask) {
@@ -572,12 +566,11 @@ __device__ void hip_intra_block_reduce_scan(
   if (DoScan) {
     // Update all the values for the respective warps (except for the last one)
     // by adding from the last value of the previous warp.
-    if (hipThreadIdx_y >= Experimental::Impl::HIPTraits::WarpSize &&
-        (hipThreadIdx_y & WarpMask) !=
+    if (threadIdx.y >= Experimental::Impl::HIPTraits::WarpSize &&
+        (threadIdx.y & WarpMask) !=
             Experimental::Impl::HIPTraits::WarpSize - 1) {
-      const int offset_to_previous_warp_total =
-          (hipThreadIdx_y & (~WarpMask)) - 1;
-      ValueJoin::join(functor, base_data + value_count * hipThreadIdx_y,
+      const int offset_to_previous_warp_total = (threadIdx.y & (~WarpMask)) - 1;
+      ValueJoin::join(functor, base_data + value_count * threadIdx.y,
                       base_data + value_count * offset_to_previous_warp_total);
     }
   }
@@ -609,13 +602,13 @@ __device__ bool hip_single_inter_block_reduce_scan2(
   using pointer_type = typename ValueTraits::pointer_type;
 
   // '__ffs' = position of the least significant bit set to 1.
-  // 'hipBlockDim_y' is guaranteed to be a power of two so this
+  // 'blockDim.y' is guaranteed to be a power of two so this
   // is the integral shift value that can replace an integral divide.
-  unsigned int const BlockSizeShift = __ffs(hipBlockDim_y) - 1;
-  unsigned int const BlockSizeMask  = hipBlockDim_y - 1;
+  unsigned int const BlockSizeShift = __ffs(blockDim.y) - 1;
+  unsigned int const BlockSizeMask  = blockDim.y - 1;
 
   // Must have power of two thread count
-  if (BlockSizeMask & hipBlockDim_y) {
+  if (BlockSizeMask & blockDim.y) {
     Kokkos::abort(
         "HIP::hip_single_inter_block_reduce_scan requires power-of-two "
         "blockDim");
@@ -635,7 +628,7 @@ __device__ bool hip_single_inter_block_reduce_scan2(
     size_type* const shared = shared_data + word_count.value * BlockSizeMask;
     size_type* const global = global_data + word_count.value * block_id;
 
-    for (size_t i = hipThreadIdx_y; i < word_count.value; i += hipBlockDim_y) {
+    for (size_t i = threadIdx.y; i < word_count.value; i += blockDim.y) {
       global[i] = shared[i];
     }
   }
@@ -651,7 +644,7 @@ __device__ bool hip_single_inter_block_reduce_scan2(
   __shared__ int n_done;
   n_done = 0;
   __syncthreads();
-  if (hipThreadIdx_y == 0) {
+  if (threadIdx.y == 0) {
     __threadfence();
     n_done = 1 + atomicInc(global_flags, block_count - 1);
   }
@@ -660,14 +653,14 @@ __device__ bool hip_single_inter_block_reduce_scan2(
 
   if (is_last_block) {
     size_type const b = (static_cast<long long int>(block_count) *
-                         static_cast<long long int>(hipThreadIdx_y)) >>
+                         static_cast<long long int>(threadIdx.y)) >>
                         BlockSizeShift;
     size_type const e = (static_cast<long long int>(block_count) *
-                         static_cast<long long int>(hipThreadIdx_y + 1)) >>
+                         static_cast<long long int>(threadIdx.y + 1)) >>
                         BlockSizeShift;
 
     {
-      void* const shared_ptr = shared_data + word_count.value * hipThreadIdx_y;
+      void* const shared_ptr = shared_data + word_count.value * threadIdx.y;
       /* reference_type shared_value = */ ValueInit::init(functor, shared_ptr);
 
       for (size_type i = b; i < e; ++i) {
@@ -681,10 +674,10 @@ __device__ bool hip_single_inter_block_reduce_scan2(
 
     if (DoScan) {
       size_type* const shared_value =
-          shared_data + word_count.value * (hipThreadIdx_y ? hipThreadIdx_y - 1
-                                                           : hipBlockDim_y);
+          shared_data +
+          word_count.value * (threadIdx.y ? threadIdx.y - 1 : blockDim.y);
 
-      if (!hipThreadIdx_y) {
+      if (!threadIdx.y) {
         ValueInit::init(functor, shared_value);
       }
 

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -77,16 +77,16 @@ struct HIPJoinFunctor {
 /**\brief  Team member_type passed to TeamPolicy or TeamTask closures.
  *
  *  HIP thread blocks for team closures are dimensioned as:
- *    hipBlockDim_x == number of "vector lanes" per "thread"
- *    hipBlockDim_y == number of "threads" per team
- *    hipBlockDim_z == number of teams in a block
+ *    blockDim.x == number of "vector lanes" per "thread"
+ *    blockDim.y == number of "threads" per team
+ *    blockDim.z == number of teams in a block
  *  where
  *    A set of teams exactly fill a warp OR a team is the whole block
- *      ( 0 == WarpSize % ( hipBlockDim_x * hipBlockDim_y ) )
+ *      ( 0 == WarpSize % ( blockDim.x * blockDim.y ) )
  *      OR
- *      ( 1 == hipBlockDim_z )
+ *      ( 1 == blockDim.z )
 
- *  Thus when 1 < hipBlockDim_z the team is warp-synchronous
+ *  Thus when 1 < blockDim.z the team is warp-synchronous
  *  and __syncthreads should not be called in team collectives.
  *
  *  When multiple teams are mapped onto a single block then the
@@ -126,7 +126,7 @@ class HIPTeamMember {
   KOKKOS_INLINE_FUNCTION int league_size() const { return m_league_size; }
   KOKKOS_INLINE_FUNCTION int team_rank() const {
 #ifdef __HIP_DEVICE_COMPILE__
-    return hipThreadIdx_y;
+    return threadIdx.y;
 #else
     return 0;
 #endif
@@ -134,7 +134,7 @@ class HIPTeamMember {
 
   KOKKOS_INLINE_FUNCTION int team_size() const {
 #ifdef __HIP_DEVICE_COMPILE__
-    return hipBlockDim_y;
+    return blockDim.y;
 #else
     return 1;
 #endif
@@ -142,7 +142,7 @@ class HIPTeamMember {
 
   KOKKOS_INLINE_FUNCTION void team_barrier() const {
 #ifdef __HIP_DEVICE_COMPILE__
-    if (1 == hipBlockDim_z)
+    if (1 == blockDim.z)
       __syncthreads();  // team == block
     else
       __threadfence_block();  // team <= warp
@@ -155,11 +155,11 @@ class HIPTeamMember {
   KOKKOS_INLINE_FUNCTION void team_broadcast(ValueType& val,
                                              const int& thread_id) const {
 #ifdef __HIP_DEVICE_COMPILE__
-    if (1 == hipBlockDim_z) {  // team == block
+    if (1 == blockDim.z) {  // team == block
       __syncthreads();
       // Wait for shared data write until all threads arrive here
-      if (hipThreadIdx_x == 0u &&
-          hipThreadIdx_y == static_cast<uint32_t>(thread_id)) {
+      if (threadIdx.x == 0u &&
+          threadIdx.y == static_cast<uint32_t>(thread_id)) {
         *(reinterpret_cast<ValueType*>(m_team_reduce)) = val;
       }
       __syncthreads();  // Wait for shared data read until root thread writes
@@ -167,7 +167,7 @@ class HIPTeamMember {
     } else {               // team <= warp
       ValueType tmp(val);  // input might not be a register variable
       ::Kokkos::Experimental::Impl::in_place_shfl(
-          val, tmp, hipBlockDim_x * thread_id, hipBlockDim_x * hipBlockDim_y);
+          val, tmp, blockDim.x * thread_id, blockDim.x * blockDim.y);
     }
 #else
     (void)val;
@@ -181,11 +181,11 @@ class HIPTeamMember {
 #ifdef __HIP_DEVICE_COMPILE__
     f(val);
 
-    if (1 == hipBlockDim_z) {  // team == block
+    if (1 == blockDim.z) {  // team == block
       __syncthreads();
       // Wait for shared data write until all threads arrive here
-      if (hipThreadIdx_x == 0u &&
-          hipThreadIdx_y == static_cast<uint32_t>(thread_id)) {
+      if (threadIdx.x == 0u &&
+          threadIdx.y == static_cast<uint32_t>(thread_id)) {
         *(reinterpret_cast<ValueType*>(m_team_reduce)) = val;
       }
       __syncthreads();  // Wait for shared data read until root thread writes
@@ -193,7 +193,7 @@ class HIPTeamMember {
     } else {               // team <= warp
       ValueType tmp(val);  // input might not be a register variable
       ::Kokkos::Experimental::Impl::in_place_shfl(
-          val, tmp, hipBlockDim_x * thread_id, hipBlockDim_x * hipBlockDim_y);
+          val, tmp, blockDim.x * thread_id, blockDim.x * blockDim.y);
     }
 #else
     (void)f;
@@ -206,16 +206,16 @@ class HIPTeamMember {
   /**\brief  Reduction across a team
    *
    *  Mapping of teams onto blocks:
-   *    hipBlockDim_x  is "vector lanes"
-   *    hipBlockDim_y  is team "threads"
-   *    hipBlockDim_z  is number of teams per block
+   *    blockDim.x  is "vector lanes"
+   *    blockDim.y  is team "threads"
+   *    blockDim.z  is number of teams per block
    *
    *  Requires:
-   *    hipBlockDim_x is power two
-   *    hipBlockDim_x <= HIPTraits::WarpSize
-   *    ( 0 == HIPTraits::WarpSize % ( hipBlockDim_x * hipBlockDim_y )
+   *    blockDim.x is power two
+   *    blockDim.x <= HIPTraits::WarpSize
+   *    ( 0 == HIPTraits::WarpSize % ( blockDim.x * blockDim.y )
    *      OR
-   *    ( 1 == hipBlockDim_z )
+   *    ( 1 == blockDim.z )
    */
   template <typename ReducerType>
   KOKKOS_INLINE_FUNCTION
@@ -230,7 +230,7 @@ class HIPTeamMember {
       team_reduce(ReducerType const& reducer,
                   typename ReducerType::value_type& value) const noexcept {
 #ifdef __HIP_DEVICE_COMPILE__
-    hip_intra_block_reduction(reducer, value, hipBlockDim_y);
+    hip_intra_block_reduction(reducer, value, blockDim.y);
 #else
     (void)reducer;
     (void)value;
@@ -256,25 +256,25 @@ class HIPTeamMember {
     __syncthreads();  // Don't write in to shared data until all threads have
                       // entered this function
 
-    if (0 == hipThreadIdx_y) {
+    if (0 == threadIdx.y) {
       base_data[0] = 0;
     }
 
-    base_data[hipThreadIdx_y + 1] = value;
+    base_data[threadIdx.y + 1] = value;
 
     Impl::hip_intra_block_reduce_scan<true, Impl::HIPJoinFunctor<Type>, void>(
         Impl::HIPJoinFunctor<Type>(), base_data + 1);
 
     if (global_accum) {
-      if (hipBlockDim_y == hipThreadIdx_y + 1) {
-        base_data[hipBlockDim_y] =
-            atomic_fetch_add(global_accum, base_data[hipBlockDim_y]);
+      if (blockDim.y == threadIdx.y + 1) {
+        base_data[blockDim.y] =
+            atomic_fetch_add(global_accum, base_data[blockDim.y]);
       }
       __syncthreads();  // Wait for atomic
-      base_data[hipThreadIdx_y] += base_data[hipBlockDim_y];
+      base_data[threadIdx.y] += base_data[blockDim.y];
     }
 
-    return base_data[hipThreadIdx_y];
+    return base_data[threadIdx.y];
 #else
     (void)value;
     (void)global_accum;
@@ -307,16 +307,16 @@ class HIPTeamMember {
       vector_reduce(ReducerType const& reducer,
                     typename ReducerType::value_type& value) {
 #ifdef __HIP_DEVICE_COMPILE__
-    if (hipBlockDim_x == 1) return;
+    if (blockDim.x == 1) return;
 
     // Intra vector lane shuffle reduction:
     typename ReducerType::value_type tmp(value);
     typename ReducerType::value_type tmp2 = tmp;
 
-    for (int i = hipBlockDim_x; (i >>= 1);) {
+    for (int i = blockDim.x; (i >>= 1);) {
       ::Kokkos::Experimental::Impl::in_place_shfl_down(tmp2, tmp, i,
-                                                       hipBlockDim_x);
-      if (static_cast<int>(hipThreadIdx_x) < i) {
+                                                       blockDim.x);
+      if (static_cast<int>(threadIdx.x) < i) {
         reducer.join(tmp, tmp2);
       }
     }
@@ -326,7 +326,7 @@ class HIPTeamMember {
     // because floating point summation is not associative
     // and thus different threads could have different results.
 
-    ::Kokkos::Experimental::Impl::in_place_shfl(tmp2, tmp, 0, hipBlockDim_x);
+    ::Kokkos::Experimental::Impl::in_place_shfl(tmp2, tmp, 0, blockDim.x);
     value               = tmp2;
     reducer.reference() = tmp2;
 #else
@@ -355,10 +355,9 @@ class HIPTeamMember {
     const int nsh = shmem_size / sizeof(value_type);
 
     // Number of HIP threads in the block, rank within the block
-    const int nid = hipBlockDim_x * hipBlockDim_y * hipBlockDim_z;
+    const int nid = blockDim.x * blockDim.y * blockDim.z;
     const int tid =
-        hipThreadIdx_x +
-        hipBlockDim_x * (hipThreadIdx_y + hipBlockDim_y * hipThreadIdx_z);
+        threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
 
     // Reduces within block using all available shared memory
     // Contributes if it is the root "vector lane"
@@ -379,11 +378,11 @@ class HIPTeamMember {
 
       int constexpr warp_size =
           ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
-      for (int i = warp_size; static_cast<int>(hipBlockDim_x) <= (i >>= 1);) {
+      for (int i = warp_size; static_cast<int>(blockDim.x) <= (i >>= 1);) {
         Impl::in_place_shfl_down(reducer.reference(), tmp, i, warp_size);
 
         // Root of each vector lane reduces "thread" contribution
-        if (0 == hipThreadIdx_x && wx < i) {
+        if (0 == threadIdx.x && wx < i) {
           reducer.join(&tmp, reducer.data());
         }
       }
@@ -440,12 +439,12 @@ class HIPTeamMember {
 
       if (0 == wx) {
         reducer.copy((reinterpret_cast<pointer_type>(global_scratch_space)) +
-                         hipBlockIdx_x * reducer.length(),
+                         blockIdx.x * reducer.length(),
                      reducer.data());
 
         __threadfence();  // Wait until global write is visible.
 
-        last_block = static_cast<int>(hipGridDim_x) ==
+        last_block = static_cast<int>(gridDim.x) ==
                      1 + Kokkos::atomic_fetch_add(global_scratch_flags, 1);
 
         // If last block then reset count
@@ -464,9 +463,8 @@ class HIPTeamMember {
     //------------------------
     // Last block reads global_scratch_memory into shared memory.
 
-    const int nentry = nid < hipGridDim_x
-                           ? (nid < nsh ? nid : nsh)
-                           : (hipGridDim_x < nsh ? hipGridDim_x : nsh);
+    const int nentry = nid < gridDim.x ? (nid < nsh ? nid : nsh)
+                                       : (gridDim.x < nsh ? gridDim.x : nsh);
 
     // nentry = min( nid , nsh , gridDim.x )
 
@@ -479,8 +477,7 @@ class HIPTeamMember {
           (reinterpret_cast<pointer_type>(shmem)) + offset,
           (reinterpret_cast<pointer_type>(global_scratch_space)) + offset);
 
-      for (int i = nentry + tid; i < static_cast<int>(hipGridDim_x);
-           i += nentry) {
+      for (int i = nentry + tid; i < static_cast<int>(gridDim.x); i += nentry) {
         reducer.join((reinterpret_cast<pointer_type>(shmem)) + offset,
                      (reinterpret_cast<pointer_type>(global_scratch_space)) +
                          i * reducer.length());
@@ -702,8 +699,8 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
         loop_boundaries,
     const Closure& closure) {
 #ifdef __HIP_DEVICE_COMPILE__
-  for (iType i = loop_boundaries.start + hipThreadIdx_y;
-       i < loop_boundaries.end; i += hipBlockDim_y)
+  for (iType i = loop_boundaries.start + threadIdx.y; i < loop_boundaries.end;
+       i += blockDim.y)
     closure(i);
 #else
   (void)loop_boundaries;
@@ -731,8 +728,8 @@ KOKKOS_INLINE_FUNCTION
   typename ReducerType::value_type value;
   reducer.init(value);
 
-  for (iType i = loop_boundaries.start + hipThreadIdx_y;
-       i < loop_boundaries.end; i += hipBlockDim_y) {
+  for (iType i = loop_boundaries.start + threadIdx.y; i < loop_boundaries.end;
+       i += blockDim.y) {
     closure(i, value);
   }
 
@@ -764,8 +761,8 @@ KOKKOS_INLINE_FUNCTION
 
   reducer.init(reducer.reference());
 
-  for (iType i = loop_boundaries.start + hipThreadIdx_y;
-       i < loop_boundaries.end; i += hipBlockDim_y) {
+  for (iType i = loop_boundaries.start + threadIdx.y; i < loop_boundaries.end;
+       i += blockDim.y) {
     closure(i, val);
   }
 
@@ -784,9 +781,8 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
         loop_boundaries,
     const Closure& closure) {
 #ifdef __HIP_DEVICE_COMPILE__
-  for (iType i = loop_boundaries.start + hipThreadIdx_y * hipBlockDim_x +
-                 hipThreadIdx_x;
-       i < loop_boundaries.end; i += hipBlockDim_y * hipBlockDim_x)
+  for (iType i = loop_boundaries.start + threadIdx.y * blockDim.x + threadIdx.x;
+       i < loop_boundaries.end; i += blockDim.y * blockDim.x)
     closure(i);
 #else
   (void)loop_boundaries;
@@ -804,9 +800,8 @@ KOKKOS_INLINE_FUNCTION
   typename ReducerType::value_type value;
   reducer.init(value);
 
-  for (iType i = loop_boundaries.start + hipThreadIdx_y * hipBlockDim_x +
-                 hipThreadIdx_x;
-       i < loop_boundaries.end; i += hipBlockDim_y * hipBlockDim_x) {
+  for (iType i = loop_boundaries.start + threadIdx.y * blockDim.x + threadIdx.x;
+       i < loop_boundaries.end; i += blockDim.y * blockDim.x) {
     closure(i, value);
   }
 
@@ -831,9 +826,8 @@ KOKKOS_INLINE_FUNCTION
 
   reducer.init(reducer.reference());
 
-  for (iType i = loop_boundaries.start + hipThreadIdx_y * hipBlockDim_x +
-                 hipThreadIdx_x;
-       i < loop_boundaries.end; i += hipBlockDim_y * hipBlockDim_x) {
+  for (iType i = loop_boundaries.start + threadIdx.y * blockDim.x + threadIdx.x;
+       i < loop_boundaries.end; i += blockDim.y * blockDim.x) {
     closure(i, val);
   }
 
@@ -861,8 +855,8 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
         loop_boundaries,
     const Closure& closure) {
 #ifdef __HIP_DEVICE_COMPILE__
-  for (iType i = loop_boundaries.start + hipThreadIdx_x;
-       i < loop_boundaries.end; i += hipBlockDim_x) {
+  for (iType i = loop_boundaries.start + threadIdx.x; i < loop_boundaries.end;
+       i += blockDim.x) {
     closure(i);
   }
 #else
@@ -893,8 +887,8 @@ KOKKOS_INLINE_FUNCTION
 #ifdef __HIP_DEVICE_COMPILE__
   reducer.init(reducer.reference());
 
-  for (iType i = loop_boundaries.start + hipThreadIdx_x;
-       i < loop_boundaries.end; i += hipBlockDim_x) {
+  for (iType i = loop_boundaries.start + threadIdx.x; i < loop_boundaries.end;
+       i += blockDim.x) {
     closure(i, reducer.reference());
   }
 
@@ -926,8 +920,8 @@ KOKKOS_INLINE_FUNCTION
 #ifdef __HIP_DEVICE_COMPILE__
   result = ValueType();
 
-  for (iType i = loop_boundaries.start + hipThreadIdx_x;
-       i < loop_boundaries.end; i += hipBlockDim_x) {
+  for (iType i = loop_boundaries.start + threadIdx.x; i < loop_boundaries.end;
+       i += blockDim.x) {
     closure(i, result);
   }
 
@@ -968,15 +962,15 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   // All thread "lanes" must loop the same number of times.
   // Determine an loop end for all thread "lanes."
   // Requires:
-  //   hipBlockDim_x is power of two and thus
-  //     ( end % hipBlockDim_x ) == ( end & ( hipBlockDim_x - 1 ) )
-  //   1 <= hipBlockDim_x <= HIPTraits::WarpSize
+  //   blockDim.x is power of two and thus
+  //     ( end % blockDim.x ) == ( end & ( blockDim.x - 1 ) )
+  //   1 <= blockDim.x <= HIPTraits::WarpSize
 
-  const int mask = hipBlockDim_x - 1;
-  const int rem  = loop_boundaries.end & mask;  // == end % hipBlockDim_x
-  const int end  = loop_boundaries.end + (rem ? hipBlockDim_x - rem : 0);
+  const int mask = blockDim.x - 1;
+  const int rem  = loop_boundaries.end & mask;  // == end % blockDim.x
+  const int end  = loop_boundaries.end + (rem ? blockDim.x - rem : 0);
 
-  for (int i = hipThreadIdx_x; i < end; i += hipBlockDim_x) {
+  for (int i = threadIdx.x; i < end; i += blockDim.x) {
     value_type val = 0;
 
     // First acquire per-lane contributions:
@@ -992,11 +986,10 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     //  [t] += [t-4] if t >= 4
     //  ...
 
-    for (int j = 1; j < static_cast<int>(hipBlockDim_x); j <<= 1) {
+    for (int j = 1; j < static_cast<int>(blockDim.x); j <<= 1) {
       value_type tmp = 0;
-      ::Kokkos::Experimental::Impl::in_place_shfl_up(tmp, sval, j,
-                                                     hipBlockDim_x);
-      if (j <= static_cast<int>(hipThreadIdx_x)) {
+      ::Kokkos::Experimental::Impl::in_place_shfl_up(tmp, sval, j, blockDim.x);
+      if (j <= static_cast<int>(threadIdx.x)) {
         sval += tmp;
       }
     }
@@ -1008,8 +1001,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     if (i < loop_boundaries.end) closure(i, val, true);
 
     // Accumulate the last value in the inclusive scan:
-    ::Kokkos::Experimental::Impl::in_place_shfl(sval, sval, hipBlockDim_x - 1,
-                                                hipBlockDim_x);
+    ::Kokkos::Experimental::Impl::in_place_shfl(sval, sval, blockDim.x - 1,
+                                                blockDim.x);
 
     accum += sval;
   }
@@ -1028,7 +1021,7 @@ KOKKOS_INLINE_FUNCTION void single(
     const Impl::VectorSingleStruct<Impl::HIPTeamMember>&,
     const FunctorType& lambda) {
 #ifdef __HIP_DEVICE_COMPILE__
-  if (hipThreadIdx_x == 0) lambda();
+  if (threadIdx.x == 0) lambda();
 #else
   (void)lambda;
 #endif
@@ -1039,7 +1032,7 @@ KOKKOS_INLINE_FUNCTION void single(
     const Impl::ThreadSingleStruct<Impl::HIPTeamMember>&,
     const FunctorType& lambda) {
 #ifdef __HIP_DEVICE_COMPILE__
-  if (hipThreadIdx_x == 0 && hipThreadIdx_y == 0) lambda();
+  if (threadIdx.x == 0 && threadIdx.y == 0) lambda();
 #else
   (void)lambda;
 #endif
@@ -1050,8 +1043,8 @@ KOKKOS_INLINE_FUNCTION void single(
     const Impl::VectorSingleStruct<Impl::HIPTeamMember>&,
     const FunctorType& lambda, ValueType& val) {
 #ifdef __HIP_DEVICE_COMPILE__
-  if (hipThreadIdx_x == 0) lambda(val);
-  ::Kokkos::Experimental::Impl::in_place_shfl(val, val, 0, hipBlockDim_x);
+  if (threadIdx.x == 0) lambda(val);
+  ::Kokkos::Experimental::Impl::in_place_shfl(val, val, 0, blockDim.x);
 #else
   (void)lambda;
   (void)val;
@@ -1066,7 +1059,7 @@ KOKKOS_INLINE_FUNCTION void single(
   (void)lambda;
   (void)val;
 #ifdef __HIP_DEVICE_COMPILE__
-  if (hipThreadIdx_x == 0 && hipThreadIdx_y == 0) {
+  if (threadIdx.x == 0 && threadIdx.y == 0) {
     lambda(val);
   }
   single_struct.team_member.team_broadcast(val, 0);

--- a/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
@@ -82,7 +82,7 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
     constexpr int filter_value =
         Kokkos::Experimental::Impl::HIPTraits::WarpSize /
         active_threads_per_warp;
-    if (0 == (hipThreadIdx_y % filter_value)) {
+    if (0 == (threadIdx.y % filter_value)) {
       // Spin until COMPLETED_TOKEN.
       // END_TOKEN indicates no work is currently available.
 

--- a/core/unit_test/hip/TestHIP_InterOp_Init.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Init.cpp
@@ -67,7 +67,7 @@ TEST(hip, raw_hip_interop) {
 
   Kokkos::finalize();
 
-  hipLaunchKernelGGL(offset, dim3(100), dim3(100), 0, 0, p);
+  offset<<<dim3(100), dim3(100), 0, 0>>>(p);
   HIP_SAFE_CALL(hipDeviceSynchronize());
 
   int* h_p = new int[100];

--- a/core/unit_test/hip/TestHIP_InterOp_Init.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Init.cpp
@@ -48,7 +48,7 @@
 namespace Test {
 
 __global__ void offset(int* p) {
-  int idx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < 100) {
     p[idx] += idx;
   }

--- a/core/unit_test/hip/TestHIP_ScanUnit.cpp
+++ b/core/unit_test/hip/TestHIP_ScanUnit.cpp
@@ -54,7 +54,7 @@ struct DummyFunctor {
 template <int N>
 __global__ void start_intra_block_scan() {
   __shared__ DummyFunctor::value_type values[N];
-  const int i = hipThreadIdx_y;
+  const int i = threadIdx.y;
   values[i]   = i + 1;
   __syncthreads();
 

--- a/core/unit_test/hip/TestHIP_ScanUnit.cpp
+++ b/core/unit_test/hip/TestHIP_ScanUnit.cpp
@@ -74,7 +74,7 @@ template <int N>
 void test_intra_block_scan() {
   dim3 grid(1, 1, 1);
   dim3 block(1, N, 1);
-  hipLaunchKernelGGL(start_intra_block_scan<N>, grid, block, 0, 0);
+  start_intra_block_scan<N><<<grid, block, 0, 0>>>();
 }
 
 TEST(TEST_CATEGORY, scan_unit) {


### PR DESCRIPTION
According to recent discussions, going back to the `CUDA` syntax seems to be the way forward. In particular, this allows us to get rid of suppressing one warning.