### PR TITLE
[3.4] Take over #3927: Fix warnings with xl compiler

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -705,6 +705,10 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
       SOURCES tools/printing-tool.cpp
     )
 
+    if((NOT (Kokkos_ENABLE_CUDA AND WIN32)) AND (NOT ("${KOKKOS_CXX_COMPILER_ID}" STREQUAL "Fujitsu")))
+      TARGET_COMPILE_FEATURES(kokkosprinter-tool PUBLIC cxx_std_14)
+    endif()
+
     KOKKOS_ADD_TEST_EXECUTABLE(
       ProfilingAllCalls
       tools/TestAllCalls.cpp

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -414,13 +414,12 @@ TEST(TEST_CATEGORY, complex_special_funtions) {
 TEST(TEST_CATEGORY, complex_io) { testComplexIO(); }
 
 TEST(TEST_CATEGORY, complex_trivially_copyable) {
-  using RealType = double;
-
   // Kokkos::complex<RealType> is trivially copyable when RealType is
   // trivially copyable
   // Simply disable the check for IBM's XL compiler since we can't reliably
   // check for a version that defines relevant functions.
 #if !defined(__ibmxl__)
+  using RealType = double;
   // clang claims compatibility with gcc 4.2.1 but all versions tested know
   // about std::is_trivially_copyable.
   ASSERT_TRUE(std::is_trivially_copyable<Kokkos::complex<RealType>>::value ||


### PR DESCRIPTION
Cherry-pick #3927 into release candidate branch.