### PR TITLE
HIP: MaxThreadsPerBlock clean up

### DIFF
--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -249,7 +249,7 @@ struct HIPGetOptBlockSize<DriverType, Kokkos::LaunchBounds<0, 0>, true> {
     int maxOccupancy  = 0;
     int bestBlockSize = 0;
 
-    while (blockSize < 1024) {
+    while (blockSize < HIPTraits::MaxThreadsPerBlock) {
       blockSize *= 2;
 
       // calculate the occupancy with that optBlockSize and check whether its
@@ -283,7 +283,7 @@ struct HIPGetOptBlockSize<DriverType, Kokkos::LaunchBounds<0, 0>, false> {
     int maxOccupancy  = 0;
     int bestBlockSize = 0;
 
-    while (blockSize < 1024) {
+    while (blockSize < HIPTraits::MaxThreadsPerBlock) {
       blockSize *= 2;
       sharedmem =
           shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -78,7 +78,7 @@ int hip_internal_get_block_size(const F &condition_check,
   const int min_blocks_per_sm =
       LaunchBounds::minBperSM == 0 ? 1 : LaunchBounds::minBperSM;
   const int max_threads_per_block = LaunchBounds::maxTperB == 0
-                                        ? hip_instance->m_maxThreadsPerBlock
+                                        ? HIPTraits::MaxThreadsPerBlock
                                         : LaunchBounds::maxTperB;
 
   const int regs_per_wavefront  = attr.numRegs;

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -222,8 +222,6 @@ void HIPInternal::initialize(int hip_device_id, hipStream_t stream) {
     m_shmemPerSM         = hipProp.maxSharedMemoryPerMultiProcessor;
     m_maxShmemPerBlock   = hipProp.sharedMemPerBlock;
     m_maxThreadsPerSM    = m_maxBlocksPerSM * HIPTraits::WarpSize;
-    m_maxThreadsPerBlock = hipProp.maxThreadsPerBlock;
-
     //----------------------------------
     // Multiblock reduction uses scratch flags for counters
     // and scratch space for partial reduction values.

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -216,12 +216,19 @@ void HIPInternal::initialize(int hip_device_id, hipStream_t stream) {
     m_maxBlock = hipProp.maxGridSize[0];
 
     // theoretically, we can get 40 WF's / CU, but only can sustain 32
+    // see
+    // https://github.com/ROCm-Developer-Tools/HIP/blob/a0b5dfd625d99af7e288629747b40dd057183173/vdi/hip_platform.cpp#L742
     m_maxBlocksPerSM = 32;
     // FIXME_HIP - Nick to implement this upstream
-    m_regsPerSM          = 262144 / 32;
-    m_shmemPerSM         = hipProp.maxSharedMemoryPerMultiProcessor;
-    m_maxShmemPerBlock   = hipProp.sharedMemPerBlock;
-    m_maxThreadsPerSM    = m_maxBlocksPerSM * HIPTraits::WarpSize;
+    //             Register count comes from Sec. 2.2. "Data Sharing" of the
+    //             Vega 7nm ISA document (see the diagram)
+    //             https://developer.amd.com/wp-content/resources/Vega_7nm_Shader_ISA.pdf
+    //             VGPRS = 4 (SIMD/CU) * 256 VGPR/SIMD * 64 registers / VGPR =
+    //             65536 VGPR/CU
+    m_regsPerSM        = 65536;
+    m_shmemPerSM       = hipProp.maxSharedMemoryPerMultiProcessor;
+    m_maxShmemPerBlock = hipProp.sharedMemPerBlock;
+    m_maxThreadsPerSM  = m_maxBlocksPerSM * HIPTraits::WarpSize;
     //----------------------------------
     // Multiblock reduction uses scratch flags for counters
     // and scratch space for partial reduction values.

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -57,6 +57,8 @@ struct HIPTraits {
   static int constexpr WarpSize       = 64;
   static int constexpr WarpIndexMask  = 0x003f; /* hexadecimal for 63 */
   static int constexpr WarpIndexShift = 6;      /* WarpSize == 1 << WarpShift*/
+  static int constexpr MaxThreadsPerBlock =
+      1024;  // FIXME_HIP -- assumed constant for now
 
   static int constexpr ConstantMemoryUsage        = 0x008000; /* 32k bytes */
   static int constexpr ConstantMemoryUseThreshold = 0x000200; /* 512 bytes */
@@ -92,7 +94,6 @@ class HIPInternal {
   int m_shmemPerSM;
   int m_maxShmemPerBlock;
   int m_maxThreadsPerSM;
-  int m_maxThreadsPerBlock;
   size_type m_scratchSpaceCount;
   size_type m_scratchFlagsCount;
   size_type *m_scratchSpace;
@@ -132,7 +133,6 @@ class HIPInternal {
         m_shmemPerSM(0),
         m_maxShmemPerBlock(0),
         m_maxThreadsPerSM(0),
-        m_maxThreadsPerBlock(0),
         m_scratchSpaceCount(0),
         m_scratchFlagsCount(0),
         m_scratchSpace(0),

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -298,7 +298,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   // Determine block size constrained by shared memory:
   // This is copy/paste from Kokkos_HIP_Parallel_Range
   inline unsigned local_block_size(const FunctorType& f) {
-    unsigned n     = Experimental::Impl::HIPTraits::WarpSize * 8;
+    unsigned int n =
+        ::Kokkos::Experimental::Impl::HIPTraits::MaxThreadsPerBlock;
     int shmem_size = ::Kokkos::Impl::hip_single_inter_block_reduce_scan_shmem<
         false, FunctorType, WorkTag>(f, n);
     while (


### PR DESCRIPTION
This PR cleans up the history of #3299. There are three commits:
 1. Implement max threads per block as constexpr: we replace `m_maxThreadsPerBlock` which is computed at runtime with `MaxThreadsPerBlock` wich is known at compile time
 2. The value of `m_regsPerSM` is updated and the documentation is improved
 3. Magic numbers and block sizes are replace by `MaxThreadsPerBlock`