### PR TITLE
Deprecate Experimental::MasterLock

### DIFF
--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -53,7 +53,9 @@
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Utilities.hpp>
 
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_3
 #include <Kokkos_MasterLock.hpp>
+#endif
 
 //----------------------------------------------------------------------------
 // Have assumed a 64bit build (8byte pointers) throughout the code base.

--- a/core/src/Kokkos_MasterLock.hpp
+++ b/core/src/Kokkos_MasterLock.hpp
@@ -47,6 +47,10 @@
 
 #include <Kokkos_Macros.hpp>
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+#error Kokkos::Experimental::MasterLock has been deprecated.
+#endif
+
 namespace Kokkos {
 namespace Experimental {
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -213,6 +213,7 @@ void OpenMP::partition_master(F const& f, int num_partitions,
 
 namespace Experimental {
 
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_3
 template <>
 class MasterLock<OpenMP> {
  public:
@@ -231,6 +232,7 @@ class MasterLock<OpenMP> {
  private:
   omp_lock_t m_lock;
 };
+#endif
 
 template <>
 class UniqueToken<OpenMP, UniqueTokenScope::Instance> {

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -377,14 +377,23 @@ if(Kokkos_ENABLE_PTHREAD)
   )
 endif()
 
-if(Kokkos_ENABLE_OPENMP)
+if (Kokkos_ENABLE_OPENMP)
+  if (Kokkos_ENABLE_DEPRECATED_CODE_3)
+    set(OpenMP_EXTRA_SOURCES
+      openmp/TestOpenMP_PartitionMaster.cpp
+      openmp/TestOpenMP_Task.cpp
+    )
+  else ()
+    set(OpenMP_EXTRA_SOURCES
+      openmp/TestOpenMP_Task.cpp
+    )
+  endif ()
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_OpenMP
     SOURCES
     UnitTestMainInit.cpp
     ${OpenMP_SOURCES}
-    openmp/TestOpenMP_PartitionMaster.cpp
-    openmp/TestOpenMP_Task.cpp
+    ${OpenMP_EXTRA_SOURCES}
   )
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_OpenMPInterOp


### PR DESCRIPTION
The class template is only specialized for the OpenMP backend.
No one seems to know anything about it.
It is apperently not used anywhere.