### PR TITLE
Reuse memory for SYCL parallel_reduce

### DIFF
--- a/core/src/Kokkos_SYCL_Space.hpp
+++ b/core/src/Kokkos_SYCL_Space.hpp
@@ -65,6 +65,7 @@ class SYCLDeviceUSMSpace {
   using size_type       = Impl::SYCLInternal::size_type;
 
   SYCLDeviceUSMSpace();
+  SYCLDeviceUSMSpace(sycl::queue queue);
 
   void* allocate(const std::size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
@@ -84,7 +85,7 @@ class SYCLDeviceUSMSpace {
   static constexpr const char* name() { return "SYCLDeviceUSM"; };
 
  private:
-  int m_device;
+  sycl::queue m_queue;
 };
 
 class SYCLSharedUSMSpace {
@@ -95,6 +96,7 @@ class SYCLSharedUSMSpace {
   using size_type       = Impl::SYCLInternal::size_type;
 
   SYCLSharedUSMSpace();
+  SYCLSharedUSMSpace(sycl::queue queue);
 
   void* allocate(const std::size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
@@ -114,7 +116,7 @@ class SYCLSharedUSMSpace {
   static constexpr const char* name() { return "SYCLSharedUSM"; };
 
  private:
-  int m_device;
+  sycl::queue m_queue;
 };
 }  // namespace Experimental
 

--- a/core/src/Kokkos_SYCL_Space.hpp
+++ b/core/src/Kokkos_SYCL_Space.hpp
@@ -65,7 +65,7 @@ class SYCLDeviceUSMSpace {
   using size_type       = Impl::SYCLInternal::size_type;
 
   SYCLDeviceUSMSpace();
-  SYCLDeviceUSMSpace(sycl::queue queue);
+  explicit SYCLDeviceUSMSpace(sycl::queue queue);
 
   void* allocate(const std::size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
@@ -96,7 +96,7 @@ class SYCLSharedUSMSpace {
   using size_type       = Impl::SYCLInternal::size_type;
 
   SYCLSharedUSMSpace();
-  SYCLSharedUSMSpace(sycl::queue queue);
+  explicit SYCLSharedUSMSpace(sycl::queue queue);
 
   void* allocate(const std::size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -139,7 +139,7 @@ void SYCLInternal::initialize(const sycl::queue& q) {
       using Record = Kokkos::Impl::SharedAllocationRecord<
           Kokkos::Experimental::SYCLDeviceUSMSpace, void>;
       Record* const r =
-          Record::allocate(Kokkos::Experimental::SYCLDeviceUSMSpace(),
+          Record::allocate(Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
                            "Kokkos::SYCL::InternalScratchBitset",
                            sizeof(uint32_t) * buffer_bound);
       Record::increment(r);

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -167,13 +167,18 @@ void SYCLInternal::initialize(const sycl::queue& q) {
 void SYCLInternal::finalize() {
   SYCL().fence();
   was_finalized = true;
-  if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
-    // FIXME_SYCL
-    std::abort();
-  }
 
-  using RecordSYCL =
-      Kokkos::Impl::SharedAllocationRecord<Experimental::SYCLDeviceUSMSpace>;
+  using RecordSYCL = Kokkos::Impl::SharedAllocationRecord<SYCLDeviceUSMSpace>;
+  if (nullptr != m_scratchSpace)
+    RecordSYCL::decrement(RecordSYCL::get_record(m_scratchSpace));
+  if (nullptr != m_scratchFlags)
+    RecordSYCL::decrement(RecordSYCL::get_record(m_scratchFlags));
+  m_syclDev           = -1;
+  m_scratchSpaceCount = 0;
+  m_scratchSpace      = nullptr;
+  m_scratchFlagsCount = 0;
+  m_scratchFlags      = nullptr;
+
   RecordSYCL::decrement(RecordSYCL::get_record(m_scratchConcurrentBitset));
   m_scratchConcurrentBitset = nullptr;
 
@@ -185,6 +190,60 @@ void SYCLInternal::finalize() {
     all_queues.erase(std::find(all_queues.begin(), all_queues.end(), &m_queue));
   }
   m_queue.reset();
+}
+
+void* SYCLInternal::scratch_space(
+    const Kokkos::Experimental::SYCL::size_type size) {
+  const size_type sizeScratchGrain =
+      sizeof(Kokkos::Experimental::SYCL::size_type);
+  if (verify_is_initialized("scratch_space") &&
+      m_scratchSpaceCount * sizeScratchGrain < size) {
+    m_scratchSpaceCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
+
+    using Record = Kokkos::Impl::SharedAllocationRecord<
+        Kokkos::Experimental::SYCLDeviceUSMSpace, void>;
+
+    if (nullptr != m_scratchSpace)
+      Record::decrement(Record::get_record(m_scratchSpace));
+
+    Record* const r = Record::allocate(
+        Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
+        "InternalScratchSpace", (sizeScratchGrain * m_scratchSpaceCount));
+
+    Record::increment(r);
+
+    m_scratchSpace = reinterpret_cast<size_type*>(r->data());
+  }
+
+  return m_scratchSpace;
+}
+
+void* SYCLInternal::scratch_flags(
+    const Kokkos::Experimental::SYCL::size_type size) {
+  const size_type sizeScratchGrain =
+      sizeof(Kokkos::Experimental::SYCL::size_type);
+  if (verify_is_initialized("scratch_flags") &&
+      m_scratchFlagsCount * sizeScratchGrain < size) {
+    m_scratchFlagsCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
+
+    using Record = Kokkos::Impl::SharedAllocationRecord<
+        Kokkos::Experimental::SYCLDeviceUSMSpace, void>;
+
+    if (nullptr != m_scratchFlags)
+      Record::decrement(Record::get_record(m_scratchFlags));
+
+    Record* const r = Record::allocate(
+        Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
+        "InternalScratchFlags", (sizeScratchGrain * m_scratchFlagsCount));
+
+    Record::increment(r);
+
+    m_scratchFlags = reinterpret_cast<size_type*>(r->data());
+  }
+  m_queue->memset(m_scratchFlags, 0, m_scratchFlagsCount * sizeScratchGrain);
+  fence(*m_queue);
+
+  return m_scratchFlags;
 }
 
 }  // namespace Impl

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -206,9 +206,10 @@ void* SYCLInternal::scratch_space(
     if (nullptr != m_scratchSpace)
       Record::decrement(Record::get_record(m_scratchSpace));
 
-    Record* const r = Record::allocate(
-        Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
-        "InternalScratchSpace", (sizeScratchGrain * m_scratchSpaceCount));
+    Record* const r =
+        Record::allocate(Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
+                         "Kokkos::InternalScratchSpace",
+                         (sizeScratchGrain * m_scratchSpaceCount));
 
     Record::increment(r);
 
@@ -232,9 +233,10 @@ void* SYCLInternal::scratch_flags(
     if (nullptr != m_scratchFlags)
       Record::decrement(Record::get_record(m_scratchFlags));
 
-    Record* const r = Record::allocate(
-        Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
-        "InternalScratchFlags", (sizeScratchGrain * m_scratchFlagsCount));
+    Record* const r =
+        Record::allocate(Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
+                         "Kokkos::InternalScratchFlags",
+                         (sizeScratchGrain * m_scratchFlagsCount));
 
     Record::increment(r);
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -66,6 +66,9 @@ class SYCLInternal {
   SYCLInternal& operator=(SYCLInternal&&) = delete;
   SYCLInternal(SYCLInternal&&)            = delete;
 
+  void* scratch_space(const size_type size);
+  void* scratch_flags(const size_type size);
+
   int m_syclDev = -1;
 
   size_t m_maxWorkgroupSize   = 0;
@@ -73,7 +76,9 @@ class SYCLInternal {
   uint64_t m_maxShmemPerBlock = 0;
 
   uint32_t* m_scratchConcurrentBitset = nullptr;
+  size_type m_scratchSpaceCount       = 0;
   size_type* m_scratchSpace           = nullptr;
+  size_type m_scratchFlagsCount       = 0;
   size_type* m_scratchFlags           = nullptr;
 
   std::optional<sycl::queue> m_queue;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -121,11 +121,12 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     const unsigned int value_count =
         FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>::value_count(
             selected_reducer);
-    const auto results_ptr = static_cast<pointer_type>(sycl::malloc_shared(
-        sizeof(value_type) * std::max(value_count, 1u) * init_size, q));
+    // FIXME_SYCL only use the first half
+    const auto results_ptr = static_cast<pointer_type>(instance.scratch_space(
+        sizeof(value_type) * std::max(value_count, 1u) * init_size * 2));
     // FIXME_SYCL without this we are running into a race condition
-    const auto results_ptr2 = static_cast<pointer_type>(sycl::malloc_shared(
-        sizeof(value_type) * std::max(value_count, 1u) * init_size, q));
+    const auto results_ptr2 =
+        results_ptr + std::max(value_count, 1u) * init_size;
 
     // If size<=1 we only call init(), the functor and possibly final once
     // working with the global scratch memory but don't copy back to
@@ -274,8 +275,6 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
           sizeof(*m_result_ptr) * value_count);
       space.fence();
     }
-
-    sycl::free(results_ptr, q);
   }
 
  public:
@@ -397,11 +396,12 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     const unsigned int value_count =
         FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>::value_count(
             selected_reducer);
-    const auto results_ptr = static_cast<pointer_type>(sycl::malloc_shared(
-        sizeof(value_type) * std::max(value_count, 1u) * init_size, q));
+    // FIXME_SYCL only use the first half
+    const auto results_ptr = static_cast<pointer_type>(instance.scratch_space(
+        sizeof(value_type) * std::max(value_count, 1u) * init_size * 2));
     // FIXME_SYCL without this we are running into a race condition
-    const auto results_ptr2 = static_cast<pointer_type>(sycl::malloc_shared(
-        sizeof(value_type) * std::max(value_count, 1u) * init_size, q));
+    const auto results_ptr2 =
+        results_ptr + std::max(value_count, 1u) * init_size;
 
     // If size<=1 we only call init(), the functor and possibly final once
     // working with the global scratch memory but don't copy back to
@@ -554,9 +554,6 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           sizeof(*m_result_ptr) * value_count);
       m_space.fence();
     }
-
-    sycl::free(results_ptr, q);
-    sycl::free(results_ptr2, q);
   }
 
  public:

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -560,16 +560,12 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     const unsigned int value_count =
         FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>::value_count(
             selected_reducer);
-    auto deleter = [&q](pointer_type ptr) { sycl::free(ptr, q); };
-    std::unique_ptr<value_type, decltype(deleter)> results_ptr(
-        static_cast<pointer_type>(sycl::malloc_shared(
-            sizeof(value_type) * std::max(value_count, 1u) * init_size, q)),
-        deleter);
+    // FIXME_SYCL only use the first half
+    const auto results_ptr = static_cast<pointer_type>(instance.scratch_space(
+        sizeof(value_type) * std::max(value_count, 1u) * init_size * 2));
     // FIXME_SYCL without this we are running into a race condition
-    std::unique_ptr<value_type, decltype(deleter)> results_ptr2(
-        static_cast<pointer_type>(sycl::malloc_shared(
-            sizeof(value_type) * std::max(value_count, 1u) * init_size, q)),
-        deleter);
+    const auto results_ptr2 =
+        results_ptr + std::max(value_count, 1u) * init_size;
 
     // If size<=1 we only call init(), the functor and possibly final once
     // working with the global scratch memory but don't copy back to
@@ -588,7 +584,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         const auto shmem_begin     = m_shmem_begin;
         const int scratch_size[2]  = {m_scratch_size[0], m_scratch_size[1]};
         void* const scratch_ptr[2] = {m_scratch_ptr[0], m_scratch_ptr[1]};
-        auto* local_results_ptr    = results_ptr.get();
 
         cgh.parallel_for(
             sycl::nd_range<2>(sycl::range<2>(1, 1), sycl::range<2>(1, 1)),
@@ -597,7 +592,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   static_cast<const FunctorType&>(functor),
                   static_cast<const ReducerType&>(reducer));
               reference_type update =
-                  ValueInit::init(selected_reducer, local_results_ptr);
+                  ValueInit::init(selected_reducer, results_ptr);
               if (size == 1) {
                 const member_type team_member(
                     team_scratch_memory_L0.get_pointer(), shmem_begin,
@@ -610,8 +605,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
               }
               if constexpr (ReduceFunctorHasFinal<FunctorType>::value)
                 FunctorFinal<FunctorType, WorkTag>::final(
-                    static_cast<const FunctorType&>(functor),
-                    local_results_ptr);
+                    static_cast<const FunctorType&>(functor), results_ptr);
             });
       });
       space.fence();
@@ -641,8 +635,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         const auto shmem_begin     = m_shmem_begin;
         const int scratch_size[2]  = {m_scratch_size[0], m_scratch_size[1]};
         void* const scratch_ptr[2] = {m_scratch_ptr[0], m_scratch_ptr[1]};
-        auto* local_results_ptr    = results_ptr.get();
-        auto* local_results_ptr2   = results_ptr2.get();
 
         cgh.parallel_for(
             sycl::nd_range<2>(
@@ -681,7 +673,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                   &local_mem[local_id * value_count]);
                 else {
                   ValueOps::copy(functor, &local_mem[local_id * value_count],
-                                 &local_results_ptr[global_id * value_count]);
+                                 &results_ptr[global_id * value_count]);
                 }
               }
               item.barrier(sycl::access::fence_space::local_space);
@@ -710,15 +702,14 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
               if (local_id == 0) {
                 ValueOps::copy(
                     functor,
-                    &local_results_ptr2[(item.get_group_linear_id()) *
-                                        value_count],
+                    &results_ptr2[(item.get_group_linear_id()) * value_count],
                     &local_mem[0]);
                 if constexpr (ReduceFunctorHasFinal<FunctorType>::value)
                   if (n_wgroups <= 1 && item.get_group_linear_id() == 0) {
                     FunctorFinal<FunctorType, WorkTag>::final(
                         static_cast<const FunctorType&>(functor),
-                        &local_results_ptr2[(item.get_group_linear_id()) *
-                                            value_count]);
+                        &results_ptr2[(item.get_group_linear_id()) *
+                                      value_count]);
                   }
               }
             });
@@ -728,7 +719,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       // FIXME_SYCL this is likely not necessary, see above
       Kokkos::Impl::DeepCopy<Kokkos::Experimental::SYCLDeviceUSMSpace,
                              Kokkos::Experimental::SYCLDeviceUSMSpace>(
-          space, results_ptr.get(), results_ptr2.get(),
+          space, results_ptr, results_ptr2,
           sizeof(*m_result_ptr) * value_count * n_wgroups);
       space.fence();
 
@@ -742,7 +733,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     if (m_result_ptr) {
       Kokkos::Impl::DeepCopy<Kokkos::Experimental::SYCLDeviceUSMSpace,
                              Kokkos::Experimental::SYCLDeviceUSMSpace>(
-          space, m_result_ptr, results_ptr.get(),
+          space, m_result_ptr, results_ptr,
           sizeof(*m_result_ptr) * value_count);
       space.fence();
     }

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -127,11 +127,13 @@ namespace Experimental {
 
 SYCLDeviceUSMSpace::SYCLDeviceUSMSpace()
     : m_queue(*SYCL().impl_internal_space_instance()->m_queue) {}
-SYCLDeviceUSMSpace::SYCLDeviceUSMSpace(sycl::queue queue) : m_queue(queue) {}
+SYCLDeviceUSMSpace::SYCLDeviceUSMSpace(sycl::queue queue)
+    : m_queue(std::move(queue)) {}
 
 SYCLSharedUSMSpace::SYCLSharedUSMSpace()
     : m_queue(*SYCL().impl_internal_space_instance()->m_queue) {}
-SYCLSharedUSMSpace::SYCLSharedUSMSpace(sycl::queue queue) : m_queue(queue) {}
+SYCLSharedUSMSpace::SYCLSharedUSMSpace(sycl::queue queue)
+    : m_queue(std::move(queue)) {}
 
 void* allocate_sycl(
     const char* arg_label, const size_t arg_alloc_size,

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -125,16 +125,19 @@ DeepCopy<Kokkos::Experimental::SYCLDeviceUSMSpace, Kokkos::HostSpace,
 namespace Kokkos {
 namespace Experimental {
 
-SYCLDeviceUSMSpace::SYCLDeviceUSMSpace() : m_device(SYCL().sycl_device()) {}
+SYCLDeviceUSMSpace::SYCLDeviceUSMSpace()
+    : m_queue(*SYCL().impl_internal_space_instance()->m_queue) {}
+SYCLDeviceUSMSpace::SYCLDeviceUSMSpace(sycl::queue queue) : m_queue(queue) {}
 
-SYCLSharedUSMSpace::SYCLSharedUSMSpace() : m_device(SYCL().sycl_device()) {}
+SYCLSharedUSMSpace::SYCLSharedUSMSpace()
+    : m_queue(*SYCL().impl_internal_space_instance()->m_queue) {}
+SYCLSharedUSMSpace::SYCLSharedUSMSpace(sycl::queue queue) : m_queue(queue) {}
 
 void* allocate_sycl(
     const char* arg_label, const size_t arg_alloc_size,
     const size_t arg_logical_size, const Kokkos::Tools::SpaceHandle arg_handle,
     const RawMemoryAllocationFailure::AllocationMechanism failure_tag,
-    const sycl::usm::alloc allocation_kind) {
-  const sycl::queue& queue = *SYCL().impl_internal_space_instance()->m_queue;
+    const sycl::usm::alloc allocation_kind, const sycl::queue& queue) {
   void* const hostPtr = sycl::malloc(arg_alloc_size, queue, allocation_kind);
 
   if (hostPtr == nullptr)
@@ -163,7 +166,7 @@ void* SYCLDeviceUSMSpace::allocate(const char* arg_label,
       arg_label, arg_alloc_size, arg_logical_size,
       Kokkos::Tools::make_space_handle(name()),
       RawMemoryAllocationFailure::AllocationMechanism::SYCLMallocDevice,
-      sycl::usm::alloc::device);
+      sycl::usm::alloc::device, m_queue);
 }
 
 void* SYCLSharedUSMSpace::allocate(const size_t arg_alloc_size) const {
@@ -176,19 +179,20 @@ void* SYCLSharedUSMSpace::allocate(const char* arg_label,
       arg_label, arg_alloc_size, arg_logical_size,
       Kokkos::Tools::make_space_handle(name()),
       RawMemoryAllocationFailure::AllocationMechanism::SYCLMallocShared,
-      sycl::usm::alloc::shared);
+      sycl::usm::alloc::shared, m_queue);
 }
 
 void sycl_deallocate(const char* arg_label, void* const arg_alloc_ptr,
                      const size_t arg_alloc_size, const size_t arg_logical_size,
-                     const Kokkos::Tools::SpaceHandle arg_handle) {
+                     const Kokkos::Tools::SpaceHandle arg_handle,
+                     const sycl::queue& queue) {
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     const size_t reported_size =
         (arg_logical_size > 0) ? arg_logical_size : arg_alloc_size;
     Kokkos::Profiling::deallocateData(arg_handle, arg_label, arg_alloc_ptr,
                                       reported_size);
   }
-  const sycl::queue& queue = *SYCL().impl_internal_space_instance()->m_queue;
+
   sycl::free(arg_alloc_ptr, queue);
 }
 
@@ -201,7 +205,7 @@ void SYCLDeviceUSMSpace::deallocate(const char* arg_label,
                                     const size_t arg_alloc_size,
                                     const size_t arg_logical_size) const {
   sycl_deallocate(arg_label, arg_alloc_ptr, arg_alloc_size, arg_logical_size,
-                  Kokkos::Tools::make_space_handle(name()));
+                  Kokkos::Tools::make_space_handle(name()), m_queue);
 }
 
 void SYCLSharedUSMSpace::deallocate(void* const arg_alloc_ptr,
@@ -214,7 +218,7 @@ void SYCLSharedUSMSpace::deallocate(const char* arg_label,
                                     const size_t arg_alloc_size,
                                     const size_t arg_logical_size) const {
   sycl_deallocate(arg_label, arg_alloc_ptr, arg_alloc_size, arg_logical_size,
-                  Kokkos::Tools::make_space_handle(name()));
+                  Kokkos::Tools::make_space_handle(name()), m_queue);
 }
 
 }  // namespace Experimental


### PR DESCRIPTION
Before this pull request, we allocated memory for all the SYCL `parallel_reduce` implementations every time anew which is wasteful. Introducing `scratch_space/scratch_flags`, the memory is now reused.