### PR TITLE
Fence active instead of default execution space instances

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -488,7 +488,7 @@ struct CudaParallelLaunchImpl<
 
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
       CUDA_SAFE_CALL(cudaGetLastError());
-      Kokkos::Cuda().fence();
+      cuda_instance->fence();
 #endif
     }
   }

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -1381,7 +1381,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           false);  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
-        Cuda().fence();
+        m_policy.space().fence();
 
         if (m_result_ptr) {
           if (m_unified_space) {

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -360,7 +360,7 @@ void *HIPInternal::resize_team_scratch_space(std::int64_t bytes,
 //----------------------------------------------------------------------------
 
 void HIPInternal::finalize() {
-  HIP().fence();
+  this->fence();
   was_finalized = true;
   if (0 != m_scratchSpace || 0 != m_scratchFlags) {
     using RecordHIP =

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -360,7 +360,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           false);  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
-        Experimental::HIP().fence();
+        m_policy.space().fence();
 
         if (m_result_ptr) {
           const int size = ValueTraits::value_size(


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/3364/files#r485331579.
This should catch all cases where an execution space instance is available but we fence the default one instead.