### PR TITLE
Fix bug in SYCL team_reduce

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -161,7 +161,7 @@ class SYCLTeamMember {
     for (int start = maximum_work_range; start < team_size();
          start += maximum_work_range) {
       if (idx >= start &&
-          idx < std::max(start + maximum_work_range, team_size()))
+          idx < std::min(start + maximum_work_range, team_size()))
         reducer.join(reduction_array[idx - start], value);
       m_item.barrier(sycl::access::fence_space::local_space);
     }


### PR DESCRIPTION
This was only triggered for SYCL+CUDA with the increased concurrency in #3833 and large types to be reduced.

We need to make sure that `idx` is within `[start, start+maximum_work_range)` and that `idx` doesn't exceed `team_size()-1` which means that we need to limit the upper bound by the minimum, not the maximum.