### PR TITLE
Fix ROCm 3.9 build

### DIFF
--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -128,7 +128,8 @@ int hip_internal_get_block_size(const F &condition_check,
     blocks_per_sm  = max_threads_per_sm / block_size;
     threads_per_sm = blocks_per_sm * block_size;
   }
-  int opt_block_size = (blocks_per_sm >= min_blocks_per_sm) ? block_size : 0;
+  int opt_block_size =
+      (blocks_per_sm >= min_blocks_per_sm) ? block_size : min_blocks_per_sm;
   int opt_threads_per_sm = threads_per_sm;
   // printf("BlockSizeMax: %i Shmem: %i %i %i %i Regs: %i %i Blocks: %i %i
   // Achieved: %i %i Opt: %i %i\n",block_size,

--- a/core/unit_test/TestTeamScratch.hpp
+++ b/core/unit_test/TestTeamScratch.hpp
@@ -55,8 +55,8 @@ TEST(TEST_CATEGORY, team_shared_request) {
 
 TEST(TEST_CATEGORY, team_scratch_request) {
   // FIXME_HIP the parallel_reduce in this test requires a team size larger than
-// 256
-#ifdef KOKKOS_ENABLE_HIP
+  // 256. Fixed in ROCm 3.9
+#if defined(KOKKOS_ENABLE_HIP) && (HIP_VERSION < 309)
   if (!std::is_same<TEST_EXECSPACE, Kokkos::Experimental::HIP>::value)
 #endif
   {
@@ -79,8 +79,8 @@ TEST(TEST_CATEGORY, shmem_size) { TestShmemSize<TEST_EXECSPACE>(); }
 
 TEST(TEST_CATEGORY, multi_level_scratch) {
   // FIXME_HIP the parallel_for and the parallel_reduce in this test requires a
-  // team size larger than 256
-#ifdef KOKKOS_ENABLE_HIP
+  // team size larger than 256. Fixed In ROCm 3.9
+#if defined(KOKKOS_ENABLE_HIP) && (HIP_VERSION < 309)
   if (!std::is_same<TEST_EXECSPACE, Kokkos::Experimental::HIP>::value)
 #endif
   {


### PR DESCRIPTION
This PR fixes ROCm 3.9 build. I've also added a comment that when we switch to ROCm 3.9 we can enable one more test. With ROCm 3.9, we need to disable a single test (atomic complex). Everything else passes but we have couple of tests (currently disabled) that segfault in Kokkos destructor. This is the weird bug that we have reported earlier. ROCm 3.9 seems to have fixed quite a few of the register spill bugs that we had.

cc: @arghdos, @stanmoore1 