### PR TITLE
create_graph() function template

### DIFF
--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -1,0 +1,185 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_GRAPH_HPP
+#define KOKKOS_GRAPH_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <impl/Kokkos_Error.hpp>  // KOKKOS_EXPECTS
+
+#include <Kokkos_Graph_fwd.hpp>
+#include <impl/Kokkos_GraphImpl_fwd.hpp>
+
+// GraphAccess needs to be defined, not just declared
+#include <impl/Kokkos_GraphImpl.hpp>
+
+#include <impl/Kokkos_Utilities.hpp>  // fold emulation
+
+#include <functional>
+#include <memory>
+
+namespace Kokkos {
+namespace Experimental {
+
+//==============================================================================
+// <editor-fold desc="GraphBuilder"> {{{1
+
+template <class ExecutionSpace>
+struct GraphBuilder {
+ public:
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="public member types"> {{{2
+
+  using execution_space = ExecutionSpace;
+  using graph           = Graph<ExecutionSpace>;
+  using graph_builder   = GraphBuilder;
+
+  // </editor-fold> end public member types }}}2
+  //----------------------------------------------------------------------------
+
+ private:
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="friends"> {{{2
+
+  friend struct Kokkos::Impl::GraphAccess;
+
+  // </editor-fold> end friends }}}2
+  //----------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="private data members"> {{{2
+
+  using graph_impl_t    = Kokkos::Impl::GraphImpl<ExecutionSpace>;
+  using root_node_ref_t = typename graph_impl_t::root_node_impl_t::node_ref_t;
+  root_node_ref_t m_root;
+
+  // </editor-fold> end private data members }}}2
+  //----------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="private ctors"> {{{2
+
+  // Note: only create_graph() uses this constructor, but we can't just make
+  // that a friend instead of GraphAccess because of the way that friend
+  // function template injection works.
+  explicit GraphBuilder(root_node_ref_t arg_root)
+      : m_root(std::move(arg_root)) {}
+
+  // </editor-fold> end private ctors }}}2
+  //----------------------------------------------------------------------------
+
+ public:
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="ctors, destructor, and assignment"> {{{2
+
+  // Rule of 6 for copy constructible
+
+  GraphBuilder() noexcept               = default;
+  GraphBuilder(GraphBuilder const&)     = default;
+  GraphBuilder(GraphBuilder&&) noexcept = default;
+  GraphBuilder& operator=(GraphBuilder const&) = default;
+  GraphBuilder& operator=(GraphBuilder&&) noexcept = default;
+
+  ~GraphBuilder() = default;
+
+  // </editor-fold> end ctors, destructor, and assignment }}}2
+  //----------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="public accessors"> {{{2
+
+  constexpr auto const& get_root() const { return m_root; }
+
+  // </editor-fold> end public accessors }}}2
+  //----------------------------------------------------------------------------
+
+  template <class... PredecessorRefs>
+  // constraints (not intended for subsumption, though...)
+  //   ((remove_cvref_t<PredecessorRefs> is a specialization of
+  //        GraphNodeRef with get_root().get_graph_impl() as its GraphImpl)
+  //      && ...)
+  auto when_all(PredecessorRefs&&... arg_pred_refs) const {
+    // TODO @graph @desul-integration check the constraints and preconditions
+    //                                once we have folded conjunctions from
+    //                                desul
+    auto graph_ptr_impl = get_root().get_graph_ptr();
+    auto node_ptr_impl = graph_ptr_impl->create_aggregate_ptr(arg_pred_refs...);
+    graph_ptr_impl->add_node(node_ptr_impl);
+    KOKKOS_IMPL_FOLD_COMMA_OPERATOR(graph_ptr_impl->add_predecessor(
+        node_ptr_impl, arg_pred_refs) /* ... */);
+    return Kokkos::Impl::GraphAccess::make_graph_node_ref(
+        graph_ptr_impl, std::move(node_ptr_impl));
+  }
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="Methods forward to their then_* analogs on root"> {{{2
+
+  template <class... Args>
+  auto parallel_for(Args&&... args) const {
+    return get_root().then_parallel_for((Args &&) args...);
+  }
+  template <class... Args>
+  auto parallel_reduce(Args&&... args) const {
+    return get_root().then_parallel_reduce((Args &&) args...);
+  }
+  template <class... Args>
+  auto parallel_scan(Args&&... args) const {
+    return get_root().then_parallel_scan((Args &&) args...);
+  }
+  template <class... Args>
+  auto deep_copy(Args&&... args) const {
+    return get_root().then_deep_copy((Args &&) args...);
+  }
+
+  // </editor-fold> end Methods forward to their then_* analogs on root }}}2
+  //----------------------------------------------------------------------------
+};
+
+// </editor-fold> end GraphBuilder }}}1
+//==============================================================================
+
+}  // end namespace Experimental
+}  // namespace Kokkos
+
+#endif  // KOKKOS_GRAPH_HPP

--- a/core/src/Kokkos_Graph_fwd.hpp
+++ b/core/src/Kokkos_Graph_fwd.hpp
@@ -1,0 +1,68 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_GRAPH_FWD_HPP
+#define KOKKOS_KOKKOS_GRAPH_FWD_HPP
+
+#include <Kokkos_Macros.hpp>
+
+namespace Kokkos {
+namespace Experimental {
+
+struct TypeErasedTag {};
+
+template <class ExecutionSpace>
+struct Graph;
+
+template <class ExecutionSpace>
+struct GraphBuilder;
+
+template <class ExecutionSpace, class Kernel = TypeErasedTag,
+          class Predecessor = TypeErasedTag>
+class GraphNodeRef;
+
+}  // end namespace Experimental
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_GRAPH_FWD_HPP

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -51,17 +51,10 @@
 #include <Kokkos_Parallel_Reduce.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_AnonymousSpace.hpp>
+#include <impl/Kokkos_Utilities.hpp>  // comma operator fold emulation
 
 namespace Kokkos {
 namespace Impl {
-
-// TODO move this to a more general backporting facilities file
-
-// acts like void for comma fold emulation
-struct _fold_comma_emulation_return {};
-
-template <class... Ts>
-KOKKOS_INLINE_FUNCTION void emulate_fold_comma_operator(Ts&&...) noexcept {}
 
 //==============================================================================
 // <editor-fold desc="CombinedReducer reducer and value storage helpers"> {{{1

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -1,0 +1,82 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP
+#define KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#include <Kokkos_Core_fwd.hpp>
+#include <Kokkos_Graph_fwd.hpp>
+
+#include <Kokkos_Concepts.hpp>  // is_execution_policy
+#include <Kokkos_PointerOwnership.hpp>
+#include <impl/Kokkos_GraphImpl_fwd.hpp>
+
+#include <memory>  // std::make_shared
+
+namespace Kokkos {
+namespace Impl {
+
+struct GraphAccess {
+  template <class GraphImplWeakPtr, class ExecutionSpace, class Kernel,
+            class Predecessor>
+  static auto make_graph_node_ref(
+      GraphImplWeakPtr graph_impl,
+      std::shared_ptr<
+          Kokkos::Impl::GraphNodeImpl<ExecutionSpace, Kernel, Predecessor>>
+          pred_impl) {
+    //----------------------------------------
+    return Kokkos::Experimental::GraphNodeRef<ExecutionSpace, Kernel,
+                                              Predecessor>{
+        std::move(graph_impl), std::move(pred_impl)};
+    //----------------------------------------
+  }
+};
+
+}  // namespace Impl
+
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -60,10 +60,35 @@ namespace Kokkos {
 namespace Impl {
 
 struct GraphAccess {
-<<<<<<< HEAD
-=======
+  template <class ExecutionSpace>
+  static Kokkos::Experimental::Graph<ExecutionSpace> construct_graph(
+      ExecutionSpace ex) {
+    //----------------------------------------//
+    return Kokkos::Experimental::Graph<ExecutionSpace>{
+        std::make_shared<GraphImpl<ExecutionSpace>>(std::move(ex))};
+    //----------------------------------------//
+  }
+  template <class ExecutionSpace>
+  static auto create_root_ref(
+      Kokkos::Experimental::Graph<ExecutionSpace>& arg_graph) {
+    auto const& graph_impl_ptr = arg_graph.m_impl_ptr;
 
->>>>>>> a3d736cf... Adds GraphBuilder class template
+    auto root_ptr = graph_impl_ptr->create_root_node_ptr();
+
+    return Kokkos::Experimental::GraphNodeRef<ExecutionSpace>{
+        graph_impl_ptr, std::move(root_ptr)};
+  }
+
+  template <class RootNodeRef>
+  // requires remove_cvref_t<RootNodeRef> is a specialization of GraphNodeRef
+  static auto create_graph_builder(RootNodeRef&& arg_root) {
+    // std::remove_cvref_t can't get here quickly enough...
+    using execution_space =
+        typename std::remove_cv<typename std::remove_reference<
+            RootNodeRef>::type>::type::execution_space;
+    return Kokkos::Experimental::GraphBuilder<execution_space>{(RootNodeRef &&)
+                                                                   arg_root};
+  }
   template <class GraphImplWeakPtr, class ExecutionSpace, class Kernel,
             class Predecessor>
   static auto make_graph_node_ref(
@@ -77,16 +102,9 @@ struct GraphAccess {
         std::move(graph_impl), std::move(pred_impl)};
     //----------------------------------------
   }
-<<<<<<< HEAD
 };
 
 }  // namespace Impl
-=======
-
-};
-
-}  // end namespace Experimental
->>>>>>> a3d736cf... Adds GraphBuilder class template
 
 }  // end namespace Kokkos
 

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -60,6 +60,10 @@ namespace Kokkos {
 namespace Impl {
 
 struct GraphAccess {
+<<<<<<< HEAD
+=======
+
+>>>>>>> a3d736cf... Adds GraphBuilder class template
   template <class GraphImplWeakPtr, class ExecutionSpace, class Kernel,
             class Predecessor>
   static auto make_graph_node_ref(
@@ -73,9 +77,16 @@ struct GraphAccess {
         std::move(graph_impl), std::move(pred_impl)};
     //----------------------------------------
   }
+<<<<<<< HEAD
 };
 
 }  // namespace Impl
+=======
+
+};
+
+}  // end namespace Experimental
+>>>>>>> a3d736cf... Adds GraphBuilder class template
 
 }  // end namespace Kokkos
 

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -58,6 +58,9 @@ struct GraphImpl;
 
 struct GraphAccess;
 
+// TODO move this to a more appropriate place
+struct AlwaysDeduceThisTemplateParameter;
+
 }  // end namespace Impl
 }  // end namespace Kokkos
 

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -1,0 +1,64 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_IMPL_KOKKOS_GRAPHIMPL_FWD_HPP
+#define KOKKOS_IMPL_KOKKOS_GRAPHIMPL_FWD_HPP
+
+#include <Kokkos_Macros.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+template <class ExecutionSpace, class Kernel, class Predecessor>
+struct GraphNodeImpl;
+
+template <class ExecutionSpace>
+struct GraphImpl;
+
+struct GraphAccess;
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_IMPL_KOKKOS_GRAPHIMPL_FWD_HPP

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -48,6 +48,7 @@
 #include <Kokkos_Macros.hpp>
 #include <cstdint>
 #include <type_traits>
+#include <initializer_list>  // in-order comma operator fold emulation
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -444,6 +445,26 @@ template <template <class...> class Template, class... Args>
 struct is_specialization_of<Template<Args...>, Template> : std::true_type {};
 
 // </editor-fold> end is_specialization_of }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="Folding emulation"> {{{1
+
+// acts like void for comma fold emulation
+struct _fold_comma_emulation_return {};
+
+template <class... Ts>
+constexpr KOKKOS_INLINE_FUNCTION _fold_comma_emulation_return
+emulate_fold_comma_operator(Ts&&...) noexcept {
+  return _fold_comma_emulation_return{};
+}
+
+#define KOKKOS_IMPL_FOLD_COMMA_OPERATOR(expr)                                \
+  ::Kokkos::Impl::emulate_fold_comma_operator(                               \
+      ::std::initializer_list<::Kokkos::Impl::_fold_comma_emulation_return>{ \
+          ((expr), ::Kokkos::Impl::_fold_comma_emulation_return{})...})
+
+// </editor-fold> end Folding emulation }}}1
 //==============================================================================
 
 }  // namespace Impl


### PR DESCRIPTION
The `create_graph()` function template takes a closure in which the user constructs the graph from a `GraphBuilder` and returns a `Graph` object that the user can submit at some later time. This depends on #3350 and #3352.