### PR TITLE
Fix setting the HIP architecture flag

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -117,7 +117,6 @@ ENDIF()
 
 IF (KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
   SET(CUDA_ARCH_FLAG "--cuda-gpu-arch")
-  SET(AMDGPU_ARCH_FLAG "--amdgpu-target")
   GLOBAL_APPEND(KOKKOS_CUDA_OPTIONS -x cuda)
   IF (KOKKOS_ENABLE_CUDA)
      SET(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND ON CACHE BOOL "enable CUDA Clang workarounds" FORCE)
@@ -136,6 +135,15 @@ IF (KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA)
     GLOBAL_APPEND(KOKKOS_CUDAFE_OPTIONS --diag_suppress=esa_on_defaulted_function_ignored)
   ENDIF()
 ENDIF()
+
+
+#------------------------------- KOKKOS_HIP_OPTIONS ---------------------------
+#clear anything that might be in the cache
+GLOBAL_SET(KOKKOS_AMDGPU_OPTIONS)
+IF(KOKKOS_CXX_COMPILER_ID STREQUAL HIP)
+  SET(AMDGPU_ARCH_FLAG "--amdgpu-target")
+ENDIF()
+
 
 IF (KOKKOS_ARCH_ARMV80)
   COMPILER_SPECIFIC_FLAGS(


### PR DESCRIPTION
After changing the compiler id for HIP, I forgot update this one location. We didn't notice in the CI since we don't set the architecture explicitly but rely on auto-detection.
Also, we didn't reset the flag and were appending the same flag for every `CMake` call.