### PR TITLE
HIP: Implement max threads per block as constexpr

### DIFF
--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -78,7 +78,7 @@ int hip_internal_get_block_size(const F &condition_check,
   const int min_blocks_per_sm =
       LaunchBounds::minBperSM == 0 ? 1 : LaunchBounds::minBperSM;
   const int max_threads_per_block = LaunchBounds::maxTperB == 0
-                                        ? hip_instance->m_maxThreadsPerBlock
+                                        ? HIPTraits::MaxThreadsPerBlock
                                         : LaunchBounds::maxTperB;
 
   const int regs_per_wavefront  = attr.numRegs;
@@ -255,7 +255,7 @@ struct HIPGetOptBlockSize<DriverType, Kokkos::LaunchBounds<0, 0>, true> {
     int maxOccupancy  = 0;
     int bestBlockSize = 0;
 
-    while (blockSize < 1024) {
+    while (blockSize < HIPTraits::MaxThreadsPerBlock) {
       blockSize *= 2;
 
       // calculate the occupancy with that optBlockSize and check whether its
@@ -289,7 +289,7 @@ struct HIPGetOptBlockSize<DriverType, Kokkos::LaunchBounds<0, 0>, false> {
     int maxOccupancy  = 0;
     int bestBlockSize = 0;
 
-    while (blockSize < 1024) {
+    while (blockSize < HIPTraits::MaxThreadsPerBlock) {
       blockSize *= 2;
       sharedmem =
           shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -220,7 +220,12 @@ void HIPInternal::initialize(int hip_device_id, hipStream_t stream) {
     // https://github.com/ROCm-Developer-Tools/HIP/blob/a0b5dfd625d99af7e288629747b40dd057183173/vdi/hip_platform.cpp#L742
     m_maxBlocksPerSM = 32;
     // FIXME_HIP - Nick to implement this upstream
-    m_regsPerSM        = 262144 / m_maxBlocksPerSM;
+    //             Register count comes from Sec. 2.2. "Data Sharing" of the
+    //             Vega 7nm ISA document (see the diagram)
+    //             https://developer.amd.com/wp-content/resources/Vega_7nm_Shader_ISA.pdf
+    //             VGPRS = 4 (SIMD/CU) * 256 VGPR/SIMD * 64 registers / VGPR =
+    //             65536 VGPR/CU
+    m_regsPerSM        = 65536;
     m_shmemPerSM       = hipProp.maxSharedMemoryPerMultiProcessor;
     m_maxShmemPerBlock = hipProp.sharedMemPerBlock;
     m_maxThreadsPerSM  = m_maxBlocksPerSM * HIPTraits::WarpSize;

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -222,7 +222,6 @@ void HIPInternal::initialize(int hip_device_id, hipStream_t stream) {
     m_shmemPerSM         = hipProp.maxSharedMemoryPerMultiProcessor;
     m_maxShmemPerBlock   = hipProp.sharedMemPerBlock;
     m_maxThreadsPerSM    = m_maxBlocksPerSM * HIPTraits::WarpSize;
-    m_maxThreadsPerBlock = hipProp.maxThreadsPerBlock;
 
     //----------------------------------
     // Multiblock reduction uses scratch flags for counters

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -57,6 +57,8 @@ struct HIPTraits {
   static int constexpr WarpSize       = 64;
   static int constexpr WarpIndexMask  = 0x003f; /* hexadecimal for 63 */
   static int constexpr WarpIndexShift = 6;      /* WarpSize == 1 << WarpShift*/
+  static int constexpr MaxThreadsPerBlock =
+      1024;  // FIXME_HIP -- assumed constant for now
 
   static int constexpr ConstantMemoryUsage        = 0x008000; /* 32k bytes */
   static int constexpr ConstantMemoryUseThreshold = 0x000200; /* 512 bytes */
@@ -92,7 +94,6 @@ class HIPInternal {
   int m_shmemPerSM;
   int m_maxShmemPerBlock;
   int m_maxThreadsPerSM;
-  int m_maxThreadsPerBlock;
   size_type m_scratchSpaceCount;
   size_type m_scratchFlagsCount;
   size_type *m_scratchSpace;
@@ -132,7 +133,6 @@ class HIPInternal {
         m_shmemPerSM(0),
         m_maxShmemPerBlock(0),
         m_maxThreadsPerSM(0),
-        m_maxThreadsPerBlock(0),
         m_scratchSpaceCount(0),
         m_scratchFlagsCount(0),
         m_scratchSpace(0),

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -298,7 +298,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   // Determine block size constrained by shared memory:
   // This is copy/paste from Kokkos_HIP_Parallel_Range
   inline unsigned local_block_size(const FunctorType& f) {
-    unsigned n     = Experimental::Impl::HIPTraits::WarpSize * 8;
+    unsigned int n =
+        ::Kokkos::Experimental::Impl::HIPTraits::MaxThreadsPerBlock;
     int shmem_size = ::Kokkos::Impl::hip_single_inter_block_reduce_scan_shmem<
         false, FunctorType, WorkTag>(f, n);
     while (

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -307,8 +307,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    // FIXME_HIP I don't know where 8 comes from
-    unsigned int n = ::Kokkos::Experimental::Impl::HIPTraits::WarpSize * 8;
+    unsigned int n =
+        ::Kokkos::Experimental::Impl::HIPTraits::MaxThreadsPerBlock;
     int shmem_size =
         hip_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag>(
             f, n);

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -108,7 +108,11 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
   inline void execute() const {
     const typename Policy::index_type nwork = m_policy.end() - m_policy.begin();
 
-    const int block_size = 256;  // FIXME_HIP Choose block_size better
+    const int block_size =
+        LaunchBounds::maxTperB
+            ? LaunchBounds::maxTperB
+            : ::Kokkos::Experimental::Impl::HIPTraits::
+                  MaxThreadsPerBlock;  // FIXME_HIP Choose block_size better
     const dim3 block(1, block_size, 1);
     const dim3 grid(
         typename Policy::index_type((nwork + block.y - 1) / block.y), 1, 1);


### PR DESCRIPTION
Eliminates more magic "1024/512", etc. constants in the code, placing them in HIPTraits::MaxThreadsPerBlock. I am currently treating this as a constant, such that it can be marked constexpr and used in templates.