### PR TITLE
Enable Bitset container test for SYCL

### DIFF
--- a/containers/src/impl/Kokkos_Bitset_impl.hpp
+++ b/containers/src/impl/Kokkos_Bitset_impl.hpp
@@ -58,9 +58,21 @@ namespace Kokkos {
 namespace Impl {
 
 KOKKOS_FORCEINLINE_FUNCTION
+unsigned rotate_left(unsigned i, int r) {
+  constexpr int size = static_cast<int>(sizeof(unsigned) * CHAR_BIT);
+  return r ? ((i << r) | (i >> (size - r))) : i;
+}
+
+KOKKOS_FORCEINLINE_FUNCTION
 unsigned rotate_right(unsigned i, int r) {
-  enum { size = static_cast<int>(sizeof(unsigned) * CHAR_BIT) };
+  constexpr int size = static_cast<int>(sizeof(unsigned) * CHAR_BIT);
+  // FIXME_SYCL llvm.fshr.i32 missing
+  // (https://github.com/intel/llvm/issues/3308)
+#ifdef __SYCL_DEVICE_ONLY__
+  return rotate_left(i, size - r);
+#else
   return r ? ((i >> r) | (i << (size - r))) : i;
+#endif
 }
 
 template <typename Bitset>

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -42,7 +42,6 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
       list(APPEND UnitTestSources ${file})
     endforeach()
     list(REMOVE_ITEM UnitTestSources
-        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_Bitset.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_ScatterView.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_UnorderedMap.cpp
         )


### PR DESCRIPTION
A missing mapping for an intrinsic required implementing bit rotate right in terms of bit rotate left, see https://github.com/intel/llvm/issues/3308.