### PR TITLE
Implement SYCL Random

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -675,6 +675,8 @@ struct Random_UniqueIndex<Kokkos::Experimental::SYCL> {
   KOKKOS_FUNCTION
   static int get_state_idx(const locks_view_type& locks_) {
     // FIXME_SYCL get an index that is specific to each thread.
+    // Starting from 0 for every thread is not incorrect but
+    // will lead to a lot of contention and loop iterations.
     int i = 0;
     while (Kokkos::atomic_compare_exchange(&locks_(i), 0, 1)) {
       i += 1;

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -668,6 +668,23 @@ struct Random_UniqueIndex<Kokkos::Experimental::HIP> {
 };
 #endif
 
+#ifdef KOKKOS_ENABLE_SYCL
+template <>
+struct Random_UniqueIndex<Kokkos::Experimental::SYCL> {
+  using locks_view_type = View<int*, Kokkos::Experimental::SYCL>;
+  KOKKOS_FUNCTION
+  static int get_state_idx(const locks_view_type& locks_) {
+    // FIXME_SYCL get an index that is specific to each thread.
+    int i = 0;
+    while (Kokkos::atomic_compare_exchange(&locks_(i), 0, 1)) {
+      i += 1;
+      i = i % static_cast<int>(locks_.extent(0));
+    }
+    return i;
+  }
+};
+#endif
+
 }  // namespace Impl
 
 template <class DeviceType>

--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -47,6 +47,12 @@ IF(Kokkos_ENABLE_OPENMP)
   )
 ENDIF()
 
+IF(Kokkos_ENABLE_SYCL)
+  LIST( APPEND SOURCES
+	  TestSYCL.cpp
+  )
+ENDIF()
+
 IF(Kokkos_ENABLE_HIP)
   LIST( APPEND SOURCES
     TestHIP.cpp

--- a/algorithms/unit_tests/TestSYCL.cpp
+++ b/algorithms/unit_tests/TestSYCL.cpp
@@ -42,9 +42,6 @@
 //@HEADER
 */
 
-#include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_SYCL
-
 #include <cstdint>
 #include <iostream>
 #include <iomanip>
@@ -80,6 +77,3 @@ TEST(sycl, SortUnsigned) {
   Impl::test_sort<Kokkos::Experimental::SYCL, unsigned>(171);
 }
 }  // namespace Test
-#else
-void KOKKOS_ALGORITHMS_UNITTESTS_TESTSYCL_PREVENT_LINK_ERROR() {}
-#endif /* #ifdef KOKKOS_ENABLE_SYCL */

--- a/algorithms/unit_tests/TestSYCL.cpp
+++ b/algorithms/unit_tests/TestSYCL.cpp
@@ -1,0 +1,85 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_SYCL
+
+#include <cstdint>
+#include <iostream>
+#include <iomanip>
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+
+#include <TestRandom.hpp>
+#include <TestSort.hpp>
+
+namespace Test {
+
+void sycl_test_random_xorshift64(size_t num_draws) {
+  Impl::test_random<Kokkos::Random_XorShift64_Pool<Kokkos::Experimental::SYCL>>(
+      num_draws);
+  Impl::test_random<Kokkos::Random_XorShift64_Pool<Kokkos::Device<
+      Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>>>(
+      num_draws);
+}
+
+void sycl_test_random_xorshift1024(size_t num_draws) {
+  Impl::test_random<
+      Kokkos::Random_XorShift1024_Pool<Kokkos::Experimental::SYCL>>(num_draws);
+  Impl::test_random<Kokkos::Random_XorShift1024_Pool<Kokkos::Device<
+      Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>>>(
+      num_draws);
+}
+
+TEST(sycl, Random_XorShift64) { sycl_test_random_xorshift64(132141141); }
+TEST(sycl, Random_XorShift1024_0) { sycl_test_random_xorshift1024(52428813); }
+TEST(sycl, SortUnsigned) {
+  Impl::test_sort<Kokkos::Experimental::SYCL, unsigned>(171);
+}
+}  // namespace Test
+#else
+void KOKKOS_ALGORITHMS_UNITTESTS_TESTSYCL_PREVENT_LINK_ERROR() {}
+#endif /* #ifdef KOKKOS_ENABLE_SYCL */

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -94,9 +94,7 @@ SYCL::SYCL(const sycl::queue& stream)
 }
 
 int SYCL::concurrency() {
-  // FIXME_SYCL We need a value larger than 1 here for some tests to pass,
-  // clearly this is true but not the roght value
-  return 2;
+  return Impl::SYCLInternal::singleton().m_maxConcurrency;
 }
 
 const char* SYCL::name() { return "SYCL"; }

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -126,6 +126,11 @@ void SYCLInternal::initialize(const sycl::queue& q) {
 
     m_maxThreadsPerSM =
         d.template get_info<sycl::info::device::max_work_group_size>();
+    // FIXME_SYCL this should give the correct value for NVIDIA GPUs
+    m_maxConcurrency =
+        m_maxThreadsPerSM * 2 *
+        d.template get_info<sycl::info::device::max_compute_units>();
+
     m_maxShmemPerBlock =
         d.template get_info<sycl::info::device::local_mem_size>();
     m_indirectKernelMem.reset(*m_queue);

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -124,11 +124,11 @@ void SYCLInternal::initialize(const sycl::queue& q) {
     const sycl::device& d = m_queue->get_device();
     std::cout << SYCL::SYCLDevice(d) << '\n';
 
-    m_maxThreadsPerSM =
+    m_maxWorkgroupSize =
         d.template get_info<sycl::info::device::max_work_group_size>();
     // FIXME_SYCL this should give the correct value for NVIDIA GPUs
     m_maxConcurrency =
-        m_maxThreadsPerSM * 2 *
+        m_maxWorkgroupSize * 2 *
         d.template get_info<sycl::info::device::max_compute_units>();
 
     m_maxShmemPerBlock =

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -68,7 +68,7 @@ class SYCLInternal {
 
   int m_syclDev = -1;
 
-  size_t m_maxThreadsPerSM    = 0;
+  size_t m_maxWorkgroupSize   = 0;
   uint32_t m_maxConcurrency   = 0;
   uint64_t m_maxShmemPerBlock = 0;
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -69,6 +69,7 @@ class SYCLInternal {
   int m_syclDev = -1;
 
   size_t m_maxThreadsPerSM    = 0;
+  uint32_t m_maxConcurrency   = 0;
   uint64_t m_maxShmemPerBlock = 0;
 
   size_type* m_scratchSpace = nullptr;

--- a/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_MDRangePolicy.hpp
@@ -25,7 +25,7 @@ inline TileSizeProperties get_tile_size_properties<Kokkos::Experimental::SYCL>(
     const Kokkos::Experimental::SYCL& space) {
   TileSizeProperties properties;
   properties.max_threads =
-      space.impl_internal_space_instance()->m_maxThreadsPerSM;
+      space.impl_internal_space_instance()->m_maxWorkgroupSize;
   properties.default_largest_tile_size = 16;
   properties.default_tile_size         = 2;
   properties.max_total_tile_size       = properties.max_threads;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
@@ -243,7 +243,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   template <typename Policy, typename Functor>
   static int max_tile_size_product(const Policy& policy, const Functor&) {
-    return policy.space().impl_internal_space_instance()->m_maxThreadsPerSM;
+    return policy.space().impl_internal_space_instance()->m_maxWorkgroupSize;
   }
 
   void execute() const {

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -128,7 +128,7 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
   int team_size_recommended(FunctorType const& /*f*/,
                             ParallelForTag const&) const {
     // FIXME_SYCL optimize
-    return m_space.impl_internal_space_instance()->m_maxThreadsPerSM;
+    return m_space.impl_internal_space_instance()->m_maxWorkgroupSize;
   }
 
   template <typename FunctorType>
@@ -341,7 +341,7 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
     // If no scratch memory per thread is requested, the maximum is simply the
     // maximum number of threads allowed in a workgroup.
     if (m_thread_scratch_size[0] == 0)
-      return m_space.impl_internal_space_instance()->m_maxThreadsPerSM;
+      return m_space.impl_internal_space_instance()->m_maxWorkgroupSize;
 
     // Otherwise, we choose the maximum as the minimum of the number of threads
     // allowed in a workgroup and the number of threads that allow allocating
@@ -354,7 +354,7 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
          m_team_scratch_size[0]) /
         m_thread_scratch_size[0];
     return std::min<int>(
-        m_space.impl_internal_space_instance()->m_maxThreadsPerSM,
+        m_space.impl_internal_space_instance()->m_maxWorkgroupSize,
         max_threads_for_memory);
   }
 


### PR DESCRIPTION
We just run through the whole lock array starting from zero on each thread which is likely prohibitively expensive but should at least work.