### PR TITLE
Enable launch latency simulations

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -112,7 +112,9 @@ bool profileLibraryLoaded() {
 void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
                       uint64_t* kernelID) {
   if (Experimental::current_callbacks.begin_parallel_for != nullptr) {
+#ifndef KOKKOS_IMPL_SIMULATE_LAUNCH_LATENCY
     Kokkos::fence();
+#endif
     (*Experimental::current_callbacks.begin_parallel_for)(kernelPrefix.c_str(),
                                                           devID, kernelID);
   }
@@ -132,7 +134,9 @@ void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
 
 void endParallelFor(const uint64_t kernelID) {
   if (Experimental::current_callbacks.end_parallel_for != nullptr) {
+#ifndef KOKKOS_IMPL_SIMULATE_LAUNCH_LATENCY
     Kokkos::fence();
+#endif
     (*Experimental::current_callbacks.end_parallel_for)(kernelID);
   }
 #ifdef KOKKOS_ENABLE_TUNING
@@ -145,7 +149,9 @@ void endParallelFor(const uint64_t kernelID) {
 void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
                        uint64_t* kernelID) {
   if (Experimental::current_callbacks.begin_parallel_scan != nullptr) {
+#ifndef KOKKOS_IMPL_SIMULATE_LAUNCH_LATENCY
     Kokkos::fence();
+#endif
     (*Experimental::current_callbacks.begin_parallel_scan)(kernelPrefix.c_str(),
                                                            devID, kernelID);
   }
@@ -165,7 +171,9 @@ void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
 
 void endParallelScan(const uint64_t kernelID) {
   if (Experimental::current_callbacks.end_parallel_scan != nullptr) {
+#ifndef KOKKOS_IMPL_SIMULATE_LAUNCH_LATENCY
     Kokkos::fence();
+#endif
     (*Experimental::current_callbacks.end_parallel_scan)(kernelID);
   }
 #ifdef KOKKOS_ENABLE_TUNING
@@ -178,7 +186,9 @@ void endParallelScan(const uint64_t kernelID) {
 void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
                          uint64_t* kernelID) {
   if (Experimental::current_callbacks.begin_parallel_reduce != nullptr) {
+#ifndef KOKKOS_IMPL_SIMULATE_LAUNCH_LATENCY
     Kokkos::fence();
+#endif
     (*Experimental::current_callbacks.begin_parallel_reduce)(
         kernelPrefix.c_str(), devID, kernelID);
   }
@@ -198,7 +208,9 @@ void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
 
 void endParallelReduce(const uint64_t kernelID) {
   if (Experimental::current_callbacks.end_parallel_reduce != nullptr) {
+#ifndef KOKKOS_IMPL_SIMULATE_LAUNCH_LATENCY
     Kokkos::fence();
+#endif
     (*Experimental::current_callbacks.end_parallel_reduce)(kernelID);
   }
 #ifdef KOKKOS_ENABLE_TUNING


### PR DESCRIPTION
So this is a weird one. There's a lot of interest in how badly launch latency impacts our performance. The "well, duh" answer is to have a tool that sleeps for some microseconds before a kernel. Problem is that a begin_parallel_for event means a fence, which perturbs the measurement.

So doing this needs an option to remove said fences. I think this option should not be documented, as users will abuse it. But it would be helpful if we could build Kokkos in a way that enables this functionality (with a requirement to just specify the CMAKE_CXX_FLAG so that nothing shows up in our ccmake). This is a PR where if people say "no, we shouldn't add this in" I completely understand, but I wanted to have the discussion.