### PR TITLE
Hip: fix template deduction

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -118,9 +118,9 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
                        m_policy.m_tile[2], m_policy.m_tile[3]);
       dim3 const grid(
-          std::min(static_cast<index_type>(m_policy.m_tile_end[0] *
-                                           m_policy.m_tile_end[1]),
-                   static_cast<index_type>(maxblocks)),
+          std::min(static_cast<uint32_t>(m_policy.m_tile_end[0] *
+                                         m_policy.m_tile_end[1]),
+                   static_cast<uint32_t>(maxblocks)),
           std::min((m_policy.m_upper[2] - m_policy.m_lower[2] + block.y - 1) /
                        block.y,
                    maxblocks),
@@ -343,7 +343,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       // REQUIRED ( 1 , N , 1 )
       const dim3 block(1, block_size, 1);
       // Required grid.x <= block.y
-      const dim3 grid(std::min(int(block.y), int(nwork)), 1, 1);
+      const dim3 grid(std::min(static_cast<uint32_t>(block.y),
+                               static_cast<uint32_t>(nwork)),
+                      1, 1);
 
       const int shmem =
           UseShflReduction

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -349,7 +349,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       // REQUIRED ( 1 , N , 1 )
       const dim3 block(1, block_size, 1);
       // Required grid.x <= block.y
-      const dim3 grid(std::min(block.y, (nwork + block.y - 1) / block.y), 1, 1);
+      const dim3 grid(std::min(block.y, static_cast<uint32_t>(
+                                            (nwork + block.y - 1) / block.y)),
+                      1, 1);
 
       const int shmem =
           UseShflReduction

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -204,6 +204,12 @@ struct TestRange {
     // sum( 0 .. N-1 )
     ASSERT_EQ(size_t((N - 1) * (N) / 2), size_t(total));
 
+    Kokkos::parallel_reduce("TestKernelReduce_long",
+                            Kokkos::RangePolicy<ExecSpace, ScheduleType, long>(0, N),
+                            *this, total);
+    // sum( 0 .. N-1 )
+    ASSERT_EQ(size_t((N - 1) * (N) / 2), size_t(total));
+
     Kokkos::parallel_reduce(
         Kokkos::RangePolicy<ExecSpace, ScheduleType, OffsetTag>(offset,
                                                                 N + offset),

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -204,9 +204,9 @@ struct TestRange {
     // sum( 0 .. N-1 )
     ASSERT_EQ(size_t((N - 1) * (N) / 2), size_t(total));
 
-    Kokkos::parallel_reduce("TestKernelReduce_long",
-                            Kokkos::RangePolicy<ExecSpace, ScheduleType, long>(0, N),
-                            *this, total);
+    Kokkos::parallel_reduce(
+        "TestKernelReduce_long",
+        Kokkos::RangePolicy<ExecSpace, ScheduleType, long>(0, N), *this, total);
     // sum( 0 .. N-1 )
     ASSERT_EQ(size_t((N - 1) * (N) / 2), size_t(total));
 


### PR DESCRIPTION
Casting inputs parameters for std::min to get successful template deduction, see issue #3386.
Added a small test that exemplifies the failure mode in first commit, second commit fixes the test.