### PR TITLE
Fix race condition in HIP backend

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Shuffle_Reduce.hpp
+++ b/core/src/HIP/Kokkos_HIP_Shuffle_Reduce.hpp
@@ -81,11 +81,6 @@ __device__ inline void hip_intra_warp_shuffle_reduction(
       join(result, tmp);
     }
     shift *= 2;
-    // Not sure why there is a race condition here but we need to wait for the
-    // join operation to be finished to perform the next shuffle. Note that the
-    // problem was also found in the CUDA backend with CUDA clang
-    // (https://github.com/kokkos/kokkos/issues/941)
-    __syncthreads();
   }
 
   // Broadcast the result to all the threads in the warp
@@ -204,7 +199,6 @@ __device__ inline bool hip_inter_block_shuffle_reduction(
           value_type tmp = Kokkos::Experimental::shfl_down(value, i, warp_size);
           if (id + i < gridDim.x) join(value, tmp);
         }
-        __syncthreads();
       }
     }
   }

--- a/core/src/HIP/Kokkos_HIP_Vectorization.hpp
+++ b/core/src/HIP/Kokkos_HIP_Vectorization.hpp
@@ -128,7 +128,13 @@ struct in_place_shfl_fn : in_place_shfl_op<in_place_shfl_fn> {
   template <class T>
   __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
                                                   int width) const noexcept {
-    return __shfl(val, lane, width);
+    // FIXME_HIP Not sure why there is a race condition here. Note that the
+    // problem was also found in the CUDA backend with CUDA clang
+    // (https://github.com/kokkos/kokkos/issues/941) but it seems more limited
+    // in CUDA clang.
+    auto return_val = __shfl(val, lane, width);
+    __threadfence();
+    return return_val;
   }
 };
 
@@ -141,7 +147,13 @@ struct in_place_shfl_up_fn : in_place_shfl_op<in_place_shfl_up_fn> {
   template <class T>
   __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
                                                   int width) const noexcept {
-    return __shfl_up(val, lane, width);
+    // FIXME_HIP Not sure why there is a race condition here. Note that the
+    // problem was also found in the CUDA backend with CUDA clang
+    // (https://github.com/kokkos/kokkos/issues/941) but it seems more limited
+    // in CUDA clang.
+    auto return_val = __shfl_up(val, lane, width);
+    __threadfence();
+    return return_val;
   }
 };
 
@@ -155,7 +167,13 @@ struct in_place_shfl_down_fn : in_place_shfl_op<in_place_shfl_down_fn> {
   template <class T>
   __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
                                                   int width) const noexcept {
-    return __shfl_down(val, lane, width);
+    // FIXME_HIP Not sure why there is a race condition here. Note that the
+    // problem was also found in the CUDA backend with CUDA clang
+    // (https://github.com/kokkos/kokkos/issues/941) but it seems more limited
+    // in CUDA clang.
+    auto return_val = __shfl_down(val, lane, width);
+    __threadfence();
+    return return_val;
   }
 };
 

--- a/core/unit_test/TestTeamVectorRange.hpp
+++ b/core/unit_test/TestTeamVectorRange.hpp
@@ -477,11 +477,8 @@ bool Test(int test) {
            test_scalar<long long int, ExecutionSpace>(317, team_size, test);
   passed = passed && test_scalar<float, ExecutionSpace>(317, team_size, test);
   passed = passed && test_scalar<double, ExecutionSpace>(317, team_size, test);
-  // FIXME_HIP
-#ifndef KOKKOS_ENABLE_HIP
   passed =
       passed && test_scalar<my_complex, ExecutionSpace>(317, team_size, test);
-#endif
 
   return passed;
 }


### PR DESCRIPTION
This PR add new `__syncthreads()` after shuffle and move another synchronization just after a shuffle. This allows us to enable one more tests. This should not be necessary but there is a race condition in shuffle with HIP. This bug has already been reported to AMD.