### PR TITLE
Temporarily use HIP_DYNAMIC_SHARED to declare LDS

### DIFF
--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -64,7 +64,7 @@ namespace Kokkos {
 namespace Experimental {
 template <typename T>
 inline __device__ T *kokkos_impl_hip_shared_memory() {
-  extern __shared__ HIPSpace::size_type sh[];
+  HIP_DYNAMIC_SHARED(HIPSpace::size_type, sh);
   return (T *)sh;
 }
 }  // namespace Experimental


### PR DESCRIPTION
This macro takes into account any static LDS allocated by the the compiler.  We are working on a fix for this in the compiler, but it hasn't landed yet.