### PR TITLE
Detect icpx from oneAPI as IntelClang

### DIFF
--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -112,7 +112,7 @@ IF(KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
   ENDIF()
   # The clang based Intel compiler reports as Clang to most versions of CMake
   EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} --version
-                  COMMAND grep -c icpx
+                  COMMAND grep -c "DPC++\\|icpx"
                   OUTPUT_VARIABLE INTERNAL_HAVE_INTEL_COMPILER
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
   IF (INTERNAL_HAVE_INTEL_COMPILER) #not actually Clang


### PR DESCRIPTION
With the gold release of oneAPI, their `icpx` version string is now reporting itself as dpc++:
```
> which icpx
/opt/intel/oneapi/compiler/2021.1.1/linux/bin/icpx
> icpx --version
Intel(R) oneAPI DPC++ Compiler 2021.1 (2020.10.0.1113)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/intel/oneapi/compiler/2021.1.1/linux/bin
```
Confusingly:
```
> which dpcpp
/opt/intel/oneapi/compiler/2021.1.1/linux/bin/dpcpp
> dpcpp --version
Intel(R) oneAPI DPC++ Compiler 2021.1 (2020.10.0.1113)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/intel/oneapi/compiler/2021.1.1/linux/bin
```
For reference, the beta version says:
```
icpx (ICX) 2021.1 Beta 20200715
Copyright (C) 1985-2020 Intel Corporation. All rights reserved.
```


I initially thought they finally merged icpx and dpcpp into one thing and one of them is a symlink, turns out it wasn't:
```
/opt/intel/oneapi/compiler/2021.1.1/linux/bin> ls -lah | grep "dpcpp\\|icpx"
-rwxr-xr-x. 1 root root 655K Nov 14 04:51 dpcpp
-rwxr-xr-x. 1 root root 3.3M Nov 14 04:51 icpx
```
The hash is also different.
This PR simply allows the `icpx` who reports itself as DPC++  to be detected as `IntelClang`.
Aside: Technically speaking, dpcpp for SYCL is also clang derived so it's also `IntelClang` I guess.
