### PR TITLE
Reuse scratch memory in SYCL TeamPolicy

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -42,15 +42,7 @@
 //@HEADER
 */
 
-#include <Kokkos_Core.hpp>
-#include <Kokkos_Concepts.hpp>
-#include <SYCL/Kokkos_SYCL_Instance.hpp>
-#include <KokkosCore_Config_DeclareBackend.hpp>
-#include <Kokkos_SYCL.hpp>
-#include <Kokkos_HostSpace.hpp>
-#include <Kokkos_Serial.hpp>
-#include <impl/Kokkos_ConcurrentBitset.hpp>
-#include <impl/Kokkos_Error.hpp>
+#include <Kokkos_Core.hpp>  //kokkos_malloc
 
 namespace Kokkos {
 namespace Experimental {

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -174,7 +174,8 @@ void* SYCLInternal::resize_team_scratch_space(std::int64_t bytes,
     m_team_scratch_current_size = bytes;
     m_team_scratch_ptr =
         Kokkos::kokkos_malloc<Experimental::SYCLDeviceUSMSpace>(
-            "SYCLDeviceUSMSpace::ScratchMemory", m_team_scratch_current_size);
+            "Kokkos::SYCLDeviceUSMSpace::TeamScratchMemory",
+            m_team_scratch_current_size);
   }
   if ((bytes > m_team_scratch_current_size) ||
       ((bytes < m_team_scratch_current_size) && (force_shrink))) {

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -68,6 +68,8 @@ class SYCLInternal {
 
   void* scratch_space(const size_type size);
   void* scratch_flags(const size_type size);
+  void* resize_team_scratch_space(std::int64_t bytes,
+                                  bool force_shrink = false);
 
   int m_syclDev = -1;
 
@@ -80,6 +82,9 @@ class SYCLInternal {
   size_type* m_scratchSpace           = nullptr;
   size_type m_scratchFlagsCount       = 0;
   size_type* m_scratchFlags           = nullptr;
+
+  int64_t m_team_scratch_current_size = 0;
+  void* m_team_scratch_ptr            = nullptr;
 
   std::optional<sycl::queue> m_queue;
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -451,15 +451,10 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     // FIXME_SYCL so far accessors used instead of these pointers
     // Functor's reduce memory, team scan memory, and team shared memory depend
     // upon team size.
-    const auto& space = *m_policy.space().impl_internal_space_instance();
-    m_scratch_ptr[0]  = nullptr;
-    m_scratch_ptr[1]  = m_team_size <= 0
-                           ? nullptr
-                           : m_policy.space()
-                                 .impl_internal_space_instance()
-                                 ->resize_team_scratch_space(
-                                     static_cast<ptrdiff_t>(m_scratch_size[1]) *
-                                     m_league_size);
+    auto& space      = *m_policy.space().impl_internal_space_instance();
+    m_scratch_ptr[0] = nullptr;
+    m_scratch_ptr[1] = space.resize_team_scratch_space(
+        static_cast<ptrdiff_t>(m_scratch_size[1]) * m_league_size);
 
     if (static_cast<int>(space.m_maxShmemPerBlock) <
         m_shmem_size - m_shmem_begin) {
@@ -467,8 +462,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
       out << "Kokkos::Impl::ParallelFor<SYCL> insufficient shared memory! "
              "Requested "
           << m_shmem_size - m_shmem_begin << " bytes but maximum is "
-          << m_policy.space().impl_internal_space_instance()->m_maxShmemPerBlock
-          << '\n';
+          << space.m_maxShmemPerBlock << '\n';
       Kokkos::Impl::throw_runtime_exception(out.str());
     }
 
@@ -770,15 +764,10 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     // FIXME_SYCL so far accessors used instead of these pointers
     // Functor's reduce memory, team scan memory, and team shared memory depend
     // upon team size.
-    const auto& space = *m_policy.space().impl_internal_space_instance();
-    m_scratch_ptr[0]  = nullptr;
-    m_scratch_ptr[1]  = m_team_size <= 0
-                           ? nullptr
-                           : m_policy.space()
-                                 .impl_internal_space_instance()
-                                 ->resize_team_scratch_space(
-                                     static_cast<ptrdiff_t>(m_scratch_size[1]) *
-                                     m_league_size);
+    auto& space      = *m_policy.space().impl_internal_space_instance();
+    m_scratch_ptr[0] = nullptr;
+    m_scratch_ptr[1] = space.resize_team_scratch_space(
+        static_cast<ptrdiff_t>(m_scratch_size[1]) * m_league_size);
 
     if (static_cast<int>(space.m_maxShmemPerBlock) <
         m_shmem_size - m_shmem_begin) {
@@ -786,8 +775,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       out << "Kokkos::Impl::ParallelFor<SYCL> insufficient shared memory! "
              "Requested "
           << m_shmem_size - m_shmem_begin << " bytes but maximum is "
-          << m_policy.space().impl_internal_space_instance()->m_maxShmemPerBlock
-          << '\n';
+          << space.m_maxShmemPerBlock << '\n';
       Kokkos::Impl::throw_runtime_exception(out.str());
     }
 


### PR DESCRIPTION
Similar to #3873, we can reuse the scratch memory allocated for `TeamPolicy`.