### PR TITLE
Added additional missing functions to HPX Backend

### DIFF
--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -788,10 +788,14 @@ class TeamPolicyInternal<Kokkos::Experimental::HPX, Properties...>
                             const ParallelReduceTag &) const {
     return 1;
   }
+
+  static int vector_length_max() { return 1; }
+
   inline int impl_vector_length() noexcept { return 1; }
   inline bool impl_auto_team_size() noexcept { return false; }
   inline bool impl_auto_vector_length() noexcept { return false; }
   inline void impl_set_vector_length(int) noexcept {}
+  inline void impl_set_team_size(int) noexcept {}
 
  private:
   inline void init(const int league_size_request, const int team_size_request) {

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -788,6 +788,10 @@ class TeamPolicyInternal<Kokkos::Experimental::HPX, Properties...>
                             const ParallelReduceTag &) const {
     return 1;
   }
+  inline int impl_vector_length() noexcept { return 1; }
+  inline bool impl_auto_team_size() noexcept { return false; }
+  inline bool impl_auto_vector_length() noexcept { return false; }
+  inline void impl_set_vector_length(int) noexcept {}
 
  private:
   inline void init(const int league_size_request, const int team_size_request) {


### PR DESCRIPTION
Follow-on to #3468 (merge that one first, or merge this into that). There are missing functions in the HPX TeamPolicy implementation for Tuning (and a few for basic functionality). This PR adds them 