### PR TITLE
replace [=] with [&] in TestGraph

### DIFF
--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -202,7 +202,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(count_bugs), when_all_cycle) {
 // even asynchronously. We _may_ want to do that eventually?
 TEST_F(TEST_CATEGORY_FIXTURE(count_bugs), DISABLED_repeat_chain) {
   auto graph = Kokkos::Experimental::create_graph(
-      ex, [=, count_host = count_host](auto root) {
+      ex, [&, count_host = count_host](auto root) {
         //----------------------------------------
         root.then_parallel_for(1, set_functor{count, 0})
             .then_parallel_for(1, count_functor{count, bugs, 0, 0})

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -118,7 +118,7 @@ struct TEST_CATEGORY_FIXTURE(count_bugs) : public ::testing::Test {
 
 TEST_F(TEST_CATEGORY_FIXTURE(count_bugs), launch_one) {
   auto graph =
-      Kokkos::Experimental::create_graph<TEST_EXECSPACE>([=](auto root) {
+      Kokkos::Experimental::create_graph<TEST_EXECSPACE>([&](auto root) {
         root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
       });
   graph.submit();
@@ -130,7 +130,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(count_bugs), launch_one) {
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(count_bugs), launch_one_rvalue) {
-  Kokkos::Experimental::create_graph(ex, [=](auto root) {
+  Kokkos::Experimental::create_graph(ex, [&](auto root) {
     root.then_parallel_for(1, count_functor{count, bugs, 0, 0});
   }).submit();
   Kokkos::deep_copy(ex, count_host, count);
@@ -141,7 +141,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(count_bugs), launch_one_rvalue) {
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(count_bugs), launch_six) {
-  auto graph = Kokkos::Experimental::create_graph(ex, [=](auto root) {
+  auto graph = Kokkos::Experimental::create_graph(ex, [&](auto root) {
     auto f_setup_count = root.then_parallel_for(1, set_functor{count, 0});
     auto f_setup_bugs  = root.then_parallel_for(1, set_functor{bugs, 0});
 
@@ -176,7 +176,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(count_bugs), launch_six) {
 TEST_F(TEST_CATEGORY_FIXTURE(count_bugs), when_all_cycle) {
   view_type reduction_out{"reduction_out"};
   view_host reduction_host{"reduction_host"};
-  Kokkos::Experimental::create_graph(ex, [=](auto root) {
+  Kokkos::Experimental::create_graph(ex, [&](auto root) {
     //----------------------------------------
     // Test when_all when redundant dependencies are given
     auto f1 = root.then_parallel_for(1, set_functor{count, 0});
@@ -227,7 +227,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(count_bugs), DISABLED_repeat_chain) {
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(count_bugs), zero_work_reduce) {
-  auto graph = Kokkos::Experimental::create_graph(ex, [=](auto root) {
+  auto graph = Kokkos::Experimental::create_graph(ex, [&](auto root) {
     root.then_parallel_reduce(0, set_result_functor{bugs}, count);
   });
   graph.submit();


### PR DESCRIPTION
Addresses C++20 deprecation warning that #3477 previously tried to address.