### PR TITLE
Temporarily disable HIP build on Jenkins CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -9,35 +9,36 @@ pipeline {
     stages {
         stage('Build') {
             parallel {
-                stage('HIP-3.5-HCC') {
-                    agent {
-                        dockerfile {
-                            filename 'Dockerfile.hipcc'
-                            dir 'scripts/docker'
-                            additionalBuildArgs '--pull --build-arg BASE=rocm/dev-ubuntu-18.04:3.5'
-                            label 'rocm-docker && vega'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video'
-                        }
-                    }
-                    steps {
-                        sh 'ccache --zero-stats'
-                        sh '''rm -rf build && mkdir -p build && cd build && \
-                              cmake \
-                                -DCMAKE_BUILD_TYPE=Debug \
-                                -DCMAKE_CXX_COMPILER=hipcc \
-                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -Wno-braced-scalar-init" \
-                                -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
-                                -DKokkos_ENABLE_TESTS=ON \
-                                -DKokkos_ENABLE_HIP=ON \
-                              .. && \
-                              make -j8 && ctest --output-on-failure'''
-                    }
-                    post {
-                        always {
-                            sh 'ccache --show-stats'
-                        }
-                    }
-                }
+// TEMPORARILY DISABLE HIP BECAUSE TEST MACHINE IS UNAVAILABLE
+//                stage('HIP-3.5-HCC') {
+//                    agent {
+//                        dockerfile {
+//                            filename 'Dockerfile.hipcc'
+//                            dir 'scripts/docker'
+//                            additionalBuildArgs '--pull --build-arg BASE=rocm/dev-ubuntu-18.04:3.5'
+//                            label 'rocm-docker && vega'
+//                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video'
+//                        }
+//                    }
+//                    steps {
+//                        sh 'ccache --zero-stats'
+//                        sh '''rm -rf build && mkdir -p build && cd build && \
+//                              cmake \
+//                                -DCMAKE_BUILD_TYPE=Debug \
+//                                -DCMAKE_CXX_COMPILER=hipcc \
+//                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -Wno-braced-scalar-init" \
+//                                -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
+//                                -DKokkos_ENABLE_TESTS=ON \
+//                                -DKokkos_ENABLE_HIP=ON \
+//                              .. && \
+//                              make -j8 && ctest --output-on-failure'''
+//                    }
+//                    post {
+//                        always {
+//                            sh 'ccache --show-stats'
+//                        }
+//                    }
+//                }
                 stage('OPENMPTARGET-Clang') {
                     agent {
                         dockerfile {


### PR DESCRIPTION
Just being practical because the test machine with MI60s is not back online and it is not clear that the issue will be resolved timely.