### PR TITLE
Don't force NDEBUG for HIP >= 3.6.0

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -40,7 +40,7 @@ pipeline {
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER=hipcc \
-                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument" \
+                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -DNDEBUG" \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_HIP=ON \

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -166,13 +166,6 @@
 
 #if defined(KOKKOS_ENABLE_HIP)
 
-#if !(HIP_VERSION_MAJOR > 3 || HIP_VERSION_MINOR > 5 || \
-      HIP_VERSION_PATCH >= 20226)
-#ifndef NDEBUG
-#define NDEBUG
-#endif
-#endif
-
 #define HIP_ENABLE_PRINTF
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -166,9 +166,11 @@
 
 #if defined(KOKKOS_ENABLE_HIP)
 
-// FIXME_HIP Not defining NDEBUG makes some tests fail.
+#if !(HIP_VERSION_MAJOR > 3 || HIP_VERSION_MINOR > 5 || \
+      HIP_VERSION_PATCH >= 20226)
 #ifndef NDEBUG
 #define NDEBUG
+#endif
 #endif
 
 #define HIP_ENABLE_PRINTF


### PR DESCRIPTION
Apparently, all the tests pass without forcing `NDEBUG` for HIP 3.6.0.