### PR TITLE
CMake check for C++14

### DIFF
--- a/cmake/compile_tests/cplusplus14.cpp
+++ b/cmake/compile_tests/cplusplus14.cpp
@@ -1,0 +1,8 @@
+#include <type_traits>
+
+int main() {
+  // _t versions of type traits were added in C++14
+  std::remove_cv_t<int> i = 0;
+
+  return i;
+}

--- a/cmake/kokkos_test_cxx_std.cmake
+++ b/cmake/kokkos_test_cxx_std.cmake
@@ -86,6 +86,17 @@ ELSE()
   MESSAGE(FATAL_ERROR "Unknown C++ standard ${KOKKOS_CXX_STANDARD} - must be 14, 17, or 20")
 ENDIF()
 
+# Enforce that we can compile a simple C++14 program
+
+TRY_COMPILE(CAN_COMPILE_CPP14
+  ${KOKKOS_TOP_BUILD_DIR}/corner_cases
+  ${KOKKOS_SOURCE_DIR}/cmake/compile_tests/cplusplus14.cpp
+)
+if (NOT CAN_COMPILE_CPP14)
+  UNSET(CAN_COMPILE_CPP14 CACHE) #make sure CMake always re-runs this
+  MESSAGE(FATAL_ERROR "C++${KOKKOS_CXX_STANDARD}-compliant compiler detected, but unable to compile C++14 or later program. Verify that ${CMAKE_CXX_COMPILER_ID}:${CMAKE_CXX_COMPILER_VERSION} is set up correctly (e.g., check that correct library headers are being used).")
+ENDIF()
+UNSET(CAN_COMPILE_CPP14 CACHE) #make sure CMake always re-runs this
 
 
 # Enforce that extensions are turned off for nvcc_wrapper.


### PR DESCRIPTION
Issue #3789 

This adds a CMake check for C++14 (for all compilers) by seeing if `std::remove_cv_t` compiles, as the `_t` versions of type traits were first added in C++14.