### PR TITLE
Enable more SYCL tests

### DIFF
--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -561,8 +561,6 @@ void test_memory_pool_huge() {
 
 namespace Test {
 
-// FIXME_SYCL needs Kokkos::memory_fence
-#ifndef KOKKOS_ENABLE_SYCL
 TEST(TEST_CATEGORY, memory_pool) {
   TestMemoryPool::test_host_memory_pool_defaults<>();
   TestMemoryPool::test_host_memory_pool_stats<>();
@@ -572,7 +570,6 @@ TEST(TEST_CATEGORY, memory_pool) {
   TestMemoryPool::test_memory_pool_huge<TEST_EXECSPACE>();
 #endif
 }
-#endif
 
 }  // namespace Test
 

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -432,8 +432,6 @@ TEST(TEST_CATEGORY, range_reduce) {
   }
 }
 
-// FIXME_SYCL needs parallel_scan
-#ifndef KOKKOS_ENABLE_SYCL
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
 TEST(TEST_CATEGORY, range_scan) {
   {
@@ -484,6 +482,5 @@ TEST(TEST_CATEGORY, range_scan) {
   }
 #endif
 }
-#endif
 #endif
 }  // namespace Test

--- a/core/unit_test/TestRangePolicyRequire.hpp
+++ b/core/unit_test/TestRangePolicyRequire.hpp
@@ -444,8 +444,6 @@ TEST(TEST_CATEGORY, range_reduce_require) {
   }
 }
 
-// FIXME_SYCL needs parallel_scan
-#ifndef KOKKOS_ENABLE_SYCL
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
 TEST(TEST_CATEGORY, range_scan_require) {
   using Property = Kokkos::Experimental::WorkItemProperty::HintLightWeight_t;
@@ -512,6 +510,5 @@ TEST(TEST_CATEGORY, range_scan_require) {
   }
 #endif
 }
-#endif
 #endif
 }  // namespace Test

--- a/core/unit_test/TestScan.hpp
+++ b/core/unit_test/TestScan.hpp
@@ -75,15 +75,11 @@ struct TestScan {
       if (answer != update) {
         int fail = errors()++;
 
-        // FIXME_SYCL
-#ifndef KOKKOS_ENABLE_SYCL
         if (fail < 20) {
-          printf("TestScan(%d,%ld) != %ld\n", iwork, static_cast<long>(update),
-                 static_cast<long>(answer));
+          KOKKOS_IMPL_DO_NOT_USE_PRINTF("TestScan(%d,%ld) != %ld\n", iwork,
+                                        static_cast<long>(update),
+                                        static_cast<long>(answer));
         }
-#else
-        (void)fail;
-#endif
       }
     }
   }

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1495,13 +1495,21 @@ class TestViewAPI {
       // quickly.
       if (msg.find("is not a valid size") != std::string::npos) {
         ASSERT_PRED_FORMAT2(::testing::IsSubstring, "is not a valid size", msg);
-      } else if (msg.find("insufficient memory") != std::string::npos) {
+      } else
+#ifdef KOKKOS_ENABLE_SYCL
+          if (msg.find("insufficient memory") != std::string::npos)
+#endif
+      {
         ASSERT_PRED_FORMAT2(::testing::IsSubstring, "insufficient memory", msg);
-      } else {
+      }
+      // SYCL cannot tell the reason why a memory allocation failed
+#ifdef KOKKOS_ENABLE_SYCL
+      else {
         // Otherwise, there has to be some sort of "unknown error" error
         ASSERT_PRED_FORMAT2(::testing::IsSubstring,
                             "because of an unknown error.", msg);
       }
+#endif
     }
   }
 };

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1479,12 +1479,6 @@ class TestViewAPI {
                      Kokkos::Experimental::OpenMPTargetSpace>::value)
       return;
 #endif
-// FIXME_SYCL
-#ifdef KOKKOS_ENABLE_SYCL
-    if (std::is_same<typename dView1::memory_space,
-                     Kokkos::Experimental::SYCLDeviceUSMSpace>::value)
-      return;
-#endif
     auto alloc_size = std::numeric_limits<size_t>::max() - 42;
     try {
       auto should_always_fail = dView1("hello_world_failure", alloc_size);
@@ -1501,9 +1495,12 @@ class TestViewAPI {
       // quickly.
       if (msg.find("is not a valid size") != std::string::npos) {
         ASSERT_PRED_FORMAT2(::testing::IsSubstring, "is not a valid size", msg);
-      } else {
-        // Otherwise, there has to be some sort of "insufficient memory" error
+      } else if (msg.find("insufficient memory") != std::string::npos) {
         ASSERT_PRED_FORMAT2(::testing::IsSubstring, "insufficient memory", msg);
+      } else {
+        // Otherwise, there has to be some sort of "unknown error" error
+        ASSERT_PRED_FORMAT2(::testing::IsSubstring,
+                            "because of an unknown error.", msg);
       }
     }
   }

--- a/core/unit_test/TestViewAPI_c.hpp
+++ b/core/unit_test/TestViewAPI_c.hpp
@@ -47,10 +47,7 @@
 namespace Test {
 
 TEST(TEST_CATEGORY, view_api_c) {
-  // FIXME_SYCL requires deep_copy on the default memory space
-#ifndef KOKKOS_ENABLE_SYCL
   TestViewAPI<double, TEST_EXECSPACE>::run_test_deep_copy_empty();
-#endif
   TestViewAPI<double, TEST_EXECSPACE>::run_test_view_operator_b();
 }
 

--- a/core/unit_test/TestViewLayoutStrideAssignment.hpp
+++ b/core/unit_test/TestViewLayoutStrideAssignment.hpp
@@ -661,9 +661,8 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
     ASSERT_EQ(dst.span(), src.span());
     ASSERT_EQ(test, true);
   }
-// FIXME_SYCL deadlocks
 // WORKAROUND OPENMPTARGET : death tests don't seem to work ...
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_SYCL)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)
   return;
 #endif
   {  // Assignment of rank-2 LayoutLeft = LayoutStride (LayoutRight compatible)
@@ -817,9 +816,8 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
     ASSERT_EQ(dst.span(), src.span());
     ASSERT_EQ(test, true);
   }
-// FIXME_SYCL deadlocks
 // WORKAROUND OPENMPTARGET : death tests don't seem to work ...
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_SYCL)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)
   return;
 #endif
   {  // Assignment of rank-2 LayoutRight = LayoutStride (LayoutLeft compatible)


### PR DESCRIPTION
It turns out that there were various places in the test suite that were still disabled for `SYCL` but already work.