### PR TITLE
core/Cuda: Handle half_t mixed precision

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -300,6 +300,8 @@ class half_t {
   }
 
   // Compund operators: upcast overloads for +=
+  // TODO: Determine why this overload is not considered
+  #if 0
   template <class T>
   KOKKOS_FUNCTION std::enable_if_t<
       std::is_same<T, float>::value || std::is_same<T, double>::value, T>
@@ -308,6 +310,7 @@ class half_t {
     val = static_cast<impl_type>(result);
     return static_cast<T>(val);
   }
+  #endif
 
   KOKKOS_FUNCTION
   half_t& operator+=(float rhs) {

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -340,6 +340,7 @@ class half_t {
     return lhs;
   }
 
+  // Binary Arithmetic upcast operators for +
   template <class T>
   KOKKOS_FUNCTION std::enable_if_t<
       std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
@@ -364,6 +365,7 @@ class half_t {
     return lhs;
   }
 
+  // Binary Arithmetic upcast operators for -
   template <class T>
   KOKKOS_FUNCTION std::enable_if_t<
       std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
@@ -388,6 +390,7 @@ class half_t {
     return lhs;
   }
 
+  // Binary Arithmetic upcast operators for *
   template <class T>
   KOKKOS_FUNCTION std::enable_if_t<
       std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
@@ -412,6 +415,7 @@ class half_t {
     return lhs;
   }
 
+  // Binary Arithmetic upcast operators for /
   template <class T>
   KOKKOS_FUNCTION std::enable_if_t<
       std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -300,15 +300,12 @@ class half_t {
   }
 
   // Compund operators: upcast overloads for +=
-  // TODO: Determine why this overload is not considered
-  #if 1
   template <class T>
   KOKKOS_FUNCTION std::enable_if_t<
       std::is_same<T, float>::value || std::is_same<T, double>::value, T>
   friend operator+=(T lhs, half_t rhs) {
     return lhs + static_cast<T>(rhs);
   }
-#endif
 
   KOKKOS_FUNCTION
   half_t& operator+=(float rhs) {

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -306,9 +306,7 @@ class half_t {
   KOKKOS_FUNCTION std::enable_if_t<
       std::is_same<T, float>::value || std::is_same<T, double>::value, T>
   friend operator+=(T lhs, half_t rhs) {
-    lhs = lhs + static_cast<T>(rhs);
-    val = static_cast<impl_type>(lhs);
-    return lhs;
+    return lhs + static_cast<T>(rhs);
   }
 #endif
 

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -300,16 +300,13 @@ class half_t {
   }
 
   // Compund operators: upcast overloads for +=
-  float operator+=(half_t rhs) {
-    float result = static_cast<float>(val) + static_cast<float>(rhs);
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T>
+  operator+=(half_t rhs) {
+    T result = static_cast<T>(val) + static_cast<T>(rhs);
     val = static_cast<impl_type>(result);
-    return result;
-  }
-
-  double operator+=(half_t rhs) {
-    double result = static_cast<double>(val) + static_cast<double>(rhs);
-    val = static_cast<impl_type>(result);
-    return result;
+    return static_cast<T>(val);
   }
 
   KOKKOS_FUNCTION

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -332,6 +332,29 @@ class half_t {
     return *this;
   }
 
+  // Compund operators: upcast overloads for -=
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator-=(T& lhs, half_t rhs) {
+    lhs -= static_cast<T>(rhs);
+    return lhs;
+  }
+
+  KOKKOS_FUNCTION
+  half_t& operator-=(float rhs) {
+    float result = static_cast<float>(val) - rhs;
+    val          = static_cast<impl_type>(result);
+    return *this;
+  }
+
+  KOKKOS_FUNCTION
+  half_t& operator-=(double rhs) {
+    double result = static_cast<double>(val) - rhs;
+    val           = static_cast<impl_type>(result);
+    return *this;
+  }
+
   KOKKOS_FUNCTION
   half_t& operator*=(half_t rhs) {
 #ifdef __CUDA_ARCH__
@@ -342,6 +365,29 @@ class half_t {
     return *this;
   }
 
+  // Compund operators: upcast overloads for *=
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator*=(T& lhs, half_t rhs) {
+    lhs *= static_cast<T>(rhs);
+    return lhs;
+  }
+
+  KOKKOS_FUNCTION
+  half_t& operator*=(float rhs) {
+    float result = static_cast<float>(val) * rhs;
+    val          = static_cast<impl_type>(result);
+    return *this;
+  }
+
+  KOKKOS_FUNCTION
+  half_t& operator*=(double rhs) {
+    double result = static_cast<double>(val) * rhs;
+    val           = static_cast<impl_type>(result);
+    return *this;
+  }
+
   KOKKOS_FUNCTION
   half_t& operator/=(half_t rhs) {
 #ifdef __CUDA_ARCH__
@@ -349,6 +395,29 @@ class half_t {
 #else
     val     = __float2half(__half2float(val) / __half2float(rhs.val));
 #endif
+    return *this;
+  }
+
+  // Compund operators: upcast overloads for /=
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator/=(T& lhs, half_t rhs) {
+    lhs /= static_cast<T>(rhs);
+    return lhs;
+  }
+
+  KOKKOS_FUNCTION
+  half_t& operator/=(float rhs) {
+    float result = static_cast<float>(val) / rhs;
+    val          = static_cast<impl_type>(result);
+    return *this;
+  }
+
+  KOKKOS_FUNCTION
+  half_t& operator/=(double rhs) {
+    double result = static_cast<double>(val) / rhs;
+    val           = static_cast<impl_type>(result);
     return *this;
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -299,16 +299,16 @@ class half_t {
     return *this;
   }
 
-// Compund operators: upcast overloads for +=
-// TODO: Determine why this overload is not considered
-#if 0
+  // Compund operators: upcast overloads for +=
+  // TODO: Determine why this overload is not considered
+  #if 1
   template <class T>
   KOKKOS_FUNCTION std::enable_if_t<
       std::is_same<T, float>::value || std::is_same<T, double>::value, T>
-  operator+=(half_t rhs) {
-    T result = static_cast<T>(val) + static_cast<T>(rhs);
-    val = static_cast<impl_type>(result);
-    return static_cast<T>(val);
+  friend operator+=(T lhs, half_t rhs) {
+    lhs = lhs + static_cast<T>(rhs);
+    val = static_cast<impl_type>(lhs);
+    return lhs;
   }
 #endif
 

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -303,8 +303,9 @@ class half_t {
   template <class T>
   KOKKOS_FUNCTION std::enable_if_t<
       std::is_same<T, float>::value || std::is_same<T, double>::value, T>
-  friend operator+=(T lhs, half_t rhs) {
-    return lhs + static_cast<T>(rhs);
+  friend operator+=(T& lhs, half_t rhs) {
+    lhs += static_cast<T>(rhs);
+    return lhs;
   }
 
   KOKKOS_FUNCTION

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -299,6 +299,30 @@ class half_t {
     return *this;
   }
 
+  // Compund operators: upcast overloads for +=
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T>
+  operator+=(half_t rhs) {
+    T result = static_cast<T>(val) + static_cast<T>(rhs);
+    val = static_cast<impl_type>(result);
+    return *this;
+  }
+
+  KOKKOS_FUNCTION
+  half_t& operator+=(float rhs) {
+    float result = static_cast<float>(val) + rhs;
+    val = static_cast<impl_type>(result);
+    return *this;
+  }
+
+  KOKKOS_FUNCTION
+  half_t& operator+=(double rhs) {
+    double result = static_cast<double>(val) + rhs;
+    val = static_cast<impl_type>(result);
+    return *this;
+  }
+
   KOKKOS_FUNCTION
   half_t& operator-=(half_t rhs) {
 #ifdef __CUDA_ARCH__

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -300,13 +300,16 @@ class half_t {
   }
 
   // Compund operators: upcast overloads for +=
-  template <class T>
-  KOKKOS_FUNCTION std::enable_if_t<
-      std::is_same<T, float>::value || std::is_same<T, double>::value, T>
-  operator+=(half_t rhs) {
-    T result = static_cast<T>(val) + static_cast<T>(rhs);
+  float operator+=(half_t rhs) {
+    float result = static_cast<float>(val) + static_cast<float>(rhs);
     val = static_cast<impl_type>(result);
-    return *this;
+    return result;
+  }
+
+  double operator+=(half_t rhs) {
+    double result = static_cast<double>(val) + static_cast<double>(rhs);
+    val = static_cast<impl_type>(result);
+    return result;
   }
 
   KOKKOS_FUNCTION

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -299,9 +299,9 @@ class half_t {
     return *this;
   }
 
-  // Compund operators: upcast overloads for +=
-  // TODO: Determine why this overload is not considered
-  #if 0
+// Compund operators: upcast overloads for +=
+// TODO: Determine why this overload is not considered
+#if 0
   template <class T>
   KOKKOS_FUNCTION std::enable_if_t<
       std::is_same<T, float>::value || std::is_same<T, double>::value, T>
@@ -310,19 +310,19 @@ class half_t {
     val = static_cast<impl_type>(result);
     return static_cast<T>(val);
   }
-  #endif
+#endif
 
   KOKKOS_FUNCTION
   half_t& operator+=(float rhs) {
     float result = static_cast<float>(val) + rhs;
-    val = static_cast<impl_type>(result);
+    val          = static_cast<impl_type>(result);
     return *this;
   }
 
   KOKKOS_FUNCTION
   half_t& operator+=(double rhs) {
     double result = static_cast<double>(val) + rhs;
-    val = static_cast<impl_type>(result);
+    val           = static_cast<impl_type>(result);
     return *this;
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -302,8 +302,8 @@ class half_t {
   // Compund operators: upcast overloads for +=
   template <class T>
   KOKKOS_FUNCTION std::enable_if_t<
-      std::is_same<T, float>::value || std::is_same<T, double>::value, T>
-  friend operator+=(T& lhs, half_t rhs) {
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator+=(T& lhs, half_t rhs) {
     lhs += static_cast<T>(rhs);
     return lhs;
   }

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -175,30 +175,42 @@ class half_t {
     return cast_from_half<unsigned long long>(*this);
   }
 
+  /**
+   * Conversion constructors.
+   *
+   * Support implicit conversions from impl_type, float, double -> half_t
+   * Mixed precision expressions require upcasting which is done in the
+   * "// Binary Arithmetic" operator overloads below.
+   *
+   * Support implicit conversions from integral types -> half_t.
+   * Expressions involving half_t with integral types require downcasting
+   * the integral types to half_t. Existing operator overloads can handle this
+   * with the addition of the below implicit conversion constructors.
+   */
   KOKKOS_FUNCTION
   half_t(impl_type rhs) : val(rhs) {}
   KOKKOS_FUNCTION
-  explicit half_t(float rhs) : val(cast_to_half(rhs).val) {}
+  half_t(float rhs) : val(cast_to_half(rhs).val) {}
+  KOKKOS_FUNCTION
+  half_t(double rhs) : val(cast_to_half(rhs).val) {}
   KOKKOS_FUNCTION
   explicit half_t(bool rhs) : val(cast_to_half(rhs).val) {}
   KOKKOS_FUNCTION
-  explicit half_t(double rhs) : val(cast_to_half(rhs).val) {}
+  half_t(short rhs) : val(cast_to_half(rhs).val) {}
   KOKKOS_FUNCTION
-  explicit half_t(short rhs) : val(cast_to_half(rhs).val) {}
+  half_t(int rhs) : val(cast_to_half(rhs).val) {}
   KOKKOS_FUNCTION
-  explicit half_t(int rhs) : val(cast_to_half(rhs).val) {}
+  half_t(long rhs) : val(cast_to_half(rhs).val) {}
   KOKKOS_FUNCTION
-  explicit half_t(long rhs) : val(cast_to_half(rhs).val) {}
+  half_t(long long rhs) : val(cast_to_half(rhs).val) {}
   KOKKOS_FUNCTION
-  explicit half_t(long long rhs) : val(cast_to_half(rhs).val) {}
+  half_t(unsigned short rhs) : val(cast_to_half(rhs).val) {}
   KOKKOS_FUNCTION
-  explicit half_t(unsigned short rhs) : val(cast_to_half(rhs).val) {}
+  half_t(unsigned int rhs) : val(cast_to_half(rhs).val) {}
   KOKKOS_FUNCTION
-  explicit half_t(unsigned int rhs) : val(cast_to_half(rhs).val) {}
+  half_t(unsigned long rhs) : val(cast_to_half(rhs).val) {}
   KOKKOS_FUNCTION
-  explicit half_t(unsigned long rhs) : val(cast_to_half(rhs).val) {}
-  KOKKOS_FUNCTION
-  explicit half_t(unsigned long long rhs) : val(cast_to_half(rhs).val) {}
+  half_t(unsigned long long rhs) : val(cast_to_half(rhs).val) {}
 
   // Unary operators
   KOKKOS_FUNCTION
@@ -328,6 +340,20 @@ class half_t {
     return lhs;
   }
 
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator+(half_t lhs, T rhs) {
+    return T(lhs) + rhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator+(T lhs, half_t rhs) {
+    return lhs + T(rhs);
+  }
+
   KOKKOS_FUNCTION
   half_t friend operator-(half_t lhs, half_t rhs) {
 #ifdef __CUDA_ARCH__
@@ -336,6 +362,20 @@ class half_t {
     lhs.val = __float2half(__half2float(lhs.val) - __half2float(rhs.val));
 #endif
     return lhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator-(half_t lhs, T rhs) {
+    return T(lhs) - rhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator-(T lhs, half_t rhs) {
+    return lhs - T(rhs);
   }
 
   KOKKOS_FUNCTION
@@ -348,6 +388,20 @@ class half_t {
     return lhs;
   }
 
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator*(half_t lhs, T rhs) {
+    return T(lhs) * rhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator*(T lhs, half_t rhs) {
+    return lhs * T(rhs);
+  }
+
   KOKKOS_FUNCTION
   half_t friend operator/(half_t lhs, half_t rhs) {
 #ifdef __CUDA_ARCH__
@@ -356,6 +410,20 @@ class half_t {
     lhs.val = __float2half(__half2float(lhs.val) / __half2float(rhs.val));
 #endif
     return lhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator/(half_t lhs, T rhs) {
+    return T(lhs) / rhs;
+  }
+
+  template <class T>
+  KOKKOS_FUNCTION std::enable_if_t<
+      std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
+  operator/(T lhs, half_t rhs) {
+    return lhs / T(rhs);
   }
 
   // Logical operators

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -74,7 +74,7 @@ enum OP_TESTS {
   CMUL_H_S,
   CDIV_H_H,
   CDIV_H_S,
-  ADD_H_H, 
+  ADD_H_H,
   ADD_H_S,
   ADD_S_H,
   ADD_H_D,
@@ -120,29 +120,128 @@ enum OP_TESTS {
   SUB_H_S,
   SUB_S_H,
   SUB_H_D,
-  SUB_D_H,  // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+  SUB_D_H,
+  SUB_H_H_SZ,
   SUB_H_S_SZ,
   SUB_S_H_SZ,
   SUB_H_D_SZ,
   SUB_D_H_SZ,
+  SUB_SI_H,
+  SUB_SI_H_SZ,
+  SUB_I_H,
+  SUB_I_H_SZ,
+  SUB_LI_H,
+  SUB_LI_H_SZ,
+  SUB_LLI_H,
+  SUB_LLI_H_SZ,
+  SUB_USI_H,
+  SUB_USI_H_SZ,
+  SUB_UI_H,
+  SUB_UI_H_SZ,
+  SUB_ULI_H,
+  SUB_ULI_H_SZ,
+  SUB_ULLI_H,
+  SUB_ULLI_H_SZ,
+  SUB_H_SI,
+  SUB_H_SI_SZ,
+  SUB_H_I,
+  SUB_H_I_SZ,
+  SUB_H_LI,
+  SUB_H_LI_SZ,
+  SUB_H_LLI,
+  SUB_H_LLI_SZ,
+  SUB_H_USI,
+  SUB_H_USI_SZ,
+  SUB_H_UI,
+  SUB_H_UI_SZ,
+  SUB_H_ULI,
+  SUB_H_ULI_SZ,
+  SUB_H_ULLI,
+  SUB_H_ULLI_SZ,
   MUL_H_H,
   MUL_H_S,
   MUL_S_H,
   MUL_H_D,
-  MUL_D_H,  // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+  MUL_D_H,
+  MUL_H_H_SZ,
   MUL_H_S_SZ,
   MUL_S_H_SZ,
   MUL_H_D_SZ,
   MUL_D_H_SZ,
+  MUL_SI_H,
+  MUL_SI_H_SZ,
+  MUL_I_H,
+  MUL_I_H_SZ,
+  MUL_LI_H,
+  MUL_LI_H_SZ,
+  MUL_LLI_H,
+  MUL_LLI_H_SZ,
+  MUL_USI_H,
+  MUL_USI_H_SZ,
+  MUL_UI_H,
+  MUL_UI_H_SZ,
+  MUL_ULI_H,
+  MUL_ULI_H_SZ,
+  MUL_ULLI_H,
+  MUL_ULLI_H_SZ,
+  MUL_H_SI,
+  MUL_H_SI_SZ,
+  MUL_H_I,
+  MUL_H_I_SZ,
+  MUL_H_LI,
+  MUL_H_LI_SZ,
+  MUL_H_LLI,
+  MUL_H_LLI_SZ,
+  MUL_H_USI,
+  MUL_H_USI_SZ,
+  MUL_H_UI,
+  MUL_H_UI_SZ,
+  MUL_H_ULI,
+  MUL_H_ULI_SZ,
+  MUL_H_ULLI,
+  MUL_H_ULLI_SZ,
   DIV_H_H,
   DIV_H_S,
   DIV_S_H,
   DIV_H_D,
-  DIV_D_H,  // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+  DIV_D_H,
+  DIV_H_H_SZ,
   DIV_H_S_SZ,
   DIV_S_H_SZ,
   DIV_H_D_SZ,
   DIV_D_H_SZ,
+  DIV_SI_H,
+  DIV_SI_H_SZ,
+  DIV_I_H,
+  DIV_I_H_SZ,
+  DIV_LI_H,
+  DIV_LI_H_SZ,
+  DIV_LLI_H,
+  DIV_LLI_H_SZ,
+  DIV_USI_H,
+  DIV_USI_H_SZ,
+  DIV_UI_H,
+  DIV_UI_H_SZ,
+  DIV_ULI_H,
+  DIV_ULI_H_SZ,
+  DIV_ULLI_H,
+  DIV_ULLI_H_SZ,
+  DIV_H_SI,
+  DIV_H_SI_SZ,
+  DIV_H_I,
+  DIV_H_I_SZ,
+  DIV_H_LI,
+  DIV_H_LI_SZ,
+  DIV_H_LLI,
+  DIV_H_LLI_SZ,
+  DIV_H_USI,
+  DIV_H_USI_SZ,
+  DIV_H_UI,
+  DIV_H_UI_SZ,
+  DIV_H_ULI,
+  DIV_H_ULI_SZ,
+  DIV_H_ULLI,
+  DIV_H_ULLI_SZ,
   NEG,
   AND,
   OR,
@@ -151,7 +250,7 @@ enum OP_TESTS {
   LT,
   GT,
   LE,
-  GE, // TODO: TW,
+  GE,  // TODO: TW,
   PASS_BY_REF,
   AO_IMPL_HALF,
   AO_HALF_T,
@@ -171,11 +270,6 @@ struct Functor_TestHalfOperators {
     d_lhs        = cast_from_half<double>(h_lhs);
     d_rhs        = cast_from_half<double>(h_rhs);
 
-    for (int i = 0; i < N_OP_TESTS; ++i) {
-      actual_lhs(i) = 1;
-      expected_lhs(i) = -1;
-    }
-
     if (std::is_same<view_type, ViewTypeHost>::value) {
       auto run_on_host = *this;
       run_on_host(0);
@@ -185,13 +279,15 @@ struct Functor_TestHalfOperators {
     }
   }
 
-  template<class LhsType, class RhsType, class ExpectedResultType>
-  KOKKOS_INLINE_FUNCTION
-  void test_add(int op_test_idx, int op_test_sz_idx) const {
-    auto sum                = static_cast<LhsType>(h_lhs) + static_cast<RhsType>(h_rhs);
+  // BEGIN: Binary Arithmetic test helpers
+  template <class LhsType, class RhsType, class ExpectedResultType>
+  KOKKOS_INLINE_FUNCTION void test_add(int op_test_idx,
+                                       int op_test_sz_idx) const {
+    auto sum = static_cast<LhsType>(h_lhs) + static_cast<RhsType>(h_rhs);
     actual_lhs(op_test_idx) = static_cast<double>(sum);
 
-    if (std::is_same<RhsType, half_t>::value && std::is_same<LhsType, half_t>::value) {
+    if (std::is_same<RhsType, half_t>::value &&
+        std::is_same<LhsType, half_t>::value) {
       expected_lhs(op_test_idx) = d_lhs + d_rhs;
     } else {
       if (std::is_same<LhsType, half_t>::value)
@@ -204,12 +300,79 @@ struct Functor_TestHalfOperators {
     expected_lhs(op_test_sz_idx) = sizeof(ExpectedResultType);
   }
 
+  template <class LhsType, class RhsType, class ExpectedResultType>
+  KOKKOS_INLINE_FUNCTION void test_sub(int op_test_idx,
+                                       int op_test_sz_idx) const {
+    auto result = static_cast<LhsType>(h_lhs) - static_cast<RhsType>(h_rhs);
+    actual_lhs(op_test_idx) = static_cast<double>(result);
+
+    if (std::is_same<RhsType, half_t>::value &&
+        std::is_same<LhsType, half_t>::value) {
+      expected_lhs(op_test_idx) = d_lhs - d_rhs;
+    } else {
+      if (std::is_same<LhsType, half_t>::value)
+        expected_lhs(op_test_idx) = d_lhs - static_cast<RhsType>(d_rhs);
+      if (std::is_same<RhsType, half_t>::value)
+        expected_lhs(op_test_idx) = static_cast<LhsType>(d_lhs) - d_rhs;
+    }
+
+    actual_lhs(op_test_sz_idx)   = sizeof(result);
+    expected_lhs(op_test_sz_idx) = sizeof(ExpectedResultType);
+  }
+
+  template <class LhsType, class RhsType, class ExpectedResultType>
+  KOKKOS_INLINE_FUNCTION void test_mul(int op_test_idx,
+                                       int op_test_sz_idx) const {
+    auto result = static_cast<LhsType>(h_lhs) * static_cast<RhsType>(h_rhs);
+    actual_lhs(op_test_idx) = static_cast<double>(result);
+
+    if (std::is_same<RhsType, half_t>::value &&
+        std::is_same<LhsType, half_t>::value) {
+      expected_lhs(op_test_idx) = d_lhs * d_rhs;
+    } else {
+      if (std::is_same<LhsType, half_t>::value)
+        expected_lhs(op_test_idx) = d_lhs * static_cast<RhsType>(d_rhs);
+      if (std::is_same<RhsType, half_t>::value)
+        expected_lhs(op_test_idx) = static_cast<LhsType>(d_lhs) * d_rhs;
+    }
+
+    actual_lhs(op_test_sz_idx)   = sizeof(result);
+    expected_lhs(op_test_sz_idx) = sizeof(ExpectedResultType);
+  }
+
+  template <class LhsType, class RhsType, class ExpectedResultType>
+  KOKKOS_INLINE_FUNCTION void test_div(int op_test_idx,
+                                       int op_test_sz_idx) const {
+    auto result = static_cast<LhsType>(h_lhs) / static_cast<RhsType>(h_rhs);
+    actual_lhs(op_test_idx) = static_cast<double>(result);
+
+    if (std::is_same<RhsType, half_t>::value &&
+        std::is_same<LhsType, half_t>::value) {
+      expected_lhs(op_test_idx) = d_lhs / d_rhs;
+    } else {
+      if (std::is_same<LhsType, half_t>::value)
+        expected_lhs(op_test_idx) = d_lhs / static_cast<RhsType>(d_rhs);
+      if (std::is_same<RhsType, half_t>::value)
+        expected_lhs(op_test_idx) = static_cast<LhsType>(d_lhs) / d_rhs;
+    }
+
+    actual_lhs(op_test_sz_idx)   = sizeof(result);
+    expected_lhs(op_test_sz_idx) = sizeof(ExpectedResultType);
+  }
+  // END: Binary Arithmetic test helpers
+
   KOKKOS_FUNCTION
   void operator()(int) const {
     half_t tmp_lhs, tmp2_lhs, *tmp_ptr;
     double tmp_d_lhs;
     using half_impl_type = Kokkos::Impl::half_impl_t::type;
     half_impl_type half_tmp;
+
+    // Initialze output views to catch missing test invocations
+    for (int i = 0; i < N_OP_TESTS; ++i) {
+      actual_lhs(i)   = 1;
+      expected_lhs(i) = -1;
+    }
 
     tmp_lhs              = h_lhs;
     actual_lhs(ASSIGN)   = cast_from_half<double>(tmp_lhs);
@@ -298,7 +461,7 @@ struct Functor_TestHalfOperators {
     actual_lhs(CDIV_H_S)   = cast_from_half<double>(tmp_lhs);
     expected_lhs(CDIV_H_S) = d_lhs;
     expected_lhs(CDIV_H_S) /= d_rhs;
-   
+
     test_add<half_t, half_t, half_t>(ADD_H_H, ADD_H_H_SZ);
     test_add<float, half_t, float>(ADD_S_H, ADD_S_H_SZ);
     test_add<double, half_t, double>(ADD_D_H, ADD_D_H_SZ);
@@ -313,124 +476,211 @@ struct Functor_TestHalfOperators {
     test_add<half_t, long int, half_t>(ADD_H_LI, ADD_H_LI_SZ);
     test_add<half_t, long long int, half_t>(ADD_H_LLI, ADD_H_LLI_SZ);
 
-    if (h_lhs >= 0 && h_rhs >= 0) {
+    // Check for potential overflow due to negative half_t -> unsigned integral
+    // cast
+    if (h_lhs >= 0) {
       test_add<unsigned short int, half_t, half_t>(ADD_USI_H, ADD_USI_H_SZ);
       test_add<unsigned int, half_t, half_t>(ADD_UI_H, ADD_UI_H_SZ);
       test_add<unsigned long int, half_t, half_t>(ADD_ULI_H, ADD_ULI_H_SZ);
-      test_add<unsigned long long int, half_t, half_t>(ADD_ULLI_H, ADD_ULLI_H_SZ);
+      test_add<unsigned long long int, half_t, half_t>(ADD_ULLI_H,
+                                                       ADD_ULLI_H_SZ);
+    } else {
+      actual_lhs(ADD_USI_H)     = expected_lhs(ADD_USI_H);
+      actual_lhs(ADD_USI_H_SZ)  = expected_lhs(ADD_USI_H_SZ);
+      actual_lhs(ADD_UI_H)      = expected_lhs(ADD_UI_H);
+      actual_lhs(ADD_UI_H_SZ)   = expected_lhs(ADD_UI_H_SZ);
+      actual_lhs(ADD_ULI_H)     = expected_lhs(ADD_ULI_H);
+      actual_lhs(ADD_ULI_H_SZ)  = expected_lhs(ADD_ULI_H_SZ);
+      actual_lhs(ADD_ULLI_H)    = expected_lhs(ADD_ULLI_H);
+      actual_lhs(ADD_ULLI_H_SZ) = expected_lhs(ADD_ULLI_H_SZ);
+    }
+
+    // Check for potential overflow due to negative half_t -> unsigned integral
+    // cast
+    if (h_rhs >= 0) {
       test_add<half_t, unsigned short int, half_t>(ADD_H_USI, ADD_H_USI_SZ);
       test_add<half_t, unsigned int, half_t>(ADD_H_UI, ADD_H_UI_SZ);
       test_add<half_t, unsigned long int, half_t>(ADD_H_ULI, ADD_H_ULI_SZ);
-      test_add<half_t, unsigned long long int, half_t>(ADD_H_ULLI, ADD_H_ULLI_SZ);
+      test_add<half_t, unsigned long long int, half_t>(ADD_H_ULLI,
+                                                       ADD_H_ULLI_SZ);
     } else {
-      actual_lhs(ADD_USI_H) =
-      actual_lhs(ADD_USI_H_SZ) =
-      actual_lhs(ADD_UI_H) =
-      actual_lhs(ADD_UI_H_SZ) =
-      actual_lhs(ADD_ULI_H) =
-      actual_lhs(ADD_ULI_H_SZ) =
-      actual_lhs(ADD_ULLI_H) =
-      actual_lhs(ADD_ULLI_H_SZ) =
-      actual_lhs(ADD_H_USI) =
-      actual_lhs(ADD_H_USI_SZ) =
-      actual_lhs(ADD_H_UI) =
-      actual_lhs(ADD_H_UI_SZ) =
-      actual_lhs(ADD_H_ULI) =
-      actual_lhs(ADD_H_ULI_SZ) =
-      actual_lhs(ADD_H_ULLI) =
-      actual_lhs(ADD_H_ULLI_SZ) =
-      expected_lhs(ADD_USI_H) =
-      expected_lhs(ADD_USI_H_SZ) =
-      expected_lhs(ADD_UI_H) =
-      expected_lhs(ADD_UI_H_SZ) =
-      expected_lhs(ADD_ULI_H) =
-      expected_lhs(ADD_ULI_H_SZ) =
-      expected_lhs(ADD_ULLI_H) =
-      expected_lhs(ADD_ULLI_H_SZ) =
-      expected_lhs(ADD_H_USI) =
-      expected_lhs(ADD_H_USI_SZ) =
-      expected_lhs(ADD_H_UI) =
-      expected_lhs(ADD_H_UI_SZ) =
-      expected_lhs(ADD_H_ULI) =
-      expected_lhs(ADD_H_ULI_SZ) =
-      expected_lhs(ADD_H_ULLI) =
-      expected_lhs(ADD_H_ULLI_SZ) = 0;
+      actual_lhs(ADD_H_USI)     = expected_lhs(ADD_H_USI);
+      actual_lhs(ADD_H_USI_SZ)  = expected_lhs(ADD_H_USI_SZ);
+      actual_lhs(ADD_H_UI)      = expected_lhs(ADD_H_UI);
+      actual_lhs(ADD_H_UI_SZ)   = expected_lhs(ADD_H_UI_SZ);
+      actual_lhs(ADD_H_ULI)     = expected_lhs(ADD_H_ULI);
+      actual_lhs(ADD_H_ULI_SZ)  = expected_lhs(ADD_H_ULI_SZ);
+      actual_lhs(ADD_H_ULLI)    = expected_lhs(ADD_H_ULLI);
+      actual_lhs(ADD_H_ULLI_SZ) = expected_lhs(ADD_H_ULLI_SZ);
     }
 
-    actual_lhs(SUB_H_H)   = cast_from_half<double>(h_lhs - h_rhs);
-    expected_lhs(SUB_H_H) = d_lhs - d_rhs;
-    auto sub_h_s          = h_lhs - static_cast<float>(d_rhs);
-    actual_lhs(SUB_H_S)   = sub_h_s;
-    expected_lhs(SUB_H_S) = d_lhs - d_rhs;
-    auto sub_s_h          = static_cast<float>(d_lhs) - h_rhs;
-    actual_lhs(SUB_S_H)   = sub_s_h;
-    expected_lhs(SUB_S_H) = d_lhs - d_rhs;
-    auto sub_h_d          = h_lhs - d_rhs;
-    actual_lhs(SUB_H_D)   = sub_h_d;
-    expected_lhs(SUB_H_D) = d_lhs - d_rhs;
-    auto sub_d_h          = d_lhs - h_rhs;
-    actual_lhs(SUB_D_H)   = sub_d_h;
-    expected_lhs(SUB_D_H) = d_lhs - d_rhs;
-    // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+    test_sub<half_t, half_t, half_t>(SUB_H_H, SUB_H_H_SZ);
+    test_sub<float, half_t, float>(SUB_S_H, SUB_S_H_SZ);
+    test_sub<double, half_t, double>(SUB_D_H, SUB_D_H_SZ);
+    test_sub<short int, half_t, half_t>(SUB_SI_H, SUB_SI_H_SZ);
+    test_sub<int, half_t, half_t>(SUB_I_H, SUB_I_H_SZ);
+    test_sub<long int, half_t, half_t>(SUB_LI_H, SUB_LI_H_SZ);
+    test_sub<long long int, half_t, half_t>(SUB_LLI_H, SUB_LLI_H_SZ);
+    test_sub<half_t, float, float>(SUB_H_S, SUB_H_S_SZ);
+    test_sub<half_t, double, double>(SUB_H_D, SUB_H_D_SZ);
+    test_sub<half_t, short int, half_t>(SUB_H_SI, SUB_H_SI_SZ);
+    test_sub<half_t, int, half_t>(SUB_H_I, SUB_H_I_SZ);
+    test_sub<half_t, long int, half_t>(SUB_H_LI, SUB_H_LI_SZ);
+    test_sub<half_t, long long int, half_t>(SUB_H_LLI, SUB_H_LLI_SZ);
 
-    actual_lhs(SUB_H_S_SZ)   = sizeof(sub_h_s);
-    expected_lhs(SUB_H_S_SZ) = sizeof(float);
-    actual_lhs(SUB_S_H_SZ)   = sizeof(sub_s_h);
-    expected_lhs(SUB_S_H_SZ) = sizeof(float);
-    actual_lhs(SUB_H_D_SZ)   = sizeof(sub_h_d);
-    expected_lhs(SUB_H_D_SZ) = sizeof(double);
-    actual_lhs(SUB_D_H_SZ)   = sizeof(sub_d_h);
-    expected_lhs(SUB_D_H_SZ) = sizeof(double);
+    // Check for potential overflow due to negative half_t -> unsigned integral
+    // cast
+    if (h_lhs >= half_t(0)) {
+      test_sub<unsigned short int, half_t, half_t>(SUB_USI_H, SUB_USI_H_SZ);
+      test_sub<unsigned int, half_t, half_t>(SUB_UI_H, SUB_UI_H_SZ);
+      test_sub<unsigned long int, half_t, half_t>(SUB_ULI_H, SUB_ULI_H_SZ);
+      test_sub<unsigned long long int, half_t, half_t>(SUB_ULLI_H,
+                                                       SUB_ULLI_H_SZ);
+    } else {
+      actual_lhs(SUB_USI_H)     = expected_lhs(SUB_USI_H);
+      actual_lhs(SUB_USI_H_SZ)  = expected_lhs(SUB_USI_H_SZ);
+      actual_lhs(SUB_UI_H)      = expected_lhs(SUB_UI_H);
+      actual_lhs(SUB_UI_H_SZ)   = expected_lhs(SUB_UI_H_SZ);
+      actual_lhs(SUB_ULI_H)     = expected_lhs(SUB_ULI_H);
+      actual_lhs(SUB_ULI_H_SZ)  = expected_lhs(SUB_ULI_H_SZ);
+      actual_lhs(SUB_ULLI_H)    = expected_lhs(SUB_ULLI_H);
+      actual_lhs(SUB_ULLI_H_SZ) = expected_lhs(SUB_ULLI_H_SZ);
+    }
 
-    actual_lhs(MUL_H_H)   = cast_from_half<double>(h_lhs * h_rhs);
-    expected_lhs(MUL_H_H) = d_lhs * d_rhs;
-    auto mul_h_s          = h_lhs * static_cast<float>(d_rhs);
-    actual_lhs(MUL_H_S)   = mul_h_s;
-    expected_lhs(MUL_H_S) = d_lhs * d_rhs;
-    auto mul_s_h          = static_cast<float>(d_lhs) * h_rhs;
-    actual_lhs(MUL_S_H)   = mul_s_h;
-    expected_lhs(MUL_S_H) = d_lhs * d_rhs;
-    auto mul_h_d          = h_lhs * d_rhs;
-    actual_lhs(MUL_H_D)   = mul_h_d;
-    expected_lhs(MUL_H_D) = d_lhs * d_rhs;
-    auto mul_d_h          = d_lhs * h_rhs;
-    actual_lhs(MUL_D_H)   = mul_d_h;
-    expected_lhs(MUL_D_H) = d_lhs * d_rhs;
-    // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+    // Check for potential overflow due to negative half_t -> unsigned integral
+    // cast
+    if (h_rhs >= half_t(0)) {
+      test_sub<half_t, unsigned short int, half_t>(SUB_H_USI, SUB_H_USI_SZ);
+      test_sub<half_t, unsigned int, half_t>(SUB_H_UI, SUB_H_UI_SZ);
+      test_sub<half_t, unsigned long int, half_t>(SUB_H_ULI, SUB_H_ULI_SZ);
+      test_sub<half_t, unsigned long long int, half_t>(SUB_H_ULLI,
+                                                       SUB_H_ULLI_SZ);
+    } else {
+      actual_lhs(SUB_H_USI)     = expected_lhs(SUB_H_USI);
+      actual_lhs(SUB_H_USI_SZ)  = expected_lhs(SUB_H_USI_SZ);
+      actual_lhs(SUB_H_UI)      = expected_lhs(SUB_H_UI);
+      actual_lhs(SUB_H_UI_SZ)   = expected_lhs(SUB_H_UI_SZ);
+      actual_lhs(SUB_H_ULI)     = expected_lhs(SUB_H_ULI);
+      actual_lhs(SUB_H_ULI_SZ)  = expected_lhs(SUB_H_ULI_SZ);
+      actual_lhs(SUB_H_ULLI)    = expected_lhs(SUB_H_ULLI);
+      actual_lhs(SUB_H_ULLI_SZ) = expected_lhs(SUB_H_ULLI_SZ);
+    }
 
-    actual_lhs(MUL_H_S_SZ)   = sizeof(mul_h_s);
-    expected_lhs(MUL_H_S_SZ) = sizeof(float);
-    actual_lhs(MUL_S_H_SZ)   = sizeof(mul_s_h);
-    expected_lhs(MUL_S_H_SZ) = sizeof(float);
-    actual_lhs(MUL_H_D_SZ)   = sizeof(mul_h_d);
-    expected_lhs(MUL_H_D_SZ) = sizeof(double);
-    actual_lhs(MUL_D_H_SZ)   = sizeof(mul_d_h);
-    expected_lhs(MUL_D_H_SZ) = sizeof(double);
+    test_mul<half_t, half_t, half_t>(MUL_H_H, MUL_H_H_SZ);
+    test_mul<float, half_t, float>(MUL_S_H, MUL_S_H_SZ);
+    test_mul<double, half_t, double>(MUL_D_H, MUL_D_H_SZ);
+    test_mul<short int, half_t, half_t>(MUL_SI_H, MUL_SI_H_SZ);
+    test_mul<int, half_t, half_t>(MUL_I_H, MUL_I_H_SZ);
+    test_mul<long int, half_t, half_t>(MUL_LI_H, MUL_LI_H_SZ);
+    test_mul<long long int, half_t, half_t>(MUL_LLI_H, MUL_LLI_H_SZ);
+    test_mul<half_t, float, float>(MUL_H_S, MUL_H_S_SZ);
+    test_mul<half_t, double, double>(MUL_H_D, MUL_H_D_SZ);
+    test_mul<half_t, short int, half_t>(MUL_H_SI, MUL_H_SI_SZ);
+    test_mul<half_t, int, half_t>(MUL_H_I, MUL_H_I_SZ);
+    test_mul<half_t, long int, half_t>(MUL_H_LI, MUL_H_LI_SZ);
+    test_mul<half_t, long long int, half_t>(MUL_H_LLI, MUL_H_LLI_SZ);
 
-    actual_lhs(DIV_H_H)   = cast_from_half<double>(h_lhs / h_rhs);
-    expected_lhs(DIV_H_H) = d_lhs / d_rhs;
-    auto div_h_s          = h_lhs / static_cast<float>(d_rhs);
-    actual_lhs(DIV_H_S)   = div_h_s;
-    expected_lhs(DIV_H_S) = d_lhs / d_rhs;
-    auto div_s_h          = static_cast<float>(d_lhs) / h_rhs;
-    actual_lhs(DIV_S_H)   = div_s_h;
-    expected_lhs(DIV_S_H) = d_lhs / d_rhs;
-    auto div_h_d          = h_lhs / d_rhs;
-    actual_lhs(DIV_H_D)   = div_h_d;
-    expected_lhs(DIV_H_D) = d_lhs / d_rhs;
-    auto div_d_h          = d_lhs / h_rhs;
-    actual_lhs(DIV_D_H)   = div_d_h;
-    expected_lhs(DIV_D_H) = d_lhs / d_rhs;
-    // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+    // Check for potential overflow due to negative half_t -> unsigned integral
+    // cast
+    if (h_lhs >= half_t(0)) {
+      test_mul<unsigned short int, half_t, half_t>(MUL_USI_H, MUL_USI_H_SZ);
+      test_mul<unsigned int, half_t, half_t>(MUL_UI_H, MUL_UI_H_SZ);
+      test_mul<unsigned long int, half_t, half_t>(MUL_ULI_H, MUL_ULI_H_SZ);
+      test_mul<unsigned long long int, half_t, half_t>(MUL_ULLI_H,
+                                                       MUL_ULLI_H_SZ);
+    } else {
+      actual_lhs(MUL_USI_H)     = expected_lhs(MUL_USI_H);
+      actual_lhs(MUL_UI_H)      = expected_lhs(MUL_UI_H);
+      actual_lhs(MUL_ULI_H)     = expected_lhs(MUL_ULI_H);
+      actual_lhs(MUL_ULLI_H)    = expected_lhs(MUL_ULLI_H);
+      actual_lhs(MUL_USI_H_SZ)  = expected_lhs(MUL_USI_H_SZ);
+      actual_lhs(MUL_UI_H_SZ)   = expected_lhs(MUL_UI_H_SZ);
+      actual_lhs(MUL_ULI_H_SZ)  = expected_lhs(MUL_ULI_H_SZ);
+      actual_lhs(MUL_ULLI_H_SZ) = expected_lhs(MUL_ULLI_H_SZ);
+    }
 
-    actual_lhs(DIV_H_S_SZ)   = sizeof(div_h_s);
-    expected_lhs(DIV_H_S_SZ) = sizeof(float);
-    actual_lhs(DIV_S_H_SZ)   = sizeof(div_s_h);
-    expected_lhs(DIV_S_H_SZ) = sizeof(float);
-    actual_lhs(DIV_H_D_SZ)   = sizeof(div_h_d);
-    expected_lhs(DIV_H_D_SZ) = sizeof(double);
-    actual_lhs(DIV_D_H_SZ)   = sizeof(div_d_h);
-    expected_lhs(DIV_D_H_SZ) = sizeof(double);
+    // Check for potential overflow due to negative half_t -> unsigned integral
+    // cast
+    if (h_rhs >= half_t(0)) {
+      test_mul<half_t, unsigned short int, half_t>(MUL_H_USI, MUL_H_USI_SZ);
+      test_mul<half_t, unsigned int, half_t>(MUL_H_UI, MUL_H_UI_SZ);
+      test_mul<half_t, unsigned long int, half_t>(MUL_H_ULI, MUL_H_ULI_SZ);
+      test_mul<half_t, unsigned long long int, half_t>(MUL_H_ULLI,
+                                                       MUL_H_ULLI_SZ);
+    } else {
+      actual_lhs(MUL_H_USI)     = expected_lhs(MUL_H_USI);
+      actual_lhs(MUL_H_UI)      = expected_lhs(MUL_H_UI);
+      actual_lhs(MUL_H_ULI)     = expected_lhs(MUL_H_ULI);
+      actual_lhs(MUL_H_ULLI)    = expected_lhs(MUL_H_ULLI);
+      actual_lhs(MUL_H_USI_SZ)  = expected_lhs(MUL_H_USI_SZ);
+      actual_lhs(MUL_H_UI_SZ)   = expected_lhs(MUL_H_UI_SZ);
+      actual_lhs(MUL_H_ULI_SZ)  = expected_lhs(MUL_H_ULI_SZ);
+      actual_lhs(MUL_H_ULLI_SZ) = expected_lhs(MUL_H_ULLI_SZ);
+    }
+
+    test_div<half_t, half_t, half_t>(DIV_H_H, DIV_H_H_SZ);
+    test_div<float, half_t, float>(DIV_S_H, DIV_S_H_SZ);
+    test_div<double, half_t, double>(DIV_D_H, DIV_D_H_SZ);
+    test_div<short int, half_t, half_t>(DIV_SI_H, DIV_SI_H_SZ);
+    test_div<int, half_t, half_t>(DIV_I_H, DIV_I_H_SZ);
+    test_div<long int, half_t, half_t>(DIV_LI_H, DIV_LI_H_SZ);
+    test_div<long long int, half_t, half_t>(DIV_LLI_H, DIV_LLI_H_SZ);
+    test_div<half_t, float, float>(DIV_H_S, DIV_H_S_SZ);
+    test_div<half_t, double, double>(DIV_H_D, DIV_H_D_SZ);
+
+    // Check for division by zero due to truncation by half_t -> integral cast
+    if (h_rhs >= half_t(1) || h_rhs <= half_t(-1)) {
+      test_div<half_t, short int, half_t>(DIV_H_SI, DIV_H_SI_SZ);
+      test_div<half_t, int, half_t>(DIV_H_I, DIV_H_I_SZ);
+      test_div<half_t, long int, half_t>(DIV_H_LI, DIV_H_LI_SZ);
+      test_div<half_t, long long int, half_t>(DIV_H_LLI, DIV_H_LLI_SZ);
+    } else {
+      actual_lhs(DIV_H_SI)     = expected_lhs(DIV_H_SI);
+      actual_lhs(DIV_H_I)      = expected_lhs(DIV_H_I);
+      actual_lhs(DIV_H_LI)     = expected_lhs(DIV_H_LI);
+      actual_lhs(DIV_H_LLI)    = expected_lhs(DIV_H_LLI);
+      actual_lhs(DIV_H_SI_SZ)  = expected_lhs(DIV_H_SI_SZ);
+      actual_lhs(DIV_H_I_SZ)   = expected_lhs(DIV_H_I_SZ);
+      actual_lhs(DIV_H_LI_SZ)  = expected_lhs(DIV_H_LI_SZ);
+      actual_lhs(DIV_H_LLI_SZ) = expected_lhs(DIV_H_LLI_SZ);
+    }
+
+    // Check for potential overflow due to negative half_t -> unsigned integral
+    // cast
+    if (h_lhs >= half_t(0)) {
+      test_div<unsigned short int, half_t, half_t>(DIV_USI_H, DIV_USI_H_SZ);
+      test_div<unsigned int, half_t, half_t>(DIV_UI_H, DIV_UI_H_SZ);
+      test_div<unsigned long int, half_t, half_t>(DIV_ULI_H, DIV_ULI_H_SZ);
+      test_div<unsigned long long int, half_t, half_t>(DIV_ULLI_H,
+                                                       DIV_ULLI_H_SZ);
+    } else {
+      actual_lhs(DIV_USI_H)     = expected_lhs(DIV_USI_H);
+      actual_lhs(DIV_UI_H)      = expected_lhs(DIV_UI_H);
+      actual_lhs(DIV_ULI_H)     = expected_lhs(DIV_ULI_H);
+      actual_lhs(DIV_ULLI_H)    = expected_lhs(DIV_ULLI_H);
+      actual_lhs(DIV_USI_H_SZ)  = expected_lhs(DIV_USI_H_SZ);
+      actual_lhs(DIV_UI_H_SZ)   = expected_lhs(DIV_UI_H_SZ);
+      actual_lhs(DIV_ULI_H_SZ)  = expected_lhs(DIV_ULI_H_SZ);
+      actual_lhs(DIV_ULLI_H_SZ) = expected_lhs(DIV_ULLI_H_SZ);
+    }
+
+    // Check for division by zero due to truncation by half_t -> integral cast
+    if (h_rhs >= half_t(1)) {
+      test_div<half_t, unsigned short int, half_t>(DIV_H_USI, DIV_H_USI_SZ);
+      test_div<half_t, unsigned int, half_t>(DIV_H_UI, DIV_H_UI_SZ);
+      test_div<half_t, unsigned long int, half_t>(DIV_H_ULI, DIV_H_ULI_SZ);
+      test_div<half_t, unsigned long long int, half_t>(DIV_H_ULLI,
+                                                       DIV_H_ULLI_SZ);
+    } else {
+      actual_lhs(DIV_H_USI)     = expected_lhs(DIV_H_USI);
+      actual_lhs(DIV_H_USI_SZ)  = expected_lhs(DIV_H_USI_SZ);
+      actual_lhs(DIV_H_UI)      = expected_lhs(DIV_H_UI);
+      actual_lhs(DIV_H_UI_SZ)   = expected_lhs(DIV_H_UI_SZ);
+      actual_lhs(DIV_H_ULI)     = expected_lhs(DIV_H_ULI);
+      actual_lhs(DIV_H_ULI_SZ)  = expected_lhs(DIV_H_ULI_SZ);
+      actual_lhs(DIV_H_ULLI)    = expected_lhs(DIV_H_ULLI);
+      actual_lhs(DIV_H_ULLI_SZ) = expected_lhs(DIV_H_ULLI_SZ);
+    }
 
     // TODO: figure out why operator{!,&&,||} are returning __nv_bool
     actual_lhs(NEG)   = static_cast<double>(!h_lhs);
@@ -529,8 +779,13 @@ void __test_half_operators(half_t h_lhs, half_t h_rhs) {
 void test_half_operators() {
   half_t h_lhs = half_t(0.23458), h_rhs = half_t(0.67898);
   for (int i = -3; i < 2; i++) {
+    // printf("%f OP %f\n", float(h_lhs + cast_to_half(i + 1)), float(h_rhs +
+    // cast_to_half(i)));
     __test_half_operators(h_lhs + cast_to_half(i + 1), h_rhs + cast_to_half(i));
+    // TODO: __test_half_operators(h_lhs + cast_to_half(i + 1), half_t(0));
+    // TODO: __test_half_operators(half_t(0), h_rhs + cast_to_half(i));
   }
+  // TODO: __test_half_operators(0, 0);
 }
 
 TEST(TEST_CATEGORY, half_operators) { test_half_operators(); }

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -430,13 +430,13 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_S) = d_lhs;
     expected_lhs(CADD_H_S) += d_rhs;
 
-    tmp_s_lhs = h_lhs;
+    tmp_s_lhs = static_cast<float>(h_lhs);
     tmp_s_lhs += h_rhs;
     actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
     expected_lhs(CADD_S_H) = d_lhs;
     expected_lhs(CADD_S_H) += d_rhs;
 
-    tmp_lhs = h_lhs;
+    tmp_lhs = static_cast<double>(h_lhs);
     tmp_lhs += static_cast<double>(d_rhs);
     actual_lhs(CADD_H_D)   = cast_from_half<double>(tmp_lhs);
     expected_lhs(CADD_H_D) = d_lhs;

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -67,10 +67,8 @@ enum OP_TESTS {
   POSTFIX_INC,
   POSTFIX_DEC,
   CADD_H_H,
-  CADD_H_S,
-  CADD_S_H,
-  CADD_H_D,
-  CADD_D_H,
+  CADD_H_S, //   CADD_S_H,
+  CADD_H_D, //   CADD_D_H,
   CSUB_H_H,
   CSUB_H_S,
   CMUL_H_H,
@@ -430,11 +428,12 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_S) = d_lhs;
     expected_lhs(CADD_H_S) += d_rhs;
 
-    tmp_s_lhs = static_cast<float>(h_lhs);
-    tmp_s_lhs += h_rhs;
-    actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
-    expected_lhs(CADD_S_H) = d_lhs;
-    expected_lhs(CADD_S_H) += d_rhs;
+    //NOTE: Commented out as the toolchain cannot find the float operator+=(half_t) overload
+    //tmp_s_lhs = static_cast<float>(h_lhs);
+    //tmp_s_lhs += h_rhs;
+    //actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
+    //expected_lhs(CADD_S_H) = d_lhs;
+    //expected_lhs(CADD_S_H) += d_rhs;
 
     tmp_lhs = static_cast<double>(h_lhs);
     tmp_lhs += static_cast<double>(d_rhs);
@@ -442,11 +441,12 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_D) = d_lhs;
     expected_lhs(CADD_H_D) += d_rhs;
 
-    tmp_d_lhs = h_lhs;
-    tmp_d_lhs += h_rhs;
-    actual_lhs(CADD_D_H) = static_cast<double>(tmp_d_lhs);
-    expected_lhs(CADD_D_H) = d_lhs;
-    expected_lhs(CADD_D_H) += d_rhs;
+    //NOTE: Commented out as the toolchain cannot find the double operator+=(half_t) overload
+    //tmp_d_lhs = static_cast<double>(h_lhs);
+    //tmp_d_lhs += h_rhs;
+    //actual_lhs(CADD_D_H) = static_cast<double>(tmp_d_lhs);
+    //expected_lhs(CADD_D_H) = d_lhs;
+    //expected_lhs(CADD_D_H) += d_rhs;
 
     tmp_lhs = h_lhs;
     tmp_lhs -= h_rhs;

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -77,15 +77,43 @@ enum OP_TESTS {
   ADD_H_H,
   ADD_H_S,
   ADD_S_H,
+  ADD_H_D,
+  ADD_D_H,
+  ADD_H_I,  // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+  ADD_I_H,
+  ADD_H_S_SZ,
+  ADD_S_H_SZ,
+  ADD_H_D_SZ,
+  ADD_D_H_SZ,
+  ADD_H_I_SZ,
+  ADD_I_H_SZ,
   SUB_H_H,
   SUB_H_S,
   SUB_S_H,
+  SUB_H_D,
+  SUB_D_H,  // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+  SUB_H_S_SZ,
+  SUB_S_H_SZ,
+  SUB_H_D_SZ,
+  SUB_D_H_SZ,
   MUL_H_H,
   MUL_H_S,
   MUL_S_H,
+  MUL_H_D,
+  MUL_D_H,  // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+  MUL_H_S_SZ,
+  MUL_S_H_SZ,
+  MUL_H_D_SZ,
+  MUL_D_H_SZ,
   DIV_H_H,
   DIV_H_S,
   DIV_S_H,
+  DIV_H_D,
+  DIV_D_H,  // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+  DIV_H_S_SZ,
+  DIV_S_H_SZ,
+  DIV_H_D_SZ,
+  DIV_D_H_SZ,
   NEG,
   AND,
   OR,
@@ -177,11 +205,11 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_H) = d_lhs;
     expected_lhs(CADD_H_H) += d_rhs;
 
-    // tmp_lhs = h_lhs;
-    // tmp_lhs += static_cast<float>(d_rhs);
-    // actual_lhs(CADD_H_S)   = cast_from_half<double>(tmp_lhs);
-    // expected_lhs(CADD_H_S) = d_lhs;
-    // expected_lhs(CADD_H_S) += d_rhs;
+    tmp_lhs = h_lhs;
+    tmp_lhs += static_cast<float>(d_rhs);
+    actual_lhs(CADD_H_S)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CADD_H_S) = d_lhs;
+    expected_lhs(CADD_H_S) += d_rhs;
 
     tmp_lhs = h_lhs;
     tmp_lhs -= h_rhs;
@@ -189,11 +217,11 @@ struct Functor_TestHalfOperators {
     expected_lhs(CSUB_H_H) = d_lhs;
     expected_lhs(CSUB_H_H) -= d_rhs;
 
-    // tmp_lhs = h_lhs;
-    // tmp_lhs -= static_cast<float>(d_rhs);
-    // actual_lhs(CSUB_H_S)   = cast_from_half<double>(tmp_lhs);
-    // expected_lhs(CSUB_H_S) = d_lhs;
-    // expected_lhs(CSUB_H_S) -= d_rhs;
+    tmp_lhs = h_lhs;
+    tmp_lhs -= static_cast<float>(d_rhs);
+    actual_lhs(CSUB_H_S)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CSUB_H_S) = d_lhs;
+    expected_lhs(CSUB_H_S) -= d_rhs;
 
     tmp_lhs = h_lhs;
     tmp_lhs *= h_rhs;
@@ -201,11 +229,11 @@ struct Functor_TestHalfOperators {
     expected_lhs(CMUL_H_H) = d_lhs;
     expected_lhs(CMUL_H_H) *= d_rhs;
 
-    // tmp_lhs = h_lhs;
-    // tmp_lhs *= static_cast<float>(d_rhs);
-    // actual_lhs(CMUL_H_S)   = cast_from_half<double>(tmp_lhs);
-    // expected_lhs(CMUL_H_S) = d_lhs;
-    // expected_lhs(CMUL_H_S) *= d_rhs;
+    tmp_lhs = h_lhs;
+    tmp_lhs *= static_cast<float>(d_rhs);
+    actual_lhs(CMUL_H_S)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CMUL_H_S) = d_lhs;
+    expected_lhs(CMUL_H_S) *= d_rhs;
 
     tmp_lhs = h_lhs;
     tmp_lhs /= h_rhs;
@@ -213,47 +241,121 @@ struct Functor_TestHalfOperators {
     expected_lhs(CDIV_H_H) = d_lhs;
     expected_lhs(CDIV_H_H) /= d_rhs;
 
-    // tmp_lhs = h_lhs;
-    // tmp_lhs /= static_cast<float>(d_rhs);
-    // actual_lhs(CDIV_H_S)   = cast_from_half<double>(tmp_lhs);
-    // expected_lhs(CDIV_H_S) = d_lhs;
-    // expected_lhs(CDIV_H_S) /= d_rhs;
+    tmp_lhs = h_lhs;
+    tmp_lhs /= static_cast<float>(d_rhs);
+    actual_lhs(CDIV_H_S)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CDIV_H_S) = d_lhs;
+    expected_lhs(CDIV_H_S) /= d_rhs;
 
     actual_lhs(ADD_H_H)   = cast_from_half<double>(h_lhs + h_rhs);
     expected_lhs(ADD_H_H) = d_lhs + d_rhs;
-    // actual_lhs(ADD_H_S) =
-    //    cast_from_half<double>(h_lhs + static_cast<float>(d_rhs));
-    // expected_lhs(ADD_H_S) = d_lhs + d_rhs;
-    // actual_lhs(ADD_S_H) =
-    //    cast_from_half<double>(static_cast<float>(d_lhs) + h_rhs);
-    // expected_lhs(ADD_S_H) = d_lhs + d_rhs;
+    auto add_h_s          = h_lhs + static_cast<float>(d_rhs);
+    actual_lhs(ADD_H_S)   = add_h_s;
+    expected_lhs(ADD_H_S) = d_lhs + d_rhs;
+    auto add_s_h          = static_cast<float>(d_lhs) + h_rhs;
+    actual_lhs(ADD_S_H)   = add_s_h;
+    expected_lhs(ADD_S_H) = d_lhs + d_rhs;
+    auto add_h_d          = h_lhs + d_rhs;
+    actual_lhs(ADD_H_D)   = add_h_d;
+    expected_lhs(ADD_H_D) = d_lhs + d_rhs;
+    auto add_d_h          = d_lhs + h_rhs;
+    actual_lhs(ADD_D_H)   = add_d_h;
+    expected_lhs(ADD_D_H) = d_lhs + d_rhs;
+    auto add_h_i          = h_lhs + int(d_rhs);
+    actual_lhs(ADD_H_I)   = cast_from_half<double>(add_h_i);
+    expected_lhs(ADD_H_I) = d_lhs + int(d_rhs);
+    auto add_i_h          = int(d_lhs) + h_rhs;
+    actual_lhs(ADD_I_H)   = cast_from_half<double>(add_i_h);
+    expected_lhs(ADD_I_H) = int(d_lhs) + d_rhs;
+    // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+
+    actual_lhs(ADD_H_S_SZ)   = sizeof(add_h_s);
+    expected_lhs(ADD_H_S_SZ) = sizeof(float);
+    actual_lhs(ADD_S_H_SZ)   = sizeof(add_s_h);
+    expected_lhs(ADD_S_H_SZ) = sizeof(float);
+    actual_lhs(ADD_H_D_SZ)   = sizeof(add_h_d);
+    expected_lhs(ADD_H_D_SZ) = sizeof(double);
+    actual_lhs(ADD_D_H_SZ)   = sizeof(add_d_h);
+    expected_lhs(ADD_D_H_SZ) = sizeof(double);
+    actual_lhs(ADD_H_I_SZ)   = sizeof(add_h_i);
+    expected_lhs(ADD_H_I_SZ) = sizeof(half_t);
+    actual_lhs(ADD_I_H_SZ)   = sizeof(add_i_h);
+    expected_lhs(ADD_I_H_SZ) = sizeof(half_t);
 
     actual_lhs(SUB_H_H)   = cast_from_half<double>(h_lhs - h_rhs);
     expected_lhs(SUB_H_H) = d_lhs - d_rhs;
-    // actual_lhs(SUB_H_S) =
-    //    cast_from_half<double>(h_lhs - static_cast<float>(d_rhs));
-    // expected_lhs(SUB_H_S) = d_lhs - d_rhs;
-    // actual_lhs(SUB_S_H) =
-    //    cast_from_half<double>(static_cast<float>(d_lhs) - h_rhs);
-    // expected_lhs(SUB_S_H) = d_lhs - d_rhs;
+    auto sub_h_s          = h_lhs - static_cast<float>(d_rhs);
+    actual_lhs(SUB_H_S)   = sub_h_s;
+    expected_lhs(SUB_H_S) = d_lhs - d_rhs;
+    auto sub_s_h          = static_cast<float>(d_lhs) - h_rhs;
+    actual_lhs(SUB_S_H)   = sub_s_h;
+    expected_lhs(SUB_S_H) = d_lhs - d_rhs;
+    auto sub_h_d          = h_lhs - d_rhs;
+    actual_lhs(SUB_H_D)   = sub_h_d;
+    expected_lhs(SUB_H_D) = d_lhs - d_rhs;
+    auto sub_d_h          = d_lhs - h_rhs;
+    actual_lhs(SUB_D_H)   = sub_d_h;
+    expected_lhs(SUB_D_H) = d_lhs - d_rhs;
+    // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+
+    actual_lhs(SUB_H_S_SZ)   = sizeof(sub_h_s);
+    expected_lhs(SUB_H_S_SZ) = sizeof(float);
+    actual_lhs(SUB_S_H_SZ)   = sizeof(sub_s_h);
+    expected_lhs(SUB_S_H_SZ) = sizeof(float);
+    actual_lhs(SUB_H_D_SZ)   = sizeof(sub_h_d);
+    expected_lhs(SUB_H_D_SZ) = sizeof(double);
+    actual_lhs(SUB_D_H_SZ)   = sizeof(sub_d_h);
+    expected_lhs(SUB_D_H_SZ) = sizeof(double);
 
     actual_lhs(MUL_H_H)   = cast_from_half<double>(h_lhs * h_rhs);
     expected_lhs(MUL_H_H) = d_lhs * d_rhs;
-    // actual_lhs(MUL_H_S) =
-    //    cast_from_half<double>(h_lhs * static_cast<float>(d_rhs));
-    // expected_lhs(MUL_H_S) = d_lhs * d_rhs;
-    // actual_lhs(MUL_S_H) =
-    //    cast_from_half<double>(static_cast<float>(d_lhs) * h_rhs);
-    // expected_lhs(MUL_S_H) = d_lhs * d_rhs;
+    auto mul_h_s          = h_lhs * static_cast<float>(d_rhs);
+    actual_lhs(MUL_H_S)   = mul_h_s;
+    expected_lhs(MUL_H_S) = d_lhs * d_rhs;
+    auto mul_s_h          = static_cast<float>(d_lhs) * h_rhs;
+    actual_lhs(MUL_S_H)   = mul_s_h;
+    expected_lhs(MUL_S_H) = d_lhs * d_rhs;
+    auto mul_h_d          = h_lhs * d_rhs;
+    actual_lhs(MUL_H_D)   = mul_h_d;
+    expected_lhs(MUL_H_D) = d_lhs * d_rhs;
+    auto mul_d_h          = d_lhs * h_rhs;
+    actual_lhs(MUL_D_H)   = mul_d_h;
+    expected_lhs(MUL_D_H) = d_lhs * d_rhs;
+    // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+
+    actual_lhs(MUL_H_S_SZ)   = sizeof(mul_h_s);
+    expected_lhs(MUL_H_S_SZ) = sizeof(float);
+    actual_lhs(MUL_S_H_SZ)   = sizeof(mul_s_h);
+    expected_lhs(MUL_S_H_SZ) = sizeof(float);
+    actual_lhs(MUL_H_D_SZ)   = sizeof(mul_h_d);
+    expected_lhs(MUL_H_D_SZ) = sizeof(double);
+    actual_lhs(MUL_D_H_SZ)   = sizeof(mul_d_h);
+    expected_lhs(MUL_D_H_SZ) = sizeof(double);
 
     actual_lhs(DIV_H_H)   = cast_from_half<double>(h_lhs / h_rhs);
     expected_lhs(DIV_H_H) = d_lhs / d_rhs;
-    // actual_lhs(DIV_H_S) =
-    //    cast_from_half<double>(h_lhs / static_cast<float>(d_rhs));
-    // expected_lhs(DIV_H_S) = d_lhs / d_rhs;
-    // actual_lhs(DIV_S_H) =
-    //    cast_from_half<double>(static_cast<float>(d_lhs) / h_rhs);
-    // expected_lhs(DIV_S_H) = d_lhs / d_rhs;
+    auto div_h_s          = h_lhs / static_cast<float>(d_rhs);
+    actual_lhs(DIV_H_S)   = div_h_s;
+    expected_lhs(DIV_H_S) = d_lhs / d_rhs;
+    auto div_s_h          = static_cast<float>(d_lhs) / h_rhs;
+    actual_lhs(DIV_S_H)   = div_s_h;
+    expected_lhs(DIV_S_H) = d_lhs / d_rhs;
+    auto div_h_d          = h_lhs / d_rhs;
+    actual_lhs(DIV_H_D)   = div_h_d;
+    expected_lhs(DIV_H_D) = d_lhs / d_rhs;
+    auto div_d_h          = d_lhs / h_rhs;
+    actual_lhs(DIV_D_H)   = div_d_h;
+    expected_lhs(DIV_D_H) = d_lhs / d_rhs;
+    // TODO: SI, I, LI, LLI, USI, UI, ULI, ULLI
+
+    actual_lhs(DIV_H_S_SZ)   = sizeof(div_h_s);
+    expected_lhs(DIV_H_S_SZ) = sizeof(float);
+    actual_lhs(DIV_S_H_SZ)   = sizeof(div_s_h);
+    expected_lhs(DIV_S_H_SZ) = sizeof(float);
+    actual_lhs(DIV_H_D_SZ)   = sizeof(div_h_d);
+    expected_lhs(DIV_H_D_SZ) = sizeof(double);
+    actual_lhs(DIV_D_H_SZ)   = sizeof(div_d_h);
+    expected_lhs(DIV_D_H_SZ) = sizeof(double);
 
     // TODO: figure out why operator{!,&&,||} are returning __nv_bool
     actual_lhs(NEG)   = static_cast<double>(!h_lhs);
@@ -303,7 +405,8 @@ struct Functor_TestHalfOperators {
     actual_lhs(AO_HALF_T)   = cast_from_half<double>(tmp_ptr[0]);
     expected_lhs(AO_HALF_T) = d_lhs;
 
-    // TODO: Add upcast / downcast tests using sizeof
+    // TODO: Check upcasting and downcasting in large expressions involving
+    // integral and floating point types
   }
 };
 
@@ -320,7 +423,7 @@ void __test_half_operators(half_t h_lhs, half_t h_rhs) {
   Kokkos::deep_copy(f_device_actual_lhs, f_device.actual_lhs);
   Kokkos::deep_copy(f_device_expected_lhs, f_device.expected_lhs);
   for (int op_test = 0; op_test < N_OP_TESTS; op_test++) {
-    // printf("%lf\n", actual_lhs(op));
+    // printf("op_test = %d\n", op_test);
     ASSERT_NEAR(f_device_actual_lhs(op_test), f_device_expected_lhs(op_test),
                 epsilon);
     ASSERT_NEAR(f_host.actual_lhs(op_test), f_host.expected_lhs(op_test),

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -67,8 +67,8 @@ enum OP_TESTS {
   POSTFIX_INC,
   POSTFIX_DEC,
   CADD_H_H,
-  CADD_H_S, //   CADD_S_H,
-  CADD_H_D, //   CADD_D_H,
+  CADD_H_S,  //   CADD_S_H,
+  CADD_H_D,  //   CADD_D_H,
   CSUB_H_H,
   CSUB_H_S,
   CMUL_H_H,
@@ -428,12 +428,12 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_S) = d_lhs;
     expected_lhs(CADD_H_S) += d_rhs;
 
-    //NOTE: Commented out as the toolchain cannot find the float operator+=(half_t) overload
-    //tmp_s_lhs = static_cast<float>(h_lhs);
-    //tmp_s_lhs += h_rhs;
-    //actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
-    //expected_lhs(CADD_S_H) = d_lhs;
-    //expected_lhs(CADD_S_H) += d_rhs;
+    // NOTE: Commented out as the toolchain cannot find the float
+    // operator+=(half_t) overload tmp_s_lhs = static_cast<float>(h_lhs);
+    // tmp_s_lhs += h_rhs;
+    // actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
+    // expected_lhs(CADD_S_H) = d_lhs;
+    // expected_lhs(CADD_S_H) += d_rhs;
 
     tmp_lhs = static_cast<double>(h_lhs);
     tmp_lhs += static_cast<double>(d_rhs);
@@ -441,12 +441,12 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_D) = d_lhs;
     expected_lhs(CADD_H_D) += d_rhs;
 
-    //NOTE: Commented out as the toolchain cannot find the double operator+=(half_t) overload
-    //tmp_d_lhs = static_cast<double>(h_lhs);
-    //tmp_d_lhs += h_rhs;
-    //actual_lhs(CADD_D_H) = static_cast<double>(tmp_d_lhs);
-    //expected_lhs(CADD_D_H) = d_lhs;
-    //expected_lhs(CADD_D_H) += d_rhs;
+    // NOTE: Commented out as the toolchain cannot find the double
+    // operator+=(half_t) overload tmp_d_lhs = static_cast<double>(h_lhs);
+    // tmp_d_lhs += h_rhs;
+    // actual_lhs(CADD_D_H) = static_cast<double>(tmp_d_lhs);
+    // expected_lhs(CADD_D_H) = d_lhs;
+    // expected_lhs(CADD_D_H) += d_rhs;
 
     tmp_lhs = h_lhs;
     tmp_lhs -= h_rhs;

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -68,6 +68,9 @@ enum OP_TESTS {
   POSTFIX_DEC,
   CADD_H_H,
   CADD_H_S,
+  CADD_S_H,
+  CADD_H_D,
+  CADD_D_H,
   CSUB_H_H,
   CSUB_H_S,
   CMUL_H_H,
@@ -365,6 +368,7 @@ struct Functor_TestHalfOperators {
   void operator()(int) const {
     half_t tmp_lhs, tmp2_lhs, *tmp_ptr;
     double tmp_d_lhs;
+    float tmp_s_lhs;
     using half_impl_type = Kokkos::Impl::half_impl_t::type;
     half_impl_type half_tmp;
 
@@ -425,6 +429,24 @@ struct Functor_TestHalfOperators {
     actual_lhs(CADD_H_S)   = cast_from_half<double>(tmp_lhs);
     expected_lhs(CADD_H_S) = d_lhs;
     expected_lhs(CADD_H_S) += d_rhs;
+
+    tmp_s_lhs = h_lhs;
+    tmp_s_lhs += h_rhs;
+    actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
+    expected_lhs(CADD_S_H) = d_lhs;
+    expected_lhs(CADD_S_H) += d_rhs;
+
+    tmp_lhs = h_lhs;
+    tmp_lhs += static_cast<double>(d_rhs);
+    actual_lhs(CADD_H_D)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CADD_H_D) = d_lhs;
+    expected_lhs(CADD_H_D) += d_rhs;
+
+    tmp_d_lhs = h_lhs;
+    tmp_d_lhs += h_rhs;
+    actual_lhs(CADD_D_H) = static_cast<double>(tmp_d_lhs);
+    expected_lhs(CADD_D_H) = d_lhs;
+    expected_lhs(CADD_D_H) += d_rhs;
 
     tmp_lhs = h_lhs;
     tmp_lhs -= h_rhs;

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -67,7 +67,7 @@ enum OP_TESTS {
   POSTFIX_INC,
   POSTFIX_DEC,
   CADD_H_H,
-  CADD_H_S,  
+  CADD_H_S,
   CADD_S_H,
   CADD_H_D,
   CADD_D_H,
@@ -432,7 +432,7 @@ struct Functor_TestHalfOperators {
 
     tmp_s_lhs = static_cast<float>(h_lhs);
     tmp_s_lhs += h_rhs;
-    actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
+    actual_lhs(CADD_S_H)   = static_cast<double>(tmp_s_lhs);
     expected_lhs(CADD_S_H) = d_lhs;
     expected_lhs(CADD_S_H) += d_rhs;
 
@@ -444,7 +444,7 @@ struct Functor_TestHalfOperators {
 
     tmp_d_lhs = static_cast<double>(h_lhs);
     tmp_d_lhs += h_rhs;
-    actual_lhs(CADD_D_H) = static_cast<double>(tmp_d_lhs);
+    actual_lhs(CADD_D_H)   = static_cast<double>(tmp_d_lhs);
     expected_lhs(CADD_D_H) = d_lhs;
     expected_lhs(CADD_D_H) += d_rhs;
 

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -430,7 +430,7 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_S) = d_lhs;
     expected_lhs(CADD_H_S) += d_rhs;
 
-    tmp_s_lhs = h_lhs;
+    tmp_s_lhs = static_cast<float>(h_lhs);
     tmp_s_lhs += h_rhs;
     actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
     expected_lhs(CADD_S_H) = d_lhs;
@@ -442,7 +442,7 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_D) = d_lhs;
     expected_lhs(CADD_H_D) += d_rhs;
 
-    tmp_d_lhs = h_lhs;
+    tmp_d_lhs = static_cast<double>(h_lhs);
     tmp_d_lhs += h_rhs;
     actual_lhs(CADD_D_H) = static_cast<double>(tmp_d_lhs);
     expected_lhs(CADD_D_H) = d_lhs;

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -69,7 +69,8 @@ enum OP_TESTS {
   CADD_H_H,
   CADD_H_S,  
   CADD_S_H,
-  CADD_H_D,  //   CADD_D_H,
+  CADD_H_D,
+  CADD_D_H,
   CSUB_H_H,
   CSUB_H_S,
   CMUL_H_H,
@@ -429,8 +430,6 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_S) = d_lhs;
     expected_lhs(CADD_H_S) += d_rhs;
 
-    // NOTE: Commented out as the toolchain cannot find the float
-    // operator+=(half_t) overload tmp_s_lhs = static_cast<float>(h_lhs);
     tmp_s_lhs += h_rhs;
     actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
     expected_lhs(CADD_S_H) = d_lhs;
@@ -442,12 +441,10 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_D) = d_lhs;
     expected_lhs(CADD_H_D) += d_rhs;
 
-    // NOTE: Commented out as the toolchain cannot find the double
-    // operator+=(half_t) overload tmp_d_lhs = static_cast<double>(h_lhs);
-    // tmp_d_lhs += h_rhs;
-    // actual_lhs(CADD_D_H) = static_cast<double>(tmp_d_lhs);
-    // expected_lhs(CADD_D_H) = d_lhs;
-    // expected_lhs(CADD_D_H) += d_rhs;
+    tmp_d_lhs += h_rhs;
+    actual_lhs(CADD_D_H) = static_cast<double>(tmp_d_lhs);
+    expected_lhs(CADD_D_H) = d_lhs;
+    expected_lhs(CADD_D_H) += d_rhs;
 
     tmp_lhs = h_lhs;
     tmp_lhs -= h_rhs;

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -67,7 +67,8 @@ enum OP_TESTS {
   POSTFIX_INC,
   POSTFIX_DEC,
   CADD_H_H,
-  CADD_H_S,  //   CADD_S_H,
+  CADD_H_S,  
+  CADD_S_H,
   CADD_H_D,  //   CADD_D_H,
   CSUB_H_H,
   CSUB_H_S,
@@ -430,10 +431,10 @@ struct Functor_TestHalfOperators {
 
     // NOTE: Commented out as the toolchain cannot find the float
     // operator+=(half_t) overload tmp_s_lhs = static_cast<float>(h_lhs);
-    // tmp_s_lhs += h_rhs;
-    // actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
-    // expected_lhs(CADD_S_H) = d_lhs;
-    // expected_lhs(CADD_S_H) += d_rhs;
+    tmp_s_lhs += h_rhs;
+    actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
+    expected_lhs(CADD_S_H) = d_lhs;
+    expected_lhs(CADD_S_H) += d_rhs;
 
     tmp_lhs = static_cast<double>(h_lhs);
     tmp_lhs += static_cast<double>(d_rhs);

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -430,6 +430,7 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_S) = d_lhs;
     expected_lhs(CADD_H_S) += d_rhs;
 
+    tmp_s_lhs = h_lhs;
     tmp_s_lhs += h_rhs;
     actual_lhs(CADD_S_H) = static_cast<double>(tmp_s_lhs);
     expected_lhs(CADD_S_H) = d_lhs;
@@ -441,6 +442,7 @@ struct Functor_TestHalfOperators {
     expected_lhs(CADD_H_D) = d_lhs;
     expected_lhs(CADD_H_D) += d_rhs;
 
+    tmp_d_lhs = h_lhs;
     tmp_d_lhs += h_rhs;
     actual_lhs(CADD_D_H) = static_cast<double>(tmp_d_lhs);
     expected_lhs(CADD_D_H) = d_lhs;

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -73,10 +73,19 @@ enum OP_TESTS {
   CADD_D_H,
   CSUB_H_H,
   CSUB_H_S,
+  CSUB_S_H,
+  CSUB_H_D,
+  CSUB_D_H,
   CMUL_H_H,
   CMUL_H_S,
+  CMUL_S_H,
+  CMUL_H_D,
+  CMUL_D_H,
   CDIV_H_H,
   CDIV_H_S,
+  CDIV_S_H,
+  CDIV_H_D,
+  CDIV_D_H,
   ADD_H_H,
   ADD_H_S,
   ADD_S_H,
@@ -460,6 +469,24 @@ struct Functor_TestHalfOperators {
     expected_lhs(CSUB_H_S) = d_lhs;
     expected_lhs(CSUB_H_S) -= d_rhs;
 
+    tmp_s_lhs = static_cast<float>(h_lhs);
+    tmp_s_lhs -= h_rhs;
+    actual_lhs(CSUB_S_H)   = static_cast<double>(tmp_s_lhs);
+    expected_lhs(CSUB_S_H) = d_lhs;
+    expected_lhs(CSUB_S_H) -= d_rhs;
+
+    tmp_lhs = h_lhs;
+    tmp_lhs -= d_rhs;
+    actual_lhs(CSUB_H_D)   = static_cast<double>(tmp_lhs);
+    expected_lhs(CSUB_H_D) = d_lhs;
+    expected_lhs(CSUB_H_D) -= d_rhs;
+
+    tmp_d_lhs = static_cast<double>(h_lhs);
+    tmp_d_lhs -= h_rhs;
+    actual_lhs(CSUB_D_H)   = tmp_d_lhs;
+    expected_lhs(CSUB_D_H) = d_lhs;
+    expected_lhs(CSUB_D_H) -= d_rhs;
+
     tmp_lhs = h_lhs;
     tmp_lhs *= h_rhs;
     actual_lhs(CMUL_H_H)   = cast_from_half<double>(tmp_lhs);
@@ -472,6 +499,24 @@ struct Functor_TestHalfOperators {
     expected_lhs(CMUL_H_S) = d_lhs;
     expected_lhs(CMUL_H_S) *= d_rhs;
 
+    tmp_s_lhs = static_cast<float>(h_lhs);
+    tmp_s_lhs *= h_rhs;
+    actual_lhs(CMUL_S_H)   = static_cast<double>(tmp_s_lhs);
+    expected_lhs(CMUL_S_H) = d_lhs;
+    expected_lhs(CMUL_S_H) *= d_rhs;
+
+    tmp_lhs = h_lhs;
+    tmp_lhs *= d_rhs;
+    actual_lhs(CMUL_H_D)   = static_cast<double>(tmp_lhs);
+    expected_lhs(CMUL_H_D) = d_lhs;
+    expected_lhs(CMUL_H_D) *= d_rhs;
+
+    tmp_d_lhs = static_cast<double>(h_lhs);
+    tmp_d_lhs *= h_rhs;
+    actual_lhs(CMUL_D_H)   = tmp_d_lhs;
+    expected_lhs(CMUL_D_H) = d_lhs;
+    expected_lhs(CMUL_D_H) *= d_rhs;
+
     tmp_lhs = h_lhs;
     tmp_lhs /= h_rhs;
     actual_lhs(CDIV_H_H)   = cast_from_half<double>(tmp_lhs);
@@ -483,6 +528,24 @@ struct Functor_TestHalfOperators {
     actual_lhs(CDIV_H_S)   = cast_from_half<double>(tmp_lhs);
     expected_lhs(CDIV_H_S) = d_lhs;
     expected_lhs(CDIV_H_S) /= d_rhs;
+
+    tmp_s_lhs = static_cast<float>(h_lhs);
+    tmp_s_lhs /= h_rhs;
+    actual_lhs(CDIV_S_H)   = static_cast<double>(tmp_s_lhs);
+    expected_lhs(CDIV_S_H) = d_lhs;
+    expected_lhs(CDIV_S_H) /= d_rhs;
+
+    tmp_lhs = h_lhs;
+    tmp_lhs /= d_rhs;
+    actual_lhs(CDIV_H_D)   = static_cast<double>(tmp_lhs);
+    expected_lhs(CDIV_H_D) = d_lhs;
+    expected_lhs(CDIV_H_D) /= d_rhs;
+
+    tmp_d_lhs = static_cast<double>(h_lhs);
+    tmp_d_lhs /= h_rhs;
+    actual_lhs(CDIV_D_H)   = tmp_d_lhs;
+    expected_lhs(CDIV_D_H) = d_lhs;
+    expected_lhs(CDIV_D_H) /= d_rhs;
 
     test_add<half_t, half_t, half_t>(ADD_H_H, ADD_H_H_SZ);
     test_add<float, half_t, float>(ADD_S_H, ADD_S_H_SZ);


### PR DESCRIPTION
Add Binary Arithmetic operators and Compound operators that upcast for mixed precision
expressions involving float and double. Add implicit conversions from
half_t to integral, float, and double types. Integral types should be implicitly downcast to half_t.