### PR TITLE
Remove unused traits

### DIFF
--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -247,28 +247,6 @@ template <typename Cond, typename TrueType, typename FalseType>
 struct if_ : public if_c<Cond::value, TrueType, FalseType> {};
 
 //----------------------------------------------------------------------------
-
-template <typename T>
-struct is_label : public std::false_type {};
-
-template <>
-struct is_label<const char*> : public std::true_type {};
-
-template <>
-struct is_label<char*> : public std::true_type {};
-
-template <int N>
-struct is_label<const char[N]> : public std::true_type {};
-
-template <int N>
-struct is_label<char[N]> : public std::true_type {};
-
-template <>
-struct is_label<const std::string> : public std::true_type {};
-
-template <>
-struct is_label<std::string> : public std::true_type {};
-
 // These 'constexpr'functions can be used as
 // both regular functions and meta-function.
 

--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -352,35 +352,6 @@ struct integral_nonzero_constant<T, zero, false> {
 
 //----------------------------------------------------------------------------
 
-template <class...>
-class TypeList;
-
-//----------------------------------------------------------------------------
-
-template <class>
-struct ReverseTypeList;
-
-template <class Head, class... Tail>
-struct ReverseTypeList<TypeList<Head, Tail...>> {
-  template <class... ReversedTail>
-  struct impl {
-    using type = typename ReverseTypeList<TypeList<Tail...>>::template impl<
-        Head, ReversedTail...>::type;
-  };
-  using type = typename impl<>::type;
-};
-
-template <>
-struct ReverseTypeList<TypeList<>> {
-  template <class... ReversedTail>
-  struct impl {
-    using type = TypeList<ReversedTail...>;
-  };
-  using type = TypeList<>;
-};
-
-//----------------------------------------------------------------------------
-
 template <class T>
 struct make_all_extents_into_pointers {
   using type = T;

--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -243,9 +243,6 @@ struct if_c<true, void, FalseType> {
   using value_type = void;
 };
 
-template <typename Cond, typename TrueType, typename FalseType>
-struct if_ : public if_c<Cond::value, TrueType, FalseType> {};
-
 //----------------------------------------------------------------------------
 // These 'constexpr'functions can be used as
 // both regular functions and meta-function.


### PR DESCRIPTION
Removed more dead code related to metaprogramming facilities that I don't want to maintain (and that we don't need to maintain any more).

Removed:
* `if_`
* `is_label`
* `TypeList`
* `ReverseTypeList`