### PR TITLE
Fix SYCL memory access in allocation

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -224,7 +224,9 @@ SharedAllocationRecord<Kokkos::Experimental::SYCLDeviceUSMSpace, void>::
   // Set last element zero, in case c_str is too long
   header.m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
 
-  memcpy(m_alloc_ptr, &header, sizeof(SharedAllocationHeader));
+  // Copy to device memory
+  Kokkos::Impl::DeepCopy<Kokkos::Experimental::SYCLDeviceUSMSpace, HostSpace>(
+      RecordBase::m_alloc_ptr, &header, sizeof(SharedAllocationHeader));
 }
 
 }  // namespace Impl


### PR DESCRIPTION
Previously, we were copying memory from the host to the device via `memcpy`. I am somewhat surprised that this ever worked for some GPUs.

It might be a good idea to consider this for the release.