### PR TITLE
Replace cl::sycl

### DIFF
--- a/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
@@ -52,8 +52,8 @@ namespace Test {
 // Test whether allocations survive Kokkos initialize/finalize if done via Raw
 // SYCL.
 TEST(sycl, raw_sycl_interop) {
-  cl::sycl::default_selector device_selector;
-  cl::sycl::queue queue(device_selector);
+  sycl::default_selector device_selector;
+  sycl::queue queue(device_selector);
   constexpr int n = 100;
   int* p          = sycl::malloc_device<int>(n, queue);
 
@@ -66,7 +66,7 @@ TEST(sycl, raw_sycl_interop) {
   }
   Kokkos::finalize();
 
-  queue.submit([&](cl::sycl::handler& cgh) {
+  queue.submit([&](sycl::handler& cgh) {
     cgh.parallel_for(sycl::range<1>(n), [=](int idx) { p[idx] += idx; });
   });
   queue.wait_and_throw();

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
@@ -54,8 +54,8 @@ TEST(sycl, raw_sycl_interop_context_1) {
   Kokkos::Experimental::SYCL default_space;
   sycl::context default_context = default_space.sycl_context();
 
-  cl::sycl::default_selector device_selector;
-  cl::sycl::queue queue(default_context, device_selector);
+  sycl::default_selector device_selector;
+  sycl::queue queue(default_context, device_selector);
   constexpr int n = 100;
   int* p          = sycl::malloc_device<int>(n, queue);
 
@@ -63,7 +63,7 @@ TEST(sycl, raw_sycl_interop_context_1) {
   Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged>> v(p, n);
   Kokkos::deep_copy(v, 5);
 
-  queue.submit([&](cl::sycl::handler& cgh) {
+  queue.submit([&](sycl::handler& cgh) {
     cgh.parallel_for(sycl::range<1>(n), [=](int idx) { p[idx] += idx; });
   });
   queue.wait_and_throw();
@@ -88,8 +88,8 @@ TEST(sycl, raw_sycl_interop_context_2) {
   Kokkos::Experimental::SYCL default_space;
   sycl::context default_context = default_space.sycl_context();
 
-  cl::sycl::default_selector device_selector;
-  cl::sycl::queue queue(default_context, device_selector);
+  sycl::default_selector device_selector;
+  sycl::queue queue(default_context, device_selector);
   constexpr int n = 100;
 
   Kokkos::Experimental::SYCL space(queue);
@@ -98,7 +98,7 @@ TEST(sycl, raw_sycl_interop_context_2) {
   Kokkos::deep_copy(space, v, 5);
 
   auto* v_ptr = v.data();
-  queue.submit([&](cl::sycl::handler& cgh) {
+  queue.submit([&](sycl::handler& cgh) {
     cgh.parallel_for(sycl::range<1>(n), [=](int idx) { v_ptr[idx] += idx; });
   });
   queue.wait_and_throw();

--- a/core/unit_test/sycl/TestSYCL_InterOp_Streams.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Streams.cpp
@@ -48,8 +48,8 @@
 namespace Test {
 // Test Interoperability with SYCL Streams
 TEST(sycl, raw_sycl_queues) {
-  cl::sycl::default_selector device_selector;
-  cl::sycl::queue queue(device_selector);
+  sycl::default_selector device_selector;
+  sycl::queue queue(device_selector);
   Kokkos::InitArguments arguments{-1, -1, -1, false};
   Kokkos::initialize(arguments);
   int* p            = sycl::malloc_device<int>(100, queue);
@@ -98,7 +98,7 @@ TEST(sycl, raw_sycl_queues) {
 
   // Try to use the queue after Kokkos' copy got out-of-scope.
   // This kernel corresponds to "offset_streams" in the HIP and CUDA tests.
-  queue.submit([&](cl::sycl::handler& cgh) {
+  queue.submit([&](sycl::handler& cgh) {
     cgh.parallel_for(sycl::range<1>(100), [=](int idx) { p[idx] += idx; });
   });
   queue.wait_and_throw();


### PR DESCRIPTION
Apparently, we introduced some occurrences of the deprecated namespace or forgot to remove them.