### PR TITLE
Remove superfluous FunctorFinal specialization

### DIFF
--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -2108,7 +2108,7 @@ struct FunctorFinal<
     typename std::enable_if<
         std::is_same<ArgTag, void>::value,
         decltype(FunctorFinalFunction<FunctorType, ArgTag>::enable_if(
-            &FunctorType::final))>::typei> {
+            &FunctorType::final))>::type> {
   KOKKOS_FORCEINLINE_FUNCTION static void final(const FunctorType& f, void* p) {
     f.final((T*)p);
   }
@@ -2137,7 +2137,7 @@ struct FunctorFinal<
     FunctorType, ArgTag,
     T*
     // First  substitution failure when FunctorType::final does not exist.
-    // Second substitution failure when FunctorType::final is not compatible
+    // Second substitution failure when FunctorType::final is not compatible.
     ,
     typename std::enable_if<
         !std::is_same<ArgTag, void>::value,

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -2148,46 +2148,6 @@ struct FunctorFinal<
   }
 };
 
-/* 'final' function provided for array value */
-template <class FunctorType, class ArgTag, class T>
-struct FunctorFinal<FunctorType, ArgTag,
-                    T*
-                    // First  substitution failure when FunctorType::final does
-                    // not exist. Second substitution failure when enable_if( &
-                    // Functor::final ) does not exist
-                    ,
-                    decltype(
-                        FunctorFinalFunction<FunctorType, ArgTag>::enable_if(
-                            &FunctorType::final))> {
-  template <typename Dummy = ArgTag>
-  KOKKOS_FORCEINLINE_FUNCTION static std::enable_if_t<
-      std::is_same<Dummy, void>::value>
-  final(const FunctorType& f, void* p) {
-    f.final((T*)p);
-  }
-
-  template <typename Dummy = ArgTag>
-  KOKKOS_FORCEINLINE_FUNCTION static std::enable_if_t<
-      !std::is_same<Dummy, void>::value>
-  final(const FunctorType& f, void* p) {
-    f.final(ArgTag(), (T*)p);
-  }
-
-  template <typename Dummy = ArgTag>
-  KOKKOS_FORCEINLINE_FUNCTION static std::enable_if_t<
-      std::is_same<Dummy, void>::value>
-  final(FunctorType& f, void* p) {
-    f.final((T*)p);
-  }
-
-  template <typename Dummy = ArgTag>
-  KOKKOS_FORCEINLINE_FUNCTION static std::enable_if_t<
-      !std::is_same<Dummy, void>::value>
-  final(FunctorType& f, void* p) {
-    f.final(ArgTag(), (T*)p);
-  }
-};
-
 }  // namespace Impl
 }  // namespace Kokkos
 


### PR DESCRIPTION
Fixes #3651. We already handle all cases (scalar/array, Tag/void) above.