### PR TITLE
Make SYCLInternal::m_queue optional

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -110,7 +110,7 @@ void SYCLInternal::initialize(const sycl::device& d) {
         Kokkos::Impl::throw_runtime_exception(
             "There was an asynchronous SYCL error!\n");
     };
-    m_queue = std::make_unique<sycl::queue>(d, exception_handler);
+    m_queue.emplace(d, exception_handler);
     std::cout << SYCL::SYCLDevice(d) << '\n';
     m_indirectKernel.emplace(IndirectKernelAllocator(*m_queue));
   } else {

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -45,7 +45,7 @@
 #ifndef KOKKOS_SYCL_INSTANCE_HPP_
 #define KOKKOS_SYCL_INSTANCE_HPP_
 
-#include <memory>
+#include <optional>
 #include <CL/sycl.hpp>
 
 namespace Kokkos {
@@ -68,7 +68,7 @@ class SYCLInternal {
   size_type* m_scratchSpace = nullptr;
   size_type* m_scratchFlags = nullptr;
 
-  std::unique_ptr<sycl::queue> m_queue;
+  std::optional<sycl::queue> m_queue;
 
   // An indirect kernel is one where the functor to be executed is explicitly
   // created in USM shared memory before being executed, to get around the
@@ -91,7 +91,7 @@ class SYCLInternal {
 
   void initialize(const sycl::device& d);
 
-  int is_initialized() const { return m_queue != nullptr; }
+  int is_initialized() const { return m_queue.has_value(); }
 
   void finalize();
 };


### PR DESCRIPTION
In SYCLInternal, changed m_queue from a `unique_ptr<sycl::queue>` to an `optional<sycl::queue>`.

Ideally, it should just be a `sycl::queue` directly, but given
current issues with assignability under SYCL+CUDA, this is
the best we can do right now.

Because it was initially developed under C++14, `unique_ptr`
was used (as `optional` wasn't there), but it is better to
have fewer heap allocations, instead of unnecessary ones.