### PR TITLE
Dual View Tool Events

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -457,7 +457,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     }
     return dev;
   }
-  constexpr const int view_header_size = 128;
+  static constexpr const int view_header_size = 128;
   void impl_report_host_sync() const noexcept {
     Kokkos::Tools::syncDualView(
         h_view.label(),
@@ -643,14 +643,14 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     Kokkos::Tools::modifyDualView(
         d_view.label(),
         reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(d_view.data()) -
-                                128),
+                                view_header_size),
         true);
   }
   void impl_report_host_modification() {
     Kokkos::Tools::modifyDualView(
         h_view.label(),
         reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(h_view.data()) -
-                                128),
+                                view_header_size),
         false);
   }
   /// \brief Mark data as modified on the given device \c Device.

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -457,18 +457,19 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     }
     return dev;
   }
+  constexpr const int view_header_size = 128;
   void impl_report_host_sync() const noexcept {
     Kokkos::Tools::syncDualView(
         h_view.label(),
         reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(h_view.data()) -
-                                128),
+                                view_header_size),
         false);
   }
   void impl_report_device_sync() const noexcept {
     Kokkos::Tools::syncDualView(
         d_view.label(),
         reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(d_view.data()) -
-                                128),
+                                view_header_size),
         true);
   }
   /// \brief Update data on device or host only if data in the other

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -457,14 +457,14 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     }
     return dev;
   }
-  void impl_report_host_sync() {
+  void impl_report_host_sync() const noexcept {
     Kokkos::Tools::syncDualView(
         h_view.label(),
         reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(h_view.data()) -
                                 128),
         false);
   }
-  void impl_report_device_sync() {
+  void impl_report_device_sync() const noexcept {
     Kokkos::Tools::syncDualView(
         d_view.label(),
         reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(d_view.data()) -

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -457,7 +457,20 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     }
     return dev;
   }
-
+  void impl_report_host_sync() {
+    Kokkos::Tools::syncDualView(
+        h_view.label(),
+        reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(h_view.data()) -
+                                128),
+        false);
+  }
+  void impl_report_device_sync() {
+    Kokkos::Tools::syncDualView(
+        d_view.label(),
+        reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(d_view.data()) -
+                                128),
+        true);
+  }
   /// \brief Update data on device or host only if data in the other
   ///   space has been marked as modified.
   ///
@@ -499,6 +512,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
 
         deep_copy(d_view, h_view);
         modified_flags(0) = modified_flags(1) = 0;
+        impl_report_device_sync();
       }
     }
     if (dev == 0) {  // hopefully Device is the same as DualView's host type
@@ -515,6 +529,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
 
         deep_copy(h_view, d_view);
         modified_flags(0) = modified_flags(1) = 0;
+        impl_report_host_sync();
       }
     }
     if (std::is_same<typename t_host::memory_space,
@@ -539,12 +554,14 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
         Impl::throw_runtime_exception(
             "Calling sync on a DualView with a const datatype.");
       }
+      impl_report_device_sync();
     }
     if (dev == 0) {  // hopefully Device is the same as DualView's host type
       if ((modified_flags(1) > 0) && (modified_flags(1) >= modified_flags(0))) {
         Impl::throw_runtime_exception(
             "Calling sync on a DualView with a const datatype.");
       }
+      impl_report_host_sync();
     }
   }
 
@@ -567,6 +584,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
 
       deep_copy(h_view, d_view);
       modified_flags(1) = modified_flags(0) = 0;
+      impl_report_host_sync();
     }
   }
 
@@ -589,6 +607,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
 
       deep_copy(d_view, h_view);
       modified_flags(1) = modified_flags(0) = 0;
+      impl_report_device_sync();
     }
   }
 
@@ -619,7 +638,20 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     if (modified_flags.data() == nullptr) return false;
     return modified_flags(1) < modified_flags(0);
   }
-
+  void impl_report_device_modification() {
+    Kokkos::Tools::modifyDualView(
+        d_view.label(),
+        reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(d_view.data()) -
+                                128),
+        true);
+  }
+  void impl_report_host_modification() {
+    Kokkos::Tools::modifyDualView(
+        h_view.label(),
+        reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(h_view.data()) -
+                                128),
+        false);
+  }
   /// \brief Mark data as modified on the given device \c Device.
   ///
   /// If \c Device is the same as this DualView's device type, then
@@ -631,11 +663,13 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     int dev = get_device_side<Device>();
 
     if (dev == 1) {  // if Device is the same as DualView's device type
+
       // Increment the device's modified count.
       modified_flags(1) =
           (modified_flags(1) > modified_flags(0) ? modified_flags(1)
                                                  : modified_flags(0)) +
           1;
+      impl_report_device_modification();
     }
     if (dev == 0) {  // hopefully Device is the same as DualView's host type
       // Increment the host's modified count.
@@ -643,6 +677,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
           (modified_flags(1) > modified_flags(0) ? modified_flags(1)
                                                  : modified_flags(0)) +
           1;
+      impl_report_host_modification();
     }
 
 #ifdef KOKKOS_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK
@@ -663,6 +698,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
           (modified_flags(1) > modified_flags(0) ? modified_flags(1)
                                                  : modified_flags(0)) +
           1;
+      impl_report_host_modification();
 #ifdef KOKKOS_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK
       if (modified_flags(0) && modified_flags(1)) {
         std::string msg = "Kokkos::DualView::modify_host ERROR: ";
@@ -682,6 +718,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
           (modified_flags(1) > modified_flags(0) ? modified_flags(1)
                                                  : modified_flags(0)) +
           1;
+      impl_report_device_modification();
 #ifdef KOKKOS_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK
       if (modified_flags(0) && modified_flags(1)) {
         std::string msg = "Kokkos::DualView::modify_device ERROR: ";

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -560,8 +560,8 @@ void syncDualView(const std::string& label, const void* const ptr,
 void modifyDualView(const std::string& label, const void* const ptr,
                     bool on_device) {
   if (Experimental::current_callbacks.sync_dual_view != nullptr) {
-    (*Experimental::current_callbacks.sync_dual_view)(label.c_str(), ptr,
-                                                      on_device);
+    (*Experimental::current_callbacks.modify_dual_view)(label.c_str(), ptr,
+                                                        on_device);
   }
 }
 

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -551,10 +551,10 @@ void finalize() {
 }
 
 void syncDualView(const std::string& label, const void* const ptr,
-                  bool on_device) {
+                  bool to_device) {
   if (Experimental::current_callbacks.sync_dual_view != nullptr) {
     (*Experimental::current_callbacks.sync_dual_view)(label.c_str(), ptr,
-                                                      on_device);
+                                                      to_device);
   }
 }
 void modifyDualView(const std::string& label, const void* const ptr,

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -559,7 +559,7 @@ void syncDualView(const std::string& label, const void* const ptr,
 }
 void modifyDualView(const std::string& label, const void* const ptr,
                     bool on_device) {
-  if (Experimental::current_callbacks.sync_dual_view != nullptr) {
+  if (Experimental::current_callbacks.modify_dual_view != nullptr) {
     (*Experimental::current_callbacks.modify_dual_view)(label.c_str(), ptr,
                                                         on_device);
   }

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -94,7 +94,8 @@ bool eventSetsEqual(const EventSet& l, const EventSet& r) {
          l.profile_event == r.profile_event &&
          l.begin_deep_copy == r.begin_deep_copy &&
          l.end_deep_copy == r.end_deep_copy && l.begin_fence == r.begin_fence &&
-         l.end_fence == r.end_fence &&
+         l.end_fence == r.end_fence && l.sync_dual_view == r.sync_dual_view &&
+         l.modify_dual_view == r.modify_dual_view &&
          l.declare_input_type == r.declare_input_type &&
          l.declare_output_type == r.declare_output_type &&
          l.end_tuning_context == r.end_tuning_context &&
@@ -542,6 +543,21 @@ void finalize() {
 #endif
 }
 
+void syncDualView(const std::string& label, const void* const ptr,
+                  bool on_device) {
+  if (Experimental::current_callbacks.sync_dual_view != nullptr) {
+    (*Experimental::current_callbacks.sync_dual_view)(label.c_str(), ptr,
+                                                      on_device);
+  }
+}
+void modifyDualView(const std::string& label, const void* const ptr,
+                    bool on_device) {
+  if (Experimental::current_callbacks.sync_dual_view != nullptr) {
+    (*Experimental::current_callbacks.sync_dual_view)(label.c_str(), ptr,
+                                                      on_device);
+  }
+}
+
 }  // namespace Tools
 
 namespace Tools {
@@ -610,6 +626,13 @@ void set_begin_fence_callback(beginFenceFunction callback) {
 }
 void set_end_fence_callback(endFenceFunction callback) {
   current_callbacks.end_fence = callback;
+}
+
+void set_dual_view_sync_callback(dualViewSyncFunction callback) {
+  current_callbacks.sync_dual_view = callback;
+}
+void set_dual_view_modify_callback(dualViewModifyFunction callback) {
+  current_callbacks.modify_dual_view = callback;
 }
 
 void set_declare_output_type_callback(outputTypeDeclarationFunction callback) {

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -402,46 +402,53 @@ void initialize() {
       Experimental::set_end_fence_callback(
           *reinterpret_cast<endFenceFunction*>(&p16));
 
-      auto p17 = dlsym(firstProfileLibrary, "kokkosp_create_profile_section");
-      Experimental::set_create_profile_section_callback(
-          *(reinterpret_cast<createProfileSectionFunction*>(&p17)));
-      auto p18 = dlsym(firstProfileLibrary, "kokkosp_start_profile_section");
-      Experimental::set_start_profile_section_callback(
-          *reinterpret_cast<startProfileSectionFunction*>(&p18));
-      auto p19 = dlsym(firstProfileLibrary, "kokkosp_stop_profile_section");
-      Experimental::set_stop_profile_section_callback(
-          *reinterpret_cast<stopProfileSectionFunction*>(&p19));
-      auto p20 = dlsym(firstProfileLibrary, "kokkosp_destroy_profile_section");
-      Experimental::set_destroy_profile_section_callback(
-          *(reinterpret_cast<destroyProfileSectionFunction*>(&p20)));
+      auto p17 = dlsym(firstProfileLibrary, "kokkosp_dual_view_sync");
+      Experimental::set_dual_view_sync_callback(
+          *reinterpret_cast<dualViewSyncFunction*>(&p17));
+      auto p18 = dlsym(firstProfileLibrary, "kokkosp_dual_view_modify");
+      Experimental::set_dual_view_modify_callback(
+          *reinterpret_cast<dualViewModifyFunction*>(&p18));
 
-      auto p21 = dlsym(firstProfileLibrary, "kokkosp_profile_event");
+      auto p19 = dlsym(firstProfileLibrary, "kokkosp_create_profile_section");
+      Experimental::set_create_profile_section_callback(
+          *(reinterpret_cast<createProfileSectionFunction*>(&p19)));
+      auto p20 = dlsym(firstProfileLibrary, "kokkosp_start_profile_section");
+      Experimental::set_start_profile_section_callback(
+          *reinterpret_cast<startProfileSectionFunction*>(&p20));
+      auto p21 = dlsym(firstProfileLibrary, "kokkosp_stop_profile_section");
+      Experimental::set_stop_profile_section_callback(
+          *reinterpret_cast<stopProfileSectionFunction*>(&p21));
+      auto p22 = dlsym(firstProfileLibrary, "kokkosp_destroy_profile_section");
+      Experimental::set_destroy_profile_section_callback(
+          *(reinterpret_cast<destroyProfileSectionFunction*>(&p22)));
+
+      auto p23 = dlsym(firstProfileLibrary, "kokkosp_profile_event");
       Experimental::set_profile_event_callback(
-          *reinterpret_cast<profileEventFunction*>(&p21));
+          *reinterpret_cast<profileEventFunction*>(&p23));
 
 #ifdef KOKKOS_ENABLE_TUNING
-      auto p22 = dlsym(firstProfileLibrary, "kokkosp_declare_output_type");
+      auto p24 = dlsym(firstProfileLibrary, "kokkosp_declare_output_type");
       Experimental::set_declare_output_type_callback(
           *reinterpret_cast<Experimental::outputTypeDeclarationFunction*>(
-              &p22));
+              &p24));
 
-      auto p23 = dlsym(firstProfileLibrary, "kokkosp_declare_input_type");
+      auto p25 = dlsym(firstProfileLibrary, "kokkosp_declare_input_type");
       Experimental::set_declare_input_type_callback(
-          *reinterpret_cast<Experimental::inputTypeDeclarationFunction*>(&p23));
-      auto p24 = dlsym(firstProfileLibrary, "kokkosp_request_values");
+          *reinterpret_cast<Experimental::inputTypeDeclarationFunction*>(&p25));
+      auto p26 = dlsym(firstProfileLibrary, "kokkosp_request_values");
       Experimental::set_request_output_values_callback(
-          *reinterpret_cast<Experimental::requestValueFunction*>(&p24));
-      auto p25 = dlsym(firstProfileLibrary, "kokkosp_end_context");
+          *reinterpret_cast<Experimental::requestValueFunction*>(&p26));
+      auto p27 = dlsym(firstProfileLibrary, "kokkosp_end_context");
       Experimental::set_end_context_callback(
-          *reinterpret_cast<Experimental::contextEndFunction*>(&p25));
-      auto p26 = dlsym(firstProfileLibrary, "kokkosp_begin_context");
+          *reinterpret_cast<Experimental::contextEndFunction*>(&p27));
+      auto p28 = dlsym(firstProfileLibrary, "kokkosp_begin_context");
       Experimental::set_begin_context_callback(
-          *reinterpret_cast<Experimental::contextBeginFunction*>(&p26));
-      auto p27 =
+          *reinterpret_cast<Experimental::contextBeginFunction*>(&p28));
+      auto p29 =
           dlsym(firstProfileLibrary, "kokkosp_declare_optimization_goal");
       Experimental::set_declare_optimization_goal_callback(
           *reinterpret_cast<Experimental::optimizationGoalDeclarationFunction*>(
-              &p27));
+              &p29));
 #endif  // KOKKOS_ENABLE_TUNING
     }
   }

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -89,8 +89,33 @@ void endDeepCopy();
 void beginFence(const std::string name, const uint32_t deviceId,
                 uint64_t* handle);
 void endFence(const uint64_t handle);
+
+/**
+ * syncDualView declares to the tool that a given DualView
+ * has been synced.
+ *
+ * Arguments:
+ *
+ * label:     name of the View within the DualView
+ * ptr:       that View's data ptr
+ * to_device: true if the data is being synchronized to the device
+ * 		false otherwise
+ */
 void syncDualView(const std::string& label, const void* const ptr,
-                  bool on_device);
+                  bool to_device);
+/**
+ * modifyDualView declares to the tool that a given DualView
+ * has been modified. Note: this means that somebody *called*
+ * modify on the DualView, this doesn't get called any time
+ * somebody touches the data
+ *
+ * Arguments:
+ *
+ * label:     name of the View within the DualView
+ * ptr:       that View's data ptr
+ * on_device: true if the data is being modified on the device
+ * 		false otherwise
+ */
 void modifyDualView(const std::string& label, const void* const ptr,
                     bool on_device);
 

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -89,6 +89,10 @@ void endDeepCopy();
 void beginFence(const std::string name, const uint32_t deviceId,
                 uint64_t* handle);
 void endFence(const uint64_t handle);
+void syncDualView(const std::string& label, const void* const ptr,
+                  bool on_device);
+void modifyDualView(const std::string& label, const void* const ptr,
+                    bool on_device);
 
 void initialize();
 void finalize();
@@ -119,6 +123,8 @@ void set_begin_deep_copy_callback(beginDeepCopyFunction callback);
 void set_end_deep_copy_callback(endDeepCopyFunction callback);
 void set_begin_fence_callback(beginFenceFunction callback);
 void set_end_fence_callback(endFenceFunction callback);
+void set_dual_view_sync_callback(dualViewSyncFunction callback);
+void set_dual_view_modify_callback(dualViewModifyFunction callback);
 
 void set_declare_output_type_callback(outputTypeDeclarationFunction callback);
 void set_declare_input_type_callback(inputTypeDeclarationFunction callback);
@@ -167,7 +173,6 @@ void beginDeepCopy(const SpaceHandle dst_space, const std::string dst_label,
                    const std::string src_label, const void* src_ptr,
                    const uint64_t size);
 void endDeepCopy();
-
 void finalize();
 void initialize();
 SpaceHandle make_space_handle(const char* space_name);

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -115,6 +115,14 @@ typedef void (*Kokkos_Profiling_beginFenceFunction)(const char*, const uint32_t,
                                                     uint64_t*);
 typedef void (*Kokkos_Profiling_endFenceFunction)(uint64_t);
 
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_dualViewSyncFunction)(const char*,
+                                                      const void* const, bool);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_dualViewModifyFunction)(const char*,
+                                                        const void* const,
+                                                        bool);
+
 // Tuning
 
 #define KOKKOS_TOOLS_TUNING_STRING_LENGTH 64
@@ -233,7 +241,9 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_endDeepCopyFunction end_deep_copy;
   Kokkos_Profiling_beginFenceFunction begin_fence;
   Kokkos_Profiling_endFenceFunction end_fence;
-  char profiling_padding[14 * sizeof(function_pointer)];
+  Kokkos_Profiling_dualViewSyncFunction sync_dual_view;
+  Kokkos_Profiling_dualViewModifyFunction modify_dual_view;
+  char profiling_padding[12 * sizeof(function_pointer)];
   Kokkos_Tools_outputTypeDeclarationFunction declare_output_type;
   Kokkos_Tools_inputTypeDeclarationFunction declare_input_type;
   Kokkos_Tools_requestValueFunction request_output_values;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -122,6 +122,8 @@ using beginDeepCopyFunction = Kokkos_Profiling_beginDeepCopyFunction;
 using endDeepCopyFunction   = Kokkos_Profiling_endDeepCopyFunction;
 using beginFenceFunction    = Kokkos_Profiling_beginFenceFunction;
 using endFenceFunction      = Kokkos_Profiling_endFenceFunction;
+using dualViewSyncFunction   = Kokkos_Profiling_dualViewSyncFunction;
+using dualViewModifyFunction = Kokkos_Profiling_dualViewModifyFunction;
 
 }  // namespace Tools
 

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -117,11 +117,11 @@ using startProfileSectionFunction =
 using stopProfileSectionFunction = Kokkos_Profiling_stopProfileSectionFunction;
 using destroyProfileSectionFunction =
     Kokkos_Profiling_destroyProfileSectionFunction;
-using profileEventFunction  = Kokkos_Profiling_profileEventFunction;
-using beginDeepCopyFunction = Kokkos_Profiling_beginDeepCopyFunction;
-using endDeepCopyFunction   = Kokkos_Profiling_endDeepCopyFunction;
-using beginFenceFunction    = Kokkos_Profiling_beginFenceFunction;
-using endFenceFunction      = Kokkos_Profiling_endFenceFunction;
+using profileEventFunction   = Kokkos_Profiling_profileEventFunction;
+using beginDeepCopyFunction  = Kokkos_Profiling_beginDeepCopyFunction;
+using endDeepCopyFunction    = Kokkos_Profiling_endDeepCopyFunction;
+using beginFenceFunction     = Kokkos_Profiling_beginFenceFunction;
+using endFenceFunction       = Kokkos_Profiling_endFenceFunction;
 using dualViewSyncFunction   = Kokkos_Profiling_dualViewSyncFunction;
 using dualViewModifyFunction = Kokkos_Profiling_dualViewModifyFunction;
 


### PR DESCRIPTION
This PR adds Dual View events to the callback interface, and implements them. Current signature (up for debate) are events on sync and modify that pass

1. The name of the view (const char*)
2. The beginning of the allocation (const void* const)
3. Whether the sync/modify was on the device side (bool: true means on device)

Questions I have for reviewers (other than "should this go in")

1. Right now we pass the host View name if the sync/modify is on the host, device view name otherwise. I could see it being smart to pass the same name to both events, though I decided not to. Game to hear other opinions though
2. Are these the only events that matter (pretty sure yes but I don't know Dual Views)?