### PR TITLE
Remove unimplemented member functions of SYCLDevice

### DIFF
--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -123,20 +123,16 @@ class SYCL {
    */
 
   struct SYCLDevice {
-    SYCLDevice();
+    SYCLDevice() : SYCLDevice(sycl::default_selector()) {}
     explicit SYCLDevice(sycl::device d);
     explicit SYCLDevice(const sycl::device_selector& selector);
     explicit SYCLDevice(size_t id);
-    explicit SYCLDevice(const std::function<bool(const sycl::device&)>& pred);
 
     sycl::device get_device() const;
 
     friend std::ostream& operator<<(std::ostream& os, const SYCLDevice& that) {
       return that.info(os);
     }
-
-    static std::ostream& list_devices(std::ostream& os);
-    static void list_devices();
 
    private:
     std::ostream& info(std::ostream& os) const;


### PR DESCRIPTION
Related to #3918. I decided to still implement the default constructor since that is the default argument for `impl_initialize`.
`SYCLDevice(size_t id);` is implemented in #3918.