### PR TITLE
Fixed command line parsing bug

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -756,6 +756,7 @@ void parse_command_line_arguments(int& narg, char* arg[],
       for (int k = iarg; k < narg - 1; k++) {
         arg[k] = arg[k + 1];
       }
+      narg--;
     } else if (check_str_arg(arg[iarg], "--kokkos-tools-library", tool_lib)) {
       for (int k = iarg; k < narg - 1; k++) {
         arg[k] = arg[k + 1];


### PR DESCRIPTION
Somehow, between `master` and `develop`, the `narg--` from the kokkos-tune-internals got removed. This puts it back? Not sure how that happened