### PR TITLE
added `GraphNodeRef`

### DIFF
--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -196,6 +196,7 @@ KOKKOS_IMPL_IS_CONCEPT(index_type)
 KOKKOS_IMPL_IS_CONCEPT(launch_bounds)
 KOKKOS_IMPL_IS_CONCEPT(thread_team_member)
 KOKKOS_IMPL_IS_CONCEPT(host_thread_team_member)
+KOKKOS_IMPL_IS_CONCEPT(graph_kernel)
 
 }  // namespace Impl
 

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -1,0 +1,185 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_GRAPH_HPP
+#define KOKKOS_GRAPH_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <impl/Kokkos_Error.hpp>  // KOKKOS_EXPECTS
+
+#include <Kokkos_Graph_fwd.hpp>
+#include <impl/Kokkos_GraphImpl_fwd.hpp>
+
+// GraphAccess needs to be defined, not just declared
+#include <impl/Kokkos_GraphImpl.hpp>
+
+#include <impl/Kokkos_Utilities.hpp>  // fold emulation
+
+#include <functional>
+#include <memory>
+
+namespace Kokkos {
+namespace Experimental {
+
+//==============================================================================
+// <editor-fold desc="GraphBuilder"> {{{1
+
+template <class ExecutionSpace>
+struct GraphBuilder {
+ public:
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="public member types"> {{{2
+
+  using execution_space = ExecutionSpace;
+  using graph           = Graph<ExecutionSpace>;
+  using graph_builder   = GraphBuilder;
+
+  // </editor-fold> end public member types }}}2
+  //----------------------------------------------------------------------------
+
+ private:
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="friends"> {{{2
+
+  friend struct Kokkos::Impl::GraphAccess;
+
+  // </editor-fold> end friends }}}2
+  //----------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="private data members"> {{{2
+
+  using graph_impl_t    = Kokkos::Impl::GraphImpl<ExecutionSpace>;
+  using root_node_ref_t = typename graph_impl_t::root_node_impl_t::node_ref_t;
+  root_node_ref_t m_root;
+
+  // </editor-fold> end private data members }}}2
+  //----------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="private ctors"> {{{2
+
+  // Note: only create_graph() uses this constructor, but we can't just make
+  // that a friend instead of GraphAccess because of the way that friend
+  // function template injection works.
+  explicit GraphBuilder(root_node_ref_t arg_root)
+      : m_root(std::move(arg_root)) {}
+
+  // </editor-fold> end private ctors }}}2
+  //----------------------------------------------------------------------------
+
+ public:
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="ctors, destructor, and assignment"> {{{2
+
+  // Rule of 6 for copy constructible
+
+  GraphBuilder() noexcept               = default;
+  GraphBuilder(GraphBuilder const&)     = default;
+  GraphBuilder(GraphBuilder&&) noexcept = default;
+  GraphBuilder& operator=(GraphBuilder const&) = default;
+  GraphBuilder& operator=(GraphBuilder&&) noexcept = default;
+
+  ~GraphBuilder() = default;
+
+  // </editor-fold> end ctors, destructor, and assignment }}}2
+  //----------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="public accessors"> {{{2
+
+  constexpr auto const& get_root() const { return m_root; }
+
+  // </editor-fold> end public accessors }}}2
+  //----------------------------------------------------------------------------
+
+  template <class... PredecessorRefs>
+  // constraints (not intended for subsumption, though...)
+  //   ((remove_cvref_t<PredecessorRefs> is a specialization of
+  //        GraphNodeRef with get_root().get_graph_impl() as its GraphImpl)
+  //      && ...)
+  auto when_all(PredecessorRefs&&... arg_pred_refs) const {
+    // TODO @graph @desul-integration check the constraints and preconditions
+    //                                once we have folded conjunctions from
+    //                                desul
+    auto graph_ptr_impl = get_root().get_graph_ptr();
+    auto node_ptr_impl = graph_ptr_impl->create_aggregate_ptr(arg_pred_refs...);
+    graph_ptr_impl->add_node(node_ptr_impl);
+    KOKKOS_IMPL_FOLD_COMMA_OPERATOR(graph_ptr_impl->add_predecessor(
+        node_ptr_impl, arg_pred_refs) /* ... */);
+    return Kokkos::Impl::GraphAccess::make_graph_node_ref(
+        graph_ptr_impl, std::move(node_ptr_impl));
+  }
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="Methods forward to their then_* analogs on root"> {{{2
+
+  template <class... Args>
+  auto parallel_for(Args&&... args) const {
+    return get_root().then_parallel_for((Args &&) args...);
+  }
+  template <class... Args>
+  auto parallel_reduce(Args&&... args) const {
+    return get_root().then_parallel_reduce((Args &&) args...);
+  }
+  template <class... Args>
+  auto parallel_scan(Args&&... args) const {
+    return get_root().then_parallel_scan((Args &&) args...);
+  }
+  template <class... Args>
+  auto deep_copy(Args&&... args) const {
+    return get_root().then_deep_copy((Args &&) args...);
+  }
+
+  // </editor-fold> end Methods forward to their then_* analogs on root }}}2
+  //----------------------------------------------------------------------------
+};
+
+// </editor-fold> end GraphBuilder }}}1
+//==============================================================================
+
+}  // end namespace Experimental
+}  // namespace Kokkos
+
+#endif  // KOKKOS_GRAPH_HPP

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -1,0 +1,469 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_GRAPHNODE_HPP
+#define KOKKOS_KOKKOS_GRAPHNODE_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#include <impl/Kokkos_Error.hpp>  // contract macros
+
+#include <Kokkos_Core_fwd.hpp>
+#include <Kokkos_Graph_fwd.hpp>
+#include <impl/Kokkos_GraphImpl_fwd.hpp>
+#include <Kokkos_Parallel_Reduce.hpp>
+#include <impl/Kokkos_GraphImpl_Utilities.hpp>
+#include <impl/Kokkos_GraphImpl.hpp>  // GraphAccess
+
+#include <memory>  // std::shared_ptr
+
+namespace Kokkos {
+namespace Experimental {
+
+template <class ExecutionSpace, class Kernel /*= TypeErasedTag*/,
+          class Predecessor /*= TypeErasedTag*/>
+class GraphNodeRef {
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="template parameter constraints"> {{{2
+
+  // Note: because of these assertions, instantiating this class template is not
+  //       intended to be SFINAE-safe, so do validation before you instantiate.
+
+  static_assert(
+      std::is_same<Predecessor, TypeErasedTag>::value ||
+          Kokkos::Impl::is_specialization_of<Predecessor, GraphNodeRef>::value,
+      "Invalid predecessor template parameter given to GraphNodeRef");
+
+  static_assert(
+      Kokkos::is_execution_space<ExecutionSpace>::value,
+      "Invalid execution space template parameter given to GraphNodeRef");
+
+  static_assert(std::is_same<Predecessor, TypeErasedTag>::value ||
+                    Kokkos::Impl::is_graph_kernel<Kernel>::value,
+                "Invalid kernel template parameter given to GraphNodeRef");
+
+  static_assert(!Kokkos::Impl::is_more_type_erased<Kernel, Predecessor>::value,
+                "The kernel of a graph node can't be more type-erased than the "
+                "predecessor");
+
+  // </editor-fold> end template parameter constraints }}}2
+  //----------------------------------------------------------------------------
+
+ public:
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="public member types"> {{{2
+
+  using execution_space   = ExecutionSpace;
+  using graph_kernel      = Kernel;
+  using graph_predecessor = Predecessor;
+
+  // </editor-fold> end public member types }}}2
+  //----------------------------------------------------------------------------
+
+ private:
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="Friends"> {{{2
+
+  template <class, class, class>
+  friend class GraphNodeRef;
+  template <class>
+  friend struct GraphBuilder;
+  template <class, class, class>
+  friend struct Kokkos::Impl::GraphNodeImpl;
+  template <class>
+  friend struct Kokkos::Impl::GraphImpl;
+  template <class>
+  friend struct Kokkos::Impl::GraphNodeBackendSpecificDetails;
+  friend struct Kokkos::Impl::GraphAccess;
+
+  // </editor-fold> end Friends }}}2
+  //----------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="Private Data Members"> {{{2
+
+  using graph_impl_t = Kokkos::Impl::GraphImpl<ExecutionSpace>;
+  std::weak_ptr<graph_impl_t> m_graph_impl;
+
+  // TODO @graphs figure out if we can get away with a weak reference here?
+  //              GraphNodeRef instances shouldn't be stored by users outside
+  //              of the create_graph closure, and so if we restructure things
+  //              slightly, we could make it so that the graph owns the
+  //              node_impl_t instance and this only holds a std::weak_ptr to
+  //              it.
+  using node_impl_t =
+      Kokkos::Impl::GraphNodeImpl<ExecutionSpace, Kernel, Predecessor>;
+  std::shared_ptr<node_impl_t> m_node_impl;
+
+  // </editor-fold> end Private Data Members }}}2
+  //----------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="Implementation detail accessors"> {{{2
+
+  // Internally, use shallow constness
+  node_impl_t& get_node_impl() const { return *m_node_impl.get(); }
+  std::shared_ptr<node_impl_t> const& get_node_ptr() const& {
+    return m_node_impl;
+  }
+  std::shared_ptr<node_impl_t> get_node_ptr() && {
+    return std::move(m_node_impl);
+  }
+  graph_impl_t& get_graph_impl() const { return *m_graph_impl; }
+  std::shared_ptr<graph_impl_t> get_graph_ptr() const {
+    return m_graph_impl.lock();
+  }
+  std::weak_ptr<graph_impl_t> get_graph_weak_ptr() const {
+    return m_graph_impl;
+  }
+
+  // </editor-fold> end Implementation detail accessors }}}2
+  //----------------------------------------------------------------------------
+
+  // TODO kernel name propagation and exposure
+
+  template <class NextKernelDeduced>
+  auto _then_kernel(NextKernelDeduced&& arg_kernel) const {
+    // readability note:
+    //   std::remove_cvref_t<NextKernelDeduced> is a specialization of
+    //   Kokkos::Impl::GraphNodeKernelImpl:
+    static_assert(Kokkos::Impl::is_specialization_of<
+                      Kokkos::Impl::remove_cvref_t<NextKernelDeduced>,
+                      Kokkos::Impl::GraphNodeKernelImpl>::value,
+                  "Kokkos internal error");
+
+    auto graph_ptr = m_graph_impl.lock();
+    KOKKOS_EXPECTS(graph_ptr);
+
+    using next_kernel_t = Kokkos::Impl::remove_cvref_t<NextKernelDeduced>;
+
+    using return_t = GraphNodeRef<ExecutionSpace, next_kernel_t, GraphNodeRef>;
+
+    auto rv = Kokkos::Impl::GraphAccess::make_graph_node_ref(
+        m_graph_impl,
+        Kokkos::Impl::GraphAccess::make_node_shared_ptr_with_deleter(
+            new typename return_t::node_impl_t{
+                m_node_impl->execution_space_instance(),
+                Kokkos::Impl::_graph_node_kernel_ctor_tag{},
+                (NextKernelDeduced &&) arg_kernel,
+                // *this is the predecessor
+                Kokkos::Impl::_graph_node_predecessor_ctor_tag{}, *this}));
+
+    // Add the node itself to the backend's graph data structure, now that
+    // everything is set up.
+    graph_ptr->add_node(rv.m_node_impl);
+    // Add the predecessaor we stored in the constructor above in the backend's
+    // data structure, now that everything is set up.
+    graph_ptr->add_predecessor(rv.m_node_impl, *this);
+    KOKKOS_ENSURES(bool(rv.m_node_impl))
+    return rv;
+  }
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="Private constructors"> {{{2
+
+  GraphNodeRef(std::weak_ptr<graph_impl_t> arg_graph_impl,
+               std::shared_ptr<node_impl_t> arg_node_impl)
+      : m_graph_impl(std::move(arg_graph_impl)),
+        m_node_impl(std::move(arg_node_impl)) {}
+
+  // </editor-fold> end Private constructors }}}2
+  //----------------------------------------------------------------------------
+
+ public:
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="Constructors, destructors, and assignment"> {{{2
+
+  //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  // <editor-fold desc="rule of 6 ctors"> {{{3
+
+  // Copyable and movable (basically just shared_ptr semantics
+  GraphNodeRef() noexcept               = default;
+  GraphNodeRef(GraphNodeRef const&)     = default;
+  GraphNodeRef(GraphNodeRef&&) noexcept = default;
+  GraphNodeRef& operator=(GraphNodeRef const&) = default;
+  GraphNodeRef& operator=(GraphNodeRef&&) noexcept = default;
+  ~GraphNodeRef()                                  = default;
+
+  // </editor-fold> end rule of 6 ctors }}}3
+  //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  // <editor-fold desc="Type-erasing converting ctor and assignment"> {{{3
+
+  template <
+      class OtherKernel, class OtherPredecessor,
+      typename std::enable_if<
+          // Not a copy/move constructor
+          !std::is_same<GraphNodeRef, GraphNodeRef<execution_space, OtherKernel,
+                                                   OtherPredecessor>>::value &&
+              // must be an allowed type erasure of the kernel
+              Kokkos::Impl::is_compatible_type_erasure<OtherKernel,
+                                                       graph_kernel>::value &&
+              // must be an allowed type erasure of the predecessor
+              Kokkos::Impl::is_compatible_type_erasure<
+                  OtherPredecessor, graph_predecessor>::value,
+          int>::type = 0>
+  /* implicit */
+  GraphNodeRef(
+      GraphNodeRef<execution_space, OtherKernel, OtherPredecessor> const& other)
+      : m_graph_impl(other.m_graph_impl), m_node_impl(other.m_node_impl) {}
+
+  // Note: because this is an implicit conversion (as is supposed to be the
+  //       case with most type-erasing wrappers like this), we don't also need
+  //       a converting assignment operator.
+
+  // </editor-fold> end Type-erasing converting ctor and assignment }}}3
+  //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  // </editor-fold> end Constructors, destructors, and assignment }}}2
+  //----------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="then_parallel_for"> {{{2
+
+  template <
+      class Policy, class Functor,
+      typename std::enable_if<
+          // equivalent to:
+          //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
+          is_execution_policy<Kokkos::Impl::remove_cvref_t<Policy>>::value,
+          // --------------------
+          int>::type = 0>
+  auto then_parallel_for(std::string arg_name, Policy&& arg_policy,
+                         Functor&& functor) const {
+    //----------------------------------------
+    KOKKOS_EXPECTS(!m_graph_impl.expired())
+    KOKKOS_EXPECTS(bool(m_node_impl))
+    // TODO @graph restore this expectation once we add comparability to space
+    //      instances
+    // KOKKOS_EXPECTS(
+    //   arg_policy.space() == m_graph_impl->get_execution_space());
+
+    // needs to static assert constraint: DataParallelFunctor<Functor>
+
+    using policy_t = typename std::remove_cv<
+        typename std::remove_reference<Policy>::type>::type;
+    // constraint check: same execution space type (or defaulted, maybe?)
+    static_assert(
+        std::is_same<typename policy_t::execution_space,
+                     execution_space>::value,
+        // TODO @graph make defaulted execution space work
+        //|| policy_t::execution_space_is_defaulted,
+        "Execution Space mismatch between execution policy and graph");
+
+    auto policy = Experimental::require((Policy &&) arg_policy,
+                                        Kokkos::Impl::KernelInGraphProperty{});
+
+    using next_policy_t = decltype(policy);
+    using next_kernel_t =
+        Kokkos::Impl::GraphNodeKernelImpl<ExecutionSpace, next_policy_t,
+                                          std::decay_t<Functor>,
+                                          Kokkos::ParallelForTag>;
+    return this->_then_kernel(next_kernel_t{std::move(arg_name), policy.space(),
+                                            (Functor &&) functor,
+                                            (Policy &&) policy});
+  }
+
+  template <
+      class Policy, class Functor,
+      typename std::enable_if<
+          // equivalent to:
+          //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
+          is_execution_policy<Kokkos::Impl::remove_cvref_t<Policy>>::value,
+          // --------------------
+          int>::type = 0>
+  auto then_parallel_for(Policy&& policy, Functor&& functor) const {
+    // needs to static assert constraint: DataParallelFunctor<Functor>
+    return this->then_parallel_for("", (Policy &&) policy,
+                                   (Functor &&) functor);
+  }
+
+  template <class Functor>
+  auto then_parallel_for(std::string name, std::size_t n,
+                         Functor&& functor) const {
+    // needs to static assert constraint: DataParallelFunctor<Functor>
+    return this->then_parallel_for(std::move(name),
+                                   Kokkos::RangePolicy<execution_space>(0, n),
+                                   (Functor &&) functor);
+  }
+
+  template <class Functor>
+  auto then_parallel_for(std::size_t n, Functor&& functor) const {
+    // needs to static assert constraint: DataParallelFunctor<Functor>
+    return this->then_parallel_for("", n, (Functor &&) functor);
+  }
+
+  // </editor-fold> end then_parallel_for }}}2
+  //----------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------
+  // <editor-fold desc="then_parallel_reduce"> {{{2
+
+  template <
+      class Policy, class Functor, class ReturnType,
+      typename std::enable_if<
+          // equivalent to:
+          //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
+          is_execution_policy<Kokkos::Impl::remove_cvref_t<Policy>>::value,
+          // --------------------
+          int>::type = 0>
+  auto then_parallel_reduce(std::string arg_name, Policy&& arg_policy,
+                            Functor&& functor,
+                            ReturnType&& return_value) const {
+    auto graph_impl_ptr = m_graph_impl.lock();
+    KOKKOS_EXPECTS(bool(graph_impl_ptr))
+    KOKKOS_EXPECTS(bool(m_node_impl))
+    // TODO @graph restore this expectation once we add comparability to space
+    //      instances
+    // KOKKOS_EXPECTS(
+    //   arg_policy.space() == m_graph_impl->get_execution_space());
+
+    // needs static assertion of constraint:
+    //   DataParallelReductionFunctor<Functor, ReturnType>
+
+    using policy_t = typename std::remove_cv<
+        typename std::remove_reference<Policy>::type>::type;
+    static_assert(
+        std::is_same<typename policy_t::execution_space,
+                     execution_space>::value,
+        // TODO @graph make defaulted execution space work
+        // || policy_t::execution_space_is_defaulted,
+        "Execution Space mismatch between execution policy and graph");
+
+    // This is also just an expectation, but it's one that we expect the user
+    // to interact with (even in release mode), so we should throw an exception
+    // with an explanation rather than just doing a contract assertion.
+    if (Kokkos::Impl::parallel_reduce_needs_fence(
+            graph_impl_ptr->get_execution_space(), return_value)) {
+      Kokkos::Impl::throw_runtime_exception(
+          "Parallel reductions in graphs can't operate on Reducers that "
+          "reference a scalar because they can't complete synchronously. Use a "
+          "Kokkos::View instead and keep in mind the result will only be "
+          "available once the graph is submitted (or in tasks that depend on "
+          "this one).");
+    }
+
+    //----------------------------------------
+    // This is a disaster, but I guess it's not a my disaster to fix right now
+    using return_type_remove_cvref = typename std::remove_cv<
+        typename std::remove_reference<ReturnType>::type>::type;
+    static_assert(Kokkos::is_view<return_type_remove_cvref>::value ||
+                      Kokkos::is_reducer<return_type_remove_cvref>::value,
+                  "Output argument to parallel reduce in a graph must be a "
+                  "View or a Reducer");
+    using return_type =
+        // Yes, you do really have to do this...
+        std::conditional_t<Kokkos::is_reducer<return_type_remove_cvref>::value,
+                           return_type_remove_cvref,
+                           const return_type_remove_cvref>;
+    using functor_type = Kokkos::Impl::remove_cvref_t<Functor>;
+    // see Kokkos_Parallel_Reduce.hpp for how these details are used there;
+    // we're just doing the same thing here
+    using return_value_adapter =
+        Kokkos::Impl::ParallelReduceReturnValue<void, return_type,
+                                                functor_type>;
+    using functor_adaptor = Kokkos::Impl::ParallelReduceFunctorType<
+        functor_type, Policy, typename return_value_adapter::value_type,
+        execution_space>;
+    // End of Kokkos reducer disaster
+    //----------------------------------------
+
+    auto policy = Experimental::require((Policy &&) arg_policy,
+                                        Kokkos::Impl::KernelInGraphProperty{});
+
+    using next_policy_t = decltype(policy);
+    using next_kernel_t = Kokkos::Impl::GraphNodeKernelImpl<
+        ExecutionSpace, next_policy_t, typename functor_adaptor::functor_type,
+        Kokkos::ParallelReduceTag, typename return_value_adapter::reducer_type>;
+
+    return this->_then_kernel(next_kernel_t{
+        std::move(arg_name), graph_impl_ptr->get_execution_space(),
+        (Functor &&) functor, (Policy &&) policy,
+        return_value_adapter::return_value(return_value, functor)});
+  }
+
+  template <
+      class Policy, class Functor, class ReturnType,
+      typename std::enable_if<
+          // equivalent to:
+          //   requires Kokkos::ExecutionPolicy<remove_cvref_t<Policy>>
+          is_execution_policy<Kokkos::Impl::remove_cvref_t<Policy>>::value,
+          // --------------------
+          int>::type = 0>
+  auto then_parallel_reduce(Policy&& arg_policy, Functor&& functor,
+                            ReturnType&& return_value) const {
+    return this->then_parallel_reduce("", (Policy &&) arg_policy,
+                                      (Functor &&) functor,
+                                      (ReturnType &&) return_value);
+  }
+
+  template <class Functor, class ReturnType>
+  auto then_parallel_reduce(std::string label,
+                            typename execution_space::size_type idx_end,
+                            Functor&& functor,
+                            ReturnType&& return_value) const {
+    return this->then_parallel_reduce(
+        std::move(label), Kokkos::RangePolicy<execution_space>{0, idx_end},
+        (Functor &&) functor, (ReturnType &&) return_value);
+  }
+
+  template <class Functor, class ReturnType>
+  auto then_parallel_reduce(typename execution_space::size_type idx_end,
+                            Functor&& functor,
+                            ReturnType&& return_value) const {
+    return this->then_parallel_reduce("", idx_end, (Functor &&) functor,
+                                      (ReturnType &&) return_value);
+  }
+
+  // </editor-fold> end then_parallel_reduce }}}2
+  //----------------------------------------------------------------------------
+
+  // TODO @graph parallel scan, deep copy, etc.
+};
+
+}  // end namespace Experimental
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_GRAPHNODE_HPP

--- a/core/src/Kokkos_Graph_fwd.hpp
+++ b/core/src/Kokkos_Graph_fwd.hpp
@@ -1,0 +1,68 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_GRAPH_FWD_HPP
+#define KOKKOS_KOKKOS_GRAPH_FWD_HPP
+
+#include <Kokkos_Macros.hpp>
+
+namespace Kokkos {
+namespace Experimental {
+
+struct TypeErasedTag {};
+
+template <class ExecutionSpace>
+struct Graph;
+
+template <class ExecutionSpace>
+struct GraphBuilder;
+
+template <class ExecutionSpace, class Kernel = TypeErasedTag,
+          class Predecessor = TypeErasedTag>
+class GraphNodeRef;
+
+}  // end namespace Experimental
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_GRAPH_FWD_HPP

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -51,17 +51,10 @@
 #include <Kokkos_Parallel_Reduce.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_AnonymousSpace.hpp>
+#include <impl/Kokkos_Utilities.hpp>  // comma operator fold emulation
 
 namespace Kokkos {
 namespace Impl {
-
-// TODO move this to a more general backporting facilities file
-
-// acts like void for comma fold emulation
-struct _fold_comma_emulation_return {};
-
-template <class... Ts>
-KOKKOS_INLINE_FUNCTION void emulate_fold_comma_operator(Ts&&...) noexcept {}
 
 //==============================================================================
 // <editor-fold desc="CombinedReducer reducer and value storage helpers"> {{{1

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -89,6 +89,19 @@ struct GraphAccess {
     return Kokkos::Experimental::GraphBuilder<execution_space>{(RootNodeRef &&)
                                                                    arg_root};
   }
+
+  template <class NodeImpl>
+  static auto make_node_shared_ptr_with_deleter(
+      Kokkos::OwningRawPtr<NodeImpl> node_impl_ptr) {
+    // NodeImpl instances aren't movable, so we have to create them on the call
+    // side and take a pointer here. We assume ownership and pass it on to the
+    // shared_ptr we're creating
+    using new_node_impl_t = typename std::remove_cv<NodeImpl>::type;
+    // We can't use make_shared because we have a custom deleter
+    return std::shared_ptr<new_node_impl_t>{
+        node_impl_ptr, typename new_node_impl_t::Deleter{}};
+  }
+
   template <class GraphImplWeakPtr, class ExecutionSpace, class Kernel,
             class Predecessor>
   static auto make_graph_node_ref(

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -1,0 +1,82 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP
+#define KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#include <Kokkos_Core_fwd.hpp>
+#include <Kokkos_Graph_fwd.hpp>
+
+#include <Kokkos_Concepts.hpp>  // is_execution_policy
+#include <Kokkos_PointerOwnership.hpp>
+#include <impl/Kokkos_GraphImpl_fwd.hpp>
+
+#include <memory>  // std::make_shared
+
+namespace Kokkos {
+namespace Impl {
+
+struct GraphAccess {
+  template <class GraphImplWeakPtr, class ExecutionSpace, class Kernel,
+            class Predecessor>
+  static auto make_graph_node_ref(
+      GraphImplWeakPtr graph_impl,
+      std::shared_ptr<
+          Kokkos::Impl::GraphNodeImpl<ExecutionSpace, Kernel, Predecessor>>
+          pred_impl) {
+    //----------------------------------------
+    return Kokkos::Experimental::GraphNodeRef<ExecutionSpace, Kernel,
+                                              Predecessor>{
+        std::move(graph_impl), std::move(pred_impl)};
+    //----------------------------------------
+  }
+};
+
+}  // namespace Impl
+
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -60,10 +60,35 @@ namespace Kokkos {
 namespace Impl {
 
 struct GraphAccess {
-<<<<<<< HEAD
-=======
+  template <class ExecutionSpace>
+  static Kokkos::Experimental::Graph<ExecutionSpace> construct_graph(
+      ExecutionSpace ex) {
+    //----------------------------------------//
+    return Kokkos::Experimental::Graph<ExecutionSpace>{
+        std::make_shared<GraphImpl<ExecutionSpace>>(std::move(ex))};
+    //----------------------------------------//
+  }
+  template <class ExecutionSpace>
+  static auto create_root_ref(
+      Kokkos::Experimental::Graph<ExecutionSpace>& arg_graph) {
+    auto const& graph_impl_ptr = arg_graph.m_impl_ptr;
 
->>>>>>> a3d736cf... Adds GraphBuilder class template
+    auto root_ptr = graph_impl_ptr->create_root_node_ptr();
+
+    return Kokkos::Experimental::GraphNodeRef<ExecutionSpace>{
+        graph_impl_ptr, std::move(root_ptr)};
+  }
+
+  template <class RootNodeRef>
+  // requires remove_cvref_t<RootNodeRef> is a specialization of GraphNodeRef
+  static auto create_graph_builder(RootNodeRef&& arg_root) {
+    // std::remove_cvref_t can't get here quickly enough...
+    using execution_space =
+        typename std::remove_cv<typename std::remove_reference<
+            RootNodeRef>::type>::type::execution_space;
+    return Kokkos::Experimental::GraphBuilder<execution_space>{(RootNodeRef &&)
+                                                                   arg_root};
+  }
   template <class GraphImplWeakPtr, class ExecutionSpace, class Kernel,
             class Predecessor>
   static auto make_graph_node_ref(
@@ -77,16 +102,9 @@ struct GraphAccess {
         std::move(graph_impl), std::move(pred_impl)};
     //----------------------------------------
   }
-<<<<<<< HEAD
 };
 
 }  // namespace Impl
-=======
-
-};
-
-}  // end namespace Experimental
->>>>>>> a3d736cf... Adds GraphBuilder class template
 
 }  // end namespace Kokkos
 

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -104,7 +104,27 @@ struct GraphAccess {
   }
 };
 
-}  // namespace Impl
+template <class Policy>
+struct _add_graph_kernel_tag;
+
+template <template <class...> class PolicyTemplate, class... PolicyTraits>
+struct _add_graph_kernel_tag<PolicyTemplate<PolicyTraits...>> {
+  using type = PolicyTemplate<PolicyTraits..., IsGraphKernelTag>;
+};
+
+}  // end namespace Impl
+
+namespace Experimental {  // but not for users, so...
+
+template <class Policy>
+// requires ExecutionPolicy<Policy>
+auto require(Policy const& policy, Kokkos::Impl::KernelInGraphProperty) {
+  static_assert(Kokkos::is_execution_policy<Policy>::value,
+                "Internal implementation error!");
+  return typename Kokkos::Impl::_add_graph_kernel_tag<Policy>::type{policy};
+}
+
+}  // end namespace Experimental
 
 }  // end namespace Kokkos
 

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -60,6 +60,10 @@ namespace Kokkos {
 namespace Impl {
 
 struct GraphAccess {
+<<<<<<< HEAD
+=======
+
+>>>>>>> a3d736cf... Adds GraphBuilder class template
   template <class GraphImplWeakPtr, class ExecutionSpace, class Kernel,
             class Predecessor>
   static auto make_graph_node_ref(
@@ -73,9 +77,16 @@ struct GraphAccess {
         std::move(graph_impl), std::move(pred_impl)};
     //----------------------------------------
   }
+<<<<<<< HEAD
 };
 
 }  // namespace Impl
+=======
+
+};
+
+}  // end namespace Experimental
+>>>>>>> a3d736cf... Adds GraphBuilder class template
 
 }  // end namespace Kokkos
 

--- a/core/src/impl/Kokkos_GraphImpl_Utilities.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_Utilities.hpp
@@ -1,0 +1,119 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_GRAPHIMPL_UTILITIES_HPP
+#define KOKKOS_KOKKOS_GRAPHIMPL_UTILITIES_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#include <Kokkos_Graph_fwd.hpp>
+
+#include <type_traits>
+
+namespace Kokkos {
+namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="is_compatible_type_erasure"> {{{1
+
+template <class Src, class Dst, class Enable = void>
+struct is_compatible_type_erasure : std::false_type {};
+
+template <class T>
+struct is_compatible_type_erasure<T, Kokkos::Experimental::TypeErasedTag>
+    : std::true_type {};
+
+template <>
+struct is_compatible_type_erasure<Kokkos::Experimental::TypeErasedTag,
+                                  Kokkos::Experimental::TypeErasedTag>
+    : std::true_type {};
+
+template <class T>
+struct is_compatible_type_erasure<T, T> : std::true_type {};
+
+// So there are a couple of ways we could do this, but I didn't want to set up
+// all of the machinery to do a lazy instantiation of the convertibility
+// condition in the converting constructor of GraphNodeRef, so I'm going with
+// this for now:
+// TODO @desul-integration make this variadic once we have a meta-conjunction
+template <template <class, class, class> class Template, class TSrc, class USrc,
+          class VSrc, class TDst, class UDst, class VDst>
+struct is_compatible_type_erasure<
+    Template<TSrc, USrc, VSrc>, Template<TDst, UDst, VDst>,
+    // Because gcc thinks this is ambiguous, we need to add this:
+    std::enable_if_t<!std::is_same<TSrc, TDst>::value ||
+                     !std::is_same<USrc, UDst>::value ||
+                     !std::is_same<VSrc, VDst>::value>>
+    : std::integral_constant<
+          bool, is_compatible_type_erasure<TSrc, TDst>::value &&
+                    is_compatible_type_erasure<USrc, UDst>::value &&
+                    is_compatible_type_erasure<VSrc, VDst>::value> {};
+
+// </editor-fold> end is_compatible_type_erasure }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="is_more_type_erased"> {{{1
+
+template <class T, class U>
+struct is_more_type_erased : std::false_type {};
+
+template <class T>
+struct is_more_type_erased<Kokkos::Experimental::TypeErasedTag, T>
+    : std::true_type {};
+
+template <>
+struct is_more_type_erased<Kokkos::Experimental::TypeErasedTag,
+                           Kokkos::Experimental::TypeErasedTag>
+    : std::false_type {};
+
+// TODO @desul-integration variadic version of this, like the above
+
+// </editor-fold> end is_more_type_erased }}}1
+//==============================================================================
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_GRAPHIMPL_UTILITIES_HPP

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -61,6 +61,10 @@ struct GraphAccess;
 // TODO move this to a more appropriate place
 struct AlwaysDeduceThisTemplateParameter;
 
+struct KernelInGraphProperty {};
+
+struct IsGraphKernelTag {};
+
 }  // end namespace Impl
 }  // end namespace Kokkos
 

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -58,6 +58,9 @@ struct GraphImpl;
 
 struct GraphAccess;
 
+// TODO move this to a more appropriate place
+struct AlwaysDeduceThisTemplateParameter;
+
 }  // end namespace Impl
 }  // end namespace Kokkos
 

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -1,0 +1,64 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_IMPL_KOKKOS_GRAPHIMPL_FWD_HPP
+#define KOKKOS_IMPL_KOKKOS_GRAPHIMPL_FWD_HPP
+
+#include <Kokkos_Macros.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+template <class ExecutionSpace, class Kernel, class Predecessor>
+struct GraphNodeImpl;
+
+template <class ExecutionSpace>
+struct GraphImpl;
+
+struct GraphAccess;
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_IMPL_KOKKOS_GRAPHIMPL_FWD_HPP

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -56,7 +56,18 @@ struct GraphNodeImpl;
 template <class ExecutionSpace>
 struct GraphImpl;
 
+template <class ExecutionSpace, class Policy, class Functor,
+          class KernelTypeTag, class... Args>
+class GraphNodeKernelImpl;
+
+struct _graph_node_kernel_ctor_tag {};
+struct _graph_node_predecessor_ctor_tag {};
+
 struct GraphAccess;
+
+// Customizable for backends
+template <class ExecutionSpace>
+struct GraphNodeBackendSpecificDetails;
 
 // TODO move this to a more appropriate place
 struct AlwaysDeduceThisTemplateParameter;

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -48,6 +48,7 @@
 #include <Kokkos_Macros.hpp>
 #include <cstdint>
 #include <type_traits>
+#include <initializer_list>  // in-order comma operator fold emulation
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -444,6 +445,26 @@ template <template <class...> class Template, class... Args>
 struct is_specialization_of<Template<Args...>, Template> : std::true_type {};
 
 // </editor-fold> end is_specialization_of }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="Folding emulation"> {{{1
+
+// acts like void for comma fold emulation
+struct _fold_comma_emulation_return {};
+
+template <class... Ts>
+constexpr KOKKOS_INLINE_FUNCTION _fold_comma_emulation_return
+emulate_fold_comma_operator(Ts&&...) noexcept {
+  return _fold_comma_emulation_return{};
+}
+
+#define KOKKOS_IMPL_FOLD_COMMA_OPERATOR(expr)                                \
+  ::Kokkos::Impl::emulate_fold_comma_operator(                               \
+      ::std::initializer_list<::Kokkos::Impl::_fold_comma_emulation_return>{ \
+          ((expr), ::Kokkos::Impl::_fold_comma_emulation_return{})...})
+
+// </editor-fold> end Folding emulation }}}1
 //==============================================================================
 
 }  // namespace Impl


### PR DESCRIPTION
`GraphNodeRef` is the primary user interface for objects returned by `then_parallel_*` methods during graph construction. The name is deliberately vague (e.g., it's not something like "future") to prevent the user from making incorrect assumptions about its behavior based on other constructs in popular tasking interfaces.