### PR TITLE
cmake: Conditionally skip KokkosTargets

### DIFF
--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -9,6 +9,9 @@ INCLUDE(CMakeFindDependencyMacro)
 @KOKKOS_TPL_EXPORTS@
 
 GET_FILENAME_COMPONENT(Kokkos_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-INCLUDE("${Kokkos_CMAKE_DIR}/KokkosTargets.cmake")
+#If the Kokkos::kokkos target has not been added, skip including KokkosTargets
+IF(NOT TARGET Kokkos::kokkos)
+  INCLUDE("${Kokkos_CMAKE_DIR}/KokkosTargets.cmake")
+ENDIF()
 INCLUDE("${Kokkos_CMAKE_DIR}/KokkosConfigCommon.cmake")
 UNSET(Kokkos_CMAKE_DIR)


### PR DESCRIPTION
When including kokkos source via `add_subdirectory`, cmake will attempt to include `KokkosTargets.cmake` which may not exist. To support building kokkos as part of the application instead of installing it before building the application, this change conditionally includes `KokkosTargets.cmake` if the `Kokkos::kokkos` target has not been added.

Related to https://github.com/kokkos/kokkos-kernels/issues/802.

@jjwilke, @dalg24 