### PR TITLE
Major duplicate code removal in SharedAllocationRecord specializations

### DIFF
--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -856,13 +856,15 @@ namespace Impl {
 
 template <>
 class SharedAllocationRecord<Kokkos::CudaSpace, void>
-    : public CudaSharedAllocationRecordCommon<Kokkos::CudaSpace> {
+    : public HostInaccessibleSharedAllocationRecordCommon<Kokkos::CudaSpace> {
  private:
   friend class SharedAllocationRecord<Kokkos::CudaUVMSpace, void>;
   friend class SharedAllocationRecordCommon<Kokkos::CudaSpace>;
+  friend class HostInaccessibleSharedAllocationRecordCommon<Kokkos::CudaSpace>;
 
   using RecordBase = SharedAllocationRecord<void, void>;
-  using base_t     = CudaSharedAllocationRecordCommon<Kokkos::CudaSpace>;
+  using base_t =
+      HostInaccessibleSharedAllocationRecordCommon<Kokkos::CudaSpace>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
@@ -888,10 +890,6 @@ class SharedAllocationRecord<Kokkos::CudaSpace, void>
       const RecordBase::function_type arg_dealloc = &base_t::deallocate);
 
  public:
-  std::string get_label() const;
-
-  static SharedAllocationRecord* get_record(void* arg_alloc_ptr);
-
   template <typename AliasType>
   inline ::cudaTextureObject_t attach_texture_object() {
     static_assert((std::is_same<AliasType, int>::value ||
@@ -914,9 +912,6 @@ class SharedAllocationRecord<Kokkos::CudaSpace, void>
     // Texture object is attached to the entire allocation range
     return ptr - reinterpret_cast<AliasType*>(RecordBase::m_alloc_ptr);
   }
-
-  static void print_records(std::ostream&, const Kokkos::CudaSpace&,
-                            bool detail = false);
 };
 
 template <>
@@ -969,9 +964,6 @@ class SharedAllocationRecord<Kokkos::CudaUVMSpace, void>
     // Texture object is attached to the entire allocation range
     return ptr - reinterpret_cast<AliasType*>(RecordBase::m_alloc_ptr);
   }
-
-  static void print_records(std::ostream&, const Kokkos::CudaUVMSpace&,
-                            bool detail = false);
 };
 
 template <>
@@ -998,10 +990,6 @@ class SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>
       const Kokkos::CudaHostPinnedSpace& arg_space,
       const std::string& arg_label, const size_t arg_alloc_size,
       const RecordBase::function_type arg_dealloc = &deallocate);
-
- public:
-  static void print_records(std::ostream&, const Kokkos::CudaHostPinnedSpace&,
-                            bool detail = false);
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -834,18 +834,19 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
 namespace Kokkos {
 namespace Impl {
 
-template <class MemorySpace>
+template <class MemorySpace,
+          class Derived = SharedAllocationRecord<MemorySpace, void>>
 class CudaSharedAllocationRecordCommon
-  : public SharedAllocationRecordCommon<Kokkos::CudaSpace> {
+    : public SharedAllocationRecordCommon<MemorySpace> {
  private:
-  using derived_t = SharedAllocationRecord<MemorySpace, void>;
-  using base_t = SharedAllocationRecordCommon<Kokkos::CudaSpace>;
+  using base_t = SharedAllocationRecordCommon<MemorySpace>;
+
  protected:
   using base_t::base_t;
 };
 
-} // end namespace Impl
-} // end namespace Kokkos
+}  // end namespace Impl
+}  // end namespace Kokkos
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -858,9 +859,10 @@ class SharedAllocationRecord<Kokkos::CudaSpace, void>
     : public CudaSharedAllocationRecordCommon<Kokkos::CudaSpace> {
  private:
   friend class SharedAllocationRecord<Kokkos::CudaUVMSpace, void>;
+  friend class SharedAllocationRecordCommon<Kokkos::CudaSpace>;
 
   using RecordBase = SharedAllocationRecord<void, void>;
-  using base_t = CudaSharedAllocationRecordCommon<Kokkos::CudaSpace>;
+  using base_t     = CudaSharedAllocationRecordCommon<Kokkos::CudaSpace>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
@@ -919,9 +921,11 @@ class SharedAllocationRecord<Kokkos::CudaSpace, void>
 
 template <>
 class SharedAllocationRecord<Kokkos::CudaUVMSpace, void>
-    : public CudaSharedAllocationRecordCommon<Kokkos::CudaSpace> {
+    : public CudaSharedAllocationRecordCommon<Kokkos::CudaUVMSpace> {
  private:
-  using base_t = CudaSharedAllocationRecordCommon<Kokkos::CudaSpace>;
+  friend class SharedAllocationRecordCommon<Kokkos::CudaUVMSpace>;
+
+  using base_t     = CudaSharedAllocationRecordCommon<Kokkos::CudaUVMSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
@@ -972,10 +976,12 @@ class SharedAllocationRecord<Kokkos::CudaUVMSpace, void>
 
 template <>
 class SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>
-    : public CudaSharedAllocationRecordCommon<Kokkos::CudaSpace> {
+    : public CudaSharedAllocationRecordCommon<Kokkos::CudaHostPinnedSpace> {
  private:
+  friend class SharedAllocationRecordCommon<Kokkos::CudaHostPinnedSpace>;
+
   using RecordBase = SharedAllocationRecord<void, void>;
-  using base_t = CudaSharedAllocationRecordCommon<Kokkos::CudaSpace>;
+  using base_t = CudaSharedAllocationRecordCommon<Kokkos::CudaHostPinnedSpace>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -834,26 +834,6 @@ struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
 namespace Kokkos {
 namespace Impl {
 
-template <class MemorySpace,
-          class Derived = SharedAllocationRecord<MemorySpace, void>>
-class CudaSharedAllocationRecordCommon
-    : public SharedAllocationRecordCommon<MemorySpace> {
- private:
-  using base_t = SharedAllocationRecordCommon<MemorySpace>;
-
- protected:
-  using base_t::base_t;
-};
-
-}  // end namespace Impl
-}  // end namespace Kokkos
-
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
-
-namespace Kokkos {
-namespace Impl {
-
 template <>
 class SharedAllocationRecord<Kokkos::CudaSpace, void>
     : public HostInaccessibleSharedAllocationRecordCommon<Kokkos::CudaSpace> {
@@ -916,11 +896,11 @@ class SharedAllocationRecord<Kokkos::CudaSpace, void>
 
 template <>
 class SharedAllocationRecord<Kokkos::CudaUVMSpace, void>
-    : public CudaSharedAllocationRecordCommon<Kokkos::CudaUVMSpace> {
+    : public SharedAllocationRecordCommon<Kokkos::CudaUVMSpace> {
  private:
   friend class SharedAllocationRecordCommon<Kokkos::CudaUVMSpace>;
 
-  using base_t     = CudaSharedAllocationRecordCommon<Kokkos::CudaUVMSpace>;
+  using base_t     = SharedAllocationRecordCommon<Kokkos::CudaUVMSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
@@ -968,12 +948,12 @@ class SharedAllocationRecord<Kokkos::CudaUVMSpace, void>
 
 template <>
 class SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>
-    : public CudaSharedAllocationRecordCommon<Kokkos::CudaHostPinnedSpace> {
+    : public SharedAllocationRecordCommon<Kokkos::CudaHostPinnedSpace> {
  private:
   friend class SharedAllocationRecordCommon<Kokkos::CudaHostPinnedSpace>;
 
   using RecordBase = SharedAllocationRecord<void, void>;
-  using base_t = CudaSharedAllocationRecordCommon<Kokkos::CudaHostPinnedSpace>;
+  using base_t = SharedAllocationRecordCommon<Kokkos::CudaHostPinnedSpace>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -877,12 +877,12 @@ class SharedAllocationRecord<Kokkos::CudaSpace, void>
   static RecordBase s_root_record;
 #endif
 
-  ::cudaTextureObject_t m_tex_obj;
+  ::cudaTextureObject_t m_tex_obj = 0;
   const Kokkos::CudaSpace m_space;
 
  protected:
   ~SharedAllocationRecord();
-  SharedAllocationRecord() : base_t(), m_tex_obj(0), m_space() {}
+  SharedAllocationRecord() = default;
 
   SharedAllocationRecord(
       const Kokkos::CudaSpace& arg_space, const std::string& arg_label,
@@ -928,12 +928,12 @@ class SharedAllocationRecord<Kokkos::CudaUVMSpace, void>
 
   static RecordBase s_root_record;
 
-  ::cudaTextureObject_t m_tex_obj;
+  ::cudaTextureObject_t m_tex_obj = 0;
   const Kokkos::CudaUVMSpace m_space;
 
  protected:
   ~SharedAllocationRecord();
-  SharedAllocationRecord() : base_t(), m_tex_obj(0), m_space() {}
+  SharedAllocationRecord() = default;
 
   SharedAllocationRecord(
       const Kokkos::CudaUVMSpace& arg_space, const std::string& arg_label,
@@ -984,7 +984,7 @@ class SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>
 
  protected:
   ~SharedAllocationRecord();
-  SharedAllocationRecord() : base_t(), m_space() {}
+  SharedAllocationRecord() = default;
 
   SharedAllocationRecord(
       const Kokkos::CudaHostPinnedSpace& arg_space,

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -953,7 +953,7 @@ class SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>
   friend class SharedAllocationRecordCommon<Kokkos::CudaHostPinnedSpace>;
 
   using RecordBase = SharedAllocationRecord<void, void>;
-  using base_t = SharedAllocationRecordCommon<Kokkos::CudaHostPinnedSpace>;
+  using base_t     = SharedAllocationRecordCommon<Kokkos::CudaHostPinnedSpace>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -519,14 +519,14 @@ namespace Impl {
 
 template <>
 class SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>
-    : public SharedAllocationRecord<void, void> {
+    : public SharedAllocationRecordCommon<Kokkos::Experimental::HIPSpace> {
  private:
+  friend class SharedAllocationRecordCommon<Kokkos::Experimental::HIPSpace>;
+  using base_t = SharedAllocationRecordCommon<Kokkos::Experimental::HIPSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
-
-  static void deallocate(RecordBase*);
 
 #ifdef KOKKOS_ENABLE_DEBUG
   static RecordBase s_root_record;
@@ -540,27 +540,9 @@ class SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>
   SharedAllocationRecord(
       const Kokkos::Experimental::HIPSpace& arg_space,
       const std::string& arg_label, const size_t arg_alloc_size,
-      const RecordBase::function_type arg_dealloc = &deallocate);
+      const RecordBase::function_type arg_dealloc = &base_t::deallocate);
 
  public:
-  std::string get_label() const;
-
-  static SharedAllocationRecord* allocate(
-      const Kokkos::Experimental::HIPSpace& arg_space,
-      const std::string& arg_label, const size_t arg_alloc_size);
-
-  /**\brief  Allocate tracked memory in the space */
-  static void* allocate_tracked(const Kokkos::Experimental::HIPSpace& arg_space,
-                                const std::string& arg_label,
-                                const size_t arg_alloc_size);
-
-  /**\brief  Reallocate tracked memory in the space */
-  static void* reallocate_tracked(void* const arg_alloc_ptr,
-                                  const size_t arg_alloc_size);
-
-  /**\brief  Deallocate tracked memory in the space */
-  static void deallocate_tracked(void* const arg_alloc_ptr);
-
   static SharedAllocationRecord* get_record(void* arg_alloc_ptr);
 
   static void print_records(std::ostream&,
@@ -570,14 +552,17 @@ class SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>
 
 template <>
 class SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>
-    : public SharedAllocationRecord<void, void> {
+    : public SharedAllocationRecordCommon<
+          Kokkos::Experimental::HIPHostPinnedSpace> {
  private:
+  friend class SharedAllocationRecordCommon<
+      Kokkos::Experimental::HIPHostPinnedSpace>;
+  using base_t =
+      SharedAllocationRecordCommon<Kokkos::Experimental::HIPHostPinnedSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
-
-  static void deallocate(RecordBase*);
 
 #ifdef KOKKOS_ENABLE_DEBUG
   static RecordBase s_root_record;
@@ -592,31 +577,8 @@ class SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>
   SharedAllocationRecord(
       const Kokkos::Experimental::HIPHostPinnedSpace& arg_space,
       const std::string& arg_label, const size_t arg_alloc_size,
-      const RecordBase::function_type arg_dealloc = &deallocate);
+      const RecordBase::function_type arg_dealloc = &base_t::deallocate);
 
- public:
-  std::string get_label() const;
-
-  static SharedAllocationRecord* allocate(
-      const Kokkos::Experimental::HIPHostPinnedSpace& arg_space,
-      const std::string& arg_label, const size_t arg_alloc_size);
-  /**\brief  Allocate tracked memory in the space */
-  static void* allocate_tracked(
-      const Kokkos::Experimental::HIPHostPinnedSpace& arg_space,
-      const std::string& arg_label, const size_t arg_alloc_size);
-
-  /**\brief  Reallocate tracked memory in the space */
-  static void* reallocate_tracked(void* const arg_alloc_ptr,
-                                  const size_t arg_alloc_size);
-
-  /**\brief  Deallocate tracked memory in the space */
-  static void deallocate_tracked(void* const arg_alloc_ptr);
-
-  static SharedAllocationRecord* get_record(void* arg_alloc_ptr);
-
-  static void print_records(std::ostream&,
-                            const Kokkos::Experimental::HIPHostPinnedSpace&,
-                            bool detail = false);
 };
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -578,7 +578,6 @@ class SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>
       const Kokkos::Experimental::HIPHostPinnedSpace& arg_space,
       const std::string& arg_label, const size_t arg_alloc_size,
       const RecordBase::function_type arg_dealloc = &base_t::deallocate);
-
 };
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -519,10 +519,14 @@ namespace Impl {
 
 template <>
 class SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>
-    : public SharedAllocationRecordCommon<Kokkos::Experimental::HIPSpace> {
+    : public HostInaccessibleSharedAllocationRecordCommon<
+          Kokkos::Experimental::HIPSpace> {
  private:
   friend class SharedAllocationRecordCommon<Kokkos::Experimental::HIPSpace>;
-  using base_t = SharedAllocationRecordCommon<Kokkos::Experimental::HIPSpace>;
+  friend class HostInaccessibleSharedAllocationRecordCommon<
+      Kokkos::Experimental::HIPSpace>;
+  using base_t = HostInaccessibleSharedAllocationRecordCommon<
+      Kokkos::Experimental::HIPSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
@@ -541,13 +545,6 @@ class SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>
       const Kokkos::Experimental::HIPSpace& arg_space,
       const std::string& arg_label, const size_t arg_alloc_size,
       const RecordBase::function_type arg_dealloc = &base_t::deallocate);
-
- public:
-  static SharedAllocationRecord* get_record(void* arg_alloc_ptr);
-
-  static void print_records(std::ostream&,
-                            const Kokkos::Experimental::HIPSpace&,
-                            bool detail = false);
 };
 
 template <>

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -569,7 +569,7 @@ class SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>
 
  protected:
   ~SharedAllocationRecord();
-  SharedAllocationRecord() : RecordBase(), m_space() {}
+  SharedAllocationRecord() = default;
 
   SharedAllocationRecord(
       const Kokkos::Experimental::HIPHostPinnedSpace& arg_space,

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -242,16 +242,16 @@ namespace Impl {
 
 template <>
 class SharedAllocationRecord<Kokkos::HostSpace, void>
-    : public SharedAllocationRecord<void, void> {
+    : public SharedAllocationRecordCommon<Kokkos::HostSpace> {
  private:
   friend Kokkos::HostSpace;
+  friend class SharedAllocationRecordCommon<Kokkos::HostSpace>;
 
+  using base_t = SharedAllocationRecordCommon<Kokkos::HostSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
-
-  static void deallocate(RecordBase*);
 
 #ifdef KOKKOS_ENABLE_DEBUG
   /**\brief  Root record for tracked allocations from this HostSpace instance */
@@ -261,12 +261,7 @@ class SharedAllocationRecord<Kokkos::HostSpace, void>
   const Kokkos::HostSpace m_space;
 
  protected:
-  ~SharedAllocationRecord()
-#if defined( \
-    KOKKOS_IMPL_INTEL_WORKAROUND_NOEXCEPT_SPECIFICATION_VIRTUAL_FUNCTION)
-      noexcept
-#endif
-      ;
+  ~SharedAllocationRecord() noexcept;
   SharedAllocationRecord() = default;
 
   SharedAllocationRecord(
@@ -275,10 +270,6 @@ class SharedAllocationRecord<Kokkos::HostSpace, void>
       const RecordBase::function_type arg_dealloc = &deallocate);
 
  public:
-  inline std::string get_label() const {
-    return std::string(RecordBase::head()->m_label);
-  }
-
   KOKKOS_INLINE_FUNCTION static SharedAllocationRecord* allocate(
       const Kokkos::HostSpace& arg_space, const std::string& arg_label,
       const size_t arg_alloc_size) {
@@ -291,23 +282,6 @@ class SharedAllocationRecord<Kokkos::HostSpace, void>
     return (SharedAllocationRecord*)0;
 #endif
   }
-
-  /**\brief  Allocate tracked memory in the space */
-  static void* allocate_tracked(const Kokkos::HostSpace& arg_space,
-                                const std::string& arg_label,
-                                const size_t arg_alloc_size);
-
-  /**\brief  Reallocate tracked memory in the space */
-  static void* reallocate_tracked(void* const arg_alloc_ptr,
-                                  const size_t arg_alloc_size);
-
-  /**\brief  Deallocate tracked memory in the space */
-  static void deallocate_tracked(void* const arg_alloc_ptr);
-
-  static SharedAllocationRecord* get_record(void* arg_alloc_ptr);
-
-  static void print_records(std::ostream&, const Kokkos::HostSpace&,
-                            bool detail = false);
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -247,7 +247,7 @@ class SharedAllocationRecord<Kokkos::HostSpace, void>
   friend Kokkos::HostSpace;
   friend class SharedAllocationRecordCommon<Kokkos::HostSpace>;
 
-  using base_t = SharedAllocationRecordCommon<Kokkos::HostSpace>;
+  using base_t     = SharedAllocationRecordCommon<Kokkos::HostSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -261,7 +261,12 @@ class SharedAllocationRecord<Kokkos::HostSpace, void>
   const Kokkos::HostSpace m_space;
 
  protected:
-  ~SharedAllocationRecord() noexcept;
+  ~SharedAllocationRecord()
+#if defined( \
+    KOKKOS_IMPL_INTEL_WORKAROUND_NOEXCEPT_SPECIFICATION_VIRTUAL_FUNCTION)
+      noexcept
+#endif
+      ;
   SharedAllocationRecord() = default;
 
   SharedAllocationRecord(

--- a/core/src/Kokkos_OpenMPTargetSpace.hpp
+++ b/core/src/Kokkos_OpenMPTargetSpace.hpp
@@ -150,6 +150,8 @@ class SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>
     : public HostInaccessibleSharedAllocationRecordCommon<
           Kokkos::Experimental::OpenMPTargetSpace> {
  private:
+  friend class HostInaccessibleSharedAllocationRecordCommon<
+      Kokkos::Experimental::OpenMPTargetSpace>;
   friend class SharedAllocationRecordCommon<
       Kokkos::Experimental::OpenMPTargetSpace>;
   friend Kokkos::Experimental::OpenMPTargetSpace;

--- a/core/src/Kokkos_OpenMPTargetSpace.hpp
+++ b/core/src/Kokkos_OpenMPTargetSpace.hpp
@@ -147,16 +147,19 @@ namespace Impl {
 
 template <>
 class SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>
-    : public SharedAllocationRecord<void, void> {
+    : public SharedAllocationRecordCommon<
+          Kokkos::Experimental::OpenMPTargetSpace> {
  private:
+  friend class SharedAllocationRecordCommon<
+      Kokkos::Experimental::OpenMPTargetSpace>;
   friend Kokkos::Experimental::OpenMPTargetSpace;
 
+  using base_t =
+      SharedAllocationRecordCommon<Kokkos::Experimental::OpenMPTargetSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
-
-  static void deallocate(RecordBase*);
 
   /**\brief  Root record for tracked allocations from this OpenMPTargetSpace
    * instance */
@@ -186,23 +189,11 @@ class SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>
 #endif
   }
 
-  /**\brief  Allocate tracked memory in the space */
-  static void* allocate_tracked(
-      const Kokkos::Experimental::OpenMPTargetSpace& arg_space,
-      const std::string& arg_label, const size_t arg_alloc_size);
-
   /**\brief  Reallocate tracked memory in the space */
   static void* reallocate_tracked(void* const arg_alloc_ptr,
                                   const size_t arg_alloc_size);
 
-  /**\brief  Deallocate tracked memory in the space */
-  static void deallocate_tracked(void* const arg_alloc_ptr);
-
   static SharedAllocationRecord* get_record(void* arg_alloc_ptr);
-
-  static void print_records(std::ostream&,
-                            const Kokkos::Experimental::OpenMPTargetSpace&,
-                            bool detail = false);
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_OpenMPTargetSpace.hpp
+++ b/core/src/Kokkos_OpenMPTargetSpace.hpp
@@ -147,15 +147,15 @@ namespace Impl {
 
 template <>
 class SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>
-    : public SharedAllocationRecordCommon<
+    : public HostInaccessibleSharedAllocationRecordCommon<
           Kokkos::Experimental::OpenMPTargetSpace> {
  private:
   friend class SharedAllocationRecordCommon<
       Kokkos::Experimental::OpenMPTargetSpace>;
   friend Kokkos::Experimental::OpenMPTargetSpace;
 
-  using base_t =
-      SharedAllocationRecordCommon<Kokkos::Experimental::OpenMPTargetSpace>;
+  using base_t = HostInaccessibleSharedAllocationRecordCommon<
+      Kokkos::Experimental::OpenMPTargetSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
@@ -192,8 +192,6 @@ class SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>
   /**\brief  Reallocate tracked memory in the space */
   static void* reallocate_tracked(void* const arg_alloc_ptr,
                                   const size_t arg_alloc_size);
-
-  static SharedAllocationRecord* get_record(void* arg_alloc_ptr);
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_SYCL_Space.hpp
+++ b/core/src/Kokkos_SYCL_Space.hpp
@@ -289,7 +289,8 @@ class SharedAllocationRecord<Kokkos::Experimental::SYCLSharedUSMSpace, void>
 
  protected:
   ~SharedAllocationRecord();
-  SharedAllocationRecord() : RecordBase(), m_space() {}
+
+  SharedAllocationRecord() = default;
 
   SharedAllocationRecord(
       const Kokkos::Experimental::SYCLSharedUSMSpace& arg_space,

--- a/core/src/Kokkos_SYCL_Space.hpp
+++ b/core/src/Kokkos_SYCL_Space.hpp
@@ -236,13 +236,15 @@ namespace Impl {
 
 template <>
 class SharedAllocationRecord<Kokkos::Experimental::SYCLDeviceUSMSpace, void>
-    : public SharedAllocationRecordCommon<
+    : public HostInaccessibleSharedAllocationRecordCommon<
           Kokkos::Experimental::SYCLDeviceUSMSpace> {
  private:
   friend class SharedAllocationRecordCommon<
       Kokkos::Experimental::SYCLDeviceUSMSpace>;
-  using base_t =
-      SharedAllocationRecordCommon<Kokkos::Experimental::SYCLDeviceUSMSpace>;
+  friend class HostInaccessibleSharedAllocationRecordCommon<
+      Kokkos::Experimental::SYCLDeviceUSMSpace>;
+  using base_t = HostInaccessibleSharedAllocationRecordCommon<
+      Kokkos::Experimental::SYCLDeviceUSMSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
@@ -263,15 +265,6 @@ class SharedAllocationRecord<Kokkos::Experimental::SYCLDeviceUSMSpace, void>
       const Kokkos::Experimental::SYCLDeviceUSMSpace& arg_space,
       const std::string& arg_label, const size_t arg_alloc_size,
       const RecordBase::function_type arg_dealloc = &base_t::deallocate);
-
- public:
-  std::string get_label() const;
-
-  static SharedAllocationRecord* get_record(void* arg_alloc_ptr);
-
-  static void print_records(std::ostream&,
-                            const Kokkos::Experimental::SYCLDeviceUSMSpace&,
-                            bool detail = false);
 };
 
 template <>
@@ -302,9 +295,6 @@ class SharedAllocationRecord<Kokkos::Experimental::SYCLSharedUSMSpace, void>
       const Kokkos::Experimental::SYCLSharedUSMSpace& arg_space,
       const std::string& arg_label, const size_t arg_alloc_size,
       const RecordBase::function_type arg_dealloc = &base_t::deallocate);
-
- public:
-  std::string get_label() const;
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_SYCL_Space.hpp
+++ b/core/src/Kokkos_SYCL_Space.hpp
@@ -236,16 +236,19 @@ namespace Impl {
 
 template <>
 class SharedAllocationRecord<Kokkos::Experimental::SYCLDeviceUSMSpace, void>
-    : public SharedAllocationRecord<void, void> {
+    : public SharedAllocationRecordCommon<
+          Kokkos::Experimental::SYCLDeviceUSMSpace> {
  private:
+  friend class SharedAllocationRecordCommon<
+      Kokkos::Experimental::SYCLDeviceUSMSpace>;
+  using base_t =
+      SharedAllocationRecordCommon<Kokkos::Experimental::SYCLDeviceUSMSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord(SharedAllocationRecord&&)      = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord& operator=(SharedAllocationRecord&&) = delete;
-
-  static void deallocate(RecordBase*);
 
 #ifdef KOKKOS_ENABLE_DEBUG
   static RecordBase s_root_record;
@@ -259,26 +262,10 @@ class SharedAllocationRecord<Kokkos::Experimental::SYCLDeviceUSMSpace, void>
   SharedAllocationRecord(
       const Kokkos::Experimental::SYCLDeviceUSMSpace& arg_space,
       const std::string& arg_label, const size_t arg_alloc_size,
-      const RecordBase::function_type arg_dealloc = &deallocate);
+      const RecordBase::function_type arg_dealloc = &base_t::deallocate);
 
  public:
   std::string get_label() const;
-
-  static SharedAllocationRecord* allocate(
-      const Kokkos::Experimental::SYCLDeviceUSMSpace& arg_space,
-      const std::string& arg_label, const size_t arg_alloc_size);
-
-  /**\brief  Allocate tracked memory in the space */
-  static void* allocate_tracked(
-      const Kokkos::Experimental::SYCLDeviceUSMSpace& arg_space,
-      const std::string& arg_label, const size_t arg_alloc_size);
-
-  /**\brief  Reallocate tracked memory in the space */
-  static void* reallocate_tracked(void* const arg_alloc_ptr,
-                                  const size_t arg_alloc_size);
-
-  /**\brief  Deallocate tracked memory in the space */
-  static void deallocate_tracked(void* const arg_alloc_ptr);
 
   static SharedAllocationRecord* get_record(void* arg_alloc_ptr);
 
@@ -289,16 +276,19 @@ class SharedAllocationRecord<Kokkos::Experimental::SYCLDeviceUSMSpace, void>
 
 template <>
 class SharedAllocationRecord<Kokkos::Experimental::SYCLSharedUSMSpace, void>
-    : public SharedAllocationRecord<void, void> {
+    : public SharedAllocationRecordCommon<
+          Kokkos::Experimental::SYCLSharedUSMSpace> {
  private:
+  friend class SharedAllocationRecordCommon<
+      Kokkos::Experimental::SYCLSharedUSMSpace>;
+  using base_t =
+      SharedAllocationRecordCommon<Kokkos::Experimental::SYCLSharedUSMSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
   SharedAllocationRecord(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord(SharedAllocationRecord&&)      = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
   SharedAllocationRecord& operator=(SharedAllocationRecord&&) = delete;
-
-  static void deallocate(RecordBase*);
 
   static RecordBase s_root_record;
 
@@ -311,32 +301,10 @@ class SharedAllocationRecord<Kokkos::Experimental::SYCLSharedUSMSpace, void>
   SharedAllocationRecord(
       const Kokkos::Experimental::SYCLSharedUSMSpace& arg_space,
       const std::string& arg_label, const size_t arg_alloc_size,
-      const RecordBase::function_type arg_dealloc = &deallocate);
+      const RecordBase::function_type arg_dealloc = &base_t::deallocate);
 
  public:
   std::string get_label() const;
-
-  static SharedAllocationRecord* allocate(
-      const Kokkos::Experimental::SYCLSharedUSMSpace& arg_space,
-      const std::string& arg_label, const size_t arg_alloc_size);
-
-  /**\brief  Allocate tracked memory in the space */
-  static void* allocate_tracked(
-      const Kokkos::Experimental::SYCLSharedUSMSpace& arg_space,
-      const std::string& arg_label, const size_t arg_alloc_size);
-
-  /**\brief  Reallocate tracked memory in the space */
-  static void* reallocate_tracked(void* const arg_alloc_ptr,
-                                  const size_t arg_alloc_size);
-
-  /**\brief  Deallocate tracked memory in the space */
-  static void deallocate_tracked(void* const arg_alloc_ptr);
-
-  static SharedAllocationRecord* get_record(void* arg_alloc_ptr);
-
-  static void print_records(std::ostream&,
-                            const Kokkos::Experimental::SYCLSharedUSMSpace&,
-                            bool detail = false);
 };
 
 }  // namespace Impl

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -113,12 +113,6 @@ std::string SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace,
   return std::string("OpenMPTargetAllocation");
 }
 
-void SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace,
-                            void>::deallocate(SharedAllocationRecord<void, void>
-                                                  *arg_rec) {
-  delete static_cast<SharedAllocationRecord *>(arg_rec);
-}
-
 SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
     SharedAllocationRecord(
         const Kokkos::Experimental::OpenMPTargetSpace &arg_space,
@@ -146,30 +140,6 @@ SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
 }
 
 //----------------------------------------------------------------------------
-
-void *SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
-    allocate_tracked(const Kokkos::Experimental::OpenMPTargetSpace &arg_space,
-                     const std::string &arg_alloc_label,
-                     const size_t arg_alloc_size) {
-  if (!arg_alloc_size) return nullptr;
-
-  SharedAllocationRecord *const r =
-      allocate(arg_space, arg_alloc_label, arg_alloc_size);
-
-  RecordBase::increment(r);
-
-  return r->data();
-}
-
-void SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace,
-                            void>::deallocate_tracked(void *const
-                                                          arg_alloc_ptr) {
-  if (arg_alloc_ptr != nullptr) {
-    SharedAllocationRecord *const r = get_record(arg_alloc_ptr);
-
-    RecordBase::decrement(r);
-  }
-}
 
 void *SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
     reallocate_tracked(void *const arg_alloc_ptr, const size_t arg_alloc_size) {

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -57,6 +57,7 @@
 #include <sstream>
 #include <cstring>
 
+#include <Kokkos_OpenMPTarget.hpp>
 #include <Kokkos_OpenMPTargetSpace.hpp>
 #include <impl/Kokkos_Error.hpp>
 #include <Kokkos_Atomic.hpp>
@@ -125,7 +126,7 @@ SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
         const SharedAllocationRecord<void, void>::function_type arg_dealloc)
     // Pass through allocated [ SharedAllocationHeader , user_memory ]
     // Pass through deallocation function
-    : SharedAllocationRecord<void, void>(
+    : base_t(
 #ifdef KOKKOS_ENABLE_DEBUG
           &SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace,
                                   void>::s_root_record,

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -42,9 +42,12 @@
 //@HEADER
 */
 
+#include <Kokkos_Macros.hpp>
+
+#include <impl/Kokkos_SharedAlloc_timpl.hpp>
+
 #include <algorithm>
 #include <omp.h>
-#include <Kokkos_Macros.hpp>
 
 /*--------------------------------------------------------------------------*/
 
@@ -93,6 +96,18 @@ void OpenMPTargetSpace::deallocate(void *const arg_alloc_ptr,
 
 namespace Kokkos {
 namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="Explicit instantiations of CRTP Base classes"> {{{1
+
+// To avoid additional compilation cost for something that's (mostly?) not
+// performance sensitive, we explicity instantiate these CRTP base classes here,
+// where we have access to the associated *_timpl.hpp header files.
+template class SharedAllocationRecordCommon<
+    Kokkos::Experimental::OpenMPTargetSpace>;
+
+// </editor-fold> end Explicit instantiations of CRTP Base classes }}}1
+//==============================================================================
 
 #ifdef KOKKOS_ENABLE_DEBUG
 SharedAllocationRecord<void, void> SharedAllocationRecord<

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -135,12 +135,8 @@ SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
       m_space(arg_space) {
   SharedAllocationHeader header;
 
-  header.m_record = static_cast<SharedAllocationRecord<void, void> *>(this);
+  this->base_t::_fill_host_accessible_header_info(header, arg_label);
 
-  strncpy(header.m_label, arg_label.c_str(),
-          SharedAllocationHeader::maximum_label_length - 1);
-  // Set last element zero, in case c_str is too long
-  header.m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
   // TODO DeepCopy
   // DeepCopy
   Kokkos::Impl::DeepCopy<Experimental::OpenMPTargetSpace, HostSpace>(

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -265,7 +265,7 @@ SharedAllocationRecord<Kokkos::Experimental::SYCLDeviceUSMSpace, void>::
 
   SharedAllocationHeader header;
 
-  this->base_t::_fill_host_accessible_header_info(header, arg_label);
+  this->base_t::_fill_host_accessible_header_info(header, label);
 
   // Copy to device memory
   Kokkos::Impl::DeepCopy<Kokkos::Experimental::SYCLDeviceUSMSpace, HostSpace>(
@@ -279,7 +279,7 @@ SharedAllocationRecord<Kokkos::Experimental::SYCLSharedUSMSpace, void>::
         const SharedAllocationRecord<void, void>::function_type arg_dealloc)
     // Pass through allocated [ SharedAllocationHeader , user_memory ]
     // Pass through deallocation function
-    : SharedAllocationRecord<void, void>(
+    : base_t(
 #ifdef KOKKOS_ENABLE_DEBUG
           &SharedAllocationRecord<Kokkos::Experimental::SYCLSharedUSMSpace,
                                   void>::s_root_record,

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -348,6 +348,8 @@ namespace Impl {
 // To avoid additional compilation cost for something that's (mostly?) not
 // performance sensitive, we explicity instantiate these CRTP base classes here,
 // where we have access to the associated *_timpl.hpp header files.
+template class HostInaccessibleSharedAllocationRecordCommon<
+    Kokkos::Experimental::SYCLDeviceUSMSpace>;
 template class SharedAllocationRecordCommon<
     Kokkos::Experimental::SYCLDeviceUSMSpace>;
 template class SharedAllocationRecordCommon<

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -44,8 +44,6 @@
 
 #include <Kokkos_Macros.hpp>
 
-#include <impl/Kokkos_SharedAlloc_timpl.hpp>
-
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_MemorySpace.hpp>
 #include <impl/Kokkos_Tools.hpp>
@@ -348,17 +346,6 @@ void HostSpace::impl_deallocate(
 namespace Kokkos {
 namespace Impl {
 
-//==============================================================================
-// <editor-fold desc="Explicit instantiations of CRTP Base classes"> {{{1
-
-// To avoid additional compilation cost for something that's (mostly?) not
-// performance sensitive, we explicity instantiate these CRTP base classes here,
-// where we have access to the associated *_timpl.hpp header files.
-template class SharedAllocationRecordCommon<Kokkos::HostSpace>;
-
-// </editor-fold> end Explicit instantiations of CRTP Base classes }}}1
-//==============================================================================
-
 #ifdef KOKKOS_ENABLE_DEBUG
 SharedAllocationRecord<void, void>
     SharedAllocationRecord<Kokkos::HostSpace, void>::s_root_record;
@@ -489,3 +476,22 @@ void unlock_address_host_space(void *ptr) {
 
 }  // namespace Impl
 }  // namespace Kokkos
+
+//==============================================================================
+// <editor-fold desc="Explicit instantiations of CRTP Base classes"> {{{1
+
+#include <impl/Kokkos_SharedAlloc_timpl.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+// To avoid additional compilation cost for something that's (mostly?) not
+// performance sensitive, we explicity instantiate these CRTP base classes here,
+// where we have access to the associated *_timpl.hpp header files.
+template class SharedAllocationRecordCommon<Kokkos::HostSpace>;
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+// </editor-fold> end Explicit instantiations of CRTP Base classes }}}1
+//==============================================================================

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -42,9 +42,10 @@
 //@HEADER
 */
 
-#include <cstdio>
-#include <algorithm>
 #include <Kokkos_Macros.hpp>
+
+#include <impl/Kokkos_SharedAlloc_timpl.hpp>
+
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_MemorySpace.hpp>
 #include <impl/Kokkos_Tools.hpp>
@@ -347,23 +348,24 @@ void HostSpace::impl_deallocate(
 namespace Kokkos {
 namespace Impl {
 
+//==============================================================================
+// <editor-fold desc="Explicit instantiations of CRTP Base classes"> {{{1
+
+// To avoid additional compilation cost for something that's (mostly?) not
+// performance sensitive, we explicity instantiate these CRTP base classes here,
+// where we have access to the associated *_timpl.hpp header files.
+template class SharedAllocationRecordCommon<Kokkos::HostSpace>;
+
+// </editor-fold> end Explicit instantiations of CRTP Base classes }}}1
+//==============================================================================
+
 #ifdef KOKKOS_ENABLE_DEBUG
 SharedAllocationRecord<void, void>
     SharedAllocationRecord<Kokkos::HostSpace, void>::s_root_record;
 #endif
 
-void SharedAllocationRecord<Kokkos::HostSpace, void>::deallocate(
-    SharedAllocationRecord<void, void> *arg_rec) {
-  delete static_cast<SharedAllocationRecord *>(arg_rec);
-}
-
-SharedAllocationRecord<Kokkos::HostSpace, void>::~SharedAllocationRecord()
-#if defined( \
-    KOKKOS_IMPL_INTEL_WORKAROUND_NOEXCEPT_SPECIFICATION_VIRTUAL_FUNCTION)
-    noexcept
-#endif
-{
-
+SharedAllocationRecord<Kokkos::HostSpace,
+                       void>::~SharedAllocationRecord() noexcept {
   m_space.deallocate(RecordBase::m_alloc_ptr->m_label,
                      SharedAllocationRecord<void, void>::m_alloc_ptr,
                      SharedAllocationRecord<void, void>::m_alloc_size,
@@ -399,7 +401,7 @@ SharedAllocationRecord<Kokkos::HostSpace, void>::SharedAllocationRecord(
     const SharedAllocationRecord<void, void>::function_type arg_dealloc)
     // Pass through allocated [ SharedAllocationHeader , user_memory ]
     // Pass through deallocation function
-    : SharedAllocationRecord<void, void>(
+    : base_t(
 #ifdef KOKKOS_ENABLE_DEBUG
           &SharedAllocationRecord<Kokkos::HostSpace, void>::s_root_record,
 #endif
@@ -407,90 +409,9 @@ SharedAllocationRecord<Kokkos::HostSpace, void>::SharedAllocationRecord(
                                                arg_alloc_size),
           sizeof(SharedAllocationHeader) + arg_alloc_size, arg_dealloc),
       m_space(arg_space) {
-  // Fill in the Header information
-  RecordBase::m_alloc_ptr->m_record =
-      static_cast<SharedAllocationRecord<void, void> *>(this);
-
-  strncpy(RecordBase::m_alloc_ptr->m_label, arg_label.c_str(),
-          SharedAllocationHeader::maximum_label_length - 1);
-  // Set last element zero, in case c_str is too long
-  RecordBase::m_alloc_ptr
-      ->m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
+  this->base_t::_fill_host_accessible_header_info(*RecordBase::m_alloc_ptr,
+                                                  arg_label);
 }
-
-//----------------------------------------------------------------------------
-
-void *SharedAllocationRecord<Kokkos::HostSpace, void>::allocate_tracked(
-    const Kokkos::HostSpace &arg_space, const std::string &arg_alloc_label,
-    const size_t arg_alloc_size) {
-  if (!arg_alloc_size) return nullptr;
-
-  SharedAllocationRecord *const r =
-      allocate(arg_space, arg_alloc_label, arg_alloc_size);
-
-  RecordBase::increment(r);
-
-  return r->data();
-}
-
-void SharedAllocationRecord<Kokkos::HostSpace, void>::deallocate_tracked(
-    void *const arg_alloc_ptr) {
-  if (arg_alloc_ptr != nullptr) {
-    SharedAllocationRecord *const r = get_record(arg_alloc_ptr);
-
-    RecordBase::decrement(r);
-  }
-}
-
-void *SharedAllocationRecord<Kokkos::HostSpace, void>::reallocate_tracked(
-    void *const arg_alloc_ptr, const size_t arg_alloc_size) {
-  SharedAllocationRecord *const r_old = get_record(arg_alloc_ptr);
-  SharedAllocationRecord *const r_new =
-      allocate(r_old->m_space, r_old->get_label(), arg_alloc_size);
-
-  Kokkos::Impl::DeepCopy<HostSpace, HostSpace>(
-      r_new->data(), r_old->data(), std::min(r_old->size(), r_new->size()));
-
-  RecordBase::increment(r_new);
-  RecordBase::decrement(r_old);
-
-  return r_new->data();
-}
-
-SharedAllocationRecord<Kokkos::HostSpace, void> *
-SharedAllocationRecord<Kokkos::HostSpace, void>::get_record(void *alloc_ptr) {
-  using Header     = SharedAllocationHeader;
-  using RecordHost = SharedAllocationRecord<Kokkos::HostSpace, void>;
-
-  SharedAllocationHeader const *const head =
-      alloc_ptr ? Header::get_header(alloc_ptr) : nullptr;
-  RecordHost *const record =
-      head ? static_cast<RecordHost *>(head->m_record) : nullptr;
-
-  if (!alloc_ptr || record->m_alloc_ptr != head) {
-    Kokkos::Impl::throw_runtime_exception(
-        std::string("Kokkos::Impl::SharedAllocationRecord< Kokkos::HostSpace , "
-                    "void >::get_record ERROR"));
-  }
-
-  return record;
-}
-
-// Iterate records to print orphaned memory ...
-#ifdef KOKKOS_ENABLE_DEBUG
-void SharedAllocationRecord<Kokkos::HostSpace, void>::print_records(
-    std::ostream &s, const Kokkos::HostSpace &, bool detail) {
-  SharedAllocationRecord<void, void>::print_host_accessible_records(
-      s, "HostSpace", &s_root_record, detail);
-}
-#else
-void SharedAllocationRecord<Kokkos::HostSpace, void>::print_records(
-    std::ostream &, const Kokkos::HostSpace &, bool) {
-  throw_runtime_exception(
-      "SharedAllocationRecord<HostSpace>::print_records only works with "
-      "KOKKOS_ENABLE_DEBUG enabled");
-}
-#endif
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -351,8 +351,12 @@ SharedAllocationRecord<void, void>
     SharedAllocationRecord<Kokkos::HostSpace, void>::s_root_record;
 #endif
 
-SharedAllocationRecord<Kokkos::HostSpace,
-                       void>::~SharedAllocationRecord() noexcept {
+SharedAllocationRecord<Kokkos::HostSpace, void>::~SharedAllocationRecord()
+#if defined( \
+    KOKKOS_IMPL_INTEL_WORKAROUND_NOEXCEPT_SPECIFICATION_VIRTUAL_FUNCTION)
+    noexcept
+#endif
+{
   m_space.deallocate(RecordBase::m_alloc_ptr->m_label,
                      SharedAllocationRecord<void, void>::m_alloc_ptr,
                      SharedAllocationRecord<void, void>::m_alloc_size,

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -432,8 +432,8 @@ union SharedAllocationTracker {
   }
 
   template <class MemorySpace>
-  constexpr SharedAllocationRecord<MemorySpace, void>* get_record()
-      const noexcept {
+  constexpr SharedAllocationRecord<MemorySpace, void>* get_record() const
+      noexcept {
     return (m_record_bits & DO_NOT_DEREF_FLAG)
                ? nullptr
                : static_cast<SharedAllocationRecord<MemorySpace, void>*>(

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -93,6 +93,8 @@ class SharedAllocationHeader {
   friend class SharedAllocationRecord;
   template <class>
   friend class SharedAllocationRecordCommon;
+  template <class>
+  friend class HostInaccessibleSharedAllocationRecordCommon;
 
   Record* m_record;
   char m_label[maximum_label_length];
@@ -119,6 +121,8 @@ class SharedAllocationRecord<void, void> {
   friend class SharedAllocationRecord;
   template <class>
   friend class SharedAllocationRecordCommon;
+  template <class>
+  friend class HostInaccessibleSharedAllocationRecordCommon;
 
   using function_type = void (*)(SharedAllocationRecord<void, void>*);
 
@@ -263,30 +267,42 @@ class SharedAllocationRecordCommon : public SharedAllocationRecord<void, void> {
   void _fill_host_accessible_header_info(SharedAllocationHeader& arg_header,
                                          std::string const& arg_label);
 
+  static void deallocate(record_base_t* arg_rec);
+
  public:
   static auto allocate(MemorySpace const& arg_space,
                        std::string const& arg_label, size_t arg_alloc_size)
       -> derived_t*;
-
-  static void deallocate(record_base_t* arg_rec);
-
   /**\brief  Allocate tracked memory in the space */
   static void* allocate_tracked(MemorySpace const& arg_space,
                                 std::string const& arg_alloc_label,
                                 size_t arg_alloc_size);
-
   /**\brief  Reallocate tracked memory in the space */
   static void deallocate_tracked(void* arg_alloc_ptr);
-
   /**\brief  Deallocate tracked memory in the space */
   static void* reallocate_tracked(void* arg_alloc_ptr, size_t arg_alloc_size);
-
   static auto get_record(void* alloc_ptr) -> derived_t*;
-
   std::string get_label() const;
-
   static void print_records(std::ostream& s, MemorySpace const&,
                             bool detail = false);
+};
+
+template <class MemorySpace>
+class HostInaccessibleSharedAllocationRecordCommon
+    : public SharedAllocationRecordCommon<MemorySpace> {
+ private:
+  using base_t        = SharedAllocationRecordCommon<MemorySpace>;
+  using derived_t     = SharedAllocationRecord<MemorySpace, void>;
+  using record_base_t = SharedAllocationRecord<void, void>;
+
+ protected:
+  using base_t::base_t;
+
+ public:
+  static void print_records(std::ostream& s, MemorySpace const&,
+                            bool detail = false);
+  static auto get_record(void* alloc_ptr) -> derived_t*;
+  std::string get_label() const;
 };
 
 namespace {

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -270,12 +270,15 @@ class SharedAllocationRecordCommon : public SharedAllocationRecord<void, void> {
 
   static void deallocate(record_base_t* arg_rec);
 
+  /**\brief  Allocate tracked memory in the space */
   static void* allocate_tracked(MemorySpace const& arg_space,
                                 std::string const& arg_alloc_label,
                                 size_t arg_alloc_size);
 
+  /**\brief  Reallocate tracked memory in the space */
   static void deallocate_tracked(void* arg_alloc_ptr);
 
+  /**\brief  Deallocate tracked memory in the space */
   static void* reallocate_tracked(void* arg_alloc_ptr, size_t arg_alloc_size);
 
   static auto get_record(void* alloc_ptr) -> derived_t*;

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -144,8 +144,7 @@ void SharedAllocationRecordCommon<MemorySpace>::
   strncpy(arg_header.m_label, arg_label.c_str(),
           SharedAllocationHeader::maximum_label_length);
   // Set last element zero, in case c_str is too long
-  arg_header.m_label[SharedAllocationHeader::maximum_label_length - 1] =
-      (char)0;
+  arg_header.m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
 }
 
 template <class MemorySpace>

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -50,8 +50,8 @@
 
 #include <impl/Kokkos_SharedAlloc.hpp>
 
-#include <string>  // std::string
-#include <cstring> // strncpy
+#include <string>   // std::string
+#include <cstring>  // strncpy
 
 namespace Kokkos {
 namespace Impl {
@@ -113,8 +113,7 @@ auto SharedAllocationRecordCommon<MemorySpace>::get_record(void* alloc_ptr)
     -> derived_t* {
   using Header = SharedAllocationHeader;
 
-  Header const* const h =
-      alloc_ptr ? Header::get_header(alloc_ptr) : nullptr;
+  Header const* const h = alloc_ptr ? Header::get_header(alloc_ptr) : nullptr;
 
   if (!alloc_ptr || h->m_record->m_alloc_ptr != h) {
     Kokkos::Impl::throw_runtime_exception(
@@ -156,9 +155,9 @@ void SharedAllocationRecordCommon<MemorySpace>::print_records(
       s, MemorySpace::name(), &derived_t::s_root_record, detail);
 #else
   Kokkos::Impl::throw_runtime_exception(
-      std::string{"SharedAllocationHeader<"} + std::string{MemorySpace::name} +
-      std::string{
-          ">::print_records only works with KOKKOS_ENABLE_DEBUG enabled"});
+      std::string("SharedAllocationHeader<") + std::string(MemorySpace::name) +
+      std::string(
+          ">::print_records only works with KOKKOS_ENABLE_DEBUG enabled"));
 #endif
 }
 

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -51,6 +51,7 @@
 #include <impl/Kokkos_SharedAlloc.hpp>
 
 #include <string>  // std::string
+#include <cstring> // strncpy
 
 namespace Kokkos {
 namespace Impl {
@@ -112,8 +113,8 @@ auto SharedAllocationRecordCommon<MemorySpace>::get_record(void* alloc_ptr)
     -> derived_t* {
   using Header = SharedAllocationHeader;
 
-  Header* const h =
-      alloc_ptr ? reinterpret_cast<Header*>(alloc_ptr) - 1 : nullptr;
+  Header const* const h =
+      alloc_ptr ? Header::get_header(alloc_ptr) : nullptr;
 
   if (!alloc_ptr || h->m_record->m_alloc_ptr != h) {
     Kokkos::Impl::throw_runtime_exception(

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -1,0 +1,167 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (12/8/20) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_IMPL_SHAREDALLOC_TIMPL_HPP
+#define KOKKOS_IMPL_SHAREDALLOC_TIMPL_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Core_fwd.hpp>
+
+#include <impl/Kokkos_SharedAlloc.hpp>
+
+#include <string>  // std::string
+
+namespace Kokkos {
+namespace Impl {
+
+template <class MemorySpace>
+auto SharedAllocationRecordCommon<MemorySpace>::allocate(
+    MemorySpace const& arg_space, std::string const& arg_label,
+    size_t arg_alloc_size) -> derived_t* {
+  return new derived_t(arg_space, arg_label, arg_alloc_size);
+}
+
+template <class MemorySpace>
+void* SharedAllocationRecordCommon<MemorySpace>::allocate_tracked(
+    const MemorySpace& arg_space, const std::string& arg_alloc_label,
+    size_t arg_alloc_size) {
+  if (!arg_alloc_size) return nullptr;
+
+  SharedAllocationRecord* const r =
+      allocate(arg_space, arg_alloc_label, arg_alloc_size);
+
+  record_base_t::increment(r);
+
+  return r->data();
+}
+
+template <class MemorySpace>
+void SharedAllocationRecordCommon<MemorySpace>::deallocate(
+    SharedAllocationRecordCommon::record_base_t* arg_rec) {
+  delete static_cast<derived_t*>(arg_rec);
+}
+
+template <class MemorySpace>
+void SharedAllocationRecordCommon<MemorySpace>::deallocate_tracked(
+    void* arg_alloc_ptr) {
+  if (arg_alloc_ptr != nullptr) {
+    SharedAllocationRecord* const r = derived_t::get_record(arg_alloc_ptr);
+    record_base_t::decrement(r);
+  }
+}
+
+template <class MemorySpace>
+void* SharedAllocationRecordCommon<MemorySpace>::reallocate_tracked(
+    void* arg_alloc_ptr, size_t arg_alloc_size) {
+  derived_t* const r_old = derived_t::get_record(arg_alloc_ptr);
+  derived_t* const r_new =
+      allocate(r_old->m_space, r_old->get_label(), arg_alloc_size);
+
+  Kokkos::Impl::DeepCopy<MemorySpace, MemorySpace>(
+      r_new->data(), r_old->data(), std::min(r_old->size(), r_new->size()));
+
+  record_base_t::increment(r_new);
+  record_base_t::decrement(r_old);
+
+  return r_new->data();
+}
+
+template <class MemorySpace>
+auto SharedAllocationRecordCommon<MemorySpace>::get_record(void* alloc_ptr)
+    -> derived_t* {
+  using Header = SharedAllocationHeader;
+
+  Header* const h =
+      alloc_ptr ? reinterpret_cast<Header*>(alloc_ptr) - 1 : nullptr;
+
+  if (!alloc_ptr || h->m_record->m_alloc_ptr != h) {
+    Kokkos::Impl::throw_runtime_exception(
+        std::string("Kokkos::Impl::SharedAllocationRecordCommon<") +
+        std::string(MemorySpace::name()) +
+        std::string(">::get_record() ERROR"));
+  }
+
+  return static_cast<derived_t*>(h->m_record);
+}
+
+template <class MemorySpace>
+std::string SharedAllocationRecordCommon<MemorySpace>::get_label() const {
+  return std::string(record_base_t::head()->m_label);
+}
+
+template <class MemorySpace>
+void SharedAllocationRecordCommon<MemorySpace>::
+    _fill_host_accessible_header_info(SharedAllocationHeader& arg_header,
+                                      std::string const& arg_label) {
+  // Fill in the Header information, directly accessible on the host
+
+  arg_header.m_record = &self();
+
+  strncpy(arg_header.m_label, arg_label.c_str(),
+          SharedAllocationHeader::maximum_label_length);
+  // Set last element zero, in case c_str is too long
+  arg_header.m_label[SharedAllocationHeader::maximum_label_length - 1] =
+      (char)0;
+}
+
+template <class MemorySpace>
+void SharedAllocationRecordCommon<MemorySpace>::print_records(
+    std::ostream& s, const MemorySpace&, bool detail) {
+  (void)s;
+  (void)detail;
+#ifdef KOKKOS_ENABLE_DEBUG
+  SharedAllocationRecord<void, void>::print_host_accessible_records(
+      s, MemorySpace::name(), &derived_t::s_root_record, detail);
+#else
+  Kokkos::Impl::throw_runtime_exception(
+      std::string{"SharedAllocationHeader<"} + std::string{MemorySpace::name} +
+      std::string{
+          ">::print_records only works with KOKKOS_ENABLE_DEBUG enabled"});
+#endif
+}
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_IMPL_SHAREDALLOC_TIMPL_HPP

--- a/core/src/impl/Kokkos_ViewTracker.hpp
+++ b/core/src/impl/Kokkos_ViewTracker.hpp
@@ -75,9 +75,7 @@ struct ViewTracker {
 
   KOKKOS_INLINE_FUNCTION
   ViewTracker(const ViewTracker& vt) noexcept
-      : m_tracker(vt.m_tracker, view_traits::is_managed) {
-    // call ViewHook
-  }
+      : m_tracker(vt.m_tracker, view_traits::is_managed) {}
 
   KOKKOS_INLINE_FUNCTION
   explicit ViewTracker(const ParentView& vt) noexcept : m_tracker() {

--- a/core/src/impl/Kokkos_ViewTracker.hpp
+++ b/core/src/impl/Kokkos_ViewTracker.hpp
@@ -75,7 +75,9 @@ struct ViewTracker {
 
   KOKKOS_INLINE_FUNCTION
   ViewTracker(const ViewTracker& vt) noexcept
-      : m_tracker(vt.m_tracker, view_traits::is_managed) {}
+      : m_tracker(vt.m_tracker, view_traits::is_managed) {
+    // call ViewHook
+  }
 
   KOKKOS_INLINE_FUNCTION
   explicit ViewTracker(const ParentView& vt) noexcept : m_tracker() {


### PR DESCRIPTION
While working on the `View` refactor for `mdspan`, it became clear that there is a _massive_ amount of (relatively technical, hard to understand, hard to recognize as identical) duplicated code across backends with respect to `SharedAllocationRecord` partial specializations. Since `SharedAllocationRecord` and `SharedAllocationTracker` are part of the `View` refactor, I literally needed to rewrite a bunch of this code in a common place just to determine whether or not it's the same. I'd like to avoid touching individual backends in the actual `View` refactor, and this is a start towards being able to do this.

This pull request basically just introduces a CRTP base class named `SharedAllocationRecordCommon` that contains all of the default implementations that had been copy-pasted across backends over the past 10 years.