### PR TITLE
More extensive disentangling of Policy Traits (Replaces #3564) 

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -50,7 +50,6 @@
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Tags.hpp>
 #include <impl/Kokkos_AnalyzePolicy.hpp>
-
 #include <Kokkos_Concepts.hpp>
 #include <typeinfo>
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -50,6 +50,7 @@
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Tags.hpp>
 #include <impl/Kokkos_AnalyzePolicy.hpp>
+
 #include <Kokkos_Concepts.hpp>
 #include <typeinfo>
 
@@ -903,85 +904,6 @@ struct ParallelConstructName<FunctorType, TagType, false> {
 }  // namespace Kokkos
 
 namespace Kokkos {
-namespace Experimental {
-
-namespace Impl {
-template <class Property, class Policy>
-struct PolicyPropertyAdaptor;
-
-template <unsigned long P, template <class...> class Policy,
-          class... Properties>
-struct PolicyPropertyAdaptor<WorkItemProperty::ImplWorkItemProperty<P>,
-                             Policy<Properties...>> {
-  using policy_in_t = Policy<Properties...>;
-  static_assert(is_execution_policy<policy_in_t>::value, "");
-  using policy_out_t = Policy<typename policy_in_t::traits::execution_space,
-                              typename policy_in_t::traits::schedule_type,
-                              typename policy_in_t::traits::work_tag,
-                              typename policy_in_t::traits::index_type,
-                              typename policy_in_t::traits::iteration_pattern,
-                              typename policy_in_t::traits::launch_bounds,
-                              WorkItemProperty::ImplWorkItemProperty<P>,
-                              typename policy_in_t::traits::occupancy_control>;
-};
-
-template <template <class...> class Policy, class... Properties>
-struct PolicyPropertyAdaptor<DesiredOccupancy, Policy<Properties...>> {
-  using policy_in_t = Policy<Properties...>;
-  static_assert(is_execution_policy<policy_in_t>::value, "");
-  using policy_out_t = Policy<typename policy_in_t::traits::execution_space,
-                              typename policy_in_t::traits::schedule_type,
-                              typename policy_in_t::traits::work_tag,
-                              typename policy_in_t::traits::index_type,
-                              typename policy_in_t::traits::iteration_pattern,
-                              typename policy_in_t::traits::launch_bounds,
-                              typename policy_in_t::traits::work_item_property,
-                              DesiredOccupancy>;
-  static_assert(policy_out_t::experimental_contains_desired_occupancy, "");
-};
-
-template <template <class...> class Policy, class... Properties>
-struct PolicyPropertyAdaptor<MaximizeOccupancy, Policy<Properties...>> {
-  using policy_in_t = Policy<Properties...>;
-  static_assert(is_execution_policy<policy_in_t>::value, "");
-  using policy_out_t = Policy<typename policy_in_t::traits::execution_space,
-                              typename policy_in_t::traits::schedule_type,
-                              typename policy_in_t::traits::work_tag,
-                              typename policy_in_t::traits::index_type,
-                              typename policy_in_t::traits::iteration_pattern,
-                              typename policy_in_t::traits::launch_bounds,
-                              typename policy_in_t::traits::work_item_property,
-                              MaximizeOccupancy>;
-  static_assert(!policy_out_t::experimental_contains_desired_occupancy, "");
-};
-}  // namespace Impl
-
-template <class PolicyType, unsigned long P>
-constexpr typename Impl::PolicyPropertyAdaptor<
-    WorkItemProperty::ImplWorkItemProperty<P>, PolicyType>::policy_out_t
-require(const PolicyType p, WorkItemProperty::ImplWorkItemProperty<P>) {
-  return typename Impl::PolicyPropertyAdaptor<
-      WorkItemProperty::ImplWorkItemProperty<P>, PolicyType>::policy_out_t(p);
-}
-
-template <typename Policy>
-/*constexpr*/ typename Impl::PolicyPropertyAdaptor<DesiredOccupancy,
-                                                   Policy>::policy_out_t
-prefer(Policy const& p, DesiredOccupancy occ) {
-  typename Impl::PolicyPropertyAdaptor<DesiredOccupancy, Policy>::policy_out_t
-      pwo{p};
-  pwo.impl_set_desired_occupancy(occ);
-  return pwo;
-}
-
-template <typename Policy>
-constexpr typename Impl::PolicyPropertyAdaptor<MaximizeOccupancy,
-                                               Policy>::policy_out_t
-prefer(Policy const& p, MaximizeOccupancy) {
-  return {p};
-}
-
-}  // namespace Experimental
 
 namespace Impl {
 

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -50,289 +50,72 @@
 #include <impl/Kokkos_Tags.hpp>
 #include <impl/Kokkos_GraphImpl_fwd.hpp>
 #include <impl/Kokkos_Error.hpp>
+#include <traits/Kokkos_Traits_fwd.hpp>
+#include <traits/Kokkos_PolicyTraitAdaptor.hpp>
+
+#include <traits/Kokkos_ExecutionSpaceTrait.hpp>
+#include <traits/Kokkos_GraphKernelTrait.hpp>
+#include <traits/Kokkos_IndexTypeTrait.hpp>
+#include <traits/Kokkos_IterationPatternTrait.hpp>
+#include <traits/Kokkos_LaunchBoundsTrait.hpp>
+#include <traits/Kokkos_OccupancyControlTrait.hpp>
+#include <traits/Kokkos_ScheduleTrait.hpp>
+#include <traits/Kokkos_WorkItemPropertyTrait.hpp>
+#include <traits/Kokkos_WorkTagTrait.hpp>
 
 namespace Kokkos {
-namespace Experimental {
-struct MaximizeOccupancy;
-struct DesiredOccupancy {
-  int m_occ = 100;
-  explicit constexpr DesiredOccupancy(int occ) : m_occ(occ) {
-    KOKKOS_EXPECTS(0 <= occ && occ <= 100);
-  }
-  explicit constexpr operator int() const { return m_occ; }
-  constexpr int value() const { return m_occ; }
-  DesiredOccupancy() = default;
-  explicit DesiredOccupancy(MaximizeOccupancy const&) : DesiredOccupancy() {}
-};
-struct MaximizeOccupancy {
-  MaximizeOccupancy() = default;
-};
-}  // namespace Experimental
-
 namespace Impl {
 
 //------------------------------------------------------------------------------
-template <class Enable, class... TraitsList>
-struct AnalyzePolicy;
 
-//------------------------------------------------------------------------------
-
-template <class AnalysisResults>
-struct PolicyTraitsWithDefaults;
-
-//------------------------------------------------------------------------------
-// ExecutionSpace case
-template <class ExecutionSpace, class... Traits>
-struct AnalyzePolicy<
-    std::enable_if_t<Impl::is_execution_space<ExecutionSpace>::value>,
-    ExecutionSpace, Traits...> : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(base_t::execution_space_is_defaulted,
-                "Kokkos Error: More than one execution space given");
-  static constexpr bool execution_space_is_defaulted = false;
-  using execution_space                              = ExecutionSpace;
-};
-
-//------------------------------------------------------------------------------
-// Schedule case
-template <class ScheduleType, class... Traits>
-struct AnalyzePolicy<void, Kokkos::Schedule<ScheduleType>, Traits...>
-    : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(base_t::schedule_type_is_defaulted,
-                "Kokkos Error: More than one schedule type given");
-  static constexpr bool schedule_type_is_defaulted = false;
-  using schedule_type = Kokkos::Schedule<ScheduleType>;
-};
-
-//------------------------------------------------------------------------------
-// IndexType case
-template <class IntegralIndexType, class... Traits>
-struct AnalyzePolicy<void, Kokkos::IndexType<IntegralIndexType>, Traits...>
-    : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(base_t::index_type_is_defaulted,
-                "Kokkos Error: More than one index type given");
-  static constexpr bool index_type_is_defaulted = false;
-  using index_type = Kokkos::IndexType<IntegralIndexType>;
-};
-
-// IndexType given as an integral type directly
-template <class IntegralIndexType, class... Traits>
-struct AnalyzePolicy<
-    std::enable_if_t<std::is_integral<IntegralIndexType>::value>,
-    IntegralIndexType, Traits...> : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(base_t::index_type_is_defaulted,
-                "Kokkos Error: More than one index type given");
-  static constexpr bool index_type_is_defaulted = false;
-  using index_type = Kokkos::IndexType<IntegralIndexType>;
-};
-
-//------------------------------------------------------------------------------
-// Iteration pattern case
-template <class IterationPattern, class... Traits>
-struct AnalyzePolicy<
-    std::enable_if_t<Impl::is_iteration_pattern<IterationPattern>::value>,
-    IterationPattern, Traits...> : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(std::is_void<typename base_t::iteration_pattern>::value,
-                "Kokkos Error: More than one iteration pattern given");
-  using iteration_pattern = IterationPattern;
-};
-
-//------------------------------------------------------------------------------
-// Launch bounds case
-template <unsigned int... Bounds, class... Traits>
-struct AnalyzePolicy<void, Kokkos::LaunchBounds<Bounds...>, Traits...>
-    : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(base_t::launch_bounds_is_defaulted,
-                "Kokkos Error: More than one launch_bounds given");
-  static constexpr bool launch_bounds_is_defaulted = false;
-  using launch_bounds = Kokkos::LaunchBounds<Bounds...>;
-};
-
-//------------------------------------------------------------------------------
-// Work item propoerty case
-template <class Property, class... Traits>
-struct AnalyzePolicy<
-    std::enable_if_t<
-        Kokkos::Experimental::is_work_item_property<Property>::value>,
-    Property, Traits...> : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(
-      std::is_same<typename base_t::work_item_property,
-                   Kokkos::Experimental::WorkItemProperty::None_t>::value,
-      "Kokkos Error: More than one work item property given");
-  using work_item_property = Property;
-};
-
-//------------------------------------------------------------------------------
-// GraphKernel Tag case
-template <class... Traits>
-struct AnalyzePolicy<void, Impl::IsGraphKernelTag, Traits...>
-    : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-  using is_graph_kernel = std::true_type;
-};
-
-//------------------------------------------------------------------------------
-// Occupancy control case
-// The DesiredOccupancy case has runtime storage, so we need to handle copies
-// and assignments
-template <class... Traits>
-struct AnalyzePolicy<void, Kokkos::Experimental::DesiredOccupancy, Traits...>
-    : AnalyzePolicy<void, Traits...> {
- public:
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-  using occupancy_control = Kokkos::Experimental::DesiredOccupancy;
-  static constexpr bool experimental_contains_desired_occupancy = true;
-
- private:
-  // storage for a stateful desired occupancy
-  occupancy_control m_desired_occupancy = {};
-
- public:
-  // Converting constructor
-  // Just rely on the convertibility of occupancy_control to transfer the data
-  template <class Other>
-  AnalyzePolicy(PolicyTraitsWithDefaults<Other> const& other)
-      : base_t(other),
-        m_desired_occupancy(other.impl_get_occupancy_control()) {}
-
-  // Converting assignment operator
-  // Just rely on the convertibility of occupancy_control to transfer the data
-  template <class Other>
-  AnalyzePolicy& operator=(PolicyTraitsWithDefaults<Other> const& other) {
-    *static_cast<base_t*>(this) = other;
-    this->impl_set_desired_occupancy(
-        occupancy_control{other.impl_get_occupancy_control()});
-    return *this;
-  }
-
-  // Access to occupancy control instance, usable in generic context
-  constexpr occupancy_control impl_get_occupancy_control() const {
-    return m_desired_occupancy;
-  }
-
-  // Access to desired occupancy (getter and setter)
-  Kokkos::Experimental::DesiredOccupancy impl_get_desired_occupancy() const {
-    return m_desired_occupancy;
-  }
-
-  void impl_set_desired_occupancy(occupancy_control desired_occupancy) {
-    m_desired_occupancy = desired_occupancy;
-  }
-};
-
-template <class... Traits>
-struct AnalyzePolicy<void, Kokkos::Experimental::MaximizeOccupancy, Traits...>
-    : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-  using occupancy_control = Kokkos::Experimental::MaximizeOccupancy;
-  static constexpr bool experimental_contains_desired_occupancy = false;
-};
+using execution_policy_trait_specifications =
+    type_list<ExecutionSpaceTrait, GraphKernelTrait, IndexTypeTrait,
+              IterationPatternTrait, LaunchBoundsTrait, OccupancyControlTrait,
+              ScheduleTrait, WorkItemPropertyTrait, WorkTagTrait>;
 
 //------------------------------------------------------------------------------
 // Ignore void for backwards compatibility purposes, though hopefully no one is
 // using this in application code
 template <class... Traits>
-struct AnalyzePolicy<void, void, Traits...> : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
+struct AnalyzeExecPolicy<void, void, Traits...>
+    : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
   using base_t::base_t;
 };
 
 //------------------------------------------------------------------------------
-// Handle work tag: if nothing else matches, tread the trait as a work tag
+// Mix in the defaults (base_traits) for the traits that aren't yet handled
 
-// Since we don't have subsumption in pre-C++20, we need to have the work tag
-// "trait" handling code be unspecialized, so we handle it instead in a class
-// with a different name.
-template <class... Traits>
-struct AnalyzePolicyHandleWorkTag : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-};
-
-template <class WorkTag, class... Traits>
-struct AnalyzePolicyHandleWorkTag<WorkTag, Traits...>
-    : AnalyzePolicy<void, Traits...> {
-  using base_t = AnalyzePolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(std::is_void<typename base_t::work_tag>::value,
-                "Kokkos Error: More than one work tag given");
-  using work_tag = WorkTag;
-};
-
-// This only works if this is not a partial specialization, so we have to
-// do the partial specialization elsewhere
-template <class Enable, class... Traits>
-struct AnalyzePolicy : AnalyzePolicyHandleWorkTag<Traits...> {
-  using base_t = AnalyzePolicyHandleWorkTag<Traits...>;
-  using base_t::base_t;
-};
-
-//------------------------------------------------------------------------------
-// Defaults, for the traits that aren't yet handled
-
-// A tag class for dependent defaults that must be handled by the
-// PolicyTraitsWithDefaults wrapper, since their defaults depend on other traits
-struct dependent_policy_trait_default;
+template <class TraitSpecList>
+struct AnalyzeExecPolicyBaseTraits;
+template <class... TraitSpecifications>
+struct AnalyzeExecPolicyBaseTraits<type_list<TraitSpecifications...>>
+    : TraitSpecifications::base_traits... {};
 
 template <>
-struct AnalyzePolicy<void> {
-  static constexpr auto execution_space_is_defaulted = true;
-  using execution_space = Kokkos::DefaultExecutionSpace;
-
-  static constexpr bool schedule_type_is_defaulted = true;
-  using schedule_type                              = Schedule<Static>;
-
-  static constexpr bool index_type_is_defaulted = true;
-  using index_type = dependent_policy_trait_default;
-
-  using iteration_pattern = void;  // TODO set default iteration pattern
-
-  static constexpr bool launch_bounds_is_defaulted = true;
-  using launch_bounds                              = LaunchBounds<>;
-
-  using work_item_property = Kokkos::Experimental::WorkItemProperty::None_t;
-  using is_graph_kernel    = std::false_type;
-
-  using occupancy_control = Kokkos::Experimental::MaximizeOccupancy;
-  static constexpr bool experimental_contains_desired_occupancy = false;
-  // Default access occupancy_control, for when it is the (stateless) default
-  constexpr occupancy_control impl_get_occupancy_control() const {
-    return occupancy_control{};
-  }
-
+struct AnalyzeExecPolicy<void>
+    : AnalyzeExecPolicyBaseTraits<execution_policy_trait_specifications> {
   using work_tag = void;
 
-  AnalyzePolicy() = default;
+  // Ensure default constructibility since a converting constructor causes it to
+  // be deleted.
+  AnalyzeExecPolicy() = default;
 
-  // Base converting constructors: unless an individual policy analysis
-  // deletes a constructor, assume it's convertible
+  // Base converting constructor and assignment operator: unless an individual
+  // policy analysis deletes a constructor, assume it's convertible
   template <class Other>
-  AnalyzePolicy(PolicyTraitsWithDefaults<Other> const&) {}
+  AnalyzeExecPolicy(ExecPolicyTraitsWithDefaults<Other> const&) {}
 
   template <class Other>
-  AnalyzePolicy& operator=(PolicyTraitsWithDefaults<Other> const&) {}
+  AnalyzeExecPolicy& operator=(ExecPolicyTraitsWithDefaults<Other> const&) {
+    return *this;
+  }
 };
 
 //------------------------------------------------------------------------------
 // Used for defaults that depend on other analysis results
 template <class AnalysisResults>
-struct PolicyTraitsWithDefaults : AnalysisResults {
+struct ExecPolicyTraitsWithDefaults : AnalysisResults {
   using base_t = AnalysisResults;
   using base_t::base_t;
   // The old code turned this into an integral type for backwards compatibility,
@@ -347,8 +130,10 @@ struct PolicyTraitsWithDefaults : AnalysisResults {
 
 //------------------------------------------------------------------------------
 template <typename... Traits>
-struct PolicyTraits : PolicyTraitsWithDefaults<AnalyzePolicy<void, Traits...>> {
-  using base_t = PolicyTraitsWithDefaults<AnalyzePolicy<void, Traits...>>;
+struct PolicyTraits
+    : ExecPolicyTraitsWithDefaults<AnalyzeExecPolicy<void, Traits...>> {
+  using base_t =
+      ExecPolicyTraitsWithDefaults<AnalyzeExecPolicy<void, Traits...>>;
   template <class... Args>
   PolicyTraits(PolicyTraits<Args...> const& p) : base_t(p) {}
   PolicyTraits() = default;

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -46,10 +46,7 @@
 #define KOKKOS_IMPL_ANALYZE_POLICY_HPP
 
 #include <Kokkos_Core_fwd.hpp>
-#include <Kokkos_Concepts.hpp>
-#include <impl/Kokkos_Tags.hpp>
-#include <impl/Kokkos_GraphImpl_fwd.hpp>
-#include <impl/Kokkos_Error.hpp>
+#include <Kokkos_Concepts.hpp>  // IndexType
 #include <traits/Kokkos_Traits_fwd.hpp>
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
 
@@ -95,8 +92,6 @@ struct AnalyzeExecPolicyBaseTraits<type_list<TraitSpecifications...>>
 template <>
 struct AnalyzeExecPolicy<void>
     : AnalyzeExecPolicyBaseTraits<execution_policy_trait_specifications> {
-  using work_tag = void;
-
   // Ensure default constructibility since a converting constructor causes it to
   // be deleted.
   AnalyzeExecPolicy() = default;

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -83,11 +83,19 @@ struct AnalyzeExecPolicy<void, void, Traits...>
 //------------------------------------------------------------------------------
 // Mix in the defaults (base_traits) for the traits that aren't yet handled
 
+// MSVC Workaround: linearize base traits to help with EBO?
+template <class... Ts>
+struct LinearizeInheritance;
+template <class T, class... Ts>
+struct LinearizeInheritance<T, Ts...> : T, LinearizeInheritance<Ts...> {};
+template <>
+struct LinearizeInheritance<> {};
+
 template <class TraitSpecList>
 struct AnalyzeExecPolicyBaseTraits;
 template <class... TraitSpecifications>
 struct AnalyzeExecPolicyBaseTraits<type_list<TraitSpecifications...>>
-    : TraitSpecifications::base_traits... {};
+    : LinearizeInheritance<typename TraitSpecifications::base_traits...> {};
 
 template <>
 struct AnalyzeExecPolicy<void>

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -134,9 +134,7 @@ struct PolicyTraits
     : ExecPolicyTraitsWithDefaults<AnalyzeExecPolicy<void, Traits...>> {
   using base_t =
       ExecPolicyTraitsWithDefaults<AnalyzeExecPolicy<void, Traits...>>;
-  template <class... Args>
-  PolicyTraits(PolicyTraits<Args...> const& p) : base_t(p) {}
-  PolicyTraits() = default;
+  using base_t::base_t;
 };
 
 }  // namespace Impl

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -136,6 +136,16 @@ struct destruct_delete {
 };
 //==============================================================================
 
+//==============================================================================
+// <editor-fold desc="type_list"> {{{1
+
+// An intentionally uninstantiateable type_list for metaprogramming purposes
+template <class...>
+struct type_list;
+
+// </editor-fold> end type_list }}}1
+//==============================================================================
+
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -146,6 +146,27 @@ struct type_list;
 // </editor-fold> end type_list }}}1
 //==============================================================================
 
+//==============================================================================
+// <editor-fold desc="MSVC linearize base workaround"> {{{1
+
+// MSVC workaround: more than two base classes (and more than one if the
+// hierarchy gets too deep) causes problems with EBO, so we need to linearize
+// the inheritance hierarchy to avoid losing EBO and ending up with an object
+// representation that is larger than it needs to be.
+// Note: by convention, the nested template in a higher-order metafunction like
+// GetBase is named apply, so we use that name here (this convention grew out
+// of Boost MPL)
+template <template <class> class GetBase, class...>
+struct linearize_bases;
+template <template <class> class GetBase, class T, class... Ts>
+struct linearize_bases<GetBase, T, Ts...> : GetBase<T>::template apply<Ts...> {
+};
+template <template <class> class GetBase>
+struct linearize_bases<GetBase> {};
+
+// </editor-fold> end MSVC linearize base workaround }}}1
+//==============================================================================
+
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
+++ b/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
@@ -63,8 +63,7 @@ struct ExecutionSpaceTrait : TraitSpecificationBase<ExecutionSpaceTrait> {
     using execution_space = Kokkos::DefaultExecutionSpace;
   };
   template <class T>
-  static constexpr bool trait_matches_specification =
-      is_execution_space<T>::value;
+  using trait_matches_specification = is_execution_space<T>;
 };
 
 // </editor-fold> end trait specification }}}1
@@ -75,8 +74,7 @@ struct ExecutionSpaceTrait : TraitSpecificationBase<ExecutionSpaceTrait> {
 
 template <class ExecutionSpace, class... Traits>
 struct AnalyzeExecPolicy<
-    std::enable_if_t<ExecutionSpaceTrait::template trait_matches_specification<
-        ExecutionSpace>>,
+    std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value>,
     ExecutionSpace, Traits...> : AnalyzeExecPolicy<void, Traits...> {
   using base_t = AnalyzeExecPolicy<void, Traits...>;
   using base_t::base_t;

--- a/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
+++ b/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
@@ -57,7 +57,9 @@ namespace Impl {
 // <editor-fold desc="trait specification"> {{{1
 
 struct ExecutionSpaceTrait : TraitSpecificationBase<ExecutionSpaceTrait> {
-  struct base_traits {
+  // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
+  template <template <class> class GetBase, class... OtherTraits>
+  struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     static constexpr auto execution_space_is_defaulted = true;
 
     using execution_space = Kokkos::DefaultExecutionSpace;

--- a/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
+++ b/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
@@ -1,0 +1,97 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_EXECUTIONSPACETRAIT_HPP
+#define KOKKOS_KOKKOS_EXECUTIONSPACETRAIT_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Concepts.hpp>  // is_execution_space
+#include <traits/Kokkos_PolicyTraitAdaptor.hpp>
+#include <traits/Kokkos_Traits_fwd.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="trait specification"> {{{1
+
+struct ExecutionSpaceTrait : TraitSpecificationBase<ExecutionSpaceTrait> {
+  struct base_traits {
+    static constexpr auto execution_space_is_defaulted = true;
+
+    using execution_space = Kokkos::DefaultExecutionSpace;
+  };
+  template <class T>
+  static constexpr bool trait_matches_specification =
+      is_execution_space<T>::value;
+};
+
+// </editor-fold> end trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
+
+template <class ExecutionSpace, class... Traits>
+struct AnalyzeExecPolicy<
+    std::enable_if_t<ExecutionSpaceTrait::template trait_matches_specification<
+        ExecutionSpace>>,
+    ExecutionSpace, Traits...> : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+
+  static_assert(base_t::execution_space_is_defaulted,
+                "Kokkos Error: More than one execution space given");
+
+  static constexpr bool execution_space_is_defaulted = false;
+
+  using execution_space = ExecutionSpace;
+};
+
+// </editor-fold> end AnalyzeExecPolicy specializations }}}1
+//==============================================================================
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_EXECUTIONSPACETRAIT_HPP

--- a/core/src/traits/Kokkos_GraphKernelTrait.hpp
+++ b/core/src/traits/Kokkos_GraphKernelTrait.hpp
@@ -47,6 +47,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
+#include <impl/Kokkos_GraphImpl_fwd.hpp>  // IsGraphKernelTag
 #include <traits/Kokkos_Traits_fwd.hpp>
 
 namespace Kokkos {

--- a/core/src/traits/Kokkos_GraphKernelTrait.hpp
+++ b/core/src/traits/Kokkos_GraphKernelTrait.hpp
@@ -1,0 +1,86 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_GRAPHKERNELTRAIT_HPP
+#define KOKKOS_KOKKOS_GRAPHKERNELTRAIT_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <traits/Kokkos_PolicyTraitAdaptor.hpp>
+#include <traits/Kokkos_Traits_fwd.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="trait specification"> {{{1
+
+struct GraphKernelTrait : TraitSpecificationBase<GraphKernelTrait> {
+  struct base_traits {
+    using is_graph_kernel = std::false_type;
+  };
+  template <class T>
+  static constexpr bool trait_matches_specification =
+      std::is_same<T, IsGraphKernelTag>::value;
+};
+
+// </editor-fold> end trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
+
+template <class... Traits>
+struct AnalyzeExecPolicy<void, Impl::IsGraphKernelTag, Traits...>
+    : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+  using is_graph_kernel = std::true_type;
+};
+
+// </editor-fold> end AnalyzeExecPolicy specializations }}}1
+//==============================================================================
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_GRAPHKERNELTRAIT_HPP

--- a/core/src/traits/Kokkos_GraphKernelTrait.hpp
+++ b/core/src/traits/Kokkos_GraphKernelTrait.hpp
@@ -49,6 +49,7 @@
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
 #include <impl/Kokkos_GraphImpl_fwd.hpp>  // IsGraphKernelTag
 #include <traits/Kokkos_Traits_fwd.hpp>
+#include <impl/Kokkos_Utilities.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -57,7 +58,9 @@ namespace Impl {
 // <editor-fold desc="trait specification"> {{{1
 
 struct GraphKernelTrait : TraitSpecificationBase<GraphKernelTrait> {
-  struct base_traits {
+  // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
+  template <template <class> class GetBase, class... OtherTraits>
+  struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     using is_graph_kernel = std::false_type;
   };
   template <class T>

--- a/core/src/traits/Kokkos_GraphKernelTrait.hpp
+++ b/core/src/traits/Kokkos_GraphKernelTrait.hpp
@@ -60,8 +60,7 @@ struct GraphKernelTrait : TraitSpecificationBase<GraphKernelTrait> {
     using is_graph_kernel = std::false_type;
   };
   template <class T>
-  static constexpr bool trait_matches_specification =
-      std::is_same<T, IsGraphKernelTag>::value;
+  using trait_matches_specification = std::is_same<T, IsGraphKernelTag>;
 };
 
 // </editor-fold> end trait specification }}}1

--- a/core/src/traits/Kokkos_IndexTypeTrait.hpp
+++ b/core/src/traits/Kokkos_IndexTypeTrait.hpp
@@ -62,8 +62,9 @@ struct IndexTypeTrait : TraitSpecificationBase<IndexTypeTrait> {
     using index_type = dependent_policy_trait_default;
   };
   template <class T>
-  static constexpr bool trait_matches_specification =
-      std::is_integral<T>::value || is_index_type<T>::value;
+  using trait_matches_specification =
+      std::integral_constant<bool, std::is_integral<T>::value ||
+                                       is_index_type<T>::value>;
 };
 
 // </editor-fold> end trait specification }}}1

--- a/core/src/traits/Kokkos_IndexTypeTrait.hpp
+++ b/core/src/traits/Kokkos_IndexTypeTrait.hpp
@@ -57,7 +57,9 @@ namespace Impl {
 // <editor-fold desc="trait specification"> {{{1
 
 struct IndexTypeTrait : TraitSpecificationBase<IndexTypeTrait> {
-  struct base_traits {
+  // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
+  template <template <class> class GetBase, class... OtherTraits>
+  struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     static constexpr bool index_type_is_defaulted = true;
     using index_type = dependent_policy_trait_default;
   };

--- a/core/src/traits/Kokkos_IndexTypeTrait.hpp
+++ b/core/src/traits/Kokkos_IndexTypeTrait.hpp
@@ -1,0 +1,106 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_INDEXTYPETRAIT_HPP
+#define KOKKOS_KOKKOS_INDEXTYPETRAIT_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Concepts.hpp>  // is_execution_space
+#include <traits/Kokkos_PolicyTraitAdaptor.hpp>
+#include <traits/Kokkos_Traits_fwd.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="trait specification"> {{{1
+
+struct IndexTypeTrait : TraitSpecificationBase<IndexTypeTrait> {
+  struct base_traits {
+    static constexpr bool index_type_is_defaulted = true;
+    using index_type = dependent_policy_trait_default;
+  };
+  template <class T>
+  static constexpr bool trait_matches_specification =
+      std::is_integral<T>::value || is_index_type<T>::value;
+};
+
+// </editor-fold> end trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
+
+// Index type given as IndexType template
+template <class IntegralIndexType, class... Traits>
+struct AnalyzeExecPolicy<void, Kokkos::IndexType<IntegralIndexType>, Traits...>
+    : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+  static_assert(base_t::index_type_is_defaulted,
+                "Kokkos Error: More than one index type given");
+  static constexpr bool index_type_is_defaulted = false;
+  using index_type = Kokkos::IndexType<IntegralIndexType>;
+};
+
+// IndexType given as an integral type directly
+template <class IntegralIndexType, class... Traits>
+struct AnalyzeExecPolicy<
+    std::enable_if_t<std::is_integral<IntegralIndexType>::value>,
+    IntegralIndexType, Traits...> : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+  static_assert(base_t::index_type_is_defaulted,
+                "Kokkos Error: More than one index type given");
+  static constexpr bool index_type_is_defaulted = false;
+  using index_type = Kokkos::IndexType<IntegralIndexType>;
+};
+
+// </editor-fold> end AnalyzeExecPolicy specializations }}}1
+//==============================================================================
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_INDEXTYPETRAIT_HPP

--- a/core/src/traits/Kokkos_IndexTypeTrait.hpp
+++ b/core/src/traits/Kokkos_IndexTypeTrait.hpp
@@ -46,7 +46,7 @@
 #define KOKKOS_KOKKOS_INDEXTYPETRAIT_HPP
 
 #include <Kokkos_Macros.hpp>
-#include <Kokkos_Concepts.hpp>  // is_execution_space
+#include <Kokkos_Concepts.hpp>  // IndexType, is_index_type
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
 #include <traits/Kokkos_Traits_fwd.hpp>
 

--- a/core/src/traits/Kokkos_IterationPatternTrait.hpp
+++ b/core/src/traits/Kokkos_IterationPatternTrait.hpp
@@ -55,7 +55,9 @@ namespace Impl {
 // <editor-fold desc="trait specification"> {{{1
 
 struct IterationPatternTrait : TraitSpecificationBase<IterationPatternTrait> {
-  struct base_traits {
+  // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
+  template <template <class> class GetBase, class... OtherTraits>
+  struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     using iteration_pattern = void;  // TODO set default iteration pattern
   };
   template <class T>

--- a/core/src/traits/Kokkos_IterationPatternTrait.hpp
+++ b/core/src/traits/Kokkos_IterationPatternTrait.hpp
@@ -58,8 +58,7 @@ struct IterationPatternTrait : TraitSpecificationBase<IterationPatternTrait> {
     using iteration_pattern = void;  // TODO set default iteration pattern
   };
   template <class T>
-  static constexpr bool trait_matches_specification =
-      Impl::is_iteration_pattern<T>::value;
+  using trait_matches_specification = Impl::is_iteration_pattern<T>;
 };
 
 // </editor-fold> end trait specification }}}1
@@ -70,8 +69,7 @@ struct IterationPatternTrait : TraitSpecificationBase<IterationPatternTrait> {
 
 template <class IterationPattern, class... Traits>
 struct AnalyzeExecPolicy<
-    std::enable_if_t<
-        IterationPatternTrait::trait_matches_specification<IterationPattern>>,
+    std::enable_if_t<is_iteration_pattern<IterationPattern>::value>,
     IterationPattern, Traits...> : AnalyzeExecPolicy<void, Traits...> {
   using base_t = AnalyzeExecPolicy<void, Traits...>;
   using base_t::base_t;

--- a/core/src/traits/Kokkos_IterationPatternTrait.hpp
+++ b/core/src/traits/Kokkos_IterationPatternTrait.hpp
@@ -1,0 +1,89 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_ITERATIONPATTERNTRAIT_HPP
+#define KOKKOS_KOKKOS_ITERATIONPATTERNTRAIT_HPP
+
+#include <impl/Kokkos_Error.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="trait specification"> {{{1
+
+struct IterationPatternTrait : TraitSpecificationBase<IterationPatternTrait> {
+  struct base_traits {
+    using iteration_pattern = void;  // TODO set default iteration pattern
+  };
+  template <class T>
+  static constexpr bool trait_matches_specification =
+      Impl::is_iteration_pattern<T>::value;
+};
+
+// </editor-fold> end trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
+
+template <class IterationPattern, class... Traits>
+struct AnalyzeExecPolicy<
+    std::enable_if_t<
+        IterationPatternTrait::trait_matches_specification<IterationPattern>>,
+    IterationPattern, Traits...> : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+  static_assert(std::is_void<typename base_t::iteration_pattern>::value,
+                "Kokkos Error: More than one iteration pattern given");
+  using iteration_pattern = IterationPattern;
+};
+
+// </editor-fold> end AnalyzeExecPolicy specializations }}}1
+//==============================================================================
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_ITERATIONPATTERNTRAIT_HPP

--- a/core/src/traits/Kokkos_IterationPatternTrait.hpp
+++ b/core/src/traits/Kokkos_IterationPatternTrait.hpp
@@ -45,7 +45,8 @@
 #ifndef KOKKOS_KOKKOS_ITERATIONPATTERNTRAIT_HPP
 #define KOKKOS_KOKKOS_ITERATIONPATTERNTRAIT_HPP
 
-#include <impl/Kokkos_Error.hpp>
+#include <Kokkos_Concepts.hpp>  // is_iteration_pattern
+#include <type_traits>          // is_void
 
 namespace Kokkos {
 namespace Impl {
@@ -58,7 +59,7 @@ struct IterationPatternTrait : TraitSpecificationBase<IterationPatternTrait> {
     using iteration_pattern = void;  // TODO set default iteration pattern
   };
   template <class T>
-  using trait_matches_specification = Impl::is_iteration_pattern<T>;
+  using trait_matches_specification = is_iteration_pattern<T>;
 };
 
 // </editor-fold> end trait specification }}}1

--- a/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
+++ b/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
@@ -63,8 +63,7 @@ struct LaunchBoundsTrait : TraitSpecificationBase<LaunchBoundsTrait> {
     using launch_bounds = LaunchBounds<>;
   };
   template <class T>
-  static constexpr bool trait_matches_specification =
-      is_launch_bounds<T>::value;
+  using trait_matches_specification = is_launch_bounds<T>;
 };
 
 // </editor-fold> end trait specification }}}1

--- a/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
+++ b/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
@@ -72,15 +72,15 @@ struct LaunchBoundsTrait : TraitSpecificationBase<LaunchBoundsTrait> {
 //==============================================================================
 // <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
 
-template <unsigned int... Bounds, class... Traits>
-struct AnalyzeExecPolicy<void, Kokkos::LaunchBounds<Bounds...>, Traits...>
+template <unsigned int MaxT, unsigned int MinB, class... Traits>
+struct AnalyzeExecPolicy<void, Kokkos::LaunchBounds<MaxT, MinB>, Traits...>
     : AnalyzeExecPolicy<void, Traits...> {
   using base_t = AnalyzeExecPolicy<void, Traits...>;
   using base_t::base_t;
   static_assert(base_t::launch_bounds_is_defaulted,
                 "Kokkos Error: More than one launch_bounds given");
   static constexpr bool launch_bounds_is_defaulted = false;
-  using launch_bounds = Kokkos::LaunchBounds<Bounds...>;
+  using launch_bounds = Kokkos::LaunchBounds<MaxT, MinB>;
 };
 
 // </editor-fold> end AnalyzeExecPolicy specializations }}}1

--- a/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
+++ b/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
@@ -57,7 +57,9 @@ namespace Impl {
 // <editor-fold desc="trait specification"> {{{1
 
 struct LaunchBoundsTrait : TraitSpecificationBase<LaunchBoundsTrait> {
-  struct base_traits {
+  // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
+  template <template <class> class GetBase, class... OtherTraits>
+  struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     static constexpr bool launch_bounds_is_defaulted = true;
 
     using launch_bounds = LaunchBounds<>;

--- a/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
+++ b/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
@@ -1,0 +1,92 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_LAUNCHBOUNDSTRAIT_HPP
+#define KOKKOS_KOKKOS_LAUNCHBOUNDSTRAIT_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Concepts.hpp>  // LaunchBounds
+#include <traits/Kokkos_PolicyTraitAdaptor.hpp>
+#include <traits/Kokkos_Traits_fwd.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="trait specification"> {{{1
+
+struct LaunchBoundsTrait : TraitSpecificationBase<LaunchBoundsTrait> {
+  struct base_traits {
+    static constexpr bool launch_bounds_is_defaulted = true;
+
+    using launch_bounds = LaunchBounds<>;
+  };
+  template <class T>
+  static constexpr bool trait_matches_specification =
+      is_launch_bounds<T>::value;
+};
+
+// </editor-fold> end trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
+
+template <unsigned int... Bounds, class... Traits>
+struct AnalyzeExecPolicy<void, Kokkos::LaunchBounds<Bounds...>, Traits...>
+    : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+  static_assert(base_t::launch_bounds_is_defaulted,
+                "Kokkos Error: More than one launch_bounds given");
+  static constexpr bool launch_bounds_is_defaulted = false;
+  using launch_bounds = Kokkos::LaunchBounds<Bounds...>;
+};
+
+// </editor-fold> end AnalyzeExecPolicy specializations }}}1
+//==============================================================================
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_LAUNCHBOUNDSTRAIT_HPP

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -120,11 +120,11 @@ struct AnalyzeExecPolicy<void, Kokkos::Experimental::DesiredOccupancy,
   template <class OccControl>
   using with_occupancy_control = AnalyzeExecPolicy<void, OccControl, Traits...>;
 
-  // Treat this as private, but make it public so that MSVC will still treat this
-  // as a standard layout class and make it the right size:
-  // storage for a stateful desired occupancy
-  // private:
-  occupancy_control m_desired_occupancy = {};
+  // Treat this as private, but make it public so that MSVC will still treat
+  // this as a standard layout class and make it the right size: storage for a
+  // stateful desired occupancy
+  //   private:
+  occupancy_control m_desired_occupancy;
 
   AnalyzeExecPolicy() = default;
   // Converting constructor

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -1,0 +1,205 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_OCCUPANCYCONTROLTRAIT_HPP
+#define KOKKOS_KOKKOS_OCCUPANCYCONTROLTRAIT_HPP
+
+#include <impl/Kokkos_Error.hpp>  // KOKKOS_EXPECTS macro
+
+#include <traits/Kokkos_PolicyTraitAdaptor.hpp>
+
+#include <traits/Kokkos_Traits_fwd.hpp>
+
+namespace Kokkos {
+
+namespace Experimental {
+
+//==============================================================================
+// <editor-fold desc="Occupancy control user interface"> {{{1
+
+struct MaximizeOccupancy;
+
+struct DesiredOccupancy {
+  int m_occ = 100;
+  explicit constexpr DesiredOccupancy(int occ) : m_occ(occ) {
+    KOKKOS_EXPECTS(0 <= occ && occ <= 100);
+  }
+  explicit constexpr operator int() const { return m_occ; }
+  constexpr int value() const { return m_occ; }
+  DesiredOccupancy() = default;
+  explicit DesiredOccupancy(MaximizeOccupancy const&) : DesiredOccupancy() {}
+};
+
+struct MaximizeOccupancy {
+  MaximizeOccupancy() = default;
+};
+
+// </editor-fold> end Occupancy control user interface }}}1
+//==============================================================================
+
+}  // end namespace Experimental
+
+namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="Occupancy control trait specification"> {{{1
+
+struct OccupancyControlTrait : TraitSpecificationBase<OccupancyControlTrait> {
+  struct base_traits {
+    using occupancy_control = Kokkos::Experimental::MaximizeOccupancy;
+    static constexpr bool experimental_contains_desired_occupancy = false;
+    // Default access occupancy_control, for when it is the (stateless) default
+    static constexpr occupancy_control impl_get_occupancy_control() {
+      return occupancy_control{};
+    }
+  };
+  template <class T>
+  static constexpr bool trait_matches_specification =
+      std::is_same<T, Kokkos::Experimental::DesiredOccupancy>::value ||
+      std::is_same<T, Kokkos::Experimental::MaximizeOccupancy>::value;
+};
+
+// </editor-fold> end Occupancy control trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
+
+// The DesiredOccupancy case has runtime storage, so we need to handle copies
+// and assignments
+template <class... Traits>
+struct AnalyzeExecPolicy<void, Kokkos::Experimental::DesiredOccupancy,
+                         Traits...> : AnalyzeExecPolicy<void, Traits...> {
+ public:
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+  using occupancy_control = Kokkos::Experimental::DesiredOccupancy;
+  static constexpr bool experimental_contains_desired_occupancy = true;
+
+  template <class OccControl>
+  using with_occupancy_control = AnalyzeExecPolicy<void, OccControl, Traits...>;
+
+ private:
+  // storage for a stateful desired occupancy
+  occupancy_control m_desired_occupancy = {};
+
+ public:
+  // Converting constructor
+  // Just rely on the convertibility of occupancy_control to transfer the data
+  template <class Other>
+  AnalyzeExecPolicy(ExecPolicyTraitsWithDefaults<Other> const& other)
+      : base_t(other),
+        m_desired_occupancy(other.impl_get_occupancy_control()) {}
+
+  // Converting assignment operator
+  // Just rely on the convertibility of occupancy_control to transfer the data
+  template <class Other>
+  AnalyzeExecPolicy& operator=(
+      ExecPolicyTraitsWithDefaults<Other> const& other) {
+    *static_cast<base_t*>(this) = other;
+    this->impl_set_desired_occupancy(
+        occupancy_control{other.impl_get_occupancy_control()});
+    return *this;
+  }
+
+  // Access to occupancy control instance, usable in generic context
+  constexpr occupancy_control impl_get_occupancy_control() const {
+    return m_desired_occupancy;
+  }
+
+  // Access to desired occupancy (getter and setter)
+  Kokkos::Experimental::DesiredOccupancy impl_get_desired_occupancy() const {
+    return m_desired_occupancy;
+  }
+
+  void impl_set_desired_occupancy(occupancy_control desired_occupancy) {
+    m_desired_occupancy = desired_occupancy;
+  }
+};
+
+template <class... Traits>
+struct AnalyzeExecPolicy<void, Kokkos::Experimental::MaximizeOccupancy,
+                         Traits...> : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+  using occupancy_control = Kokkos::Experimental::MaximizeOccupancy;
+  static constexpr bool experimental_contains_desired_occupancy = false;
+};
+
+// </editor-fold> end AnalyzeExecPolicy specializations }}}1
+//==============================================================================
+
+}  // end namespace Impl
+
+namespace Experimental {
+
+//==============================================================================
+// <editor-fold desc="User interface"> {{{1
+
+template <typename Policy>
+auto prefer(Policy const& p, DesiredOccupancy occ) {
+  using new_policy_t =
+      typename Kokkos::Impl::OccupancyControlTrait::template policy_with_trait<
+          Policy, DesiredOccupancy>;
+  new_policy_t pwo{p};
+  pwo.impl_set_desired_occupancy(occ);
+  return pwo;
+}
+
+template <typename Policy>
+constexpr auto prefer(Policy const& p, MaximizeOccupancy) {
+  using new_policy_t =
+      typename Kokkos::Impl::OccupancyControlTrait::template policy_with_trait<
+          Policy, MaximizeOccupancy>;
+  return new_policy_t{p};
+}
+
+// </editor-fold> end User interface }}}1
+//==============================================================================
+
+}  // end namespace Experimental
+
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_OCCUPANCYCONTROLTRAIT_HPP

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -86,7 +86,9 @@ namespace Impl {
 // <editor-fold desc="Occupancy control trait specification"> {{{1
 
 struct OccupancyControlTrait : TraitSpecificationBase<OccupancyControlTrait> {
-  struct base_traits {
+  // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
+  template <template <class> class GetBase, class... OtherTraits>
+  struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     using occupancy_control = Kokkos::Experimental::MaximizeOccupancy;
     static constexpr bool experimental_contains_desired_occupancy = false;
     // Default access occupancy_control, for when it is the (stateless) default

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -95,9 +95,10 @@ struct OccupancyControlTrait : TraitSpecificationBase<OccupancyControlTrait> {
     }
   };
   template <class T>
-  static constexpr bool trait_matches_specification =
+  using trait_matches_specification = std::integral_constant<
+      bool,
       std::is_same<T, Kokkos::Experimental::DesiredOccupancy>::value ||
-      std::is_same<T, Kokkos::Experimental::MaximizeOccupancy>::value;
+          std::is_same<T, Kokkos::Experimental::MaximizeOccupancy>::value>;
 };
 
 // </editor-fold> end Occupancy control trait specification }}}1
@@ -112,8 +113,7 @@ template <class... Traits>
 struct AnalyzeExecPolicy<void, Kokkos::Experimental::DesiredOccupancy,
                          Traits...> : AnalyzeExecPolicy<void, Traits...> {
  public:
-  using base_t = AnalyzeExecPolicy<void, Traits...>;
-  using base_t::base_t;
+  using base_t            = AnalyzeExecPolicy<void, Traits...>;
   using occupancy_control = Kokkos::Experimental::DesiredOccupancy;
   static constexpr bool experimental_contains_desired_occupancy = true;
 
@@ -125,6 +125,7 @@ struct AnalyzeExecPolicy<void, Kokkos::Experimental::DesiredOccupancy,
   occupancy_control m_desired_occupancy = {};
 
  public:
+  AnalyzeExecPolicy() = default;
   // Converting constructor
   // Just rely on the convertibility of occupancy_control to transfer the data
   template <class Other>

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -120,11 +120,12 @@ struct AnalyzeExecPolicy<void, Kokkos::Experimental::DesiredOccupancy,
   template <class OccControl>
   using with_occupancy_control = AnalyzeExecPolicy<void, OccControl, Traits...>;
 
- private:
+  // Treat this as private, but make it public so that MSVC will still treat this
+  // as a standard layout class and make it the right size:
   // storage for a stateful desired occupancy
+  // private:
   occupancy_control m_desired_occupancy = {};
 
- public:
   AnalyzeExecPolicy() = default;
   // Converting constructor
   // Just rely on the convertibility of occupancy_control to transfer the data

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -193,6 +193,7 @@ auto prefer(Policy const& p, DesiredOccupancy occ) {
 
 template <typename Policy>
 constexpr auto prefer(Policy const& p, MaximizeOccupancy) {
+  static_assert(Kokkos::is_execution_policy<Policy>::value, "");
   using new_policy_t =
       Kokkos::Impl::OccupancyControlTrait::policy_with_trait<Policy,
                                                              MaximizeOccupancy>;

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -72,7 +72,7 @@ struct DesiredOccupancy {
 };
 
 struct MaximizeOccupancy {
-  MaximizeOccupancy() = default;
+  explicit MaximizeOccupancy() = default;
 };
 
 // </editor-fold> end Occupancy control user interface }}}1
@@ -182,8 +182,8 @@ namespace Experimental {
 template <typename Policy>
 auto prefer(Policy const& p, DesiredOccupancy occ) {
   using new_policy_t =
-      typename Kokkos::Impl::OccupancyControlTrait::template policy_with_trait<
-          Policy, DesiredOccupancy>;
+      Kokkos::Impl::OccupancyControlTrait::policy_with_trait<Policy,
+                                                             DesiredOccupancy>;
   new_policy_t pwo{p};
   pwo.impl_set_desired_occupancy(occ);
   return pwo;
@@ -192,8 +192,8 @@ auto prefer(Policy const& p, DesiredOccupancy occ) {
 template <typename Policy>
 constexpr auto prefer(Policy const& p, MaximizeOccupancy) {
   using new_policy_t =
-      typename Kokkos::Impl::OccupancyControlTrait::template policy_with_trait<
-          Policy, MaximizeOccupancy>;
+      Kokkos::Impl::OccupancyControlTrait::policy_with_trait<Policy,
+                                                             MaximizeOccupancy>;
   return new_policy_t{p};
 }
 

--- a/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
+++ b/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
@@ -1,0 +1,155 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <impl/Kokkos_Utilities.hpp>  // type_list
+
+#include <traits/Kokkos_Traits_fwd.hpp>
+
+#ifndef KOKKOS_KOKKOS_POLICYTRAITADAPTOR_HPP
+#define KOKKOS_KOKKOS_POLICYTRAITADAPTOR_HPP
+
+namespace Kokkos {
+namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="Adapter for replacing/adding a trait"> {{{1
+
+//------------------------------------------------------------------------------
+
+// General strategy: given a TraitSpecification, go through the entries in the
+// parameter pack of the policy template and find the first one that returns
+// `true` for the nested `trait_matches_specification` variable template. If
+// that nested variable template is not found these overloads should be safely
+// ignored, and the trait can specialize PolicyTraitAdapterImpl to get the
+// desired behavior.
+
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// <editor-fold desc="PolicyTraitMatcher"> {{{2
+
+// To handle the WorkTag case, we need more than just a predicate; we need
+// something that we can default to in the unspecialized case, just like we
+// do for AnalyzeExecPolicy
+template <class TraitSpec, class Trait, class Enable = void>
+struct PolicyTraitMatcher;
+
+template <class TraitSpec, class Trait>
+struct PolicyTraitMatcher<
+    TraitSpec, Trait,
+    std::enable_if_t<TraitSpec::template trait_matches_specification<Trait>>>
+    : std::true_type {};
+
+// </editor-fold> end PolicyTraitMatcher }}}2
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// <editor-fold desc="PolicyTraitAdaptorImpl specializations"> {{{2
+
+// Matching version, replace the trait
+template <class TraitSpec, template <class...> class PolicyTemplate,
+          class... ProcessedTraits, class MatchingTrait,
+          class... ToProcessTraits, class NewTrait>
+struct PolicyTraitAdaptorImpl<
+    TraitSpec, PolicyTemplate, type_list<ProcessedTraits...>,
+    type_list<MatchingTrait, ToProcessTraits...>, NewTrait,
+    std::enable_if_t<PolicyTraitMatcher<TraitSpec, MatchingTrait>::value>> {
+  static_assert(PolicyTraitMatcher<TraitSpec, NewTrait>::value, "");
+  using type = PolicyTemplate<ProcessedTraits..., NewTrait, ToProcessTraits...>;
+};
+
+// Non-matching version, check the next option
+template <class TraitSpec, template <class...> class PolicyTemplate,
+          class... ProcessedTraits, class NonMatchingTrait,
+          class... ToProcessTraits, class NewTrait>
+struct PolicyTraitAdaptorImpl<
+    TraitSpec, PolicyTemplate, type_list<ProcessedTraits...>,
+    type_list<NonMatchingTrait, ToProcessTraits...>, NewTrait,
+    std::enable_if_t<!PolicyTraitMatcher<TraitSpec, NonMatchingTrait>::value>> {
+  using type = typename PolicyTraitAdaptorImpl<
+      TraitSpec, PolicyTemplate,
+      type_list<ProcessedTraits..., NonMatchingTrait>,
+      type_list<ToProcessTraits...>, NewTrait>::type;
+};
+
+// Base case: no matches found; just add the trait to the end of the list
+template <class TraitSpec, template <class...> class PolicyTemplate,
+          class... ProcessedTraits, class NewTrait>
+struct PolicyTraitAdaptorImpl<TraitSpec, PolicyTemplate,
+                              type_list<ProcessedTraits...>, type_list<>,
+                              NewTrait> {
+  static_assert(PolicyTraitMatcher<TraitSpec, NewTrait>::value, "");
+  using type = PolicyTemplate<ProcessedTraits..., NewTrait>;
+};
+
+// </editor-fold> end PolicyTraitAdaptorImpl specializations }}}2
+//------------------------------------------------------------------------------
+
+template <class TraitSpec, template <class...> class PolicyTemplate,
+          class... Traits, class NewTrait>
+struct PolicyTraitAdaptor<TraitSpec, PolicyTemplate<Traits...>, NewTrait>
+    : PolicyTraitAdaptorImpl<TraitSpec, PolicyTemplate, type_list<>,
+                             type_list<Traits...>, NewTrait> {};
+
+// </editor-fold> end Adapter for replacing/adding a trait }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="CRTP Base clasee for trait specifications"> {{{1
+
+template <class TraitSpec>
+struct TraitSpecificationBase {
+  using trait_specification = TraitSpec;
+  template <class Policy, class Trait>
+  using policy_with_trait =
+      typename PolicyTraitAdaptor<TraitSpec, Policy, Trait>::type;
+};
+
+// </editor-fold> end CRTP Base clasee for trait specifications }}}1
+//==============================================================================
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_POLICYTRAITADAPTOR_HPP

--- a/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
+++ b/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
@@ -78,7 +78,8 @@ struct PolicyTraitMatcher;
 template <class TraitSpec, class Trait>
 struct PolicyTraitMatcher<
     TraitSpec, Trait,
-    std::enable_if_t<TraitSpec::template trait_matches_specification<Trait>>>
+    std::enable_if_t<
+        TraitSpec::template trait_matches_specification<Trait>::value>>
     : std::true_type {};
 
 // </editor-fold> end PolicyTraitMatcher }}}2

--- a/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
+++ b/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
@@ -137,7 +137,7 @@ struct PolicyTraitAdaptor<TraitSpec, PolicyTemplate<Traits...>, NewTrait>
 //==============================================================================
 
 //==============================================================================
-// <editor-fold desc="CRTP Base clasee for trait specifications"> {{{1
+// <editor-fold desc="CRTP Base class for trait specifications"> {{{1
 
 template <class TraitSpec>
 struct TraitSpecificationBase {
@@ -147,7 +147,7 @@ struct TraitSpecificationBase {
       typename PolicyTraitAdaptor<TraitSpec, Policy, Trait>::type;
 };
 
-// </editor-fold> end CRTP Base clasee for trait specifications }}}1
+// </editor-fold> end CRTP Base class for trait specifications }}}1
 //==============================================================================
 
 }  // end namespace Impl

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -96,9 +96,8 @@ namespace Experimental {
 
 template <class Policy, class ScheduleType>
 constexpr auto require(Policy const& p, Kokkos::Schedule<ScheduleType>) {
-  using new_policy_t =
-      typename Kokkos::Impl::ScheduleTrait::template policy_with_trait<
-          Policy, Kokkos::Schedule<ScheduleType>>;
+  using new_policy_t = Kokkos::Impl::ScheduleTrait::policy_with_trait<
+      Policy, Kokkos::Schedule<ScheduleType>>;
   return new_policy_t{p};
 }
 

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -1,0 +1,113 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_SCHEDULETRAIT_HPP
+#define KOKKOS_KOKKOS_SCHEDULETRAIT_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Concepts.hpp>  // is_schedule_type, Schedule
+#include <traits/Kokkos_PolicyTraitAdaptor.hpp>
+#include <traits/Kokkos_Traits_fwd.hpp>
+
+namespace Kokkos {
+
+namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="trait specification"> {{{1
+
+struct ScheduleTrait : TraitSpecificationBase<ScheduleTrait> {
+  struct base_traits {
+    static constexpr auto schedule_type_is_defaulted = true;
+
+    using schedule_type = Schedule<Static>;
+  };
+  template <class T>
+  static constexpr bool trait_matches_specification =
+      is_schedule_type<T>::value;
+};
+
+// </editor-fold> end trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
+
+template <class ScheduleType, class... Traits>
+struct AnalyzeExecPolicy<void, Kokkos::Schedule<ScheduleType>, Traits...>
+    : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+  static_assert(base_t::schedule_type_is_defaulted,
+                "Kokkos Error: More than one schedule type given");
+  static constexpr bool schedule_type_is_defaulted = false;
+  using schedule_type = Kokkos::Schedule<ScheduleType>;
+};
+
+// </editor-fold> end AnalyzeExecPolicy specializations }}}1
+//==============================================================================
+
+}  // end namespace Impl
+
+namespace Experimental {
+
+//==============================================================================
+// <editor-fold desc="User interface"> {{{1
+
+template <class Policy, class ScheduleType>
+constexpr auto require(Policy const& p, Kokkos::Schedule<ScheduleType>) {
+  using new_policy_t =
+      typename Kokkos::Impl::ScheduleTrait::template policy_with_trait<
+          Policy, Kokkos::Schedule<ScheduleType>>;
+  return new_policy_t{p};
+}
+
+// </editor-fold> end User interface }}}1
+//==============================================================================
+
+}  // end namespace Experimental
+
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_SCHEDULETRAIT_HPP

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -58,7 +58,9 @@ namespace Impl {
 // <editor-fold desc="trait specification"> {{{1
 
 struct ScheduleTrait : TraitSpecificationBase<ScheduleTrait> {
-  struct base_traits {
+  // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
+  template <template <class> class GetBase, class... OtherTraits>
+  struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     static constexpr auto schedule_type_is_defaulted = true;
 
     using schedule_type = Schedule<Static>;

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -64,8 +64,7 @@ struct ScheduleTrait : TraitSpecificationBase<ScheduleTrait> {
     using schedule_type = Schedule<Static>;
   };
   template <class T>
-  static constexpr bool trait_matches_specification =
-      is_schedule_type<T>::value;
+  using trait_matches_specification = is_schedule_type<T>;
 };
 
 // </editor-fold> end trait specification }}}1

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -98,6 +98,7 @@ namespace Experimental {
 
 template <class Policy, class ScheduleType>
 constexpr auto require(Policy const& p, Kokkos::Schedule<ScheduleType>) {
+  static_assert(Kokkos::is_execution_policy<Policy>::value, "");
   using new_policy_t = Kokkos::Impl::ScheduleTrait::policy_with_trait<
       Policy, Kokkos::Schedule<ScheduleType>>;
   return new_policy_t{p};

--- a/core/src/traits/Kokkos_Traits_fwd.hpp
+++ b/core/src/traits/Kokkos_Traits_fwd.hpp
@@ -1,0 +1,73 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_TRAITS_FWD_HPP
+#define KOKKOS_KOKKOS_TRAITS_FWD_HPP
+
+namespace Kokkos {
+namespace Impl {
+
+template <class Enable, class... TraitsList>
+struct AnalyzeExecPolicy;
+
+template <class AnalysisResults>
+struct ExecPolicyTraitsWithDefaults;
+
+template <class TraitSpec, template <class...> class PolicyTemplate,
+          class AlreadyProcessedList, class ToProcessList, class NewTrait,
+          class Enable = void>
+struct PolicyTraitAdaptorImpl;
+
+template <class TraitSpec, class Policy, class NewTrait>
+struct PolicyTraitAdaptor;
+
+// A tag class for dependent defaults that must be handled by the
+// ExecPolicyTraitsWithDefaults wrapper, since their defaults depend on other
+// traits
+struct dependent_policy_trait_default;
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_TRAITS_FWD_HPP

--- a/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
+++ b/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
@@ -101,9 +101,8 @@ template <class Policy, unsigned long Property>
 constexpr auto require(const Policy p,
                        WorkItemProperty::ImplWorkItemProperty<Property>) {
   static_assert(Kokkos::is_execution_policy<Policy>::value, "");
-  using new_policy_t =
-      typename Kokkos::Impl::WorkItemPropertyTrait::template policy_with_trait<
-          Policy, WorkItemProperty::ImplWorkItemProperty<Property>>;
+  using new_policy_t = Kokkos::Impl::WorkItemPropertyTrait::policy_with_trait<
+      Policy, WorkItemProperty::ImplWorkItemProperty<Property>>;
   return new_policy_t{p};
 }
 

--- a/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
+++ b/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
@@ -97,12 +97,13 @@ namespace Experimental {
 //==============================================================================
 // <editor-fold desc="User interface"> {{{1
 
-template <class PolicyType, unsigned long P>
-constexpr auto require(const PolicyType p,
-                       WorkItemProperty::ImplWorkItemProperty<P>) {
+template <class Policy, unsigned long Property>
+constexpr auto require(const Policy p,
+                       WorkItemProperty::ImplWorkItemProperty<Property>) {
+  static_assert(Kokkos::is_execution_policy<Policy>::value, "");
   using new_policy_t =
       typename Kokkos::Impl::WorkItemPropertyTrait::template policy_with_trait<
-          PolicyType, WorkItemProperty::ImplWorkItemProperty<P>>;
+          Policy, WorkItemProperty::ImplWorkItemProperty<Property>>;
   return new_policy_t{p};
 }
 

--- a/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
+++ b/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
@@ -57,7 +57,9 @@ namespace Impl {
 // <editor-fold desc="trait specification"> {{{1
 
 struct WorkItemPropertyTrait : TraitSpecificationBase<WorkItemPropertyTrait> {
-  struct base_traits {
+  // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
+  template <template <class> class GetBase, class... OtherTraits>
+  struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     using work_item_property = Kokkos::Experimental::WorkItemProperty::None_t;
   };
   template <class T>

--- a/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
+++ b/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
@@ -1,0 +1,114 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_WORKITEMPROPERTYTRAIT_HPP
+#define KOKKOS_KOKKOS_WORKITEMPROPERTYTRAIT_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Concepts.hpp>  // WorkItemProperty
+#include <traits/Kokkos_PolicyTraitAdaptor.hpp>
+#include <traits/Kokkos_Traits_fwd.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="trait specification"> {{{1
+
+struct WorkItemPropertyTrait : TraitSpecificationBase<WorkItemPropertyTrait> {
+  struct base_traits {
+    using work_item_property = Kokkos::Experimental::WorkItemProperty::None_t;
+  };
+  template <class T>
+  static constexpr bool trait_matches_specification =
+      Kokkos::Experimental::is_work_item_property<T>::value;
+};
+
+// </editor-fold> end trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
+
+template <class Property, class... Traits>
+struct AnalyzeExecPolicy<
+    std::enable_if_t<
+        Kokkos::Experimental::is_work_item_property<Property>::value>,
+    Property, Traits...> : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+  static_assert(
+      std::is_same<typename base_t::work_item_property,
+                   Kokkos::Experimental::WorkItemProperty::None_t>::value,
+      "Kokkos Error: More than one work item property given");
+  using work_item_property = Property;
+};
+
+// </editor-fold> end AnalyzeExecPolicy specializations }}}1
+//==============================================================================
+
+}  // end namespace Impl
+
+namespace Experimental {
+
+//==============================================================================
+// <editor-fold desc="User interface"> {{{1
+
+template <class PolicyType, unsigned long P>
+constexpr auto require(const PolicyType p,
+                       WorkItemProperty::ImplWorkItemProperty<P>) {
+  using new_policy_t =
+      typename Kokkos::Impl::WorkItemPropertyTrait::template policy_with_trait<
+          PolicyType, WorkItemProperty::ImplWorkItemProperty<P>>;
+  return new_policy_t{p};
+}
+
+// </editor-fold> end User interface }}}1
+//==============================================================================
+
+}  // namespace Experimental
+
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_WORKITEMPROPERTYTRAIT_HPP

--- a/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
+++ b/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
@@ -61,8 +61,8 @@ struct WorkItemPropertyTrait : TraitSpecificationBase<WorkItemPropertyTrait> {
     using work_item_property = Kokkos::Experimental::WorkItemProperty::None_t;
   };
   template <class T>
-  static constexpr bool trait_matches_specification =
-      Kokkos::Experimental::is_work_item_property<T>::value;
+  using trait_matches_specification =
+      Kokkos::Experimental::is_work_item_property<T>;
 };
 
 // </editor-fold> end trait specification }}}1

--- a/core/src/traits/Kokkos_WorkTagTrait.hpp
+++ b/core/src/traits/Kokkos_WorkTagTrait.hpp
@@ -57,7 +57,9 @@ namespace Impl {
 // <editor-fold desc="trait specification"> {{{1
 
 struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
-  struct base_traits {
+  // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
+  template <template <class> class GetBase, class... OtherTraits>
+  struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     using work_tag = void;
   };
 };

--- a/core/src/traits/Kokkos_WorkTagTrait.hpp
+++ b/core/src/traits/Kokkos_WorkTagTrait.hpp
@@ -60,9 +60,6 @@ struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
   struct base_traits {
     using work_tag = void;
   };
-  // Matching is handled through PolicyTraitsMatcher, not through this
-  template <class T>
-  static constexpr bool trait_matches_specification = false;
 };
 
 // </editor-fold> end trait specification }}}1

--- a/core/src/traits/Kokkos_WorkTagTrait.hpp
+++ b/core/src/traits/Kokkos_WorkTagTrait.hpp
@@ -1,0 +1,127 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_KOKKOS_WORKTAGTRAIT_HPP
+#define KOKKOS_KOKKOS_WORKTAGTRAIT_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Concepts.hpp>  // is_execution_space
+#include <traits/Kokkos_PolicyTraitAdaptor.hpp>
+#include <traits/Kokkos_Traits_fwd.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+//==============================================================================
+// <editor-fold desc="trait specification"> {{{1
+
+struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
+  struct base_traits {
+    using work_tag = void;
+  };
+  // Matching is handled through PolicyTraitsMatcher, not through this
+  template <class T>
+  static constexpr bool trait_matches_specification = false;
+};
+
+// </editor-fold> end trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
+
+// Since we don't have subsumption in pre-C++20, we need to have the work tag
+// "trait" handling code be unspecialized, so we handle it instead in a class
+// with a different name.
+template <class... Traits>
+struct AnalyzeExecPolicyHandleWorkTag : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+};
+
+template <class WorkTag, class... Traits>
+struct AnalyzeExecPolicyHandleWorkTag<WorkTag, Traits...>
+    : AnalyzeExecPolicy<void, Traits...> {
+  using base_t = AnalyzeExecPolicy<void, Traits...>;
+  using base_t::base_t;
+  static_assert(std::is_void<typename base_t::work_tag>::value,
+                "Kokkos Error: More than one work tag given");
+  using work_tag = WorkTag;
+};
+
+// This only works if this is not a partial specialization, so we have to
+// do the partial specialization elsewhere
+template <class Enable, class... Traits>
+struct AnalyzeExecPolicy : AnalyzeExecPolicyHandleWorkTag<Traits...> {
+  using base_t = AnalyzeExecPolicyHandleWorkTag<Traits...>;
+  using base_t::base_t;
+};
+
+// </editor-fold> end AnalyzeExecPolicy specializations }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="PolicyTraitMatcher specializations"> {{{1
+
+// In order to match the work tag trait the work tag "matcher" needs to be
+// unspecialized and the logic needs to be handled in a differently-named class,
+// just like above.
+template <class TraitSpec, class Trait>
+struct PolicyTraitMatcherHandleWorkTag : std::false_type {};
+
+template <class Trait>
+struct PolicyTraitMatcherHandleWorkTag<WorkTagTrait, Trait>
+    : std::integral_constant<bool, !std::is_void<Trait>::value> {};
+
+template <class TraitSpec, class Trait, class Enable>
+struct PolicyTraitMatcher /* unspecialized! */
+    : PolicyTraitMatcherHandleWorkTag<TraitSpec, Trait> {};
+
+// </editor-fold> end PolicyTraitMatcher specializations }}}1
+//==============================================================================
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_KOKKOS_WORKTAGTRAIT_HPP

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -908,5 +908,9 @@ TEST(TEST_CATEGORY, policy_set_worktag) {
 
   auto p3 = set_worktag<OtherWorkTag>(p2);
   static_assert(std::is_same<decltype(p3)::work_tag, OtherWorkTag>::value, "");
+
+  // NOTE this does not currently compile
+  // auto p4 = set_worktag<void>(p3);
+  // static_assert(std::is_void<decltype(p4)::work_tag>::value, "");
 }
 }  // namespace Test

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -764,10 +764,9 @@ void test_prefer_desired_occupancy(Policy const& policy) {
 template <class... Args>
 struct DummyPolicy : Kokkos::Impl::PolicyTraits<Args...> {
   using execution_policy = DummyPolicy;
-  using traits           = Kokkos::Impl::PolicyTraits<Args...>;
-  template <class... OtherArgs>
-  DummyPolicy(DummyPolicy<OtherArgs...> const& p) : traits(p) {}
-  DummyPolicy() = default;
+
+  using base_t = Kokkos::Impl::PolicyTraits<Args...>;
+  using base_t::base_t;
 };
 
 TEST(TEST_CATEGORY, desired_occupancy_prefer) {

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -777,15 +777,34 @@ TEST(TEST_CATEGORY, desired_occupancy_prefer) {
   test_prefer_desired_occupancy(Kokkos::TeamPolicy<TEST_EXECSPACE>{});
 }
 
+// For a more informative static assertion:
+template <size_t>
+struct static_assert_dummy_policy_must_be_size_one;
+template <>
+struct static_assert_dummy_policy_must_be_size_one<1> {};
+template <size_t, size_t>
+struct static_assert_dummy_policy_must_be_size_of_desired_occupancy;
+template <>
+struct static_assert_dummy_policy_must_be_size_of_desired_occupancy<
+    sizeof(Kokkos::Experimental::DesiredOccupancy),
+    sizeof(Kokkos::Experimental::DesiredOccupancy)> {};
+
 TEST(TEST_CATEGORY, desired_occupancy_empty_base_optimization) {
   DummyPolicy<TEST_EXECSPACE> const policy{};
   static_assert(sizeof(decltype(policy)) == 1, "");
+  static_assert_dummy_policy_must_be_size_one<sizeof(decltype(policy))>
+      _assert1{};
+  (void)_assert1;  // avoid unused variable warning
 
   using Kokkos::Experimental::DesiredOccupancy;
   auto policy_with_occ =
       Kokkos::Experimental::prefer(policy, DesiredOccupancy{50});
   static_assert(sizeof(decltype(policy_with_occ)) == sizeof(DesiredOccupancy),
                 "");
+  static_assert_dummy_policy_must_be_size_of_desired_occupancy<
+      sizeof(decltype(policy_with_occ)), sizeof(DesiredOccupancy)>
+      _assert2{};
+  (void)_assert2;  // avoid unused variable warning
 }
 
 template <typename Policy>


### PR DESCRIPTION
- made implementation of `require` and `prefer` much easier
- introduced the notion of a `TraitSpecification`, which helper templates use to make these things easier
- moved each trait category into its own file, further emphasizing the separation of concerns
- moved specification of defaults to a place more directly associated with the trait itself.
- moved `require` and `prefer` overloads to be with the traits they interact with.
- significant reduction in the amount of boilerplate associated with a trait. Much of this should be reusable for other composable entities in Kokkos, like Views