### PR TITLE
TestCXX11.hpp: fix signed overflow -Wall error with lambdas enabled

### DIFF
--- a/core/unit_test/TestCXX11.hpp
+++ b/core/unit_test/TestCXX11.hpp
@@ -150,9 +150,10 @@ double AddTestLambda() {
 
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(const team_member& dev) {
-          const int begin = dev.league_rank() * 4;
-          const int end   = begin + 4;
-          for (int i = begin + dev.team_rank(); i < end; i += dev.team_size()) {
+          const unsigned int begin = dev.league_rank() * 4;
+          const unsigned int end   = begin + 4;
+          for (unsigned int i = begin + dev.team_rank(); i < end;
+               i += dev.team_size()) {
             b(i, 0) = a(i, 1) + a(i, 2);
             b(i, 1) = a(i, 0) - a(i, 3);
             b(i, 2) = a(i, 4) + a(i, 0);
@@ -290,9 +291,10 @@ double ReduceTestLambda() {
     Kokkos::parallel_reduce(
         policy_type(25, Kokkos::AUTO),
         KOKKOS_LAMBDA(const team_member& dev, double& sum) {
-          const int begin = dev.league_rank() * 4;
-          const int end   = begin + 4;
-          for (int i = begin + dev.team_rank(); i < end; i += dev.team_size()) {
+          const unsigned int begin = dev.league_rank() * 4;
+          const unsigned int end   = begin + 4;
+          for (unsigned int i = begin + dev.team_rank(); i < end;
+               i += dev.team_size()) {
             sum += a(i, 1) + a(i, 2);
             sum += a(i, 0) - a(i, 3);
             sum += a(i, 4) + a(i, 0);


### PR DESCRIPTION
This change removes strict-overflow error triggered with -Wall and
-Werror in Cuda builds with lambda support enabled.
The strict-overflow error only occurs with the flag combo in Cuda builds
with nvcc+gcc compiler options, does not occur in builds with clang as
cuda compiler