### PR TITLE
Fix compiling with HIP and C++17

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -195,7 +195,7 @@ void HIPInternal::initialize(int hip_device_id, hipStream_t stream) {
     m_hipDev     = hip_device_id;
     m_deviceProp = hipProp;
 
-    hipSetDevice(m_hipDev);
+    HIP_SAFE_CALL(hipSetDevice(m_hipDev));
 
     m_stream = stream;
 
@@ -332,7 +332,8 @@ Kokkos::Experimental::HIP::size_type *HIPInternal::scratch_flags(
 
     m_scratchFlags = reinterpret_cast<size_type *>(r->data());
 
-    hipMemset(m_scratchFlags, 0, m_scratchFlagsCount * sizeScratchGrain);
+    HIP_SAFE_CALL(
+        hipMemset(m_scratchFlags, 0, m_scratchFlagsCount * sizeScratchGrain));
   }
 
   return m_scratchFlags;

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -170,12 +170,15 @@ struct HIPParallelLaunch<
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    hipFuncAttributes attr;
-    hipFuncGetAttributes(
-        &attr,
-        reinterpret_cast<void const *>(
-            hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
-                                             MinBlocksPerSM>));
+    static hipFuncAttributes attr = []() {
+      hipFuncAttributes attr;
+      HIP_SAFE_CALL(hipFuncGetAttributes(
+          &attr,
+          reinterpret_cast<void const *>(
+              hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
+                                               MinBlocksPerSM>)));
+      return attr;
+    }();
     return attr;
   }
 };
@@ -213,10 +216,13 @@ struct HIPParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    hipFuncAttributes attr;
-    hipFuncGetAttributes(
-        &attr, reinterpret_cast<void *>(
-                   &hip_parallel_launch_local_memory<DriverType, 1024, 1>));
+    static hipFuncAttributes attr = []() {
+      hipFuncAttributes attr;
+      HIP_SAFE_CALL(hipFuncGetAttributes(
+          &attr, reinterpret_cast<void const *>(
+                     hip_parallel_launch_local_memory<DriverType, 1024, 1>)));
+      return attr;
+    }();
     return attr;
   }
 };

--- a/core/src/HIP/Kokkos_HIP_Locks.cpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.cpp
@@ -102,9 +102,9 @@ void initialize_host_hip_lock_arrays() {
 
 void finalize_host_hip_lock_arrays() {
   if (g_host_hip_lock_arrays.atomic == nullptr) return;
-  hipFree(g_host_hip_lock_arrays.atomic);
+  HIP_SAFE_CALL(hipFree(g_host_hip_lock_arrays.atomic));
   g_host_hip_lock_arrays.atomic = nullptr;
-  hipFree(g_host_hip_lock_arrays.scratch);
+  HIP_SAFE_CALL(hipFree(g_host_hip_lock_arrays.scratch));
   g_host_hip_lock_arrays.scratch = nullptr;
   g_host_hip_lock_arrays.n       = 0;
 #ifdef KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -211,8 +211,7 @@ void* HIPSpace::allocate(
   if (error_code != hipSuccess) {
     // This is the only way to clear the last error, which we should do here
     // since we're turning it into an exception here
-    auto dummy = hipGetLastError();
-    (void)dummy;
+    (void)hipGetLastError();
     throw HIPRawMemoryAllocationFailure(
         arg_alloc_size, error_code,
         RawMemoryAllocationFailure::AllocationMechanism::HIPMalloc);
@@ -240,8 +239,7 @@ void* HIPHostPinnedSpace::allocate(const char* arg_label,
   if (error_code != hipSuccess) {
     // This is the only way to clear the last error, which we should do here
     // since we're turning it into an exception here
-    auto dummy = hipGetLastError();
-    (void)dummy;
+    (void)hipGetLastError();
     throw HIPRawMemoryAllocationFailure(
         arg_alloc_size, error_code,
         RawMemoryAllocationFailure::AllocationMechanism::HIPHostMalloc);

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -161,7 +161,7 @@ DeepCopy<Kokkos::Experimental::HIPHostPinnedSpace, HostSpace,
 void DeepCopyAsyncHIP(void* dst, void const* src, size_t n) {
   hipStream_t s = get_deep_copy_stream();
   HIP_SAFE_CALL(hipMemcpyAsync(dst, src, n, hipMemcpyDefault, s));
-  hipStreamSynchronize(s);
+  HIP_SAFE_CALL(hipStreamSynchronize(s));
 }
 
 }  // namespace Impl
@@ -209,9 +209,10 @@ void* HIPSpace::allocate(
 
   auto const error_code = hipMalloc(&ptr, arg_alloc_size);
   if (error_code != hipSuccess) {
-    hipGetLastError();  // This is the only way to clear the last error, which
-                        // we should do here since we're turning it into an
-                        // exception here
+    // This is the only way to clear the last error, which we should do here
+    // since we're turning it into an exception here
+    auto dummy = hipGetLastError();
+    (void)dummy;
     throw HIPRawMemoryAllocationFailure(
         arg_alloc_size, error_code,
         RawMemoryAllocationFailure::AllocationMechanism::HIPMalloc);
@@ -237,9 +238,10 @@ void* HIPHostPinnedSpace::allocate(const char* arg_label,
 
   auto const error_code = hipHostMalloc(&ptr, arg_alloc_size);
   if (error_code != hipSuccess) {
-    hipGetLastError();  // This is the only way to clear the last error, which
-                        // we should do here since we're turning it into an
-                        // exception here
+    // This is the only way to clear the last error, which we should do here
+    // since we're turning it into an exception here
+    auto dummy = hipGetLastError();
+    (void)dummy;
     throw HIPRawMemoryAllocationFailure(
         arg_alloc_size, error_code,
         RawMemoryAllocationFailure::AllocationMechanism::HIPHostMalloc);

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -170,6 +170,9 @@
 #include <hip/hip_runtime_api.h>
 
 #define KOKKOS_LAMBDA [=] __host__ __device__
+#if defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)
+#define KOKKOS_CLASS_LAMBDA [ =, *this ] __host__ __device__
+#endif
 #endif  // #if defined(KOKKOS_ENABLE_HIP)
 
 //----------------------------------------------------------------------------
@@ -286,9 +289,6 @@
 #define KOKKOS_IMPL_FUNCTION __device__ __host__
 #define KOKKOS_IMPL_HOST_FUNCTION __host__
 #define KOKKOS_IMPL_DEVICE_FUNCTION __device__
-#if defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20)
-#define KOKKOS_CLASS_LAMBDA [ =, *this ] __host__ __device__
-#endif
 #endif  // #if defined( KOKKOS_ENABLE_HIP )
 
 #if defined(_OPENMP)

--- a/core/unit_test/hip/TestHIP_InterOp_Init.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Init.cpp
@@ -58,7 +58,7 @@ __global__ void offset(int* p) {
 // HIP.
 TEST(hip, raw_hip_interop) {
   int* p;
-  hipMalloc(&p, sizeof(int) * 100);
+  HIP_SAFE_CALL(hipMalloc(&p, sizeof(int) * 100));
   Kokkos::InitArguments arguments{-1, -1, -1, false};
   Kokkos::initialize(arguments);
 
@@ -71,7 +71,7 @@ TEST(hip, raw_hip_interop) {
   HIP_SAFE_CALL(hipDeviceSynchronize());
 
   int* h_p = new int[100];
-  hipMemcpy(h_p, p, sizeof(int) * 100, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(h_p, p, sizeof(int) * 100, hipMemcpyDefault));
   HIP_SAFE_CALL(hipDeviceSynchronize());
   int64_t sum        = 0;
   int64_t sum_expect = 0;

--- a/core/unit_test/hip/TestHIP_InterOp_Streams.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Streams.cpp
@@ -51,11 +51,11 @@ namespace Test {
 // bound in HIP due to an error when computing the block size.
 TEST(hip, raw_hip_streams) {
   hipStream_t stream;
-  hipStreamCreate(&stream);
+  HIP_SAFE_CALL(hipStreamCreate(&stream));
   Kokkos::InitArguments arguments{-1, -1, -1, false};
   Kokkos::initialize(arguments);
   int* p;
-  hipMalloc(&p, sizeof(int) * 100);
+  HIP_SAFE_CALL(hipMalloc(&p, sizeof(int) * 100));
   using MemorySpace = typename TEST_EXECSPACE::memory_space;
 
   {
@@ -98,10 +98,10 @@ TEST(hip, raw_hip_streams) {
   Kokkos::finalize();
   offset_streams<<<100, 64, 0, stream>>>(p);
   HIP_SAFE_CALL(hipDeviceSynchronize());
-  hipStreamDestroy(stream);
+  HIP_SAFE_CALL(hipStreamDestroy(stream));
 
   int h_p[100];
-  hipMemcpy(h_p, p, sizeof(int) * 100, hipMemcpyDefault);
+  HIP_SAFE_CALL(hipMemcpy(h_p, p, sizeof(int) * 100, hipMemcpyDefault));
   HIP_SAFE_CALL(hipDeviceSynchronize());
   int64_t sum        = 0;
   int64_t sum_expect = 0;


### PR DESCRIPTION
Fixes [`Use C++17 in ROCm-3.7 build` (#3333)](https://github.com/kokkos/kokkos/pull/3333/commits/0a0897700c94fd8ba97a1521a317483a000c513e) and includes the analogon to [`CUDA: Fix thread unsafe setting of functor attributes.` (#3269)](https://github.com/kokkos/kokkos/pull/3269/commits/e3350ee50b3db405564caeb5fe84f4733d535f6b) for HIP.
Part of this is to also check the return value of the HIP function calls and fixing the definition of `KOKKOS_CLASS_LAMBDA`.