### PR TITLE
Constructing Atomic Subviews

### DIFF
--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2684,7 +2684,7 @@ struct ViewDataHandle<
   template <class SrcHandleType>
   KOKKOS_INLINE_FUNCTION static handle_type assign(
       const SrcHandleType& arg_handle, size_t offset) {
-    return handle_type(arg_handle.ptr + offset);
+    return handle_type(arg_handle + offset);
   }
 };
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -229,6 +229,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
       SubView_c11
       SubView_c12
       SubView_c13
+      SubView_c14
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/core/unit_test/TestSubView_c14.hpp
+++ b/core/unit_test/TestSubView_c14.hpp
@@ -1,0 +1,56 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_TEST_SUBVIEW_C14_HPP
+#define KOKKOS_TEST_SUBVIEW_C14_HPP
+#include <TestViewSubview.hpp>
+
+namespace Test {
+
+TEST(TEST_CATEGORY, view_subview_memory_traits_construction) {
+  TestViewSubview::test_subview_memory_traits_construction();
+}
+
+}  // namespace Test
+#endif

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2136,11 +2136,15 @@ void test_unmanaged_subview_reset() {
 template <std::underlying_type_t<Kokkos::MemoryTraitsFlags> MTF>
 struct TestSubviewMemoryTraitsConstruction {
   void operator()() const noexcept {
-    Kokkos::View<double*, Kokkos::HostSpace> v("v", 7);
-    for (int i = 0; i != v.size(); ++i) v[i] = static_cast<double>(i);
+    using view_type          = Kokkos::View<double*, Kokkos::HostSpace>;
+    using size_type          = view_type::size_type;
+    using memory_traits_type = Kokkos::MemoryTraits<MTF>;
+
+    view_type v("v", 7);
+    for (size_type i = 0; i != v.size(); ++i) v[i] = static_cast<double>(i);
 
     std::pair<int, int> range(3, 5);
-    auto sv = Kokkos::subview<Kokkos::MemoryTraits<MTF>>(v, range);
+    auto sv = Kokkos::subview<memory_traits_type>(v, range);
 
     ASSERT_EQ(2u, sv.size());
     EXPECT_EQ(3., sv[0]);
@@ -2149,7 +2153,11 @@ struct TestSubviewMemoryTraitsConstruction {
 };
 
 inline void test_subview_memory_traits_construction() {
-  // Test all combinations of Unmanaged, RandomAccess, Atomic and Restricted
+  // Test all combinations of MemoryTraits:
+  // Unmanaged (1)
+  // RandomAccess (2)
+  // Atomic (4)
+  // Restricted (8)
   TestSubviewMemoryTraitsConstruction<0>()();
   TestSubviewMemoryTraitsConstruction<1>()();
   TestSubviewMemoryTraitsConstruction<2>()();

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2133,6 +2133,43 @@ void test_unmanaged_subview_reset() {
 
 //----------------------------------------------------------------------------
 
+template <std::underlying_type_t<Kokkos::MemoryTraitsFlags> MTF>
+struct TestSubviewMemoryTraitsConstruction {
+  void operator()() const noexcept {
+    Kokkos::View<double*, Kokkos::HostSpace> v("v", 7);
+    for (int i = 0; i != v.size(); ++i) v[i] = static_cast<double>(i);
+
+    std::pair<int, int> range(3, 5);
+    auto sv = Kokkos::subview<Kokkos::MemoryTraits<MTF>>(v, range);
+
+    ASSERT_EQ(2u, sv.size());
+    EXPECT_EQ(3., sv[0]);
+    EXPECT_EQ(4., sv[1]);
+  }
+};
+
+inline void test_subview_memory_traits_construction() {
+  // Test all combinations of Unmanaged, RandomAccess, Atomic and Restricted
+  TestSubviewMemoryTraitsConstruction<0>()();
+  TestSubviewMemoryTraitsConstruction<1>()();
+  TestSubviewMemoryTraitsConstruction<2>()();
+  TestSubviewMemoryTraitsConstruction<3>()();
+  TestSubviewMemoryTraitsConstruction<4>()();
+  TestSubviewMemoryTraitsConstruction<5>()();
+  TestSubviewMemoryTraitsConstruction<6>()();
+  TestSubviewMemoryTraitsConstruction<7>()();
+  TestSubviewMemoryTraitsConstruction<8>()();
+  TestSubviewMemoryTraitsConstruction<9>()();
+  TestSubviewMemoryTraitsConstruction<10>()();
+  TestSubviewMemoryTraitsConstruction<11>()();
+  TestSubviewMemoryTraitsConstruction<12>()();
+  TestSubviewMemoryTraitsConstruction<13>()();
+  TestSubviewMemoryTraitsConstruction<14>()();
+  TestSubviewMemoryTraitsConstruction<15>()();
+}
+
+//----------------------------------------------------------------------------
+
 template <class T>
 struct get_view_type;
 


### PR DESCRIPTION
Issue #3765 

    View<double*> a("a",10);
    auto range = std::pair(0,4);
    auto s3 = subview<MemoryTraits<Atomic>>(a, range);

We get to down to:
ViewDataHandle (specialized for MemoryTraits<Atomic>)::

    template <class SrcHandleType>
    KOKKOS_INLINE_FUNCTION static handle_type assign(
        const SrcHandleType& arg_handle, size_t offset) {
      return handle_type(arg_handle.ptr + offset);
    }

arg_handle is already a pointer (double*), so .ptr is incorrect.

This fixes the compile time problem, but still needs run time test cases.