### PR TITLE
replace cuda enabled check with cuda active execution memory space check

### DIFF
--- a/core/src/Kokkos_Atomic.hpp
+++ b/core/src/Kokkos_Atomic.hpp
@@ -79,7 +79,7 @@
 #define KOKKOS_ENABLE_CUDA_ATOMICS
 #endif
 #else
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA)
 
 // Compiling NVIDIA device code, must use Cuda atomics:
 


### PR DESCRIPTION
Cuda atomics are only relevant within the active cuda execution memory 