### PR TITLE
Update CUDA occupancy calculation

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -63,18 +63,14 @@ inline int cuda_max_active_blocks_per_sm(cudaDeviceProp const& properties,
   int const max_blocks_regs = regs_per_sm / (regs_per_thread * block_size);
 
   // Limits due to shared memory/SM
-  size_t const shmem_per_sm    = properties.sharedMemPerMultiprocessor;
-  size_t const shmem_per_block = properties.sharedMemPerBlock;
-  size_t const static_shmem    = attributes.sharedSizeBytes;
-  // Temporarily commented since was not used previously in block size deduction
-  // size_t const dynamic_shmem_per_block =
-  // attributes.maxDynamicSharedSizeBytes;
-  size_t const total_shmem = static_shmem + dynamic_shmem;
+  size_t const shmem_per_sm            = properties.sharedMemPerMultiprocessor;
+  size_t const shmem_per_block         = properties.sharedMemPerBlock;
+  size_t const static_shmem            = attributes.sharedSizeBytes;
+  size_t const dynamic_shmem_per_block = attributes.maxDynamicSharedSizeBytes;
+  size_t const total_shmem             = static_shmem + dynamic_shmem;
 
   int const max_blocks_shmem =
-      total_shmem > shmem_per_block
-          //      total_shmem > shmem_per_block || dynamic_shmem >
-          //      dynamic_shmem_per_block
+      total_shmem > shmem_per_block || dynamic_shmem > dynamic_shmem_per_block
           ? 0
           : (total_shmem > 0 ? (int)shmem_per_sm / total_shmem
                              : max_blocks_regs);


### PR DESCRIPTION
This is a small follow-up to #3103 that does two things:
* Take into account the actual maximum shared memory per block
* Ensure the computed active blocks per multiprocessor does not exceed the device limit (instead of checking when we scan block sizes)

The intent is to slightly improve the accuracy of the occupancy calculation without impacting much the evaluation cost.