### PR TITLE
OpenMPTarget: MD implementation for parallel_for and parallel_reduce. 

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -84,7 +84,7 @@ namespace Impl {
 
 template <class Reducer>
 struct OpenMPTargetReducerWrapper {
-  typedef typename Reducer::value_type value_type;
+  using value_type = typename Reducer::value_type;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -117,7 +117,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<Sum<Scalar, Space>> {
  public:
   // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
+  using value_type = typename std::remove_cv<Scalar>::type;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -143,7 +143,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<Prod<Scalar, Space>> {
  public:
   // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
+  using value_type = typename std::remove_cv<Scalar>::type;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -169,7 +169,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<Min<Scalar, Space>> {
  public:
   // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
+  using value_type = typename std::remove_cv<Scalar>::type;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -197,7 +197,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<Max<Scalar, Space>> {
  public:
   // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
+  using value_type = typename std::remove_cv<Scalar>::type;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -226,7 +226,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<LAnd<Scalar, Space>> {
  public:
   // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
+  using value_type = typename std::remove_cv<Scalar>::type;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -253,9 +253,9 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<LOr<Scalar, Space>> {
  public:
   // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
+  using value_type = typename std::remove_cv<Scalar>::type;
 
-  typedef Kokkos::View<value_type, Space> result_view_type;
+  using result_view_type = Kokkos::View<value_type, Space>;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -283,7 +283,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<BAnd<Scalar, Space>> {
  public:
   // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
+  using value_type = typename std::remove_cv<Scalar>::type;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -311,7 +311,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<BOr<Scalar, Space>> {
  public:
   // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
+  using value_type = typename std::remove_cv<Scalar>::type;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -338,12 +338,12 @@ struct OpenMPTargetReducerWrapper<BOr<Scalar, Space>> {
 template <class Scalar, class Index, class Space>
 struct OpenMPTargetReducerWrapper<MinLoc<Scalar, Index, Space>> {
  private:
-  typedef typename std::remove_cv<Scalar>::type scalar_type;
-  typedef typename std::remove_cv<Index>::type index_type;
+  using scalar_type = typename std::remove_cv<Scalar>::type;
+  using index_type  = typename std::remove_cv<Index>::type;
 
  public:
   // Required
-  typedef ValLocScalar<scalar_type, index_type> value_type;
+  using value_type = ValLocScalar<scalar_type, index_type>;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -371,12 +371,12 @@ struct OpenMPTargetReducerWrapper<MinLoc<Scalar, Index, Space>> {
 template <class Scalar, class Index, class Space>
 struct OpenMPTargetReducerWrapper<MaxLoc<Scalar, Index, Space>> {
  private:
-  typedef typename std::remove_cv<Scalar>::type scalar_type;
-  typedef typename std::remove_cv<Index>::type index_type;
+  using scalar_type = typename std::remove_cv<Scalar>::type;
+  using index_type  = typename std::remove_cv<Index>::type;
 
  public:
   // Required
-  typedef ValLocScalar<scalar_type, index_type> value_type;
+  using value_type = ValLocScalar<scalar_type, index_type>;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -403,11 +403,11 @@ struct OpenMPTargetReducerWrapper<MaxLoc<Scalar, Index, Space>> {
 template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<MinMax<Scalar, Space>> {
  private:
-  typedef typename std::remove_cv<Scalar>::type scalar_type;
+  using scalar_type = typename std::remove_cv<Scalar>::type;
 
  public:
   // Required
-  typedef MinMaxScalar<scalar_type> value_type;
+  using value_type = MinMaxScalar<scalar_type>;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -445,12 +445,12 @@ struct OpenMPTargetReducerWrapper<MinMax<Scalar, Space>> {
 template <class Scalar, class Index, class Space>
 struct OpenMPTargetReducerWrapper<MinMaxLoc<Scalar, Index, Space>> {
  private:
-  typedef typename std::remove_cv<Scalar>::type scalar_type;
-  typedef typename std::remove_cv<Index>::type index_type;
+  using scalar_type = typename std::remove_cv<Scalar>::type;
+  using index_type  = typename std::remove_cv<Index>::type;
 
  public:
   // Required
-  typedef MinMaxLocScalar<scalar_type, index_type> value_type;
+  using value_type = MinMaxLocScalar<scalar_type, index_type>;
 
 // WORKAROUND OPENMPTARGET
 // This pragma omp declare target should not be necessary, but Intel compiler
@@ -490,25 +490,6 @@ struct OpenMPTargetReducerWrapper<MinMaxLoc<Scalar, Index, Space>> {
   }
 #pragma omp end declare target
 };
-/*
-template<class ReducerType>
-class OpenMPTargetReducerWrapper {
-  public:
-    const ReducerType& reducer;
-    typedef typename ReducerType::value_type value_type;
-    value_type& value;
-
-    KOKKOS_INLINE_FUNCTION
-    void join(const value_type& upd) {
-      reducer.join(value,upd);
-    }
-
-    KOKKOS_INLINE_FUNCTION
-    void init(const value_type& upd) {
-      reducer.init(value,upd);
-    }
-};*/
-
 }  // namespace Impl
 }  // namespace Kokkos
 
@@ -525,8 +506,8 @@ class OpenMPTargetExecTeamMember {
   /** \brief  Thread states for team synchronization */
   enum { Active = 0, Rendezvous = 1 };
 
-  typedef Kokkos::Experimental::OpenMPTarget execution_space;
-  typedef execution_space::scratch_memory_space scratch_memory_space;
+  using execution_space      = Kokkos::Experimental::OpenMPTarget;
+  using scratch_memory_space = execution_space::scratch_memory_space;
 
   scratch_memory_space m_team_shared;
   int m_team_scratch_size[2];
@@ -622,12 +603,12 @@ class OpenMPTargetExecTeamMember {
                                                const JoinOp& op_in) const {
 #pragma omp barrier
 
-    typedef ValueType value_type;
+    using value_type = ValueType;
     const JoinLambdaAdapter<value_type, JoinOp> op(op_in);
 
     // Make sure there is enough scratch space:
-    typedef typename if_c<sizeof(value_type) < TEAM_REDUCE_SIZE, value_type,
-                          void>::type type;
+    using type = typename if_c<sizeof(value_type) < TEAM_REDUCE_SIZE,
+                               value_type, void>::type;
 
     const int n_values = TEAM_REDUCE_SIZE / sizeof(value_type);
     type* team_scratch =
@@ -722,7 +703,7 @@ class OpenMPTargetExecTeamMember {
   // Private for the driver
 
  private:
-  typedef execution_space::scratch_memory_space space;
+  using space = execution_space::scratch_memory_space;
 
  public:
   inline OpenMPTargetExecTeamMember(
@@ -755,9 +736,9 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget, Properties...>
     : public PolicyTraits<Properties...> {
  public:
   //! Tag this class as a kokkos execution policy
-  typedef TeamPolicyInternal execution_policy;
+  using execution_policy = TeamPolicyInternal;
 
-  typedef PolicyTraits<Properties...> traits;
+  using traits = PolicyTraits<Properties...>;
 
   TeamPolicyInternal& operator=(const TeamPolicyInternal& p) {
     m_league_size            = p.m_league_size;
@@ -952,7 +933,7 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget, Properties...>
   }
 
  public:
-  typedef Impl::OpenMPTargetExecTeamMember member_type;
+  using member_type = Impl::OpenMPTargetExecTeamMember;
 };
 }  // namespace Impl
 
@@ -1201,8 +1182,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     const Impl::ThreadVectorRangeBoundariesStruct<
         iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
     const FunctorType& lambda) {
-  typedef Kokkos::Impl::FunctorValueTraits<FunctorType, void> ValueTraits;
-  typedef typename ValueTraits::value_type value_type;
+  using ValueTraits = Kokkos::Impl::FunctorValueTraits<FunctorType, void>;
+  using value_type  = typename ValueTraits::value_type;
 
   value_type scan_val = value_type();
 

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -79,6 +79,437 @@ class OpenMPTargetExec {
 };
 
 }  // namespace Impl
+
+namespace Impl {
+
+template <class Reducer>
+struct OpenMPTargetReducerWrapper {
+  typedef typename Reducer::value_type value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type&, const value_type&) {
+    printf(
+        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
+        "implemented.");
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type&, const volatile value_type&) {
+    printf(
+        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
+        "implemented.");
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type&) {
+    printf(
+        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
+        "implemented.");
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Space>
+struct OpenMPTargetReducerWrapper<Sum<Scalar, Space>> {
+ public:
+  // Required
+  typedef typename std::remove_cv<Scalar>::type value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  // Required
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) { dest += src; }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    dest += src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val = reduction_identity<value_type>::sum();
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Space>
+struct OpenMPTargetReducerWrapper<Prod<Scalar, Space>> {
+ public:
+  // Required
+  typedef typename std::remove_cv<Scalar>::type value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  // Required
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) { dest *= src; }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    dest *= src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val = reduction_identity<value_type>::prod();
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Space>
+struct OpenMPTargetReducerWrapper<Min<Scalar, Space>> {
+ public:
+  // Required
+  typedef typename std::remove_cv<Scalar>::type value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  // Required
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) {
+    if (src < dest) dest = src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    if (src < dest) dest = src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val = reduction_identity<value_type>::min();
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Space>
+struct OpenMPTargetReducerWrapper<Max<Scalar, Space>> {
+ public:
+  // Required
+  typedef typename std::remove_cv<Scalar>::type value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  // Required
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) {
+    if (src > dest) dest = src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    if (src > dest) dest = src;
+  }
+
+  // Required
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val = reduction_identity<value_type>::max();
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Space>
+struct OpenMPTargetReducerWrapper<LAnd<Scalar, Space>> {
+ public:
+  // Required
+  typedef typename std::remove_cv<Scalar>::type value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) {
+    dest = dest && src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    dest = dest && src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val = reduction_identity<value_type>::land();
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Space>
+struct OpenMPTargetReducerWrapper<LOr<Scalar, Space>> {
+ public:
+  // Required
+  typedef typename std::remove_cv<Scalar>::type value_type;
+
+  typedef Kokkos::View<value_type, Space> result_view_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  // Required
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) {
+    dest = dest || src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    dest = dest || src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val = reduction_identity<value_type>::lor();
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Space>
+struct OpenMPTargetReducerWrapper<BAnd<Scalar, Space>> {
+ public:
+  // Required
+  typedef typename std::remove_cv<Scalar>::type value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  // Required
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) {
+    dest = dest & src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    dest = dest & src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val = reduction_identity<value_type>::band();
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Space>
+struct OpenMPTargetReducerWrapper<BOr<Scalar, Space>> {
+ public:
+  // Required
+  typedef typename std::remove_cv<Scalar>::type value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  // Required
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) {
+    dest = dest | src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    dest = dest | src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val = reduction_identity<value_type>::bor();
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Index, class Space>
+struct OpenMPTargetReducerWrapper<MinLoc<Scalar, Index, Space>> {
+ private:
+  typedef typename std::remove_cv<Scalar>::type scalar_type;
+  typedef typename std::remove_cv<Index>::type index_type;
+
+ public:
+  // Required
+  typedef ValLocScalar<scalar_type, index_type> value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  // Required
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) {
+    if (src.val < dest.val) dest = src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    if (src.val < dest.val) dest = src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val.val = reduction_identity<scalar_type>::min();
+    val.loc = reduction_identity<index_type>::min();
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Index, class Space>
+struct OpenMPTargetReducerWrapper<MaxLoc<Scalar, Index, Space>> {
+ private:
+  typedef typename std::remove_cv<Scalar>::type scalar_type;
+  typedef typename std::remove_cv<Index>::type index_type;
+
+ public:
+  // Required
+  typedef ValLocScalar<scalar_type, index_type> value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) {
+    if (src.val > dest.val) dest = src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    if (src.val > dest.val) dest = src;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val.val = reduction_identity<scalar_type>::max();
+    val.loc = reduction_identity<index_type>::min();
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Space>
+struct OpenMPTargetReducerWrapper<MinMax<Scalar, Space>> {
+ private:
+  typedef typename std::remove_cv<Scalar>::type scalar_type;
+
+ public:
+  // Required
+  typedef MinMaxScalar<scalar_type> value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  // Required
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) {
+    if (src.min_val < dest.min_val) {
+      dest.min_val = src.min_val;
+    }
+    if (src.max_val > dest.max_val) {
+      dest.max_val = src.max_val;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    if (src.min_val < dest.min_val) {
+      dest.min_val = src.min_val;
+    }
+    if (src.max_val > dest.max_val) {
+      dest.max_val = src.max_val;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val.max_val = reduction_identity<scalar_type>::max();
+    val.min_val = reduction_identity<scalar_type>::min();
+  }
+#pragma omp end declare target
+};
+
+template <class Scalar, class Index, class Space>
+struct OpenMPTargetReducerWrapper<MinMaxLoc<Scalar, Index, Space>> {
+ private:
+  typedef typename std::remove_cv<Scalar>::type scalar_type;
+  typedef typename std::remove_cv<Index>::type index_type;
+
+ public:
+  // Required
+  typedef MinMaxLocScalar<scalar_type, index_type> value_type;
+
+// WORKAROUND OPENMPTARGET
+// This pragma omp declare target should not be necessary, but Intel compiler
+// fails without it
+#pragma omp declare target
+  // Required
+  KOKKOS_INLINE_FUNCTION
+  static void join(value_type& dest, const value_type& src) {
+    if (src.min_val < dest.min_val) {
+      dest.min_val = src.min_val;
+      dest.min_loc = src.min_loc;
+    }
+    if (src.max_val > dest.max_val) {
+      dest.max_val = src.max_val;
+      dest.max_loc = src.max_loc;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void join(volatile value_type& dest, const volatile value_type& src) {
+    if (src.min_val < dest.min_val) {
+      dest.min_val = src.min_val;
+      dest.min_loc = src.min_loc;
+    }
+    if (src.max_val > dest.max_val) {
+      dest.max_val = src.max_val;
+      dest.max_loc = src.max_loc;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  static void init(value_type& val) {
+    val.max_val = reduction_identity<scalar_type>::max();
+    val.min_val = reduction_identity<scalar_type>::min();
+    val.max_loc = reduction_identity<index_type>::min();
+    val.min_loc = reduction_identity<index_type>::min();
+  }
+#pragma omp end declare target
+};
+/*
+template<class ReducerType>
+class OpenMPTargetReducerWrapper {
+  public:
+    const ReducerType& reducer;
+    typedef typename ReducerType::value_type value_type;
+    value_type& value;
+
+    KOKKOS_INLINE_FUNCTION
+    void join(const value_type& upd) {
+      reducer.join(value,upd);
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    void init(const value_type& upd) {
+      reducer.init(value,upd);
+    }
+};*/
+
+}  // namespace Impl
 }  // namespace Kokkos
 
 //----------------------------------------------------------------------------
@@ -106,6 +537,7 @@ class OpenMPTargetExecTeamMember {
   int m_vector_length;
   int m_vector_lane;
   void* m_glb_scratch;
+  void* m_reduce_scratch;
 
   /*
   // Fan-in team threads, root of the fan-in which does not block returns true
@@ -158,6 +590,9 @@ class OpenMPTargetExecTeamMember {
   KOKKOS_INLINE_FUNCTION int league_size() const { return m_league_size; }
   KOKKOS_INLINE_FUNCTION int team_rank() const { return m_team_rank; }
   KOKKOS_INLINE_FUNCTION int team_size() const { return m_team_size; }
+  KOKKOS_INLINE_FUNCTION void* impl_reduce_scratch() const {
+    return m_reduce_scratch;
+  }
 
   KOKKOS_INLINE_FUNCTION void team_barrier() const {
 #pragma omp barrier
@@ -304,10 +739,12 @@ class OpenMPTargetExecTeamMember {
         m_league_rank(league_rank),
         m_league_size(league_size),
         m_glb_scratch(glb_scratch) {
-    const int omp_tid = omp_get_thread_num();
-    m_league_rank     = league_rank;
-    m_team_rank       = omp_tid / m_vector_length;
-    m_vector_lane     = omp_tid % m_vector_length;
+    const int omp_tid      = omp_get_thread_num();
+    const int omp_team_num = omp_get_team_num();
+    m_reduce_scratch = (char*)glb_scratch + omp_team_num * TEAM_REDUCE_SIZE;
+    m_league_rank    = league_rank;
+    m_team_rank      = omp_tid;
+    m_vector_lane    = 0;
   }
 
   static inline int team_reduce_size() { return TEAM_REDUCE_SIZE; }
@@ -584,8 +1021,8 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
     const Impl::TeamThreadRangeBoundariesStruct<
         iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
     const Lambda& lambda) {
-  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
-       i += loop_boundaries.increment)
+#pragma omp for nowait
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end; i += 1)
     lambda(i);
 }
 
@@ -596,21 +1033,64 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
  * and a summation of val is performed and put into result. This functionality
  * requires C++11 support.*/
 template <typename iType, class Lambda, typename ValueType>
-KOKKOS_INLINE_FUNCTION void parallel_reduce(
-    const Impl::TeamThreadRangeBoundariesStruct<
-        iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
-    const Lambda& lambda, ValueType& result) {
+KOKKOS_INLINE_FUNCTION
+    typename std::enable_if<!Kokkos::is_reducer<ValueType>::value>::type
+    parallel_reduce(
+        const Impl::TeamThreadRangeBoundariesStruct<
+            iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
+        const Lambda& lambda, ValueType& result) {
   result = ValueType();
 
-  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
-       i += loop_boundaries.increment) {
+  ValueType* tmp_scratch =
+      (ValueType*)loop_boundaries.team.impl_reduce_scratch();
+#pragma omp barrier
+  tmp_scratch[0] = ValueType();
+#pragma omp barrier
+
+#pragma omp for reduction(+ : tmp_scratch[:1]) schedule(static, 1)
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end; i += 1) {
     ValueType tmp = ValueType();
     lambda(i, tmp);
-    result += tmp;
+    tmp_scratch[0] += tmp;
   }
 
-  // result =
-  // loop_boundaries.thread.team_reduce(result,Impl::JoinAdd<ValueType>());
+  result = tmp_scratch[0];
+
+#pragma omp barrier
+}
+
+template <typename iType, class Lambda, typename ReducerType>
+KOKKOS_INLINE_FUNCTION
+    typename std::enable_if<Kokkos::is_reducer<ReducerType>::value>::type
+    parallel_reduce(
+        const Impl::TeamThreadRangeBoundariesStruct<
+            iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
+        const Lambda& lambda, const ReducerType& reducer) {
+  // TODO: custom reductions don't work if the functions from ReducerWrappers
+  // are used alongside the "omp for reduction"
+  /*
+  typedef typename ReducerType::value_type value_type;
+
+#pragma omp declare reduction(                                         \
+    custom:value_type                                                   \
+    : Impl::OpenMPTargetReducerWrapper <ReducerType>::join(omp_out, omp_in)) \
+    initializer(Impl::OpenMPTargetReducerWrapper <ReducerType>::init(omp_priv))
+
+  value_type* tmp_scratch =
+      (value_type*)loop_boundaries.team.impl_reduce_scratch();
+#pragma omp barrier
+//  Impl::OpenMPTargetReducerWrapper<ReducerType>::init(tmp_scratch[0]);
+#pragma omp barrier
+
+#pragma omp for reduction(custom: tmp_scratch[:1])
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end; i += 1) {
+    value_type tmp = value_type();
+    Impl::OpenMPTargetReducerWrapper<ReducerType>::init(tmp);
+    lambda(i, tmp);
+    Impl::OpenMPTargetReducerWrapper<ReducerType>::join(tmp_scratch[0], tmp);
+  }
+#pragma omp barrier
+*/
 }
 
 /** \brief  Intra-thread vector parallel_reduce. Executes lambda(iType i,
@@ -652,8 +1132,8 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
     const Impl::ThreadVectorRangeBoundariesStruct<
         iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
     const Lambda& lambda) {
-  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
-       i += loop_boundaries.increment)
+#pragma omp simd
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end; i += 1)
     lambda(i);
 }
 
@@ -669,8 +1149,9 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
         iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
     const Lambda& lambda, ValueType& result) {
   result = ValueType();
-  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
-       i += loop_boundaries.increment) {
+
+#pragma omp simd reduction(+ : result)
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end; i += 1) {
     ValueType tmp = ValueType();
     lambda(i, tmp);
     result += tmp;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -55,461 +55,16 @@
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-// namespace Impl {
-//
-// template <class Reducer>
-// struct OpenMPTargetReducerWrapper {
-//  typedef typename Reducer::value_type value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type&, const value_type&) {
-//    printf(
-//        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
-//        "implemented.");
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type&, const volatile value_type&) {
-//    printf(
-//        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
-//        "implemented.");
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type&) {
-//    printf(
-//        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
-//        "implemented.");
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Space>
-// struct OpenMPTargetReducerWrapper<Sum<Scalar, Space>> {
-// public:
-//  // Required
-//  typedef typename std::remove_cv<Scalar>::type value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  // Required
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) { dest += src; }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    dest += src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val = reduction_identity<value_type>::sum();
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Space>
-// struct OpenMPTargetReducerWrapper<Prod<Scalar, Space>> {
-// public:
-//  // Required
-//  typedef typename std::remove_cv<Scalar>::type value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  // Required
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) { dest *= src; }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    dest *= src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val = reduction_identity<value_type>::prod();
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Space>
-// struct OpenMPTargetReducerWrapper<Min<Scalar, Space>> {
-// public:
-//  // Required
-//  typedef typename std::remove_cv<Scalar>::type value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  // Required
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) {
-//    if (src < dest) dest = src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    if (src < dest) dest = src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val = reduction_identity<value_type>::min();
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Space>
-// struct OpenMPTargetReducerWrapper<Max<Scalar, Space>> {
-// public:
-//  // Required
-//  typedef typename std::remove_cv<Scalar>::type value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  // Required
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) {
-//    if (src > dest) dest = src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    if (src > dest) dest = src;
-//  }
-//
-//  // Required
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val = reduction_identity<value_type>::max();
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Space>
-// struct OpenMPTargetReducerWrapper<LAnd<Scalar, Space>> {
-// public:
-//  // Required
-//  typedef typename std::remove_cv<Scalar>::type value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) {
-//    dest = dest && src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    dest = dest && src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val = reduction_identity<value_type>::land();
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Space>
-// struct OpenMPTargetReducerWrapper<LOr<Scalar, Space>> {
-// public:
-//  // Required
-//  typedef typename std::remove_cv<Scalar>::type value_type;
-//
-//  typedef Kokkos::View<value_type, Space> result_view_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  // Required
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) {
-//    dest = dest || src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    dest = dest || src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val = reduction_identity<value_type>::lor();
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Space>
-// struct OpenMPTargetReducerWrapper<BAnd<Scalar, Space>> {
-// public:
-//  // Required
-//  typedef typename std::remove_cv<Scalar>::type value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  // Required
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) {
-//    dest = dest & src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    dest = dest & src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val = reduction_identity<value_type>::band();
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Space>
-// struct OpenMPTargetReducerWrapper<BOr<Scalar, Space>> {
-// public:
-//  // Required
-//  typedef typename std::remove_cv<Scalar>::type value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  // Required
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) {
-//    dest = dest | src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    dest = dest | src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val = reduction_identity<value_type>::bor();
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Index, class Space>
-// struct OpenMPTargetReducerWrapper<MinLoc<Scalar, Index, Space>> {
-// private:
-//  typedef typename std::remove_cv<Scalar>::type scalar_type;
-//  typedef typename std::remove_cv<Index>::type index_type;
-//
-// public:
-//  // Required
-//  typedef ValLocScalar<scalar_type, index_type> value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  // Required
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) {
-//    if (src.val < dest.val) dest = src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    if (src.val < dest.val) dest = src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val.val = reduction_identity<scalar_type>::min();
-//    val.loc = reduction_identity<index_type>::min();
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Index, class Space>
-// struct OpenMPTargetReducerWrapper<MaxLoc<Scalar, Index, Space>> {
-// private:
-//  typedef typename std::remove_cv<Scalar>::type scalar_type;
-//  typedef typename std::remove_cv<Index>::type index_type;
-//
-// public:
-//  // Required
-//  typedef ValLocScalar<scalar_type, index_type> value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) {
-//    if (src.val > dest.val) dest = src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    if (src.val > dest.val) dest = src;
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val.val = reduction_identity<scalar_type>::max();
-//    val.loc = reduction_identity<index_type>::min();
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Space>
-// struct OpenMPTargetReducerWrapper<MinMax<Scalar, Space>> {
-// private:
-//  typedef typename std::remove_cv<Scalar>::type scalar_type;
-//
-// public:
-//  // Required
-//  typedef MinMaxScalar<scalar_type> value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  // Required
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) {
-//    if (src.min_val < dest.min_val) {
-//      dest.min_val = src.min_val;
-//    }
-//    if (src.max_val > dest.max_val) {
-//      dest.max_val = src.max_val;
-//    }
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    if (src.min_val < dest.min_val) {
-//      dest.min_val = src.min_val;
-//    }
-//    if (src.max_val > dest.max_val) {
-//      dest.max_val = src.max_val;
-//    }
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val.max_val = reduction_identity<scalar_type>::max();
-//    val.min_val = reduction_identity<scalar_type>::min();
-//  }
-//#pragma omp end declare target
-//};
-//
-// template <class Scalar, class Index, class Space>
-// struct OpenMPTargetReducerWrapper<MinMaxLoc<Scalar, Index, Space>> {
-// private:
-//  typedef typename std::remove_cv<Scalar>::type scalar_type;
-//  typedef typename std::remove_cv<Index>::type index_type;
-//
-// public:
-//  // Required
-//  typedef MinMaxLocScalar<scalar_type, index_type> value_type;
-//
-//// WORKAROUND OPENMPTARGET
-//// This pragma omp declare target should not be necessary, but Intel compiler
-//// fails without it
-//#pragma omp declare target
-//  // Required
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(value_type& dest, const value_type& src) {
-//    if (src.min_val < dest.min_val) {
-//      dest.min_val = src.min_val;
-//      dest.min_loc = src.min_loc;
-//    }
-//    if (src.max_val > dest.max_val) {
-//      dest.max_val = src.max_val;
-//      dest.max_loc = src.max_loc;
-//    }
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void join(volatile value_type& dest, const volatile value_type& src)
-//  {
-//    if (src.min_val < dest.min_val) {
-//      dest.min_val = src.min_val;
-//      dest.min_loc = src.min_loc;
-//    }
-//    if (src.max_val > dest.max_val) {
-//      dest.max_val = src.max_val;
-//      dest.max_loc = src.max_loc;
-//    }
-//  }
-//
-//  KOKKOS_INLINE_FUNCTION
-//  static void init(value_type& val) {
-//    val.max_val = reduction_identity<scalar_type>::max();
-//    val.min_val = reduction_identity<scalar_type>::min();
-//    val.max_loc = reduction_identity<index_type>::min();
-//    val.min_loc = reduction_identity<index_type>::min();
-//  }
-//#pragma omp end declare target
-//};
-///*
-// template<class ReducerType>
-// class OpenMPTargetReducerWrapper {
-//  public:
-//    const ReducerType& reducer;
-//    typedef typename ReducerType::value_type value_type;
-//    value_type& value;
-//
-//    KOKKOS_INLINE_FUNCTION
-//    void join(const value_type& upd) {
-//      reducer.join(value,upd);
-//    }
-//
-//    KOKKOS_INLINE_FUNCTION
-//    void init(const value_type& upd) {
-//      reducer.init(value,upd);
-//    }
-//};*/
-//
-//}  // namespace Impl
-}  // namespace Kokkos
-
-namespace Kokkos {
 namespace Impl {
 
 template <class FunctorType, class... Traits>
 class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
                   Kokkos::Experimental::OpenMPTarget> {
  private:
-  typedef Kokkos::RangePolicy<Traits...> Policy;
-  typedef typename Policy::work_tag WorkTag;
-  typedef typename Policy::WorkRange WorkRange;
-  typedef typename Policy::member_type Member;
+  using Policy    = Kokkos::RangePolicy<Traits...>;
+  using WorkTag   = typename Policy::work_tag;
+  using WorkRange = typename Policy::WorkRange;
+  using Member    = typename Policy::member_type;
 
   const FunctorType m_functor;
   const Policy m_policy;
@@ -596,7 +151,7 @@ template <class FunctorType, class ReducerType, class PointerType,
           class ValueType, class... PolicyArgs>
 struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
                                 ReducerType, PointerType, ValueType, 0, 0> {
-  typedef Kokkos::RangePolicy<PolicyArgs...> PolicyType;
+  using PolicyType = Kokkos::RangePolicy<PolicyArgs...>;
   template <class TagType>
   inline static
       typename std::enable_if<std::is_same<TagType, void>::value>::type
@@ -718,37 +273,34 @@ template <class FunctorType, class ReducerType, class... Traits>
 class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                      Kokkos::Experimental::OpenMPTarget> {
  private:
-  typedef Kokkos::RangePolicy<Traits...> Policy;
+  using Policy = Kokkos::RangePolicy<Traits...>;
+  using WorkTag = typename Policy::work_tag;
+  using WorkRange = typename Policy::WorkRange;
+  using Member = typename Policy::member_type;
 
-  typedef typename Policy::work_tag WorkTag;
-  typedef typename Policy::WorkRange WorkRange;
-  typedef typename Policy::member_type Member;
-
-  typedef Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
+  using ReducerConditional = Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
                              FunctorType, ReducerType>
-      ReducerConditional;
-  typedef typename ReducerConditional::type ReducerTypeFwd;
-  typedef
+      ;
+  using ReducerTypeFwd = typename ReducerConditional::type;
+  using WorkTagFwd =
       typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type WorkTagFwd;
+                                  WorkTag, void>::type;
 
   // Static Assert WorkTag void if ReducerType not InvalidType
 
-  typedef Kokkos::Impl::FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>
-      ValueTraits;
-  typedef Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd> ValueInit;
-  typedef Kokkos::Impl::FunctorValueJoin<ReducerTypeFwd, WorkTagFwd> ValueJoin;
+  using ValueTraits = Kokkos::Impl::FunctorValueTraits<ReducerTypeFwd, WorkTagFwd> ;
+  using ValueInit =  Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd>;
+  using ValueJoin =  Kokkos::Impl::FunctorValueJoin<ReducerTypeFwd, WorkTagFwd>;
 
   enum { HasJoin = ReduceFunctorHasJoin<FunctorType>::value };
   enum { UseReducer = is_reducer_type<ReducerType>::value };
 
-  typedef typename ValueTraits::pointer_type pointer_type;
-  typedef typename ValueTraits::reference_type reference_type;
+  using pointer_type = typename ValueTraits::pointer_type;
+  using reference_type = typename ValueTraits::reference_type;
 
-  typedef ParallelReduceSpecialize<
+  using ParReduceSpecialize = ParallelReduceSpecialize<
       FunctorType, Policy, ReducerType, pointer_type,
-      typename ValueTraits::value_type, HasJoin, UseReducer>
-      ParReduceSpecialize;
+      typename ValueTraits::value_type, HasJoin, UseReducer>;
 
   const FunctorType m_functor;
   const Policy m_policy;
@@ -793,19 +345,16 @@ template <class FunctorType, class... Traits>
 class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
                    Kokkos::Experimental::OpenMPTarget> {
  private:
-  typedef Kokkos::RangePolicy<Traits...> Policy;
-
-  typedef typename Policy::work_tag WorkTag;
-  typedef typename Policy::WorkRange WorkRange;
-  typedef typename Policy::member_type Member;
-
-  typedef Kokkos::Impl::FunctorValueTraits<FunctorType, WorkTag> ValueTraits;
-  typedef Kokkos::Impl::FunctorValueInit<FunctorType, WorkTag> ValueInit;
-  typedef Kokkos::Impl::FunctorValueJoin<FunctorType, WorkTag> ValueJoin;
-  typedef Kokkos::Impl::FunctorValueOps<FunctorType, WorkTag> ValueOps;
-
-  typedef typename ValueTraits::pointer_type pointer_type;
-  typedef typename ValueTraits::reference_type reference_type;
+  using Policy = Kokkos::RangePolicy<Traits...>;
+  using WorkTag = typename Policy::work_tag;
+  using WorkRange = typename Policy::WorkRange;
+  using Member = typename Policy::member_type;
+  using ValueTraits = Kokkos::Impl::FunctorValueTraits<FunctorType, WorkTag>;
+  using ValueInit = Kokkos::Impl::FunctorValueInit<FunctorType, WorkTag>;
+  using ValueJoin = Kokkos::Impl::FunctorValueJoin<FunctorType, WorkTag>;
+  using ValueOps = Kokkos::Impl::FunctorValueOps<FunctorType, WorkTag>;
+  using pointer_type = typename ValueTraits::pointer_type;
+  using reference_type = typename ValueTraits::reference_type;
 
   const FunctorType m_functor;
   const Policy m_policy;
@@ -923,11 +472,10 @@ template <class FunctorType, class... Properties>
 class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   Kokkos::Experimental::OpenMPTarget> {
  private:
-  typedef Kokkos::Impl::TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget,
-                                           Properties...>
-      Policy;
-  typedef typename Policy::work_tag WorkTag;
-  typedef typename Policy::member_type Member;
+  using Policy = Kokkos::Impl::TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget,
+                                           Properties...>;
+  using WorkTag = typename Policy::work_tag;
+  using Member = typename Policy::member_type;
 
   const FunctorType m_functor;
   const Policy m_policy;
@@ -1021,7 +569,7 @@ template <class FunctorType, class ReducerType, class PointerType,
           class ValueType, class... PolicyArgs>
 struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
                                 ReducerType, PointerType, ValueType, 0, 0> {
-  typedef TeamPolicyInternal<PolicyArgs...> PolicyType;
+  using PolicyType = TeamPolicyInternal<PolicyArgs...>;
 
   template <class TagType>
   inline static
@@ -1057,7 +605,6 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
                                             league_size, team_size,
                                             vector_length, scratch_ptr, 0, 0);
       f(team, inner_result);
-//      if (team.m_vector_lane != 0) result = 0;
       }
       result = inner_result;
     }
@@ -1123,7 +670,7 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
     : OpenMPTargetReducerWrapper <ReducerType>::join(omp_out, omp_in)) \
     initializer(OpenMPTargetReducerWrapper <ReducerType>::init(omp_priv))
 
-  typedef TeamPolicyInternal<PolicyArgs...> PolicyType;
+  using PolicyType = TeamPolicyInternal<PolicyArgs...>;
 
   template <class TagType>
   inline static
@@ -1224,37 +771,31 @@ template <class FunctorType, class ReducerType, class... Properties>
 class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                      ReducerType, Kokkos::Experimental::OpenMPTarget> {
  private:
-  typedef Kokkos::Impl::TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget,
-                                           Properties...>
-      Policy;
+  using Policy = Kokkos::Impl::TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget,
+                                           Properties...>;
+  using WorkTag = typename Policy::work_tag;
+  using Member = typename Policy::member_type;
 
-  typedef typename Policy::work_tag WorkTag;
-  typedef typename Policy::member_type Member;
-
-  typedef Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                             FunctorType, ReducerType>
-      ReducerConditional;
-  typedef typename ReducerConditional::type ReducerTypeFwd;
-  typedef
+  using ReducerConditional =  Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
+                             FunctorType, ReducerType>;
+  using ReducerTypeFwd = typename ReducerConditional::type;
+  using WorkTagFwd =
       typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type WorkTagFwd;
+                                  WorkTag, void>::type;
 
-  typedef Kokkos::Impl::FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>
-      ValueTraits;
-  typedef Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd> ValueInit;
-  typedef Kokkos::Impl::FunctorValueJoin<ReducerTypeFwd, WorkTagFwd> ValueJoin;
-
-  typedef typename ValueTraits::pointer_type pointer_type;
-  typedef typename ValueTraits::reference_type reference_type;
-  typedef typename ValueTraits::value_type value_type;
+  using ValueTraits = Kokkos::Impl::FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>;
+  using ValueInit =  Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd>;
+  using ValueJoin =  Kokkos::Impl::FunctorValueJoin<ReducerTypeFwd, WorkTagFwd>;
+  using pointer_type =  typename ValueTraits::pointer_type;
+  using reference_type =  typename ValueTraits::reference_type;
+  using value_type =  typename ValueTraits::value_type;
 
   enum { HasJoin = ReduceFunctorHasJoin<FunctorType>::value };
   enum { UseReducer = is_reducer_type<ReducerType>::value };
 
-  typedef ParallelReduceSpecialize<
+  using ParReduceSpecialize = ParallelReduceSpecialize<
       FunctorType, Policy, ReducerType, pointer_type,
-      typename ValueTraits::value_type, HasJoin, UseReducer>
-      ParReduceSpecialize;
+      typename ValueTraits::value_type, HasJoin, UseReducer>;
 
   const FunctorType m_functor;
   const Policy m_policy;
@@ -1355,7 +896,7 @@ namespace Impl {
 
 template <typename iType>
 struct TeamThreadRangeBoundariesStruct<iType, OpenMPTargetExecTeamMember> {
-  typedef iType index_type;
+  using index_type = iType;
   const iType start;
   const iType end;
   const OpenMPTargetExecTeamMember& team ;
@@ -1377,7 +918,7 @@ struct TeamThreadRangeBoundariesStruct<iType, OpenMPTargetExecTeamMember> {
 
 template <typename iType>
 struct ThreadVectorRangeBoundariesStruct<iType, OpenMPTargetExecTeamMember> {
-  typedef iType index_type;
+  using index_type = iType;
   const index_type start;
   const index_type end;
   const OpenMPTargetExecTeamMember& team ;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -55,436 +55,448 @@
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-namespace Impl {
-
-template <class Reducer>
-struct OpenMPTargetReducerWrapper {
-  typedef typename Reducer::value_type value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type&, const value_type&) {
-    printf(
-        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
-        "implemented.");
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type&, const volatile value_type&) {
-    printf(
-        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
-        "implemented.");
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type&) {
-    printf(
-        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
-        "implemented.");
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Space>
-struct OpenMPTargetReducerWrapper<Sum<Scalar, Space>> {
- public:
-  // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) { dest += src; }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest += src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val = reduction_identity<value_type>::sum();
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Space>
-struct OpenMPTargetReducerWrapper<Prod<Scalar, Space>> {
- public:
-  // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) { dest *= src; }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest *= src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val = reduction_identity<value_type>::prod();
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Space>
-struct OpenMPTargetReducerWrapper<Min<Scalar, Space>> {
- public:
-  // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) {
-    if (src < dest) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    if (src < dest) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val = reduction_identity<value_type>::min();
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Space>
-struct OpenMPTargetReducerWrapper<Max<Scalar, Space>> {
- public:
-  // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) {
-    if (src > dest) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    if (src > dest) dest = src;
-  }
-
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val = reduction_identity<value_type>::max();
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Space>
-struct OpenMPTargetReducerWrapper<LAnd<Scalar, Space>> {
- public:
-  // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) {
-    dest = dest && src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest = dest && src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val = reduction_identity<value_type>::land();
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Space>
-struct OpenMPTargetReducerWrapper<LOr<Scalar, Space>> {
- public:
-  // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
-
-  typedef Kokkos::View<value_type, Space> result_view_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) {
-    dest = dest || src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest = dest || src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val = reduction_identity<value_type>::lor();
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Space>
-struct OpenMPTargetReducerWrapper<BAnd<Scalar, Space>> {
- public:
-  // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) {
-    dest = dest & src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest = dest & src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val = reduction_identity<value_type>::band();
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Space>
-struct OpenMPTargetReducerWrapper<BOr<Scalar, Space>> {
- public:
-  // Required
-  typedef typename std::remove_cv<Scalar>::type value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) {
-    dest = dest | src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    dest = dest | src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val = reduction_identity<value_type>::bor();
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Index, class Space>
-struct OpenMPTargetReducerWrapper<MinLoc<Scalar, Index, Space>> {
- private:
-  typedef typename std::remove_cv<Scalar>::type scalar_type;
-  typedef typename std::remove_cv<Index>::type index_type;
-
- public:
-  // Required
-  typedef ValLocScalar<scalar_type, index_type> value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) {
-    if (src.val < dest.val) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    if (src.val < dest.val) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val.val = reduction_identity<scalar_type>::min();
-    val.loc = reduction_identity<index_type>::min();
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Index, class Space>
-struct OpenMPTargetReducerWrapper<MaxLoc<Scalar, Index, Space>> {
- private:
-  typedef typename std::remove_cv<Scalar>::type scalar_type;
-  typedef typename std::remove_cv<Index>::type index_type;
-
- public:
-  // Required
-  typedef ValLocScalar<scalar_type, index_type> value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) {
-    if (src.val > dest.val) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    if (src.val > dest.val) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val.val = reduction_identity<scalar_type>::max();
-    val.loc = reduction_identity<index_type>::min();
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Space>
-struct OpenMPTargetReducerWrapper<MinMax<Scalar, Space>> {
- private:
-  typedef typename std::remove_cv<Scalar>::type scalar_type;
-
- public:
-  // Required
-  typedef MinMaxScalar<scalar_type> value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) {
-    if (src.min_val < dest.min_val) {
-      dest.min_val = src.min_val;
-    }
-    if (src.max_val > dest.max_val) {
-      dest.max_val = src.max_val;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    if (src.min_val < dest.min_val) {
-      dest.min_val = src.min_val;
-    }
-    if (src.max_val > dest.max_val) {
-      dest.max_val = src.max_val;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val.max_val = reduction_identity<scalar_type>::max();
-    val.min_val = reduction_identity<scalar_type>::min();
-  }
-#pragma omp end declare target
-};
-
-template <class Scalar, class Index, class Space>
-struct OpenMPTargetReducerWrapper<MinMaxLoc<Scalar, Index, Space>> {
- private:
-  typedef typename std::remove_cv<Scalar>::type scalar_type;
-  typedef typename std::remove_cv<Index>::type index_type;
-
- public:
-  // Required
-  typedef MinMaxLocScalar<scalar_type, index_type> value_type;
-
-// WORKAROUND OPENMPTARGET
-// This pragma omp declare target should not be necessary, but Intel compiler
-// fails without it
-#pragma omp declare target
-  // Required
-  KOKKOS_INLINE_FUNCTION
-  static void join(value_type& dest, const value_type& src) {
-    if (src.min_val < dest.min_val) {
-      dest.min_val = src.min_val;
-      dest.min_loc = src.min_loc;
-    }
-    if (src.max_val > dest.max_val) {
-      dest.max_val = src.max_val;
-      dest.max_loc = src.max_loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& dest, const volatile value_type& src) {
-    if (src.min_val < dest.min_val) {
-      dest.min_val = src.min_val;
-      dest.min_loc = src.min_loc;
-    }
-    if (src.max_val > dest.max_val) {
-      dest.max_val = src.max_val;
-      dest.max_loc = src.max_loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static void init(value_type& val) {
-    val.max_val = reduction_identity<scalar_type>::max();
-    val.min_val = reduction_identity<scalar_type>::min();
-    val.max_loc = reduction_identity<index_type>::min();
-    val.min_loc = reduction_identity<index_type>::min();
-  }
-#pragma omp end declare target
-};
-/*
-template<class ReducerType>
-class OpenMPTargetReducerWrapper {
-  public:
-    const ReducerType& reducer;
-    typedef typename ReducerType::value_type value_type;
-    value_type& value;
-
-    KOKKOS_INLINE_FUNCTION
-    void join(const value_type& upd) {
-      reducer.join(value,upd);
-    }
-
-    KOKKOS_INLINE_FUNCTION
-    void init(const value_type& upd) {
-      reducer.init(value,upd);
-    }
-};*/
-
-}  // namespace Impl
+// namespace Impl {
+//
+// template <class Reducer>
+// struct OpenMPTargetReducerWrapper {
+//  typedef typename Reducer::value_type value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type&, const value_type&) {
+//    printf(
+//        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
+//        "implemented.");
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type&, const volatile value_type&) {
+//    printf(
+//        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
+//        "implemented.");
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type&) {
+//    printf(
+//        "Using a generic unknown Reducer for the OpenMPTarget backend is not "
+//        "implemented.");
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Space>
+// struct OpenMPTargetReducerWrapper<Sum<Scalar, Space>> {
+// public:
+//  // Required
+//  typedef typename std::remove_cv<Scalar>::type value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  // Required
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) { dest += src; }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    dest += src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val = reduction_identity<value_type>::sum();
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Space>
+// struct OpenMPTargetReducerWrapper<Prod<Scalar, Space>> {
+// public:
+//  // Required
+//  typedef typename std::remove_cv<Scalar>::type value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  // Required
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) { dest *= src; }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    dest *= src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val = reduction_identity<value_type>::prod();
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Space>
+// struct OpenMPTargetReducerWrapper<Min<Scalar, Space>> {
+// public:
+//  // Required
+//  typedef typename std::remove_cv<Scalar>::type value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  // Required
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) {
+//    if (src < dest) dest = src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    if (src < dest) dest = src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val = reduction_identity<value_type>::min();
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Space>
+// struct OpenMPTargetReducerWrapper<Max<Scalar, Space>> {
+// public:
+//  // Required
+//  typedef typename std::remove_cv<Scalar>::type value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  // Required
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) {
+//    if (src > dest) dest = src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    if (src > dest) dest = src;
+//  }
+//
+//  // Required
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val = reduction_identity<value_type>::max();
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Space>
+// struct OpenMPTargetReducerWrapper<LAnd<Scalar, Space>> {
+// public:
+//  // Required
+//  typedef typename std::remove_cv<Scalar>::type value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) {
+//    dest = dest && src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    dest = dest && src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val = reduction_identity<value_type>::land();
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Space>
+// struct OpenMPTargetReducerWrapper<LOr<Scalar, Space>> {
+// public:
+//  // Required
+//  typedef typename std::remove_cv<Scalar>::type value_type;
+//
+//  typedef Kokkos::View<value_type, Space> result_view_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  // Required
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) {
+//    dest = dest || src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    dest = dest || src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val = reduction_identity<value_type>::lor();
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Space>
+// struct OpenMPTargetReducerWrapper<BAnd<Scalar, Space>> {
+// public:
+//  // Required
+//  typedef typename std::remove_cv<Scalar>::type value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  // Required
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) {
+//    dest = dest & src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    dest = dest & src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val = reduction_identity<value_type>::band();
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Space>
+// struct OpenMPTargetReducerWrapper<BOr<Scalar, Space>> {
+// public:
+//  // Required
+//  typedef typename std::remove_cv<Scalar>::type value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  // Required
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) {
+//    dest = dest | src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    dest = dest | src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val = reduction_identity<value_type>::bor();
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Index, class Space>
+// struct OpenMPTargetReducerWrapper<MinLoc<Scalar, Index, Space>> {
+// private:
+//  typedef typename std::remove_cv<Scalar>::type scalar_type;
+//  typedef typename std::remove_cv<Index>::type index_type;
+//
+// public:
+//  // Required
+//  typedef ValLocScalar<scalar_type, index_type> value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  // Required
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) {
+//    if (src.val < dest.val) dest = src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    if (src.val < dest.val) dest = src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val.val = reduction_identity<scalar_type>::min();
+//    val.loc = reduction_identity<index_type>::min();
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Index, class Space>
+// struct OpenMPTargetReducerWrapper<MaxLoc<Scalar, Index, Space>> {
+// private:
+//  typedef typename std::remove_cv<Scalar>::type scalar_type;
+//  typedef typename std::remove_cv<Index>::type index_type;
+//
+// public:
+//  // Required
+//  typedef ValLocScalar<scalar_type, index_type> value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) {
+//    if (src.val > dest.val) dest = src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    if (src.val > dest.val) dest = src;
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val.val = reduction_identity<scalar_type>::max();
+//    val.loc = reduction_identity<index_type>::min();
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Space>
+// struct OpenMPTargetReducerWrapper<MinMax<Scalar, Space>> {
+// private:
+//  typedef typename std::remove_cv<Scalar>::type scalar_type;
+//
+// public:
+//  // Required
+//  typedef MinMaxScalar<scalar_type> value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  // Required
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) {
+//    if (src.min_val < dest.min_val) {
+//      dest.min_val = src.min_val;
+//    }
+//    if (src.max_val > dest.max_val) {
+//      dest.max_val = src.max_val;
+//    }
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    if (src.min_val < dest.min_val) {
+//      dest.min_val = src.min_val;
+//    }
+//    if (src.max_val > dest.max_val) {
+//      dest.max_val = src.max_val;
+//    }
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val.max_val = reduction_identity<scalar_type>::max();
+//    val.min_val = reduction_identity<scalar_type>::min();
+//  }
+//#pragma omp end declare target
+//};
+//
+// template <class Scalar, class Index, class Space>
+// struct OpenMPTargetReducerWrapper<MinMaxLoc<Scalar, Index, Space>> {
+// private:
+//  typedef typename std::remove_cv<Scalar>::type scalar_type;
+//  typedef typename std::remove_cv<Index>::type index_type;
+//
+// public:
+//  // Required
+//  typedef MinMaxLocScalar<scalar_type, index_type> value_type;
+//
+//// WORKAROUND OPENMPTARGET
+//// This pragma omp declare target should not be necessary, but Intel compiler
+//// fails without it
+//#pragma omp declare target
+//  // Required
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(value_type& dest, const value_type& src) {
+//    if (src.min_val < dest.min_val) {
+//      dest.min_val = src.min_val;
+//      dest.min_loc = src.min_loc;
+//    }
+//    if (src.max_val > dest.max_val) {
+//      dest.max_val = src.max_val;
+//      dest.max_loc = src.max_loc;
+//    }
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void join(volatile value_type& dest, const volatile value_type& src)
+//  {
+//    if (src.min_val < dest.min_val) {
+//      dest.min_val = src.min_val;
+//      dest.min_loc = src.min_loc;
+//    }
+//    if (src.max_val > dest.max_val) {
+//      dest.max_val = src.max_val;
+//      dest.max_loc = src.max_loc;
+//    }
+//  }
+//
+//  KOKKOS_INLINE_FUNCTION
+//  static void init(value_type& val) {
+//    val.max_val = reduction_identity<scalar_type>::max();
+//    val.min_val = reduction_identity<scalar_type>::min();
+//    val.max_loc = reduction_identity<index_type>::min();
+//    val.min_loc = reduction_identity<index_type>::min();
+//  }
+//#pragma omp end declare target
+//};
+///*
+// template<class ReducerType>
+// class OpenMPTargetReducerWrapper {
+//  public:
+//    const ReducerType& reducer;
+//    typedef typename ReducerType::value_type value_type;
+//    value_type& value;
+//
+//    KOKKOS_INLINE_FUNCTION
+//    void join(const value_type& upd) {
+//      reducer.join(value,upd);
+//    }
+//
+//    KOKKOS_INLINE_FUNCTION
+//    void init(const value_type& upd) {
+//      reducer.init(value,upd);
+//    }
+//};*/
+//
+//}  // namespace Impl
 }  // namespace Kokkos
 
 namespace Kokkos {
@@ -950,15 +962,19 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     void* scratch_ptr = OpenMPTargetExec::get_scratch_ptr();
 
     FunctorType a_functor(m_functor);
-#pragma omp target teams distribute parallel for num_teams(league_size) \
-    num_threads(team_size* vector_length) schedule(static, 1)           \
+#pragma omp target teams distribute \
         map(to                                                          \
-            : a_functor, scratch_ptr)
-    for (int i = 0; i < league_size * team_size * vector_length; i++) {
-      typename Policy::member_type team(i / (team_size * vector_length),
-                                        league_size, team_size, vector_length,
-                                        scratch_ptr, 0, 0);
-      m_functor(team);
+            : a_functor, scratch_ptr) \
+    num_teams(nteams) thread_limit(team_size)
+    for (int i = 0; i < league_size ; i++) {
+      // Start parallel threads for each block
+#pragma omp parallel
+      {
+        typename Policy::member_type team(i ,
+                                          league_size, team_size, vector_length,
+                                          scratch_ptr, 0, 0);
+        m_functor(team);
+      }
     }
   }
 
@@ -1029,14 +1045,21 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
     void* scratch_ptr = OpenMPTargetExec::get_scratch_ptr();
 
     ValueType result = ValueType();
-#pragma omp target teams distribute parallel for num_teams(nteams) num_threads(team_size*vector_length) \
-         map(to:f,scratch_ptr) map(tofrom:result) reduction(+: result) schedule(static,1)
-    for (int i = 0; i < league_size * team_size * vector_length; i++) {
-      typename PolicyType::member_type team(i / (team_size * vector_length),
+
+#pragma omp target teams distribute num_teams(nteams) thread_limit(team_size) \
+         map(to:f,scratch_ptr) map(tofrom:result) reduction(+: result)
+    for (int i = 0; i < league_size ; i++) {
+      ValueType inner_result = ValueType();
+#pragma omp parallel \
+    reduction(+:inner_result)
+      {
+      typename PolicyType::member_type team(i ,
                                             league_size, team_size,
                                             vector_length, scratch_ptr, 0, 0);
-      f(team, result);
-      if (team.m_vector_lane != 0) result = 0;
+      f(team, inner_result);
+//      if (team.m_vector_lane != 0) result = 0;
+      }
+      result = inner_result;
     }
 
     *result_ptr = result;
@@ -1064,15 +1087,130 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
     void* scratch_ptr = OpenMPTargetExec::get_scratch_ptr();
 
     ValueType result = ValueType();
-#pragma omp target teams distribute parallel for num_teams(nteams) num_threads(team_size*vector_length) \
-         map(to:f,scratch_ptr) map(tofrom:result) reduction(+: result) schedule(static,1)
-    for (int i = 0; i < league_size * team_size * vector_length; i++) {
-      typename PolicyType::member_type team(i / (team_size * vector_length),
+
+#pragma omp target teams distribute num_teams(nteams) thread_limit(team_size) \
+         map(to:f,scratch_ptr) map(tofrom:result) reduction(+: result)
+    for (int i = 0; i < league_size ; i++) {
+      ValueType inner_result = ValueType();
+#pragma omp parallel \
+    reduction(+:inner_result)
+      {
+      typename PolicyType::member_type team(i ,
                                             league_size, team_size,
                                             vector_length, scratch_ptr, 0, 0);
-      f(TagType(), team, result);
-      if (team.vector_lane != 0) result = 0;
+      f(TagType(), team, inner_result);
+//      if (team.m_vector_lane != 0) result = 0;
+      }
+
+      result = inner_result;
     }
+
+    *result_ptr = result;
+  }
+
+  inline static void execute(const FunctorType& f, const PolicyType& p,
+                             PointerType ptr) {
+    execute_impl<typename PolicyType::work_tag>(f, p, ptr);
+  }
+};
+
+template <class FunctorType, class ReducerType, class PointerType,
+          class ValueType, class... PolicyArgs>
+struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
+                                ReducerType, PointerType, ValueType, 0, 1> {
+#pragma omp declare reduction(                                         \
+    custom:ValueType                                                   \
+    : OpenMPTargetReducerWrapper <ReducerType>::join(omp_out, omp_in)) \
+    initializer(OpenMPTargetReducerWrapper <ReducerType>::init(omp_priv))
+
+  typedef TeamPolicyInternal<PolicyArgs...> PolicyType;
+
+  template <class TagType>
+  inline static
+      typename std::enable_if<std::is_same<TagType, void>::value>::type
+      execute_impl(const FunctorType& f, const PolicyType& p,
+                   PointerType result_ptr) {
+    OpenMPTargetExec::verify_is_process(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
+    OpenMPTargetExec::verify_initialized(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
+
+    const int league_size   = p.league_size();
+    const int team_size     = p.team_size();
+    const int vector_length = p.vector_length();
+    const int nteams        = OpenMPTargetExec::MAX_ACTIVE_TEAMS < league_size
+                           ? OpenMPTargetExec::MAX_ACTIVE_TEAMS
+                           : league_size;
+
+    OpenMPTargetExec::resize_scratch(
+        0, PolicyType::member_type::TEAM_REDUCE_SIZE, 0, 0);
+    void* scratch_ptr = OpenMPTargetExec::get_scratch_ptr();
+
+    ValueType result = ValueType();
+    OpenMPTargetReducerWrapper<ReducerType>::init(result);
+
+#pragma omp target teams distribute num_teams(nteams) thread_limit(team_size) \
+         map(to:f,scratch_ptr) map(tofrom:result) reduction(custom: result)
+    for (int i = 0; i < league_size ; i++) {
+    ValueType inner_result = ValueType();
+    OpenMPTargetReducerWrapper<ReducerType>::init(inner_result);
+#pragma omp parallel \
+    reduction(custom:inner_result)
+      {
+        typename PolicyType::member_type team(i ,
+                                              league_size, team_size,
+                                              vector_length, scratch_ptr, 0, 0);
+        f(team, inner_result);
+      }
+      result = inner_result;
+    }
+
+    *result_ptr = result;
+  }
+
+  template <class TagType>
+  inline static
+      typename std::enable_if<!std::is_same<TagType, void>::value>::type
+      execute_impl(const FunctorType& f, const PolicyType& p,
+                   PointerType result_ptr) {
+    OpenMPTargetExec::verify_is_process(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
+    OpenMPTargetExec::verify_initialized(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
+
+    const int league_size   = p.league_size();
+    const int team_size     = p.team_size();
+    const int vector_length = p.vector_length();
+    const int nteams        = OpenMPTargetExec::MAX_ACTIVE_TEAMS < league_size
+                           ? OpenMPTargetExec::MAX_ACTIVE_TEAMS
+                           : league_size;
+
+    OpenMPTargetExec::resize_scratch(
+        0, PolicyType::member_type::TEAM_REDUCE_SIZE, 0, 0);
+    void* scratch_ptr = OpenMPTargetExec::get_scratch_ptr();
+
+
+    ValueType result = ValueType();
+    OpenMPTargetReducerWrapper<ReducerType>::init(result);
+
+#pragma omp target teams distribute num_teams(nteams) thread_limit(team_size) \
+         map(to:f,scratch_ptr) map(tofrom:result) reduction(custom: result)
+    for (int i = 0; i < league_size ; i++) {
+    ValueType inner_result = ValueType();
+    OpenMPTargetReducerWrapper<ReducerType>::init(inner_result);
+#pragma omp parallel \
+    reduction(custom:inner_result)
+      {
+      typename PolicyType::member_type team(i ,
+                                            league_size, team_size,
+                                            vector_length, scratch_ptr, 0, 0);
+      f(TagType(), team, inner_result);
+//      if (team.m_vector_lane != 0) result = 0;
+      }
+
+      result = inner_result;
+    }
+
     *result_ptr = result;
   }
 
@@ -1116,7 +1254,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   typedef ParallelReduceSpecialize<
       FunctorType, Policy, ReducerType, pointer_type,
       typename ValueTraits::value_type, HasJoin, UseReducer>
-      ParForSpecialize;
+      ParReduceSpecialize;
 
   const FunctorType m_functor;
   const Policy m_policy;
@@ -1125,9 +1263,58 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   const int m_shmem_size;
 
  public:
+  private :
+    template <class TagType>
+    inline typename std::enable_if<std::is_same<TagType, void>::value>::type
+    execute_impl() const {
+
+    OpenMPTargetExec::verify_is_process(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
+    OpenMPTargetExec::verify_initialized(
+        "Kokkos::Experimental::OpenMPTarget parallel_for");
+    const int league_size   = m_policy.league_size();
+    const int team_size     = m_policy.team_size();
+    const int vector_length = m_policy.vector_length();
+    const int nteams        = OpenMPTargetExec::MAX_ACTIVE_TEAMS < league_size
+                           ? OpenMPTargetExec::MAX_ACTIVE_TEAMS
+                           : league_size;
+
+    OpenMPTargetExec::resize_scratch(0, Policy::member_type::TEAM_REDUCE_SIZE,
+                                     0, 0);
+
+    void* scratch_ptr = OpenMPTargetExec::get_scratch_ptr();
+    value_type result = value_type();
+
+    FunctorType a_functor(m_functor);
+    ReducerType a_reducer(m_reducer);
+
+
+#pragma omp declare reduction ( \
+custom:value_type : \
+OpenMPTargetReducerWrapper<Sum <value_type,Kokkos::Experimental::OpenMPTarget >>::join(omp_out, omp_in))
+
+#pragma omp target teams distribute \
+    map(to:a_functor, scratch_ptr) \
+    reduction(custom: result) \
+    num_teams(nteams) thread_limit(team_size)
+    for(int i = 0; i < league_size; ++i)
+    {
+#pragma omp parallel
+      {
+        typename Policy::member_type team(i ,
+                                          league_size, team_size, vector_length,
+                                          scratch_ptr, 0, 0);
+        m_functor(team, result);
+      }
+    }
+
+    *m_result_ptr = result;
+    }
+
+
+ public:
   inline void execute() const {
-    // ParForSpecialize::execute(m_functor, m_policy, m_result_ptr);
-  }
+    ParReduceSpecialize::execute(m_functor, m_policy, m_result_ptr); }
 
   template <class ViewType>
   inline ParallelReduce(
@@ -1171,18 +1358,21 @@ struct TeamThreadRangeBoundariesStruct<iType, OpenMPTargetExecTeamMember> {
   typedef iType index_type;
   const iType start;
   const iType end;
-  const iType increment;
+  const OpenMPTargetExecTeamMember& team ;
+
 
   inline TeamThreadRangeBoundariesStruct(
-      const OpenMPTargetExecTeamMember& thread_, iType count)
-      : start(thread_.team_rank()),
+      const OpenMPTargetExecTeamMember& team_in, iType count)
+      : start(0),
         end(count),
-        increment(thread_.team_size()) {}
+        team(team_in)
+        {}
   inline TeamThreadRangeBoundariesStruct(
-      const OpenMPTargetExecTeamMember& thread_, iType begin_, iType end_)
-      : start(begin_ + thread_.team_rank()),
+      const OpenMPTargetExecTeamMember& team_in, iType begin_, iType end_)
+      : start(begin_),
         end(end_),
-        increment(thread_.team_size()) {}
+        team(team_in)
+        {}
 };
 
 template <typename iType>
@@ -1190,19 +1380,21 @@ struct ThreadVectorRangeBoundariesStruct<iType, OpenMPTargetExecTeamMember> {
   typedef iType index_type;
   const index_type start;
   const index_type end;
-  const index_type increment;
+  const OpenMPTargetExecTeamMember& team ;
 
   inline ThreadVectorRangeBoundariesStruct(
-      const OpenMPTargetExecTeamMember& thread_, index_type count)
-      : start(thread_.m_vector_lane),
+      const OpenMPTargetExecTeamMember& team_in, index_type count)
+      : start(0),
         end(count),
-        increment(thread_.m_vector_length) {}
+        team(team_in)
+        {}
+
   inline ThreadVectorRangeBoundariesStruct(
-      const OpenMPTargetExecTeamMember& thread_, index_type begin_,
+      const OpenMPTargetExecTeamMember& team_in, index_type begin_,
       index_type end_)
-      : start(begin_ + thread_.m_vector_lane),
+      : start(begin_ ),
         end(end_),
-        increment(thread_.m_vector_length) {}
+        team(team_in) {}
 };
 
 template <typename iType>


### PR DESCRIPTION
Kokkos league level maps to teams distribute,
Thread level maps to parallel for and
Vector level maps to simd

Custom reducers do not work yet.