### PR TITLE
Replace unsigned size_type 

### DIFF
--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -74,7 +74,7 @@ template <typename Device>
 class Bitset {
  public:
   using execution_space = Device;
-  using size_type       = unsigned int;
+  using size_type       = int;
 
   enum { BIT_SCAN_REVERSE = 1u };
   enum { MOVE_HINT_BACKWARD = 2u };
@@ -309,7 +309,7 @@ template <typename Device>
 class ConstBitset {
  public:
   using execution_space = Device;
-  using size_type       = unsigned int;
+  using size_type       = int;
 
  private:
   enum { block_size = static_cast<unsigned>(sizeof(unsigned) * CHAR_BIT) };

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -78,7 +78,7 @@ class CudaSpace {
   using execution_space = Kokkos::Cuda;
   using device_type     = Kokkos::Device<execution_space, memory_space>;
 
-  using size_type = unsigned int;
+  using size_type = int;
 
   /*--------------------------------*/
 
@@ -166,7 +166,7 @@ class CudaUVMSpace {
   using memory_space    = CudaUVMSpace;
   using execution_space = Cuda;
   using device_type     = Kokkos::Device<execution_space, memory_space>;
-  using size_type       = unsigned int;
+  using size_type       = int;
 
   /** \brief  If UVM capability is available */
   static bool available();
@@ -232,7 +232,7 @@ class CudaHostPinnedSpace {
   using execution_space = HostSpace::execution_space;
   using memory_space    = CudaHostPinnedSpace;
   using device_type     = Kokkos::Device<execution_space, memory_space>;
-  using size_type       = unsigned int;
+  using size_type       = int;
 
   /*--------------------------------*/
 

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -76,7 +76,7 @@ class HIPSpace {
   using execution_space = Kokkos::Experimental::HIP;
   using device_type     = Kokkos::Device<execution_space, memory_space>;
 
-  using size_type = unsigned int;
+  using size_type = int;
 
   /*--------------------------------*/
 
@@ -168,7 +168,7 @@ class HIPHostPinnedSpace {
   using execution_space = HostSpace::execution_space;
   using memory_space    = HIPHostPinnedSpace;
   using device_type     = Kokkos::Device<execution_space, memory_space>;
-  using size_type       = unsigned int;
+  using size_type       = int;
 
   /*--------------------------------*/
 

--- a/core/src/Kokkos_SYCL_Space.hpp
+++ b/core/src/Kokkos_SYCL_Space.hpp
@@ -58,7 +58,7 @@ class SYCLDeviceUSMSpace {
   using execution_space = SYCL;
   using memory_space    = SYCLDeviceUSMSpace;
   using device_type     = Kokkos::Device<execution_space, memory_space>;
-  using size_type       = unsigned int;
+  using size_type       = int;
 
   SYCLDeviceUSMSpace();
 


### PR DESCRIPTION
@crtrott wants `size_type` to be signed. This pull request changes all the places that define `size_type` to be something with `unsigned` in their type.