### PR TITLE
Document Process for app performance tracking

### DIFF
--- a/doc/PerfTracking.md
+++ b/doc/PerfTracking.md
@@ -1,0 +1,55 @@
+# Performance Tracking
+
+This is a design document describing the motivation, ideas, design, and prototype implementation for a generic Kokkos performance tracking system
+
+## Motivation
+
+Currently, the Kokkos team doesn't have a way to track how changes in our code shape the performance of Kokkos applications. Generally, the way we learn about performance bugs is by Stan Moore saying "I tried kokkos develop yesterday and it slowed down \[input deck\] by \[big\]%. We greatly appreciate these efforts, but want something perhaps more formal. Thankfully, this is solveable through our performance tools. 
+
+## Changes in your code
+
+First, the Kokkos team recommends that users include pushRegion/popRegion calls in their code at a reasonably coarse granularity. Remember that such a call introduces a "fence" operation, which can perturb results. We also recommend that teams declare "metadata" about their runs. Kokkos already declares a significant amount of metadata about itself (how it was compiled, what backends are enabled, various options). But you might have code metadata. Basically, imagine a user came up to you and said "I ran the code with my input deck and the performance was bad." If there's a question you might ask such a user about that input deck, declare it as metadata using Kokkos, and our facilities for performance tracking will make use of it:
+
+Kokkos::Tools::declareMetadata("number\_of\_particles",std::to\_string(input\_deck.number\_of\_particles));
+
+For now, and only for the purposes of performance tracking, we recommend the following block of code to enable tools to follow region callbacks, without slowing down your application with individual kernel fences
+
+void hacky\thing\_kokkos\_should\_do\_for\_me(){
+   auto events = Kokkos::Tools::Experimental::get\_callbacks();
+   auto push = events.push\_region;
+   auto pop = events.pop\_region;
+   auto metadata = events.declare\_metadata;
+   Kokkos::Tools::Experimental::pause\_tools();
+   Kokkos::Tools::Experimental::set\_push\_region\_callback(push);
+   Kokkos::Tools::Experimental::set\_pop\_region\_callback(pop);
+   Kokkos::Tools::Experimental::set\_declare\_metadata\_callback(metadata);
+}
+
+If called immediately after Kokkos::initialize, you'll get region timings without kernel fences.
+
+## SPOT
+
+SPOT (Software Performance Optimization Tracker) is a utility developed at LLNL, used by their multiphysics codes (ALE3D, Ares, MARBL, Ardra, Teton, Kull) to track performance as they develop their software. It consists of three components
+
+1) Caliper: a highly configurable timing library developed by David Boehme
+2) Adiak: a library for declaring run metadata
+3) The Spot Web Frontend: for visualizing the results
+
+In Kokkos, we bundle the first two for you in the "spot bundle," which you can check out and build here:
+https://github.com/DavidPoliakoff/spot\_kokkos\_bundle.git . Note that you'll need an MPI module loaded, but then simply type "make" in the root directory of that repo and you should get a libspot-bundle.so.
+
+When you go to run your application, point KOKKOS\_PROFILE\_LIBRARY at that libspot-bundle.so, set the environment variable "CALI\_CONFIG" to "spot(profile.kokkos)" and you should get an output file with a ".cali" suffix wherever you ran your application.
+
+Simply upload these ".cali" profiles to a Spot Hosting service at which it is safe to do so, and you can visualize your performance data. For UUR profiles, we can set up hosting at NERSC's install of SPOT, as follows:
+
+TODO: NERSC Hosting
+
+For profile that can be transferred to LLNL, simply upload your profiles onto an LLNL cluster, and access the SPOT instance here: 
+
+TODO: LLNL Hosting
+
+For other profiles, contact David Poliakoff for info about setting up a hosted SPOT instance.
+
+## How do I prevent Kokkos bugs from harming my app?
+
+Simply have a nightly/weekly CI configuration that checks out Kokkos develop and does the above for a set of input decks you care about. Spot will give you the ability to check for any spikes in the runtime. Note that if you update both your app and Kokkos, it will require some work to see if changes are in the app or Kokkos itself.

--- a/doc/PerfTracking.md
+++ b/doc/PerfTracking.md
@@ -1,4 +1,4 @@
-# Performance Tracking
+#Performance Tracking
 
 This is a design document describing the motivation, ideas, design, and prototype implementation for a generic Kokkos performance tracking system
 
@@ -15,14 +15,14 @@ Kokkos::Tools::declareMetadata("number\_of\_particles",std::to\_string(input\_de
 For now, and only for the purposes of performance tracking, we recommend the following block of code to enable tools to follow region callbacks, without slowing down your application with individual kernel fences
 
 void hacky\thing\_kokkos\_should\_do\_for\_me(){
-   auto events = Kokkos::Tools::Experimental::get\_callbacks();
-   auto push = events.push\_region;
-   auto pop = events.pop\_region;
-   auto metadata = events.declare\_metadata;
-   Kokkos::Tools::Experimental::pause\_tools();
-   Kokkos::Tools::Experimental::set\_push\_region\_callback(push);
-   Kokkos::Tools::Experimental::set\_pop\_region\_callback(pop);
-   Kokkos::Tools::Experimental::set\_declare\_metadata\_callback(metadata);
+  auto events   = Kokkos::Tools::Experimental::get\_callbacks();
+  auto push     = events.push\_region;
+  auto pop      = events.pop\_region;
+  auto metadata = events.declare\_metadata;
+  Kokkos::Tools::Experimental::pause\_tools();
+  Kokkos::Tools::Experimental::set\_push\_region\_callback(push);
+  Kokkos::Tools::Experimental::set\_pop\_region\_callback(pop);
+  Kokkos::Tools::Experimental::set\_declare\_metadata\_callback(metadata);
 }
 
 If called immediately after Kokkos::initialize, you'll get region timings without kernel fences.
@@ -36,7 +36,7 @@ SPOT (Software Performance Optimization Tracker) is a utility developed at LLNL,
 3) The Spot Web Frontend: for visualizing the results
 
 In Kokkos, we bundle the first two for you in the "spot bundle," which you can check out and build here:
-https://github.com/DavidPoliakoff/spot\_kokkos\_bundle.git . Note that you'll need an MPI module loaded, but then simply type "make" in the root directory of that repo and you should get a libspot-bundle.so.
+https://github.com/DavidPoliakoff/spot_kokkos_bundle.git . Note that you'll need an MPI module loaded, but then simply type "make" in the root directory of that repo and you should get a libspot-bundle.so.
 
 When you go to run your application, point KOKKOS\_PROFILE\_LIBRARY at that libspot-bundle.so, set the environment variable "CALI\_CONFIG" to "spot(profile.kokkos)" and you should get an output file with a ".cali" suffix wherever you ran your application.
 
@@ -50,7 +50,7 @@ TODO: LLNL Hosting
 
 If you're comfortable with Docker, and can host your profiles on a local machine (at most labs, *not* one of your production clusters), there are instructions for building the Docker container for Spot here:
 
-https://github.com/LLNL/spot2\_container
+https://github.com/LLNL/spot2_container
 
 For other profiles, contact David Poliakoff for info about setting up a hosted SPOT instance. If profiles from your code don't fit one of the above categories, however, things are likely to be difficult
 

--- a/doc/PerfTracking.md
+++ b/doc/PerfTracking.md
@@ -48,7 +48,11 @@ For profile that can be transferred to LLNL, simply upload your profiles onto an
 
 TODO: LLNL Hosting
 
-For other profiles, contact David Poliakoff for info about setting up a hosted SPOT instance.
+If you're comfortable with Docker, and can host your profiles on a local machine (at most labs, *not* one of your production clusters), there are instructions for building the Docker container for Spot here:
+
+https://github.com/LLNL/spot2\_container
+
+For other profiles, contact David Poliakoff for info about setting up a hosted SPOT instance. If profiles from your code don't fit one of the above categories, however, things are likely to be difficult
 
 ## How do I prevent Kokkos bugs from harming my app?
 


### PR DESCRIPTION
There are a number of performance tracking efforts going on in the Kokkos team. This PR adds a documentation for how to use one such tool (SPOT) to check whether Kokkos is having an impact on the performance of an application.

Three big TODO's: I mention a hacky code block. We need to find a less bad way of doing what I'm doing there. We also need to fill in the gaps in terms of where we host the viz. Also: needs a merge on #3729

Smaller TODO: if we decide this process is good, move the spot_kokkos_bundle into the Kokkos org.

But really this is an attempt to solicit feedback on this workflow. If a user was to do this, and send us links when we screwed up their performance, what would we need to effectively debug whatever concerns they raised.

For folks like @stanmoore1 (our current performance CI system ;) ) does this look like a reasonable process to you?