### PR TITLE
Temporary workaround to avoid undefined behavior in Threads backend

### DIFF
--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -593,6 +593,13 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
 
     m_team_size = team_size_request < team_max ? team_size_request : team_max;
 
+    // FIXME This is a temporary fix until we handle this more gracefully.
+    // Assign recommended team size if the team size is garbage.
+    // Default constructed team policy led to -1 which causes int overflow in
+    // set_auto_chunk_size()
+    if (m_team_size <= 0)
+      m_team_size = traits::execution_space::impl_thread_pool_size(2);
+
     // Round team size up to a multiple of 'team_gain'
     const int team_size_grain =
         team_grain * ((m_team_size + team_grain - 1) / team_grain);


### PR DESCRIPTION
Yet another attempt to fix #3497

Caught this with Clang UBSan:
```
core/src/Threads/Kokkos_ThreadsTeam.hpp:820:27: runtime error: signed integer overflow: 33554432 * 100 cannot be represented in type 'int'
```

@ndellingwood Please confirm whether that resolves the failure of the CI build from the nightlies.
@DavidPoliakoff Please review and consider suggesting a better fix.