### PR TITLE
Cleaned up use of the __CUDACC__ macro

### DIFF
--- a/core/src/Cuda/KokkosExp_Cuda_IterateTile.hpp
+++ b/core/src/Cuda/KokkosExp_Cuda_IterateTile.hpp
@@ -46,7 +46,7 @@
 #define KOKKOS_CUDA_EXP_ITERATE_TILE_HPP
 
 #include <Kokkos_Macros.hpp>
-#if defined(__CUDACC__) && defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA)
 
 #include <algorithm>
 #include <cstdio>

--- a/core/src/Cuda/KokkosExp_Cuda_IterateTile_Refactor.hpp
+++ b/core/src/Cuda/KokkosExp_Cuda_IterateTile_Refactor.hpp
@@ -46,7 +46,7 @@
 #define KOKKOS_CUDA_EXP_ITERATE_TILE_REFACTOR_HPP
 
 #include <Kokkos_Macros.hpp>
-#if defined(__CUDACC__) && defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA)
 
 #include <algorithm>
 

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -60,8 +60,6 @@
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#if defined(__CUDACC__)
-
 /** \brief  Access to constant memory on the device */
 #ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
 
@@ -544,6 +542,5 @@ struct CudaParallelLaunch<DriverType, LaunchBounds, LaunchMechanism,
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#endif /* defined( __CUDACC__ ) */
 #endif /* defined( KOKKOS_ENABLE_CUDA ) */
 #endif /* #ifndef KOKKOS_CUDAEXEC_HPP */

--- a/core/src/Cuda/Kokkos_Cuda_Locks.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.hpp
@@ -81,8 +81,6 @@ void finalize_host_cuda_lock_arrays();
 }  // namespace Impl
 }  // namespace Kokkos
 
-#if defined(__CUDACC__)
-
 namespace Kokkos {
 namespace Impl {
 
@@ -172,8 +170,6 @@ inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
 #define KOKKOS_ENSURE_CUDA_LOCK_ARRAYS_ON_DEVICE() \
   KOKKOS_COPY_CUDA_LOCK_ARRAYS_TO_DEVICE()
 #endif
-
-#endif /* defined( __CUDACC__ ) */
 
 #endif /* defined( KOKKOS_ENABLE_CUDA ) */
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -46,7 +46,7 @@
 #define KOKKOS_CUDA_PARALLEL_HPP
 
 #include <Kokkos_Macros.hpp>
-#if defined(__CUDACC__) && defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA)
 
 #include <algorithm>
 #include <string>
@@ -2762,5 +2762,5 @@ struct ParallelReduceFunctorType<FunctorTypeIn, ExecPolicy, ValueType, Cuda> {
 
 }  // namespace Kokkos
 
-#endif /* defined( __CUDACC__ ) */
+#endif /* defined(KOKKOS_ENABLE_CUDA) */
 #endif /* #ifndef KOKKOS_CUDA_PARALLEL_HPP */

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -46,7 +46,7 @@
 #define KOKKOS_CUDA_REDUCESCAN_HPP
 
 #include <Kokkos_Macros.hpp>
-#if defined(__CUDACC__) && defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA)
 
 #include <utility>
 
@@ -983,5 +983,5 @@ inline unsigned cuda_single_inter_block_reduce_scan_shmem(
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#endif /* #if defined( __CUDACC__ ) */
+#endif /* #if defined(KOKKOS_ENABLE_CUDA) */
 #endif /* KOKKOS_CUDA_REDUCESCAN_HPP */

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -50,7 +50,7 @@
 #include <Kokkos_Macros.hpp>
 
 /* only compile this file if CUDA is enabled for Kokkos */
-#if defined(__CUDACC__) && defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA)
 
 #include <utility>
 #include <Kokkos_Parallel.hpp>
@@ -1089,6 +1089,6 @@ KOKKOS_INLINE_FUNCTION void single(
 
 }  // namespace Kokkos
 
-#endif /* defined( __CUDACC__ ) */
+#endif /* defined(KOKKOS_ENABLE_CUDA) */
 
 #endif /* #ifndef KOKKOS_CUDA_TEAM_HPP */

--- a/core/src/Cuda/Kokkos_Cuda_abort.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_abort.hpp
@@ -48,7 +48,7 @@
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 #include <Kokkos_Macros.hpp>
-#if defined(__CUDACC__) && defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA)
 
 #include <cuda.h>
 
@@ -97,5 +97,5 @@ __device__ inline void cuda_abort(const char *const message) {
 }  // namespace Kokkos
 #else
 void KOKKOS_CORE_SRC_CUDA_ABORT_PREVENT_LINK_ERROR() {}
-#endif /* #if defined(__CUDACC__) && defined( KOKKOS_ENABLE_CUDA ) */
+#endif /* #if defined( KOKKOS_ENABLE_CUDA ) */
 #endif /* #ifndef KOKKOS_CUDA_ABORT_HPP */

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -53,7 +53,7 @@
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_Parallel.hpp>
 
-#if defined(__CUDACC__) && defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_ENABLE_CUDA)
 #include <Cuda/KokkosExp_Cuda_IterateTile.hpp>
 #include <Cuda/KokkosExp_Cuda_IterateTile_Refactor.hpp>
 #endif

--- a/core/src/setup/Kokkos_Setup_Cuda.hpp
+++ b/core/src/setup/Kokkos_Setup_Cuda.hpp
@@ -45,7 +45,16 @@
 #ifndef KOKKOS_CUDA_SETUP_HPP_
 #define KOKKOS_CUDA_SETUP_HPP_
 
-#if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDACC__)
+#if !defined(KOKKOS_ENABLE_CUDA)
+#error \
+    "KOKKOS_ENABLE_CUDA was not defined, but Kokkos_Setup_Cuda.hpp was included anyway."
+#endif
+
+#if defined(KOKKOS_ENABLE_CUDA) && !defined(__CUDACC__)
+#error \
+    "KOKKOS_ENABLE_CUDA defined but the compiler is not defining the __CUDACC__ macro as expected"
+#endif /* defined(KOKKOS_ENABLE_CUDA) && !defined(__CUDACC__) */
+
 // Compiling with a CUDA compiler.
 //
 //  Include <cuda.h> to pick up the CUDA_VERSION macro defined as:
@@ -100,11 +109,6 @@
 #endif
 #endif
 
-#endif  // #if defined( KOKKOS_ENABLE_CUDA ) && defined( __CUDACC__ )
-
-#if defined(KOKKOS_ENABLE_CUDA)
-// Compiling Cuda code to 'ptx'
-
 #define KOKKOS_IMPL_FORCEINLINE_FUNCTION __device__ __host__ __forceinline__
 #define KOKKOS_IMPL_FORCEINLINE __forceinline__
 #define KOKKOS_IMPL_INLINE_FUNCTION __device__ __host__ inline
@@ -123,6 +127,5 @@
 #endif
 #define KOKKOS_IMPL_HOST_FUNCTION __host__
 #define KOKKOS_IMPL_DEVICE_FUNCTION __device__
-#endif
 
-#endif
+#endif /* KOKKOS_CUDA_SETUP_HPP_ */

--- a/core/src/setup/Kokkos_Setup_Cuda.hpp
+++ b/core/src/setup/Kokkos_Setup_Cuda.hpp
@@ -53,6 +53,8 @@
 #if defined(KOKKOS_ENABLE_CUDA) && !defined(__CUDACC__)
 #error \
     "KOKKOS_ENABLE_CUDA defined but the compiler is not defining the __CUDACC__ macro as expected"
+// Some tooling environments will still function better if we do this here.
+#define __CUDACC__
 #endif /* defined(KOKKOS_ENABLE_CUDA) && !defined(__CUDACC__) */
 
 // Compiling with a CUDA compiler.


### PR DESCRIPTION
This messes with tooling because it's defined in the compiler
and not in a reachable header file. It should always be defined
if and only if `KOKKOS_ENABLE_CUDA` is defined, so I've added a
more helpful error message to that effect and removed it from
everywhere else in the code that it's used. We should probably
do something analogous for HIP in a different pull request.