### PR TITLE
fixed Kokkos::LayoutStride::order_dimensions

### DIFF
--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -167,9 +167,13 @@ struct LayoutStride {
     if (0 == check_input) {
       size_t n = 1;
       for (int r = 0; r < rank; ++r) {
-        tmp.stride[order[r]] = n;
-        n *= (dimen[order[r]]);
         tmp.dimension[r] = dimen[r];
+        for (int r1 = 0; r1 < rank; ++r1) {
+          if(order[r1]==r){
+            tmp.stride[r1] = n;
+            n *= (dimen[r1]);
+          }
+        }
       }
     }
     return tmp;


### PR DESCRIPTION
 I found that the `stride` method return strides which differ from the input stride. I tested it with the following lines of code

````
  const int rank = 3; 
  int order[3]= {2,0,1} ;
  const unsigned dim[] = { 2 , 2 , 2 };
  
  Kokkos::LayoutStride layout_stride = Kokkos::LayoutStride::order_dimensions( rank , order , dim );
  Kokkos::View<double***, Kokkos::LayoutStride  > tmp("tmp",layout_stride);;
    
  printf("input stride\n");
  printf("%d    %d    %d\n",order[0], order[1], order[2]);
  int strides [3]; // any integer type works in stride ()
  tmp.stride (strides );
  printf("output stride\n");
  printf("%d    %d    %d\n",strides[0], strides[1], strides[2]);
````
were giving as output
```
input stride
2    0    1
output stride
2    4    1
```
while  with my proposed change, the output is 
```
output stride
4    1    2
```
As I think it should be because `order[3]= {2,0,1}` implies that entries  (i, j, k) and (i, j+1, k) should be contiguous.
On a CPU I checked the memory with a View's "raw" pointer
 ```
  for ( int i = 0; i < 2; ++i ) 
      for ( int j = 0; j < 2; ++j ) 
            for ( int k = 0; k < 2; ++k ) 
                tmp( i, j,k ) = i;
  double *p=&tmp(0,0,0);
  for ( int i = 0; i < 8; ++i )
      printf("%f\t",*(p+i));
  printf("\n");
```
and I was getting 
`0.000000        0.000000        1.000000        1.000000        0.000000        0.000000        1.000000        1.000000
`
while after my proposed change I get 
`0.000000        0.000000        0.000000        0.000000        1.000000        1.000000        1.000000        1.000000`

