### PR TITLE
optimize min/max atomics with early exit on no-op case

### DIFF
--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -87,9 +87,7 @@ struct AddOper {
     return val1 + val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1&, const Scalar2&) {
-    return false;
-  }
+  static bool test(const Scalar1&, const Scalar2&) { return false; }
 };
 
 template <class Scalar1, class Scalar2>
@@ -99,9 +97,7 @@ struct SubOper {
     return val1 - val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1&, const Scalar2&) {
-    return false;
-  }
+  static bool test(const Scalar1&, const Scalar2&) { return false; }
 };
 
 template <class Scalar1, class Scalar2>
@@ -111,9 +107,7 @@ struct MulOper {
     return val1 * val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1&, const Scalar2&) {
-    return false;
-  }
+  static bool test(const Scalar1&, const Scalar2&) { return false; }
 };
 
 template <class Scalar1, class Scalar2>
@@ -123,9 +117,7 @@ struct DivOper {
     return val1 / val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1&, const Scalar2&) {
-    return false;
-  }
+  static bool test(const Scalar1&, const Scalar2&) { return false; }
 };
 
 template <class Scalar1, class Scalar2>
@@ -135,9 +127,7 @@ struct ModOper {
     return val1 % val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1&, const Scalar2&) {
-    return false;
-  }
+  static bool test(const Scalar1&, const Scalar2&) { return false; }
 };
 
 template <class Scalar1, class Scalar2>
@@ -147,9 +137,7 @@ struct AndOper {
     return val1 & val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1&, const Scalar2&) {
-    return false;
-  }
+  static bool test(const Scalar1&, const Scalar2&) { return false; }
 };
 
 template <class Scalar1, class Scalar2>
@@ -159,9 +147,7 @@ struct OrOper {
     return val1 | val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1&, const Scalar2&) {
-    return false;
-  }
+  static bool test(const Scalar1&, const Scalar2&) { return false; }
 };
 
 template <class Scalar1, class Scalar2>
@@ -171,9 +157,7 @@ struct XorOper {
     return val1 ^ val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1&, const Scalar2&) {
-    return false;
-  }
+  static bool test(const Scalar1&, const Scalar2&) { return false; }
 };
 
 template <class Scalar1, class Scalar2>
@@ -183,9 +167,7 @@ struct LShiftOper {
     return val1 << val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1&, const Scalar2&) {
-    return false;
-  }
+  static bool test(const Scalar1&, const Scalar2&) { return false; }
 };
 
 template <class Scalar1, class Scalar2>
@@ -195,9 +177,7 @@ struct RShiftOper {
     return val1 >> val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1&, const Scalar2&) {
-    return false;
-  }
+  static bool test(const Scalar1&, const Scalar2&) { return false; }
 };
 
 template <class Oper, typename T>

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -86,6 +86,10 @@ struct AddOper {
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 + val2;
   }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return false;
+  }
 };
 
 template <class Scalar1, class Scalar2>
@@ -93,6 +97,10 @@ struct SubOper {
   KOKKOS_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 - val2;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return false;
   }
 };
 
@@ -102,6 +110,10 @@ struct MulOper {
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 * val2;
   }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return false;
+  }
 };
 
 template <class Scalar1, class Scalar2>
@@ -109,6 +121,10 @@ struct DivOper {
   KOKKOS_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 / val2;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return false;
   }
 };
 
@@ -118,6 +134,10 @@ struct ModOper {
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 % val2;
   }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return false;
+  }
 };
 
 template <class Scalar1, class Scalar2>
@@ -125,6 +145,10 @@ struct AndOper {
   KOKKOS_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 & val2;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return false;
   }
 };
 
@@ -134,6 +158,10 @@ struct OrOper {
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 | val2;
   }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return false;
+  }
 };
 
 template <class Scalar1, class Scalar2>
@@ -141,6 +169,10 @@ struct XorOper {
   KOKKOS_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 ^ val2;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return false;
   }
 };
 
@@ -150,6 +182,10 @@ struct LShiftOper {
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 << val2;
   }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return false;
+  }
 };
 
 template <class Scalar1, class Scalar2>
@@ -157,6 +193,10 @@ struct RShiftOper {
   KOKKOS_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return val1 >> val2;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return false;
   }
 };
 
@@ -173,6 +213,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
   } oldval, assume, newval;
 
   oldval.t = *dest;
+  if (op.test(oldval.t, val)) return oldval.t;
 
   do {
     assume.i = oldval.i;
@@ -197,6 +238,7 @@ KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
   } oldval, assume, newval;
 
   oldval.t = *dest;
+  if (op.test(oldval.t, val)) return oldval.t;
 
   do {
     assume.i = oldval.i;
@@ -219,6 +261,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
   } oldval, assume, newval;
 
   oldval.t = *dest;
+  if (op.test(oldval.t, val)) return oldval.t;
 
   do {
     assume.i = oldval.i;
@@ -240,6 +283,7 @@ KOKKOS_INLINE_FUNCTION T atomic_oper_fetch(
   } oldval, assume, newval;
 
   oldval.t = *dest;
+  if (op.test(oldval.t, val)) return oldval.t;
 
   do {
     assume.i = oldval.i;
@@ -380,232 +424,6 @@ atomic_oper_fetch(const Oper& op, volatile T* const dest,
 #endif
 }
 
-// MIN/MAX-specialized atomics that do early exit when no update required
-
-template <class Oper, typename T>
-KOKKOS_INLINE_FUNCTION T atomic_fetch_minmax(
-    const Oper& op, volatile T* const dest,
-    typename std::enable_if<sizeof(T) != sizeof(int) &&
-                                sizeof(T) == sizeof(unsigned long long int),
-                            const T>::type val) {
-  union U {
-    unsigned long long int i;
-    T t;
-    KOKKOS_INLINE_FUNCTION U() {}
-  } oldval, assume, newval;
-
-  oldval.t = *dest;
-  if (op.test(oldval.t, val)) return oldval.t;
-
-  do {
-    assume.i = oldval.i;
-    newval.t = op.apply(assume.t, val);
-    oldval.i = Kokkos::atomic_compare_exchange((unsigned long long int*)dest,
-                                               assume.i, newval.i);
-  } while (assume.i != oldval.i);
-
-  return oldval.t;
-}
-
-template <class Oper, typename T>
-KOKKOS_INLINE_FUNCTION T atomic_minmax_fetch(
-    const Oper& op, volatile T* const dest,
-    typename std::enable_if<sizeof(T) != sizeof(int) &&
-                                sizeof(T) == sizeof(unsigned long long int),
-                            const T>::type val) {
-  union U {
-    unsigned long long int i;
-    T t;
-    KOKKOS_INLINE_FUNCTION U() {}
-  } oldval, assume, newval;
-
-  oldval.t = *dest;
-  if (op.test(oldval.t, val)) return oldval.t;
-
-  do {
-    assume.i = oldval.i;
-    newval.t = op.apply(assume.t, val);
-    oldval.i = Kokkos::atomic_compare_exchange((unsigned long long int*)dest,
-                                               assume.i, newval.i);
-  } while (assume.i != oldval.i);
-
-  return newval.t;
-}
-
-template <class Oper, typename T>
-KOKKOS_INLINE_FUNCTION T atomic_fetch_minmax(
-    const Oper& op, volatile T* const dest,
-    typename std::enable_if<sizeof(T) == sizeof(int), const T>::type val) {
-  union U {
-    int i;
-    T t;
-    KOKKOS_INLINE_FUNCTION U() {}
-  } oldval, assume, newval;
-
-  oldval.t = *dest;
-  if (op.test(oldval.t, val)) return oldval.t;
-
-  do {
-    assume.i = oldval.i;
-    newval.t = op.apply(assume.t, val);
-    oldval.i = Kokkos::atomic_compare_exchange((int*)dest, assume.i, newval.i);
-  } while (assume.i != oldval.i);
-
-  return oldval.t;
-}
-
-template <class Oper, typename T>
-KOKKOS_INLINE_FUNCTION T atomic_minmax_fetch(
-    const Oper& op, volatile T* const dest,
-    typename std::enable_if<sizeof(T) == sizeof(int), const T>::type val) {
-  union U {
-    int i;
-    T t;
-    KOKKOS_INLINE_FUNCTION U() {}
-  } oldval, assume, newval;
-
-  oldval.t = *dest;
-  if (op.test(oldval.t, val)) return oldval.t;
-
-  do {
-    assume.i = oldval.i;
-    newval.t = op.apply(assume.t, val);
-    oldval.i = Kokkos::atomic_compare_exchange((int*)dest, assume.i, newval.i);
-  } while (assume.i != oldval.i);
-
-  return newval.t;
-}
-
-template <class Oper, typename T>
-KOKKOS_INLINE_FUNCTION T atomic_minmax_oper(
-    const Oper& op, volatile T* const dest,
-    typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8), const T>::type
-        val) {
-#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
-  while (!Impl::lock_address_host_space((void*)dest))
-    ;
-  T return_val = *dest;
-  *dest        = op.apply(return_val, val);
-  Impl::unlock_address_host_space((void*)dest);
-  return return_val;
-#elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA)
-  // This is a way to (hopefully) avoid dead lock in a warp
-  T return_val;
-  int done                 = 0;
-#ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
-  unsigned int mask        = KOKKOS_IMPL_CUDA_ACTIVEMASK;
-  unsigned int active      = KOKKOS_IMPL_CUDA_BALLOT_MASK(mask, 1);
-#else
-  unsigned int active = KOKKOS_IMPL_CUDA_BALLOT(1);
-#endif
-  unsigned int done_active = 0;
-  while (active != done_active) {
-    if (!done) {
-      if (Impl::lock_address_cuda_space((void*)dest)) {
-        return_val = *dest;
-        *dest      = op.apply(return_val, val);
-        Impl::unlock_address_cuda_space((void*)dest);
-        done = 1;
-      }
-    }
-#ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
-    done_active = KOKKOS_IMPL_CUDA_BALLOT_MASK(mask, done);
-#else
-    done_active = KOKKOS_IMPL_CUDA_BALLOT(done);
-#endif
-  }
-  return return_val;
-#elif defined(__HIP_DEVICE_COMPILE__)
-  // FIXME_HIP
-  Kokkos::abort("atomic_minmax_oper not implemented for large types.");
-  T return_val             = *dest;
-  int done                 = 0;
-  unsigned int active      = __ballot(1);
-  unsigned int done_active = 0;
-  while (active != done_active) {
-    if (!done) {
-      // if (Impl::lock_address_hip_space((void*)dest))
-      {
-        return_val = *dest;
-        *dest      = op.apply(return_val, val);
-        // Impl::unlock_address_hip_space((void*)dest);
-        done = 1;
-      }
-    }
-    done_active = __ballot(done);
-  }
-  return return_val;
-#endif
-}
-
-template <class Oper, typename T>
-KOKKOS_INLINE_FUNCTION T
-atomic_oper_minmax(const Oper& op, volatile T* const dest,
-                  typename std::enable_if<(sizeof(T) != 4) && (sizeof(T) != 8)
-#if defined(KOKKOS_ENABLE_ASM) && \
-    defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-                                              && (sizeof(T) != 16)
-#endif
-                                              ,
-                                          const T>::type& val) {
-
-#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
-  while (!Impl::lock_address_host_space((void*)dest))
-    ;
-  T return_val = op.apply(*dest, val);
-  *dest        = return_val;
-  Impl::unlock_address_host_space((void*)dest);
-  return return_val;
-#elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA)
-  T return_val;
-  // This is a way to (hopefully) avoid dead lock in a warp
-  int done                 = 0;
-#ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
-  unsigned int mask        = KOKKOS_IMPL_CUDA_ACTIVEMASK;
-  unsigned int active      = KOKKOS_IMPL_CUDA_BALLOT_MASK(mask, 1);
-#else
-  unsigned int active = KOKKOS_IMPL_CUDA_BALLOT(1);
-#endif
-  unsigned int done_active = 0;
-  while (active != done_active) {
-    if (!done) {
-      if (Impl::lock_address_cuda_space((void*)dest)) {
-        return_val = op.apply(*dest, val);
-        *dest      = return_val;
-        Impl::unlock_address_cuda_space((void*)dest);
-        done = 1;
-      }
-    }
-#ifdef KOKKOS_IMPL_CUDA_SYNCWARP_NEEDS_MASK
-    done_active = KOKKOS_IMPL_CUDA_BALLOT_MASK(mask, done);
-#else
-    done_active = KOKKOS_IMPL_CUDA_BALLOT(done);
-#endif
-  }
-  return return_val;
-#elif defined(__HIP_DEVICE_COMPILE__)
-  // FIXME_HIP
-  Kokkos::abort("atomic_oper_minmax not implemented for large types.");
-  T return_val;
-  int done                 = 0;
-  unsigned int active      = __ballot(1);
-  unsigned int done_active = 0;
-  while (active != done_active) {
-    if (!done) {
-      // if (Impl::lock_address_hip_space((void*)dest))
-      {
-        return_val = op.apply(*dest, val);
-        *dest      = return_val;
-        // Impl::unlock_address_hip_space((void*)dest);
-        done = 1;
-      }
-    }
-    done_active = __ballot(done);
-  }
-  return return_val;
-#endif
-}
-
 }  // namespace Impl
 }  // namespace Kokkos
 
@@ -614,12 +432,12 @@ namespace Kokkos {
 // Fetch_Oper atomics: return value before operation
 template <typename T>
 KOKKOS_INLINE_FUNCTION T atomic_fetch_max(volatile T* const dest, const T val) {
-  return Impl::atomic_fetch_minmax(Impl::MaxOper<T, const T>(), dest, val);
+  return Impl::atomic_fetch_oper(Impl::MaxOper<T, const T>(), dest, val);
 }
 
 template <typename T>
 KOKKOS_INLINE_FUNCTION T atomic_fetch_min(volatile T* const dest, const T val) {
-  return Impl::atomic_fetch_minmax(Impl::MinOper<T, const T>(), dest, val);
+  return Impl::atomic_fetch_oper(Impl::MinOper<T, const T>(), dest, val);
 }
 
 template <typename T>

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -87,7 +87,7 @@ struct AddOper {
     return val1 + val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1& val1, const Scalar2& val2) {
+  static bool test(const Scalar1&, const Scalar2&) {
     return false;
   }
 };
@@ -99,7 +99,7 @@ struct SubOper {
     return val1 - val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1& val1, const Scalar2& val2) {
+  static bool test(const Scalar1&, const Scalar2&) {
     return false;
   }
 };
@@ -111,7 +111,7 @@ struct MulOper {
     return val1 * val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1& val1, const Scalar2& val2) {
+  static bool test(const Scalar1&, const Scalar2&) {
     return false;
   }
 };
@@ -123,7 +123,7 @@ struct DivOper {
     return val1 / val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1& val1, const Scalar2& val2) {
+  static bool test(const Scalar1&, const Scalar2&) {
     return false;
   }
 };
@@ -135,7 +135,7 @@ struct ModOper {
     return val1 % val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1& val1, const Scalar2& val2) {
+  static bool test(const Scalar1&, const Scalar2&) {
     return false;
   }
 };
@@ -147,7 +147,7 @@ struct AndOper {
     return val1 & val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1& val1, const Scalar2& val2) {
+  static bool test(const Scalar1&, const Scalar2&) {
     return false;
   }
 };
@@ -159,7 +159,7 @@ struct OrOper {
     return val1 | val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1& val1, const Scalar2& val2) {
+  static bool test(const Scalar1&, const Scalar2&) {
     return false;
   }
 };
@@ -171,7 +171,7 @@ struct XorOper {
     return val1 ^ val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1& val1, const Scalar2& val2) {
+  static bool test(const Scalar1&, const Scalar2&) {
     return false;
   }
 };
@@ -183,7 +183,7 @@ struct LShiftOper {
     return val1 << val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1& val1, const Scalar2& val2) {
+  static bool test(const Scalar1&, const Scalar2&) {
     return false;
   }
 };
@@ -195,7 +195,7 @@ struct RShiftOper {
     return val1 >> val2;
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  static bool test(const Scalar1& val1, const Scalar2& val2) {
+  static bool test(const Scalar1&, const Scalar2&) {
     return false;
   }
 };

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -62,6 +62,10 @@ struct MaxOper {
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return (val1 > val2 ? val1 : val2);
   }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return (val1 > val2);
+  }
 };
 
 template <class Scalar1, class Scalar2>
@@ -69,6 +73,10 @@ struct MinOper {
   KOKKOS_FORCEINLINE_FUNCTION
   static Scalar1 apply(const Scalar1& val1, const Scalar2& val2) {
     return (val1 < val2 ? val1 : val2);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  static bool test(const Scalar1& val1, const Scalar2& val2) {
+    return (val1 < val2);
   }
 };
 
@@ -387,6 +395,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_minmax(
   } oldval, assume, newval;
 
   oldval.t = *dest;
+  if (op.test(oldval.t, val)) return oldval.t;
 
   do {
     assume.i = oldval.i;
@@ -411,6 +420,7 @@ KOKKOS_INLINE_FUNCTION T atomic_minmax_fetch(
   } oldval, assume, newval;
 
   oldval.t = *dest;
+  if (op.test(oldval.t, val)) return oldval.t;
 
   do {
     assume.i = oldval.i;
@@ -433,6 +443,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_minmax(
   } oldval, assume, newval;
 
   oldval.t = *dest;
+  if (op.test(oldval.t, val)) return oldval.t;
 
   do {
     assume.i = oldval.i;
@@ -454,6 +465,7 @@ KOKKOS_INLINE_FUNCTION T atomic_minmax_fetch(
   } oldval, assume, newval;
 
   oldval.t = *dest;
+  if (op.test(oldval.t, val)) return oldval.t;
 
   do {
     assume.i = oldval.i;


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/3144.

Tests pass with OpenMP back-end with 8 threads on a 4-core Intel(R) Core(TM) i7-8809G CPU.  I assume you all test atomics well enough that I don't have to do this exhaustively, although I guess I have access to almost everything you do.

I didn't change the case for not 4 or 8 bytes.  I might optimize that one for CMPXCHG16B later.

Update: passes with Pthreads back-end on the same system.