### PR TITLE
Fixup cache CUDA fallback execution space instance used by DualView::sync

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -99,8 +99,7 @@ namespace Impl {
 inline const Kokkos::Cuda& get_cuda_space(const Kokkos::Cuda& in) { return in; }
 
 inline const Kokkos::Cuda& get_cuda_space() {
-  static Cuda space(Kokkos::Impl::cuda_get_deep_copy_stream());
-  return space;
+  return *Kokkos::Impl::cuda_get_deep_copy_space();
 }
 
 template <typename NonCudaExecSpace>

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -98,13 +98,14 @@ namespace Impl {
 
 inline const Kokkos::Cuda& get_cuda_space(const Kokkos::Cuda& in) { return in; }
 
-inline Kokkos::Cuda get_cuda_space() {
-  return Kokkos::Cuda(Kokkos::Impl::cuda_get_deep_copy_stream());
+inline const Kokkos::Cuda& get_cuda_space() {
+  static Cuda space(Kokkos::Impl::cuda_get_deep_copy_stream());
+  return space;
 }
 
 template <typename NonCudaExecSpace>
-inline Kokkos::Cuda get_cuda_space(const NonCudaExecSpace&) {
-  return Kokkos::Cuda(Kokkos::Impl::cuda_get_deep_copy_stream());
+inline const Kokkos::Cuda& get_cuda_space(const NonCudaExecSpace&) {
+  return get_cuda_space();
 }
 
 #endif  // KOKKOS_ENABLE_CUDA

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -65,6 +65,14 @@
 /*--------------------------------------------------------------------------*/
 /*--------------------------------------------------------------------------*/
 
+cudaStream_t Kokkos::Impl::cuda_get_deep_copy_stream() {
+  static cudaStream_t s = nullptr;
+  if (s == nullptr) {
+    cudaStreamCreate(&s);
+  }
+  return s;
+}
+
 namespace Kokkos {
 namespace Impl {
 
@@ -73,14 +81,6 @@ namespace {
 static std::atomic<int> num_uvm_allocations(0);
 
 }  // namespace
-
-cudaStream_t cuda_get_deep_copy_stream() {
-  static cudaStream_t s = nullptr;
-  if (s == nullptr) {
-    cudaStreamCreate(&s);
-  }
-  return s;
-}
 
 DeepCopy<CudaSpace, CudaSpace, Cuda>::DeepCopy(void *dst, const void *src,
                                                size_t n) {

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -73,6 +73,14 @@ cudaStream_t Kokkos::Impl::cuda_get_deep_copy_stream() {
   return s;
 }
 
+const std::unique_ptr<Kokkos::Cuda> &Kokkos::Impl::cuda_get_deep_copy_space(
+    bool initialize) {
+  static std::unique_ptr<Cuda> space = nullptr;
+  if (!space && initialize)
+    space = std::make_unique<Cuda>(Kokkos::Impl::cuda_get_deep_copy_stream());
+  return space;
+}
+
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -709,6 +709,7 @@ void CudaInternal::finalize() {
   if (this == &singleton()) {
     cudaFreeHost(constantMemHostStaging);
     cudaEventDestroy(constantMemReusable);
+    cudaStreamDestroy(cuda_get_deep_copy_stream());
   }
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -663,9 +663,6 @@ void *CudaInternal::resize_team_scratch_space(std::int64_t bytes,
 //----------------------------------------------------------------------------
 
 void CudaInternal::finalize() {
-  // skip if Kokkos::finalize() has already been called
-  if (!singleton().was_finalized) return;
-
   was_finalized = true;
   if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
     // Only finalize this if we're the singleton

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -663,6 +663,9 @@ void *CudaInternal::resize_team_scratch_space(std::int64_t bytes,
 //----------------------------------------------------------------------------
 
 void CudaInternal::finalize() {
+  // skip if Kokkos::finalize() has already been called
+  if (!singleton().was_finalized) return;
+
   was_finalized = true;
   if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
     // Only finalize this if we're the singleton

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -53,6 +53,7 @@
 #include <iosfwd>
 #include <typeinfo>
 #include <string>
+#include <memory>
 
 #include <Kokkos_HostSpace.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
@@ -279,6 +280,9 @@ namespace Kokkos {
 namespace Impl {
 
 cudaStream_t cuda_get_deep_copy_stream();
+
+const std::unique_ptr<Kokkos::Cuda>& cuda_get_deep_copy_space(
+    bool initialize = true);
 
 static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
                                               Kokkos::CudaSpace>::assignable,


### PR DESCRIPTION
Fixup for #3822
Creating a new execution space instance every time is inefficient.  I considered changing `get_cuda_space(...)` to `get_cuda_stream(...)` but it turns out`Kokkos::Impl::cuda_prefetch_pointer` also requires the device ID so the CUDA execution space instance seems like the right abstraction to pass.

I am proposing to cache the CUDA execution space instance constructed on the deep_copy stream.

https://github.com/kokkos/kokkos/blob/018721fb734c461bb41d2f5c99c49fe16c638894/core/src/Cuda/Kokkos_CudaSpace.cpp#L572-L591