### PR TITLE
ScatterView: fix for OpenmpTarget remove inheritance from reducers

### DIFF
--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -333,10 +333,10 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, DeviceType,
       : value(other.value) {}
 
   KOKKOS_FORCEINLINE_FUNCTION void operator*=(ValueType const& rhs) {
-    value *= rhs;
+    Kokkos::atomic_mul(&value, rhs);
   }
   KOKKOS_FORCEINLINE_FUNCTION void operator/=(ValueType const& rhs) {
-    value /= rhs;
+    Kokkos::atomic_div(&value, rhs);
   }
 
   KOKKOS_FORCEINLINE_FUNCTION

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -209,6 +209,11 @@ struct DefaultContribution<Kokkos::Experimental::HIP,
 template <typename ValueType, int Op, typename DeviceType, int contribution>
 struct ScatterValue;
 
+// FIXME All these scatter values need overhaul:
+//   - like should they be copyable at all?
+//   - what is the internal handle type
+//   - remove join
+//   - consistently use the update function in operators
 template <typename ValueType, typename DeviceType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, DeviceType,
                     Kokkos::Experimental::ScatterNonAtomic> {

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -353,16 +353,16 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, DeviceType,
 
   KOKKOS_INLINE_FUNCTION
   void join(ValueType& dest, const ValueType& src) const {
-    atomic_prod(dest, src);
+    atomic_prod(&dest, src);
   }
 
   KOKKOS_INLINE_FUNCTION
   void join(volatile ValueType& dest, const volatile ValueType& src) const {
-    atomic_prod(dest, src);
+    atomic_prod(&dest, src);
   }
 
   KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
-    value *= rhs;
+    atomic_prod(&value, rhs);
   }
   KOKKOS_FORCEINLINE_FUNCTION void reset() {
     value = reduction_identity<ValueType>::prod();

--- a/core/src/impl/Kokkos_Atomic_Generic_Secondary.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic_Secondary.hpp
@@ -72,5 +72,15 @@ KOKKOS_INLINE_FUNCTION void atomic_sub(volatile T* const dest, const T val) {
   (void)atomic_fetch_sub(dest, val);
 }
 
+template <typename T>
+KOKKOS_INLINE_FUNCTION void atomic_mul(volatile T* const dest, const T val) {
+  (void)atomic_fetch_mul(dest, val);
+}
+
+template <typename T>
+KOKKOS_INLINE_FUNCTION void atomic_div(volatile T* const dest, const T val) {
+  (void)atomic_fetch_div(dest, val);
+}
+
 }  // namespace Kokkos
 #endif


### PR DESCRIPTION
Inheriting from Reducers broke OpenMPTarget, but it also means
every scatter element has unnecessarily a view member.
IMO there is also not code complexity gain from inheriting, rather
the opposite.