### PR TITLE
Let extent return size_type

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -830,7 +830,8 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr
-      typename std::enable_if<std::is_integral<iType>::value, size_t>::type
+      typename std::enable_if<std::is_integral<iType>::value,
+                              typename traits::size_type>::type
       extent(const iType& r) const {
     return d_view.extent(r);
   }

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -470,7 +470,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr
-      typename std::enable_if<std::is_integral<iType>::value, size_t>::type
+      typename std::enable_if<std::is_integral<iType>::value,
+                              typename traits::size_type>::type
       extent(const iType& r) const {
     return m_map.extent(r);
   }

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -182,7 +182,8 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
   }
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION size_t extent(const iType& r) const {
+  KOKKOS_INLINE_FUNCTION typename traits::size_type extent(
+      const iType& r) const {
     return r == 0 ? size() : 1;
   }
 

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -256,7 +256,8 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr
-      typename std::enable_if<std::is_integral<iType>::value, size_t>::type
+      typename std::enable_if<std::is_integral<iType>::value,
+                              typename traits::size_type>::type
       extent(const iType& r) const {
     return m_map.extent(r);
   }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -654,7 +654,8 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr
-      typename std::enable_if<std::is_integral<iType>::value, size_t>::type
+      typename std::enable_if<std::is_integral<iType>::value,
+                              typename traits::size_type>::type
       extent(const iType& r) const noexcept {
     return m_map.extent(r);
   }

--- a/core/src/impl/Kokkos_ViewArray.hpp
+++ b/core/src/impl/Kokkos_ViewArray.hpp
@@ -154,7 +154,8 @@ class ViewMapping<Traits, Kokkos::Array<>> {
   enum { Rank = Traits::dimension::rank };
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION constexpr size_t extent(const iType &r) const {
+  KOKKOS_INLINE_FUNCTION constexpr typename Traits::size_type
+  extent(const iType &r) const {
     return m_impl_offset.m_dim.extent(r);
   }
 

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2985,7 +2985,8 @@ class ViewMapping<
   enum { Rank = Traits::dimension::rank };
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION constexpr size_t extent(const iType& r) const {
+  KOKKOS_INLINE_FUNCTION constexpr typename Traits::size_type
+  extent(const iType& r) const {
     return m_impl_offset.m_dim.extent(r);
   }
 


### PR DESCRIPTION
Motivated by #3691 it seems sensible to let the return type for `extent` be the `size_type` corresponding to the class. Of course, this is not backward-compatible, so controversial.