### PR TITLE
Update .gitignore for common IDE files/folders and build folders in root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,12 @@ testing/
 /out/build
 /CMakeSettings.json
 /out/mytest
+
+# build directories in source tree
+/build*
+
+# IDE-specific files/folders
+## VSCode
+/.vscode
+## QtCreator
+/CMakeLists.txt.user*


### PR DESCRIPTION
- Ignore folders in root dir starting with "build", e.g. `/build`, `/build-ignore-common-ide-files-folders`
- Ignore common IDE generated files/folders
  - QtCreator generates a `CMakeLists.txt.user` in the source directory and upgrades to QtCreator generate a `CMakeLists.txt.user.pre-vXYZ`
  - Visual Studio Code generates a `.vscode` folder

Any others?
