### PR TITLE
[HIP] Fix atomics of large data types and clean up lock arrays

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Atomic.hpp
+++ b/core/src/HIP/Kokkos_HIP_Atomic.hpp
@@ -47,6 +47,7 @@
 
 #include <impl/Kokkos_Atomic_Memory_Order.hpp>
 #include <impl/Kokkos_Memory_Fence.hpp>
+#include <HIP/Kokkos_HIP_Locks.hpp>
 
 #if defined(KOKKOS_ENABLE_HIP_ATOMICS)
 namespace Kokkos {
@@ -106,19 +107,16 @@ atomic_exchange(volatile T *const dest,
                 typename std::enable_if<sizeof(T) != sizeof(int) &&
                                             sizeof(T) != sizeof(long long),
                                         const T>::type &val) {
-  // FIXME_HIP
-  Kokkos::abort("atomic_exchange not implemented for large types.\n");
   T return_val;
   int done                 = 0;
   unsigned int active      = __ballot(1);
   unsigned int done_active = 0;
   while (active != done_active) {
     if (!done) {
-      // if (Impl::lock_address_hip_space((void*)dest))
-      {
+      if (Impl::lock_address_hip_space((void *)dest)) {
         return_val = *dest;
         *dest      = val;
-        // Impl::unlock_address_hip_space((void*)dest);
+        Impl::unlock_address_hip_space((void *)dest);
         done = 1;
       }
     }
@@ -218,19 +216,16 @@ __inline__ __device__ T atomic_compare_exchange(
     typename std::enable_if<sizeof(T) != sizeof(int) &&
                                 sizeof(T) != sizeof(long long),
                             const T>::type &val) {
-  // FIXME_HIP
-  Kokkos::abort("atomic_compare_exchange not implemented for large types.\n");
   T return_val;
   int done                 = 0;
   unsigned int active      = __ballot(1);
   unsigned int done_active = 0;
   while (active != done_active) {
     if (!done) {
-      // if (Impl::lock_address_hip_space((void*)dest))
-      {
+      if (Impl::lock_address_hip_space((void *)dest)) {
         return_val = *dest;
         if (return_val == compare) *dest = val;
-        // Impl::unlock_address_hip_space((void*)dest);
+        Impl::unlock_address_hip_space((void *)dest);
         done = 1;
       }
     }
@@ -353,19 +348,16 @@ atomic_fetch_add(volatile T *dest,
                  typename std::enable_if<sizeof(T) != sizeof(int) &&
                                              sizeof(T) != sizeof(long long),
                                          const T &>::type val) {
-  // FIXME_HIP
-  Kokkos::abort("atomic_fetch_add not implemented for large types.\n");
   T return_val;
   int done                 = 0;
   unsigned int active      = __ballot(1);
   unsigned int done_active = 0;
   while (active != done_active) {
     if (!done) {
-      // if(Kokkos::Impl::lock_address_hip_space((void *)dest))
-      {
+      if (Kokkos::Impl::lock_address_hip_space((void *)dest)) {
         return_val = *dest;
         *dest      = return_val + val;
-        // Kokkos::Impl::unlock_address_hip_space((void *)dest);
+        Kokkos::Impl::unlock_address_hip_space((void *)dest);
         done = 1;
       }
     }
@@ -516,19 +508,16 @@ atomic_fetch_sub(volatile T *const dest,
                  typename std::enable_if<sizeof(T) != sizeof(int) &&
                                              sizeof(T) != sizeof(long long),
                                          const T>::type &val) {
-  // FIXME_HIP
-  Kokkos::abort("atomic_fetch_sub not implemented for large types.\n");
   T return_val;
   int done                 = 0;
   unsigned int active      = __ballot(1);
   unsigned int done_active = 0;
   while (active != done_active) {
     if (!done) {
-      /*if (Impl::lock_address_hip_space((void*)dest)) */
-      {
+      if (Impl::lock_address_hip_space((void *)dest)) {
         return_val = *dest;
         *dest      = return_val - val;
-        // Impl::unlock_address_hip_space((void*)dest);
+        Impl::unlock_address_hip_space((void *)dest);
         done = 1;
       }
     }

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -146,6 +146,8 @@ struct HIPParallelLaunch<
             "HIPParallelLaunch FAILED: shared memory request is too large");
       }
 
+      KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
+
       // FIXME_HIP -- there is currently an error copying (some) structs
       // by value to the device in HIP-Clang / VDI
       // As a workaround, we can malloc the DriverType and explictly copy over.
@@ -193,6 +195,8 @@ struct HIPParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
         Kokkos::Impl::throw_runtime_exception(std::string(
             "HIPParallelLaunch FAILED: shared memory request is too large"));
       }
+
+      KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
 
       // Invoke the driver function on the device
 

--- a/core/src/HIP/Kokkos_HIP_Locks.cpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.cpp
@@ -52,26 +52,28 @@
 
 #include <iostream>
 
+namespace Kokkos {
+
 #ifdef KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE
+namespace Impl {
 __device__ __constant__ HIPLockArrays g_device_hip_lock_arrays = {nullptr,
                                                                   nullptr, 0};
+}
 #endif
-
-namespace Kokkos {
 
 namespace {
 
 __global__ void init_lock_array_kernel_atomic() {
   unsigned i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < KOKKOS_IMPL_HIP_SPACE_ATOMIC_MASK + 1) {
-    g_device_hip_lock_arrays.atomic[i] = 0;
+    Kokkos::Impl::g_device_hip_lock_arrays.atomic[i] = 0;
   }
 }
 
 __global__ void init_lock_array_kernel_threadid(int N) {
   unsigned i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < static_cast<unsigned>(N)) {
-    g_device_hip_lock_arrays.scratch[i] = 0;
+    Kokkos::Impl::g_device_hip_lock_arrays.scratch[i] = 0;
   }
 }
 

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -327,19 +327,16 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
   }
   return return_val;
 #elif defined(__HIP_DEVICE_COMPILE__)
-  // FIXME_HIP
-  Kokkos::abort("atomic_fetch_oper not implemented for large types.");
   T return_val             = *dest;
   int done                 = 0;
   unsigned int active      = __ballot(1);
   unsigned int done_active = 0;
   while (active != done_active) {
     if (!done) {
-      // if (Impl::lock_address_hip_space((void*)dest))
-      {
+      if (Impl::lock_address_hip_space((void*)dest)) {
         return_val = *dest;
         *dest      = op.apply(return_val, val);
-        // Impl::unlock_address_hip_space((void*)dest);
+        Impl::unlock_address_hip_space((void*)dest);
         done = 1;
       }
     }
@@ -406,19 +403,16 @@ atomic_oper_fetch(const Oper& op, volatile T* const dest,
   }
   return return_val;
 #elif defined(__HIP_DEVICE_COMPILE__)
-  // FIXME_HIP
-  Kokkos::abort("atomic_oper_fetch not implemented for large types.");
   T return_val;
   int done                 = 0;
   unsigned int active      = __ballot(1);
   unsigned int done_active = 0;
   while (active != done_active) {
     if (!done) {
-      // if (Impl::lock_address_hip_space((void*)dest))
-      {
+      if (Impl::lock_address_hip_space((void*)dest)) {
         return_val = op.apply(*dest, val);
         *dest      = return_val;
-        // Impl::unlock_address_hip_space((void*)dest);
+        Impl::unlock_address_hip_space((void*)dest);
         done = 1;
       }
     }

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -380,11 +380,6 @@ if(Kokkos_ENABLE_CUDA)
 endif()
 
 if(Kokkos_ENABLE_HIP)
-  # FIXME_HIP
-  LIST(REMOVE_ITEM HIP_SOURCES
-    ${CMAKE_CURRENT_BINARY_DIR}/hip/TestHIP_AtomicOperations_complexdouble.cpp
-  )
-
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_HIP
     SOURCES


### PR DESCRIPTION
This PR:
- cleans up the use of the global lock arrays: 
   - `hipcc` now supports the use global variable in a namespace
   - remove a local lock arrays variable that was used as a workaround
- enables the atomic of large data types
- enables the last disabled test file for HIP

With this PR all the test files are enable with HIP but there are still a few tests in these files that are disabled/modified for HIP.