### PR TITLE
Avoid (void) interface

### DIFF
--- a/cmake/compile_tests/pthread.cpp
+++ b/cmake/compile_tests/pthread.cpp
@@ -2,7 +2,7 @@
 
 void* kokkos_test(void* args) { return args; }
 
-int main(void) {
+int main() {
   pthread_t thread;
   /* Use NULL to avoid C++11. Some compilers
      do not have C++11 by default.  Forcing C++11

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -476,7 +476,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 
   Policy const& get_policy() const { return m_policy; }
 
-  inline __device__ void operator()(void) const {
+  inline __device__ void operator()() const {
     const Member work_stride = blockDim.y * gridDim.x;
     const Member work_end    = m_policy.end();
 
@@ -555,7 +555,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
         static_cast<int>(Kokkos::Impl::CudaTraits::MaxHierarchicalParallelism));
   }
   Policy const& get_policy() const { return m_rp; }
-  inline __device__ void operator()(void) const {
+  inline __device__ void operator()() const {
     Kokkos::Impl::DeviceIterateTile<Policy::rank, Policy, FunctorType,
                                     typename Policy::work_tag>(m_rp, m_functor)
         .exec_range();
@@ -705,7 +705,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
  public:
   Policy const& get_policy() const { return m_policy; }
 
-  __device__ inline void operator()(void) const {
+  __device__ inline void operator()() const {
     // Iterate this block through the league
     int64_t threadid = 0;
     if (m_scratch_size[1] > 0) {
@@ -1287,7 +1287,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
         .exec_range();
   }
 
-  inline __device__ void operator()(void) const {
+  inline __device__ void operator()() const {
     /*    run(Kokkos::Impl::if_c<UseShflReduction, DummyShflReductionType,
       DummySHMEMReductionType>::select(1,1.0) );
       }
@@ -2103,7 +2103,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 
   //----------------------------------------
 
-  __device__ inline void initial(void) const {
+  __device__ inline void initial() const {
     const integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /
                                                    sizeof(size_type)>
         word_count(ValueTraits::value_size(m_functor) / sizeof(size_type));
@@ -2139,7 +2139,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 
   //----------------------------------------
 
-  __device__ inline void final(void) const {
+  __device__ inline void final() const {
     const integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /
                                                    sizeof(size_type)>
         word_count(ValueTraits::value_size(m_functor) / sizeof(size_type));
@@ -2224,7 +2224,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 
   //----------------------------------------
 
-  __device__ inline void operator()(void) const {
+  __device__ inline void operator()() const {
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
     if (m_run_serial) {
       typename ValueTraits::value_type value;
@@ -2393,7 +2393,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
   //----------------------------------------
 
-  __device__ inline void initial(void) const {
+  __device__ inline void initial() const {
     const integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /
                                                    sizeof(size_type)>
         word_count(ValueTraits::value_size(m_functor) / sizeof(size_type));
@@ -2429,7 +2429,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
   //----------------------------------------
 
-  __device__ inline void final(void) const {
+  __device__ inline void final() const {
     const integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /
                                                    sizeof(size_type)>
         word_count(ValueTraits::value_size(m_functor) / sizeof(size_type));
@@ -2516,7 +2516,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
   //----------------------------------------
 
-  __device__ inline void operator()(void) const {
+  __device__ inline void operator()() const {
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
     if (m_run_serial) {
       typename ValueTraits::value_type value;

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -73,7 +73,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   ParallelFor& operator=(ParallelFor const&) = delete;
 
  public:
-  inline __device__ void operator()(void) const {
+  inline __device__ void operator()() const {
     Kokkos::Impl::DeviceIterateTile<Policy::rank, Policy, FunctorType,
                                     typename Policy::work_tag>(m_policy,
                                                                m_functor)
@@ -251,7 +251,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     DeviceIteratePattern(m_policy, m_functor, update).exec_range();
   }
 
-  inline __device__ void operator()(void) const {
+  inline __device__ void operator()() const {
     const integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /
                                                    sizeof(size_type)>
         word_count(ValueTraits::value_size(

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -92,7 +92,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
  public:
   using functor_type = FunctorType;
 
-  inline __device__ void operator()(void) const {
+  inline __device__ void operator()() const {
     const Member work_stride = blockDim.y * gridDim.x;
     const Member work_end    = m_policy.end();
 
@@ -502,7 +502,7 @@ class ParallelScanHIPBase {
 
   //----------------------------------------
 
-  __device__ inline void initial(void) const {
+  __device__ inline void initial() const {
     const integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /
                                                    sizeof(size_type)>
         word_count(ValueTraits::value_size(m_functor) / sizeof(size_type));
@@ -538,7 +538,7 @@ class ParallelScanHIPBase {
 
   //----------------------------------------
 
-  __device__ inline void final(void) const {
+  __device__ inline void final() const {
     const integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /
                                                    sizeof(size_type)>
         word_count(ValueTraits::value_size(m_functor) / sizeof(size_type));
@@ -615,7 +615,7 @@ class ParallelScanHIPBase {
  public:
   //----------------------------------------
 
-  __device__ inline void operator()(void) const {
+  __device__ inline void operator()() const {
     if (!m_final) {
       initial();
     } else {

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -449,7 +449,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
  public:
-  __device__ inline void operator()(void) const {
+  __device__ inline void operator()() const {
     // Iterate this block through the league
     int64_t threadid = 0;
     if (m_scratch_size[1] > 0) {

--- a/core/src/Kokkos_AnonymousSpace.hpp
+++ b/core/src/Kokkos_AnonymousSpace.hpp
@@ -107,14 +107,14 @@ struct MemorySpaceAccess<Kokkos::AnonymousSpace, Kokkos::AnonymousSpace> {
 template <typename OtherSpace>
 struct VerifyExecutionCanAccessMemorySpace<OtherSpace, Kokkos::AnonymousSpace> {
   enum { value = 1 };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {}
+  KOKKOS_INLINE_FUNCTION static void verify() {}
   KOKKOS_INLINE_FUNCTION static void verify(const void *) {}
 };
 
 template <typename OtherSpace>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::AnonymousSpace, OtherSpace> {
   enum { value = 1 };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {}
+  KOKKOS_INLINE_FUNCTION static void verify() {}
   KOKKOS_INLINE_FUNCTION static void verify(const void *) {}
 };
 

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -204,7 +204,7 @@ struct VerifyExecutionCanAccessMemorySpace {
 template <class Space>
 struct VerifyExecutionCanAccessMemorySpace<Space, Space> {
   enum { value = 1 };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {}
+  KOKKOS_INLINE_FUNCTION static void verify() {}
   KOKKOS_INLINE_FUNCTION static void verify(const void *) {}
 };
 

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -313,7 +313,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
                                            Kokkos::Cuda::scratch_memory_space> {
   enum : bool { value = true };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {}
+  KOKKOS_INLINE_FUNCTION static void verify() {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
 
@@ -321,7 +321,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::Cuda::scratch_memory_space> {
   enum : bool { value = false };
-  inline static void verify(void) { CudaSpace::access_error(); }
+  inline static void verify() { CudaSpace::access_error(); }
   inline static void verify(const void* p) { CudaSpace::access_error(p); }
 };
 

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -753,7 +753,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
                                            Kokkos::HostSpace> {
   enum : bool { value = false };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {
+  KOKKOS_INLINE_FUNCTION static void verify() {
     Kokkos::abort("Cuda code attempted to access HostSpace memory");
   }
 
@@ -767,7 +767,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
                                            Kokkos::CudaUVMSpace> {
   enum : bool { value = true };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {}
+  KOKKOS_INLINE_FUNCTION static void verify() {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
 
@@ -776,7 +776,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::CudaSpace,
                                            Kokkos::CudaHostPinnedSpace> {
   enum : bool { value = true };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {}
+  KOKKOS_INLINE_FUNCTION static void verify() {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
 
@@ -787,7 +787,7 @@ struct VerifyExecutionCanAccessMemorySpace<
                             Kokkos::CudaSpace>::type,
     OtherSpace> {
   enum : bool { value = false };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {
+  KOKKOS_INLINE_FUNCTION static void verify() {
     Kokkos::abort("Cuda code attempted to access unknown Space memory");
   }
 
@@ -802,7 +802,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::CudaSpace> {
   enum : bool { value = false };
-  inline static void verify(void) { CudaSpace::access_error(); }
+  inline static void verify() { CudaSpace::access_error(); }
   inline static void verify(const void* p) { CudaSpace::access_error(p); }
 };
 
@@ -811,7 +811,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::CudaUVMSpace> {
   enum : bool { value = true };
-  inline static void verify(void) {}
+  inline static void verify() {}
   inline static void verify(const void*) {}
 };
 
@@ -820,7 +820,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::CudaHostPinnedSpace> {
   enum : bool { value = true };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {}
+  KOKKOS_INLINE_FUNCTION static void verify() {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
 

--- a/core/src/Kokkos_HBWSpace.hpp
+++ b/core/src/Kokkos_HBWSpace.hpp
@@ -324,7 +324,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::Experimental::HBWSpace> {
   enum : bool { value = true };
-  inline static void verify(void) {}
+  inline static void verify() {}
   inline static void verify(const void*) {}
 };
 
@@ -332,7 +332,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::Experimental::HBWSpace,
                                            Kokkos::HostSpace> {
   enum : bool { value = true };
-  inline static void verify(void) {}
+  inline static void verify() {}
   inline static void verify(const void*) {}
 };
 

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -452,7 +452,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::Experimental::HIPSpace,
                                            Kokkos::HostSpace> {
   enum : bool { value = false };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {
+  KOKKOS_INLINE_FUNCTION static void verify() {
     Kokkos::abort("HIP code attempted to access HostSpace memory");
   }
 
@@ -466,7 +466,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPHostPinnedSpace> {
   enum : bool { value = true };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {}
+  KOKKOS_INLINE_FUNCTION static void verify() {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
 
@@ -478,7 +478,7 @@ struct VerifyExecutionCanAccessMemorySpace<
         Kokkos::Experimental::HIPSpace>::type,
     OtherSpace> {
   enum : bool { value = false };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {
+  KOKKOS_INLINE_FUNCTION static void verify() {
     Kokkos::abort("HIP code attempted to access unknown Space memory");
   }
 
@@ -493,7 +493,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<Kokkos::HostSpace,
                                            Kokkos::Experimental::HIPSpace> {
   enum : bool { value = false };
-  inline static void verify(void) {
+  inline static void verify() {
     Kokkos::Experimental::HIPSpace::access_error();
   }
   inline static void verify(const void* p) {
@@ -506,7 +506,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::HostSpace, Kokkos::Experimental::HIPHostPinnedSpace> {
   enum : bool { value = true };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {}
+  KOKKOS_INLINE_FUNCTION static void verify() {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
 }  // namespace Impl
@@ -755,7 +755,7 @@ struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Experimental::HIP::memory_space,
     Kokkos::Experimental::HIP::scratch_memory_space> {
   enum : bool { value = true };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {}
+  KOKKOS_INLINE_FUNCTION static void verify() {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
 
@@ -763,7 +763,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::HostSpace, Kokkos::Experimental::HIP::scratch_memory_space> {
   enum : bool { value = false };
-  inline static void verify(void) {
+  inline static void verify() {
     Kokkos::Experimental::HIPSpace::access_error();
   }
   inline static void verify(const void* p) {

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -528,7 +528,7 @@ struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Experimental::HPX::memory_space,
     Kokkos::Experimental::HPX::scratch_memory_space> {
   enum : bool { value = true };
-  inline static void verify(void) {}
+  inline static void verify() {}
   inline static void verify(const void *) {}
 };
 }  // namespace Impl

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -212,7 +212,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::OpenMP::memory_space, Kokkos::OpenMP::scratch_memory_space> {
   enum : bool { value = true };
-  inline static void verify(void) {}
+  inline static void verify() {}
   inline static void verify(const void*) {}
 };
 

--- a/core/src/Kokkos_OpenMPTarget.hpp
+++ b/core/src/Kokkos_OpenMPTarget.hpp
@@ -158,7 +158,7 @@ struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Experimental::OpenMPTarget::memory_space,
     Kokkos::Experimental::OpenMPTarget::scratch_memory_space> {
   enum : bool { value = true };
-  inline static void verify(void) {}
+  inline static void verify() {}
   inline static void verify(const void*) {}
 };
 

--- a/core/src/Kokkos_OpenMPTargetSpace.hpp
+++ b/core/src/Kokkos_OpenMPTargetSpace.hpp
@@ -276,7 +276,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::HostSpace, Kokkos::Experimental::OpenMPTargetSpace> {
   enum : bool { value = false };
-  inline static void verify(void) {}
+  inline static void verify() {}
   inline static void verify(const void*) {}
 };
 

--- a/core/src/Kokkos_SYCL_Space.hpp
+++ b/core/src/Kokkos_SYCL_Space.hpp
@@ -214,7 +214,7 @@ struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Experimental::SYCLDeviceUSMSpace,
     Kokkos::ScratchMemorySpace<Kokkos::Experimental::SYCL>> {
   enum : bool { value = true };
-  KOKKOS_INLINE_FUNCTION static void verify(void) {}
+  KOKKOS_INLINE_FUNCTION static void verify() {}
   KOKKOS_INLINE_FUNCTION static void verify(const void*) {}
 };
 
@@ -222,7 +222,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::HostSpace, Kokkos::ScratchMemorySpace<Kokkos::Experimental::SYCL>> {
   enum : bool { value = false };
-  inline static void verify(void) {
+  inline static void verify() {
     Experimental::SYCLDeviceUSMSpace::impl_access_error();
   }
   inline static void verify(const void* p) {

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -201,7 +201,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Serial::memory_space, Kokkos::Serial::scratch_memory_space> {
   enum : bool { value = true };
-  inline static void verify(void) {}
+  inline static void verify() {}
   inline static void verify(const void*) {}
 };
 

--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -215,7 +215,7 @@ template <>
 struct VerifyExecutionCanAccessMemorySpace<
     Kokkos::Threads::memory_space, Kokkos::Threads::scratch_memory_space> {
   enum : bool { value = true };
-  inline static void verify(void) {}
+  inline static void verify() {}
   inline static void verify(const void*) {}
 };
 

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -111,7 +111,7 @@ namespace Impl {
 
 void execute_function_noop(ThreadsExec &, const void *) {}
 
-void ThreadsExec::driver(void) {
+void ThreadsExec::driver() {
   SharedAllocationRecord<void, void>::tracking_enable();
 
   ThreadsExec this_thread;

--- a/core/src/impl/Kokkos_ClockTic.hpp
+++ b/core/src/impl/Kokkos_ClockTic.hpp
@@ -69,7 +69,7 @@ namespace Impl {
  */
 
 KOKKOS_FORCEINLINE_FUNCTION
-uint64_t clock_tic(void) noexcept {
+uint64_t clock_tic() noexcept {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 
   // Return value of 64-bit hi-res clock register.


### PR DESCRIPTION
I would prefer to use a common syntax for functions without parameters.