### PR TITLE
NVIDIA_VISIBLE_DEVICES in CUDA CI builds on Jenkins

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -93,7 +93,7 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--pull'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }
                     steps {
@@ -124,7 +124,7 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--pull'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }
                     steps {
@@ -159,7 +159,7 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--pull --build-arg BASE=nvidia/cuda:9.2-devel'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }
                     steps {
@@ -188,7 +188,7 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--pull --build-arg BASE=nvidia/cuda:11.0-devel --build-arg ADDITIONAL_PACKAGES="g++-8 gfortran" --build-arg CMAKE_VERSION=3.17.3'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }
                     environment {
@@ -251,7 +251,7 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--pull --build-arg BASE=nvidia/cuda:10.1-devel --build-arg CMAKE_VERSION=3.15.5'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }
                     steps {


### PR DESCRIPTION
This is meant for GPU isolation on our CI builds.
We are adding a machine that has multiple V100s, the extra argument passed to docker ensures we grab the appropriate GPU.