### PR TITLE
Require C++17 for SYCL (at configuration time)

### DIFF
--- a/cmake/kokkos_enable_devices.cmake
+++ b/cmake/kokkos_enable_devices.cmake
@@ -154,5 +154,8 @@ KOKKOS_DEVICE_OPTION(SYCL OFF DEVICE "Whether to build SYCL backend")
 
 ## SYCL has extra setup requirements, turn on Kokkos_Setup_SYCL.hpp in macros
 IF (KOKKOS_ENABLE_SYCL)
+  IF(KOKKOS_CXX_STANDARD LESS 17)
+    MESSAGE(FATAL_ERROR "SYCL backend requires C++17 or newer!")
+  ENDIF()
   LIST(APPEND DEVICE_SETUP_LIST SYCL)
 ENDIF()


### PR DESCRIPTION
I was running into some issues when building apps without explicitly requesting C++17 support.