### PR TITLE
Avoid duplicated code in ScratchMemorySpace

### DIFF
--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -108,6 +108,7 @@ class ScratchMemorySpace {
     return get_shmem_common</*aligned*/ true>(size, alignment, level);
   }
 
+ private:
   template <bool aligned, typename IntType>
   KOKKOS_INLINE_FUNCTION void* get_shmem_common(const IntType& size,
                                                 const ptrdiff_t alignment,
@@ -135,6 +136,7 @@ class ScratchMemorySpace {
     return tmp;
   }
 
+ public:
   KOKKOS_DEFAULTED_FUNCTION
   ScratchMemorySpace() = default;
 


### PR DESCRIPTION
It turns out that the code for `get_shmem` and `get_shmem_aligned` can be combined relatively easy avoiding code duplication also for level0/level1.