### PR TITLE
[HIP] Clean up shuffle reduction in MDRange and in Team

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -227,16 +227,6 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   using DeviceIteratePattern = typename Kokkos::Impl::Reduce::DeviceIterateTile<
       Policy::rank, Policy, FunctorType, WorkTag, reference_type>;
 
-  // Shall we use the shfl based reduction or not (only use it for static sized
-  // types of more than 128bit
-  static constexpr bool UseShflReduction = false;
-  // ((sizeof(value_type) > 2 * sizeof(double)) && (ValueTraits::StaticValueSize
-  // != 0))
-  // Some crutch to do function overloading
- private:
-  using DummyShflReductionType  = double;
-  using DummySHMEMReductionType = int;
-
  public:
   inline __device__ void exec_range(reference_type update) const {
     DeviceIteratePattern(m_policy, m_functor, update).exec_range();
@@ -348,10 +338,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                       1, 1);
 
       const int shmem =
-          UseShflReduction
-              ? 0
-              : ::Kokkos::Impl::hip_single_inter_block_reduce_scan_shmem<
-                    false, FunctorType, WorkTag>(m_functor, block.y);
+          ::Kokkos::Impl::hip_single_inter_block_reduce_scan_shmem<
+              false, FunctorType, WorkTag>(m_functor, block.y);
 
       Kokkos::Experimental::Impl::HIPParallelLaunch<ParallelReduce,
                                                     LaunchBounds>(


### PR DESCRIPTION
- Remove `UseShflReduction` in `Parallel_HIP_MDRange` since it's always false
- Use tags in `Parallel_HIP_Team` similar to what we do in `Parallel_HIP_Range`
- Fix a `FIXME_HIP`: there was a comment that two functions were similar, but they only have the following code in common 
```C++
	// Iterate this block through the league
    for (int league_rank = blockIdx.x; league_rank < int_league_size;
         league_rank += gridDim.x) {
      this->template exec_team<work_tag>(...);
```