### PR TITLE
Fixup undefined behavior in subview unit tests

### DIFF
--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2233,7 +2233,7 @@ struct TestSubviewStaticSizes {
            test_8 + test_9 + test_10 + test_11;
   }
 
-  TestSubviewStaticSizes() : a(Kokkos::view_alloc(), 20), b() {}
+  TestSubviewStaticSizes() : a(Kokkos::view_alloc("a"), 20), b("b") {}
 };
 
 template <class Space>


### PR DESCRIPTION
Issue arises when taking subview of default constructed view with all compile-time dimensions.

Clang UBSan was reporting
```
core/src/impl/Kokkos_ViewMapping.hpp:2662:37: runtime error: applying non-zero offset 8 to null pointer
core/src/impl/Kokkos_ViewMapping.hpp:2662:37: runtime error: applying non-zero offset 448 to null pointer
```