### PR TITLE
Fix multi stream scratch

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -931,29 +931,6 @@ void SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::print_records(
 // </editor-fold> end SharedAllocationRecord::print_records() }}}1
 //==============================================================================
 
-void *cuda_resize_scratch_space(std::int64_t bytes, bool force_shrink) {
-  static void *ptr                 = nullptr;
-  static std::int64_t current_size = 0;
-  if (current_size == 0) {
-    current_size = bytes;
-    ptr = Kokkos::kokkos_malloc<Kokkos::CudaSpace>("CudaSpace::ScratchMemory",
-                                                   current_size);
-  }
-  if (bytes > current_size) {
-    current_size = bytes;
-    Kokkos::kokkos_free<Kokkos::CudaSpace>(ptr);
-    ptr = Kokkos::kokkos_malloc<Kokkos::CudaSpace>("CudaSpace::ScratchMemory",
-                                                   current_size);
-  }
-  if ((bytes < current_size) && (force_shrink)) {
-    current_size = bytes;
-    Kokkos::kokkos_free<Kokkos::CudaSpace>(ptr);
-    ptr = Kokkos::kokkos_malloc<Kokkos::CudaSpace>("CudaSpace::ScratchMemory",
-                                                   current_size);
-  }
-  return ptr;
-}
-
 void cuda_prefetch_pointer(const Cuda &space, const void *ptr, size_t bytes,
                            bool to_device) {
   if ((ptr == nullptr) || (bytes == 0)) return;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -277,23 +277,25 @@ CudaInternal::~CudaInternal() {
     std::cerr.flush();
   }
 
-  m_cudaDev                 = -1;
-  m_cudaArch                = -1;
-  m_multiProcCount          = 0;
-  m_maxWarpCount            = 0;
-  m_maxBlock                = 0;
-  m_maxSharedWords          = 0;
-  m_maxConcurrency          = 0;
-  m_scratchSpaceCount       = 0;
-  m_scratchFlagsCount       = 0;
-  m_scratchUnifiedCount     = 0;
-  m_scratchUnifiedSupported = 0;
-  m_streamCount             = 0;
-  m_scratchSpace            = nullptr;
-  m_scratchFlags            = nullptr;
-  m_scratchUnified          = nullptr;
-  m_scratchConcurrentBitset = nullptr;
-  m_stream                  = nullptr;
+  m_cudaDev                   = -1;
+  m_cudaArch                  = -1;
+  m_multiProcCount            = 0;
+  m_maxWarpCount              = 0;
+  m_maxBlock                  = 0;
+  m_maxSharedWords            = 0;
+  m_maxConcurrency            = 0;
+  m_scratchSpaceCount         = 0;
+  m_scratchFlagsCount         = 0;
+  m_scratchUnifiedCount       = 0;
+  m_scratchUnifiedSupported   = 0;
+  m_streamCount               = 0;
+  m_scratchSpace              = nullptr;
+  m_scratchFlags              = nullptr;
+  m_scratchUnified            = nullptr;
+  m_scratchConcurrentBitset   = nullptr;
+  m_stream                    = nullptr;
+  m_team_scratch_current_size = 0;
+  m_team_scratch_ptr          = nullptr;
 }
 
 int CudaInternal::verify_is_initialized(const char *const label) const {
@@ -552,7 +554,9 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream) {
     CUDA_SAFE_CALL(cudaEventCreate(&constantMemReusable));
   }
 
-  m_stream = stream;
+  m_stream                    = stream;
+  m_team_scratch_current_size = 0;
+  m_team_scratch_ptr          = nullptr;
 }
 
 //----------------------------------------------------------------------------
@@ -653,6 +657,28 @@ Cuda::size_type *CudaInternal::scratch_functor(
   return m_scratchFunctor;
 }
 
+void *CudaInternal::resize_team_scratch_space(std::int64_t bytes,
+                                              bool force_shrink) {
+  if (m_team_scratch_current_size == 0) {
+    m_team_scratch_current_size = bytes;
+    m_team_scratch_ptr          = Kokkos::kokkos_malloc<Kokkos::CudaSpace>(
+        "CudaSpace::ScratchMemory", m_team_scratch_current_size);
+  }
+  if (bytes > m_team_scratch_current_size) {
+    m_team_scratch_current_size = bytes;
+    Kokkos::kokkos_free<Kokkos::CudaSpace>(m_team_scratch_ptr);
+    m_team_scratch_ptr = Kokkos::kokkos_malloc<Kokkos::CudaSpace>(
+        "CudaSpace::ScratchMemory", m_team_scratch_current_size);
+  }
+  if ((bytes < m_team_scratch_current_size) && (force_shrink)) {
+    m_team_scratch_current_size = bytes;
+    Kokkos::kokkos_free<Kokkos::CudaSpace>(m_team_scratch_ptr);
+    m_team_scratch_ptr = Kokkos::kokkos_malloc<Kokkos::CudaSpace>(
+        "CudaSpace::ScratchMemory", m_team_scratch_current_size);
+  }
+  return m_team_scratch_ptr;
+}
+
 //----------------------------------------------------------------------------
 
 void CudaInternal::finalize() {
@@ -671,20 +697,25 @@ void CudaInternal::finalize() {
     if (m_scratchFunctorSize > 0)
       RecordCuda::decrement(RecordCuda::get_record(m_scratchFunctor));
 
-    m_cudaDev                 = -1;
-    m_multiProcCount          = 0;
-    m_maxWarpCount            = 0;
-    m_maxBlock                = 0;
-    m_maxSharedWords          = 0;
-    m_scratchSpaceCount       = 0;
-    m_scratchFlagsCount       = 0;
-    m_scratchUnifiedCount     = 0;
-    m_streamCount             = 0;
-    m_scratchSpace            = nullptr;
-    m_scratchFlags            = nullptr;
-    m_scratchUnified          = nullptr;
-    m_scratchConcurrentBitset = nullptr;
-    m_stream                  = nullptr;
+    if (m_team_scratch_current_size > 0)
+      Kokkos::kokkos_free<Kokkos::CudaSpace>(m_team_scratch_ptr);
+
+    m_cudaDev                   = -1;
+    m_multiProcCount            = 0;
+    m_maxWarpCount              = 0;
+    m_maxBlock                  = 0;
+    m_maxSharedWords            = 0;
+    m_scratchSpaceCount         = 0;
+    m_scratchFlagsCount         = 0;
+    m_scratchUnifiedCount       = 0;
+    m_streamCount               = 0;
+    m_scratchSpace              = nullptr;
+    m_scratchFlags              = nullptr;
+    m_scratchUnified            = nullptr;
+    m_scratchConcurrentBitset   = nullptr;
+    m_stream                    = nullptr;
+    m_team_scratch_current_size = 0;
+    m_team_scratch_ptr          = nullptr;
   }
 
   // only destroy these if we're finalizing the singleton

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -104,10 +104,12 @@ class CudaInternal {
 
   cudaDeviceProp m_deviceProp;
 
+  // Scratch Spaces for Reductions
   mutable size_type m_scratchSpaceCount;
   mutable size_type m_scratchFlagsCount;
   mutable size_type m_scratchUnifiedCount;
   mutable size_type m_scratchFunctorSize;
+
   size_type m_scratchUnifiedSupported;
   size_type m_streamCount;
   mutable size_type* m_scratchSpace;
@@ -116,6 +118,10 @@ class CudaInternal {
   mutable size_type* m_scratchFunctor;
   uint32_t* m_scratchConcurrentBitset;
   cudaStream_t m_stream;
+
+  // Team Scratch Level 1 Space
+  mutable int64_t m_team_scratch_current_size;
+  mutable void* m_team_scratch_ptr;
 
   bool was_initialized = false;
   bool was_finalized   = false;
@@ -172,12 +178,19 @@ class CudaInternal {
         m_scratchUnified(nullptr),
         m_scratchFunctor(nullptr),
         m_scratchConcurrentBitset(nullptr),
-        m_stream(nullptr) {}
+        m_stream(nullptr),
+        m_team_scratch_current_size(0),
+        m_team_scratch_ptr(nullptr) {}
 
+  // Resizing of reduction related scratch spaces
   size_type* scratch_space(const size_type size) const;
   size_type* scratch_flags(const size_type size) const;
   size_type* scratch_unified(const size_type size) const;
   size_type* scratch_functor(const size_type size) const;
+
+  // Resizing of team level 1 scratch
+  void* resize_team_scratch_space(std::int64_t bytes,
+                                  bool force_shrink = false);
 };
 
 }  // Namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -290,15 +290,19 @@ struct CudaParallelLaunch<
   }
 
   static cudaFuncAttributes get_cuda_func_attributes() {
-    static cudaFuncAttributes attr;
-    static bool attr_set = false;
-    if (!attr_set) {
+    // Race condition inside of cudaFuncGetAttributes if the same address is
+    // given requires using a local variable as input instead of a static Rely
+    // on static variable initialization to make sure only one thread executes
+    // the code and the result is visible.
+    auto wrap_get_attributes = []() -> cudaFuncAttributes {
+      cudaFuncAttributes attr_tmp;
       CUDA_SAFE_CALL(cudaFuncGetAttributes(
-          &attr,
+          &attr_tmp,
           cuda_parallel_launch_constant_memory<DriverType, MaxThreadsPerBlock,
                                                MinBlocksPerSM>));
-      attr_set = true;
-    }
+      return attr_tmp;
+    };
+    static cudaFuncAttributes attr = wrap_get_attributes();
     return attr;
   }
 };
@@ -364,13 +368,17 @@ struct CudaParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
   }
 
   static cudaFuncAttributes get_cuda_func_attributes() {
-    static cudaFuncAttributes attr;
-    static bool attr_set = false;
-    if (!attr_set) {
+    // Race condition inside of cudaFuncGetAttributes if the same address is
+    // given requires using a local variable as input instead of a static Rely
+    // on static variable initialization to make sure only one thread executes
+    // the code and the result is visible.
+    auto wrap_get_attributes = []() -> cudaFuncAttributes {
+      cudaFuncAttributes attr_tmp;
       CUDA_SAFE_CALL(cudaFuncGetAttributes(
-          &attr, cuda_parallel_launch_constant_memory<DriverType>));
-      attr_set = true;
-    }
+          &attr_tmp, cuda_parallel_launch_constant_memory<DriverType>));
+      return attr_tmp;
+    };
+    static cudaFuncAttributes attr = wrap_get_attributes();
     return attr;
   }
 };
@@ -424,15 +432,19 @@ struct CudaParallelLaunch<
   }
 
   static cudaFuncAttributes get_cuda_func_attributes() {
-    static cudaFuncAttributes attr;
-    static bool attr_set = false;
-    if (!attr_set) {
+    // Race condition inside of cudaFuncGetAttributes if the same address is
+    // given requires using a local variable as input instead of a static Rely
+    // on static variable initialization to make sure only one thread executes
+    // the code and the result is visible.
+    auto wrap_get_attributes = []() -> cudaFuncAttributes {
+      cudaFuncAttributes attr_tmp;
       CUDA_SAFE_CALL(cudaFuncGetAttributes(
-          &attr,
+          &attr_tmp,
           cuda_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
                                             MinBlocksPerSM>));
-      attr_set = true;
-    }
+      return attr_tmp;
+    };
+    static cudaFuncAttributes attr = wrap_get_attributes();
     return attr;
   }
 };
@@ -482,13 +494,17 @@ struct CudaParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
   }
 
   static cudaFuncAttributes get_cuda_func_attributes() {
-    static cudaFuncAttributes attr;
-    static bool attr_set = false;
-    if (!attr_set) {
+    // Race condition inside of cudaFuncGetAttributes if the same address is
+    // given requires using a local variable as input instead of a static Rely
+    // on static variable initialization to make sure only one thread executes
+    // the code and the result is visible.
+    auto wrap_get_attributes = []() -> cudaFuncAttributes {
+      cudaFuncAttributes attr_tmp;
       CUDA_SAFE_CALL(cudaFuncGetAttributes(
-          &attr, cuda_parallel_launch_local_memory<DriverType>));
-      attr_set = true;
-    }
+          &attr_tmp, cuda_parallel_launch_local_memory<DriverType>));
+      return attr_tmp;
+    };
+    static cudaFuncAttributes attr = wrap_get_attributes();
     return attr;
   }
 };
@@ -544,15 +560,19 @@ struct CudaParallelLaunch<
     }
   }
   static cudaFuncAttributes get_cuda_func_attributes() {
-    static cudaFuncAttributes attr;
-    static bool attr_set = false;
-    if (!attr_set) {
+    // Race condition inside of cudaFuncGetAttributes if the same address is
+    // given requires using a local variable as input instead of a static Rely
+    // on static variable initialization to make sure only one thread executes
+    // the code and the result is visible.
+    auto wrap_get_attributes = []() -> cudaFuncAttributes {
+      cudaFuncAttributes attr_tmp;
       CUDA_SAFE_CALL(cudaFuncGetAttributes(
-          &attr,
+          &attr_tmp,
           cuda_parallel_launch_global_memory<DriverType, MaxThreadsPerBlock,
                                              MinBlocksPerSM>));
-      attr_set = true;
-    }
+      return attr_tmp;
+    };
+    static cudaFuncAttributes attr = wrap_get_attributes();
     return attr;
   }
 };
@@ -604,13 +624,17 @@ struct CudaParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
   }
 
   static cudaFuncAttributes get_cuda_func_attributes() {
-    static cudaFuncAttributes attr;
-    static bool attr_set = false;
-    if (!attr_set) {
+    // Race condition inside of cudaFuncGetAttributes if the same address is
+    // given requires using a local variable as input instead of a static Rely
+    // on static variable initialization to make sure only one thread executes
+    // the code and the result is visible.
+    auto wrap_get_attributes = []() -> cudaFuncAttributes {
+      cudaFuncAttributes attr_tmp;
       CUDA_SAFE_CALL(cudaFuncGetAttributes(
-          &attr, cuda_parallel_launch_global_memory<DriverType>));
-      attr_set = true;
-    }
+          &attr_tmp, cuda_parallel_launch_global_memory<DriverType>));
+      return attr_tmp;
+    };
+    static cudaFuncAttributes attr = wrap_get_attributes();
     return attr;
   }
 };

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -75,12 +75,6 @@ __device__ __constant__ unsigned long kokkos_impl_cuda_constant_memory_buffer
 
 #endif
 
-namespace Kokkos {
-namespace Impl {
-void* cuda_resize_scratch_space(std::int64_t bytes, bool force_shrink = false);
-}
-}  // namespace Kokkos
-
 template <typename T>
 inline __device__ T* kokkos_impl_cuda_shared_memory() {
   extern __shared__ Kokkos::CudaSpace::size_type sh[];

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -775,10 +775,12 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     m_scratch_ptr[1] =
         m_team_size <= 0
             ? nullptr
-            : cuda_resize_scratch_space(
-                  static_cast<ptrdiff_t>(m_scratch_size[1]) *
-                  static_cast<ptrdiff_t>(Cuda::concurrency() /
-                                         (m_team_size * m_vector_size)));
+            : m_policy.space()
+                  .impl_internal_space_instance()
+                  ->resize_team_scratch_space(
+                      static_cast<ptrdiff_t>(m_scratch_size[1]) *
+                      static_cast<ptrdiff_t>(Cuda::concurrency() /
+                                             (m_team_size * m_vector_size)));
 
     const int shmem_size_total = m_shmem_begin + m_shmem_size;
     if (m_policy.space().impl_internal_space_instance()->m_maxShmemPerBlock <
@@ -1750,10 +1752,13 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     m_scratch_ptr[1] =
         m_team_size <= 0
             ? nullptr
-            : cuda_resize_scratch_space(
-                  static_cast<std::int64_t>(m_scratch_size[1]) *
-                  (static_cast<std::int64_t>(Cuda::concurrency() /
-                                             (m_team_size * m_vector_size))));
+            : m_policy.space()
+                  .impl_internal_space_instance()
+                  ->resize_team_scratch_space(
+                      static_cast<std::int64_t>(m_scratch_size[1]) *
+                      (static_cast<std::int64_t>(
+                          Cuda::concurrency() /
+                          (m_team_size * m_vector_size))));
 
     // The global parallel_reduce does not support vector_length other than 1 at
     // the moment
@@ -1849,10 +1854,12 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     m_scratch_ptr[1] =
         m_team_size <= 0
             ? nullptr
-            : cuda_resize_scratch_space(
-                  static_cast<ptrdiff_t>(m_scratch_size[1]) *
-                  static_cast<ptrdiff_t>(Cuda::concurrency() /
-                                         (m_team_size * m_vector_size)));
+            : m_policy.space()
+                  .impl_internal_space_instance()
+                  ->resize_team_scratch_space(
+                      static_cast<ptrdiff_t>(m_scratch_size[1]) *
+                      static_cast<ptrdiff_t>(Cuda::concurrency() /
+                                             (m_team_size * m_vector_size)));
 
     // The global parallel_reduce does not support vector_length other than 1 at
     // the moment


### PR DESCRIPTION
This fixes #3246 by making team scratch allocations a per Cuda instance property instead of global. 