### PR TITLE
Support Reducer in ThreadVectorRange parallel_scan

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -1016,6 +1016,91 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
 #endif
 }
 
+//----------------------------------------------------------------------------
+
+/** \brief  Intra-thread vector parallel scan with reducer.
+ *
+ *  Executes closure(iType i, ValueType & val, bool final) for each i=[0..N)
+ *
+ *  The range [0..N) is mapped to all vector lanes in the
+ *  thread and a scan operation is performed.
+ *  The last call to closure has final == true.
+ */
+template <typename iType, class Closure, typename ReducerType>
+KOKKOS_INLINE_FUNCTION typename std::enable_if<
+    Kokkos::is_reducer<ReducerType>::value>::type
+parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
+                  iType, Impl::CudaTeamMember>& loop_boundaries,
+              const Closure& closure, const ReducerType& reducer) {
+  (void)loop_boundaries;
+  (void)closure;
+#ifdef __CUDA_ARCH__
+
+  using value_type = typename ReducerType::value_type;
+  value_type accum;
+  reducer.init(accum);
+  const value_type identity = accum;
+
+  // Loop through boundaries by vector-length chunks
+  // must scan at each iteration
+
+  // All thread "lanes" must loop the same number of times.
+  // Determine an loop end for all thread "lanes."
+  // Requires:
+  //   blockDim.x is power of two and thus
+  //     ( end % blockDim.x ) == ( end & ( blockDim.x - 1 ) )
+  //   1 <= blockDim.x <= CudaTraits::WarpSize
+
+  const int mask = blockDim.x - 1;
+  const unsigned active_mask =
+      blockDim.x == 32 ? 0xffffffff
+                       : ((1 << blockDim.x) - 1)
+                             << (threadIdx.y % (32 / blockDim.x)) * blockDim.x;
+  const int rem = loop_boundaries.end & mask;  // == end % blockDim.x
+  const int end = loop_boundaries.end + (rem ? blockDim.x - rem : 0);
+
+  for (int i = threadIdx.x; i < end; i += blockDim.x) {
+    value_type val = identity;
+
+    // First acquire per-lane contributions.
+    // This sets i's val to i-1's contribution
+    // to make the latter in_place_shfl_up an
+    // exclusive scan -- the final accumulation
+    // of i's val will be inclucded in the second
+    // closure call later.
+    if (i < loop_boundaries.end && threadIdx.x > 0) closure(i - 1, val, false);
+
+    // Bottom up exclusive scan in triangular pattern
+    // where each CUDA thread is the root of a reduction tree
+    // from the zeroth "lane" to itself.
+    //  [t] += [t-1] if t >= 1
+    //  [t] += [t-2] if t >= 2
+    //  [t] += [t-4] if t >= 4
+    //  ...
+    //  This differs from the non-reducer overload, where an inclusive scan was
+    //  implemented, because in general the binary operator cannot be inverted
+    //  and we would not be able to remove the inclusive contribution by
+    //  inversion.
+    for (int j = 1; j < (int)blockDim.x; j <<= 1) {
+      value_type tmp = identity;
+      Impl::in_place_shfl_up(tmp, val, j, blockDim.x, active_mask);
+      if (j <= (int)threadIdx.x) {
+        reducer.join(val, tmp);
+      }
+    }
+
+    // Include accumulation
+    reducer.join(val, accum);
+
+    // Update i's contribution into the val
+    // and add it to accum for next round
+    if (i < loop_boundaries.end) closure(i, val, true);
+    Impl::in_place_shfl(accum, val, mask, blockDim.x, active_mask);
+  }
+
+#endif
+}
+
 }  // namespace Kokkos
 
 namespace Kokkos {

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -2615,6 +2615,28 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   }
 }
 
+/** \brief  Intra-thread vector parallel scan with reducer
+ *
+ */
+template <typename iType, class FunctorType, typename ReducerType>
+KOKKOS_INLINE_FUNCTION typename std::enable_if<
+    Kokkos::is_reducer<ReducerType>::value>::type
+parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
+                  iType, Impl::HPXTeamMember>& loop_boundaries,
+              const FunctorType& lambda, const ReducerType& reducer) {
+
+  typename ReducerType::value_type scan_val;
+  reducer.init(scan_val);
+
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
+       i += loop_boundaries.increment) {
+    lambda(i, scan_val, true);
+  }
+}
+
 template <class FunctorType>
 KOKKOS_INLINE_FUNCTION void single(
     const Impl::VectorSingleStruct<Impl::HPXTeamMember> &,

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -1271,6 +1271,28 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   }
 }
 
+/** \brief  Intra-thread vector parallel scan with reducer
+ *
+ */
+template <typename iType, class FunctorType, typename ReducerType>
+KOKKOS_INLINE_FUNCTION typename std::enable_if<
+    Kokkos::is_reducer<ReducerType>::value>::type
+parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
+                  iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
+              const FunctorType& lambda, const ReducerType& reducer) {
+
+  typename ReducerType::value_type scan_val;
+  reducer.init(scan_val);
+
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
+       i += loop_boundaries.increment) {
+    lambda(i, scan_val, true);
+  }
+}
+
 }  // namespace Kokkos
 
 namespace Kokkos {

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -1059,6 +1059,28 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   }
 }
 
+/** \brief  Intra-thread vector parallel scan with reducer
+ *
+ */
+template <typename iType, class FunctorType, typename ReducerType>
+KOKKOS_INLINE_FUNCTION typename std::enable_if<
+    Kokkos::is_reducer<ReducerType>::value>::type
+parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
+                  iType, Impl::ThreadsExecTeamMember>& loop_boundaries,
+              const FunctorType& lambda, const ReducerType& reducer) {
+
+  typename ReducerType::value_type scan_val;
+  reducer.init(scan_val);
+
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
+       i += loop_boundaries.increment) {
+    lambda(i, scan_val, true);
+  }
+}
+
 }  // namespace Kokkos
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -1023,6 +1023,26 @@ parallel_scan(Impl::ThreadVectorRangeBoundariesStruct<iType, Member> const&
   }
 }
 
+template <typename iType, class Lambda, typename ReducerType, typename Member>
+KOKKOS_INLINE_FUNCTION typename std::enable_if<
+    Kokkos::is_reducer<ReducerType>::value &&
+    Impl::is_host_thread_team_member<Member>::value>::type
+parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<iType, Member>&
+                    loop_boundaries,
+              const Lambda& lambda, const ReducerType& reducer) {
+
+  typename ReducerType::value_type scan_val;
+  reducer.init(scan_val);
+
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
+       i += loop_boundaries.increment) {
+    lambda(i, scan_val, true);
+  }
+}
+
 //----------------------------------------------------------------------------
 
 template <class Member>


### PR DESCRIPTION
Partially address https://github.com/kokkos/kokkos/issues/3584

This doesn't include the HIP and/or task backend.

I have tested these using the following code:

```c++
#include <iostream>
#include <iomanip>
#include <utility>
#include <typeinfo>
#include <string>
#include <type_traits>
#include <Kokkos_Core.hpp>
#include <Kokkos_Random.hpp>
#include <Kokkos_DualView.hpp>

using ExecutionSpace = Kokkos::DefaultExecutionSpace;
using namespace std;

using TeamPolicy = Kokkos::TeamPolicy<ExecutionSpace>;
using Team = TeamPolicy::member_type;
static constexpr int n = 1e6;
static constexpr int nTeamThreadRange = 1e3;
static constexpr int nThreadVectorRange = 1e2;
static constexpr int nPerTeam = nTeamThreadRange * nThreadVectorRange;
static constexpr int nTeams = n / nPerTeam;

template < bool bInclusive, class Reducer, class ... Ts>
Kokkos::View<typename Reducer::value_type[n], Ts...>
getExpectedResults(const Reducer& reducer,
  const Kokkos::View<typename Reducer::value_type[n], Ts...>& inputs) {
  using value_type = typename Reducer::value_type;
  static_assert(Kokkos::View<value_type[n], Ts...>::is_hostspace,
    "Input view is not on the host space");
  value_type identity;
  reducer.init(identity);
  Kokkos::View<value_type[n], Ts...> expecteds("expecteds");
  for(int i = 0; i < expecteds.extent(0); ++i) {
    const int iVector = i % nThreadVectorRange;
    const value_type accum = iVector == 0 ? identity : expecteds(i-1);
    const value_type val  = bInclusive ? inputs(i) :
      (iVector == 0 ? identity : inputs(i-1));
    expecteds(i) = accum;
    reducer.join(expecteds(i), val);
  }
  return expecteds;
}

template < bool bInclusive, class Reducer>
void checkScan(const Kokkos::DualView<typename Reducer::value_type[n], ExecutionSpace>& inputs) {

  using value_type = typename Reducer::value_type;
  value_type tmp;
  Reducer reducer(tmp);

  Kokkos::DualView<typename Reducer::value_type[n], ExecutionSpace> outputs("outputs");

  //run ThreadVectorRange parallel_scan 
  TeamPolicy policy(nTeams, Kokkos::AUTO, Kokkos::AUTO);
  const std::string label = (bInclusive ? std::string("inclusive") : std::string("exclusive")) +
    std::string("Scan") + std::string(typeid(Reducer).name());
  Kokkos::parallel_for(label, policy, KOKKOS_LAMBDA (const Team& team) {
    const int iTeam = team.league_rank();
    const int iTeamOffset = iTeam * nPerTeam;
    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nTeamThreadRange),
      [&](const int i) {
      const int iThreadOffset = i * nThreadVectorRange;
      Kokkos::parallel_scan(Kokkos::ThreadVectorRange(team, nThreadVectorRange),
        [&](const int j, value_type& update, const bool bFinal) {
          const int iElement = j + iTeamOffset + iThreadOffset;
          const auto tmp = inputs.d_view(iElement);
          if(bInclusive) {
            reducer.join(update, tmp);
            if(bFinal) {
              outputs.d_view(iElement) = update;
            }
          } else {
            if(bFinal) {
              outputs.d_view(iElement) = update;
            }
            reducer.join(update, tmp);
          }
      }, reducer);
    });
  });
  Kokkos::fence();
  outputs.modify_device();
  outputs.sync_host();

  auto expected = getExpectedResults<bInclusive>(reducer, inputs.h_view);

  for(int i = 0; i < outputs.extent(0); ++i) {
    if(outputs.h_view(i) != expected(i)) {
      cerr << 
        setw(50) << 
        std::string("Wrong ") + label + std::string(" outputs at ") << 
        setw(10) <<
        i <<
        setw(20) << std::scientific << 
        outputs.h_view(i) <<
        setw(6) <<
        std::string(" != ") << 
        setw(20) << std::scientific << 
        expected(i) << "\n";
    }
    /* else { */
    /*   cout << */
    /*     setw(50) << */
    /*     std::string("Right ") + label + std::string(" outputs at ") << */ 
    /*     setw(10) << */
    /*     i << */ 
    /*     setw(20) << std::scientific << */ 
    /*     outputs.h_view(i) << "\n"; */
    /* } */
  }
}

int main(int argc, char* argv[]) {
  Kokkos::initialize(argc,argv); {
  using T = double;


  Kokkos::DualView<T[n], ExecutionSpace> inputs("inputs");
  Kokkos::Random_XorShift64_Pool<ExecutionSpace> rndPool(1931);
  Kokkos::fill_random(inputs.d_view, rndPool, T{1.0});

  Kokkos::fence();
  inputs.modify_device();
  inputs.sync_host();

  checkScan<false, Kokkos::Prod<T, ExecutionSpace>>(inputs);
  checkScan<true,  Kokkos::Prod<T, ExecutionSpace>>(inputs);

  checkScan<false, Kokkos::Max<T, ExecutionSpace>>(inputs);
  checkScan<true,  Kokkos::Max<T, ExecutionSpace>>(inputs);

  checkScan<false, Kokkos::Min<T, ExecutionSpace>>(inputs);
  checkScan<true,  Kokkos::Min<T, ExecutionSpace>>(inputs);

  } Kokkos::finalize();
}

```
