### PR TITLE
Update clang.tidy to also consider Kokkos header files.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,3 @@
 Checks: '-*,kokkos-*,modernize-use-using,modernize-use-nullptr'
 FormatStyle: file
+HeaderFilterRegex: '.*/*.hpp'

--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -74,7 +74,7 @@ template <typename Device>
 class Bitset {
  public:
   using execution_space = Device;
-  using size_type       = unsigned;
+  using size_type       = unsigned int;
 
   enum { BIT_SCAN_REVERSE = 1u };
   enum { MOVE_HINT_BACKWARD = 2u };
@@ -309,7 +309,7 @@ template <typename Device>
 class ConstBitset {
  public:
   using execution_space = Device;
-  using size_type       = unsigned;
+  using size_type       = unsigned int;
 
  private:
   enum { block_size = static_cast<unsigned>(sizeof(unsigned) * CHAR_BIT) };

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1940,7 +1940,7 @@ create_mirror(
     const Kokkos::Experimental::OffsetView<T, P...>& src,
     typename std::enable_if<
         !std::is_same<typename Kokkos::ViewTraits<T, P...>::array_layout,
-                      Kokkos::LayoutStride>::value>::type* = 0) {
+                      Kokkos::LayoutStride>::value>::type* = nullptr) {
   using src_type = Experimental::OffsetView<T, P...>;
   using dst_type = typename src_type::HostMirror;
 
@@ -1960,7 +1960,7 @@ create_mirror(
     const Kokkos::Experimental::OffsetView<T, P...>& src,
     typename std::enable_if<
         std::is_same<typename Kokkos::ViewTraits<T, P...>::array_layout,
-                     Kokkos::LayoutStride>::value>::type* = 0) {
+                     Kokkos::LayoutStride>::value>::type* = nullptr) {
   using src_type = Experimental::OffsetView<T, P...>;
   using dst_type = typename src_type::HostMirror;
 
@@ -2028,7 +2028,7 @@ create_mirror_view(
           std::is_same<
               typename Kokkos::Experimental::OffsetView<T, P...>::data_type,
               typename Kokkos::Experimental::OffsetView<
-                  T, P...>::HostMirror::data_type>::value)>::type* = 0) {
+                  T, P...>::HostMirror::data_type>::value)>::type* = nullptr) {
   return Kokkos::create_mirror(src);
 }
 
@@ -2038,7 +2038,7 @@ typename Kokkos::Impl::MirrorOffsetViewType<Space, T, P...>::view_type
 create_mirror_view(const Space&,
                    const Kokkos::Experimental::OffsetView<T, P...>& src,
                    typename std::enable_if<Impl::MirrorOffsetViewType<
-                       Space, T, P...>::is_same_memspace>::type* = 0) {
+                       Space, T, P...>::is_same_memspace>::type* = nullptr) {
   return src;
 }
 
@@ -2048,7 +2048,7 @@ typename Kokkos::Impl::MirrorOffsetViewType<Space, T, P...>::view_type
 create_mirror_view(const Space&,
                    const Kokkos::Experimental::OffsetView<T, P...>& src,
                    typename std::enable_if<!Impl::MirrorOffsetViewType<
-                       Space, T, P...>::is_same_memspace>::type* = 0) {
+                       Space, T, P...>::is_same_memspace>::type* = nullptr) {
   return typename Kokkos::Impl::MirrorOffsetViewType<Space, T, P...>::view_type(
       src.label(), src.layout(),
       {src.begin(0), src.begin(1), src.begin(2), src.begin(3), src.begin(4),
@@ -2063,7 +2063,7 @@ create_mirror_view(const Space&,
 //                              , std::string const& name = ""
 //                                  , typename
 //                                  std::enable_if<Impl::MirrorViewType<Space,T,P
-//                                  ...>::is_same_memspace>::type* = 0 ) {
+//                                  ...>::is_same_memspace>::type* = nullptr) {
 //    (void)name;
 //    return src;
 //  }
@@ -2076,7 +2076,7 @@ create_mirror_view(const Space&,
 //                              , std::string const& name = ""
 //                                  , typename
 //                                  std::enable_if<!Impl::MirrorViewType<Space,T,P
-//                                  ...>::is_same_memspace>::type* = 0 ) {
+//                                  ...>::is_same_memspace>::type* = nullptr) {
 //    using Mirror = typename
 //    Kokkos::Experimental::Impl::MirrorViewType<Space,T,P ...>::view_type;
 //    std::string label = name.empty() ? src.label() : name;

--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -212,7 +212,7 @@ void run_test_graph3(size_t B, size_t N) {
 
 template <class Space>
 void run_test_graph4() {
-  using ordinal_type       = unsigned;
+  using ordinal_type       = unsigned int;
   using layout_type        = Kokkos::LayoutRight;
   using space_type         = Space;
   using memory_traits_type = Kokkos::MemoryUnmanaged;

--- a/core/src/Kokkos_Future.hpp
+++ b/core/src/Kokkos_Future.hpp
@@ -311,7 +311,7 @@ class BasicFuture {
 
   KOKKOS_INLINE_FUNCTION
   int reference_count() const {
-    return 0 != m_task ? m_task->reference_count() : 0;
+    return nullptr != m_task ? m_task->reference_count() : 0;
   }
 
   //----------------------------------------


### PR DESCRIPTION
My original plan was to split this into multiple pull requests and I am happy still do this. However, we can only enable the changes to `.clang-tidy` once all of them are in.