### PR TITLE
Avoid memory leak in HIP::Internal::scratch_space/scratch_flags

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -305,6 +305,8 @@ Kokkos::Experimental::HIP::size_type *HIPInternal::scratch_space(
         Kokkos::Impl::SharedAllocationRecord<Kokkos::Experimental::HIPSpace,
                                              void>;
 
+    if (m_scratchFlags) Record::decrement(Record::get_record(m_scratchSpace));
+
     static Record *const r = Record::allocate(
         Kokkos::Experimental::HIPSpace(), "InternalScratchSpace",
         (sizeScratchGrain * m_scratchSpaceCount));
@@ -326,6 +328,8 @@ Kokkos::Experimental::HIP::size_type *HIPInternal::scratch_flags(
     using Record =
         Kokkos::Impl::SharedAllocationRecord<Kokkos::Experimental::HIPSpace,
                                              void>;
+
+    if (m_scratchFlags) Record::decrement(Record::get_record(m_scratchFlags));
 
     Record *const r = Record::allocate(
         Kokkos::Experimental::HIPSpace(), "InternalScratchFlags",


### PR DESCRIPTION
AFAICT, the memory for these variables was never freed when resizing. Probably depends on #3886.