### PR TITLE
Update Docker image for OpenMP Target CI build on Jenkins

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -138,7 +138,7 @@ pipeline {
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER=clang++ \
-                                -DCMAKE_CXX_FLAGS="--gcc-toolchain=$GCC_DIR -Werror" \
+                                -DCMAKE_CXX_FLAGS="-Werror" \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_TUNING=ON \

--- a/.jenkins
+++ b/.jenkins
@@ -138,7 +138,7 @@ pipeline {
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER=clang++ \
-                                -DCMAKE_CXX_FLAGS="-Werror" \
+                                -DCMAKE_CXX_FLAGS="-Wno-unknown-cuda-version -Werror" \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_TUNING=ON \

--- a/scripts/docker/Dockerfile.openmptarget
+++ b/scripts/docker/Dockerfile.openmptarget
@@ -1,4 +1,4 @@
-ARG BASE=nvidia/cuda:10.1-devel
+ARG BASE=nvidia/cuda:11.1-devel-ubuntu20.04
 FROM $BASE
 
 RUN apt-get update && apt-get install -y \

--- a/scripts/docker/Dockerfile.openmptarget
+++ b/scripts/docker/Dockerfile.openmptarget
@@ -32,15 +32,11 @@ RUN CMAKE_KEY=2D2CEF1034921684 && \
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
 ENV LLVM_DIR=/opt/llvm
-RUN LLVM_VERSION=10.0.0 && \
-    LLVM_KEY="345AD05D 86419D8A" && \
-    LLVM_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION} &&\
-    LLVM_ARCHIVE=llvm-project-${LLVM_VERSION}.tar.xz &&\
+RUN LLVM_VERSION=887c7660bdf3f300bd1997dcfd7ace91787c0584 && \
+    LLVM_URL=https://github.com/llvm/llvm-project/archive &&\
+    LLVM_ARCHIVE=${LLVM_VERSION}.tar.gz &&\
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${LLVM_URL}/${LLVM_ARCHIVE} && \
-    wget --quiet ${LLVM_URL}/${LLVM_ARCHIVE}.sig && \
-    gpg --keyserver hkps.pool.sks-keyservers.net --recv-keys ${LLVM_KEY} && \
-    gpg --verify ${LLVM_ARCHIVE}.sig ${LLVM_ARCHIVE} && \
     mkdir llvm-project && \
     tar -xf ${LLVM_ARCHIVE} -C llvm-project --strip-components=1 && \
     cd llvm-project && \

--- a/scripts/docker/Dockerfile.openmptarget
+++ b/scripts/docker/Dockerfile.openmptarget
@@ -31,25 +31,6 @@ RUN CMAKE_KEY=2D2CEF1034921684 && \
     rm ${CMAKE_SCRIPT}
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
-ENV GCC_DIR=/opt/gcc
-RUN GCC_VERSION=6.5.0 && \
-    GNU_MIRROR=https://gnu.freemirror.org/gnu && \
-    wget --quiet ${GNU_MIRROR}/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz && \
-    wget --quiet ${GNU_MIRROR}/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz.sig && \
-    wget --quiet ${GNU_MIRROR}/gnu-keyring.gpg && \
-    gpg --verify --no-default-keyring --keyring ./gnu-keyring.gpg gcc-${GCC_VERSION}.tar.xz.sig && \
-    tar -xf gcc-${GCC_VERSION}.tar.xz && \
-    cd gcc-${GCC_VERSION} && \
-    ./contrib/download_prerequisites && \
-    cd .. && \
-    mkdir gcc-${GCC_VERSION}-build && \
-    cd gcc-${GCC_VERSION}-build && \
-    $PWD/../gcc-${GCC_VERSION}/configure --prefix=${GCC_DIR} --enable-languages=c,c++ --disable-multilib && \
-    make -j${NPROC} && \
-    make install && \
-    cd .. && rm -rf gcc-*
-ENV PATH=${GCC_DIR}/bin:$PATH
-
 ENV LLVM_DIR=/opt/llvm
 RUN LLVM_VERSION=10.0.0 && \
     LLVM_KEY="345AD05D 86419D8A" && \

--- a/scripts/docker/Dockerfile.openmptarget
+++ b/scripts/docker/Dockerfile.openmptarget
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 
 ARG NPROC=8
 
-ARG CMAKE_VERSION=3.10.3
+ARG CMAKE_VERSION=3.18.5
 ENV CMAKE_DIR=/opt/cmake
 RUN CMAKE_KEY=2D2CEF1034921684 && \
     CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \


### PR DESCRIPTION
#3462 build passes with the updated image.  Clang segfaults we the current one.