### PR TITLE
[HIP] Use shuffle for range reduction

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -174,11 +174,14 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   size_type* m_scratch_space = nullptr;
   size_type* m_scratch_flags = nullptr;
 
-  // FIXME_HIP_PERFORMANCE Need a rule to choose when to use shared memory and
-  // when to use shuffle
+#if HIP_VERSION < 401
   static bool constexpr UseShflReduction =
       ((sizeof(value_type) > 2 * sizeof(double)) &&
        static_cast<bool>(ValueTraits::StaticValueSize));
+#else
+  static bool constexpr UseShflReduction =
+      static_cast<bool>(ValueTraits::StaticValueSize);
+#endif
 
  private:
   struct ShflReductionTag {};


### PR DESCRIPTION
Looking at our performance unit test, I noticed that `Time RangePolicy Reduce` is significantly slower than `parallel_for`. This only happens for `RangePolicy`, `MDRange` and `Team` are fine. Using shuffle for Range reduction when the datatype size is known at compile time, I get a speed up of a factor two. This brings the performance of `parallel_reduce` Range policy in line with `parallel_for`. This requires rocm 4.1 because of a register spill bug. 