### PR TITLE
Add support for -Wno-deprecated-gpu-targets

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -195,7 +195,7 @@ do
     cuda_args="$cuda_args $1"
     ;;
   #Handle more known nvcc args
-  --expt-extended-lambda|--expt-relaxed-constexpr)
+  --expt-extended-lambda|--expt-relaxed-constexpr|--Wno-deprecated-gpu-targets|-Wno-deprecated-gpu-targets)
     cuda_args="$cuda_args $1"
     ;;
   #Handle known nvcc args that have an argument


### PR DESCRIPTION
The flag `-Wno-deprecated-gpu-targets` seems to be ignored, here's a snippet from the compilation of DARMA-tasking/vt:

```
$ /usr/bin/ccache /nvcc_wrapper/build/nvcc_wrapper \
  -DFMT_HEADER_ONLY=1 -DFMT_USE_USER_DEFINED_LITERALS=0 \
  -DHAS_DETECTION_COMPONENT=1 -I/vt/lib/fmt -I/vt/lib/CLI -I/vt/lib/libfort/lib -Idebug -I/vt/src \
  -isystem /build/checkpoint/install/include -isystem /build/detector/install/include -Wall -pedantic -Wshadow \
  -Wno-unknown-pragmas -Wsign-compare -ftemplate-backtrace-limit=100 \
  -Wno-deprecated-gpu-targets -g -fdiagnostics-color=always -fPIC -fopenmp -std=c++14 \
  -MD -MT examples/callback/CMakeFiles/callback.dir/Unity/unity_0_cxx.cxx.o \
  -MF examples/callback/CMakeFiles/callback.dir/Unity/unity_0_cxx.cxx.o.d \
  -o examples/callback/CMakeFiles/callback.dir/Unity/unity_0_cxx.cxx.o \
  -c examples/callback/CMakeFiles/callback.dir/Unity/unity_0_cxx.cxx

nvcc warning : The 'compute_35', 'compute_37', 'compute_50', 'sm_35', 'sm_37' and 'sm_50' architectures are deprecated, and may be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
```

As you can see, even though the flag is present, the compiler still complains about deprecated architectures.

This PR fixes the problem.