### PR TITLE
Kokkos_MemoryPool.hpp: include iostream

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -238,6 +238,7 @@ pipeline {
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_OPENMP=ON \
+                                -DKokkos_ENABLE_PROFILING=OFF \
                               .. && \
                               make -j8 && ctest --output-on-failure'''
                     }

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -52,6 +52,8 @@
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
 
+#include <iosfwd>
+
 namespace Kokkos {
 namespace Impl {
 /* Report violation of size constraints:

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -52,7 +52,7 @@
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
 
-#include <iosfwd>
+#include <iostream>
 
 namespace Kokkos {
 namespace Impl {


### PR DESCRIPTION
address build errors when profiling disabled