### PR TITLE
Fix OpenMP API check for omp_get_max_active_levels

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -158,7 +158,7 @@ inline bool OpenMP::is_asynchronous(OpenMP const& /*instance*/) noexcept {
 template <typename F>
 void OpenMP::partition_master(F const& f, int num_partitions,
                               int partition_size) {
-#if _OPENMP >= 201811
+#if _OPENMP >= 201511
   if (omp_get_max_active_levels() > 1) {
 #else
   if (omp_get_nested()) {


### PR DESCRIPTION
omp_get_max_active_levels was already part of OpenMP 4.5, see https://www.openmp.org/wp-content/uploads/openmp-4.5.pdf page 248.
This results in a runtime warning "OMP: Info #270: omp_get_nested routine deprecated, please use omp_get_max_active_levels instead." as the deprecated function is called.