### PR TITLE
Run Clang-Format as a pre-check on Jenkins CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -7,6 +7,21 @@ pipeline {
         CCACHE_CPP2 = 'true'
     }
     stages {
+        stage('Clang-Format') {
+            agent {
+                dockerfile {
+                    filename 'Dockerfile.clang'
+                    dir 'scripts/docker'
+                    additionalBuildArgs '--pull'
+                    label 'nvidia-docker || docker'
+                    args '-v /tmp/ccache.kokkos:/tmp/ccache'
+                }
+            }
+            steps {
+                sh './scripts/docker/check_format_cpp.sh'
+            }
+        }
+
         stage('Build') {
             parallel {
                 stage('HIP-3.5-HCC') {
@@ -253,20 +268,6 @@ pipeline {
                                 -DKokkos_ENABLE_LIBDL=OFF \
                               .. && \
                               make -j8 && ctest --output-on-failure && gcc -I$PWD/../core/src/ ../core/unit_test/tools/TestCInterface.c'''
-                    }
-                }
-                stage('Clang-Format') {
-                    agent {
-                        dockerfile {
-                            filename 'Dockerfile.clang'
-                            dir 'scripts/docker'
-                            additionalBuildArgs '--pull'
-                            label 'nvidia-docker || docker'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache'
-                        }
-                    }
-                    steps {
-                        sh './scripts/docker/check_format_cpp.sh'
                     }
                 }
             }


### PR DESCRIPTION
As decided on the last developer meeting, this will make Jenkins CI fail early if the style is not compliant.