### PR TITLE
Fix issue 3331 zero length reductions

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -1582,7 +1582,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     }
 
     // Reduce with final value at blockDim.y - 1 location.
-    bool do_final_reduce = m_league_size == 0;
+    bool do_final_reduce = (m_league_size == 0);
     if (!do_final_reduce)
       do_final_reduce =
           cuda_single_inter_block_reduce_scan<false, FunctorType, WorkTag>(
@@ -1692,7 +1692,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       dim3 grid(block_count, 1, 1);
       const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
 
-      if ((nwork < 1)
+      if ((nwork == 0)
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
           || Kokkos::Impl::CudaInternal::cuda_use_serial_execution()
 #endif

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -170,6 +170,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   const ReducerType m_reducer;
   const pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
+  const bool m_result_ptr_host_accessible;
   size_type* m_scratch_space = nullptr;
   size_type* m_scratch_flags = nullptr;
 
@@ -234,11 +235,16 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     }
 
     // Reduce with final value at blockDim.y - 1 location.
-    if (hip_single_inter_block_reduce_scan<false, ReducerTypeFwd, WorkTagFwd>(
-            ReducerConditional::select(m_functor, m_reducer), blockIdx.x,
-            gridDim.x,
-            ::Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>(),
-            m_scratch_space, m_scratch_flags)) {
+    // Shortcut for length zero reduction
+    bool do_final_reduction = m_policy.begin() == m_policy.end();
+    if (!do_final_reduction)
+      do_final_reduction = hip_single_inter_block_reduce_scan<
+          false, ReducerTypeFwd, WorkTagFwd>(
+          ReducerConditional::select(m_functor, m_reducer), blockIdx.x,
+          gridDim.x,
+          ::Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>(),
+          m_scratch_space, m_scratch_flags);
+    if (do_final_reduction) {
       // This is the final block with the final result at the final threads'
       // location
 
@@ -292,11 +298,19 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
     value_type init;
     ValueInit::init(ReducerConditional::select(m_functor, m_reducer), &init);
-    if (Impl::hip_inter_block_shuffle_reduction<ReducerTypeFwd, ValueJoin,
-                                                WorkTagFwd>(
-            value, init,
-            ValueJoin(ReducerConditional::select(m_functor, m_reducer)),
-            m_scratch_space, result, m_scratch_flags, max_active_thread)) {
+    if (m_policy.begin() == m_policy.end()) {
+      Kokkos::Impl::FunctorFinal<ReducerTypeFwd, WorkTagFwd>::final(
+          ReducerConditional::select(m_functor, m_reducer),
+          reinterpret_cast<void*>(&value));
+      pointer_type const final_result =
+          m_result_ptr_device_accessible ? m_result_ptr : result;
+      *final_result = value;
+    } else if (Impl::hip_inter_block_shuffle_reduction<ReducerTypeFwd,
+                                                       ValueJoin, WorkTagFwd>(
+                   value, init,
+                   ValueJoin(ReducerConditional::select(m_functor, m_reducer)),
+                   m_scratch_space, result, m_scratch_flags,
+                   max_active_thread)) {
       unsigned int const id = threadIdx.y * blockDim.x + threadIdx.x;
       if (id == 0) {
         Kokkos::Impl::FunctorFinal<ReducerTypeFwd, WorkTagFwd>::final(
@@ -332,8 +346,12 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   }
 
   inline void execute() {
-    const index_type nwork = m_policy.end() - m_policy.begin();
-    if (nwork) {
+    const index_type nwork     = m_policy.end() - m_policy.begin();
+    const bool need_device_set = ReduceFunctorHasInit<FunctorType>::value ||
+                                 ReduceFunctorHasFinal<FunctorType>::value ||
+                                 !m_result_ptr_host_accessible ||
+                                 !std::is_same<ReducerType, InvalidType>::value;
+    if ((nwork > 0) || need_device_set) {
       const int block_size = local_block_size(m_functor);
       KOKKOS_ASSERT(block_size > 0);
 
@@ -347,12 +365,14 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
               sizeof(size_type));
 
       // REQUIRED ( 1 , N , 1 )
-      const dim3 block(1, block_size, 1);
+      dim3 block(1, block_size, 1);
       // Required grid.x <= block.y
-      const dim3 grid(std::min(block.y, static_cast<uint32_t>(
-                                            (nwork + block.y - 1) / block.y)),
-                      1, 1);
+      dim3 grid(std::min(block.y, static_cast<uint32_t>((nwork + block.y - 1) / block.y)), 1, 1);
 
+      if (nwork == 0) {
+        block = dim3(1, 1, 1);
+        grid  = dim3(1, 1, 1);
+      }
       const int shmem =
           UseShflReduction
               ? 0
@@ -395,6 +415,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
         m_result_ptr(arg_result.data()),
         m_result_ptr_device_accessible(
             MemorySpaceAccess<Kokkos::Experimental::HIPSpace,
+                              typename ViewType::memory_space>::accessible),
+        m_result_ptr_host_accessible(
+            MemorySpaceAccess<Kokkos::HostSpace,
                               typename ViewType::memory_space>::accessible) {}
 
   ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
@@ -405,6 +428,10 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
         m_result_ptr(reducer.view().data()),
         m_result_ptr_device_accessible(
             MemorySpaceAccess<Kokkos::Experimental::HIPSpace,
+                              typename ReducerType::result_view_type::
+                                  memory_space>::accessible),
+        m_result_ptr_host_accessible(
+            MemorySpaceAccess<Kokkos::HostSpace,
                               typename ReducerType::result_view_type::
                                   memory_space>::accessible) {}
 };

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -367,7 +367,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       // REQUIRED ( 1 , N , 1 )
       dim3 block(1, block_size, 1);
       // Required grid.x <= block.y
-      dim3 grid(std::min(block.y, static_cast<uint32_t>((nwork + block.y - 1) / block.y)), 1, 1);
+      dim3 grid(std::min(block.y, static_cast<uint32_t>((nwork + block.y - 1) /
+                                                        block.y)),
+                1, 1);
 
       if (nwork == 0) {
         block = dim3(1, 1, 1);

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -743,7 +743,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     }
 
     // Reduce with final value at blockDim.y - 1 location.
-    bool do_final_reduce = m_league_size == 0;
+    bool do_final_reduce = (m_league_size == 0);
     if (!do_final_reduce)
       do_final_reduce =
           hip_single_inter_block_reduce_scan<false, FunctorType, work_tag>(
@@ -918,17 +918,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   m_policy.thread_scratch_size(0)) /
                   m_vector_size;
 
-    // We can't early exit here because the result place might not be accessible
-    // or the functor/reducer init not callable on the host. But I am not sure
-    // all the other code below is kosher with zero work length ...
-    //
-    // Return Init value if the number of worksets is zero
-    // if (m_league_size * m_team_size == 0) {
-    //  value_init::init(reducer_conditional::select(m_functor, m_reducer),
-    //                   arg_result.data());
-    //  return;
-    //}
-
     m_team_begin =
         UseShflReduction
             ? 0
@@ -1024,17 +1013,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   m_functor, m_vector_size, m_policy.team_scratch_size(0),
                   m_policy.thread_scratch_size(0)) /
                   m_vector_size;
-
-    // We can't early exit here because the result place might not be accessible
-    // or the functor/reducer init not callable on the host. But I am not sure
-    // all the other code below is kosher with zero work length ...
-    //
-    // Return Init value if the number of worksets is zero
-    // if (arg_policy.league_size() == 0) {
-    //   value_init::init(reducer_conditional::select(m_functor, m_reducer),
-    //                   m_result_ptr);
-    //  return;
-    //}
 
     m_team_begin =
         UseShflReduction

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -745,12 +745,12 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     // Reduce with final value at blockDim.y - 1 location.
     bool do_final_reduce = m_league_size == 0;
     if (!do_final_reduce)
-      do_final_reduce = 
-         hip_single_inter_block_reduce_scan<false, FunctorType, work_tag>(
-            reducer_conditional::select(m_functor, m_reducer), blockIdx.x,
-            gridDim.x,
-            Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>(),
-            m_scratch_space, m_scratch_flags);
+      do_final_reduce =
+          hip_single_inter_block_reduce_scan<false, FunctorType, work_tag>(
+              reducer_conditional::select(m_functor, m_reducer), blockIdx.x,
+              gridDim.x,
+              Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>(),
+              m_scratch_space, m_scratch_flags);
     if (do_final_reduce) {
       // This is the final block with the final result at the final threads'
       // location
@@ -808,15 +808,16 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     value_type init;
     value_init::init(reducer_conditional::select(m_functor, m_reducer), &init);
     if (int_league_size == 0) {
-        Kokkos::Impl::FunctorFinal<reducer_type_fwd, work_tag_fwd>::final(
-            reducer_conditional::select(m_functor, m_reducer),
-            reinterpret_cast<void*>(&value));
-        *result = value;
+      Kokkos::Impl::FunctorFinal<reducer_type_fwd, work_tag_fwd>::final(
+          reducer_conditional::select(m_functor, m_reducer),
+          reinterpret_cast<void*>(&value));
+      *result = value;
     } else if (Impl::hip_inter_block_shuffle_reduction<FunctorType, value_join,
-                                                work_tag>(
-            value, init,
-            value_join(reducer_conditional::select(m_functor, m_reducer)),
-            m_scratch_space, result, m_scratch_flags, blockDim.y)) {
+                                                       work_tag>(
+                   value, init,
+                   value_join(
+                       reducer_conditional::select(m_functor, m_reducer)),
+                   m_scratch_space, result, m_scratch_flags, blockDim.y)) {
       unsigned int const id = threadIdx.y * blockDim.x + threadIdx.x;
       if (id == 0) {
         Kokkos::Impl::FunctorFinal<reducer_type_fwd, work_tag_fwd>::final(
@@ -828,7 +829,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   inline void execute() {
-    const int nwork = m_league_size * m_team_size;
+    const int nwork            = m_league_size * m_team_size;
     const bool need_device_set = ReduceFunctorHasInit<FunctorType>::value ||
                                  ReduceFunctorHasFinal<FunctorType>::value ||
                                  !m_result_ptr_host_accessible ||
@@ -918,11 +919,11 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   m_vector_size;
 
     // We can't early exit here because the result place might not be accessible
-    // or the functor/reducer init not callable on the host. But I am not sure all 
-    // the other code below is kosher with zero work length ...
+    // or the functor/reducer init not callable on the host. But I am not sure
+    // all the other code below is kosher with zero work length ...
     //
     // Return Init value if the number of worksets is zero
-    //if (m_league_size * m_team_size == 0) {
+    // if (m_league_size * m_team_size == 0) {
     //  value_init::init(reducer_conditional::select(m_functor, m_reducer),
     //                   arg_result.data());
     //  return;
@@ -1025,11 +1026,11 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   m_vector_size;
 
     // We can't early exit here because the result place might not be accessible
-    // or the functor/reducer init not callable on the host. But I am not sure all 
-    // the other code below is kosher with zero work length ...
+    // or the functor/reducer init not callable on the host. But I am not sure
+    // all the other code below is kosher with zero work length ...
     //
     // Return Init value if the number of worksets is zero
-    //if (arg_policy.league_size() == 0) {
+    // if (arg_policy.league_size() == 0) {
     //   value_init::init(reducer_conditional::select(m_functor, m_reducer),
     //                   m_result_ptr);
     //  return;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -646,6 +646,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   const ReducerType m_reducer;
   const pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
+  const bool m_result_ptr_host_accessible;
   size_type* m_scratch_space;
   size_type* m_scratch_flags;
   size_type m_team_begin;
@@ -742,11 +743,15 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     }
 
     // Reduce with final value at blockDim.y - 1 location.
-    if (hip_single_inter_block_reduce_scan<false, FunctorType, work_tag>(
+    bool do_final_reduce = m_league_size == 0;
+    if (!do_final_reduce)
+      do_final_reduce = 
+         hip_single_inter_block_reduce_scan<false, FunctorType, work_tag>(
             reducer_conditional::select(m_functor, m_reducer), blockIdx.x,
             gridDim.x,
             Kokkos::Experimental::kokkos_impl_hip_shared_memory<size_type>(),
-            m_scratch_space, m_scratch_flags)) {
+            m_scratch_space, m_scratch_flags);
+    if (do_final_reduce) {
       // This is the final block with the final result at the final threads'
       // location
 
@@ -802,7 +807,12 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
     value_type init;
     value_init::init(reducer_conditional::select(m_functor, m_reducer), &init);
-    if (Impl::hip_inter_block_shuffle_reduction<FunctorType, value_join,
+    if (int_league_size == 0) {
+        Kokkos::Impl::FunctorFinal<reducer_type_fwd, work_tag_fwd>::final(
+            reducer_conditional::select(m_functor, m_reducer),
+            reinterpret_cast<void*>(&value));
+        *result = value;
+    } else if (Impl::hip_inter_block_shuffle_reduction<FunctorType, value_join,
                                                 work_tag>(
             value, init,
             value_join(reducer_conditional::select(m_functor, m_reducer)),
@@ -819,7 +829,11 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
   inline void execute() {
     const int nwork = m_league_size * m_team_size;
-    if (nwork) {
+    const bool need_device_set = ReduceFunctorHasInit<FunctorType>::value ||
+                                 ReduceFunctorHasFinal<FunctorType>::value ||
+                                 !m_result_ptr_host_accessible ||
+                                 !std::is_same<ReducerType, InvalidType>::value;
+    if ((nwork > 0) || need_device_set) {
       const int block_count =
           UseShflReduction
               ? std::min(
@@ -837,6 +851,10 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
       dim3 block(m_vector_size, m_team_size, 1);
       dim3 grid(block_count, 1, 1);
+      if (nwork == 0) {
+        block = dim3(1, 1, 1);
+        grid  = dim3(1, 1, 1);
+      }
       const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
 
       Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelReduce,
@@ -875,6 +893,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         m_result_ptr_device_accessible(
             MemorySpaceAccess<Kokkos::Experimental::HIPSpace,
                               typename ViewType::memory_space>::accessible),
+        m_result_ptr_host_accessible(
+            MemorySpaceAccess<Kokkos::HostSpace,
+                              typename ViewType::memory_space>::accessible),
         m_scratch_space(0),
         m_scratch_flags(0),
         m_team_begin(0),
@@ -896,12 +917,16 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   m_policy.thread_scratch_size(0)) /
                   m_vector_size;
 
+    // We can't early exit here because the result place might not be accessible
+    // or the functor/reducer init not callable on the host. But I am not sure all 
+    // the other code below is kosher with zero work length ...
+    //
     // Return Init value if the number of worksets is zero
-    if (m_league_size * m_team_size == 0) {
-      value_init::init(reducer_conditional::select(m_functor, m_reducer),
-                       arg_result.data());
-      return;
-    }
+    //if (m_league_size * m_team_size == 0) {
+    //  value_init::init(reducer_conditional::select(m_functor, m_reducer),
+    //                   arg_result.data());
+    //  return;
+    //}
 
     m_team_begin =
         UseShflReduction
@@ -974,6 +999,10 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
             MemorySpaceAccess<Kokkos::Experimental::HIPSpace,
                               typename ReducerType::result_view_type::
                                   memory_space>::accessible),
+        m_result_ptr_host_accessible(
+            MemorySpaceAccess<Kokkos::HostSpace,
+                              typename ReducerType::result_view_type::
+                                  memory_space>::accessible),
         m_scratch_space(0),
         m_scratch_flags(0),
         m_team_begin(0),
@@ -995,12 +1024,16 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   m_policy.thread_scratch_size(0)) /
                   m_vector_size;
 
+    // We can't early exit here because the result place might not be accessible
+    // or the functor/reducer init not callable on the host. But I am not sure all 
+    // the other code below is kosher with zero work length ...
+    //
     // Return Init value if the number of worksets is zero
-    if (arg_policy.league_size() == 0) {
-      value_init::init(reducer_conditional::select(m_functor, m_reducer),
-                       m_result_ptr);
-      return;
-    }
+    //if (arg_policy.league_size() == 0) {
+    //   value_init::init(reducer_conditional::select(m_functor, m_reducer),
+    //                   m_result_ptr);
+    //  return;
+    //}
 
     m_team_begin =
         UseShflReduction

--- a/core/unit_test/TestReduceCombinatorical.hpp
+++ b/core/unit_test/TestReduceCombinatorical.hpp
@@ -394,20 +394,27 @@ struct TestReduceCombinatoricalInstantiation {
   }
 
   template <class... Args>
-  static void AddReturnArgument(Args... args) {
-    Kokkos::View<double, Kokkos::HostSpace> result_view("ResultView");
-    double expected_result = 1000.0 * 999.0 / 2.0;
+  static void AddReturnArgument(int N, Args... args) {
+    Kokkos::View<double, Kokkos::HostSpace> result_view("ResultViewHost");
+    Kokkos::View<double, ExecSpace> result_view_device("ResultViewDevice");
+    double expected_result = (1.0 * N) * (1.0 * N - 1.0) / 2.0;
 
-    double value = 0;
+    double value = 99;
     Kokkos::parallel_reduce(args..., value);
     ASSERT_EQ(expected_result, value);
 
-    result_view() = 0;
+    result_view() = 99;
     CallParallelReduce(args..., result_view);
     Kokkos::fence();
     ASSERT_EQ(expected_result, result_view());
 
-    value = 0;
+    result_view() = 99;
+    CallParallelReduce(args..., result_view_device);
+    Kokkos::fence();
+    Kokkos::deep_copy(result_view, result_view_device);
+    ASSERT_EQ(expected_result, result_view());
+
+    value = 99;
     CallParallelReduce(
         args...,
         Kokkos::View<double, Kokkos::HostSpace,
@@ -415,7 +422,7 @@ struct TestReduceCombinatoricalInstantiation {
     Kokkos::fence();
     ASSERT_EQ(expected_result, value);
 
-    result_view() = 0;
+    result_view() = 99;
     const Kokkos::View<double, Kokkos::HostSpace,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
         result_view_const_um = result_view;
@@ -423,29 +430,30 @@ struct TestReduceCombinatoricalInstantiation {
     Kokkos::fence();
     ASSERT_EQ(expected_result, result_view_const_um());
 
-    value = 0;
+    value = 99;
 // WORKAROUND OPENMPTARGET Custom Reducers not implemented
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
     CallParallelReduce(args...,
                        Test::ReduceCombinatorical::AddPlus<double>(value));
     if ((Kokkos::DefaultExecutionSpace::concurrency() > 1) &&
-        (ExecSpace::concurrency() > 1)) {
-      ASSERT_TRUE(expected_result < value);
-    } else if ((Kokkos::DefaultExecutionSpace::concurrency() > 1) ||
-               (ExecSpace::concurrency() > 1)) {
+        (ExecSpace::concurrency() > 1) && (expected_result > 0)) {
+    } else if (((Kokkos::DefaultExecutionSpace::concurrency() > 1) ||
+                (ExecSpace::concurrency() > 1)) &&
+               (expected_result > 0)) {
       ASSERT_TRUE(expected_result <= value);
     } else {
       ASSERT_EQ(expected_result, value);
     }
 
-    value = 0;
+    value = 99;
     Test::ReduceCombinatorical::AddPlus<double> add(value);
     CallParallelReduce(args..., add);
     if ((Kokkos::DefaultExecutionSpace::concurrency() > 1) &&
-        (ExecSpace::concurrency() > 1)) {
+        (ExecSpace::concurrency() > 1) && (expected_result > 0)) {
       ASSERT_TRUE(expected_result < value);
-    } else if ((Kokkos::DefaultExecutionSpace::concurrency() > 1) ||
-               (ExecSpace::concurrency() > 1)) {
+    } else if (((Kokkos::DefaultExecutionSpace::concurrency() > 1) ||
+                (ExecSpace::concurrency() > 1)) &&
+               (expected_result > 0)) {
       ASSERT_TRUE(expected_result <= value);
     } else {
       ASSERT_EQ(expected_result, value);
@@ -454,49 +462,50 @@ struct TestReduceCombinatoricalInstantiation {
   }
 
   template <class... Args>
-  static void AddLambdaRange(void*, Args... args) {
+  static void AddLambdaRange(int N, void*, Args... args) {
     AddReturnArgument(
-        args..., KOKKOS_LAMBDA(const int& i, double& lsum) { lsum += i; });
+        N, args..., KOKKOS_LAMBDA(const int& i, double& lsum) { lsum += i; });
   }
 
   template <class... Args>
-  static void AddLambdaTeam(void*, Args... args) {
+  static void AddLambdaTeam(int N, void*, Args... args) {
     AddReturnArgument(
-        args..., KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& team,
-                               double& update) {
+        N, args...,
+        KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& team,
+                      double& update) {
           update += 1.0 / team.team_size() * team.league_rank();
         });
   }
 
   template <class... Args>
-  static void AddLambdaRange(Kokkos::InvalidType, Args... /*args*/) {}
+  static void AddLambdaRange(int N, Kokkos::InvalidType, Args... /*args*/) {}
 
   template <class... Args>
-  static void AddLambdaTeam(Kokkos::InvalidType, Args... /*args*/) {}
+  static void AddLambdaTeam(int N, Kokkos::InvalidType, Args... /*args*/) {}
 
   template <int ISTEAM, class... Args>
-  static void AddFunctor(Args... args) {
-    Kokkos::View<double> result_view("FunctorView");
+  static void AddFunctor(int N, Args... args) {
+    Kokkos::View<double, ExecSpace> result_view("FunctorView");
     auto h_r = Kokkos::create_mirror_view(result_view);
     Test::ReduceCombinatorical::FunctorScalar<ISTEAM> functor(result_view);
 
-    AddReturnArgument(args..., functor);
+    AddReturnArgument(N, args..., functor);
     AddReturnArgument(
-        args...,
+        N, args...,
         Test::ReduceCombinatorical::FunctorScalar<ISTEAM>(result_view));
 // WORKAROUND OPENMPTARGET: reductions with functor join/init/final not
 // implemented
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
-    double expected_result = 1000.0 * 999.0 / 2.0;
+    double expected_result = (1.0 * N) * (1.0 * N - 1.0) / 2.0;
 
     AddReturnArgument(
-        args...,
+        N, args...,
         Test::ReduceCombinatorical::FunctorScalarInit<ISTEAM>(result_view));
     AddReturnArgument(
-        args...,
+        N, args...,
         Test::ReduceCombinatorical::FunctorScalarJoin<ISTEAM>(result_view));
     AddReturnArgument(
-        args...,
+        N, args...,
         Test::ReduceCombinatorical::FunctorScalarJoinInit<ISTEAM>(result_view));
 
     h_r() = 0;
@@ -529,10 +538,11 @@ struct TestReduceCombinatoricalInstantiation {
   }
 
   template <class... Args>
-  static void AddFunctorLambdaRange(Args... args) {
-    AddFunctor<0, Args...>(args...);
+  static void AddFunctorLambdaRange(int N, Args... args) {
+    AddFunctor<0, Args...>(N, args...);
 #ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
     AddLambdaRange(
+        N,
         typename std::conditional<
             std::is_same<ExecSpace, Kokkos::DefaultExecutionSpace>::value,
             void*, Kokkos::InvalidType>::type(),
@@ -541,10 +551,11 @@ struct TestReduceCombinatoricalInstantiation {
   }
 
   template <class... Args>
-  static void AddFunctorLambdaTeam(Args... args) {
-    AddFunctor<1, Args...>(args...);
+  static void AddFunctorLambdaTeam(int N, Args... args) {
+    AddFunctor<1, Args...>(N, args...);
 #ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
     AddLambdaTeam(
+        N,
         typename std::conditional<
             std::is_same<ExecSpace, Kokkos::DefaultExecutionSpace>::value,
             void*, Kokkos::InvalidType>::type(),
@@ -553,95 +564,95 @@ struct TestReduceCombinatoricalInstantiation {
   }
 
   template <class... Args>
-  static void AddPolicy_1(Args... args) {
-    int N = 1000;
+  static void AddPolicy_1(int N, Args... args) {
     Kokkos::RangePolicy<ExecSpace> policy(0, N);
 
-    AddFunctorLambdaRange(args..., 1000);
-    AddFunctorLambdaRange(args..., N);
-    AddFunctorLambdaRange(args..., policy);
+    AddFunctorLambdaRange(1000, args..., 1000);
+    AddFunctorLambdaRange(N, args..., N);
+    AddFunctorLambdaRange(N, args..., policy);
   }
 
   template <class... Args>
-  static void AddPolicy_2(Args... args) {
-    int N = 1000;
+  static void AddPolicy_2(int N, Args... args) {
     Kokkos::RangePolicy<ExecSpace> policy(0, N);
 
-    AddFunctorLambdaRange(args..., Kokkos::RangePolicy<ExecSpace>(0, N));
+    AddFunctorLambdaRange(N, args..., Kokkos::RangePolicy<ExecSpace>(0, N));
     AddFunctorLambdaRange(
-        args...,
+        N, args...,
         Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >(0,
                                                                            N));
     AddFunctorLambdaRange(
-        args...,
+        N, args...,
         Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Static> >(0, N)
             .set_chunk_size(10));
     AddFunctorLambdaRange(
-        args...,
+        N, args...,
         Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >(0, N)
             .set_chunk_size(10));
   }
 
   template <class... Args>
-  static void AddPolicy_3(Args... args) {
-    int N = 1000;
+  static void AddPolicy_3(int N, Args... args) {
     Kokkos::RangePolicy<ExecSpace> policy(0, N);
 
-    AddFunctorLambdaTeam(args...,
+    AddFunctorLambdaTeam(N, args...,
                          Kokkos::TeamPolicy<ExecSpace>(N, Kokkos::AUTO));
     AddFunctorLambdaTeam(
-        args...,
+        N, args...,
         Kokkos::TeamPolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >(
             N, Kokkos::AUTO));
     AddFunctorLambdaTeam(
-        args...,
+        N, args...,
         Kokkos::TeamPolicy<ExecSpace, Kokkos::Schedule<Kokkos::Static> >(
             N, Kokkos::AUTO)
             .set_chunk_size(10));
     AddFunctorLambdaTeam(
-        args...,
+        N, args...,
         Kokkos::TeamPolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >(
             N, Kokkos::AUTO)
             .set_chunk_size(10));
   }
 
-  static void execute_a1() { AddPolicy_1(); }
+  static void execute_a1() { AddPolicy_1(1000); }
 
   static void execute_b1() {
     std::string s("Std::String");
-    AddPolicy_1(s.c_str());
-    AddPolicy_1("Char Constant");
+    AddPolicy_1(1000, s.c_str());
+    AddPolicy_1(1000, "Char Constant");
+    AddPolicy_1(0, "Char Constant");
   }
 
   static void execute_c1() {
     std::string s("Std::String");
-    AddPolicy_1(s);
+    AddPolicy_1(1000, s);
   }
 
-  static void execute_a2() { AddPolicy_2(); }
+  static void execute_a2() { AddPolicy_2(1000); }
 
   static void execute_b2() {
     std::string s("Std::String");
-    AddPolicy_2(s.c_str());
-    AddPolicy_2("Char Constant");
+    AddPolicy_2(1000, s.c_str());
+    AddPolicy_2(1000, "Char Constant");
+    AddPolicy_2(0, "Char Constant");
   }
 
   static void execute_c2() {
     std::string s("Std::String");
-    AddPolicy_2(s);
+    AddPolicy_2(1000, s);
   }
 
-  static void execute_a3() { AddPolicy_1(); }
+  static void execute_a3() { AddPolicy_3(1000); }
 
   static void execute_b3() {
     std::string s("Std::String");
-    AddPolicy_1(s.c_str());
-    AddPolicy_1("Char Constant");
+    AddPolicy_3(1000, s.c_str());
+    AddPolicy_3(1000, "Char Constant");
+    AddPolicy_3(0, "Char Constant");
   }
 
   static void execute_c3() {
     std::string s("Std::String");
-    AddPolicy_1(s);
+    AddPolicy_3(1000, s);
   }
 };
 

--- a/core/unit_test/TestReduceCombinatorical.hpp
+++ b/core/unit_test/TestReduceCombinatorical.hpp
@@ -408,11 +408,13 @@ struct TestReduceCombinatoricalInstantiation {
     Kokkos::fence();
     ASSERT_EQ(expected_result, result_view());
 
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     result_view() = 99;
     CallParallelReduce(args..., result_view_device);
     Kokkos::fence();
     Kokkos::deep_copy(result_view, result_view_device);
     ASSERT_EQ(expected_result, result_view());
+#endif
 
     value = 99;
     CallParallelReduce(
@@ -437,6 +439,7 @@ struct TestReduceCombinatoricalInstantiation {
                        Test::ReduceCombinatorical::AddPlus<double>(value));
     if ((Kokkos::DefaultExecutionSpace::concurrency() > 1) &&
         (ExecSpace::concurrency() > 1) && (expected_result > 0)) {
+      ASSERT_TRUE(expected_result < value);
     } else if (((Kokkos::DefaultExecutionSpace::concurrency() > 1) ||
                 (ExecSpace::concurrency() > 1)) &&
                (expected_result > 0)) {
@@ -478,10 +481,10 @@ struct TestReduceCombinatoricalInstantiation {
   }
 
   template <class... Args>
-  static void AddLambdaRange(int N, Kokkos::InvalidType, Args... /*args*/) {}
+  static void AddLambdaRange(int, Kokkos::InvalidType, Args... /*args*/) {}
 
   template <class... Args>
-  static void AddLambdaTeam(int N, Kokkos::InvalidType, Args... /*args*/) {}
+  static void AddLambdaTeam(int, Kokkos::InvalidType, Args... /*args*/) {}
 
   template <int ISTEAM, class... Args>
   static void AddFunctor(int N, Args... args) {
@@ -574,8 +577,6 @@ struct TestReduceCombinatoricalInstantiation {
 
   template <class... Args>
   static void AddPolicy_2(int N, Args... args) {
-    Kokkos::RangePolicy<ExecSpace> policy(0, N);
-
     AddFunctorLambdaRange(N, args..., Kokkos::RangePolicy<ExecSpace>(0, N));
     AddFunctorLambdaRange(
         N, args...,
@@ -593,8 +594,6 @@ struct TestReduceCombinatoricalInstantiation {
 
   template <class... Args>
   static void AddPolicy_3(int N, Args... args) {
-    Kokkos::RangePolicy<ExecSpace> policy(0, N);
-
     AddFunctorLambdaTeam(N, args...,
                          Kokkos::TeamPolicy<ExecSpace>(N, Kokkos::AUTO));
     AddFunctorLambdaTeam(
@@ -619,7 +618,9 @@ struct TestReduceCombinatoricalInstantiation {
     std::string s("Std::String");
     AddPolicy_1(1000, s.c_str());
     AddPolicy_1(1000, "Char Constant");
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     AddPolicy_1(0, "Char Constant");
+#endif
   }
 
   static void execute_c1() {
@@ -633,7 +634,9 @@ struct TestReduceCombinatoricalInstantiation {
     std::string s("Std::String");
     AddPolicy_2(1000, s.c_str());
     AddPolicy_2(1000, "Char Constant");
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     AddPolicy_2(0, "Char Constant");
+#endif
   }
 
   static void execute_c2() {
@@ -641,18 +644,26 @@ struct TestReduceCombinatoricalInstantiation {
     AddPolicy_2(1000, s);
   }
 
-  static void execute_a3() { AddPolicy_3(1000); }
+  static void execute_a3() {
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
+    AddPolicy_3(1000);
+#endif
+  }
 
   static void execute_b3() {
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     std::string s("Std::String");
     AddPolicy_3(1000, s.c_str());
     AddPolicy_3(1000, "Char Constant");
     AddPolicy_3(0, "Char Constant");
+#endif
   }
 
   static void execute_c3() {
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     std::string s("Std::String");
     AddPolicy_3(1000, s);
+#endif
   }
 };
 

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -351,7 +351,8 @@ struct TestReducers {
     {
       Kokkos::View<Scalar, typename ExecSpace::memory_space> sum_view("View");
       Kokkos::deep_copy(sum_view, Scalar(1));
-      Kokkos::Sum<Scalar, typename ExecSpace::memory_space> reducer_view(sum_view);
+      Kokkos::Sum<Scalar, typename ExecSpace::memory_space> reducer_view(
+          sum_view);
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
                               reducer_view);
       Kokkos::fence();
@@ -412,7 +413,7 @@ struct TestReducers {
                               reducer_view);
       Kokkos::fence();
       Scalar prod_view_scalar = prod_view();
-      ASSERT_EQ(prod_view_scalar, reference_prod);
+      ASSERT_EQ(prod_view_scalar, init);
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
                               reducer_view);
@@ -427,13 +428,14 @@ struct TestReducers {
     {
       Kokkos::View<Scalar, typename ExecSpace::memory_space> prod_view("View");
       Kokkos::deep_copy(prod_view, Scalar(0));
-      Kokkos::Prod<Scalar,typename ExecSpace::memory_space> reducer_view(prod_view);
+      Kokkos::Prod<Scalar, typename ExecSpace::memory_space> reducer_view(
+          prod_view);
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
                               reducer_view);
       Kokkos::fence();
       Scalar prod_view_scalar;
       Kokkos::deep_copy(prod_view_scalar, prod_view);
-      ASSERT_EQ(prod_view_scalar, reference_prod);
+      ASSERT_EQ(prod_view_scalar, init);
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
                               reducer_view);

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -313,7 +313,10 @@ struct TestReducers {
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
                               reducer_scalar);
+// Zero length reduction not yet supported
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
       ASSERT_EQ(sum_scalar, init);
+#endif
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
                               reducer_scalar);
@@ -336,7 +339,10 @@ struct TestReducers {
                               reducer_view);
       Kokkos::fence();
       Scalar sum_view_scalar = sum_view();
+// Zero length reduction not yet supported
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
       ASSERT_EQ(sum_view_scalar, init);
+#endif
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
                               reducer_view);
@@ -348,6 +354,8 @@ struct TestReducers {
       ASSERT_EQ(sum_view_view, reference_sum);
     }
 
+    // Reduction to device view not yet supported
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     {
       Kokkos::View<Scalar, typename ExecSpace::memory_space> sum_view("View");
       Kokkos::deep_copy(sum_view, Scalar(1));
@@ -366,6 +374,7 @@ struct TestReducers {
       Kokkos::deep_copy(sum_view_scalar, sum_view);
       ASSERT_EQ(sum_view_scalar, reference_sum);
     }
+#endif
   }
 
   static void test_prod(int N) {
@@ -390,7 +399,10 @@ struct TestReducers {
       Kokkos::Prod<Scalar> reducer_scalar(prod_scalar);
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
                               reducer_scalar);
+// Zero length reduction not yet supported
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
       ASSERT_EQ(prod_scalar, init);
+#endif
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
                               reducer_scalar);
@@ -413,7 +425,10 @@ struct TestReducers {
                               reducer_view);
       Kokkos::fence();
       Scalar prod_view_scalar = prod_view();
+// Zero length reduction not yet supported
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
       ASSERT_EQ(prod_view_scalar, init);
+#endif
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
                               reducer_view);
@@ -425,6 +440,8 @@ struct TestReducers {
       ASSERT_EQ(prod_view_view, reference_prod);
     }
 
+    // Reduction to device view not yet supported
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
     {
       Kokkos::View<Scalar, typename ExecSpace::memory_space> prod_view("View");
       Kokkos::deep_copy(prod_view, Scalar(0));
@@ -443,6 +460,7 @@ struct TestReducers {
       Kokkos::deep_copy(prod_view_scalar, prod_view);
       ASSERT_EQ(prod_view_scalar, reference_prod);
     }
+#endif
   }
 
   static void test_min(int N) {


### PR DESCRIPTION
This is the start of fixing zero length reductions corner cases described in #3331 . The first two commits add a test for RangePolicy zero length reductions into scalars, host and device views (for all backends) and the fix for the RangePolicy for CUDA. 

TODO: 
- Fix ROCM RangePolicy
- Add Test for MDRangePolicy and TeamPolicy
- Fix CUDA and ROCM MDRangePolicy and TeamPolicy
- Fix OpenMPTarget backend maybe?