### PR TITLE
Actually specify the correct CUDA architecture using SYCL

### DIFF
--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -327,10 +327,6 @@ template <class RandomGenerator, class Scalar>
 struct test_random_scalar {
   using rnd_type = typename RandomGenerator::generator_type;
 
-  int pass_mean, pass_var, pass_covar;
-  int pass_hist1d_mean, pass_hist1d_var, pass_hist1d_covar;
-  int pass_hist3d_mean, pass_hist3d_var, pass_hist3d_covar;
-
   test_random_scalar(
       typename test_random_functor<RandomGenerator, int>::type_1d& density_1d,
       typename test_random_functor<RandomGenerator, int>::type_3d& density_3d,
@@ -357,18 +353,9 @@ struct test_random_scalar {
           variance_expect / (result.variance / num_draws / 3) - 1.0;
       double covariance_eps =
           result.covariance / num_draws / 2 / variance_expect;
-      pass_mean = ((-tolerance < mean_eps) && (tolerance > mean_eps)) ? 1 : 0;
-      pass_var  = ((-1.5 * tolerance < variance_eps) &&
-                  (1.5 * tolerance > variance_eps))
-                     ? 1
-                     : 0;
-      pass_covar = ((-2.0 * tolerance < covariance_eps) &&
-                    (2.0 * tolerance > covariance_eps))
-                       ? 1
-                       : 0;
-      cout << "Pass: " << pass_mean << " " << pass_var << " " << mean_eps << " "
-           << variance_eps << " " << covariance_eps << " || " << tolerance
-           << endl;
+      EXPECT_LT(std::abs(mean_eps), tolerance);
+      EXPECT_LT(std::abs(variance_eps), 1.5 * tolerance);
+      EXPECT_LT(std::abs(covariance_eps), 2.0 * tolerance);
     }
     {
       cout << " -- Testing 1-D histogram" << endl;
@@ -399,17 +386,9 @@ struct test_random_scalar {
       }
 #endif
 
-      pass_hist1d_mean =
-          ((-mean_eps_expect < mean_eps) && (mean_eps_expect > mean_eps)) ? 1
-                                                                          : 0;
-      pass_hist1d_var = ((-variance_eps_expect < variance_eps) &&
-                         (variance_eps_expect > variance_eps))
-                            ? 1
-                            : 0;
-      pass_hist1d_covar = ((-covariance_eps_expect < covariance_eps) &&
-                           (covariance_eps_expect > covariance_eps))
-                              ? 1
-                              : 0;
+      EXPECT_LT(std::abs(mean_eps), mean_eps_expect);
+      EXPECT_LT(std::abs(variance_eps), variance_eps_expect);
+      EXPECT_LT(std::abs(covariance_eps), covariance_eps_expect);
 
       cout << "Density 1D: " << mean_eps << " " << variance_eps << " "
            << (result.covariance / HIST_DIM1D / HIST_DIM1D) << " || "
@@ -445,16 +424,9 @@ struct test_random_scalar {
       }
 #endif
 
-      pass_hist3d_mean =
-          ((-tolerance < mean_eps) && (tolerance > mean_eps)) ? 1 : 0;
-      pass_hist3d_var = ((-variance_factor * tolerance < variance_eps) &&
-                         (variance_factor * tolerance > variance_eps))
-                            ? 1
-                            : 0;
-      pass_hist3d_covar = ((-variance_factor * tolerance < covariance_eps) &&
-                           (variance_factor * tolerance > covariance_eps))
-                              ? 1
-                              : 0;
+      EXPECT_LT(std::abs(mean_eps), tolerance);
+      EXPECT_LT(std::abs(variance_eps), variance_factor);
+      EXPECT_LT(std::abs(covariance_eps), variance_factor);
 
       cout << "Density 3D: " << mean_eps << " " << variance_eps << " "
            << result.covariance / HIST_DIM1D / HIST_DIM1D << " || " << tolerance
@@ -479,105 +451,42 @@ void test_random(unsigned int num_draws) {
   cout << "Test Scalar=int" << endl;
   test_random_scalar<RandomGenerator, int> test_int(density_1d, density_3d,
                                                     pool, num_draws);
-  ASSERT_EQ(test_int.pass_mean, 1);
-  ASSERT_EQ(test_int.pass_var, 1);
-  ASSERT_EQ(test_int.pass_covar, 1);
-  ASSERT_EQ(test_int.pass_hist1d_mean, 1);
-  ASSERT_EQ(test_int.pass_hist1d_var, 1);
-  ASSERT_EQ(test_int.pass_hist1d_covar, 1);
-  ASSERT_EQ(test_int.pass_hist3d_mean, 1);
-  ASSERT_EQ(test_int.pass_hist3d_var, 1);
-  ASSERT_EQ(test_int.pass_hist3d_covar, 1);
   deep_copy(density_1d, 0);
   deep_copy(density_3d, 0);
 
   cout << "Test Scalar=unsigned int" << endl;
   test_random_scalar<RandomGenerator, unsigned int> test_uint(
       density_1d, density_3d, pool, num_draws);
-  ASSERT_EQ(test_uint.pass_mean, 1);
-  ASSERT_EQ(test_uint.pass_var, 1);
-  ASSERT_EQ(test_uint.pass_covar, 1);
-  ASSERT_EQ(test_uint.pass_hist1d_mean, 1);
-  ASSERT_EQ(test_uint.pass_hist1d_var, 1);
-  ASSERT_EQ(test_uint.pass_hist1d_covar, 1);
-  ASSERT_EQ(test_uint.pass_hist3d_mean, 1);
-  ASSERT_EQ(test_uint.pass_hist3d_var, 1);
-  ASSERT_EQ(test_uint.pass_hist3d_covar, 1);
   deep_copy(density_1d, 0);
   deep_copy(density_3d, 0);
 
   cout << "Test Scalar=int64_t" << endl;
   test_random_scalar<RandomGenerator, int64_t> test_int64(
       density_1d, density_3d, pool, num_draws);
-  ASSERT_EQ(test_int64.pass_mean, 1);
-  ASSERT_EQ(test_int64.pass_var, 1);
-  ASSERT_EQ(test_int64.pass_covar, 1);
-  ASSERT_EQ(test_int64.pass_hist1d_mean, 1);
-  ASSERT_EQ(test_int64.pass_hist1d_var, 1);
-  ASSERT_EQ(test_int64.pass_hist1d_covar, 1);
-  ASSERT_EQ(test_int64.pass_hist3d_mean, 1);
-  ASSERT_EQ(test_int64.pass_hist3d_var, 1);
-  ASSERT_EQ(test_int64.pass_hist3d_covar, 1);
   deep_copy(density_1d, 0);
   deep_copy(density_3d, 0);
 
   cout << "Test Scalar=uint64_t" << endl;
   test_random_scalar<RandomGenerator, uint64_t> test_uint64(
       density_1d, density_3d, pool, num_draws);
-  ASSERT_EQ(test_uint64.pass_mean, 1);
-  ASSERT_EQ(test_uint64.pass_var, 1);
-  ASSERT_EQ(test_uint64.pass_covar, 1);
-  ASSERT_EQ(test_uint64.pass_hist1d_mean, 1);
-  ASSERT_EQ(test_uint64.pass_hist1d_var, 1);
-  ASSERT_EQ(test_uint64.pass_hist1d_covar, 1);
-  ASSERT_EQ(test_uint64.pass_hist3d_mean, 1);
-  ASSERT_EQ(test_uint64.pass_hist3d_var, 1);
-  ASSERT_EQ(test_uint64.pass_hist3d_covar, 1);
   deep_copy(density_1d, 0);
   deep_copy(density_3d, 0);
 
   cout << "Test Scalar=half" << endl;
   test_random_scalar<RandomGenerator, Kokkos::Experimental::half_t> test_half(
       density_1d, density_3d, pool, num_draws);
-  ASSERT_EQ(test_half.pass_mean, 1);
-  ASSERT_EQ(test_half.pass_var, 1);
-  ASSERT_EQ(test_half.pass_covar, 1);
-  ASSERT_EQ(test_half.pass_hist1d_mean, 1);
-  ASSERT_EQ(test_half.pass_hist1d_var, 1);
-  ASSERT_EQ(test_half.pass_hist1d_covar, 1);
-  ASSERT_EQ(test_half.pass_hist3d_mean, 1);
-  ASSERT_EQ(test_half.pass_hist3d_var, 1);
-  ASSERT_EQ(test_half.pass_hist3d_covar, 1);
   deep_copy(density_1d, 0);
   deep_copy(density_3d, 0);
 
   cout << "Test Scalar=float" << endl;
   test_random_scalar<RandomGenerator, float> test_float(density_1d, density_3d,
                                                         pool, num_draws);
-  ASSERT_EQ(test_float.pass_mean, 1);
-  ASSERT_EQ(test_float.pass_var, 1);
-  ASSERT_EQ(test_float.pass_covar, 1);
-  ASSERT_EQ(test_float.pass_hist1d_mean, 1);
-  ASSERT_EQ(test_float.pass_hist1d_var, 1);
-  ASSERT_EQ(test_float.pass_hist1d_covar, 1);
-  ASSERT_EQ(test_float.pass_hist3d_mean, 1);
-  ASSERT_EQ(test_float.pass_hist3d_var, 1);
-  ASSERT_EQ(test_float.pass_hist3d_covar, 1);
   deep_copy(density_1d, 0);
   deep_copy(density_3d, 0);
 
   cout << "Test Scalar=double" << endl;
   test_random_scalar<RandomGenerator, double> test_double(
       density_1d, density_3d, pool, num_draws);
-  ASSERT_EQ(test_double.pass_mean, 1);
-  ASSERT_EQ(test_double.pass_var, 1);
-  ASSERT_EQ(test_double.pass_covar, 1);
-  ASSERT_EQ(test_double.pass_hist1d_mean, 1);
-  ASSERT_EQ(test_double.pass_hist1d_var, 1);
-  ASSERT_EQ(test_double.pass_hist1d_covar, 1);
-  ASSERT_EQ(test_double.pass_hist3d_mean, 1);
-  ASSERT_EQ(test_double.pass_hist3d_var, 1);
-  ASSERT_EQ(test_double.pass_hist3d_covar, 1);
 }
 }  // namespace Impl
 

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -550,7 +550,7 @@ IF (KOKKOS_ENABLE_SYCL)
   IF(CUDA_ARCH_ALREADY_SPECIFIED)
     IF(KOKKOS_ENABLE_UNSUPPORTED_ARCHS)
       COMPILER_SPECIFIC_FLAGS(
-        DEFAULT -fsycl-targets=nvptx64-nvidia-cuda
+        DEFAULT -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend "${CUDA_ARCH_FLAG}=${KOKKOS_CUDA_ARCH_FLAG}"
       )
     ELSE()
       MESSAGE(SEND_ERROR "Setting a CUDA architecture for SYCL is only allowed with Kokkos_ENABLE_UNSUPPORTED_ARCHS=ON!")


### PR DESCRIPTION
Even if we can build without it currently, it just seems to be right to make sure we are building for the correct architecture.