### PR TITLE
Fix compiling SYCL with OpenMP

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -49,7 +49,7 @@
 #if defined(KOKKOS_ENABLE_OPENMP)
 
 #if !defined(_OPENMP) && !defined(__CUDA_ARCH__) && \
-    !defined(__HIP_DEVICE_COMPILE__)
+    !defined(__HIP_DEVICE_COMPILE__) && !defined(__SYCL_DEVICE_ONLY__)
 #error \
     "You enabled Kokkos OpenMP support without enabling OpenMP in the compiler!"
 #endif

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -44,6 +44,7 @@
 
 #include <Kokkos_Concepts.hpp>
 #include <SYCL/Kokkos_SYCL_Instance.hpp>
+#include <KokkosCore_Config_DeclareBackend.hpp>
 #include <Kokkos_SYCL.hpp>
 #include <Kokkos_HostSpace.hpp>
 #include <Kokkos_Serial.hpp>

--- a/core/src/impl/Kokkos_Memory_Fence.hpp
+++ b/core/src/impl/Kokkos_Memory_Fence.hpp
@@ -45,6 +45,7 @@
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ATOMIC_HPP) && !defined(KOKKOS_MEMORY_FENCE_HPP)
 #define KOKKOS_MEMORY_FENCE_HPP
+
 namespace Kokkos {
 
 //----------------------------------------------------------------------------
@@ -57,7 +58,7 @@ void memory_fence() {
 #pragma omp flush
 #elif defined(__HIP_DEVICE_COMPILE__)
   __threadfence();
-#elif defined(__SYCL_DEVICE_ONLY__)
+#elif defined(KOKKOS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__)
   sycl::ONEAPI::atomic_fence(sycl::ONEAPI::memory_order::acq_rel,
                              sycl::ONEAPI::memory_scope::device);
 #elif defined(KOKKOS_ENABLE_ASM) && defined(KOKKOS_ENABLE_ISA_X86_64)

--- a/core/src/impl/Kokkos_Memory_Fence.hpp
+++ b/core/src/impl/Kokkos_Memory_Fence.hpp
@@ -45,7 +45,6 @@
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ATOMIC_HPP) && !defined(KOKKOS_MEMORY_FENCE_HPP)
 #define KOKKOS_MEMORY_FENCE_HPP
-
 namespace Kokkos {
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Apparently, some of the compilers still also do a `device` pass even when only activating `OpenMP`. I checked that with this pull request I could run the tests with `OpenMP` alone and with `OpenMP` and `SYCL`. AFAICT, the `SYCL` CI doesn't support `OpenMP` as of now, though.