### PR TITLE
Avoid more warnings with clang and C++20

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -17,30 +17,30 @@ namespace Kokkos {
 namespace Impl {
 
 struct CudaTraits {
-  enum : CudaSpace::size_type { WarpSize = 32 /* 0x0020 */ };
-  enum : CudaSpace::size_type {
-    WarpIndexMask = 0x001f /* Mask for warpindex */
-  };
-  enum : CudaSpace::size_type {
-    WarpIndexShift = 5 /* WarpSize == 1 << WarpShift */
-  };
+  static constexpr CudaSpace::size_type WarpSize = 32 /* 0x0020 */;
+  static constexpr CudaSpace::size_type WarpIndexMask =
+      0x001f /* Mask for warpindex */
+      ;
+  static constexpr CudaSpace::size_type WarpIndexShift =
+      5 /* WarpSize == 1 << WarpShift */
+      ;
 
-  enum : CudaSpace::size_type {
-    ConstantMemoryUsage = 0x008000 /* 32k bytes */
-  };
-  enum : CudaSpace::size_type {
-    ConstantMemoryCache = 0x002000 /*  8k bytes */
-  };
-  enum : CudaSpace::size_type {
-    KernelArgumentLimit = 0x001000 /*  4k bytes */
-  };
-  enum : CudaSpace::size_type {
-    MaxHierarchicalParallelism = 1024 /* team_size * vector_length */
-  };
+  static constexpr CudaSpace::size_type ConstantMemoryUsage =
+      0x008000 /* 32k bytes */
+      ;
+  static constexpr CudaSpace::size_type ConstantMemoryCache =
+      0x002000 /*  8k bytes */
+      ;
+  static constexpr CudaSpace::size_type KernelArgumentLimit =
+      0x001000 /*  4k bytes */
+      ;
+  static constexpr CudaSpace::size_type MaxHierarchicalParallelism =
+      1024 /* team_size * vector_length */
+      ;
   using ConstantGlobalBufferType =
       unsigned long[ConstantMemoryUsage / sizeof(unsigned long)];
 
-  enum { ConstantMemoryUseThreshold = 0x000200 /* 512 bytes */ };
+  static constexpr auto ConstantMemoryUseThreshold = 0x000200 /* 512 bytes */;
 
   KOKKOS_INLINE_FUNCTION static CudaSpace::size_type warp_count(
       CudaSpace::size_type i) {

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -19,28 +19,22 @@ namespace Impl {
 struct CudaTraits {
   static constexpr CudaSpace::size_type WarpSize = 32 /* 0x0020 */;
   static constexpr CudaSpace::size_type WarpIndexMask =
-      0x001f /* Mask for warpindex */
-      ;
+      0x001f; /* Mask for warpindex */
   static constexpr CudaSpace::size_type WarpIndexShift =
-      5 /* WarpSize == 1 << WarpShift */
-      ;
+      5; /* WarpSize == 1 << WarpShift */
 
   static constexpr CudaSpace::size_type ConstantMemoryUsage =
-      0x008000 /* 32k bytes */
-      ;
+      0x008000; /* 32k bytes */
   static constexpr CudaSpace::size_type ConstantMemoryCache =
-      0x002000 /*  8k bytes */
-      ;
+      0x002000; /*  8k bytes */
   static constexpr CudaSpace::size_type KernelArgumentLimit =
-      0x001000 /*  4k bytes */
-      ;
+      0x001000; /*  4k bytes */
   static constexpr CudaSpace::size_type MaxHierarchicalParallelism =
-      1024 /* team_size * vector_length */
-      ;
+      1024; /* team_size * vector_length */
   using ConstantGlobalBufferType =
       unsigned long[ConstantMemoryUsage / sizeof(unsigned long)];
 
-  static constexpr auto ConstantMemoryUseThreshold = 0x000200 /* 512 bytes */;
+  static constexpr int ConstantMemoryUseThreshold = 0x000200 /* 512 bytes */;
 
   KOKKOS_INLINE_FUNCTION static CudaSpace::size_type warp_count(
       CudaSpace::size_type i) {

--- a/core/src/impl/Kokkos_Atomic_View.hpp
+++ b/core/src/impl/Kokkos_Atomic_View.hpp
@@ -299,14 +299,18 @@ class AtomicDataElement {
   }
 
   KOKKOS_INLINE_FUNCTION
-  bool operator==(const_value_type& val) const { return *ptr == val; }
+  bool operator==(const AtomicDataElement& val) const { return *ptr == val; }
   KOKKOS_INLINE_FUNCTION
-  bool operator==(volatile const_value_type& val) const { return *ptr == val; }
+  bool operator==(volatile const AtomicDataElement& val) const {
+    return *ptr == val;
+  }
 
   KOKKOS_INLINE_FUNCTION
-  bool operator!=(const_value_type& val) const { return *ptr != val; }
+  bool operator!=(const AtomicDataElement& val) const { return *ptr != val; }
   KOKKOS_INLINE_FUNCTION
-  bool operator!=(volatile const_value_type& val) const { return *ptr != val; }
+  bool operator!=(volatile const AtomicDataElement& val) const {
+    return *ptr != val;
+  }
 
   KOKKOS_INLINE_FUNCTION
   bool operator>=(const_value_type& val) const { return *ptr >= val; }

--- a/core/src/impl/Kokkos_ViewLayoutTiled.hpp
+++ b/core/src/impl/Kokkos_ViewLayoutTiled.hpp
@@ -122,12 +122,10 @@ struct ViewOffset<
                              is_array_layout<Layout>::value &&
                              is_array_layout_tiled<Layout>::value)>::type> {
  public:
-  //  static constexpr auto outer_pattern = Layout::outer_pattern };
-  //  static constexpr auto inner_pattern = Layout::inner_pattern };
   static constexpr Kokkos::Iterate outer_pattern = Layout::outer_pattern;
   static constexpr Kokkos::Iterate inner_pattern = Layout::inner_pattern;
 
-  static constexpr auto VORank = Dimension::rank;
+  static constexpr int VORank = Dimension::rank;
 
   static constexpr unsigned SHIFT_0 =
       Kokkos::Impl::integral_power_of_two(Layout::N0);
@@ -145,14 +143,14 @@ struct ViewOffset<
       Kokkos::Impl::integral_power_of_two(Layout::N6);
   static constexpr unsigned SHIFT_7 =
       Kokkos::Impl::integral_power_of_two(Layout::N7);
-  static constexpr auto MASK_0 = Layout::N0 - 1;
-  static constexpr auto MASK_1 = Layout::N1 - 1;
-  static constexpr auto MASK_2 = Layout::N2 - 1;
-  static constexpr auto MASK_3 = Layout::N3 - 1;
-  static constexpr auto MASK_4 = Layout::N4 - 1;
-  static constexpr auto MASK_5 = Layout::N5 - 1;
-  static constexpr auto MASK_6 = Layout::N6 - 1;
-  static constexpr auto MASK_7 = Layout::N7 - 1;
+  static constexpr int MASK_0 = Layout::N0 - 1;
+  static constexpr int MASK_1 = Layout::N1 - 1;
+  static constexpr int MASK_2 = Layout::N2 - 1;
+  static constexpr int MASK_3 = Layout::N3 - 1;
+  static constexpr int MASK_4 = Layout::N4 - 1;
+  static constexpr int MASK_5 = Layout::N5 - 1;
+  static constexpr int MASK_6 = Layout::N6 - 1;
+  static constexpr int MASK_7 = Layout::N7 - 1;
 
   static constexpr unsigned SHIFT_2T = SHIFT_0 + SHIFT_1;
   static constexpr unsigned SHIFT_3T = SHIFT_0 + SHIFT_1 + SHIFT_2;
@@ -689,8 +687,8 @@ class ViewMapping<
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T**, src_layout, P...>;
 
-  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
-  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
+  static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -741,8 +739,8 @@ class ViewMapping<typename std::enable_if<(N3 == 0 && N4 == 0 && N5 == 0 &&
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T***, src_layout, P...>;
 
-  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
-  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
+  static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -799,8 +797,8 @@ class ViewMapping<typename std::enable_if<(N4 == 0 && N5 == 0 && N6 == 0 &&
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T****, src_layout, P...>;
 
-  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
-  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
+  static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -862,8 +860,8 @@ class ViewMapping<
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T*****, src_layout, P...>;
 
-  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
-  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
+  static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -930,8 +928,8 @@ class ViewMapping<typename std::enable_if<(N6 == 0 && N7 == 0)>::type  // void
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T******, src_layout, P...>;
 
-  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
-  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
+  static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -1004,8 +1002,8 @@ class ViewMapping<typename std::enable_if<(N7 == 0)>::type  // void
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T*******, src_layout, P...>;
 
-  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
-  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
+  static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -1087,8 +1085,8 @@ class ViewMapping<typename std::enable_if<(N0 != 0 && N1 != 0 && N2 != 0 &&
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T********, src_layout, P...>;
 
-  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
-  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
+  static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;

--- a/core/src/impl/Kokkos_ViewLayoutTiled.hpp
+++ b/core/src/impl/Kokkos_ViewLayoutTiled.hpp
@@ -122,47 +122,49 @@ struct ViewOffset<
                              is_array_layout<Layout>::value &&
                              is_array_layout_tiled<Layout>::value)>::type> {
  public:
-  //  enum { outer_pattern = Layout::outer_pattern };
-  //  enum { inner_pattern = Layout::inner_pattern };
+  //  static constexpr auto outer_pattern = Layout::outer_pattern };
+  //  static constexpr auto inner_pattern = Layout::inner_pattern };
   static constexpr Kokkos::Iterate outer_pattern = Layout::outer_pattern;
   static constexpr Kokkos::Iterate inner_pattern = Layout::inner_pattern;
 
-  enum { VORank = Dimension::rank };
+  static constexpr auto VORank = Dimension::rank;
 
-  enum : unsigned { SHIFT_0 = Kokkos::Impl::integral_power_of_two(Layout::N0) };
-  enum : unsigned { SHIFT_1 = Kokkos::Impl::integral_power_of_two(Layout::N1) };
-  enum : unsigned { SHIFT_2 = Kokkos::Impl::integral_power_of_two(Layout::N2) };
-  enum : unsigned { SHIFT_3 = Kokkos::Impl::integral_power_of_two(Layout::N3) };
-  enum : unsigned { SHIFT_4 = Kokkos::Impl::integral_power_of_two(Layout::N4) };
-  enum : unsigned { SHIFT_5 = Kokkos::Impl::integral_power_of_two(Layout::N5) };
-  enum : unsigned { SHIFT_6 = Kokkos::Impl::integral_power_of_two(Layout::N6) };
-  enum : unsigned { SHIFT_7 = Kokkos::Impl::integral_power_of_two(Layout::N7) };
-  enum { MASK_0 = Layout::N0 - 1 };
-  enum { MASK_1 = Layout::N1 - 1 };
-  enum { MASK_2 = Layout::N2 - 1 };
-  enum { MASK_3 = Layout::N3 - 1 };
-  enum { MASK_4 = Layout::N4 - 1 };
-  enum { MASK_5 = Layout::N5 - 1 };
-  enum { MASK_6 = Layout::N6 - 1 };
-  enum { MASK_7 = Layout::N7 - 1 };
+  static constexpr unsigned SHIFT_0 =
+      Kokkos::Impl::integral_power_of_two(Layout::N0);
+  static constexpr unsigned SHIFT_1 =
+      Kokkos::Impl::integral_power_of_two(Layout::N1);
+  static constexpr unsigned SHIFT_2 =
+      Kokkos::Impl::integral_power_of_two(Layout::N2);
+  static constexpr unsigned SHIFT_3 =
+      Kokkos::Impl::integral_power_of_two(Layout::N3);
+  static constexpr unsigned SHIFT_4 =
+      Kokkos::Impl::integral_power_of_two(Layout::N4);
+  static constexpr unsigned SHIFT_5 =
+      Kokkos::Impl::integral_power_of_two(Layout::N5);
+  static constexpr unsigned SHIFT_6 =
+      Kokkos::Impl::integral_power_of_two(Layout::N6);
+  static constexpr unsigned SHIFT_7 =
+      Kokkos::Impl::integral_power_of_two(Layout::N7);
+  static constexpr auto MASK_0 = Layout::N0 - 1;
+  static constexpr auto MASK_1 = Layout::N1 - 1;
+  static constexpr auto MASK_2 = Layout::N2 - 1;
+  static constexpr auto MASK_3 = Layout::N3 - 1;
+  static constexpr auto MASK_4 = Layout::N4 - 1;
+  static constexpr auto MASK_5 = Layout::N5 - 1;
+  static constexpr auto MASK_6 = Layout::N6 - 1;
+  static constexpr auto MASK_7 = Layout::N7 - 1;
 
-  enum : unsigned { SHIFT_2T = SHIFT_0 + SHIFT_1 };
-  enum : unsigned { SHIFT_3T = SHIFT_0 + SHIFT_1 + SHIFT_2 };
-  enum : unsigned { SHIFT_4T = SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 };
-  enum : unsigned {
-    SHIFT_5T = SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 + SHIFT_4
-  };
-  enum : unsigned {
-    SHIFT_6T = SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 + SHIFT_4 + SHIFT_5
-  };
-  enum : unsigned {
-    SHIFT_7T =
-        SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 + SHIFT_4 + SHIFT_5 + SHIFT_6
-  };
-  enum : unsigned {
-    SHIFT_8T = SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 + SHIFT_4 + SHIFT_5 +
-               SHIFT_6 + SHIFT_7
-  };
+  static constexpr unsigned SHIFT_2T = SHIFT_0 + SHIFT_1;
+  static constexpr unsigned SHIFT_3T = SHIFT_0 + SHIFT_1 + SHIFT_2;
+  static constexpr unsigned SHIFT_4T = SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3;
+  static constexpr unsigned SHIFT_5T =
+      SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 + SHIFT_4;
+  static constexpr unsigned SHIFT_6T =
+      SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 + SHIFT_4 + SHIFT_5;
+  static constexpr unsigned SHIFT_7T =
+      SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 + SHIFT_4 + SHIFT_5 + SHIFT_6;
+  static constexpr unsigned SHIFT_8T = SHIFT_0 + SHIFT_1 + SHIFT_2 + SHIFT_3 +
+                                       SHIFT_4 + SHIFT_5 + SHIFT_6 + SHIFT_7;
 
   // Is an irregular layout that does not have uniform striding for each index.
   using is_mapping_plugin = std::true_type;
@@ -687,8 +689,8 @@ class ViewMapping<
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T**, src_layout, P...>;
 
-  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
+  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -739,8 +741,8 @@ class ViewMapping<typename std::enable_if<(N3 == 0 && N4 == 0 && N5 == 0 &&
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T***, src_layout, P...>;
 
-  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
+  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -797,8 +799,8 @@ class ViewMapping<typename std::enable_if<(N4 == 0 && N5 == 0 && N6 == 0 &&
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T****, src_layout, P...>;
 
-  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
+  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -860,8 +862,8 @@ class ViewMapping<
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T*****, src_layout, P...>;
 
-  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
+  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -928,8 +930,8 @@ class ViewMapping<typename std::enable_if<(N6 == 0 && N7 == 0)>::type  // void
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T******, src_layout, P...>;
 
-  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
+  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -1002,8 +1004,8 @@ class ViewMapping<typename std::enable_if<(N7 == 0)>::type  // void
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T*******, src_layout, P...>;
 
-  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
+  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;
@@ -1085,8 +1087,8 @@ class ViewMapping<typename std::enable_if<(N0 != 0 && N1 != 0 && N2 != 0 &&
                                         N6, N7, true>;
   using src_traits = Kokkos::ViewTraits<T********, src_layout, P...>;
 
-  enum { is_outer_left = (OuterP == Kokkos::Iterate::Left) };
-  enum { is_inner_left = (InnerP == Kokkos::Iterate::Left) };
+  static constexpr auto is_outer_left = (OuterP == Kokkos::Iterate::Left);
+  static constexpr auto is_inner_left = (InnerP == Kokkos::Iterate::Left);
   using array_layout =
       typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
                                 Kokkos::LayoutRight>::type;

--- a/core/unit_test/TestAtomics.hpp
+++ b/core/unit_test/TestAtomics.hpp
@@ -122,7 +122,7 @@ struct SuperScalar {
   }
 
   KOKKOS_INLINE_FUNCTION
-  bool operator==(const SuperScalar& src) {
+  bool operator==(const SuperScalar& src) const {
     bool compare = true;
     for (int i = 0; i < N; i++) {
       compare = compare && (val[i] == src.val[i]);
@@ -131,7 +131,7 @@ struct SuperScalar {
   }
 
   KOKKOS_INLINE_FUNCTION
-  bool operator!=(const SuperScalar& src) {
+  bool operator!=(const SuperScalar& src) const {
     bool compare = true;
     for (int i = 0; i < N; i++) {
       compare = compare && (val[i] == src.val[i]);

--- a/core/unit_test/TestNonTrivialScalarTypes.hpp
+++ b/core/unit_test/TestNonTrivialScalarTypes.hpp
@@ -173,17 +173,17 @@ struct my_complex {
   }
 
   KOKKOS_INLINE_FUNCTION
-  bool operator==(const my_complex &src) {
+  bool operator==(const my_complex &src) const {
     return (re == src.re) && (im == src.im) && (dummy == src.dummy);
   }
 
   KOKKOS_INLINE_FUNCTION
-  bool operator!=(const my_complex &src) {
+  bool operator!=(const my_complex &src) const {
     return (re != src.re) || (im != src.im) || (dummy != src.dummy);
   }
 
   KOKKOS_INLINE_FUNCTION
-  bool operator!=(const double &val) {
+  bool operator!=(const double &val) const {
     return (re != val) || (im != 0) || (dummy != 0);
   }
 

--- a/core/unit_test/TestTeamVectorRange.hpp
+++ b/core/unit_test/TestTeamVectorRange.hpp
@@ -169,17 +169,17 @@ struct my_complex {
   }
 
   KOKKOS_INLINE_FUNCTION
-  bool operator==(const my_complex& src) {
+  bool operator==(const my_complex& src) const {
     return (re == src.re) && (im == src.im) && (dummy == src.dummy);
   }
 
   KOKKOS_INLINE_FUNCTION
-  bool operator!=(const my_complex& src) {
+  bool operator!=(const my_complex& src) const {
     return (re != src.re) || (im != src.im) || (dummy != src.dummy);
   }
 
   KOKKOS_INLINE_FUNCTION
-  bool operator!=(const double& val) {
+  bool operator!=(const double& val) const {
     return (re != val) || (im != 0) || (dummy != 0);
   }
 


### PR DESCRIPTION
Since all of the changed enums are in internal classes any ODR-usage should also be internal. Hence, I didn't provide extra definitions in namescape scope. Also, we don't have them for the corresponding `HIP` variables.

The changes to the comparison operators in `core/src/impl/Kokkos_Atomic_View.hpp` rely on the existence of implicit conversion operators.