### PR TITLE
GitHub OSX CI

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,0 +1,38 @@
+name: github-OSX
+
+on: [push, pull_request]
+
+jobs:
+  osxci:
+    name: osx-ci
+    runs-on: [macos-latest]
+
+    strategy:
+      matrix:
+        include:
+          - backend: "SERIAL"
+            cmake_build_type: "RelWithDebInfo"
+          - backend: "PTHREAD"
+            cmake_build_type: "RelWithDebInfo"
+          - backend: "SERIAL"
+            cmake_build_type: "Debug"
+          - backend: "SERIAL"
+            cmake_build_type: "Release"
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: configure
+        run:
+          cmake -B build .
+            -DKokkos_ENABLE_${{ matrix.backend }}=On
+            -DCMAKE_CXX_FLAGS="-Werror"
+            -DCMAKE_CXX_STANDARD=14
+            -DKokkos_ENABLE_COMPILER_WARNINGS=ON
+            -DKokkos_ENABLE_TESTS=On
+            -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
+      - name: build
+        run:
+          cmake --build build --parallel 2
+      - name: test
+        working-directory: build
+        run: ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: cpp
 
 os:
   - linux
-  - osx
 
 compiler:
   - gcc
@@ -42,30 +41,11 @@ env:
 
 matrix:
   exclude:
-# Apple GCC is just an alias to AppleClang
-    - os: osx
-      compiler: gcc
-# Apple Clang doesn't support OpenMP
-    - os: osx
-      compiler: clang
-      env: CMAKE_BUILD_TYPE=Debug BACKEND="OPENMP" COVERAGE=yes GTEST_FILTER="-*DeathTest*"
-    - os: osx
-      compiler: clang
-      env: CMAKE_BUILD_TYPE=Release BACKEND="OPENMP"
-# We do this as canary
     - os: linux
       compiler: gcc
       env: CMAKE_BUILD_TYPE=Release BACKEND="OPENMP"
 
 before_script:
-  - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
-      brew update;
-      export HOMEBREW_NO_AUTO_UPDATE=1;
-      brew ls --versions ccache   > /dev/null || brew install ccache;
-      export PATH=/usr/local/opt/ccache/libexec:$PATH;
-      export CXXFLAGS="${CXXFLAGS} -Wno-unused-command-line-argument";
-      if [[ ${BACKEND} == "OPENMP" ]]; then brew install libomp; fi
-    fi
   - ccache -z
   - if [[ ${COVERAGE} ]]; then export CXX="${CXX} --coverage"; fi
   - if [[ ! ${CMAKE_BUILD_TYPE} ]]; then export CXXFLAGS="${CXXFLAGS} -O2"; fi


### PR DESCRIPTION
We are having problems with Travis CI timing out increasingly often, especially for the OSX builds. This pull request moves these four builds to GitHub Actions.