### PR TITLE
Allow using OpenMP with HIP

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -48,7 +48,8 @@
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_OPENMP)
 
-#if !defined(_OPENMP) && !defined(__CUDA_ARCH__)
+#if !defined(_OPENMP) && !defined(__CUDA_ARCH__) && \
+    !defined(__HIP_DEVICE_COMPILE__)
 #error \
     "You enabled Kokkos OpenMP support without enabling OpenMP in the compiler!"
 #endif


### PR DESCRIPTION
We need this, for compiling with the `OpenMP` backend and the `HIP` backend simultaneously.