### PR TITLE
Let RangePolicy converting constructor take other policy by ref

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -125,7 +125,7 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   RangePolicy(RangePolicy&&)      = default;
 
   template <class... OtherProperties>
-  RangePolicy(const RangePolicy<OtherProperties...> p) {
+  RangePolicy(const RangePolicy<OtherProperties...>& p) {
     m_space            = p.m_space;
     m_begin            = p.m_begin;
     m_end              = p.m_end;

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -125,13 +125,12 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   RangePolicy(RangePolicy&&)      = default;
 
   template <class... OtherProperties>
-  RangePolicy(const RangePolicy<OtherProperties...>& p) {
-    m_space            = p.m_space;
-    m_begin            = p.m_begin;
-    m_end              = p.m_end;
-    m_granularity      = p.m_granularity;
-    m_granularity_mask = p.m_granularity_mask;
-  }
+  RangePolicy(const RangePolicy<OtherProperties...>& p)
+      : m_space(p.m_space),
+        m_begin(p.m_begin),
+        m_end(p.m_end),
+        m_granularity(p.m_granularity),
+        m_granularity_mask(p.m_granularity_mask) {}
 
   inline RangePolicy() : m_space(), m_begin(0), m_end(0) {}
 


### PR DESCRIPTION
Pushing uncontroversial drive-by change from #3196 because we don't have yet reached an agreement on the design for the policy types.