### PR TITLE
HIP: Add ROCm 3.7 build to Jenkins CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -41,7 +41,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                                 -DCMAKE_CXX_COMPILER=hipcc \
                                 -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument" \
-                                -DCMAKE_CXX_STANDARD=14 \
+                                -DCMAKE_CXX_STANDARD=17 \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_HIP=ON \

--- a/.jenkins
+++ b/.jenkins
@@ -38,9 +38,9 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
-                                -DCMAKE_BUILD_TYPE=Debug \
+                                -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                                 -DCMAKE_CXX_COMPILER=hipcc \
-                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -DNDEBUG" \
+                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument" \
                                 -DCMAKE_CXX_STANDARD=14 \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \

--- a/.jenkins
+++ b/.jenkins
@@ -24,7 +24,38 @@ pipeline {
 
         stage('Build') {
             parallel {
-                stage('HIP-3.5-HCC') {
+                stage('HIP-ROCm-3.7') {
+                    agent {
+                        dockerfile {
+                            filename 'Dockerfile.hipcc'
+                            dir 'scripts/docker'
+                            additionalBuildArgs '--pull --build-arg BASE=rocm/dev-ubuntu-20.04:3.7'
+                            label 'rocm-docker && vega'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
+                        }
+                    }
+                    steps {
+                        sh 'ccache --zero-stats'
+                        sh '''rm -rf build && mkdir -p build && cd build && \
+                              cmake \
+                                -DCMAKE_BUILD_TYPE=Debug \
+                                -DCMAKE_CXX_COMPILER=hipcc \
+                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -DNDEBUG" \
+                                -DCMAKE_CXX_STANDARD=14 \
+                                -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
+                                -DKokkos_ENABLE_TESTS=ON \
+                                -DKokkos_ENABLE_HIP=ON \
+                                -DKokkos_ARCH_VEGA906=ON \
+                              .. && \
+                              make -j8 && ctest --output-on-failure'''
+                    }
+                    post {
+                        always {
+                            sh 'ccache --show-stats'
+                        }
+                    }
+                }
+                stage('HIP-ROCm-3.5') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.hipcc'


### PR DESCRIPTION
Since we closed #3303 and decided to support ROCm 3.5 a little bit longer, add a build for ROCm 3.7 besides the 3.5 one.
New build ~~has RDC on and~~ is `RelWithDebInfo` instead of `Debug`.

~~Depending on how much longer the build take we might revert the enable relocatable device code.~~
**Edited** RDC does not build so not enabling