### PR TITLE
OpenMPTarget: UniqueToken::Global implementation.

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
@@ -92,10 +92,11 @@ void OpenMPTargetExec::verify_initialized(const char* const label) {
   }
 }
 
-void* OpenMPTargetExec::m_scratch_ptr    = nullptr;
-int64_t OpenMPTargetExec::m_scratch_size = 0;
-int* OpenMPTargetExec::m_lock_array      = nullptr;
-int64_t OpenMPTargetExec::m_lock_size    = 0;
+void* OpenMPTargetExec::m_scratch_ptr         = nullptr;
+int64_t OpenMPTargetExec::m_scratch_size      = 0;
+int* OpenMPTargetExec::m_lock_array           = nullptr;
+int64_t OpenMPTargetExec::m_lock_size         = 0;
+uint32_t* OpenMPTargetExec::m_uniquetoken_ptr = nullptr;
 
 void OpenMPTargetExec::clear_scratch() {
   Kokkos::Experimental::OpenMPTargetSpace space;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -521,6 +521,7 @@ class OpenMPTargetExec {
   static int64_t m_scratch_size;
   static int* m_lock_array;
   static int64_t m_lock_size;
+  static uint32_t* m_uniquetoken_ptr;
 };
 
 }  // namespace Impl

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
@@ -180,8 +180,9 @@ UniqueToken<Kokkos::Experimental::OpenMPTarget,
             "Kokkos::OpenMPTarget::m_uniquetoken_ptr", size));
     uint32_t* h_ptr = new uint32_t[size / sizeof(uint32_t)];
     memset(h_ptr, 0, size);
-    omp_target_memcpy(ptr, h_ptr, size, 0, 0, omp_get_default_device(),
-                      omp_get_initial_device());
+    OMPT_SAFE_CALL(omp_target_memcpy(ptr, h_ptr, size, 0, 0,
+                                     omp_get_default_device(),
+                                     omp_get_initial_device()));
 
     delete[] h_ptr;
     Kokkos::Impl::OpenMPTargetExec::m_uniquetoken_ptr = ptr;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_UniqueToken.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_UniqueToken.hpp
@@ -121,7 +121,7 @@ class UniqueToken<OpenMPTarget, UniqueTokenScope::Instance>
 
   UniqueToken(size_type max_size, execution_space const& = execution_space())
       : m_buffer_view(
-            "UniqueToken::m_buffer_view",
+            "Kokkos::UniqueToken::m_buffer_view",
             ::Kokkos::Impl::concurrent_bitset::buffer_bound(max_size)) {
     m_buffer = m_buffer_view.data();
     m_count  = max_size;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_UniqueToken.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_UniqueToken.hpp
@@ -1,0 +1,135 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_OPENMPTARGET_UNIQUE_TOKEN_HPP
+#define KOKKOS_OPENMPTARGET_UNIQUE_TOKEN_HPP
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+
+#include <Kokkos_OpenMPTargetSpace.hpp>
+#include <Kokkos_UniqueToken.hpp>
+#include <impl/Kokkos_SharedAlloc.hpp>
+#include <impl/Kokkos_ConcurrentBitset.hpp>
+
+namespace Kokkos {
+namespace Experimental {
+
+// both global and instance Unique Tokens are implemented in the same way
+template <>
+class UniqueToken<OpenMPTarget, UniqueTokenScope::Global> {
+ protected:
+  uint32_t volatile* m_buffer;
+  uint32_t m_count;
+
+ public:
+  using execution_space = OpenMPTarget;
+  using size_type       = int32_t;
+
+  explicit UniqueToken(execution_space const& = execution_space());
+
+  KOKKOS_DEFAULTED_FUNCTION
+  UniqueToken(const UniqueToken&) = default;
+
+  KOKKOS_DEFAULTED_FUNCTION
+  UniqueToken(UniqueToken&&) = default;
+
+  KOKKOS_DEFAULTED_FUNCTION
+  UniqueToken& operator=(const UniqueToken&) = default;
+
+  KOKKOS_DEFAULTED_FUNCTION
+  UniqueToken& operator=(UniqueToken&&) = default;
+
+  /// \brief upper bound for acquired values, i.e. 0 <= value < size()
+  KOKKOS_INLINE_FUNCTION
+  size_type size() const noexcept { return m_count; }
+
+  /// \brief acquire value such that 0 <= value < size()
+  KOKKOS_INLINE_FUNCTION
+  size_type acquire() const {
+    const Kokkos::pair<int, int> result =
+        Kokkos::Impl::concurrent_bitset::acquire_bounded(
+            m_buffer, m_count, Kokkos::Impl::clock_tic() % m_count);
+
+    if (result.first < 0) {
+      Kokkos::abort(
+          "UniqueToken<OpenMPTarget> failure to acquire tokens, no tokens "
+          "available");
+    }
+
+    return result.first;
+  }
+
+  /// \brief release an acquired value
+  KOKKOS_INLINE_FUNCTION
+  void release(size_type i) const noexcept {
+    Kokkos::Impl::concurrent_bitset::release(m_buffer, i);
+  }
+};
+
+template <>
+class UniqueToken<OpenMPTarget, UniqueTokenScope::Instance>
+    : public UniqueToken<OpenMPTarget, UniqueTokenScope::Global> {
+ private:
+  Kokkos::View<uint32_t*, ::Kokkos::Experimental::OpenMPTargetSpace>
+      m_buffer_view;
+
+ public:
+  explicit UniqueToken(execution_space const& arg = execution_space())
+      : UniqueToken<OpenMPTarget, UniqueTokenScope::Global>(arg) {}
+
+  UniqueToken(size_type max_size, execution_space const& = execution_space())
+      : m_buffer_view(
+            "UniqueToken::m_buffer_view",
+            ::Kokkos::Impl::concurrent_bitset::buffer_bound(max_size)) {
+    m_buffer = m_buffer_view.data();
+    m_count  = max_size;
+  }
+};
+
+}  // namespace Experimental
+}  // namespace Kokkos
+
+#endif  // KOKKOS_ENABLE_OPENMPTARGET
+#endif  // KOKKOS_OPENMPTARGET_UNIQUE_TOKEN_HPP

--- a/core/src/decl/Kokkos_Declare_OPENMPTARGET.hpp
+++ b/core/src/decl/Kokkos_Declare_OPENMPTARGET.hpp
@@ -48,6 +48,7 @@
 #if defined(KOKKOS_ENABLE_OPENMPTARGET)
 #include <Kokkos_OpenMPTarget.hpp>
 #include <Kokkos_OpenMPTargetSpace.hpp>
+#include <OpenMPTarget/Kokkos_OpenMPTarget_UniqueToken.hpp>
 #endif
 
 #endif

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -259,7 +259,6 @@ if(Kokkos_ENABLE_OPENMPTARGET)
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamTeamSize.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamScan.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_UniqueToken.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewAPI_e.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewCopy_a.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewCopy_b.cpp

--- a/core/unit_test/TestUniqueToken.hpp
+++ b/core/unit_test/TestUniqueToken.hpp
@@ -166,11 +166,8 @@ TEST(TEST_CATEGORY, unique_token_global) {
 }
 
 TEST(TEST_CATEGORY, unique_token_instance) {
-  // FIXME_OPENMPTARGET - Not yet implemented.
-#if !defined(KOKKOS_ENABLE_OPENMPTARGET)
   TestUniqueToken<TEST_EXECSPACE,
                   Kokkos::Experimental::UniqueTokenScope::Instance>::run();
-#endif
 }
 
 template <class Space>

--- a/core/unit_test/TestUniqueToken.hpp
+++ b/core/unit_test/TestUniqueToken.hpp
@@ -166,8 +166,11 @@ TEST(TEST_CATEGORY, unique_token_global) {
 }
 
 TEST(TEST_CATEGORY, unique_token_instance) {
+  // FIXME_OPENMPTARGET - Not yet implemented.
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET)
   TestUniqueToken<TEST_EXECSPACE,
                   Kokkos::Experimental::UniqueTokenScope::Instance>::run();
+#endif
 }
 
 template <class Space>
@@ -271,7 +274,10 @@ class TestAcquireTeamUniqueToken {
 };
 
 TEST(TEST_CATEGORY, acquire_team_unique_token) {
+  // FIXME_OPENMPTARGET - Not yet implemented.
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET)
   TestAcquireTeamUniqueToken<TEST_EXECSPACE>::run();
+#endif
 }
 
 }  // namespace Test


### PR DESCRIPTION
The PR contains the following updates: 
1. Implementation for UniqueToken::Global scope
2. Uncomment the UniqeToken unit tests 
3. Comment the UniqueToken::Instance and AcquireUniqueToken tests. These features are not yet implemented.
4. Add a new `m_uniquetoken_ptr` to OpenMPTargetExec class.