### PR TITLE
Replaced nanosleep and sched_yield with STL routines

### DIFF
--- a/core/src/impl/Kokkos_HostBarrier.cpp
+++ b/core/src/impl/Kokkos_HostBarrier.cpp
@@ -61,7 +61,6 @@ namespace Impl {
 
 void HostBarrier::impl_backoff_wait_until_equal(
     int* ptr, const int v, const bool active_wait) noexcept {
-#if !defined(_WIN32)
   unsigned count = 0u;
 
   while (!test_equal(ptr, v)) {
@@ -87,18 +86,6 @@ void HostBarrier::impl_backoff_wait_until_equal(
 #endif
 #endif
   }
-#else  // _WIN32
-  while (!test_equal(ptr, v)) {
-#if defined(KOKKOS_ENABLE_ASM)
-    for (int j = 0; j < num_nops; ++j) {
-      __asm__ __volatile__("nop\n");
-    }
-    __asm__ __volatile__("pause\n" ::: "memory");
-#endif
-  }
-#endif
-  // printf("W: %d\n", count);
 }
-
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_HostBarrier.cpp
+++ b/core/src/impl/Kokkos_HostBarrier.cpp
@@ -49,10 +49,8 @@
 
 #include <impl/Kokkos_HostBarrier.hpp>
 
-#if !defined(_WIN32)
-#include <sched.h>
-#include <time.h>
-#else
+#include <thread>
+#if defined(_WIN32)
 #include <process.h>
 #include <winsock2.h>
 #include <windows.h>
@@ -64,17 +62,15 @@ namespace Impl {
 void HostBarrier::impl_backoff_wait_until_equal(
     int* ptr, const int v, const bool active_wait) noexcept {
 #if !defined(_WIN32)
-  timespec req;
-  req.tv_sec     = 0;
   unsigned count = 0u;
 
   while (!test_equal(ptr, v)) {
     const int c = ::Kokkos::log2(++count);
     if (!active_wait || c > log2_iterations_till_sleep) {
-      req.tv_nsec = c < 16 ? 256 * c : 4096;
-      nanosleep(&req, nullptr);
+      std::this_thread::sleep_for(
+          std::chrono::nanoseconds(c < 16 ? 256 * c : 4096));
     } else if (c > log2_iterations_till_yield) {
-      sched_yield();
+      std::this_thread::yield();
     }
 #if defined(KOKKOS_ENABLE_ASM)
 #if defined(__PPC64__)


### PR DESCRIPTION
- nanosleep and sched_yield are specific to UNIX
- closes #3816 (theoretically)
- `KOKKOS_ENABLE_STDTHREAD` is probably old pre-C++11 code. It isn't defined anywhere so it was removed

Benchmarked (via [QuickBench](https://quick-bench.com/):

```cpp
      auto start = std::chrono::high_resolution_clock::now();
      std::this_thread::yield();
      std::this_thread::sleep_until(start + std::chrono::nanoseconds(c * 1000));
```

vs.

```cpp
      std::this_thread::yield();
      std::this_thread::sleep_for(std::chrono::microseconds(c));
```

and found the latter to be more efficient.

@crtrott Can you take a look at `HostBarrier::impl_backoff_wait_until_equal` as a whole? There is a weird `#if !defined(_WIN32)` and the `#else` for Windows doesn't seem to implement the same algorithm at all.
