### PR TITLE
Bugfix: overfetching of labels in Tools interface

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -444,18 +444,24 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   }
   static constexpr const int view_header_size = 128;
   void impl_report_host_sync() const noexcept {
-    Kokkos::Tools::syncDualView(
-        h_view.label(),
-        reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(h_view.data()) -
-                                view_header_size),
-        false);
+    if (Kokkos::Tools::Experimental::get_callbacks().sync_dual_view !=
+        nullptr) {
+      Kokkos::Tools::syncDualView(
+          h_view.label(),
+          reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(h_view.data()) -
+                                  view_header_size),
+          false);
+    }
   }
   void impl_report_device_sync() const noexcept {
-    Kokkos::Tools::syncDualView(
-        d_view.label(),
-        reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(d_view.data()) -
-                                view_header_size),
-        true);
+    if (Kokkos::Tools::Experimental::get_callbacks().sync_dual_view !=
+        nullptr) {
+      Kokkos::Tools::syncDualView(
+          d_view.label(),
+          reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(d_view.data()) -
+                                  view_header_size),
+          true);
+    }
   }
   /// \brief Update data on device or host only if data in the other
   ///   space has been marked as modified.
@@ -625,18 +631,24 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     return modified_flags(1) < modified_flags(0);
   }
   void impl_report_device_modification() {
-    Kokkos::Tools::modifyDualView(
-        d_view.label(),
-        reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(d_view.data()) -
-                                view_header_size),
-        true);
+    if (Kokkos::Tools::Experimental::get_callbacks().modify_dual_view !=
+        nullptr) {
+      Kokkos::Tools::modifyDualView(
+          d_view.label(),
+          reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(d_view.data()) -
+                                  view_header_size),
+          true);
+    }
   }
   void impl_report_host_modification() {
-    Kokkos::Tools::modifyDualView(
-        h_view.label(),
-        reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(h_view.data()) -
-                                view_header_size),
-        false);
+    if (Kokkos::Tools::Experimental::get_callbacks().modify_dual_view !=
+        nullptr) {
+      Kokkos::Tools::modifyDualView(
+          h_view.label(),
+          reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(h_view.data()) -
+                                  view_header_size),
+          false);
+    }
   }
   /// \brief Mark data as modified on the given device \c Device.
   ///

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1267,7 +1267,7 @@ inline void deep_copy(
   using ViewType        = View<DT, DP...>;
   using exec_space_type = typename ViewType::execution_space;
 
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
         Kokkos::Profiling::make_space_handle(ViewType::memory_space::name()),
         dst.label(), dst.data(),
@@ -1277,7 +1277,7 @@ inline void deep_copy(
 
   if (dst.data() == nullptr) {
     Kokkos::fence();
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
+    if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
       Kokkos::Profiling::endDeepCopy();
     }
     return;
@@ -1308,7 +1308,7 @@ inline void deep_copy(
                              ViewTypeFlat::Rank, int64_t>(dst_flat, value,
                                                           exec_space_type());
     Kokkos::fence();
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
+    if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
       Kokkos::Profiling::endDeepCopy();
     }
     return;
@@ -1364,7 +1364,7 @@ inline void deep_copy(
   }
   Kokkos::fence();
 
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
     Kokkos::Profiling::endDeepCopy();
   }
 }
@@ -1383,7 +1383,7 @@ inline void deep_copy(
   static_assert(src_traits::rank == 0,
                 "ERROR: Non-rank-zero view in deep_copy( value , View )");
 
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
         Kokkos::Profiling::make_space_handle(Kokkos::HostSpace::name()),
         "Scalar", &dst,
@@ -1394,7 +1394,7 @@ inline void deep_copy(
 
   if (src.data() == nullptr) {
     Kokkos::fence();
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
+    if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
       Kokkos::Profiling::endDeepCopy();
     }
     return;
@@ -1402,7 +1402,7 @@ inline void deep_copy(
 
   Kokkos::Impl::DeepCopy<HostSpace, src_memory_space>(&dst, src.data(),
                                                       sizeof(ST));
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
     Kokkos::Profiling::endDeepCopy();
   }
 }
@@ -1429,7 +1429,7 @@ inline void deep_copy(
                              typename src_type::non_const_value_type>::value,
                 "deep_copy requires matching non-const destination type");
 
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
         Kokkos::Profiling::make_space_handle(dst_memory_space::name()),
         dst.label(), dst.data(),
@@ -1440,7 +1440,7 @@ inline void deep_copy(
 
   if (dst.data() == nullptr && src.data() == nullptr) {
     Kokkos::fence();
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
+    if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
       Kokkos::Profiling::endDeepCopy();
     }
     return;
@@ -1452,7 +1452,7 @@ inline void deep_copy(
         dst.data(), src.data(), sizeof(value_type));
     Kokkos::fence();
   }
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
     Kokkos::Profiling::endDeepCopy();
   }
 }
@@ -1485,7 +1485,7 @@ inline void deep_copy(
   static_assert((unsigned(dst_type::rank) == unsigned(src_type::rank)),
                 "deep_copy requires Views of equal rank");
 
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
         Kokkos::Profiling::make_space_handle(dst_memory_space::name()),
         dst.label(), dst.data(),
@@ -1523,7 +1523,7 @@ inline void deep_copy(
       Kokkos::Impl::throw_runtime_exception(message);
     }
     Kokkos::fence();
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
+    if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
       Kokkos::Profiling::endDeepCopy();
     }
     return;
@@ -1550,7 +1550,7 @@ inline void deep_copy(
       ((std::ptrdiff_t)dst_end == (std::ptrdiff_t)src_end) &&
       (dst.span_is_contiguous() && src.span_is_contiguous())) {
     Kokkos::fence();
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
+    if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
       Kokkos::Profiling::endDeepCopy();
     }
     return;
@@ -1631,7 +1631,7 @@ inline void deep_copy(
     Impl::view_copy(dst, src);
     Kokkos::fence();
   }
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
     Kokkos::Profiling::endDeepCopy();
   }
 }
@@ -2429,7 +2429,7 @@ inline void deep_copy(
                              typename dst_traits::value_type>::value,
                 "deep_copy requires non-const type");
   using dst_memory_space = typename dst_traits::memory_space;
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
         Kokkos::Profiling::make_space_handle(dst_memory_space::name()),
         dst.label(), dst.data(),
@@ -2446,7 +2446,7 @@ inline void deep_copy(
     Kokkos::Impl::ViewFill<ViewTypeUniform, typename dst_traits::array_layout,
                            ExecSpace>(dst, value, space);
   }
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
     Kokkos::Profiling::endDeepCopy();
   }
 }
@@ -2469,7 +2469,7 @@ inline void deep_copy(
                              typename dst_traits::value_type>::value,
                 "deep_copy requires non-const type");
   using dst_memory_space = typename dst_traits::memory_space;
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
         Kokkos::Profiling::make_space_handle(dst_memory_space::name()),
         dst.label(), dst.data(),
@@ -2489,7 +2489,7 @@ inline void deep_copy(
                            fill_exec_space>(dst, value, fill_exec_space());
     fill_exec_space().fence();
   }
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
     Kokkos::Profiling::endDeepCopy();
   }
 }
@@ -2508,7 +2508,7 @@ inline void deep_copy(
   using src_memory_space = typename src_traits::memory_space;
   static_assert(src_traits::rank == 0,
                 "ERROR: Non-rank-zero view in deep_copy( value , View )");
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
         Kokkos::Profiling::make_space_handle(Kokkos::HostSpace::name()),
         "(none)", &dst,
@@ -2518,7 +2518,7 @@ inline void deep_copy(
 
   if (src.data() == nullptr) {
     exec_space.fence();
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
+    if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
       Kokkos::Profiling::endDeepCopy();
     }
     return;
@@ -2526,7 +2526,7 @@ inline void deep_copy(
 
   Kokkos::Impl::DeepCopy<HostSpace, src_memory_space, ExecSpace>(
       exec_space, &dst, src.data(), sizeof(ST));
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
     Kokkos::Profiling::endDeepCopy();
   }
 }
@@ -2553,7 +2553,7 @@ inline void deep_copy(
                              typename src_traits::non_const_value_type>::value,
                 "deep_copy requires matching non-const destination type");
 
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
         Kokkos::Profiling::make_space_handle(dst_memory_space::name()),
         dst.label(), dst.data(),
@@ -2563,7 +2563,7 @@ inline void deep_copy(
 
   if (dst.data() == nullptr && src.data() == nullptr) {
     exec_space.fence();
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
+    if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
       Kokkos::Profiling::endDeepCopy();
     }
     return;
@@ -2574,7 +2574,7 @@ inline void deep_copy(
         exec_space, dst.data(), src.data(),
         sizeof(typename dst_traits::value_type));
   }
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
     Kokkos::Profiling::endDeepCopy();
   }
 }
@@ -2610,7 +2610,7 @@ inline void deep_copy(
   using dst_value_type      = typename dst_type::value_type;
   using src_value_type      = typename src_type::value_type;
 
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().begin_deep_copy != nullptr) {
     Kokkos::Profiling::beginDeepCopy(
         Kokkos::Profiling::make_space_handle(dst_memory_space::name()),
         dst.label(), dst.data(),
@@ -2654,7 +2654,7 @@ inline void deep_copy(
 
       Kokkos::Impl::throw_runtime_exception(message);
     }
-    if (Kokkos::Profiling::profileLibraryLoaded()) {
+    if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
       Kokkos::Profiling::endDeepCopy();
     }
     return;
@@ -2765,7 +2765,7 @@ inline void deep_copy(
           "deep_copy given views that would require a temporary allocation");
     }
   }
-  if (Kokkos::Profiling::profileLibraryLoaded()) {
+  if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
     Kokkos::Profiling::endDeepCopy();
   }
 }


### PR DESCRIPTION
This fixes two bugs

1) Due to some real brilliance on my part, we requested the label on DualViews every time we called sync/modify, regardless of whether a tool was loaded
2) We fetch the labels on deep copies if a _tool is loaded_, not if the tool _subscribes to deep copy events_. This is inefficient.

I'm not sure about whether this is the right target branch, feel free to tell me to target something else. Oof. Thanks @stanmoore1 for calling this out before we made it too permanent