### PR TITLE
Use NVCC11 release for CI testing

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -152,7 +152,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.nvcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--pull --build-arg BASE=nvidia/cuda:11.0-devel-rc --build-arg ADDITIONAL_PACKAGES="g++-8 gfortran" --build-arg CMAKE_VERSION=3.17.3'
+                            additionalBuildArgs '--pull --build-arg BASE=nvidia/cuda:11.0-devel --build-arg ADDITIONAL_PACKAGES="g++-8 gfortran" --build-arg CMAKE_VERSION=3.17.3'
                             label 'nvidia-docker && volta'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache'
                         }


### PR DESCRIPTION
https://hub.docker.com/layers/nvidia/cuda/11.0-devel/images/sha256-b1d096ea82db17efe839fa205e5cc74f946b11a1e8f9a12394008aca8c74bcb9?context=explore