### PR TITLE
Changes Kokkos_BINARY_DIR to CMAKE_CURRENT_BINARY_DIR in kokkos_insta…

### DIFF
--- a/cmake/kokkos_install.cmake
+++ b/cmake/kokkos_install.cmake
@@ -9,31 +9,31 @@ IF (NOT KOKKOS_HAS_TRILINOS)
   INCLUDE(CMakePackageConfigHelpers)
   CONFIGURE_PACKAGE_CONFIG_FILE(
     cmake/KokkosConfig.cmake.in
-    "${Kokkos_BINARY_DIR}/KokkosConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/KokkosConfig.cmake"
     INSTALL_DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake)
 
   CONFIGURE_PACKAGE_CONFIG_FILE(
 	  cmake/KokkosConfigCommon.cmake.in
-	  "${Kokkos_BINARY_DIR}/KokkosConfigCommon.cmake"
+	  "${CMAKE_CURRENT_BINARY_DIR}/KokkosConfigCommon.cmake"
     INSTALL_DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake)
 
-  WRITE_BASIC_PACKAGE_VERSION_FILE("${Kokkos_BINARY_DIR}/KokkosConfigVersion.cmake"
+  WRITE_BASIC_PACKAGE_VERSION_FILE("${CMAKE_CURRENT_BINARY_DIR}/KokkosConfigVersion.cmake"
       VERSION "${Kokkos_VERSION}"
       COMPATIBILITY SameMajorVersion)
 
   # Install the KokkosConfig*.cmake files
   install(FILES
-    "${Kokkos_BINARY_DIR}/KokkosConfig.cmake"
-    "${Kokkos_BINARY_DIR}/KokkosConfigCommon.cmake"
-    "${Kokkos_BINARY_DIR}/KokkosConfigVersion.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/KokkosConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/KokkosConfigCommon.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/KokkosConfigVersion.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Kokkos)
   install(EXPORT KokkosTargets NAMESPACE Kokkos:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Kokkos)
 ELSE()
-  CONFIGURE_FILE(cmake/KokkosConfigCommon.cmake.in ${Kokkos_BINARY_DIR}/KokkosConfigCommon.cmake @ONLY)
-  file(READ ${Kokkos_BINARY_DIR}/KokkosConfigCommon.cmake KOKKOS_CONFIG_COMMON)
+  CONFIGURE_FILE(cmake/KokkosConfigCommon.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/KokkosConfigCommon.cmake @ONLY)
+  file(READ ${CMAKE_CURRENT_BINARY_DIR}/KokkosConfigCommon.cmake KOKKOS_CONFIG_COMMON)
   file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/KokkosConfig_install.cmake" "${KOKKOS_CONFIG_COMMON}")
-  CONFIGURE_FILE(cmake/KokkosTrilinosConfig.cmake.in ${Kokkos_BINARY_DIR}/KokkosTrilinosConfig.cmake @ONLY)
-  file(READ ${Kokkos_BINARY_DIR}/KokkosTrilinosConfig.cmake KOKKOS_TRILINOS_CONFIG)
+  CONFIGURE_FILE(cmake/KokkosTrilinosConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/KokkosTrilinosConfig.cmake @ONLY)
+  file(READ ${CMAKE_CURRENT_BINARY_DIR}/KokkosTrilinosConfig.cmake KOKKOS_TRILINOS_CONFIG)
   file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/KokkosConfig_install.cmake" "${KOKKOS_TRILINOS_CONFIG}")
 
   WRITE_BASIC_PACKAGE_VERSION_FILE("${CMAKE_CURRENT_BINARY_DIR}/KokkosConfigVersion.cmake"


### PR DESCRIPTION
Changes Kokkos_BINARY_DIR to CMAKE_CURRENT_BINARY_DIR in kokkos_install.cmake

* Kokkos_BINARY_DIR isn't being defined on Power9s when Kokkos is included as a subdirectory.  Attempted build with CMake 3.15.3 and 3.17.3.
* CMAKE_CURRENT_BINARY_DIR is equivalent to Kokkos_BINARY_DIR and doesn't rely on Kokkos being defined as a project.