### PR TITLE
Use runtime values in KokkosExp_MDRangePolicy.hpp

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -54,6 +54,7 @@
 #include <Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp>
 #include <Cuda/Kokkos_Cuda_Instance.hpp>
 #include <Cuda/Kokkos_Cuda_Locks.hpp>
+#include <Cuda/Kokkos_Cuda_UniqueToken.hpp>
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Tools.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
@@ -26,9 +26,9 @@ inline TileSizeProperties get_tile_size_properties<Kokkos::Cuda>(
   TileSizeProperties properties;
   properties.max_threads =
       space.impl_internal_space_instance()->m_maxThreadsPerSM;
-  properties.max_tile_size       = 16;
-  properties.default_tile_size   = 2;
-  properties.max_total_tile_size = 512;
+  properties.default_largest_tile_size = 16;
+  properties.default_tile_size         = 2;
+  properties.max_total_tile_size       = 512;
   return properties;
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
@@ -21,10 +21,11 @@ namespace Impl {
 
 // Settings for MDRangePolicy
 template <>
-inline TileSizeProperties 
-get_tile_size_properties<Kokkos::Cuda>(const Kokkos::Cuda& space) {
+inline TileSizeProperties get_tile_size_properties<Kokkos::Cuda>(
+    const Kokkos::Cuda& space) {
   TileSizeProperties properties;
-  properties.max_threads = space.impl_internal_space_instance()->m_maxThreadsPerSM;
+  properties.max_threads =
+      space.impl_internal_space_instance()->m_maxThreadsPerSM;
   properties.max_tile_size       = 16;
   properties.default_tile_size   = 2;
   properties.max_total_tile_size = 512;

--- a/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_MDRangePolicy.hpp
@@ -1,0 +1,36 @@
+#ifndef KOKKOS_CUDA_MDRANGEPOLICY_HPP_
+#define KOKKOS_CUDA_MDRANGEPOLICY_HPP_
+
+#include <KokkosExp_MDRangePolicy.hpp>
+
+namespace Kokkos {
+
+template <>
+struct default_outer_direction<Kokkos::Cuda> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+
+template <>
+struct default_inner_direction<Kokkos::Cuda> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+
+namespace Impl {
+
+// Settings for MDRangePolicy
+template <>
+inline TileSizeProperties 
+get_tile_size_properties<Kokkos::Cuda>(const Kokkos::Cuda& space) {
+  TileSizeProperties properties;
+  properties.max_threads = space.impl_internal_space_instance()->m_maxThreadsPerSM;
+  properties.max_tile_size       = 16;
+  properties.default_tile_size   = 2;
+  properties.max_total_tile_size = 512;
+  return properties;
+}
+
+}  // Namespace Impl
+}  // Namespace Kokkos
+#endif

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -48,7 +48,7 @@
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_CUDA)
 
-#include <algorithm>
+/*#include <algorithm>
 #include <string>
 #include <cstdio>
 #include <cstdint>
@@ -66,7 +66,7 @@
 #include <impl/Kokkos_Tools.hpp>
 #include <typeinfo>
 
-#include <KokkosExp_MDRangePolicy.hpp>
+#include <KokkosExp_MDRangePolicy.hpp>*/
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -68,6 +68,7 @@
 #include <typeinfo>
 
 #include <KokkosExp_MDRangePolicy.hpp>
+#include <impl/KokkosExp_IterateTileGPU.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -48,7 +48,7 @@
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_CUDA)
 
-/*#include <algorithm>
+#include <algorithm>
 #include <string>
 #include <cstdio>
 #include <cstdint>
@@ -60,13 +60,14 @@
 #include <Cuda/Kokkos_Cuda_ReduceScan.hpp>
 #include <Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp>
 #include <Cuda/Kokkos_Cuda_Locks.hpp>
+#include <Cuda/Kokkos_Cuda_Team.hpp>
 #include <Kokkos_Vectorization.hpp>
 #include <Cuda/Kokkos_Cuda_Version_9_8_Compatibility.hpp>
 
 #include <impl/Kokkos_Tools.hpp>
 #include <typeinfo>
 
-#include <KokkosExp_MDRangePolicy.hpp>*/
+#include <KokkosExp_MDRangePolicy.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -46,6 +46,7 @@
 #define KOKKOS_CUDA_WORKGRAPHPOLICY_HPP
 
 #include <Kokkos_Cuda.hpp>
+#include <Cuda/Kokkos_Cuda_KernelLaunch.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
@@ -1,0 +1,37 @@
+#ifndef KOKKOS_HIP_MDRANGEPOLICY_HPP_
+#define KOKKOS_HIP_MDRANGEPOLICY_HPP_
+
+#include <KokkosExp_MDRangePolicy.hpp>
+
+namespace Kokkos {
+
+template <>
+struct default_outer_direction<Kokkos::Experimental::HIP> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+
+template <>
+struct default_inner_direction<Kokkos::Experimental::HIP> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+
+namespace Impl {
+
+// Settings for MDRangePolicy
+template <>
+inline TileSizeProperties get_tile_size_properties<Kokkos::Experimental::HIP>(
+    const Kokkos::Experimental::HIP& space) {
+  TileSizeProperties properties;
+  properties.max_threads =
+      space.impl_internal_space_instance()->m_maxThreadsPerSM;
+  properties.max_tile_size       = 16;
+  properties.default_tile_size   = 4;
+  properties.max_total_tile_size = 1024;
+  return properties;
+}
+
+}  // Namespace Impl
+}  // Namespace Kokkos
+#endif

--- a/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_MDRangePolicy.hpp
@@ -26,9 +26,9 @@ inline TileSizeProperties get_tile_size_properties<Kokkos::Experimental::HIP>(
   TileSizeProperties properties;
   properties.max_threads =
       space.impl_internal_space_instance()->m_maxThreadsPerSM;
-  properties.max_tile_size       = 16;
-  properties.default_tile_size   = 4;
-  properties.max_total_tile_size = 1024;
+  properties.default_largest_tile_size = 16;
+  properties.default_tile_size         = 4;
+  properties.max_total_tile_size       = 1024;
   return properties;
 }
 

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -49,6 +49,7 @@
 #include <HIP/Kokkos_HIP_KernelLaunch.hpp>
 #include <HIP/Kokkos_HIP_ReduceScan.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>
+#include <impl/KokkosExp_IterateTileGPU.hpp>
 #include <Kokkos_Parallel.hpp>
 
 namespace Kokkos {

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -54,10 +54,6 @@
 #include <Kokkos_Parallel.hpp>
 #include <type_traits>
 
-#if defined(KOKKOS_ENABLE_SYCL)
-#include <Kokkos_SYCL.hpp>
-#endif
-
 namespace Kokkos {
 
 // ------------------------------------------------------------------ //
@@ -77,27 +73,11 @@ struct default_outer_direction {
   static constexpr Iterate value = Iterate::Right;
 };
 
-#ifdef KOKKOS_ENABLE_SYCL
-template <>
-struct default_outer_direction<Kokkos::Experimental::SYCL> {
-  using type                     = Iterate;
-  static constexpr Iterate value = Iterate::Left;
-};
-#endif
-
 template <typename ExecSpace>
 struct default_inner_direction {
   using type                     = Iterate;
   static constexpr Iterate value = Iterate::Right;
 };
-
-#ifdef KOKKOS_ENABLE_SYCL
-template <>
-struct default_inner_direction<Kokkos::Experimental::SYCL> {
-  using type                     = Iterate;
-  static constexpr Iterate value = Iterate::Left;
-};
-#endif
 
 // Iteration Pattern
 template <unsigned N, Iterate OuterDir = Iterate::Default,
@@ -373,17 +353,6 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   bool impl_tune_tile_size() const { return m_tune_tile_size; }
 
  private:
-  /*
-  #if defined(KOKKOS_ENABLE_SYCL)
-    void init(const Kokkos::Experimental::SYCL& space) {
-      const index_type max_threads =
-          space.impl_internal_space_instance()->m_maxThreadsPerSM;
-      const index_type max_tile_size     = 16;
-      const index_type default_tile_size = 2;
-      init_helper(max_threads, max_tile_size, default_tile_size, max_threads);
-    }
-  #endif*/
-
   void init_helper(Impl::TileSizeProperties properties) {
     int increment  = 1;
     int rank_start = 0;

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -84,25 +84,63 @@ enum class Iterate
 
 template <typename ExecSpace>
 struct default_outer_direction {
-  using type = Iterate;
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL)
-  static constexpr Iterate value = Iterate::Left;
-#else
+  using type                     = Iterate;
   static constexpr Iterate value = Iterate::Right;
-#endif
 };
+
+#ifdef KOKKOS_ENABLE_CUDA
+template <>
+struct default_outer_direction<Kokkos::Cuda> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+#endif
+
+#ifdef KOKKOS_ENABLE_HIP
+template <>
+struct default_outer_direction<Kokkos::Experimental::HIP> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+#endif
+
+#ifdef KOKKOS_ENABLE_SYCL
+template <>
+struct default_outer_direction<Kokkos::Experimental::SYCL> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+#endif
 
 template <typename ExecSpace>
 struct default_inner_direction {
-  using type = Iterate;
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL)
-  static constexpr Iterate value = Iterate::Left;
-#else
+  using type                     = Iterate;
   static constexpr Iterate value = Iterate::Right;
-#endif
 };
+
+#ifdef KOKKOS_ENABLE_CUDA
+template <>
+struct default_inner_direction<Kokkos::Cuda> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+#endif
+
+#ifdef KOKKOS_ENABLE_HIP
+template <>
+struct default_inner_direction<Kokkos::Experimental::HIP> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+#endif
+
+#ifdef KOKKOS_ENABLE_SYCL
+template <>
+struct default_inner_direction<Kokkos::Experimental::SYCL> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+#endif
 
 // Iteration Pattern
 template <unsigned N, Iterate OuterDir = Iterate::Default,

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -293,9 +293,6 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
           ? iteration_pattern::inner_direction
           : default_inner_direction<typename traits::execution_space>::value;
 
-  static constexpr auto Right = Iterate::Right;
-  static constexpr auto Left  = Iterate::Left;
-
   KOKKOS_INLINE_FUNCTION const typename traits::execution_space& space() const {
     return m_space;
   }
@@ -446,7 +443,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
     int increment  = 1;
     int rank_start = 0;
     int rank_end   = rank;
-    if (inner_direction == Right) {
+    if (inner_direction == Iterate::Right) {
       increment  = -1;
       rank_start = rank - 1;
       rank_end   = -1;
@@ -455,8 +452,8 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
       const index_type length = m_upper[i] - m_lower[i];
       if (m_tile[i] <= 0) {
 	m_tune_tile_size = true;
-        if ((inner_direction == Right && (i < rank - 1)) ||
-            (inner_direction == Left && (i > 0))) {
+        if ((inner_direction == Iterate::Right && (i < rank - 1)) ||
+            (inner_direction == Iterate::Left && (i > 0))) {
           if (m_prod_tile_dims * default_tile_size < max_total_tile_size) {
             m_tile[i] = default_tile_size;
           } else {

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -206,23 +206,20 @@ constexpr NVCC_WONT_LET_ME_CALL_YOU_Array to_array_potentially_narrowing(
   return a;
 }
 
-struct TileSizeProperties
-{
-   int max_threads;
-   int max_tile_size;
-   int default_tile_size;
-   int max_total_tile_size;
+struct TileSizeProperties {
+  int max_threads;
+  int max_tile_size;
+  int default_tile_size;
+  int max_total_tile_size;
 };
 
 template <typename ExecutionSpace>
-TileSizeProperties 
-get_tile_size_properties(const ExecutionSpace&)
-{
+TileSizeProperties get_tile_size_properties(const ExecutionSpace&) {
   // Host settings
   TileSizeProperties properties;
-  properties.max_threads       = std::numeric_limits<int>::max();
-  properties.max_tile_size     = 0;
-  properties.default_tile_size = 2;
+  properties.max_threads         = std::numeric_limits<int>::max();
+  properties.max_tile_size       = 0;
+  properties.default_tile_size   = 2;
   properties.max_total_tile_size = std::numeric_limits<int>::max();
   return properties;
 }
@@ -395,28 +392,28 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   bool impl_tune_tile_size() const { return m_tune_tile_size; }
 
  private:
-/*
-#if defined(KOKKOS_ENABLE_HIP)
-  void init(const Kokkos::Experimental::HIP& space) {
-    const index_type max_threads =
-        space.impl_internal_space_instance()->m_maxThreadsPerSM;
-    const index_type max_tile_size       = 16;
-    const index_type default_tile_size   = 4;
-    const index_type max_total_tile_size = 1024;
-    init_helper(max_threads, max_tile_size, default_tile_size,
-                max_total_tile_size);
-  }
-#endif
+  /*
+  #if defined(KOKKOS_ENABLE_HIP)
+    void init(const Kokkos::Experimental::HIP& space) {
+      const index_type max_threads =
+          space.impl_internal_space_instance()->m_maxThreadsPerSM;
+      const index_type max_tile_size       = 16;
+      const index_type default_tile_size   = 4;
+      const index_type max_total_tile_size = 1024;
+      init_helper(max_threads, max_tile_size, default_tile_size,
+                  max_total_tile_size);
+    }
+  #endif
 
-#if defined(KOKKOS_ENABLE_SYCL)
-  void init(const Kokkos::Experimental::SYCL& space) {
-    const index_type max_threads =
-        space.impl_internal_space_instance()->m_maxThreadsPerSM;
-    const index_type max_tile_size     = 16;
-    const index_type default_tile_size = 2;
-    init_helper(max_threads, max_tile_size, default_tile_size, max_threads);
-  }
-#endif*/
+  #if defined(KOKKOS_ENABLE_SYCL)
+    void init(const Kokkos::Experimental::SYCL& space) {
+      const index_type max_threads =
+          space.impl_internal_space_instance()->m_maxThreadsPerSM;
+      const index_type max_tile_size     = 16;
+      const index_type default_tile_size = 2;
+      init_helper(max_threads, max_tile_size, default_tile_size, max_threads);
+    }
+  #endif*/
 
   void init_helper(Impl::TileSizeProperties properties) {
     int increment  = 1;
@@ -433,14 +430,15 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
         m_tune_tile_size = true;
         if ((inner_direction == Iterate::Right && (i < rank - 1)) ||
             (inner_direction == Iterate::Left && (i > 0))) {
-          if (m_prod_tile_dims * properties.default_tile_size < static_cast<index_type>(properties.max_total_tile_size)) {
+          if (m_prod_tile_dims * properties.default_tile_size <
+              static_cast<index_type>(properties.max_total_tile_size)) {
             m_tile[i] = properties.default_tile_size;
           } else {
             m_tile[i] = 1;
           }
         } else {
-          m_tile[i] =
-              properties.max_tile_size == 0 ? std::max<int>(length, 1) : properties.max_tile_size;
+          m_tile[i] = properties.max_tile_size == 0 ? std::max<int>(length, 1)
+                                                    : properties.max_tile_size;
         }
       }
       m_tile_end[i] =

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -374,15 +374,15 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   // Host
   template <typename ExecutionSpace>
   void init(const ExecutionSpace&) {
-    const int max_threads       = std::numeric_limits<int>::max();
-    const int max_tile_size     = std::numeric_limits<int>::max();
-    const int default_tile_size = 2;
+    const index_type max_threads = std::numeric_limits<int>::max();
+    const int max_tile_size      = std::numeric_limits<int>::max();
+    const int default_tile_size  = 2;
     init_helper(max_threads, max_tile_size, default_tile_size);
   }
 
 #if defined(KOKKOS_ENABLE_CUDA)
   void init(const Kokkos::Cuda& space) {
-    const int max_threads =
+    const index_type max_threads =
         space.impl_internal_space_instance()->m_maxThreadsPerSM;
     const int max_tile_size     = 16;
     const int default_tile_size = 2;
@@ -392,7 +392,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
 
 #if defined(KOKKOS_ENABLE_HIP)
   void init(const Kokkos::Experimental::HIP& space) {
-    const int max_threads =
+    const index_type max_threads =
         space.impl_internal_space_instance()->m_maxThreadsPerSM;
     const int max_tile_size     = 16;
     const int default_tile_size = 4;
@@ -402,7 +402,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
 
 #if defined(KOKKOS_ENABLE_SYCL)
   void init(const Kokkos::Experimental::SYCL& space) {
-    const int max_threads =
+    const index_type max_threads =
         space.impl_internal_space_instance()->m_maxThreadsPerSM;
     const int max_tile_size     = 16;
     const int default_tile_size = 2;
@@ -410,7 +410,8 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   }
 #endif
 
-  void init_helper(int max_threads, int max_tile_size, int default_tile_size) {
+  void init_helper(index_type max_threads, int max_tile_size,
+                   int default_tile_size) {
     index_type span;
     int increment  = 1;
     int rank_start = 0;

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -54,10 +54,7 @@
 #include <Kokkos_Parallel.hpp>
 #include <type_traits>
 
-#if defined(KOKKOS_ENABLE_HIP)
-#include <Kokkos_HIP_Space.hpp>
-#include <HIP/Kokkos_HIP_Instance.hpp>
-#elif defined(KOKKOS_ENABLE_SYCL)
+#if defined(KOKKOS_ENABLE_SYCL)
 #include <Kokkos_SYCL.hpp>
 #endif
 
@@ -80,14 +77,6 @@ struct default_outer_direction {
   static constexpr Iterate value = Iterate::Right;
 };
 
-#ifdef KOKKOS_ENABLE_HIP
-template <>
-struct default_outer_direction<Kokkos::Experimental::HIP> {
-  using type                     = Iterate;
-  static constexpr Iterate value = Iterate::Left;
-};
-#endif
-
 #ifdef KOKKOS_ENABLE_SYCL
 template <>
 struct default_outer_direction<Kokkos::Experimental::SYCL> {
@@ -101,14 +90,6 @@ struct default_inner_direction {
   using type                     = Iterate;
   static constexpr Iterate value = Iterate::Right;
 };
-
-#ifdef KOKKOS_ENABLE_HIP
-template <>
-struct default_inner_direction<Kokkos::Experimental::HIP> {
-  using type                     = Iterate;
-  static constexpr Iterate value = Iterate::Left;
-};
-#endif
 
 #ifdef KOKKOS_ENABLE_SYCL
 template <>
@@ -393,18 +374,6 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
 
  private:
   /*
-  #if defined(KOKKOS_ENABLE_HIP)
-    void init(const Kokkos::Experimental::HIP& space) {
-      const index_type max_threads =
-          space.impl_internal_space_instance()->m_maxThreadsPerSM;
-      const index_type max_tile_size       = 16;
-      const index_type default_tile_size   = 4;
-      const index_type max_total_tile_size = 1024;
-      init_helper(max_threads, max_tile_size, default_tile_size,
-                  max_total_tile_size);
-    }
-  #endif
-
   #if defined(KOKKOS_ENABLE_SYCL)
     void init(const Kokkos::Experimental::SYCL& space) {
       const index_type max_threads =

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -432,7 +432,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
 	m_tune_tile_size = true;
         if ((inner_direction == Right && (i < rank - 1)) ||
             (inner_direction == Left && (i > 0))) {
-          if (m_prod_tile_dims < max_threads) {
+          if (m_prod_tile_dims * default_tile_size < max_threads) {
             m_tile[i] = default_tile_size;
           } else {
             m_tile[i] = 1;

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -293,6 +293,9 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
           ? iteration_pattern::inner_direction
           : default_inner_direction<typename traits::execution_space>::value;
 
+  static constexpr auto Right = Iterate::Right;
+  static constexpr auto Left  = Iterate::Left;
+
   KOKKOS_INLINE_FUNCTION const typename traits::execution_space& space() const {
     return m_space;
   }

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -400,9 +400,9 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   // Host
   template <typename ExecutionSpace>
   void init(const ExecutionSpace&) {
-    const index_type max_threads = std::numeric_limits<int>::max();
-    const int max_tile_size      = -1;
-    const int default_tile_size  = 2;
+    const index_type max_threads       = std::numeric_limits<int>::max();
+    const index_type max_tile_size     = 0;
+    const index_type default_tile_size = 2;
     init_helper(max_threads, max_tile_size, default_tile_size, max_threads);
   }
 
@@ -410,9 +410,9 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   void init(const Kokkos::Cuda& space) {
     const index_type max_threads =
         space.impl_internal_space_instance()->m_maxThreadsPerSM;
-    const int max_tile_size       = 16;
-    const int default_tile_size   = 2;
-    const int max_total_tile_size = 512;
+    const index_type max_tile_size       = 16;
+    const index_type default_tile_size   = 2;
+    const index_type max_total_tile_size = 512;
     init_helper(max_threads, max_tile_size, default_tile_size,
                 max_total_tile_size);
   }
@@ -422,9 +422,9 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   void init(const Kokkos::Experimental::HIP& space) {
     const index_type max_threads =
         space.impl_internal_space_instance()->m_maxThreadsPerSM;
-    const int max_tile_size       = 16;
-    const int default_tile_size   = 4;
-    const int max_total_tile_size = 1024;
+    const index_type max_tile_size       = 16;
+    const index_type default_tile_size   = 4;
+    const index_type max_total_tile_size = 1024;
     init_helper(max_threads, max_tile_size, default_tile_size,
                 max_total_tile_size);
   }
@@ -434,8 +434,8 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   void init(const Kokkos::Experimental::SYCL& space) {
     const index_type max_threads =
         space.impl_internal_space_instance()->m_maxThreadsPerSM;
-    const int max_tile_size     = 16;
-    const int default_tile_size = 2;
+    const index_type max_tile_size     = 16;
+    const index_type default_tile_size = 2;
     init_helper(max_threads, max_tile_size, default_tile_size, max_threads);
   }
 #endif
@@ -464,7 +464,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
           }
         } else {
           m_tile[i] =
-              max_tile_size <= 0 ? std::max<int>(length, 1) : max_tile_size;
+              max_tile_size == 0 ? std::max<int>(length, 1) : max_tile_size;
         }
       }
       m_tile_end[i] =

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -59,7 +59,11 @@
 #include <impl/KokkosExp_IterateTileGPU.hpp>
 #endif
 
-#if defined(KOKKOS_ENABLE_SYCL)
+#if defined(KOKKOS_ENABLE_CUDA)
+#include <Kokkos_Cuda.hpp>
+#elif defined(KOKKOS_ENABLE_HIP)
+#include <Kokkos_HIP.hpp>
+#elif defined(KOKKOS_ENABLE_SYCL)
 #include <Kokkos_SYCL.hpp>
 #endif
 

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -63,7 +63,8 @@
 #include <Kokkos_Cuda.hpp>
 #include <Cuda/Kokkos_Cuda_Instance.hpp>
 #elif defined(KOKKOS_ENABLE_HIP)
-#include <Kokkos_HIP.hpp>
+#include <Kokkos_HIP_Space.hpp>
+#include <HIP/Kokkos_HIP_Instance.hpp>
 #elif defined(KOKKOS_ENABLE_SYCL)
 #include <Kokkos_SYCL.hpp>
 #endif

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -258,7 +258,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   using launch_bounds     = typename traits::launch_bounds;
   using member_type       = typename range_policy::member_type;
 
-  enum { rank = static_cast<int>(iteration_pattern::rank) };
+  static constexpr int rank = iteration_pattern::rank;
 
   using index_type       = typename traits::index_type;
   using array_index_type = std::int64_t;
@@ -283,36 +283,18 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   index_type m_prod_tile_dims = 1;
   bool m_tune_tile_size       = false;
 
-  /*
-    // NDE enum impl definition alternative - replace static constexpr int ?
-    enum { outer_direction = static_cast<int> (
-        (iteration_pattern::outer_direction != Iterate::Default)
-      ? iteration_pattern::outer_direction
-      : default_outer_direction< typename traits::execution_space>::value ) };
-
-    enum { inner_direction = static_cast<int> (
-        iteration_pattern::inner_direction != Iterate::Default
-      ? iteration_pattern::inner_direction
-      : default_inner_direction< typename traits::execution_space>::value ) };
-
-    enum { Right = static_cast<int>( Iterate::Right ) };
-    enum { Left  = static_cast<int>( Iterate::Left ) };
-  */
-  // static constexpr int rank = iteration_pattern::rank;
-
-  static constexpr int outer_direction = static_cast<int>(
+  static constexpr auto outer_direction =
       (iteration_pattern::outer_direction != Iterate::Default)
           ? iteration_pattern::outer_direction
-          : default_outer_direction<typename traits::execution_space>::value);
+          : default_outer_direction<typename traits::execution_space>::value;
 
-  static constexpr int inner_direction = static_cast<int>(
+  static constexpr auto inner_direction =
       iteration_pattern::inner_direction != Iterate::Default
           ? iteration_pattern::inner_direction
-          : default_inner_direction<typename traits::execution_space>::value);
+          : default_inner_direction<typename traits::execution_space>::value;
 
-  // Ugly ugly workaround intel 14 not handling scoped enum correctly
-  static constexpr int Right = static_cast<int>(Iterate::Right);
-  static constexpr int Left  = static_cast<int>(Iterate::Left);
+  static constexpr auto Right = Iterate::Right;
+  static constexpr auto Left  = Iterate::Left;
 
   KOKKOS_INLINE_FUNCTION const typename traits::execution_space& space() const {
     return m_space;

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -169,7 +169,7 @@ constexpr NVCC_WONT_LET_ME_CALL_YOU_Array to_array_potentially_narrowing(
 
 struct TileSizeProperties {
   int max_threads;
-  int max_tile_size;
+  int default_largest_tile_size;
   int default_tile_size;
   int max_total_tile_size;
 };
@@ -178,10 +178,10 @@ template <typename ExecutionSpace>
 TileSizeProperties get_tile_size_properties(const ExecutionSpace&) {
   // Host settings
   TileSizeProperties properties;
-  properties.max_threads         = std::numeric_limits<int>::max();
-  properties.max_tile_size       = 0;
-  properties.default_tile_size   = 2;
-  properties.max_total_tile_size = std::numeric_limits<int>::max();
+  properties.max_threads               = std::numeric_limits<int>::max();
+  properties.default_largest_tile_size = 0;
+  properties.default_tile_size         = 2;
+  properties.max_total_tile_size       = std::numeric_limits<int>::max();
   return properties;
 }
 
@@ -375,8 +375,9 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
             m_tile[i] = 1;
           }
         } else {
-          m_tile[i] = properties.max_tile_size == 0 ? std::max<int>(length, 1)
-                                                    : properties.max_tile_size;
+          m_tile[i] = properties.default_largest_tile_size == 0
+                          ? std::max<int>(length, 1)
+                          : properties.default_largest_tile_size;
         }
       }
       m_tile_end[i] =

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -443,7 +443,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
     }
     if (m_prod_tile_dims > max_threads) {
       printf(" Product of tile dimensions exceed maximum limit: %d\n",
-             max_threads);
+             static_cast<int>(max_threads));
       Kokkos::abort(
           "ExecSpace Error: MDRange tile dims exceed maximum number "
           "of threads per block - choose smaller tile dims");

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -418,32 +418,31 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
 
   void init_helper(index_type max_threads, int max_tile_size,
                    int default_tile_size) {
-    index_type span;
     int increment  = 1;
     int rank_start = 0;
     int rank_end   = rank;
-    if ((int)inner_direction == (int)Right) {
+    if (inner_direction == Right) {
       increment  = -1;
       rank_start = rank - 1;
       rank_end   = -1;
     }
     for (int i = rank_start; i != rank_end; i += increment) {
-      span = m_upper[i] - m_lower[i];
+      const index_type length = m_upper[i] - m_lower[i];
       if (m_tile[i] <= 0) {
-        m_tune_tile_size = true; 
-        if (((int)inner_direction == (int)Right && (i < rank - 1)) ||
-            ((int)inner_direction == (int)Left && (i > 0))) {
+	m_tune_tile_size = true;
+        if ((inner_direction == Right && (i < rank - 1)) ||
+            (inner_direction == Left && (i > 0))) {
           if (m_prod_tile_dims < max_threads) {
             m_tile[i] = default_tile_size;
           } else {
             m_tile[i] = 1;
           }
         } else {
-          m_tile[i] = std::max(std::min<int>(span, max_tile_size), 1);
+          m_tile[i] = std::max(std::min<int>(length, max_tile_size), 1);
         }
       }
       m_tile_end[i] =
-          static_cast<index_type>((span + m_tile[i] - 1) / m_tile[i]);
+          static_cast<index_type>((length + m_tile[i] - 1) / m_tile[i]);
       m_num_tiles *= m_tile_end[i];
       m_prod_tile_dims *= m_tile[i];
     }

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -454,7 +454,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
     for (int i = rank_start; i != rank_end; i += increment) {
       const index_type length = m_upper[i] - m_lower[i];
       if (m_tile[i] <= 0) {
-	m_tune_tile_size = true;
+        m_tune_tile_size = true;
         if ((inner_direction == Iterate::Right && (i < rank - 1)) ||
             (inner_direction == Iterate::Left && (i > 0))) {
           if (m_prod_tile_dims * default_tile_size < max_total_tile_size) {

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -420,8 +420,9 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   }
 #endif
 
-  void init_helper(index_type max_threads, int max_tile_size,
-                   int default_tile_size, int max_total_tile_size) {
+  void init_helper(index_type max_threads, index_type max_tile_size,
+                   index_type default_tile_size,
+                   index_type max_total_tile_size) {
     int increment  = 1;
     int rank_start = 0;
     int rank_end   = rank;

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -61,6 +61,7 @@
 
 #if defined(KOKKOS_ENABLE_CUDA)
 #include <Kokkos_Cuda.hpp>
+#include <Cuda/Kokkos_Cuda_Instance.hpp>
 #elif defined(KOKKOS_ENABLE_HIP)
 #include <Kokkos_HIP.hpp>
 #elif defined(KOKKOS_ENABLE_SYCL)

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -50,6 +50,8 @@
 
 #include <Kokkos_Core_fwd.hpp>
 
+#include <Kokkos_CudaSpace.hpp>
+
 #include <iosfwd>
 #include <vector>
 
@@ -345,7 +347,7 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
 #include <Cuda/Kokkos_Cuda_Instance.hpp>
 #include <Cuda/Kokkos_Cuda_View.hpp>
 #include <Cuda/Kokkos_Cuda_Team.hpp>
-#include <Cuda/Kokkos_Cuda_Parallel.hpp>
+//#include <Cuda/Kokkos_Cuda_Parallel.hpp>
 #include <Cuda/Kokkos_Cuda_Task.hpp>
 #include <Cuda/Kokkos_Cuda_UniqueToken.hpp>
 

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -50,8 +50,6 @@
 
 #include <Kokkos_Core_fwd.hpp>
 
-#include <Kokkos_CudaSpace.hpp>
-
 #include <iosfwd>
 #include <vector>
 
@@ -339,20 +337,6 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
 
 }  // namespace Impl
 }  // namespace Kokkos
-
-/*--------------------------------------------------------------------------*/
-/*--------------------------------------------------------------------------*/
-
-#include <Cuda/Kokkos_Cuda_KernelLaunch.hpp>
-#include <Cuda/Kokkos_Cuda_Instance.hpp>
-#include <Cuda/Kokkos_Cuda_View.hpp>
-#include <Cuda/Kokkos_Cuda_Team.hpp>
-//#include <Cuda/Kokkos_Cuda_Parallel.hpp>
-#include <Cuda/Kokkos_Cuda_Task.hpp>
-#include <Cuda/Kokkos_Cuda_UniqueToken.hpp>
-
-#include <KokkosExp_MDRangePolicy.hpp>
-//----------------------------------------------------------------------------
 
 #endif /* #if defined( KOKKOS_ENABLE_CUDA ) */
 #endif /* #ifndef KOKKOS_CUDA_HPP */

--- a/core/src/Kokkos_HIP.hpp
+++ b/core/src/Kokkos_HIP.hpp
@@ -57,6 +57,7 @@
 #include <impl/Kokkos_Tags.hpp>
 
 #include <HIP/Kokkos_HIP_Instance.hpp>
+#include <HIP/Kokkos_HIP_MDRangePolicy.hpp>
 #include <HIP/Kokkos_HIP_Parallel_Range.hpp>
 #include <HIP/Kokkos_HIP_Parallel_MDRange.hpp>
 #include <HIP/Kokkos_HIP_Parallel_Team.hpp>

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -113,6 +113,9 @@ void SYCLInternal::initialize(const sycl::device& d) {
     m_queue.emplace(d, exception_handler);
     std::cout << SYCL::SYCLDevice(d) << '\n';
     m_indirectKernel.emplace(IndirectKernelAllocator(*m_queue));
+
+    m_maxThreadsPerSM =
+        d.template get_info<cl::sycl::info::device::max_work_group_size>();
   } else {
     std::ostringstream msg;
     msg << "Kokkos::Experimental::SYCL::initialize(...) FAILED";

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -115,7 +115,7 @@ void SYCLInternal::initialize(const sycl::device& d) {
     m_indirectKernel.emplace(IndirectKernelAllocator(*m_queue));
 
     m_maxThreadsPerSM =
-        d.template get_info<cl::sycl::info::device::max_work_group_size>();
+        d.template get_info<sycl::info::device::max_work_group_size>();
   } else {
     std::ostringstream msg;
     msg << "Kokkos::Experimental::SYCL::initialize(...) FAILED";

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -64,7 +64,10 @@ class SYCLInternal {
   SYCLInternal& operator=(SYCLInternal&&) = delete;
   SYCLInternal(SYCLInternal&&)            = delete;
 
-  int m_syclDev             = -1;
+  int m_syclDev = -1;
+
+  int m_maxThreadsPerSM = 0;
+
   size_type* m_scratchSpace = nullptr;
   size_type* m_scratchFlags = nullptr;
 

--- a/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
@@ -1,0 +1,37 @@
+#ifndef KOKKOS_SYCL_MDRANGEPOLICY_HPP_
+#define KOKKOS_SYCL_MDRANGEPOLICY_HPP_
+
+#include <KokkosExp_MDRangePolicy.hpp>
+
+namespace Kokkos {
+
+template <>
+struct default_outer_direction<Kokkos::Experimental::SYCL> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+
+template <>
+struct default_inner_direction<Kokkos::Experimental::SYCL> {
+  using type                     = Iterate;
+  static constexpr Iterate value = Iterate::Left;
+};
+
+namespace Impl {
+
+// Settings for MDRangePolicy
+template <>
+inline TileSizeProperties get_tile_size_properties<Kokkos::Experimental::SYCL>(
+    const Kokkos::Experimental::SYCL& space) {
+  TileSizeProperties properties;
+  properties.max_threads =
+      space.impl_internal_space_instance()->m_maxThreadsPerSM;
+  properties.max_tile_size       = 16;
+  properties.default_tile_size   = 2;
+  properties.max_total_tile_size = properties.max_threads;
+  return properties;
+}
+
+}  // Namespace Impl
+}  // Namespace Kokkos
+#endif

--- a/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
@@ -26,9 +26,9 @@ inline TileSizeProperties get_tile_size_properties<Kokkos::Experimental::SYCL>(
   TileSizeProperties properties;
   properties.max_threads =
       space.impl_internal_space_instance()->m_maxThreadsPerSM;
-  properties.max_tile_size       = 16;
-  properties.default_tile_size   = 2;
-  properties.max_total_tile_size = properties.max_threads;
+  properties.default_largest_tile_size = 16;
+  properties.default_tile_size         = 2;
+  properties.max_total_tile_size       = properties.max_threads;
   return properties;
 }
 

--- a/core/src/decl/Kokkos_Declare_CUDA.hpp
+++ b/core/src/decl/Kokkos_Declare_CUDA.hpp
@@ -47,6 +47,7 @@
 
 #if defined(KOKKOS_ENABLE_CUDA)
 #include <Kokkos_Cuda.hpp>
+#include <Cuda/Kokkos_Cuda_Parallel.hpp>
 #endif
 
 #endif

--- a/core/src/decl/Kokkos_Declare_CUDA.hpp
+++ b/core/src/decl/Kokkos_Declare_CUDA.hpp
@@ -48,6 +48,13 @@
 #if defined(KOKKOS_ENABLE_CUDA)
 #include <Kokkos_Cuda.hpp>
 #include <Cuda/Kokkos_Cuda_Parallel.hpp>
+#include <Cuda/Kokkos_Cuda_KernelLaunch.hpp>
+#include <Cuda/Kokkos_Cuda_Instance.hpp>
+#include <Cuda/Kokkos_Cuda_View.hpp>
+#include <Cuda/Kokkos_Cuda_Team.hpp>
+#include <Cuda/Kokkos_Cuda_Parallel.hpp>
+#include <Cuda/Kokkos_Cuda_Task.hpp>
+#include <Cuda/Kokkos_Cuda_UniqueToken.hpp>
 #endif
 
 #endif

--- a/core/src/decl/Kokkos_Declare_CUDA.hpp
+++ b/core/src/decl/Kokkos_Declare_CUDA.hpp
@@ -54,6 +54,7 @@
 #include <Cuda/Kokkos_Cuda_Team.hpp>
 #include <Cuda/Kokkos_Cuda_Parallel.hpp>
 #include <Cuda/Kokkos_Cuda_Task.hpp>
+#include <Cuda/Kokkos_Cuda_MDRangePolicy.hpp>
 #include <Cuda/Kokkos_Cuda_UniqueToken.hpp>
 #endif
 

--- a/core/src/decl/Kokkos_Declare_SYCL.hpp
+++ b/core/src/decl/Kokkos_Declare_SYCL.hpp
@@ -48,6 +48,7 @@
 #if defined(KOKKOS_ENABLE_SYCL)
 #include <Kokkos_SYCL.hpp>
 #include <SYCL/Kokkos_SYCL_DeepCopy.hpp>
+#include <SYCL/Kokkos_SYCL_MDRangePolicy.hpp>
 #include <SYCL/Kokkos_SYCL_Parallel_Range.hpp>
 #include <SYCL/Kokkos_SYCL_Parallel_Reduce.hpp>
 #include <SYCL/Kokkos_SYCL_Parallel_Scan.hpp>

--- a/core/src/impl/KokkosExp_Host_IterateTile.hpp
+++ b/core/src/impl/KokkosExp_Host_IterateTile.hpp
@@ -1582,7 +1582,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -1600,7 +1600,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    Tile_Loop_Type<RP::rank, (RP::inner_direction == RP::Left), index_type,
+    Tile_Loop_Type<RP::rank, (RP::inner_direction == Iterate::Left), index_type,
                    Tag>::apply(m_func, full_tile, m_offset, m_rp.m_tile,
                                m_tiledims);
   }
@@ -1618,7 +1618,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -1636,7 +1636,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_2L(index_type, m_tiledims) { apply(LOOP_ARGS_2); }
@@ -1644,7 +1644,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_2L(index_type, m_tiledims) { apply(LOOP_ARGS_2); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -1653,7 +1653,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_2R(index_type, m_tiledims) { apply(LOOP_ARGS_2); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 2
 
@@ -1662,7 +1662,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -1680,7 +1680,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_3L(index_type, m_tiledims) { apply(LOOP_ARGS_3); }
@@ -1688,7 +1688,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_3L(index_type, m_tiledims) { apply(LOOP_ARGS_3); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -1697,7 +1697,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_3R(index_type, m_tiledims) { apply(LOOP_ARGS_3); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 3
 
@@ -1706,7 +1706,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -1724,7 +1724,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_4L(index_type, m_tiledims) { apply(LOOP_ARGS_4); }
@@ -1732,7 +1732,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_4L(index_type, m_tiledims) { apply(LOOP_ARGS_4); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -1741,7 +1741,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_4R(index_type, m_tiledims) { apply(LOOP_ARGS_4); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 4
 
@@ -1750,7 +1750,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -1768,7 +1768,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_5L(index_type, m_tiledims) { apply(LOOP_ARGS_5); }
@@ -1776,7 +1776,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_5L(index_type, m_tiledims) { apply(LOOP_ARGS_5); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -1785,7 +1785,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_5R(index_type, m_tiledims) { apply(LOOP_ARGS_5); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 5
 
@@ -1794,7 +1794,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -1812,7 +1812,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_6L(index_type, m_tiledims) { apply(LOOP_ARGS_6); }
@@ -1820,7 +1820,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_6L(index_type, m_tiledims) { apply(LOOP_ARGS_6); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -1829,7 +1829,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_6R(index_type, m_tiledims) { apply(LOOP_ARGS_6); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 6
 
@@ -1838,7 +1838,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -1856,7 +1856,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_7L(index_type, m_tiledims) { apply(LOOP_ARGS_7); }
@@ -1864,7 +1864,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_7L(index_type, m_tiledims) { apply(LOOP_ARGS_7); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -1873,7 +1873,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_7R(index_type, m_tiledims) { apply(LOOP_ARGS_7); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 7
 
@@ -1882,7 +1882,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -1900,7 +1900,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_8L(index_type, m_tiledims) { apply(LOOP_ARGS_8); }
@@ -1908,7 +1908,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_8L(index_type, m_tiledims) { apply(LOOP_ARGS_8); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -1917,7 +1917,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_8R(index_type, m_tiledims) { apply(LOOP_ARGS_8); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 8
 #endif
@@ -2003,7 +2003,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2021,7 +2021,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    Tile_Loop_Type<RP::rank, (RP::inner_direction == RP::Left), index_type,
+    Tile_Loop_Type<RP::rank, (RP::inner_direction == Iterate::Left), index_type,
                    Tag>::apply(m_v, m_func, full_tile, m_offset, m_rp.m_tile,
                                m_tiledims);
   }
@@ -2039,7 +2039,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2057,7 +2057,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_2L(index_type, m_tiledims) { apply(LOOP_ARGS_2); }
@@ -2065,7 +2065,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_2L(index_type, m_tiledims) { apply(LOOP_ARGS_2); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2074,7 +2074,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_2R(index_type, m_tiledims) { apply(LOOP_ARGS_2); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 2
 
@@ -2083,7 +2083,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2101,7 +2101,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_3L(index_type, m_tiledims) { apply(LOOP_ARGS_3); }
@@ -2109,7 +2109,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_3L(index_type, m_tiledims) { apply(LOOP_ARGS_3); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2118,7 +2118,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_3R(index_type, m_tiledims) { apply(LOOP_ARGS_3); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 3
 
@@ -2127,7 +2127,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2145,7 +2145,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_4L(index_type, m_tiledims) { apply(LOOP_ARGS_4); }
@@ -2153,7 +2153,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_4L(index_type, m_tiledims) { apply(LOOP_ARGS_4); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2162,7 +2162,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_4R(index_type, m_tiledims) { apply(LOOP_ARGS_4); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 4
 
@@ -2171,7 +2171,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2189,7 +2189,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_5L(index_type, m_tiledims) { apply(LOOP_ARGS_5); }
@@ -2197,7 +2197,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_5L(index_type, m_tiledims) { apply(LOOP_ARGS_5); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2206,7 +2206,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_5R(index_type, m_tiledims) { apply(LOOP_ARGS_5); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 5
 
@@ -2215,7 +2215,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2233,7 +2233,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_6L(index_type, m_tiledims) { apply(LOOP_ARGS_6); }
@@ -2241,7 +2241,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_6L(index_type, m_tiledims) { apply(LOOP_ARGS_6); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2250,7 +2250,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_6R(index_type, m_tiledims) { apply(LOOP_ARGS_6); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 6
 
@@ -2259,7 +2259,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2277,7 +2277,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_7L(index_type, m_tiledims) { apply(LOOP_ARGS_7); }
@@ -2285,7 +2285,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_7L(index_type, m_tiledims) { apply(LOOP_ARGS_7); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2294,7 +2294,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_7R(index_type, m_tiledims) { apply(LOOP_ARGS_7); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 7
 
@@ -2303,7 +2303,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2321,7 +2321,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_8L(index_type, m_tiledims) { apply(LOOP_ARGS_8); }
@@ -2329,7 +2329,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_8L(index_type, m_tiledims) { apply(LOOP_ARGS_8); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2338,7 +2338,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_8R(index_type, m_tiledims) { apply(LOOP_ARGS_8); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 8
 #endif
@@ -2426,7 +2426,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2444,7 +2444,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    Tile_Loop_Type<RP::rank, (RP::inner_direction == RP::Left), index_type,
+    Tile_Loop_Type<RP::rank, (RP::inner_direction == Iterate::Left), index_type,
                    Tag>::apply(m_v, m_func, full_tile, m_offset, m_rp.m_tile,
                                m_tiledims);
   }
@@ -2462,7 +2462,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2480,7 +2480,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_2L(index_type, m_tiledims) { apply(LOOP_ARGS_2); }
@@ -2488,7 +2488,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_2L(index_type, m_tiledims) { apply(LOOP_ARGS_2); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2497,7 +2497,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_2R(index_type, m_tiledims) { apply(LOOP_ARGS_2); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 2
 
@@ -2506,7 +2506,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2524,7 +2524,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_3L(index_type, m_tiledims) { apply(LOOP_ARGS_3); }
@@ -2532,7 +2532,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_3L(index_type, m_tiledims) { apply(LOOP_ARGS_3); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2541,7 +2541,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_3R(index_type, m_tiledims) { apply(LOOP_ARGS_3); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 3
 
@@ -2550,7 +2550,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2568,7 +2568,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_4L(index_type, m_tiledims) { apply(LOOP_ARGS_4); }
@@ -2576,7 +2576,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_4L(index_type, m_tiledims) { apply(LOOP_ARGS_4); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2585,7 +2585,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_4R(index_type, m_tiledims) { apply(LOOP_ARGS_4); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 4
 
@@ -2594,7 +2594,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2612,7 +2612,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_5L(index_type, m_tiledims) { apply(LOOP_ARGS_5); }
@@ -2620,7 +2620,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_5L(index_type, m_tiledims) { apply(LOOP_ARGS_5); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2629,7 +2629,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_5R(index_type, m_tiledims) { apply(LOOP_ARGS_5); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 5
 
@@ -2638,7 +2638,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2656,7 +2656,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_6L(index_type, m_tiledims) { apply(LOOP_ARGS_6); }
@@ -2664,7 +2664,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_6L(index_type, m_tiledims) { apply(LOOP_ARGS_6); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2673,7 +2673,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_6R(index_type, m_tiledims) { apply(LOOP_ARGS_6); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 6
 
@@ -2682,7 +2682,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2700,7 +2700,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_7L(index_type, m_tiledims) { apply(LOOP_ARGS_7); }
@@ -2708,7 +2708,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_7L(index_type, m_tiledims) { apply(LOOP_ARGS_7); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2717,7 +2717,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_7R(index_type, m_tiledims) { apply(LOOP_ARGS_7); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 7
 
@@ -2726,7 +2726,7 @@ struct HostIterateTile<
     point_type m_offset;
     point_type m_tiledims;
 
-    if (RP::outer_direction == RP::Left) {
+    if (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
         m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
@@ -2744,7 +2744,7 @@ struct HostIterateTile<
     // partial tile dims
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    if (RP::inner_direction == RP::Left) {
+    if (RP::inner_direction == Iterate::Left) {
       if (full_tile) {
         //      #pragma simd
         LOOP_8L(index_type, m_tiledims) { apply(LOOP_ARGS_8); }
@@ -2752,7 +2752,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_8L(index_type, m_tiledims) { apply(LOOP_ARGS_8); }
       }
-    }  // end RP::Left
+    }  // end Iterate::Left
     else {
       if (full_tile) {
         //      #pragma simd
@@ -2761,7 +2761,7 @@ struct HostIterateTile<
         //      #pragma simd
         LOOP_8R(index_type, m_tiledims) { apply(LOOP_ARGS_8); }
       }
-    }  // end RP::Right
+    }  // end Iterate::Right
 
   }  // end op() rank == 8
 #endif

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -123,7 +123,7 @@ struct DeviceIterateTile<2, PolicyType, Functor, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    if (PolicyType::inner_direction == PolicyType::Left) {
+    if (PolicyType::inner_direction == Iterate::Left) {
       // Loop over size maxnumblocks until full range covered
       for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
            tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
@@ -205,7 +205,7 @@ struct DeviceIterateTile<3, PolicyType, Functor, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    if (PolicyType::inner_direction == PolicyType::Left) {
+    if (PolicyType::inner_direction == Iterate::Left) {
       for (index_type tile_id2 = static_cast<index_type>(blockIdx.z);
            tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.z) {
         const index_type offset_2 =
@@ -308,7 +308,7 @@ struct DeviceIterateTile<4, PolicyType, Functor, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    if (PolicyType::inner_direction == PolicyType::Left) {
+    if (PolicyType::inner_direction == Iterate::Left) {
       const index_type temp0  = m_policy.m_tile_end[0];
       const index_type temp1  = m_policy.m_tile_end[1];
       const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
@@ -461,7 +461,7 @@ struct DeviceIterateTile<5, PolicyType, Functor, Tag> {
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
     // LL
-    if (PolicyType::inner_direction == PolicyType::Left) {
+    if (PolicyType::inner_direction == Iterate::Left) {
       index_type temp0        = m_policy.m_tile_end[0];
       index_type temp1        = m_policy.m_tile_end[1];
       const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
@@ -662,7 +662,7 @@ struct DeviceIterateTile<6, PolicyType, Functor, Tag> {
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
     // LL
-    if (PolicyType::inner_direction == PolicyType::Left) {
+    if (PolicyType::inner_direction == Iterate::Left) {
       index_type temp0        = m_policy.m_tile_end[0];
       index_type temp1        = m_policy.m_tile_end[1];
       const index_type numbl0 = (temp0 <= max_blocks ? temp0 : max_blocks);
@@ -974,7 +974,7 @@ struct DeviceIterateTile {
         bool in_bounds      = true;
 
         // LL
-        if (PolicyType::inner_direction == PolicyType::Left) {
+        if (PolicyType::inner_direction == Iterate::Left) {
           for (int i = 0; i < PolicyType::rank; ++i) {
             m_offset[i] =
                 (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +


### PR DESCRIPTION
This pull request queries the maximum number of threads at runtime and uses that value for setting up default tile sizes. Also, unify the implementation a little better. 