### PR TITLE
Fix half precision base support

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -47,9 +47,9 @@
 
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
-#if !(defined(KOKKOS_COMPILER_CLANG) && KOKKOS_COMPILER_CLANG < 900) && \
-    !(defined(KOKKOS_ARCH_KEPLER30) || defined(KOKKOS_ARCH_KEPLER32) || \
-      defined(KOKKOS_ARCH_KEPLER37)) &&                                 \
+#if !(defined(KOKKOS_COMPILER_CLANG) && KOKKOS_COMPILER_CLANG < 900) &&  \
+    !(defined(KOKKOS_ARCH_KEPLER30) || defined(KOKKOS_ARCH_KEPLER32) ||  \
+      defined(KOKKOS_ARCH_KEPLER35) || defined(KOKKOS_ARCH_KEPLER37)) && \
     !(defined(KOKKOS_ARCH_MAXWELL50) || defined(KOKKOS_ARCH_MAXWELL52))
 #include <cuda_fp16.h>
 

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -47,10 +47,9 @@
 
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
-#if !(defined(KOKKOS_COMPILER_CLANG) && KOKKOS_COMPILER_CLANG < 900) &&  \
-    !(defined(KOKKOS_ARCH_KEPLER30) || defined(KOKKOS_ARCH_KEPLER32) ||  \
-      defined(KOKKOS_ARCH_KEPLER35) || defined(KOKKOS_ARCH_KEPLER37)) && \
-    !(defined(KOKKOS_ARCH_MAXWELL50) || defined(KOKKOS_ARCH_MAXWELL52))
+#if !(defined(KOKKOS_COMPILER_CLANG) && KOKKOS_COMPILER_CLANG < 900) && \
+    !((defined(KOKKOS_ARCH_KEPLER)) ||                                  \
+      !(defined(KOKKOS_ARCH_MAXWELL50) || defined(KOKKOS_ARCH_MAXWELL52)))
 #include <cuda_fp16.h>
 
 #ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -47,12 +47,13 @@
 
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
+#if !(defined(KOKKOS_COMPILER_CLANG) && KOKKOS_COMPILER_CLANG < 900) && \
+    !defined(KOKKOS_ARCH_KEPLER35)
 #include <cuda_fp16.h>
 
 #ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
 // Make sure no one else tries to define half_t
 #define KOKKOS_IMPL_HALF_TYPE_DEFINED
-#define KOKKOS_ENABLE_CUDA_HALF
 
 namespace Kokkos {
 namespace Impl {
@@ -442,8 +443,6 @@ class half_t {
   }
 };
 
-constexpr const bool half_is_float = false;
-
 // CUDA before 11.1 only has the half <-> float conversions marked host device
 // So we will largely convert to float on the host for conversion
 // But still call the correct functions on the device
@@ -705,4 +704,5 @@ KOKKOS_INLINE_FUNCTION
 }  // namespace Kokkos
 #endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
 #endif  // KOKKOS_ENABLE_CUDA
+#endif  // Disables for half_t on cuda: Clang/8||KEPLER35
 #endif

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -48,7 +48,9 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_CUDA
 #if !(defined(KOKKOS_COMPILER_CLANG) && KOKKOS_COMPILER_CLANG < 900) && \
-    !defined(KOKKOS_ARCH_KEPLER35)
+    !(defined(KOKKOS_ARCH_KEPLER30) || defined(KOKKOS_ARCH_KEPLER32) || \
+      defined(KOKKOS_ARCH_KEPLER37)) &&                                 \
+    !(defined(KOKKOS_ARCH_MAXWELL50) || defined(KOKKOS_ARCH_MAXWELL52))
 #include <cuda_fp16.h>
 
 #ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
@@ -704,5 +706,6 @@ KOKKOS_INLINE_FUNCTION
 }  // namespace Kokkos
 #endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
 #endif  // KOKKOS_ENABLE_CUDA
-#endif  // Disables for half_t on cuda: Clang/8||KEPLER35
+#endif  // Disables for half_t on cuda:
+        // Clang/8||KEPLER30||KEPLER32||KEPLER37||MAXWELL50||MAXWELL52
 #endif

--- a/core/src/Kokkos_Half.hpp
+++ b/core/src/Kokkos_Half.hpp
@@ -49,10 +49,7 @@
 #include <Kokkos_Macros.hpp>
 
 // Include special backend specific versions here
-// TODO: figure out why this include fails in Clang
-#if !(defined(KOKKOS_COMPILER_CLANG) && KOKKOS_COMPILER_CLANG < 900)
 #include <Cuda/Kokkos_Cuda_Half.hpp>
-#endif  // KOKKOS_COMPILER_CLANG
 
 // Potentially include special compiler specific versions here
 // e.g. for Intel
@@ -61,6 +58,7 @@
 // define a fallback implementation here using float
 #ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
 #define KOKKOS_IMPL_HALF_TYPE_DEFINED
+#define KOKKOS_HALF_T_IS_FLOAT true
 namespace Kokkos {
 namespace Impl {
 struct half_impl_t {
@@ -69,8 +67,7 @@ struct half_impl_t {
 }  // namespace Impl
 namespace Experimental {
 
-using half_t                       = Kokkos::Impl::half_impl_t::type;
-constexpr const bool half_is_float = true;
+using half_t = Kokkos::Impl::half_impl_t::type;
 
 // cast_to_half
 KOKKOS_INLINE_FUNCTION
@@ -116,5 +113,7 @@ cast_from_half(half_t val) {
 }  // namespace Experimental
 }  // namespace Kokkos
 
-#endif
-#endif
+#else
+#define KOKKOS_HALF_T_IS_FLOAT false
+#endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
+#endif  // KOKKOS_HALF_HPP_

--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -49,8 +49,8 @@ namespace Test {
 
 template <class T>
 void test_half_conversion_type() {
-  double epsilon = Kokkos::Experimental::half_is_float ? 0.0000003 : 0.0003;
-  T base         = static_cast<T>(3.3);
+  double epsilon                 = KOKKOS_HALF_T_IS_FLOAT ? 0.0000003 : 0.0003;
+  T base                         = static_cast<T>(3.3);
   Kokkos::Experimental::half_t a = Kokkos::Experimental::cast_to_half(base);
   T b                            = Kokkos::Experimental::cast_from_half<T>(a);
   ASSERT_TRUE((double(b - base) / double(base)) < epsilon);

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -305,7 +305,7 @@ struct Functor_TestHalfOperators {
 };
 
 void __test_half_operators(half_t h_lhs, half_t h_rhs) {
-  double epsilon = half_is_float ? FLT_EPSILON : FP16_EPSILON;
+  double epsilon = KOKKOS_HALF_T_IS_FLOAT ? FLT_EPSILON : FP16_EPSILON;
   Functor_TestHalfOperators<ViewType> f_device(h_lhs, h_rhs);  // Run on device
   Functor_TestHalfOperators<ViewTypeHost> f_host(h_lhs, h_rhs);  // Run on host
   typename ViewType::HostMirror f_device_actual_lhs =


### PR DESCRIPTION
Excludes Maxwell{50,52} and Keppler{37,32,35,30}.