### PR TITLE
V1.1 Tools Interface: incremental, action-based

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -72,7 +72,7 @@ void tool_invoked_fence(const uint32_t /* devID */) {
    */
   Kokkos::fence();
 }
-};  // namespace Impl
+}  // namespace Impl
 #ifdef KOKKOS_ENABLE_TUNING
 static size_t kernel_name_context_variable_id;
 static size_t kernel_type_context_variable_id;

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -429,8 +429,8 @@ void lookup_function(void* dlopen_handle, const std::string& basename,
   // workaround the issue by casting pointer to pointers.
   v2 = *reinterpret_cast<V2Function*>(&p);
   if (v2 == nullptr) {
-    p      = dlsym(dlopen_handle, basename.c_str());
-    v1     = *reinterpret_cast<V1Function*>(&p);
+    p  = dlsym(dlopen_handle, basename.c_str());
+    v1 = *reinterpret_cast<V1Function*>(&p);
   }
 }
 

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -422,6 +422,7 @@ SpaceHandle make_space_handle(const char* space_name) {
 template <typename V1Function, typename V2Function>
 void lookup_function(void* dlopen_handle, const std::string& basename,
                      V2Function& v2, V1Function& v1) {
+#ifdef KOKKOS_ENABLE_LIBDL
   auto v2name = basename + "_v2";
   auto p      = dlsym(dlopen_handle, v2name.c_str());
   // dlsym returns a pointer to an object, while we want to assign to
@@ -432,6 +433,7 @@ void lookup_function(void* dlopen_handle, const std::string& basename,
     p  = dlsym(dlopen_handle, basename.c_str());
     v1 = *reinterpret_cast<V1Function*>(&p);
   }
+#endif
 }
 
 void initialize(const std::string& profileLibrary) {

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -429,7 +429,7 @@ void lookup_function(void* dlopen_handle, const std::string& basename,
   // workaround the issue by casting pointer to pointers.
   v2 = *reinterpret_cast<V2Function*>(&p);
   if (v2 == nullptr) {
-    auto p = dlsym(dlopen_handle, basename.c_str());
+    p      = dlsym(dlopen_handle, basename.c_str());
     v1     = *reinterpret_cast<V1Function*>(&p);
   }
 }

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -85,7 +85,7 @@ static std::unordered_map<size_t, VariableInfo> variable_metadata;
 static EventSet current_callbacks;
 static EventSet backup_callbacks;
 static EventSet no_profiling;
-static Kokkos::Tools::Experimental::ToolResponses tool_requirements;
+static Kokkos::Tools::Experimental::ToolSettings tool_requirements;
 bool eventSetsEqual(const EventSet& l, const EventSet& r) {
   return l.init == r.init && l.finalize == r.finalize &&
          l.parse_args == r.parse_args && l.print_help == r.print_help &&
@@ -118,8 +118,8 @@ bool eventSetsEqual(const EventSet& l, const EventSet& r) {
          l.declare_optimization_goal == r.declare_optimization_goal;
 }
 template <typename Callback, typename BooleanConstant, typename... Args>
-void call_kokkos_callback(const Callback callback, BooleanConstant,
-                          Args... args) {
+inline void call_kokkos_callback(const Callback callback, BooleanConstant,
+                                 Args... args) {
   if (callback != nullptr) {
     if ((BooleanConstant::value) &&
         (Kokkos::Tools::Experimental::tool_requirements
@@ -549,7 +549,7 @@ void initialize(const std::string& profileLibrary) {
           firstProfileLibrary, "kokkosp_transmit_actions",
           Kokkos::Tools::Experimental::current_callbacks.transmit_actions);
       lookup_function(
-          firstProfileLibrary, "kokkosp_request_responses",
+          firstProfileLibrary, "kokkosp_request_settings",
           Kokkos::Tools::Experimental::current_callbacks.request_responses);
     }
   }
@@ -567,7 +567,7 @@ void initialize(const std::string& profileLibrary) {
       Kokkos::Tools::Experimental::current_callbacks.request_responses,
       std::false_type{}, &Kokkos::Tools::Experimental::tool_requirements);
 
-  Kokkos::Tools::Experimental::ToolActions actions;
+  Kokkos::Tools::Experimental::ToolInvokedActions actions;
   actions.num_supported_actions = 1;
   actions.fence = &Kokkos::Tools::Experimental::Impl::tool_invoked_fence;
 

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -108,8 +108,9 @@ bool eventSetsEqual(const EventSet& l, const EventSet& r) {
          l.end_fence == r.end_fence && l.sync_dual_view == r.sync_dual_view &&
          l.modify_dual_view == r.modify_dual_view &&
          l.declare_metadata == r.declare_metadata &&
-         l.request_settings == r.request_settings &&
-         l.transmit_actions == r.transmit_actions &&
+         l.request_tool_settings == r.request_tool_settings &&
+         l.provide_tool_programming_interface ==
+             r.provide_tool_programming_interface &&
          l.declare_input_type == r.declare_input_type &&
          l.declare_output_type == r.declare_output_type &&
          l.end_tuning_context == r.end_tuning_context &&
@@ -549,12 +550,13 @@ void initialize(const std::string& profileLibrary) {
       lookup_function(
           firstProfileLibrary, "kokkosp_parse_args",
           Kokkos::Tools::Experimental::current_callbacks.parse_args);
+      lookup_function(firstProfileLibrary,
+                      "kokkosp_provide_tool_programming_interface",
+                      Kokkos::Tools::Experimental::current_callbacks
+                          .provide_tool_programming_interface);
       lookup_function(
-          firstProfileLibrary, "kokkosp_transmit_actions",
-          Kokkos::Tools::Experimental::current_callbacks.transmit_actions);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_request_settings",
-          Kokkos::Tools::Experimental::current_callbacks.request_settings);
+          firstProfileLibrary, "kokkosp_request_tool_settings",
+          Kokkos::Tools::Experimental::current_callbacks.request_tool_settings);
     }
   }
 #else
@@ -567,14 +569,15 @@ void initialize(const std::string& profileLibrary) {
   Kokkos::Tools::Experimental::tool_requirements.requires_global_fencing = true;
 
   Kokkos::Tools::Experimental::invoke_kokkos_callback(
-      Kokkos::Tools::Experimental::current_callbacks.request_settings,
+      Kokkos::Tools::Experimental::current_callbacks.request_tool_settings,
       std::false_type{}, 1, &Kokkos::Tools::Experimental::tool_requirements);
 
-  Kokkos::Tools::Experimental::ToolInvokedActions actions;
+  Kokkos::Tools::Experimental::ToolProgrammingInterface actions;
   actions.fence = &Kokkos::Tools::Experimental::Impl::tool_invoked_fence;
 
   Kokkos::Tools::Experimental::invoke_kokkos_callback(
-      Kokkos::Tools::Experimental::current_callbacks.transmit_actions,
+      Kokkos::Tools::Experimental::current_callbacks
+          .provide_tool_programming_interface,
       std::false_type{}, 1, actions);
 
 #ifdef KOKKOS_ENABLE_TUNING

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -136,14 +136,14 @@ typedef void (*Kokkos_Tools_toolInvokedFenceFunction)(const uint32_t);
 
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Tools_function_pointer)();
-struct Kokkos_Tools_ToolActions {
+struct Kokkos_Tools_ToolInvokedActions {
   int num_supported_actions;
   Kokkos_Tools_toolInvokedFenceFunction fence;
   // allow addition of more actions
   Kokkos_Tools_function_pointer padding[31];
 };
 
-struct Kokkos_Tools_ToolResponses {
+struct Kokkos_Tools_ToolSettings {
   int num_supported_responses;
   bool requires_global_fencing;
   bool padding[255];
@@ -151,10 +151,10 @@ struct Kokkos_Tools_ToolResponses {
 
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Tools_transmitActionsFunction)(
-    struct Kokkos_Tools_ToolActions);
+    struct Kokkos_Tools_ToolInvokedActions);
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Tools_requestResponsesFunction)(
-    struct Kokkos_Tools_ToolResponses*);
+    struct Kokkos_Tools_ToolSettings*);
 
 // Tuning
 

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -135,11 +135,11 @@ typedef void (*Kokkos_Profiling_declareMetadataFunction)(const char*,
 typedef void (*Kokkos_Tools_toolInvokedFenceFunction)(const uint32_t);
 
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
-typedef void (*Kokkos_Tools_function_pointer)();
+typedef void (*Kokkos_Tools_functionPointer)();
 struct Kokkos_Tools_ToolProgrammingInterface {
   Kokkos_Tools_toolInvokedFenceFunction fence;
   // allow addition of more actions
-  Kokkos_Tools_function_pointer padding[31];
+  Kokkos_Tools_functionPointer padding[31];
 };
 
 struct Kokkos_Tools_ToolSettings {
@@ -278,7 +278,7 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Tools_provideToolProgrammingInterfaceFunction
       provide_tool_programming_interface;
   Kokkos_Tools_requestSettingsFunction request_tool_settings;
-  char profiling_padding[9 * sizeof(Kokkos_Tools_function_pointer)];
+  char profiling_padding[9 * sizeof(Kokkos_Tools_functionPointer)];
   Kokkos_Tools_outputTypeDeclarationFunction declare_output_type;
   Kokkos_Tools_inputTypeDeclarationFunction declare_input_type;
   Kokkos_Tools_requestValueFunction request_output_values;
@@ -287,10 +287,10 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Tools_optimizationGoalDeclarationFunction declare_optimization_goal;
   char padding[232 *
                sizeof(
-                   Kokkos_Tools_function_pointer)];  // allows us to add another
-                                                     // 256 events to the Tools
-                                                     // interface without
-                                                     // changing struct layout
+                   Kokkos_Tools_functionPointer)];  // allows us to add another
+                                                    // 256 events to the Tools
+                                                    // interface without
+                                                    // changing struct layout
 };
 
 #endif  // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -131,9 +131,29 @@ typedef void (*Kokkos_Profiling_dualViewModifyFunction)(const char*,
 typedef void (*Kokkos_Profiling_declareMetadataFunction)(const char*,
                                                          const char*);
 
-typedef void (*Kokkos_Profiling_toolInvokedFenceFunction)(const uint32_t);
-typedef void (*Kokkos_Profiling_transmitFenceFunction)(
-    Kokkos_Profiling_toolInvokedFenceFunction);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_toolInvokedFenceFunction)(const uint32_t);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_function_pointer)();
+struct Kokkos_Tools_ToolActions {
+  int num_supported_actions;
+  Kokkos_Tools_toolInvokedFenceFunction fence;
+  // allow addition of more actions
+  Kokkos_Tools_function_pointer padding[31];
+};
+
+struct Kokkos_Tools_ToolResponses {
+  int num_supported_responses;
+  bool requires_global_fencing;
+  bool padding[255];
+};
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_transmitActionsFunction)(Kokkos_Tools_ToolActions);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Tools_requestResponsesFunction)(
+    Kokkos_Tools_ToolResponses*);
 
 // Tuning
 
@@ -229,8 +249,6 @@ typedef void (*Kokkos_Tools_contextEndFunction)(
 typedef void (*Kokkos_Tools_optimizationGoalDeclarationFunction)(
     const size_t, const struct Kokkos_Tools_OptimzationGoal goal);
 
-typedef void (*function_pointer)();
-
 struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_initFunction init;
   Kokkos_Profiling_finalizeFunction finalize;
@@ -258,8 +276,9 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_dualViewSyncFunction sync_dual_view;
   Kokkos_Profiling_dualViewModifyFunction modify_dual_view;
   Kokkos_Profiling_declareMetadataFunction declare_metadata;
-  Kokkos_Profiling_transmitFenceFunction transmit_fence;
-  char profiling_padding[10 * sizeof(function_pointer)];
+  Kokkos_Tools_transmitActionsFunction transmit_actions;
+  Kokkos_Tools_requestResponsesFunction request_responses;
+  char profiling_padding[9 * sizeof(Kokkos_Tools_function_pointer)];
   Kokkos_Tools_outputTypeDeclarationFunction declare_output_type;
   Kokkos_Tools_inputTypeDeclarationFunction declare_input_type;
   Kokkos_Tools_requestValueFunction request_output_values;
@@ -267,9 +286,11 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Tools_contextEndFunction end_tuning_context;
   Kokkos_Tools_optimizationGoalDeclarationFunction declare_optimization_goal;
   char padding[232 *
-               sizeof(function_pointer)];  // allows us to add another 256
-                                           // events to the Tools interface
-                                           // without changing struct layout
+               sizeof(
+                   Kokkos_Tools_function_pointer)];  // allows us to add another
+                                                     // 256 events to the Tools
+                                                     // interface without
+                                                     // changing struct layout
 };
 
 #endif  // KOKKOS_PROFILING_C_INTERFACE_HPP

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -66,21 +66,10 @@ struct Kokkos_Profiling_SpaceHandle {
   char name[64];
 };
 
-struct Kokkos_Profiling_ToolResponse {
-  bool should_fence;
-};
-
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_initFunction)(
     const int, const uint64_t, const uint32_t,
     struct Kokkos_Profiling_KokkosPDeviceInfo*);
-
-// NOLINTNEXTLINE(modernize-use-using): C compatibility
-typedef void (*Kokkos_Profiling_initFunction_v2)(
-    const int, const uint64_t, const uint32_t,
-    struct Kokkos_Profiling_KokkosPDeviceInfo*,
-    struct Kokkos_Profiling_ToolResponse*);
-
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_finalizeFunction)();
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
@@ -91,13 +80,7 @@ typedef void (*Kokkos_Profiling_printHelpFunction)(char*);
 typedef void (*Kokkos_Profiling_beginFunction)(const char*, const uint32_t,
                                                uint64_t*);
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
-typedef void (*Kokkos_Profiling_beginFunction_v2)(
-    const char*, const uint32_t, uint64_t*,
-    struct Kokkos_Profiling_ToolResponse*);
-// NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_endFunction)(uint64_t);
-typedef void (*Kokkos_Profiling_endFunction_v2)(
-    uint64_t, struct Kokkos_Profiling_ToolResponse*);
 
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_pushFunction)(const char*);
@@ -147,6 +130,10 @@ typedef void (*Kokkos_Profiling_dualViewModifyFunction)(const char*,
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_declareMetadataFunction)(const char*,
                                                          const char*);
+
+typedef void (*Kokkos_Profiling_toolInvokedFenceFunction)(const uint32_t);
+typedef void (*Kokkos_Profiling_transmitFenceFunction)(
+    Kokkos_Profiling_toolInvokedFenceFunction);
 
 // Tuning
 
@@ -246,22 +233,15 @@ typedef void (*function_pointer)();
 
 struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_initFunction init;
-  Kokkos_Profiling_initFunction_v2 init_v2;
   Kokkos_Profiling_finalizeFunction finalize;
   Kokkos_Profiling_parseArgsFunction parse_args;
   Kokkos_Profiling_printHelpFunction print_help;
   Kokkos_Profiling_beginFunction begin_parallel_for;
-  Kokkos_Profiling_beginFunction_v2 begin_parallel_for_v2;
   Kokkos_Profiling_endFunction end_parallel_for;
-  Kokkos_Profiling_endFunction_v2 end_parallel_for_v2;
   Kokkos_Profiling_beginFunction begin_parallel_reduce;
-  Kokkos_Profiling_beginFunction_v2 begin_parallel_reduce_v2;
   Kokkos_Profiling_endFunction end_parallel_reduce;
-  Kokkos_Profiling_endFunction_v2 end_parallel_reduce_v2;
   Kokkos_Profiling_beginFunction begin_parallel_scan;
-  Kokkos_Profiling_beginFunction_v2 begin_parallel_scan_v2;
   Kokkos_Profiling_endFunction end_parallel_scan;
-  Kokkos_Profiling_endFunction_v2 end_parallel_scan_v2;
   Kokkos_Profiling_pushFunction push_region;
   Kokkos_Profiling_popFunction pop_region;
   Kokkos_Profiling_allocateDataFunction allocate_data;
@@ -278,14 +258,15 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_dualViewSyncFunction sync_dual_view;
   Kokkos_Profiling_dualViewModifyFunction modify_dual_view;
   Kokkos_Profiling_declareMetadataFunction declare_metadata;
-  char profiling_padding[11 * sizeof(function_pointer)];
+  Kokkos_Profiling_transmitFenceFunction transmit_fence;
+  char profiling_padding[10 * sizeof(function_pointer)];
   Kokkos_Tools_outputTypeDeclarationFunction declare_output_type;
   Kokkos_Tools_inputTypeDeclarationFunction declare_input_type;
   Kokkos_Tools_requestValueFunction request_output_values;
   Kokkos_Tools_contextBeginFunction begin_tuning_context;
   Kokkos_Tools_contextEndFunction end_tuning_context;
   Kokkos_Tools_optimizationGoalDeclarationFunction declare_optimization_goal;
-  char padding[225 *
+  char padding[232 *
                sizeof(function_pointer)];  // allows us to add another 256
                                            // events to the Tools interface
                                            // without changing struct layout

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -137,24 +137,22 @@ typedef void (*Kokkos_Tools_toolInvokedFenceFunction)(const uint32_t);
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Tools_function_pointer)();
 struct Kokkos_Tools_ToolInvokedActions {
-  int num_supported_actions;
   Kokkos_Tools_toolInvokedFenceFunction fence;
   // allow addition of more actions
   Kokkos_Tools_function_pointer padding[31];
 };
 
 struct Kokkos_Tools_ToolSettings {
-  int num_supported_responses;
   bool requires_global_fencing;
   bool padding[255];
 };
 
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Tools_transmitActionsFunction)(
-    struct Kokkos_Tools_ToolInvokedActions);
+    const uint32_t, struct Kokkos_Tools_ToolInvokedActions);
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
-typedef void (*Kokkos_Tools_requestResponsesFunction)(
-    struct Kokkos_Tools_ToolSettings*);
+typedef void (*Kokkos_Tools_requestSettingsFunction)(
+    const uint32_t, struct Kokkos_Tools_ToolSettings*);
 
 // Tuning
 
@@ -278,7 +276,7 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_dualViewModifyFunction modify_dual_view;
   Kokkos_Profiling_declareMetadataFunction declare_metadata;
   Kokkos_Tools_transmitActionsFunction transmit_actions;
-  Kokkos_Tools_requestResponsesFunction request_responses;
+  Kokkos_Tools_requestSettingsFunction request_settings;
   char profiling_padding[9 * sizeof(Kokkos_Tools_function_pointer)];
   Kokkos_Tools_outputTypeDeclarationFunction declare_output_type;
   Kokkos_Tools_inputTypeDeclarationFunction declare_input_type;

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -54,7 +54,7 @@
 #include <stdbool.h>
 #endif
 
-#define KOKKOSP_INTERFACE_VERSION 20210106
+#define KOKKOSP_INTERFACE_VERSION 20210225
 
 // Profiling
 

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -150,10 +150,11 @@ struct Kokkos_Tools_ToolResponses {
 };
 
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
-typedef void (*Kokkos_Tools_transmitActionsFunction)(Kokkos_Tools_ToolActions);
+typedef void (*Kokkos_Tools_transmitActionsFunction)(
+    struct Kokkos_Tools_ToolActions);
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Tools_requestResponsesFunction)(
-    Kokkos_Tools_ToolResponses*);
+    struct Kokkos_Tools_ToolResponses*);
 
 // Tuning
 

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -66,10 +66,21 @@ struct Kokkos_Profiling_SpaceHandle {
   char name[64];
 };
 
+struct Kokkos_Profiling_ToolResponse {
+  bool should_fence;
+};
+
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_initFunction)(
     const int, const uint64_t, const uint32_t,
     struct Kokkos_Profiling_KokkosPDeviceInfo*);
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_initFunction_v2)(
+    const int, const uint64_t, const uint32_t,
+    struct Kokkos_Profiling_KokkosPDeviceInfo*,
+    struct Kokkos_Profiling_ToolResponse*);
+
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_finalizeFunction)();
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
@@ -80,7 +91,13 @@ typedef void (*Kokkos_Profiling_printHelpFunction)(char*);
 typedef void (*Kokkos_Profiling_beginFunction)(const char*, const uint32_t,
                                                uint64_t*);
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef void (*Kokkos_Profiling_beginFunction_v2)(
+    const char*, const uint32_t, uint64_t*,
+    struct Kokkos_Profiling_ToolResponse*);
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_endFunction)(uint64_t);
+typedef void (*Kokkos_Profiling_endFunction_v2)(
+    uint64_t, struct Kokkos_Profiling_ToolResponse*);
 
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Profiling_pushFunction)(const char*);
@@ -229,15 +246,22 @@ typedef void (*function_pointer)();
 
 struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_initFunction init;
+  Kokkos_Profiling_initFunction_v2 init_v2;
   Kokkos_Profiling_finalizeFunction finalize;
   Kokkos_Profiling_parseArgsFunction parse_args;
   Kokkos_Profiling_printHelpFunction print_help;
   Kokkos_Profiling_beginFunction begin_parallel_for;
+  Kokkos_Profiling_beginFunction_v2 begin_parallel_for_v2;
   Kokkos_Profiling_endFunction end_parallel_for;
+  Kokkos_Profiling_endFunction_v2 end_parallel_for_v2;
   Kokkos_Profiling_beginFunction begin_parallel_reduce;
+  Kokkos_Profiling_beginFunction_v2 begin_parallel_reduce_v2;
   Kokkos_Profiling_endFunction end_parallel_reduce;
+  Kokkos_Profiling_endFunction_v2 end_parallel_reduce_v2;
   Kokkos_Profiling_beginFunction begin_parallel_scan;
+  Kokkos_Profiling_beginFunction_v2 begin_parallel_scan_v2;
   Kokkos_Profiling_endFunction end_parallel_scan;
+  Kokkos_Profiling_endFunction_v2 end_parallel_scan_v2;
   Kokkos_Profiling_pushFunction push_region;
   Kokkos_Profiling_popFunction pop_region;
   Kokkos_Profiling_allocateDataFunction allocate_data;
@@ -261,7 +285,7 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Tools_contextBeginFunction begin_tuning_context;
   Kokkos_Tools_contextEndFunction end_tuning_context;
   Kokkos_Tools_optimizationGoalDeclarationFunction declare_optimization_goal;
-  char padding[232 *
+  char padding[225 *
                sizeof(function_pointer)];  // allows us to add another 256
                                            // events to the Tools interface
                                            // without changing struct layout

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -151,7 +151,7 @@ struct Kokkos_Tools_ToolSettings {
 typedef void (*Kokkos_Tools_provideToolProgrammingInterfaceFunction)(
     const uint32_t, struct Kokkos_Tools_ToolProgrammingInterface);
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
-typedef void (*Kokkos_Tools_requestSettingsFunction)(
+typedef void (*Kokkos_Tools_requestToolSettingsFunction)(
     const uint32_t, struct Kokkos_Tools_ToolSettings*);
 
 // Tuning
@@ -277,7 +277,7 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_declareMetadataFunction declare_metadata;
   Kokkos_Tools_provideToolProgrammingInterfaceFunction
       provide_tool_programming_interface;
-  Kokkos_Tools_requestSettingsFunction request_tool_settings;
+  Kokkos_Tools_requestToolSettingsFunction request_tool_settings;
   char profiling_padding[9 * sizeof(Kokkos_Tools_functionPointer)];
   Kokkos_Tools_outputTypeDeclarationFunction declare_output_type;
   Kokkos_Tools_inputTypeDeclarationFunction declare_input_type;

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -136,7 +136,7 @@ typedef void (*Kokkos_Tools_toolInvokedFenceFunction)(const uint32_t);
 
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Tools_function_pointer)();
-struct Kokkos_Tools_ToolInvokedActions {
+struct Kokkos_Tools_ToolProgrammingInterface {
   Kokkos_Tools_toolInvokedFenceFunction fence;
   // allow addition of more actions
   Kokkos_Tools_function_pointer padding[31];
@@ -148,8 +148,8 @@ struct Kokkos_Tools_ToolSettings {
 };
 
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
-typedef void (*Kokkos_Tools_transmitActionsFunction)(
-    const uint32_t, struct Kokkos_Tools_ToolInvokedActions);
+typedef void (*Kokkos_Tools_provideToolProgrammingInterfaceFunction)(
+    const uint32_t, struct Kokkos_Tools_ToolProgrammingInterface);
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Tools_requestSettingsFunction)(
     const uint32_t, struct Kokkos_Tools_ToolSettings*);
@@ -275,8 +275,9 @@ struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_dualViewSyncFunction sync_dual_view;
   Kokkos_Profiling_dualViewModifyFunction modify_dual_view;
   Kokkos_Profiling_declareMetadataFunction declare_metadata;
-  Kokkos_Tools_transmitActionsFunction transmit_actions;
-  Kokkos_Tools_requestSettingsFunction request_settings;
+  Kokkos_Tools_provideToolProgrammingInterfaceFunction
+      provide_tool_programming_interface;
+  Kokkos_Tools_requestSettingsFunction request_tool_settings;
   char profiling_padding[9 * sizeof(Kokkos_Tools_function_pointer)];
   Kokkos_Tools_outputTypeDeclarationFunction declare_output_type;
   Kokkos_Tools_inputTypeDeclarationFunction declare_input_type;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -108,8 +108,8 @@ static_assert(sizeof(EventSet) / sizeof(Kokkos_Tools_function_pointer) == 275,
 using toolInvokedFenceFunction = Kokkos_Tools_toolInvokedFenceFunction;
 using transmitActionsFunction  = Kokkos_Tools_transmitActionsFunction;
 using requestResponseFunction  = Kokkos_Tools_requestResponsesFunction;
-using ToolResponses            = Kokkos_Tools_ToolResponses;
-using ToolActions              = Kokkos_Tools_ToolActions;
+using ToolSettings             = Kokkos_Tools_ToolSettings;
+using ToolInvokedActions       = Kokkos_Tools_ToolInvokedActions;
 }  // namespace Experimental
 using initFunction           = Kokkos_Profiling_initFunction;
 using finalizeFunction       = Kokkos_Profiling_finalizeFunction;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -117,8 +117,8 @@ using toolInvokedFenceFunction = Kokkos_Tools_toolInvokedFenceFunction;
 using provideToolProgrammingInterfaceFunction =
     Kokkos_Tools_provideToolProgrammingInterfaceFunction;
 using requestToolSettingsFunction = Kokkos_Tools_requestToolSettingsFunction;
-using ToolSettings             = Kokkos_Tools_ToolSettings;
-using ToolProgrammingInterface = Kokkos_Tools_ToolProgrammingInterface;
+using ToolSettings                = Kokkos_Tools_ToolSettings;
+using ToolProgrammingInterface    = Kokkos_Tools_ToolProgrammingInterface;
 }  // namespace Experimental
 using initFunction           = Kokkos_Profiling_initFunction;
 using finalizeFunction       = Kokkos_Profiling_finalizeFunction;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -107,17 +107,18 @@ static_assert(sizeof(EventSet) / sizeof(Kokkos_Tools_function_pointer) == 275,
 static_assert(sizeof(Kokkos_Tools_ToolSettings) / sizeof(bool) == 256,
               "sizeof EventSet has changed, this is an error on the part of a "
               "Kokkos developer");
-static_assert(sizeof(Kokkos_Tools_ToolInvokedActions) /
+static_assert(sizeof(Kokkos_Tools_ToolProgrammingInterface) /
                       sizeof(Kokkos_Tools_function_pointer) ==
                   32,
               "sizeof EventSet has changed, this is an error on the part of a "
               "Kokkos developer");
 
 using toolInvokedFenceFunction = Kokkos_Tools_toolInvokedFenceFunction;
-using transmitActionsFunction  = Kokkos_Tools_transmitActionsFunction;
+using provideToolProgrammingInterfaceFunction =
+    Kokkos_Tools_provideToolProgrammingInterfaceFunction;
 using requestSettingsFunction  = Kokkos_Tools_requestSettingsFunction;
 using ToolSettings             = Kokkos_Tools_ToolSettings;
-using ToolInvokedActions       = Kokkos_Tools_ToolInvokedActions;
+using ToolProgrammingInterface = Kokkos_Tools_ToolProgrammingInterface;
 }  // namespace Experimental
 using initFunction           = Kokkos_Profiling_initFunction;
 using finalizeFunction       = Kokkos_Profiling_finalizeFunction;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -101,14 +101,14 @@ namespace Tools {
 
 namespace Experimental {
 using EventSet = Kokkos_Profiling_EventSet;
-static_assert(sizeof(EventSet) / sizeof(Kokkos_Tools_function_pointer) == 275,
+static_assert(sizeof(EventSet) / sizeof(Kokkos_Tools_functionPointer) == 275,
               "sizeof EventSet has changed, this is an error on the part of a "
               "Kokkos developer");
 static_assert(sizeof(Kokkos_Tools_ToolSettings) / sizeof(bool) == 256,
               "sizeof EventSet has changed, this is an error on the part of a "
               "Kokkos developer");
 static_assert(sizeof(Kokkos_Tools_ToolProgrammingInterface) /
-                      sizeof(Kokkos_Tools_function_pointer) ==
+                      sizeof(Kokkos_Tools_functionPointer) ==
                   32,
               "sizeof EventSet has changed, this is an error on the part of a "
               "Kokkos developer");

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -101,16 +101,20 @@ namespace Tools {
 
 namespace Experimental {
 using EventSet = Kokkos_Profiling_EventSet;
+using ToolResponse = Kokkos_Profiling_ToolResponse;
 static_assert(sizeof(EventSet) / sizeof(function_pointer) == 275,
               "sizeof EventSet has changed, this is an error on the part of a "
               "Kokkos developer");
 }  // namespace Experimental
 using initFunction           = Kokkos_Profiling_initFunction;
+using initFunction_v2        = Kokkos_Profiling_initFunction_v2;
 using finalizeFunction       = Kokkos_Profiling_finalizeFunction;
 using parseArgsFunction      = Kokkos_Profiling_parseArgsFunction;
 using printHelpFunction      = Kokkos_Profiling_printHelpFunction;
 using beginFunction          = Kokkos_Profiling_beginFunction;
+using beginFunction_v2       = Kokkos_Profiling_beginFunction_v2;
 using endFunction            = Kokkos_Profiling_endFunction;
+using endFunction_v2         = Kokkos_Profiling_endFunction_v2;
 using pushFunction           = Kokkos_Profiling_pushFunction;
 using popFunction            = Kokkos_Profiling_popFunction;
 using allocateDataFunction   = Kokkos_Profiling_allocateDataFunction;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -104,10 +104,18 @@ using EventSet = Kokkos_Profiling_EventSet;
 static_assert(sizeof(EventSet) / sizeof(Kokkos_Tools_function_pointer) == 275,
               "sizeof EventSet has changed, this is an error on the part of a "
               "Kokkos developer");
+static_assert(sizeof(Kokkos_Tools_ToolSettings) / sizeof(bool) == 256,
+              "sizeof EventSet has changed, this is an error on the part of a "
+              "Kokkos developer");
+static_assert(sizeof(Kokkos_Tools_ToolInvokedActions) /
+                      sizeof(Kokkos_Tools_function_pointer) ==
+                  32,
+              "sizeof EventSet has changed, this is an error on the part of a "
+              "Kokkos developer");
 
 using toolInvokedFenceFunction = Kokkos_Tools_toolInvokedFenceFunction;
 using transmitActionsFunction  = Kokkos_Tools_transmitActionsFunction;
-using requestResponseFunction  = Kokkos_Tools_requestResponsesFunction;
+using requestSettingsFunction  = Kokkos_Tools_requestSettingsFunction;
 using ToolSettings             = Kokkos_Tools_ToolSettings;
 using ToolInvokedActions       = Kokkos_Tools_ToolInvokedActions;
 }  // namespace Experimental

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -116,7 +116,7 @@ static_assert(sizeof(Kokkos_Tools_ToolProgrammingInterface) /
 using toolInvokedFenceFunction = Kokkos_Tools_toolInvokedFenceFunction;
 using provideToolProgrammingInterfaceFunction =
     Kokkos_Tools_provideToolProgrammingInterfaceFunction;
-using requestSettingsFunction  = Kokkos_Tools_requestSettingsFunction;
+using requestToolSettingsFunction = Kokkos_Tools_requestToolSettingsFunction;
 using ToolSettings             = Kokkos_Tools_ToolSettings;
 using ToolProgrammingInterface = Kokkos_Tools_ToolProgrammingInterface;
 }  // namespace Experimental

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -100,21 +100,19 @@ using SpaceHandle = Kokkos_Profiling_SpaceHandle;
 namespace Tools {
 
 namespace Experimental {
-using EventSet     = Kokkos_Profiling_EventSet;
-using ToolResponse = Kokkos_Profiling_ToolResponse;
+using EventSet = Kokkos_Profiling_EventSet;
 static_assert(sizeof(EventSet) / sizeof(function_pointer) == 275,
               "sizeof EventSet has changed, this is an error on the part of a "
               "Kokkos developer");
+using toolInvokedFenceFunction = Kokkos_Profiling_toolInvokedFenceFunction;
+using transmitFenceFunction    = Kokkos_Profiling_transmitFenceFunction;
 }  // namespace Experimental
 using initFunction           = Kokkos_Profiling_initFunction;
-using initFunction_v2        = Kokkos_Profiling_initFunction_v2;
 using finalizeFunction       = Kokkos_Profiling_finalizeFunction;
 using parseArgsFunction      = Kokkos_Profiling_parseArgsFunction;
 using printHelpFunction      = Kokkos_Profiling_printHelpFunction;
 using beginFunction          = Kokkos_Profiling_beginFunction;
-using beginFunction_v2       = Kokkos_Profiling_beginFunction_v2;
 using endFunction            = Kokkos_Profiling_endFunction;
-using endFunction_v2         = Kokkos_Profiling_endFunction_v2;
 using pushFunction           = Kokkos_Profiling_pushFunction;
 using popFunction            = Kokkos_Profiling_popFunction;
 using allocateDataFunction   = Kokkos_Profiling_allocateDataFunction;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -101,11 +101,15 @@ namespace Tools {
 
 namespace Experimental {
 using EventSet = Kokkos_Profiling_EventSet;
-static_assert(sizeof(EventSet) / sizeof(function_pointer) == 275,
+static_assert(sizeof(EventSet) / sizeof(Kokkos_Tools_function_pointer) == 275,
               "sizeof EventSet has changed, this is an error on the part of a "
               "Kokkos developer");
-using toolInvokedFenceFunction = Kokkos_Profiling_toolInvokedFenceFunction;
-using transmitFenceFunction    = Kokkos_Profiling_transmitFenceFunction;
+
+using toolInvokedFenceFunction = Kokkos_Tools_toolInvokedFenceFunction;
+using transmitActionsFunction  = Kokkos_Tools_transmitActionsFunction;
+using requestResponseFunction  = Kokkos_Tools_requestResponsesFunction;
+using ToolResponses            = Kokkos_Tools_ToolResponses;
+using ToolActions              = Kokkos_Tools_ToolActions;
 }  // namespace Experimental
 using initFunction           = Kokkos_Profiling_initFunction;
 using finalizeFunction       = Kokkos_Profiling_finalizeFunction;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -100,7 +100,7 @@ using SpaceHandle = Kokkos_Profiling_SpaceHandle;
 namespace Tools {
 
 namespace Experimental {
-using EventSet = Kokkos_Profiling_EventSet;
+using EventSet     = Kokkos_Profiling_EventSet;
 using ToolResponse = Kokkos_Profiling_ToolResponse;
 static_assert(sizeof(EventSet) / sizeof(function_pointer) == 275,
               "sizeof EventSet has changed, this is an error on the part of a "


### PR DESCRIPTION
Alternative to #3799

Rather than have a different _set_ of callbacks, in which a tool can tell Kokkos what to do (the 3799 approach), this is much more incremental, but probably just as featureful. Basically, at init, Kokkos requests that a tool enumerate its requirements (global fencing), and gives the tool a list of actions (function pointers) it can take (like fence Kokkos)

Still after init, we request that a tool tell us whether it requires the current "global" fence behavior in a new callback (`kokkosp_request_responses`). This callback accepts a pointer to a struct in which the tool can declare settings. Right now it only has one setting (`requires_global_fencing`, default true), but this leaves us room to expand. One problem with expanding it, though, is that a tool might be from a newer Kokkos than an application, so I enumerate how many responses are supported by Kokkos. I'll also _try_ to be diligent about updating KOKKOSP_INTERFACE_VERSION, but that's a bit of a crapshoot, so this is an extra guard rail. Speaking of guard rails, if a tool _doesn't_ implement this function, the result is that no settings are overwritten. Since the settings default to current behavior, we guarantee (*check me on this*) backwards compatibility.

As to how the tool fences Kokkos, we have another callback (`kokkosp_transmit_actions`), that takes in a `ToolActions` struct containing a set of function pointers. At this point, all we have is a "fence" function that takes in a device ID. At the moment, that device ID is ignored, but long term we might change the invoked function from a global `Kokkos::fence()` to something more selective. ToolActions is implemented the same as ToolResponses, it has padding and reports the number of implemented callbacks, so tools can reason about what is supported.

Personally, at this point I favor this approach over that of 3799, it's powerful, but a very small change.

edit: additionally, replaced the "function_pointer" typedef in the C_Interface.h file with Kokkos_Tools_functionPointer, to avoid name collisions and make the naming scheme a bit more consistent