### PR TITLE
Add modernize-use-using clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,2 @@
-Checks: '-*,kokkos-*'
+Checks: '-*,kokkos-*,modernize-use-using'
 FormatStyle: file

--- a/core/perf_test/PerfTestGramSchmidt.cpp
+++ b/core/perf_test/PerfTestGramSchmidt.cpp
@@ -58,7 +58,7 @@ namespace Test {
 // PostProcess : R(j,j) = result ; inv = 1 / result ;
 template <class VectorView, class ValueView>
 struct InvNorm2 : public Kokkos::DotSingle<VectorView> {
-  typedef typename Kokkos::DotSingle<VectorView>::value_type value_type;
+  using value_type = typename Kokkos::DotSingle<VectorView>::value_type;
 
   ValueView Rjj;
   ValueView inv;
@@ -85,7 +85,7 @@ inline void invnorm2(const VectorView& x, const ValueView& r,
 // PostProcess : tmp = - ( R(j,k) = result );
 template <class VectorView, class ValueView>
 struct DotM : public Kokkos::Dot<VectorView> {
-  typedef typename Kokkos::Dot<VectorView>::value_type value_type;
+  using value_type = typename Kokkos::Dot<VectorView>::value_type;
 
   ValueView Rjk;
   ValueView tmp;
@@ -110,16 +110,16 @@ inline void dot_neg(const VectorView& x, const VectorView& y,
 
 template <typename Scalar, class DeviceType>
 struct ModifiedGramSchmidt {
-  typedef DeviceType execution_space;
-  typedef typename execution_space::size_type size_type;
+  using execution_space = DeviceType;
+  using size_type       = typename execution_space::size_type;
 
-  typedef Kokkos::View<Scalar**, Kokkos::LayoutLeft, execution_space>
-      multivector_type;
+  using multivector_type =
+      Kokkos::View<Scalar**, Kokkos::LayoutLeft, execution_space>;
 
-  typedef Kokkos::View<Scalar*, Kokkos::LayoutLeft, execution_space>
-      vector_type;
+  using vector_type =
+      Kokkos::View<Scalar*, Kokkos::LayoutLeft, execution_space>;
 
-  typedef Kokkos::View<Scalar, Kokkos::LayoutLeft, execution_space> value_view;
+  using value_view = Kokkos::View<Scalar, Kokkos::LayoutLeft, execution_space>;
 
   multivector_type Q;
   multivector_type R;

--- a/core/perf_test/PerfTestHexGrad.cpp
+++ b/core/perf_test/PerfTestHexGrad.cpp
@@ -51,20 +51,20 @@ namespace Test {
 template <class DeviceType, typename CoordScalarType = double,
           typename GradScalarType = float>
 struct HexGrad {
-  typedef DeviceType execution_space;
-  typedef typename execution_space::size_type size_type;
+  using execution_space = DeviceType;
+  using size_type       = typename execution_space::size_type;
 
-  typedef HexGrad<DeviceType, CoordScalarType, GradScalarType> self_type;
+  using self_type = HexGrad<DeviceType, CoordScalarType, GradScalarType>;
 
   // 3D array : ( ParallelWork , Space , Node )
 
   enum { NSpace = 3, NNode = 8 };
 
-  typedef Kokkos::View<CoordScalarType * [NSpace][NNode], execution_space>
-      elem_coord_type;
+  using elem_coord_type =
+      Kokkos::View<CoordScalarType * [NSpace][NNode], execution_space>;
 
-  typedef Kokkos::View<GradScalarType * [NSpace][NNode], execution_space>
-      elem_grad_type;
+  using elem_grad_type =
+      Kokkos::View<GradScalarType * [NSpace][NNode], execution_space>;
 
   elem_coord_type coords;
   elem_grad_type grad_op;
@@ -179,7 +179,7 @@ struct HexGrad {
   //--------------------------------------------------------------------------
 
   struct Init {
-    typedef typename self_type::execution_space execution_space;
+    using execution_space = typename self_type::execution_space;
 
     elem_coord_type coords;
 

--- a/core/perf_test/test_atomic.cpp
+++ b/core/perf_test/test_atomic.cpp
@@ -49,7 +49,7 @@
 #include <Kokkos_Core.hpp>
 #include <impl/Kokkos_Timer.hpp>
 
-typedef Kokkos::DefaultExecutionSpace exec_space;
+using exec_space = Kokkos::DefaultExecutionSpace;
 
 #define RESET 0
 #define BRIGHT 1
@@ -80,9 +80,9 @@ void textcolor_standard() { textcolor(RESET, BLACK, WHITE); }
 
 template <class T, class DEVICE_TYPE>
 struct ZeroFunctor {
-  typedef DEVICE_TYPE execution_space;
-  typedef typename Kokkos::View<T, execution_space> type;
-  typedef typename Kokkos::View<T, execution_space>::HostMirror h_type;
+  using execution_space = DEVICE_TYPE;
+  using type            = typename Kokkos::View<T, execution_space>;
+  using h_type          = typename Kokkos::View<T, execution_space>::HostMirror;
   type data;
   KOKKOS_INLINE_FUNCTION
   void operator()(int) const { data() = 0; }
@@ -94,8 +94,8 @@ struct ZeroFunctor {
 
 template <class T, class DEVICE_TYPE>
 struct AddFunctor {
-  typedef DEVICE_TYPE execution_space;
-  typedef Kokkos::View<T, execution_space> type;
+  using execution_space = DEVICE_TYPE;
+  using type            = Kokkos::View<T, execution_space>;
   type data;
 
   KOKKOS_INLINE_FUNCTION
@@ -123,8 +123,8 @@ T AddLoop(int loop) {
 
 template <class T, class DEVICE_TYPE>
 struct AddNonAtomicFunctor {
-  typedef DEVICE_TYPE execution_space;
-  typedef Kokkos::View<T, execution_space> type;
+  using execution_space = DEVICE_TYPE;
+  using type            = Kokkos::View<T, execution_space>;
   type data;
 
   KOKKOS_INLINE_FUNCTION
@@ -166,8 +166,8 @@ T AddLoopSerial(int loop) {
 
 template <class T, class DEVICE_TYPE>
 struct CASFunctor {
-  typedef DEVICE_TYPE execution_space;
-  typedef Kokkos::View<T, execution_space> type;
+  using execution_space = DEVICE_TYPE;
+  using type            = Kokkos::View<T, execution_space>;
   type data;
 
   KOKKOS_INLINE_FUNCTION
@@ -204,8 +204,8 @@ T CASLoop(int loop) {
 
 template <class T, class DEVICE_TYPE>
 struct CASNonAtomicFunctor {
-  typedef DEVICE_TYPE execution_space;
-  typedef Kokkos::View<T, execution_space> type;
+  using execution_space = DEVICE_TYPE;
+  using type            = Kokkos::View<T, execution_space>;
   type data;
 
   KOKKOS_INLINE_FUNCTION
@@ -268,8 +268,8 @@ T CASLoopSerial(int loop) {
 
 template <class T, class DEVICE_TYPE>
 struct ExchFunctor {
-  typedef DEVICE_TYPE execution_space;
-  typedef Kokkos::View<T, execution_space> type;
+  using execution_space = DEVICE_TYPE;
+  using type            = Kokkos::View<T, execution_space>;
   type data, data2;
 
   KOKKOS_INLINE_FUNCTION
@@ -309,8 +309,8 @@ T ExchLoop(int loop) {
 
 template <class T, class DEVICE_TYPE>
 struct ExchNonAtomicFunctor {
-  typedef DEVICE_TYPE execution_space;
-  typedef Kokkos::View<T, execution_space> type;
+  using execution_space = DEVICE_TYPE;
+  using type            = Kokkos::View<T, execution_space>;
   type data, data2;
 
   KOKKOS_INLINE_FUNCTION

--- a/core/perf_test/test_mempool.cpp
+++ b/core/perf_test/test_mempool.cpp
@@ -56,7 +56,7 @@ using MemorySpace = Kokkos::DefaultExecutionSpace::memory_space;
 using MemoryPool = Kokkos::MemoryPool<ExecSpace>;
 
 struct TestFunctor {
-  typedef Kokkos::View<uintptr_t*, ExecSpace> ptrs_type;
+  using ptrs_type = Kokkos::View<uintptr_t*, ExecSpace>;
 
   enum : unsigned { chunk = 32 };
 
@@ -87,7 +87,7 @@ struct TestFunctor {
 
   //----------------------------------------
 
-  typedef long value_type;
+  using value_type = long;
 
   //----------------------------------------
 
@@ -107,7 +107,7 @@ struct TestFunctor {
   }
 
   bool test_fill() {
-    typedef Kokkos::RangePolicy<ExecSpace, TagFill> policy;
+    using policy = Kokkos::RangePolicy<ExecSpace, TagFill>;
 
     long result = 0;
 
@@ -134,7 +134,7 @@ struct TestFunctor {
   }
 
   void test_del() {
-    typedef Kokkos::RangePolicy<ExecSpace, TagDel> policy;
+    using policy = Kokkos::RangePolicy<ExecSpace, TagDel>;
 
     Kokkos::parallel_for(policy(0, range_iter), *this);
     Kokkos::fence();
@@ -164,7 +164,7 @@ struct TestFunctor {
   }
 
   bool test_alloc_dealloc() {
-    typedef Kokkos::RangePolicy<ExecSpace, TagAllocDealloc> policy;
+    using policy = Kokkos::RangePolicy<ExecSpace, TagAllocDealloc>;
 
     long error_count = 0;
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -447,8 +447,8 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream) {
 
       // Allocate and initialize uint32_t[ buffer_bound ]
 
-      typedef Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaSpace, void>
-          Record;
+      using Record =
+          Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaSpace, void>;
 
       Record *const r =
           Record::allocate(Kokkos::CudaSpace(), "InternalScratchBitset",
@@ -543,7 +543,7 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream) {
 
 //----------------------------------------------------------------------------
 
-typedef Cuda::size_type ScratchGrain[Impl::CudaTraits::WarpSize];
+using ScratchGrain = Cuda::size_type[Impl::CudaTraits::WarpSize];
 enum { sizeScratchGrain = sizeof(ScratchGrain) };
 
 Cuda::size_type *CudaInternal::scratch_flags(const Cuda::size_type size) const {
@@ -551,8 +551,8 @@ Cuda::size_type *CudaInternal::scratch_flags(const Cuda::size_type size) const {
       m_scratchFlagsCount * sizeScratchGrain < size) {
     m_scratchFlagsCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
 
-    typedef Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaSpace, void>
-        Record;
+    using Record =
+        Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaSpace, void>;
 
     if (m_scratchFlags) Record::decrement(Record::get_record(m_scratchFlags));
 
@@ -576,8 +576,8 @@ Cuda::size_type *CudaInternal::scratch_space(const Cuda::size_type size) const {
       m_scratchSpaceCount * sizeScratchGrain < size) {
     m_scratchSpaceCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
 
-    typedef Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaSpace, void>
-        Record;
+    using Record =
+        Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaSpace, void>;
 
     if (m_scratchSpace) Record::decrement(Record::get_record(m_scratchSpace));
 
@@ -599,9 +599,8 @@ Cuda::size_type *CudaInternal::scratch_unified(
       m_scratchUnifiedCount * sizeScratchGrain < size) {
     m_scratchUnifiedCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
 
-    typedef Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaHostPinnedSpace,
-                                                 void>
-        Record;
+    using Record =
+        Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>;
 
     if (m_scratchUnified)
       Record::decrement(Record::get_record(m_scratchUnified));
@@ -623,8 +622,8 @@ Cuda::size_type *CudaInternal::scratch_functor(
   if (verify_is_initialized("scratch_functor") && m_scratchFunctorSize < size) {
     m_scratchFunctorSize = size;
 
-    typedef Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaSpace, void>
-        Record;
+    using Record =
+        Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaSpace, void>;
 
     if (m_scratchFunctor)
       Record::decrement(Record::get_record(m_scratchFunctor));
@@ -647,9 +646,9 @@ void CudaInternal::finalize() {
   if (0 != m_scratchSpace || 0 != m_scratchFlags) {
     Impl::finalize_host_cuda_lock_arrays();
 
-    typedef Kokkos::Impl::SharedAllocationRecord<CudaSpace> RecordCuda;
-    typedef Kokkos::Impl::SharedAllocationRecord<CudaHostPinnedSpace>
-        RecordHost;
+    using RecordCuda = Kokkos::Impl::SharedAllocationRecord<CudaSpace>;
+    using RecordHost =
+        Kokkos::Impl::SharedAllocationRecord<CudaHostPinnedSpace>;
 
     RecordCuda::decrement(RecordCuda::get_record(m_scratchFlags));
     RecordCuda::decrement(RecordCuda::get_record(m_scratchSpace));

--- a/core/unit_test/default/TestDefaultDeviceType.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType.cpp
@@ -52,10 +52,10 @@
 namespace Test {
 
 TEST(TEST_CATEGORY, host_space_access) {
-  typedef Kokkos::HostSpace::execution_space host_exec_space;
-  typedef Kokkos::Device<host_exec_space, Kokkos::HostSpace> device_space;
-  typedef Kokkos::Impl::HostMirror<Kokkos::DefaultExecutionSpace>::Space
-      mirror_space;
+  using host_exec_space = Kokkos::HostSpace::execution_space;
+  using device_space    = Kokkos::Device<host_exec_space, Kokkos::HostSpace>;
+  using mirror_space =
+      Kokkos::Impl::HostMirror<Kokkos::DefaultExecutionSpace>::Space;
 
   static_assert(Kokkos::Impl::SpaceAccessibility<host_exec_space,
                                                  Kokkos::HostSpace>::accessible,

--- a/core/unit_test/default/TestDefaultDeviceTypeResize.cpp
+++ b/core/unit_test/default/TestDefaultDeviceTypeResize.cpp
@@ -50,7 +50,7 @@ namespace Test {
 TEST(kokkosresize, host_space_access) {
   // Test with the default device type.
   using TestViewResize::testResize;
-  typedef Kokkos::View<int*>::device_type device_type;
+  using device_type = Kokkos::View<int *>::device_type;
   testResize<device_type>();
 }
 


### PR DESCRIPTION
This also fixes the places the current CI running the check is complaining about.