### PR TITLE
Remove Impl::enable_if_type

### DIFF
--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -262,7 +262,7 @@ template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
           int Rank, typename iType>
 struct ViewCopy;
 
-template <class Functor, class Policy, class Enable = void>
+template <class Functor, class Policy>
 struct FunctorPolicyExecutionSpace;
 
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -262,8 +262,7 @@ template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
           int Rank, typename iType>
 struct ViewCopy;
 
-template <class Functor, class Policy, class EnableFunctor = void,
-          class EnablePolicy = void>
+template <class Functor, class Policy, class Enable = void>
 struct FunctorPolicyExecutionSpace;
 
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -159,9 +159,8 @@ template <class FunctorType, class ArgTag, class Enable = void>
 struct FunctorDeclaresValueType : public std::false_type {};
 
 template <class FunctorType, class ArgTag>
-struct FunctorDeclaresValueType<
-    FunctorType, ArgTag,
-    typename Impl::enable_if_type<typename FunctorType::value_type>::type>
+struct FunctorDeclaresValueType<FunctorType, ArgTag,
+                                void_t<typename FunctorType::value_type>>
     : public std::true_type {};
 
 template <class FunctorType,

--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -148,13 +148,6 @@ namespace Kokkos {
 namespace Impl {
 
 //----------------------------------------------------------------------------
-
-template <class, class T = void>
-struct enable_if_type {
-  using type = T;
-};
-
-//----------------------------------------------------------------------------
 // if_
 
 template <bool Cond, typename TrueType, typename FalseType>

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -65,6 +65,14 @@ struct identity {
 template <typename T>
 using identity_t = typename identity<T>::type;
 
+#if defined(__cpp_lib_void_t)
+// since C++17
+using std::void_t;
+#else
+template <class...>
+using void_t = void;
+#endif
+
 //==============================================================================
 // <editor-fold desc="remove_cvref_t"> {{{1
 

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -65,6 +65,13 @@ struct identity {
 template <typename T>
 using identity_t = typename identity<T>::type;
 
+struct not_a_type {
+  not_a_type()                  = delete;
+  ~not_a_type()                 = delete;
+  not_a_type(not_a_type const&) = delete;
+  void operator=(not_a_type const&) = delete;
+};
+
 #if defined(__cpp_lib_void_t)
 // since C++17
 using std::void_t;

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3846,8 +3846,8 @@ template <class T, class Enable = void>
 struct has_printable_label_typedef : public std::false_type {};
 
 template <class T>
-struct has_printable_label_typedef<
-    T, typename enable_if_type<typename T::printable_label_typedef>::type>
+struct has_printable_label_typedef<T,
+                                   void_t<typename T::printable_label_typedef>>
     : public std::true_type {};
 
 template <class MapType>


### PR DESCRIPTION
Rational: You are probably wondering: "What is `enable_if_type` anyway?"  Well we were not using it much, I could not find it in any other packages in Trilinos, and part of its functionality is superseded by `std::void_t`.  I opted for removal and ended up rewriting `FunctorPolicyExecutionSpace`.

I know some of us would like to go further and add the detection idiom but let's not address this here.