### PR TITLE
SYCL choose a specific GPU

### DIFF
--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -127,7 +127,6 @@ class SYCL {
     explicit SYCLDevice(sycl::device d);
     explicit SYCLDevice(const sycl::device_selector& selector);
     explicit SYCLDevice(size_t id);
-    explicit SYCLDevice(const std::function<bool(const sycl::device&)>& pred);
 
     sycl::device get_device() const;
 

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -132,7 +132,7 @@ SYCL::SYCLDevice::SYCLDevice(size_t id) {
     std::stringstream error_message;
     error_message << "Requested GPU with id " << id << " but only "
                   << gpu_devices.size() << " GPU(s) available!\n";
-    Kokkos::abort(error_message.str().c_str());
+    Kokkos::Impl::throw_runtime_exception(error_message.str());
   }
   m_device = gpu_devices[id];
 }

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -125,6 +125,18 @@ SYCL::SYCLDevice::SYCLDevice(sycl::device d) : m_device(std::move(d)) {}
 SYCL::SYCLDevice::SYCLDevice(const sycl::device_selector& selector)
     : m_device(selector.select_device()) {}
 
+SYCL::SYCLDevice::SYCLDevice(size_t id) {
+  std::vector<sycl::device> gpu_devices =
+      sycl::device::get_devices(sycl::info::device_type::gpu);
+  if (id >= gpu_devices.size()) {
+    std::stringstream error_message;
+    error_message << "Requested GPU with id " << id << " but only "
+                  << gpu_devices.size() << " GPU(s) available!\n";
+    Kokkos::abort(error_message.str().c_str());
+  }
+  m_device = gpu_devices[id];
+}
+
 sycl::device SYCL::SYCLDevice::get_device() const { return m_device; }
 
 void SYCL::impl_initialize(SYCL::SYCLDevice d) {
@@ -257,9 +269,13 @@ void SYCLSpaceInitializer::initialize(const InitArguments& args) {
   if (std::is_same<Kokkos::Experimental::SYCL,
                    Kokkos::DefaultExecutionSpace>::value ||
       0 < use_gpu) {
-    // FIXME_SYCL choose a specific device
-    Kokkos::Experimental::SYCL::impl_initialize(
-        Kokkos::Experimental::SYCL::SYCLDevice(sycl::default_selector()));
+    if (use_gpu > -1) {
+      Kokkos::Experimental::SYCL::impl_initialize(
+          Kokkos::Experimental::SYCL::SYCLDevice(use_gpu));
+    } else {
+      Kokkos::Experimental::SYCL::impl_initialize(
+          Kokkos::Experimental::SYCL::SYCLDevice(sycl::default_selector()));
+    }
   }
 }
 


### PR DESCRIPTION
So far, we were always using the `default_selector` and use whatever `SYCL` device we got from that. With this pull request, a specific GPU can be specified (by its position in the list of all `GPU` devices). The default behavior is still to use `default_selector`.

Also, delete a constructor that was not implemented (and not used).