### PR TITLE
Fix bowman scatterview unit test

### DIFF
--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -620,12 +620,6 @@ void test_scatter_view(int n) {
 #ifdef KOKKOS_ENABLE_SERIAL
   }
 #endif
-  {
-    test_default_scatter_view<DeviceType, Kokkos::LayoutRight, ScatterType,
-                              NumberType>
-        test_default_sv;
-    test_default_sv.run_test(n);
-  }
   // with hundreds of threads we were running out of memory.
   // limit (n) so that duplication doesn't exceed 4GB
   constexpr std::size_t maximum_allowed_total_bytes =
@@ -637,6 +631,14 @@ void test_scatter_view(int n) {
   std::size_t const maximum_allowed_copy_values =
       maximum_allowed_copy_bytes / bytes_per_value;
   n = std::min(n, int(maximum_allowed_copy_values));
+
+  // if the default is duplicated, this needs to follow the limit
+  {
+    test_default_scatter_view<DeviceType, Kokkos::LayoutRight, ScatterType,
+                              NumberType>
+        test_default_sv;
+    test_default_sv.run_test(n);
+  }
   TestDuplicatedScatterView<DeviceType, ScatterType, NumberType> duptest(n);
 }
 


### PR DESCRIPTION
We recently added to the overloads for create_scatter_view a version that will determine the defaults for duplication and contribution.  The test case for this has to be treated like a duplication test because if the default is duplicated, then the behavior will match.  The fix here is to move the default test case below where the duplicated limit is set, thus making it work the same as the duplicated test (for execution space that is duplicated.)