### PR TITLE
Added work around for clang-cuda issue.

### DIFF
--- a/core/src/impl/Kokkos_Atomic_Fetch_And.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_And.hpp
@@ -69,6 +69,18 @@ __inline__ __device__ unsigned int atomic_fetch_and(
   return atomicAnd((unsigned int*)dest, val);
 }
 
+// 08/05/20 Overload to work around https://bugs.llvm.org/show_bug.cgi?id=46922
+__inline__ __device__ unsigned long atomic_fetch_and(
+    volatile unsigned long* const dest, const unsigned long val) {
+  return atomic_fetch_and<unsigned long>(dest, val);
+}
+
+// 08/05/20 Overload to work around https://bugs.llvm.org/show_bug.cgi?id=46922
+__inline__ __device__ long atomic_fetch_and(volatile long* const dest,
+                                            long val) {
+  return atomic_fetch_and<long>(dest, val);
+}
+
 #if defined(__CUDA_ARCH__) && (350 <= __CUDA_ARCH__)
 __inline__ __device__ unsigned long long int atomic_fetch_and(
     volatile unsigned long long int* const dest,

--- a/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
@@ -69,6 +69,18 @@ __inline__ __device__ unsigned int atomic_fetch_or(
   return atomicOr((unsigned int*)dest, val);
 }
 
+// 08/05/20 Overload to work around https://bugs.llvm.org/show_bug.cgi?id=46922
+__inline__ __device__ unsigned long atomic_fetch_or(
+    volatile unsigned long* const dest, const unsigned long val) {
+  return atomic_fetch_or<unsigned long>(dest, val);
+}
+
+// 08/05/20 Overload to work around https://bugs.llvm.org/show_bug.cgi?id=46922
+__inline__ __device__ long atomic_fetch_or(volatile long* const dest,
+                                           long val) {
+  return atomic_fetch_or<long>(dest, val);
+}
+
 #if defined(__CUDA_ARCH__) && (350 <= __CUDA_ARCH__)
 __inline__ __device__ unsigned long long int atomic_fetch_or(
     volatile unsigned long long int* const dest,


### PR DESCRIPTION
Issue is here: https://bugs.llvm.org/show_bug.cgi?id=46922, work around is just to create exact match overloads that call the template function we wanted to get called in the first place. 