### PR TITLE
Implementation Sketch: Portable Stream creation/destruction

### DIFF
--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -91,6 +91,9 @@ class AnonymousSpace;
 template <class ExecutionSpace, class MemorySpace>
 struct Device;
 
+template<typename ExecutionSpace>
+auto create_stream() -> typename ExecutionSpace::stream_type;
+
 // forward declare here so that backend initializer calls can use it.
 struct InitArguments;
 

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -94,6 +94,9 @@ struct Device;
 template<typename ExecutionSpace>
 auto create_stream() -> typename ExecutionSpace::stream_type;
 
+template<typename ExecutionSpace>
+void destroy_stream(typename ExecutionSpace::stream_type&);
+
 // forward declare here so that backend initializer calls can use it.
 struct InitArguments;
 

--- a/core/src/Kokkos_DummyStream.hpp
+++ b/core/src/Kokkos_DummyStream.hpp
@@ -1,4 +1,3 @@
-
 /*
 //@HEADER
 // ************************************************************************
@@ -43,18 +42,16 @@
 //@HEADER
 */
 
-#include <gtest/gtest.h>
+/// \file Kokkos_DummyStream.hpp
+/// \brief Declaration and definition of the Dummy Stream type
 
-#include <Kokkos_Core.hpp>
+#include <Kokkos_Macros.hpp>
 
-#include <default/TestDefaultDeviceType_Category.hpp>
+namespace Kokkos {
+  class DummyStream {};
+} // namespace Kokkos
 
-namespace Test {
+#ifndef KOKKOS_KOKKOS_DUMMYSTREAM_HPP
+#define KOKKOS_KOKKOS_DUMMYSTREAM_HPP
 
-TEST(defaultdevicetype, development_test) {
-   using stream_type = Kokkos::DefaultExecutionSpace::stream_type;
-   stream_type stream = Kokkos::create_stream<Kokkos::DefaultExecutionSpace>();
-   Kokkos::DefaultExecutionSpace space(stream);
-   auto stream_2 = space.get_stream();
-}
-}  // namespace Test
+#endif  // KOKKOS_KOKKOS_DUMMYSTREAM_HPP

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -49,6 +49,7 @@
 #define KOKKOS_SERIAL_HPP
 
 #include <Kokkos_Macros.hpp>
+#include <Kokkos_DummyStream.hpp>
 #if defined(KOKKOS_ENABLE_SERIAL)
 
 #include <cstddef>
@@ -105,6 +106,11 @@ class Serial {
   /// \brief  Scratch memory space
   using scratch_memory_space = ScratchMemorySpace<Kokkos::Serial>;
 
+  using stream_type = Kokkos::DummyStream;
+  Serial() = default;
+  Serial(stream_type& stream){}
+
+  stream_type get_stream() { return stream_type(); }
   //@}
 
   /// \brief True if and only if this method is being called in a
@@ -158,6 +164,9 @@ class Serial {
   static const char* name();
   //--------------------------------------------------------------------------
 };
+
+template<>
+auto create_stream<Kokkos::Serial>() -> Kokkos::Serial::stream_type;
 
 namespace Tools {
 namespace Experimental {

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -168,6 +168,9 @@ class Serial {
 template<>
 auto create_stream<Kokkos::Serial>() -> Kokkos::Serial::stream_type;
 
+template<>
+void destroy_stream<Kokkos::Serial>(Kokkos::Serial::stream_type &);
+
 namespace Tools {
 namespace Experimental {
 template <>

--- a/core/src/impl/Kokkos_Serial.cpp
+++ b/core/src/impl/Kokkos_Serial.cpp
@@ -141,6 +141,13 @@ HostThreadTeamData* serial_get_thread_team_data() {
 }
 
 }  // namespace Impl
+
+template<>
+auto create_stream<Kokkos::Serial>() -> Kokkos::Serial::stream_type {
+  return Kokkos::Serial::stream_type();
+}
+
+
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/impl/Kokkos_Serial.cpp
+++ b/core/src/impl/Kokkos_Serial.cpp
@@ -146,6 +146,10 @@ template<>
 auto create_stream<Kokkos::Serial>() -> Kokkos::Serial::stream_type {
   return Kokkos::Serial::stream_type();
 }
+template<>
+void destroy_stream<Kokkos::Serial>(Kokkos::Serial::stream_type &) {
+
+}
 
 
 }  // namespace Kokkos

--- a/core/unit_test/default/TestDefaultDeviceDevelop.cpp
+++ b/core/unit_test/default/TestDefaultDeviceDevelop.cpp
@@ -56,5 +56,6 @@ TEST(defaultdevicetype, development_test) {
    stream_type stream = Kokkos::create_stream<Kokkos::DefaultExecutionSpace>();
    Kokkos::DefaultExecutionSpace space(stream);
    auto stream_2 = space.get_stream();
+   Kokkos::destroy_stream<Kokkos::DefaultExecutionSpace>(stream);
 }
 }  // namespace Test


### PR DESCRIPTION
There's conversation about how streams should work, allowing people to avoid calling cudaStreamCreate directly in their code. This is a sketch on Serial of what such a mechanism might look like. It introduces

1) A stream_type type alias in execution spaces

This is how users will refer to cudaStreams and the like, as Kokkos::[Cuda/HIP/SYCL/Serial]::stream_type

2) A DummyStream

For models that don't support streams, they can use this as their stream type

3) Stream constructors for spaces, and a get_stream method

ExecutionSpaces now have a constructor from stream_type, and a get_stream that returns the instance's stream_type.

4) create_stream<ExecutionSpace>() (edit: and destroy_stream<ExecutionSpace>(stream_type&) )

This is how our users will call "cudaStreamCreate" and the like. For non-stream-supporting instances, returns a DummyStream

This is an implementation sketch using Serial. If I get signoff, I'll implement it for all ExecSpaces (DummyStreams if I don't know how to make it work i.e. SYCL)