### PR TITLE
Introduce HostSharedPtr to manage m_space_instance for Cuda/HIP/SYCL

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -822,60 +822,21 @@ Cuda::size_type Cuda::device_arch() {
 void Cuda::impl_finalize() { Impl::CudaInternal::singleton().finalize(); }
 
 Cuda::Cuda()
-    : m_space_instance(&Impl::CudaInternal::singleton()), m_counter(nullptr) {
+    : m_space_instance(&Impl::CudaInternal::singleton(),
+                       [](Impl::CudaInternal *) {}) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
 }
 
 Cuda::Cuda(cudaStream_t stream)
-    : m_space_instance(new Impl::CudaInternal), m_counter(new int(1)) {
+    : m_space_instance(new Impl::CudaInternal, [](Impl::CudaInternal *ptr) {
+        ptr->finalize();
+        delete ptr;
+      }) {
   Impl::CudaInternal::singleton().verify_is_initialized(
       "Cuda instance constructor");
   m_space_instance->initialize(Impl::CudaInternal::singleton().m_cudaDev,
                                stream);
-}
-
-KOKKOS_FUNCTION Cuda::Cuda(Cuda &&other) noexcept {
-  m_space_instance       = other.m_space_instance;
-  other.m_space_instance = nullptr;
-  m_counter              = other.m_counter;
-  other.m_counter        = nullptr;
-}
-
-KOKKOS_FUNCTION Cuda::Cuda(const Cuda &other)
-    : m_space_instance(other.m_space_instance), m_counter(other.m_counter) {
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA
-  if (m_counter) Kokkos::atomic_add(m_counter, 1);
-#endif
-}
-
-KOKKOS_FUNCTION Cuda &Cuda::operator=(Cuda &&other) noexcept {
-  m_space_instance       = other.m_space_instance;
-  other.m_space_instance = nullptr;
-  m_counter              = other.m_counter;
-  other.m_counter        = nullptr;
-  return *this;
-}
-
-KOKKOS_FUNCTION Cuda &Cuda::operator=(const Cuda &other) {
-  m_space_instance = other.m_space_instance;
-  m_counter        = other.m_counter;
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA
-  if (m_counter) Kokkos::atomic_add(m_counter, 1);
-#endif
-  return *this;
-}
-
-KOKKOS_FUNCTION Cuda::~Cuda() noexcept {
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA
-  if (m_counter == nullptr) return;
-  int const count = Kokkos::atomic_fetch_sub(m_counter, 1);
-  if (count == 1) {
-    delete m_counter;
-    m_space_instance->finalize();
-    delete m_space_instance;
-  }
-#endif
 }
 
 void Cuda::print_configuration(std::ostream &s, const bool) {

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -680,61 +680,20 @@ void HIP::impl_initialize(const HIP::SelectDevice config) {
 void HIP::impl_finalize() { Impl::HIPInternal::singleton().finalize(); }
 
 HIP::HIP()
-    : m_space_instance(&Impl::HIPInternal::singleton()), m_counter(nullptr) {
+    : m_space_instance(&Impl::HIPInternal::singleton(),
+                       [](Impl::HIPInternal*) {}) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
 }
 
 HIP::HIP(hipStream_t const stream)
-    : m_space_instance(new Impl::HIPInternal), m_counter(new int(1)) {
+    : m_space_instance(new Impl::HIPInternal, [](Impl::HIPInternal* ptr) {
+        ptr->finalize();
+        delete ptr;
+      }) {
   Impl::HIPInternal::singleton().verify_is_initialized(
       "HIP instance constructor");
   m_space_instance->initialize(Impl::HIPInternal::singleton().m_hipDev, stream);
-}
-
-KOKKOS_FUNCTION HIP::HIP(HIP&& other) noexcept {
-  m_space_instance       = other.m_space_instance;
-  other.m_space_instance = nullptr;
-  m_counter              = other.m_counter;
-  other.m_counter        = nullptr;
-}
-
-KOKKOS_FUNCTION HIP::HIP(HIP const& other)
-    : m_space_instance(other.m_space_instance), m_counter(other.m_counter) {
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HIP_GPU
-  if (m_counter) Kokkos::atomic_add(m_counter, 1);
-#endif
-}
-
-KOKKOS_FUNCTION HIP& HIP::operator=(HIP&& other) noexcept {
-  m_space_instance       = other.m_space_instance;
-  other.m_space_instance = nullptr;
-  m_counter              = other.m_counter;
-  other.m_counter        = nullptr;
-
-  return *this;
-}
-
-KOKKOS_FUNCTION HIP& HIP::operator=(HIP const& other) {
-  m_space_instance = other.m_space_instance;
-  m_counter        = other.m_counter;
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HIP_GPU
-  if (m_counter) Kokkos::atomic_add(m_counter, 1);
-#endif
-
-  return *this;
-}
-
-KOKKOS_FUNCTION HIP::~HIP() noexcept {
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HIP_GPU
-  if (m_counter == nullptr) return;
-  int const count = Kokkos::atomic_fetch_sub(m_counter, 1);
-  if (count == 1) {
-    delete m_counter;
-    m_space_instance->finalize();
-    delete m_space_instance;
-  }
-#endif
 }
 
 void HIP::print_configuration(std::ostream& s, const bool) {

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -63,6 +63,7 @@
 #include <Kokkos_MemoryTraits.hpp>
 #include <impl/Kokkos_Tags.hpp>
 #include <impl/Kokkos_ExecSpaceInitializer.hpp>
+#include <impl/Kokkos_HostSharedPtr.hpp>
 
 /*--------------------------------------------------------------------------*/
 
@@ -198,16 +199,6 @@ class Cuda {
 
   Cuda();
 
-  KOKKOS_FUNCTION Cuda(Cuda&& other) noexcept;
-
-  KOKKOS_FUNCTION Cuda(const Cuda& other);
-
-  KOKKOS_FUNCTION Cuda& operator=(Cuda&& other) noexcept;
-
-  KOKKOS_FUNCTION Cuda& operator=(const Cuda& other);
-
-  KOKKOS_FUNCTION ~Cuda() noexcept;
-
   Cuda(cudaStream_t stream);
 
   //--------------------------------------------------------------------------
@@ -253,13 +244,12 @@ class Cuda {
   static const char* name();
 
   inline Impl::CudaInternal* impl_internal_space_instance() const {
-    return m_space_instance;
+    return m_space_instance.get();
   }
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  Impl::CudaInternal* m_space_instance;
-  int* m_counter;
+  Kokkos::Impl::HostSharedPtr<Impl::CudaInternal> m_space_instance;
 };
 
 namespace Tools {

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -61,6 +61,7 @@
 
 #include <impl/Kokkos_Profiling_Interface.hpp>
 #include <impl/Kokkos_ExecSpaceInitializer.hpp>
+#include <impl/Kokkos_HostSharedPtr.hpp>
 
 #include <hip/hip_runtime_api.h>
 /*--------------------------------------------------------------------------*/
@@ -650,13 +651,6 @@ class HIP {
   HIP();
   HIP(hipStream_t stream);
 
-  KOKKOS_FUNCTION HIP(HIP&& other) noexcept;
-  KOKKOS_FUNCTION HIP(HIP const& other);
-  KOKKOS_FUNCTION HIP& operator=(HIP&&) noexcept;
-  KOKKOS_FUNCTION HIP& operator=(HIP const&);
-
-  KOKKOS_FUNCTION ~HIP() noexcept;
-
   //@}
   //------------------------------------
   //! \name Functions that all Kokkos devices must implement.
@@ -712,14 +706,13 @@ class HIP {
   static const char* name();
 
   inline Impl::HIPInternal* impl_internal_space_instance() const {
-    return m_space_instance;
+    return m_space_instance.get();
   }
 
   uint32_t impl_instance_id() const noexcept { return 0; }
 
  private:
-  Impl::HIPInternal* m_space_instance;
-  int* m_counter;
+  Kokkos::Impl::HostSharedPtr<Impl::HIPInternal> m_space_instance;
 };
 }  // namespace Experimental
 namespace Tools {

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -54,6 +54,7 @@
 #include <Kokkos_ScratchSpace.hpp>
 #include <impl/Kokkos_ExecSpaceInitializer.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
+#include <impl/Kokkos_HostSharedPtr.hpp>
 
 namespace Kokkos {
 namespace Experimental {
@@ -79,14 +80,8 @@ class SYCL {
 
   using scratch_memory_space = ScratchMemorySpace<SYCL>;
 
-  ~SYCL();
   SYCL();
   explicit SYCL(const sycl::queue&);
-
-  SYCL(SYCL&&) noexcept;
-  SYCL(const SYCL&);
-  SYCL& operator=(SYCL&&) noexcept;
-  SYCL& operator=(const SYCL&);
 
   uint32_t impl_instance_id() const noexcept { return 0; }
 
@@ -159,13 +154,11 @@ class SYCL {
   static const char* name();
 
   inline Impl::SYCLInternal* impl_internal_space_instance() const {
-    return m_space_instance;
+    return m_space_instance.get();
   }
 
  private:
-  KOKKOS_FUNCTION void cleanup() noexcept;
-  Impl::SYCLInternal* m_space_instance;
-  int* m_counter;
+  Kokkos::Impl::HostSharedPtr<Impl::SYCLInternal> m_space_instance;
 };
 
 namespace Impl {

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -77,68 +77,20 @@ int get_gpu(const InitArguments& args);
 
 namespace Experimental {
 SYCL::SYCL()
-    : m_space_instance(&Impl::SYCLInternal::singleton()), m_counter(nullptr) {
+    : m_space_instance(&Impl::SYCLInternal::singleton(),
+                       [](Impl::SYCLInternal*) {}) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
 }
 
 SYCL::SYCL(const sycl::queue& stream)
-    : m_space_instance(new Impl::SYCLInternal), m_counter(new int(1)) {
+    : m_space_instance(new Impl::SYCLInternal, [](Impl::SYCLInternal* ptr) {
+        ptr->finalize();
+        delete ptr;
+      }) {
   Impl::SYCLInternal::singleton().verify_is_initialized(
       "SYCL instance constructor");
   m_space_instance->initialize(stream);
-}
-
-KOKKOS_FUNCTION SYCL::SYCL(SYCL&& other) noexcept
-    : m_space_instance(other.m_space_instance), m_counter(other.m_counter) {
-  other.m_space_instance = nullptr;
-  other.m_counter        = nullptr;
-}
-
-KOKKOS_FUNCTION SYCL::SYCL(const SYCL& other)
-    : m_space_instance(other.m_space_instance), m_counter(other.m_counter) {
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL
-  if (m_counter) Kokkos::atomic_add(m_counter, 1);
-#endif
-}
-
-KOKKOS_FUNCTION SYCL& SYCL::operator=(SYCL&& other) noexcept {
-  if (&other != this) {
-    cleanup();
-    m_space_instance       = other.m_space_instance;
-    other.m_space_instance = nullptr;
-    m_counter              = other.m_counter;
-    other.m_counter        = nullptr;
-  }
-  return *this;
-}
-
-KOKKOS_FUNCTION SYCL& SYCL::operator=(const SYCL& other) {
-  if (&other != this) {
-    cleanup();
-    m_space_instance = other.m_space_instance;
-    m_counter        = other.m_counter;
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL
-    if (m_counter) Kokkos::atomic_add(m_counter, 1);
-#endif
-  }
-  return *this;
-}
-
-KOKKOS_FUNCTION SYCL::~SYCL() { cleanup(); }
-
-KOKKOS_FUNCTION void SYCL::cleanup() noexcept {
-#ifndef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL
-  // If m_counter is set, then this instance is responsible for managing the
-  // objects pointed to by m_counter and m_space_instance.
-  if (m_counter == nullptr) return;
-  int const count = Kokkos::atomic_fetch_sub(m_counter, 1);
-  if (count == 1) {
-    delete m_counter;
-    m_space_instance->finalize();
-    delete m_space_instance;
-  }
-#endif
 }
 
 int SYCL::concurrency() {

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -1,0 +1,178 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_IMPL_HOST_SHARED_PTR_HPP
+#define KOKKOS_IMPL_HOST_SHARED_PTR_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Atomic.hpp>
+
+#include <functional>
+
+namespace Kokkos {
+namespace Impl {
+
+template <typename T>
+class HostSharedPtr {
+ public:
+  using element_type = T;
+
+  KOKKOS_DEFAULTED_FUNCTION constexpr HostSharedPtr() = default;
+  KOKKOS_FUNCTION constexpr HostSharedPtr(std::nullptr_t) {}
+
+  explicit HostSharedPtr(T* element_ptr)
+      : HostSharedPtr(element_ptr, [](T* const t) { delete t; }) {}
+
+  template <class Deleter>
+  HostSharedPtr(T* element_ptr, const Deleter& deleter)
+      : m_element_ptr(element_ptr) {
+#ifdef KOKKOS_ENABLE_CXX17
+    static_assert(std::is_invocable_v<Deleter, T*> &&
+                  std::is_copy_constructible_v<Deleter>);
+#endif
+    if (element_ptr) {
+      try {
+        m_control = new Control{deleter, 1};
+      } catch (...) {
+        deleter(element_ptr);
+        throw;
+      }
+    }
+  }
+
+  KOKKOS_FUNCTION HostSharedPtr(HostSharedPtr&& other) noexcept
+      : m_element_ptr(other.m_element_ptr), m_control(other.m_control) {
+    other.m_element_ptr = nullptr;
+    other.m_control     = nullptr;
+  }
+
+  KOKKOS_FUNCTION HostSharedPtr(const HostSharedPtr& other) noexcept
+      : m_element_ptr(other.m_element_ptr), m_control(other.m_control) {
+    // FIXME_OPENMPTARGET requires something like KOKKOS_IMPL_IF_ON_HOST
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    if (m_control) Kokkos::atomic_add(&(m_control->m_counter), 1);
+#endif
+  }
+
+  KOKKOS_FUNCTION HostSharedPtr& operator=(HostSharedPtr&& other) noexcept {
+    if (&other != this) {
+      cleanup();
+      m_element_ptr       = other.m_element_ptr;
+      other.m_element_ptr = nullptr;
+      m_control           = other.m_control;
+      other.m_control     = nullptr;
+    }
+    return *this;
+  }
+
+  KOKKOS_FUNCTION HostSharedPtr& operator=(
+      const HostSharedPtr& other) noexcept {
+    if (&other != this) {
+      cleanup();
+      m_element_ptr = other.m_element_ptr;
+      m_control     = other.m_control;
+      // FIXME_OPENMPTARGET
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+      if (m_control) Kokkos::atomic_add(&(m_control->m_counter), 1);
+#endif
+    }
+    return *this;
+  }
+
+  KOKKOS_FUNCTION ~HostSharedPtr() { cleanup(); }
+
+  // returns the stored pointer
+  KOKKOS_FUNCTION T* get() const noexcept { return m_element_ptr; }
+  // dereferences the stored pointer
+  KOKKOS_FUNCTION T& operator*() const noexcept {
+    KOKKOS_EXPECTS(bool(*this));
+    return *get();
+  }
+  // dereferences the stored pointer
+  KOKKOS_FUNCTION T* operator->() const noexcept {
+    KOKKOS_EXPECTS(bool(*this));
+    return get();
+  }
+
+  // checks if the stored pointer is not null
+  KOKKOS_FUNCTION explicit operator bool() const noexcept {
+    return get() != nullptr;
+  }
+
+  // returns the number of HostSharedPtr instances managing the curent object or
+  // 0 if there is no managed object.
+  int use_count() const noexcept {
+    return m_control ? m_control->m_counter : 0;
+  }
+
+ private:
+  KOKKOS_FUNCTION void cleanup() noexcept {
+    // FIXME_OPENMPTARGET
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    // If m_counter is set, then this instance is responsible for managing the
+    // object pointed to by m_counter and m_element_ptr.
+    if (m_control) {
+      int const count = Kokkos::atomic_fetch_sub(&(m_control->m_counter), 1);
+      if (count == 1) {
+        (m_control->m_deleter)(m_element_ptr);
+        m_element_ptr = nullptr;
+        delete m_control;
+        m_control = nullptr;
+      }
+    }
+#endif
+  }
+
+  struct Control {
+    std::function<void(T*)> m_deleter;
+    int m_counter;
+  };
+
+  T* m_element_ptr   = nullptr;
+  Control* m_control = nullptr;
+};
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -98,6 +98,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
         MDRange_a
         MDRange_b
         MDRange_c
+        HostSharedPtr
+        HostSharedPtrAccessOnDevice
         )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/core/unit_test/TestHostSharedPtr.hpp
+++ b/core/unit_test/TestHostSharedPtr.hpp
@@ -1,0 +1,157 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <impl/Kokkos_HostSharedPtr.hpp>
+
+#include <gtest/gtest.h>
+
+using Kokkos::Impl::HostSharedPtr;
+
+TEST(TEST_CATEGORY, host_shared_ptr_use_count) {
+  using T = int;
+  {
+    HostSharedPtr<T> p1;
+    EXPECT_EQ(p1.use_count(), 0);
+  }
+  {
+    HostSharedPtr<T> p1(nullptr);
+    EXPECT_EQ(p1.use_count(), 0);
+  }
+  {
+    HostSharedPtr<T> p1(new T());
+    EXPECT_EQ(p1.use_count(), 1);
+  }
+  {
+    HostSharedPtr<T> p1(new T(), [](T* p) { delete p; });
+    EXPECT_EQ(p1.use_count(), 1);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    EXPECT_EQ(p1.use_count(), 1);
+  }
+  {
+    HostSharedPtr<T> p1(new T());
+    HostSharedPtr<T> p2(p1);  // copy construction
+    EXPECT_EQ(p1.use_count(), 2);
+    EXPECT_EQ(p2.use_count(), 2);
+  }
+  {
+    HostSharedPtr<T> p1(new T());
+    HostSharedPtr<T> p2(std::move(p1));  // move construction
+    EXPECT_EQ(p1.use_count(), 0);
+    EXPECT_EQ(p2.use_count(), 1);
+  }
+  {
+    HostSharedPtr<T> p1(new T());
+    HostSharedPtr<T> p2;
+    p2 = p1;  // copy assignment
+    EXPECT_EQ(p1.use_count(), 2);
+    EXPECT_EQ(p2.use_count(), 2);
+  }
+  {
+    HostSharedPtr<T> p1(new T());
+    HostSharedPtr<T> p2;
+    p2 = std::move(p1);  // move assignment
+    EXPECT_EQ(p1.use_count(), 0);
+    EXPECT_EQ(p2.use_count(), 1);
+  }
+}
+
+TEST(TEST_CATEGORY, host_shared_ptr_get) {
+  using T = int;
+  {
+    HostSharedPtr<T> p1;
+    EXPECT_EQ(p1.get(), nullptr);
+  }
+  {
+    HostSharedPtr<T> p1(nullptr);
+    EXPECT_EQ(p1.get(), nullptr);
+  }
+  {
+    T* p_i = new T();
+    HostSharedPtr<T> p1(p_i);
+    EXPECT_EQ(p1.get(), p_i);
+  }
+  {
+    T* p_i = new T();
+    HostSharedPtr<T> p1(p_i, [](T* p) { delete p; });
+    EXPECT_EQ(p1.get(), p_i);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    EXPECT_EQ(p1.get(), &i);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    HostSharedPtr<T> p2(p1);  // copy construction
+    EXPECT_EQ(p1.get(), &i);
+    EXPECT_EQ(p1.get(), &i);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    HostSharedPtr<T> p2(std::move(p1));  // move construction
+    EXPECT_EQ(p1.get(), nullptr);
+    EXPECT_EQ(p2.get(), &i);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    HostSharedPtr<T> p2;
+    p2 = p1;  // copy assignment
+    EXPECT_EQ(p1.get(), &i);
+    EXPECT_EQ(p1.get(), &i);
+  }
+  {
+    T i;
+    HostSharedPtr<T> p1(&i, [](T*) {});
+    HostSharedPtr<T> p2;
+    p2 = std::move(p1);  // move assignment
+    EXPECT_EQ(p1.get(), nullptr);
+    EXPECT_EQ(p2.get(), &i);
+  }
+}

--- a/core/unit_test/TestHostSharedPtr.hpp
+++ b/core/unit_test/TestHostSharedPtr.hpp
@@ -80,7 +80,6 @@ TEST(TEST_CATEGORY, host_shared_ptr_use_count) {
   {
     HostSharedPtr<T> p1(new T());
     HostSharedPtr<T> p2(std::move(p1));  // move construction
-    EXPECT_EQ(p1.use_count(), 0);
     EXPECT_EQ(p2.use_count(), 1);
   }
   {
@@ -94,7 +93,6 @@ TEST(TEST_CATEGORY, host_shared_ptr_use_count) {
     HostSharedPtr<T> p1(new T());
     HostSharedPtr<T> p2;
     p2 = std::move(p1);  // move assignment
-    EXPECT_EQ(p1.use_count(), 0);
     EXPECT_EQ(p2.use_count(), 1);
   }
 }

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -1,0 +1,156 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <impl/Kokkos_HostSharedPtr.hpp>
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+using Kokkos::Impl::HostSharedPtr;
+
+namespace {
+
+class Data {
+  Kokkos::Array<char, 64> d;
+
+ public:
+  KOKKOS_FUNCTION void write(char const* c) {
+    for (int i = 0; i < 64 && c; ++i, ++c) {
+      d[i] = *c;
+    }
+  }
+};
+
+template <class SmartPtr>
+struct CheckAccessStoredPointerAndDereferenceOnDevice {
+  SmartPtr m_device_ptr;
+  using ElementType = typename SmartPtr::element_type;
+  static_assert(std::is_same<ElementType, Data>::value, "");
+
+  CheckAccessStoredPointerAndDereferenceOnDevice(SmartPtr device_ptr)
+      : m_device_ptr(device_ptr) {
+    int errors;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), *this,
+                            errors);
+    EXPECT_EQ(errors, 0);
+  }
+
+  KOKKOS_FUNCTION void operator()(int, int& e) const {
+    auto raw_ptr = m_device_ptr.get();  // get
+
+    auto tmp = new (raw_ptr) ElementType();
+
+    auto& obj = *m_device_ptr;  // operator*
+    if (&obj != raw_ptr) ++e;
+
+    m_device_ptr->write("hello world");  // operator->
+
+    tmp->~ElementType();
+  }
+};
+
+template <class Ptr>
+CheckAccessStoredPointerAndDereferenceOnDevice<Ptr>
+check_access_stored_pointer_and_dereference_on_device(Ptr p) {
+  return {p};
+}
+
+template <class SmartPtr>
+struct CheckSpecialMembersOnDevice {
+  SmartPtr m_device_ptr;
+
+  KOKKOS_FUNCTION void operator()(int, int& e) const {
+    SmartPtr p1 = m_device_ptr;   // copy construction
+    SmartPtr p2 = std::move(p1);  // move construction
+
+    p1 = p2;             // copy assignment
+    p2 = std::move(p1);  // move assignment
+
+    SmartPtr p3;  // default constructor
+    if (p3) ++e;
+    SmartPtr p4{nullptr};
+    if (p4) ++e;
+  }
+
+  CheckSpecialMembersOnDevice(SmartPtr device_ptr) : m_device_ptr(device_ptr) {
+    int errors;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), *this,
+                            errors);
+    EXPECT_EQ(errors, 0);
+  }
+};
+
+template <class Ptr>
+CheckSpecialMembersOnDevice<Ptr> check_special_members_on_device(Ptr p) {
+  return {p};
+}
+
+}  // namespace
+
+TEST(TEST_CATEGORY, host_shared_ptr_dereference_on_device) {
+  using T = Data;
+
+  using MemorySpace = TEST_EXECSPACE::memory_space;
+
+  HostSharedPtr<T> device_ptr(
+      static_cast<T*>(Kokkos::kokkos_malloc<MemorySpace>(sizeof(T))),
+      [](T* p) { Kokkos::kokkos_free<MemorySpace>(p); });
+
+  check_access_stored_pointer_and_dereference_on_device(device_ptr);
+}
+
+// FIXME_OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
+TEST(TEST_CATEGORY, host_shared_ptr_special_members_on_device) {
+  using T = Data;
+
+  using MemorySpace = TEST_EXECSPACE::memory_space;
+
+  HostSharedPtr<T> device_ptr(
+      static_cast<T*>(Kokkos::kokkos_malloc<MemorySpace>(sizeof(T))),
+      [](T* p) { Kokkos::kokkos_free<MemorySpace>(p); });
+
+  check_special_members_on_device(device_ptr);
+}
+#endif


### PR DESCRIPTION
This is meant to supersede #3796 
I opened a new pull request so it is easier to compare the two alternate implementations.
I added `check_copy_on_device` in `TestHostSharedPtrAccessOnDevice.hpp` and did a few minor edits in `<Kokkos_HostSharedPtr.hpp>`.

The last thing I am not sure about is whether we should make `HostSharedPtr` default constructible on the device.  That said this is something we can fix later.