### PR TITLE
Move all builds to C++14 on Jenkins CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -41,6 +41,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER=hipcc \
                                 -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -DNDEBUG" \
+                                -DCMAKE_CXX_STANDARD=14 \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_HIP=ON \
@@ -104,6 +105,7 @@ pipeline {
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=clang++ \
                                 -DCMAKE_CXX_FLAGS=-Werror \
+                                -DCMAKE_CXX_STANDARD=14 \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_CUDA=ON \
@@ -135,6 +137,7 @@ pipeline {
                               ../gnu_generate_makefile.bash \
                                 --with-options=compiler_warnings \
                                 --cxxflags="-Werror" \
+                                --cxxstandard=c++14 \
                                 --with-cuda \
                                 --with-cuda-options=enable_lambda \
                                 --arch=Volta70 \
@@ -190,6 +193,7 @@ pipeline {
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \
                                 -DCMAKE_CXX_FLAGS=-Werror \
+                                -DCMAKE_CXX_STANDARD=17 \
                                 -DKokkos_INSTALL_TESTING=ON \
                               .. && \
                               make -j8 && ctest --output-on-failure && \
@@ -199,6 +203,7 @@ pipeline {
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \
                                 -DCMAKE_CXX_FLAGS=-Werror \
+                                -DCMAKE_CXX_STANDARD=17 \
                               .. && \
                               make -j8 && ctest --output-on-failure'''
                     }
@@ -226,6 +231,7 @@ pipeline {
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \
                                 -DCMAKE_CXX_FLAGS=-Werror \
+                                -DCMAKE_CXX_STANDARD=14 \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_DEBUG=ON \
                                 -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON \
@@ -237,7 +243,7 @@ pipeline {
                               make -j8 && ctest --output-on-failure && \
                               cd ../example/build_cmake_in_tree && \
                               rm -rf build && mkdir -p build && cd build && \
-                              cmake .. && make -j8 && ctest --output-on-failure'''
+                              cmake -DCMAKE_CXX_STANDARD=14 .. && make -j8 && ctest --output-on-failure'''
                     }
                     post {
                         always {

--- a/.jenkins
+++ b/.jenkins
@@ -251,7 +251,7 @@ pipeline {
                         }
                     }
                 }
-                stage('GCC-4.8.4') {
+                stage('GCC-5.3.0') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.gcc'
@@ -268,6 +268,7 @@ pipeline {
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
+                                -DCMAKE_CXX_STANDARD=14 \
                                 -DCMAKE_CXX_FLAGS=-Werror \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \

--- a/scripts/docker/Dockerfile.gcc
+++ b/scripts/docker/Dockerfile.gcc
@@ -1,4 +1,4 @@
-FROM gcc:4.8.4
+FROM gcc:5.3.0
 
 ARG CMAKE_VERSION=3.10.3
 ENV CMAKE_DIR=/opt/cmake


### PR DESCRIPTION
GCC 4.8.4 does not support C++14.   Bumping the minimum version to 5.3.0.