### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -449,7 +449,13 @@ H := \#
 # Do not append first line
 tmp := $(shell echo "/* ---------------------------------------------" > KokkosCore_config.tmp)
 tmp := $(call kokkos_append_header,"Makefile constructed configuration:")
-tmp := $(call kokkos_append_header,"$(shell date)")
+# SOURCE_DATE_EPOCH is a variable people/distros can set to make the build more reproducible by setting it to a positive integer (seconds since 1970-01-01)
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" 2>/dev/null || date -u)
+else
+    BUILD_DATE ?= $(shell date)
+endif
+tmp := $(call kokkos_append_header,"$(BUILD_DATE)")
 tmp := $(call kokkos_append_header,"----------------------------------------------*/")
 
 tmp := $(call kokkos_append_header,'$H''if !defined(KOKKOS_MACROS_HPP) || defined(KOKKOS_CORE_CONFIG_H)')


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible (of the `trilinos` package).
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This date call is designed to work with all variants of date.

Also use UTC to be independent of timezone.

As an alternative, the date could be dropped to reduce complexity.

This PR was done while working on reproducible builds for openSUSE.