### PR TITLE
Introduce KOKKOS_PRINTF

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -39,7 +39,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=Release \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=clang++ \
-                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unknown-cuda-version" \
+                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unknown-cuda-version -Wno-gnu-zero-variadic-macro-arguments" \
                                 -DKokkos_ARCH_VOLTA70=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \

--- a/cmake/kokkos_enable_devices.cmake
+++ b/cmake/kokkos_enable_devices.cmake
@@ -152,3 +152,8 @@ IF (KOKKOS_ENABLE_HIP)
 ENDIF()
 
 KOKKOS_DEVICE_OPTION(SYCL OFF DEVICE "Whether to build SYCL backend")
+
+## SYCL has extra setup requirements, turn on Kokkos_Setup_SYCL.hpp in macros
+IF (KOKKOS_ENABLE_SYCL)
+  LIST(APPEND DEVICE_SETUP_LIST SYCL)
+ENDIF()

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -245,13 +245,10 @@ KOKKOS_INLINE_FUNCTION bool dyn_rank_view_verify_operator_bounds(
     return (size_t(i) < map.extent(R)) &&
            dyn_rank_view_verify_operator_bounds<R + 1>(rank, map, args...);
   } else if (i != 0) {
-    // FIXME_SYCL SYCL doesn't allow printf in kernels
-#ifndef KOKKOS_ENABLE_SYCL
-    printf(
+    KOKKOS_IMPL_PRINTF(
         "DynRankView Debug Bounds Checking Error: at rank %u\n  Extra "
         "arguments beyond the rank must be zero \n",
         R);
-#endif
     return (false) &&
            dyn_rank_view_verify_operator_bounds<R + 1>(rank, map, args...);
   } else {

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -245,7 +245,7 @@ KOKKOS_INLINE_FUNCTION bool dyn_rank_view_verify_operator_bounds(
     return (size_t(i) < map.extent(R)) &&
            dyn_rank_view_verify_operator_bounds<R + 1>(rank, map, args...);
   } else if (i != 0) {
-    KOKKOS_IMPL_PRINTF(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "DynRankView Debug Bounds Checking Error: at rank %u\n  Extra "
         "arguments beyond the rank must be zero \n",
         R);

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -540,7 +540,7 @@ class UnorderedMap {
           // Previously claimed an unused entry that was not inserted.
           // Release this unused entry immediately.
           if (!m_available_indexes.reset(new_index)) {
-            KOKKOS_IMPL_PRINTF("Unable to free existing\n");
+            KOKKOS_IMPL_DO_NOT_USE_PRINTF("Unable to free existing\n");
           }
         }
 

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -540,10 +540,7 @@ class UnorderedMap {
           // Previously claimed an unused entry that was not inserted.
           // Release this unused entry immediately.
           if (!m_available_indexes.reset(new_index)) {
-            // FIXME_SYCL SYCL doesn't allow printf in kernels
-#ifndef KOKKOS_ENABLE_SYCL
-            printf("Unable to free existing\n");
-#endif
+            KOKKOS_IMPL_PRINTF("Unable to free existing\n");
           }
         }
 

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -382,6 +382,8 @@
 #define KOKKOS_IMPL_DEVICE_FUNCTION
 #endif
 
+// Temporary solution for SYCL not supporting printf in kernels.
+// Might disappear at any point once we have found another solution.
 #if !defined(KOKKOS_IMPL_PRINTF)
 #define KOKKOS_IMPL_PRINTF(...) printf(__VA_ARGS__)
 #endif

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -382,6 +382,10 @@
 #define KOKKOS_IMPL_DEVICE_FUNCTION
 #endif
 
+#if !defined(KOKKOS_IMPL_PRINTF)
+#define KOKKOS_IMPL_PRINTF(...) printf(__VA_ARGS__)
+#endif
+
 //----------------------------------------------------------------------------
 // Define final version of functions. This is so that clang tidy can find these
 // macros more easily

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -384,8 +384,8 @@
 
 // Temporary solution for SYCL not supporting printf in kernels.
 // Might disappear at any point once we have found another solution.
-#if !defined(KOKKOS_IMPL_PRINTF)
-#define KOKKOS_IMPL_PRINTF(...) printf(__VA_ARGS__)
+#if !defined(KOKKOS_IMPL_DO_NOT_USE_PRINTF)
+#define KOKKOS_IMPL_DO_NOT_USE_PRINTF(...) printf(__VA_ARGS__)
 #endif
 
 //----------------------------------------------------------------------------

--- a/core/src/SYCL/Kokkos_SYCL_Abort.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Abort.hpp
@@ -52,7 +52,7 @@ namespace Kokkos {
 namespace Impl {
 
 inline void sycl_abort(char const *msg) {
-  KOKKOS_IMPL_PRINTF("Aborting with message %s.\n", msg);
+  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Aborting with message %s.\n", msg);
 }
 
 }  // namespace Impl

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -57,12 +57,12 @@ void sink(Args&&... args) {
 }
 }  // namespace ImplSYCL
 }  // namespace Kokkos
-#define KOKKOS_IMPL_PRINTF(...)          \
-  do {                                   \
-    Kokkos::ImplSYCL::sink(__VA_ARGS__); \
+#define KOKKOS_IMPL_DO_NOT_USE_PRINTF(...) \
+  do {                                     \
+    Kokkos::ImplSYCL::sink(__VA_ARGS__);   \
   } while (0)
 #else
-#define KOKKOS_IMPL_PRINTF(format, ...)                                  \
+#define KOKKOS_IMPL_DO_NOT_USE_PRINTF(format, ...)                       \
   do {                                                                   \
     static const __attribute__((opencl_constant)) char fmt[] = (format); \
     sycl::ONEAPI::experimental::printf(fmt, ##__VA_ARGS__);              \

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -42,21 +42,32 @@
 //@HEADER
 */
 
-#ifndef KOKKOS_SYCL_ABORT_HPP
-#define KOKKOS_SYCL_ABORT_HPP
+#ifndef KOKKOS_SETUP_SYCL_HPP_
+#define KOKKOS_SETUP_SYCL_HPP_
 
-#include <Kokkos_Macros.hpp>
-#if defined(KOKKOS_ENABLE_SYCL)
+#include <CL/sycl.hpp>
 
+#ifdef __SYCL_DEVICE_ONLY__
+#ifdef KOKKOS_IMPL_DISABLE_SYCL_DEVICE_PRINTF
 namespace Kokkos {
-namespace Impl {
-
-inline void sycl_abort(char const *msg) {
-  KOKKOS_IMPL_PRINTF("Aborting with message %s.\n", msg);
+namespace ImplSYCL {
+template <typename... Args>
+void sink(Args&&... args) {
+  (void)(sizeof...(args));
 }
-
-}  // namespace Impl
+}  // namespace ImplSYCL
 }  // namespace Kokkos
-
+#define KOKKOS_IMPL_PRINTF(...)          \
+  do {                                   \
+    Kokkos::ImplSYCL::sink(__VA_ARGS__); \
+  } while (0)
+#else
+#define KOKKOS_IMPL_PRINTF(format, ...)                                  \
+  do {                                                                   \
+    static const __attribute__((opencl_constant)) char fmt[] = (format); \
+    sycl::ONEAPI::experimental::printf(fmt, ##__VA_ARGS__);              \
+  } while (0)
 #endif
+#endif
+
 #endif

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -162,8 +162,8 @@ struct TestRange {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyInitTag &, const int i) const {
     if (i != m_flags(i)) {
-      KOKKOS_IMPL_PRINTF("TestRange::test_for_error at %d != %d\n", i,
-                         m_flags(i));
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("TestRange::test_for_error at %d != %d\n",
+                                    i, m_flags(i));
     }
   }
 
@@ -175,8 +175,8 @@ struct TestRange {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyResetTag &, const int i) const {
     if (2 * i != m_flags(i)) {
-      KOKKOS_IMPL_PRINTF("TestRange::test_for_error at %d != %d\n", i,
-                         m_flags(i));
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("TestRange::test_for_error at %d != %d\n",
+                                    i, m_flags(i));
     }
   }
 
@@ -188,8 +188,8 @@ struct TestRange {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyOffsetTag &, const int i) const {
     if (i + offset != m_flags(i)) {
-      KOKKOS_IMPL_PRINTF("TestRange::test_for_error at %d != %d\n", i + offset,
-                         m_flags(i));
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("TestRange::test_for_error at %d != %d\n",
+                                    i + offset, m_flags(i));
     }
   }
 
@@ -272,8 +272,9 @@ struct TestRange {
 
     if (final) {
       if (update != (i * (i + 1)) / 2) {
-        KOKKOS_IMPL_PRINTF("TestRange::test_scan error (%d,%d) : %d != %d\n", i,
-                           m_flags(i), (i * (i + 1)) / 2, update);
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "TestRange::test_scan error (%d,%d) : %d != %d\n", i, m_flags(i),
+            (i * (i + 1)) / 2, update);
       }
       result_view(i) = update;
     }

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -162,10 +162,8 @@ struct TestRange {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyInitTag &, const int i) const {
     if (i != m_flags(i)) {
-      // FIXME_SYCL printf needs a workaround
-#ifndef __SYCL_DEVICE_ONLY__
-      printf("TestRange::test_for_error at %d != %d\n", i, m_flags(i));
-#endif
+      KOKKOS_IMPL_PRINTF("TestRange::test_for_error at %d != %d\n", i,
+                         m_flags(i));
     }
   }
 
@@ -177,10 +175,8 @@ struct TestRange {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyResetTag &, const int i) const {
     if (2 * i != m_flags(i)) {
-      // FIXME_SYCL printf needs a workaround
-#ifndef __SYCL_DEVICE_ONLY__
-      printf("TestRange::test_for_error at %d != %d\n", i, m_flags(i));
-#endif
+      KOKKOS_IMPL_PRINTF("TestRange::test_for_error at %d != %d\n", i,
+                         m_flags(i));
     }
   }
 
@@ -192,10 +188,8 @@ struct TestRange {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyOffsetTag &, const int i) const {
     if (i + offset != m_flags(i)) {
-      // FIXME_SYCL printf needs a workaround
-#ifndef __SYCL_DEVICE_ONLY__
-      printf("TestRange::test_for_error at %d != %d\n", i + offset, m_flags(i));
-#endif
+      KOKKOS_IMPL_PRINTF("TestRange::test_for_error at %d != %d\n", i + offset,
+                         m_flags(i));
     }
   }
 
@@ -278,10 +272,8 @@ struct TestRange {
 
     if (final) {
       if (update != (i * (i + 1)) / 2) {
-#ifndef __SYCL_DEVICE_ONLY__
-        printf("TestRange::test_scan error (%d,%d) : %d != %d\n", i, m_flags(i),
-               (i * (i + 1)) / 2, update);
-#endif
+        KOKKOS_IMPL_PRINTF("TestRange::test_scan error (%d,%d) : %d != %d\n", i,
+                           m_flags(i), (i * (i + 1)) / 2, update);
       }
       result_view(i) = update;
     }

--- a/core/unit_test/TestRangePolicyRequire.hpp
+++ b/core/unit_test/TestRangePolicyRequire.hpp
@@ -170,8 +170,8 @@ struct TestRangeRequire {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyInitTag &, const int i) const {
     if (i != m_flags(i)) {
-      KOKKOS_IMPL_PRINTF("TestRangeRequire::test_for error at %d != %d\n", i,
-                         m_flags(i));
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "TestRangeRequire::test_for error at %d != %d\n", i, m_flags(i));
     }
   }
 
@@ -183,8 +183,8 @@ struct TestRangeRequire {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyResetTag &, const int i) const {
     if (2 * i != m_flags(i)) {
-      KOKKOS_IMPL_PRINTF("TestRangeRequire::test_for error at %d != %d\n", i,
-                         m_flags(i));
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "TestRangeRequire::test_for error at %d != %d\n", i, m_flags(i));
     }
   }
 
@@ -196,8 +196,9 @@ struct TestRangeRequire {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyOffsetTag &, const int i) const {
     if (i + offset != m_flags(i)) {
-      KOKKOS_IMPL_PRINTF("TestRangeRequire::test_for error at %d != %d\n",
-                         i + offset, m_flags(i));
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "TestRangeRequire::test_for error at %d != %d\n", i + offset,
+          m_flags(i));
     }
   }
 
@@ -264,8 +265,9 @@ struct TestRangeRequire {
 
     if (final) {
       if (update != (i * (i + 1)) / 2) {
-        KOKKOS_IMPL_PRINTF("TestRangeRequire::test_scan error %d : %d != %d\n",
-                           i, (i * (i + 1)) / 2, m_flags(i));
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "TestRangeRequire::test_scan error %d : %d != %d\n", i,
+            (i * (i + 1)) / 2, m_flags(i));
       }
     }
   }

--- a/core/unit_test/TestRangePolicyRequire.hpp
+++ b/core/unit_test/TestRangePolicyRequire.hpp
@@ -170,10 +170,8 @@ struct TestRangeRequire {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyInitTag &, const int i) const {
     if (i != m_flags(i)) {
-      // FIXME_SYCL printf needs a workaround
-#ifndef __SYCL_DEVICE_ONLY__
-      printf("TestRangeRequire::test_for error at %d != %d\n", i, m_flags(i));
-#endif
+      KOKKOS_IMPL_PRINTF("TestRangeRequire::test_for error at %d != %d\n", i,
+                         m_flags(i));
     }
   }
 
@@ -185,10 +183,8 @@ struct TestRangeRequire {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyResetTag &, const int i) const {
     if (2 * i != m_flags(i)) {
-      // FIXME_SYCL printf needs a workaround
-#ifndef __SYCL_DEVICE_ONLY__
-      printf("TestRangeRequire::test_for error at %d != %d\n", i, m_flags(i));
-#endif
+      KOKKOS_IMPL_PRINTF("TestRangeRequire::test_for error at %d != %d\n", i,
+                         m_flags(i));
     }
   }
 
@@ -200,11 +196,8 @@ struct TestRangeRequire {
   KOKKOS_INLINE_FUNCTION
   void operator()(const VerifyOffsetTag &, const int i) const {
     if (i + offset != m_flags(i)) {
-      // FIXME_SYCL printf needs a workaround
-#ifndef __SYCL_DEVICE_ONLY__
-      printf("TestRangeRequire::test_for error at %d != %d\n", i + offset,
-             m_flags(i));
-#endif
+      KOKKOS_IMPL_PRINTF("TestRangeRequire::test_for error at %d != %d\n",
+                         i + offset, m_flags(i));
     }
   }
 
@@ -271,11 +264,8 @@ struct TestRangeRequire {
 
     if (final) {
       if (update != (i * (i + 1)) / 2) {
-        // FIXME_SYCL printf needs a workaround
-#ifndef __SYCL_DEVICE_ONLY__
-        printf("TestRangeRequire::test_scan error %d : %d != %d\n", i,
-               (i * (i + 1)) / 2, m_flags(i));
-#endif
+        KOKKOS_IMPL_PRINTF("TestRangeRequire::test_scan error %d : %d != %d\n",
+                           i, (i * (i + 1)) / 2, m_flags(i));
       }
     }
   }


### PR DESCRIPTION
`printf` can't be used in SYCL kernels but needs an experimental feature that requires a slightly different syntax. This pull request aims to provide a version that can be used independent of the backend. It is up for discussion if this is something we want.
The current version doesn't work with an empty parameter list.

Based on top of #3609. https://github.com/kokkos/kokkos/commit/5eb7441deabf0a23a6ddea6fa34f65fd3e4908fe is the relevant commit.