### PR TITLE
Avoid undefined behavior in KokkosCore_UnitTest_TuningBasics

### DIFF
--- a/core/unit_test/tools/printing-tool.cpp
+++ b/core/unit_test/tools/printing-tool.cpp
@@ -2,6 +2,8 @@
 #include <inttypes.h>
 #include <iostream>
 
+struct Kokkos_Profiling_KokkosPDeviceInfo;
+
 struct SpaceHandle {
   char name[64];
 };
@@ -10,10 +12,10 @@ const int parallel_for_id    = 0;
 const int parallel_reduce_id = 1;
 const int parallel_scan_id   = 2;
 
-extern "C" void kokkosp_init_library(const int /*loadSeq*/,
-                                     const uint64_t /*interfaceVer*/,
-                                     const uint32_t /*devInfoCount*/,
-                                     void* /* deviceInfo */) {
+extern "C" void kokkosp_init_library(
+    const int /*loadSeq*/, const uint64_t /*interfaceVer*/,
+    const uint32_t /*devInfoCount*/,
+    Kokkos_Profiling_KokkosPDeviceInfo* /* deviceInfo */) {
   std::cout << "kokkosp_init_library::";
 }
 


### PR DESCRIPTION
The sanitizer complains with
```
/tmp/kokkos_new/core/src/impl/Kokkos_Profiling.cpp:426:5: runtime error: call to function kokkosp_init_library through pointer to incorrect function type 'void (*)(int, unsigned long, unsigned int, Kokkos_Profiling_KokkosPDeviceInfo *)'
/tmp/kokkos_new/core/unit_test/tools/printing-tool.cpp:18: note: kokkosp_init_library defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/kokkos_new/core/src/impl/Kokkos_Profiling.cpp:426:5
```