### PR TITLE
constexpr if macro

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -569,4 +569,10 @@
 #define KOKKOS_IMPL_ENFORCE_EMPTY_BASE_OPTIMIZATION
 #endif
 
+#if __cplusplus >= 201703L
+#define KOKKOS_IMPL_IF_CONSTEXPR if constexpr
+#else
+#define KOKKOS_IMPL_IF_CONSTEXPR if
+#endif
+
 #endif  // #ifndef KOKKOS_MACROS_HPP


### PR DESCRIPTION
Adds a macro for "constexpr if" when C++17 is enabled, reverts to "if" when not. Note that code must be compilable on either branch. I don't want to implement this in multiple places, in case a compiler requires disabling `if constexpr` I'd like a centralized location. I also don't have enough confidence to place this outside of an IMPL, because stuff happens