### PR TITLE
Apply [[noreturn]] to Kokkos::abort for HIP

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Abort.hpp
+++ b/core/src/HIP/Kokkos_HIP_Abort.hpp
@@ -53,13 +53,19 @@
 namespace Kokkos {
 namespace Impl {
 
-__device__ __attribute__((noinline)) void hip_abort(char const *msg) {
+[[noreturn]] __device__ __attribute__((noinline)) void hip_abort(
+    char const *msg) {
 #ifndef NDEBUG
   // disable printf on release builds, as it has a non-trivial performance
   // impact
   printf("Aborting with message `%s'.\n", msg);
 #endif
   abort();
+  // This loop is never executed. It's intended to suppress warnings that the
+  // function returns, even though it does not. This is necessary because
+  // abort() is not marked as [[noreturn]], even though it does not return.
+  while (true)
+    ;
 }
 
 }  // namespace Impl

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -175,8 +175,8 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
 #endif
 
 #elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
-// HIP does not abort
-#define KOKKOS_IMPL_ABORT_NORETURN
+// HIP aborts
+#define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
 #elif !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(__HCC_ACCELERATOR__)
 // Host aborts
 #define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]


### PR DESCRIPTION
Follow-up to #3106. Only the last commit is relevant. I checked manually that the same trick as for `CUDA` also works for `HIP`.