### PR TITLE
Add atomic functions for unsigned long long using gcc built-in

### DIFF
--- a/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
+++ b/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
@@ -185,6 +185,12 @@ inline unsigned long atomic_compare_exchange(volatile unsigned long* const dest,
   return __sync_val_compare_and_swap(dest, compare, val);
 }
 
+inline unsigned long long atomic_compare_exchange(
+    volatile unsigned long long* const dest, const unsigned long long compare,
+    const unsigned long long val) {
+  return __sync_val_compare_and_swap(dest, compare, val);
+}
+
 #endif
 
 template <typename T>

--- a/core/src/impl/Kokkos_Atomic_Compare_Exchange_Weak.hpp
+++ b/core/src/impl/Kokkos_Atomic_Compare_Exchange_Weak.hpp
@@ -261,6 +261,12 @@ inline unsigned long atomic_compare_exchange(volatile unsigned long* const dest,
   return __sync_val_compare_and_swap(dest, compare, val);
 }
 
+inline unsigned long long atomic_compare_exchange(
+    volatile unsigned long long* const dest, const unsigned long long compare,
+    const unsigned long long val) {
+  return __sync_val_compare_and_swap(dest, compare, val);
+}
+
 #endif
 
 template <typename T>

--- a/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
@@ -234,6 +234,15 @@ inline unsigned long int atomic_fetch_add(
   return __sync_fetch_and_add(dest, val);
 }
 
+inline unsigned long long int atomic_fetch_add(
+    volatile unsigned long long int* const dest,
+    const unsigned long long int val) {
+#if defined(KOKKOS_ENABLE_RFO_PREFETCH)
+  _mm_prefetch((const char*)dest, _MM_HINT_ET0);
+#endif
+  return __sync_fetch_and_add(dest, val);
+}
+
 #endif
 
 template <typename T>

--- a/core/src/impl/Kokkos_Atomic_Fetch_And.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_And.hpp
@@ -132,6 +132,15 @@ inline unsigned long int atomic_fetch_and(
   return __sync_fetch_and_and(dest, val);
 }
 
+inline unsigned long long int atomic_fetch_and(
+    volatile unsigned long long int* const dest,
+    const unsigned long long int val) {
+#if defined(KOKKOS_ENABLE_RFO_PREFETCH)
+  _mm_prefetch((const char*)dest, _MM_HINT_ET0);
+#endif
+  return __sync_fetch_and_and(dest, val);
+}
+
 #endif
 
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
@@ -133,6 +133,15 @@ inline unsigned long int atomic_fetch_or(volatile unsigned long int* const dest,
   return __sync_fetch_and_or(dest, val);
 }
 
+inline unsigned long long int atomic_fetch_or(
+    volatile unsigned long long int* const dest,
+    const unsigned long long int val) {
+#if defined(KOKKOS_ENABLE_RFO_PREFETCH)
+  _mm_prefetch((const char*)dest, _MM_HINT_ET0);
+#endif
+  return __sync_fetch_and_or(dest, val);
+}
+
 #endif
 
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
@@ -209,6 +209,15 @@ inline unsigned long int atomic_fetch_sub(
   return __sync_fetch_and_sub(dest, val);
 }
 
+inline unsigned long long int atomic_fetch_sub(
+    volatile unsigned long long int* const dest,
+    const unsigned long long int val) {
+#if defined(KOKKOS_ENABLE_RFO_PREFETCH)
+  _mm_prefetch((const char*)dest, _MM_HINT_ET0);
+#endif
+  return __sync_fetch_and_sub(dest, val);
+}
+
 #endif
 
 template <typename T>


### PR DESCRIPTION
This fixes issue https://github.com/kokkos/kokkos/issues/3581 for me. I don't know why these overloads were missing since they are supported (see [here](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fsync-Builtins.html)). 

I am not sure of the exact problem in https://github.com/kokkos/kokkos/issues/3581 because I couldn't create a simple reproducer.