### PR TITLE
Updated comments and enabled no-op for kokkos_launch_compiler

### DIFF
--- a/cmake/KokkosConfig.cmake.in
+++ b/cmake/KokkosConfig.cmake.in
@@ -21,7 +21,13 @@ UNSET(Kokkos_CMAKE_DIR)
 
 # if CUDA was enabled and separable compilation was specified, e.g.
 #   find_package(Kokkos COMPONENTS separable_compilation)
-# then we set the RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK
+# then we expect the user to call kokkos_compilation(PROJECT|DIRECTORY|TARGET|SOURCE ...)
+# for the scope they want the RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK to be applied.
+# If CUDA was enabled, a standard find_package was used, and the CMAKE_CXX_COMPILER cannot
+# compile CUDA, then set the RULE_LAUNCH_COMPILE and RULE_LAUNCH_LINK globally and
+# kokkos_launch_compiler will re-direct to nvcc_wrapper when the compiler command
+# matches ${CMAKE_CXX_COMPILER} and -DKOKKOS_DEPENDENCE is present, otherwise,
+# kokkos_launch_compiler will execute the original command
 IF(@Kokkos_ENABLE_CUDA@ AND NOT "separable_compilation" IN_LIST Kokkos_FIND_COMPONENTS)
     # run test to see if CMAKE_CXX_COMPILER=nvcc_wrapper
     kokkos_compiler_is_nvcc(IS_NVCC ${CMAKE_CXX_COMPILER})

--- a/cmake/KokkosConfigCommon.cmake.in
+++ b/cmake/KokkosConfigCommon.cmake.in
@@ -101,6 +101,13 @@ endfunction()
 FUNCTION(kokkos_compilation)
     CMAKE_PARSE_ARGUMENTS(COMP "GLOBAL;PROJECT" "" "DIRECTORY;TARGET;SOURCE" ${ARGN})
 
+    # if built w/o CUDA support, we want to basically make this a no-op
+    SET(_Kokkos_ENABLE_CUDA @Kokkos_ENABLE_CUDA@)
+
+    IF(NOT _Kokkos_ENABLE_CUDA)
+        RETURN()
+    ENDIF()
+
     # search relative first and then absolute
     SET(_HINTS "${CMAKE_CURRENT_LIST_DIR}/../.." "@CMAKE_INSTALL_PREFIX@")
 
@@ -158,4 +165,3 @@ FUNCTION(kokkos_compiler_is_nvcc VAR COMPILER)
         ENDIF()
     ENDIF()
 ENDFUNCTION()
-


### PR DESCRIPTION
- Fixes comments in `KokkosConfig.cmake.in` w.r.t. the behavior of kokkos_launch_compiler
- Updated `KokkosConfigCommon.cmake.in` to encode `@Kokkos_ENABLE_CUDA@` so that if called when Kokkos was not built with CUDA support, the command is ignored (since it would be an error)