### PR TITLE
Fix undefined reference to Kokkos::Profiling::profileLibraryLoaded()

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -886,6 +886,11 @@ void declare_optimization_goal(const size_t context,
 #include <cstring>
 
 namespace Kokkos {
+
+namespace Profiling {
+bool profileLibraryLoaded() { return false; }
+}  // namespace Profiling
+
 namespace Tools {
 
 bool profileLibraryLoaded() { return false; }


### PR DESCRIPTION
Fixes the failures, e.g., in https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/Kokkos/detail/Kokkos/2023/pipeline.