### PR TITLE
Disable numeric traits long double epsilon unit test with IBM XL

### DIFF
--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -204,7 +204,7 @@ TEST(TEST_CATEGORY, numeric_traits_infinity) {
 TEST(TEST_CATEGORY, numeric_traits_epsilon) {
   TestNumericTraits<TEST_EXECSPACE, float, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, double, Epsilon>();
-#ifndef KOKKOS_COMPILER_IBM
+#ifndef KOKKOS_COMPILER_IBM  // fails with XL 16.1.1
   TestNumericTraits<TEST_EXECSPACE, long double, Epsilon>();
 #endif
 }

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -204,7 +204,9 @@ TEST(TEST_CATEGORY, numeric_traits_infinity) {
 TEST(TEST_CATEGORY, numeric_traits_epsilon) {
   TestNumericTraits<TEST_EXECSPACE, float, Epsilon>();
   TestNumericTraits<TEST_EXECSPACE, double, Epsilon>();
+#ifndef KOKKOS_COMPILER_IBM
   TestNumericTraits<TEST_EXECSPACE, long double, Epsilon>();
+#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_round_error) {


### PR DESCRIPTION
Fix #3675