### PR TITLE
Alternative implementation for SYCL TeamPolicy

### DIFF
--- a/core/unit_test/TestCXX11.hpp
+++ b/core/unit_test/TestCXX11.hpp
@@ -318,8 +318,12 @@ double TestVariantLambda(int test) {
   switch (test) {
     case 1: return AddTestLambda<DeviceType, false>();
     case 2: return AddTestLambda<DeviceType, true>();
-    case 3: return ReduceTestLambda<DeviceType, false>();
+    case 3:
+      return ReduceTestLambda<DeviceType, false>();
+      // FIXME_SYCL requires TeamPolicy reduce
+#ifndef KOKKOS_ENABLE_SYCL
     case 4: return ReduceTestLambda<DeviceType, true>();
+#endif
   }
 
   return 0;
@@ -330,8 +334,12 @@ double TestVariantFunctor(int test) {
   switch (test) {
     case 1: return AddTestFunctor<DeviceType, false>();
     case 2: return AddTestFunctor<DeviceType, true>();
-    case 3: return ReduceTestFunctor<DeviceType, false>();
+    case 3:
+      return ReduceTestFunctor<DeviceType, false>();
+// FIXME_SYCL requires TeamPolicy reduce
+#ifndef KOKKOS_ENABLE_SYCL
     case 4: return ReduceTestFunctor<DeviceType, true>();
+#endif
   }
 
   return 0;
@@ -371,8 +379,6 @@ bool Test(int test) {
 }  // namespace TestCXX11
 
 namespace Test {
-// FIXME_SYCL requires TeamPolicy and team_rank
-#ifndef KOKKOS_ENABLE_SYCL
 TEST(TEST_CATEGORY, cxx11) {
   if (std::is_same<Kokkos::DefaultExecutionSpace, TEST_EXECSPACE>::value) {
     ASSERT_TRUE((TestCXX11::Test<TEST_EXECSPACE>(1)));
@@ -381,6 +387,5 @@ TEST(TEST_CATEGORY, cxx11) {
     ASSERT_TRUE((TestCXX11::Test<TEST_EXECSPACE>(4)));
   }
 }
-#endif
 
 }  // namespace Test

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -152,10 +152,6 @@ struct TestTeamPolicy {
   }
 
   static void test_for(const size_t league_size) {
-    // FIXME_SYCL requires team rank
-#ifdef KOKKOS_ENABLE_SYCL
-    if (league_size == 0)
-#endif
     {
       TestTeamPolicy functor(league_size);
       using policy_type = Kokkos::TeamPolicy<ScheduleType, ExecSpace>;

--- a/core/unit_test/incremental/Test10_HierarchicalBasics.hpp
+++ b/core/unit_test/incremental/Test10_HierarchicalBasics.hpp
@@ -70,22 +70,15 @@ struct HierarchicalBasics {
     Kokkos::View<int **, ExecSpace> v("Array_A", nP, nT);
     Kokkos::parallel_for(
         "Teams", pol, KOKKOS_LAMBDA(const team_t &team) {
-    // FIXME_SYCL Can't ask for team_rank
-#ifndef KOKKOS_ENABLE_SYCL
           const int tR = team.team_rank();
-#endif
           const int tS = team.team_size();
           const int lR = team.league_rank();
           const int lS = team.league_size();
-      // FIXME_SYCL Can't ask for team_rank
-#ifdef KOKKOS_ENABLE_SYCL
-          for (int tR = 0; tR < tS; ++tR)
-#endif
-            if (lR < lS) {
-              v(lR, tR) = lR * tS + tR;
-            } else {
-              v(lR, tR) = 100000;
-            }
+          if (lR < lS) {
+            v(lR, tR) = lR * tS + tR;
+          } else {
+            v(lR, tR) = 100000;
+          }
         });
     Kokkos::fence();
     auto h_v = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);


### PR DESCRIPTION
SYCL implements hierarchical parallelism with a fork-join model that doesn't much the `Kokkos` model. This pull request provides an alternative implementation that doesn't use `parallel_for_work_group`/`parallel_for_work_item`.