### PR TITLE
Fixup MDRangePolicy construction from Kokkos arrays

### DIFF
--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -309,6 +309,9 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
         "MDRangePolicy: Constructor initializer lists have wrong size");
   }
 
+  // NOTE: Keeping these two constructor despite the templated constructors
+  // from Kokkos arrays for backwards compability to allow construction from
+  // double-braced initializer lists.
   MDRangePolicy(point_type const& lower, point_type const& upper,
                 tile_type const& tile = tile_type{})
       : MDRangePolicy(typename traits::execution_space(), lower, upper, tile) {}

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -165,11 +165,12 @@ constexpr Array to_array_potentially_narrowing(const U (&init)[M]) {
 // is true to reduce code complexity.  You may change this if you have a good
 // reason to.  Intentionally not enabling std::array at this time but this may
 // change too.
-template <class IndexType, class Array, class U, std::size_t M>
-constexpr Array to_array_potentially_narrowing(
+template <class IndexType, class NVCC_WONT_LET_ME_CALL_YOU_Array, class U,
+          std::size_t M>
+constexpr NVCC_WONT_LET_ME_CALL_YOU_Array to_array_potentially_narrowing(
     Kokkos::Array<U, M> const& other) {
-  using T = typename Array::value_type;
-  Array a{};
+  using T = typename NVCC_WONT_LET_ME_CALL_YOU_Array::value_type;
+  NVCC_WONT_LET_ME_CALL_YOU_Array a{};
   constexpr std::size_t N = a.size();
   static_assert(M <= N, "");
   for (std::size_t i = 0; i < M; ++i) {

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -819,6 +819,18 @@ TEST(TEST_CATEGORY, desired_occupancy_converting_constructors) {
 }
 
 #ifndef KOKKOS_ENABLE_SYCL
+template <class T>
+void more_md_range_policy_construction_test() {
+  (void)Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{
+      Kokkos::Array<T, 2>{}, Kokkos::Array<T, 2>{}};
+
+  (void)Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{{T(0), T(0)}},
+                                                               {{T(2), T(2)}}};
+
+  (void)Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>{{T(0), T(0)},
+                                                               {T(2), T(2)}};
+}
+
 TEST(TEST_CATEGORY, md_range_policy_construction_from_arrays) {
   {
     // Check that construction from Kokkos::Array of long compiles for backwards
@@ -850,6 +862,21 @@ TEST(TEST_CATEGORY, md_range_policy_construction_from_arrays) {
            Kokkos::Array<index_type, 2>{{2, 3}},
            Kokkos::Array<index_type, 1>{{4}});
   }
+  {
+    // Check that construction from double-braced initliazer list
+    // works.
+    using index_type = unsigned long long;
+    Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>> p1({{0, 1}},
+                                                              {{2, 3}});
+    Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
+                          Kokkos::IndexType<index_type>>
+        p2({{0, 1}}, {{2, 3}});
+  }
+
+  more_md_range_policy_construction_test<char>();
+  more_md_range_policy_construction_test<int>();
+  more_md_range_policy_construction_test<unsigned long>();
+  more_md_range_policy_construction_test<std::int64_t>();
 }
 #endif
 

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -818,4 +818,39 @@ TEST(TEST_CATEGORY, desired_occupancy_converting_constructors) {
 #endif
 }
 
+#ifndef KOKKOS_ENABLE_SYCL
+TEST(TEST_CATEGORY, md_range_policy_construction_from_arrays) {
+  {
+    // Check that construction from Kokkos::Array of long compiles for backwards
+    // compability.  This was broken in
+    // https://github.com/kokkos/kokkos/pull/3527/commits/88ea8eec6567c84739d77bdd25fdbc647fae28bb#r512323639
+    Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>> p1(
+        Kokkos::Array<long, 2>{{0, 1}}, Kokkos::Array<long, 2>{{2, 3}});
+    Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>> p2(
+        Kokkos::Array<long, 2>{{0, 1}}, Kokkos::Array<long, 2>{{2, 3}});
+    Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>> p3(
+        Kokkos::Array<long, 2>{{0, 1}}, Kokkos::Array<long, 2>{{2, 3}},
+        Kokkos::Array<long, 1>{{4}});
+  }
+  {
+    // Check that construction from Kokkos::Array of the specified index type
+    // works.
+    using index_type = unsigned long long;
+    Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
+                          Kokkos::IndexType<index_type>>
+        p1(Kokkos::Array<index_type, 2>{{0, 1}},
+           Kokkos::Array<index_type, 2>{{2, 3}});
+    Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
+                          Kokkos::IndexType<index_type>>
+        p2(Kokkos::Array<index_type, 2>{{0, 1}},
+           Kokkos::Array<index_type, 2>{{2, 3}});
+    Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
+                          Kokkos::IndexType<index_type>>
+        p3(Kokkos::Array<index_type, 2>{{0, 1}},
+           Kokkos::Array<index_type, 2>{{2, 3}},
+           Kokkos::Array<index_type, 1>{{4}});
+  }
+}
+#endif
+
 }  // namespace Test


### PR DESCRIPTION
Changes from #3527 broke
```C++
Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>> policy(
    Kokkos::Array<long, 2>{0, 1},
    Kokkos::Array<long, 2>{2, 3});
```
Reported by @sslattery who noticed Cabana does not build with current HEAD of the `develop` branch
https://github.com/ECP-copa/Cabana/blob/a7ace070fa620dda285e7df2ed130416ec8524c8/cajita/src/Cajita_IndexSpace.hpp#L184-L186

The changes proposed enable constructions from Kokkos arrays of integral types (other than the internal storage type`std::int64_t` which should be seen as implementation detail).  Similarly to the construction from braced initializer lists, the conversions are checked.