### PR TITLE
Enable TestDefaultDeviceType* tests for SYCL

### DIFF
--- a/core/unit_test/default/TestDefaultDeviceType_a1.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_a1.cpp
@@ -51,13 +51,6 @@
 #include <default/TestDefaultDeviceType_Category.hpp>
 #include <TestReduceCombinatorical.hpp>
 
-// FIXME_SYCL
-// C++ exception with description "Global_work_size not evenly divisible by
-// local_work_size. Non-uniform work-groups are not allowed by default.
-// Underlying OpenCL 2.x implementation supports this feature and to enable it,
-// build device program with -cl-std=CL2.0 -54 (CL_INVALID_WORK_GROUP_SIZE)"
-// thrown in the test body.
-#ifndef KOKKOS_ENABLE_SYCL
 namespace Test {
 
 TEST(defaultdevicetype, reduce_instantiation_a1) {
@@ -65,5 +58,4 @@ TEST(defaultdevicetype, reduce_instantiation_a1) {
 }
 
 }  // namespace Test
-#endif
 #endif

--- a/core/unit_test/default/TestDefaultDeviceType_a2.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_a2.cpp
@@ -51,13 +51,6 @@
 #include <default/TestDefaultDeviceType_Category.hpp>
 #include <TestReduceCombinatorical.hpp>
 
-// FIXME_SYCL
-// C++ exception with description "Global_work_size not evenly divisible by
-// local_work_size. Non-uniform work-groups are not allowed by default.
-// Underlying OpenCL 2.x implementation supports this feature and to enable it,
-// build device program with -cl-std=CL2.0 -54 (CL_INVALID_WORK_GROUP_SIZE)"
-// thrown in the test body.
-#ifndef KOKKOS_ENABLE_SYCL
 namespace Test {
 
 TEST(defaultdevicetype, reduce_instantiation_a2) {
@@ -66,5 +59,4 @@ TEST(defaultdevicetype, reduce_instantiation_a2) {
 
 }  // namespace Test
 
-#endif
 #endif

--- a/core/unit_test/default/TestDefaultDeviceType_b1.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_b1.cpp
@@ -51,13 +51,6 @@
 #include <default/TestDefaultDeviceType_Category.hpp>
 #include <TestReduceCombinatorical.hpp>
 
-// FIXME_SYCL
-// C++ exception with description "Global_work_size not evenly divisible by
-// local_work_size. Non-uniform work-groups are not allowed by default.
-// Underlying OpenCL 2.x implementation supports this feature and to enable it,
-// build device program with -cl-std=CL2.0 -54 (CL_INVALID_WORK_GROUP_SIZE)"
-// thrown in the test body.
-#ifndef KOKKOS_ENABLE_SYCL
 namespace Test {
 
 TEST(defaultdevicetype, reduce_instantiation_b1) {
@@ -65,5 +58,4 @@ TEST(defaultdevicetype, reduce_instantiation_b1) {
 }
 
 }  // namespace Test
-#endif
 #endif

--- a/core/unit_test/default/TestDefaultDeviceType_b2.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_b2.cpp
@@ -51,13 +51,6 @@
 #include <default/TestDefaultDeviceType_Category.hpp>
 #include <TestReduceCombinatorical.hpp>
 
-// FIXME_SYCL
-// C++ exception with description "Global_work_size not evenly divisible by
-// local_work_size. Non-uniform work-groups are not allowed by default.
-// Underlying OpenCL 2.x implementation supports this feature and to enable it,
-// build device program with -cl-std=CL2.0 -54 (CL_INVALID_WORK_GROUP_SIZE)"
-// thrown in the test body.
-#ifndef KOKKOS_ENABLE_SYCL
 namespace Test {
 
 TEST(defaultdevicetype, reduce_instantiation_b2) {
@@ -66,5 +59,4 @@ TEST(defaultdevicetype, reduce_instantiation_b2) {
 
 }  // namespace Test
 
-#endif
 #endif

--- a/core/unit_test/default/TestDefaultDeviceType_c1.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_c1.cpp
@@ -51,13 +51,6 @@
 #include <default/TestDefaultDeviceType_Category.hpp>
 #include <TestReduceCombinatorical.hpp>
 
-// FIXME_SYCL
-// C++ exception with description "Global_work_size not evenly divisible by
-// local_work_size. Non-uniform work-groups are not allowed by default.
-// Underlying OpenCL 2.x implementation supports this feature and to enable it,
-// build device program with -cl-std=CL2.0 -54 (CL_INVALID_WORK_GROUP_SIZE)"
-// thrown in the test body.
-#ifndef KOKKOS_ENABLE_SYCL
 namespace Test {
 
 TEST(defaultdevicetype, reduce_instantiation_c1) {
@@ -65,5 +58,4 @@ TEST(defaultdevicetype, reduce_instantiation_c1) {
 }
 
 }  // namespace Test
-#endif
 #endif

--- a/core/unit_test/default/TestDefaultDeviceType_c2.cpp
+++ b/core/unit_test/default/TestDefaultDeviceType_c2.cpp
@@ -51,13 +51,6 @@
 #include <default/TestDefaultDeviceType_Category.hpp>
 #include <TestReduceCombinatorical.hpp>
 
-// FIXME_SYCL
-// C++ exception with description "Global_work_size not evenly divisible by
-// local_work_size. Non-uniform work-groups are not allowed by default.
-// Underlying OpenCL 2.x implementation supports this feature and to enable it,
-// build device program with -cl-std=CL2.0 -54 (CL_INVALID_WORK_GROUP_SIZE)"
-// thrown in the test body.
-#ifndef KOKKOS_ENABLE_SYCL
 namespace Test {
 
 TEST(defaultdevicetype, reduce_instantiation_c2) {
@@ -66,5 +59,4 @@ TEST(defaultdevicetype, reduce_instantiation_c2) {
 
 }  // namespace Test
 
-#endif
 #endif


### PR DESCRIPTION
Based on top of #3619.

It turns out that we don't run into the weird errors I was seeing elsewhere on a CUDA device so I enabled the related tests again. This required calling FunctorFinal on the device in parallel_reduce which in the end forces us to also use the indirect launch mechanism for the empty-range case. Hence, that case is now also handled in sycl_direct_launch.