### PR TITLE
Implement multiple occupancy paths for various HIP kernel launchers

### DIFF
--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -190,7 +190,7 @@ struct HIPGetMaxBlockSize<DriverType, LaunchBounds, true> {
                             size_t const shmem_extra_block,
                             size_t const shmem_extra_thread) {
     int numBlocks = 0;
-    int blockSize = 1024;
+    int blockSize = LaunchBounds::maxTperB == 0 ? 1024 : LaunchBounds::maxTperB;
     int sharedmem =
         shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
         ::Kokkos::Impl::FunctorTeamShmemSize<

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -55,6 +55,26 @@
 namespace Kokkos {
 namespace Experimental {
 namespace Impl {
+
+template <typename DriverType, bool, int MaxThreadsPerBlock, int MinBlocksPerSM>
+void hipOccupancy(int *numBlocks, int blockSize, int sharedmem) {
+  // FIXME_HIP - currently the "constant" path is unimplemented.
+  //             we should look at whether it's functional, and
+  //             perform some simple scaling studies to see when /
+  //             if the constant launcher outperforms the current
+  //             pass by pointer shared launcher
+  HIP_SAFE_CALL(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      numBlocks,
+      hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
+                                       MinBlocksPerSM>,
+      blockSize, sharedmem));
+}
+
+template <typename DriverType, bool constant>
+void hipOccupancy(int *numBlocks, int blockSize, int sharedmem) {
+  hipOccupancy<DriverType, constant, HIPTraits::MaxThreadsPerBlock, 1>(
+      numBlocks, blockSize, sharedmem);
+}
 template <typename DriverType, typename LaunchBounds, bool Large>
 struct HIPGetMaxBlockSize;
 
@@ -163,8 +183,8 @@ int hip_get_max_block_size(const HIPInternal *hip_instance,
       [](int x) { return x == 0; }, hip_instance, attr, f, vector_length,
       shmem_block, shmem_thread);
 }
-template <typename DriverType>
-struct HIPGetMaxBlockSize<DriverType, Kokkos::LaunchBounds<>, true> {
+template <typename DriverType, class LaunchBounds>
+struct HIPGetMaxBlockSize<DriverType, LaunchBounds, true> {
   static int get_block_size(typename DriverType::functor_type const &f,
                             size_t const vector_length,
                             size_t const shmem_extra_block,
@@ -176,9 +196,8 @@ struct HIPGetMaxBlockSize<DriverType, Kokkos::LaunchBounds<>, true> {
         ::Kokkos::Impl::FunctorTeamShmemSize<
             typename DriverType::functor_type>::value(f, blockSize /
                                                              vector_length);
-    hipOccupancyMaxActiveBlocksPerMultiprocessor(
-        &numBlocks, hip_parallel_launch_constant_memory<DriverType>, blockSize,
-        sharedmem);
+
+    hipOccupancy<DriverType, true>(&numBlocks, blockSize, sharedmem);
 
     if (numBlocks > 0) return blockSize;
     while (blockSize > HIPTraits::WarpSize && numBlocks == 0) {
@@ -189,9 +208,7 @@ struct HIPGetMaxBlockSize<DriverType, Kokkos::LaunchBounds<>, true> {
               typename DriverType::functor_type>::value(f, blockSize /
                                                                vector_length);
 
-      hipOccupancyMaxActiveBlocksPerMultiprocessor(
-          &numBlocks, hip_parallel_launch_constant_memory<DriverType>,
-          blockSize, sharedmem);
+      hipOccupancy<DriverType, true>(&numBlocks, blockSize, sharedmem);
     }
     int blockSizeUpperBound = blockSize * 2;
     while (blockSize < blockSizeUpperBound && numBlocks > 0) {
@@ -202,9 +219,7 @@ struct HIPGetMaxBlockSize<DriverType, Kokkos::LaunchBounds<>, true> {
               typename DriverType::functor_type>::value(f, blockSize /
                                                                vector_length);
 
-      hipOccupancyMaxActiveBlocksPerMultiprocessor(
-          &numBlocks, hip_parallel_launch_constant_memory<DriverType>,
-          blockSize, sharedmem);
+      hipOccupancy<DriverType, true>(&numBlocks, blockSize, sharedmem);
     }
     return blockSize - HIPTraits::WarpSize;
   }
@@ -259,9 +274,7 @@ struct HIPGetOptBlockSize<DriverType, Kokkos::LaunchBounds<0, 0>, true> {
           ::Kokkos::Impl::FunctorTeamShmemSize<
               typename DriverType::functor_type>::value(f, blockSize /
                                                                vector_length);
-      hipOccupancyMaxActiveBlocksPerMultiprocessor(
-          &numBlocks, hip_parallel_launch_constant_memory<DriverType>,
-          blockSize, sharedmem);
+      hipOccupancy<DriverType, true>(&numBlocks, blockSize, sharedmem);
       if (maxOccupancy < numBlocks * blockSize) {
         maxOccupancy  = numBlocks * blockSize;
         bestBlockSize = blockSize;
@@ -291,9 +304,7 @@ struct HIPGetOptBlockSize<DriverType, Kokkos::LaunchBounds<0, 0>, false> {
               typename DriverType::functor_type>::value(f, blockSize /
                                                                vector_length);
 
-      hipOccupancyMaxActiveBlocksPerMultiprocessor(
-          &numBlocks, hip_parallel_launch_local_memory<DriverType>, blockSize,
-          sharedmem);
+      hipOccupancy<DriverType, false>(&numBlocks, blockSize, sharedmem);
 
       if (maxOccupancy < numBlocks * blockSize) {
         maxOccupancy  = numBlocks * blockSize;
@@ -334,11 +345,8 @@ struct HIPGetOptBlockSize<
           ::Kokkos::Impl::FunctorTeamShmemSize<
               typename DriverType::functor_type>::value(f, blockSize /
                                                                vector_length);
-      hipOccupancyMaxActiveBlocksPerMultiprocessor(
-          &numBlocks,
-          hip_parallel_launch_constant_memory<DriverType, MaxThreadsPerBlock,
-                                              MinBlocksPerSM>,
-          blockSize, sharedmem);
+      hipOccupancy<DriverType, true, MaxThreadsPerBlock, MinBlocksPerSM>(
+          &numBlocks, blockSize, sharedmem);
       if (numBlocks >= static_cast<int>(MinBlocksPerSM) &&
           blockSize <= static_cast<int>(MaxThreadsPerBlock)) {
         if (maxOccupancy < numBlocks * blockSize) {
@@ -378,11 +386,8 @@ struct HIPGetOptBlockSize<
               typename DriverType::functor_type>::value(f, blockSize /
                                                                vector_length);
 
-      hipOccupancyMaxActiveBlocksPerMultiprocessor(
-          &numBlocks,
-          hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
-                                           MinBlocksPerSM>,
-          blockSize, sharedmem);
+      hipOccupancy<DriverType, false, MaxThreadsPerBlock, MinBlocksPerSM>(
+          &numBlocks, blockSize, sharedmem);
       if (numBlocks >= int(MinBlocksPerSM) &&
           blockSize <= int(MaxThreadsPerBlock)) {
         if (maxOccupancy < numBlocks * blockSize) {


### PR DESCRIPTION
Cleaned version of #3300:

Ensure that the occupancy checked in Kokkos_HIP_BlockSize_Deduction.hpp matches the kernel launcher used in Kokkos_HIP_KernelLaunch.hpp, i.e., hip_parallel_launch_local_memory. Previously, if the occupancy was determined for the constant launcher, subtle launch-time resource utilization bugs could be introduced (e.g., not enough LDS for the scatchpad) due to minor differences in the kernels.