### PR TITLE
Use nullptr in some more places

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,2 @@
-Checks: '-*,kokkos-*,modernize-use-using'
+Checks: '-*,kokkos-*,modernize-use-using,modernize-use-nullptr'
 FormatStyle: file

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2004,7 +2004,7 @@ inline typename DynRankView<T, P...>::HostMirror create_mirror_view(
               typename DynRankView<T, P...>::HostMirror::memory_space>::value &&
           std::is_same<typename DynRankView<T, P...>::data_type,
                        typename DynRankView<T, P...>::HostMirror::data_type>::
-              value)>::type* = 0) {
+              value)>::type* = nullptr) {
   return Kokkos::create_mirror(src);
 }
 
@@ -2023,7 +2023,8 @@ template <class Space, class T, class... P>
 typename Impl::MirrorDRViewType<Space, T, P...>::view_type create_mirror_view(
     const Space&, const Kokkos::DynRankView<T, P...>& src,
     typename std::enable_if<
-        !Impl::MirrorDRViewType<Space, T, P...>::is_same_memspace>::type* = 0) {
+        !Impl::MirrorDRViewType<Space, T, P...>::is_same_memspace>::type* =
+        nullptr) {
   return typename Impl::MirrorDRViewType<Space, T, P...>::view_type(
       src.label(), Impl::reconstructLayout(src.layout(), src.rank()));
 }
@@ -2050,7 +2051,8 @@ create_mirror_view_and_copy(
     const Space&, const Kokkos::DynRankView<T, P...>& src,
     std::string const& name = "",
     typename std::enable_if<
-        !Impl::MirrorDRViewType<Space, T, P...>::is_same_memspace>::type* = 0) {
+        !Impl::MirrorDRViewType<Space, T, P...>::is_same_memspace>::type* =
+        nullptr) {
   using Mirror = typename Impl::MirrorDRViewType<Space, T, P...>::view_type;
   std::string label = name.empty() ? src.label() : name;
   auto mirror       = Mirror(Kokkos::ViewAllocateWithoutInitializing(label),

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -73,8 +73,8 @@ namespace {
 static std::atomic<int> num_uvm_allocations(0);
 
 cudaStream_t get_deep_copy_stream() {
-  static cudaStream_t s = 0;
-  if (s == 0) {
+  static cudaStream_t s = nullptr;
+  if (s == nullptr) {
     cudaStreamCreate(&s);
   }
   return s;
@@ -392,7 +392,8 @@ SharedAllocationRecord<Kokkos::CudaSpace, void>::attach_texture_object(
     size_t const alloc_size) {
   enum { TEXTURE_BOUND_1D = 1u << 27 };
 
-  if ((alloc_ptr == 0) || (sizeof_alias * TEXTURE_BOUND_1D <= alloc_size)) {
+  if ((alloc_ptr == nullptr) ||
+      (sizeof_alias * TEXTURE_BOUND_1D <= alloc_size)) {
     std::ostringstream msg;
     msg << "Kokkos::CudaSpace ERROR: Cannot attach texture object to"
         << " alloc_ptr(" << alloc_ptr << ")"
@@ -637,7 +638,7 @@ SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::
 void *SharedAllocationRecord<Kokkos::CudaSpace, void>::allocate_tracked(
     const Kokkos::CudaSpace &arg_space, const std::string &arg_alloc_label,
     const size_t arg_alloc_size) {
-  if (!arg_alloc_size) return (void *)0;
+  if (!arg_alloc_size) return nullptr;
 
   SharedAllocationRecord *const r =
       allocate(arg_space, arg_alloc_label, arg_alloc_size);
@@ -649,7 +650,7 @@ void *SharedAllocationRecord<Kokkos::CudaSpace, void>::allocate_tracked(
 
 void SharedAllocationRecord<Kokkos::CudaSpace, void>::deallocate_tracked(
     void *const arg_alloc_ptr) {
-  if (arg_alloc_ptr != 0) {
+  if (arg_alloc_ptr != nullptr) {
     SharedAllocationRecord *const r = get_record(arg_alloc_ptr);
 
     RecordBase::decrement(r);
@@ -674,7 +675,7 @@ void *SharedAllocationRecord<Kokkos::CudaSpace, void>::reallocate_tracked(
 void *SharedAllocationRecord<Kokkos::CudaUVMSpace, void>::allocate_tracked(
     const Kokkos::CudaUVMSpace &arg_space, const std::string &arg_alloc_label,
     const size_t arg_alloc_size) {
-  if (!arg_alloc_size) return (void *)0;
+  if (!arg_alloc_size) return nullptr;
 
   SharedAllocationRecord *const r =
       allocate(arg_space, arg_alloc_label, arg_alloc_size);
@@ -686,7 +687,7 @@ void *SharedAllocationRecord<Kokkos::CudaUVMSpace, void>::allocate_tracked(
 
 void SharedAllocationRecord<Kokkos::CudaUVMSpace, void>::deallocate_tracked(
     void *const arg_alloc_ptr) {
-  if (arg_alloc_ptr != 0) {
+  if (arg_alloc_ptr != nullptr) {
     SharedAllocationRecord *const r = get_record(arg_alloc_ptr);
 
     RecordBase::decrement(r);
@@ -712,7 +713,7 @@ void *
 SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::allocate_tracked(
     const Kokkos::CudaHostPinnedSpace &arg_space,
     const std::string &arg_alloc_label, const size_t arg_alloc_size) {
-  if (!arg_alloc_size) return (void *)0;
+  if (!arg_alloc_size) return nullptr;
 
   SharedAllocationRecord *const r =
       allocate(arg_space, arg_alloc_label, arg_alloc_size);
@@ -725,7 +726,7 @@ SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::allocate_tracked(
 void SharedAllocationRecord<Kokkos::CudaHostPinnedSpace,
                             void>::deallocate_tracked(void *const
                                                           arg_alloc_ptr) {
-  if (arg_alloc_ptr != 0) {
+  if (arg_alloc_ptr != nullptr) {
     SharedAllocationRecord *const r = get_record(arg_alloc_ptr);
 
     RecordBase::decrement(r);
@@ -764,7 +765,7 @@ SharedAllocationRecord<Kokkos::CudaSpace, void>::get_record(void *alloc_ptr) {
   Header head;
 
   Header const *const head_cuda =
-      alloc_ptr ? Header::get_header(alloc_ptr) : (Header *)0;
+      alloc_ptr ? Header::get_header(alloc_ptr) : nullptr;
 
   if (alloc_ptr) {
     Kokkos::Impl::DeepCopy<HostSpace, CudaSpace>(
@@ -772,7 +773,7 @@ SharedAllocationRecord<Kokkos::CudaSpace, void>::get_record(void *alloc_ptr) {
   }
 
   RecordCuda *const record =
-      alloc_ptr ? static_cast<RecordCuda *>(head.m_record) : (RecordCuda *)0;
+      alloc_ptr ? static_cast<RecordCuda *>(head.m_record) : nullptr;
 
   if (!alloc_ptr || record->m_alloc_ptr != head_cuda) {
     Kokkos::Impl::throw_runtime_exception(
@@ -789,7 +790,7 @@ SharedAllocationRecord<Kokkos::CudaUVMSpace, void> *SharedAllocationRecord<
   using RecordCuda = SharedAllocationRecord<Kokkos::CudaUVMSpace, void>;
 
   Header *const h =
-      alloc_ptr ? reinterpret_cast<Header *>(alloc_ptr) - 1 : (Header *)0;
+      alloc_ptr ? reinterpret_cast<Header *>(alloc_ptr) - 1 : nullptr;
 
   if (!alloc_ptr || h->m_record->m_alloc_ptr != h) {
     Kokkos::Impl::throw_runtime_exception(
@@ -807,7 +808,7 @@ SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>
   using RecordCuda = SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>;
 
   Header *const h =
-      alloc_ptr ? reinterpret_cast<Header *>(alloc_ptr) - 1 : (Header *)0;
+      alloc_ptr ? reinterpret_cast<Header *>(alloc_ptr) - 1 : nullptr;
 
   if (!alloc_ptr || h->m_record->m_alloc_ptr != h) {
     Kokkos::Impl::throw_runtime_exception(

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -286,11 +286,11 @@ CudaInternal::~CudaInternal() {
   m_scratchUnifiedCount     = 0;
   m_scratchUnifiedSupported = 0;
   m_streamCount             = 0;
-  m_scratchSpace            = 0;
-  m_scratchFlags            = 0;
-  m_scratchUnified          = 0;
-  m_scratchConcurrentBitset = 0;
-  m_stream                  = 0;
+  m_scratchSpace            = nullptr;
+  m_scratchFlags            = nullptr;
+  m_scratchUnified          = nullptr;
+  m_scratchConcurrentBitset = nullptr;
+  m_stream                  = nullptr;
 }
 
 int CudaInternal::verify_is_initialized(const char *const label) const {
@@ -326,7 +326,7 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream) {
 
   const CudaInternalDevices &dev_info = CudaInternalDevices::singleton();
 
-  const bool ok_init = 0 == m_scratchSpace || 0 == m_scratchFlags;
+  const bool ok_init = nullptr == m_scratchSpace || nullptr == m_scratchFlags;
 
   const bool ok_id =
       0 <= cuda_device_id && cuda_device_id < dev_info.m_cudaDevCount;
@@ -536,7 +536,7 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream) {
 #endif
 
   // Init the array for used for arbitrarily sized atomics
-  if (stream == 0) Impl::initialize_host_cuda_lock_arrays();
+  if (stream == nullptr) Impl::initialize_host_cuda_lock_arrays();
 
   m_stream = stream;
 }
@@ -643,7 +643,7 @@ Cuda::size_type *CudaInternal::scratch_functor(
 
 void CudaInternal::finalize() {
   was_finalized = true;
-  if (0 != m_scratchSpace || 0 != m_scratchFlags) {
+  if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
     Impl::finalize_host_cuda_lock_arrays();
 
     using RecordCuda = Kokkos::Impl::SharedAllocationRecord<CudaSpace>;
@@ -666,11 +666,11 @@ void CudaInternal::finalize() {
     m_scratchFlagsCount       = 0;
     m_scratchUnifiedCount     = 0;
     m_streamCount             = 0;
-    m_scratchSpace            = 0;
-    m_scratchFlags            = 0;
-    m_scratchUnified          = 0;
-    m_scratchConcurrentBitset = 0;
-    m_stream                  = 0;
+    m_scratchSpace            = nullptr;
+    m_scratchFlags            = nullptr;
+    m_scratchUnified          = nullptr;
+    m_scratchConcurrentBitset = nullptr;
+    m_stream                  = nullptr;
   }
 }
 
@@ -740,7 +740,7 @@ int Cuda::impl_is_initialized() {
 
 void Cuda::impl_initialize(const Cuda::SelectDevice config,
                            size_t /*num_instances*/) {
-  Impl::CudaInternal::singleton().initialize(config.cuda_device_id, 0);
+  Impl::CudaInternal::singleton().initialize(config.cuda_device_id, nullptr);
 }
 
 std::vector<unsigned> Cuda::detect_device_arch() {

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -125,10 +125,10 @@ class CudaInternal {
   int verify_is_initialized(const char* const label) const;
 
   int is_initialized() const {
-    return 0 != m_scratchSpace && 0 != m_scratchFlags;
+    return nullptr != m_scratchSpace && nullptr != m_scratchFlags;
   }
 
-  void initialize(int cuda_device_id, cudaStream_t stream = 0);
+  void initialize(int cuda_device_id, cudaStream_t stream = nullptr);
   void finalize();
 
   void print_configuration(std::ostream&) const;
@@ -162,12 +162,12 @@ class CudaInternal {
         m_scratchFunctorSize(0),
         m_scratchUnifiedSupported(0),
         m_streamCount(0),
-        m_scratchSpace(0),
-        m_scratchFlags(0),
-        m_scratchUnified(0),
-        m_scratchFunctor(0),
-        m_scratchConcurrentBitset(0),
-        m_stream(0) {}
+        m_scratchSpace(nullptr),
+        m_scratchFlags(nullptr),
+        m_scratchUnified(nullptr),
+        m_scratchFunctor(nullptr),
+        m_scratchConcurrentBitset(nullptr),
+        m_stream(nullptr) {}
 
   size_type* scratch_space(const size_type size) const;
   size_type* scratch_flags(const size_type size) const;

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -1098,9 +1098,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
         m_result_ptr_device_accessible(
             MemorySpaceAccess<Kokkos::CudaSpace,
                               typename ViewType::memory_space>::accessible),
-        m_scratch_space(0),
-        m_scratch_flags(0),
-        m_unified_space(0) {}
+        m_scratch_space(nullptr),
+        m_scratch_flags(nullptr),
+        m_unified_space(nullptr) {}
 
   ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
                  const ReducerType& reducer)
@@ -1112,9 +1112,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
             MemorySpaceAccess<Kokkos::CudaSpace,
                               typename ReducerType::result_view_type::
                                   memory_space>::accessible),
-        m_scratch_space(0),
-        m_scratch_flags(0),
-        m_unified_space(0) {}
+        m_scratch_space(nullptr),
+        m_scratch_flags(nullptr),
+        m_unified_space(nullptr) {}
 };
 
 // MDRangePolicy impl
@@ -1396,9 +1396,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
         m_result_ptr_device_accessible(
             MemorySpaceAccess<Kokkos::CudaSpace,
                               typename ViewType::memory_space>::accessible),
-        m_scratch_space(0),
-        m_scratch_flags(0),
-        m_unified_space(0) {}
+        m_scratch_space(nullptr),
+        m_scratch_flags(nullptr),
+        m_unified_space(nullptr) {}
 
   ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
                  const ReducerType& reducer)
@@ -1410,9 +1410,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
             MemorySpaceAccess<Kokkos::CudaSpace,
                               typename ReducerType::result_view_type::
                                   memory_space>::accessible),
-        m_scratch_space(0),
-        m_scratch_flags(0),
-        m_unified_space(0) {}
+        m_scratch_space(nullptr),
+        m_scratch_flags(nullptr),
+        m_unified_space(nullptr) {}
 };
 
 //----------------------------------------------------------------------------
@@ -1707,9 +1707,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         m_result_ptr_device_accessible(
             MemorySpaceAccess<Kokkos::CudaSpace,
                               typename ViewType::memory_space>::accessible),
-        m_scratch_space(0),
-        m_scratch_flags(0),
-        m_unified_space(0),
+        m_scratch_space(nullptr),
+        m_scratch_flags(nullptr),
+        m_unified_space(nullptr),
         m_team_begin(0),
         m_shmem_begin(0),
         m_shmem_size(0),
@@ -1806,9 +1806,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
             MemorySpaceAccess<Kokkos::CudaSpace,
                               typename ReducerType::result_view_type::
                                   memory_space>::accessible),
-        m_scratch_space(0),
-        m_scratch_flags(0),
-        m_unified_space(0),
+        m_scratch_space(nullptr),
+        m_scratch_flags(nullptr),
+        m_unified_space(nullptr),
         m_team_begin(0),
         m_shmem_begin(0),
         m_shmem_size(0),
@@ -2173,8 +2173,8 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
   ParallelScan(const FunctorType& arg_functor, const Policy& arg_policy)
       : m_functor(arg_functor),
         m_policy(arg_policy),
-        m_scratch_space(0),
-        m_scratch_flags(0),
+        m_scratch_space(nullptr),
+        m_scratch_flags(nullptr),
         m_final(false)
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
         ,
@@ -2476,8 +2476,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
                         const Policy& arg_policy, ReturnType& arg_returnvalue)
       : m_functor(arg_functor),
         m_policy(arg_policy),
-        m_scratch_space(0),
-        m_scratch_flags(0),
+        m_scratch_space(nullptr),
+        m_scratch_flags(nullptr),
         m_final(false),
         m_returnvalue(arg_returnvalue)
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -219,7 +219,7 @@ class has_member_team_shmem_size {
 
  public:
   constexpr static bool value =
-      sizeof(test_for_member<Object>(0)) == sizeof(int32_t);
+      sizeof(test_for_member<Object>(nullptr)) == sizeof(int32_t);
 };
 
 template <class Object>

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2537,7 +2537,8 @@ inline void deep_copy(
         std::is_same<typename ViewTraits<DT, DP...>::specialize, void>::value &&
         std::is_same<typename ViewTraits<ST, SP...>::specialize, void>::value &&
         (unsigned(ViewTraits<DT, DP...>::rank) == unsigned(0) &&
-         unsigned(ViewTraits<ST, SP...>::rank) == unsigned(0)))>::type* = 0) {
+         unsigned(ViewTraits<ST, SP...>::rank) == unsigned(0)))>::type* =
+        nullptr) {
   using src_traits = ViewTraits<ST, SP...>;
   using dst_traits = ViewTraits<DT, DP...>;
 
@@ -3167,7 +3168,7 @@ inline typename Kokkos::View<T, P...>::HostMirror create_mirror_view(
             typename Kokkos::View<T, P...>::HostMirror::memory_space>::value &&
         std::is_same<typename Kokkos::View<T, P...>::data_type,
                      typename Kokkos::View<T, P...>::HostMirror::data_type>::
-            value)>::type* = 0) {
+            value)>::type* = nullptr) {
   return Kokkos::create_mirror(src);
 }
 
@@ -3186,7 +3187,8 @@ template <class Space, class T, class... P>
 typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
     const Space&, const Kokkos::View<T, P...>& src,
     typename std::enable_if<
-        !Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* = 0) {
+        !Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* =
+        nullptr) {
   return typename Impl::MirrorViewType<Space, T, P...>::view_type(src.label(),
                                                                   src.layout());
 }
@@ -3214,7 +3216,8 @@ create_mirror_view_and_copy(
     const Space&, const Kokkos::View<T, P...>& src,
     std::string const& name = "",
     typename std::enable_if<
-        !Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* = 0) {
+        !Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* =
+        nullptr) {
   using Mirror      = typename Impl::MirrorViewType<Space, T, P...>::view_type;
   std::string label = name.empty() ? src.label() : name;
   auto mirror       = typename Mirror::non_const_type{
@@ -3242,7 +3245,8 @@ typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
     const Space&, const Kokkos::View<T, P...>& src,
     Kokkos::Impl::WithoutInitializing_t,
     typename std::enable_if<
-        !Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* = 0) {
+        !Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* =
+        nullptr) {
   using Mirror = typename Impl::MirrorViewType<Space, T, P...>::view_type;
   return Mirror(Kokkos::ViewAllocateWithoutInitializing(src.label()),
                 src.layout());

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -642,7 +642,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
           m_functor, range.begin(), range.end(), update_sum, false);
 
       if (data.pool_rendezvous()) {
-        pointer_type ptr_prev = 0;
+        pointer_type ptr_prev = nullptr;
 
         const int n = omp_get_num_threads();
 
@@ -756,7 +756,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
           m_functor, range.begin(), range.end(), update_sum, false);
 
       if (data.pool_rendezvous()) {
-        pointer_type ptr_prev = 0;
+        pointer_type ptr_prev = nullptr;
 
         const int n = omp_get_num_threads();
 

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -441,7 +441,7 @@ class ThreadsExec {
     } else {
       // Root thread does the thread-scan before releasing threads
 
-      scalar_type *ptr_prev = 0;
+      scalar_type *ptr_prev = nullptr;
 
       for (int rank = 0; rank < m_pool_size; ++rank) {
         scalar_type *const ptr =

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -230,7 +230,7 @@ class ThreadsExecTeamMember {
     typedef
         typename if_c<sizeof(Type) < TEAM_REDUCE_SIZE, Type, void>::type type;
 
-    if (0 == m_exec) return value;
+    if (nullptr == m_exec) return value;
 
     if (team_rank() != team_size() - 1)
       *((volatile type*)m_exec->scratch_memory()) = value;
@@ -275,7 +275,7 @@ class ThreadsExecTeamMember {
     typedef typename if_c<sizeof(value_type) < TEAM_REDUCE_SIZE, value_type,
                           void>::type type;
 
-    if (0 == m_exec) return;
+    if (nullptr == m_exec) return;
 
     type* const local_value = ((type*)m_exec->scratch_memory());
 
@@ -337,7 +337,7 @@ class ThreadsExecTeamMember {
         typename if_c<sizeof(ArgType) < TEAM_REDUCE_SIZE, ArgType, void>::type
             type;
 
-    if (0 == m_exec) return type(0);
+    if (nullptr == m_exec) return type(0);
 
     volatile type* const work_value = ((type*)m_exec->scratch_memory());
 
@@ -386,7 +386,7 @@ class ThreadsExecTeamMember {
    */
   template <typename ArgType>
   KOKKOS_INLINE_FUNCTION ArgType team_scan(const ArgType& value) const {
-    return this->template team_scan<ArgType>(value, 0);
+    return this->template team_scan<ArgType>(value, nullptr);
   }
 
   //----------------------------------------
@@ -398,8 +398,8 @@ class ThreadsExecTeamMember {
       const TeamPolicyInternal<Kokkos::Threads, Properties...>& team,
       const int shared_size)
       : m_exec(exec),
-        m_team_base(0),
-        m_team_shared(0, 0),
+        m_team_base(nullptr),
+        m_team_shared(nullptr, 0),
         m_team_shared_size(shared_size),
         m_team_size(team.team_size()),
         m_team_rank(0),
@@ -479,9 +479,9 @@ class ThreadsExecTeamMember {
   }
 
   ThreadsExecTeamMember()
-      : m_exec(0),
-        m_team_base(0),
-        m_team_shared(0, 0),
+      : m_exec(nullptr),
+        m_team_base(nullptr),
+        m_team_shared(nullptr, 0),
         m_team_shared_size(0),
         m_team_size(1),
         m_team_rank(0),

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -375,7 +375,7 @@ union SharedAllocationTracker {
   constexpr SharedAllocationRecord<MemorySpace, void>* get_record() const
       noexcept {
     return (m_record_bits & DO_NOT_DEREF_FLAG)
-               ? (SharedAllocationRecord<MemorySpace, void>*)0
+               ? nullptr
                : static_cast<SharedAllocationRecord<MemorySpace, void>*>(
                      m_record);
   }


### PR DESCRIPTION
Fixing `header-filter` in #3213 revealed a few more places to be fixed (for `OpenMP` and `Threads`, `CUDA`).