### PR TITLE
Allow custom temp dir for nvcc_wrapper

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -90,6 +90,11 @@ replace_pragma_ident=0
 # Mark first host compiler argument
 first_xcompiler_arg=1
 
+# Allow for setting temp dir without setting TMPDIR in parent (see https://docs.olcf.ornl.gov/systems/summit_user_guide.html#setting-tmpdir-causes-jsm-jsrun-errors-job-state-flip-flop)
+if [[ ! -z ${_NVCC_WRAPPER_TMPDIR_OVERRIDE+x} ]]
+then
+  export TMPDIR=${_NVCC_WRAPPER_TMPDIR_OVERRIDE}
+fi
 temp_dir=${TMPDIR:-/tmp}
 
 # optimization flag added as a command-line argument

--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -91,11 +91,11 @@ replace_pragma_ident=0
 first_xcompiler_arg=1
 
 # Allow for setting temp dir without setting TMPDIR in parent (see https://docs.olcf.ornl.gov/systems/summit_user_guide.html#setting-tmpdir-causes-jsm-jsrun-errors-job-state-flip-flop)
-if [[ ! -z ${_NVCC_WRAPPER_TMPDIR_OVERRIDE+x} ]]
-then
-  export TMPDIR=${_NVCC_WRAPPER_TMPDIR_OVERRIDE}
+if [[ ! -z ${NVCC_WRAPPER_TMPDIR+x} ]]; then
+  temp_dir=${TMPDIR:-/tmp}
+else
+  temp_dir=${NVCC_WRAPPER_TMPDIR+x}
 fi
-temp_dir=${TMPDIR:-/tmp}
 
 # optimization flag added as a command-line argument
 optimization_flag=""


### PR DESCRIPTION
Difficult to set TMPDIR in build environment without impacting runtime
environment (due to how most of us use environment modules).
nvcc_wrapper allows a very convenient insertion point for a custom
override of the TMPDIR environment variable ONLY for the compile
commands.  So, allow _NVCC_WRAPPER_TMPDIR_OVERRIDE to take precedence.

See
https://docs.olcf.ornl.gov/systems/summit_user_guide.html#setting-tmpdir-causes-jsm-jsrun-errors-job-state-flip-flop