### PR TITLE
Add Spack test support for Kokkos

### DIFF
--- a/scripts/spack_test/CMakeLists.txt
+++ b/scripts/spack_test/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+project(SpackTestGen)
+set(TEST_LIST_DEF ${CMAKE_CURRENT_SOURCE_DIR}/test_list.def)
+file(STRINGS ${TEST_LIST_DEF} TEST_FILES)
+
+#Copy test source to Spack test directory
+foreach (TEST_FILE ${TEST_FILES})
+  set(TEST_FILE_LOCATION ${SPACK_PACKAGE_SOURCE_DIR}/${TEST_FILE})
+  file(COPY ${TEST_FILE_LOCATION} DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/out)
+endforeach()
+
+#Clean up names
+foreach(TEST_FILE ${TEST_FILES} )
+  string( REGEX REPLACE ".+\/" "" TEST_FILE ${TEST_FILE} )
+  list(APPEND SRC_NAME_LIST ${TEST_FILE})
+  string( REPLACE ".cpp" "" TEST_FILE ${TEST_FILE} )
+  list(APPEND BIN_NAME_LIST ${TEST_FILE})
+endforeach()
+
+#Configure test cmake script and run script
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt.in ${CMAKE_CURRENT_SOURCE_DIR}/out/CMakeLists.txt @ONLY)

--- a/scripts/spack_test/CMakeLists.txt.in
+++ b/scripts/spack_test/CMakeLists.txt.in
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.16) 
+project(kokkos_spack_test CXX)
+find_package(Kokkos REQUIRED)
+
+set(SRC_NAME_LIST "@SRC_NAME_LIST@")
+set(BIN_NAME_LIST "@BIN_NAME_LIST@")
+
+enable_testing()
+list(LENGTH SRC_NAME_LIST LEN) 
+math(EXPR LEN "${LEN}-1")
+
+set(CMAKE_CXX_COMPILER ${Kokkos_CXX_COMPILER})
+
+foreach (it RANGE ${LEN}) 
+  list(GET SRC_NAME_LIST ${it} src) 
+  list(GET BIN_NAME_LIST ${it} bin)
+  add_executable(${bin} ${src})
+  target_link_libraries(${bin} Kokkos::kokkos)
+  add_test(NAME ${bin} COMMAND ${bin})
+  set_tests_properties(${bin} PROPERTIES
+    LABELS "Kokkos"
+    PROCESSORS 1
+    TIMEOUT 60)
+endforeach()

--- a/scripts/spack_test/test_list.def
+++ b/scripts/spack_test/test_list.def
@@ -1,0 +1,4 @@
+example/tutorial/01_hello_world/hello_world.cpp
+example/tutorial/02_simple_reduce/simple_reduce.cpp
+example/tutorial/Algorithms/01_random_numbers/random_numbers.cpp
+example/tutorial/Advanced_Views/04_dualviews/dual_view.cpp


### PR DESCRIPTION
Adds Spack test support for Kokkos.
- CMakeLists.txt is used to assemble test files, to generate CmakeLists files for tests, and to generate a run script.
- Tests are defined in the 'test_list.def' file. The list can be extended to cover other tests.
- Tests are built and run at "spack test run" time. 