### PR TITLE
Tool interface V2 implementation sketch

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -429,8 +429,8 @@ void lookup_function(void* dlopen_handle, const std::string& basename,
   // workaround the issue by casting pointer to pointers.
   v2 = *reinterpret_cast<V2Function*>(&p);
   if (v2 == nullptr) {
-    p      = dlsym(dlopen_handle, basename.c_str());
-    v1     = *reinterpret_cast<V1Function*>(&p);
+    p  = dlsym(dlopen_handle, basename.c_str());
+    v1 = *reinterpret_cast<V1Function*>(&p);
   }
 }
 

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -422,6 +422,7 @@ SpaceHandle make_space_handle(const char* space_name) {
 template <typename V1Function, typename V2Function>
 void lookup_function(void* dlopen_handle, const std::string& basename,
                      V2Function& v2, V1Function& v1) {
+#ifdef KOKKOS_ENABLE_LIBDL
   auto v2name = basename + "_v2";
   auto p      = dlsym(dlopen_handle, v2name.c_str());
   // dlsym returns a pointer to an object, while we want to assign to
@@ -432,6 +433,7 @@ void lookup_function(void* dlopen_handle, const std::string& basename,
     p  = dlsym(dlopen_handle, basename.c_str());
     v1 = *reinterpret_cast<V1Function*>(&p);
   }
+#endif
 }
 
 void initialize(const std::string& profileLibrary) {

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -429,7 +429,7 @@ void lookup_function(void* dlopen_handle, const std::string& basename,
   // workaround the issue by casting pointer to pointers.
   v2 = *reinterpret_cast<V2Function*>(&p);
   if (v2 == nullptr) {
-    auto p = dlsym(dlopen_handle, basename.c_str());
+    p      = dlsym(dlopen_handle, basename.c_str());
     v1     = *reinterpret_cast<V1Function*>(&p);
   }
 }

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -66,10 +66,21 @@ struct Kokkos_Profiling_SpaceHandle {
   char name[64];
 };
 
+struct Kokkos_Profiling_ToolResponse {
+  bool should_fence;
+};
+
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_initFunction)(
     const int, const uint64_t, const uint32_t,
     struct Kokkos_Profiling_KokkosPDeviceInfo*);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_initFunction_v2)(
+    const int, const uint64_t, const uint32_t,
+    struct Kokkos_Profiling_KokkosPDeviceInfo*,
+    struct Kokkos_Profiling_ToolResponse*);
+
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_finalizeFunction)();
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
@@ -80,7 +91,13 @@ typedef void (*Kokkos_Profiling_printHelpFunction)(char*);
 typedef void (*Kokkos_Profiling_beginFunction)(const char*, const uint32_t,
                                                uint64_t*);
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_beginFunction_v2)(
+    const char*, const uint32_t, uint64_t*,
+    struct Kokkos_Profiling_ToolResponse*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_endFunction)(uint64_t);
+typedef void (*Kokkos_Profiling_endFunction_v2)(
+    uint64_t, struct Kokkos_Profiling_ToolResponse*);
 
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_pushFunction)(const char*);
@@ -229,15 +246,22 @@ typedef void (*function_pointer)();
 
 struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_initFunction init;
+  Kokkos_Profiling_initFunction_v2 init_v2;
   Kokkos_Profiling_finalizeFunction finalize;
   Kokkos_Profiling_parseArgsFunction parse_args;
   Kokkos_Profiling_printHelpFunction print_help;
   Kokkos_Profiling_beginFunction begin_parallel_for;
+  Kokkos_Profiling_beginFunction_v2 begin_parallel_for_v2;
   Kokkos_Profiling_endFunction end_parallel_for;
+  Kokkos_Profiling_endFunction_v2 end_parallel_for_v2;
   Kokkos_Profiling_beginFunction begin_parallel_reduce;
+  Kokkos_Profiling_beginFunction_v2 begin_parallel_reduce_v2;
   Kokkos_Profiling_endFunction end_parallel_reduce;
+  Kokkos_Profiling_endFunction_v2 end_parallel_reduce_v2;
   Kokkos_Profiling_beginFunction begin_parallel_scan;
+  Kokkos_Profiling_beginFunction_v2 begin_parallel_scan_v2;
   Kokkos_Profiling_endFunction end_parallel_scan;
+  Kokkos_Profiling_endFunction_v2 end_parallel_scan_v2;
   Kokkos_Profiling_pushFunction push_region;
   Kokkos_Profiling_popFunction pop_region;
   Kokkos_Profiling_allocateDataFunction allocate_data;
@@ -261,7 +285,7 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Tools_contextBeginFunction begin_tuning_context;
   Kokkos_Tools_contextEndFunction end_tuning_context;
   Kokkos_Tools_optimizationGoalDeclarationFunction declare_optimization_goal;
-  char padding[232 *
+  char padding[225 *
                sizeof(function_pointer)];  // allows us to add another 256
                                            // events to the Tools interface
                                            // without changing struct layout

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -101,16 +101,20 @@ namespace Tools {
 
 namespace Experimental {
 using EventSet = Kokkos_Profiling_EventSet;
+using ToolResponse = Kokkos_Profiling_ToolResponse;
 static_assert(sizeof(EventSet) / sizeof(function_pointer) == 275,
               "sizeof EventSet has changed, this is an error on the part of a "
               "Kokkos developer");
 }  // namespace Experimental
 using initFunction           = Kokkos_Profiling_initFunction;
+using initFunction_v2        = Kokkos_Profiling_initFunction_v2;
 using finalizeFunction       = Kokkos_Profiling_finalizeFunction;
 using parseArgsFunction      = Kokkos_Profiling_parseArgsFunction;
 using printHelpFunction      = Kokkos_Profiling_printHelpFunction;
 using beginFunction          = Kokkos_Profiling_beginFunction;
+using beginFunction_v2       = Kokkos_Profiling_beginFunction_v2;
 using endFunction            = Kokkos_Profiling_endFunction;
+using endFunction_v2         = Kokkos_Profiling_endFunction_v2;
 using pushFunction           = Kokkos_Profiling_pushFunction;
 using popFunction            = Kokkos_Profiling_popFunction;
 using allocateDataFunction   = Kokkos_Profiling_allocateDataFunction;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -100,7 +100,7 @@ using SpaceHandle = Kokkos_Profiling_SpaceHandle;
 namespace Tools {
 
 namespace Experimental {
-using EventSet = Kokkos_Profiling_EventSet;
+using EventSet     = Kokkos_Profiling_EventSet;
 using ToolResponse = Kokkos_Profiling_ToolResponse;
 static_assert(sizeof(EventSet) / sizeof(function_pointer) == 275,
               "sizeof EventSet has changed, this is an error on the part of a "


### PR DESCRIPTION
In #3723, we're discussing the various ways the Tools interface could be extended to avoid fencing, while preserving the existing semantics (get pretty Kokkos names, etc.). Props to everybody there for anything good in this design, but I'm taking credit for all the bugs.

One model for this is that the tool should be able to overwrite the fencing decisions Kokkos makes. Using that ability, it could tell Kokkos "don't fence," and associate the kernel launched between the begin and end events using a tool interface like CUPTI. The tool could then tie the end event it gets with CUPTI back to the name of the kernel, established beforehand.

Merging this requires three things

1) Determining that this is the model we want to use
2) Determining that the design is good
3) Determining that the code is good

I have no interest in 3 until discussing 1&2.

So, the design. (Some/All?) Kokkos callbacks are getting a _v2 version, which allows for the tool to respond to Kokkos and inform it of what it should do. Right now, "what it should do" only includes "fence/don't fence". Kokkos will have its own default behavior, which *must* match the behavior of the v1 interface. So "always fence" in this instance. In the absence of a v2 symbol, Kokkos falls back to the v1 symbol (name unchanged).

For init, the ToolResponse modified by the v2 symbol will become the default behavior of Kokkos. This gives tools a one-stop place to say "I want Kokkos to default to not fencing." Then, every other v2 event will be passed the ToolResponse filled out by init. If they want to override the default for that event, they may.

So, right now I'm looking at two use cases.

1) I'm a smrt tool like APEX and I don't need fences. @khuck and I might work on testing out this use case, but I'm open to other collaborators
2) I'm a tuning tool. Once I've converged, I want to stop fencing the application. This one I already know how to make work
3) I'm a traditional tool. Test that I don't get screwed up by this

Can anybody think of others?