### PR TITLE
Always set the variabe UseShfflReduction to false

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -1170,10 +1170,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
   // Shall we use the shfl based reduction or not (only use it for static sized
   // types of more than 128bit
-  enum {
-    UseShflReduction = ((sizeof(value_type) > 2 * sizeof(double)) &&
-                        (ValueTraits::StaticValueSize != 0))
-  };
+  static constexpr bool UseShflReduction = false;
+  //((sizeof(value_type)>2*sizeof(double)) && ValueTraits::StaticValueSize)
   // Some crutch to do function overloading
  private:
   using DummyShflReductionType  = double;

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -229,10 +229,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
   // Shall we use the shfl based reduction or not (only use it for static sized
   // types of more than 128bit
-  enum {
-    UseShflReduction = ((sizeof(value_type) > 2 * sizeof(double)) &&
-                        (ValueTraits::StaticValueSize != 0))
-  };
+  static constexpr bool UseShflReduction = false;
+  // ((sizeof(value_type) > 2 * sizeof(double)) && (ValueTraits::StaticValueSize
+  // != 0))
   // Some crutch to do function overloading
  private:
   using DummyShflReductionType  = double;

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -92,6 +92,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP)
       ${dir}/Test${Tag}_MDRange_c.cpp
       ${dir}/Test${Tag}_MDRange_d.cpp
       ${dir}/Test${Tag}_MDRange_e.cpp
+      ${dir}/Test${Tag}_MDRange_f.cpp
       ${dir}/Test${Tag}_Other.cpp
       ${dir}/Test${Tag}_RangePolicy.cpp
       ${dir}/Test${Tag}_RangePolicyRequire.cpp
@@ -154,6 +155,7 @@ if(Kokkos_ENABLE_OPENMPTARGET)
     openmptarget/TestOpenMPTarget_MDRange_c.cpp
     openmptarget/TestOpenMPTarget_MDRange_d.cpp
     openmptarget/TestOpenMPTarget_MDRange_e.cpp
+    openmptarget/TestOpenMPTarget_MDRange_f.cpp
     openmptarget/TestOpenMPTarget_Other.cpp
     openmptarget/TestOpenMPTarget_Scan.cpp
     openmptarget/TestOpenMPTarget_Team.cpp

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -108,7 +108,7 @@ struct TestMDRange_ReduceArray_2D {
                                          Kokkos::IndexType<int>, InitTag>;
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -195,7 +195,7 @@ struct TestMDRange_ReduceArray_3D {
                                          Kokkos::IndexType<int>, InitTag>;
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -259,7 +259,7 @@ struct TestMDRange_2D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -279,7 +279,7 @@ struct TestMDRange_2D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -299,7 +299,7 @@ struct TestMDRange_2D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       int s0 = 1;
       int s1 = 1;
       range_type range({{s0, s1}}, {{N0, N1}}, {{3, 3}});
@@ -319,7 +319,7 @@ struct TestMDRange_2D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       int s0 = 1;
       int s1 = 1;
       range_type range({{s0, s1}}, {{N0, N1}}, {{3, 3}});
@@ -339,7 +339,7 @@ struct TestMDRange_2D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0}}, {{N0, N1}}, {{3, 3}});
 
       TestMDRange_2D functor(N0, N1);
@@ -362,7 +362,7 @@ struct TestMDRange_2D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{1, 1}}, {{N0, N1}}, {{3, 3}});
 
       Kokkos::View<double **, ExecSpace> v_in("v_in", N0, N1);
@@ -427,7 +427,7 @@ struct TestMDRange_2D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<2, Iterate::Default, Iterate::Default>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -446,7 +446,7 @@ struct TestMDRange_2D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<2, Iterate::Left, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -465,7 +465,7 @@ struct TestMDRange_2D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<2, Iterate::Left, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -484,7 +484,7 @@ struct TestMDRange_2D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<2, Iterate::Right, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -503,7 +503,7 @@ struct TestMDRange_2D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<2, Iterate::Right, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -525,7 +525,7 @@ struct TestMDRange_2D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -665,7 +665,7 @@ struct TestMDRange_2D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -696,7 +696,7 @@ struct TestMDRange_2D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<2, Iterate::Default, Iterate::Default>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -727,7 +727,7 @@ struct TestMDRange_2D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<2, Iterate::Left, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -758,7 +758,7 @@ struct TestMDRange_2D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<2, Iterate::Left, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -789,7 +789,7 @@ struct TestMDRange_2D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<2, Iterate::Right, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -820,7 +820,7 @@ struct TestMDRange_2D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<2, Iterate::Right, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -893,7 +893,7 @@ struct TestMDRange_3D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -912,7 +912,7 @@ struct TestMDRange_3D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -935,7 +935,7 @@ struct TestMDRange_3D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0}}, {{N0, N1, N2}}, {{3, 3, 3}});
 
       TestMDRange_3D functor(N0, N1, N2);
@@ -953,7 +953,7 @@ struct TestMDRange_3D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0}}, {{N0, N1, N2}}, {{3, 3, 3}});
 
       TestMDRange_3D functor(N0, N1, N2);
@@ -971,7 +971,7 @@ struct TestMDRange_3D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0}}, {{N0, N1, N2}}, {{3, 3, 3}});
 
       TestMDRange_3D functor(N0, N1, N2);
@@ -994,7 +994,7 @@ struct TestMDRange_3D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
 
       range_type range({{1, 1, 1}}, {{N0, N1, N2}}, {{3, 3, 3}});
 
@@ -1068,7 +1068,7 @@ struct TestMDRange_3D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<3, Iterate::Default, Iterate::Default>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1087,7 +1087,7 @@ struct TestMDRange_3D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<3, Iterate::Left, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1106,7 +1106,7 @@ struct TestMDRange_3D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<3, Iterate::Left, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1125,7 +1125,7 @@ struct TestMDRange_3D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<3, Iterate::Right, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1144,7 +1144,7 @@ struct TestMDRange_3D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<3, Iterate::Right, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1166,7 +1166,7 @@ struct TestMDRange_3D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1209,7 +1209,7 @@ struct TestMDRange_3D {
 
     {
       using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3> >;
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>>;
       using point_type = typename range_type::point_type;
 
       range_type range(point_type{{0, 0, 0}}, point_type{{N0, N1, N2}});
@@ -1278,7 +1278,7 @@ struct TestMDRange_3D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1311,7 +1311,7 @@ struct TestMDRange_3D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<3, Iterate::Default, Iterate::Default>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1343,7 +1343,7 @@ struct TestMDRange_3D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<3, Iterate::Left, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1375,7 +1375,7 @@ struct TestMDRange_3D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<3, Iterate::Left, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1407,7 +1407,7 @@ struct TestMDRange_3D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<3, Iterate::Right, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1439,7 +1439,7 @@ struct TestMDRange_3D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<3, Iterate::Right, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1515,7 +1515,7 @@ struct TestMDRange_4D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1534,7 +1534,7 @@ struct TestMDRange_4D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1558,7 +1558,7 @@ struct TestMDRange_4D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0, 0}}, {{N0, N1, N2, N3}}, {{3, 3, 3, 3}});
 
       TestMDRange_4D functor(N0, N1, N2, N3);
@@ -1577,7 +1577,7 @@ struct TestMDRange_4D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0, 0}}, {{N0, N1, N2, N3}}, {{3, 3, 3, 3}});
 
       TestMDRange_4D functor(N0, N1, N2, N3);
@@ -1596,7 +1596,7 @@ struct TestMDRange_4D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0, 0}}, {{N0, N1, N2, N3}}, {{3, 3, 3, 3}});
 
       TestMDRange_4D functor(N0, N1, N2, N3);
@@ -1620,7 +1620,7 @@ struct TestMDRange_4D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
 
       range_type range({{1, 1, 1, 1}}, {{N0, N1, N2, N3}}, {{3, 3, 3, 3}});
 
@@ -1691,7 +1691,7 @@ struct TestMDRange_4D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<4, Iterate::Default, Iterate::Default>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1710,7 +1710,7 @@ struct TestMDRange_4D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<4, Iterate::Left, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1729,7 +1729,7 @@ struct TestMDRange_4D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<4, Iterate::Left, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1748,7 +1748,7 @@ struct TestMDRange_4D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<4, Iterate::Right, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1767,7 +1767,7 @@ struct TestMDRange_4D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<4, Iterate::Right, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1790,7 +1790,7 @@ struct TestMDRange_4D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1834,7 +1834,7 @@ struct TestMDRange_4D {
 
     {
       using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4> >;
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>;
       using point_type = typename range_type::point_type;
 
       range_type range(point_type{{0, 0, 0, 0}}, point_type{{N0, N1, N2, N3}});
@@ -1906,7 +1906,7 @@ struct TestMDRange_4D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1940,7 +1940,7 @@ struct TestMDRange_4D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<4, Iterate::Default, Iterate::Default>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -1974,7 +1974,7 @@ struct TestMDRange_4D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<4, Iterate::Left, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2008,7 +2008,7 @@ struct TestMDRange_4D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<4, Iterate::Left, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2042,7 +2042,7 @@ struct TestMDRange_4D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<4, Iterate::Right, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2076,7 +2076,7 @@ struct TestMDRange_4D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<4, Iterate::Right, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2155,7 +2155,7 @@ struct TestMDRange_5D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2176,7 +2176,7 @@ struct TestMDRange_5D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2203,7 +2203,7 @@ struct TestMDRange_5D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4}},
                        {{3, 3, 3, 3, 3}});
 
@@ -2223,7 +2223,7 @@ struct TestMDRange_5D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4}},
                        {{3, 3, 3, 3, 3}});
 
@@ -2243,7 +2243,7 @@ struct TestMDRange_5D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4}},
                        {{3, 3, 3, 3, 3}});
 
@@ -2268,7 +2268,7 @@ struct TestMDRange_5D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
 
       range_type range({{1, 1, 1, 1, 1}}, {{N0, N1, N2, N3, N4}},
                        {{3, 3, 3, 2, 2}});
@@ -2349,7 +2349,7 @@ struct TestMDRange_5D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2397,7 +2397,7 @@ struct TestMDRange_5D {
 
     {
       using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5> >;
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>>;
       using point_type = typename range_type::point_type;
 
       range_type range(point_type{{0, 0, 0, 0, 0}},
@@ -2474,7 +2474,7 @@ struct TestMDRange_5D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2510,7 +2510,7 @@ struct TestMDRange_5D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<5, Iterate::Default, Iterate::Default>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2546,7 +2546,7 @@ struct TestMDRange_5D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<5, Iterate::Left, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2582,7 +2582,7 @@ struct TestMDRange_5D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<5, Iterate::Left, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2618,7 +2618,7 @@ struct TestMDRange_5D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<5, Iterate::Right, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2654,7 +2654,7 @@ struct TestMDRange_5D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<5, Iterate::Right, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2736,7 +2736,7 @@ struct TestMDRange_6D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2757,7 +2757,7 @@ struct TestMDRange_6D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2785,7 +2785,7 @@ struct TestMDRange_6D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 3, 3, 2}});
 
@@ -2805,7 +2805,7 @@ struct TestMDRange_6D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 3, 3, 2}});
 
@@ -2825,7 +2825,7 @@ struct TestMDRange_6D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 3, 3, 2}});
 
@@ -2850,7 +2850,7 @@ struct TestMDRange_6D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
 
       range_type range({{1, 1, 1, 1, 1, 1}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 2, 2, 1}});
@@ -2934,7 +2934,7 @@ struct TestMDRange_6D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2984,7 +2984,7 @@ struct TestMDRange_6D {
 
     {
       using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6> >;
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>;
       using point_type = typename range_type::point_type;
 
       range_type range(point_type{{0, 0, 0, 0, 0, 0}},
@@ -3066,7 +3066,7 @@ struct TestMDRange_6D {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3103,7 +3103,7 @@ struct TestMDRange_6D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3140,7 +3140,7 @@ struct TestMDRange_6D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<6, Iterate::Left, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3177,7 +3177,7 @@ struct TestMDRange_6D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<6, Iterate::Left, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3214,7 +3214,7 @@ struct TestMDRange_6D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<6, Iterate::Right, Iterate::Left>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3251,7 +3251,7 @@ struct TestMDRange_6D {
     {
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::Rank<6, Iterate::Right, Iterate::Right>,
-          Kokkos::IndexType<int> >;
+          Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3321,7 +3321,7 @@ struct TestMDRange_2D_NegIdx {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3383,7 +3383,7 @@ struct TestMDRange_3D_NegIdx {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3450,7 +3450,7 @@ struct TestMDRange_4D_NegIdx {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3521,7 +3521,7 @@ struct TestMDRange_5D_NegIdx {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3598,7 +3598,7 @@ struct TestMDRange_6D_NegIdx {
     {
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int> >;
+                                         Kokkos::IndexType<int>>;
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3625,6 +3625,63 @@ struct TestMDRange_6D_NegIdx {
                          (upper[2] - lower[2]) * (upper[3] - lower[3]) *
                          (upper[4] - lower[4]) * (upper[5] - lower[5]));
     }
+  }
+};
+
+template <typename ExecSpace>
+struct TestMDRange_ReduceScalar {
+  struct Scalar {
+    double v[4];
+    KOKKOS_INLINE_FUNCTION
+    Scalar() {
+      for (int i = 0; i < 4; i++) v[i] = 0;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    Scalar(const Scalar &src) {
+      for (int i = 0; i < 4; i++) v[i] = src.v[i];
+    }
+    KOKKOS_INLINE_FUNCTION
+    void operator=(const Scalar &src) {
+      for (int i = 0; i < 4; i++) v[i] = src.v[i];
+    }
+    KOKKOS_INLINE_FUNCTION
+    void operator+=(const Scalar &src) {
+      for (int i = 0; i < 4; i++) v[i] += src.v[i];
+    }
+    KOKKOS_INLINE_FUNCTION
+    void operator=(const volatile Scalar &src) volatile {
+      for (int i = 0; i < 4; i++) v[i] = src.v[i];
+    }
+    KOKKOS_INLINE_FUNCTION
+    void operator+=(const volatile Scalar &src) volatile {
+      for (int i = 0; i < 4; i++) v[i] += src.v[i];
+    }
+  };
+
+  static void test_scalar_reduce(const int N0, const int N1) {
+#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+    Scalar sum;
+    using range_type =
+        typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>,
+                                       Kokkos::IndexType<int>>;
+    using tile_type  = typename range_type::tile_type;
+    using point_type = typename range_type::point_type;
+
+    range_type range(point_type{{0, 0}}, point_type{{N0, N1}},
+                     tile_type{{3, 3}});
+
+    parallel_reduce(
+        range,
+        KOKKOS_LAMBDA(int, int, Scalar &lsum) {
+          for (int i = 0; i < 4; i++) lsum.v[i]++;
+        },
+        sum);
+    for (int i = 0; i < 4; i++) ASSERT_EQ(sum.v[i], N0 * N1);
+#else
+    std::ignore = N0;
+    std::ignore = N1;
+#endif
   }
 };
 

--- a/core/unit_test/TestMDRange_f.hpp
+++ b/core/unit_test/TestMDRange_f.hpp
@@ -1,0 +1,53 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <TestMDRange.hpp>
+
+namespace Test {
+
+TEST(TEST_CATEGORY, mdrange_scalar) {
+  TestMDRange_ReduceScalar<TEST_EXECSPACE>::test_scalar_reduce(12, 11);
+}
+
+}  // namespace Test

--- a/core/unit_test/cuda/TestCuda_MDRange_f.cpp
+++ b/core/unit_test/cuda/TestCuda_MDRange_f.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <cuda/TestCuda_Category.hpp>
+#include <TestMDRange_f.hpp>

--- a/core/unit_test/hip/TestHIP_MDRange_f.cpp
+++ b/core/unit_test/hip/TestHIP_MDRange_f.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hip/TestHIP_Category.hpp>
+#include <TestMDRange_f.hpp>

--- a/core/unit_test/hpx/TestHPX_MDRange_f.cpp
+++ b/core/unit_test/hpx/TestHPX_MDRange_f.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <hpx/TestHPX_Category.hpp>
+#include <TestMDRange_f.hpp>

--- a/core/unit_test/openmp/TestOpenMP_MDRange_f.cpp
+++ b/core/unit_test/openmp/TestOpenMP_MDRange_f.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <openmp/TestOpenMP_Category.hpp>
+#include <TestMDRange_f.hpp>

--- a/core/unit_test/openmptarget/TestOpenMPTarget_MDRange_f.cpp
+++ b/core/unit_test/openmptarget/TestOpenMPTarget_MDRange_f.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <openmptarget/TestOpenMPTarget_Category.hpp>
+#include <TestMDRange_f.hpp>

--- a/core/unit_test/serial/TestSerial_MDRange_f.cpp
+++ b/core/unit_test/serial/TestSerial_MDRange_f.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <serial/TestSerial_Category.hpp>
+#include <TestMDRange_f.hpp>

--- a/core/unit_test/threads/TestThreads_MDRange_f.cpp
+++ b/core/unit_test/threads/TestThreads_MDRange_f.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <threads/TestThreads_Category.hpp>
+#include <TestMDRange_f.hpp>


### PR DESCRIPTION
This fixes a bug where the variable `UseShflReduction` is true but where the code path for `ShfleReduction` does not exist. This looks pretty harmless except that if the variable is set to true, we set the amount of shared memory needed to zero [here](https://github.com/kokkos/kokkos/blob/develop/core/src/Cuda/Kokkos_Cuda_Parallel.hpp#L1045-L1050).

I am not sure this is the way we want to fix the bug but this is how we have done it for `Range`