### PR TITLE
Fixup constness change in CUDA Graph API

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -168,7 +168,7 @@ struct GraphImpl<Kokkos::Cuda> {
     auto /*const*/& pred_cuda_node = pred_ptr->node_details_t::node;
     KOKKOS_EXPECTS(bool(pred_cuda_node))
 
-    auto& cuda_node = arg_node_ptr->node_details_t::node;
+    auto /*const*/& cuda_node = arg_node_ptr->node_details_t::node;
     KOKKOS_EXPECTS(bool(cuda_node))
 
     CUDA_SAFE_CALL(

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -159,7 +159,13 @@ struct GraphImpl<Kokkos::Cuda> {
     auto pred_ptr = GraphAccess::get_node_ptr(arg_pred_ref);
     KOKKOS_EXPECTS(bool(pred_ptr))
 
-    auto& pred_cuda_node = pred_ptr->node_details_t::node;
+    // clang-format off
+    // NOTE const-qualifiers below are commented out because of an API break
+    // from CUDA 10.0 to CUDA 10.1
+    // cudaGraphAddDependencies(cudaGraph_t, cudaGraphNode_t*, cudaGraphNode_t*, size_t)
+    // cudaGraphAddDependencies(cudaGraph_t, const cudaGraphNode_t*, const cudaGraphNode_t*, size_t)
+    // clang-format on
+    auto /*const*/& pred_cuda_node = pred_ptr->node_details_t::node;
     KOKKOS_EXPECTS(bool(pred_cuda_node))
 
     auto& cuda_node = arg_node_ptr->node_details_t::node;

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -159,10 +159,10 @@ struct GraphImpl<Kokkos::Cuda> {
     auto pred_ptr = GraphAccess::get_node_ptr(arg_pred_ref);
     KOKKOS_EXPECTS(bool(pred_ptr))
 
-    auto const& pred_cuda_node = pred_ptr->node_details_t::node;
+    auto& pred_cuda_node = pred_ptr->node_details_t::node;
     KOKKOS_EXPECTS(bool(pred_cuda_node))
 
-    auto const& cuda_node = arg_node_ptr->node_details_t::node;
+    auto& cuda_node = arg_node_ptr->node_details_t::node;
     KOKKOS_EXPECTS(bool(cuda_node))
 
     CUDA_SAFE_CALL(


### PR DESCRIPTION
Apparently, very early versions of the CudaGraphs API had less constness than the newer ones 🤷🏼‍♀️

Fix #3562 and #3559