### PR TITLE
Fixup remove_cvref type traits

### DIFF
--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -425,7 +425,9 @@ using std::remove_cvref;
 using std::remove_cvref_t;
 #else
 template <class T>
-struct remove_cvref : std::remove_cv_t<std::remove_reference_t<T>>::type {};
+struct remove_cvref {
+  using type = std::remove_cv_t<std::remove_reference_t<T>>;
+};
 
 template <class T>
 using remove_cvref_t = typename remove_cvref<T>::type;

--- a/core/unit_test/TestConcepts.hpp
+++ b/core/unit_test/TestConcepts.hpp
@@ -78,4 +78,10 @@ static_assert(!Kokkos::is_space<ExecutionSpace &>{}, "");
 static_assert(!Kokkos::is_space<MemorySpace &>{}, "");
 static_assert(!Kokkos::is_space<DeviceType &>{}, "");
 
+static_assert(
+    std::is_same<float, Kokkos::Impl::remove_cvref_t<float const &>>{}, "");
+static_assert(std::is_same<int, Kokkos::Impl::remove_cvref_t<int &>>{}, "");
+static_assert(std::is_same<int, Kokkos::Impl::remove_cvref_t<int const>>{}, "");
+static_assert(std::is_same<float, Kokkos::Impl::remove_cvref_t<float>>{}, "");
+
 }  // namespace TestConcept


### PR DESCRIPTION
Fixup for #3340 where I messed up and added a trailing `::type` by mistake.