### PR TITLE
Fix gcc-10.1 C++20 warnings

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -596,7 +596,7 @@ SharedAllocationRecord<Kokkos::CudaSpace, void>::SharedAllocationRecord(
   header.m_record = static_cast<SharedAllocationRecord<void, void> *>(this);
 
   strncpy(header.m_label, arg_label.c_str(),
-          SharedAllocationHeader::maximum_label_length);
+          SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   header.m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
 
@@ -625,7 +625,7 @@ SharedAllocationRecord<Kokkos::CudaUVMSpace, void>::SharedAllocationRecord(
   RecordBase::m_alloc_ptr->m_record = this;
 
   strncpy(RecordBase::m_alloc_ptr->m_label, arg_label.c_str(),
-          SharedAllocationHeader::maximum_label_length);
+          SharedAllocationHeader::maximum_label_length - 1);
 
   // Set last element zero, in case c_str is too long
   RecordBase::m_alloc_ptr
@@ -653,7 +653,7 @@ SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::
   RecordBase::m_alloc_ptr->m_record = this;
 
   strncpy(RecordBase::m_alloc_ptr->m_label, arg_label.c_str(),
-          SharedAllocationHeader::maximum_label_length);
+          SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   RecordBase::m_alloc_ptr
       ->m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -598,7 +598,7 @@ SharedAllocationRecord<Kokkos::CudaSpace, void>::SharedAllocationRecord(
   strncpy(header.m_label, arg_label.c_str(),
           SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
-  header.m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
+  header.m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
 
   // Copy to device memory
   Kokkos::Impl::DeepCopy<CudaSpace, HostSpace>(RecordBase::m_alloc_ptr, &header,
@@ -629,7 +629,7 @@ SharedAllocationRecord<Kokkos::CudaUVMSpace, void>::SharedAllocationRecord(
 
   // Set last element zero, in case c_str is too long
   RecordBase::m_alloc_ptr
-      ->m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
+      ->m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
 }
 
 SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::
@@ -656,7 +656,7 @@ SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::
           SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   RecordBase::m_alloc_ptr
-      ->m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
+      ->m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
 }
 
 // </editor-fold> end SharedAllocationRecord constructors }}}1

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -411,7 +411,7 @@ SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::
   strncpy(header.m_label, arg_label.c_str(),
           SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
-  header.m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
+  header.m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
 
   // Copy to device memory
   Kokkos::Impl::DeepCopy<Kokkos::Experimental::HIPSpace, HostSpace>(
@@ -442,7 +442,7 @@ SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>::
           SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   RecordBase::m_alloc_ptr
-      ->m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
+      ->m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -409,7 +409,7 @@ SharedAllocationRecord<Kokkos::Experimental::HIPSpace, void>::
   header.m_record = static_cast<SharedAllocationRecord<void, void>*>(this);
 
   strncpy(header.m_label, arg_label.c_str(),
-          SharedAllocationHeader::maximum_label_length);
+          SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   header.m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
 
@@ -439,7 +439,7 @@ SharedAllocationRecord<Kokkos::Experimental::HIPHostPinnedSpace, void>::
   RecordBase::m_alloc_ptr->m_record = this;
 
   strncpy(RecordBase::m_alloc_ptr->m_label, arg_label.c_str(),
-          SharedAllocationHeader::maximum_label_length);
+          SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   RecordBase::m_alloc_ptr
       ->m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;

--- a/core/src/Kokkos_LogicalSpaces.hpp
+++ b/core/src/Kokkos_LogicalSpaces.hpp
@@ -267,7 +267,7 @@ class SharedAllocationRecord<Kokkos::Experimental::LogicalMemorySpace<
             SharedAllocationHeader::maximum_label_length - 1);
     // Set last element zero, in case c_str is too long
     RecordBase::m_alloc_ptr
-        ->m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
+        ->m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
   }
 
  public:

--- a/core/src/Kokkos_LogicalSpaces.hpp
+++ b/core/src/Kokkos_LogicalSpaces.hpp
@@ -264,7 +264,7 @@ class SharedAllocationRecord<Kokkos::Experimental::LogicalMemorySpace<
         static_cast<SharedAllocationRecord<void, void>*>(this);
 
     strncpy(RecordBase::m_alloc_ptr->m_label, arg_label.c_str(),
-            SharedAllocationHeader::maximum_label_length);
+            SharedAllocationHeader::maximum_label_length - 1);
     // Set last element zero, in case c_str is too long
     RecordBase::m_alloc_ptr
         ->m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -140,7 +140,7 @@ SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
   strncpy(header.m_label, arg_label.c_str(),
           SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
-  header.m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
+  header.m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
   // TODO DeepCopy
   // DeepCopy
   Kokkos::Impl::DeepCopy<Experimental::OpenMPTargetSpace, HostSpace>(

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -138,7 +138,7 @@ SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
   header.m_record = static_cast<SharedAllocationRecord<void, void> *>(this);
 
   strncpy(header.m_label, arg_label.c_str(),
-          SharedAllocationHeader::maximum_label_length);
+          SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   header.m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
   // TODO DeepCopy

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -261,7 +261,7 @@ SharedAllocationRecord<Kokkos::Experimental::SYCLDeviceUSMSpace, void>::
   header.m_record = static_cast<SharedAllocationRecord<void, void>*>(this);
 
   strncpy(header.m_label, label.c_str(),
-          SharedAllocationHeader::maximum_label_length);
+          SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   header.m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
 
@@ -290,7 +290,7 @@ SharedAllocationRecord<Kokkos::Experimental::SYCLSharedUSMSpace, void>::
   RecordBase::m_alloc_ptr->m_record = this;
 
   strncpy(RecordBase::m_alloc_ptr->m_label, arg_label.c_str(),
-          SharedAllocationHeader::maximum_label_length);
+          SharedAllocationHeader::maximum_label_length - 1);
 
   // Set last element zero, in case c_str is too long
   RecordBase::m_alloc_ptr

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -461,7 +461,7 @@ void parse_command_line_arguments(int& narg, char* arg[],
       int num1_len    = num2 == nullptr ? strlen(num1) : num2 - num1;
       char* num1_only = new char[num1_len + 1];
       strncpy(num1_only, num1, num1_len - 1);
-      num1_only[num1_len] = 0;
+      num1_only[num1_len] = '\0';
 
       if (!is_unsigned_int(num1_only) || (strlen(num1_only) == 0)) {
         throw_runtime_exception(

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -460,7 +460,7 @@ void parse_command_line_arguments(int& narg, char* arg[],
       char* num2      = strpbrk(num1, ",");
       int num1_len    = num2 == nullptr ? strlen(num1) : num2 - num1;
       char* num1_only = new char[num1_len + 1];
-      strncpy(num1_only, num1, num1_len);
+      strncpy(num1_only, num1, num1_len - 1);
       num1_only[num1_len] = 0;
 
       if (!is_unsigned_int(num1_only) || (strlen(num1_only) == 0)) {

--- a/core/src/impl/Kokkos_HBWSpace.cpp
+++ b/core/src/impl/Kokkos_HBWSpace.cpp
@@ -250,7 +250,7 @@ SharedAllocationRecord<Kokkos::Experimental::HBWSpace, void>::
       static_cast<SharedAllocationRecord<void, void> *>(this);
 
   strncpy(RecordBase::m_alloc_ptr->m_label, arg_label.c_str(),
-          SharedAllocationHeader::maximum_label_length);
+          SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   RecordBase::m_alloc_ptr
       ->m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;

--- a/core/src/impl/Kokkos_HBWSpace.cpp
+++ b/core/src/impl/Kokkos_HBWSpace.cpp
@@ -253,7 +253,7 @@ SharedAllocationRecord<Kokkos::Experimental::HBWSpace, void>::
           SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   RecordBase::m_alloc_ptr
-      ->m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
+      ->m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -415,7 +415,7 @@ SharedAllocationRecord<Kokkos::HostSpace, void>::SharedAllocationRecord(
           SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   RecordBase::m_alloc_ptr
-      ->m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;
+      ->m_label[SharedAllocationHeader::maximum_label_length - 1] = '\0';
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -412,7 +412,7 @@ SharedAllocationRecord<Kokkos::HostSpace, void>::SharedAllocationRecord(
       static_cast<SharedAllocationRecord<void, void> *>(this);
 
   strncpy(RecordBase::m_alloc_ptr->m_label, arg_label.c_str(),
-          SharedAllocationHeader::maximum_label_length);
+          SharedAllocationHeader::maximum_label_length - 1);
   // Set last element zero, in case c_str is too long
   RecordBase::m_alloc_ptr
       ->m_label[SharedAllocationHeader::maximum_label_length - 1] = (char)0;


### PR DESCRIPTION
Accompanying #3716. This fixes
```
warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound 120 equals destination size [-Wstringop-truncation]
```
which was the only warning with `-std=c++2a` using `gcc-10.1`.
Note that we set the last element to `\0` anyway in the next line.