### PR TITLE
Let SYCL USMObjectMem use SharedAllocationRecord

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -208,7 +208,7 @@ void* SYCLInternal::scratch_space(
 
     Record* const r =
         Record::allocate(Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
-                         "Kokkos::InternalScratchSpace",
+                         "Kokkos::SYCL::InternalScratchSpace",
                          (sizeScratchGrain * m_scratchSpaceCount));
 
     Record::increment(r);
@@ -235,7 +235,7 @@ void* SYCLInternal::scratch_flags(
 
     Record* const r =
         Record::allocate(Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
-                         "Kokkos::InternalScratchFlags",
+                         "Kokkos::SYCL::InternalScratchFlags",
                          (sizeScratchGrain * m_scratchFlagsCount));
 
     Record::increment(r);
@@ -258,8 +258,8 @@ size_t SYCLInternal::USMObjectMem<Kind>::reserve(size_t n) {
     // First free what we have (in case malloc can reuse it)
     if (m_data) Record::decrement(Record::get_record(m_data));
 
-    Record* const r =
-        Record::allocate(AllocationSpace(*m_q), "Kokkos::USMObjectMem", n);
+    Record* const r = Record::allocate(AllocationSpace(*m_q),
+                                       "Kokkos::SYCL::USMObjectMem", n);
     Record::increment(r);
 
     m_data     = r->data();

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -283,16 +283,6 @@ void SYCLInternal::USMObjectMem<Kind>::reset() {
   m_q.reset();
 }
 
-template <sycl::usm::alloc Kind>
-SYCLInternal::USMObjectMem<Kind>::~USMObjectMem<Kind>() {
-  assert(m_size == 0);
-
-  if (m_data) {
-    using Record = Kokkos::Impl::SharedAllocationRecord<AllocationSpace, void>;
-    Record::decrement(Record::get_record(m_data));
-  }
-}
-
 template class SYCLInternal::USMObjectMem<sycl::usm::alloc::shared>;
 template class SYCLInternal::USMObjectMem<sycl::usm::alloc::device>;
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -254,14 +254,12 @@ size_t SYCLInternal::USMObjectMem<Kind>::reserve(size_t n) {
   assert(m_q);
 
   if (m_capacity < n) {
-    using Space  = std::conditional_t<Kind == sycl::usm::alloc::device,
-                                     Kokkos::Experimental::SYCLDeviceUSMSpace,
-                                     Kokkos::Experimental::SYCLSharedUSMSpace>;
-    using Record = Kokkos::Impl::SharedAllocationRecord<Space, void>;
+    using Record = Kokkos::Impl::SharedAllocationRecord<AllocationSpace, void>;
     // First free what we have (in case malloc can reuse it)
     if (m_data) Record::decrement(Record::get_record(m_data));
 
-    Record* const r = Record::allocate(Space(*m_q), "Kokkos::USMObjectMem", n);
+    Record* const r =
+        Record::allocate(AllocationSpace(*m_q), "Kokkos::USMObjectMem", n);
     Record::increment(r);
 
     m_data     = r->data();
@@ -276,11 +274,7 @@ void SYCLInternal::USMObjectMem<Kind>::reset() {
   assert(m_size == 0);
 
   if (m_data) {
-    using Record = Kokkos::Impl::SharedAllocationRecord<
-        std::conditional_t<Kind == sycl::usm::alloc::device,
-                           Kokkos::Experimental::SYCLDeviceUSMSpace,
-                           Kokkos::Experimental::SYCLSharedUSMSpace>,
-        void>;
+    using Record = Kokkos::Impl::SharedAllocationRecord<AllocationSpace, void>;
     Record::decrement(Record::get_record(m_data));
 
     m_capacity = 0;
@@ -294,11 +288,7 @@ SYCLInternal::USMObjectMem<Kind>::~USMObjectMem<Kind>() {
   assert(m_size == 0);
 
   if (m_data) {
-    using Record = Kokkos::Impl::SharedAllocationRecord<
-        std::conditional_t<Kind == sycl::usm::alloc::device,
-                           Kokkos::Experimental::SYCLDeviceUSMSpace,
-                           Kokkos::Experimental::SYCLSharedUSMSpace>,
-        void>;
+    using Record = Kokkos::Impl::SharedAllocationRecord<AllocationSpace, void>;
     Record::decrement(Record::get_record(m_data));
   }
 }

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -134,7 +134,7 @@ class SYCLInternal {
     USMObjectMem& operator=(USMObjectMem&&) = delete;
     USMObjectMem& operator=(USMObjectMem const&) = delete;
 
-    ~USMObjectMem();
+    ~USMObjectMem() { reset(); };
 
     void* data() noexcept { return m_data; }
     const void* data() const noexcept { return m_data; }

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -147,6 +147,11 @@ class SYCLInternal {
     size_t reserve(size_t n);
 
    private:
+    using AllocationSpace =
+        std::conditional_t<Kind == sycl::usm::alloc::device,
+                           Kokkos::Experimental::SYCLDeviceUSMSpace,
+                           Kokkos::Experimental::SYCLSharedUSMSpace>;
+
     // This will memcpy an object T into memory held by this object
     // returns: a T* to that object
     //


### PR DESCRIPTION
Based on top of https://github.com/kokkos/kokkos/pull/3873.
To avoid circular dependencies I needed to move the definitions using `SharedAllocationRecord` to the `*.cpp` file. After moving, this pull request only replaces `sycl::malloc` with `Record::allocate` and `sycl::free` with `Record::decfement`.