### PR TITLE
Add missing TeamPolicyInternal<OpenMPTarget> converting constructor

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -835,6 +835,9 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget, Properties...>
     set_auto_chunk_size();
   }
 
+  template <typename ExecSpace, typename... OtherProperties>
+  friend class TeamPolicyInternal;
+
  public:
   inline bool impl_auto_team_size() const { return m_tune_team_size; }
   inline bool impl_auto_vector_length() const { return m_tune_vector_length; }
@@ -857,6 +860,19 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget, Properties...>
   inline Kokkos::Experimental::OpenMPTarget space() const {
     return Kokkos::Experimental::OpenMPTarget();
   }
+
+  template <class... OtherProperties>
+  TeamPolicyInternal(const TeamPolicyInternal<OtherProperties...>& p)
+      : m_league_size(p.m_league_size),
+        m_team_size(p.m_team_size),
+        m_vector_length(p.m_vector_length),
+        m_team_alloc(p.m_team_alloc),
+        m_team_iter(p.m_team_iter),
+        m_team_scratch_size(p.m_team_scratch_size),
+        m_thread_scratch_size(p.m_thread_scratch_size),
+        m_tune_team_size(p.m_tune_team_size),
+        m_tune_vector_length(p.m_tune_vector_length),
+        m_chunk_size(p.m_chunk_size) {}
 
   /** \brief  Specify league size, request team size */
   TeamPolicyInternal(typename traits::execution_space&, int league_size_request,

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -813,8 +813,8 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget, Properties...>
   int m_vector_length;
   int m_team_alloc;
   int m_team_iter;
-  size_t m_team_scratch_size[2];
-  size_t m_thread_scratch_size[2];
+  std::array<size_t, 2> m_team_scratch_size;
+  std::array<size_t, 2> m_thread_scratch_size;
   bool m_tune_team_size;
   bool m_tune_vector_length;
   constexpr const static size_t default_team_size = 256;

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -699,4 +699,21 @@ TEST(TEST_CATEGORY, policy_construction) {
   TestTeamPolicyConstruction<TEST_EXECSPACE>();
 }
 
+template <template <class...> class Policy, class... Args>
+void check_converting_constructor_add_work_tag(Policy<Args...> const& policy) {
+  // Not the greatest but at least checking it compiles
+  struct WorkTag {};
+  Policy<Args..., WorkTag> policy_with_tag = policy;
+  (void)policy_with_tag;
+}
+
+TEST(TEST_CATEGORY, policy_converting_constructor_from_other_policy) {
+  check_converting_constructor_add_work_tag(
+      Kokkos::RangePolicy<TEST_EXECSPACE>{});
+  check_converting_constructor_add_work_tag(
+      Kokkos::TeamPolicy<TEST_EXECSPACE>{});
+  check_converting_constructor_add_work_tag(
+      Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{0, 1}, {2, 3}});
+}
+
 }  // namespace Test


### PR DESCRIPTION
Realized it was missing when working on #3379 