### PR TITLE
Replace Kokkos::Experimental::deep_copy/create_mirror[_view]

### DIFF
--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1823,10 +1823,10 @@ KOKKOS_INLINE_FUNCTION bool operator==(const OffsetView<LT, LP...>& lhs,
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Experimental {
+
 template <class DT, class... DP>
 inline void deep_copy(
-    const OffsetView<DT, DP...>& dst,
+    const Experimental::OffsetView<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value,
     typename std::enable_if<std::is_same<
         typename ViewTraits<DT, DP...>::specialize, void>::value>::type* =
@@ -1842,7 +1842,8 @@ inline void deep_copy(
 
 template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
-    const OffsetView<DT, DP...>& dst, const OffsetView<ST, SP...>& value,
+    const Experimental::OffsetView<DT, DP...>& dst,
+    const Experimental::OffsetView<ST, SP...>& value,
     typename std::enable_if<std::is_same<
         typename ViewTraits<DT, DP...>::specialize, void>::value>::type* =
         nullptr) {
@@ -1856,7 +1857,8 @@ inline void deep_copy(
 }
 template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
-    const OffsetView<DT, DP...>& dst, const View<ST, SP...>& value,
+    const Experimental::OffsetView<DT, DP...>& dst,
+    const View<ST, SP...>& value,
     typename std::enable_if<std::is_same<
         typename ViewTraits<DT, DP...>::specialize, void>::value>::type* =
         nullptr) {
@@ -1871,7 +1873,8 @@ inline void deep_copy(
 
 template <class DT, class... DP, class ST, class... SP>
 inline void deep_copy(
-    const View<DT, DP...>& dst, const OffsetView<ST, SP...>& value,
+    const View<DT, DP...>& dst,
+    const Experimental::OffsetView<ST, SP...>& value,
     typename std::enable_if<std::is_same<
         typename ViewTraits<DT, DP...>::specialize, void>::value>::type* =
         nullptr) {
@@ -1882,6 +1885,7 @@ inline void deep_copy(
 
   Kokkos::deep_copy(dst, value.view());
 }
+
 namespace Impl {
 
 // Deduce Mirror Types
@@ -1940,7 +1944,7 @@ create_mirror(
     typename std::enable_if<
         !std::is_same<typename Kokkos::ViewTraits<T, P...>::array_layout,
                       Kokkos::LayoutStride>::value>::type* = 0) {
-  typedef OffsetView<T, P...> src_type;
+  typedef Experimental::OffsetView<T, P...> src_type;
   typedef typename src_type::HostMirror dst_type;
 
   return dst_type(
@@ -1960,7 +1964,7 @@ create_mirror(
     typename std::enable_if<
         std::is_same<typename Kokkos::ViewTraits<T, P...>::array_layout,
                      Kokkos::LayoutStride>::value>::type* = 0) {
-  typedef OffsetView<T, P...> src_type;
+  typedef Experimental::OffsetView<T, P...> src_type;
   typedef typename src_type::HostMirror dst_type;
 
   Kokkos::LayoutStride layout;
@@ -1990,14 +1994,13 @@ create_mirror(
 
 // Create a mirror in a new space (specialization for different space)
 template <class Space, class T, class... P>
-typename Kokkos::Experimental::Impl::MirrorOffsetType<Space, T, P...>::view_type
+typename Kokkos::Impl::MirrorOffsetType<Space, T, P...>::view_type
 create_mirror(const Space&,
               const Kokkos::Experimental::OffsetView<T, P...>& src) {
-  return typename Kokkos::Experimental::Impl::MirrorOffsetType<
-      Space, T, P...>::view_type(src.label(), src.layout(),
-                                 {src.begin(0), src.begin(1), src.begin(2),
-                                  src.begin(3), src.begin(4), src.begin(5),
-                                  src.begin(6), src.begin(7)});
+  return typename Kokkos::Impl::MirrorOffsetType<Space, T, P...>::view_type(
+      src.label(), src.layout(),
+      {src.begin(0), src.begin(1), src.begin(2), src.begin(3), src.begin(4),
+       src.begin(5), src.begin(6), src.begin(7)});
 }
 
 template <class T, class... P>
@@ -2029,13 +2032,12 @@ create_mirror_view(
               typename Kokkos::Experimental::OffsetView<T, P...>::data_type,
               typename Kokkos::Experimental::OffsetView<
                   T, P...>::HostMirror::data_type>::value)>::type* = 0) {
-  return Kokkos::Experimental::create_mirror(src);
+  return Kokkos::create_mirror(src);
 }
 
 // Create a mirror view in a new space (specialization for same space)
 template <class Space, class T, class... P>
-typename Kokkos::Experimental::Impl::MirrorOffsetViewType<Space, T,
-                                                          P...>::view_type
+typename Kokkos::Impl::MirrorOffsetViewType<Space, T, P...>::view_type
 create_mirror_view(const Space&,
                    const Kokkos::Experimental::OffsetView<T, P...>& src,
                    typename std::enable_if<Impl::MirrorOffsetViewType<
@@ -2045,17 +2047,15 @@ create_mirror_view(const Space&,
 
 // Create a mirror view in a new space (specialization for different space)
 template <class Space, class T, class... P>
-typename Kokkos::Experimental::Impl::MirrorOffsetViewType<Space, T,
-                                                          P...>::view_type
+typename Kokkos::Impl::MirrorOffsetViewType<Space, T, P...>::view_type
 create_mirror_view(const Space&,
                    const Kokkos::Experimental::OffsetView<T, P...>& src,
                    typename std::enable_if<!Impl::MirrorOffsetViewType<
                        Space, T, P...>::is_same_memspace>::type* = 0) {
-  return typename Kokkos::Experimental::Impl::MirrorOffsetViewType<
-      Space, T, P...>::view_type(src.label(), src.layout(),
-                                 {src.begin(0), src.begin(1), src.begin(2),
-                                  src.begin(3), src.begin(4), src.begin(5),
-                                  src.begin(6), src.begin(7)});
+  return typename Kokkos::Impl::MirrorOffsetViewType<Space, T, P...>::view_type(
+      src.label(), src.layout(),
+      {src.begin(0), src.begin(1), src.begin(2), src.begin(3), src.begin(4),
+       src.begin(5), src.begin(6), src.begin(7)});
 }
 //
 //  // Create a mirror view and deep_copy in a new space (specialization for
@@ -2091,7 +2091,6 @@ create_mirror_view(const Space&,
 //    return mirror;
 //  }
 
-}  // namespace Experimental
 } /* namespace Kokkos */
 
 //----------------------------------------------------------------------------

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -122,9 +122,9 @@ void test_offsetview_construction() {
   {  // test deep copy of scalar const value into mirro
     const int constVal = 6;
     typename offset_view_type::HostMirror hostOffsetView =
-        Kokkos::Experimental::create_mirror_view(ov);
+        Kokkos::create_mirror_view(ov);
 
-    Kokkos::Experimental::deep_copy(hostOffsetView, constVal);
+    Kokkos::deep_copy(hostOffsetView, constVal);
 
     for (int i = hostOffsetView.begin(0); i < hostOffsetView.end(0); ++i) {
       for (int j = hostOffsetView.begin(1); j < hostOffsetView.end(1); ++j) {
@@ -149,9 +149,9 @@ void test_offsetview_construction() {
 
   // test offsetview to offsetviewmirror deep copy
   typename offset_view_type::HostMirror hostOffsetView =
-      Kokkos::Experimental::create_mirror_view(ov);
+      Kokkos::create_mirror_view(ov);
 
-  Kokkos::Experimental::deep_copy(hostOffsetView, ov);
+  Kokkos::deep_copy(hostOffsetView, ov);
 
   for (int i = hostOffsetView.begin(0); i < hostOffsetView.end(0); ++i) {
     for (int j = hostOffsetView.begin(1); j < hostOffsetView.end(1); ++j) {
@@ -258,7 +258,7 @@ void test_offsetview_construction() {
 
   {  // test offsetview to view deep copy
     view_type aView("aView", ov.extent(0), ov.extent(1));
-    Kokkos::Experimental::deep_copy(aView, ov);
+    Kokkos::deep_copy(aView, ov);
 
 #if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
     int sum = 0;
@@ -277,7 +277,7 @@ void test_offsetview_construction() {
     view_type aView("aView", ov.extent(0), ov.extent(1));
 
     Kokkos::deep_copy(aView, 99);
-    Kokkos::Experimental::deep_copy(ov, aView);
+    Kokkos::deep_copy(ov, aView);
 
 #if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
     int sum = 0;


### PR DESCRIPTION
`containers/src/Kokkos_OffsetView.hpp` is the only place where we define `Kokkos::Experimental::deep_copy/create_mirror[_view]` overloads in namespace `Kokkos::Experimental`. Even for other experimental types, like `DynamicView`, we define them in namespace `Kokkos`. This is confusing at best as recently proven on `Slack`.
I am not quite sure if backward-compatibility is necessary here, though.