### PR TITLE
Replace KOKKOS_DEBUG with KOKKOS_ENABLE_DEBUG

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -375,7 +375,7 @@ void CudaHostPinnedSpace::deallocate(const char *arg_label,
 namespace Kokkos {
 namespace Impl {
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
 SharedAllocationRecord<void, void>
     SharedAllocationRecord<Kokkos::CudaSpace, void>::s_root_record;
 
@@ -551,7 +551,7 @@ SharedAllocationRecord<Kokkos::CudaSpace, void>::SharedAllocationRecord(
     // Pass through allocated [ SharedAllocationHeader , user_memory ]
     // Pass through deallocation function
     : SharedAllocationRecord<void, void>(
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
           &SharedAllocationRecord<Kokkos::CudaSpace, void>::s_root_record,
 #endif
           Impl::checked_allocation_with_header(arg_space, arg_label,
@@ -582,7 +582,7 @@ SharedAllocationRecord<Kokkos::CudaUVMSpace, void>::SharedAllocationRecord(
     // Pass through allocated [ SharedAllocationHeader , user_memory ]
     // Pass through deallocation function
     : SharedAllocationRecord<void, void>(
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
           &SharedAllocationRecord<Kokkos::CudaUVMSpace, void>::s_root_record,
 #endif
           Impl::checked_allocation_with_header(arg_space, arg_label,
@@ -610,7 +610,7 @@ SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::
     // Pass through allocated [ SharedAllocationHeader , user_memory ]
     // Pass through deallocation function
     : SharedAllocationRecord<void, void>(
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
           &SharedAllocationRecord<Kokkos::CudaHostPinnedSpace,
                                   void>::s_root_record,
 #endif
@@ -830,7 +830,7 @@ void SharedAllocationRecord<Kokkos::CudaSpace, void>::print_records(
     std::ostream &s, const Kokkos::CudaSpace &, bool detail) {
   (void)s;
   (void)detail;
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   SharedAllocationRecord<void, void> *r = &s_root_record;
 
   char buffer[256];
@@ -896,7 +896,7 @@ void SharedAllocationRecord<Kokkos::CudaSpace, void>::print_records(
 #else
   Kokkos::Impl::throw_runtime_exception(
       "SharedAllocationHeader<CudaSpace>::print_records only works with "
-      "KOKKOS_DEBUG enabled");
+      "KOKKOS_ENABLE_DEBUG enabled");
 #endif
 }
 
@@ -904,13 +904,13 @@ void SharedAllocationRecord<Kokkos::CudaUVMSpace, void>::print_records(
     std::ostream &s, const Kokkos::CudaUVMSpace &, bool detail) {
   (void)s;
   (void)detail;
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   SharedAllocationRecord<void, void>::print_host_accessible_records(
       s, "CudaUVM", &s_root_record, detail);
 #else
   Kokkos::Impl::throw_runtime_exception(
       "SharedAllocationHeader<CudaSpace>::print_records only works with "
-      "KOKKOS_DEBUG enabled");
+      "KOKKOS_ENABLE_DEBUG enabled");
 #endif
 }
 
@@ -918,13 +918,13 @@ void SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::print_records(
     std::ostream &s, const Kokkos::CudaHostPinnedSpace &, bool detail) {
   (void)s;
   (void)detail;
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   SharedAllocationRecord<void, void>::print_host_accessible_records(
       s, "CudaHostPinned", &s_root_record, detail);
 #else
   Kokkos::Impl::throw_runtime_exception(
       "SharedAllocationHeader<CudaSpace>::print_records only works with "
-      "KOKKOS_DEBUG enabled");
+      "KOKKOS_ENABLE_DEBUG enabled");
 #endif
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -390,7 +390,7 @@ class TaskQueueSpecializationConstrained<
       ((int*)&task_ptr)[0] = KOKKOS_IMPL_CUDA_SHFL(((int*)&task_ptr)[0], 0, 32);
       ((int*)&task_ptr)[1] = KOKKOS_IMPL_CUDA_SHFL(((int*)&task_ptr)[1], 0, 32);
 
-#if defined(KOKKOS_DEBUG)
+#if defined(KOKKOS_ENABLE_DEBUG)
       KOKKOS_IMPL_CUDA_SYNCWARP_OR_RETURN("TaskQueue CUDA task_ptr");
 #endif
 

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -299,7 +299,7 @@ void HIPHostPinnedSpace::deallocate(const char* arg_label,
 namespace Kokkos {
 namespace Impl {
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
 SharedAllocationRecord<void, void>
     SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::s_root_record;
 
@@ -375,7 +375,7 @@ SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::
     // Pass through allocated [ SharedAllocationHeader , user_memory ]
     // Pass through deallocation function
     : SharedAllocationRecord<void, void>(
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
           &SharedAllocationRecord<Kokkos::Experimental::HIPSpace,
                                   void>::s_root_record,
 #endif
@@ -407,7 +407,7 @@ SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>::
     // Pass through allocated [ SharedAllocationHeader , user_memory ]
     // Pass through deallocation function
     : SharedAllocationRecord<void, void>(
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
           &SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace,
                                   void>::s_root_record,
 #endif
@@ -563,7 +563,7 @@ SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace,
 void SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::
     print_records(std::ostream& s, const Kokkos::Experimental::HIPSpace& space,
                   bool detail) {
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   SharedAllocationRecord<void, void>* r = &s_root_record;
 
   char buffer[256];
@@ -632,7 +632,7 @@ void SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::
   (void)detail;
   throw_runtime_exception(
       "Kokkos::Impl::SharedAllocationRecord<HIPSpace>::print_records"
-      " only works with KOKKOS_DEBUG enabled");
+      " only works with KOKKOS_ENABLE_DEBUG enabled");
 #endif
 }
 

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -561,7 +561,7 @@ SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace,
 
 // Iterate records to print orphaned memory ...
 void SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::
-    print_records(std::ostream& s, const Kokkos::Experimental::HIPSpace& space,
+    print_records(std::ostream& s, const Kokkos::Experimental::HIPSpace&,
                   bool detail) {
 #ifdef KOKKOS_ENABLE_DEBUG
   SharedAllocationRecord<void, void>* r = &s_root_record;
@@ -598,7 +598,7 @@ void SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::
                reinterpret_cast<uintptr_t>(r->m_alloc_ptr), r->m_alloc_size,
                r->m_count, reinterpret_cast<uintptr_t>(r->m_dealloc),
                head.m_label);
-      std::cout << buffer;
+      s << buffer;
       r = r->m_next;
     } while (r != &s_root_record);
   } else {
@@ -622,13 +622,12 @@ void SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::
       } else {
         snprintf(buffer, 256, "HIP [ 0 + 0 ]\n");
       }
-      std::cout << buffer;
+      s << buffer;
       r = r->m_next;
     } while (r != &s_root_record);
   }
 #else
   (void)s;
-  (void)space;
   (void)detail;
   throw_runtime_exception(
       "Kokkos::Impl::SharedAllocationRecord<HIPSpace>::print_records"

--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -79,7 +79,7 @@ void HPX::impl_initialize(int thread_count) {
   if (rt == nullptr) {
     std::vector<std::string> config = {
         "hpx.os_threads=" + std::to_string(thread_count),
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
         "--hpx:attach-debugger=exception",
 #endif
     };
@@ -110,7 +110,7 @@ void HPX::impl_initialize() {
   hpx::runtime *rt = hpx::get_runtime_ptr();
   if (rt == nullptr) {
     std::vector<std::string> config = {
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
         "--hpx:attach-debugger=exception",
 #endif
     };

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -844,7 +844,7 @@ class SharedAllocationRecord<Kokkos::CudaSpace, void>
       const unsigned sizeof_alias, void* const alloc_ptr,
       const size_t alloc_size);
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   static RecordBase s_root_record;
 #endif
 

--- a/core/src/Kokkos_HBWSpace.hpp
+++ b/core/src/Kokkos_HBWSpace.hpp
@@ -172,7 +172,7 @@ class SharedAllocationRecord<Kokkos::Experimental::HBWSpace, void>
 
   static void deallocate(RecordBase*);
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   /**\brief  Root record for tracked allocations from this HBWSpace instance */
   static RecordBase s_root_record;
 #endif

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -537,7 +537,7 @@ class SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>
 
   static void deallocate(RecordBase*);
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   static RecordBase s_root_record;
 #endif
 
@@ -588,7 +588,7 @@ class SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>
 
   static void deallocate(RecordBase*);
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   static RecordBase s_root_record;
 #endif
 

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -238,7 +238,7 @@ class SharedAllocationRecord<Kokkos::HostSpace, void>
 
   static void deallocate(RecordBase*);
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   /**\brief  Root record for tracked allocations from this HostSpace instance */
   static RecordBase s_root_record;
 #endif

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -105,7 +105,7 @@ class ScratchMemorySpace {
       void* tmp = m_iter_L0 + m_offset * align(size);
       if (m_end_L0 < (m_iter_L0 += align(size) * m_multiplier)) {
         m_iter_L0 -= align(size) * m_multiplier;  // put it back like it was
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
         // mfh 23 Jun 2015: printf call consumes 25 registers
         // in a CUDA build, so only print in debug mode.  The
         // function still returns nullptr if not enough memory.
@@ -113,7 +113,7 @@ class ScratchMemorySpace {
             "ScratchMemorySpace<...>::get_shmem: Failed to allocate "
             "%ld byte(s); remaining capacity is %ld byte(s)\n",
             long(size), long(m_end_L0 - m_iter_L0));
-#endif  // KOKKOS_DEBUG
+#endif  // KOKKOS_ENABLE_DEBUG
         tmp = nullptr;
       }
       return tmp;
@@ -121,7 +121,7 @@ class ScratchMemorySpace {
       void* tmp = m_iter_L1 + m_offset * align(size);
       if (m_end_L1 < (m_iter_L1 += align(size) * m_multiplier)) {
         m_iter_L1 -= align(size) * m_multiplier;  // put it back like it was
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
         // mfh 23 Jun 2015: printf call consumes 25 registers
         // in a CUDA build, so only print in debug mode.  The
         // function still returns nullptr if not enough memory.
@@ -129,7 +129,7 @@ class ScratchMemorySpace {
             "ScratchMemorySpace<...>::get_shmem: Failed to allocate "
             "%ld byte(s); remaining capacity is %ld byte(s)\n",
             long(size), long(m_end_L1 - m_iter_L1));
-#endif  // KOKKOS_DEBUG
+#endif  // KOKKOS_ENABLE_DEBUG
         tmp = nullptr;
       }
       return tmp;
@@ -148,7 +148,7 @@ class ScratchMemorySpace {
       void* tmp = m_iter_L0 + m_offset * size;
       if (m_end_L0 < (m_iter_L0 += size * m_multiplier)) {
         m_iter_L0 = previous;  // put it back like it was
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
         // mfh 23 Jun 2015: printf call consumes 25 registers
         // in a CUDA build, so only print in debug mode.  The
         // function still returns nullptr if not enough memory.
@@ -156,7 +156,7 @@ class ScratchMemorySpace {
             "ScratchMemorySpace<...>::get_shmem: Failed to allocate "
             "%ld byte(s); remaining capacity is %ld byte(s)\n",
             long(size), long(m_end_L0 - m_iter_L0));
-#endif  // KOKKOS_DEBUG
+#endif  // KOKKOS_ENABLE_DEBUG
         tmp = nullptr;
       }
       return tmp;
@@ -168,7 +168,7 @@ class ScratchMemorySpace {
       void* tmp = m_iter_L1 + m_offset * size;
       if (m_end_L1 < (m_iter_L1 += size * m_multiplier)) {
         m_iter_L1 = previous;  // put it back like it was
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
         // mfh 23 Jun 2015: printf call consumes 25 registers
         // in a CUDA build, so only print in debug mode.  The
         // function still returns nullptr if not enough memory.
@@ -176,7 +176,7 @@ class ScratchMemorySpace {
             "ScratchMemorySpace<...>::get_shmem: Failed to allocate "
             "%ld byte(s); remaining capacity is %ld byte(s)\n",
             long(size), long(m_end_L1 - m_iter_L1));
-#endif  // KOKKOS_DEBUG
+#endif  // KOKKOS_ENABLE_DEBUG
         tmp = nullptr;
       }
       return tmp;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -218,7 +218,7 @@ SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>
 // Iterate records to print orphaned memory ...
 void SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
     print_records(std::ostream &s,
-                  const Kokkos::Experimental::OpenMPTargetSpace &space,
+                  const Kokkos::Experimental::OpenMPTargetSpace &,
                   bool detail) {
 #ifdef KOKKOS_ENABLE_DEBUG
   SharedAllocationRecord<void, void>::print_host_accessible_records(

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -94,7 +94,7 @@ void OpenMPTargetSpace::deallocate(void *const arg_alloc_ptr,
 namespace Kokkos {
 namespace Impl {
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
 SharedAllocationRecord<void, void> SharedAllocationRecord<
     Kokkos::Experimental::OpenMPTargetSpace, void>::s_root_record;
 #endif
@@ -125,7 +125,7 @@ SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
     // Pass through allocated [ SharedAllocationHeader , user_memory ]
     // Pass through deallocation function
     : SharedAllocationRecord<void, void>(
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
           &SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace,
                                   void>::s_root_record,
 #endif
@@ -220,7 +220,7 @@ void SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
     print_records(std::ostream &s,
                   const Kokkos::Experimental::OpenMPTargetSpace &space,
                   bool detail) {
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   SharedAllocationRecord<void, void>::print_host_accessible_records(
       s, "OpenMPTargetSpace", &s_root_record, detail);
 #else
@@ -229,7 +229,7 @@ void SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
   (void)detail;
   throw_runtime_exception(
       "SharedAllocationRecord<OpenMPTargetSpace>::print_records"
-      " only works with KOKKOS_DEBUG enabled");
+      " only works with KOKKOS_ENABLE_DEBUG enabled");
 #endif
 }
 

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -207,7 +207,7 @@ KOKKOS_IMPL_ABORT_NORETURN KOKKOS_INLINE_FUNCTION void abort(
 //----------------------------------------------------------------------------
 
 #if !defined(NDEBUG) || defined(KOKKOS_ENFORCE_CONTRACTS) || \
-    defined(KOKKOS_DEBUG)
+    defined(KOKKOS_ENABLE_DEBUG)
 #define KOKKOS_EXPECTS(...)                                               \
   {                                                                       \
     if (!bool(__VA_ARGS__)) {                                             \

--- a/core/src/impl/Kokkos_HBWSpace.cpp
+++ b/core/src/impl/Kokkos_HBWSpace.cpp
@@ -195,7 +195,7 @@ void HBWSpace::deallocate(const char *arg_label, void *const arg_alloc_ptr,
 namespace Kokkos {
 namespace Impl {
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
 SharedAllocationRecord<void, void>
     SharedAllocationRecord<Kokkos::Experimental::HBWSpace, void>::s_root_record;
 #endif
@@ -228,7 +228,7 @@ SharedAllocationRecord<Kokkos::Experimental::HBWSpace, void>::
     // Pass through allocated [ SharedAllocationHeader , user_memory ]
     // Pass through deallocation function
     : SharedAllocationRecord<void, void>(
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
           &SharedAllocationRecord<Kokkos::Experimental::HBWSpace,
                                   void>::s_root_record,
 #endif
@@ -314,13 +314,13 @@ SharedAllocationRecord<Kokkos::Experimental::HBWSpace, void>
 void SharedAllocationRecord<Kokkos::Experimental::HBWSpace, void>::
     print_records(std::ostream &s, const Kokkos::Experimental::HBWSpace &space,
                   bool detail) {
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   SharedAllocationRecord<void, void>::print_host_accessible_records(
       s, "HBWSpace", &s_root_record, detail);
 #else
   throw_runtime_exception(
       "SharedAllocationRecord<HBWSpace>::print_records"
-      " only works with KOKKOS_DEBUG enabled");
+      " only works with KOKKOS_ENABLE_DEBUG enabled");
 #endif
 }
 

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -338,7 +338,7 @@ void HostSpace::deallocate(const char *arg_label, void *const arg_alloc_ptr,
 namespace Kokkos {
 namespace Impl {
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
 SharedAllocationRecord<void, void>
     SharedAllocationRecord<Kokkos::HostSpace, void>::s_root_record;
 #endif
@@ -391,7 +391,7 @@ SharedAllocationRecord<Kokkos::HostSpace, void>::SharedAllocationRecord(
     // Pass through allocated [ SharedAllocationHeader , user_memory ]
     // Pass through deallocation function
     : SharedAllocationRecord<void, void>(
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
           &SharedAllocationRecord<Kokkos::HostSpace, void>::s_root_record,
 #endif
           Impl::checked_allocation_with_header(arg_space, arg_label,
@@ -468,7 +468,7 @@ SharedAllocationRecord<Kokkos::HostSpace, void>::get_record(void *alloc_ptr) {
 }
 
 // Iterate records to print orphaned memory ...
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
 void SharedAllocationRecord<Kokkos::HostSpace, void>::print_records(
     std::ostream &s, const Kokkos::HostSpace &, bool detail) {
   SharedAllocationRecord<void, void>::print_host_accessible_records(
@@ -479,7 +479,7 @@ void SharedAllocationRecord<Kokkos::HostSpace, void>::print_records(
     std::ostream &, const Kokkos::HostSpace &, bool) {
   throw_runtime_exception(
       "SharedAllocationRecord<HostSpace>::print_records only works with "
-      "KOKKOS_DEBUG enabled");
+      "KOKKOS_ENABLE_DEBUG enabled");
 }
 #endif
 

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -50,7 +50,7 @@ namespace Impl {
 KOKKOS_THREAD_LOCAL int SharedAllocationRecord<void, void>::t_tracking_enabled =
     1;
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
 bool SharedAllocationRecord<void, void>::is_sane(
     SharedAllocationRecord<void, void>* arg_record) {
   SharedAllocationRecord* const root = arg_record ? arg_record->m_root : 0;
@@ -122,12 +122,12 @@ bool SharedAllocationRecord<void, void>::is_sane(
     SharedAllocationRecord<void, void>*) {
   Kokkos::Impl::throw_runtime_exception(
       "Kokkos::Impl::SharedAllocationRecord::is_sane only works with "
-      "KOKKOS_DEBUG enabled");
+      "KOKKOS_ENABLE_DEBUG enabled");
   return false;
 }
-#endif  //#ifdef KOKKOS_DEBUG
+#endif  //#ifdef KOKKOS_ENABLE_DEBUG
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
 SharedAllocationRecord<void, void>* SharedAllocationRecord<void, void>::find(
     SharedAllocationRecord<void, void>* const arg_root,
     void* const arg_data_ptr) {
@@ -161,7 +161,8 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<void, void>::find(
 SharedAllocationRecord<void, void>* SharedAllocationRecord<void, void>::find(
     SharedAllocationRecord<void, void>* const, void* const) {
   Kokkos::Impl::throw_runtime_exception(
-      "Kokkos::Impl::SharedAllocationRecord::find only works with KOKKOS_DEBUG "
+      "Kokkos::Impl::SharedAllocationRecord::find only works with "
+      "KOKKOS_ENABLE_DEBUG "
       "enabled");
   return nullptr;
 }
@@ -171,7 +172,7 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<void, void>::find(
  *         use_count is zero.
  */
 SharedAllocationRecord<void, void>::SharedAllocationRecord(
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
     SharedAllocationRecord<void, void>* arg_root,
 #endif
     SharedAllocationHeader* arg_alloc_ptr, size_t arg_alloc_size,
@@ -179,7 +180,7 @@ SharedAllocationRecord<void, void>::SharedAllocationRecord(
     : m_alloc_ptr(arg_alloc_ptr),
       m_alloc_size(arg_alloc_size),
       m_dealloc(arg_dealloc)
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
       ,
       m_root(arg_root),
       m_prev(0),
@@ -188,7 +189,7 @@ SharedAllocationRecord<void, void>::SharedAllocationRecord(
       ,
       m_count(0) {
   if (nullptr != arg_alloc_ptr) {
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
     // Insert into the root double-linked list for tracking
     //
     // before:  arg_root->m_next == next ; next->m_prev == arg_root
@@ -243,7 +244,7 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<
       Kokkos::Impl::throw_runtime_exception(s);
     }
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
     // before:  arg_record->m_prev->m_next == arg_record  &&
     //          arg_record->m_next->m_prev == arg_record
     //
@@ -297,7 +298,7 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<
   return arg_record;
 }
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
 void SharedAllocationRecord<void, void>::print_host_accessible_records(
     std::ostream& s, const char* const space_name,
     const SharedAllocationRecord* const root, const bool detail) {
@@ -359,7 +360,7 @@ void SharedAllocationRecord<void, void>::print_host_accessible_records(
     const bool) {
   Kokkos::Impl::throw_runtime_exception(
       "Kokkos::Impl::SharedAllocationRecord::print_host_accessible_records"
-      " only works with KOKKOS_DEBUG enabled");
+      " only works with KOKKOS_ENABLE_DEBUG enabled");
 }
 #endif
 

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -105,7 +105,7 @@ class SharedAllocationRecord<void, void> {
   SharedAllocationHeader* const m_alloc_ptr;
   size_t const m_alloc_size;
   function_type const m_dealloc;
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
   SharedAllocationRecord* const m_root;
   SharedAllocationRecord* m_prev;
   SharedAllocationRecord* m_next;
@@ -121,7 +121,7 @@ class SharedAllocationRecord<void, void> {
    *         use_count is zero.
    */
   SharedAllocationRecord(
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
       SharedAllocationRecord* arg_root,
 #endif
       SharedAllocationHeader* arg_alloc_ptr, size_t arg_alloc_size,
@@ -166,7 +166,7 @@ class SharedAllocationRecord<void, void> {
       : m_alloc_ptr(nullptr),
         m_alloc_size(0),
         m_dealloc(nullptr)
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
         ,
         m_root(this),
         m_prev(this),

--- a/core/unit_test/TestCompilerMacros.hpp
+++ b/core/unit_test/TestCompilerMacros.hpp
@@ -81,7 +81,7 @@ struct AddFunctor {
 #ifdef KOKKOS_ENABLE_PRAGMA_LOOPCOUNT
 #pragma loop count(128)
 #endif
-#ifndef KOKKOS_DEBUG
+#ifndef KOKKOS_ENABLE_DEBUG
 #ifdef KOKKOS_ENABLE_PRAGMA_SIMD
 #pragma simd
 #endif

--- a/core/unit_test/TestSharedAlloc.hpp
+++ b/core/unit_test/TestSharedAlloc.hpp
@@ -108,7 +108,7 @@ void test_shared_alloc() {
 
     Kokkos::fence();
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
     // Sanity check for the whole set of allocation records to which this record
     // belongs.
     RecordBase::is_sane(r[0]);
@@ -118,7 +118,7 @@ void test_shared_alloc() {
     Kokkos::parallel_for(range, [=](size_t i) {
       while (nullptr !=
              (r[i] = static_cast<RecordMemS*>(RecordBase::decrement(r[i])))) {
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
         if (r[i]->use_count() == 1) RecordBase::is_sane(r[i]);
 #endif
       }
@@ -152,14 +152,14 @@ void test_shared_alloc() {
 
     Kokkos::fence();
 
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
     RecordBase::is_sane(r[0]);
 #endif
 
     Kokkos::parallel_for(range, [=](size_t i) {
       while (nullptr !=
              (r[i] = static_cast<RecordMemS*>(RecordBase::decrement(r[i])))) {
-#ifdef KOKKOS_DEBUG
+#ifdef KOKKOS_ENABLE_DEBUG
         if (r[i]->use_count() == 1) RecordBase::is_sane(r[i]);
 #endif
       }

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -869,7 +869,7 @@ TEST(TEST_CATEGORY, team_vector) {
 
 #if !defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND)
 TEST(TEST_CATEGORY, triple_nested_parallelism) {
-// With KOKKOS_DEBUG enabled, the functor uses too many registers to run
+// With KOKKOS_ENABLE_DEBUG enabled, the functor uses too many registers to run
 // with a team size of 32 on GPUs, 16 is the max possible (at least on a K80
 // GPU) See https://github.com/kokkos/kokkos/issues/1513
 #if defined(KOKKOS_ENABLE_DEBUG) && defined(KOKKOS_ENABLE_CUDA)


### PR DESCRIPTION
AFAICT `KOKKOS_DEBUG` is never defined (via `CMake`) and should be replaced by `KOKKOS_ENABLE_DEBUG` which is what this pull request does.