### PR TITLE
Implement subgroup reduction for SYCL RangePolicy parallel_reduce

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -218,10 +218,10 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
               item.barrier(sycl::access::fence_space::local_space);
 
               // from the Intel implementation for sub group reduce without init
-              auto sg     = item.get_sub_group();
-              auto result = &local_mem[local_id * value_count];
-              for (int mask = 1; mask < sg.get_max_local_range()[0];
-                   mask *= 2) {
+              auto sg                   = item.get_sub_group();
+              auto result               = &local_mem[local_id * value_count];
+              const int max_local_range = sg.get_max_local_range()[0];
+              for (int mask = 1; mask < max_local_range; mask *= 2) {
                 auto tmp = sg.shuffle_xor(result, sycl::id<1>(mask));
                 if ((sg.get_local_id()[0] ^ mask) < sg.get_local_range()[0]) {
                   ValueJoin::join(selected_reducer, result, tmp);

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -408,12 +408,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     const unsigned int value_count =
         FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>::value_count(
             selected_reducer);
-    // FIXME_SYCL only use the first half
     const auto results_ptr = static_cast<pointer_type>(instance.scratch_space(
-        sizeof(value_type) * std::max(value_count, 1u) * init_size * 2));
-    // FIXME_SYCL without this we are running into a race condition
-    const auto results_ptr2 =
-        results_ptr + std::max(value_count, 1u) * init_size;
+        sizeof(value_type) * std::max(value_count, 1u) * init_size));
 
     // If size<=1 we only call init(), the functor and possibly final once
     // working with the global scratch memory but don't copy back to
@@ -510,46 +506,62 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           }
           item.barrier(sycl::access::fence_space::local_space);
 
+          auto sg                   = item.get_sub_group();
+          auto* result              = &local_mem[local_id * value_count];
+          const int max_local_range = sg.get_max_local_range()[0];
+          for (unsigned int stride = max_local_range / 2; stride > 0;
+               stride >>= 1)
+            ValueJoin::join(selected_reducer, result,
+                            sg.shuffle_down(result, stride));
+
+          item.barrier(sycl::access::fence_space::local_space);
+          if (sg.get_local_id()[0] == 0)
+            ValueOps::copy(functor,
+                           &local_mem[sg.get_group_id()[0] * value_count],
+                           result);
+          item.barrier(sycl::access::fence_space::local_space);
+
           // Perform the actual workgroup reduction. To achieve a better
           // memory access pattern, we use sequential addressing and a
           // reversed loop. If the workgroup size is 8, the first element
           // contains all the values with index%4==0, after the second one
           // the values with index%2==0 and after the third one index%1==0,
           // i.e., all values.
-          for (unsigned int stride = wgroup_size / 2; stride > 0;
-               stride >>= 1) {
-            const auto idx = local_id;
-            if (idx < stride) {
-              ValueJoin::join(selected_reducer, &local_mem[idx * value_count],
-                              &local_mem[(idx + stride) * value_count]);
+          if (sg.get_group_id()[0] == 0) {
+            const auto local_range = sg.get_local_range()[0];
+            const auto n_subgroups = sg.get_group_range()[0];
+            const auto id_in_sg    = sg.get_local_id()[0];
+            auto* result_          = &local_mem[id_in_sg * value_count];
+            for (unsigned int offset = local_range; offset < n_subgroups;
+                 offset += local_range)
+              if (id_in_sg + offset < n_subgroups)
+                ValueJoin::join(selected_reducer, result_,
+                                &local_mem[(id_in_sg + offset) * value_count]);
+            for (unsigned int stride = local_range / 2; stride > 0;
+                 stride >>= 1) {
+              auto* tmp = sg.shuffle_down(result_, stride);
+              if (id_in_sg + stride < n_subgroups)
+                ValueJoin::join(selected_reducer, result_, tmp);
             }
-            item.barrier(sycl::access::fence_space::local_space);
-          }
 
-          // Finally, we copy the workgroup results back to global memory to
-          // be used in the next iteration. If this is the last iteration,
-          // i.e., there is only one workgroup also call final() if
-          // necessary.
-          if (local_id == 0) {
-            ValueOps::copy(
-                functor,
-                &results_ptr2[(item.get_group_linear_id()) * value_count],
-                &local_mem[0]);
-            if constexpr (ReduceFunctorHasFinal<FunctorType>::value)
-              if (n_wgroups <= 1)
-                FunctorFinal<FunctorType, WorkTag>::final(
-                    static_cast<const FunctorType&>(functor),
-                    &results_ptr2[(item.get_group_linear_id()) * value_count]);
+            // Finally, we copy the workgroup results back to global memory
+            // to be used in the next iteration. If this is the last
+            // iteration, i.e., there is only one workgroup also call
+            // final() if necessary.
+            if (id_in_sg == 0) {
+              ValueOps::copy(
+                  functor,
+                  &results_ptr[(item.get_group_linear_id()) * value_count],
+                  &local_mem[0]);
+              if constexpr (ReduceFunctorHasFinal<FunctorType>::value)
+                if (n_wgroups <= 1)
+                  FunctorFinal<FunctorType, WorkTag>::final(
+                      static_cast<const FunctorType&>(functor),
+                      &results_ptr[(item.get_group_linear_id()) * value_count]);
+            }
           }
         });
       });
-      m_space.fence();
-
-      // FIXME_SYCL this is likely not necessary, see above
-      Kokkos::Impl::DeepCopy<Kokkos::Experimental::SYCLDeviceUSMSpace,
-                             Kokkos::Experimental::SYCLDeviceUSMSpace>(
-          m_space, results_ptr, results_ptr2,
-          sizeof(*m_result_ptr) * value_count * n_wgroups);
       m_space.fence();
 
       first_run = false;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -87,7 +87,7 @@ void workgroup_reduction(sycl::nd_item<dim>& item,
 
   // Copy the subgroup results into the first positions of the
   // reduction array.
-  if (sg.get_local_id()[0] == 0 && sg.get_local_id()[0] < wgroup_size)
+  if (id_in_sg == 0)
     ValueOps::copy(functor, &local_mem[sg.get_group_id()[0] * value_count],
                    result);
   item.barrier(sycl::access::fence_space::local_space);

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -121,12 +121,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     const unsigned int value_count =
         FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>::value_count(
             selected_reducer);
-    // FIXME_SYCL only use the first half
     const auto results_ptr = static_cast<pointer_type>(instance.scratch_space(
-        sizeof(value_type) * std::max(value_count, 1u) * init_size * 2));
-    // FIXME_SYCL without this we are running into a race condition
-    const auto results_ptr2 =
-        results_ptr + std::max(value_count, 1u) * init_size;
+        sizeof(value_type) * std::max(value_count, 1u) * init_size));
 
     // If size<=1 we only call init(), the functor and possibly final once
     // working with the global scratch memory but don't copy back to
@@ -265,24 +261,17 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
               if (local_id == 0) {
                 ValueOps::copy(
                     functor,
-                    &results_ptr2[(item.get_group_linear_id()) * value_count],
+                    &results_ptr[(item.get_group_linear_id()) * value_count],
                     &local_mem[0]);
                 if constexpr (ReduceFunctorHasFinal<FunctorType>::value)
                   if (n_wgroups <= 1)
                     FunctorFinal<FunctorType, WorkTag>::final(
                         static_cast<const FunctorType&>(functor),
-                        &results_ptr2[(item.get_group_linear_id()) *
-                                      value_count]);
+                        &results_ptr[(item.get_group_linear_id()) *
+                                     value_count]);
               }
             });
       });
-      space.fence();
-
-      // FIXME_SYCL this is likely not necessary, see above
-      Kokkos::Impl::DeepCopy<Kokkos::Experimental::SYCLDeviceUSMSpace,
-                             Kokkos::Experimental::SYCLDeviceUSMSpace>(
-          space, results_ptr, results_ptr2,
-          sizeof(*m_result_ptr) * value_count * n_wgroups);
       space.fence();
 
       first_run = false;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -545,12 +545,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     const unsigned int value_count =
         FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>::value_count(
             selected_reducer);
-    // FIXME_SYCL only use the first half
     const auto results_ptr = static_cast<pointer_type>(instance.scratch_space(
-        sizeof(value_type) * std::max(value_count, 1u) * init_size * 2));
-    // FIXME_SYCL without this we are running into a race condition
-    const auto results_ptr2 =
-        results_ptr + std::max(value_count, 1u) * init_size;
+        sizeof(value_type) * std::max(value_count, 1u) * init_size));
 
     // If size<=1 we only call init(), the functor and possibly final once
     // working with the global scratch memory but don't copy back to
@@ -663,49 +659,64 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
               }
               item.barrier(sycl::access::fence_space::local_space);
 
+              auto sg                   = item.get_sub_group();
+              auto* result              = &local_mem[local_id * value_count];
+              const int max_local_range = sg.get_max_local_range()[0];
+              for (unsigned int stride = max_local_range / 2; stride > 0;
+                   stride >>= 1)
+                ValueJoin::join(selected_reducer, result,
+                                sg.shuffle_down(result, stride));
+
+              item.barrier(sycl::access::fence_space::local_space);
+              if (sg.get_local_id()[0] == 0)
+                ValueOps::copy(functor,
+                               &local_mem[sg.get_group_id()[0] * value_count],
+                               result);
+              item.barrier(sycl::access::fence_space::local_space);
+
               // Perform the actual workgroup reduction. To achieve a better
               // memory access pattern, we use sequential addressing and a
               // reversed loop. If the workgroup size is 8, the first element
               // contains all the values with index%4==0, after the second one
               // the values with index%2==0 and after the third one index%1==0,
               // i.e., all values.
-              for (unsigned int stride = wgroup_size / 2; stride > 0;
-                   stride >>= 1) {
-                const auto idx = local_id;
-                if (idx < stride) {
-                  ValueJoin::join(selected_reducer,
-                                  &local_mem[idx * value_count],
-                                  &local_mem[(idx + stride) * value_count]);
+              if (sg.get_group_id()[0] == 0) {
+                const auto local_range = sg.get_local_range()[0];
+                const auto n_subgroups = sg.get_group_range()[0];
+                const auto id_in_sg    = sg.get_local_id()[0];
+                auto* result_          = &local_mem[id_in_sg * value_count];
+                for (unsigned int offset = local_range; offset < n_subgroups;
+                     offset += local_range)
+                  if (id_in_sg + offset < n_subgroups)
+                    ValueJoin::join(
+                        selected_reducer, result_,
+                        &local_mem[(id_in_sg + offset) * value_count]);
+                for (unsigned int stride = local_range / 2; stride > 0;
+                     stride >>= 1) {
+                  auto* tmp = sg.shuffle_down(result_, stride);
+                  if (id_in_sg + stride < n_subgroups)
+                    ValueJoin::join(selected_reducer, result_, tmp);
                 }
-                item.barrier(sycl::access::fence_space::local_space);
-              }
 
-              // Finally, we copy the workgroup results back to global memory to
-              // be used in the next iteration. If this is the last iteration,
-              // i.e., there is only one workgroup also call final() if
-              // necessary.
-              if (local_id == 0) {
-                ValueOps::copy(
-                    functor,
-                    &results_ptr2[(item.get_group_linear_id()) * value_count],
-                    &local_mem[0]);
-                if constexpr (ReduceFunctorHasFinal<FunctorType>::value)
-                  if (n_wgroups <= 1 && item.get_group_linear_id() == 0) {
-                    FunctorFinal<FunctorType, WorkTag>::final(
-                        static_cast<const FunctorType&>(functor),
-                        &results_ptr2[(item.get_group_linear_id()) *
-                                      value_count]);
-                  }
+                // Finally, we copy the workgroup results back to global memory
+                // to be used in the next iteration. If this is the last
+                // iteration, i.e., there is only one workgroup also call
+                // final() if necessary.
+                if (id_in_sg == 0) {
+                  ValueOps::copy(
+                      functor,
+                      &results_ptr[(item.get_group_linear_id()) * value_count],
+                      &local_mem[0]);
+                  if constexpr (ReduceFunctorHasFinal<FunctorType>::value)
+                    if (n_wgroups <= 1 && item.get_group_linear_id() == 0)
+                      FunctorFinal<FunctorType, WorkTag>::final(
+                          static_cast<const FunctorType&>(functor),
+                          &results_ptr[(item.get_group_linear_id()) *
+                                       value_count]);
+                }
               }
             });
       });
-      space.fence();
-
-      // FIXME_SYCL this is likely not necessary, see above
-      Kokkos::Impl::DeepCopy<Kokkos::Experimental::SYCLDeviceUSMSpace,
-                             Kokkos::Experimental::SYCLDeviceUSMSpace>(
-          space, results_ptr, results_ptr2,
-          sizeof(*m_result_ptr) * value_count * n_wgroups);
       space.fence();
 
       first_run = false;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -659,38 +659,44 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
               }
               item.barrier(sycl::access::fence_space::local_space);
 
-              auto sg                   = item.get_sub_group();
-              auto* result              = &local_mem[local_id * value_count];
-              const int max_local_range = sg.get_max_local_range()[0];
-              for (unsigned int stride = max_local_range / 2; stride > 0;
+              // Perform the actual workgroup reduction in each subgroup
+              // separately. To achieve a better memory access pattern, we use
+              // sequential addressing and a reversed loop. If the workgroup
+              // size is 8, the first element contains all the values with
+              // index%4==0, after the second one the values with index%2==0 and
+              // after the third one index%1==0, i.e., all values.
+              auto sg               = item.get_sub_group();
+              auto* result          = &local_mem[local_id * value_count];
+              const int local_range = sg.get_local_range()[0];
+              for (unsigned int stride = local_range / 2; stride > 0;
                    stride >>= 1)
                 ValueJoin::join(selected_reducer, result,
                                 sg.shuffle_down(result, stride));
-
               item.barrier(sycl::access::fence_space::local_space);
+
+              // Copy the subgroup results into the first positions of the
+              // reduction array.
               if (sg.get_local_id()[0] == 0)
                 ValueOps::copy(functor,
                                &local_mem[sg.get_group_id()[0] * value_count],
                                result);
               item.barrier(sycl::access::fence_space::local_space);
 
-              // Perform the actual workgroup reduction. To achieve a better
-              // memory access pattern, we use sequential addressing and a
-              // reversed loop. If the workgroup size is 8, the first element
-              // contains all the values with index%4==0, after the second one
-              // the values with index%2==0 and after the third one index%1==0,
-              // i.e., all values.
+              // Do the final reduction only using the first subgroup.
               if (sg.get_group_id()[0] == 0) {
-                const auto local_range = sg.get_local_range()[0];
                 const auto n_subgroups = sg.get_group_range()[0];
                 const auto id_in_sg    = sg.get_local_id()[0];
                 auto* result_          = &local_mem[id_in_sg * value_count];
+                // In case the number of subgroups is larger than the range of
+                // the first subgroup, we first combine the items with a higher
+                // index.
                 for (unsigned int offset = local_range; offset < n_subgroups;
                      offset += local_range)
                   if (id_in_sg + offset < n_subgroups)
                     ValueJoin::join(
                         selected_reducer, result_,
                         &local_mem[(id_in_sg + offset) * value_count]);
+                // Then, we proceed as before.
                 for (unsigned int stride = local_range / 2; stride > 0;
                      stride >>= 1) {
                   auto* tmp = sg.shuffle_down(result_, stride);

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -665,18 +665,23 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
               // size is 8, the first element contains all the values with
               // index%4==0, after the second one the values with index%2==0 and
               // after the third one index%1==0, i.e., all values.
-              auto sg               = item.get_sub_group();
-              auto* result          = &local_mem[local_id * value_count];
-              const int local_range = sg.get_local_range()[0];
+              auto sg             = item.get_sub_group();
+              auto* result        = &local_mem[local_id * value_count];
+              const auto id_in_sg = sg.get_local_id()[0];
+              const auto local_range =
+                  std::min(sg.get_local_range()[0], wgroup_size);
               for (unsigned int stride = local_range / 2; stride > 0;
-                   stride >>= 1)
-                ValueJoin::join(selected_reducer, result,
-                                sg.shuffle_down(result, stride));
+                   stride >>= 1) {
+                auto* tmp = sg.shuffle_down(result, stride);
+                if (id_in_sg + stride < local_range)
+                  ValueJoin::join(selected_reducer, result, tmp);
+              }
               item.barrier(sycl::access::fence_space::local_space);
 
               // Copy the subgroup results into the first positions of the
               // reduction array.
-              if (sg.get_local_id()[0] == 0)
+              if (sg.get_local_id()[0] == 0 &&
+                  sg.get_local_id()[0] < wgroup_size)
                 ValueOps::copy(functor,
                                &local_mem[sg.get_group_id()[0] * value_count],
                                result);
@@ -685,7 +690,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
               // Do the final reduction only using the first subgroup.
               if (sg.get_group_id()[0] == 0) {
                 const auto n_subgroups = sg.get_group_range()[0];
-                const auto id_in_sg    = sg.get_local_id()[0];
                 auto* result_          = &local_mem[id_in_sg * value_count];
                 // In case the number of subgroups is larger than the range of
                 // the first subgroup, we first combine the items with a higher

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -47,6 +47,7 @@
 
 #include <Kokkos_Parallel.hpp>
 
+#include <SYCL/Kokkos_SYCL_Parallel_Reduce.hpp>  // workgroup_reduction
 #include <SYCL/Kokkos_SYCL_Team.hpp>
 
 namespace Kokkos {
@@ -538,8 +539,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     sycl::queue& q = *instance.m_queue;
 
     // FIXME_SYCL optimize
-    const size_t wgroup_size = m_team_size;
-    std::size_t size         = m_league_size * m_team_size;
+    const size_t wgroup_size = m_team_size * m_vector_size;
+    std::size_t size         = m_league_size * m_team_size * m_vector_size;
     const auto init_size =
         std::max<std::size_t>((size + wgroup_size - 1) / wgroup_size, 1);
     const unsigned int value_count =
@@ -632,9 +633,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
               // In the first iteration, we call functor to initialize the local
               // memory. Otherwise, the local memory is initialized with the
               // results from the previous iteration that are stored in global
-              // memory. Note that we load values_per_thread values per thread
-              // and immediately combine them to avoid too many threads being
-              // idle in the actual workgroup reduction.
+              // memory.
               if (first_run) {
                 reference_type update = ValueInit::init(
                     selected_reducer, &local_mem[local_id * value_count]);
@@ -659,72 +658,10 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
               }
               item.barrier(sycl::access::fence_space::local_space);
 
-              // Perform the actual workgroup reduction in each subgroup
-              // separately. To achieve a better memory access pattern, we use
-              // sequential addressing and a reversed loop. If the workgroup
-              // size is 8, the first element contains all the values with
-              // index%4==0, after the second one the values with index%2==0 and
-              // after the third one index%1==0, i.e., all values.
-              auto sg             = item.get_sub_group();
-              auto* result        = &local_mem[local_id * value_count];
-              const auto id_in_sg = sg.get_local_id()[0];
-              const auto local_range =
-                  std::min(sg.get_local_range()[0], wgroup_size);
-              for (unsigned int stride = local_range / 2; stride > 0;
-                   stride >>= 1) {
-                auto* tmp = sg.shuffle_down(result, stride);
-                if (id_in_sg + stride < local_range)
-                  ValueJoin::join(selected_reducer, result, tmp);
-              }
-              item.barrier(sycl::access::fence_space::local_space);
-
-              // Copy the subgroup results into the first positions of the
-              // reduction array.
-              if (sg.get_local_id()[0] == 0 &&
-                  sg.get_local_id()[0] < wgroup_size)
-                ValueOps::copy(functor,
-                               &local_mem[sg.get_group_id()[0] * value_count],
-                               result);
-              item.barrier(sycl::access::fence_space::local_space);
-
-              // Do the final reduction only using the first subgroup.
-              if (sg.get_group_id()[0] == 0) {
-                const auto n_subgroups = sg.get_group_range()[0];
-                auto* result_          = &local_mem[id_in_sg * value_count];
-                // In case the number of subgroups is larger than the range of
-                // the first subgroup, we first combine the items with a higher
-                // index.
-                for (unsigned int offset = local_range; offset < n_subgroups;
-                     offset += local_range)
-                  if (id_in_sg + offset < n_subgroups)
-                    ValueJoin::join(
-                        selected_reducer, result_,
-                        &local_mem[(id_in_sg + offset) * value_count]);
-                // Then, we proceed as before.
-                for (unsigned int stride = local_range / 2; stride > 0;
-                     stride >>= 1) {
-                  auto* tmp = sg.shuffle_down(result_, stride);
-                  if (id_in_sg + stride < n_subgroups)
-                    ValueJoin::join(selected_reducer, result_, tmp);
-                }
-
-                // Finally, we copy the workgroup results back to global memory
-                // to be used in the next iteration. If this is the last
-                // iteration, i.e., there is only one workgroup also call
-                // final() if necessary.
-                if (id_in_sg == 0) {
-                  ValueOps::copy(
-                      functor,
-                      &results_ptr[(item.get_group_linear_id()) * value_count],
-                      &local_mem[0]);
-                  if constexpr (ReduceFunctorHasFinal<FunctorType>::value)
-                    if (n_wgroups <= 1 && item.get_group_linear_id() == 0)
-                      FunctorFinal<FunctorType, WorkTag>::final(
-                          static_cast<const FunctorType&>(functor),
-                          &results_ptr[(item.get_group_linear_id()) *
-                                       value_count]);
-                }
-              }
+              SYCLReduction::workgroup_reduction<ValueJoin, ValueOps, WorkTag>(
+                  item, local_mem.get_pointer(), results_ptr, value_count,
+                  selected_reducer, static_cast<const FunctorType&>(functor),
+                  n_wgroups <= 1 && item.get_group_linear_id() == 0);
             });
       });
       space.fence();


### PR DESCRIPTION
Using subgroups for the reductions should improve the performance for `parallel_reduce` using `SYCL`.