### PR TITLE
Introduce HostSharedPtr to manage m_space_instance for Cuda/HIP/SYCL

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -823,7 +823,7 @@ void Cuda::impl_finalize() { Impl::CudaInternal::singleton().finalize(); }
 
 Cuda::Cuda()
     : m_space_instance(&Impl::CudaInternal::singleton(),
-                       [](Impl::CudaInternal *ptr) {}) {
+                       [](Impl::CudaInternal *) {}) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
 }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -822,14 +822,14 @@ Cuda::size_type Cuda::device_arch() {
 void Cuda::impl_finalize() { Impl::CudaInternal::singleton().finalize(); }
 
 Cuda::Cuda()
-    : m_space_instance(Kokkos::Impl::UnmanagedPtr<Impl::CudaInternal>(
+    : m_space_instance(Kokkos::Experimental::UnmanagedPtr<Impl::CudaInternal>(
           &Impl::CudaInternal::singleton())) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
 }
 
 Cuda::Cuda(cudaStream_t stream)
-    : m_space_instance(Kokkos::Impl::HostSharedPtr<Impl::CudaInternal>(
+    : m_space_instance(Kokkos::Experimental::HostSharedPtr<Impl::CudaInternal>(
           new Impl::CudaInternal, [](Impl::CudaInternal *ptr) {
             ptr->finalize();
             delete ptr;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -821,19 +821,16 @@ Cuda::size_type Cuda::device_arch() {
 
 void Cuda::impl_finalize() { Impl::CudaInternal::singleton().finalize(); }
 
-Cuda::Cuda()
-    : m_space_instance(&Impl::CudaInternal::singleton(), /*owning*/ false,
-                       [](Impl::CudaInternal *) {}) {
+Cuda::Cuda() : m_space_instance(&Impl::CudaInternal::singleton()) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
 }
 
 Cuda::Cuda(cudaStream_t stream)
-    : m_space_instance(new Impl::CudaInternal, /*owning*/ true,
-                       [](Impl::CudaInternal *ptr) {
-                         ptr->finalize();
-                         delete ptr;
-                       }) {
+    : m_space_instance(new Impl::CudaInternal, [](Impl::CudaInternal *ptr) {
+        ptr->finalize();
+        delete ptr;
+      }) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
   m_space_instance->initialize(Impl::CudaInternal::singleton().m_cudaDev,

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -822,18 +822,18 @@ Cuda::size_type Cuda::device_arch() {
 void Cuda::impl_finalize() { Impl::CudaInternal::singleton().finalize(); }
 
 Cuda::Cuda()
-    : m_space_instance(
-          Kokkos::Impl::UnmanagedPtr(&Impl::CudaInternal::singleton())) {
+    : m_space_instance(Kokkos::Impl::UnmanagedPtr<Impl::CudaInternal>(
+          &Impl::CudaInternal::singleton())) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
 }
 
 Cuda::Cuda(cudaStream_t stream)
-    : m_space_instance(Kokkos::Impl::HostSharedPtr(new Impl::CudaInternal,
-                                                   [](Impl::CudaInternal *ptr) {
-                                                     ptr->finalize();
-                                                     delete ptr;
-                                                   })) {
+    : m_space_instance(Kokkos::Impl::HostSharedPtr<Impl::CudaInternal>(
+          new Impl::CudaInternal, [](Impl::CudaInternal *ptr) {
+            ptr->finalize();
+            delete ptr;
+          })) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
   m_space_instance->initialize(Impl::CudaInternal::singleton().m_cudaDev,

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -822,60 +822,17 @@ Cuda::size_type Cuda::device_arch() {
 void Cuda::impl_finalize() { Impl::CudaInternal::singleton().finalize(); }
 
 Cuda::Cuda()
-    : m_space_instance(&Impl::CudaInternal::singleton()), m_counter(nullptr) {
+    : m_space_instance(&Impl::CudaInternal::singleton(), /*owning*/ false) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
 }
 
 Cuda::Cuda(cudaStream_t stream)
-    : m_space_instance(new Impl::CudaInternal), m_counter(new int(1)) {
+    : m_space_instance(new Impl::CudaInternal, /*owning*/ true) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
   m_space_instance->initialize(Impl::CudaInternal::singleton().m_cudaDev,
                                stream);
-}
-
-KOKKOS_FUNCTION Cuda::Cuda(Cuda &&other) noexcept {
-  m_space_instance       = other.m_space_instance;
-  other.m_space_instance = nullptr;
-  m_counter              = other.m_counter;
-  other.m_counter        = nullptr;
-}
-
-KOKKOS_FUNCTION Cuda::Cuda(const Cuda &other)
-    : m_space_instance(other.m_space_instance), m_counter(other.m_counter) {
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA
-  if (m_counter) Kokkos::atomic_add(m_counter, 1);
-#endif
-}
-
-KOKKOS_FUNCTION Cuda &Cuda::operator=(Cuda &&other) noexcept {
-  m_space_instance       = other.m_space_instance;
-  other.m_space_instance = nullptr;
-  m_counter              = other.m_counter;
-  other.m_counter        = nullptr;
-  return *this;
-}
-
-KOKKOS_FUNCTION Cuda &Cuda::operator=(const Cuda &other) {
-  m_space_instance = other.m_space_instance;
-  m_counter        = other.m_counter;
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA
-  if (m_counter) Kokkos::atomic_add(m_counter, 1);
-#endif
-  return *this;
-}
-
-KOKKOS_FUNCTION Cuda::~Cuda() noexcept {
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA
-  if (m_counter == nullptr) return;
-  int const count = Kokkos::atomic_fetch_sub(m_counter, 1);
-  if (count == 1) {
-    delete m_counter;
-    m_space_instance->finalize();
-    delete m_space_instance;
-  }
-#endif
 }
 
 void Cuda::print_configuration(std::ostream &s, const bool) {

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -821,16 +821,19 @@ Cuda::size_type Cuda::device_arch() {
 
 void Cuda::impl_finalize() { Impl::CudaInternal::singleton().finalize(); }
 
-Cuda::Cuda() : m_space_instance(&Impl::CudaInternal::singleton()) {
+Cuda::Cuda()
+    : m_space_instance(
+          Kokkos::Impl::UnmanagedPtr(&Impl::CudaInternal::singleton())) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
 }
 
 Cuda::Cuda(cudaStream_t stream)
-    : m_space_instance(new Impl::CudaInternal, [](Impl::CudaInternal *ptr) {
-        ptr->finalize();
-        delete ptr;
-      }) {
+    : m_space_instance(Kokkos::Impl::HostSharedPtr(new Impl::CudaInternal,
+                                                   [](Impl::CudaInternal *ptr) {
+                                                     ptr->finalize();
+                                                     delete ptr;
+                                                   })) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
   m_space_instance->initialize(Impl::CudaInternal::singleton().m_cudaDev,

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -822,13 +822,18 @@ Cuda::size_type Cuda::device_arch() {
 void Cuda::impl_finalize() { Impl::CudaInternal::singleton().finalize(); }
 
 Cuda::Cuda()
-    : m_space_instance(&Impl::CudaInternal::singleton(), /*owning*/ false) {
+    : m_space_instance(&Impl::CudaInternal::singleton(), /*owning*/ false,
+                       [](Impl::CudaInternal *) {}) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
 }
 
 Cuda::Cuda(cudaStream_t stream)
-    : m_space_instance(new Impl::CudaInternal, /*owning*/ true) {
+    : m_space_instance(new Impl::CudaInternal, /*owning*/ true,
+                       [](Impl::CudaInternal *ptr) {
+                         ptr->finalize();
+                         delete ptr;
+                       }) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
   m_space_instance->initialize(Impl::CudaInternal::singleton().m_cudaDev,

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -822,18 +822,17 @@ Cuda::size_type Cuda::device_arch() {
 void Cuda::impl_finalize() { Impl::CudaInternal::singleton().finalize(); }
 
 Cuda::Cuda()
-    : m_space_instance(Kokkos::Experimental::UnmanagedPtr<Impl::CudaInternal>(
-          &Impl::CudaInternal::singleton())) {
+    : m_space_instance(&Impl::CudaInternal::singleton(),
+                       [](Impl::CudaInternal *ptr) {}) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
 }
 
 Cuda::Cuda(cudaStream_t stream)
-    : m_space_instance(Kokkos::Experimental::HostSharedPtr<Impl::CudaInternal>(
-          new Impl::CudaInternal, [](Impl::CudaInternal *ptr) {
-            ptr->finalize();
-            delete ptr;
-          })) {
+    : m_space_instance(new Impl::CudaInternal, [](Impl::CudaInternal *ptr) {
+        ptr->finalize();
+        delete ptr;
+      }) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
   m_space_instance->initialize(Impl::CudaInternal::singleton().m_cudaDev,

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -680,13 +680,18 @@ void HIP::impl_initialize(const HIP::SelectDevice config) {
 void HIP::impl_finalize() { Impl::HIPInternal::singleton().finalize(); }
 
 HIP::HIP()
-    : m_space_instance(&Impl::HIPInternal::singleton(), /*owning*/ false) {
+    : m_space_instance(&Impl::HIPInternal::singleton(), /*owning*/ false,
+                       [](Impl::HIPInternal*) {}) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
 }
 
 HIP::HIP(hipStream_t const stream)
-    : m_space_instance(new Impl::HIPInternal, /*owning*/ true) {
+    : m_space_instance(new Impl::HIPInternal, /*owning*/ true,
+                       [](Impl::HIPInternal* ptr) {
+                         ptr->finalize();
+                         delete ptr;
+                       }) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
   m_space_instance->initialize(Impl::HIPInternal::singleton().m_hipDev, stream);

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -679,16 +679,19 @@ void HIP::impl_initialize(const HIP::SelectDevice config) {
 
 void HIP::impl_finalize() { Impl::HIPInternal::singleton().finalize(); }
 
-HIP::HIP() : m_space_instance(&Impl::HIPInternal::singleton()) {
+HIP::HIP()
+    : m_space_instance(
+          Kokkos::Impl::UnmanagedPtr(&Impl::HIPInternal::singleton())) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
 }
 
 HIP::HIP(hipStream_t const stream)
-    : m_space_instance(new Impl::HIPInternal, [](Impl::HIPInternal* ptr) {
-        ptr->finalize();
-        delete ptr;
-      }) {
+    : m_space_instance(Kokkos::Impl::HostSharedPtr(new Impl::HIPInternal,
+                                                   [](Impl::HIPInternal* ptr) {
+                                                     ptr->finalize();
+                                                     delete ptr;
+                                                   })) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
   m_space_instance->initialize(Impl::HIPInternal::singleton().m_hipDev, stream);

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -680,18 +680,18 @@ void HIP::impl_initialize(const HIP::SelectDevice config) {
 void HIP::impl_finalize() { Impl::HIPInternal::singleton().finalize(); }
 
 HIP::HIP()
-    : m_space_instance(
-          Kokkos::Impl::UnmanagedPtr(&Impl::HIPInternal::singleton())) {
+    : m_space_instance(Kokkos::Impl::UnmanagedPtr<Impl::HIPInternal>(
+          &Impl::HIPInternal::singleton())) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
 }
 
 HIP::HIP(hipStream_t const stream)
-    : m_space_instance(Kokkos::Impl::HostSharedPtr(new Impl::HIPInternal,
-                                                   [](Impl::HIPInternal* ptr) {
-                                                     ptr->finalize();
-                                                     delete ptr;
-                                                   })) {
+    : m_space_instance(Kokkos::Impl::HostSharedPtr<Impl::HIPInternal>(
+          new Impl::HIPInternal, [](Impl::HIPInternal* ptr) {
+            ptr->finalize();
+            delete ptr;
+          })) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
   m_space_instance->initialize(Impl::HIPInternal::singleton().m_hipDev, stream);

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -680,18 +680,17 @@ void HIP::impl_initialize(const HIP::SelectDevice config) {
 void HIP::impl_finalize() { Impl::HIPInternal::singleton().finalize(); }
 
 HIP::HIP()
-    : m_space_instance(Kokkos::Experimental::UnmanagedPtr<Impl::HIPInternal>(
-          &Impl::HIPInternal::singleton())) {
+    : m_space_instance(&Impl::HIPInternal::singleton(),
+                       [](Impl::HIPInternal* ptr) {}) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
 }
 
 HIP::HIP(hipStream_t const stream)
-    : m_space_instance(Kokkos::Experimental::HostSharedPtr<Impl::HIPInternal>(
-          new Impl::HIPInternal, [](Impl::HIPInternal* ptr) {
-            ptr->finalize();
-            delete ptr;
-          })) {
+    : m_space_instance(new Impl::HIPInternal, [](Impl::HIPInternal* ptr) {
+        ptr->finalize();
+        delete ptr;
+      }) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
   m_space_instance->initialize(Impl::HIPInternal::singleton().m_hipDev, stream);

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -680,14 +680,14 @@ void HIP::impl_initialize(const HIP::SelectDevice config) {
 void HIP::impl_finalize() { Impl::HIPInternal::singleton().finalize(); }
 
 HIP::HIP()
-    : m_space_instance(Kokkos::Impl::UnmanagedPtr<Impl::HIPInternal>(
+    : m_space_instance(Kokkos::Experimental::UnmanagedPtr<Impl::HIPInternal>(
           &Impl::HIPInternal::singleton())) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
 }
 
 HIP::HIP(hipStream_t const stream)
-    : m_space_instance(Kokkos::Impl::HostSharedPtr<Impl::HIPInternal>(
+    : m_space_instance(Kokkos::Experimental::HostSharedPtr<Impl::HIPInternal>(
           new Impl::HIPInternal, [](Impl::HIPInternal* ptr) {
             ptr->finalize();
             delete ptr;

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -681,7 +681,7 @@ void HIP::impl_finalize() { Impl::HIPInternal::singleton().finalize(); }
 
 HIP::HIP()
     : m_space_instance(&Impl::HIPInternal::singleton(),
-                       [](Impl::HIPInternal* ptr) {}) {
+                       [](Impl::HIPInternal*) {}) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
 }

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -679,19 +679,16 @@ void HIP::impl_initialize(const HIP::SelectDevice config) {
 
 void HIP::impl_finalize() { Impl::HIPInternal::singleton().finalize(); }
 
-HIP::HIP()
-    : m_space_instance(&Impl::HIPInternal::singleton(), /*owning*/ false,
-                       [](Impl::HIPInternal*) {}) {
+HIP::HIP() : m_space_instance(&Impl::HIPInternal::singleton()) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
 }
 
 HIP::HIP(hipStream_t const stream)
-    : m_space_instance(new Impl::HIPInternal, /*owning*/ true,
-                       [](Impl::HIPInternal* ptr) {
-                         ptr->finalize();
-                         delete ptr;
-                       }) {
+    : m_space_instance(new Impl::HIPInternal, [](Impl::HIPInternal* ptr) {
+        ptr->finalize();
+        delete ptr;
+      }) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
   m_space_instance->initialize(Impl::HIPInternal::singleton().m_hipDev, stream);

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -249,7 +249,8 @@ class Cuda {
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  Kokkos::Impl::MaybeReferenceCountedPtr<Impl::CudaInternal> m_space_instance;
+  Kokkos::Experimental::MaybeReferenceCountedPtr<Impl::CudaInternal>
+      m_space_instance;
 };
 
 namespace Tools {

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -249,7 +249,7 @@ class Cuda {
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  HostSharedPtr<Impl::CudaInternal> m_space_instance;
+  Kokkos::Impl::HostSharedPtr<Impl::CudaInternal> m_space_instance;
 };
 
 namespace Tools {

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -249,7 +249,7 @@ class Cuda {
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  Kokkos::Impl::HostSharedPtr<Impl::CudaInternal> m_space_instance;
+  Kokkos::Impl::MaybeReferenceCountedPtr<Impl::CudaInternal> m_space_instance;
 };
 
 namespace Tools {

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -63,6 +63,7 @@
 #include <Kokkos_MemoryTraits.hpp>
 #include <impl/Kokkos_Tags.hpp>
 #include <impl/Kokkos_ExecSpaceInitializer.hpp>
+#include <impl/Kokkos_HostSharedPtr.hpp>
 
 /*--------------------------------------------------------------------------*/
 
@@ -198,16 +199,6 @@ class Cuda {
 
   Cuda();
 
-  KOKKOS_FUNCTION Cuda(Cuda&& other) noexcept;
-
-  KOKKOS_FUNCTION Cuda(const Cuda& other);
-
-  KOKKOS_FUNCTION Cuda& operator=(Cuda&& other) noexcept;
-
-  KOKKOS_FUNCTION Cuda& operator=(const Cuda& other);
-
-  KOKKOS_FUNCTION ~Cuda() noexcept;
-
   Cuda(cudaStream_t stream);
 
   //--------------------------------------------------------------------------
@@ -253,13 +244,12 @@ class Cuda {
   static const char* name();
 
   inline Impl::CudaInternal* impl_internal_space_instance() const {
-    return m_space_instance;
+    return m_space_instance.get();
   }
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  Impl::CudaInternal* m_space_instance;
-  int* m_counter;
+  HostSharedPtr<Impl::CudaInternal> m_space_instance;
 };
 
 namespace Tools {

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -249,8 +249,7 @@ class Cuda {
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  Kokkos::Experimental::MaybeReferenceCountedPtr<Impl::CudaInternal>
-      m_space_instance;
+  Kokkos::Impl::HostSharedPtr<Impl::CudaInternal> m_space_instance;
 };
 
 namespace Tools {

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -712,7 +712,7 @@ class HIP {
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  Kokkos::Impl::HostSharedPtr<Impl::HIPInternal> m_space_instance;
+  Kokkos::Impl::MaybeReferenceCountedPtr<Impl::HIPInternal> m_space_instance;
 };
 }  // namespace Experimental
 namespace Tools {

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -712,7 +712,8 @@ class HIP {
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  Kokkos::Impl::MaybeReferenceCountedPtr<Impl::HIPInternal> m_space_instance;
+  Kokkos::Experimental::MaybeReferenceCountedPtr<Impl::HIPInternal>
+      m_space_instance;
 };
 }  // namespace Experimental
 namespace Tools {

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -61,6 +61,7 @@
 
 #include <impl/Kokkos_Profiling_Interface.hpp>
 #include <impl/Kokkos_ExecSpaceInitializer.hpp>
+#include <impl/Kokkos_HostSharedPtr.hpp>
 
 #include <hip/hip_runtime_api.h>
 /*--------------------------------------------------------------------------*/
@@ -650,13 +651,6 @@ class HIP {
   HIP();
   HIP(hipStream_t stream);
 
-  KOKKOS_FUNCTION HIP(HIP&& other) noexcept;
-  KOKKOS_FUNCTION HIP(HIP const& other);
-  KOKKOS_FUNCTION HIP& operator=(HIP&&) noexcept;
-  KOKKOS_FUNCTION HIP& operator=(HIP const&);
-
-  KOKKOS_FUNCTION ~HIP() noexcept;
-
   //@}
   //------------------------------------
   //! \name Functions that all Kokkos devices must implement.
@@ -712,14 +706,13 @@ class HIP {
   static const char* name();
 
   inline Impl::HIPInternal* impl_internal_space_instance() const {
-    return m_space_instance;
+    return m_space_instance.get();
   }
 
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  Impl::HIPInternal* m_space_instance;
-  int* m_counter;
+  HostSharedPtr<Impl::HIPInternal> m_space_instance;
 };
 }  // namespace Experimental
 namespace Tools {

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -712,7 +712,7 @@ class HIP {
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  HostSharedPtr<Impl::HIPInternal> m_space_instance;
+  Kokkos::Impl::HostSharedPtr<Impl::HIPInternal> m_space_instance;
 };
 }  // namespace Experimental
 namespace Tools {

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -712,8 +712,7 @@ class HIP {
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  Kokkos::Experimental::MaybeReferenceCountedPtr<Impl::HIPInternal>
-      m_space_instance;
+  Kokkos::Impl::HostSharedPtr<Impl::HIPInternal> m_space_instance;
 };
 }  // namespace Experimental
 namespace Tools {

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -158,7 +158,7 @@ class SYCL {
   }
 
  private:
-  Kokkos::Impl::HostSharedPtr<Impl::SYCLInternal> m_space_instance;
+  Kokkos::Impl::MaybeReferenceCountedPtr<Impl::SYCLInternal> m_space_instance;
 };
 
 namespace Impl {

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -158,7 +158,7 @@ class SYCL {
   }
 
  private:
-  HostSharedPtr<Impl::SYCLInternal> m_space_instance;
+  Kokkos::Impl::HostSharedPtr<Impl::SYCLInternal> m_space_instance;
 };
 
 namespace Impl {

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -158,7 +158,8 @@ class SYCL {
   }
 
  private:
-  Kokkos::Impl::MaybeReferenceCountedPtr<Impl::SYCLInternal> m_space_instance;
+  Kokkos::Experimental::MaybeReferenceCountedPtr<Impl::SYCLInternal>
+      m_space_instance;
 };
 
 namespace Impl {

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -54,6 +54,7 @@
 #include <Kokkos_ScratchSpace.hpp>
 #include <impl/Kokkos_ExecSpaceInitializer.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
+#include <impl/Kokkos_HostSharedPtr.hpp>
 
 namespace Kokkos {
 namespace Experimental {
@@ -79,14 +80,8 @@ class SYCL {
 
   using scratch_memory_space = ScratchMemorySpace<SYCL>;
 
-  ~SYCL();
   SYCL();
   explicit SYCL(const sycl::queue&);
-
-  SYCL(SYCL&&) noexcept;
-  SYCL(const SYCL&);
-  SYCL& operator=(SYCL&&) noexcept;
-  SYCL& operator=(const SYCL&);
 
   uint32_t impl_instance_id() const noexcept { return 0; }
 
@@ -159,13 +154,11 @@ class SYCL {
   static const char* name();
 
   inline Impl::SYCLInternal* impl_internal_space_instance() const {
-    return m_space_instance;
+    return m_space_instance.get();
   }
 
  private:
-  KOKKOS_FUNCTION void cleanup() noexcept;
-  Impl::SYCLInternal* m_space_instance;
-  int* m_counter;
+  HostSharedPtr<Impl::SYCLInternal> m_space_instance;
 };
 
 namespace Impl {

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -158,8 +158,7 @@ class SYCL {
   }
 
  private:
-  Kokkos::Experimental::MaybeReferenceCountedPtr<Impl::SYCLInternal>
-      m_space_instance;
+  Kokkos::Impl::HostSharedPtr<Impl::SYCLInternal> m_space_instance;
 };
 
 namespace Impl {

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -76,19 +76,16 @@ int get_gpu(const InitArguments& args);
 }  // namespace Impl
 
 namespace Experimental {
-SYCL::SYCL()
-    : m_space_instance(&Impl::SYCLInternal::singleton(), /*owning*/ false,
-                       [](Impl::SYCLInternal*) {}) {
+SYCL::SYCL() : m_space_instance(&Impl::SYCLInternal::singleton()) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
 }
 
 SYCL::SYCL(const sycl::queue& stream)
-    : m_space_instance(new Impl::SYCLInternal, /*owning*/ true,
-                       [](Impl::SYCLInternal* ptr) {
-                         ptr->finalize();
-                         delete ptr;
-                       }) {
+    : m_space_instance(new Impl::SYCLInternal, [](Impl::SYCLInternal* ptr) {
+        ptr->finalize();
+        delete ptr;
+      }) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
   m_space_instance->initialize(stream);

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -77,13 +77,18 @@ int get_gpu(const InitArguments& args);
 
 namespace Experimental {
 SYCL::SYCL()
-    : m_space_instance(&Impl::SYCLInternal::singleton(), /*owning*/ false) {
+    : m_space_instance(&Impl::SYCLInternal::singleton(), /*owning*/ false,
+                       [](Impl::SYCLInternal*) {}) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
 }
 
 SYCL::SYCL(const sycl::queue& stream)
-    : m_space_instance(new Impl::SYCLInternal, /*owning*/ true) {
+    : m_space_instance(new Impl::SYCLInternal, /*owning*/ true,
+                       [](Impl::SYCLInternal* ptr) {
+                         ptr->finalize();
+                         delete ptr;
+                       }) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
   m_space_instance->initialize(stream);

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -76,16 +76,19 @@ int get_gpu(const InitArguments& args);
 }  // namespace Impl
 
 namespace Experimental {
-SYCL::SYCL() : m_space_instance(&Impl::SYCLInternal::singleton()) {
+SYCL::SYCL()
+    : m_space_instance(
+          Kokkos::Impl::UnmanagedPtr(&Impl::SYCLInternal::singleton())) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
 }
 
 SYCL::SYCL(const sycl::queue& stream)
-    : m_space_instance(new Impl::SYCLInternal, [](Impl::SYCLInternal* ptr) {
-        ptr->finalize();
-        delete ptr;
-      }) {
+    : m_space_instance(Kokkos::Impl::HostSharedPtr(new Impl::SYCLInternal,
+                                                   [](Impl::SYCLInternal* ptr) {
+                                                     ptr->finalize();
+                                                     delete ptr;
+                                                   })) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
   m_space_instance->initialize(stream);

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -77,14 +77,14 @@ int get_gpu(const InitArguments& args);
 
 namespace Experimental {
 SYCL::SYCL()
-    : m_space_instance(Kokkos::Impl::UnmanagedPtr<Impl::SYCLInternal>(
+    : m_space_instance(Kokkos::Experimental::UnmanagedPtr<Impl::SYCLInternal>(
           &Impl::SYCLInternal::singleton())) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
 }
 
 SYCL::SYCL(const sycl::queue& stream)
-    : m_space_instance(Kokkos::Impl::HostSharedPtr<Impl::SYCLInternal>(
+    : m_space_instance(Kokkos::Experimental::HostSharedPtr<Impl::SYCLInternal>(
           new Impl::SYCLInternal, [](Impl::SYCLInternal* ptr) {
             ptr->finalize();
             delete ptr;

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -77,18 +77,17 @@ int get_gpu(const InitArguments& args);
 
 namespace Experimental {
 SYCL::SYCL()
-    : m_space_instance(Kokkos::Experimental::UnmanagedPtr<Impl::SYCLInternal>(
-          &Impl::SYCLInternal::singleton())) {
+    : m_space_instance(&Impl::SYCLInternal::singleton(),
+                       [](Impl::SYCLInternal*) {}) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
 }
 
 SYCL::SYCL(const sycl::queue& stream)
-    : m_space_instance(Kokkos::Experimental::HostSharedPtr<Impl::SYCLInternal>(
-          new Impl::SYCLInternal, [](Impl::SYCLInternal* ptr) {
-            ptr->finalize();
-            delete ptr;
-          })) {
+    : m_space_instance(new Impl::SYCLInternal, [](Impl::SYCLInternal* ptr) {
+        ptr->finalize();
+        delete ptr;
+      }) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
   m_space_instance->initialize(stream);

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -77,18 +77,18 @@ int get_gpu(const InitArguments& args);
 
 namespace Experimental {
 SYCL::SYCL()
-    : m_space_instance(
-          Kokkos::Impl::UnmanagedPtr(&Impl::SYCLInternal::singleton())) {
+    : m_space_instance(Kokkos::Impl::UnmanagedPtr<Impl::SYCLInternal>(
+          &Impl::SYCLInternal::singleton())) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
 }
 
 SYCL::SYCL(const sycl::queue& stream)
-    : m_space_instance(Kokkos::Impl::HostSharedPtr(new Impl::SYCLInternal,
-                                                   [](Impl::SYCLInternal* ptr) {
-                                                     ptr->finalize();
-                                                     delete ptr;
-                                                   })) {
+    : m_space_instance(Kokkos::Impl::HostSharedPtr<Impl::SYCLInternal>(
+          new Impl::SYCLInternal, [](Impl::SYCLInternal* ptr) {
+            ptr->finalize();
+            delete ptr;
+          })) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
   m_space_instance->initialize(stream);

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -77,68 +77,16 @@ int get_gpu(const InitArguments& args);
 
 namespace Experimental {
 SYCL::SYCL()
-    : m_space_instance(&Impl::SYCLInternal::singleton()), m_counter(nullptr) {
+    : m_space_instance(&Impl::SYCLInternal::singleton(), /*owning*/ false) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
 }
 
 SYCL::SYCL(const sycl::queue& stream)
-    : m_space_instance(new Impl::SYCLInternal), m_counter(new int(1)) {
+    : m_space_instance(new Impl::SYCLInternal, /*owning*/ true) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
   m_space_instance->initialize(stream);
-}
-
-KOKKOS_FUNCTION SYCL::SYCL(SYCL&& other) noexcept
-    : m_space_instance(other.m_space_instance), m_counter(other.m_counter) {
-  other.m_space_instance = nullptr;
-  other.m_counter        = nullptr;
-}
-
-KOKKOS_FUNCTION SYCL::SYCL(const SYCL& other)
-    : m_space_instance(other.m_space_instance), m_counter(other.m_counter) {
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL
-  if (m_counter) Kokkos::atomic_add(m_counter, 1);
-#endif
-}
-
-KOKKOS_FUNCTION SYCL& SYCL::operator=(SYCL&& other) noexcept {
-  if (&other != this) {
-    cleanup();
-    m_space_instance       = other.m_space_instance;
-    other.m_space_instance = nullptr;
-    m_counter              = other.m_counter;
-    other.m_counter        = nullptr;
-  }
-  return *this;
-}
-
-KOKKOS_FUNCTION SYCL& SYCL::operator=(const SYCL& other) {
-  if (&other != this) {
-    cleanup();
-    m_space_instance = other.m_space_instance;
-    m_counter        = other.m_counter;
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL
-    if (m_counter) Kokkos::atomic_add(m_counter, 1);
-#endif
-  }
-  return *this;
-}
-
-KOKKOS_FUNCTION SYCL::~SYCL() { cleanup(); }
-
-KOKKOS_FUNCTION void SYCL::cleanup() noexcept {
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL
-  // If m_counter is set, then this instance is responsible for managing the
-  // objects pointed to by m_counter and m_space_instance.
-  if (m_counter == nullptr) return;
-  int const count = Kokkos::atomic_fetch_sub(m_counter, 1);
-  if (count == 1) {
-    delete m_counter;
-    m_space_instance->finalize();
-    delete m_space_instance;
-  }
-#endif
 }
 
 int SYCL::concurrency() {

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -56,12 +56,14 @@ namespace Impl {
 template <typename T>
 class HostSharedPtr {
  public:
+  HostSharedPtr(T* value_ptr = nullptr)
+      : m_value_ptr(value_ptr), m_deleter(nullptr), m_counter(nullptr) {}
+
   template <class Deleter>
-  HostSharedPtr(T* value_ptr, bool owning, Deleter deleter)
+  HostSharedPtr(T* value_ptr, Deleter deleter)
       : m_value_ptr(value_ptr),
-        m_deleter(owning ? (new std::function<void(T*)>(std::move(deleter)))
-                         : nullptr),
-        m_counter(owning ? (new int(1)) : nullptr) {}
+        m_deleter(new std::function<void(T*)>(std::move(deleter))),
+        m_counter(new int(1)) {}
 
   KOKKOS_FUNCTION HostSharedPtr(HostSharedPtr&& other) noexcept
       : m_value_ptr(other.m_value_ptr),

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -63,10 +63,10 @@ class MaybeReferenceCountedPtr {
       : m_element_ptr(element_ptr), m_control(nullptr) {}
 
   template <class Deleter>
-  MaybeReferenceCountedPtr(T* element_ptr, Deleter deleter)
+  MaybeReferenceCountedPtr(T* element_ptr, const Deleter& deleter)
       : m_element_ptr(element_ptr) {
     try {
-      m_control = new Control{std::move(deleter), 1};
+      m_control = new Control{deleter, 1};
     } catch (...) {
       deleter(element_ptr);
       throw;
@@ -176,8 +176,8 @@ class HostSharedPtr : public MaybeReferenceCountedPtr<T> {
   }
 
   template <class Deleter>
-  HostSharedPtr(T* element_ptr, Deleter deleter)
-      : MaybeReferenceCountedPtr<T>(element_ptr, std::move(deleter)) {}
+  HostSharedPtr(T* element_ptr, const Deleter& deleter)
+      : MaybeReferenceCountedPtr<T>(element_ptr, deleter) {}
 
   int use_count() const noexcept {
     return this->m_control ? this->m_control->m_counter : 0;

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -64,12 +64,14 @@ class MaybeReferenceCountedPtr {
 
   template <class Deleter>
   MaybeReferenceCountedPtr(T* element_ptr, const Deleter& deleter)
-      : m_element_ptr(element_ptr) {
-    try {
-      m_control = new Control{deleter, 1};
-    } catch (...) {
-      deleter(element_ptr);
-      throw;
+      : m_element_ptr(element_ptr), m_control(nullptr) {
+    if (element_ptr) {
+      try {
+        m_control = new Control{deleter, 1};
+      } catch (...) {
+        deleter(element_ptr);
+        throw;
+      }
     }
   }
 

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -124,6 +124,10 @@ class HostSharedPtr {
   // checks whether the HostSharedPtr manages the lifetime of the object
   KOKKOS_FUNCTION bool owner() const noexcept { return m_counter != nullptr; }
 
+  KOKKOS_FUNCTION int use_count() const noexcept {
+    return m_counter ? *m_counter : 0;
+  }
+
  private:
   KOKKOS_FUNCTION void cleanup() noexcept {
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -1,0 +1,120 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_IMPL_HOST_SHARED_PTR_HPP
+#define KOKKOS_IMPL_HOST_SHARED_PTR_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Atomic.hpp>
+
+#include <functional>
+
+template <typename T>
+class HostSharedPtr {
+ public:
+  HostSharedPtr(T* value_ptr, bool owning)
+      : m_value_ptr(value_ptr), m_counter(owning ? (new int(1)) : nullptr) {}
+
+  KOKKOS_FUNCTION HostSharedPtr(HostSharedPtr&& other) noexcept
+      : m_value_ptr(other.m_value_ptr), m_counter(other.m_counter) {
+    other.m_value_ptr = nullptr;
+    other.m_counter   = nullptr;
+  }
+
+  KOKKOS_FUNCTION HostSharedPtr(const HostSharedPtr& other)
+      : m_value_ptr(other.m_value_ptr), m_counter(other.m_counter) {
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    if (m_counter) Kokkos::atomic_add(m_counter, 1);
+#endif
+  }
+
+  KOKKOS_FUNCTION HostSharedPtr& operator=(HostSharedPtr&& other) noexcept {
+    if (&other != this) {
+      cleanup();
+      m_value_ptr       = other.m_value_ptr;
+      other.m_value_ptr = nullptr;
+      m_counter         = other.m_counter;
+      other.m_counter   = nullptr;
+    }
+    return *this;
+  }
+
+  KOKKOS_FUNCTION HostSharedPtr& operator=(const HostSharedPtr& other) {
+    if (&other != this) {
+      cleanup();
+      m_value_ptr = other.m_value_ptr;
+      m_counter   = other.m_counter;
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+      if (m_counter) Kokkos::atomic_add(m_counter, 1);
+#endif
+    }
+    return *this;
+  }
+
+  KOKKOS_FUNCTION ~HostSharedPtr() { cleanup(); }
+
+  KOKKOS_FUNCTION T* get() const noexcept { return m_value_ptr; }
+  KOKKOS_FUNCTION T& operator*() const noexcept { return *get(); }
+  KOKKOS_FUNCTION T* operator->() const noexcept { return get(); }
+
+ private:
+  KOKKOS_FUNCTION void cleanup() noexcept {
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    // If m_counter is set, then this instance is responsible for managing the
+    // objects pointed to by m_counter and m_value_ptr.
+    if (m_counter == nullptr) return;
+    int const count = Kokkos::atomic_fetch_sub(m_counter, 1);
+    if (count == 1) {
+      delete m_counter;
+      m_value_ptr->finalize();
+      delete m_value_ptr;
+    }
+#endif
+  }
+
+  T* m_value_ptr;
+  int* m_counter;
+};
+
+#endif

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -176,8 +176,7 @@ class HostSharedPtr : public MaybeReferenceCountedPtr<T> {
   }
 
   template <class Deleter>
-  explicit HostSharedPtr(
-      T* element_ptr, Deleter deleter = [](T* const t) { delete t; })
+  HostSharedPtr(T* element_ptr, Deleter deleter)
       : MaybeReferenceCountedPtr<T>(element_ptr, std::move(deleter)) {}
 
   int use_count() const noexcept {

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -56,7 +56,7 @@ namespace Experimental {
 template <typename T>
 class MaybeReferenceCountedPtr {
  public:
-  using elemeny_type = T;
+  using element_type = T;
 
  protected:
   MaybeReferenceCountedPtr(T* element_ptr)

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -131,8 +131,11 @@ class HostSharedPtr {
     int const count = Kokkos::atomic_fetch_sub(m_counter, 1);
     if (count == 1) {
       delete m_counter;
+      m_counter = nullptr;
       (*m_deleter)(m_value_ptr);
+      m_value_ptr = nullptr;
       delete m_deleter;
+      m_deleter = nullptr;
     }
 #endif
   }

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -166,7 +166,12 @@ class MaybeReferenceCountedPtr {
 template <class T>
 class HostSharedPtr : public MaybeReferenceCountedPtr<T> {
  public:
-  explicit HostSharedPtr(T* element_ptr = nullptr)
+  // Objects that are default-constructed or initialized with an (explicit)
+  // nullptr are not considered reference-counted.
+  HostSharedPtr() noexcept : MaybeReferenceCountedPtr<T>(nullptr) {}
+  HostSharedPtr(std::nullptr_t) noexcept : HostSharedPtr() {}
+
+  explicit HostSharedPtr(T* element_ptr)
       : MaybeReferenceCountedPtr<T>(element_ptr, [](T* const t) { delete t; }) {
   }
 
@@ -183,7 +188,7 @@ class HostSharedPtr : public MaybeReferenceCountedPtr<T> {
 template <class T>
 class UnmanagedPtr : public MaybeReferenceCountedPtr<T> {
  public:
-  explicit UnmanagedPtr(T* element_ptr = nullptr)
+  explicit UnmanagedPtr(T* element_ptr = nullptr) noexcept
       : MaybeReferenceCountedPtr<T>(element_ptr) {}
 };
 }  // namespace Experimental

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -108,6 +108,14 @@ class HostSharedPtr {
   KOKKOS_FUNCTION T& operator*() const noexcept { return *get(); }
   KOKKOS_FUNCTION T* operator->() const noexcept { return get(); }
 
+  // checks if the stored pointer is not null
+  KOKKOS_FUNCTION explicit operator bool() const noexcept {
+    return get() != nullptr;
+  }
+
+  // checks whether the HostSharedPtr manages the lifetime of the object
+  KOKKOS_FUNCTION bool owner() const noexcept { return m_counter != nullptr; }
+
  private:
   KOKKOS_FUNCTION void cleanup() noexcept {
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -189,7 +189,9 @@ class HostSharedPtr : public MaybeReferenceCountedPtr<T> {
 template <class T>
 class UnmanagedPtr : public MaybeReferenceCountedPtr<T> {
  public:
-  explicit UnmanagedPtr(T* element_ptr = nullptr) noexcept
+  UnmanagedPtr() noexcept : MaybeReferenceCountedPtr<T>(nullptr) {}
+
+  explicit UnmanagedPtr(T* element_ptr) noexcept
       : MaybeReferenceCountedPtr<T>(element_ptr) {}
 };
 }  // namespace Experimental

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -50,6 +50,9 @@
 
 #include <functional>
 
+namespace Kokkos {
+namespace Impl {
+
 template <typename T>
 class HostSharedPtr {
  public:
@@ -138,5 +141,7 @@ class HostSharedPtr {
   std::function<void(T*)>* m_deleter;
   int* m_counter;
 };
+}  // namespace Impl
+}  // namespace Kokkos
 
 #endif

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -172,7 +172,7 @@ class HostSharedPtr : public MaybeReferenceCountedPtr<T> {
 
   template <class Deleter>
   explicit HostSharedPtr(
-      T* element_ptr = nullptr, Deleter deleter = [](T* const t) { delete t; })
+      T* element_ptr, Deleter deleter = [](T* const t) { delete t; })
       : MaybeReferenceCountedPtr<T>(element_ptr, std::move(deleter)) {}
 
   int use_count() const noexcept {

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -119,8 +119,8 @@ class MaybeReferenceCountedPtr {
     return get() != nullptr;
   }
 
-  // checks whether the MaybeReferenceCountedPtr manages the lifetime of the
-  // object
+  // checks whether the MaybeReferenceCountedPtr does reference counting
+  // which implies managing the lifetime of the object
   KOKKOS_FUNCTION bool is_reference_counted() const noexcept {
     return m_control != nullptr;
   }

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -75,6 +75,29 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
     # file. That then exceeded the shell command line max length.
     set(${Tag}_SOURCES1A)
     foreach(Name
+        AtomicOperations_int
+        AtomicOperations_unsignedint
+        AtomicOperations_longint
+        AtomicOperations_unsignedlongint
+        AtomicOperations_longlongint
+        AtomicOperations_double
+        AtomicOperations_float
+        AtomicOperations_complexdouble
+        AtomicOperations_complexfloat
+        AtomicViews
+        Atomics
+        BlockSizeDeduction
+        Concepts
+        Complex
+        Crs
+        DeepCopyAlignment
+        FunctorAnalysis
+        Init
+        LocalDeepCopy
+        MathematicalFunctions
+        MDRange_a
+        MDRange_b
+        MDRange_c
         HostSharedPtr
         HostSharedPtrAccessOnDevice
         )

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -75,7 +75,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
     # file. That then exceeded the shell command line max length.
     set(${Tag}_SOURCES1A)
     foreach(Name
-	HostSharedPtr
+        HostSharedPtr
+        HostSharedPtrAccessOnDevice
         )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -75,30 +75,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
     # file. That then exceeded the shell command line max length.
     set(${Tag}_SOURCES1A)
     foreach(Name
-        AtomicOperations_int
-        AtomicOperations_unsignedint
-        AtomicOperations_longint
-        AtomicOperations_unsignedlongint
-        AtomicOperations_longlongint
-        AtomicOperations_double
-        AtomicOperations_float
-        AtomicOperations_complexdouble
-        AtomicOperations_complexfloat
-        AtomicViews
-        Atomics
-        BlockSizeDeduction
-        Concepts
-        Complex
-        Crs
-        DeepCopyAlignment
-        FunctorAnalysis
 	HostSharedPtr
-        Init
-        LocalDeepCopy
-        MathematicalFunctions
-        MDRange_a
-        MDRange_b
-        MDRange_c
         )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -92,6 +92,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
         Crs
         DeepCopyAlignment
         FunctorAnalysis
+	HostSharedPtr
         Init
         LocalDeepCopy
         MathematicalFunctions

--- a/core/unit_test/TestHostSharedPtr.hpp
+++ b/core/unit_test/TestHostSharedPtr.hpp
@@ -46,31 +46,31 @@
 
 #include <gtest/gtest.h>
 
-using Kokkos::Impl::HostSharedPtr;
-using Kokkos::Impl::UnmanagedPtr;
+using Kokkos::Experimental::HostSharedPtr;
+using Kokkos::Experimental::UnmanagedPtr;
 
-TEST(TEST_CATEGORY, host_shared_ptr_owner) {
+TEST(TEST_CATEGORY, host_shared_ptr_is_reference_counted) {
   using T = int;  // default constructible
   {
     HostSharedPtr<T> p1;
-    EXPECT_TRUE(p1.owner());
+    EXPECT_TRUE(p1.is_reference_counted());
   }
   {
     HostSharedPtr<T> p1(nullptr);
-    EXPECT_TRUE(p1.owner());
+    EXPECT_TRUE(p1.is_reference_counted());
   }
   {
     HostSharedPtr<T> p1(new T());
-    EXPECT_TRUE(p1.owner());
+    EXPECT_TRUE(p1.is_reference_counted());
   }
   {
     HostSharedPtr<T> p1(new T(), [](T* p) { delete p; });
-    EXPECT_TRUE(p1.owner());
+    EXPECT_TRUE(p1.is_reference_counted());
   }
   {
     T i;
     HostSharedPtr<T> p1(&i, [](T*) {});
-    EXPECT_TRUE(p1.owner());
+    EXPECT_TRUE(p1.is_reference_counted());
   }
 }
 
@@ -182,63 +182,20 @@ TEST(TEST_CATEGORY, host_shared_ptr_get) {
   }
 }
 
-TEST(TEST_CATEGORY, unmanaged_ptr_owner) {
+TEST(TEST_CATEGORY, unmanaged_ptr_is_reference_counted) {
   using T = int;  // default constructible
   {
     UnmanagedPtr<T> p1;
-    EXPECT_FALSE(p1.owner());
+    EXPECT_FALSE(p1.is_reference_counted());
   }
   {
     UnmanagedPtr<T> p1(nullptr);
-    EXPECT_FALSE(p1.owner());
+    EXPECT_FALSE(p1.is_reference_counted());
   }
   {
     T i;
     UnmanagedPtr<T> p1(&i);
-    EXPECT_FALSE(p1.owner());
-  }
-}
-
-TEST(TEST_CATEGORY, unmanaged_ptr_use_count) {
-  using T = int;
-  {
-    UnmanagedPtr<T> p1;
-    EXPECT_EQ(p1.use_count(), 0);
-  }
-  {
-    UnmanagedPtr<T> p1(nullptr);
-    EXPECT_EQ(p1.use_count(), 0);
-  }
-  {
-    T i;
-    UnmanagedPtr<T> p1(&i);
-    EXPECT_EQ(p1.use_count(), 0);
-  }
-  {
-    UnmanagedPtr<T> p1(new T());
-    UnmanagedPtr<T> p2(p1);  // copy construction
-    EXPECT_EQ(p1.use_count(), 0);
-    EXPECT_EQ(p2.use_count(), 0);
-  }
-  {
-    UnmanagedPtr<T> p1(new T());
-    UnmanagedPtr<T> p2(std::move(p1));  // move construction
-    EXPECT_EQ(p1.use_count(), 0);
-    EXPECT_EQ(p2.use_count(), 0);
-  }
-  {
-    UnmanagedPtr<T> p1(new T());
-    UnmanagedPtr<T> p2;
-    p2 = p1;  // copy assignment
-    EXPECT_EQ(p1.use_count(), 0);
-    EXPECT_EQ(p2.use_count(), 0);
-  }
-  {
-    UnmanagedPtr<T> p1(new T());
-    UnmanagedPtr<T> p2;
-    p2 = std::move(p1);  // move assignment
-    EXPECT_EQ(p1.use_count(), 0);
-    EXPECT_EQ(p2.use_count(), 0);
+    EXPECT_FALSE(p1.is_reference_counted());
   }
 }
 

--- a/core/unit_test/TestHostSharedPtr.hpp
+++ b/core/unit_test/TestHostSharedPtr.hpp
@@ -1,0 +1,174 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <impl/Kokkos_HostSharedPtr.hpp>
+
+#include <gtest/gtest.h>
+
+using Kokkos::Impl::HostSharedPtr;
+
+TEST(TEST_CATEGORY, host_shared_ptr_owner) {
+  using T = int;  // default constructible
+  {
+    HostSharedPtr<T> p1;
+    EXPECT_FALSE(p1.owner());
+  }
+  {
+    HostSharedPtr<T> p1(nullptr);
+    EXPECT_FALSE(p1.owner());
+  }
+  {
+    HostSharedPtr<T> p1(new T(), [](T* p) { delete p; });
+    EXPECT_TRUE(p1.owner());
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    EXPECT_TRUE(p1.owner());
+  }
+}
+
+TEST(TEST_CATEGORY, host_shared_ptr_use_count) {
+  using T = int;
+  {
+    HostSharedPtr<T> p1;
+    EXPECT_EQ(p1.use_count(), 0);
+  }
+  {
+    HostSharedPtr<T> p1(nullptr);
+    EXPECT_EQ(p1.use_count(), 0);
+  }
+  {
+    HostSharedPtr<T> p1(new T(), [](T* p) { delete p; });
+    EXPECT_EQ(p1.use_count(), 1);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    EXPECT_EQ(p1.use_count(), 1);
+  }
+  {
+    HostSharedPtr<T> p1(new T(), [](T* p) { delete p; });
+    HostSharedPtr<T> p2(p1);  // copy construction
+    EXPECT_EQ(p1.use_count(), 2);
+    EXPECT_EQ(p2.use_count(), 2);
+  }
+  {
+    HostSharedPtr<T> p1(new T(), [](T* p) { delete p; });
+    HostSharedPtr<T> p2(std::move(p1));  // move construction
+    EXPECT_EQ(p1.use_count(), 0);
+    EXPECT_EQ(p2.use_count(), 1);
+  }
+  {
+    HostSharedPtr<T> p1(new T(), [](T* p) { delete p; });
+    HostSharedPtr<T> p2;
+    p2 = p1;  // copy assignment
+    EXPECT_EQ(p1.use_count(), 2);
+    EXPECT_EQ(p2.use_count(), 2);
+  }
+  {
+    HostSharedPtr<T> p1(new T(), [](T* p) { delete p; });
+    HostSharedPtr<T> p2;
+    p2 = std::move(p1);  // move assignment
+    EXPECT_EQ(p1.use_count(), 0);
+    EXPECT_EQ(p2.use_count(), 1);
+  }
+}
+
+TEST(TEST_CATEGORY, host_shared_ptr_get) {
+  using T = int;
+  {
+    HostSharedPtr<T> p1;
+    EXPECT_EQ(p1.get(), nullptr);
+  }
+  {
+    HostSharedPtr<T> p1(nullptr);
+    EXPECT_EQ(p1.get(), nullptr);
+  }
+  {
+    T* p_i = new T();
+    HostSharedPtr<T> p1(p_i);
+    EXPECT_EQ(p1.get(), p_i);
+  }
+  {
+    T* p_i = new T();
+    HostSharedPtr<T> p1(p_i, [](T* p) { delete p; });
+    EXPECT_EQ(p1.get(), p_i);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    EXPECT_EQ(p1.get(), &i);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    HostSharedPtr<T> p2(p1);  // copy construction
+    EXPECT_EQ(p1.get(), &i);
+    EXPECT_EQ(p1.get(), &i);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    HostSharedPtr<T> p2(std::move(p1));  // move construction
+    EXPECT_EQ(p1.get(), nullptr);
+    EXPECT_EQ(p2.get(), &i);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    HostSharedPtr<T> p2;
+    p2 = p1;  // copy assignment
+    EXPECT_EQ(p1.get(), &i);
+    EXPECT_EQ(p1.get(), &i);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    HostSharedPtr<T> p2;
+    p2 = std::move(p1);  // move assignment
+    EXPECT_EQ(p1.get(), nullptr);
+    EXPECT_EQ(p2.get(), &i);
+  }
+}

--- a/core/unit_test/TestHostSharedPtr.hpp
+++ b/core/unit_test/TestHostSharedPtr.hpp
@@ -53,11 +53,11 @@ TEST(TEST_CATEGORY, host_shared_ptr_is_reference_counted) {
   using T = int;  // default constructible
   {
     HostSharedPtr<T> p1;
-    EXPECT_TRUE(p1.is_reference_counted());
+    EXPECT_FALSE(p1.is_reference_counted());
   }
   {
     HostSharedPtr<T> p1(nullptr);
-    EXPECT_TRUE(p1.is_reference_counted());
+    EXPECT_FALSE(p1.is_reference_counted());
   }
   {
     HostSharedPtr<T> p1(new T());
@@ -78,11 +78,11 @@ TEST(TEST_CATEGORY, host_shared_ptr_use_count) {
   using T = int;
   {
     HostSharedPtr<T> p1;
-    EXPECT_EQ(p1.use_count(), 1);
+    EXPECT_EQ(p1.use_count(), 0);
   }
   {
     HostSharedPtr<T> p1(nullptr);
-    EXPECT_EQ(p1.use_count(), 1);
+    EXPECT_EQ(p1.use_count(), 0);
   }
   {
     HostSharedPtr<T> p1(new T());

--- a/core/unit_test/TestHostSharedPtr.hpp
+++ b/core/unit_test/TestHostSharedPtr.hpp
@@ -46,33 +46,7 @@
 
 #include <gtest/gtest.h>
 
-using Kokkos::Experimental::HostSharedPtr;
-using Kokkos::Experimental::UnmanagedPtr;
-
-TEST(TEST_CATEGORY, host_shared_ptr_is_reference_counted) {
-  using T = int;  // default constructible
-  {
-    HostSharedPtr<T> p1;
-    EXPECT_FALSE(p1.is_reference_counted());
-  }
-  {
-    HostSharedPtr<T> p1(nullptr);
-    EXPECT_FALSE(p1.is_reference_counted());
-  }
-  {
-    HostSharedPtr<T> p1(new T());
-    EXPECT_TRUE(p1.is_reference_counted());
-  }
-  {
-    HostSharedPtr<T> p1(new T(), [](T* p) { delete p; });
-    EXPECT_TRUE(p1.is_reference_counted());
-  }
-  {
-    T i;
-    HostSharedPtr<T> p1(&i, [](T*) {});
-    EXPECT_TRUE(p1.is_reference_counted());
-  }
-}
+using Kokkos::Impl::HostSharedPtr;
 
 TEST(TEST_CATEGORY, host_shared_ptr_use_count) {
   using T = int;
@@ -176,70 +150,6 @@ TEST(TEST_CATEGORY, host_shared_ptr_get) {
     T i;
     HostSharedPtr<T> p1(&i, [](T*) {});
     HostSharedPtr<T> p2;
-    p2 = std::move(p1);  // move assignment
-    EXPECT_EQ(p1.get(), nullptr);
-    EXPECT_EQ(p2.get(), &i);
-  }
-}
-
-TEST(TEST_CATEGORY, unmanaged_ptr_is_reference_counted) {
-  using T = int;  // default constructible
-  {
-    UnmanagedPtr<T> p1;
-    EXPECT_FALSE(p1.is_reference_counted());
-  }
-  {
-    UnmanagedPtr<T> p1(nullptr);
-    EXPECT_FALSE(p1.is_reference_counted());
-  }
-  {
-    T i;
-    UnmanagedPtr<T> p1(&i);
-    EXPECT_FALSE(p1.is_reference_counted());
-  }
-}
-
-TEST(TEST_CATEGORY, unmanaged_ptr_get) {
-  using T = int;
-  {
-    UnmanagedPtr<T> p1;
-    EXPECT_EQ(p1.get(), nullptr);
-  }
-  {
-    UnmanagedPtr<T> p1(nullptr);
-    EXPECT_EQ(p1.get(), nullptr);
-  }
-  {
-    T i;
-    UnmanagedPtr<T> p1(&i);
-    EXPECT_EQ(p1.get(), &i);
-  }
-  {
-    T i;
-    UnmanagedPtr<T> p1(&i);
-    UnmanagedPtr<T> p2(p1);  // copy construction
-    EXPECT_EQ(p1.get(), &i);
-    EXPECT_EQ(p1.get(), &i);
-  }
-  {
-    T i;
-    UnmanagedPtr<T> p1(&i);
-    UnmanagedPtr<T> p2(std::move(p1));  // move construction
-    EXPECT_EQ(p1.get(), nullptr);
-    EXPECT_EQ(p2.get(), &i);
-  }
-  {
-    T i;
-    UnmanagedPtr<T> p1(&i);
-    UnmanagedPtr<T> p2;
-    p2 = p1;  // copy assignment
-    EXPECT_EQ(p1.get(), &i);
-    EXPECT_EQ(p1.get(), &i);
-  }
-  {
-    T i;
-    UnmanagedPtr<T> p1(&i);
-    UnmanagedPtr<T> p2;
     p2 = std::move(p1);  // move assignment
     EXPECT_EQ(p1.get(), nullptr);
     EXPECT_EQ(p2.get(), &i);

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -94,7 +94,7 @@ struct CheckAccessStoredPointerAndDereferenceOnDevice {
 
 template <class Ptr>
 CheckAccessStoredPointerAndDereferenceOnDevice<Ptr>
-check_access_strored_pointer_and_dereference_on_device(Ptr p) {
+check_access_stored_pointer_and_dereference_on_device(Ptr p) {
   return {p};
 }
 
@@ -109,7 +109,7 @@ TEST(TEST_CATEGORY, host_shared_ptr_dereference_on_device) {
       static_cast<T*>(Kokkos::kokkos_malloc<MemorySpace>(sizeof(T))),
       [](T* p) { Kokkos::kokkos_free<MemorySpace>(p); });
 
-  check_access_strored_pointer_and_dereference_on_device(device_ptr);
+  check_access_stored_pointer_and_dereference_on_device(device_ptr);
 }
 
 TEST(TEST_CATEGORY, unmanaged_ptr_dereference_on_device) {
@@ -120,7 +120,7 @@ TEST(TEST_CATEGORY, unmanaged_ptr_dereference_on_device) {
   UnmanagedPtr<T> device_ptr(
       static_cast<T*>(Kokkos::kokkos_malloc<MemorySpace>(sizeof(T))));
 
-  check_access_strored_pointer_and_dereference_on_device(device_ptr);
+  check_access_stored_pointer_and_dereference_on_device(device_ptr);
 
   Kokkos::kokkos_free<MemorySpace>(device_ptr.get());
 }

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -1,0 +1,128 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <impl/Kokkos_HostSharedPtr.hpp>
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+using Kokkos::Experimental::HostSharedPtr;
+using Kokkos::Experimental::UnmanagedPtr;
+
+using Data = Kokkos::Array<char, 32>;
+
+namespace {
+
+class Data {
+  Kokkos::Array<char, 64> d;
+
+ public:
+  KOKKOS_FUNCTION void write(char const* c) {
+    for (int i = 0; i < 64 && c; ++i, ++c) {
+      d[i] = *c;
+    }
+  }
+};
+
+template <class MoreOrLessSmartPtr>
+struct CheckAccessStoredPointerAndDereferenceOnDevice {
+  MoreOrLessSmartPtr m_device_ptr;
+  // FIXME deduce from the smart pointer
+  using ElementType = std::decay_t<decltype(*m_device_ptr)>;
+  static_assert(std::same<ElementType, Data>::value, "");
+
+  CheckAccessStoredPointerAndDereferenceOnDevice(MoreOrLessSmartPtr device_ptr)
+      : m_device_ptr(device_ptr) {
+    int errors;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), *this,
+                            errors);
+    EXPECT_EQ(errors, 0);
+  }
+
+  KOKKOS_FUNCTION void operator()(int, int& e) const {
+    auto raw_ptr = m_device_ptr.get();  // get
+
+    auto tmp = new (raw_ptr) ElementType();
+
+    auto& obj = *m_device_ptr;  // operator*
+    if (&obj != raw_ptr) ++e;
+
+    m_device_ptr->write("hello world");  // operator->
+
+    tmp->~ElementType();
+  }
+};
+
+template <class Ptr>
+CheckAccessStoredPointerAndDereferenceOnDevice<Ptr>
+check_access_strored_pointer_and_dereference_on_device(Ptr p) {
+  return {p};
+}
+
+}  // namespace
+
+TEST(TEST_CATEGORY, host_shared_ptr_dereference_on_device) {
+  using T = Data;
+
+  using MemorySpace = TEST_EXECSPACE::memory_space;
+
+  HostSharedPtr<T> device_ptr(
+      static_cast<T*>(Kokkos::kokkos_malloc<MemorySpace>(sizeof(T))),
+      [](T* p) { Kokkos::kokkos_free<MemorySpace>(p); });
+
+  check_access_strored_pointer_and_dereference_on_device(device_ptr);
+}
+
+TEST(TEST_CATEGORY, unmanaged_ptr_dereference_on_device) {
+  using T = Data;
+
+  using MemorySpace = TEST_EXECSPACE::memory_space;
+
+  UnmanagedPtr<T> device_ptr(
+      static_cast<T*>(Kokkos::kokkos_malloc<MemorySpace>(sizeof(T))));
+
+  check_access_strored_pointer_and_dereference_on_device(device_ptr);
+
+  Kokkos::kokkos_free<MemorySpace>(device_ptr.get());
+}

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -50,8 +50,6 @@
 using Kokkos::Experimental::HostSharedPtr;
 using Kokkos::Experimental::UnmanagedPtr;
 
-using Data = Kokkos::Array<char, 32>;
-
 namespace {
 
 class Data {
@@ -70,7 +68,7 @@ struct CheckAccessStoredPointerAndDereferenceOnDevice {
   MoreOrLessSmartPtr m_device_ptr;
   // FIXME deduce from the smart pointer
   using ElementType = std::decay_t<decltype(*m_device_ptr)>;
-  static_assert(std::same<ElementType, Data>::value, "");
+  static_assert(std::is_same<ElementType, Data>::value, "");
 
   CheckAccessStoredPointerAndDereferenceOnDevice(MoreOrLessSmartPtr device_ptr)
       : m_device_ptr(device_ptr) {

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -47,8 +47,7 @@
 
 #include <gtest/gtest.h>
 
-using Kokkos::Experimental::HostSharedPtr;
-using Kokkos::Experimental::UnmanagedPtr;
+using Kokkos::Impl::HostSharedPtr;
 
 namespace {
 
@@ -110,17 +109,4 @@ TEST(TEST_CATEGORY, host_shared_ptr_dereference_on_device) {
       [](T* p) { Kokkos::kokkos_free<MemorySpace>(p); });
 
   check_access_stored_pointer_and_dereference_on_device(device_ptr);
-}
-
-TEST(TEST_CATEGORY, unmanaged_ptr_dereference_on_device) {
-  using T = Data;
-
-  using MemorySpace = TEST_EXECSPACE::memory_space;
-
-  UnmanagedPtr<T> device_ptr(
-      static_cast<T*>(Kokkos::kokkos_malloc<MemorySpace>(sizeof(T))));
-
-  check_access_stored_pointer_and_dereference_on_device(device_ptr);
-
-  Kokkos::kokkos_free<MemorySpace>(device_ptr.get());
 }


### PR DESCRIPTION
Fixes #3791, fixes #3817 by moving the SYCL implementation in its own class.