### PR TITLE
Use bool for enums representing bools 

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -146,9 +146,9 @@ void CudaSpace::access_error(const void *const) {
 
 bool CudaUVMSpace::available() {
 #if defined(CUDA_VERSION) && !defined(__APPLE__)
-  enum { UVM_available = true };
+  enum : bool { UVM_available = true };
 #else
-  enum { UVM_available = false };
+  enum : bool { UVM_available = false };
 #endif
   return UVM_available;
 }

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -1470,7 +1470,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   using functor_type = FunctorType;
   using size_type    = Cuda::size_type;
 
-  enum { UseShflReduction = (true && (ValueTraits::StaticValueSize != 0)) };
+  enum : bool {
+    UseShflReduction = (true && (ValueTraits::StaticValueSize != 0))
+  };
 
  private:
   using DummyShflReductionType  = double;

--- a/core/src/Kokkos_AnonymousSpace.hpp
+++ b/core/src/Kokkos_AnonymousSpace.hpp
@@ -85,23 +85,23 @@ namespace Impl {
 
 template <typename OtherSpace>
 struct MemorySpaceAccess<Kokkos::AnonymousSpace, OtherSpace> {
-  enum { assignable = true };
-  enum { accessible = true };
-  enum { deepcopy = true };
+  enum : bool { assignable = true };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = true };
 };
 
 template <typename OtherSpace>
 struct MemorySpaceAccess<OtherSpace, Kokkos::AnonymousSpace> {
-  enum { assignable = true };
-  enum { accessible = true };
-  enum { deepcopy = true };
+  enum : bool { assignable = true };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::AnonymousSpace, Kokkos::AnonymousSpace> {
-  enum { assignable = true };
-  enum { accessible = true };
-  enum { deepcopy = true };
+  enum : bool { assignable = true };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = true };
 };
 
 template <typename OtherSpace>

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -281,9 +281,9 @@ namespace Impl {
 template <>
 struct MemorySpaceAccess<Kokkos::CudaSpace,
                          Kokkos::Cuda::scratch_memory_space> {
-  enum { assignable = false };
-  enum { accessible = true };
-  enum { deepcopy = false };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = false };
 };
 
 #if defined(KOKKOS_ENABLE_CUDA_UVM)
@@ -297,9 +297,9 @@ struct MemorySpaceAccess<Kokkos::CudaSpace,
 template <>
 struct MemorySpaceAccess<Kokkos::CudaUVMSpace,
                          Kokkos::Cuda::scratch_memory_space> {
-  enum { assignable = false };
-  enum { accessible = true };
-  enum { deepcopy = false };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = false };
 };
 
 #endif
@@ -307,7 +307,7 @@ struct MemorySpaceAccess<Kokkos::CudaUVMSpace,
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
                                            Kokkos::Cuda::scratch_memory_space> {
-  enum { value = true };
+  enum : bool { value = true };
   KOKKOS_INLINE_FUNCTION static void verify(void) {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
@@ -315,7 +315,7 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::Cuda::scratch_memory_space> {
-  enum { value = false };
+  enum : bool { value = false };
   inline static void verify(void) { CudaSpace::access_error(); }
   inline static void verify(const void* p) { CudaSpace::access_error(p); }
 };

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -286,50 +286,50 @@ static_assert(
 
 template <>
 struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaSpace> {
-  enum { assignable = false };
-  enum { accessible = false };
-  enum { deepcopy = true };
+  enum : bool { assignable = false };
+  enum : bool { accessible = false };
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaUVMSpace> {
   // HostSpace::execution_space != CudaUVMSpace::execution_space
-  enum { assignable = false };
-  enum { accessible = true };
-  enum { deepcopy = true };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaHostPinnedSpace> {
   // HostSpace::execution_space == CudaHostPinnedSpace::execution_space
-  enum { assignable = true };
-  enum { accessible = true };
-  enum { deepcopy = true };
+  enum : bool { assignable = true };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::HostSpace> {
-  enum { assignable = false };
-  enum { accessible = false };
-  enum { deepcopy = true };
+  enum : bool { assignable = false };
+  enum : bool { accessible = false };
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::CudaUVMSpace> {
   // CudaSpace::execution_space == CudaUVMSpace::execution_space
-  enum { assignable = true };
-  enum { accessible = true };
-  enum { deepcopy = true };
+  enum : bool { assignable = true };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::CudaHostPinnedSpace> {
   // CudaSpace::execution_space != CudaHostPinnedSpace::execution_space
-  enum { assignable = false };
-  enum { accessible = true };  // CudaSpace::execution_space
-  enum { deepcopy = true };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };  // CudaSpace::execution_space
+  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
@@ -338,28 +338,28 @@ struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::CudaHostPinnedSpace> {
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::HostSpace> {
-  enum { assignable = false };
-  enum { accessible = false };  // Cuda cannot access HostSpace
-  enum { deepcopy = true };
+  enum : bool { assignable = false };
+  enum : bool { accessible = false };  // Cuda cannot access HostSpace
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::CudaSpace> {
   // CudaUVMSpace::execution_space == CudaSpace::execution_space
   // Can access CudaUVMSpace from Host but cannot access CudaSpace from Host
-  enum { assignable = false };
+  enum : bool { assignable = false };
 
   // CudaUVMSpace::execution_space can access CudaSpace
-  enum { accessible = true };
-  enum { deepcopy = true };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::CudaHostPinnedSpace> {
   // CudaUVMSpace::execution_space != CudaHostPinnedSpace::execution_space
-  enum { assignable = false };
-  enum { accessible = true };  // CudaUVMSpace::execution_space
-  enum { deepcopy = true };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };  // CudaUVMSpace::execution_space
+  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
@@ -368,23 +368,23 @@ struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::CudaHostPinnedSpace> {
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::HostSpace> {
-  enum { assignable = false };  // Cannot access from Cuda
-  enum { accessible = true };   // CudaHostPinnedSpace::execution_space
-  enum { deepcopy = true };
+  enum : bool { assignable = false };  // Cannot access from Cuda
+  enum : bool { accessible = true };   // CudaHostPinnedSpace::execution_space
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::CudaSpace> {
-  enum { assignable = false };  // Cannot access from Host
-  enum { accessible = false };
-  enum { deepcopy = true };
+  enum : bool { assignable = false };  // Cannot access from Host
+  enum : bool { accessible = false };
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::CudaUVMSpace> {
-  enum { assignable = false };  // different execution_space
-  enum { accessible = true };   // same accessibility
-  enum { deepcopy = true };
+  enum : bool { assignable = false };  // different execution_space
+  enum : bool { accessible = true };   // same accessibility
+  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
@@ -746,7 +746,7 @@ namespace Impl {
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
                                            Kokkos::HostSpace> {
-  enum { value = false };
+  enum : bool { value = false };
   KOKKOS_INLINE_FUNCTION static void verify(void) {
     Kokkos::abort("Cuda code attempted to access HostSpace memory");
   }
@@ -760,7 +760,7 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
                                            Kokkos::CudaUVMSpace> {
-  enum { value = true };
+  enum : bool { value = true };
   KOKKOS_INLINE_FUNCTION static void verify(void) {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
@@ -769,7 +769,7 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
                                            Kokkos::CudaHostPinnedSpace> {
-  enum { value = true };
+  enum : bool { value = true };
   KOKKOS_INLINE_FUNCTION static void verify(void) {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
@@ -780,7 +780,7 @@ struct VerifyExecutionCanAccessMemorySpace<
     typename std::enable_if<!std::is_same<Kokkos::CudaSpace, OtherSpace>::value,
                             Kokkos::CudaSpace>::type,
     OtherSpace> {
-  enum { value = false };
+  enum : bool { value = false };
   KOKKOS_INLINE_FUNCTION static void verify(void) {
     Kokkos::abort("Cuda code attempted to access unknown Space memory");
   }
@@ -795,7 +795,7 @@ struct VerifyExecutionCanAccessMemorySpace<
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::CudaSpace> {
-  enum { value = false };
+  enum : bool { value = false };
   inline static void verify(void) { CudaSpace::access_error(); }
   inline static void verify(const void* p) { CudaSpace::access_error(p); }
 };
@@ -804,7 +804,7 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::CudaUVMSpace> {
-  enum { value = true };
+  enum : bool { value = true };
   inline static void verify(void) {}
   inline static void verify(const void*) {}
 };
@@ -813,7 +813,7 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::CudaHostPinnedSpace> {
-  enum { value = true };
+  enum : bool { value = true };
   KOKKOS_INLINE_FUNCTION static void verify(void) {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };

--- a/core/src/Kokkos_HBWSpace.hpp
+++ b/core/src/Kokkos_HBWSpace.hpp
@@ -257,16 +257,16 @@ static_assert(
 
 template <>
 struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::Experimental::HBWSpace> {
-  enum { assignable = true };
-  enum { accessible = true };
-  enum { deepcopy = true };
+  enum : bool { assignable = true };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::Experimental::HBWSpace, Kokkos::HostSpace> {
-  enum { assignable = false };
-  enum { accessible = true };
-  enum { deepcopy = true };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = true };
 };
 
 }  // namespace Impl
@@ -321,7 +321,7 @@ namespace Impl {
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::Experimental::HBWSpace> {
-  enum { value = true };
+  enum : bool { value = true };
   inline static void verify(void) {}
   inline static void verify(const void*) {}
 };
@@ -329,7 +329,7 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::Experimental::HBWSpace,
                                            Kokkos::HostSpace> {
-  enum { value = true };
+  enum : bool { value = true };
   inline static void verify(void) {}
   inline static void verify(const void*) {}
 };

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -212,36 +212,36 @@ static_assert(
 
 template <>
 struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::Experimental::HIPSpace> {
-  enum { assignable = false };
-  enum { accessible = false };
-  enum { deepcopy = true };
+  enum : bool { assignable = false };
+  enum : bool { accessible = false };
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::HostSpace,
                          Kokkos::Experimental::HIPHostPinnedSpace> {
   // HostSpace::execution_space == HIPHostPinnedSpace::execution_space
-  enum { assignable = true };
-  enum { accessible = true };
-  enum { deepcopy = true };
+  enum : bool { assignable = true };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
 
 template <>
 struct MemorySpaceAccess<Kokkos::Experimental::HIPSpace, Kokkos::HostSpace> {
-  enum { assignable = false };
-  enum { accessible = false };
-  enum { deepcopy = true };
+  enum : bool { assignable = false };
+  enum : bool { accessible = false };
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::Experimental::HIPSpace,
                          Kokkos::Experimental::HIPHostPinnedSpace> {
   // HIPSpace::execution_space != HIPHostPinnedSpace::execution_space
-  enum { assignable = false };
-  enum { accessible = true };  // HIPSpace::execution_space
-  enum { deepcopy = true };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };  // HIPSpace::execution_space
+  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
@@ -251,17 +251,17 @@ struct MemorySpaceAccess<Kokkos::Experimental::HIPSpace,
 template <>
 struct MemorySpaceAccess<Kokkos::Experimental::HIPHostPinnedSpace,
                          Kokkos::HostSpace> {
-  enum { assignable = false };  // Cannot access from HIP
-  enum { accessible = true };   // HIPHostPinnedSpace::execution_space
-  enum { deepcopy = true };
+  enum : bool { assignable = false };  // Cannot access from HIP
+  enum : bool { accessible = true };   // HIPHostPinnedSpace::execution_space
+  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::Experimental::HIPHostPinnedSpace,
                          Kokkos::Experimental::HIPSpace> {
-  enum { assignable = false };  // Cannot access from Host
-  enum { accessible = false };
-  enum { deepcopy = true };
+  enum : bool { assignable = false };  // Cannot access from Host
+  enum : bool { accessible = false };
+  enum : bool { deepcopy = true };
 };
 
 };  // namespace Impl
@@ -458,7 +458,7 @@ namespace Impl {
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::Experimental::HIPSpace,
                                            Kokkos::HostSpace> {
-  enum { value = false };
+  enum : bool { value = false };
   KOKKOS_INLINE_FUNCTION static void verify(void) {
     Kokkos::abort("HIP code attempted to access HostSpace memory");
   }
@@ -472,7 +472,7 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::Experimental::HIPSpace,
 template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPHostPinnedSpace> {
-  enum { value = true };
+  enum : bool { value = true };
   KOKKOS_INLINE_FUNCTION static void verify(void) {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
@@ -484,7 +484,7 @@ struct VerifyExecutionCanAccessMemorySpace<
         !std::is_same<Kokkos::Experimental::HIPSpace, OtherSpace>::value,
         Kokkos::Experimental::HIPSpace>::type,
     OtherSpace> {
-  enum { value = false };
+  enum : bool { value = false };
   KOKKOS_INLINE_FUNCTION static void verify(void) {
     Kokkos::abort("HIP code attempted to access unknown Space memory");
   }
@@ -499,7 +499,7 @@ struct VerifyExecutionCanAccessMemorySpace<
 template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::Experimental::HIPSpace> {
-  enum { value = false };
+  enum : bool { value = false };
   inline static void verify(void) {
     Kokkos::Experimental::HIPSpace::access_error();
   }
@@ -512,7 +512,7 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
 template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::HostSpace, Kokkos::Experimental::HIPHostPinnedSpace> {
-  enum { value = true };
+  enum : bool { value = true };
   KOKKOS_INLINE_FUNCTION static void verify(void) {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
@@ -746,16 +746,16 @@ namespace Impl {
 template <>
 struct MemorySpaceAccess<Kokkos::Experimental::HIPSpace,
                          Kokkos::Experimental::HIP::scratch_memory_space> {
-  enum { assignable = false };
-  enum { accessible = true };
-  enum { deepcopy = false };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = false };
 };
 
 template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Experimental::HIP::memory_space,
     Kokkos::Experimental::HIP::scratch_memory_space> {
-  enum { value = true };
+  enum : bool { value = true };
   KOKKOS_INLINE_FUNCTION static void verify(void) {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
@@ -763,7 +763,7 @@ struct VerifyExecutionCanAccessMemorySpace<
 template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::HostSpace, Kokkos::Experimental::HIP::scratch_memory_space> {
-  enum { value = false };
+  enum : bool { value = false };
   inline static void verify(void) {
     Kokkos::Experimental::HIPSpace::access_error();
   }

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -506,16 +506,16 @@ namespace Impl {
 template <>
 struct MemorySpaceAccess<Kokkos::Experimental::HPX::memory_space,
                          Kokkos::Experimental::HPX::scratch_memory_space> {
-  enum { assignable = false };
-  enum { accessible = true };
-  enum { deepcopy = false };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = false };
 };
 
 template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Experimental::HPX::memory_space,
     Kokkos::Experimental::HPX::scratch_memory_space> {
-  enum { value = true };
+  enum : bool { value = true };
   inline static void verify(void) {}
   inline static void verify(const void *) {}
 };

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -77,7 +77,7 @@ struct LayoutLeft {
 
   size_t dimension[ARRAY_LAYOUT_MAX_RANK];
 
-  enum { is_extent_constructible = true };
+  enum : bool { is_extent_constructible = true };
 
   LayoutLeft(LayoutLeft const&) = default;
   LayoutLeft(LayoutLeft&&)      = default;
@@ -111,7 +111,7 @@ struct LayoutRight {
 
   size_t dimension[ARRAY_LAYOUT_MAX_RANK];
 
-  enum { is_extent_constructible = true };
+  enum : bool { is_extent_constructible = true };
 
   LayoutRight(LayoutRight const&) = default;
   LayoutRight(LayoutRight&&)      = default;
@@ -136,7 +136,7 @@ struct LayoutStride {
   size_t dimension[ARRAY_LAYOUT_MAX_RANK];
   size_t stride[ARRAY_LAYOUT_MAX_RANK];
 
-  enum { is_extent_constructible = false };
+  enum : bool { is_extent_constructible = false };
 
   LayoutStride(LayoutStride const&) = default;
   LayoutStride(LayoutStride&&)      = default;
@@ -257,7 +257,7 @@ struct LayoutTiled {
 
   size_t dimension[ARRAY_LAYOUT_MAX_RANK];
 
-  enum { is_extent_constructible = true };
+  enum : bool { is_extent_constructible = true };
 
   LayoutTiled(LayoutTiled const&) = default;
   LayoutTiled(LayoutTiled&&)      = default;

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -188,15 +188,15 @@ namespace Impl {
 template <>
 struct MemorySpaceAccess<Kokkos::OpenMP::memory_space,
                          Kokkos::OpenMP::scratch_memory_space> {
-  enum { assignable = false };
-  enum { accessible = true };
-  enum { deepcopy = false };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = false };
 };
 
 template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::OpenMP::memory_space, Kokkos::OpenMP::scratch_memory_space> {
-  enum { value = true };
+  enum : bool { value = true };
   inline static void verify(void) {}
   inline static void verify(const void*) {}
 };

--- a/core/src/Kokkos_OpenMPTarget.hpp
+++ b/core/src/Kokkos_OpenMPTarget.hpp
@@ -142,7 +142,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Experimental::OpenMPTarget::memory_space,
     Kokkos::Experimental::OpenMPTarget::scratch_memory_space> {
-  enum { value = true };
+  enum : bool { value = true };
   inline static void verify(void) {}
   inline static void verify(const void*) {}
 };

--- a/core/src/Kokkos_OpenMPTargetSpace.hpp
+++ b/core/src/Kokkos_OpenMPTargetSpace.hpp
@@ -258,7 +258,7 @@ struct DeepCopy<HostSpace, Kokkos::Experimental::OpenMPTargetSpace,
 template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::HostSpace, Kokkos::Experimental::OpenMPTargetSpace> {
-  enum { value = false };
+  enum : bool { value = false };
   inline static void verify(void) {}
   inline static void verify(const void*) {}
 };

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -176,15 +176,15 @@ namespace Impl {
 template <>
 struct MemorySpaceAccess<Kokkos::Serial::memory_space,
                          Kokkos::Serial::scratch_memory_space> {
-  enum { assignable = false };
-  enum { accessible = true };
-  enum { deepcopy = false };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = false };
 };
 
 template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Serial::memory_space, Kokkos::Serial::scratch_memory_space> {
-  enum { value = true };
+  enum : bool { value = true };
   inline static void verify(void) {}
   inline static void verify(const void*) {}
 };

--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -191,15 +191,15 @@ namespace Impl {
 template <>
 struct MemorySpaceAccess<Kokkos::Threads::memory_space,
                          Kokkos::Threads::scratch_memory_space> {
-  enum { assignable = false };
-  enum { accessible = true };
-  enum { deepcopy = false };
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = false };
 };
 
 template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Threads::memory_space, Kokkos::Threads::scratch_memory_space> {
-  enum { value = true };
+  enum : bool { value = true };
   inline static void verify(void) {}
   inline static void verify(const void*) {}
 };

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -74,8 +74,8 @@ struct ViewDataAnalysis;
 template <class, class...>
 class ViewMapping {
  public:
-  enum { is_assignable_data_type = false };
-  enum { is_assignable = false };
+  enum : bool { is_assignable_data_type = false };
+  enum : bool { is_assignable = false };
 };
 
 template <typename IntType>

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -895,7 +895,7 @@ void push_finalize_hook(std::function<void()> f) { finalize_hooks.push(f); }
 void finalize() { Impl::finalize_internal(); }
 
 void finalize_all() {
-  enum { all_spaces = true };
+  enum : bool { all_spaces = true };
   Impl::finalize_internal(all_spaces);
 }
 

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -58,7 +58,7 @@ namespace Impl {
 
 template <class FunctorType, class Enable = void>
 struct ReduceFunctorHasInit {
-  enum { value = false };
+  enum : bool { value = false };
 };
 
 // The else clause idiom failed with NVCC+MSVC, causing some symbols not being
@@ -75,20 +75,20 @@ using init_archetype = decltype(&F::init);
 template <class FunctorType>
 struct ReduceFunctorHasInit<
     FunctorType, impl_void_t_workaround<init_archetype<FunctorType>>> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 #else
 template <class FunctorType>
 struct ReduceFunctorHasInit<
     FunctorType,
     typename std::enable_if<0 < sizeof(&FunctorType::init)>::type> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 #endif
 
 template <class FunctorType, class Enable = void>
 struct ReduceFunctorHasJoin {
-  enum { value = false };
+  enum : bool { value = false };
 };
 
 #if defined(KOKKOS_COMPILER_MSVC) || defined(KOKKOS_IMPL_WINDOWS_CUDA)
@@ -98,20 +98,20 @@ using join_archetype = decltype(&F::join);
 template <class FunctorType>
 struct ReduceFunctorHasJoin<
     FunctorType, impl_void_t_workaround<join_archetype<FunctorType>>> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 #else
 template <class FunctorType>
 struct ReduceFunctorHasJoin<
     FunctorType,
     typename std::enable_if<0 < sizeof(&FunctorType::join)>::type> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 #endif
 
 template <class FunctorType, class Enable = void>
 struct ReduceFunctorHasFinal {
-  enum { value = false };
+  enum : bool { value = false };
 };
 
 #if defined(KOKKOS_COMPILER_MSVC) || defined(KOKKOS_IMPL_WINDOWS_CUDA)
@@ -121,20 +121,20 @@ using final_archetype = decltype(&F::final);
 template <class FunctorType>
 struct ReduceFunctorHasFinal<
     FunctorType, impl_void_t_workaround<final_archetype<FunctorType>>> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 #else
 template <class FunctorType>
 struct ReduceFunctorHasFinal<
     FunctorType,
     typename std::enable_if<0 < sizeof(&FunctorType::final)>::type> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 #endif
 
 template <class FunctorType, class Enable = void>
 struct ReduceFunctorHasShmemSize {
-  enum { value = false };
+  enum : bool { value = false };
 };
 
 #if defined(KOKKOS_COMPILER_MSVC) || defined(KOKKOS_IMPL_WINDOWS_CUDA)
@@ -144,14 +144,14 @@ using shmemsize_archetype = decltype(&F::team_shmem_size);
 template <class FunctorType>
 struct ReduceFunctorHasShmemSize<
     FunctorType, impl_void_t_workaround<shmemsize_archetype<FunctorType>>> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 #else
 template <class FunctorType>
 struct ReduceFunctorHasShmemSize<
     FunctorType,
     typename std::enable_if<0 < sizeof(&FunctorType::team_shmem_size)>::type> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 #endif
 
@@ -171,12 +171,12 @@ template <class FunctorType,
                         (ReduceFunctorHasFinal<FunctorType>::value) ||
                         (ReduceFunctorHasShmemSize<FunctorType>::value)>
 struct IsNonTrivialReduceFunctor {
-  enum { value = false };
+  enum : bool { value = false };
 };
 
 template <class FunctorType>
 struct IsNonTrivialReduceFunctor<FunctorType, true> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 
 /** \brief  Query Functor and execution policy argument tag for value type.

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -104,14 +104,14 @@ struct FunctorAnalysis {
   template <typename T, typename = std::false_type>
   struct has_execution_space {
     using type = void;
-    enum { value = false };
+    enum : bool { value = false };
   };
 
   template <typename T>
   struct has_execution_space<
       T, typename std::is_same<typename T::execution_space, void>::type> {
     using type = typename T::execution_space;
-    enum { value = true };
+    enum : bool { value = true };
   };
 
   using policy_has_space  = has_execution_space<Policy>;
@@ -479,7 +479,7 @@ struct FunctorAnalysis {
 
   template <class F = Functor, INTERFACE = DEDUCED, typename = void>
   struct DeduceJoin {
-    enum { value = false };
+    enum : bool { value = false };
 
     KOKKOS_INLINE_FUNCTION static void join(F const* const f,
                                             ValueType volatile* dst,
@@ -491,7 +491,7 @@ struct FunctorAnalysis {
 
   template <class F>
   struct DeduceJoin<F, DISABLE, void> {
-    enum { value = false };
+    enum : bool { value = false };
 
     KOKKOS_INLINE_FUNCTION static void join(F const* const, ValueType volatile*,
                                             ValueType volatile const*) {}
@@ -501,7 +501,7 @@ struct FunctorAnalysis {
   struct DeduceJoin<F, I,
                     decltype(has_join_function<F, I>::enable_if(&F::join))>
       : public has_join_function<F, I> {
-    enum { value = true };
+    enum : bool { value = true };
   };
 
   //----------------------------------------
@@ -569,7 +569,7 @@ struct FunctorAnalysis {
 
   template <class F = Functor, INTERFACE = DEDUCED, typename = void>
   struct DeduceInit {
-    enum { value = false };
+    enum : bool { value = false };
 
     KOKKOS_INLINE_FUNCTION static void init(F const* const, ValueType* dst) {
       new (dst) ValueType();
@@ -578,7 +578,7 @@ struct FunctorAnalysis {
 
   template <class F>
   struct DeduceInit<F, DISABLE, void> {
-    enum { value = false };
+    enum : bool { value = false };
 
     KOKKOS_INLINE_FUNCTION static void init(F const* const, ValueType*) {}
   };
@@ -587,7 +587,7 @@ struct FunctorAnalysis {
   struct DeduceInit<F, I,
                     decltype(has_init_function<F, I>::enable_if(&F::init))>
       : public has_init_function<F, I> {
-    enum { value = true };
+    enum : bool { value = true };
   };
 
   //----------------------------------------
@@ -659,7 +659,7 @@ struct FunctorAnalysis {
 
   template <class F = Functor, INTERFACE = DEDUCED, typename = void>
   struct DeduceFinal {
-    enum { value = false };
+    enum : bool { value = false };
 
     KOKKOS_INLINE_FUNCTION
     static void final(F const* const, ValueType*) {}
@@ -669,14 +669,14 @@ struct FunctorAnalysis {
   struct DeduceFinal<F, I,
                      decltype(has_final_function<F, I>::enable_if(&F::final))>
       : public has_final_function<F, I> {
-    enum { value = true };
+    enum : bool { value = true };
   };
 
   //----------------------------------------
 
   template <class F = Functor, typename = void>
   struct DeduceTeamShmem {
-    enum { value = false };
+    enum : bool { value = false };
 
     static size_t team_shmem_size(F const&, int) { return 0; }
   };
@@ -684,7 +684,7 @@ struct FunctorAnalysis {
   template <class F>
   struct DeduceTeamShmem<
       F, typename std::enable_if<0 < sizeof(&F::team_shmem_size)>::type> {
-    enum { value = true };
+    enum : bool { value = true };
 
     static size_t team_shmem_size(F const* const f, int team_size) {
       return f->team_shmem_size(team_size);
@@ -694,7 +694,7 @@ struct FunctorAnalysis {
   template <class F>
   struct DeduceTeamShmem<
       F, typename std::enable_if<0 < sizeof(&F::shmem_size)>::type> {
-    enum { value = true };
+    enum : bool { value = true };
 
     static size_t team_shmem_size(F const* const f, int team_size) {
       return f->shmem_size(team_size);

--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -75,7 +75,7 @@ struct get_type<I, T, Pack...> {
 
 template <typename T, typename... Pack>
 struct has_type {
-  enum { value = false };
+  enum : bool { value = false };
 };
 
 template <typename T, typename S, typename... Pack>
@@ -90,13 +90,13 @@ struct has_type<T, S, Pack...> {
       "Error: more than one member of the argument pack matches the type");
 
  public:
-  enum { value = self_value || next::value };
+  enum : bool { value = self_value || next::value };
 };
 
 template <typename DefaultType, template <typename> class Condition,
           typename... Pack>
 struct has_condition {
-  enum { value = false };
+  enum : bool { value = false };
   using type = DefaultType;
 };
 
@@ -113,7 +113,7 @@ struct has_condition<DefaultType, Condition, S, Pack...> {
       "Error: more than one member of the argument pack satisfies condition");
 
  public:
-  enum { value = self_value || next::value };
+  enum : bool { value = self_value || next::value };
 
   using type =
       typename std::conditional<self_value, S, typename next::type>::type;
@@ -121,7 +121,7 @@ struct has_condition<DefaultType, Condition, S, Pack...> {
 
 template <class... Args>
 struct are_integral {
-  enum { value = true };
+  enum : bool { value = true };
 };
 
 template <typename T, class... Args>
@@ -159,7 +159,7 @@ struct enable_if_type {
 
 template <bool Cond, typename TrueType, typename FalseType>
 struct if_c {
-  enum { value = Cond };
+  enum : bool { value = Cond };
 
   using type = FalseType;
 
@@ -194,7 +194,7 @@ struct if_c {
 
 template <typename TrueType, typename FalseType>
 struct if_c<true, TrueType, FalseType> {
-  enum { value = true };
+  enum : bool { value = true };
 
   using type = TrueType;
 
@@ -229,7 +229,7 @@ struct if_c<true, TrueType, FalseType> {
 
 template <typename TrueType>
 struct if_c<false, TrueType, void> {
-  enum { value = false };
+  enum : bool { value = false };
 
   using type       = void;
   using value_type = void;
@@ -237,7 +237,7 @@ struct if_c<false, TrueType, void> {
 
 template <typename FalseType>
 struct if_c<true, void, FalseType> {
-  enum { value = true };
+  enum : bool { value = true };
 
   using type       = void;
   using value_type = void;

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -186,7 +186,7 @@ struct ViewCtorProp<T *> {
   KOKKOS_INLINE_FUNCTION
   ViewCtorProp(const type arg) : value(arg) {}
 
-  enum { has_pointer = true };
+  enum : bool { has_pointer = true };
   using pointer_type = type;
   type value;
 };

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -317,23 +317,23 @@ namespace Impl {
 
 template <class T>
 struct is_integral_extent_type {
-  enum { value = std::is_same<T, Kokkos::Impl::ALL_t>::value ? 1 : 0 };
+  enum : bool { value = std::is_same<T, Kokkos::Impl::ALL_t>::value ? 1 : 0 };
 };
 
 template <class iType>
 struct is_integral_extent_type<std::pair<iType, iType>> {
-  enum { value = std::is_integral<iType>::value ? 1 : 0 };
+  enum : bool { value = std::is_integral<iType>::value ? 1 : 0 };
 };
 
 template <class iType>
 struct is_integral_extent_type<Kokkos::pair<iType, iType>> {
-  enum { value = std::is_integral<iType>::value ? 1 : 0 };
+  enum : bool { value = std::is_integral<iType>::value ? 1 : 0 };
 };
 
 // Assuming '2 == initializer_list<iType>::size()'
 template <class iType>
 struct is_integral_extent_type<std::initializer_list<iType>> {
-  enum { value = std::is_integral<iType>::value ? 1 : 0 };
+  enum : bool { value = std::is_integral<iType>::value ? 1 : 0 };
 };
 
 template <unsigned I, class... Args>
@@ -342,7 +342,7 @@ struct is_integral_extent {
   using type = typename std::remove_cv<typename std::remove_reference<
       typename Kokkos::Impl::get_type<I, Args...>::type>::type>::type;
 
-  enum { value = is_integral_extent_type<type>::value };
+  enum : bool { value = is_integral_extent_type<type>::value };
 
   static_assert(value || std::is_integral<type>::value ||
                     std::is_same<type, void>::value,
@@ -420,21 +420,21 @@ template <int RankDest, int RankSrc, int CurrentArg, class... SubViewArgs>
 struct SubviewLegalArgsCompileTime<Kokkos::LayoutStride, Kokkos::LayoutLeft,
                                    RankDest, RankSrc, CurrentArg,
                                    SubViewArgs...> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 
 template <int RankDest, int RankSrc, int CurrentArg, class... SubViewArgs>
 struct SubviewLegalArgsCompileTime<Kokkos::LayoutStride, Kokkos::LayoutRight,
                                    RankDest, RankSrc, CurrentArg,
                                    SubViewArgs...> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 
 template <int RankDest, int RankSrc, int CurrentArg, class... SubViewArgs>
 struct SubviewLegalArgsCompileTime<Kokkos::LayoutStride, Kokkos::LayoutStride,
                                    RankDest, RankSrc, CurrentArg,
                                    SubViewArgs...> {
-  enum { value = true };
+  enum : bool { value = true };
 };
 
 template <unsigned DomainRank, unsigned RangeRank>

--- a/core/unit_test/TestIrregularLayout.hpp
+++ b/core/unit_test/TestIrregularLayout.hpp
@@ -58,7 +58,7 @@ struct LayoutSelective {
   size_t offset_list[OFFSET_LIST_MAX_SIZE];
   size_t list_size;
 
-  enum { is_extent_constructible = false };
+  enum : bool { is_extent_constructible = false };
 
   KOKKOS_INLINE_FUNCTION
   LayoutSelective() {


### PR DESCRIPTION
This avoids some implicit conversions that would be detected by some static analyzers.