### PR TITLE
In hip summary, replace 'wavefront' with 'block'

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -114,7 +114,7 @@ void HIPInternal::print_configuration(std::ostream &s) const {
       << (dev_info.m_hipProp[i].major) << "." << dev_info.m_hipProp[i].minor
       << ", Total Global Memory: "
       << ::Kokkos::Impl::human_memory_size(dev_info.m_hipProp[i].totalGlobalMem)
-      << ", Shared Memory per Wavefront: "
+      << ", Shared Memory per Block: "
       << ::Kokkos::Impl::human_memory_size(
              dev_info.m_hipProp[i].sharedMemPerBlock);
     if (m_hipDev == i) s << " : Selected";


### PR DESCRIPTION
The summary prints out shared memory per block, not wavefront. This is consistent with CUDA, which also says "per block".