### PR TITLE
use explicit staging buffer for constant mem optimization and make synchronization less pessimistic

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -120,6 +120,11 @@ class CudaInternal {
   bool was_initialized = false;
   bool was_finalized   = false;
 
+  // FIXME_CUDA: these want to be per-device, not per-stream...  use of 'static'
+  //  here will break once there are multiple devices though
+  static unsigned long* constantMemHostStaging;
+  static cudaEvent_t constantMemReusable;
+
   static CudaInternal& singleton();
 
   int verify_is_initialized(const char* const label) const;


### PR DESCRIPTION
This pull request does two related things:
1. It introduces an explicit staging buffer in pinned host memory for kernel launch data that's destined for
device constant memory, allowing a clear separation between the part of the transfer that's synchronous
(i.e. the transfer from the caller's stack to the staging buffer) and the part that's asynchronous (the transfer
from the staging buffer to actual device constant memory).
Note that the staging buffer's property of being per-device (as opposed to per-stream or truly global) is
a bit awkward for the current Kokkos implementation.  I'm tracking the constant buffer using static members
of the `CudaInternal` class so that they're properly shared by all `Kokkos::Cuda` instances (that are right now
all on the same device), but changes to Kokkos to better support multiple devices will need to move these to
whatever object tracks per-device information.

2. Cleans up the host/device synchronization to be both correct (i.e. actually guarantee that the copy from
the caller's stack is complete before returning) and more precise (i.e. waiting only for the most recent grid
launch to use the constant mem buffer rather than waiting for all previously issued CUDA work, whether or
not its using the constant mem buffer).  A side benefit from a Legion+Kokkos interop perspective is that the
use of `cudaEventSynchronize` plays more nicely with Legion task parallelism than `cudaDeviceSynchroinze`
does.
Although it is not attempted in this PR, the use of events for the host/device synchronization permits a further
performance optimization in which multiple grid launches that collectively fit within the 32KB constant mem
buffer could be permitted to run concurrently.  A new launch would then just wait on exactly the events for the
grids using constant mem buffer locations that are about to be reused.  The current implementation represents
the degenerate case in which every grid is assumed to need the whole 32KB.