### PR TITLE
Make TeamPolicy default constructible

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -545,6 +545,8 @@ class TeamPolicy
 
   TeamPolicy& operator=(const TeamPolicy&) = default;
 
+  TeamPolicy() : internal_policy(0, AUTO) {}
+
   /** \brief  Construct policy with the given instance of the execution space */
   TeamPolicy(const typename traits::execution_space& space_,
              int league_size_request, int team_size_request,

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -655,6 +655,10 @@ class TestTeamPolicyConstruction {
     ASSERT_EQ(p7.team_size(), team_size);
     ASSERT_EQ(p7.chunk_size(), chunk_size);
     ASSERT_EQ(p7.scratch_size(0), scratch_size);
+
+    policy_t p8;  // default constructed
+    ASSERT_EQ(p8.league_size(), 0);
+    ASSERT_EQ(p8.scratch_size(0), 0);
   }
 
   void test_run_time_parameters() {

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -326,6 +326,12 @@ class TestRangePolicyConstruction {
       ASSERT_TRUE((p.end() == 15));
       ASSERT_TRUE((p.chunk_size() == 10));
     }
+    {
+      typedef Kokkos::RangePolicy<> policy_t;
+      policy_t p;
+      ASSERT_TRUE((p.begin() == 0));
+      ASSERT_TRUE((p.end() == 0));
+    }
   }
 };
 


### PR DESCRIPTION
Moving another seemingly uncontroversial part of #3196 into its own PR

There was no test for a default constructed RangePolicy so I went ahead and added one.