### PR TITLE
Decrease the number of Fibonacci iterations when using HIP

### DIFF
--- a/core/unit_test/TestWorkGraph.hpp
+++ b/core/unit_test/TestWorkGraph.hpp
@@ -159,7 +159,12 @@ struct TestWorkGraph {
 }  // anonymous namespace
 
 TEST(TEST_CATEGORY, workgraph_fib) {
+  // FIXME_HIP The test is very slow with HIP and it causes the CI to timeout
+#ifdef KOKKOS_ENABLE_HIP
+  int limit = 7;
+#else
   int limit = 27;
+#endif
   for (int i = 0; i < limit; ++i) {
     TestWorkGraph<TEST_EXECSPACE> f(i);
     f.test_for();


### PR DESCRIPTION
I see a large time variability in this test. Wit this PR it takes between 9 seconds to 60 seconds to run.