### PR TITLE
Atrocious bug in MDRange tuning

### DIFF
--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -353,9 +353,10 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
 
  private:
   void init_helper(Impl::TileSizeProperties properties) {
-    int increment  = 1;
-    int rank_start = 0;
-    int rank_end   = rank;
+    m_prod_tile_dims = 1;
+    int increment    = 1;
+    int rank_start   = 0;
+    int rank_end     = rank;
     if (inner_direction == Iterate::Right) {
       increment  = -1;
       rank_start = rank - 1;


### PR DESCRIPTION
So, I only tested an MDRange tuning process with OpenMP. Turns out, we weren't resetting the tile product calculation, between runs of the init_helper, so it was getting summed. This works perfectly, unless you run your kernels more than nine times. This one-liner just resets the tile size product to 1 before recomputing. Oof