### PR TITLE
[HIP] Enable one more test

### DIFF
--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -293,8 +293,8 @@ void test_deep_copy(uint32_t num_nodes) {
   }
 }
 
-// FIXME_HIP wrong result in CI but works locally
-#ifndef KOKKOS_ENABLE_HIP
+// FIXME_HIP
+#if !(defined(KOKKOS_ENABLE_HIP) && (HIP_VERSION < 401))
 // WORKAROUND MSVC
 #ifndef _WIN32
 TEST(TEST_CATEGORY, UnorderedMap_insert) {


### PR DESCRIPTION
This test now works with ROCm HIP 4.1 I've changed the comment because I can reproduce the bug locally with HIP 4.0 and older.