### PR TITLE
Fixed macro if/else condition on KOKKOS_FORCEINLINE_FUNCTION.

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -353,7 +353,7 @@
 #define KOKKOS_ENABLE_ASM 1
 #endif
 
-#if !defined(KOKKOS_FORCEINLINE_FUNCTION)
+#if !defined(KOKKOS_IMPL_FORCEINLINE_FUNCTION)
 #if !defined(_WIN32)
 #define KOKKOS_IMPL_FORCEINLINE_FUNCTION inline __attribute__((always_inline))
 #define KOKKOS_IMPL_FORCEINLINE __attribute__((always_inline))


### PR DESCRIPTION
I think this addresses #3249, when moving to using `KOKKOS_IMPL_FORCEINLINE_FUNCTION` I missed this path through the intel compiler and it didn't trigger an error in CI so it got in.