### PR TITLE
iostream removals in OpenMP-specific headers

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -62,10 +62,6 @@
 
 #include <Kokkos_UniqueToken.hpp>
 
-#include <iostream>
-#include <sstream>
-#include <fstream>
-
 #include <omp.h>
 
 //----------------------------------------------------------------------------

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -49,7 +49,6 @@
 #if defined(KOKKOS_ENABLE_OPENMP)
 
 #include <omp.h>
-#include <iostream>
 #include <OpenMP/Kokkos_OpenMP_Exec.hpp>
 #include <impl/Kokkos_FunctorAdapter.hpp>
 


### PR DESCRIPTION
The iostream inclusions in OpenMP backend-specific headers appear to be entirely superfluous.