### PR TITLE
Bug: Fixing DynamicView reporting correct sizes and labels

### DIFF
--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -299,19 +299,21 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
 
     // *m_chunks[m_chunk_max] stores the current number of chunks being used
     uintptr_t* const pc = reinterpret_cast<uintptr_t*>(m_chunks + m_chunk_max);
-
+    std::string _label =
+        m_track.template get_label<typename traits::memory_space>();
     if (*pc < NC) {
       while (*pc < NC) {
         m_chunks[*pc] = reinterpret_cast<value_pointer_type>(
-            typename traits::memory_space().allocate(sizeof(local_value_type)
-                                                     << m_chunk_shift));
+            typename traits::memory_space().allocate(
+                _label.c_str(), sizeof(local_value_type) << m_chunk_shift));
         ++*pc;
       }
     } else {
       while (NC + 1 <= *pc) {
         --*pc;
         typename traits::memory_space().deallocate(
-            m_chunks[*pc], sizeof(local_value_type) << m_chunk_shift);
+            _label.c_str(), m_chunks[*pc],
+            sizeof(local_value_type) << m_chunk_shift);
         m_chunks[*pc] = nullptr;
       }
     }
@@ -356,7 +358,9 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
   //----------------------------------------------------------------------
 
   struct Destroy {
-    typename traits::value_type** m_chunks;
+    using local_value_type = typename traits::value_type;
+    std::string m_label;
+    local_value_type** m_chunks;
     unsigned m_chunk_max;
     bool m_destroy;
     unsigned m_chunk_size;
@@ -365,7 +369,9 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
     // Two entries beyond the max chunks are allocation counters.
     inline void operator()(unsigned i) const {
       if (m_destroy && i < m_chunk_max && nullptr != m_chunks[i]) {
-        typename traits::memory_space().deallocate(m_chunks[i], m_chunk_size);
+        typename traits::memory_space().deallocate(
+            m_label.c_str(), m_chunks[i],
+            sizeof(local_value_type) * m_chunk_size);
       }
       m_chunks[i] = nullptr;
     }
@@ -397,9 +403,10 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
     Destroy& operator=(Destroy&&) = default;
     Destroy& operator=(const Destroy&) = default;
 
-    Destroy(typename traits::value_type** arg_chunk,
+    Destroy(std::string label, typename traits::value_type** arg_chunk,
             const unsigned arg_chunk_max, const unsigned arg_chunk_size)
-        : m_chunks(arg_chunk),
+        : m_label(label),
+          m_chunks(arg_chunk),
           m_chunk_max(arg_chunk_max),
           m_destroy(false),
           m_chunk_size(arg_chunk_size) {}
@@ -443,7 +450,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
 
     m_chunks = reinterpret_cast<pointer_type*>(record->data());
 
-    record->m_destroy = Destroy(m_chunks, m_chunk_max, m_chunk_size);
+    record->m_destroy = Destroy(arg_label, m_chunks, m_chunk_max, m_chunk_size);
 
     // Initialize to zero
     record->m_destroy.construct_shared_allocation();


### PR DESCRIPTION
The chunk allocations do not report correctly memory sizes at deallocation in the tools, and also don't add labels to the chunks. THis fixes it.