### PR TITLE
Fixup return type of Kokkos::Vector::data()

### DIFF
--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -221,7 +221,7 @@ class vector : public DualView<Scalar*, LayoutLeft, Arg1Type> {
   size_type span() const { return DV::span(); }
   bool empty() const { return _size == 0; }
 
-  iterator data() const { return DV::h_view.data(); }
+  pointer data() const { return DV::h_view.data(); }
 
   iterator begin() const { return DV::h_view.data(); }
 


### PR DESCRIPTION
Per https://github.com/kokkos/kokkos/pull/3123#pullrequestreview-447732229

As @nliber pointed out, we were returning non-const pointer/iterator from function members marked as `const` and the return type of `Vector::data()` should be a pointer not an iterator (even if the underlying implementation yields the same type).