### PR TITLE
printf to fprintf in OpenMPTarget_Abort.hpp

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Abort.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Abort.hpp
@@ -52,7 +52,7 @@ namespace Kokkos {
 namespace Impl {
 
 KOKKOS_INLINE_FUNCTION void OpenMPTarget_abort(char const *msg) {
-  printf("%s.\n", msg);
+  fprintf(stderr, "%s.\n", msg);
   std::abort();
 }
 


### PR DESCRIPTION
Changing printf to fprintf so that the error message is printed before abort