### PR TITLE
Test05_ParallelReduce_RangePolicy.hpp: update for c++20

### DIFF
--- a/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
+++ b/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
@@ -68,6 +68,7 @@ struct NonTrivialReduceFunctor {
     UpdateSum += (i + 1) * value;
   }
 
+  NonTrivialReduceFunctor()                                = default;
   NonTrivialReduceFunctor(NonTrivialReduceFunctor const &) = default;
   NonTrivialReduceFunctor(NonTrivialReduceFunctor &&)      = default;
   NonTrivialReduceFunctor &operator=(NonTrivialReduceFunctor &&) = default;


### PR DESCRIPTION
Address issue #3568
Add default NonTrivialReduceFunctor ctor to bypass gcc/9.2 and clang/9 compilation error with c++20