### PR TITLE
Adding non-public graph dispatch property to AnalyzePolicy

### DIFF
--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -69,7 +69,8 @@ namespace Experimental {  // but not for users, so...
 
 template <class Policy>
 // requires ExecutionPolicy<Policy>
-auto require(Policy const& policy, Kokkos::Impl::KernelInGraphProperty) {
+constexpr auto require(Policy const& policy,
+                       Kokkos::Impl::KernelInGraphProperty) {
   static_assert(Kokkos::is_execution_policy<Policy>::value,
                 "Internal implementation error!");
   return typename Kokkos::Impl::_add_graph_kernel_tag<Policy>::type{policy};

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -1,0 +1,82 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP
+#define KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#include <Kokkos_Core_fwd.hpp>
+
+#include <Kokkos_Concepts.hpp>  // is_execution_policy
+#include <impl/Kokkos_GraphImpl_fwd.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+template <class Policy>
+struct _add_graph_kernel_tag;
+
+template <template <class...> class PolicyTemplate, class... PolicyTraits>
+struct _add_graph_kernel_tag<PolicyTemplate<PolicyTraits...>> {
+  using type = PolicyTemplate<PolicyTraits..., IsGraphKernelTag>;
+};
+
+}  // end namespace Impl
+
+namespace Experimental {  // but not for users, so...
+
+template <class Policy>
+// requires ExecutionPolicy<Policy>
+auto require(Policy const& policy, Kokkos::Impl::KernelInGraphProperty) {
+  static_assert(Kokkos::is_execution_policy<Policy>::value,
+                "Internal implementation error!");
+  return typename Kokkos::Impl::_add_graph_kernel_tag<Policy>::type{policy};
+}
+
+}  // end namespace Experimental
+
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_IMPL_KOKKOS_GRAPHIMPL_HPP

--- a/core/src/impl/Kokkos_GraphImpl_fwd.hpp
+++ b/core/src/impl/Kokkos_GraphImpl_fwd.hpp
@@ -1,0 +1,60 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_IMPL_KOKKOS_GRAPHIMPL_FWD_HPP
+#define KOKKOS_IMPL_KOKKOS_GRAPHIMPL_FWD_HPP
+
+#include <Kokkos_Macros.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+struct KernelInGraphProperty {};
+
+struct IsGraphKernelTag {};
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_IMPL_KOKKOS_GRAPHIMPL_FWD_HPP


### PR DESCRIPTION
We need to communicate the information that this kernel is a part of a graph to the backend without the middle layer that does the parallel dispatch knowing what's happening. We're using a policy tag for this purpose.