### PR TITLE
Workaround GraphNodeRef static_assert that does not compile with IBM XL

### DIFF
--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -70,10 +70,13 @@ class GraphNodeRef {
   // Note: because of these assertions, instantiating this class template is not
   //       intended to be SFINAE-safe, so do validation before you instantiate.
 
+// WORKAROUND Could not get it to compile with IBM XL V16.1.1
+#ifndef KOKKOS_COMPILER_IBM
   static_assert(
       std::is_same<Predecessor, TypeErasedTag>::value ||
           Kokkos::Impl::is_specialization_of<Predecessor, GraphNodeRef>::value,
       "Invalid predecessor template parameter given to GraphNodeRef");
+#endif
 
   static_assert(
       Kokkos::is_execution_space<ExecutionSpace>::value,

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -162,7 +162,8 @@
 #define KOKKOS_COMPILER_APPLECC __APPLE_CC__
 #endif
 
-#if defined(__clang__) && !defined(KOKKOS_COMPILER_INTEL)
+#if defined(__clang__) && !defined(KOKKOS_COMPILER_INTEL) && \
+    !defined(KOKKOS_COMPILER_IBM)
 #define KOKKOS_COMPILER_CLANG \
   __clang_major__ * 100 + __clang_minor__ * 10 + __clang_patchlevel__
 #endif

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -154,6 +154,8 @@
 #define KOKKOS_COMPILER_IBM __IBMCPP__
 #elif defined(__IBMC__)
 #define KOKKOS_COMPILER_IBM __IBMC__
+#elif defined(__ibmxl_vrm__)  // xlclang++
+#define KOKKOS_COMPILER_IBM __ibmxl_vrm__
 #endif
 
 #if defined(__APPLE_CC__)

--- a/core/src/impl/Kokkos_BitOps.hpp
+++ b/core/src/impl/Kokkos_BitOps.hpp
@@ -62,8 +62,6 @@ int log2(unsigned i) {
   return shift - __clz(i);
 #elif defined(KOKKOS_COMPILER_INTEL)
   return _bit_scan_reverse(i);
-#elif defined(KOKKOS_COMPILER_IBM)
-  return shift - __cntlz4(i);
 #elif defined(KOKKOS_COMPILER_CRAYC)
   return i ? shift - _leadz32(i) : 0;
 #elif defined(__GNUC__) || defined(__GNUG__)
@@ -92,8 +90,6 @@ int bit_first_zero(unsigned i) noexcept {
   return full != i ? __ffs(~i) - 1 : -1;
 #elif defined(KOKKOS_COMPILER_INTEL)
   return full != i ? _bit_scan_forward(~i) : -1;
-#elif defined(KOKKOS_COMPILER_IBM)
-  return full != i ? __cnttz4(~i) : -1;
 #elif defined(KOKKOS_COMPILER_CRAYC)
   return full != i ? _popcnt(i ^ (i + 1)) - 1 : -1;
 #elif defined(KOKKOS_COMPILER_GNU) || defined(__GNUC__) || defined(__GNUG__)
@@ -114,8 +110,6 @@ int bit_scan_forward(unsigned i) {
   return __ffs(i) - 1;
 #elif defined(KOKKOS_COMPILER_INTEL)
   return _bit_scan_forward(i);
-#elif defined(KOKKOS_COMPILER_IBM)
-  return __cnttz4(i);
 #elif defined(KOKKOS_COMPILER_CRAYC)
   return i ? _popcnt(~i & (i - 1)) : -1;
 #elif defined(KOKKOS_COMPILER_GNU) || defined(__GNUC__) || defined(__GNUG__)
@@ -137,8 +131,6 @@ int bit_count(unsigned i) {
   return __popc(i);
 #elif defined(__INTEL_COMPILER)
   return _popcnt32(i);
-#elif defined(KOKKOS_COMPILER_IBM)
-  return __popcnt4(i);
 #elif defined(KOKKOS_COMPILER_CRAYC)
   return _popcnt(i);
 #elif defined(__GNUC__) || defined(__GNUG__)

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -155,19 +155,6 @@ class HostThreadTeamData {
   }
 
   inline int pool_rendezvous() const noexcept {
-// not sure if the follow hack is still needed with the new barrier
-#if 0
-    static constexpr bool active_wait =
-#if defined(KOKKOS_COMPILER_IBM)
-      // If running on IBM POWER architecture the global
-      // level rendzvous should immediately yield when
-      // waiting for other threads in the pool to arrive.
-      false;
-#else
-      true;
-#endif
-#endif
-
     int* ptr = (int*)(m_pool_scratch + m_pool_rendezvous);
     HostBarrier::split_arrive(ptr, m_pool_size, m_pool_rendezvous_step);
     if (m_pool_rank != 0) {


### PR DESCRIPTION
Reported by @ndellingwood and reproduced on Summit
```
core/src/Kokkos_GraphNode.hpp:75:59: error: template argument for template template parameter must be a class template or type
      alias template
          Kokkos::Impl::is_specialization_of<Predecessor, GraphNodeRef>::value,
                                                          ^
```

Updated `<Kokkos_Macros.hpp>` to detect the use of `xlclang++` and dropped use of legacy IBM XL-based built-in functions in `<Kokkos_BitOps.hpp>`.
