### PR TITLE
cuda_abort: remove [[no return]] with KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_abort.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_abort.hpp
@@ -65,6 +65,8 @@ namespace Kokkos {
 namespace Impl {
 
 #if !defined(__APPLE__)
+// required to workaround failures in random number generator unit tests with
+// pre-volta architectures
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
 __device__ inline void cuda_abort(const char *const message) {
 #else
@@ -78,6 +80,8 @@ __device__ inline void cuda_abort(const char *const message) {
   // This loop is never executed. It's intended to suppress warnings that the
   // function returns, even though it does not. This is necessary because
   // __assertfail is not marked as [[noreturn]], even though it does not return.
+  //  Disable with KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK to workaround failures
+  //  in random number generator unit tests with pre-volta architectures
 #if !defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
   while (true)
     ;

--- a/core/src/Cuda/Kokkos_Cuda_abort.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_abort.hpp
@@ -65,7 +65,11 @@ namespace Kokkos {
 namespace Impl {
 
 #if !defined(__APPLE__)
+#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+__device__ inline void cuda_abort(const char *const message) {
+#else
 [[noreturn]] __device__ inline void cuda_abort(const char *const message) {
+#endif
   const char empty[] = "";
 
   __assertfail((const void *)message, (const void *)empty, (unsigned int)0,
@@ -74,8 +78,10 @@ namespace Impl {
   // This loop is never executed. It's intended to suppress warnings that the
   // function returns, even though it does not. This is necessary because
   // __assertfail is not marked as [[noreturn]], even though it does not return.
+#if !defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
   while (true)
     ;
+#endif
 }
 #else
 __device__ inline void cuda_abort(const char *const message) {

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -168,6 +168,8 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
 
 #if defined(__APPLE__) || defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
 // cuda_abort does not abort when building for macOS.
+// required to workaround failures in random number generator unit tests with
+// pre-volta architectures
 #define KOKKOS_IMPL_ABORT_NORETURN
 #else
 // cuda_abort aborts when building for other platforms than macOS

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -166,7 +166,7 @@ class RawMemoryAllocationFailure : public std::bad_alloc {
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
 // cuda_abort does not abort when building for macOS.
 #define KOKKOS_IMPL_ABORT_NORETURN
 #else


### PR DESCRIPTION
addresses cuda random number generator test failures on Pre-Volta archs