### PR TITLE
Improve apply-clang-format

### DIFF
--- a/benchmarks/gups/gups-kokkos.cc
+++ b/benchmarks/gups/gups-kokkos.cc
@@ -60,141 +60,142 @@ typedef Kokkos::View<int64_t*, Kokkos::HostSpace> GUPSDeviceArray;
 typedef int GUPSIndex;
 
 double now() {
-	struct timeval now;
-	gettimeofday(&now, nullptr);
+  struct timeval now;
+  gettimeofday(&now, nullptr);
 
-	return (double) now.tv_sec + ((double) now.tv_usec * 1.0e-6);
+  return (double)now.tv_sec + ((double)now.tv_usec * 1.0e-6);
 }
 
-void randomize_indices(GUPSHostArray& indices, GUPSDeviceArray& dev_indices, const int64_t dataCount) {
-	for( GUPSIndex i = 0; i < indices.extent(0); ++i ) {
-		indices[i] = lrand48() % dataCount;
-	}
+void randomize_indices(GUPSHostArray& indices, GUPSDeviceArray& dev_indices,
+                       const int64_t dataCount) {
+  for (GUPSIndex i = 0; i < indices.extent(0); ++i) {
+    indices[i] = lrand48() % dataCount;
+  }
 
-	Kokkos::deep_copy(dev_indices, indices);
+  Kokkos::deep_copy(dev_indices, indices);
 }
 
-void run_gups(GUPSDeviceArray& indices, GUPSDeviceArray& data, const int64_t datum,
-	const bool performAtomics) {
+void run_gups(GUPSDeviceArray& indices, GUPSDeviceArray& data,
+              const int64_t datum, const bool performAtomics) {
+  if (performAtomics) {
+    Kokkos::parallel_for(
+        "bench-gups-atomic", indices.extent(0),
+        KOKKOS_LAMBDA(const GUPSIndex i) {
+          Kokkos::atomic_fetch_xor(&data[indices[i]], datum);
+        });
+  } else {
+    Kokkos::parallel_for(
+        "bench-gups-non-atomic", indices.extent(0),
+        KOKKOS_LAMBDA(const GUPSIndex i) { data[indices[i]] ^= datum; });
+  }
 
-	if( performAtomics ) {
-		Kokkos::parallel_for("bench-gups-atomic", indices.extent(0), KOKKOS_LAMBDA(const GUPSIndex i) {
-			Kokkos::atomic_fetch_xor( &data[indices[i]], datum );
-		});
-	} else {
-		Kokkos::parallel_for("bench-gups-non-atomic", indices.extent(0), KOKKOS_LAMBDA(const GUPSIndex i) {
-			data[indices[i]] ^= datum;
-		});
-	}
-
-	Kokkos::fence();
+  Kokkos::fence();
 }
 
-int run_benchmark(const GUPSIndex indicesCount, const GUPSIndex dataCount, const int repeats,
-	const bool useAtomics) {
+int run_benchmark(const GUPSIndex indicesCount, const GUPSIndex dataCount,
+                  const int repeats, const bool useAtomics) {
+  printf("Reports fastest timing per kernel\n");
+  printf("Creating Views...\n");
 
-	printf("Reports fastest timing per kernel\n");
-	printf("Creating Views...\n");
+  printf("Memory Sizes:\n");
+  printf("- Elements:      %15" PRIu64 " (%12.4f MB)\n",
+         static_cast<uint64_t>(dataCount),
+         1.0e-6 * ((double)dataCount * (double)sizeof(int64_t)));
+  printf("- Indices:       %15" PRIu64 " (%12.4f MB)\n",
+         static_cast<uint64_t>(indicesCount),
+         1.0e-6 * ((double)indicesCount * (double)sizeof(int64_t)));
+  printf(" - Atomics:      %15s\n", (useAtomics ? "Yes" : "No"));
+  printf("Benchmark kernels will be performed for %d iterations.\n", repeats);
 
-	printf("Memory Sizes:\n");
-	printf("- Elements:      %15" PRIu64 " (%12.4f MB)\n", static_cast<uint64_t>(dataCount),
-		1.0e-6 * ((double) dataCount * (double) sizeof(int64_t)));
-	printf("- Indices:       %15" PRIu64 " (%12.4f MB)\n", static_cast<uint64_t>(indicesCount),
-		1.0e-6 * ((double) indicesCount * (double) sizeof(int64_t)));
-	printf(" - Atomics:      %15s\n", (useAtomics ? "Yes" : "No") );
-	printf("Benchmark kernels will be performed for %d iterations.\n", repeats);
+  printf(HLINE);
 
-	printf(HLINE);
+  GUPSDeviceArray dev_indices("indices", indicesCount);
+  GUPSDeviceArray dev_data("data", dataCount);
+  int64_t datum = -1;
 
-	GUPSDeviceArray dev_indices("indices", indicesCount);
-	GUPSDeviceArray dev_data("data", dataCount);
-	int64_t datum = -1;
+  GUPSHostArray indices = Kokkos::create_mirror_view(dev_indices);
+  GUPSHostArray data    = Kokkos::create_mirror_view(dev_data);
 
-	GUPSHostArray indices = Kokkos::create_mirror_view(dev_indices);
-	GUPSHostArray data    = Kokkos::create_mirror_view(dev_data);
+  double gupsTime = 0.0;
 
-	double gupsTime  = 0.0;
-
-	printf("Initializing Views...\n");
+  printf("Initializing Views...\n");
 
 #if defined(KOKKOS_HAVE_OPENMP)
-	Kokkos::parallel_for("init-data", Kokkos::RangePolicy<Kokkos::OpenMP>(0, dataCount),
+  Kokkos::parallel_for(
+      "init-data", Kokkos::RangePolicy<Kokkos::OpenMP>(0, dataCount),
 #else
-	Kokkos::parallel_for("init-data", Kokkos::RangePolicy<Kokkos::Serial>(0, dataCount),
+  Kokkos::parallel_for(
+      "init-data", Kokkos::RangePolicy<Kokkos::Serial>(0, dataCount),
 #endif
-		KOKKOS_LAMBDA(const int i) {
-
-		data[i] = 10101010101;
-	});
+      KOKKOS_LAMBDA(const int i) { data[i] = 10101010101; });
 
 #if defined(KOKKOS_HAVE_OPENMP)
-	Kokkos::parallel_for("init-indices", Kokkos::RangePolicy<Kokkos::OpenMP>(0, indicesCount),
+  Kokkos::parallel_for(
+      "init-indices", Kokkos::RangePolicy<Kokkos::OpenMP>(0, indicesCount),
 #else
-	Kokkos::parallel_for("init-indices", Kokkos::RangePolicy<Kokkos::Serial>(0, indicesCount),
+  Kokkos::parallel_for(
+      "init-indices", Kokkos::RangePolicy<Kokkos::Serial>(0, indicesCount),
 #endif
-		KOKKOS_LAMBDA(const int i) {
+      KOKKOS_LAMBDA(const int i) { indices[i] = 0; });
 
-		indices[i] = 0;
-	});
+  Kokkos::deep_copy(dev_data, data);
+  Kokkos::deep_copy(dev_indices, indices);
+  double start;
 
-	Kokkos::deep_copy(dev_data, data);
-	Kokkos::deep_copy(dev_indices, indices);
-	double start;
+  printf("Starting benchmarking...\n");
 
-	printf("Starting benchmarking...\n");
+  for (GUPSIndex k = 0; k < repeats; ++k) {
+    randomize_indices(indices, dev_indices, data.extent(0));
 
-	for( GUPSIndex k = 0; k < repeats; ++k ) {
-		randomize_indices(indices, dev_indices, data.extent(0));
+    start = now();
+    run_gups(dev_indices, dev_data, datum, useAtomics);
+    gupsTime += now() - start;
+  }
 
-		start = now();
-		run_gups(dev_indices, dev_data, datum, useAtomics);
-		gupsTime += now() - start;
-	}
+  Kokkos::deep_copy(indices, dev_indices);
+  Kokkos::deep_copy(data, dev_data);
 
-	Kokkos::deep_copy(indices, dev_indices);
-	Kokkos::deep_copy(data, dev_data);
+  printf(HLINE);
+  printf(
+      "GUP/s Random:      %18.6f\n",
+      (1.0e-9 * ((double)repeats) * (double)dev_indices.extent(0)) / gupsTime);
+  printf(HLINE);
 
-	printf(HLINE);
-	printf("GUP/s Random:      %18.6f\n",
-		(1.0e-9 * ((double) repeats) * (double) dev_indices.extent(0)) / gupsTime);
-	printf(HLINE);
-
-	return 0;
+  return 0;
 }
 
 int main(int argc, char* argv[]) {
+  printf(HLINE);
+  printf("Kokkos GUPS Benchmark\n");
+  printf(HLINE);
 
-	printf(HLINE);
-	printf("Kokkos GUPS Benchmark\n");
-	printf(HLINE);
+  srand48(1010101);
 
-	srand48(1010101);
+  Kokkos::initialize(argc, argv);
 
-	Kokkos::initialize(argc, argv);
+  int64_t indices = 8192;
+  int64_t data    = 33554432;
+  int64_t repeats = 10;
+  bool useAtomics = false;
 
-	int64_t indices = 8192;
-	int64_t data    = 33554432;
-	int64_t repeats = 10;
-	bool useAtomics = false;
+  for (int i = 1; i < argc; ++i) {
+    if (strcmp(argv[i], "--indices") == 0) {
+      indices = std::atoll(argv[i + 1]);
+      ++i;
+    } else if (strcmp(argv[i], "--data") == 0) {
+      data = std::atoll(argv[i + 1]);
+      ++i;
+    } else if (strcmp(argv[i], "--repeats") == 0) {
+      repeats = std::atoll(argv[i + 1]);
+      ++i;
+    } else if (strcmp(argv[i], "--atomics") == 0) {
+      useAtomics = true;
+    }
+  }
 
-	for( int i = 1; i < argc; ++i ) {
-		if( strcmp( argv[i], "--indices" ) == 0 ) {
-			indices = std::atoll(argv[i+1]);
-			++i;
-		} else if( strcmp( argv[i], "--data" ) == 0 ) {
-			data = std::atoll(argv[i+1]);
-			++i;
-		} else if( strcmp( argv[i], "--repeats" ) == 0 ) {
-			repeats = std::atoll(argv[i+1]);
-			++i;
-		} else if( strcmp( argv[i], "--atomics" ) == 0 ) {
-			useAtomics = true;
-		}
-	}
+  const int rc = run_benchmark(indices, data, repeats, useAtomics);
 
-	const int rc = run_benchmark(indices, data, repeats, useAtomics);
+  Kokkos::finalize();
 
-	Kokkos::finalize();
-
-	return rc;
+  return rc;
 }

--- a/benchmarks/stream/stream-kokkos.cc
+++ b/benchmarks/stream/stream-kokkos.cc
@@ -48,7 +48,7 @@
 #include <sys/time.h>
 
 #define STREAM_ARRAY_SIZE 100000000
-#define STREAM_NTIMES     20
+#define STREAM_NTIMES 20
 
 #define HLINE "-------------------------------------------------------------\n"
 
@@ -63,204 +63,209 @@ typedef Kokkos::View<double*, Kokkos::HostSpace> StreamDeviceArray;
 typedef int StreamIndex;
 
 double now() {
-	struct timeval now;
-	gettimeofday(&now, nullptr);
+  struct timeval now;
+  gettimeofday(&now, nullptr);
 
-	return (double) now.tv_sec + ((double) now.tv_usec * 1.0e-6);
+  return (double)now.tv_sec + ((double)now.tv_usec * 1.0e-6);
 }
 
-void perform_copy(StreamDeviceArray& a, StreamDeviceArray& b, StreamDeviceArray& c) {
+void perform_copy(StreamDeviceArray& a, StreamDeviceArray& b,
+                  StreamDeviceArray& c) {
+  Kokkos::parallel_for(
+      "copy", a.extent(0), KOKKOS_LAMBDA(const StreamIndex i) { c[i] = a[i]; });
 
-	Kokkos::parallel_for("copy", a.extent(0), KOKKOS_LAMBDA(const StreamIndex i) {
-		c[i] = a[i];
-	});
-
-	Kokkos::fence();
+  Kokkos::fence();
 }
 
-void perform_scale(StreamDeviceArray& a, StreamDeviceArray& b, StreamDeviceArray& c,
-       	const double scalar) {
+void perform_scale(StreamDeviceArray& a, StreamDeviceArray& b,
+                   StreamDeviceArray& c, const double scalar) {
+  Kokkos::parallel_for(
+      "copy", a.extent(0),
+      KOKKOS_LAMBDA(const StreamIndex i) { b[i] = scalar * c[i]; });
 
-	Kokkos::parallel_for("copy", a.extent(0), KOKKOS_LAMBDA(const StreamIndex i) {
-		b[i] = scalar * c[i];
-	});
-
-	Kokkos::fence();
+  Kokkos::fence();
 }
 
-void perform_add(StreamDeviceArray& a, StreamDeviceArray& b, StreamDeviceArray& c) {
-	Kokkos::parallel_for("add", a.extent(0), KOKKOS_LAMBDA(const StreamIndex i) {
-                c[i] = a[i] + b[i];
-        });
+void perform_add(StreamDeviceArray& a, StreamDeviceArray& b,
+                 StreamDeviceArray& c) {
+  Kokkos::parallel_for(
+      "add", a.extent(0),
+      KOKKOS_LAMBDA(const StreamIndex i) { c[i] = a[i] + b[i]; });
 
-	Kokkos::fence();
+  Kokkos::fence();
 }
 
-void perform_triad(StreamDeviceArray& a, StreamDeviceArray& b, StreamDeviceArray& c,
-	const double scalar) {
+void perform_triad(StreamDeviceArray& a, StreamDeviceArray& b,
+                   StreamDeviceArray& c, const double scalar) {
+  Kokkos::parallel_for(
+      "triad", a.extent(0),
+      KOKKOS_LAMBDA(const StreamIndex i) { a[i] = b[i] + scalar * c[i]; });
 
-	Kokkos::parallel_for("triad", a.extent(0), KOKKOS_LAMBDA(const StreamIndex i) {
-		a[i] = b[i] + scalar * c[i];
-	});
-
-	Kokkos::fence();
+  Kokkos::fence();
 }
 
-int perform_validation(StreamHostArray& a, StreamHostArray& b, StreamHostArray& c,
-	const StreamIndex arraySize, const double scalar) {
+int perform_validation(StreamHostArray& a, StreamHostArray& b,
+                       StreamHostArray& c, const StreamIndex arraySize,
+                       const double scalar) {
+  double ai = 1.0;
+  double bi = 2.0;
+  double ci = 0.0;
 
-	double ai = 1.0;
-	double bi = 2.0;
-	double ci = 0.0;
+  for (StreamIndex i = 0; i < arraySize; ++i) {
+    ci = ai;
+    bi = scalar * ci;
+    ci = ai + bi;
+    ai = bi + scalar * ci;
+  };
 
-	for( StreamIndex i = 0; i < arraySize; ++i ) {
-		ci = ai;
-		bi = scalar * ci;
-		ci = ai + bi;
-		ai = bi + scalar * ci;
-	};
+  double aError = 0.0;
+  double bError = 0.0;
+  double cError = 0.0;
 
-	double aError = 0.0;
-	double bError = 0.0;
-	double cError = 0.0;
+  for (StreamIndex i = 0; i < arraySize; ++i) {
+    aError = std::abs(a[i] - ai);
+    bError = std::abs(b[i] - bi);
+    cError = std::abs(c[i] - ci);
+  }
 
-	for( StreamIndex i = 0; i < arraySize; ++i ) {
-		aError = std::abs( a[i] - ai );
-		bError = std::abs( b[i] - bi );
-		cError = std::abs( c[i] - ci );
-	}
+  double aAvgError = aError / (double)arraySize;
+  double bAvgError = bError / (double)arraySize;
+  double cAvgError = cError / (double)arraySize;
 
-	double aAvgError = aError / (double) arraySize;
-	double bAvgError = bError / (double) arraySize;
-	double cAvgError = cError / (double) arraySize;
+  const double epsilon = 1.0e-13;
+  int errorCount       = 0;
 
-	const double epsilon = 1.0e-13;
-	int errorCount = 0;
+  if (std::abs(aAvgError / ai) > epsilon) {
+    fprintf(stderr, "Error: validation check on View a failed.\n");
+    errorCount++;
+  }
 
-	if( std::abs( aAvgError / ai ) > epsilon ) {
-		fprintf(stderr, "Error: validation check on View a failed.\n");
-		errorCount++;
-	}
+  if (std::abs(bAvgError / bi) > epsilon) {
+    fprintf(stderr, "Error: validation check on View b failed.\n");
+    errorCount++;
+  }
 
-	if( std::abs( bAvgError / bi ) > epsilon ) {
-		fprintf(stderr, "Error: validation check on View b failed.\n");
-		errorCount++;
-	}
+  if (std::abs(cAvgError / ci) > epsilon) {
+    fprintf(stderr, "Error: validation check on View c failed.\n");
+    errorCount++;
+  }
 
-	if( std::abs( cAvgError / ci ) > epsilon ) {
-		fprintf(stderr, "Error: validation check on View c failed.\n");
-		errorCount++;
-	}
+  if (errorCount == 0) {
+    printf("All solutions checked and verified.\n");
+  }
 
-	if( errorCount == 0 ) {
-		printf("All solutions checked and verified.\n");
-	}
-
-	return errorCount;
+  return errorCount;
 }
 
 int run_benchmark() {
+  printf("Reports fastest timing per kernel\n");
+  printf("Creating Views...\n");
 
-	printf("Reports fastest timing per kernel\n");
-	printf("Creating Views...\n");
+  printf("Memory Sizes:\n");
+  printf("- Array Size:    %" PRIu64 "\n",
+         static_cast<uint64_t>(STREAM_ARRAY_SIZE));
+  printf("- Per Array:     %12.2f MB\n",
+         1.0e-6 * (double)STREAM_ARRAY_SIZE * (double)sizeof(double));
+  printf("- Total:         %12.2f MB\n",
+         3.0e-6 * (double)STREAM_ARRAY_SIZE * (double)sizeof(double));
 
-	printf("Memory Sizes:\n");
-	printf("- Array Size:    %" PRIu64 "\n", static_cast<uint64_t>(STREAM_ARRAY_SIZE));
-	printf("- Per Array:     %12.2f MB\n", 1.0e-6 * (double) STREAM_ARRAY_SIZE * (double) sizeof(double));
-	printf("- Total:         %12.2f MB\n", 3.0e-6 * (double) STREAM_ARRAY_SIZE * (double) sizeof(double));
+  printf("Benchmark kernels will be performed for %d iterations.\n",
+         STREAM_NTIMES);
 
-	printf("Benchmark kernels will be performed for %d iterations.\n", STREAM_NTIMES);
+  printf(HLINE);
 
-	printf(HLINE);
+  StreamDeviceArray dev_a("a", STREAM_ARRAY_SIZE);
+  StreamDeviceArray dev_b("b", STREAM_ARRAY_SIZE);
+  StreamDeviceArray dev_c("c", STREAM_ARRAY_SIZE);
 
-	StreamDeviceArray dev_a("a", STREAM_ARRAY_SIZE);
-	StreamDeviceArray dev_b("b", STREAM_ARRAY_SIZE);
-	StreamDeviceArray dev_c("c", STREAM_ARRAY_SIZE);
+  StreamHostArray a = Kokkos::create_mirror_view(dev_a);
+  StreamHostArray b = Kokkos::create_mirror_view(dev_b);
+  StreamHostArray c = Kokkos::create_mirror_view(dev_c);
 
-	StreamHostArray a = Kokkos::create_mirror_view(dev_a);
-	StreamHostArray b = Kokkos::create_mirror_view(dev_b);
-	StreamHostArray c = Kokkos::create_mirror_view(dev_c);
+  const double scalar = 3.0;
 
-	const double scalar = 3.0;
+  double copyTime  = std::numeric_limits<double>::max();
+  double scaleTime = std::numeric_limits<double>::max();
+  double addTime   = std::numeric_limits<double>::max();
+  double triadTime = std::numeric_limits<double>::max();
 
-	double copyTime  = std::numeric_limits<double>::max();
-	double scaleTime = std::numeric_limits<double>::max();
-	double addTime   = std::numeric_limits<double>::max();
-	double triadTime = std::numeric_limits<double>::max();
-
-	printf("Initializing Views...\n");
+  printf("Initializing Views...\n");
 
 #if defined(KOKKOS_HAVE_OPENMP)
-	Kokkos::parallel_for("init", Kokkos::RangePolicy<Kokkos::OpenMP>(0, STREAM_ARRAY_SIZE),
+  Kokkos::parallel_for(
+      "init", Kokkos::RangePolicy<Kokkos::OpenMP>(0, STREAM_ARRAY_SIZE),
 #else
-	Kokkos::parallel_for("init", Kokkos::RangePolicy<Kokkos::Serial>(0, STREAM_ARRAY_SIZE),
+  Kokkos::parallel_for(
+      "init", Kokkos::RangePolicy<Kokkos::Serial>(0, STREAM_ARRAY_SIZE),
 #endif
-		KOKKOS_LAMBDA(const int i) {
+      KOKKOS_LAMBDA(const int i) {
+        a[i] = 1.0;
+        b[i] = 2.0;
+        c[i] = 0.0;
+      });
 
-		a[i] = 1.0;
-		b[i] = 2.0;
-		c[i] = 0.0;
-	});
+  // Copy contents of a (from the host) to the dev_a (device)
+  Kokkos::deep_copy(dev_a, a);
+  Kokkos::deep_copy(dev_b, b);
+  Kokkos::deep_copy(dev_c, c);
 
-	// Copy contents of a (from the host) to the dev_a (device)
-	Kokkos::deep_copy(dev_a, a);
-	Kokkos::deep_copy(dev_b, b);
-	Kokkos::deep_copy(dev_c, c);
+  double start;
 
-	double start;
+  printf("Starting benchmarking...\n");
 
-	printf("Starting benchmarking...\n");
+  for (StreamIndex k = 0; k < STREAM_NTIMES; ++k) {
+    start = now();
+    perform_copy(dev_a, dev_b, dev_c);
+    copyTime = std::min(copyTime, (now() - start));
 
-	for( StreamIndex k = 0; k < STREAM_NTIMES; ++k ) {
-		start = now();
-		perform_copy(dev_a, dev_b, dev_c);
-		copyTime = std::min( copyTime, (now() - start) );
+    start = now();
+    perform_scale(dev_a, dev_b, dev_c, scalar);
+    scaleTime = std::min(scaleTime, (now() - start));
 
-		start = now();
-		perform_scale(dev_a, dev_b, dev_c, scalar);
-		scaleTime = std::min( scaleTime, (now() - start) );
+    start = now();
+    perform_add(dev_a, dev_b, dev_c);
+    addTime = std::min(addTime, (now() - start));
 
-		start = now();
-		perform_add(dev_a, dev_b, dev_c);
-		addTime = std::min( addTime, (now() - start) );
+    start = now();
+    perform_triad(dev_a, dev_b, dev_c, scalar);
+    triadTime = std::min(triadTime, (now() - start));
+  }
 
-		start = now();
-		perform_triad(dev_a, dev_b, dev_c, scalar);
-		triadTime = std::min( triadTime, (now() - start) );
-	}
+  Kokkos::deep_copy(a, dev_a);
+  Kokkos::deep_copy(b, dev_b);
+  Kokkos::deep_copy(c, dev_c);
 
-	Kokkos::deep_copy(a, dev_a);
-	Kokkos::deep_copy(b, dev_b);
-	Kokkos::deep_copy(c, dev_c);
+  printf("Performing validation...\n");
+  int rc = perform_validation(a, b, c, STREAM_ARRAY_SIZE, scalar);
 
-	printf("Performing validation...\n");
-	int rc = perform_validation(a, b, c, STREAM_ARRAY_SIZE, scalar);
+  printf(HLINE);
 
-	printf(HLINE);
+  printf("Copy            %11.2f MB/s\n",
+         (1.0e-06 * 2.0 * (double)sizeof(double) * (double)STREAM_ARRAY_SIZE) /
+             copyTime);
+  printf("Scale           %11.2f MB/s\n",
+         (1.0e-06 * 2.0 * (double)sizeof(double) * (double)STREAM_ARRAY_SIZE) /
+             scaleTime);
+  printf("Add             %11.2f MB/s\n",
+         (1.0e-06 * 3.0 * (double)sizeof(double) * (double)STREAM_ARRAY_SIZE) /
+             addTime);
+  printf("Triad           %11.2f MB/s\n",
+         (1.0e-06 * 3.0 * (double)sizeof(double) * (double)STREAM_ARRAY_SIZE) /
+             triadTime);
 
-	printf("Copy            %11.2f MB/s\n",
-		( 1.0e-06 * 2.0 * (double) sizeof(double) * (double) STREAM_ARRAY_SIZE) / copyTime );
-	printf("Scale           %11.2f MB/s\n",
-		( 1.0e-06 * 2.0 * (double) sizeof(double) * (double) STREAM_ARRAY_SIZE) / scaleTime );
-	printf("Add             %11.2f MB/s\n",
-		( 1.0e-06 * 3.0 * (double) sizeof(double) * (double) STREAM_ARRAY_SIZE) / addTime );
-	printf("Triad           %11.2f MB/s\n",
-		( 1.0e-06 * 3.0 * (double) sizeof(double) * (double) STREAM_ARRAY_SIZE) / triadTime );
+  printf(HLINE);
 
-	printf(HLINE);
-
-	return rc;
+  return rc;
 }
 
 int main(int argc, char* argv[]) {
+  printf(HLINE);
+  printf("Kokkos STREAM Benchmark\n");
+  printf(HLINE);
 
-	printf(HLINE);
-	printf("Kokkos STREAM Benchmark\n");
-	printf(HLINE);
+  Kokkos::initialize(argc, argv);
+  const int rc = run_benchmark();
+  Kokkos::finalize();
 
-	Kokkos::initialize(argc, argv);
-	const int rc = run_benchmark();
-	Kokkos::finalize();
-
-	return rc;
+  return rc;
 }

--- a/cmake/compile_tests/cuda_compute_capability.cc
+++ b/cmake/compile_tests/cuda_compute_capability.cc
@@ -42,7 +42,6 @@
 //@HEADER
 */
 
-
 #include <iostream>
 
 int main() {

--- a/cmake/compile_tests/cuda_compute_capability.cc
+++ b/cmake/compile_tests/cuda_compute_capability.cc
@@ -59,6 +59,7 @@ int main() {
   std::cout << compute_capability;
 #else
   switch (compute_capability) {
+      // clang-format off
     case 30: std::cout << "Set -DKokkos_ARCH_KEPLER30=ON ." << std::endl; break;
     case 32: std::cout << "Set -DKokkos_ARCH_KEPLER32=ON ." << std::endl; break;
     case 35: std::cout << "Set -DKokkos_ARCH_KEPLER35=ON ." << std::endl; break;
@@ -75,6 +76,7 @@ int main() {
     default:
       std::cout << "Compute capability " << compute_capability
                 << " is not supported" << std::endl;
+      // clang-format on
   }
 #endif
   return 0;

--- a/scripts/apply-clang-format
+++ b/scripts/apply-clang-format
@@ -19,11 +19,20 @@ if [ "${CLANG_FORMAT_MAJOR_VERSION}" -ne 8 ] || [ "${CLANG_FORMAT_MINOR_VERSION}
   exit 1
 fi
 
-find . -name '*.cpp' -o -name '*.hpp' | xargs ${CLANG_FORMAT_EXECUTABLE} -i
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"/..
+cd $BASE_DIR
+
+TRACKED_FILES="$(git ls-files)"
+
+find ${TRACKED_FILES} \
+  -type f -name '*.cpp' -o -name '*.hpp' -o -name '*.cc' -o -name '*.h' |
+  xargs -n 1 -P 10 ${CLANG_FORMAT_EXECUTABLE} -i
 
 # Now also check for trailing whitspace. Mac OSX creates backup files
 # that we need to delete manually.
-find . -type f \( -name "*.md" -o -name "*.cc" -o -name "*.h" -o -name "*.txt" -o -name "*.cmake" \) |
+TRACKED_FILES="$(git ls-tree HEAD --name-only)"
+find ${TRACKED_FILES} \
+  -type f \( -name "*.md" -o -name "*.cc" -o -name "*.h" -o -name "*.txt" -o -name "*.cmake" \) |
   xargs -n 1 -P 10 -I {} bash -c "sed -i -e 's/\s\+$//g' {} && rm -f '{}-e'"
 
 # Check that we do not introduce any file with the old copyright

--- a/tpls/.clang-format
+++ b/tpls/.clang-format
@@ -1,0 +1,3 @@
+#Official Tool: clang-format version 8.0.0
+DisableFormat: true
+SortIncludes: false


### PR DESCRIPTION
Make sure that the script can be executed no matter where it is run from. Also, make sure that only tracked files are considered for formatting.