### PR TITLE
Avoid using sudo cmake in GitHub CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -53,5 +53,3 @@ jobs:
         run: ctest --output-on-failure
       - name: Test DESTDIR Install
         run: DESTDIR=${PWD}/install cmake --build builddir --target install && rm -rf ${PWD}/install/usr && rmdir ${PWD}/install
-      - name: Install
-        run: sudo cmake --build builddir --target install


### PR DESCRIPTION
We don't install `cmake` in a folder `sudo` can use anymore.