### PR TITLE
Prefer -std=* over --std=*

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -287,11 +287,11 @@ else
       #KOKKOS_INTERNAL_CXX1Z_FLAG := -hstd=c++1z
       #KOKKOS_INTERNAL_CXX2A_FLAG := -hstd=c++2a
     else
-      KOKKOS_INTERNAL_CXX14_FLAG := --std=c++14
-      KOKKOS_INTERNAL_CXX1Y_FLAG := --std=c++1y
-      KOKKOS_INTERNAL_CXX17_FLAG := --std=c++17
-      KOKKOS_INTERNAL_CXX1Z_FLAG := --std=c++1z
-      KOKKOS_INTERNAL_CXX2A_FLAG := --std=c++2a
+      KOKKOS_INTERNAL_CXX14_FLAG := -std=c++14
+      KOKKOS_INTERNAL_CXX1Y_FLAG := -std=c++1y
+      KOKKOS_INTERNAL_CXX17_FLAG := -std=c++17
+      KOKKOS_INTERNAL_CXX1Z_FLAG := -std=c++1z
+      KOKKOS_INTERNAL_CXX2A_FLAG := -std=c++2a
     endif
   endif
 endif
@@ -1331,7 +1331,7 @@ ifneq ($(KOKKOS_INTERNAL_USE_SERIAL), 1)
 endif
 
 # With Cygwin functions such as fdopen and fileno are not defined
-# when strict ansi is enabled. strict ansi gets enabled with --std=c++14
+# when strict ansi is enabled. strict ansi gets enabled with -std=c++14
 # though. So we hard undefine it here. Not sure if that has any bad side effects
 # This is needed for gtest actually, not for Kokkos itself!
 ifeq ($(KOKKOS_INTERNAL_OS_CYGWIN), 1)

--- a/generate_makefile.bash
+++ b/generate_makefile.bash
@@ -199,7 +199,7 @@ display_help_text() {
       echo "--cxxflags=[FLAGS]            Overwrite CXXFLAGS for library build and test"
       echo "                                build.  This will still set certain required"
       echo "                                flags via KOKKOS_CXXFLAGS (such as -fopenmp,"
-      echo "                                --std=c++14, etc.)."
+      echo "                                -std=c++14, etc.)."
       echo "--cxxstandard=[FLAGS]         Set CMAKE_CXX_STANDARD for library build and test"
       echo "                                c++14 (default), c++17, c++1y, c++1z, c++2a"
       echo "--ldflags=[FLAGS]             Overwrite LDFLAGS for library build and test"

--- a/gnu_generate_makefile.bash
+++ b/gnu_generate_makefile.bash
@@ -174,7 +174,7 @@ do
       echo "--cxxflags=[FLAGS]            Overwrite CXXFLAGS for library build and test"
       echo "                                build.  This will still set certain required"
       echo "                                flags via KOKKOS_CXXFLAGS (such as -fopenmp,"
-      echo "                                --std=c++14, etc.)."
+      echo "                                -std=c++14, etc.)."
       echo "--cxxstandard=[FLAGS]         Overwrite KOKKOS_CXX_STANDARD for library build and test"
       echo "                                c++14 (default), c++17, c++1y, c++1z, c++2a"
       echo "--ldflags=[FLAGS]             Overwrite LDFLAGS for library build and test"

--- a/scripts/testing_scripts/generate_makefile.bash
+++ b/scripts/testing_scripts/generate_makefile.bash
@@ -166,7 +166,7 @@ do
       echo "--cxxflags=[FLAGS]            Overwrite CXXFLAGS for library build and test"
       echo "                                build.  This will still set certain required"
       echo "                                flags via KOKKOS_CXXFLAGS (such as -fopenmp,"
-      echo "                                --std=c++14, etc.)."
+      echo "                                -std=c++14, etc.)."
       echo "--cxxstandard=[FLAGS]         Overwrite KOKKOS_CXX_STANDARD for library build and test"
       echo "                                c++14 (default), c++17, c++1y, c++1z, c++2a"
       echo "--ldflags=[FLAGS]             Overwrite LDFLAGS for library build and test"


### PR DESCRIPTION
AFAICT `-std=*` is more standard then `--std=*` and ICC doesn't seem to like the latter, see https://godbolt.org/z/e6Wshq. In particular, @stanmoore1 was running into an issue as reported in slack.