### PR TITLE
Fixup bug introduced in SharedAllocationRecord<OpenMPTarget>

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -225,7 +225,6 @@ void SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
       s, "OpenMPTargetSpace", &s_root_record, detail);
 #else
   (void)s;
-  (void)space;
   (void)detail;
   throw_runtime_exception(
       "SharedAllocationRecord<OpenMPTargetSpace>::print_records"


### PR DESCRIPTION
I found this while unit  testing view hooks.  looks  like a cut  and past issue.  The space parameter is never used  or declared, but  it is needed for function specialization.  I just removed the line.