### PR TITLE
[HIP] fix multithreaded access to get_next_driver

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -401,6 +401,7 @@ void HIPInternal::finalize() {
 }
 
 char *HIPInternal::get_next_driver(size_t driverTypeSize) const {
+  std::lock_guard<std::mutex> const lock(m_mutexWorkArray);
   if (d_driverWorkArray == nullptr) {
     HIP_SAFE_CALL(
         hipHostMalloc(&d_driverWorkArray,

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -49,6 +49,8 @@
 
 #include <Kokkos_HIP_Space.hpp>
 
+#include <mutex>
+
 namespace Kokkos {
 namespace Experimental {
 namespace Impl {
@@ -104,6 +106,8 @@ class HIPInternal {
   mutable size_t m_maxDriverTypeSize = 1024 * 10;
   // the current index in the driverWorkArray
   mutable int m_cycleId = 0;
+  // mutex to access d_driverWorkArray
+  mutable std::mutex m_mutexWorkArray;
 
   // Scratch Spaces for Reductions
   size_type m_scratchSpaceCount = 0;


### PR DESCRIPTION
In HIP, we have a pool of Drivers that we use when launching a kernel. If two threads try to launch a kernel at the same time, they could both use the same Driver from the pool. This PR uses a lock to prevent this scenario. I have measured the impact of an uncontested lock using the code in #3670 and I did not see any penalty.