### PR TITLE
Remove ExtendedReferenceWrapper for SYCL parallel_reduce

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
@@ -98,8 +98,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, ExecPolicy,
                                 .impl_internal_space_instance()
                                 ->m_indirectKernelMem;
 
-    const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper<
-        std::reference_wrapper<FunctorType>>(m_functor, indirectKernelMem);
+    const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper(
+        m_functor, indirectKernelMem);
     sycl_direct_launch(m_policy, functor_wrapper.get_functor());
   }
 
@@ -246,8 +246,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         indirectKernelMem =
             m_space.impl_internal_space_instance()->m_indirectKernelMem;
 
-    const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper<
-        std::reference_wrapper<FunctorType>>(m_functor, indirectKernelMem);
+    const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper(
+        m_functor, indirectKernelMem);
     sycl_direct_launch(functor_wrapper.get_functor());
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -287,10 +287,10 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     IndirectKernelMem& indirectKernelMem  = instance.m_indirectKernelMem;
     IndirectKernelMem& indirectReducerMem = instance.m_indirectReducerMem;
 
-    const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper<
-        std::reference_wrapper<FunctorType>>(m_functor, indirectKernelMem);
-    const auto reducer_wrapper = Experimental::Impl::make_sycl_function_wrapper<
-        std::reference_wrapper<ReducerType>>(m_reducer, indirectReducerMem);
+    const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper(
+        m_functor, indirectKernelMem);
+    const auto reducer_wrapper = Experimental::Impl::make_sycl_function_wrapper(
+        m_reducer, indirectReducerMem);
 
     sycl_direct_launch(m_policy, functor_wrapper.get_functor(),
                        reducer_wrapper.get_functor());

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -86,78 +86,21 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
         m_result_ptr(reducer.view().data()) {}
 
  private:
-  template <typename T>
-  struct HasJoin {
-    template <typename U>
-    static constexpr decltype(
-        std::declval<U>().join(
-            std::declval<
-                typename FunctorValueTraits<T, WorkTag>::value_type&>(),
-            std::declval<
-                const typename FunctorValueTraits<T, WorkTag>::value_type&>()),
-        bool())
-    test_join(int) {
-      return true;
-    }
-
-    template <typename U>
-    static constexpr bool test_join(...) {
-      return false;
-    }
-
-    static constexpr bool value = test_join<T>(int());
-  };
-
-  template <typename T>
-  struct ExtendedReferenceWrapper : std::reference_wrapper<T> {
-    using std::reference_wrapper<T>::reference_wrapper;
-
-    using value_type = typename FunctorValueTraits<T, WorkTag>::value_type;
-
-    template <typename Dummy = T>
-    std::enable_if_t<std::is_same_v<Dummy, T> &&
-                     ReduceFunctorHasInit<Dummy>::value>
-    init(value_type& value) const {
-      return this->get().init(value);
-    }
-
-    template <typename Dummy = T>
-    std::enable_if_t<std::is_same_v<Dummy, T> && HasJoin<Dummy>::value> join(
-        volatile value_type& dest, const volatile value_type& src) const {
-      return this->get().join(dest, src);
-    }
-
-    template <typename Dummy = T>
-    std::enable_if_t<std::is_same_v<Dummy, T> &&
-                     ReduceFunctorHasFinal<Dummy>::value>
-    final(value_type& value) const {
-      return this->get().final(value);
-    }
-  };
-
   template <typename PolicyType, typename Functor, typename Reducer>
   void sycl_direct_launch(const PolicyType& policy, const Functor& functor,
                           const Reducer& reducer) const {
-    static_assert(ReduceFunctorHasInit<Functor>::value ==
-                  ReduceFunctorHasInit<FunctorType>::value);
-    static_assert(ReduceFunctorHasFinal<Functor>::value ==
-                  ReduceFunctorHasFinal<FunctorType>::value);
-    static_assert(HasJoin<Functor>::value == HasJoin<FunctorType>::value);
-    if constexpr (!std::is_same<Reducer, InvalidType>::value)
-      static_assert(HasJoin<Reducer>::value == HasJoin<ReducerType>::value);
-
     using ReducerConditional =
-        Kokkos::Impl::if_c<std::is_same<InvalidType, Reducer>::value, Functor,
-                           Reducer>;
+        Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
+                           FunctorType, ReducerType>;
     using ReducerTypeFwd = typename ReducerConditional::type;
     using WorkTagFwd =
-        std::conditional_t<std::is_same<InvalidType, Reducer>::value, WorkTag,
-                           void>;
+        std::conditional_t<std::is_same<InvalidType, ReducerType>::value,
+                           WorkTag, void>;
     using ValueInit =
         Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd>;
     using ValueJoin =
         Kokkos::Impl::FunctorValueJoin<ReducerTypeFwd, WorkTagFwd>;
-    using ValueOps = Kokkos::Impl::FunctorValueOps<Functor, WorkTag>;
+    using ValueOps = Kokkos::Impl::FunctorValueOps<FunctorType, WorkTag>;
 
     auto selected_reducer = ReducerConditional::select(functor, reducer);
 
@@ -191,6 +134,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       q.submit([&](sycl::handler& cgh) {
         const auto begin = policy.begin();
         cgh.single_task([=]() {
+          const auto& selected_reducer = ReducerConditional::select(
+              static_cast<const FunctorType&>(functor),
+              static_cast<const ReducerType&>(reducer));
           reference_type update =
               ValueInit::init(selected_reducer, results_ptr);
           if (size == 1) {
@@ -199,8 +145,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
             else
               functor(WorkTag(), begin, update);
           }
-          if constexpr (ReduceFunctorHasFinal<Functor>::value)
-            FunctorFinal<Functor, WorkTag>::final(functor, results_ptr);
+          if constexpr (ReduceFunctorHasFinal<FunctorType>::value)
+            FunctorFinal<FunctorType, WorkTag>::final(
+                static_cast<const FunctorType&>(functor), results_ptr);
         });
       });
       space.fence();
@@ -229,6 +176,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
               const auto global_id =
                   wgroup_size * item.get_group_linear_id() * values_per_thread +
                   local_id;
+              const auto& selected_reducer = ReducerConditional::select(
+                  static_cast<const FunctorType&>(functor),
+                  static_cast<const ReducerType&>(reducer));
 
               // In the first iteration, we call functor to initialize the local
               // memory. Otherwise, the local memory is initialized with the
@@ -292,11 +242,12 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                     functor,
                     &results_ptr2[(item.get_group_linear_id()) * value_count],
                     &local_mem[0]);
-                if constexpr (ReduceFunctorHasFinal<Functor>::value)
+                if constexpr (ReduceFunctorHasFinal<FunctorType>::value)
                   if (n_wgroups <= 1)
-                    FunctorFinal<Functor, WorkTag>::final(
-                        functor, &results_ptr2[(item.get_group_linear_id()) *
-                                               value_count]);
+                    FunctorFinal<FunctorType, WorkTag>::final(
+                        static_cast<const FunctorType&>(functor),
+                        &results_ptr2[(item.get_group_linear_id()) *
+                                      value_count]);
               }
             });
       });
@@ -337,9 +288,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     IndirectKernelMem& indirectReducerMem = instance.m_indirectReducerMem;
 
     const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper<
-        ExtendedReferenceWrapper<FunctorType>>(m_functor, indirectKernelMem);
+        std::reference_wrapper<FunctorType>>(m_functor, indirectKernelMem);
     const auto reducer_wrapper = Experimental::Impl::make_sycl_function_wrapper<
-        ExtendedReferenceWrapper<ReducerType>>(m_reducer, indirectReducerMem);
+        std::reference_wrapper<ReducerType>>(m_reducer, indirectReducerMem);
 
     sycl_direct_launch(m_policy, functor_wrapper.get_functor(),
                        reducer_wrapper.get_functor());

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -245,8 +245,8 @@ class ParallelScanSYCLBase {
                                 .impl_internal_space_instance()
                                 ->m_indirectKernelMem;
 
-    const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper<
-        std::reference_wrapper<FunctorType>>(m_functor, indirectKernelMem);
+    const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper(
+        m_functor, indirectKernelMem);
 
     sycl_direct_launch(functor_wrapper.get_functor());
     post_functor();

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -437,8 +437,8 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                 .impl_internal_space_instance()
                                 ->m_indirectKernelMem;
 
-    const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper<
-        std::reference_wrapper<FunctorType>>(m_functor, indirectKernelMem);
+    const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper(
+        m_functor, indirectKernelMem);
 
     sycl_direct_launch(m_policy, functor_wrapper.get_functor());
   }

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -84,16 +84,6 @@ struct ReduceFunctorHasInit<
     typename std::enable_if<0 < sizeof(&FunctorType::init)>::type> {
   enum : bool { value = true };
 };
-// FIXME_SYCL not all compilers distinguish between the FunctorType::init and
-// the FunctorType::template init<> specialization
-#ifdef KOKKOS_ENABLE_SYCL
-template <class FunctorType>
-struct ReduceFunctorHasInit<
-    FunctorType,
-    typename std::enable_if<0 < sizeof(&FunctorType::template init<>)>::type> {
-  enum : bool { value = true };
-};
-#endif
 #endif
 
 template <class FunctorType, class Enable = void>
@@ -117,16 +107,6 @@ struct ReduceFunctorHasJoin<
     typename std::enable_if<0 < sizeof(&FunctorType::join)>::type> {
   enum : bool { value = true };
 };
-// FIXME_SYCL not all compilers distinguish between the FunctorType::join and
-// the FunctorType::template join<> specialization
-#ifdef KOKKOS_ENABLE_SYCL
-template <class FunctorType>
-struct ReduceFunctorHasJoin<
-    FunctorType,
-    typename std::enable_if<0 < sizeof(&FunctorType::template join<>)>::type> {
-  enum : bool { value = true };
-};
-#endif
 #endif
 
 template <class FunctorType, class Enable = void>
@@ -150,16 +130,6 @@ struct ReduceFunctorHasFinal<
     typename std::enable_if<0 < sizeof(&FunctorType::final)>::type> {
   enum : bool { value = true };
 };
-// FIXME_SYCL not all compilers distinguish between the FunctorType::final and
-// the FunctorType::template final<> specialization
-#ifdef KOKKOS_ENABLE_SYCL
-template <class FunctorType>
-struct ReduceFunctorHasFinal<
-    FunctorType,
-    typename std::enable_if<0 < sizeof(&FunctorType::template final<>)>::type> {
-  enum : bool { value = true };
-};
-#endif
 #endif
 
 template <class FunctorType, class Enable = void>
@@ -183,18 +153,6 @@ struct ReduceFunctorHasShmemSize<
     typename std::enable_if<0 < sizeof(&FunctorType::team_shmem_size)>::type> {
   enum : bool { value = true };
 };
-// FIXME_SYCL not all compilers distinguish between the
-// FunctorType::team_shmem_size and the FunctorType::template team_shmem_size<>
-// specialization
-#ifdef KOKKOS_ENABLE_SYCL
-template <class FunctorType>
-struct ReduceFunctorHasShmemSize<
-    FunctorType,
-    typename std::enable_if<
-        0 < sizeof(&FunctorType::template team_shmem_size<>)>::type> {
-  enum : bool { value = true };
-};
-#endif
 #endif
 
 template <class FunctorType, class ArgTag, class Enable = void>


### PR DESCRIPTION
It turns out that we actually don't need ExtendedReferenceWrapper if we are a bit more careful with the point when we set up the functor we actually want to run.
Using `std::reference_wrapper` instead also allows us to simplify `make_sycl_function_wrapper` and we can remove some code in `Kokkos_FunctorAdapter.hpp`, too.