### PR TITLE
Replace most uses of `if_c`

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -389,17 +389,17 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   ///   typename dual_view_type::t_host hostView = DV.view<host_device_type> ();
   /// \endcode
   template <class Device>
-  KOKKOS_INLINE_FUNCTION const typename Impl::if_c<
+  KOKKOS_INLINE_FUNCTION const typename std::conditional_t<
       impl_device_matches_tdev_device<Device>::value, t_dev,
-      typename Impl::if_c<
+      typename std::conditional_t<
           impl_device_matches_thost_device<Device>::value, t_host,
-          typename Impl::if_c<
+          typename std::conditional_t<
               impl_device_matches_thost_exec<Device>::value, t_host,
-              typename Impl::if_c<
+              typename std::conditional_t<
                   impl_device_matches_tdev_exec<Device>::value, t_dev,
-                  typename Impl::if_c<
+                  typename std::conditional_t<
                       impl_device_matches_tdev_memory_space<Device>::value,
-                      t_dev, t_host>::type>::type>::type>::type>::type
+                      t_dev, t_host> > > > >
   view() const {
     constexpr bool device_is_memspace =
         std::is_same<Device, typename Device::memory_space>::value;

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -1421,21 +1421,21 @@ template <typename Op          = Kokkos::Experimental::ScatterSum,
 ScatterView<
     RT, typename ViewTraits<RT, RP...>::array_layout,
     typename ViewTraits<RT, RP...>::device_type, Op,
-    typename Kokkos::Impl::if_c<
+    std::conditional_t<
         std::is_same<Duplication, void>::value,
         typename Kokkos::Impl::Experimental::DefaultDuplication<
             typename ViewTraits<RT, RP...>::execution_space>::type,
-        Duplication>::type,
-    typename Kokkos::Impl::if_c<
+        Duplication>,
+    std::conditional_t<
         std::is_same<Contribution, void>::value,
         typename Kokkos::Impl::Experimental::DefaultContribution<
             typename ViewTraits<RT, RP...>::execution_space,
-            typename Kokkos::Impl::if_c<
+            typename std::conditional_t<
                 std::is_same<Duplication, void>::value,
                 typename Kokkos::Impl::Experimental::DefaultDuplication<
                     typename ViewTraits<RT, RP...>::execution_space>::type,
-                Duplication>::type>::type,
-        Contribution>::type>
+                Duplication>>::type,
+        Contribution>>
 create_scatter_view(View<RT, RP...> const& original_view) {
   return original_view;  // implicit ScatterView constructor call
 }

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -264,26 +264,24 @@ class UnorderedMap {
  private:
   enum : size_type { invalid_index = ~static_cast<size_type>(0) };
 
-  using impl_value_type =
-      typename Impl::if_c<is_set, int, declared_value_type>::type;
+  using impl_value_type = std::conditional_t<is_set, int, declared_value_type>;
 
-  using key_type_view = typename Impl::if_c<
+  using key_type_view = std::conditional_t<
       is_insertable_map, View<key_type *, device_type>,
-      View<const key_type *, device_type, MemoryTraits<RandomAccess> > >::type;
+      View<const key_type *, device_type, MemoryTraits<RandomAccess> > >;
 
-  using value_type_view =
-      typename Impl::if_c<is_insertable_map || is_modifiable_map,
-                          View<impl_value_type *, device_type>,
-                          View<const impl_value_type *, device_type,
-                               MemoryTraits<RandomAccess> > >::type;
+  using value_type_view = std::conditional_t<
+      is_insertable_map || is_modifiable_map,
+      View<impl_value_type *, device_type>,
+      View<const impl_value_type *, device_type, MemoryTraits<RandomAccess> > >;
 
-  using size_type_view = typename Impl::if_c<
+  using size_type_view = std::conditional_t<
       is_insertable_map, View<size_type *, device_type>,
-      View<const size_type *, device_type, MemoryTraits<RandomAccess> > >::type;
+      View<const size_type *, device_type, MemoryTraits<RandomAccess> > >;
 
   using bitset_type =
-      typename Impl::if_c<is_insertable_map, Bitset<execution_space>,
-                          ConstBitset<execution_space> >::type;
+      std::conditional_t<is_insertable_map, Bitset<execution_space>,
+                         ConstBitset<execution_space> >;
 
   enum { modified_idx = 0, erasable_idx = 1, failed_insert_idx = 2 };
   enum { num_scalars = 3 };
@@ -656,8 +654,8 @@ class UnorderedMap {
   ///
   /// 'const value_type' via Cuda texture fetch must return by value.
   KOKKOS_FORCEINLINE_FUNCTION
-  typename Impl::if_c<(is_set || has_const_value), impl_value_type,
-                      impl_value_type &>::type
+  std::conditional_t<(is_set || has_const_value), impl_value_type,
+                     impl_value_type &>
   value_at(size_type i) const {
     return m_values[is_set ? 0 : (i < capacity() ? i : capacity())];
   }

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -744,8 +744,8 @@ struct ParallelReduceReturnValue<
   using value_type_scalar = typename return_type::value_type;
   using value_type_array  = typename return_type::value_type* const;
 
-  using value_type = typename if_c<return_type::rank == 0, value_type_scalar,
-                                   value_type_array>::type;
+  using value_type = std::conditional_t<return_type::rank == 0,
+                                        value_type_scalar, value_type_array>;
 
   static return_type& return_value(ReturnType& return_val, const FunctorType&) {
     return return_val;
@@ -1109,10 +1109,9 @@ inline void parallel_reduce(
         Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* =
         nullptr) {
   using ValueTraits = Kokkos::Impl::FunctorValueTraits<FunctorType, void>;
-  using value_type =
-      typename Kokkos::Impl::if_c<(ValueTraits::StaticValueSize != 0),
-                                  typename ValueTraits::value_type,
-                                  typename ValueTraits::pointer_type>::type;
+  using value_type  = std::conditional_t<(ValueTraits::StaticValueSize != 0),
+                                        typename ValueTraits::value_type,
+                                        typename ValueTraits::pointer_type>;
 
   static_assert(
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
@@ -1135,10 +1134,9 @@ inline void parallel_reduce(
         Kokkos::Impl::is_execution_policy<PolicyType>::value>::type* =
         nullptr) {
   using ValueTraits = Kokkos::Impl::FunctorValueTraits<FunctorType, void>;
-  using value_type =
-      typename Kokkos::Impl::if_c<(ValueTraits::StaticValueSize != 0),
-                                  typename ValueTraits::value_type,
-                                  typename ValueTraits::pointer_type>::type;
+  using value_type  = std::conditional_t<(ValueTraits::StaticValueSize != 0),
+                                        typename ValueTraits::value_type,
+                                        typename ValueTraits::pointer_type>;
 
   static_assert(
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
@@ -1160,10 +1158,9 @@ inline void parallel_reduce(const size_t& policy, const FunctorType& functor) {
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
   using ValueTraits = Kokkos::Impl::FunctorValueTraits<FunctorType, void>;
-  using value_type =
-      typename Kokkos::Impl::if_c<(ValueTraits::StaticValueSize != 0),
-                                  typename ValueTraits::value_type,
-                                  typename ValueTraits::pointer_type>::type;
+  using value_type  = std::conditional_t<(ValueTraits::StaticValueSize != 0),
+                                        typename ValueTraits::value_type,
+                                        typename ValueTraits::pointer_type>;
 
   static_assert(
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
@@ -1188,10 +1185,9 @@ inline void parallel_reduce(const std::string& label, const size_t& policy,
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
   using ValueTraits = Kokkos::Impl::FunctorValueTraits<FunctorType, void>;
-  using value_type =
-      typename Kokkos::Impl::if_c<(ValueTraits::StaticValueSize != 0),
-                                  typename ValueTraits::value_type,
-                                  typename ValueTraits::pointer_type>::type;
+  using value_type  = std::conditional_t<(ValueTraits::StaticValueSize != 0),
+                                        typename ValueTraits::value_type,
+                                        typename ValueTraits::pointer_type>;
 
   static_assert(
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -466,8 +466,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
   using ReducerTypeFwd = typename ReducerConditional::type;
   using WorkTagFwd =
-      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
+                         void>;
 
   using Analysis =
       FunctorAnalysis<FunctorPatternInterface::REDUCE, Policy, FunctorType>;
@@ -751,8 +751,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                          FunctorType, ReducerType>;
   using ReducerTypeFwd = typename ReducerConditional::type;
   using WorkTagFwd =
-      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
+                         void>;
 
   using Analysis = FunctorAnalysis<FunctorPatternInterface::REDUCE,
                                    MDRangePolicy, FunctorType>;
@@ -932,8 +932,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                          FunctorType, ReducerType>;
   using ReducerTypeFwd = typename ReducerConditional::type;
   using WorkTagFwd =
-      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
+                         void>;
 
   using ValueInit = Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd>;
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -266,8 +266,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                          FunctorType, ReducerType>;
   using ReducerTypeFwd = typename ReducerConditional::type;
   using WorkTagFwd =
-      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
+                         void>;
 
   // Static Assert WorkTag void if ReducerType not InvalidType
 
@@ -439,8 +439,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                          FunctorType, ReducerType>;
   using ReducerTypeFwd = typename ReducerConditional::type;
   using WorkTagFwd =
-      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
+                         void>;
 
   using ValueInit = Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd>;
   using ValueJoin = Kokkos::Impl::FunctorValueJoin<ReducerTypeFwd, WorkTagFwd>;
@@ -981,8 +981,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
   using ReducerTypeFwd = typename ReducerConditional::type;
   using WorkTagFwd =
-      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
+                         void>;
 
   using ValueInit = Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd>;
   using ValueJoin = Kokkos::Impl::FunctorValueJoin<ReducerTypeFwd, WorkTagFwd>;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -623,8 +623,8 @@ class OpenMPTargetExecTeamMember {
         { }
     #else
         // Make sure there is enough scratch space:
-        using type  = typename if_c< sizeof(ValueType) < TEAM_REDUCE_SIZE
-                             , ValueType , void >::type;
+        using type  = std::conditional_t< sizeof(ValueType) < TEAM_REDUCE_SIZE
+                             , ValueType , void >;
 
         type * const local_value = ((type*) m_exec.scratch_thread());
         if(team_rank() == thread_id)
@@ -644,8 +644,8 @@ class OpenMPTargetExecTeamMember {
     const JoinLambdaAdapter<value_type, JoinOp> op(op_in);
 
     // Make sure there is enough scratch space:
-    using type = typename if_c<sizeof(value_type) < TEAM_REDUCE_SIZE,
-                               value_type, void>::type;
+    using type = std::conditional_t<(sizeof(value_type) < TEAM_REDUCE_SIZE),
+                                    value_type, void>;
 
     const int n_values = TEAM_REDUCE_SIZE / sizeof(value_type);
     type* team_scratch =
@@ -685,7 +685,7 @@ class OpenMPTargetExecTeamMember {
     // FIXME_OPENMPTARGET
     /*  // Make sure there is enough scratch space:
       using type =
-        typename if_c<sizeof(ArgType) < TEAM_REDUCE_SIZE, ArgType, void>::type;
+        std::conditional_t<(sizeof(ArgType) < TEAM_REDUCE_SIZE), ArgType, void>;
 
       volatile type * const work_value  = ((type*) m_exec.scratch_thread());
 

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -286,8 +286,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                          FunctorType, ReducerType>;
   using ReducerTypeFwd = typename ReducerConditional::type;
   using WorkTagFwd =
-      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
+                         void>;
 
   // Static Assert WorkTag void if ReducerType not InvalidType
 
@@ -979,8 +979,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                          FunctorType, ReducerType>;
   using ReducerTypeFwd = typename ReducerConditional::type;
   using WorkTagFwd =
-      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
+                         void>;
 
   using ValueTraits =
       Kokkos::Impl::FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>;

--- a/core/src/impl/Kokkos_Atomic_Exchange.hpp
+++ b/core/src/impl/Kokkos_Atomic_Exchange.hpp
@@ -191,8 +191,7 @@ inline T atomic_exchange(volatile T* const dest,
                          typename std::enable_if<sizeof(T) == sizeof(int) ||
                                                      sizeof(T) == sizeof(long),
                                                  const T&>::type val) {
-  using type =
-      typename Kokkos::Impl::if_c<sizeof(T) == sizeof(int), int, long>::type;
+  using type = std::conditional_t<sizeof(T) == sizeof(int), int, long>;
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);
 #endif
@@ -285,8 +284,7 @@ inline void atomic_assign(volatile T* const dest,
                           typename std::enable_if<sizeof(T) == sizeof(int) ||
                                                       sizeof(T) == sizeof(long),
                                                   const T&>::type val) {
-  using type =
-      typename Kokkos::Impl::if_c<sizeof(T) == sizeof(int), int, long>::type;
+  using type = std::conditional_t<sizeof(T) == sizeof(int), int, long>;
 
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);

--- a/core/src/impl/Kokkos_FunctorAdapter.hpp
+++ b/core/src/impl/Kokkos_FunctorAdapter.hpp
@@ -248,8 +248,7 @@ struct FunctorValueTraits<FunctorType, ArgTag,
   // The reference_type for an array is 'value_type *'
   // The reference_type for a single value is 'value_type &'
 
-  using reference_type =
-      typename Impl::if_c<IsArray, value_type*, value_type&>::type;
+  using reference_type = std::conditional_t<IsArray, value_type*, value_type&>;
 
   // Number of values if single value
   template <class F>
@@ -287,8 +286,8 @@ struct FunctorValueTraits<FunctorType, ArgTag,
   struct REJECTTAG {
   };  // Reject tagged operator() when using non-tagged execution policy.
 
-  using tag_type = typename Impl::if_c<std::is_same<ArgTag, void>::value,
-                                       VOIDTAG, ArgTag>::type;
+  using tag_type =
+      std::conditional_t<std::is_same<ArgTag, void>::value, VOIDTAG, ArgTag>;
 
   //----------------------------------------
   // parallel_for operator without a tag:
@@ -1329,12 +1328,11 @@ struct FunctorValueTraits<FunctorType, ArgTag,
   enum { IS_REJECT = std::is_same<REJECTTAG, ValueType>::value };
 
  public:
-  using value_type =
-      typename Impl::if_c<IS_VOID || IS_REJECT, void, ValueType>::type;
+  using value_type = std::conditional_t<IS_VOID || IS_REJECT, void, ValueType>;
   using pointer_type =
-      typename Impl::if_c<IS_VOID || IS_REJECT, void, ValueType*>::type;
+      std::conditional_t<IS_VOID || IS_REJECT, void, ValueType*>;
   using reference_type =
-      typename Impl::if_c<IS_VOID || IS_REJECT, void, ValueType&>::type;
+      std::conditional_t<IS_VOID || IS_REJECT, void, ValueType&>;
   using functor_type = FunctorType;
 
   static_assert(


### PR DESCRIPTION
Most of these can be replaced with `std::conditional` (or `std::conditional_t` for a more modern approach),
even though there are a couple of things that `if_c` does that `std::conditional` doesn't.