### PR TITLE
Prepare for deprecation of ViewAllocateWithoutInitializing

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -222,12 +222,12 @@ class BinSort {
         "Kokkos::SortImpl::BinSortFunctor::bin_count", bin_op.max_bins());
     bin_count_const = bin_count_atomic;
     bin_offsets =
-        offset_type(ViewAllocateWithoutInitializing(
-                        "Kokkos::SortImpl::BinSortFunctor::bin_offsets"),
+        offset_type(view_alloc(WithoutInitializing,
+                               "Kokkos::SortImpl::BinSortFunctor::bin_offsets"),
                     bin_op.max_bins());
     sort_order =
-        offset_type(ViewAllocateWithoutInitializing(
-                        "Kokkos::SortImpl::BinSortFunctor::sort_order"),
+        offset_type(view_alloc(WithoutInitializing,
+                               "Kokkos::SortImpl::BinSortFunctor::sort_order"),
                     range_end - range_begin);
   }
 
@@ -279,8 +279,8 @@ class BinSort {
     }
 
     scratch_view_type sorted_values(
-        ViewAllocateWithoutInitializing(
-            "Kokkos::SortImpl::BinSortFunctor::sorted_values"),
+        view_alloc(WithoutInitializing,
+                   "Kokkos::SortImpl::BinSortFunctor::sorted_values"),
         values.rank_dynamic > 0 ? len : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
         values.rank_dynamic > 1 ? values.extent(1)
                                 : KOKKOS_IMPL_CTOR_DEFAULT_ARG,

--- a/benchmarks/policy_performance/main.cpp
+++ b/benchmarks/policy_performance/main.cpp
@@ -146,11 +146,11 @@ int main(int argc, char* argv[]) {
   // Call a 'warmup' test with 1 repeat - this will initialize the corresponding
   // view appropriately for test and should obey first-touch etc Second call to
   // test is the one we actually care about and time
-  view_type_1d v_1(Kokkos::ViewAllocateWithoutInitializing("v_1"),
+  view_type_1d v_1(Kokkos::view_alloc(Kokkos::WithoutInitializing, "v_1"),
                    team_range * team_size);
-  view_type_2d v_2(Kokkos::ViewAllocateWithoutInitializing("v_2"),
+  view_type_2d v_2(Kokkos::view_alloc(Kokkos::WithoutInitializing, "v_2"),
                    team_range * team_size, thread_range);
-  view_type_3d v_3(Kokkos::ViewAllocateWithoutInitializing("v_3"),
+  view_type_3d v_3(Kokkos::view_alloc(Kokkos::WithoutInitializing, "v_3"),
                    team_range * team_size, thread_range, vector_range);
 
   double result_computed = 0.0;

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -245,21 +245,6 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
         h_view(create_mirror_view(d_view))  // without UVM, host View mirrors
   {}
 
-  explicit inline DualView(const ViewAllocateWithoutInitializing& arg_prop,
-                           const size_t arg_N0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                           const size_t arg_N1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                           const size_t arg_N2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                           const size_t arg_N3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                           const size_t arg_N4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                           const size_t arg_N5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                           const size_t arg_N6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                           const size_t arg_N7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
-      : DualView(Impl::ViewCtorProp<std::string,
-                                    Kokkos::Impl::WithoutInitializing_t>(
-                     arg_prop.label, Kokkos::WithoutInitializing),
-                 arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6,
-                 arg_N7) {}
-
   //! Copy constructor (shallow copy)
   template <class SS, class LS, class DS, class MS>
   DualView(const DualView<SS, LS, DS, MS>& src)

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1264,33 +1264,6 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
             typename traits::array_layout(arg_N0, arg_N1, arg_N2, arg_N3,
                                           arg_N4, arg_N5, arg_N6, arg_N7)) {}
 
-  // For backward compatibility
-  // NDE This ctor does not take ViewCtorProp argument - should not use
-  // alternative createLayout call
-  explicit inline DynRankView(const ViewAllocateWithoutInitializing& arg_prop,
-                              const typename traits::array_layout& arg_layout)
-      : DynRankView(
-            Kokkos::Impl::ViewCtorProp<std::string,
-                                       Kokkos::Impl::WithoutInitializing_t>(
-                arg_prop.label, Kokkos::WithoutInitializing),
-            arg_layout) {}
-
-  explicit inline DynRankView(const ViewAllocateWithoutInitializing& arg_prop,
-                              const size_t arg_N0 = KOKKOS_INVALID_INDEX,
-                              const size_t arg_N1 = KOKKOS_INVALID_INDEX,
-                              const size_t arg_N2 = KOKKOS_INVALID_INDEX,
-                              const size_t arg_N3 = KOKKOS_INVALID_INDEX,
-                              const size_t arg_N4 = KOKKOS_INVALID_INDEX,
-                              const size_t arg_N5 = KOKKOS_INVALID_INDEX,
-                              const size_t arg_N6 = KOKKOS_INVALID_INDEX,
-                              const size_t arg_N7 = KOKKOS_INVALID_INDEX)
-      : DynRankView(
-            Kokkos::Impl::ViewCtorProp<std::string,
-                                       Kokkos::Impl::WithoutInitializing_t>(
-                arg_prop.label, Kokkos::WithoutInitializing),
-            typename traits::array_layout(arg_N0, arg_N1, arg_N2, arg_N3,
-                                          arg_N4, arg_N5, arg_N6, arg_N7)) {}
-
   //----------------------------------------
   // Memory span required to wrap these dimensions.
   static constexpr size_t required_allocation_size(

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2017,7 +2017,7 @@ create_mirror_view_and_copy(
         nullptr) {
   using Mirror = typename Impl::MirrorDRViewType<Space, T, P...>::view_type;
   std::string label = name.empty() ? src.label() : name;
-  auto mirror       = Mirror(Kokkos::ViewAllocateWithoutInitializing(label),
+  auto mirror       = Mirror(view_alloc(WithoutInitializing, label),
                        Impl::reconstructLayout(src.layout(), src.rank()));
   deep_copy(mirror, src);
   return mirror;

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -2080,7 +2080,7 @@ create_mirror_view(const Space&,
 //    using Mirror = typename
 //    Kokkos::Experimental::Impl::MirrorViewType<Space,T,P ...>::view_type;
 //    std::string label = name.empty() ? src.label() : name;
-//    auto mirror = Mirror(ViewAllocateWithoutInitializing(label), src.layout(),
+//    auto mirror = Mirror(view_alloc(WithoutInitializing, label), src.layout(),
 //                         { src.begin(0), src.begin(1), src.begin(2),
 //                         src.begin(3), src.begin(4),
 //                             src.begin(5), src.begin(6), src.begin(7) });

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -931,8 +931,8 @@ class ScatterView<DataType, Kokkos::LayoutRight, DeviceType, Op,
   ScatterView(View<RT, RP...> const& original_view)
       : unique_token(),
         internal_view(
-            Kokkos::ViewAllocateWithoutInitializing(std::string("duplicated_") +
-                                                    original_view.label()),
+            view_alloc(WithoutInitializing,
+                       std::string("duplicated_") + original_view.label()),
             unique_token.size(),
             original_view.rank_dynamic > 0 ? original_view.extent(0)
                                            : KOKKOS_IMPL_CTOR_DEFAULT_ARG,
@@ -955,7 +955,7 @@ class ScatterView<DataType, Kokkos::LayoutRight, DeviceType, Op,
 
   template <typename... Dims>
   ScatterView(std::string const& name, Dims... dims)
-      : internal_view(Kokkos::ViewAllocateWithoutInitializing(name),
+      : internal_view(view_alloc(WithoutInitializing, name),
                       unique_token.size(), dims...) {
     reset();
   }
@@ -1094,8 +1094,8 @@ class ScatterView<DataType, Kokkos::LayoutLeft, DeviceType, Op,
                        KOKKOS_IMPL_CTOR_DEFAULT_ARG};
     arg_N[internal_view_type::rank - 1] = unique_token.size();
     internal_view                       = internal_view_type(
-        Kokkos::ViewAllocateWithoutInitializing(std::string("duplicated_") +
-                                                original_view.label()),
+        view_alloc(WithoutInitializing,
+                   std::string("duplicated_") + original_view.label()),
         arg_N[0], arg_N[1], arg_N[2], arg_N[3], arg_N[4], arg_N[5], arg_N[6],
         arg_N[7]);
     reset();
@@ -1121,9 +1121,9 @@ class ScatterView<DataType, Kokkos::LayoutLeft, DeviceType, Op,
                        KOKKOS_IMPL_CTOR_DEFAULT_ARG};
     Kokkos::Impl::Experimental::args_to_array(arg_N, 0, dims...);
     arg_N[internal_view_type::rank - 1] = unique_token.size();
-    internal_view                       = internal_view_type(
-        Kokkos::ViewAllocateWithoutInitializing(name), arg_N[0], arg_N[1],
-        arg_N[2], arg_N[3], arg_N[4], arg_N[5], arg_N[6], arg_N[7]);
+    internal_view = internal_view_type(view_alloc(WithoutInitializing, name),
+                                       arg_N[0], arg_N[1], arg_N[2], arg_N[3],
+                                       arg_N[4], arg_N[5], arg_N[6], arg_N[7]);
     reset();
   }
 

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -306,9 +306,9 @@ class UnorderedMap {
         m_equal_to(equal_to),
         m_size(),
         m_available_indexes(calculate_capacity(capacity_hint)),
-        m_hash_lists(ViewAllocateWithoutInitializing("UnorderedMap hash list"),
+        m_hash_lists(view_alloc(WithoutInitializing, "UnorderedMap hash list"),
                      Impl::find_hash_size(capacity())),
-        m_next_index(ViewAllocateWithoutInitializing("UnorderedMap next index"),
+        m_next_index(view_alloc(WithoutInitializing, "UnorderedMap next index"),
                      capacity() + 1)  // +1 so that the *_at functions can
                                       // always return a valid reference
         ,
@@ -729,16 +729,16 @@ class UnorderedMap {
       tmp.m_size              = src.size();
       tmp.m_available_indexes = bitset_type(src.capacity());
       tmp.m_hash_lists        = size_type_view(
-          ViewAllocateWithoutInitializing("UnorderedMap hash list"),
+          view_alloc(WithoutInitializing, "UnorderedMap hash list"),
           src.m_hash_lists.extent(0));
       tmp.m_next_index = size_type_view(
-          ViewAllocateWithoutInitializing("UnorderedMap next index"),
+          view_alloc(WithoutInitializing, "UnorderedMap next index"),
           src.m_next_index.extent(0));
       tmp.m_keys =
-          key_type_view(ViewAllocateWithoutInitializing("UnorderedMap keys"),
+          key_type_view(view_alloc(WithoutInitializing, "UnorderedMap keys"),
                         src.m_keys.extent(0));
       tmp.m_values = value_type_view(
-          ViewAllocateWithoutInitializing("UnorderedMap values"),
+          view_alloc(WithoutInitializing, "UnorderedMap values"),
           src.m_values.extent(0));
       tmp.m_scalars = scalars_view("UnorderedMap scalars");
 

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -108,7 +108,7 @@ struct test_dualview_combinations {
     if (with_init) {
       a = ViewType("A", n, m);
     } else {
-      a = ViewType(Kokkos::ViewAllocateWithoutInitializing("A"), n, m);
+      a = ViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "A"), n, m);
     }
     Kokkos::deep_copy(a.d_view, 1);
 

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -1063,8 +1063,8 @@ class TestDynViewAPI {
       (void)thing;
     }
 
-    dView0 d_uninitialized(Kokkos::ViewAllocateWithoutInitializing("uninit"),
-                           10, 20);
+    dView0 d_uninitialized(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "uninit"), 10, 20);
     ASSERT_TRUE(d_uninitialized.data() != nullptr);
     ASSERT_EQ(d_uninitialized.rank(), 2);
     ASSERT_EQ(d_uninitialized.extent(0), 10);

--- a/core/perf_test/PerfTest_ViewResize.hpp
+++ b/core/perf_test/PerfTest_ViewResize.hpp
@@ -120,7 +120,7 @@ void run_resizeview_tests123(int N, int R) {
     Kokkos::Timer timer;
     for (int r = 0; r < R; r++) {
       Kokkos::View<double*, Layout> a1(
-          Kokkos::ViewAllocateWithoutInitializing("A1"), int(N8 * 1.1));
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "A1"), int(N8 * 1.1));
       double* a1_ptr = a1.data();
       Kokkos::parallel_for(
           N8, KOKKOS_LAMBDA(const int& i) { a1_ptr[i] = a_ptr[i]; });
@@ -201,7 +201,7 @@ void run_resizeview_tests45(int N, int R) {
     Kokkos::Timer timer;
     for (int r = 0; r < R; r++) {
       Kokkos::View<double*, Layout> a1(
-          Kokkos::ViewAllocateWithoutInitializing("A1"), int(N8 * 1.1));
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "A1"), int(N8 * 1.1));
       double* a1_ptr = a1.data();
       Kokkos::parallel_for(
           N8, KOKKOS_LAMBDA(const int& i) { a1_ptr[i] = a_ptr[i]; });
@@ -258,7 +258,7 @@ void run_resizeview_tests6(int N, int R) {
     Kokkos::Timer timer;
     for (int r = 0; r < R; r++) {
       Kokkos::View<double*, Layout> a1(
-          Kokkos::ViewAllocateWithoutInitializing("A1"), int(N8 * 1.1));
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "A1"), int(N8 * 1.1));
       double* a1_ptr = a1.data();
       Kokkos::parallel_for(
           N8, KOKKOS_LAMBDA(const int& i) { a1_ptr[i] = a_ptr[i]; });
@@ -311,7 +311,7 @@ void run_resizeview_tests7(int N, int R) {
     Kokkos::Timer timer;
     for (int r = 0; r < R; r++) {
       Kokkos::View<double*, Layout> a1(
-          Kokkos::ViewAllocateWithoutInitializing("A1"), int(N8 * 1.1));
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "A1"), int(N8 * 1.1));
       double* a1_ptr = a1.data();
       Kokkos::parallel_for(
           N8, KOKKOS_LAMBDA(const int& i) { a1_ptr[i] = a_ptr[i]; });
@@ -366,7 +366,7 @@ void run_resizeview_tests8(int N, int R) {
     Kokkos::Timer timer;
     for (int r = 0; r < R; r++) {
       Kokkos::View<double*, Layout> a1(
-          Kokkos::ViewAllocateWithoutInitializing("A1"), int(N8 * 1.1));
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "A1"), int(N8 * 1.1));
       double* a1_ptr = a1.data();
       Kokkos::parallel_for(
           N8, KOKKOS_LAMBDA(const int& i) { a1_ptr[i] = a_ptr[i]; });

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3221,7 +3221,7 @@ create_mirror_view_and_copy(
   using Mirror      = typename Impl::MirrorViewType<Space, T, P...>::view_type;
   std::string label = name.empty() ? src.label() : name;
   auto mirror       = typename Mirror::non_const_type{
-      ViewAllocateWithoutInitializing(label), src.layout()};
+      view_alloc(WithoutInitializing, label), src.layout()};
   deep_copy(mirror, src);
   return mirror;
 }
@@ -3248,8 +3248,7 @@ typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
         !Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* =
         nullptr) {
   using Mirror = typename Impl::MirrorViewType<Space, T, P...>::view_type;
-  return Mirror(Kokkos::ViewAllocateWithoutInitializing(src.label()),
-                src.layout());
+  return Mirror(view_alloc(WithoutInitializing, src.label()), src.layout());
 }
 
 } /* namespace Kokkos */

--- a/core/src/Kokkos_Crs.hpp
+++ b/core/src/Kokkos_Crs.hpp
@@ -287,7 +287,7 @@ void get_crs_transpose_counts(
 template <class OutRowMap, class InCounts>
 typename OutRowMap::value_type get_crs_row_map_from_counts(
     OutRowMap& out, InCounts const& in, std::string const& name) {
-  out = OutRowMap(ViewAllocateWithoutInitializing(name), in.size() + 1);
+  out = OutRowMap(view_alloc(WithoutInitializing, name), in.size() + 1);
   Kokkos::Impl::CrsRowMapFromCounts<InCounts, OutRowMap> functor(in, out);
   return functor.execute();
 }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1706,41 +1706,6 @@ class View : public ViewTraits<DataType, Properties...> {
 #endif
   }
 
-  // For backward compatibility
-  explicit inline View(const ViewAllocateWithoutInitializing& arg_prop,
-                       const typename traits::array_layout& arg_layout)
-      : View(Impl::ViewCtorProp<std::string,
-                                Kokkos::Impl::WithoutInitializing_t>(
-                 arg_prop.label, Kokkos::WithoutInitializing),
-             arg_layout) {}
-
-  explicit inline View(const ViewAllocateWithoutInitializing& arg_prop,
-                       const size_t arg_N0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                       const size_t arg_N7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
-      : View(Impl::ViewCtorProp<std::string,
-                                Kokkos::Impl::WithoutInitializing_t>(
-                 arg_prop.label, Kokkos::WithoutInitializing),
-             typename traits::array_layout(arg_N0, arg_N1, arg_N2, arg_N3,
-                                           arg_N4, arg_N5, arg_N6, arg_N7)) {
-#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
-    Impl::runtime_check_rank_host(
-        traits::rank_dynamic,
-        std::is_same<typename traits::specialize, void>::value, arg_N0, arg_N1,
-        arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7, label());
-#else
-    Impl::runtime_check_rank_device(
-        traits::rank_dynamic,
-        std::is_same<typename traits::specialize, void>::value, arg_N0, arg_N1,
-        arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7);
-
-#endif
-  }
   // Construct view from ViewTracker and map
   // This should be the preferred method because future extensions may need to
   // use the ViewTracker class.

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -49,27 +49,6 @@
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-
-/* For backward compatibility */
-
-struct ViewAllocateWithoutInitializing {
-  const std::string label;
-
-  ViewAllocateWithoutInitializing() : label() {}
-
-  explicit ViewAllocateWithoutInitializing(const std::string &arg_label)
-      : label(arg_label) {}
-
-  explicit ViewAllocateWithoutInitializing(const char *const arg_label)
-      : label(arg_label) {}
-};
-
-} /* namespace Kokkos */
-
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
-
-namespace Kokkos {
 namespace Impl {
 
 struct WithoutInitializing_t {};
@@ -284,6 +263,27 @@ struct ViewCtorProp : public ViewCtorProp<void, P>... {
 };
 
 } /* namespace Impl */
+} /* namespace Kokkos */
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace Kokkos {
+
+/* For backward compatibility */
+
+struct ViewAllocateWithoutInitializing {
+  const std::string label;
+
+  ViewAllocateWithoutInitializing() : label() {}
+
+  explicit ViewAllocateWithoutInitializing(const std::string &arg_label)
+      : label(arg_label) {}
+
+  explicit ViewAllocateWithoutInitializing(const char *const arg_label)
+      : label(arg_label) {}
+};
+
 } /* namespace Kokkos */
 
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -272,17 +272,11 @@ namespace Kokkos {
 
 /* For backward compatibility */
 
-struct ViewAllocateWithoutInitializing {
-  const std::string label;
-
-  ViewAllocateWithoutInitializing() : label() {}
-
-  explicit ViewAllocateWithoutInitializing(const std::string &arg_label)
-      : label(arg_label) {}
-
-  explicit ViewAllocateWithoutInitializing(const char *const arg_label)
-      : label(arg_label) {}
-};
+template <typename AlwaysVoid = void>
+Impl::ViewCtorProp<std::string, Impl::WithoutInitializing_t>
+ViewAllocateWithoutInitializing(std::string label) {
+  return {std::move(label), Impl::WithoutInitializing_t()};
+}
 
 } /* namespace Kokkos */
 

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -275,6 +275,7 @@ namespace Kokkos {
 // NOTE Cheap trick to avoid duplicated symbol error.  The alternative is
 // moving the definition to a .cpp file.
 template <typename AlwaysVoid = void>
+/*[[deprecated(Use Kokkos::alloc(Kokkos::WithoutInitializing, label) instead]]*/
 Impl::ViewCtorProp<std::string, Impl::WithoutInitializing_t>
 ViewAllocateWithoutInitializing(std::string label) {
   return {std::move(label), Impl::WithoutInitializing_t()};

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -272,6 +272,8 @@ namespace Kokkos {
 
 /* For backward compatibility */
 
+// NOTE Cheap trick to avoid duplicated symbol error.  The alternative is
+// moving the definition to a .cpp file.
 template <typename AlwaysVoid = void>
 Impl::ViewCtorProp<std::string, Impl::WithoutInitializing_t>
 ViewAllocateWithoutInitializing(std::string label) {

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -271,15 +271,30 @@ struct ViewCtorProp : public ViewCtorProp<void, P>... {
 namespace Kokkos {
 
 /* For backward compatibility */
+namespace Impl {
+struct ViewAllocateWithoutInitializingBackwardCompat {};
 
-// NOTE Cheap trick to avoid duplicated symbol error.  The alternative is
-// moving the definition to a .cpp file.
-template <typename AlwaysVoid = void>
+template <>
+struct ViewCtorProp<void, ViewAllocateWithoutInitializingBackwardCompat> {};
+
+// NOTE This specialization is meant to be used as the
+// ViewAllocateWithoutInitializing alias below. All it does is add a
+// constructor that takes the label as single argument.
+template <>
+struct ViewCtorProp<WithoutInitializing_t, std::string,
+                    ViewAllocateWithoutInitializingBackwardCompat>
+    : ViewCtorProp<WithoutInitializing_t, std::string>,
+      ViewCtorProp<void, ViewAllocateWithoutInitializingBackwardCompat> {
+  ViewCtorProp(std::string label)
+      : ViewCtorProp<WithoutInitializing_t, std::string>(
+            WithoutInitializing_t(), std::move(label)) {}
+};
+} /* namespace Impl */
+
 /*[[deprecated(Use Kokkos::alloc(Kokkos::WithoutInitializing, label) instead]]*/
-Impl::ViewCtorProp<std::string, Impl::WithoutInitializing_t>
-ViewAllocateWithoutInitializing(std::string label) {
-  return {std::move(label), Impl::WithoutInitializing_t()};
-}
+using ViewAllocateWithoutInitializing =
+    Impl::ViewCtorProp<Impl::WithoutInitializing_t, std::string,
+                       Impl::ViewAllocateWithoutInitializingBackwardCompat>;
 
 } /* namespace Kokkos */
 

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -72,8 +72,9 @@ struct TestRange {
   int offset;
 #endif
   TestRange(const size_t N_)
-      : m_flags(Kokkos::ViewAllocateWithoutInitializing("flags"), N_),
-        result_view(Kokkos::ViewAllocateWithoutInitializing("results"), N_),
+      : m_flags(Kokkos::view_alloc(Kokkos::WithoutInitializing, "flags"), N_),
+        result_view(Kokkos::view_alloc(Kokkos::WithoutInitializing, "results"),
+                    N_),
         N(N_) {
 #ifdef KOKKOS_WORKAROUND_OPENMPTARGET_GCC
     offset = 13;

--- a/core/unit_test/TestRangeRequire.hpp
+++ b/core/unit_test/TestRangeRequire.hpp
@@ -71,7 +71,8 @@ struct TestRangeRequire {
   int N;
   static const int offset = 13;
   TestRangeRequire(const size_t N_)
-      : m_flags(Kokkos::ViewAllocateWithoutInitializing("flags"), N_), N(N_) {}
+      : m_flags(Kokkos::view_alloc(Kokkos::WithoutInitializing, "flags"), N_),
+        N(N_) {}
 
   void test_for() {
     typename view_type::HostMirror host_flags =

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -62,7 +62,7 @@ struct TestTeamPolicy {
   view_type m_flags;
 
   TestTeamPolicy(const size_t league_size)
-      : m_flags(Kokkos::ViewAllocateWithoutInitializing("flags"),
+      : m_flags(Kokkos::view_alloc(Kokkos::WithoutInitializing, "flags"),
                 Kokkos::TeamPolicy<ScheduleType, ExecSpace>(1, 1).team_size_max(
                     *this, Kokkos::ParallelReduceTag()),
                 league_size) {}

--- a/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
+++ b/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
@@ -157,4 +157,10 @@ TEST(TEST_CATEGORY, viewctorprop_embedded_dim) {
   TestViewCtorProp_EmbeddedDim<TEST_EXECSPACE>::test_vcpt(2, 3);
 }
 
+TEST(TEST_CATEGORY,
+     viewctorpop_view_allocate_without_initializing_backward_compatility) {
+  using deprecated_view_alloc = Kokkos::ViewAllocateWithoutInitializing;
+  Kokkos::View<int**, TEST_EXECSPACE> v(deprecated_view_alloc("v"), 5, 7);
+}
+
 }  // namespace Test


### PR DESCRIPTION
Per comment in the code, `ViewAllocateWithoutInitializing` was there only for backward compatibility.  Moving away from it allows us to get rid of two `View` constructor overloads*.
~~Admittedly the changes I propose would break code that relied on `Kokkos::ViewAllocateWithoutInitializing` being an actual type but I think it is ok.~~

I considered adding an implicit conversion from `ViewAllocateWithoutInitializing` to `Impl::ViewCtorProp<std::string,Impl::WithoutInitializing_t>` because that solution would be safer for code downstream.  In fact, it was originally my plan but it turned out to be harder than I thought.  I managed to implement it with the help from @nliber but it forced me to change all the overloads that took `Impl::ViewCtorProp<P...>` and I ended dropping the idea because the complexity added was not worth it.

You will notice I haven't actually yet deprecated the use of `ViewAllocateWithoutInitializing`.   My intent is to make sure we remove it from all examples and tutorials and perform the deprecation later.  Hopefully by then we will be able to use the deprecated attribute from C++14.

**TLDR** Make `ViewAllocateWithoutInitializing` a ~~function that generates a `Impl::ViewCtorProp` rather a concrete type~~ **an alias** in preparation for deprecation/removal.


*Don't worry we still have 14 besides besides the special members!