### PR TITLE
Add is_specialization_of type trait

### DIFF
--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -417,6 +417,18 @@ struct inclusive_scan_integer_sequence {
 template <typename T>
 using identity_t = T;
 
+//==============================================================================
+// <editor-fold desc="is_specialization_of"> {{{1
+
+template <class Type, template <class...> class Template, class Enable = void>
+struct is_specialization_of : std::false_type {};
+
+template <template <class...> class Template, class... Args>
+struct is_specialization_of<Template<Args...>, Template> : std::true_type {};
+
+// </editor-fold> end is_specialization_of }}}1
+//==============================================================================
+
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/unit_test/TestUtilities.hpp
+++ b/core/unit_test/TestUtilities.hpp
@@ -52,6 +52,24 @@
 
 namespace Test {
 
+void test_is_specialization_of() {
+  using Kokkos::Impl::is_specialization_of;
+  static_assert(is_specialization_of<Kokkos::pair<float, int>, Kokkos::pair>{},
+                "");
+  static_assert(!is_specialization_of<Kokkos::View<int*>, Kokkos::pair>{}, "");
+  static_assert(is_specialization_of<Kokkos::View<int*>, Kokkos::View>{}, "");
+  // NOTE Not removing cv-qualifiers
+  static_assert(!is_specialization_of<Kokkos::View<int*> const, Kokkos::View>{},
+                "");
+  // NOTE Would not compile because Kokkos::Array takes a non-type template
+  // parameter
+  // static_assert(is_specialization_of<Kokkos::Array<int, 4>, Kokkos::Array>{},
+  // "");
+  // But this is fine of course
+  static_assert(!is_specialization_of<Kokkos::Array<float, 2>, Kokkos::pair>{},
+                "");
+}
+
 inline void test_utilities() {
   using namespace Kokkos::Impl;
 


### PR DESCRIPTION
Adding useful type trait that can be leveraged a number of places when use SFINAE.

It would also in principle allow to replace code like
https://github.com/kokkos/kokkos/blob/caeeeda3a9a8bc95c21180e1c9ae1f4b9e70fbb1/core/src/Kokkos_View.hpp#L568-L575
by
```C++
template <class T>
struct is_view : Impl::is_specialization_of<std::remove_cv_t<T>, View>::type {};
```

One limitation is it won't compile if you pass a template such as `Kokkos::Array` as its second argument or any template that has a non-type template parameter.