### PR TITLE
kokkos_launch_compiler + CUDA auto-detect arch

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -256,7 +256,6 @@ pipeline {
                                 -DKokkos_ENABLE_CUDA_LAMBDA=OFF \
                                 -DKokkos_ENABLE_CUDA_UVM=ON \
                                 -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON \
-                                -DKokkos_ARCH_VOLTA70=ON \
                                 -DCMAKE_INSTALL_PREFIX=${PWD}/install \
                                 -DBUILD_NAME=${STAGE_NAME} \
                                 -DTARGET=install \

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -486,11 +486,11 @@ IF(KOKKOS_ENABLE_CUDA AND NOT CUDA_ARCH_ALREADY_SPECIFIED)
     RUN_OUTPUT_VARIABLE _CUDA_COMPUTE_CAPABILITY)
 
   # if user is using kokkos_compiler_launcher, above will fail.
-  IF(NOT _COMPILE_RESULT OR NOT _RESULT EQUAL 0 OR FLAG_INDEX EQUAL -1)
+  IF(NOT _COMPILE_RESULT OR NOT _RESULT EQUAL 0)
     # check to see if CUDA is not already enabled (may happen when Kokkos is subproject)
-    GET_PROPERTY(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+    GET_PROPERTY(_ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
     # language has to be fully enabled, just checking for CMAKE_CUDA_COMPILER isn't enough
-    IF(NOT "CUDA" IN_LIST ENABLED_LANGUAGES)
+    IF(NOT "CUDA" IN_LIST _ENABLED_LANGUAGES)
         # make sure the user knows that we aren't using CUDA compiler for anything else
         MESSAGE(STATUS "CUDA auto-detection of architecture failed with ${CMAKE_CXX_COMPILER}. Enabling CUDA language ONLY to auto-detect architecture...")
         INCLUDE(CheckLanguage)

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -491,33 +491,33 @@ IF(KOKKOS_ENABLE_CUDA AND NOT CUDA_ARCH_ALREADY_SPECIFIED)
     GET_PROPERTY(_ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
     # language has to be fully enabled, just checking for CMAKE_CUDA_COMPILER isn't enough
     IF(NOT "CUDA" IN_LIST _ENABLED_LANGUAGES)
-        # make sure the user knows that we aren't using CUDA compiler for anything else
-        MESSAGE(STATUS "CUDA auto-detection of architecture failed with ${CMAKE_CXX_COMPILER}. Enabling CUDA language ONLY to auto-detect architecture...")
-        INCLUDE(CheckLanguage)
-        CHECK_LANGUAGE(CUDA)
-        IF(CMAKE_CUDA_COMPILER)
-            ENABLE_LANGUAGE(CUDA)
-        ELSE()
-            MESSAGE(STATUS "CUDA language could not be enabled")
-        ENDIF()
+      # make sure the user knows that we aren't using CUDA compiler for anything else
+      MESSAGE(STATUS "CUDA auto-detection of architecture failed with ${CMAKE_CXX_COMPILER}. Enabling CUDA language ONLY to auto-detect architecture...")
+      INCLUDE(CheckLanguage)
+      CHECK_LANGUAGE(CUDA)
+      IF(CMAKE_CUDA_COMPILER)
+        ENABLE_LANGUAGE(CUDA)
+      ELSE()
+        MESSAGE(STATUS "CUDA language could not be enabled")
+      ENDIF()
     ENDIF()
 
     # if CUDA was enabled, this will be defined
     IF(CMAKE_CUDA_COMPILER)
-        # copy our test to .cu so cmake compiles as CUDA
-        CONFIGURE_FILE(
-            ${PROJECT_SOURCE_DIR}/cmake/compile_tests/cuda_compute_capability.cc
-            ${PROJECT_BINARY_DIR}/compile_tests/cuda_compute_capability.cu
-            COPYONLY
-        )
-        # run test again
-        TRY_RUN(
-            _RESULT
-            _COMPILE_RESULT
-            ${_BINARY_TEST_DIR}
-            ${PROJECT_BINARY_DIR}/compile_tests/cuda_compute_capability.cu
-            COMPILE_DEFINITIONS -DSM_ONLY
-            RUN_OUTPUT_VARIABLE _CUDA_COMPUTE_CAPABILITY)
+      # copy our test to .cu so cmake compiles as CUDA
+      CONFIGURE_FILE(
+        ${PROJECT_SOURCE_DIR}/cmake/compile_tests/cuda_compute_capability.cc
+        ${PROJECT_BINARY_DIR}/compile_tests/cuda_compute_capability.cu
+        COPYONLY
+      )
+      # run test again
+      TRY_RUN(
+        _RESULT
+        _COMPILE_RESULT
+        ${_BINARY_TEST_DIR}
+        ${PROJECT_BINARY_DIR}/compile_tests/cuda_compute_capability.cu
+        COMPILE_DEFINITIONS -DSM_ONLY
+        RUN_OUTPUT_VARIABLE _CUDA_COMPUTE_CAPABILITY)
     ENDIF()
   ENDIF()
 

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -484,6 +484,43 @@ IF(KOKKOS_ENABLE_CUDA AND NOT CUDA_ARCH_ALREADY_SPECIFIED)
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compile_tests/cuda_compute_capability.cc
     COMPILE_DEFINITIONS -DSM_ONLY
     RUN_OUTPUT_VARIABLE _CUDA_COMPUTE_CAPABILITY)
+
+  # if user is using kokkos_compiler_launcher, above will fail.
+  IF(NOT _COMPILE_RESULT OR NOT _RESULT EQUAL 0 OR FLAG_INDEX EQUAL -1)
+    # check to see if CUDA is not already enabled (may happen when Kokkos is subproject)
+    GET_PROPERTY(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+    # language has to be fully enabled, just checking for CMAKE_CUDA_COMPILER isn't enough
+    IF(NOT "CUDA" IN_LIST ENABLED_LANGUAGES)
+        # make sure the user knows that we aren't using CUDA compiler for anything else
+        MESSAGE(STATUS "CUDA auto-detection of architecture failed with ${CMAKE_CXX_COMPILER}. Enabling CUDA language ONLY to auto-detect architecture...")
+        INCLUDE(CheckLanguage)
+        CHECK_LANGUAGE(CUDA)
+        IF(CMAKE_CUDA_COMPILER)
+            ENABLE_LANGUAGE(CUDA)
+        ELSE()
+            MESSAGE(STATUS "CUDA language could not be enabled")
+        ENDIF()
+    ENDIF()
+
+    # if CUDA was enabled, this will be defined
+    IF(CMAKE_CUDA_COMPILER)
+        # copy our test to .cu so cmake compiles as CUDA
+        CONFIGURE_FILE(
+            ${PROJECT_SOURCE_DIR}/cmake/compile_tests/cuda_compute_capability.cc
+            ${PROJECT_BINARY_DIR}/compile_tests/cuda_compute_capability.cu
+            COPYONLY
+        )
+        # run test again
+        TRY_RUN(
+            _RESULT
+            _COMPILE_RESULT
+            ${_BINARY_TEST_DIR}
+            ${PROJECT_BINARY_DIR}/compile_tests/cuda_compute_capability.cu
+            COMPILE_DEFINITIONS -DSM_ONLY
+            RUN_OUTPUT_VARIABLE _CUDA_COMPUTE_CAPABILITY)
+    ENDIF()
+  ENDIF()
+
   LIST(FIND KOKKOS_CUDA_ARCH_FLAGS sm_${_CUDA_COMPUTE_CAPABILITY} FLAG_INDEX)
   IF(_COMPILE_RESULT AND _RESULT EQUAL 0 AND NOT FLAG_INDEX EQUAL -1)
     MESSAGE(STATUS "Detected CUDA Compute Capability ${_CUDA_COMPUTE_CAPABILITY}")


### PR DESCRIPTION
- enables CUDA as a language to auto-detect architecture when `kokkos_launch_compiler` is being used
- removes `-DKokkos_ARCH_VOLTA70=ON` from Jenkins test which tests the compiler-launcher
- Closes #3758 