### PR TITLE
Enable container unit tests for SYCL

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -245,10 +245,13 @@ KOKKOS_INLINE_FUNCTION bool dyn_rank_view_verify_operator_bounds(
     return (size_t(i) < map.extent(R)) &&
            dyn_rank_view_verify_operator_bounds<R + 1>(rank, map, args...);
   } else if (i != 0) {
+    // FIXME_SYCL SYCL doesn't allow printf in kernels
+#ifndef KOKKOS_ENABLE_SYCL
     printf(
         "DynRankView Debug Bounds Checking Error: at rank %u\n  Extra "
         "arguments beyond the rank must be zero \n",
         R);
+#endif
     return (false) &&
            dyn_rank_view_verify_operator_bounds<R + 1>(rank, map, args...);
   } else {

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -206,6 +206,23 @@ struct DefaultContribution<Kokkos::Experimental::HIP,
 };
 #endif
 
+#ifdef KOKKOS_ENABLE_SYCL
+template <>
+struct DefaultDuplication<Kokkos::Experimental::SYCL> {
+  using type = Kokkos::Experimental::ScatterNonDuplicated;
+};
+template <>
+struct DefaultContribution<Kokkos::Experimental::SYCL,
+                           Kokkos::Experimental::ScatterNonDuplicated> {
+  using type = Kokkos::Experimental::ScatterAtomic;
+};
+template <>
+struct DefaultContribution<Kokkos::Experimental::SYCL,
+                           Kokkos::Experimental::ScatterDuplicated> {
+  using type = Kokkos::Experimental::ScatterAtomic;
+};
+#endif
+
 // FIXME All these scatter values need overhaul:
 //   - like should they be copyable at all?
 //   - what is the internal handle type

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -540,7 +540,10 @@ class UnorderedMap {
           // Previously claimed an unused entry that was not inserted.
           // Release this unused entry immediately.
           if (!m_available_indexes.reset(new_index)) {
+            // FIXME_SYCL SYCL doesn't allow printf in kernels
+#ifndef KOKKOS_ENABLE_SYCL
             printf("Unable to free existing\n");
+#endif
           }
         }
 

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -3,7 +3,7 @@ KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 KOKKOS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
 KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../src )
 
-foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP)
+foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
   # Because there is always an exception to the rule
   if(Tag STREQUAL "Threads")
     set(DEVICE "PTHREAD")
@@ -38,6 +38,11 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP)
       )
       list(APPEND UnitTestSources ${file})
     endforeach()
+    list(REMOVE_ITEM UnitTestSources
+        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_Bitset.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_ScatterView.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_UnorderedMap.cpp
+        )
     KOKKOS_ADD_EXECUTABLE_AND_TEST(UnitTest_${Tag} SOURCES ${UnitTestSources})
   endif()
 endforeach()

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -404,14 +404,19 @@ void test_dualview_resize() {
   Impl::test_dualview_resize<Scalar, Device>();
 }
 
+// FIXME_SYCL requires MDRange policy
+#ifndef KOKKOS_ENABLE_SYCL
 TEST(TEST_CATEGORY, dualview_combination) {
   test_dualview_combinations<int, TEST_EXECSPACE>(10, true);
 }
+#endif
 
 TEST(TEST_CATEGORY, dualview_alloc) {
   test_dualview_alloc<int, TEST_EXECSPACE>(10);
 }
 
+// FIXME_SYCL requires MDRange policy
+#ifndef KOKKOS_ENABLE_SYCL
 TEST(TEST_CATEGORY, dualview_combinations_without_init) {
   test_dualview_combinations<int, TEST_EXECSPACE>(10, false);
 }
@@ -428,6 +433,7 @@ TEST(TEST_CATEGORY, dualview_realloc) {
 TEST(TEST_CATEGORY, dualview_resize) {
   test_dualview_resize<int, TEST_EXECSPACE>();
 }
+#endif
 
 }  // namespace Test
 

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -1532,7 +1532,7 @@ class TestDynViewAPI {
     ASSERT_EQ(ds5.extent(5), ds5plus.extent(5));
 
 #if (!defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_UVM)) && \
-    !defined(KOKKOS_ENABLE_HIP)
+    !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
     ASSERT_EQ(&ds5(1, 1, 1, 1, 0) - &ds5plus(1, 1, 1, 1, 0), 0);
     ASSERT_EQ(&ds5(1, 1, 1, 1, 0, 0) - &ds5plus(1, 1, 1, 1, 0, 0),
               0);  // passing argument to rank beyond the view's rank is allowed

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -243,6 +243,8 @@ struct TestDynamicView {
   }
 };
 
+// FIXME_SYCL needs resize_serial
+#ifndef KOKKOS_ENABLE_SYCL
 TEST(TEST_CATEGORY, dynamic_view) {
   using TestDynView = TestDynamicView<double, TEST_EXECSPACE>;
 
@@ -250,6 +252,7 @@ TEST(TEST_CATEGORY, dynamic_view) {
     TestDynView::run(100000 + 100 * i);
   }
 }
+#endif
 
 }  // namespace Test
 

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -95,10 +95,6 @@ void test_offsetview_construction() {
   ASSERT_EQ(ov.extent(1), 5);
 
 #if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
-  const int ovmin0 = ov.begin(0);
-  const int ovend0 = ov.end(0);
-  const int ovmin1 = ov.begin(1);
-  const int ovend1 = ov.end(1);
   {
     Kokkos::Experimental::OffsetView<Scalar*, Device> offsetV1("OneDOffsetView",
                                                                range0);
@@ -133,6 +129,13 @@ void test_offsetview_construction() {
       }
     }
   }
+
+  // FIXME_SYCL requires MDRange policy
+#ifndef KOKKOS_ENABLE_SYCL
+  const int ovmin0 = ov.begin(0);
+  const int ovend0 = ov.end(0);
+  const int ovmin1 = ov.begin(1);
+  const int ovend1 = ov.end(1);
 
   using range_type =
       Kokkos::MDRangePolicy<Device, Kokkos::Rank<2>, Kokkos::IndexType<int> >;
@@ -176,6 +179,7 @@ void test_offsetview_construction() {
 
   ASSERT_EQ(OVResult, answer) << "Bad data found in OffsetView";
 #endif
+#endif
 
   {
     offset_view_type ovCopy(ov);
@@ -211,6 +215,8 @@ void test_offsetview_construction() {
                                   point3_type{{extent0, extent1, extent2}});
 
 #if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
+    // FIXME_SYCL requires MDRange policy
+#ifdef KOKKOS_ENABLE_SYCL
     int view3DSum = 0;
     Kokkos::parallel_reduce(
         rangePolicy3DZero,
@@ -233,6 +239,7 @@ void test_offsetview_construction() {
 
     ASSERT_EQ(view3DSum, offsetView3DSum)
         << "construction of OffsetView from View and begins array broken.";
+#endif
 #endif
   }
   view_type viewFromOV = ov.view();
@@ -259,6 +266,8 @@ void test_offsetview_construction() {
     Kokkos::deep_copy(aView, ov);
 
 #if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
+    // FIXME_SYCL requires MDRange policy
+#ifndef KOKKOS_ENABLE_SYCL
     int sum = 0;
     Kokkos::parallel_reduce(
         rangePolicy2D,
@@ -269,6 +278,7 @@ void test_offsetview_construction() {
 
     ASSERT_EQ(sum, 0) << "deep_copy(view, offsetView) broken.";
 #endif
+#endif
   }
 
   {  // test view to  offsetview deep copy
@@ -278,6 +288,8 @@ void test_offsetview_construction() {
     Kokkos::deep_copy(ov, aView);
 
 #if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
+    // FIXME_SYCL requires MDRange policy
+#ifndef KOKKOS_ENABLE_SYCL
     int sum = 0;
     Kokkos::parallel_reduce(
         rangePolicy2D,
@@ -287,6 +299,7 @@ void test_offsetview_construction() {
         sum);
 
     ASSERT_EQ(sum, 0) << "deep_copy(offsetView, view) broken.";
+#endif
 #endif
   }
 }
@@ -458,6 +471,8 @@ void test_offsetview_subview() {
       ASSERT_EQ(offsetSubview.end(1), 9);
 
 #if defined(KOKKOS_ENABLE_CUDA_LAMBDA) || !defined(KOKKOS_ENABLE_CUDA)
+      // FIXME_SYCL requires MDRange policy
+#ifndef KOKKOS_ENABLE_SYCL
       using range_type = Kokkos::MDRangePolicy<Device, Kokkos::Rank<2>,
                                                Kokkos::IndexType<int> >;
       using point_type = typename range_type::point_type;
@@ -483,6 +498,7 @@ void test_offsetview_subview() {
           sum);
 
       ASSERT_EQ(sum, 6 * (e0 - b0) * (e1 - b1));
+#endif
 #endif
     }
 
@@ -685,9 +701,12 @@ void test_offsetview_offsets_rank3() {
 }
 #endif
 
+// FIXME_SYCL needs MDRangePolicy
+#ifndef KOKKOS_ENABLE_SYCL
 TEST(TEST_CATEGORY, offsetview_construction) {
   test_offsetview_construction<int, TEST_EXECSPACE>();
 }
+#endif
 
 TEST(TEST_CATEGORY, offsetview_unmanaged_construction) {
   test_offsetview_unmanaged_construction<int, TEST_EXECSPACE>();

--- a/containers/unit_tests/TestSYCL_Category.hpp
+++ b/containers/unit_tests/TestSYCL_Category.hpp
@@ -1,0 +1,51 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_TEST_SYCL_HPP
+#define KOKKOS_TEST_SYCL_HPP
+
+#define TEST_CATEGORY sycl
+#define TEST_EXECSPACE Kokkos::Experimental::SYCL
+
+#endif

--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -200,8 +200,7 @@ void run_test_graph3(size_t B, size_t N) {
 
   for (size_t i = 0; i < B; i++) {
     size_t ne = 0;
-    for (size_t j = hx.row_block_offsets(i); j < hx.row_block_offsets(i + 1);
-         j++)
+    for (auto j = hx.row_block_offsets(i); j < hx.row_block_offsets(i + 1); j++)
       ne += hx.row_map(j + 1) - hx.row_map(j) + C;
 
     ASSERT_FALSE(
@@ -286,7 +285,10 @@ void run_test_graph4() {
 
 TEST(TEST_CATEGORY, staticcrsgraph) {
   TestStaticCrsGraph::run_test_graph<TEST_EXECSPACE>();
+  // FIXME_SYCL requires MDRangePolicy
+#ifndef KOKKOS_ENABLE_SYCL
   TestStaticCrsGraph::run_test_graph2<TEST_EXECSPACE>();
+#endif
   TestStaticCrsGraph::run_test_graph3<TEST_EXECSPACE>(1, 0);
   TestStaticCrsGraph::run_test_graph3<TEST_EXECSPACE>(1, 1000);
   TestStaticCrsGraph::run_test_graph3<TEST_EXECSPACE>(1, 10000);

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
@@ -77,7 +77,9 @@ class Kokkos::Impl::ParallelFor<FunctorType, ExecPolicy,
       cl::sycl::range<1> range(policy.end() - policy.begin());
 
       cgh.parallel_for(range, [=](cl::sycl::item<1> item) {
-        const typename Policy::index_type id = item.get_linear_id();
+        const typename Policy::index_type id =
+            static_cast<typename Policy::index_type>(item.get_linear_id()) +
+            policy.begin();
         if constexpr (std::is_same<WorkTag, void>::value)
           functor(id);
         else


### PR DESCRIPTION
The index passed in `parallel_for` and `parallel_reduce` also needed to be fixed for ranges not starting at 0.