### PR TITLE
(Builds on #3829) More disentangling of AnalyzePolicy

### DIFF
--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -48,6 +48,7 @@
 #include <initializer_list>
 
 #include <Kokkos_Layout.hpp>
+#include <Kokkos_Rank.hpp>
 #include <Kokkos_Array.hpp>
 #include <impl/KokkosExp_Host_IterateTile.hpp>
 #include <Kokkos_ExecPolicy.hpp>
@@ -76,22 +77,6 @@ template <typename ExecSpace>
 struct default_inner_direction {
   using type                     = Iterate;
   static constexpr Iterate value = Iterate::Right;
-};
-
-// Iteration Pattern
-template <unsigned N, Iterate OuterDir = Iterate::Default,
-          Iterate InnerDir = Iterate::Default>
-struct Rank {
-  static_assert(N != 0u, "Kokkos Error: rank 0 undefined");
-  static_assert(N != 1u,
-                "Kokkos Error: rank 1 is not a multi-dimensional range");
-  static_assert(N < 7u, "Kokkos Error: Unsupported rank...");
-
-  using iteration_pattern = Rank<N, OuterDir, InnerDir>;
-
-  static constexpr int rank                = N;
-  static constexpr Iterate outer_direction = OuterDir;
-  static constexpr Iterate inner_direction = InnerDir;
 };
 
 namespace Impl {

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -190,10 +190,6 @@ using Kokkos::is_memory_traits;
 
 // Implementation concept:
 
-KOKKOS_IMPL_IS_CONCEPT(iteration_pattern)
-KOKKOS_IMPL_IS_CONCEPT(schedule_type)
-KOKKOS_IMPL_IS_CONCEPT(index_type)
-KOKKOS_IMPL_IS_CONCEPT(launch_bounds)
 KOKKOS_IMPL_IS_CONCEPT(thread_team_member)
 KOKKOS_IMPL_IS_CONCEPT(host_thread_team_member)
 KOKKOS_IMPL_IS_CONCEPT(graph_kernel)

--- a/core/src/Kokkos_Rank.hpp
+++ b/core/src/Kokkos_Rank.hpp
@@ -42,56 +42,30 @@
 //@HEADER
 */
 
-#ifndef KOKKOS_KOKKOS_LAUNCHBOUNDSTRAIT_HPP
-#define KOKKOS_KOKKOS_LAUNCHBOUNDSTRAIT_HPP
+#ifndef KOKKOS_KOKKOS_RANK_HPP
+#define KOKKOS_KOKKOS_RANK_HPP
 
 #include <Kokkos_Macros.hpp>
-#include <Kokkos_Concepts.hpp>  // LaunchBounds
-#include <traits/Kokkos_PolicyTraitAdaptor.hpp>
-#include <traits/Kokkos_Traits_fwd.hpp>
+#include <Kokkos_Layout.hpp>  // Iterate
 
 namespace Kokkos {
-namespace Impl {
 
-//==============================================================================
-// <editor-fold desc="trait specification"> {{{1
+// Iteration Pattern
+template <unsigned N, Iterate OuterDir = Iterate::Default,
+          Iterate InnerDir = Iterate::Default>
+struct Rank {
+  static_assert(N != 0u, "Kokkos Error: rank 0 undefined");
+  static_assert(N != 1u,
+                "Kokkos Error: rank 1 is not a multi-dimensional range");
+  static_assert(N < 7u, "Kokkos Error: Unsupported rank...");
 
-struct LaunchBoundsTrait : TraitSpecificationBase<LaunchBoundsTrait> {
-  // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
-  template <template <class> class GetBase, class... OtherTraits>
-  struct base_traits : linearize_bases<GetBase, OtherTraits...> {
-    static constexpr bool launch_bounds_is_defaulted = true;
+  using iteration_pattern = Rank<N, OuterDir, InnerDir>;
 
-    using launch_bounds = LaunchBounds<>;
-  };
-  template <class LaunchBoundParam, class AnalyzeNextTrait>
-  struct mixin_matching_trait : AnalyzeNextTrait {
-    using base_t = AnalyzeNextTrait;
-    using base_t::base_t;
-
-    static constexpr bool launch_bounds_is_defaulted = false;
-
-    static_assert(base_t::launch_bounds_is_defaulted,
-                  "Kokkos Error: More than one launch_bounds given");
-
-    using launch_bounds = LaunchBoundParam;
-  };
+  static constexpr int rank                = N;
+  static constexpr Iterate outer_direction = OuterDir;
+  static constexpr Iterate inner_direction = InnerDir;
 };
 
-// </editor-fold> end trait specification }}}1
-//==============================================================================
-
-//==============================================================================
-// <editor-fold desc="PolicyTraitMatcher specialization"> {{{1
-
-template <unsigned int maxT, unsigned int minB>
-struct PolicyTraitMatcher<LaunchBoundsTrait, LaunchBounds<maxT, minB>>
-    : std::true_type {};
-
-// </editor-fold> end PolicyTraitMatcher specialization }}}1
-//==============================================================================
-
-}  // end namespace Impl
 }  // end namespace Kokkos
 
-#endif  // KOKKOS_KOKKOS_LAUNCHBOUNDSTRAIT_HPP
+#endif  // KOKKOS_KOKKOS_RANK_HPP

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -65,10 +65,23 @@ namespace Impl {
 
 //------------------------------------------------------------------------------
 
+// Keep these sorted by frequency of use to reduce compilation time
+//
+// clang-format off
 using execution_policy_trait_specifications =
-    type_list<ExecutionSpaceTrait, GraphKernelTrait, IndexTypeTrait,
-              IterationPatternTrait, LaunchBoundsTrait, OccupancyControlTrait,
-              ScheduleTrait, WorkItemPropertyTrait, WorkTagTrait>;
+    type_list<
+        ExecutionSpaceTrait,
+        IndexTypeTrait,
+        ScheduleTrait,
+        IterationPatternTrait,
+        WorkItemPropertyTrait,
+        LaunchBoundsTrait,
+        OccupancyControlTrait,
+        GraphKernelTrait,
+        // This one has to be last, unfortunately:
+        WorkTagTrait
+    >;
+// clang-format on
 
 //==============================================================================
 // <editor-fold desc="AnalyzePolicyBaseTraits"> {{{1

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -63,26 +63,6 @@
 namespace Kokkos {
 namespace Impl {
 
-//------------------------------------------------------------------------------
-
-// Keep these sorted by frequency of use to reduce compilation time
-//
-// clang-format off
-using execution_policy_trait_specifications =
-    type_list<
-        ExecutionSpaceTrait,
-        IndexTypeTrait,
-        ScheduleTrait,
-        IterationPatternTrait,
-        WorkItemPropertyTrait,
-        LaunchBoundsTrait,
-        OccupancyControlTrait,
-        GraphKernelTrait,
-        // This one has to be last, unfortunately:
-        WorkTagTrait
-    >;
-// clang-format on
-
 //==============================================================================
 // <editor-fold desc="AnalyzePolicyBaseTraits"> {{{1
 
@@ -203,10 +183,13 @@ template <class>
 struct show_name_of_invalid_execution_policy_trait;
 template <class Trait, class... Traits>
 struct AnalyzeExecPolicyUseMatcher<void, type_list<>, Trait, Traits...> {
+  static constexpr auto trigger_error_message =
+      show_name_of_invalid_execution_policy_trait<Trait>{};
   static_assert(
       /* always false: */ std::is_void<Trait>::value,
-      "Unknown execution policy trait");
-  show_name_of_invalid_execution_policy_trait<Trait> trigger_error_message = {};
+      "Unknown execution policy trait. Search compiler output for "
+      "'show_name_of_invalid_execution_policy_trait' to see the type of the "
+      "invalid trait.");
 };
 
 // All traits matched case:

--- a/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
+++ b/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
@@ -66,31 +66,23 @@ struct ExecutionSpaceTrait : TraitSpecificationBase<ExecutionSpaceTrait> {
   };
   template <class T>
   using trait_matches_specification = is_execution_space<T>;
+  template <class ExecSpace, class AnalyzeNextTrait>
+  struct mixin_matching_trait : AnalyzeNextTrait {
+    using base_t = AnalyzeNextTrait;
+    using base_t::base_t;
+
+    static_assert(base_t::execution_space_is_defaulted,
+                  "Kokkos Error: More than one execution space given");
+
+    static constexpr auto execution_space_is_defaulted = false;
+
+    using execution_space = ExecSpace;
+  };
 };
 
 // </editor-fold> end trait specification }}}1
 //==============================================================================
 
-//==============================================================================
-// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
-
-template <class ExecutionSpace, class... Traits>
-struct AnalyzeExecPolicy<
-    std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value>,
-    ExecutionSpace, Traits...> : AnalyzeExecPolicy<void, Traits...> {
-  using base_t = AnalyzeExecPolicy<void, Traits...>;
-  using base_t::base_t;
-
-  static_assert(base_t::execution_space_is_defaulted,
-                "Kokkos Error: More than one execution space given");
-
-  static constexpr bool execution_space_is_defaulted = false;
-
-  using execution_space = ExecutionSpace;
-};
-
-// </editor-fold> end AnalyzeExecPolicy specializations }}}1
-//==============================================================================
 }  // end namespace Impl
 }  // end namespace Kokkos
 

--- a/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
+++ b/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
@@ -56,6 +56,11 @@ namespace Impl {
 //==============================================================================
 // <editor-fold desc="trait specification"> {{{1
 
+template <class T>
+struct show_extra_execution_space_erroneously_given_to_execution_policy;
+template <>
+struct show_extra_execution_space_erroneously_given_to_execution_policy<void> {
+};
 struct ExecutionSpaceTrait : TraitSpecificationBase<ExecutionSpaceTrait> {
   // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
   template <template <class> class GetBase, class... OtherTraits>
@@ -71,8 +76,14 @@ struct ExecutionSpaceTrait : TraitSpecificationBase<ExecutionSpaceTrait> {
     using base_t = AnalyzeNextTrait;
     using base_t::base_t;
 
+    static constexpr auto show_execution_space_error_in_compilation_message =
+        show_extra_execution_space_erroneously_given_to_execution_policy<
+            std::conditional_t<base_t::execution_space_is_defaulted, void,
+                               typename base_t::execution_space>>{};
     static_assert(base_t::execution_space_is_defaulted,
-                  "Kokkos Error: More than one execution space given");
+                  "Kokkos Error: More than one execution space given. Search "
+                  "compiler output for 'show_extra_execution_space' to see the "
+                  "type of the errant tag.");
 
     static constexpr auto execution_space_is_defaulted = false;
 

--- a/core/src/traits/Kokkos_GraphKernelTrait.hpp
+++ b/core/src/traits/Kokkos_GraphKernelTrait.hpp
@@ -63,6 +63,12 @@ struct GraphKernelTrait : TraitSpecificationBase<GraphKernelTrait> {
   struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     using is_graph_kernel = std::false_type;
   };
+  template <class, class AnalyzeNextTrait>
+  struct mixin_matching_trait : AnalyzeNextTrait {
+    using base_t = AnalyzeNextTrait;
+    using base_t::base_t;
+    using is_graph_kernel = std::true_type;
+  };
   template <class T>
   using trait_matches_specification = std::is_same<T, IsGraphKernelTag>;
 };
@@ -70,19 +76,6 @@ struct GraphKernelTrait : TraitSpecificationBase<GraphKernelTrait> {
 // </editor-fold> end trait specification }}}1
 //==============================================================================
 
-//==============================================================================
-// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
-
-template <class... Traits>
-struct AnalyzeExecPolicy<void, Impl::IsGraphKernelTag, Traits...>
-    : AnalyzeExecPolicy<void, Traits...> {
-  using base_t = AnalyzeExecPolicy<void, Traits...>;
-  using base_t::base_t;
-  using is_graph_kernel = std::true_type;
-};
-
-// </editor-fold> end AnalyzeExecPolicy specializations }}}1
-//==============================================================================
 }  // end namespace Impl
 }  // end namespace Kokkos
 

--- a/core/src/traits/Kokkos_IndexTypeTrait.hpp
+++ b/core/src/traits/Kokkos_IndexTypeTrait.hpp
@@ -46,7 +46,7 @@
 #define KOKKOS_KOKKOS_INDEXTYPETRAIT_HPP
 
 #include <Kokkos_Macros.hpp>
-#include <Kokkos_Concepts.hpp>  // IndexType, is_index_type
+#include <Kokkos_Concepts.hpp>  // IndexType
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
 #include <traits/Kokkos_Traits_fwd.hpp>
 
@@ -72,10 +72,6 @@ struct IndexTypeTrait : TraitSpecificationBase<IndexTypeTrait> {
   };
   template <class IdxType, class AnalyzeNextTrait>
   using mixin_matching_trait = IndexTypePolicyMixin<IdxType, AnalyzeNextTrait>;
-  template <class T>
-  using trait_matches_specification =
-      std::integral_constant<bool, std::is_integral<T>::value ||
-                                       is_index_type<T>::value>;
 };
 
 // </editor-fold> end trait specification }}}1
@@ -122,6 +118,22 @@ struct IndexTypePolicyMixin : AnalyzeNextTrait {
 };
 
 // </editor-fold> end AnalyzeExecPolicy specializations }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="PolicyTraitMatcher specialization"> {{{1
+
+template <class IntegralIndexType>
+struct PolicyTraitMatcher<IndexTypeTrait, IndexType<IntegralIndexType>>
+    : std::true_type {};
+
+template <class IntegralIndexType>
+struct PolicyTraitMatcher<
+    IndexTypeTrait, IntegralIndexType,
+    std::enable_if_t<std::is_integral<IntegralIndexType>::value>>
+    : std::true_type {};
+
+// </editor-fold> end PolicyTraitMatcher specialization"> }}}1
 //==============================================================================
 
 }  // end namespace Impl

--- a/core/src/traits/Kokkos_IndexTypeTrait.hpp
+++ b/core/src/traits/Kokkos_IndexTypeTrait.hpp
@@ -59,6 +59,10 @@ struct IndexTypePolicyMixin;
 //==============================================================================
 // <editor-fold desc="trait specification"> {{{1
 
+template <class T>
+struct show_extra_index_type_erroneously_given_to_execution_policy;
+template <>
+struct show_extra_index_type_erroneously_given_to_execution_policy<void> {};
 struct IndexTypeTrait : TraitSpecificationBase<IndexTypeTrait> {
   // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
   template <template <class> class GetBase, class... OtherTraits>
@@ -86,8 +90,14 @@ struct IndexTypePolicyMixin<Kokkos::IndexType<IntegralIndexType>,
                             AnalyzeNextTrait> : AnalyzeNextTrait {
   using base_t = AnalyzeNextTrait;
   using base_t::base_t;
+  static constexpr auto show_index_type_error_in_compilation_message =
+      show_extra_index_type_erroneously_given_to_execution_policy<
+          std::conditional_t<base_t::index_type_is_defaulted, void,
+                             typename base_t::schedule_type>>{};
   static_assert(base_t::index_type_is_defaulted,
-                "Kokkos Error: More than one index type given");
+                "Kokkos Error: More than one index type given. Search "
+                "compiler output for 'show_extra_index_type' to see the "
+                "type of the errant tag.");
   static constexpr bool index_type_is_defaulted = false;
   using index_type = Kokkos::IndexType<IntegralIndexType>;
 };
@@ -98,8 +108,14 @@ template <class IntegralIndexType, class AnalyzeNextTrait>
 struct IndexTypePolicyMixin : AnalyzeNextTrait {
   using base_t = AnalyzeNextTrait;
   using base_t::base_t;
+  static constexpr auto show_index_type_error_in_compilation_message =
+      show_extra_index_type_erroneously_given_to_execution_policy<
+          std::conditional_t<base_t::index_type_is_defaulted, void,
+                             typename base_t::schedule_type>>{};
   static_assert(base_t::index_type_is_defaulted,
-                "Kokkos Error: More than one index type given");
+                "Kokkos Error: More than one index type given. Search "
+                "compiler output for 'show_extra_index_type' to see the "
+                "type of the errant tag.");
   static_assert(std::is_integral<IntegralIndexType>::value, "");
   static constexpr bool index_type_is_defaulted = false;
   using index_type = Kokkos::IndexType<IntegralIndexType>;

--- a/core/src/traits/Kokkos_IterationPatternTrait.hpp
+++ b/core/src/traits/Kokkos_IterationPatternTrait.hpp
@@ -45,8 +45,11 @@
 #ifndef KOKKOS_KOKKOS_ITERATIONPATTERNTRAIT_HPP
 #define KOKKOS_KOKKOS_ITERATIONPATTERNTRAIT_HPP
 
-#include <Kokkos_Concepts.hpp>  // is_iteration_pattern
-#include <type_traits>          // is_void
+#include <Kokkos_Concepts.hpp>                   // is_iteration_pattern
+#include <traits/Kokkos_PolicyTraitAdaptor.hpp>  // TraitSpecificationBase
+#include <Kokkos_Rank.hpp>                       // Rank
+#include <Kokkos_Layout.hpp>                     // Iterate
+#include <type_traits>                           // is_void
 
 namespace Kokkos {
 namespace Impl {
@@ -79,11 +82,19 @@ struct IterationPatternTrait : TraitSpecificationBase<IterationPatternTrait> {
         "type of the errant tag.");
     using iteration_pattern = IterPattern;
   };
-  template <class T>
-  using trait_matches_specification = is_iteration_pattern<T>;
 };
 
 // </editor-fold> end trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="PolicyTraitMatcher specialization"> {{{1
+
+template <unsigned N, Iterate OuterDir, Iterate InnerDir>
+struct PolicyTraitMatcher<IterationPatternTrait, Rank<N, OuterDir, InnerDir>>
+    : std::true_type {};
+
+// </editor-fold> end  }}}1
 //==============================================================================
 
 }  // end namespace Impl

--- a/core/src/traits/Kokkos_IterationPatternTrait.hpp
+++ b/core/src/traits/Kokkos_IterationPatternTrait.hpp
@@ -54,6 +54,11 @@ namespace Impl {
 //==============================================================================
 // <editor-fold desc="trait specification"> {{{1
 
+template <class T>
+struct show_extra_iteration_pattern_erroneously_given_to_execution_policy;
+template <>
+struct show_extra_iteration_pattern_erroneously_given_to_execution_policy<
+    void> {};
 struct IterationPatternTrait : TraitSpecificationBase<IterationPatternTrait> {
   // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
   template <template <class> class GetBase, class... OtherTraits>
@@ -64,8 +69,14 @@ struct IterationPatternTrait : TraitSpecificationBase<IterationPatternTrait> {
   struct mixin_matching_trait : AnalyzeNextTrait {
     using base_t = AnalyzeNextTrait;
     using base_t::base_t;
-    static_assert(std::is_void<typename base_t::iteration_pattern>::value,
-                  "Kokkos Error: More than one iteration pattern given");
+    static constexpr auto show_iteration_pattern_error_in_compilation_message =
+        show_extra_iteration_pattern_erroneously_given_to_execution_policy<
+            typename base_t::iteration_pattern>{};
+    static_assert(
+        std::is_void<typename base_t::iteration_pattern>::value,
+        "Kokkos Error: More than one index type given. Search "
+        "compiler output for 'show_extra_iteration_pattern' to see the "
+        "type of the errant tag.");
     using iteration_pattern = IterPattern;
   };
   template <class T>

--- a/core/src/traits/Kokkos_IterationPatternTrait.hpp
+++ b/core/src/traits/Kokkos_IterationPatternTrait.hpp
@@ -60,28 +60,19 @@ struct IterationPatternTrait : TraitSpecificationBase<IterationPatternTrait> {
   struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     using iteration_pattern = void;  // TODO set default iteration pattern
   };
+  template <class IterPattern, class AnalyzeNextTrait>
+  struct mixin_matching_trait : AnalyzeNextTrait {
+    using base_t = AnalyzeNextTrait;
+    using base_t::base_t;
+    static_assert(std::is_void<typename base_t::iteration_pattern>::value,
+                  "Kokkos Error: More than one iteration pattern given");
+    using iteration_pattern = IterPattern;
+  };
   template <class T>
   using trait_matches_specification = is_iteration_pattern<T>;
 };
 
 // </editor-fold> end trait specification }}}1
-//==============================================================================
-
-//==============================================================================
-// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
-
-template <class IterationPattern, class... Traits>
-struct AnalyzeExecPolicy<
-    std::enable_if_t<is_iteration_pattern<IterationPattern>::value>,
-    IterationPattern, Traits...> : AnalyzeExecPolicy<void, Traits...> {
-  using base_t = AnalyzeExecPolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(std::is_void<typename base_t::iteration_pattern>::value,
-                "Kokkos Error: More than one iteration pattern given");
-  using iteration_pattern = IterationPattern;
-};
-
-// </editor-fold> end AnalyzeExecPolicy specializations }}}1
 //==============================================================================
 
 }  // end namespace Impl

--- a/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
+++ b/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
@@ -64,6 +64,18 @@ struct LaunchBoundsTrait : TraitSpecificationBase<LaunchBoundsTrait> {
 
     using launch_bounds = LaunchBounds<>;
   };
+  template <class LaunchBoundParam, class AnalyzeNextTrait>
+  struct mixin_matching_trait : AnalyzeNextTrait {
+    using base_t = AnalyzeNextTrait;
+    using base_t::base_t;
+
+    static constexpr bool launch_bounds_is_defaulted = false;
+
+    static_assert(base_t::launch_bounds_is_defaulted,
+                  "Kokkos Error: More than one launch_bounds given");
+
+    using launch_bounds = LaunchBoundParam;
+  };
   template <class T>
   using trait_matches_specification = is_launch_bounds<T>;
 };
@@ -71,22 +83,6 @@ struct LaunchBoundsTrait : TraitSpecificationBase<LaunchBoundsTrait> {
 // </editor-fold> end trait specification }}}1
 //==============================================================================
 
-//==============================================================================
-// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
-
-template <unsigned int MaxT, unsigned int MinB, class... Traits>
-struct AnalyzeExecPolicy<void, Kokkos::LaunchBounds<MaxT, MinB>, Traits...>
-    : AnalyzeExecPolicy<void, Traits...> {
-  using base_t = AnalyzeExecPolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(base_t::launch_bounds_is_defaulted,
-                "Kokkos Error: More than one launch_bounds given");
-  static constexpr bool launch_bounds_is_defaulted = false;
-  using launch_bounds = Kokkos::LaunchBounds<MaxT, MinB>;
-};
-
-// </editor-fold> end AnalyzeExecPolicy specializations }}}1
-//==============================================================================
 }  // end namespace Impl
 }  // end namespace Kokkos
 

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -82,6 +82,9 @@ struct MaximizeOccupancy {
 
 namespace Impl {
 
+template <class Policy, class AnalyzeNextTrait>
+struct OccupancyControlPolicyMixin;
+
 //==============================================================================
 // <editor-fold desc="Occupancy control trait specification"> {{{1
 
@@ -96,6 +99,9 @@ struct OccupancyControlTrait : TraitSpecificationBase<OccupancyControlTrait> {
       return occupancy_control{};
     }
   };
+  template <class OccControl, class AnalyzeNextTrait>
+  using mixin_matching_trait =
+      OccupancyControlPolicyMixin<OccControl, AnalyzeNextTrait>;
   template <class T>
   using trait_matches_specification = std::integral_constant<
       bool,
@@ -107,39 +113,33 @@ struct OccupancyControlTrait : TraitSpecificationBase<OccupancyControlTrait> {
 //==============================================================================
 
 //==============================================================================
-// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
+// <editor-fold desc="OccupancyControlPolicyMixin specializations"> {{{1
 
-// The DesiredOccupancy case has runtime storage, so we need to handle copies
-// and assignments
-template <class... Traits>
-struct AnalyzeExecPolicy<void, Kokkos::Experimental::DesiredOccupancy,
-                         Traits...> : AnalyzeExecPolicy<void, Traits...> {
- public:
-  using base_t            = AnalyzeExecPolicy<void, Traits...>;
+template <class AnalyzeNextTrait>
+struct OccupancyControlPolicyMixin<Kokkos::Experimental::DesiredOccupancy,
+                                   AnalyzeNextTrait> : AnalyzeNextTrait {
+  using base_t            = AnalyzeNextTrait;
   using occupancy_control = Kokkos::Experimental::DesiredOccupancy;
   static constexpr bool experimental_contains_desired_occupancy = true;
-
-  template <class OccControl>
-  using with_occupancy_control = AnalyzeExecPolicy<void, OccControl, Traits...>;
 
   // Treat this as private, but make it public so that MSVC will still treat
   // this as a standard layout class and make it the right size: storage for a
   // stateful desired occupancy
   //   private:
-  occupancy_control m_desired_occupancy;
+  occupancy_control m_desired_occupancy = occupancy_control{};
 
-  AnalyzeExecPolicy() = default;
+  OccupancyControlPolicyMixin() = default;
   // Converting constructor
   // Just rely on the convertibility of occupancy_control to transfer the data
   template <class Other>
-  AnalyzeExecPolicy(ExecPolicyTraitsWithDefaults<Other> const& other)
+  OccupancyControlPolicyMixin(ExecPolicyTraitsWithDefaults<Other> const& other)
       : base_t(other),
         m_desired_occupancy(other.impl_get_occupancy_control()) {}
 
   // Converting assignment operator
   // Just rely on the convertibility of occupancy_control to transfer the data
   template <class Other>
-  AnalyzeExecPolicy& operator=(
+  OccupancyControlPolicyMixin& operator=(
       ExecPolicyTraitsWithDefaults<Other> const& other) {
     *static_cast<base_t*>(this) = other;
     this->impl_set_desired_occupancy(
@@ -162,16 +162,16 @@ struct AnalyzeExecPolicy<void, Kokkos::Experimental::DesiredOccupancy,
   }
 };
 
-template <class... Traits>
-struct AnalyzeExecPolicy<void, Kokkos::Experimental::MaximizeOccupancy,
-                         Traits...> : AnalyzeExecPolicy<void, Traits...> {
-  using base_t = AnalyzeExecPolicy<void, Traits...>;
+template <class AnalyzeNextTrait>
+struct OccupancyControlPolicyMixin<Kokkos::Experimental::MaximizeOccupancy,
+                                   AnalyzeNextTrait> : AnalyzeNextTrait {
+  using base_t = AnalyzeNextTrait;
   using base_t::base_t;
   using occupancy_control = Kokkos::Experimental::MaximizeOccupancy;
   static constexpr bool experimental_contains_desired_occupancy = false;
 };
 
-// </editor-fold> end AnalyzeExecPolicy specializations }}}1
+// </editor-fold> end OccupancyControlPolicyMixin specializations }}}1
 //==============================================================================
 
 }  // end namespace Impl

--- a/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
+++ b/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
@@ -73,7 +73,7 @@ namespace Impl {
 // something that we can default to in the unspecialized case, just like we
 // do for AnalyzeExecPolicy
 template <class TraitSpec, class Trait, class Enable = void>
-struct PolicyTraitMatcher;
+struct PolicyTraitMatcher : std::false_type {};
 
 template <class TraitSpec, class Trait>
 struct PolicyTraitMatcher<

--- a/core/src/traits/Kokkos_PolicyTraitMatcher.hpp
+++ b/core/src/traits/Kokkos_PolicyTraitMatcher.hpp
@@ -42,72 +42,36 @@
 //@HEADER
 */
 
-#ifndef KOKKOS_KOKKOS_TRAITS_FWD_HPP
-#define KOKKOS_KOKKOS_TRAITS_FWD_HPP
+#include <impl/Kokkos_Utilities.hpp>  // type_list
+
+#include <traits/Kokkos_Traits_fwd.hpp>
+
+#ifndef KOKKOS_KOKKOS_POLICYTRAITMATCHER_HPP
+#define KOKKOS_KOKKOS_POLICYTRAITMATCHER_HPP
 
 namespace Kokkos {
 namespace Impl {
 
-template <class Enable, class... TraitsList>
-struct AnalyzeExecPolicy;
-
-template <class Enable, class TraitSpecList, class... Traits>
-struct AnalyzeExecPolicyUseMatcher;
-
-template <class AnalysisResults>
-struct ExecPolicyTraitsWithDefaults;
-
-template <class TraitSpec, class Trait, class Enable>
-struct PolicyTraitMatcher;
-
-template <class TraitSpec, template <class...> class PolicyTemplate,
-          class AlreadyProcessedList, class ToProcessList, class NewTrait,
-          class Enable = void>
-struct PolicyTraitAdaptorImpl;
-
-template <class TraitSpec, class Policy, class NewTrait>
-struct PolicyTraitAdaptor;
-
-// A tag class for dependent defaults that must be handled by the
-// ExecPolicyTraitsWithDefaults wrapper, since their defaults depend on other
-// traits
-struct dependent_policy_trait_default;
-
 //==============================================================================
-// <editor-fold desc="Execution policy trait specifications"> {{{1
+// <editor-fold desc="PolicyTraitMatcher"> {{{1
 
-struct ExecutionSpaceTrait;
-struct IndexTypeTrait;
-struct ScheduleTrait;
-struct IterationPatternTrait;
-struct WorkItemPropertyTrait;
-struct LaunchBoundsTrait;
-struct OccupancyControlTrait;
-struct GraphKernelTrait;
-struct WorkTagTrait;
+// To handle the WorkTag case, we need more than just a predicate; we need
+// something that we can default to in the unspecialized case, just like we
+// do for AnalyzeExecPolicy
+template <class TraitSpec, class Trait, class Enable = void>
+struct PolicyTraitMatcher : std::false_type {};
 
-// Keep these sorted by frequency of use to reduce compilation time
-//
-// clang-format off
-using execution_policy_trait_specifications =
-  type_list<
-    ExecutionSpaceTrait,
-    IndexTypeTrait,
-    ScheduleTrait,
-    IterationPatternTrait,
-    WorkItemPropertyTrait,
-    LaunchBoundsTrait,
-    OccupancyControlTrait,
-    GraphKernelTrait,
-    // This one has to be last, unfortunately:
-    WorkTagTrait
-  >;
-// clang-format on
+template <class TraitSpec, class Trait>
+struct PolicyTraitMatcher<
+    TraitSpec, Trait,
+    std::enable_if_t<
+        TraitSpec::template trait_matches_specification<Trait>::value>>
+    : std::true_type {};
 
-// </editor-fold> end Execution policy trait specifications }}}1
+// </editor-fold> end PolicyTraitMatcher }}}1
 //==============================================================================
 
 }  // end namespace Impl
 }  // end namespace Kokkos
 
-#endif  // KOKKOS_KOKKOS_TRAITS_FWD_HPP
+#endif  // KOKKOS_KOKKOS_POLICYTRAITMATCHER_HPP

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -84,11 +84,20 @@ struct ScheduleTrait : TraitSpecificationBase<ScheduleTrait> {
                   "type of the errant tag.");
     static constexpr bool schedule_type_is_defaulted = false;
   };
-  template <class T>
-  using trait_matches_specification = is_schedule_type<T>;
+  // template <class T>
+  // using trait_matches_specification = is_schedule_type<T>;
 };
 
 // </editor-fold> end trait specification }}}1
+//==============================================================================
+
+//==============================================================================
+// <editor-fold desc="PolicyTraitMatcher specialization"> {{{1
+
+template <class Sched>
+struct PolicyTraitMatcher<ScheduleTrait, Schedule<Sched>> : std::true_type {};
+
+// </editor-fold> end PolicyTraitMatcher specialization }}}1
 //==============================================================================
 
 }  // end namespace Impl

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -57,6 +57,10 @@ namespace Impl {
 //==============================================================================
 // <editor-fold desc="trait specification"> {{{1
 
+template <class T>
+struct show_extra_schedule_type_erroneously_given_to_execution_policy;
+template <>
+struct show_extra_schedule_type_erroneously_given_to_execution_policy<void> {};
 struct ScheduleTrait : TraitSpecificationBase<ScheduleTrait> {
   // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
   template <template <class> class GetBase, class... OtherTraits>
@@ -70,8 +74,14 @@ struct ScheduleTrait : TraitSpecificationBase<ScheduleTrait> {
     using base_t = AnalyzeNextTrait;
     using base_t::base_t;
     using schedule_type = Sched;
+    static constexpr auto show_schedule_type_error_in_compilation_message =
+        show_extra_schedule_type_erroneously_given_to_execution_policy<
+            std::conditional_t<base_t::schedule_type_is_defaulted, void,
+                               typename base_t::schedule_type>>{};
     static_assert(base_t::schedule_type_is_defaulted,
-                  "Kokkos Error: More than one schedule type given");
+                  "Kokkos Error: More than one schedule type given. Search "
+                  "compiler output for 'show_extra_schedule_type' to see the "
+                  "type of the errant tag.");
     static constexpr bool schedule_type_is_defaulted = false;
   };
   template <class T>

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -84,8 +84,6 @@ struct ScheduleTrait : TraitSpecificationBase<ScheduleTrait> {
                   "type of the errant tag.");
     static constexpr bool schedule_type_is_defaulted = false;
   };
-  // template <class T>
-  // using trait_matches_specification = is_schedule_type<T>;
 };
 
 // </editor-fold> end trait specification }}}1

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -65,28 +65,20 @@ struct ScheduleTrait : TraitSpecificationBase<ScheduleTrait> {
 
     using schedule_type = Schedule<Static>;
   };
+  template <class Sched, class AnalyzeNextTrait>
+  struct mixin_matching_trait : AnalyzeNextTrait {
+    using base_t = AnalyzeNextTrait;
+    using base_t::base_t;
+    using schedule_type = Sched;
+    static_assert(base_t::schedule_type_is_defaulted,
+                  "Kokkos Error: More than one schedule type given");
+    static constexpr bool schedule_type_is_defaulted = false;
+  };
   template <class T>
   using trait_matches_specification = is_schedule_type<T>;
 };
 
 // </editor-fold> end trait specification }}}1
-//==============================================================================
-
-//==============================================================================
-// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
-
-template <class ScheduleType, class... Traits>
-struct AnalyzeExecPolicy<void, Kokkos::Schedule<ScheduleType>, Traits...>
-    : AnalyzeExecPolicy<void, Traits...> {
-  using base_t = AnalyzeExecPolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(base_t::schedule_type_is_defaulted,
-                "Kokkos Error: More than one schedule type given");
-  static constexpr bool schedule_type_is_defaulted = false;
-  using schedule_type = Kokkos::Schedule<ScheduleType>;
-};
-
-// </editor-fold> end AnalyzeExecPolicy specializations }}}1
 //==============================================================================
 
 }  // end namespace Impl

--- a/core/src/traits/Kokkos_Traits_fwd.hpp
+++ b/core/src/traits/Kokkos_Traits_fwd.hpp
@@ -51,6 +51,9 @@ namespace Impl {
 template <class Enable, class... TraitsList>
 struct AnalyzeExecPolicy;
 
+template <class Enable, class TraitSpecList, class... Traits>
+struct AnalyzeExecPolicyUseMatcher;
+
 template <class AnalysisResults>
 struct ExecPolicyTraitsWithDefaults;
 

--- a/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
+++ b/core/src/traits/Kokkos_WorkItemPropertyTrait.hpp
@@ -62,32 +62,18 @@ struct WorkItemPropertyTrait : TraitSpecificationBase<WorkItemPropertyTrait> {
   struct base_traits : linearize_bases<GetBase, OtherTraits...> {
     using work_item_property = Kokkos::Experimental::WorkItemProperty::None_t;
   };
+  template <class WorkItemProp, class AnalyzeNextTrait>
+  struct mixin_matching_trait : AnalyzeNextTrait {
+    using base_t = AnalyzeNextTrait;
+    using base_t::base_t;
+    using work_item_property = WorkItemProp;
+  };
   template <class T>
   using trait_matches_specification =
       Kokkos::Experimental::is_work_item_property<T>;
 };
 
 // </editor-fold> end trait specification }}}1
-//==============================================================================
-
-//==============================================================================
-// <editor-fold desc="AnalyzeExecPolicy specializations"> {{{1
-
-template <class Property, class... Traits>
-struct AnalyzeExecPolicy<
-    std::enable_if_t<
-        Kokkos::Experimental::is_work_item_property<Property>::value>,
-    Property, Traits...> : AnalyzeExecPolicy<void, Traits...> {
-  using base_t = AnalyzeExecPolicy<void, Traits...>;
-  using base_t::base_t;
-  static_assert(
-      std::is_same<typename base_t::work_item_property,
-                   Kokkos::Experimental::WorkItemProperty::None_t>::value,
-      "Kokkos Error: More than one work item property given");
-  using work_item_property = Property;
-};
-
-// </editor-fold> end AnalyzeExecPolicy specializations }}}1
 //==============================================================================
 
 }  // end namespace Impl

--- a/core/src/traits/Kokkos_WorkTagTrait.hpp
+++ b/core/src/traits/Kokkos_WorkTagTrait.hpp
@@ -56,6 +56,10 @@ namespace Impl {
 //==============================================================================
 // <editor-fold desc="trait specification"> {{{1
 
+template <class T>
+struct show_extra_work_tag_erroneously_given_to_execution_policy;
+template <>
+struct show_extra_work_tag_erroneously_given_to_execution_policy<void> {};
 struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
   // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
   template <template <class> class GetBase, class... OtherTraits>
@@ -67,8 +71,13 @@ struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
     using base_t = AnalyzeNextTrait;
     using base_t::base_t;
     using work_tag = WorkTag;
-    static_assert(std::is_void<typename base_t::work_tag>::value,
-                  "Kokkos Error: More than one work tag given");
+    static constexpr auto show_work_tag_error_in_compilation_message =
+        show_extra_work_tag_erroneously_given_to_execution_policy<
+            typename base_t::work_tag>{};
+    static_assert(
+        std::is_void<typename base_t::work_tag>::value,
+        "Kokkos Error: More than one work tag given. Search compiler output "
+        "for 'show_extra_work_tag' to see the type of the errant tag.");
   };
 };
 

--- a/core/src/traits/Kokkos_WorkTagTrait.hpp
+++ b/core/src/traits/Kokkos_WorkTagTrait.hpp
@@ -49,6 +49,7 @@
 #include <Kokkos_Concepts.hpp>  // is_execution_space
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
 #include <traits/Kokkos_Traits_fwd.hpp>
+#include <impl/Kokkos_Utilities.hpp>  // type_list_any, type_list_remove_first
 
 namespace Kokkos {
 namespace Impl {
@@ -60,6 +61,19 @@ template <class T>
 struct show_extra_work_tag_erroneously_given_to_execution_policy;
 template <>
 struct show_extra_work_tag_erroneously_given_to_execution_policy<void> {};
+
+using _exec_policy_traits_without_work_tag = typename type_list_remove_first<
+    WorkTagTrait, execution_policy_trait_specifications>::type;
+
+template <class Trait>
+struct _trait_matches_spec_predicate {
+  template <class TraitSpec>
+  struct apply {
+    using type = typename PolicyTraitMatcher<TraitSpec, Trait>::type;
+    static constexpr bool value = type::value;
+  };
+};
+
 struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
   // MSVC workaround for linearizing base classes (see Impl::linearize_bases)
   template <template <class> class GetBase, class... OtherTraits>
@@ -79,33 +93,29 @@ struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
         "Kokkos Error: More than one work tag given. Search compiler output "
         "for 'show_extra_work_tag' to see the type of the errant tag.");
   };
+  // Since we don't have subsumption in pre-C++20, we need to have the work tag
+  // "trait" handling code ensure that none of the other conditions are met.
+  // * Compile time cost complexity note: at first glance it looks like this
+  //   "rechecks" all of the other trait specs when used in the context of the
+  //   full list of execution policy traits, but actually since we've already
+  //   checked all of them to get to the end of the list, the compiler will
+  //   have already generated those definitions, so there should be little extra
+  //   cost to this. However, in the scenario where we use work tag in isolation
+  //   (like if we were to add a `require()`-like thing that changes the work
+  //   tag of an existing execution policy instance), we need to check all of
+  //   the other traits to make sure that we're not replacing something else,
+  //   given that the concept of a work tag is basically unconstrained and could
+  //   be anything.  This should still be as efficient at compile time as the
+  //   old code that just did a big long series of nested std::conditionals, but
+  //   we should benchmark this assumption if it becomes a problem.
+  template <class T>
+  using trait_matches_specification = std::integral_constant<
+      bool, !std::is_void<T>::value &&
+                !type_list_any<_trait_matches_spec_predicate<T>::template apply,
+                               _exec_policy_traits_without_work_tag>::value>;
 };
 
 // </editor-fold> end trait specification }}}1
-//==============================================================================
-
-//==============================================================================
-// <editor-fold desc="PolicyTraitMatcher specializations"> {{{1
-
-// Since we don't have subsumption in pre-C++20, we need to have the work tag
-// "trait" handling code be unspecialized, so we handle it instead in a class
-// with a different name.
-// In order to match the work tag trait the work tag "matcher" needs to be
-// unspecialized and the logic needs to be handled in a differently-named class.
-template <class TraitSpec, class Trait>
-struct PolicyTraitMatcherHandleWorkTag : std::false_type {};
-
-template <class Trait>
-struct PolicyTraitMatcherHandleWorkTag<WorkTagTrait, Trait>
-    : std::integral_constant<bool, !std::is_void<Trait>::value> {};
-
-// This only works if this is not a partial specialization, so we have to
-// do the partial specialization elsewhere
-template <class TraitSpec, class Trait, class Enable>
-struct PolicyTraitMatcher /* unspecialized! */
-    : PolicyTraitMatcherHandleWorkTag<TraitSpec, Trait> {};
-
-// </editor-fold> end PolicyTraitMatcher specializations }}}1
 //==============================================================================
 
 }  // end namespace Impl


### PR DESCRIPTION
Putting this in a different pull request because #3829 is now passing CI

- `TraitSpecifications` now mixin the specialization resulting from a matching
    trait using the `mixin_matching_trait` alias template
- `AnalyzeExecPolicy` now directly queries the `PolicyTraitMatcher` and
    mixes in the effects of the trait when it matches, eliminating
    redundant trait matching
- Traits no longer need to specialize `AnalyzeExecPolicy` or anything
    else in the `Kokkos::Impl` namespace, making this a (theoretically)
    user-accessible feature.

Here's a godbolt link illustrating how this design and implementation works in principle: https://godbolt.org/z/vEPKfW