### PR TITLE
added missing fences to unique token

### DIFF
--- a/core/src/impl/Kokkos_ConcurrentBitset.hpp
+++ b/core/src/impl/Kokkos_ConcurrentBitset.hpp
@@ -249,6 +249,10 @@ struct concurrent_bitset {
       if (!(prev & mask)) {
         // Successfully claimed 'result.first' by
         // atomically setting that bit.
+        // Flush the set operation. Technically this only needs to be acquire/
+        // release semantics and not sequentially consistent, but for now
+        // we'll just do this.
+        Kokkos::memory_fence();
         return type(bit, state_bit_used + 1);
       }
 
@@ -297,6 +301,9 @@ struct concurrent_bitset {
     Kokkos::memory_fence();
 
     const int count = Kokkos::atomic_fetch_add((volatile int *)buffer, -1);
+
+    // Flush the store-release
+    Kokkos::memory_fence();
 
     return (count & state_used_mask) - 1;
   }


### PR DESCRIPTION
suggested test looks something like:

```c++
#include <Kokkos_Core.hpp>
#include <cmath>
int main(int argc, char* argv[]) {
  Kokkos::initialize(argc, argv);
  {
    int N = argc > 1 ? atoi(argv[1]) : 1000000;
    int R = argc > 2 ? atoi(argv[2]) : 10;
    Kokkos::Experimental::UniqueToken<Kokkos::DefaultExecutionSpace> token;
    int num = token.size();
    Kokkos::View<int64_t*> values("V",num);
    Kokkos::parallel_for("Start", N, KOKKOS_LAMBDA(int i) {
      int id = token.acquire();
      for(int j=0; j<R; j++) values(id)++;
      Kokkos::memory_fence();
      token.release(id);
    });
    int64_t sum;
    Kokkos::parallel_reduce("Check", num, KOKKOS_LAMBDA(int i, int64_t& lsum) {
      lsum += values(i);
    },sum);
    printf("%li %li\n",sum,int64_t(N)*R);
  }
  Kokkos::finalize();
}
```