### PR TITLE
Adding identity type traits and update definition of identity_t alias

### DIFF
--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -414,7 +414,12 @@ struct inclusive_scan_integer_sequence {
 };
 
 template <typename T>
-using identity_t = T;
+struct identity {
+  using type = T;
+};
+
+template <typename T>
+using identity_t = typename identity<T>::type;
 
 //==============================================================================
 // <editor-fold desc="remove_cvref_t"> {{{1


### PR DESCRIPTION
Rational was produced below in https://github.com/kokkos/kokkos/pull/3339#issuecomment-689716083

This change allows to derive from `identity` which arguably can be more readable in some situations.

Note that we considered that `type_identity` might be a better name since it is standardized in C++20 but we decided not to change for now.