### PR TITLE
Fix compiling SYCL with Kokkos_ENABLE_TUNING=ON

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
@@ -241,6 +241,11 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
  public:
   using functor_type = FunctorType;
 
+  template <typename Policy, typename Functor>
+  static int max_tile_size_product(const Policy& policy, const Functor&) {
+    return policy.space().impl_internal_space_instance()->m_maxThreadsPerSM;
+  }
+
   void execute() const {
     Kokkos::Experimental::Impl::SYCLInternal::IndirectKernelMem&
         indirectKernelMem =


### PR DESCRIPTION
Probably not the final implementation but this what we are using everywhere else at the moment.