### PR TITLE
Used the Kokkos Profiling interface rather than the Impl interface

### DIFF
--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2866,13 +2866,15 @@ struct ViewValueFunctor<ExecSpace, ValueType, false /* is_scalar */> {
 
   void execute(bool arg) {
     destroy = arg;
+    PolicyType policy(0, n);
     if (!space.in_parallel()) {
       uint64_t kpID = 0;
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         auto functor_name =
             (destroy ? "Kokkos::View::destruction [" + name + "]"
                      : "Kokkos::View::initialization [" + name + "]");
-        Kokkos::Profiling::beginParallelFor(functor_name.c_str(), 0, &kpID);
+        Kokkos::Tools::Impl::begin_parallel_for(policy, *this, functor_name,
+                                                kpID);
       }
 #ifdef KOKKOS_ENABLE_CUDA
       if (std::is_same<ExecSpace, Kokkos::Cuda>::value) {
@@ -2881,11 +2883,15 @@ struct ViewValueFunctor<ExecSpace, ValueType, false /* is_scalar */> {
       }
 #endif
       const Kokkos::Impl::ParallelFor<ViewValueFunctor, PolicyType> closure(
-          *this, PolicyType(0, n));
+          *this, policy);
       closure.execute();
       space.fence();
       if (Kokkos::Profiling::profileLibraryLoaded()) {
-        Kokkos::Profiling::endParallelFor(kpID);
+        auto functor_name =
+            (destroy ? "Kokkos::View::destruction [" + name + "]"
+                     : "Kokkos::View::initialization [" + name + "]");
+        Kokkos::Tools::Impl::end_parallel_for(policy, *this, functor_name,
+                                              kpID);
       }
     } else {
       for (size_t i = 0; i < n; ++i) operator()(i);

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2867,10 +2867,11 @@ struct ViewValueFunctor<ExecSpace, ValueType, false /* is_scalar */> {
   void execute(bool arg) {
     destroy = arg;
     PolicyType policy(0, n);
+    std::string functor_name;
     if (!space.in_parallel()) {
       uint64_t kpID = 0;
       if (Kokkos::Profiling::profileLibraryLoaded()) {
-        auto functor_name =
+        functor_name =
             (destroy ? "Kokkos::View::destruction [" + name + "]"
                      : "Kokkos::View::initialization [" + name + "]");
         Kokkos::Tools::Impl::begin_parallel_for(policy, *this, functor_name,
@@ -2887,9 +2888,6 @@ struct ViewValueFunctor<ExecSpace, ValueType, false /* is_scalar */> {
       closure.execute();
       space.fence();
       if (Kokkos::Profiling::profileLibraryLoaded()) {
-        auto functor_name =
-            (destroy ? "Kokkos::View::destruction [" + name + "]"
-                     : "Kokkos::View::initialization [" + name + "]");
         Kokkos::Tools::Impl::end_parallel_for(policy, *this, functor_name,
                                               kpID);
       }


### PR DESCRIPTION
There was one place left where we directly called beginParallelFor. As we expand what can happen inside beginParallelFor, that is going to become more and more of a problem. Requesting a review from @crtrott because there's like a 1% chance it used the Impl interface for a specific reason I wasn't able to figure out