### PR TITLE
Remove unused utilities (forward, move, and expand_variadic) from Kokkos::Impl

### DIFF
--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -56,32 +56,6 @@
 namespace Kokkos {
 namespace Impl {
 
-// same as std::forward
-// needed to allow perfect forwarding on the device
-template <typename T>
-KOKKOS_INLINE_FUNCTION constexpr T&& forward(
-    typename std::remove_reference<T>::type& arg) noexcept {
-  return static_cast<T&&>(arg);
-}
-
-template <typename T>
-KOKKOS_INLINE_FUNCTION constexpr T&& forward(
-    typename std::remove_reference<T>::type&& arg) noexcept {
-  return static_cast<T&&>(arg);
-}
-
-// same as std::move
-// needed to allowing moving on the device
-template <typename T>
-KOKKOS_INLINE_FUNCTION constexpr typename std::remove_reference<T>::type&& move(
-    T&& arg) noexcept {
-  return static_cast<typename std::remove_reference<T>::type&&>(arg);
-}
-
-// empty function to allow expanding a variadic argument pack
-template <typename... Args>
-KOKKOS_INLINE_FUNCTION void expand_variadic(Args&&...) {}
-
 //----------------------------------------
 // C++14 integer sequence
 template <typename T, T... Ints>

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -63,11 +63,6 @@ class TestRangePolicyConstruction {
  private:
   void test_compile_time_parameters() {
     {
-      Kokkos::Impl::expand_variadic();
-      Kokkos::Impl::expand_variadic(1, 2, 3);
-    }
-
-    {
       using policy_t        = Kokkos::RangePolicy<>;
       using execution_space = typename policy_t::execution_space;
       using index_type      = typename policy_t::index_type;


### PR DESCRIPTION
This is more old stuff that's no longer used anywhere that I can find.