### PR TITLE
DualView sync's on ExecutionSpaces

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -102,8 +102,8 @@ inline Kokkos::Cuda get_cuda_space() {
   return Kokkos::Cuda(Kokkos::Impl::cuda_get_deep_copy_stream());
 }
 
-template <typename Arg>
-inline Kokkos::Cuda get_cuda_space(Arg&) {
+template <typename NonCudaExecSpace>
+inline Kokkos::Cuda get_cuda_space(const NonCudaExecSpace&) {
   return Kokkos::Cuda(Kokkos::Impl::cuda_get_deep_copy_stream());
 }
 

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -91,6 +91,25 @@ namespace Kokkos {
  *     behavior.  Please see the documentation of Kokkos::View for
  *     examples.  The default suffices for most users.
  */
+
+namespace Impl {
+
+#ifdef KOKKOS_ENABLE_CUDA
+
+inline const Kokkos::Cuda& get_cuda_space(const Kokkos::Cuda& in) { return in; }
+
+inline Kokkos::Cuda get_cuda_space() {
+  return Kokkos::Cuda(Kokkos::Impl::cuda_get_deep_copy_stream());
+}
+
+template <typename Arg>
+inline Kokkos::Cuda get_cuda_space(Arg&) {
+  return Kokkos::Cuda(Kokkos::Impl::cuda_get_deep_copy_stream());
+}
+
+#endif  // KOKKOS_ENABLE_CUDA
+
+}  // namespace Impl
 template <class DataType, class Arg1Type = void, class Arg2Type = void,
           class Arg3Type = void>
 class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
@@ -463,6 +482,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
           true);
     }
   }
+
   /// \brief Update data on device or host only if data in the other
   ///   space has been marked as modified.
   ///
@@ -480,12 +500,9 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   ///   the data in either View.  You must manually mark modified data
   ///   as modified, by calling the modify() method with the
   ///   appropriate template parameter.
-  template <class Device>
-  void sync(const typename std::enable_if<
-                (std::is_same<typename traits::data_type,
-                              typename traits::non_const_data_type>::value) ||
-                    (std::is_same<Device, int>::value),
-                int>::type& = 0) {
+  // deliberately passing args by value as they're used multiple times
+  template <class Device, class... Args>
+  void sync_impl(const std::true_type&, Args const&... args) {
     if (modified_flags.data() == nullptr) return;
 
     int dev = get_device_side<Device>();
@@ -497,12 +514,12 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                          Kokkos::CudaUVMSpace>::value) {
           if (d_view.data() == h_view.data())
             Kokkos::Impl::cuda_prefetch_pointer(
-                Kokkos::Cuda(), d_view.data(),
+                Impl::get_cuda_space(args...), d_view.data(),
                 sizeof(typename t_dev::value_type) * d_view.span(), true);
         }
 #endif
 
-        deep_copy(d_view, h_view);
+        deep_copy(args..., d_view, h_view);
         modified_flags(0) = modified_flags(1) = 0;
         impl_report_device_sync();
       }
@@ -514,12 +531,12 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                          Kokkos::CudaUVMSpace>::value) {
           if (d_view.data() == h_view.data())
             Kokkos::Impl::cuda_prefetch_pointer(
-                Kokkos::Cuda(), d_view.data(),
+                Impl::get_cuda_space(args...), d_view.data(),
                 sizeof(typename t_dev::value_type) * d_view.span(), false);
         }
 #endif
 
-        deep_copy(h_view, d_view);
+        deep_copy(args..., h_view, d_view);
         modified_flags(0) = modified_flags(1) = 0;
         impl_report_host_sync();
       }
@@ -533,10 +550,26 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
 
   template <class Device>
   void sync(const typename std::enable_if<
-                (!std::is_same<typename traits::data_type,
-                               typename traits::non_const_data_type>::value) ||
+                (std::is_same<typename traits::data_type,
+                              typename traits::non_const_data_type>::value) ||
                     (std::is_same<Device, int>::value),
                 int>::type& = 0) {
+    sync_impl<Device>(std::true_type{});
+  }
+
+  template <class Device, class ExecutionSpace>
+  void sync(const ExecutionSpace& exec,
+            const typename std::enable_if<
+                (std::is_same<typename traits::data_type,
+                              typename traits::non_const_data_type>::value) ||
+                    (std::is_same<Device, int>::value),
+                int>::type& = 0) {
+    sync_impl<Device>(std::true_type{}, exec);
+  }
+
+  // deliberately passing args by value as they're used multiple times
+  template <class Device, class... Args>
+  void sync_impl(const std::false_type&, Args const&...) {
     if (modified_flags.data() == nullptr) return;
 
     int dev = get_device_side<Device>();
@@ -557,7 +590,27 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     }
   }
 
-  void sync_host() {
+  template <class Device>
+  void sync(const typename std::enable_if<
+                (!std::is_same<typename traits::data_type,
+                               typename traits::non_const_data_type>::value) ||
+                    (std::is_same<Device, int>::value),
+                int>::type& = 0) {
+    sync_impl<Device>(std::false_type{});
+  }
+  template <class Device, class ExecutionSpace>
+  void sync(const ExecutionSpace& exec,
+            const typename std::enable_if<
+                (!std::is_same<typename traits::data_type,
+                               typename traits::non_const_data_type>::value) ||
+                    (std::is_same<Device, int>::value),
+                int>::type& = 0) {
+    sync_impl<Device>(std::false_type{}, exec);
+  }
+
+  // deliberately passing args by value as they're used multiple times
+  template <typename... Args>
+  void sync_host_impl(Args const&... args) {
     if (!std::is_same<typename traits::data_type,
                       typename traits::non_const_data_type>::value)
       Impl::throw_runtime_exception(
@@ -569,18 +622,26 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                        Kokkos::CudaUVMSpace>::value) {
         if (d_view.data() == h_view.data())
           Kokkos::Impl::cuda_prefetch_pointer(
-              Kokkos::Cuda(), d_view.data(),
+              Impl::get_cuda_space(args...), d_view.data(),
               sizeof(typename t_dev::value_type) * d_view.span(), false);
       }
 #endif
 
-      deep_copy(h_view, d_view);
+      deep_copy(args..., h_view, d_view);
       modified_flags(1) = modified_flags(0) = 0;
       impl_report_host_sync();
     }
   }
 
-  void sync_device() {
+  template <class ExecSpace>
+  void sync_host(const ExecSpace& exec) {
+    sync_host_impl(exec);
+  }
+  void sync_host() { sync_host_impl(); }
+
+  // deliberately passing args by value as they're used multiple times
+  template <typename... Args>
+  void sync_device_impl(Args const&... args) {
     if (!std::is_same<typename traits::data_type,
                       typename traits::non_const_data_type>::value)
       Impl::throw_runtime_exception(
@@ -592,16 +653,22 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                        Kokkos::CudaUVMSpace>::value) {
         if (d_view.data() == h_view.data())
           Kokkos::Impl::cuda_prefetch_pointer(
-              Kokkos::Cuda(), d_view.data(),
+              Impl::get_cuda_space(args...), d_view.data(),
               sizeof(typename t_dev::value_type) * d_view.span(), true);
       }
 #endif
 
-      deep_copy(d_view, h_view);
+      deep_copy(args..., d_view, h_view);
       modified_flags(1) = modified_flags(0) = 0;
       impl_report_device_sync();
     }
   }
+
+  template <class ExecSpace>
+  void sync_device(const ExecSpace& exec) {
+    sync_device_impl(exec);
+  }
+  void sync_device() { sync_device_impl(); }
 
   template <class Device>
   bool need_sync() const {

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -500,9 +500,9 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   ///   the data in either View.  You must manually mark modified data
   ///   as modified, by calling the modify() method with the
   ///   appropriate template parameter.
-  // deliberately passing args by value as they're used multiple times
+  // deliberately passing args by cref as they're used multiple times
   template <class Device, class... Args>
-  void sync_impl(const std::true_type&, Args const&... args) {
+  void sync_impl(std::true_type, Args const&... args) {
     if (modified_flags.data() == nullptr) return;
 
     int dev = get_device_side<Device>();
@@ -567,9 +567,9 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     sync_impl<Device>(std::true_type{}, exec);
   }
 
-  // deliberately passing args by value as they're used multiple times
+  // deliberately passing args by cref as they're used multiple times
   template <class Device, class... Args>
-  void sync_impl(const std::false_type&, Args const&...) {
+  void sync_impl(std::false_type, Args const&...) {
     if (modified_flags.data() == nullptr) return;
 
     int dev = get_device_side<Device>();
@@ -608,7 +608,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     sync_impl<Device>(std::false_type{}, exec);
   }
 
-  // deliberately passing args by value as they're used multiple times
+  // deliberately passing args by cref as they're used multiple times
   template <typename... Args>
   void sync_host_impl(Args const&... args) {
     if (!std::is_same<typename traits::data_type,
@@ -639,7 +639,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   }
   void sync_host() { sync_host_impl(); }
 
-  // deliberately passing args by value as they're used multiple times
+  // deliberately passing args by cref as they're used multiple times
   template <typename... Args>
   void sync_device_impl(Args const&... args) {
     if (!std::is_same<typename traits::data_type,

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -114,6 +114,8 @@ struct test_dualview_combinations {
 
     a.template modify<typename ViewType::execution_space>();
     a.template sync<typename ViewType::host_mirror_space>();
+    a.template sync<typename ViewType::host_mirror_space>(
+        Kokkos::DefaultExecutionSpace{});
 
     a.h_view(5, 1) = 3;
     a.h_view(6, 1) = 4;
@@ -122,11 +124,15 @@ struct test_dualview_combinations {
     ViewType b = Kokkos::subview(a, std::pair<unsigned int, unsigned int>(6, 9),
                                  std::pair<unsigned int, unsigned int>(0, 1));
     a.template sync<typename ViewType::execution_space>();
+    a.template sync<typename ViewType::execution_space>(
+        Kokkos::DefaultExecutionSpace{});
     b.template modify<typename ViewType::execution_space>();
 
     Kokkos::deep_copy(b.d_view, 2);
 
     a.template sync<typename ViewType::host_mirror_space>();
+    a.template sync<typename ViewType::host_mirror_space>(
+        Kokkos::DefaultExecutionSpace{});
     Scalar count = 0;
     for (unsigned int i = 0; i < a.d_view.extent(0); i++)
       for (unsigned int j = 0; j < a.d_view.extent(1); j++)
@@ -180,6 +186,7 @@ struct test_dual_view_deep_copy {
     } else {
       a.modify_device();
       a.sync_host();
+      a.sync_host(Kokkos::DefaultExecutionSpace{});
     }
 
     // Check device view is initialized as expected
@@ -208,6 +215,7 @@ struct test_dual_view_deep_copy {
       b.template sync<typename ViewType::host_mirror_space>();
     } else {
       b.sync_host();
+      b.sync_host(Kokkos::DefaultExecutionSpace{});
     }
 
     // Perform same checks on b as done on a
@@ -302,6 +310,7 @@ struct test_dualview_resize {
     ASSERT_EQ(a.extent(1), m / factor);
 
     a.sync_device();
+    a.sync_device(Kokkos::DefaultExecutionSpace{});
 
     // Check device view is initialized as expected
     a_d_sum = 0;

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -72,14 +72,15 @@ namespace {
 
 static std::atomic<int> num_uvm_allocations(0);
 
-cudaStream_t get_deep_copy_stream() {
+}  // namespace
+
+cudaStream_t cuda_get_deep_copy_stream() {
   static cudaStream_t s = nullptr;
   if (s == nullptr) {
     cudaStreamCreate(&s);
   }
   return s;
 }
-}  // namespace
 
 DeepCopy<CudaSpace, CudaSpace, Cuda>::DeepCopy(void *dst, const void *src,
                                                size_t n) {
@@ -115,7 +116,7 @@ DeepCopy<CudaSpace, HostSpace, Cuda>::DeepCopy(const Cuda &instance, void *dst,
 }
 
 void DeepCopyAsyncCuda(void *dst, const void *src, size_t n) {
-  cudaStream_t s = get_deep_copy_stream();
+  cudaStream_t s = cuda_get_deep_copy_stream();
   CUDA_SAFE_CALL(cudaMemcpyAsync(dst, src, n, cudaMemcpyDefault, s));
   cudaStreamSynchronize(s);
 }

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -277,6 +277,8 @@ class CudaHostPinnedSpace {
 namespace Kokkos {
 namespace Impl {
 
+cudaStream_t cuda_get_deep_copy_stream();
+
 static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
                                               Kokkos::CudaSpace>::assignable,
               "");


### PR DESCRIPTION
This is something EMPIRE is going to need eventually, probably Trilinos too. In the spirit of removing these globally fencing 2-arg deep copies, DualViews should allow for a user to call sync on an execution space, and use that execution space for any deep copies it invokes. There's some complications, that lead to the design being a bit screwy.

First, the sync code is huge, I want to avoid code duplication. In my head, the way to do this, conceptually looks like

```c++
template<class... Args>
void sync(Args... args){
  if(i_should){ 
    Kokkos::deep_copy(args..., d_view,h_view); 
  }
}
```

If somebody passes an ExecutionSpace, we use it, otherwise we don't, just like the default.

Problem 1: the existing sync method does tricks with a default argument to specialize based on whether the DualView is of const or nonconst type.

Solution 1: Okay, use a delegating method

```c++
template<class... Args>
void sync_impl(const std::true_type&, Args... args){
  if(i_should){ 
    Kokkos::deep_copy(args..., d_view,h_view); 
  }
}

template<typename ExecutionSpace>
void sync(const ExecutionSpace& exec, /** chthonic metaprogramming incantation, true branch */) {
  sync_impl(true_type{}, exec);
}

void sync(/** chthonic metaprogramming incantation, true branch */) {
  sync_impl(true_type{});
}

//false left off here, but handled the same way
```

Problem 2: @crtrott making work for me. We have this gnarly block to handle UVM goodness in DualView's sync

```c++
Kokkos::Impl::cuda_prefetch_pointer(
  Kokkos::Cuda(), d_view.data(),
 sizeof(typename t_dev::value_type) * d_view.span(), false);
```

This should use the execution space *if and only if* it's a CUDA instance. So I added some plumbing for that, Impl::get_cuda_space, which returns a Cuda Space if one is passed to it, if anything else is passed to it, it just construct a default one (exactly what we currently do).

I really don't know enough about C++ design patterns to say whether this thing is implemented well or terribly, to be honest.

edit: Also, made our default deep copy instance for these be the deep_copy stream. Possible small asynchrony benefits there (see: https://github.com/kokkos/kokkos/pull/3822#discussion_r593469006 )