### PR TITLE
Apply [[noreturn]] to Kokkos::abort when applicable

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_abort.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_abort.hpp
@@ -56,21 +56,32 @@ extern "C" {
 /*  Cuda runtime function, declared in <crt/device_runtime.h>
  *  Requires capability 2.x or better.
  */
-[[noreturn]] __device__ void __assertfail(const void *message, const void *file,
-                                          unsigned int line,
-                                          const void *function,
-                                          size_t charsize);
+extern __device__ void __assertfail(const void *message, const void *file,
+                                    unsigned int line, const void *function,
+                                    size_t charsize);
 }
 
 namespace Kokkos {
 namespace Impl {
 
+#if !defined(__APPLE__)
 [[noreturn]] __device__ inline void cuda_abort(const char *const message) {
   const char empty[] = "";
 
   __assertfail((const void *)message, (const void *)empty, (unsigned int)0,
                (const void *)empty, sizeof(char));
+
+  // This loop is never executed. It's intended to suppress warnings that the
+  // function returns, even though it does not. This is necessary because
+  // __assertfail is not marked as [[noreturn]], even though it does not return.
+  while (true)
+    ;
 }
+#else
+__device__ inline void cuda_abort(const char *const message) {
+  // __assertfail is not supported on MAC
+}
+#endif
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Cuda/Kokkos_Cuda_abort.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_abort.hpp
@@ -64,13 +64,11 @@ extern __device__ void __assertfail(const void *message, const void *file,
 namespace Kokkos {
 namespace Impl {
 
-__device__ inline void cuda_abort(const char *const message) {
-#ifndef __APPLE__
+[[noreturn]] __device__ inline void cuda_abort(const char *const message) {
   const char empty[] = "";
 
   __assertfail((const void *)message, (const void *)empty, (unsigned int)0,
                (const void *)empty, sizeof(char));
-#endif
 }
 
 }  // namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda_abort.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_abort.hpp
@@ -56,9 +56,10 @@ extern "C" {
 /*  Cuda runtime function, declared in <crt/device_runtime.h>
  *  Requires capability 2.x or better.
  */
-extern __device__ void __assertfail(const void *message, const void *file,
-                                    unsigned int line, const void *function,
-                                    size_t charsize);
+[[noreturn]] __device__ void __assertfail(const void *message, const void *file,
+                                          unsigned int line,
+                                          const void *function,
+                                          size_t charsize);
 }
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -166,20 +166,20 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
 // CUDA aborts
-#define KOKKOS_ABORT_NORETURN [[noreturn]]
+#define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
 #elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
 // HIP does not abort
-#define KOKKOS_ABORT_NORETURN
+#define KOKKOS_IMPL_ABORT_NORETURN
 #elif !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__)
 // Host aborts
-#define KOKKOS_ABORT_NORETURN [[noreturn]]
+#define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
 #else
 // Everything else does not abort
-#define KOKKOS_ABORT_NORETURN
+#define KOKKOS_IMPL_ABORT_NORETURN
 #endif
 
 namespace Kokkos {
-KOKKOS_ABORT_NORETURN KOKKOS_INLINE_FUNCTION void abort(
+KOKKOS_IMPL_ABORT_NORETURN KOKKOS_INLINE_FUNCTION void abort(
     const char *const message) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
   Kokkos::Impl::cuda_abort(message);

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -164,10 +164,17 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#if (defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)) || \
-    (!defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__))
+#if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
+// CUDA aborts
+#define KOKKOS_ABORT_NORETURN [[noreturn]]
+#elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
+// HIP does not abort
+#define KOKKOS_ABORT_NORETURN
+#elif !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__)
+// Host aborts
 #define KOKKOS_ABORT_NORETURN [[noreturn]]
 #else
+// Everything else does not abort
 #define KOKKOS_ABORT_NORETURN
 #endif
 

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -62,7 +62,7 @@
 namespace Kokkos {
 namespace Impl {
 
-void host_abort(const char *const);
+[[noreturn]] void host_abort(const char *const);
 
 void throw_runtime_exception(const std::string &);
 
@@ -164,9 +164,16 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)) || \
+    (!defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__))
+#define KOKKOS_ABORT_NORETURN [[noreturn]]
+#else
+#define KOKKOS_ABORT_NORETURN
+#endif
+
 namespace Kokkos {
-KOKKOS_INLINE_FUNCTION
-void abort(const char *const message) {
+KOKKOS_ABORT_NORETURN KOKKOS_INLINE_FUNCTION void abort(
+    const char *const message) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
   Kokkos::Impl::cuda_abort(message);
 #elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -165,8 +165,15 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
 //----------------------------------------------------------------------------
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
-// CUDA aborts
+
+#if defined(__APPLE__)
+// cuda_abort does not abort when building for macOS.
+#define KOKKOS_IMPL_ABORT_NORETURN
+#else
+// cuda_abort aborts when building for other platforms than macOS
 #define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
+#endif
+
 #elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
 // HIP does not abort
 #define KOKKOS_IMPL_ABORT_NORETURN


### PR DESCRIPTION
I haven't run any tests beyond just building. Pushing to run CI.

I removed the `__APPLE__` check for `cuda_abort` since I don't think macOS supports CUDA in recent versions anyway. I can put it back if this configuration is still supported, though.