### PR TITLE
Run SYCL CI on a CUDA GPU

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -28,8 +28,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.sycl'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=intel/oneapi-basekit:devel-ubuntu18.04'
-                            label 'docker'
+                            label 'nvidia-docker && volta'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache'
                         }
                     }
@@ -37,10 +36,10 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
-                                -DCMAKE_BUILD_TYPE=Debug \
+                                -DCMAKE_BUILD_TYPE=Release \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=clang++ \
-                                -DCMAKE_CXX_FLAGS="-Werror" \
+                                -DCMAKE_CXX_FLAGS="-Werror -Wno-unknown-cuda-version -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice" \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_SYCL=ON \

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
@@ -117,6 +117,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, ExecPolicy,
   using functor_type = FunctorType;
 
   void execute() const {
+    if (m_policy.begin() == m_policy.end()) return;
+
     // if the functor is trivially copyable, we can launch it directly;
     // otherwise, we will launch it indirectly via explicitly creating
     // it in USM shared memory.

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -248,6 +248,8 @@ class ParallelScanSYCLBase {
  public:
   template <typename PostFunctor>
   void impl_execute(const PostFunctor& post_functor) {
+    if (m_policy.begin() == m_policy.end()) return;
+
     const auto& q = *(m_policy.space().impl_internal_space_instance()->m_queue);
     const std::size_t len = m_policy.end() - m_policy.begin();
 

--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -1,16 +1,18 @@
-ARG BASE=intel/oneapi-basekit:devel-ubuntu18.04
+ARG BASE=nvidia/cuda:10.2-devel
 FROM $BASE
 
 RUN apt-get update && apt-get install -y \
+        bc \
         wget \
         ccache \
+        ninja-build \
+        python3 \
+        git \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ENV PATH=/opt/intel/oneapi/compiler/latest/linux/bin/:$PATH
-
-ARG CMAKE_VERSION=3.10.3
+ARG CMAKE_VERSION=3.18.5
 ENV CMAKE_DIR=/opt/cmake
 RUN CMAKE_KEY=2D2CEF1034921684 && \
     CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \
@@ -26,3 +28,20 @@ RUN CMAKE_KEY=2D2CEF1034921684 && \
     sh ${CMAKE_SCRIPT} --skip-license --prefix=${CMAKE_DIR} && \
     rm cmake*
 ENV PATH=${CMAKE_DIR}/bin:$PATH
+
+ENV SYCL_DIR=/opt/sycl
+RUN SYCL_VERSION=20201119 && \
+    SYCL_URL=https://github.com/intel/llvm/archive && \
+    SYCL_ARCHIVE=${SYCL_VERSION}.tar.gz && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${SYCL_URL}/${SYCL_ARCHIVE} && \
+    mkdir llvm && \
+    tar -xf ${SYCL_ARCHIVE} -C llvm --strip-components=1 && \
+    cd llvm && \
+    python3 buildbot/configure.py --cuda && \
+    python3 buildbot/compile.py && \
+    mkdir -p ${SYCL_DIR} && \
+    mv ${SCRATCH_DIR}/llvm/build/install/* ${SYCL_DIR} && \
+    echo "${SYCL_DIR}/lib" > /etc/ld.so.conf.d/sycl.conf && ldconfig && \
+    rm -rf ${SCRATCH_DIR}
+ENV PATH=${SYCL_DIR}/bin:$PATH


### PR DESCRIPTION
Running the SYCL CI on an actual GPU should give more relevant results.

The used commit required short-cutting `parallel_scan` and `parallel_for` for empty ranges.