### PR TITLE
Reuse memory in SYCL parallel_scan 

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -88,7 +88,7 @@ class ParallelScanSYCLBase {
     // FIXME_SYCL optimize
     constexpr size_t wgroup_size = 32;
     auto n_wgroups               = (size + wgroup_size - 1) / wgroup_size;
-    auto group_results           = global_mem + size;
+    pointer_type group_results   = global_mem + size;
 
     q.submit([&](sycl::handler& cgh) {
       sycl::accessor<value_type, 1, sycl::access::mode::read_write,

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -239,8 +239,8 @@ class ParallelScanSYCLBase {
 
     // FIXME_SYCL consider only storing one value per block and recreate initial
     // results in the end before doing the final pass
-    m_scratch_space = static_cast<pointer_type>(
-        instance.scratch_space(sizeof(value_type) * total_memory));
+    m_scratch_space =
+        static_cast<pointer_type>(instance.scratch_space(total_memory));
 
     Kokkos::Experimental::Impl::SYCLInternal::IndirectKernelMem&
         indirectKernelMem = instance.m_indirectKernelMem;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -223,7 +223,10 @@ class ParallelScanSYCLBase {
     auto& instance        = *m_policy.space().impl_internal_space_instance();
     const std::size_t len = m_policy.end() - m_policy.begin();
 
-    // compute the total amount of memory we will need.
+    // Compute the total amount of memory we will need. We emulate the recursive
+    // structure that is used to do the actual scan. Essentially, we need to
+    // allocate memory for the whole range and then recursively for the reduced
+    // group results until only one group is left.
     std::size_t total_memory = 0;
     {
       size_t wgroup_size   = 32;


### PR DESCRIPTION
Based on top of #3873. This should be the last occurrence of a raw call to `sycl::malloc` outside of `SYCLDeviceUSMSpace::allocate()` or `SYCLSharedUSMSpace::allocate()`