### PR TITLE
Fix profiling when building with Makefiles by setting KOKKOS_ENABLE_L…

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -596,6 +596,8 @@ ifeq ($(KOKKOS_INTERNAL_ENABLE_TUNING), 1)
   tmp := $(call kokkos_append_header,"\#define KOKKOS_ENABLE_TUNING")
 endif
 
+tmp := $(call kokkos_append_header,"\#define KOKKOS_ENABLE_LIBDL")
+
 ifeq ($(KOKKOS_INTERNAL_USE_HWLOC), 1)
   ifneq ($(KOKKOS_CMAKE), yes)
     ifneq ($(HWLOC_PATH),)


### PR DESCRIPTION
…IBDL

note makefiles were adding libdl unconditionally anyway already.