### PR TITLE
Make ViewMapping trivially copyable

### DIFF
--- a/core/src/impl/Kokkos_ViewArray.hpp
+++ b/core/src/impl/Kokkos_ViewArray.hpp
@@ -123,7 +123,7 @@ class ViewMapping<Traits, Kokkos::Array<>> {
 
   handle_type m_impl_handle;
   offset_type m_impl_offset;
-  size_t m_stride;
+  size_t m_stride = 0;
 
   using scalar_type = typename Traits::value_type::value_type;
 
@@ -335,30 +335,7 @@ class ViewMapping<Traits, Kokkos::Array<>> {
 
   //----------------------------------------
 
-  KOKKOS_DEFAULTED_FUNCTION ~ViewMapping() = default;
-  KOKKOS_INLINE_FUNCTION ViewMapping()
-      : m_impl_handle(), m_impl_offset(), m_stride(0) {}
-  KOKKOS_INLINE_FUNCTION ViewMapping(const ViewMapping &rhs)
-      : m_impl_handle(rhs.m_impl_handle),
-        m_impl_offset(rhs.m_impl_offset),
-        m_stride(rhs.m_stride) {}
-  KOKKOS_INLINE_FUNCTION ViewMapping &operator=(const ViewMapping &rhs) {
-    m_impl_handle = rhs.m_impl_handle;
-    m_impl_offset = rhs.m_impl_offset;
-    m_stride      = rhs.m_stride;
-    return *this;
-  }
-
-  KOKKOS_INLINE_FUNCTION ViewMapping(ViewMapping &&rhs)
-      : m_impl_handle(rhs.m_impl_handle),
-        m_impl_offset(rhs.m_impl_offset),
-        m_stride(rhs.m_stride) {}
-  KOKKOS_INLINE_FUNCTION ViewMapping &operator=(ViewMapping &&rhs) {
-    m_impl_handle = rhs.m_impl_handle;
-    m_impl_offset = rhs.m_impl_offset;
-    m_stride      = rhs.m_stride;
-    return *this;
-  }
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping() = default;
 
   //----------------------------------------
 

--- a/core/unit_test/TestViewMapping_b.hpp
+++ b/core/unit_test/TestViewMapping_b.hpp
@@ -256,4 +256,14 @@ TEST(TEST_CATEGORY, view_mapping_assignable) {
   }
 }
 
+TEST(TEST_CATEGORY, view_mapping_trivially_copyable) {
+  using exec_space = TEST_EXECSPACE;
+
+  using dst_traits = Kokkos::ViewTraits<int *, exec_space>;
+  using src_traits = dst_traits;
+  using mapping    = Kokkos::Impl::ViewMapping<dst_traits, src_traits, void>;
+
+  static_assert(std::is_trivially_copyable<mapping>{}, "");
+}
+
 }  // namespace Test


### PR DESCRIPTION
Cherry-picked from [`ef2f3aa` (#3231)](https://github.com/kokkos/kokkos/pull/3231/commits/ef2f3aaad938ce51db6582acdb09f024f4c43db8).
SYCL requires classes used in Kernels to be trivially-copyable and this seems to be easy enough for ViewMapping to do without workarounds.