### PR TITLE
Implement parallel_scan with ThreadVectorRange and Reducer

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -1033,7 +1033,7 @@ KOKKOS_INLINE_FUNCTION
     // This sets i's val to i-1's contribution
     // to make the latter in_place_shfl_up an
     // exclusive scan -- the final accumulation
-    // of i's val will be inclucded in the second
+    // of i's val will be included in the second
     // closure call later.
     if (i < loop_boundaries.end && threadIdx.x > 0) closure(i - 1, val, false);
 

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -1003,7 +1003,7 @@ KOKKOS_INLINE_FUNCTION
     // This sets i's val to i-1's contribution
     // to make the latter in_place_shfl_up an
     // exclusive scan -- the final accumulation
-    // of i's val will be inclucded in the second
+    // of i's val will be included in the second
     // closure call later.
     if (i < loop_boundaries.end && threadIdx.x > 0) closure(i - 1, val, false);
 

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -962,7 +962,7 @@ KOKKOS_INLINE_FUNCTION
 
 //----------------------------------------------------------------------------
 
-/** \brief  Intra-thread vector parallel exclusive prefix sum.
+/** \brief  Intra-thread vector parallel scan with reducer.
  *
  *  Executes closure(iType i, ValueType & val, bool final) for each i=[0..N)
  *
@@ -970,21 +970,20 @@ KOKKOS_INLINE_FUNCTION
  *  thread and a scan operation is performed.
  *  The last call to closure has final == true.
  */
-template <typename iType, class Closure>
-KOKKOS_INLINE_FUNCTION void parallel_scan(
-    const Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::HIPTeamMember>&
-        loop_boundaries,
-    const Closure& closure) {
+template <typename iType, class Closure, typename ReducerType>
+KOKKOS_INLINE_FUNCTION
+    typename std::enable_if<Kokkos::is_reducer<ReducerType>::value>::type
+    parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
+                      iType, Impl::HIPTeamMember>& loop_boundaries,
+                  const Closure& closure, const ReducerType& reducer) {
 #ifdef __HIP_DEVICE_COMPILE__
-  // Extract value_type from closure
-
-  using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure>::value_type;
+  using value_type = typename ReducerType::value_type;
+  value_type accum;
+  reducer.init(accum);
+  const value_type identity = accum;
 
   // Loop through boundaries by vector-length chunks
   // must scan at each iteration
-
-  value_type accum = 0;
 
   // All thread "lanes" must loop the same number of times.
   // Determine an loop end for all thread "lanes."
@@ -998,45 +997,70 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   const int end  = loop_boundaries.end + (rem ? blockDim.x - rem : 0);
 
   for (int i = threadIdx.x; i < end; i += blockDim.x) {
-    value_type val = 0;
+    value_type val = identity;
 
-    // First acquire per-lane contributions:
-    if (i < loop_boundaries.end) closure(i, val, false);
+    // First acquire per-lane contributions.
+    // This sets i's val to i-1's contribution
+    // to make the latter in_place_shfl_up an
+    // exclusive scan -- the final accumulation
+    // of i's val will be inclucded in the second
+    // closure call later.
+    if (i < loop_boundaries.end && threadIdx.x > 0) closure(i - 1, val, false);
 
-    value_type sval = val;
-
-    // Bottom up inclusive scan in triangular pattern
+    // Bottom up exclusive scan in triangular pattern
     // where each HIP thread is the root of a reduction tree
     // from the zeroth "lane" to itself.
     //  [t] += [t-1] if t >= 1
     //  [t] += [t-2] if t >= 2
     //  [t] += [t-4] if t >= 4
     //  ...
-
+    //  This differs from the non-reducer overload, where an inclusive scan was
+    //  implemented, because in general the binary operator cannot be inverted
+    //  and we would not be able to remove the inclusive contribution by
+    //  inversion.
     for (int j = 1; j < static_cast<int>(blockDim.x); j <<= 1) {
-      value_type tmp = 0;
-      ::Kokkos::Experimental::Impl::in_place_shfl_up(tmp, sval, j, blockDim.x);
+      value_type tmp = identity;
+      ::Kokkos::Experimental::Impl::in_place_shfl_up(tmp, val, j, blockDim.x);
       if (j <= static_cast<int>(threadIdx.x)) {
-        sval += tmp;
+        reducer.join(val, tmp);
       }
     }
 
-    // Include accumulation and remove value for exclusive scan:
-    val = accum + sval - val;
+    // Include accumulation
+    reducer.join(val, accum);
 
-    // Provide exclusive scan value:
+    // Update i's contribution into the val
+    // and add it to accum for next round
     if (i < loop_boundaries.end) closure(i, val, true);
-
-    // Accumulate the last value in the inclusive scan:
-    ::Kokkos::Experimental::Impl::in_place_shfl(sval, sval, blockDim.x - 1,
+    ::Kokkos::Experimental::Impl::in_place_shfl(accum, val, blockDim.x - 1,
                                                 blockDim.x);
-
-    accum += sval;
   }
 #else
   (void)loop_boundaries;
   (void)closure;
+  (void)reducer;
 #endif
+}
+
+//----------------------------------------------------------------------------
+
+/** \brief  Intra-thread vector parallel exclusive prefix sum.
+ *
+ *  Executes closure(iType i, ValueType & val, bool final) for each i=[0..N)
+ *
+ *  The range [0..N) is mapped to all vector lanes in the
+ *  thread and a scan operation is performed.
+ *  The last call to closure has final == true.
+ */
+template <typename iType, class Closure>
+KOKKOS_INLINE_FUNCTION void parallel_scan(
+    const Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::HIPTeamMember>&
+        loop_boundaries,
+    const Closure& closure) {
+  using value_type = typename Kokkos::Impl::FunctorAnalysis<
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure>::value_type;
+  value_type dummy;
+  parallel_scan(loop_boundaries, closure, Kokkos::Sum<value_type>(dummy));
 }
 
 }  // namespace Kokkos

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -2626,6 +2626,27 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   }
 }
 
+/** \brief  Intra-thread vector parallel scan with reducer
+ *
+ */
+template <typename iType, class FunctorType, typename ReducerType>
+KOKKOS_INLINE_FUNCTION
+    typename std::enable_if<Kokkos::is_reducer<ReducerType>::value>::type
+    parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
+                      iType, Impl::HPXTeamMember> &loop_boundaries,
+                  const FunctorType &lambda, const ReducerType &reducer) {
+  typename ReducerType::value_type scan_val;
+  reducer.init(scan_val);
+
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
+       i += loop_boundaries.increment) {
+    lambda(i, scan_val, true);
+  }
+}
+
 template <class FunctorType>
 KOKKOS_INLINE_FUNCTION void single(
     const Impl::VectorSingleStruct<Impl::HPXTeamMember> &,

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -1253,6 +1253,27 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   }
 }
 
+/** \brief  Intra-thread vector parallel scan with reducer
+ *
+ */
+template <typename iType, class FunctorType, typename ReducerType>
+KOKKOS_INLINE_FUNCTION
+    typename std::enable_if<Kokkos::is_reducer<ReducerType>::value>::type
+    parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
+                      iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
+                  const FunctorType& lambda, const ReducerType& reducer) {
+  typename ReducerType::value_type scan_val;
+  reducer.init(scan_val);
+
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
+       i += loop_boundaries.increment) {
+    lambda(i, scan_val, true);
+  }
+}
+
 }  // namespace Kokkos
 
 namespace Kokkos {

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -1253,27 +1253,6 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   }
 }
 
-/** \brief  Intra-thread vector parallel scan with reducer
- *
- */
-template <typename iType, class FunctorType, typename ReducerType>
-KOKKOS_INLINE_FUNCTION
-    typename std::enable_if<Kokkos::is_reducer<ReducerType>::value>::type
-    parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
-                      iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
-                  const FunctorType& lambda, const ReducerType& reducer) {
-  typename ReducerType::value_type scan_val;
-  reducer.init(scan_val);
-
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
-       i += loop_boundaries.increment) {
-    lambda(i, scan_val, true);
-  }
-}
-
 }  // namespace Kokkos
 
 namespace Kokkos {

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -1097,6 +1097,27 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   }
 }
 
+/** \brief  Intra-thread vector parallel scan with reducer
+ *
+ */
+template <typename iType, class FunctorType, typename ReducerType>
+KOKKOS_INLINE_FUNCTION
+    typename std::enable_if<Kokkos::is_reducer<ReducerType>::value>::type
+    parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
+                      iType, Impl::ThreadsExecTeamMember>& loop_boundaries,
+                  const FunctorType& lambda, const ReducerType& reducer) {
+  typename ReducerType::value_type scan_val;
+  reducer.init(scan_val);
+
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+  for (iType i = loop_boundaries.start; i < loop_boundaries.end;
+       i += loop_boundaries.increment) {
+    lambda(i, scan_val, true);
+  }
+}
+
 }  // namespace Kokkos
 
 namespace Kokkos {

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -864,87 +864,122 @@ class TestTripleNestedReduce {
 
 #endif
 
-template <typename ExecutionSpace, bool bInclusive, class Reducer>
-void checkScan() {
-  static constexpr int n = 1000000;
-  using size_type        = typename TEST_EXECSPACE::size_type;
-  using value_type       = typename Reducer::value_type;
+namespace VectorScanReducer {
+enum class ScanType : bool { Inclusive, Exclusive };
 
-  Kokkos::View<value_type[n], TEST_EXECSPACE> inputs("inputs");
-  Kokkos::parallel_for(
-      Kokkos::RangePolicy<TEST_EXECSPACE>(0, n),
-      KOKKOS_LAMBDA(size_type i) { inputs(i) = i * 1. / n; });
+template <typename ExecutionSpace, ScanType scan_type, class Reducer>
+struct checkScan {
+  static constexpr int n              = 1000000;
+  static constexpr int n_vector_range = 100;
+  const int n_team_thread_range       = 1000;
+  const int n_per_team                = n_team_thread_range * n_vector_range;
 
-  static constexpr int nTeamThreadRange   = 1e3;
-  static constexpr int nThreadVectorRange = 1e2;
-  static constexpr int nPerTeam = nTeamThreadRange * nThreadVectorRange;
-  static constexpr int nTeams   = n / nPerTeam;
+  using size_type  = typename ExecutionSpace::size_type;
+  using value_type = typename Reducer::value_type;
+  using view_type  = Kokkos::View<value_type[n], ExecutionSpace>;
+
+  view_type inputs  = view_type{"inputs"};
+  view_type outputs = view_type{"outputs"};
 
   value_type result;
-  Reducer reducer(result);
+  Reducer reducer = {result};
 
-  Kokkos::View<typename Reducer::value_type[n], ExecutionSpace> outputs(
-      "outputs");
-
-  // run ThreadVectorRange parallel_scan
-  Kokkos::TeamPolicy<ExecutionSpace> policy(nTeams, Kokkos::AUTO, Kokkos::AUTO);
-  const std::string label =
-      (bInclusive ? std::string("inclusive") : std::string("exclusive")) +
-      std::string("Scan") + std::string(typeid(Reducer).name());
-  Kokkos::parallel_for(
-      label, policy,
-      KOKKOS_LAMBDA(
-          const typename Kokkos::TeamPolicy<ExecutionSpace>::member_type
-              &team) {
-        const int iTeam       = team.league_rank();
-        const int iTeamOffset = iTeam * nPerTeam;
-        Kokkos::parallel_for(
-            Kokkos::TeamThreadRange(team, nTeamThreadRange), [&](const int i) {
-              const int iThreadOffset = i * nThreadVectorRange;
-              Kokkos::parallel_scan(
-                  Kokkos::ThreadVectorRange(team, nThreadVectorRange),
-                  [&](const int j, value_type &update, const bool bFinal) {
-                    const int iElement = j + iTeamOffset + iThreadOffset;
-                    const auto tmp     = inputs(iElement);
-                    if (bInclusive) {
-                      reducer.join(update, tmp);
-                      if (bFinal) {
-                        outputs(iElement) = update;
-                      }
-                    } else {
-                      if (bFinal) {
-                        outputs(iElement) = update;
-                      }
-                      reducer.join(update, tmp);
-                    }
-                  },
-                  reducer);
-            });
-      });
-  Kokkos::fence();
-
-  auto host_outputs =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, outputs);
-  auto host_inputs =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, inputs);
-
-  Kokkos::View<value_type[n], Kokkos::HostSpace> expected("expected");
-  {
-    value_type identity;
-    reducer.init(identity);
-    for (int i = 0; i < expected.extent_int(0); ++i) {
-      const int iVector      = i % nThreadVectorRange;
-      const value_type accum = iVector == 0 ? identity : expected(i - 1);
-      const value_type val =
-          bInclusive ? host_inputs(i)
-                     : (iVector == 0 ? identity : host_inputs(i - 1));
-      expected(i) = accum;
-      reducer.join(expected(i), val);
+  struct ThreadVectorFunctor {
+    KOKKOS_FUNCTION void operator()(const size_type j, value_type &update,
+                                    const bool final) const {
+      const size_type element = j + m_team_offset + m_thread_offset;
+      const auto tmp          = m_inputs(element);
+      if (scan_type == ScanType::Inclusive) {
+        m_reducer.join(update, tmp);
+        if (final) {
+          m_outputs(element) = update;
+        }
+      } else {
+        if (final) {
+          m_outputs(element) = update;
+        }
+        m_reducer.join(update, tmp);
+      }
     }
+
+    const Reducer &m_reducer;
+    const size_type &m_team_offset;
+    const size_type &m_thread_offset;
+    const view_type &m_outputs;
+    const view_type &m_inputs;
+  };
+
+  struct TeamThreadRangeFunctor {
+    KOKKOS_FUNCTION void operator()(const size_type i) const {
+      const size_type thread_offset = i * n_vector_range;
+      Kokkos::parallel_scan(
+          Kokkos::ThreadVectorRange(m_team, n_vector_range),
+          ThreadVectorFunctor{m_reducer, m_team_offset, thread_offset,
+                              m_outputs, m_inputs},
+          m_reducer);
+    }
+
+    const typename Kokkos::TeamPolicy<ExecutionSpace>::member_type &m_team;
+    const Reducer &m_reducer;
+    const size_type &m_team_offset;
+    const view_type &m_outputs;
+    const view_type &m_inputs;
+  };
+
+  KOKKOS_FUNCTION void operator()(
+      const typename Kokkos::TeamPolicy<ExecutionSpace>::member_type &team)
+      const {
+    const size_type iTeam       = team.league_rank();
+    const size_type iTeamOffset = iTeam * n_per_team;
+    Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(team, n_team_thread_range),
+        TeamThreadRangeFunctor{team, reducer, iTeamOffset, outputs, inputs});
   }
-  for (int i = 0; i < host_outputs.extent_int(0); ++i)
-    ASSERT_EQ(host_outputs(i), expected(i));
-}
+
+  KOKKOS_FUNCTION void operator()(size_type i) const { inputs(i) = i * 1. / n; }
+
+  void run() {
+    const int n_teams = n / n_per_team;
+
+    using size_type = typename TEST_EXECSPACE::size_type;
+
+    Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, n), *this);
+
+    // run ThreadVectorRange parallel_scan
+    Kokkos::TeamPolicy<ExecutionSpace> policy(n_teams, Kokkos::AUTO,
+                                              Kokkos::AUTO);
+    const std::string label =
+        (scan_type == ScanType::Inclusive ? std::string("inclusive")
+                                          : std::string("exclusive")) +
+        "Scan" + typeid(Reducer).name();
+    Kokkos::parallel_for(label, policy, *this);
+    Kokkos::fence();
+
+    auto host_outputs =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, outputs);
+    auto host_inputs =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, inputs);
+
+    Kokkos::View<value_type[n], Kokkos::HostSpace> expected("expected");
+    {
+      value_type identity;
+      reducer.init(identity);
+      for (int i = 0; i < expected.extent_int(0); ++i) {
+        const int vector       = i % n_vector_range;
+        const value_type accum = vector == 0 ? identity : expected(i - 1);
+        const value_type val =
+            scan_type == ScanType::Inclusive
+                ? host_inputs(i)
+                : (vector == 0 ? identity : host_inputs(i - 1));
+        expected(i) = accum;
+        reducer.join(expected(i), val);
+      }
+    }
+    for (int i = 0; i < host_outputs.extent_int(0); ++i)
+      ASSERT_EQ(host_outputs(i), expected(i));
+  }
+};
+}  // namespace VectorScanReducer
 
 #if !(defined(KOKKOS_IMPL_CUDA_CLANG_WORKAROUND) || defined(KOKKOS_ENABLE_HIP))
 TEST(TEST_CATEGORY, team_vector) {
@@ -983,19 +1018,30 @@ TEST(TEST_CATEGORY, triple_nested_parallelism) {
 }
 #endif
 
-#if (!defined(KOKKOS_ENABLE_CUDA)) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 TEST(TEST_CATEGORY, parallel_scan_with_reducers) {
   using T = double;
+  using namespace VectorScanReducer;
 
-  checkScan<TEST_EXECSPACE, false, Kokkos::Prod<T, TEST_EXECSPACE>>();
-  checkScan<TEST_EXECSPACE, true, Kokkos::Prod<T, TEST_EXECSPACE>>();
+  checkScan<TEST_EXECSPACE, ScanType::Exclusive,
+            Kokkos::Prod<T, TEST_EXECSPACE>>()
+      .run();
+  checkScan<TEST_EXECSPACE, ScanType::Inclusive,
+            Kokkos::Prod<T, TEST_EXECSPACE>>()
+      .run();
 
-  checkScan<TEST_EXECSPACE, false, Kokkos::Max<T, TEST_EXECSPACE>>();
-  checkScan<TEST_EXECSPACE, true, Kokkos::Max<T, TEST_EXECSPACE>>();
+  checkScan<TEST_EXECSPACE, ScanType::Exclusive,
+            Kokkos::Max<T, TEST_EXECSPACE>>()
+      .run();
+  checkScan<TEST_EXECSPACE, ScanType::Inclusive,
+            Kokkos::Max<T, TEST_EXECSPACE>>()
+      .run();
 
-  checkScan<TEST_EXECSPACE, false, Kokkos::Min<T, TEST_EXECSPACE>>();
-  checkScan<TEST_EXECSPACE, true, Kokkos::Min<T, TEST_EXECSPACE>>();
+  checkScan<TEST_EXECSPACE, ScanType::Exclusive,
+            Kokkos::Min<T, TEST_EXECSPACE>>()
+      .run();
+  checkScan<TEST_EXECSPACE, ScanType::Inclusive,
+            Kokkos::Min<T, TEST_EXECSPACE>>()
+      .run();
 }
-#endif
 
 }  // namespace Test

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -941,9 +941,7 @@ struct checkScan {
   void run() {
     const int n_teams = n / n_per_team;
 
-    using size_type = typename TEST_EXECSPACE::size_type;
-
-    Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, n), *this);
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, n), *this);
 
     // run ThreadVectorRange parallel_scan
     Kokkos::TeamPolicy<ExecutionSpace> policy(n_teams, Kokkos::AUTO,


### PR DESCRIPTION
A rebased version of #3602 also including a SYCL implementation and adding the test.