### PR TITLE
Fixup int overflow in reducers unit tests

### DIFF
--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1018,9 +1018,12 @@ struct TestReducers {
     test_minmaxloc(10007);
   }
 
+  // NOTE test_prod generates N random numbers between 1 and 4.
+  // Although unlikely, the test below could still in principle overflow.
+  // For reference log(numeric_limits<int>)/log(4) is 15.5
   static void execute_integer() {
     test_sum(10001);
-    test_prod(sizeof(Scalar) > 4 ? 35 : 19);  // avoid int overflow
+    test_prod(sizeof(Scalar) > 4 ? 35 : 19);  // avoid int overflow (see above)
     test_min(10003);
     test_minloc(10003);
     test_max(10007);

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1020,7 +1020,7 @@ struct TestReducers {
 
   static void execute_integer() {
     test_sum(10001);
-    test_prod(35);
+    test_prod(sizeof(Scalar) > 4 ? 35 : 19);  // avoid int overflow
     test_min(10003);
     test_minloc(10003);
     test_max(10007);


### PR DESCRIPTION
Found along the way while working on #3512

Clang UBSan was reporting
```
core/unit_test/TestReducers.hpp:387:22: runtime error: signed integer overflow: 2038431744 * 3 cannot be represented in type 'int'
core/unit_test/TestReducers.hpp:71:64: runtime error: signed integer overflow: 2038431744 * 3 cannot be represented in type 'int'
core/unit_test/TestReducers.hpp:189:13: runtime error: signed integer overflow: 2038431744 * 3 cannot be represented in type 'int'
```