### PR TITLE
[HIP] Clean up block size deduction and remove unimplemented lock array free functions (HIP and Cuda)

### DIFF
--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -75,17 +75,6 @@ void hipOccupancy(int *numBlocks, int blockSize, int sharedmem) {
   hipOccupancy<DriverType, constant, HIPTraits::MaxThreadsPerBlock, 1>(
       numBlocks, blockSize, sharedmem);
 }
-template <typename DriverType, typename LaunchBounds, bool Large>
-struct HIPGetMaxBlockSize;
-
-template <typename DriverType, typename LaunchBounds>
-int hip_get_max_block_size(typename DriverType::functor_type const &f,
-                           size_t const vector_length,
-                           size_t const shmem_extra_block,
-                           size_t const shmem_extra_thread) {
-  return HIPGetMaxBlockSize<DriverType, LaunchBounds, true>::get_block_size(
-      f, vector_length, shmem_extra_block, shmem_extra_thread);
-}
 
 template <class FunctorType, class LaunchBounds, typename F>
 int hip_internal_get_block_size(const F &condition_check,
@@ -131,10 +120,6 @@ int hip_internal_get_block_size(const F &condition_check,
   int opt_block_size =
       (blocks_per_sm >= min_blocks_per_sm) ? block_size : min_blocks_per_sm;
   int opt_threads_per_sm = threads_per_sm;
-  // printf("BlockSizeMax: %i Shmem: %i %i %i %i Regs: %i %i Blocks: %i %i
-  // Achieved: %i %i Opt: %i %i\n",block_size,
-  //   shmem_per_sm,max_shmem_per_block,functor_shmem,total_shmem,
-  //   regs_per_sm,regs_per_wavefront,max_blocks_shmem,max_blocks_regs,blocks_per_sm,threads_per_sm,opt_block_size,opt_threads_per_sm);
   block_size -= HIPTraits::WarpSize;
   while (condition_check(blocks_per_sm) &&
          (block_size >= HIPTraits::WarpSize)) {
@@ -160,10 +145,6 @@ int hip_internal_get_block_size(const F &condition_check,
         opt_threads_per_sm = threads_per_sm;
       }
     }
-    // printf("BlockSizeMax: %i Shmem: %i %i %i %i Regs: %i %i Blocks: %i %i
-    // Achieved: %i %i Opt: %i %i\n",block_size,
-    //   shmem_per_sm,max_shmem_per_block,functor_shmem,total_shmem,
-    //   regs_per_sm,regs_per_wavefront,max_blocks_shmem,max_blocks_regs,blocks_per_sm,threads_per_sm,opt_block_size,opt_threads_per_sm);
     block_size -= HIPTraits::WarpSize;
   }
   return opt_block_size;
@@ -178,62 +159,6 @@ int hip_get_max_block_size(const HIPInternal *hip_instance,
       [](int x) { return x == 0; }, hip_instance, attr, f, vector_length,
       shmem_block, shmem_thread);
 }
-template <typename DriverType, class LaunchBounds>
-struct HIPGetMaxBlockSize<DriverType, LaunchBounds, true> {
-  static int get_block_size(typename DriverType::functor_type const &f,
-                            size_t const vector_length,
-                            size_t const shmem_extra_block,
-                            size_t const shmem_extra_thread) {
-    int numBlocks = 0;
-    int blockSize = LaunchBounds::maxTperB == 0 ? 1024 : LaunchBounds::maxTperB;
-    int sharedmem =
-        shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
-        ::Kokkos::Impl::FunctorTeamShmemSize<
-            typename DriverType::functor_type>::value(f, blockSize /
-                                                             vector_length);
-
-    hipOccupancy<DriverType, true>(&numBlocks, blockSize, sharedmem);
-
-    if (numBlocks > 0) return blockSize;
-    while (blockSize > HIPTraits::WarpSize && numBlocks == 0) {
-      blockSize /= 2;
-      sharedmem =
-          shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
-          ::Kokkos::Impl::FunctorTeamShmemSize<
-              typename DriverType::functor_type>::value(f, blockSize /
-                                                               vector_length);
-
-      hipOccupancy<DriverType, true>(&numBlocks, blockSize, sharedmem);
-    }
-    int blockSizeUpperBound = blockSize * 2;
-    while (blockSize < blockSizeUpperBound && numBlocks > 0) {
-      blockSize += HIPTraits::WarpSize;
-      sharedmem =
-          shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
-          ::Kokkos::Impl::FunctorTeamShmemSize<
-              typename DriverType::functor_type>::value(f, blockSize /
-                                                               vector_length);
-
-      hipOccupancy<DriverType, true>(&numBlocks, blockSize, sharedmem);
-    }
-    return blockSize - HIPTraits::WarpSize;
-  }
-};
-
-template <typename DriverType, typename LaunchBounds, bool Large>
-struct HIPGetOptBlockSize;
-
-template <typename DriverType, typename LaunchBounds>
-int hip_get_opt_block_size(typename DriverType::functor_type const &f,
-                           size_t const vector_length,
-                           size_t const shmem_extra_block,
-                           size_t const shmem_extra_thread) {
-  return HIPGetOptBlockSize<
-      DriverType, LaunchBounds,
-      (HIPTraits::ConstantMemoryUseThreshold <
-       sizeof(DriverType))>::get_block_size(f, vector_length, shmem_extra_block,
-                                            shmem_extra_thread);
-}
 
 template <typename FunctorType, typename LaunchBounds>
 int hip_get_opt_block_size(HIPInternal const *hip_instance,
@@ -244,157 +169,6 @@ int hip_get_opt_block_size(HIPInternal const *hip_instance,
       [](int) { return true; }, hip_instance, attr, f, vector_length,
       shmem_block, shmem_thread);
 }
-
-// FIXME_HIP the code is identical to the false struct except for
-// hip_parallel_launch_constant_memory
-template <typename DriverType>
-struct HIPGetOptBlockSize<DriverType, Kokkos::LaunchBounds<0, 0>, true> {
-  static int get_block_size(typename DriverType::functor_type const &f,
-                            size_t const vector_length,
-                            size_t const shmem_extra_block,
-                            size_t const shmem_extra_thread) {
-    int blockSize = HIPTraits::WarpSize / 2;
-    int numBlocks;
-    int sharedmem;
-    int maxOccupancy  = 0;
-    int bestBlockSize = 0;
-
-    while (blockSize < HIPTraits::MaxThreadsPerBlock) {
-      blockSize *= 2;
-
-      // calculate the occupancy with that optBlockSize and check whether its
-      // larger than the largest one found so far
-      sharedmem =
-          shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
-          ::Kokkos::Impl::FunctorTeamShmemSize<
-              typename DriverType::functor_type>::value(f, blockSize /
-                                                               vector_length);
-      hipOccupancy<DriverType, true>(&numBlocks, blockSize, sharedmem);
-      if (maxOccupancy < numBlocks * blockSize) {
-        maxOccupancy  = numBlocks * blockSize;
-        bestBlockSize = blockSize;
-      }
-    }
-    return bestBlockSize;
-  }
-};
-
-template <typename DriverType>
-struct HIPGetOptBlockSize<DriverType, Kokkos::LaunchBounds<0, 0>, false> {
-  static int get_block_size(const typename DriverType::functor_type &f,
-                            const size_t vector_length,
-                            const size_t shmem_extra_block,
-                            const size_t shmem_extra_thread) {
-    int blockSize = HIPTraits::WarpSize / 2;
-    int numBlocks;
-    int sharedmem;
-    int maxOccupancy  = 0;
-    int bestBlockSize = 0;
-
-    while (blockSize < HIPTraits::MaxThreadsPerBlock) {
-      blockSize *= 2;
-      sharedmem =
-          shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
-          ::Kokkos::Impl::FunctorTeamShmemSize<
-              typename DriverType::functor_type>::value(f, blockSize /
-                                                               vector_length);
-
-      hipOccupancy<DriverType, false>(&numBlocks, blockSize, sharedmem);
-
-      if (maxOccupancy < numBlocks * blockSize) {
-        maxOccupancy  = numBlocks * blockSize;
-        bestBlockSize = blockSize;
-      }
-    }
-    return bestBlockSize;
-  }
-};
-
-// FIXME_HIP the code is identical to the false struct except for
-// hip_parallel_launch_constant_memory
-template <typename DriverType, unsigned int MaxThreadsPerBlock,
-          unsigned int MinBlocksPerSM>
-struct HIPGetOptBlockSize<
-    DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
-    true> {
-  static int get_block_size(const typename DriverType::functor_type &f,
-                            const size_t vector_length,
-                            const size_t shmem_extra_block,
-                            const size_t shmem_extra_thread) {
-    int blockSize = HIPTraits::WarpSize / 2;
-    int numBlocks;
-    int sharedmem;
-    int maxOccupancy  = 0;
-    int bestBlockSize = 0;
-    int max_threads_per_block =
-        std::min(MaxThreadsPerBlock,
-                 hip_internal_maximum_warp_count() * HIPTraits::WarpSize);
-
-    while (blockSize < max_threads_per_block) {
-      blockSize *= 2;
-
-      // calculate the occupancy with that optBlockSize and check whether its
-      // larger than the largest one found so far
-      sharedmem =
-          shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
-          ::Kokkos::Impl::FunctorTeamShmemSize<
-              typename DriverType::functor_type>::value(f, blockSize /
-                                                               vector_length);
-      hipOccupancy<DriverType, true, MaxThreadsPerBlock, MinBlocksPerSM>(
-          &numBlocks, blockSize, sharedmem);
-      if (numBlocks >= static_cast<int>(MinBlocksPerSM) &&
-          blockSize <= static_cast<int>(MaxThreadsPerBlock)) {
-        if (maxOccupancy < numBlocks * blockSize) {
-          maxOccupancy  = numBlocks * blockSize;
-          bestBlockSize = blockSize;
-        }
-      }
-    }
-    if (maxOccupancy > 0) return bestBlockSize;
-    return -1;
-  }
-};
-
-template <typename DriverType, unsigned int MaxThreadsPerBlock,
-          unsigned int MinBlocksPerSM>
-struct HIPGetOptBlockSize<
-    DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
-    false> {
-  static int get_block_size(const typename DriverType::functor_type &f,
-                            const size_t vector_length,
-                            const size_t shmem_extra_block,
-                            const size_t shmem_extra_thread) {
-    int blockSize = HIPTraits::WarpSize / 2;
-    int numBlocks;
-    int sharedmem;
-    int maxOccupancy  = 0;
-    int bestBlockSize = 0;
-    int max_threads_per_block =
-        std::min(MaxThreadsPerBlock,
-                 hip_internal_maximum_warp_count() * HIPTraits::WarpSize);
-
-    while (blockSize < max_threads_per_block) {
-      blockSize *= 2;
-      sharedmem =
-          shmem_extra_block + shmem_extra_thread * (blockSize / vector_length) +
-          ::Kokkos::Impl::FunctorTeamShmemSize<
-              typename DriverType::functor_type>::value(f, blockSize /
-                                                               vector_length);
-
-      hipOccupancy<DriverType, false, MaxThreadsPerBlock, MinBlocksPerSM>(
-          &numBlocks, blockSize, sharedmem);
-      if (numBlocks >= int(MinBlocksPerSM) &&
-          blockSize <= int(MaxThreadsPerBlock)) {
-        if (maxOccupancy < numBlocks * blockSize) {
-          maxOccupancy  = numBlocks * blockSize;
-          bestBlockSize = blockSize;
-        }
-      }
-    }
-    if (maxOccupancy > 0) return bestBlockSize;
-    return -1;
-  }
-};
 
 }  // namespace Impl
 }  // namespace Experimental

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -83,33 +83,33 @@ class HIPInternal {
  public:
   using size_type = ::Kokkos::Experimental::HIP::size_type;
 
-  int m_hipDev;
-  int m_hipArch;
-  unsigned m_multiProcCount;
-  unsigned m_maxWarpCount;
-  unsigned m_maxBlock;
-  unsigned m_maxBlocksPerSM;
-  unsigned m_maxSharedWords;
+  int m_hipDev              = -1;
+  int m_hipArch             = -1;
+  unsigned m_multiProcCount = 0;
+  unsigned m_maxWarpCount   = 0;
+  unsigned m_maxBlock       = 0;
+  unsigned m_maxBlocksPerSM = 0;
+  unsigned m_maxSharedWords = 0;
   int m_regsPerSM;
-  int m_shmemPerSM;
-  int m_maxShmemPerBlock;
-  int m_maxThreadsPerSM;
+  int m_shmemPerSM       = 0;
+  int m_maxShmemPerBlock = 0;
+  int m_maxThreadsPerSM  = 0;
 
   // Scratch Spaces for Reductions
-  size_type m_scratchSpaceCount;
-  size_type m_scratchFlagsCount;
+  size_type m_scratchSpaceCount = 0;
+  size_type m_scratchFlagsCount = 0;
 
-  size_type *m_scratchSpace;
-  size_type *m_scratchFlags;
+  size_type *m_scratchSpace           = nullptr;
+  size_type *m_scratchFlags           = nullptr;
   uint32_t *m_scratchConcurrentBitset = nullptr;
 
   hipDeviceProp_t m_deviceProp;
 
-  hipStream_t m_stream;
+  hipStream_t m_stream = nullptr;
 
   // Team Scratch Level 1 Space
-  mutable int64_t m_team_scratch_current_size;
-  mutable void *m_team_scratch_ptr;
+  mutable int64_t m_team_scratch_current_size = 0;
+  mutable void *m_team_scratch_ptr            = nullptr;
 
   bool was_finalized = false;
 
@@ -117,9 +117,7 @@ class HIPInternal {
 
   int verify_is_initialized(const char *const label) const;
 
-  int is_initialized() const {
-    return m_hipDev >= 0;
-  }  // 0 != m_scratchSpace && 0 != m_scratchFlags ; }
+  int is_initialized() const { return m_hipDev >= 0; }
 
   void initialize(int hip_device_id, hipStream_t stream = nullptr);
   void finalize();
@@ -130,23 +128,7 @@ class HIPInternal {
 
   ~HIPInternal();
 
-  HIPInternal()
-      : m_hipDev(-1),
-        m_hipArch(-1),
-        m_multiProcCount(0),
-        m_maxWarpCount(0),
-        m_maxBlock(0),
-        m_maxSharedWords(0),
-        m_shmemPerSM(0),
-        m_maxShmemPerBlock(0),
-        m_maxThreadsPerSM(0),
-        m_scratchSpaceCount(0),
-        m_scratchFlagsCount(0),
-        m_scratchSpace(nullptr),
-        m_scratchFlags(nullptr),
-        m_stream(nullptr),
-        m_team_scratch_current_size(0),
-        m_team_scratch_ptr(nullptr) {}
+  HIPInternal() = default;
 
   // Resizing of reduction related scratch spaces
   size_type *scratch_space(const size_type size);

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -291,13 +291,19 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
         ::Kokkos::Experimental::Impl::HIPTraits::MaxThreadsPerBlock;
     int shmem_size = ::Kokkos::Impl::hip_single_inter_block_reduce_scan_shmem<
         false, FunctorType, WorkTag>(f, n);
+    using closure_type = Impl::ParallelReduce<FunctorType, Policy, ReducerType>;
+    hipFuncAttributes attr = ::Kokkos::Experimental::Impl::HIPParallelLaunch<
+        closure_type, LaunchBounds>::get_hip_func_attributes();
     while (
         (n &&
          (m_policy.space().impl_internal_space_instance()->m_maxShmemPerBlock <
           shmem_size)) ||
-        (n > static_cast<unsigned>(
-                 ::Kokkos::Experimental::Impl::hip_get_max_block_size<
-                     ParallelReduce, LaunchBounds>(f, 1, shmem_size, 0)))) {
+        (n >
+         static_cast<unsigned>(
+             ::Kokkos::Experimental::Impl::hip_get_max_block_size<FunctorType,
+                                                                  LaunchBounds>(
+                 m_policy.space().impl_internal_space_instance(), attr, f, 1,
+                 shmem_size, 0)))) {
       n >>= 1;
       shmem_size = ::Kokkos::Impl::hip_single_inter_block_reduce_scan_shmem<
           false, FunctorType, WorkTag>(f, n);

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -128,42 +128,6 @@ class CudaSpace {
   static constexpr const char* m_name = "Cuda";
   friend class Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaSpace, void>;
 };
-
-namespace Impl {
-/// \brief Initialize lock array for arbitrary size atomics.
-///
-/// Arbitrary atomics are implemented using a hash table of locks
-/// where the hash value is derived from the address of the
-/// object for which an atomic operation is performed.
-/// This function initializes the locks to zero (unset).
-void init_lock_arrays_cuda_space();
-
-/// \brief Retrieve the pointer to the lock array for arbitrary size atomics.
-///
-/// Arbitrary atomics are implemented using a hash table of locks
-/// where the hash value is derived from the address of the
-/// object for which an atomic operation is performed.
-/// This function retrieves the lock array pointer.
-/// If the array is not yet allocated it will do so.
-int* atomic_lock_array_cuda_space_ptr(bool deallocate = false);
-
-/// \brief Retrieve the pointer to the scratch array for team and thread private
-/// global memory.
-///
-/// Team and Thread private scratch allocations in
-/// global memory are acquired via locks.
-/// This function retrieves the lock array pointer.
-/// If the array is not yet allocated it will do so.
-int* scratch_lock_array_cuda_space_ptr(bool deallocate = false);
-
-/// \brief Retrieve the pointer to the scratch array for unique identifiers.
-///
-/// Unique identifiers in the range 0-Cuda::concurrency
-/// are provided via locks.
-/// This function retrieves the lock array pointer.
-/// If the array is not yet allocated it will do so.
-int* threadid_lock_array_cuda_space_ptr(bool deallocate = false);
-}  // namespace Impl
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -128,43 +128,6 @@ class HIPSpace {
 };
 
 }  // namespace Experimental
-
-namespace Impl {
-
-/// \brief Initialize lock array for arbitrary size atomics.
-///
-/// Arbitrary atomics are implemented using a hash table of locks
-/// where the hash value is derived from the address of the
-/// object for which an atomic operation is performed.
-/// This function initializes the locks to zero (unset).
-void init_lock_arrays_hip_space();
-
-/// \brief Retrieve the pointer to the lock array for arbitrary size atomics.
-///
-/// Arbitrary atomics are implemented using a hash table of locks
-/// where the hash value is derived from the address of the
-/// object for which an atomic operation is performed.
-/// This function retrieves the lock array pointer.
-/// If the array is not yet allocated it will do so.
-int* atomic_lock_array_hip_space_ptr(bool deallocate = false);
-
-/// \brief Retrieve the pointer to the scratch array for team and thread private
-/// global memory.
-///
-/// Team and Thread private scratch allocations in
-/// global memory are acquired via locks.
-/// This function retrieves the lock array pointer.
-/// If the array is not yet allocated it will do so.
-int* scratch_lock_array_hip_space_ptr(bool deallocate = false);
-
-/// \brief Retrieve the pointer to the scratch array for unique identifiers.
-///
-/// Unique identifiers in the range 0-HIP::concurrency
-/// are provided via locks.
-/// This function retrieves the lock array pointer.
-/// If the array is not yet allocated it will do so.
-int* threadid_lock_array_hip_space_ptr(bool deallocate = false);
-}  // namespace Impl
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR removes dead code in the HIP back end, most of it in `BlockSize_Deduction`. I have also removed a coupe of functions in `Kokkos_CudaSpace.hpp` because they are not implemented.