### PR TITLE
HIP: implement multiple occupancy paths for various kernel launchers in bl…

### DIFF
--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -72,7 +72,8 @@ void hipOccupancy(int *numBlocks, int blockSize, int sharedmem) {
 
 template <typename DriverType, bool constant>
 void hipOccupancy(int *numBlocks, int blockSize, int sharedmem) {
-  hipOccupancy<DriverType, constant, HIPTraits::MaxThreadsPerBlock, 1>(
+  // FIXME_HIP -- this should be the new HIPTraits::MaxThreadsPerBlock
+  hipOccupancy<DriverType, constant, 1024, 1>(
       numBlocks, blockSize, sharedmem);
 }
 template <typename DriverType, typename LaunchBounds, bool Large>

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -196,7 +196,7 @@ struct HIPGetMaxBlockSize<DriverType, LaunchBounds, true> {
     using blocktype = int;
 #endif
     blocktype numBlocks = 0;
-    int blockSize = LaunchBounds::maxTperB;
+    int blockSize       = LaunchBounds::maxTperB;
     int sharedmem =
         shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
         ::Kokkos::Impl::FunctorTeamShmemSize<

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -73,8 +73,7 @@ void hipOccupancy(int *numBlocks, int blockSize, int sharedmem) {
 template <typename DriverType, bool constant>
 void hipOccupancy(int *numBlocks, int blockSize, int sharedmem) {
   // FIXME_HIP -- this should be the new HIPTraits::MaxThreadsPerBlock
-  hipOccupancy<DriverType, constant, 1024, 1>(
-      numBlocks, blockSize, sharedmem);
+  hipOccupancy<DriverType, constant, 1024, 1>(numBlocks, blockSize, sharedmem);
 }
 template <typename DriverType, typename LaunchBounds, bool Large>
 struct HIPGetMaxBlockSize;
@@ -198,9 +197,7 @@ struct HIPGetMaxBlockSize<DriverType, LaunchBounds, true> {
 #endif
     blocktype numBlocks = 0;
     // FIXME_HIP -- this should be the new HIPTraits::MaxThreadsPerBlock
-    int blockSize       = LaunchBounds::maxTperB == 0
-                                ? 1024
-                                : LaunchBounds::maxTperB;
+    int blockSize = LaunchBounds::maxTperB == 0 ? 1024 : LaunchBounds::maxTperB;
     int sharedmem =
         shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
         ::Kokkos::Impl::FunctorTeamShmemSize<

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -63,11 +63,11 @@ void hipOccupancy(int *numBlocks, int blockSize, int sharedmem) {
   //             perform some simple scaling studies to see when /
   //             if the constant launcher outperforms the current
   //             pass by pointer shared launcher
-  hipOccupancyMaxActiveBlocksPerMultiprocessor(
+  HIP_SAFE_CALL(hipOccupancyMaxActiveBlocksPerMultiprocessor(
       numBlocks,
       hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
                                        MinBlocksPerSM>,
-      blockSize, sharedmem);
+      blockSize, sharedmem));
 }
 
 template <typename DriverType, bool constant>

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -196,7 +196,10 @@ struct HIPGetMaxBlockSize<DriverType, LaunchBounds, true> {
     using blocktype = int;
 #endif
     blocktype numBlocks = 0;
-    int blockSize       = LaunchBounds::maxTperB;
+    // FIXME_HIP -- this should be the new HIPTraits::MaxThreadsPerBlock
+    int blockSize       = LaunchBounds::maxTperB == 0
+                                ? 1024
+                                : LaunchBounds::maxTperB;
     int sharedmem =
         shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
         ::Kokkos::Impl::FunctorTeamShmemSize<


### PR DESCRIPTION
…ocksize deduction

Ensure that the occupancy checked in Kokkos_HIP_BlockSize_Deduction.hpp matches the kernel launcher used in Kokkos_HIP_KernelLaunch.hpp, i.e., hip_parallel_launch_local_memory. Previously, if the occupancy was determined for the constant launcher, subtle launch-time resource utilization bugs could be introduced (e.g., not enough LDS for the scatchpad) due to minor differences in the kernels