### PR TITLE
Use Kokkos fork of the LLVM project and associated Clang-Tidy kokkos-* checks on Jenkins CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: '-*,kokkos-*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,2 @@
 Checks: '-*,kokkos-*'
+FormatStyle: file

--- a/.jenkins
+++ b/.jenkins
@@ -69,7 +69,7 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-10.1-Clang') {
+                stage('CUDA-10.1-Clang-Tidy') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.clang'
@@ -84,6 +84,7 @@ pipeline {
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
+                                -DCMAKE_CXX_CLANG_TIDY="$LLVM_DIR/bin/clang-tidy" \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=clang++ \
                                 -DCMAKE_CXX_FLAGS=-Werror \

--- a/.jenkins
+++ b/.jenkins
@@ -69,7 +69,7 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-9.2-Clang') {
+                stage('CUDA-10.1-Clang') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.clang'

--- a/.jenkins
+++ b/.jenkins
@@ -72,7 +72,7 @@ pipeline {
                 stage('CUDA-10.1-Clang-Tidy') {
                     agent {
                         dockerfile {
-                            filename 'Dockerfile.clang'
+                            filename 'Dockerfile.kokkosllvmproject'
                             dir 'scripts/docker'
                             additionalBuildArgs '--pull'
                             label 'nvidia-docker && volta'

--- a/.jenkins
+++ b/.jenkins
@@ -84,7 +84,7 @@ pipeline {
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
-                                -DCMAKE_CXX_CLANG_TIDY="$LLVM_DIR/bin/clang-tidy" \
+                                -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=clang++ \
                                 -DCMAKE_CXX_FLAGS=-Werror \

--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -28,6 +28,11 @@ IF(NOT (Kokkos_ENABLE_CUDA AND WIN32))
 TARGET_COMPILE_FEATURES(kokkosalgorithms_gtest PUBLIC cxx_std_11)
 ENDIF()
 
+# Suppress clang-tidy diagnostics on code that we do not have control over
+IF(CMAKE_CXX_CLANG_TIDY)
+  SET_TARGET_PROPERTIES(kokkosalgorithms_gtest PROPERTIES CXX_CLANG_TIDY "")
+ENDIF()
+
 SET(SOURCES
   UnitTestMain.cpp
 )

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -959,7 +959,7 @@ __device__ bool cuda_single_inter_block_reduce_scan(
     const Cuda::size_type block_count, Cuda::size_type* const shared_data,
     Cuda::size_type* const global_data, Cuda::size_type* const global_flags) {
   typedef FunctorValueTraits<FunctorType, ArgTag> ValueTraits;
-  if (!DoScan && ValueTraits::StaticValueSize)
+  if (!DoScan && ValueTraits::StaticValueSize > 0)
     return Kokkos::Impl::CudaReductionsFunctor<
         FunctorType, ArgTag, false, (ValueTraits::StaticValueSize > 16)>::
         scalar_inter_block_reduction(functor, block_id, block_count,

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -22,6 +22,11 @@ IF(NOT (Kokkos_ENABLE_CUDA AND WIN32))
 TARGET_COMPILE_FEATURES(kokkos_gtest PUBLIC cxx_std_11)
 ENDIF()
 
+# Suppress clang-tidy diagnostics on code that we do not have control over
+IF(CMAKE_CXX_CLANG_TIDY)
+  SET_TARGET_PROPERTIES(kokkos_gtest PROPERTIES CXX_CLANG_TIDY "")
+ENDIF()
+
 #
 # Define Incremental Testing Feature Levels
 # Define Device name mappings (i.e. what comes after Kokkos:: for the ExecSpace)

--- a/scripts/docker/Dockerfile.clang
+++ b/scripts/docker/Dockerfile.clang
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:9.2-devel
+FROM nvidia/cuda:10.1-devel
 
 RUN apt-get update && apt-get install -y \
         bc \

--- a/scripts/docker/Dockerfile.clang
+++ b/scripts/docker/Dockerfile.clang
@@ -5,6 +5,8 @@ RUN apt-get update && apt-get install -y \
         git \
         wget \
         ccache \
+        python3 \
+        python3-distutils \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -26,19 +28,24 @@ RUN CMAKE_KEY=2D2CEF1034921684 && \
     rm cmake*
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
+# Clone Kokkos fork of the LLVM Project and build Clang
 ENV LLVM_DIR=/opt/llvm
-RUN LLVM_VERSION=8.0.0 && \
-    LLVM_KEY=345AD05D && \
-    LLVM_URL=http://releases.llvm.org/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \
-    LLVM_ARCHIVE=llvm-${LLVM_VERSION}.tar.xz && \
+RUN LLVM_VERSION=55b3bcf643685c63fcc529d434bed112fdf03939 && \
+    LLVM_URL=https://github.com/kokkos/llvm-project/archive/${LLVM_VERSION}.tar.gz &&\
+    LLVM_ARCHIVE=llvm.tar.xz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${LLVM_URL} --output-document=${LLVM_ARCHIVE} && \
-    wget --quiet ${LLVM_URL}.sig --output-document=${LLVM_ARCHIVE}.sig && \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys ${LLVM_KEY} && \
-    gpg --verify ${LLVM_ARCHIVE}.sig ${LLVM_ARCHIVE} && \
-    mkdir -p ${LLVM_DIR} && \
-    tar -xvf ${LLVM_ARCHIVE} -C ${LLVM_DIR} --strip-components=1 && \
+    mkdir llvm-project && \
+    tar -xf ${LLVM_ARCHIVE} -C llvm-project --strip-components=1 && \
+    cd llvm-project && \
+    mkdir build && cd build && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=$LLVM_DIR \
+      -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt" \
+    ../llvm && \
+    make -j${NPROC} && \
+    make install && \
     echo "${LLVM_DIR}/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig && \
-    rm -rf /root/.gnupg && \
     rm -rf ${SCRATCH_DIR}
 ENV PATH=${LLVM_DIR}/bin:$PATH

--- a/scripts/docker/Dockerfile.clang
+++ b/scripts/docker/Dockerfile.clang
@@ -28,6 +28,8 @@ RUN CMAKE_KEY=2D2CEF1034921684 && \
     rm cmake*
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
+ARG NPROC=8
+
 # Clone Kokkos fork of the LLVM Project and build Clang
 ENV LLVM_DIR=/opt/llvm
 RUN LLVM_VERSION=55b3bcf643685c63fcc529d434bed112fdf03939 && \

--- a/scripts/docker/Dockerfile.kokkosllvmproject
+++ b/scripts/docker/Dockerfile.kokkosllvmproject
@@ -1,10 +1,12 @@
-FROM nvidia/cuda:9.2-devel
+FROM nvidia/cuda:10.1-devel
 
 RUN apt-get update && apt-get install -y \
         bc \
         git \
         wget \
         ccache \
+        python3 \
+        python3-distutils \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -26,19 +28,26 @@ RUN CMAKE_KEY=2D2CEF1034921684 && \
     rm cmake*
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
+ARG NPROC=8
+
+# Clone Kokkos fork of the LLVM Project and build Clang
 ENV LLVM_DIR=/opt/llvm
-RUN LLVM_VERSION=8.0.0 && \
-    LLVM_KEY=345AD05D && \
-    LLVM_URL=http://releases.llvm.org/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \
-    LLVM_ARCHIVE=llvm-${LLVM_VERSION}.tar.xz && \
+RUN LLVM_VERSION=55b3bcf643685c63fcc529d434bed112fdf03939 && \
+    LLVM_URL=https://github.com/kokkos/llvm-project/archive/${LLVM_VERSION}.tar.gz &&\
+    LLVM_ARCHIVE=llvm.tar.xz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${LLVM_URL} --output-document=${LLVM_ARCHIVE} && \
-    wget --quiet ${LLVM_URL}.sig --output-document=${LLVM_ARCHIVE}.sig && \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys ${LLVM_KEY} && \
-    gpg --verify ${LLVM_ARCHIVE}.sig ${LLVM_ARCHIVE} && \
-    mkdir -p ${LLVM_DIR} && \
-    tar -xvf ${LLVM_ARCHIVE} -C ${LLVM_DIR} --strip-components=1 && \
+    mkdir llvm-project && \
+    tar -xf ${LLVM_ARCHIVE} -C llvm-project --strip-components=1 && \
+    cd llvm-project && \
+    mkdir build && cd build && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=$LLVM_DIR \
+      -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt" \
+    ../llvm && \
+    make -j${NPROC} && \
+    make install && \
     echo "${LLVM_DIR}/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig && \
-    rm -rf /root/.gnupg && \
     rm -rf ${SCRATCH_DIR}
 ENV PATH=${LLVM_DIR}/bin:$PATH


### PR DESCRIPTION
Related to #3172 

It looks like the check `readability-braces-around-statements` might be raising more warnings than GCC's `-Wdangling-else` so I am considering reverting ef60112 and fixing later.

I do not intend to enable specific checks just yet.  We can do that incrementally.