### PR TITLE
Add remove_cvref type trait

### DIFF
--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -420,12 +420,17 @@ using identity_t = T;
 //==============================================================================
 // <editor-fold desc="remove_cvref_t"> {{{1
 
+#if defined(__cpp_lib_remove_cvref)
+// since C++20
+using std::remove_cvref;
+using std::remove_cvref_t;
+#else
 template <class T>
-struct remove_cvref : identity<typename std::remove_cv<
-                          typename std::remove_reference<T>::type>::type> {};
+struct remove_cvref : std::remove_cv_t<std::remove_reference_t<T>>::type {};
 
 template <class T>
 using remove_cvref_t = typename remove_cvref<T>::type;
+#endif
 
 // </editor-fold> end remove_cvref_t }}}1
 //==============================================================================

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -145,7 +145,7 @@ struct make_integer_sequence_concat;
 
 template <typename T, T... x, T... y>
 struct make_integer_sequence_concat<integer_sequence<T, x...>,
-                                    integer_sequence<T, y...> > {
+                                    integer_sequence<T, y...>> {
   using type = integer_sequence<T, x..., (sizeof...(x) + y)...>;
 };
 
@@ -170,61 +170,61 @@ template <unsigned I, typename IntegerSequence>
 struct integer_sequence_at;
 
 template <unsigned I, typename T, T h0, T... tail>
-struct integer_sequence_at<I, integer_sequence<T, h0, tail...> >
-    : public integer_sequence_at<I - 1u, integer_sequence<T, tail...> > {
+struct integer_sequence_at<I, integer_sequence<T, h0, tail...>>
+    : public integer_sequence_at<I - 1u, integer_sequence<T, tail...>> {
   static_assert(8 <= I, "Reasoning Error");
   static_assert(I < integer_sequence<T, h0, tail...>::size(),
                 "Error: Index out of bounds");
 };
 
 template <typename T, T h0, T... tail>
-struct integer_sequence_at<0u, integer_sequence<T, h0, tail...> > {
+struct integer_sequence_at<0u, integer_sequence<T, h0, tail...>> {
   using type               = T;
   static constexpr T value = h0;
 };
 
 template <typename T, T h0, T h1, T... tail>
-struct integer_sequence_at<1u, integer_sequence<T, h0, h1, tail...> > {
+struct integer_sequence_at<1u, integer_sequence<T, h0, h1, tail...>> {
   using type               = T;
   static constexpr T value = h1;
 };
 
 template <typename T, T h0, T h1, T h2, T... tail>
-struct integer_sequence_at<2u, integer_sequence<T, h0, h1, h2, tail...> > {
+struct integer_sequence_at<2u, integer_sequence<T, h0, h1, h2, tail...>> {
   using type               = T;
   static constexpr T value = h2;
 };
 
 template <typename T, T h0, T h1, T h2, T h3, T... tail>
-struct integer_sequence_at<3u, integer_sequence<T, h0, h1, h2, h3, tail...> > {
+struct integer_sequence_at<3u, integer_sequence<T, h0, h1, h2, h3, tail...>> {
   using type               = T;
   static constexpr T value = h3;
 };
 
 template <typename T, T h0, T h1, T h2, T h3, T h4, T... tail>
 struct integer_sequence_at<4u,
-                           integer_sequence<T, h0, h1, h2, h3, h4, tail...> > {
+                           integer_sequence<T, h0, h1, h2, h3, h4, tail...>> {
   using type               = T;
   static constexpr T value = h4;
 };
 
 template <typename T, T h0, T h1, T h2, T h3, T h4, T h5, T... tail>
 struct integer_sequence_at<
-    5u, integer_sequence<T, h0, h1, h2, h3, h4, h5, tail...> > {
+    5u, integer_sequence<T, h0, h1, h2, h3, h4, h5, tail...>> {
   using type               = T;
   static constexpr T value = h5;
 };
 
 template <typename T, T h0, T h1, T h2, T h3, T h4, T h5, T h6, T... tail>
 struct integer_sequence_at<
-    6u, integer_sequence<T, h0, h1, h2, h3, h4, h5, h6, tail...> > {
+    6u, integer_sequence<T, h0, h1, h2, h3, h4, h5, h6, tail...>> {
   using type               = T;
   static constexpr T value = h6;
 };
 
 template <typename T, T h0, T h1, T h2, T h3, T h4, T h5, T h6, T h7, T... tail>
 struct integer_sequence_at<
-    7u, integer_sequence<T, h0, h1, h2, h3, h4, h5, h6, h7, tail...> > {
+    7u, integer_sequence<T, h0, h1, h2, h3, h4, h5, h6, h7, tail...>> {
   using type               = T;
   static constexpr T value = h7;
 };
@@ -330,19 +330,18 @@ constexpr T at(
 
 template <typename IntegerSequence,
           typename ResultSequence =
-              integer_sequence<typename IntegerSequence::value_type> >
+              integer_sequence<typename IntegerSequence::value_type>>
 struct reverse_integer_sequence_helper;
 
 template <typename T, T h0, T... tail, T... results>
 struct reverse_integer_sequence_helper<integer_sequence<T, h0, tail...>,
-                                       integer_sequence<T, results...> >
+                                       integer_sequence<T, results...>>
     : public reverse_integer_sequence_helper<
-          integer_sequence<T, tail...>, integer_sequence<T, h0, results...> > {
-};
+          integer_sequence<T, tail...>, integer_sequence<T, h0, results...>> {};
 
 template <typename T, T... results>
 struct reverse_integer_sequence_helper<integer_sequence<T>,
-                                       integer_sequence<T, results...> > {
+                                       integer_sequence<T, results...>> {
   using type = integer_sequence<T, results...>;
 };
 
@@ -354,20 +353,20 @@ using reverse_integer_sequence =
 
 template <typename IntegerSequence, typename Result,
           typename ResultSequence =
-              integer_sequence<typename IntegerSequence::value_type> >
+              integer_sequence<typename IntegerSequence::value_type>>
 struct exclusive_scan_integer_sequence_helper;
 
 template <typename T, T h0, T... tail, typename Result, T... results>
 struct exclusive_scan_integer_sequence_helper<
-    integer_sequence<T, h0, tail...>, Result, integer_sequence<T, results...> >
+    integer_sequence<T, h0, tail...>, Result, integer_sequence<T, results...>>
     : public exclusive_scan_integer_sequence_helper<
           integer_sequence<T, tail...>,
           std::integral_constant<T, Result::value + h0>,
-          integer_sequence<T, 0, (results + h0)...> > {};
+          integer_sequence<T, 0, (results + h0)...>> {};
 
 template <typename T, typename Result, T... results>
-struct exclusive_scan_integer_sequence_helper<
-    integer_sequence<T>, Result, integer_sequence<T, results...> > {
+struct exclusive_scan_integer_sequence_helper<integer_sequence<T>, Result,
+                                              integer_sequence<T, results...>> {
   using type               = integer_sequence<T, results...>;
   static constexpr T value = Result::value;
 };
@@ -377,7 +376,7 @@ struct exclusive_scan_integer_sequence {
   using value_type = typename IntegerSequence::value_type;
   using helper     = exclusive_scan_integer_sequence_helper<
       reverse_integer_sequence<IntegerSequence>,
-      std::integral_constant<value_type, 0> >;
+      std::integral_constant<value_type, 0>>;
   using type                        = typename helper::type;
   static constexpr value_type value = helper::value;
 };
@@ -386,20 +385,20 @@ struct exclusive_scan_integer_sequence {
 
 template <typename IntegerSequence, typename Result,
           typename ResultSequence =
-              integer_sequence<typename IntegerSequence::value_type> >
+              integer_sequence<typename IntegerSequence::value_type>>
 struct inclusive_scan_integer_sequence_helper;
 
 template <typename T, T h0, T... tail, typename Result, T... results>
 struct inclusive_scan_integer_sequence_helper<
-    integer_sequence<T, h0, tail...>, Result, integer_sequence<T, results...> >
+    integer_sequence<T, h0, tail...>, Result, integer_sequence<T, results...>>
     : public inclusive_scan_integer_sequence_helper<
           integer_sequence<T, tail...>,
           std::integral_constant<T, Result::value + h0>,
-          integer_sequence<T, h0, (results + h0)...> > {};
+          integer_sequence<T, h0, (results + h0)...>> {};
 
 template <typename T, typename Result, T... results>
-struct inclusive_scan_integer_sequence_helper<
-    integer_sequence<T>, Result, integer_sequence<T, results...> > {
+struct inclusive_scan_integer_sequence_helper<integer_sequence<T>, Result,
+                                              integer_sequence<T, results...>> {
   using type               = integer_sequence<T, results...>;
   static constexpr T value = Result::value;
 };
@@ -409,7 +408,7 @@ struct inclusive_scan_integer_sequence {
   using value_type = typename IntegerSequence::value_type;
   using helper     = inclusive_scan_integer_sequence_helper<
       reverse_integer_sequence<IntegerSequence>,
-      std::integral_constant<value_type, 0> >;
+      std::integral_constant<value_type, 0>>;
   using type                        = typename helper::type;
   static constexpr value_type value = helper::value;
 };

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -418,6 +418,19 @@ template <typename T>
 using identity_t = T;
 
 //==============================================================================
+// <editor-fold desc="remove_cvref_t"> {{{1
+
+template <class T>
+struct remove_cvref : identity<typename std::remove_cv<
+                          typename std::remove_reference<T>::type>::type> {};
+
+template <class T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+
+// </editor-fold> end remove_cvref_t }}}1
+//==============================================================================
+
+//==============================================================================
 // <editor-fold desc="is_specialization_of"> {{{1
 
 template <class Type, template <class...> class Template, class Enable = void>


### PR DESCRIPTION
The `remove_cvref` type trait is added in C++20.  It is useful for instance when using SFINAE on a function that take a forwarding reference.  Until now we were typically using `std::decay` instead.