### PR TITLE
Enable use of execution space instances in ScatterView

### DIFF
--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -778,6 +778,9 @@ class ScatterView<DataType, Layout, DeviceType, Op, ScatterNonDuplicated,
   ScatterView(std::string const& name, Dims... dims)
       : internal_view(name, dims...) {}
 
+  // This overload allows specifying an execution space instance to be
+  // used by passing, e.g., Kokkos::view_alloc(exec_space, "label") as
+  // first argument.
   template <typename... P, typename... Dims>
   ScatterView(::Kokkos::Impl::ViewCtorProp<P...> const& arg_prop, Dims... dims)
       : internal_view(arg_prop, dims...) {
@@ -990,6 +993,9 @@ class ScatterView<DataType, Kokkos::LayoutRight, DeviceType, Op,
   ScatterView(std::string const& name, Dims... dims)
       : ScatterView(view_alloc(execution_space(), name), dims...) {}
 
+  // This overload allows specifying an execution space instance to be
+  // used by passing, e.g., Kokkos::view_alloc(exec_space, "label") as
+  // first argument.
   template <typename... P, typename... Dims>
   ScatterView(::Kokkos::Impl::ViewCtorProp<P...> const& arg_prop, Dims... dims)
       : internal_view(view_alloc(WithoutInitializing,
@@ -1167,6 +1173,9 @@ class ScatterView<DataType, Kokkos::LayoutLeft, DeviceType, Op,
   ScatterView(std::string const& name, Dims... dims)
       : ScatterView(view_alloc(execution_space(), name), dims...) {}
 
+  // This overload allows specifying an execution space instance to be
+  // used by passing, e.g., Kokkos::view_alloc(exec_space, "label") as
+  // first argument.
   template <typename... P, typename... Dims>
   ScatterView(::Kokkos::Impl::ViewCtorProp<P...> const& arg_prop,
               Dims... dims) {

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -797,6 +797,11 @@ class ScatterView<DataType, Layout, DeviceType, Op, ScatterNonDuplicated,
   }
 
   template <typename DT, typename... RP>
+  void contribute_into(View<DT, RP...> const& dest) const {
+    contribute_into(execution_space(), dest);
+  }
+
+  template <typename DT, typename... RP>
   void contribute_into(execution_space const& exec_space,
                        View<DT, RP...> const& dest) const {
     using dest_type = View<DT, RP...>;
@@ -995,6 +1000,11 @@ class ScatterView<DataType, Kokkos::LayoutRight, DeviceType, Op,
   }
 
   template <typename DT, typename... RP>
+  void contribute_into(View<DT, RP...> const& dest) const {
+    contribute_into(execution_space(), dest);
+  }
+
+  template <typename DT, typename... RP>
   void contribute_into(execution_space const& exec_space,
                        View<DT, RP...> const& dest) const {
     using dest_type = View<DT, RP...>;
@@ -1183,6 +1193,11 @@ class ScatterView<DataType, Kokkos::LayoutLeft, DeviceType, Op,
 
   KOKKOS_INLINE_FUNCTION constexpr bool is_allocated() const {
     return internal_view.is_allocated();
+  }
+
+  template <typename... RP>
+  void contribute_into(View<RP...> const& dest) const {
+    contribute_into(execution_space(), dest);
   }
 
   template <typename... RP>

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -797,7 +797,8 @@ class ScatterView<DataType, Layout, DeviceType, Op, ScatterNonDuplicated,
   }
 
   template <typename DT, typename... RP>
-  void contribute_into(const execution_space & exec_space, View<DT, RP...> const& dest) const {
+  void contribute_into(execution_space const& exec_space,
+                       View<DT, RP...> const& dest) const {
     using dest_type = View<DT, RP...>;
     static_assert(std::is_same<typename dest_type::array_layout, Layout>::value,
                   "ScatterView contribute destination has different layout");
@@ -808,23 +809,26 @@ class ScatterView<DataType, Layout, DeviceType, Op, ScatterNonDuplicated,
     if (dest.data() == internal_view.data()) return;
     Kokkos::Impl::Experimental::ReduceDuplicates<execution_space,
                                                  original_value_type, Op>(
-        exec_space, internal_view.data(), dest.data(), 0, 0, 1, internal_view.label());
+        exec_space, internal_view.data(), dest.data(), 0, 0, 1,
+        internal_view.label());
   }
 
-  void reset() {
-    reset(execution_space{});
-  }
-  void reset(const execution_space & exec_space) {
+  void reset() { reset(execution_space()); }
+
+  void reset(execution_space const& exec_space) {
     Kokkos::Impl::Experimental::ResetDuplicates<execution_space,
                                                 original_value_type, Op>(
-        exec_space, internal_view.data(), internal_view.size(), internal_view.label());
+        exec_space, internal_view.data(), internal_view.size(),
+        internal_view.label());
   }
   template <typename DT, typename... RP>
   void reset_except(View<DT, RP...> const& view) {
-    reset_except(execution_space{}, view);
+    reset_except(execution_space(), view);
   }
+
   template <typename DT, typename... RP>
-  void reset_except(const execution_space & exec_space, View<DT, RP...> const& view) {
+  void reset_except(const execution_space& exec_space,
+                    View<DT, RP...> const& view) {
     if (view.data() != internal_view.data()) reset(exec_space);
   }
 
@@ -993,7 +997,8 @@ class ScatterView<DataType, Kokkos::LayoutRight, DeviceType, Op,
   }
 
   template <typename DT, typename... RP>
-  void contribute_into(const execution_space & exec_space, View<DT, RP...> const& dest) const {
+  void contribute_into(execution_space const& exec_space,
+                       View<DT, RP...> const& dest) const {
     using dest_type = View<DT, RP...>;
     static_assert(std::is_same<typename dest_type::array_layout,
                                Kokkos::LayoutRight>::value,
@@ -1006,35 +1011,35 @@ class ScatterView<DataType, Kokkos::LayoutRight, DeviceType, Op,
     size_t start  = is_equal ? 1 : 0;
     Kokkos::Impl::Experimental::ReduceDuplicates<execution_space,
                                                  original_value_type, Op>(
-        exec_space,
-        internal_view.data(), dest.data(), internal_view.stride(0), start,
-        internal_view.extent(0), internal_view.label());
+        exec_space, internal_view.data(), dest.data(), internal_view.stride(0),
+        start, internal_view.extent(0), internal_view.label());
   }
 
-  void reset() {
-    reset(execution_space{});
-  }
-  void reset(const execution_space & exec_space) {
+  void reset() { reset(execution_space()); }
+
+  void reset(execution_space const& exec_space) {
     Kokkos::Impl::Experimental::ResetDuplicates<execution_space,
                                                 original_value_type, Op>(
-        exec_space, internal_view.data(), internal_view.size(), internal_view.label());
+        exec_space, internal_view.data(), internal_view.size(),
+        internal_view.label());
   }
 
   template <typename DT, typename... RP>
   void reset_except(View<DT, RP...> const& view) {
-    reset_except(execution_space{}, view);
+    reset_except(execution_space(), view);
   }
+
   template <typename DT, typename... RP>
-  void reset_except(const execution_space & exec_space, View<DT, RP...> const& view) {
+  void reset_except(execution_space const& exec_space,
+                    View<DT, RP...> const& view) {
     if (view.data() != internal_view.data()) {
       reset(exec_space);
       return;
     }
     Kokkos::Impl::Experimental::ResetDuplicates<execution_space,
                                                 original_value_type, Op>(
-        exec_space,
-        internal_view.data() + view.size(), internal_view.size() - view.size(),
-        internal_view.label());
+        exec_space, internal_view.data() + view.size(),
+        internal_view.size() - view.size(), internal_view.label());
   }
 
   void resize(const size_t n0 = 0, const size_t n1 = 0, const size_t n2 = 0,
@@ -1185,7 +1190,8 @@ class ScatterView<DataType, Kokkos::LayoutLeft, DeviceType, Op,
   }
 
   template <typename... RP>
-  void contribute_into(const execution_space & exec_space, View<RP...> const& dest) const {
+  void contribute_into(execution_space const& exec_space,
+                       View<RP...> const& dest) const {
     using dest_type = View<RP...>;
     static_assert(
         std::is_same<typename dest_type::value_type,
@@ -1203,37 +1209,36 @@ class ScatterView<DataType, Kokkos::LayoutLeft, DeviceType, Op,
     size_t start  = is_equal ? 1 : 0;
     Kokkos::Impl::Experimental::ReduceDuplicates<execution_space,
                                                  original_value_type, Op>(
-        exec_space,
-        internal_view.data(), dest.data(),
+        exec_space, internal_view.data(), dest.data(),
         internal_view.stride(internal_view_type::rank - 1), start, extent,
         internal_view.label());
   }
 
-  void reset() {
-    reset(execution_space{});
-  }
-  void reset(const execution_space & exec_space) {
+  void reset() { reset(execution_space()); }
+
+  void reset(execution_space const& exec_space) {
     Kokkos::Impl::Experimental::ResetDuplicates<execution_space,
                                                 original_value_type, Op>(
-        exec_space,
-        internal_view.data(), internal_view.size(), internal_view.label());
+        exec_space, internal_view.data(), internal_view.size(),
+        internal_view.label());
   }
 
   template <typename DT, typename... RP>
   void reset_except(View<DT, RP...> const& view) {
-    reset_except(execution_space{}, view);
+    reset_except(execution_space(), view);
   }
+
   template <typename DT, typename... RP>
-  void reset_except(const execution_space & exec_space, View<DT, RP...> const& view) {
+  void reset_except(execution_space const& exec_space,
+                    View<DT, RP...> const& view) {
     if (view.data() != internal_view.data()) {
       reset(exec_space);
       return;
     }
     Kokkos::Impl::Experimental::ResetDuplicates<execution_space,
                                                 original_value_type, Op>(
-        exec_space,
-        internal_view.data() + view.size(), internal_view.size() - view.size(),
-        internal_view.label());
+        exec_space, internal_view.data() + view.size(),
+        internal_view.size() - view.size(), internal_view.label());
   }
 
   void resize(const size_t n0 = 0, const size_t n1 = 0, const size_t n2 = 0,
@@ -1396,10 +1401,10 @@ create_scatter_view(Op, Duplication, Contribution,
 namespace Kokkos {
 namespace Experimental {
 
-  template <typename DT1, typename DT2, typename LY, typename ES,
-          typename OP, typename CT, typename DP, typename... VP>
-  void contribute(typename ES::execution_space const& exec_space,
-    View<DT1, VP...>& dest,
+template <typename DT1, typename DT2, typename LY, typename ES, typename OP,
+          typename CT, typename DP, typename... VP>
+void contribute(
+    typename ES::execution_space const& exec_space, View<DT1, VP...>& dest,
     Kokkos::Experimental::ScatterView<DT2, LY, ES, OP, CT, DP> const& src) {
   src.contribute_into(exec_space, dest);
 }

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -813,9 +813,7 @@ class ScatterView<DataType, Layout, DeviceType, Op, ScatterNonDuplicated,
         internal_view.label());
   }
 
-  void reset() { reset(execution_space()); }
-
-  void reset(execution_space const& exec_space) {
+  void reset(execution_space const& exec_space = execution_space()) {
     Kokkos::Impl::Experimental::ResetDuplicates<execution_space,
                                                 original_value_type, Op>(
         exec_space, internal_view.data(), internal_view.size(),
@@ -1015,9 +1013,7 @@ class ScatterView<DataType, Kokkos::LayoutRight, DeviceType, Op,
         start, internal_view.extent(0), internal_view.label());
   }
 
-  void reset() { reset(execution_space()); }
-
-  void reset(execution_space const& exec_space) {
+  void reset(execution_space const& exec_space = execution_space()) {
     Kokkos::Impl::Experimental::ResetDuplicates<execution_space,
                                                 original_value_type, Op>(
         exec_space, internal_view.data(), internal_view.size(),
@@ -1214,9 +1210,7 @@ class ScatterView<DataType, Kokkos::LayoutLeft, DeviceType, Op,
         internal_view.label());
   }
 
-  void reset() { reset(execution_space()); }
-
-  void reset(execution_space const& exec_space) {
+  void reset(execution_space const& exec_space = execution_space()) {
     Kokkos::Impl::Experimental::ResetDuplicates<execution_space,
                                                 original_value_type, Op>(
         exec_space, internal_view.data(), internal_view.size(),

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -649,10 +649,9 @@ struct ReduceDuplicatesBase {
   size_t stride;
   size_t start;
   size_t n;
-  ReduceDuplicatesBase(ExecSpace exec_space,
-                       ValueType const* src_in, ValueType* dest_in,
-                       size_t stride_in, size_t start_in, size_t n_in,
-                       std::string const& name)
+  ReduceDuplicatesBase(ExecSpace const& exec_space, ValueType const* src_in,
+                       ValueType* dest_in, size_t stride_in, size_t start_in,
+                       size_t n_in, std::string const& name)
       : src(src_in), dst(dest_in), stride(stride_in), start(start_in), n(n_in) {
     parallel_for(
         std::string("Kokkos::ScatterView::ReduceDuplicates [") + name + "]",
@@ -668,10 +667,10 @@ template <typename ExecSpace, typename ValueType, typename Op>
 struct ReduceDuplicates
     : public ReduceDuplicatesBase<ExecSpace, ValueType, Op> {
   using Base = ReduceDuplicatesBase<ExecSpace, ValueType, Op>;
-  ReduceDuplicates(ExecSpace exec_space,
-                   ValueType const* src_in, ValueType* dst_in, size_t stride_in,
-                   size_t start_in, size_t n_in, std::string const& name)
-    : Base(exec_space, src_in, dst_in, stride_in, start_in, n_in, name) {}
+  ReduceDuplicates(ExecSpace const& exec_space, ValueType const* src_in,
+                   ValueType* dst_in, size_t stride_in, size_t start_in,
+                   size_t n_in, std::string const& name)
+      : Base(exec_space, src_in, dst_in, stride_in, start_in, n_in, name) {}
   KOKKOS_FORCEINLINE_FUNCTION void operator()(size_t i) const {
     for (size_t j = Base::start; j < Base::n; ++j) {
       ScatterValue<ValueType, Op, ExecSpace,
@@ -689,8 +688,8 @@ template <typename ExecSpace, typename ValueType, typename Op>
 struct ResetDuplicatesBase {
   using Derived = ResetDuplicates<ExecSpace, ValueType, Op>;
   ValueType* data;
-  ResetDuplicatesBase(ExecSpace exec_space, ValueType* data_in, size_t size_in,
-                      std::string const& name)
+  ResetDuplicatesBase(ExecSpace const& exec_space, ValueType* data_in,
+                      size_t size_in, std::string const& name)
       : data(data_in) {
     parallel_for(
         std::string("Kokkos::ScatterView::ResetDuplicates [") + name + "]",
@@ -705,9 +704,9 @@ struct ResetDuplicatesBase {
 template <typename ExecSpace, typename ValueType, typename Op>
 struct ResetDuplicates : public ResetDuplicatesBase<ExecSpace, ValueType, Op> {
   using Base = ResetDuplicatesBase<ExecSpace, ValueType, Op>;
-  ResetDuplicates(ExecSpace exec_space,
-                  ValueType* data_in, size_t size_in, std::string const& name)
-    : Base(exec_space, data_in, size_in, name) {}
+  ResetDuplicates(ExecSpace const& exec_space, ValueType* data_in,
+                  size_t size_in, std::string const& name)
+      : Base(exec_space, data_in, size_in, name) {}
   KOKKOS_FORCEINLINE_FUNCTION void operator()(size_t i) const {
     ScatterValue<ValueType, Op, ExecSpace,
                  Kokkos::Experimental::ScatterNonAtomic>

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -437,6 +437,10 @@ struct test_scatter_view_config {
                                           Contribution, Op,
                                           NumberType>::orig_view_type;
 
+  void compile_constructor() {
+    auto sv = scatter_view_def(Kokkos::view_alloc(DeviceType{}, "label"), 10);
+  }
+
   void run_test(int n) {
     // test allocation
     {


### PR DESCRIPTION
Fixes #3785