### PR TITLE
Comma operator fold emulation

### DIFF
--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -51,17 +51,10 @@
 #include <Kokkos_Parallel_Reduce.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_AnonymousSpace.hpp>
+#include <impl/Kokkos_Utilities.hpp>  // comma operator fold emulation
 
 namespace Kokkos {
 namespace Impl {
-
-// TODO move this to a more general backporting facilities file
-
-// acts like void for comma fold emulation
-struct _fold_comma_emulation_return {};
-
-template <class... Ts>
-KOKKOS_INLINE_FUNCTION void emulate_fold_comma_operator(Ts&&...) noexcept {}
 
 //==============================================================================
 // <editor-fold desc="CombinedReducer reducer and value storage helpers"> {{{1

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -48,6 +48,7 @@
 #include <Kokkos_Macros.hpp>
 #include <cstdint>
 #include <type_traits>
+#include <initializer_list>  // in-order comma operator fold emulation
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -444,6 +445,26 @@ template <template <class...> class Template, class... Args>
 struct is_specialization_of<Template<Args...>, Template> : std::true_type {};
 
 // </editor-fold> end is_specialization_of }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="Folding emulation"> {{{1
+
+// acts like void for comma fold emulation
+struct _fold_comma_emulation_return {};
+
+template <class... Ts>
+constexpr KOKKOS_INLINE_FUNCTION _fold_comma_emulation_return
+emulate_fold_comma_operator(Ts&&...) noexcept {
+  return _fold_comma_emulation_return{};
+}
+
+#define KOKKOS_IMPL_FOLD_COMMA_OPERATOR(expr)                                \
+  ::Kokkos::Impl::emulate_fold_comma_operator(                               \
+      ::std::initializer_list<::Kokkos::Impl::_fold_comma_emulation_return>{ \
+          ((expr), ::Kokkos::Impl::_fold_comma_emulation_return{})...})
+
+// </editor-fold> end Folding emulation }}}1
 //==============================================================================
 
 }  // namespace Impl

--- a/core/unit_test/TestUtilities.hpp
+++ b/core/unit_test/TestUtilities.hpp
@@ -371,4 +371,22 @@ inline void test_utilities() {
   }
 }
 
+template <std::size_t... Idxs, class... Args>
+std::size_t do_comma_emulation_test(std::integer_sequence<std::size_t, Idxs...>,
+                                    Args... args) {
+  // Count the bugs, since ASSERT_EQ is a statement and not an expression
+  std::size_t bugs = 0;
+  // Ensure in-order evaluation
+  std::size_t i = 0;
+  KOKKOS_IMPL_FOLD_COMMA_OPERATOR(bugs += std::size_t(Idxs != i++) /*, ...*/);
+  // Ensure expansion of multiple packs works
+  KOKKOS_IMPL_FOLD_COMMA_OPERATOR(bugs += std::size_t(Idxs != args) /*, ...*/);
+  return bugs;
+}
+
+TEST(utilities, comma_operator_emulation) {
+  ASSERT_EQ(
+      0, do_comma_emulation_test(std::make_index_sequence<5>{}, 0, 1, 2, 3, 4));
+}
+
 }  // namespace Test


### PR DESCRIPTION
Needed for `when_all` in GraphBuilder, PR #3350

The comma operator fold emulation helpers are moved from the combined reducer helper to utilities.
The `emulate_fold_comma_operator` return type is changed to enable chaining.  It is not needed at this point but does not hurt.
The `KOKKOS_IMPL_FOLD_COMMA_OPERATOR` macro is added with unit test to demonstrate usage.