### PR TITLE
Add complex functions

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -806,7 +806,7 @@ class Random_XorShift64 {
       const double V = 2.0 * drand() - 1.0;
       S              = U * U + V * V;
     }
-    return U * std::sqrt(-2.0 * log(S) / S);
+    return U * std::sqrt(-2.0 * std::log(S) / S);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -1042,7 +1042,7 @@ class Random_XorShift1024 {
       const double V = 2.0 * drand() - 1.0;
       S              = U * U + V * V;
     }
-    return U * std::sqrt(-2.0 * log(S) / S);
+    return U * std::sqrt(-2.0 * std::log(S) / S);
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -705,14 +705,27 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> pow(const complex<RealType>& x,
          Kokkos::complex<RealType>(std::cos(phi * e), std::sin(phi * e));
 }
 
-//! Square root of a complex number.
+//! Square root of a complex number. This is intended to match the stdc++
+//! implementation, which returns sqrt(z*z) = z; where z is complex number.
 template <class RealType>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sqrt(
     const complex<RealType>& x) {
-  RealType r   = abs(x);
-  RealType phi = std::atan(x.imag() / x.real());
-  return std::sqrt(r) *
-         Kokkos::complex<RealType>(std::cos(phi * 0.5), std::sin(phi * 0.5));
+  using std::abs;
+  using std::sqrt;
+
+  RealType r = x.real();
+  RealType i = x.imag();
+
+  if (r == RealType()) {
+    RealType t = sqrt(abs(i) / 2);
+    return Kokkos::complex<RealType>(t, i < RealType() ? -t : t);
+  } else {
+    RealType t = sqrt(2 * (abs(x) + abs(r)));
+    RealType u = t / 2;
+    return r > RealType()
+               ? Kokkos::complex<RealType>(u, i / t)
+               : Kokkos::complex<RealType>(abs(i) / t, i < RealType() ? -u : u);
+  }
 }
 
 //! Conjugate of a complex number.
@@ -727,6 +740,153 @@ template <class RealType>
 KOKKOS_INLINE_FUNCTION complex<RealType> exp(const complex<RealType>& x) {
   return std::exp(x.real()) *
          complex<RealType>(std::cos(x.imag()), std::sin(x.imag()));
+}
+
+//! natural log of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> log(
+    const complex<RealType>& x) {
+  using std::atan;
+  using std::log;
+  RealType phi = atan(x.imag() / x.real());
+  return Kokkos::complex<RealType>(log(abs(x)), phi);
+}
+
+//! sine of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sin(
+    const complex<RealType>& x) {
+  using std::cos;
+  using std::cosh;
+  using std::sin;
+  using std::sinh;
+  return Kokkos::complex<RealType>(sin(x.real()) * cosh(x.imag()),
+                                   cos(x.real()) * sinh(x.imag()));
+}
+
+//! cosine of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> cos(
+    const complex<RealType>& x) {
+  using std::cos;
+  using std::cosh;
+  using std::sin;
+  using std::sinh;
+  return Kokkos::complex<RealType>(cos(x.real()) * cosh(x.imag()),
+                                   -sin(x.real()) * sinh(x.imag()));
+}
+
+//! tangent of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> tan(
+    const complex<RealType>& x) {
+  return sin(x) / cos(x);
+}
+
+//! hyperbolic sine of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sinh(
+    const complex<RealType>& x) {
+  using std::cos;
+  using std::cosh;
+  using std::sin;
+  using std::sinh;
+  return Kokkos::complex<RealType>(sinh(x.real()) * cos(x.imag()),
+                                   cosh(x.real()) * sin(x.imag()));
+}
+
+//! hyperbolic cosine of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> cosh(
+    const complex<RealType>& x) {
+  using std::cos;
+  using std::cosh;
+  using std::sin;
+  using std::sinh;
+  return Kokkos::complex<RealType>(cosh(x.real()) * cos(x.imag()),
+                                   sinh(x.real()) * sin(x.imag()));
+}
+
+//! hyperbolic tangent of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> tanh(
+    const complex<RealType>& x) {
+  return sinh(x) / cosh(x);
+}
+
+//! inverse hyperbolic sine of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> asinh(
+    const complex<RealType>& x) {
+  return log(x + sqrt(x * x + RealType(1.0)));
+}
+
+//! inverse hyperbolic cosine of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> acosh(
+    const complex<RealType>& x) {
+  return RealType(2.0) * log(sqrt(RealType(0.5) * (x + RealType(1.0))) +
+                             sqrt(RealType(0.5) * (x - RealType(1.0))));
+}
+
+//! inverse hyperbolic tangent of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> atanh(
+    const complex<RealType>& x) {
+  using std::atan2;
+  using std::log;
+
+  const RealType i2 = x.imag() * x.imag();
+  const RealType r  = RealType(1.0) - i2 - x.real() * x.real();
+
+  RealType p = RealType(1.0) + x.real();
+  RealType m = RealType(1.0) - x.real();
+
+  p = i2 + p * p;
+  m = i2 + m * m;
+
+  RealType phi = atan2(RealType(2.0) * x.imag(), r);
+  return Kokkos::complex<RealType>(RealType(0.25) * (log(p) - log(m)),
+                                   RealType(0.5) * phi);
+}
+
+//! inverse sine of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> asin(
+    const complex<RealType>& x) {
+  Kokkos::complex<RealType> t =
+      asinh(Kokkos::complex<RealType>(-x.imag(), x.real()));
+  return Kokkos::complex<RealType>(t.imag(), -t.real());
+}
+
+//! inverse cosine of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> acos(
+    const complex<RealType>& x) {
+  using std::acos;
+  Kokkos::complex<RealType> t = asin(x);
+  RealType pi_2               = acos(RealType(0.0));
+  return Kokkos::complex<RealType>(pi_2 - t.real(), -t.imag());
+}
+
+//! inverse tangent of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> atan(
+    const complex<RealType>& x) {
+  using std::atan2;
+  using std::log;
+  const RealType r2 = x.real() * x.real();
+  const RealType i  = RealType(1.0) - r2 - x.imag() * x.imag();
+
+  RealType p = x.imag() + RealType(1.0);
+  RealType m = x.imag() - RealType(1.0);
+
+  p = r2 + p * p;
+  m = r2 + m * m;
+
+  return Kokkos::complex<RealType>(
+      RealType(0.5) * atan2(RealType(2.0) * x.real(), i),
+      RealType(0.25) * log(p / m));
 }
 
 /// This function cannot be called in a CUDA device function,

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -320,6 +320,47 @@ struct TestComplexSpecialFunctions {
     r = Kokkos::exp(a);
     ASSERT_FLOAT_EQ(h_results(4).real(), r.real());
     ASSERT_FLOAT_EQ(h_results(4).imag(), r.imag());
+#ifndef KOKKOS_WORKAROUND_OPENMPTARGET_CLANG
+    r = std::log(a);
+    ASSERT_FLOAT_EQ(h_results(5).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(5).imag(), r.imag());
+    r = std::sin(a);
+    ASSERT_FLOAT_EQ(h_results(6).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(6).imag(), r.imag());
+    r = std::cos(a);
+    ASSERT_FLOAT_EQ(h_results(7).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(7).imag(), r.imag());
+    r = std::tan(a);
+    ASSERT_FLOAT_EQ(h_results(8).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(8).imag(), r.imag());
+    r = std::sinh(a);
+    ASSERT_FLOAT_EQ(h_results(9).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(9).imag(), r.imag());
+    r = std::cosh(a);
+    ASSERT_FLOAT_EQ(h_results(10).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(10).imag(), r.imag());
+    r = std::tanh(a);
+    ASSERT_FLOAT_EQ(h_results(11).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(11).imag(), r.imag());
+    r = std::asinh(a);
+    ASSERT_FLOAT_EQ(h_results(12).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(12).imag(), r.imag());
+    r = std::acosh(a);
+    ASSERT_FLOAT_EQ(h_results(13).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(13).imag(), r.imag());
+    r = std::atanh(a);
+    ASSERT_FLOAT_EQ(h_results(14).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(14).imag(), r.imag());
+    r = std::asin(a);
+    ASSERT_FLOAT_EQ(h_results(15).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(15).imag(), r.imag());
+    r = std::acos(a);
+    ASSERT_FLOAT_EQ(h_results(16).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(16).imag(), r.imag());
+    r = std::atan(a);
+    ASSERT_FLOAT_EQ(h_results(17).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(17).imag(), r.imag());
+#endif
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -328,11 +369,24 @@ struct TestComplexSpecialFunctions {
     Kokkos::complex<double> b(3.25, 5.75);
     double c = 9.3;
 
-    d_results(0) = Kokkos::complex<double>(Kokkos::real(a), Kokkos::imag(a));
-    d_results(1) = Kokkos::sqrt(a);
-    d_results(2) = Kokkos::pow(a, c);
-    d_results(3) = Kokkos::abs(a);
-    d_results(4) = Kokkos::exp(a);
+    d_results(0)  = Kokkos::complex<double>(Kokkos::real(a), Kokkos::imag(a));
+    d_results(1)  = Kokkos::sqrt(a);
+    d_results(2)  = Kokkos::pow(a, c);
+    d_results(3)  = Kokkos::abs(a);
+    d_results(4)  = Kokkos::exp(a);
+    d_results(5)  = Kokkos::log(a);
+    d_results(6)  = Kokkos::sin(a);
+    d_results(7)  = Kokkos::cos(a);
+    d_results(8)  = Kokkos::tan(a);
+    d_results(9)  = Kokkos::sinh(a);
+    d_results(10) = Kokkos::cosh(a);
+    d_results(11) = Kokkos::tanh(a);
+    d_results(12) = Kokkos::asinh(a);
+    d_results(13) = Kokkos::acosh(a);
+    d_results(14) = Kokkos::atanh(a);
+    d_results(15) = Kokkos::asin(a);
+    d_results(16) = Kokkos::acos(a);
+    d_results(17) = Kokkos::atan(a);
   }
 };
 


### PR DESCRIPTION
Expands support for Kokkos::complex to include other functions that std::complex supports.  Some key things to check:

1) To match the stdc++ implementation, I had to change the previous implementation of Kokkos::sqrt.  Previously, Kokkos::sqrt(x*x) != x and was discovered when I tried implement Kokkos::sinh.  I recommend making the change to avoid confusion over the Kokkos:: implementations not matching the std:: implementations in the GNU implementation of the STL.

2) I do not have immediate access to test these changes with HIP.  ~Everything related to __HIP_DEVICE_COMPILE__ is purely guesswork/cargo culting, so hopefully this can be automatically/manually tested prior to accepting this PR.~ Looks like these are obsolete, based on latest in develop.  Will add these back if needed.

3) I've only tested these changes with GNU/Clang, so I'm not sure if point 1 above applied to Intel/XL/PGI etc.  I still think ensuring sqrt(x*x) == x is a good idea with whatever is implemented for Kokkos::sqrt.