### PR TITLE
Allow initializing SYCL execution space from sycl::queue and SYCL::impl_static_fence

### DIFF
--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -79,15 +79,20 @@ class SYCL {
 
   using scratch_memory_space = ScratchMemorySpace<SYCL>;
 
-  ~SYCL() = default;
+  ~SYCL();
   SYCL();
+  explicit SYCL(const sycl::queue&);
 
-  SYCL(SYCL&&)      = default;
-  SYCL(const SYCL&) = default;
-  SYCL& operator=(SYCL&&) = default;
-  SYCL& operator=(const SYCL&) = default;
+  SYCL(SYCL&&) noexcept;
+  SYCL(const SYCL&);
+  SYCL& operator=(SYCL&&) noexcept;
+  SYCL& operator=(const SYCL&);
 
   uint32_t impl_instance_id() const noexcept { return 0; }
+
+  sycl::context sycl_context() const noexcept {
+    return m_space_instance->m_queue->get_context();
+  };
 
   //@}
   //------------------------------------
@@ -158,7 +163,9 @@ class SYCL {
   }
 
  private:
+  KOKKOS_FUNCTION void cleanup() noexcept;
   Impl::SYCLInternal* m_space_instance;
+  int* m_counter;
 };
 
 namespace Impl {

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -76,9 +76,69 @@ int get_gpu(const InitArguments& args);
 }  // namespace Impl
 
 namespace Experimental {
-SYCL::SYCL() : m_space_instance(&Impl::SYCLInternal::singleton()) {
+SYCL::SYCL()
+    : m_space_instance(&Impl::SYCLInternal::singleton()), m_counter(nullptr) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
+}
+
+SYCL::SYCL(const sycl::queue& stream)
+    : m_space_instance(new Impl::SYCLInternal), m_counter(new int(1)) {
+  Impl::SYCLInternal::singleton().verify_is_initialized(
+      "SYCL instance constructor");
+  m_space_instance->initialize(stream);
+}
+
+KOKKOS_FUNCTION SYCL::SYCL(SYCL&& other) noexcept
+    : m_space_instance(other.m_space_instance), m_counter(other.m_counter) {
+  other.m_space_instance = nullptr;
+  other.m_counter        = nullptr;
+}
+
+KOKKOS_FUNCTION SYCL::SYCL(const SYCL& other)
+    : m_space_instance(other.m_space_instance), m_counter(other.m_counter) {
+#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL
+  if (m_counter) Kokkos::atomic_add(m_counter, 1);
+#endif
+}
+
+KOKKOS_FUNCTION SYCL& SYCL::operator=(SYCL&& other) noexcept {
+  if (&other != this) {
+    cleanup();
+    m_space_instance       = other.m_space_instance;
+    other.m_space_instance = nullptr;
+    m_counter              = other.m_counter;
+    other.m_counter        = nullptr;
+  }
+  return *this;
+}
+
+KOKKOS_FUNCTION SYCL& SYCL::operator=(const SYCL& other) {
+  if (&other != this) {
+    cleanup();
+    m_space_instance = other.m_space_instance;
+    m_counter        = other.m_counter;
+#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL
+    if (m_counter) Kokkos::atomic_add(m_counter, 1);
+#endif
+  }
+  return *this;
+}
+
+KOKKOS_FUNCTION SYCL::~SYCL() { cleanup(); }
+
+KOKKOS_FUNCTION void SYCL::cleanup() noexcept {
+#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL
+  // If m_counter is set, then this instance is responsible for managing the
+  // objects pointed to by m_counter and m_space_instance.
+  if (m_counter == nullptr) return;
+  int const count = Kokkos::atomic_fetch_sub(m_counter, 1);
+  if (count == 1) {
+    delete m_counter;
+    m_space_instance->finalize();
+    delete m_space_instance;
+  }
+#endif
 }
 
 int SYCL::concurrency() {

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -159,6 +159,13 @@ void SYCL::fence() const {
   Impl::SYCLInternal::fence(*m_space_instance->m_queue);
 }
 
+void SYCL::impl_static_fence() {
+  // guard accessing all_queues
+  std::lock_guard<std::mutex> lock(Impl::SYCLInternal::mutex);
+  for (auto& queue : Impl::SYCLInternal::all_queues)
+    Impl::SYCLInternal::fence(**queue);
+}
+
 int SYCL::sycl_device() const {
   return impl_internal_space_instance()->m_syclDev;
 }
@@ -316,9 +323,7 @@ void SYCLSpaceInitializer::finalize(const bool all_spaces) {
 }
 
 void SYCLSpaceInitializer::fence() {
-  // FIXME_SYCL should be
-  //  Kokkos::Experimental::SYCL::impl_static_fence();
-  Kokkos::Experimental::SYCL().fence();
+  Kokkos::Experimental::SYCL::impl_static_fence();
 }
 
 void SYCLSpaceInitializer::print_configuration(std::ostream& msg,

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -231,7 +231,7 @@ std::ostream& SYCL::SYCLDevice::info(std::ostream& os) const {
 
 namespace Impl {
 
-int g_hip_space_factory_initialized =
+int g_sycl_space_factory_initialized =
     Kokkos::Impl::initialize_space_factory<SYCLSpaceInitializer>("170_SYCL");
 
 void SYCLSpaceInitializer::initialize(const InitArguments& args) {

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -53,10 +53,11 @@ namespace Kokkos {
 namespace Experimental {
 namespace Impl {
 
-int SYCLInternal::was_finalized = 0;
+std::vector<std::optional<sycl::queue>*> SYCLInternal::all_queues;
+std::mutex SYCLInternal::mutex;
 
 SYCLInternal::~SYCLInternal() {
-  if (m_scratchSpace || m_scratchFlags) {
+  if (!was_finalized || m_scratchSpace || m_scratchFlags) {
     std::cerr << "Kokkos::Experimental::SYCL ERROR: Failed to call "
                  "Kokkos::Experimental::SYCL::finalize()"
               << std::endl;
@@ -79,8 +80,26 @@ SYCLInternal& SYCLInternal::singleton() {
   return self;
 }
 
-// FIME_SYCL
 void SYCLInternal::initialize(const sycl::device& d) {
+  auto exception_handler = [](sycl::exception_list exceptions) {
+    bool asynchronous_error = false;
+    for (std::exception_ptr const& e : exceptions) {
+      try {
+        std::rethrow_exception(e);
+      } catch (sycl::exception const& e) {
+        std::cerr << e.what() << '\n';
+        asynchronous_error = true;
+      }
+    }
+    if (asynchronous_error)
+      Kokkos::Impl::throw_runtime_exception(
+          "There was an asynchronous SYCL error!\n");
+  };
+  initialize(sycl::queue{d, exception_handler});
+}
+
+// FIXME_SYCL
+void SYCLInternal::initialize(const sycl::queue& q) {
   if (was_finalized)
     Kokkos::abort("Calling SYCL::initialize after SYCL::finalize is illegal\n");
 
@@ -96,21 +115,13 @@ void SYCLInternal::initialize(const sycl::device& d) {
   const bool ok_init = nullptr == m_scratchSpace || nullptr == m_scratchFlags;
   const bool ok_dev  = true;
   if (ok_init && ok_dev) {
-    auto exception_handler = [](sycl::exception_list exceptions) {
-      bool asynchronous_error = false;
-      for (std::exception_ptr const& e : exceptions) {
-        try {
-          std::rethrow_exception(e);
-        } catch (sycl::exception const& e) {
-          std::cerr << e.what() << '\n';
-          asynchronous_error = true;
-        }
-      }
-      if (asynchronous_error)
-        Kokkos::Impl::throw_runtime_exception(
-            "There was an asynchronous SYCL error!\n");
-    };
-    m_queue.emplace(d, exception_handler);
+    m_queue = q;
+    // guard pushing to all_queues
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      all_queues.push_back(&m_queue);
+    }
+    const sycl::device& d = m_queue->get_device();
     std::cout << SYCL::SYCLDevice(d) << '\n';
 
     m_maxThreadsPerSM =
@@ -130,7 +141,7 @@ void SYCLInternal::initialize(const sycl::device& d) {
 
 void SYCLInternal::finalize() {
   SYCL().fence();
-  was_finalized = 1;
+  was_finalized = true;
   if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
     // FIXME_SYCL
     std::abort();
@@ -138,6 +149,11 @@ void SYCLInternal::finalize() {
 
   m_indirectKernelMem.reset();
   m_indirectReducerMem.reset();
+  // guard erasing from all_queues
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    all_queues.erase(std::find(all_queues.begin(), all_queues.end(), &m_queue));
+  }
   m_queue.reset();
 }
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
@@ -73,11 +73,10 @@ class Kokkos::Impl::ParallelFor<FunctorType, ExecPolicy,
 
     q.submit([functor, policy](sycl::handler& cgh) {
       sycl::range<1> range(policy.end() - policy.begin());
+      const auto begin = policy.begin();
 
       cgh.parallel_for(range, [=](sycl::item<1> item) {
-        const typename Policy::index_type id =
-            static_cast<typename Policy::index_type>(item.get_linear_id()) +
-            policy.begin();
+        const typename Policy::index_type id = item.get_linear_id() + begin;
         if constexpr (std::is_same<WorkTag, void>::value)
           functor(id);
         else
@@ -128,7 +127,26 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   using WorkTag          = typename Policy::work_tag;
 
   const FunctorType m_functor;
-  const Policy m_policy;
+  // MDRangePolicy is not trivially copyable. Hence, replicate the data we
+  // really need in DeviceIterateTile in a trivially copyable struct.
+  const struct BarePolicy {
+    using index_type = typename Policy::index_type;
+
+    BarePolicy(const Policy& policy)
+        : m_lower(policy.m_lower),
+          m_upper(policy.m_upper),
+          m_tile(policy.m_tile),
+          m_tile_end(policy.m_tile_end),
+          m_num_tiles(policy.m_num_tiles) {}
+
+    const typename Policy::point_type m_lower;
+    const typename Policy::point_type m_upper;
+    const typename Policy::tile_type m_tile;
+    const typename Policy::point_type m_tile_end;
+    const typename Policy::index_type m_num_tiles;
+    static constexpr Iterate inner_direction = Policy::inner_direction;
+  } m_policy;
+  const Kokkos::Experimental::SYCL& m_space;
 
   sycl::nd_range<3> compute_ranges() const {
     const auto& m_tile     = m_policy.m_tile;
@@ -185,21 +203,20 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   template <typename Functor>
   void sycl_direct_launch(const Functor& functor) const {
     // Convenience references
-    const Kokkos::Experimental::SYCL& space = m_policy.space();
     Kokkos::Experimental::Impl::SYCLInternal& instance =
-        *space.impl_internal_space_instance();
+        *m_space.impl_internal_space_instance();
     sycl::queue& q = *instance.m_queue;
 
-    space.fence();
+    m_space.fence();
 
     if (m_policy.m_num_tiles == 0) return;
 
-    auto& policy = m_policy;
+    const BarePolicy bare_policy(m_policy);
 
-    q.submit([functor, this, policy](sycl::handler& cgh) {
+    q.submit([functor, this, bare_policy](sycl::handler& cgh) {
       const auto range = compute_ranges();
 
-      cgh.parallel_for(range, [functor, policy](sycl::nd_item<3> item) {
+      cgh.parallel_for(range, [functor, bare_policy](sycl::nd_item<3> item) {
         const index_type local_x    = item.get_local_id(0);
         const index_type local_y    = item.get_local_id(1);
         const index_type local_z    = item.get_local_id(2);
@@ -210,15 +227,15 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         const index_type n_global_y = item.get_group_range(1);
         const index_type n_global_z = item.get_group_range(2);
 
-        Kokkos::Impl::DeviceIterateTile<Policy::rank, Policy, Functor,
+        Kokkos::Impl::DeviceIterateTile<Policy::rank, BarePolicy, Functor,
                                         typename Policy::work_tag>(
-            policy, functor, {n_global_x, n_global_y, n_global_z},
+            bare_policy, functor, {n_global_x, n_global_y, n_global_z},
             {global_x, global_y, global_z}, {local_x, local_y, local_z})
             .exec_range();
       });
     });
 
-    space.fence();
+    m_space.fence();
   }
 
  public:
@@ -226,9 +243,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   void execute() const {
     Kokkos::Experimental::Impl::SYCLInternal::IndirectKernelMem&
-        indirectKernelMem = m_policy.space()
-                                .impl_internal_space_instance()
-                                ->m_indirectKernelMem;
+        indirectKernelMem =
+            m_space.impl_internal_space_instance()->m_indirectKernelMem;
 
     const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper<
         std::reference_wrapper<FunctorType>>(m_functor, indirectKernelMem);
@@ -242,7 +258,9 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   ~ParallelFor()                        = default;
 
   ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
-      : m_functor(arg_functor), m_policy(arg_policy) {}
+      : m_functor(arg_functor),
+        m_policy(arg_policy),
+        m_space(arg_policy.space()) {}
 };
 
 #endif  // KOKKOS_SYCL_PARALLEL_RANGE_HPP_

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -187,11 +187,10 @@ class ParallelScanSYCLBase {
     // Initialize global memory
     q.submit([&](sycl::handler& cgh) {
       auto global_mem = m_scratch_space;
-      auto policy     = m_policy;
+      auto begin      = m_policy.begin();
       cgh.parallel_for(sycl::range<1>(len), [=](sycl::item<1> item) {
         const typename Policy::index_type id =
-            static_cast<typename Policy::index_type>(item.get_id()) +
-            policy.begin();
+            static_cast<typename Policy::index_type>(item.get_id()) + begin;
         value_type update{};
         ValueInit::init(functor, &update);
         if constexpr (std::is_same<WorkTag, void>::value)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -536,6 +536,24 @@ if(Kokkos_ENABLE_SYCL)
       UnitTestMainInit.cpp
       ${SYCL_SOURCES2D}
   )
+ KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    UnitTest_SYCLInterOpInit
+    SOURCES
+      UnitTestMain.cpp
+      sycl/TestSYCL_InterOp_Init.cpp
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    UnitTest_SYCLInterOpInit_Context
+    SOURCES
+    UnitTestMainInit.cpp
+      sycl/TestSYCL_InterOp_Init_Context.cpp
+  )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    UnitTest_SYCLInterOpStreams
+    SOURCES
+      UnitTestMain.cpp
+     sycl/TestSYCL_InterOp_Streams.cpp
+  )
 endif()
 
 SET(DEFAULT_DEVICE_SOURCES

--- a/core/unit_test/Test_InterOp_Streams.hpp
+++ b/core/unit_test/Test_InterOp_Streams.hpp
@@ -46,12 +46,14 @@
 
 namespace Test {
 
+#ifndef KOKKOS_ENABLE_SYCL
 __global__ void offset_streams(int* p) {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < 100) {
     p[idx] += idx;
   }
 }
+#endif
 
 template <typename MemorySpace>
 struct FunctorRange {

--- a/core/unit_test/cuda/TestCuda_InterOp_Init.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Init.cpp
@@ -45,6 +45,8 @@
 #include <Kokkos_Core.hpp>
 #include <cuda/TestCuda_Category.hpp>
 
+#include <array>
+
 namespace Test {
 
 __global__ void offset(int* p) {
@@ -58,7 +60,7 @@ __global__ void offset(int* p) {
 // Cuda.
 TEST(cuda, raw_cuda_interop) {
   int* p;
-  cudaMalloc(&p, sizeof(int) * 100);
+  CUDA_SAFE_CALL(cudaMalloc(&p, sizeof(int) * 100));
   Kokkos::InitArguments arguments{-1, -1, -1, false};
   Kokkos::initialize(arguments);
 
@@ -70,8 +72,8 @@ TEST(cuda, raw_cuda_interop) {
   offset<<<100, 64>>>(p);
   CUDA_SAFE_CALL(cudaDeviceSynchronize());
 
-  int* h_p = new int[100];
-  cudaMemcpy(h_p, p, sizeof(int) * 100, cudaMemcpyDefault);
+  std::array<int, 100> h_p;
+  cudaMemcpy(h_p.data(), p, sizeof(int) * 100, cudaMemcpyDefault);
   CUDA_SAFE_CALL(cudaDeviceSynchronize());
   int64_t sum        = 0;
   int64_t sum_expect = 0;
@@ -81,5 +83,6 @@ TEST(cuda, raw_cuda_interop) {
   }
 
   ASSERT_EQ(sum, sum_expect);
+  CUDA_SAFE_CALL(cudaFree(p));
 }
 }  // namespace Test

--- a/core/unit_test/hip/TestHIP_InterOp_Init.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Init.cpp
@@ -45,6 +45,8 @@
 #include <Kokkos_Core.hpp>
 #include <hip/TestHIP_Category.hpp>
 
+#include <array>
+
 namespace Test {
 
 __global__ void offset(int* p) {
@@ -70,8 +72,8 @@ TEST(hip, raw_hip_interop) {
   offset<<<dim3(100), dim3(100), 0, nullptr>>>(p);
   HIP_SAFE_CALL(hipDeviceSynchronize());
 
-  int* h_p = new int[100];
-  HIP_SAFE_CALL(hipMemcpy(h_p, p, sizeof(int) * 100, hipMemcpyDefault));
+  std::array<int, 100> h_p;
+  HIP_SAFE_CALL(hipMemcpy(h_p.data(), p, sizeof(int) * 100, hipMemcpyDefault));
   HIP_SAFE_CALL(hipDeviceSynchronize());
   int64_t sum        = 0;
   int64_t sum_expect = 0;
@@ -81,5 +83,6 @@ TEST(hip, raw_hip_interop) {
   }
 
   ASSERT_EQ(sum, sum_expect);
+  HIP_SAFE_CALL(hipFree(p));
 }
 }  // namespace Test

--- a/core/unit_test/sycl/TestSYCL_Category.hpp
+++ b/core/unit_test/sycl/TestSYCL_Category.hpp
@@ -1,0 +1,54 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_TEST_SYCL_HPP
+#define KOKKOS_TEST_SYCL_HPP
+
+#include <gtest/gtest.h>
+
+#define TEST_CATEGORY sycl
+#define TEST_CATEGORY_NUMBER 7
+#define TEST_EXECSPACE Kokkos::Experimental::SYCL
+
+#endif

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
@@ -1,0 +1,88 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+#include <sycl/TestSYCL_Category.hpp>
+
+#include <array>
+
+namespace Test {
+
+// Test whether allocations survive Kokkos initialize/finalize if done via Raw
+// SYCL.
+TEST(sycl, raw_sycl_interop) {
+  cl::sycl::default_selector device_selector;
+  cl::sycl::queue queue(device_selector);
+  constexpr int n = 100;
+  int* p          = sycl::malloc_device<int>(n, queue);
+
+  Kokkos::InitArguments arguments{-1, -1, -1, false};
+  Kokkos::initialize(arguments);
+  {
+    TEST_EXECSPACE space(queue);
+    Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged>> v(p, n);
+    Kokkos::deep_copy(space, v, 5);
+  }
+  Kokkos::finalize();
+
+  queue.submit([&](cl::sycl::handler& cgh) {
+    cgh.parallel_for(sycl::range<1>(n), [=](int idx) { p[idx] += idx; });
+  });
+  queue.wait_and_throw();
+
+  std::array<int, n> h_p;
+  queue.memcpy(h_p.data(), p, sizeof(int) * n);
+  queue.wait_and_throw();
+  sycl::free(p, queue);
+
+  int64_t sum        = 0;
+  int64_t sum_expect = 0;
+  for (int i = 0; i < n; i++) {
+    sum += h_p[i];
+    sum_expect += 5 + i;
+  }
+
+  ASSERT_EQ(sum, sum_expect);
+}
+}  // namespace Test

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
@@ -1,0 +1,120 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+#include <sycl/TestSYCL_Category.hpp>
+
+#include <array>
+
+namespace Test {
+
+// Test whether external allocations can be accessed by the default queue.
+TEST(sycl, raw_sycl_interop_context_1) {
+  Kokkos::Experimental::SYCL default_space;
+  sycl::context default_context = default_space.sycl_context();
+
+  cl::sycl::default_selector device_selector;
+  cl::sycl::queue queue(default_context, device_selector);
+  constexpr int n = 100;
+  int* p          = sycl::malloc_device<int>(n, queue);
+
+  Kokkos::Experimental::SYCL space(queue);
+  Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged>> v(p, n);
+  Kokkos::deep_copy(v, 5);
+
+  queue.submit([&](cl::sycl::handler& cgh) {
+    cgh.parallel_for(sycl::range<1>(n), [=](int idx) { p[idx] += idx; });
+  });
+  queue.wait_and_throw();
+
+  std::array<int, n> h_p;
+  queue.memcpy(h_p.data(), p, sizeof(int) * n);
+  queue.wait_and_throw();
+  sycl::free(p, queue);
+
+  int64_t sum        = 0;
+  int64_t sum_expect = 0;
+  for (int i = 0; i < n; i++) {
+    sum += h_p[i];
+    sum_expect += 5 + i;
+  }
+
+  ASSERT_EQ(sum, sum_expect);
+}
+
+// Test whether regular View allocations can be accessed by non-default queues.
+TEST(sycl, raw_sycl_interop_context_2) {
+  Kokkos::Experimental::SYCL default_space;
+  sycl::context default_context = default_space.sycl_context();
+
+  cl::sycl::default_selector device_selector;
+  cl::sycl::queue queue(default_context, device_selector);
+  constexpr int n = 100;
+
+  Kokkos::Experimental::SYCL space(queue);
+  Kokkos::View<int*, Kokkos::Experimental::SYCLDeviceUSMSpace> v("default_view",
+                                                                 n);
+  Kokkos::deep_copy(space, v, 5);
+
+  auto* v_ptr = v.data();
+  queue.submit([&](cl::sycl::handler& cgh) {
+    cgh.parallel_for(sycl::range<1>(n), [=](int idx) { v_ptr[idx] += idx; });
+  });
+  queue.wait_and_throw();
+
+  std::array<int, n> h_p;
+  queue.memcpy(h_p.data(), v_ptr, sizeof(int) * n);
+  queue.wait_and_throw();
+
+  int64_t sum        = 0;
+  int64_t sum_expect = 0;
+  for (int i = 0; i < n; i++) {
+    sum += h_p[i];
+    sum_expect += 5 + i;
+  }
+
+  ASSERT_EQ(sum, sum_expect);
+}
+
+}  // namespace Test

--- a/core/unit_test/sycl/TestSYCL_InterOp_Streams.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Streams.cpp
@@ -1,0 +1,124 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <sycl/TestSYCL_Category.hpp>
+#include <Test_InterOp_Streams.hpp>
+
+namespace Test {
+// Test Interoperability with SYCL Streams
+TEST(sycl, raw_sycl_queues) {
+  cl::sycl::default_selector device_selector;
+  cl::sycl::queue queue(device_selector);
+  Kokkos::InitArguments arguments{-1, -1, -1, false};
+  Kokkos::initialize(arguments);
+  int* p            = sycl::malloc_device<int>(100, queue);
+  using MemorySpace = typename TEST_EXECSPACE::memory_space;
+
+  {
+    TEST_EXECSPACE space0(queue);
+    Kokkos::View<int*, TEST_EXECSPACE> v(p, 100);
+    Kokkos::deep_copy(space0, v, 5);
+    int sum = 0;
+
+    Kokkos::parallel_for("Test::sycl::raw_sycl_queue::Range",
+                         Kokkos::RangePolicy<TEST_EXECSPACE>(space0, 0, 100),
+                         FunctorRange<MemorySpace>(v));
+    Kokkos::parallel_reduce("Test::sycl::raw_sycl_queue::RangeReduce",
+                            Kokkos::RangePolicy<TEST_EXECSPACE>(space0, 0, 100),
+                            FunctorRangeReduce<MemorySpace>(v), sum);
+    space0.fence();
+    ASSERT_EQ(6 * 100, sum);
+
+    Kokkos::parallel_for("Test::sycl::raw_sycl_queue::MDRange",
+                         Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(
+                             space0, {0, 0}, {10, 10}),
+                         FunctorMDRange<MemorySpace>(v));
+    space0.fence();
+    // FIXME_SYCL needs MDRangePolicy reduce
+#ifndef KOKKOS_ENABLE_SYCL
+    Kokkos::parallel_reduce(
+        "Test::sycl::raw_sycl_queue::MDRangeReduce",
+        Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>(space0, {0, 0},
+                                                               {10, 10}),
+        FunctorMDRangeReduce<MemorySpace>(v), sum);
+    space0.fence();
+    ASSERT_EQ(7 * 100, sum);
+#endif
+
+    Kokkos::parallel_for("Test::sycl::raw_sycl_queue::Team",
+                         Kokkos::TeamPolicy<TEST_EXECSPACE>(space0, 10, 10),
+                         FunctorTeam<MemorySpace, TEST_EXECSPACE>(v));
+    space0.fence();
+    // FIXME_SYCL needs TeamPolicy reduce
+#ifndef KOKKOS_ENABLE_SYCL
+    Kokkos::parallel_reduce("Test::sycl::raw_sycl_queue::Team",
+                            Kokkos::TeamPolicy<TEST_EXECSPACE>(space0, 10, 10),
+                            FunctorTeamReduce<MemorySpace, TEST_EXECSPACE>(v),
+                            sum);
+    space0.fence();
+    ASSERT_EQ(8 * 100, sum);
+#endif
+  }
+  Kokkos::finalize();
+
+  // Try to use the queue after Kokkos' copy got out-of-scope.
+  // This kernel corresponds to "offset_streams" in the HIP and CUDA tests.
+  queue.submit([&](cl::sycl::handler& cgh) {
+    cgh.parallel_for(sycl::range<1>(100), [=](int idx) { p[idx] += idx; });
+  });
+  queue.wait_and_throw();
+
+  int h_p[100];
+  queue.memcpy(h_p, p, sizeof(int) * 100);
+  queue.wait_and_throw();
+  int64_t sum        = 0;
+  int64_t sum_expect = 0;
+  for (int i = 0; i < 100; i++) {
+    sum += h_p[i];
+    sum_expect += 8 + i;
+  }
+
+  ASSERT_EQ(sum, sum_expect);
+}
+}  // namespace Test


### PR DESCRIPTION
Based on #3759.

This pull request allows initializing SYCL execution space from a sycl::queue corresponding to streams for CUDA and SYCL. It also provides a valid implementation for `impl_static_fence` that simply fences all queues.
I was running into some issues with the current TeamPolicy implementation but didn't bother to look too closely since the alternative implementation in #3759 doesn't show this problem and I believe that we should move forward with that one.
Also, we need to make sure that all memory we allocate using `sycl::allocate_*` references the correct `sycl::queue`. Memory access across queues doesn't work with this kind of allocation. Thirs turned out to be a problem in the `parallel_reduce` implementation.
