### PR TITLE
Removed explicit HostSpace references within Serial

### DIFF
--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -549,10 +549,11 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     static_assert(Kokkos::is_view<HostViewType>::value,
                   "Kokkos::Serial reduce result must be a View");
 
-    static_assert(
-        Kokkos::Impl::MemorySpaceAccess<typename HostViewType::memory_space,
-                                        Kokkos::HostSpace>::accessible,
-        "Kokkos::Serial reduce result must be a View in HostSpace");
+    static_assert(Kokkos::Impl::MemorySpaceAccess<
+                      typename HostViewType::memory_space,
+                      typename Kokkos::Serial::memory_space>::accessible,
+                  "Kokkos::Serial reduce result must be a View in "
+                  "Serial::memory_space (i.e. HostSpace)");
   }
 
   inline ParallelReduce(const FunctorType& arg_functor, Policy arg_policy,
@@ -820,10 +821,11 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     static_assert(Kokkos::is_view<HostViewType>::value,
                   "Kokkos::Serial reduce result must be a View");
 
-    static_assert(
-        Kokkos::Impl::MemorySpaceAccess<typename HostViewType::memory_space,
-                                        Kokkos::HostSpace>::accessible,
-        "Kokkos::Serial reduce result must be a View in HostSpace");
+    static_assert(Kokkos::Impl::MemorySpaceAccess<
+                      typename HostViewType::memory_space,
+                      typename Kokkos::Serial::memory_space>::accessible,
+                  "Kokkos::Serial reduce result must be a View in "
+                  "Serial::memory_space (i.e. HostSpace)");
   }
 
   inline ParallelReduce(const FunctorType& arg_functor,
@@ -997,11 +999,11 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     static_assert(Kokkos::is_view<ViewType>::value,
                   "Reduction result on Kokkos::Serial must be a Kokkos::View");
 
-    static_assert(
-        Kokkos::Impl::MemorySpaceAccess<typename ViewType::memory_space,
-                                        Kokkos::HostSpace>::accessible,
-        "Reduction result on Kokkos::Serial must be a Kokkos::View in "
-        "HostSpace");
+    static_assert(Kokkos::Impl::MemorySpaceAccess<
+                      typename ViewType::memory_space,
+                      typename Kokkos::Serial::memory_space>::accessible,
+                  "Kokkos::Serial reduce result must be a View in "
+                  "Serial::memory_space (i.e. HostSpace)");
   }
 
   inline ParallelReduce(const FunctorType& arg_functor, Policy arg_policy,

--- a/core/src/impl/Kokkos_Serial.cpp
+++ b/core/src/impl/Kokkos_Serial.cpp
@@ -89,7 +89,7 @@ void serial_resize_thread_team_data(size_t pool_reduce_bytes,
                         (old_thread_local < thread_local_bytes);
 
   if (allocate) {
-    Kokkos::HostSpace space;
+    Kokkos::Serial::memory_space space;
 
     if (old_alloc_bytes) {
       g_serial_thread_team_data.disband_team();
@@ -163,7 +163,7 @@ void Serial::impl_finalize() {
     Impl::g_serial_thread_team_data.disband_team();
     Impl::g_serial_thread_team_data.disband_pool();
 
-    Kokkos::HostSpace space;
+    Kokkos::Serial::memory_space space;
 
     space.deallocate(Impl::g_serial_thread_team_data.scratch_buffer(),
                      Impl::g_serial_thread_team_data.scratch_bytes());

--- a/core/src/impl/Kokkos_Serial_Task.hpp
+++ b/core/src/impl/Kokkos_Serial_Task.hpp
@@ -67,7 +67,7 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::Serial, QueueType> > {
   // of the methods, obviously)
 
   using execution_space = Kokkos::Serial;
-  using memory_space    = Kokkos::HostSpace;
+  using memory_space    = typename execution_space::memory_space;
   using scheduler_type  = SimpleTaskScheduler<Kokkos::Serial, QueueType>;
   using member_type =
       TaskTeamMemberAdapter<HostThreadTeamMember<Kokkos::Serial>,
@@ -134,7 +134,7 @@ class TaskQueueSpecializationConstrained<
   // of the methods, obviously)
 
   using execution_space = Kokkos::Serial;
-  using memory_space    = Kokkos::HostSpace;
+  using memory_space    = typename execution_space::memory_space;
   using scheduler_type  = Scheduler;
   using member_type =
       TaskTeamMemberAdapter<HostThreadTeamMember<Kokkos::Serial>,


### PR DESCRIPTION
In a parallel effort, I'm attempting to basically duplicate the Serial backend. In the course of doing this, I realized that there are a few places within implementations in Serial in which we refer to Kokkos::HostSpace. This simply changes those to refer to Serial::memory_space, which makes variants simpler to develop. Also if we ever decide we want something other than HostSpace for Serial, that becomes simpler