### PR TITLE
Unify HIPParallelLaunch structures

### DIFF
--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -127,19 +127,69 @@ struct HIPDispatchProperties {
   HIPLaunchMechanism launch_mechanism = l;
 };
 
-template <class DriverType, class LaunchBounds = Kokkos::LaunchBounds<>,
+template <typename DriverType, typename LaunchBounds,
+          HIPLaunchMechanism LaunchMechanism>
+struct HIPParallelLaunchKernelFunc;
+
+template <typename DriverType, unsigned int MaxThreadsPerBlock,
+          unsigned int MinBlocksPerSM>
+struct HIPParallelLaunchKernelFunc<
+    DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
+    HIPLaunchMechanism::LocalMemory> {
+  static auto get_kernel_func() {
+    return hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
+                                            MinBlocksPerSM>;
+  }
+};
+
+template <typename DriverType>
+struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
+                                   HIPLaunchMechanism::LocalMemory> {
+  static auto get_kernel_func() {
+    return hip_parallel_launch_local_memory<DriverType, 1024, 1>;
+  }
+};
+
+template <typename DriverType, typename LaunchBounds,
+          HIPLaunchMechanism LaunchMechanism>
+struct HIPParallelLaunchKernelInvoker;
+
+template <typename DriverType, typename LaunchBounds>
+struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
+                                      HIPLaunchMechanism::LocalMemory>
+    : HIPParallelLaunchKernelFunc<DriverType, LaunchBounds,
+                                  HIPLaunchMechanism::LocalMemory> {
+  using base_t = HIPParallelLaunchKernelFunc<DriverType, LaunchBounds,
+                                             HIPLaunchMechanism::LocalMemory>;
+
+  static void invoke_kernel(DriverType const *driver, dim3 const &grid,
+                            dim3 const &block, int shmem,
+                            HIPInternal const *hip_instance) {
+    (base_t::get_kernel_func())<<<grid, block, shmem, hip_instance->m_stream>>>(
+        driver);
+  }
+};
+
+template <typename DriverType, typename LaunchBounds = Kokkos::LaunchBounds<>,
           HIPLaunchMechanism LaunchMechanism = HIPLaunchMechanism::LocalMemory>
 struct HIPParallelLaunch;
 
-template <class DriverType, unsigned int MaxThreadsPerBlock,
+template <typename DriverType, unsigned int MaxThreadsPerBlock,
           unsigned int MinBlocksPerSM>
 struct HIPParallelLaunch<
     DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
-    HIPLaunchMechanism::LocalMemory> {
-  inline HIPParallelLaunch(const DriverType &driver, const dim3 &grid,
-                           const dim3 &block, const int shmem,
-                           const HIPInternal *hip_instance,
-                           const bool /*prefer_shmem*/) {
+    HIPLaunchMechanism::LocalMemory>
+    : HIPParallelLaunchKernelInvoker<
+          DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
+          HIPLaunchMechanism::LocalMemory> {
+  using base_t = HIPParallelLaunchKernelInvoker<
+      DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
+      HIPLaunchMechanism::LocalMemory>;
+
+  HIPParallelLaunch(const DriverType &driver, const dim3 &grid,
+                    const dim3 &block, const int shmem,
+                    const HIPInternal *hip_instance,
+                    const bool /*prefer_shmem*/) {
     if ((grid.x != 0) && ((block.x * block.y * block.z) != 0)) {
       if (hip_instance->m_maxShmemPerBlock < shmem) {
         Kokkos::Impl::throw_runtime_exception(
@@ -152,9 +202,7 @@ struct HIPParallelLaunch<
       DriverType *d_driver = reinterpret_cast<DriverType *>(
           hip_instance->get_next_driver(sizeof(DriverType)));
       std::memcpy((void *)d_driver, (void *)&driver, sizeof(DriverType));
-      hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
-                                       MinBlocksPerSM>
-          <<<grid, block, shmem, hip_instance->m_stream>>>(d_driver);
+      base_t::invoke_kernel(d_driver, grid, block, shmem, hip_instance);
 
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
       HIP_SAFE_CALL(hipGetLastError());
@@ -167,50 +215,7 @@ struct HIPParallelLaunch<
     static hipFuncAttributes attr = []() {
       hipFuncAttributes attr;
       HIP_SAFE_CALL(hipFuncGetAttributes(
-          &attr,
-          reinterpret_cast<void const *>(
-              hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
-                                               MinBlocksPerSM>)));
-      return attr;
-    }();
-    return attr;
-  }
-};
-
-template <class DriverType>
-struct HIPParallelLaunch<DriverType, Kokkos::LaunchBounds<0, 0>,
-                         HIPLaunchMechanism::LocalMemory> {
-  inline HIPParallelLaunch(const DriverType &driver, const dim3 &grid,
-                           const dim3 &block, const int shmem,
-                           const HIPInternal *hip_instance,
-                           const bool /*prefer_shmem*/) {
-    if ((grid.x != 0) && ((block.x * block.y * block.z) != 0)) {
-      if (hip_instance->m_maxShmemPerBlock < shmem) {
-        Kokkos::Impl::throw_runtime_exception(std::string(
-            "HIPParallelLaunch FAILED: shared memory request is too large"));
-      }
-
-      KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
-      // Invoke the driver function on the device
-      DriverType *d_driver = reinterpret_cast<DriverType *>(
-          hip_instance->get_next_driver(sizeof(DriverType)));
-      std::memcpy((void *)d_driver, (void *)&driver, sizeof(DriverType));
-      hip_parallel_launch_local_memory<DriverType, 1024, 1>
-          <<<grid, block, shmem, hip_instance->m_stream>>>(d_driver);
-
-#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-      HIP_SAFE_CALL(hipGetLastError());
-      hip_instance->fence();
-#endif
-    }
-  }
-
-  static hipFuncAttributes get_hip_func_attributes() {
-    static hipFuncAttributes attr = []() {
-      hipFuncAttributes attr;
-      HIP_SAFE_CALL(hipFuncGetAttributes(
-          &attr, reinterpret_cast<void const *>(
-                     hip_parallel_launch_local_memory<DriverType, 1024, 1>)));
+          &attr, reinterpret_cast<void const *>(base_t::get_kernel_func())));
       return attr;
     }();
     return attr;


### PR DESCRIPTION
This PR refactors HIP kernel launch in line with the new CUDA code. Right now, HIP only support local memory. I am working on adding support for global memory and constant memory.