### PR TITLE
Remove HostBarrier test

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -722,11 +722,6 @@ KOKKOS_ADD_EXECUTABLE_AND_TEST(
 )
 endif()
 
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  UnitTest_HostBarrier
-  SOURCES UnitTestMain.cpp  TestHostBarrier.cpp
-)
-
 FUNCTION (KOKKOS_ADD_INCREMENTAL_TEST DEVICE)
   KOKKOS_OPTION( ${DEVICE}_EXCLUDE_TESTS "" STRING "Incremental test exclude list" )
   # Add unit test main

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -361,10 +361,6 @@ OBJ_HWLOC = TestHWLOC.o UnitTestMain.o gtest-all.o
 TARGETS += KokkosCore_UnitTest_HWLOC
 TEST_TARGETS += test-hwloc
 
-OBJ_HOST_BARRIER = TestHostBarrier.o UnitTestMain.o gtest-all.o
-TARGETS += KokkosCore_UnitTest_HostBarrier
-TEST_TARGETS += test-host-barrier
-
 OBJ_DEFAULT = UnitTestMainInit.o gtest-all.o
 ifneq ($(KOKKOS_INTERNAL_USE_OPENMPTARGET), 1)
 ifneq ($(KOKKOS_INTERNAL_COMPILER_HCC), 1)
@@ -432,9 +428,6 @@ KokkosCore_UnitTest_HPXInterOp: UnitTestMain.o gtest-all.o TestHPX_InterOp.o $(K
 KokkosCore_UnitTest_HWLOC: $(OBJ_HWLOC) $(KOKKOS_LINK_DEPENDS)
 	$(LINK) $(EXTRA_PATH) $(OBJ_HWLOC) $(KOKKOS_LIBS) $(LIB) $(KOKKOS_LDFLAGS) $(LDFLAGS) -o KokkosCore_UnitTest_HWLOC
 
-KokkosCore_UnitTest_HostBarrier: $(OBJ_HOST_BARRIER) $(KOKKOS_LINK_DEPENDS)
-	$(LINK) $(EXTRA_PATH) $(OBJ_HOST_BARRIER) $(KOKKOS_LIBS) $(LIB) $(KOKKOS_LDFLAGS) $(LDFLAGS) -o KokkosCore_UnitTest_HostBarrier
-
 KokkosCore_UnitTest_AllocationTracker: $(OBJ_ALLOCATIONTRACKER) $(KOKKOS_LINK_DEPENDS)
 	$(LINK) $(EXTRA_PATH) $(OBJ_ALLOCATIONTRACKER) $(KOKKOS_LIBS) $(KOKKOS_LDFLAGS) $(LDFLAGS) $(LIB) -o KokkosCore_UnitTest_AllocationTracker
 
@@ -481,9 +474,6 @@ test-hpx: KokkosCore_UnitTest_HPX
 
 test-hwloc: KokkosCore_UnitTest_HWLOC
 	./KokkosCore_UnitTest_HWLOC
-
-test-host-barrier: KokkosCore_UnitTest_HostBarrier
-	./KokkosCore_UnitTest_HostBarrier
 
 test-allocationtracker: KokkosCore_UnitTest_AllocationTracker
 	./KokkosCore_UnitTest_AllocationTracker

--- a/core/unit_test/TestHostBarrier.cpp
+++ b/core/unit_test/TestHostBarrier.cpp
@@ -1,7 +1,0 @@
-#include <gtest/gtest.h>
-
-namespace Test {
-
-TEST(host_barrier, openmp) {}
-
-}  // namespace Test


### PR DESCRIPTION
For reasons I still don't quite understand, compiling this test causes problems in #3833.
Since the test file is empty, I don't see much of a reason to keep it anyway.