### PR TITLE
Use alternative SYCL parallel_reduce implementation

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -116,7 +116,7 @@ void SYCLInternal::initialize(const sycl::device& d) {
     m_maxThreadsPerSM =
         d.template get_info<sycl::info::device::max_work_group_size>();
     m_indirectKernelMem.reset(*m_queue);
-    m_reductionResultMem.reset(*m_queue);
+    m_indirectReducerMem.reset(*m_queue);
   } else {
     std::ostringstream msg;
     msg << "Kokkos::Experimental::SYCL::initialize(...) FAILED";
@@ -136,8 +136,8 @@ void SYCLInternal::finalize() {
     std::abort();
   }
 
-  m_reductionResultMem.reset();
   m_indirectKernelMem.reset();
+  m_indirectReducerMem.reset();
   m_queue.reset();
 }
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -298,8 +298,8 @@ class SYCLInternal {
   using IndirectKernelMem = USMObjectMem<sycl::usm::alloc::shared>;
   IndirectKernelMem m_indirectKernelMem;
 
-  using ReductionResultMem = USMObjectMem<sycl::usm::alloc::shared>;
-  ReductionResultMem m_reductionResultMem;
+  using IndirectReducerMem = USMObjectMem<sycl::usm::alloc::shared>;
+  IndirectReducerMem m_indirectReducerMem;
 
   static int was_finalized;
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -455,12 +455,6 @@ if(Kokkos_ENABLE_SYCL)
        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_Atomics.cpp
        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_Atomics.cpp
        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_AtomicViews.cpp
-       ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_Reductions.cpp
-       ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_Reducers_a.cpp
-       ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_Reducers_b.cpp
-       ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_Reducers_c.cpp
-       ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_Reducers_d.cpp
-       ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_Reductions_DeviceView.cpp
        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_TeamBasic.cpp
        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_TeamReductionScan.cpp
        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_TeamScan.cpp

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -141,7 +141,7 @@ class RuntimeReduceFunctor {
   void operator()(size_type iwork, ScalarType dst[]) const {
     const size_type tmp[3] = {1, iwork + 1, nwork - iwork};
 
-    for (size_type i = 0; i < value_count; ++i) {
+    for (size_type i = 0; i < static_cast<size_type>(value_count); ++i) {
       dst[i] += tmp[i % 3];
     }
   }
@@ -189,7 +189,7 @@ class RuntimeReduceMinMax {
     const ScalarType tmp[2] = {ScalarType(iwork + 1),
                                ScalarType(nwork - iwork)};
 
-    for (size_type i = 0; i < value_count; ++i) {
+    for (size_type i = 0; i < static_cast<size_type>(value_count); ++i) {
       dst[i] = i % 2 ? (dst[i] < tmp[i % 2] ? dst[i] : tmp[i % 2])
                      : (dst[i] > tmp[i % 2] ? dst[i] : tmp[i % 2]);
     }
@@ -508,6 +508,8 @@ TEST(TEST_CATEGORY, int_combined_reduce) {
   ASSERT_EQ(nsum, result3);
 }
 
+// FIXME_SYCL needs parallel_reduce for MDRangePolicy
+#ifndef KOKKOS_ENABLE_SYCL
 TEST(TEST_CATEGORY, mdrange_combined_reduce) {
   using functor_type = CombinedReduceFunctorSameType<int64_t, TEST_EXECSPACE>;
   constexpr uint64_t nw = 1000;
@@ -528,6 +530,7 @@ TEST(TEST_CATEGORY, mdrange_combined_reduce) {
   ASSERT_EQ(nsum, result2);
   ASSERT_EQ(nsum, result3);
 }
+#endif
 
 TEST(TEST_CATEGORY, int_combined_reduce_mixed) {
   using functor_type = CombinedReduceFunctorSameType<int64_t, TEST_EXECSPACE>;


### PR DESCRIPTION
This implementation tries to side-step some issues with Intel implementation and should also allow more easily to enable all Reduce tests.