### PR TITLE
[CUDA] Re-set preferred cache configuration if it changed

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -166,7 +166,12 @@ inline void configure_shmem_preference(KernelFuncPtr const& func,
         (prefer_shmem ? cudaFuncCachePreferShared : cudaFuncCachePreferL1)));
     return prefer_shmem;
   }();
-  (void)cache_config_preference_cached;
+  if (cache_config_preference_cached != prefer_shmem) {
+    CUDA_SAFE_CALL(cudaFuncSetCacheConfig(
+        func,
+        (prefer_shmem ? cudaFuncCachePreferShared : cudaFuncCachePreferL1)));
+    cache_config_preference_cached = prefer_shmem;
+  }
 #else
   // Use the parameters so we don't get a warning
   (void)func;

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -160,17 +160,15 @@ inline void configure_shmem_preference(KernelFuncPtr const& func,
                                        bool prefer_shmem) {
 #ifndef KOKKOS_ARCH_KEPLER
   // On Kepler the L1 has no benefit since it doesn't cache reads
-  static bool cache_config_preference_cached = [&] {
+  auto set_cache_config = [&] {
     CUDA_SAFE_CALL(cudaFuncSetCacheConfig(
         func,
         (prefer_shmem ? cudaFuncCachePreferShared : cudaFuncCachePreferL1)));
     return prefer_shmem;
-  }();
+  };
+  static bool cache_config_preference_cached = set_cache_config();
   if (cache_config_preference_cached != prefer_shmem) {
-    CUDA_SAFE_CALL(cudaFuncSetCacheConfig(
-        func,
-        (prefer_shmem ? cudaFuncCachePreferShared : cudaFuncCachePreferL1)));
-    cache_config_preference_cached = prefer_shmem;
+    cache_config_preference_cached = set_cache_config();
   }
 #else
   // Use the parameters so we don't get a warning


### PR DESCRIPTION
In #3363 @dhollman had added an assertion that the cache configuration did not change and that assertion was failing.  We had decided to remove it on the grounds that the PR was about refactoring code, not fixing a pre-existing bug.  And somehow we forgot about it...

While working on #3379 where specifying a desired occupancy may result into changing the preference, this code is potentially an issue.  The changes proposed in this PR do the obvious thing, we check whether the preference has changed and re-set it when necessary.