### PR TITLE
String cleanup and type fixes for Tuning

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -512,9 +512,7 @@ void finalize() {
         (metadata.valueQuantity ==
          Experimental::CandidateValueType::kokkos_value_set)) {
       auto candidate_set = metadata.candidates.set;
-      for (size_t index = 0; index < candidate_set.size; ++index) {
-        free(candidate_set.values.string_value[index]);
-      }
+      delete[] candidate_set.values.string_value;
     }
   }
 #endif

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -978,9 +978,13 @@ size_t get_current_context_id() { return get_context_counter(); }
 void decrement_current_context_id() { --get_context_counter(); }
 size_t get_new_variable_id() { return get_variable_counter(); }
 
-void declare_output_type(const std::string&, size_t, VariableInfo) {}
+size_t declare_output_type(const std::string&, size_t, VariableInfo) {
+  return 0;
+}
 
-void declare_input_type(const std::string&, size_t, VariableInfo) {}
+size_t declare_input_type(const std::string&, size_t, VariableInfo) {
+  return 0;
+}
 
 void set_input_values(size_t, size_t, VariableValue*) {}
 void request_output_values(size_t, size_t, VariableValue*) {}

--- a/core/unit_test/tools/TestTuning.cpp
+++ b/core/unit_test/tools/TestTuning.cpp
@@ -88,16 +88,16 @@ int main() {
     // test that ID's are transmitted to the tool
     Kokkos::Tools::Experimental::set_declare_output_type_callback(
         [](const char*, const size_t,
-           Kokkos::Tools::Experimental::VariableInfo& info) {
-          if (info.type !=
+           Kokkos::Tools::Experimental::VariableInfo* info) {
+          if (info->type !=
               Kokkos::Tools::Experimental::ValueType::kokkos_value_int64) {
             throw(std::runtime_error("Tuning Variable has wrong type"));
           }
         });
     Kokkos::Tools::Experimental::set_declare_input_type_callback(
         [](const char*, const size_t,
-           Kokkos::Tools::Experimental::VariableInfo& info) {
-          if (info.type !=
+           Kokkos::Tools::Experimental::VariableInfo* info) {
+          if (info->type !=
               Kokkos::Tools::Experimental::ValueType::kokkos_value_int64) {
             throw(std::runtime_error("Context Variable has wrong type"));
           }


### PR DESCRIPTION
This PR actually does two things.

First, in #3129 we weren't cleaning up strings, this PR cleans those up on finalize
Second, the return type in the preprocessed off branch of KOKKOS_ENABLE_TUNING was still void