### PR TITLE
SYCL zero-length reductions

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -202,6 +202,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
           ValueInit::init(functor, m_result_ptr);
           break;
         case sycl::usm::alloc::device:
+          // non-USM-allocated memory
         case sycl::usm::alloc::unknown:
           value_type host_result;
           ValueInit::init(functor, &host_result);

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -205,11 +205,10 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
         case sycl::usm::alloc::unknown:
           value_type host_result;
           ValueInit::init(functor, &host_result);
-          q.memcpy(m_result_ptr, &host_result, sizeof(host_result));
+          q.memcpy(m_result_ptr, &host_result, sizeof(host_result)).wait();
           break;
         default: break;
       }
-      q.wait();
       return;
     }
 

--- a/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
+++ b/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
@@ -84,8 +84,7 @@ struct TestReduction {
 
   // compare and equal
   void check_correctness() {
-    int sum_local = 0;
-    for (int i = 0; i < m_num_elements; ++i) sum_local += (i + 1);
+    const int sum_local = (m_num_elements * (m_num_elements + 1)) / 2;
 
     ASSERT_EQ(sum, sum_local * value)
         << "The reduced value does not match the expected answer";

--- a/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
+++ b/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
@@ -127,13 +127,15 @@ struct TestReduction {
 
   // Allocate Memory for both device and host memory spaces
   void init() {
-    // Allocate memory on Device space.
-    deviceData = allocate_mem<d_memspace_type>(m_num_elements);
-    ASSERT_NE(deviceData, nullptr);
+    if (m_num_elements > 0) {
+      // Allocate memory on Device space.
+      deviceData = allocate_mem<d_memspace_type>(m_num_elements);
+      ASSERT_NE(deviceData, nullptr);
 
-    // Allocate memory on Host space.
-    hostData = allocate_mem<h_memspace_type>(m_num_elements);
-    ASSERT_NE(hostData, nullptr);
+      // Allocate memory on Host space.
+      hostData = allocate_mem<h_memspace_type>(m_num_elements);
+      ASSERT_NE(hostData, nullptr);
+    }
 
     // Initialize the sum value to zero.
     sum = 0.0;
@@ -143,9 +145,11 @@ struct TestReduction {
     // Check if reduction has produced correct results
     check_correctness();
 
-    // free the allocated memory
-    free_mem<d_memspace_type>(deviceData);
-    free_mem<h_memspace_type>(hostData);
+    if (m_num_elements > 0) {
+      // free the allocated memory
+      free_mem<d_memspace_type>(deviceData);
+      free_mem<h_memspace_type>(hostData);
+    }
   }
 
   void sum_reduction() {
@@ -184,7 +188,7 @@ struct TestReduction {
 };
 
 TEST(TEST_CATEGORY, IncrTest_05_reduction) {
-  for (unsigned int i = 1; i < 100; ++i) {
+  for (unsigned int i = 0; i < 100; ++i) {
     TestReduction<TEST_EXECSPACE> test(i);
     test.sum_reduction();
     test.non_trivial_sum_reduction();


### PR DESCRIPTION
We need to guard adding to the queue if we don't really have any work to do. Also the `data` in `Test05_ParallelReduce_RangePolicy.hpp` seems to be unused and removing it allows the test to be simplified.