### PR TITLE
Do not include link flags for fortran linkage: Issue #3355

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -52,12 +52,16 @@ There are numerous device backends, options, and architecture-specific optimizat
 ````
 which activates the OpenMP backend. All of the options controlling device backends, options, architectures, and third-party libraries (TPLs) are given below.
 
-## Platform-specific Problems
+## Known Issues<a name="KnownIssues"></a>
 
 ### Cray
 
 * The Cray compiler wrappers do static linking by default. This seems to break the Kokkos build. You will likely need to set the environment variable `CRAYPE_LINK_TYPE=dynamic` in order to link correctly. Kokkos warns during configure if this is missing.
 * The Cray compiler identifies to CMake as Clang, but it sometimes has its own flags that differ from Clang. We try to include all exceptions, but flag errors may occur in which a Clang-specific flag is passed that the Cray compiler does not recognize.
+
+### Fortran
+
+* In a mixed C++/Fortran code, CMake will use the C++ linker by default. If you override this behavior and use Fortran as the link language, the link may break because Kokkos adds linker flags expecting the linker to be C++. Prior to CMake 3.18, Kokkos has no way of detecting in downstream projects that the linker was changed to Fortran.  From CMake 3.18, Kokkos can use generator expressions to avoid adding flags when the linker is not C++. Note: Kokkos will not add any linker flags in this Fortran case. The user will be entirely on their own to add the appropriate linker flags.
 
 ## Spack
 An alternative to manually building with the CMake is to use the Spack package manager.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ For specifics see the LICENSE file contained in the repository or distribution.
 * ARM
     * Pthreads backend
 
+### Build system:
+* CMake >= 3.10: required
+* CMake >= 3.13: recommended
+* CMake >= 3.18: Fortran linkage. This does not affect most mixed Fortran/Kokkos builds. See [build issues](BUILD.md#KnownIssues).
 
 Primary tested compiler are passing in release mode
 with warnings as errors. They also are tested with a comprehensive set of

--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -238,12 +238,21 @@ FUNCTION(KOKKOS_SET_LIBRARY_PROPERTIES LIBRARY_NAME)
     ""
     ${ARGN})
 
-  IF(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13")
-    #great, this works the "right" way
+  IF(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18")
+    #I can use link options
+    #check for CXX linkage using the simple 3.18 way
+    TARGET_LINK_OPTIONS(
+      ${LIBRARY_NAME} PUBLIC
+      $<$<LINK_LANGUAGE:CXX>:${KOKKOS_LINK_OPTIONS}>
+    )
+  ELSEIF(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13")
+    #I can use link options
+    #just assume CXX linkage
     TARGET_LINK_OPTIONS(
       ${LIBRARY_NAME} PUBLIC ${KOKKOS_LINK_OPTIONS}
     )
   ELSE()
+    #assume CXX linkage, we have no good way to check otherwise
     IF (PARSE_PLAIN_STYLE)
       TARGET_LINK_LIBRARIES(
         ${LIBRARY_NAME} ${KOKKOS_LINK_OPTIONS}


### PR DESCRIPTION
Use generator expressions to avoid including linker flags when someone builds with Fortran.
Note:
Should be stable with CMake 3.18.
Iffy on CMake >= 3.13, but complicated to do
Does not work on 3.12. Fortran linkage will require 3.13 and above.

Fixes #3325, fixes #3355.