### PR TITLE
Make ScratchMemorySpace semi-regular

### DIFF
--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -78,9 +78,6 @@ class ScratchMemorySpace {
   mutable int m_offset;
   mutable int m_default_level;
 
-  ScratchMemorySpace();
-  ScratchMemorySpace& operator=(const ScratchMemorySpace&);
-
   enum { MASK = ALIGN - 1 };  // Alignment used by View::shmem_size
 
  public:

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -196,6 +196,12 @@ class ScratchMemorySpace {
         m_offset(0),
         m_default_level(0) {}
 
+  ScratchMemorySpace(const ScratchMemorySpace&) = default;
+  ScratchMemorySpace(ScratchMemorySpace&&)      = default;
+  ScratchMemorySpace& operator=(const ScratchMemorySpace&) = delete;
+  ScratchMemorySpace& operator=(ScratchMemorySpace&&) noexcept = default;
+  ~ScratchMemorySpace() noexcept                               = default;
+
   KOKKOS_INLINE_FUNCTION
   const ScratchMemorySpace& set_team_thread_mode(const int& level,
                                                  const int& multiplier,

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -196,12 +196,6 @@ class ScratchMemorySpace {
         m_offset(0),
         m_default_level(0) {}
 
-  ScratchMemorySpace(const ScratchMemorySpace&) = default;
-  ScratchMemorySpace(ScratchMemorySpace&&)      = default;
-  ScratchMemorySpace& operator=(const ScratchMemorySpace&) = delete;
-  ScratchMemorySpace& operator=(ScratchMemorySpace&&) noexcept = default;
-  ~ScratchMemorySpace() noexcept                               = default;
-
   KOKKOS_INLINE_FUNCTION
   const ScratchMemorySpace& set_team_thread_mode(const int& level,
                                                  const int& multiplier,

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -183,6 +183,9 @@ class ScratchMemorySpace {
     }
   }
 
+  KOKKOS_DEFAULTED_FUNCTION
+  ScratchMemorySpace() = default;
+
   template <typename IntType>
   KOKKOS_INLINE_FUNCTION ScratchMemorySpace(void* ptr_L0,
                                             const IntType& size_L0,

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -69,14 +69,14 @@ class ScratchMemorySpace {
   enum { ALIGN = 8 };
 
  private:
-  mutable char* m_iter_L0;
-  char* m_end_L0;
-  mutable char* m_iter_L1;
-  char* m_end_L1;
+  mutable char* m_iter_L0 = nullptr;
+  char* m_end_L0 = nullptr;
+  mutable char* m_iter_L1 = nullptr;
+  char* m_end_L1 = nullptr;
 
-  mutable int m_multiplier;
-  mutable int m_offset;
-  mutable int m_default_level;
+  mutable int m_multiplier = 0;
+  mutable int m_offset = 0;
+  mutable int m_default_level = 0;
 
   enum { MASK = ALIGN - 1 };  // Alignment used by View::shmem_size
 


### PR DESCRIPTION
**edited** Making `ScratchMemorySpace` easier to use and to reason about since could not think of any good reason not to do so.  The copy-assignment was intentionally deleted in the past but there was no comment explaining that choice.

---
~~These seem to not be defined.
Since there is another constructor deleting the private default constructor doesn't seem to be any effect. I could be convinced that the copy constructor should be deleted, though.~~

Don't use the pre-C++11 way to delete functions but use the rule of 5 instead and also allow move assignment/move construction.