### PR TITLE
Fix signed integer overflow in TeamPolicyInternal with pthread backend

### DIFF
--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -806,7 +806,7 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
  private:
   /** \brief finalize chunk_size if it was set to AUTO*/
   inline void set_auto_chunk_size() {
-    int concurrency = traits::execution_space::concurrency() / m_team_alloc;
+    int64_t concurrency = traits::execution_space::concurrency() / m_team_alloc;
     if (concurrency == 0) concurrency = 1;
 
     if (m_chunk_size > 0) {


### PR DESCRIPTION
Occurs in TeamPolicyInternal<Threads>::set_auto_chunk_size() in while
loop condition.  Detected with Clang's UndefinedBehaviorSanitizer in a
number of core unit tests:

    threads.policy_construction
    threads.team_for
    threads.team_policy_max_recommended

The error reads:

    core/src/Threads/Kokkos_ThreadsTeam.hpp:816:27: runtime error: signed
    integer overflow: 33554432 * 100 cannot be represented in type 'int'