### PR TITLE
Experimental feature: control cuda occupancy

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -198,6 +198,39 @@ int cuda_get_opt_block_size(const CudaInternal* cuda_instance,
                                 LaunchBounds{});
 }
 
+// Assuming cudaFuncSetCacheConfig(MyKernel, cudaFuncCachePreferL1)
+// NOTE these number can be obtained several ways:
+// * One option is to download the CUDA Occupancy Calculator spreadsheet, select
+// "Compute Capability" first and check what is the smallest "Shared Memory
+// Size Config" that is available.  The "Shared Memory Per Multiprocessor" in
+// bytes is then to be found below in the summary.
+// * Another option would be to look for the information in the "Tuning
+// Guide(s)" of the CUDA Toolkit Documentation for each GPU architecture, in
+// the "Shared Memory" section (more tedious)
+inline size_t get_shmem_per_sm_prefer_l1(cudaDeviceProp const& properties) {
+  int const compute_capability = properties.major * 10 + properties.minor;
+  return [compute_capability]() {
+    switch (compute_capability) {
+      case 30:
+      case 32:
+      case 35: return 16;
+      case 37: return 80;
+      case 50:
+      case 53:
+      case 60:
+      case 62: return 64;
+      case 52:
+      case 61: return 96;
+      case 70:
+      case 80: return 8;
+      case 75: return 32;
+      default:
+        Kokkos::Impl::throw_runtime_exception(
+            "Unknown device in cuda block size deduction");
+    }
+    return 0;
+  }() * 1024;
+}
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -51,6 +51,7 @@
 #include <mutex>
 #include <string>
 #include <cstdint>
+#include <cmath>
 #include <Kokkos_Parallel.hpp>
 #include <impl/Kokkos_Error.hpp>
 #include <Cuda/Kokkos_Cuda_abort.hpp>
@@ -190,8 +191,12 @@ modify_launch_configuration_if_desired_occupancy_is_specified(
 
   size_t const shmem_per_sm_prefer_l1 = get_shmem_per_sm_prefer_l1(properties);
   size_t const static_shmem           = attributes.sharedSizeBytes;
-  int active_blocks = properties.maxThreadsPerMultiProcessor / block_size *
-                      desired_occupancy / 100;
+
+  // round to nearest integer and avoid division by zero
+  int active_blocks = std::max(
+      1, static_cast<int>(std::round(
+             static_cast<double>(properties.maxThreadsPerMultiProcessor) /
+             block_size * desired_occupancy / 100)));
   int const dynamic_shmem =
       shmem_per_sm_prefer_l1 / active_blocks - static_shmem;
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -472,6 +472,8 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
  public:
   using functor_type = FunctorType;
 
+  Policy const& get_policy() const { return m_policy; }
+
   inline __device__ void operator()(void) const {
     const Member work_stride = blockDim.y * gridDim.x;
     const Member work_end    = m_policy.end();
@@ -535,6 +537,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
   const Policy m_rp;
 
  public:
+  Policy const& get_policy() const { return m_rp; }
+
   inline __device__ void operator()(void) const {
     Kokkos::Impl::Refactor::DeviceIterateTile<Policy::rank, Policy, FunctorType,
                                               typename Policy::work_tag>(
@@ -684,6 +688,8 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
  public:
+  Policy const& get_policy() const { return m_policy; }
+
   __device__ inline void operator()(void) const {
     // Iterate this block through the league
     int64_t threadid = 0;
@@ -878,6 +884,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   using DummySHMEMReductionType = int;
 
  public:
+  Policy const& get_policy() const { return m_policy; }
+
   // Make the exec_range calls call to Reduce::DeviceIterateTile
   template <class TagType>
   __device__ inline
@@ -1213,6 +1221,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   using DummySHMEMReductionType = int;
 
  public:
+  Policy const& get_policy() const { return m_policy; }
+
   inline __device__ void exec_range(reference_type update) const {
     Kokkos::Impl::Reduce::DeviceIterateTile<Policy::rank, Policy, FunctorType,
                                             typename Policy::work_tag,
@@ -1533,6 +1543,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
  public:
+  Policy const& get_policy() const { return m_policy; }
+
   __device__ inline void operator()() const {
     int64_t threadid = 0;
     if (m_scratch_size[1] > 0) {
@@ -2127,6 +2139,8 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
   }
 
  public:
+  Policy const& get_policy() const { return m_policy; }
+
   //----------------------------------------
 
   __device__ inline void operator()(void) const {
@@ -2417,6 +2431,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
  public:
+  Policy const& get_policy() const { return m_policy; }
+
   //----------------------------------------
 
   __device__ inline void operator()(void) const {

--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -77,6 +77,8 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
   }
 
  public:
+  Policy const& get_policy() const { return m_policy; }
+
   __device__ inline void operator()() const noexcept {
     if (0 == (threadIdx.y % 16)) {
       // Spin until COMPLETED_TOKEN.

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -307,7 +307,8 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
 
   template <class... OtherProperties>
   MDRangePolicy(const MDRangePolicy<OtherProperties...> p)
-      : m_space(p.m_space),
+      : traits(p),  // base class may contain data such as desired occupancy
+        m_space(p.m_space),
         m_lower(p.m_lower),
         m_upper(p.m_upper),
         m_tile(p.m_tile),

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -918,6 +918,36 @@ struct PolicyPropertyAdaptor<WorkItemProperty::ImplWorkItemProperty<P>,
                               WorkItemProperty::ImplWorkItemProperty<P>,
                               typename policy_in_t::traits::occupancy_control>;
 };
+
+template <template <class...> class Policy, class... Properties>
+struct PolicyPropertyAdaptor<DesiredOccupancy, Policy<Properties...>> {
+  using policy_in_t = Policy<Properties...>;
+  static_assert(is_execution_policy<policy_in_t>::value, "");
+  using policy_out_t = Policy<typename policy_in_t::traits::execution_space,
+                              typename policy_in_t::traits::schedule_type,
+                              typename policy_in_t::traits::work_tag,
+                              typename policy_in_t::traits::index_type,
+                              typename policy_in_t::traits::iteration_pattern,
+                              typename policy_in_t::traits::launch_bounds,
+                              typename policy_in_t::traits::work_item_property,
+                              DesiredOccupancy>;
+  static_assert(policy_out_t::experimental_contains_desired_occupancy, "");
+};
+
+template <template <class...> class Policy, class... Properties>
+struct PolicyPropertyAdaptor<MaximizeOccupancy, Policy<Properties...>> {
+  using policy_in_t = Policy<Properties...>;
+  static_assert(is_execution_policy<policy_in_t>::value, "");
+  using policy_out_t = Policy<typename policy_in_t::traits::execution_space,
+                              typename policy_in_t::traits::schedule_type,
+                              typename policy_in_t::traits::work_tag,
+                              typename policy_in_t::traits::index_type,
+                              typename policy_in_t::traits::iteration_pattern,
+                              typename policy_in_t::traits::launch_bounds,
+                              typename policy_in_t::traits::work_item_property,
+                              MaximizeOccupancy>;
+  static_assert(!policy_out_t::experimental_contains_desired_occupancy, "");
+};
 }  // namespace Impl
 
 template <class PolicyType, unsigned long P>
@@ -927,6 +957,24 @@ require(const PolicyType p, WorkItemProperty::ImplWorkItemProperty<P>) {
   return typename Impl::PolicyPropertyAdaptor<
       WorkItemProperty::ImplWorkItemProperty<P>, PolicyType>::policy_out_t(p);
 }
+
+template <typename Policy>
+/*constexpr*/ typename Impl::PolicyPropertyAdaptor<DesiredOccupancy,
+                                                   Policy>::policy_out_t
+prefer(Policy const& p, DesiredOccupancy occ) {
+  typename Impl::PolicyPropertyAdaptor<DesiredOccupancy, Policy>::policy_out_t
+      pwo{p};
+  pwo.impl_set_desired_occupancy(occ);
+  return pwo;
+}
+
+template <typename Policy>
+constexpr typename Impl::PolicyPropertyAdaptor<MaximizeOccupancy,
+                                               Policy>::policy_out_t
+prefer(Policy const& p, MaximizeOccupancy) {
+  return {p};
+}
+
 }  // namespace Experimental
 
 namespace Impl {

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -915,7 +915,8 @@ struct PolicyPropertyAdaptor<WorkItemProperty::ImplWorkItemProperty<P>,
                               typename policy_in_t::traits::index_type,
                               typename policy_in_t::traits::iteration_pattern,
                               typename policy_in_t::traits::launch_bounds,
-                              WorkItemProperty::ImplWorkItemProperty<P>>;
+                              WorkItemProperty::ImplWorkItemProperty<P>,
+                              typename policy_in_t::traits::occupancy_control>;
 };
 }  // namespace Impl
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -123,7 +123,8 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
 
   template <class... OtherProperties>
   RangePolicy(const RangePolicy<OtherProperties...>& p)
-      : m_space(p.m_space),
+      : traits(p),  // base class may contain data such as desired occupancy
+        m_space(p.m_space),
         m_begin(p.m_begin),
         m_end(p.m_end),
         m_granularity(p.m_granularity),
@@ -601,7 +602,11 @@ class TeamPolicy
                         Kokkos::AUTO()) {}
 
   template <class... OtherProperties>
-  TeamPolicy(const TeamPolicy<OtherProperties...> p) : internal_policy(p) {}
+  TeamPolicy(const TeamPolicy<OtherProperties...> p) : internal_policy(p) {
+    // Cannot call converting constructor in the member initializer list because
+    // it is not a direct base.
+    internal_policy::traits::operator=(p);
+  }
 
  private:
   TeamPolicy(const internal_policy& p) : internal_policy(p) {}

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -390,6 +390,7 @@ struct PolicyTraits
   using base_t::operator=;
   template <class... Args>
   PolicyTraits(PolicyTraits<Args...> const &p) : base_t(p) {}
+  PolicyTraits() = default;
 };
 
 }  // namespace Impl

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -386,8 +386,6 @@ struct PolicyTraits
           typename AnalyzePolicy<PolicyTraitsBase<>, Traits...>::type> {
   using base_t = PolicyDataStorage<
       typename AnalyzePolicy<PolicyTraitsBase<>, Traits...>::type>;
-  using base_t::base_t;
-  using base_t::operator=;
   template <class... Args>
   PolicyTraits(PolicyTraits<Args...> const &p) : base_t(p) {}
   PolicyTraits() = default;


### PR DESCRIPTION
The intent is that, passing `prefer(policy, DesiredOccupancy(33))` to a `parallel_for()`, `parallel_reduce()`, or `parallel_scan` will bypass the block size deduction that tries to maximize the occupancy and adjust the launch parameters (by fixing the block size and requesting shared memory) to achieve the specified occupancy.  The desired occupancy is in percent.

I have only implemented it for `ParallelFor<RangePolicy>` and I am looking for feedback.

I am not sure how to test the feature.  I have tried in ArborX on the main tree traversal kernel for spatial predicates.
```diff
diff --git a/src/details/ArborX_DetailsTreeTraversal.hpp b/src/details/ArborX_DetailsTreeTraversal.hpp
index 6c7fc1f..8b07297 100644
--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -62,8 +62,8 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
     else
     {
       Kokkos::parallel_for(ARBORX_MARK_REGION("BVH:spatial_queries"),
-                           Kokkos::RangePolicy<ExecutionSpace>(
-                               space, 0, Access::size(predicates)),
+                           Kokkos::Experimental::prefer(Kokkos::RangePolicy<ExecutionSpace>(
+                               space, 0, Access::size(predicates)), Kokkos::Experimental::DesiredOccupancy{25}),
                            *this);
     }
   }
```


**Update** Instead of "bypassing" the normal block size deduction, we decided to modify the launch configuration just before the kernel launch. 