### PR TITLE
Suppress openmp-mapping for OpenMPTarget

### DIFF
--- a/cmake/kokkos_enable_devices.cmake
+++ b/cmake/kokkos_enable_devices.cmake
@@ -69,7 +69,7 @@ ENDIF()
 KOKKOS_DEVICE_OPTION(OPENMPTARGET OFF DEVICE "Whether to build the OpenMP target backend")
 IF (KOKKOS_ENABLE_OPENMPTARGET)
   COMPILER_SPECIFIC_FLAGS(
-    Clang      -fopenmp -fopenmp=libomp
+    Clang      -fopenmp -fopenmp=libomp -Wno-openmp-mapping
     XL         -qsmp=omp -qoffload -qnoeh
     DEFAULT    -fopenmp
   )


### PR DESCRIPTION
Without this, everyone using the backend is flooded with warnings like
```
error: Type [...] is not trivially copyable and not guaranteed to be mapped correctly 
```