### PR TITLE
Fix MSVC build on AppVeyor (Drop no except specification for ObjectWithVLAEmulation's destructor)

### DIFF
--- a/core/src/impl/Kokkos_VLAEmulation.hpp
+++ b/core/src/impl/Kokkos_VLAEmulation.hpp
@@ -195,8 +195,7 @@ struct ObjectWithVLAEmulation {
   }
 
   KOKKOS_INLINE_FUNCTION
-  ~ObjectWithVLAEmulation() noexcept(
-      std::is_nothrow_destructible<vla_value_type>::value) {
+  ~ObjectWithVLAEmulation() {
     for (auto&& value : *this) {
       value.~vla_value_type();
     }

--- a/core/src/impl/Kokkos_VLAEmulation.hpp
+++ b/core/src/impl/Kokkos_VLAEmulation.hpp
@@ -196,7 +196,7 @@ struct ObjectWithVLAEmulation {
 
   KOKKOS_INLINE_FUNCTION
   ~ObjectWithVLAEmulation() noexcept(
-      noexcept(std::declval<vla_value_type>().~vla_value_type())) {
+      std::is_nothrow_destructible<vla_value_type>::value) {
     for (auto&& value : *this) {
       value.~vla_value_type();
     }


### PR DESCRIPTION
Failure followed update from MSVC 19.27.29112.0 to 19.28.29333.0