### PR TITLE
Fix clang-tidy complains for OpenMPTarget

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -153,7 +153,7 @@ void *SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
     allocate_tracked(const Kokkos::Experimental::OpenMPTargetSpace &arg_space,
                      const std::string &arg_alloc_label,
                      const size_t arg_alloc_size) {
-  if (!arg_alloc_size) return (void *)0;
+  if (!arg_alloc_size) return nullptr;
 
   SharedAllocationRecord *const r =
       allocate(arg_space, arg_alloc_label, arg_alloc_size);
@@ -166,7 +166,7 @@ void *SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
 void SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace,
                             void>::deallocate_tracked(void *const
                                                           arg_alloc_ptr) {
-  if (arg_alloc_ptr != 0) {
+  if (arg_alloc_ptr != nullptr) {
     SharedAllocationRecord *const r = get_record(arg_alloc_ptr);
 
     RecordBase::decrement(r);

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -739,7 +739,7 @@ class OpenMPTargetExecTeamMember {
                                // Properties ...> & team
       ,
       void* const glb_scratch, const int shmem_size_L1, const int shmem_size_L2)
-      : m_team_shared(0, 0),
+      : m_team_shared(nullptr, 0),
         m_team_scratch_size{shmem_size_L1, shmem_size_L2},
         m_team_rank(0),
         m_team_size(team_size),

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -53,12 +53,13 @@ KOKKOS_THREAD_LOCAL int SharedAllocationRecord<void, void>::t_tracking_enabled =
 #ifdef KOKKOS_ENABLE_DEBUG
 bool SharedAllocationRecord<void, void>::is_sane(
     SharedAllocationRecord<void, void>* arg_record) {
-  SharedAllocationRecord* const root = arg_record ? arg_record->m_root : 0;
+  SharedAllocationRecord* const root =
+      arg_record ? arg_record->m_root : nullptr;
 
-  bool ok = root != 0 && root->use_count() == 0;
+  bool ok = root != nullptr && root->use_count() == 0;
 
   if (ok) {
-    SharedAllocationRecord* root_next             = 0;
+    SharedAllocationRecord* root_next             = nullptr;
     static constexpr SharedAllocationRecord* zero = nullptr;
     // Lock the list:
     while ((root_next = Kokkos::atomic_exchange(&root->m_next, zero)) ==
@@ -131,7 +132,7 @@ bool SharedAllocationRecord<void, void>::is_sane(
 SharedAllocationRecord<void, void>* SharedAllocationRecord<void, void>::find(
     SharedAllocationRecord<void, void>* const arg_root,
     void* const arg_data_ptr) {
-  SharedAllocationRecord* root_next             = 0;
+  SharedAllocationRecord* root_next             = nullptr;
   static constexpr SharedAllocationRecord* zero = nullptr;
 
   // Lock the list:
@@ -148,7 +149,7 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<void, void>::find(
   }
 
   if (r == arg_root) {
-    r = 0;
+    r = nullptr;
   }
 
   if (nullptr != Kokkos::atomic_exchange(&arg_root->m_next, root_next)) {
@@ -183,8 +184,8 @@ SharedAllocationRecord<void, void>::SharedAllocationRecord(
 #ifdef KOKKOS_ENABLE_DEBUG
       ,
       m_root(arg_root),
-      m_prev(0),
-      m_next(0)
+      m_prev(nullptr),
+      m_next(nullptr)
 #endif
       ,
       m_count(0) {
@@ -251,7 +252,7 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<
     // after:   arg_record->m_prev->m_next == arg_record->m_next  &&
     //          arg_record->m_next->m_prev == arg_record->m_prev
 
-    SharedAllocationRecord* root_next             = 0;
+    SharedAllocationRecord* root_next             = nullptr;
     static constexpr SharedAllocationRecord* zero = nullptr;
 
     // Lock the list:
@@ -278,8 +279,8 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<
           "Kokkos::Impl::SharedAllocationRecord failed decrement unlocking");
     }
 
-    arg_record->m_next = 0;
-    arg_record->m_prev = 0;
+    arg_record->m_next = nullptr;
+    arg_record->m_prev = nullptr;
 #endif
 
     function_type d = arg_record->m_dealloc;


### PR DESCRIPTION
I couldn't quite figure out how to enable clang-tidy for the OpenMPTarget CI but thought it's at least worth fixing the current findings if I already have them.