### PR TITLE
Fail at configure-time for C++17 with NVCC when relaxed constexpr support not enabled

### DIFF
--- a/cmake/kokkos_corner_cases.cmake
+++ b/cmake/kokkos_corner_cases.cmake
@@ -49,11 +49,11 @@ ENDIF()
 
 IF (KOKKOS_CXX_STANDARD STREQUAL 17)
   IF (KOKKOS_CXX_COMPILER_ID STREQUAL GNU AND KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 7)
-    MESSAGE(FATAL_ERROR "You have requested c++17 support for GCC ${KOKKOS_CXX_COMPILER_VERSION}. Although CMake has allowed this and GCC accepts -std=c++1z/c++17, GCC <= 6 does not properly support *this capture. Please reduce the C++ standard to 14 or upgrade the compiler if you do need C++17 support.")
+    MESSAGE(FATAL_ERROR "You have requested C++17 support for GCC ${KOKKOS_CXX_COMPILER_VERSION}. Although CMake has allowed this and GCC accepts -std=c++1z/c++17, GCC <= 6 does not properly support *this capture. Please reduce the C++ standard to 14 or upgrade the compiler if you do need C++17 support.")
   ENDIF()
 
   IF (KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA AND KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 11)
-    MESSAGE(FATAL_ERROR "You have requested c++17 support for NVCC ${KOKKOS_CXX_COMPILER_VERSION}. NVCC only supports C++17 from version 11 on. Please reduce the C++ standard to 14 or upgrade the compiler if you need C++17 support.")
+    MESSAGE(FATAL_ERROR "You have requested C++17 support for NVCC ${KOKKOS_CXX_COMPILER_VERSION}. NVCC only supports C++17 from version 11 on. Please reduce the C++ standard to 14 or upgrade the compiler if you need C++17 support.")
   ENDIF()
 ENDIF()
 

--- a/cmake/kokkos_corner_cases.cmake
+++ b/cmake/kokkos_corner_cases.cmake
@@ -55,5 +55,8 @@ IF (KOKKOS_CXX_STANDARD STREQUAL 17)
   IF (KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA AND KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 11)
     MESSAGE(FATAL_ERROR "You have requested C++17 support for NVCC ${KOKKOS_CXX_COMPILER_VERSION}. NVCC only supports C++17 from version 11 on. Please reduce the C++ standard to 14 or upgrade the compiler if you need C++17 support.")
   ENDIF()
+  IF (KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA AND NOT KOKKOS_ENABLE_CUDA_CONSTEXPR)
+    MESSAGE(FATAL_ERROR "You have requested C++17 support for NVCC ${KOKKOS_CXX_COMPILER_VERSION}, but you forgot to enable relaxed constexpr. Please reduce the C++ standard to 14 or re-configure with -DKokkos_ENABLE_CUDA_CONSTEXPR=ON")
+  ENDIF()
 ENDIF()
 


### PR DESCRIPTION
Avoid failing at build time and confusing users