### PR TITLE
Forward declare HIPHostPinnedSpace and SYCLSharedUSMSpace

### DIFF
--- a/core/src/fwd/Kokkos_Fwd_HIP.hpp
+++ b/core/src/fwd/Kokkos_Fwd_HIP.hpp
@@ -49,7 +49,8 @@
 namespace Kokkos {
 namespace Experimental {
 class HIPSpace;  ///< Memory space on HIP GPU
-class HIP;       ///< Execution space for HIP GPU
+class HIPHostPinnedSpace;
+class HIP;  ///< Execution space for HIP GPU
 }  // namespace Experimental
 }  // namespace Kokkos
 #endif

--- a/core/src/fwd/Kokkos_Fwd_HIP.hpp
+++ b/core/src/fwd/Kokkos_Fwd_HIP.hpp
@@ -48,9 +48,9 @@
 #if defined(KOKKOS_ENABLE_HIP)
 namespace Kokkos {
 namespace Experimental {
-class HIPSpace;  ///< Memory space on HIP GPU
-class HIPHostPinnedSpace;
-class HIP;  ///< Execution space for HIP GPU
+class HIPSpace;            ///< Memory space on HIP GPU
+class HIPHostPinnedSpace;  ///< Memory space on Host accessible to HIP GPU
+class HIP;                 ///< Execution space for HIP GPU
 }  // namespace Experimental
 }  // namespace Kokkos
 #endif

--- a/core/src/fwd/Kokkos_Fwd_SYCL.hpp
+++ b/core/src/fwd/Kokkos_Fwd_SYCL.hpp
@@ -48,9 +48,11 @@
 #if defined(KOKKOS_ENABLE_SYCL)
 namespace Kokkos {
 namespace Experimental {
-class SYCLDeviceUSMSpace;  ///< Memory space on SYCL device
-class SYCLSharedUSMSpace;
-class SYCL;  ///< Execution space for SYCL
+class SYCLDeviceUSMSpace;  ///< Memory space on SYCL device, not accessible from
+                           ///< the host
+class SYCLSharedUSMSpace;  ///< Memory space accessible from both the SYCL
+                           ///< device and the host
+class SYCL;                ///< Execution space for SYCL
 }  // namespace Experimental
 }  // namespace Kokkos
 #endif

--- a/core/src/fwd/Kokkos_Fwd_SYCL.hpp
+++ b/core/src/fwd/Kokkos_Fwd_SYCL.hpp
@@ -49,7 +49,8 @@
 namespace Kokkos {
 namespace Experimental {
 class SYCLDeviceUSMSpace;  ///< Memory space on SYCL device
-class SYCL;                ///< Execution space for SYCL
+class SYCLSharedUSMSpace;
+class SYCL;  ///< Execution space for SYCL
 }  // namespace Experimental
 }  // namespace Kokkos
 #endif


### PR DESCRIPTION
As we noticed in https://github.com/kokkos/kokkos/pull/3838, these forward declarations were missing.