### PR TITLE
Use memset in deep_copy

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1352,26 +1352,6 @@ struct ZeroMemset<Kokkos::Experimental::HIP, DT, DP...> {
 };
 #endif
 
-#ifdef KOKKOS_ENABLE_SYCL
-template <class DT, class... DP>
-struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
-  static void execute(const Kokkos::Experimental::SYCL& exec_space,
-                      const View<DT, DP...>& dst,
-                      typename ViewTraits<DT, DP...>::const_value_type&) {
-    exec_space.impl_internal_space_instance()->m_queue->memset(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type));
-  }
-
-  static void execute(const View<DT, DP...>& dst,
-                      typename ViewTraits<DT, DP...>::const_value_type&) {
-    Experimental::Impl::SYCLInternal::singleton().m_queue->memset(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type));
-  }
-};
-#endif
-
 template <typename ExecutionSpace, class DT, class... DP>
 inline void memset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
                    typename ViewTraits<DT, DP...>::const_value_type& value) {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1309,27 +1309,6 @@ struct ZeroMemset {
   }
 };
 
-#ifdef KOKKOS_ENABLE_CUDA
-template <class DT, class... DP>
-struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
-  static void execute(const Kokkos::Cuda& exec_space,
-                      const View<DT, DP...>& dst,
-                      typename ViewTraits<DT, DP...>::const_value_type&) {
-    CUDA_SAFE_CALL(cudaMemsetAsync(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type),
-        exec_space.cuda_stream()));
-  }
-
-  static void execute(const View<DT, DP...>& dst,
-                      typename ViewTraits<DT, DP...>::const_value_type&) {
-    CUDA_SAFE_CALL(
-        cudaMemset(dst.data(), 0,
-                   dst.size() * sizeof(typename View<DT, DP...>::value_type)));
-  }
-};
-#endif
-
 template <typename ExecutionSpace, class DT, class... DP>
 inline void memset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
                    typename ViewTraits<DT, DP...>::const_value_type& value) {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1364,15 +1364,13 @@ struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
 };
 #endif
 
-template <class DT, class... DP>
-inline void memset(const typename View<DT, DP...>::execution_space& exec_space,
-                   const View<DT, DP...>& dst,
+template <typename ExecutionSpace, class DT, class... DP>
+inline void memset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
                    typename ViewTraits<DT, DP...>::const_value_type& value) {
-  using ViewType        = View<DT, DP...>;
-  using exec_space_type = typename ViewType::execution_space;
+  using ViewType = View<DT, DP...>;
 
   if (Impl::is_zero_byte(value))
-    ZeroMemset<exec_space_type, DT, DP...>::execute(exec_space, dst);
+    ZeroMemset<ExecutionSpace, DT, DP...>::execute(exec_space, dst);
   else
     plain_memcpy(exec_space, dst, value);
 }

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1367,8 +1367,6 @@ struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
 template <typename ExecutionSpace, class DT, class... DP>
 inline void memset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
                    typename ViewTraits<DT, DP...>::const_value_type& value) {
-  using ViewType = View<DT, DP...>;
-
   if (Impl::is_zero_byte(value))
     ZeroMemset<ExecutionSpace, DT, DP...>::execute(exec_space, dst);
   else

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1271,7 +1271,7 @@ bool is_zero_byte(const T& t) {
 }
 
 template <typename ExecutionSpace, class DT, class... DP>
-inline void plain_memcpy(
+inline void contiguous_fill(
     const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
   using ViewType     = View<DT, DP...>;
@@ -1298,12 +1298,12 @@ template <typename ExecutionSpace, class DT, class... DP>
 struct ZeroMemset {
   ZeroMemset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
              typename ViewTraits<DT, DP...>::const_value_type& value) {
-    plain_memcpy(exec_space, dst, value);
+    contiguous_fill(exec_space, dst, value);
   }
 
   ZeroMemset(const View<DT, DP...>& dst,
              typename ViewTraits<DT, DP...>::const_value_type& value) {
-    plain_memcpy(ExecutionSpace(), dst, value);
+    contiguous_fill(ExecutionSpace(), dst, value);
   }
 };
 
@@ -1317,7 +1317,7 @@ memset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
   if (Impl::is_zero_byte(value))
     ZeroMemset<ExecutionSpace, DT, DP...>(exec_space, dst, value);
   else
-    plain_memcpy(exec_space, dst, value);
+    contiguous_fill(exec_space, dst, value);
 }
 
 template <typename ExecutionSpace, class DT, class... DP>
@@ -1327,7 +1327,7 @@ inline std::enable_if_t<!(
         typename ViewTraits<DT, DP...>::const_value_type>::value)>
 memset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
        typename ViewTraits<DT, DP...>::const_value_type& value) {
-  plain_memcpy(exec_space, dst, value);
+  contiguous_fill(exec_space, dst, value);
 }
 
 template <class DT, class... DP>
@@ -1343,7 +1343,7 @@ memset(const View<DT, DP...>& dst,
   if (Impl::is_zero_byte(value))
     ZeroMemset<exec_space_type, DT, DP...>(dst, value);
   else
-    plain_memcpy(exec_space_type(), dst, value);
+    contiguous_fill(exec_space_type(), dst, value);
 }
 
 template <class DT, class... DP>
@@ -1356,7 +1356,7 @@ memset(const View<DT, DP...>& dst,
   using ViewType        = View<DT, DP...>;
   using exec_space_type = typename ViewType::execution_space;
 
-  plain_memcpy(exec_space_type(), dst, value);
+  contiguous_fill(exec_space_type(), dst, value);
 }
 }  // namespace Impl
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1270,13 +1270,12 @@ bool is_zero_byte(const T& t) {
   return true;
 }
 
-template <class DT, class... DP>
+template <typename ExecutionSpace, class DT, class... DP>
 inline void plain_memcpy(
-    const typename View<DT, DP...>::execution_space& exec_space,
+    const ExecutionSpace& exec_space,
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
   using ViewType        = View<DT, DP...>;
-  using exec_space_type = typename ViewType::execution_space;
   using ViewTypeFlat    = Kokkos::View<
       typename ViewType::value_type*, Kokkos::LayoutRight,
       Kokkos::Device<typename ViewType::execution_space,
@@ -1287,11 +1286,11 @@ inline void plain_memcpy(
 
   ViewTypeFlat dst_flat(dst.data(), dst.size());
   if (dst.span() < static_cast<size_t>(std::numeric_limits<int>::max())) {
-    Kokkos::Impl::ViewFill<ViewTypeFlat, Kokkos::LayoutRight, exec_space_type,
+    Kokkos::Impl::ViewFill<ViewTypeFlat, Kokkos::LayoutRight, ExecutionSpace,
                            ViewTypeFlat::Rank, int>(dst_flat, value,
                                                     exec_space);
   } else
-    Kokkos::Impl::ViewFill<ViewTypeFlat, Kokkos::LayoutRight, exec_space_type,
+    Kokkos::Impl::ViewFill<ViewTypeFlat, Kokkos::LayoutRight, ExecutionSpace,
                            ViewTypeFlat::Rank, int64_t>(dst_flat, value,
                                                         exec_space);
 }

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1296,14 +1296,13 @@ inline void plain_memcpy(
 
 template <typename ExecutionSpace, class DT, class... DP>
 struct ZeroMemset {
-  static void execute(const ExecutionSpace& exec_space,
-                      const View<DT, DP...>& dst,
-                      typename ViewTraits<DT, DP...>::const_value_type& value) {
+  ZeroMemset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
+             typename ViewTraits<DT, DP...>::const_value_type& value) {
     plain_memcpy(exec_space, dst, value);
   }
 
-  static void execute(const View<DT, DP...>& dst,
-                      typename ViewTraits<DT, DP...>::const_value_type& value) {
+  ZeroMemset(const View<DT, DP...>& dst,
+             typename ViewTraits<DT, DP...>::const_value_type& value) {
     plain_memcpy(ExecutionSpace(), dst, value);
   }
 };
@@ -1312,7 +1311,7 @@ template <typename ExecutionSpace, class DT, class... DP>
 inline void memset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
                    typename ViewTraits<DT, DP...>::const_value_type& value) {
   if (Impl::is_zero_byte(value))
-    ZeroMemset<ExecutionSpace, DT, DP...>::execute(exec_space, dst, value);
+    ZeroMemset<ExecutionSpace, DT, DP...>(exec_space, dst, value);
   else
     plain_memcpy(exec_space, dst, value);
 }
@@ -1324,7 +1323,7 @@ inline void memset(const View<DT, DP...>& dst,
   using exec_space_type = typename ViewType::execution_space;
 
   if (Impl::is_zero_byte(value))
-    ZeroMemset<exec_space_type, DT, DP...>::execute(dst, value);
+    ZeroMemset<exec_space_type, DT, DP...>(dst, value);
   else
     plain_memcpy(exec_space_type(), dst, value);
 }

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1312,8 +1312,9 @@ inline std::enable_if_t<
     std::is_trivial<typename ViewTraits<DT, DP...>::const_value_type>::value &&
     std::is_trivially_copy_assignable<
         typename ViewTraits<DT, DP...>::const_value_type>::value>
-memset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
-       typename ViewTraits<DT, DP...>::const_value_type& value) {
+contiguous_fill_or_memset(
+    const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
+    typename ViewTraits<DT, DP...>::const_value_type& value) {
   if (Impl::is_zero_byte(value))
     ZeroMemset<ExecutionSpace, DT, DP...>(exec_space, dst, value);
   else
@@ -1325,8 +1326,9 @@ inline std::enable_if_t<!(
     std::is_trivial<typename ViewTraits<DT, DP...>::const_value_type>::value &&
     std::is_trivially_copy_assignable<
         typename ViewTraits<DT, DP...>::const_value_type>::value)>
-memset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
-       typename ViewTraits<DT, DP...>::const_value_type& value) {
+contiguous_fill_or_memset(
+    const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
+    typename ViewTraits<DT, DP...>::const_value_type& value) {
   contiguous_fill(exec_space, dst, value);
 }
 
@@ -1335,8 +1337,9 @@ inline std::enable_if_t<
     std::is_trivial<typename ViewTraits<DT, DP...>::const_value_type>::value &&
     std::is_trivially_copy_assignable<
         typename ViewTraits<DT, DP...>::const_value_type>::value>
-memset(const View<DT, DP...>& dst,
-       typename ViewTraits<DT, DP...>::const_value_type& value) {
+contiguous_fill_or_memset(
+    const View<DT, DP...>& dst,
+    typename ViewTraits<DT, DP...>::const_value_type& value) {
   using ViewType        = View<DT, DP...>;
   using exec_space_type = typename ViewType::execution_space;
 
@@ -1351,8 +1354,9 @@ inline std::enable_if_t<!(
     std::is_trivial<typename ViewTraits<DT, DP...>::const_value_type>::value &&
     std::is_trivially_copy_assignable<
         typename ViewTraits<DT, DP...>::const_value_type>::value)>
-memset(const View<DT, DP...>& dst,
-       typename ViewTraits<DT, DP...>::const_value_type& value) {
+contiguous_fill_or_memset(
+    const View<DT, DP...>& dst,
+    typename ViewTraits<DT, DP...>::const_value_type& value) {
   using ViewType        = View<DT, DP...>;
   using exec_space_type = typename ViewType::execution_space;
 
@@ -1394,7 +1398,7 @@ inline void deep_copy(
 
   // If contiguous we can simply do a 1D flat loop or use memset
   if (dst.span_is_contiguous()) {
-    Impl::memset(dst, value);
+    Impl::contiguous_fill_or_memset(dst, value);
     Kokkos::fence();
     if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
       Kokkos::Profiling::endDeepCopy();
@@ -2527,7 +2531,7 @@ inline void deep_copy(
   if (dst.data() == nullptr) {
     space.fence();
   } else if (dst.span_is_contiguous()) {
-    Impl::memset(space, dst, value);
+    Impl::contiguous_fill_or_memset(space, dst, value);
   } else {
     using ViewTypeUniform = typename std::conditional<
         View<DT, DP...>::Rank == 0,
@@ -2572,7 +2576,7 @@ inline void deep_copy(
     space.fence();
     using fill_exec_space = typename dst_traits::memory_space::execution_space;
     if (dst.span_is_contiguous()) {
-      Impl::memset(fill_exec_space(), dst, value);
+      Impl::contiguous_fill_or_memset(fill_exec_space(), dst, value);
     } else {
       using ViewTypeUniform = typename std::conditional<
           View<DT, DP...>::Rank == 0,

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1310,7 +1310,9 @@ struct ZeroMemset {
 template <typename ExecutionSpace, class DT, class... DP>
 inline void memset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
                    typename ViewTraits<DT, DP...>::const_value_type& value) {
-  if (Impl::is_zero_byte(value))
+  using ValueType = typename ViewTraits<DT, DP...>::value_type;
+
+  if (std::is_trivially_copyable<ValueType>::value && Impl::is_zero_byte(value))
     ZeroMemset<ExecutionSpace, DT, DP...>(exec_space, dst, value);
   else
     plain_memcpy(exec_space, dst, value);
@@ -1320,9 +1322,10 @@ template <class DT, class... DP>
 inline void memset(const View<DT, DP...>& dst,
                    typename ViewTraits<DT, DP...>::const_value_type& value) {
   using ViewType        = View<DT, DP...>;
+  using ValueType       = typename ViewTraits<DT, DP...>::value_type;
   using exec_space_type = typename ViewType::execution_space;
 
-  if (Impl::is_zero_byte(value))
+  if (std::is_trivially_copyable<ValueType>::value && Impl::is_zero_byte(value))
     ZeroMemset<exec_space_type, DT, DP...>(dst, value);
   else
     plain_memcpy(exec_space_type(), dst, value);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1331,27 +1331,6 @@ struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
 };
 #endif
 
-#ifdef KOKKOS_ENABLE_HIP
-template <class DT, class... DP>
-struct ZeroMemset<Kokkos::Experimental::HIP, DT, DP...> {
-  static void execute(const Kokkos::Experimental::HIP& exec_space,
-                      const View<DT, DP...>& dst,
-                      typename ViewTraits<DT, DP...>::const_value_type&) {
-    HIP_SAFE_CALL(hipMemsetAsync(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type),
-        exec_space.hip_stream()));
-  }
-
-  static void execute(const View<DT, DP...>& dst,
-                      typename ViewTraits<DT, DP...>::const_value_type&) {
-    HIP_SAFE_CALL(
-        hipMemset(dst.data(), 0,
-                  dst.size() * sizeof(typename View<DT, DP...>::value_type)));
-  }
-};
-#endif
-
 template <typename ExecutionSpace, class DT, class... DP>
 inline void memset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
                    typename ViewTraits<DT, DP...>::const_value_type& value) {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1272,11 +1272,10 @@ bool is_zero_byte(const T& t) {
 
 template <typename ExecutionSpace, class DT, class... DP>
 inline void plain_memcpy(
-    const ExecutionSpace& exec_space,
-    const View<DT, DP...>& dst,
+    const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
-  using ViewType        = View<DT, DP...>;
-  using ViewTypeFlat    = Kokkos::View<
+  using ViewType     = View<DT, DP...>;
+  using ViewTypeFlat = Kokkos::View<
       typename ViewType::value_type*, Kokkos::LayoutRight,
       Kokkos::Device<typename ViewType::execution_space,
                      typename std::conditional<ViewType::Rank == 0,

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -253,6 +253,9 @@ template <class DstSpace, class SrcSpace,
           class ExecutionSpace = typename DstSpace::execution_space>
 struct DeepCopy;
 
+template <typename ExecutionSpace, class DT, class... DP>
+struct ZeroMemset;
+
 template <class ViewType, class Layout = typename ViewType::array_layout,
           class ExecSpace = typename ViewType::execution_space,
           int Rank = ViewType::Rank, typename iType = int64_t>

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -278,7 +278,7 @@ template <class DT, class... DP>
 struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
   static void execute(const Kokkos::Cuda& exec_space,
                       const View<DT, DP...>& dst,
-                     typename View<DT, DP...>::const_value_type&) {
+                      typename View<DT, DP...>::const_value_type&) {
     CUDA_SAFE_CALL(cudaMemsetAsync(
         dst.data(), 0,
         dst.size() * sizeof(typename View<DT, DP...>::value_type),

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -276,17 +276,16 @@ class CudaSpaceInitializer : public ExecSpaceInitializerBase {
 
 template <class DT, class... DP>
 struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
-  static void execute(const Kokkos::Cuda& exec_space,
-                      const View<DT, DP...>& dst,
-                      typename View<DT, DP...>::const_value_type&) {
+  ZeroMemset(const Kokkos::Cuda& exec_space, const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
     CUDA_SAFE_CALL(cudaMemsetAsync(
         dst.data(), 0,
         dst.size() * sizeof(typename View<DT, DP...>::value_type),
         exec_space.cuda_stream()));
   }
 
-  static void execute(const View<DT, DP...>& dst,
-                      typename View<DT, DP...>::const_value_type&) {
+  ZeroMemset(const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
     CUDA_SAFE_CALL(
         cudaMemset(dst.data(), 0,
                    dst.size() * sizeof(typename View<DT, DP...>::value_type)));

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -274,6 +274,24 @@ class CudaSpaceInitializer : public ExecSpaceInitializerBase {
   void print_configuration(std::ostream& msg, const bool detail) final;
 };
 
+template <class DT, class... DP>
+struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
+  static void execute(const Kokkos::Cuda& exec_space,
+                      const View<DT, DP...>& dst,
+                     typename View<DT, DP...>::const_value_type&) {
+    CUDA_SAFE_CALL(cudaMemsetAsync(
+        dst.data(), 0,
+        dst.size() * sizeof(typename View<DT, DP...>::value_type),
+        exec_space.cuda_stream()));
+  }
+
+  static void execute(const View<DT, DP...>& dst,
+                      typename View<DT, DP...>::const_value_type&) {
+    CUDA_SAFE_CALL(
+        cudaMemset(dst.data(), 0,
+                   dst.size() * sizeof(typename View<DT, DP...>::value_type)));
+  }
+};
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -625,17 +625,17 @@ class HIPSpaceInitializer : public Kokkos::Impl::ExecSpaceInitializerBase {
 
 template <class DT, class... DP>
 struct ZeroMemset<Kokkos::Experimental::HIP, DT, DP...> {
-  static void execute(const Kokkos::Experimental::HIP& exec_space,
-                      const View<DT, DP...>& dst,
-                      typename View<DT, DP...>::const_value_type&) {
+  ZeroMemset(const Kokkos::Experimental::HIP& exec_space,
+             const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
     HIP_SAFE_CALL(hipMemsetAsync(
         dst.data(), 0,
         dst.size() * sizeof(typename View<DT, DP...>::value_type),
         exec_space.hip_stream()));
   }
 
-  static void execute(const View<DT, DP...>& dst,
-                      typename View<DT, DP...>::const_value_type&) {
+  ZeroMemset(const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
     HIP_SAFE_CALL(
         hipMemset(dst.data(), 0,
                   dst.size() * sizeof(typename View<DT, DP...>::value_type)));

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -623,6 +623,24 @@ class HIPSpaceInitializer : public Kokkos::Impl::ExecSpaceInitializerBase {
   void print_configuration(std::ostream& msg, const bool detail) final;
 };
 
+template <class DT, class... DP>
+struct ZeroMemset<Kokkos::Experimental::HIP, DT, DP...> {
+  static void execute(const Kokkos::Experimental::HIP& exec_space,
+                      const View<DT, DP...>& dst,
+                      typename View<DT, DP...>::const_value_type&) {
+    HIP_SAFE_CALL(hipMemsetAsync(
+        dst.data(), 0,
+        dst.size() * sizeof(typename View<DT, DP...>::value_type),
+        exec_space.hip_stream()));
+  }
+
+  static void execute(const View<DT, DP...>& dst,
+                      typename View<DT, DP...>::const_value_type&) {
+    HIP_SAFE_CALL(
+        hipMemset(dst.data(), 0,
+                  dst.size() * sizeof(typename View<DT, DP...>::value_type)));
+  }
+};
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -299,15 +299,12 @@ namespace Kokkos {
 
 namespace Impl {
 
-#ifdef KOKKOS_ENABLE_SERIAL
 template <class DT, class... DP>
-struct ZeroMemset<Kokkos::Serial, DT, DP...> {
-  ZeroMemset(const Kokkos::Serial&, const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
-    std::memset(
-        dst.data(), 0,
-        sizeof(typename View<DT, DP...>::const_value_type) * dst.size());
-  }
+struct ZeroMemset<typename HostSpace::execution_space, DT, DP...> {
+  ZeroMemset(const typename HostSpace::execution_space&,
+             const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type& value)
+      : ZeroMemset(dst, value) {}
 
   ZeroMemset(const View<DT, DP...>& dst,
              typename View<DT, DP...>::const_value_type&) {
@@ -316,7 +313,6 @@ struct ZeroMemset<Kokkos::Serial, DT, DP...> {
         sizeof(typename View<DT, DP...>::const_value_type) * dst.size());
   }
 };
-#endif
 
 template <class ExecutionSpace>
 struct DeepCopy<HostSpace, HostSpace, ExecutionSpace> {

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -299,6 +299,25 @@ namespace Kokkos {
 
 namespace Impl {
 
+#ifdef KOKKOS_ENABLE_SERIAL
+template <class DT, class... DP>
+struct ZeroMemset<Kokkos::Serial, DT, DP...> {
+  ZeroMemset(const Kokkos::Serial&, const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
+    std::memset(
+        dst.data(), 0,
+        sizeof(typename View<DT, DP...>::const_value_type) * dst.size());
+  }
+
+  ZeroMemset(const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
+    std::memset(
+        dst.data(), 0,
+        sizeof(typename View<DT, DP...>::const_value_type) * dst.size());
+  }
+};
+#endif
+
 template <class ExecutionSpace>
 struct DeepCopy<HostSpace, HostSpace, ExecutionSpace> {
   DeepCopy(void* dst, const void* src, size_t n) {

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -308,9 +308,8 @@ struct ZeroMemset<typename HostSpace::execution_space, DT, DP...> {
 
   ZeroMemset(const View<DT, DP...>& dst,
              typename View<DT, DP...>::const_value_type&) {
-    std::memset(
-        dst.data(), 0,
-        sizeof(typename View<DT, DP...>::const_value_type) * dst.size());
+    using ValueType = typename View<DT, DP...>::value_type;
+    std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
   }
 };
 

--- a/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
@@ -58,9 +58,13 @@ struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
   static void execute(const Kokkos::Experimental::SYCL& exec_space,
                       const View<DT, DP...>& dst,
                       typename View<DT, DP...>::const_value_type&) {
-    exec_space.impl_internal_space_instance()->m_queue->memset(
+    auto event = exec_space.impl_internal_space_instance()->m_queue->memset(
         dst.data(), 0,
         dst.size() * sizeof(typename View<DT, DP...>::value_type));
+    // FIXME_SYCL this should rather be
+    // exec_space.impl_internal_space_instance()->m_queue->submit_barrier();
+    // but that gives currently a segfault using the CUDA backend
+    Experimental::Impl::SYCLInternal::fence(event);
   }
 
   static void execute(const View<DT, DP...>& dst,

--- a/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
@@ -53,6 +53,24 @@
 namespace Kokkos {
 namespace Impl {
 
+template <class DT, class... DP>
+struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
+  static void execute(const Kokkos::Experimental::SYCL& exec_space,
+                      const View<DT, DP...>& dst,
+                      typename View<DT, DP...>::const_value_type&) {
+    exec_space.impl_internal_space_instance()->m_queue->memset(
+        dst.data(), 0,
+        dst.size() * sizeof(typename View<DT, DP...>::value_type));
+  }
+
+  static void execute(const View<DT, DP...>& dst,
+                      typename View<DT, DP...>::const_value_type&) {
+    Experimental::Impl::SYCLInternal::singleton().m_queue->memset(
+        dst.data(), 0,
+        dst.size() * sizeof(typename View<DT, DP...>::value_type));
+  }
+};
+
 template <>
 struct DeepCopy<Kokkos::Experimental::SYCLDeviceUSMSpace,
                 Kokkos::Experimental::SYCLDeviceUSMSpace,

--- a/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
@@ -55,9 +55,9 @@ namespace Impl {
 
 template <class DT, class... DP>
 struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
-  static void execute(const Kokkos::Experimental::SYCL& exec_space,
-                      const View<DT, DP...>& dst,
-                      typename View<DT, DP...>::const_value_type&) {
+  ZeroMemset(const Kokkos::Experimental::SYCL& exec_space,
+             const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
     auto event = exec_space.impl_internal_space_instance()->m_queue->memset(
         dst.data(), 0,
         dst.size() * sizeof(typename View<DT, DP...>::value_type));
@@ -67,8 +67,8 @@ struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
     Experimental::Impl::SYCLInternal::fence(event);
   }
 
-  static void execute(const View<DT, DP...>& dst,
-                      typename View<DT, DP...>::const_value_type&) {
+  ZeroMemset(const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
     Experimental::Impl::SYCLInternal::singleton().m_queue->memset(
         dst.data(), 0,
         dst.size() * sizeof(typename View<DT, DP...>::value_type));


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/3930. As noted in https://github.com/kokkos/kokkos/issues/3930#issuecomment-819867352 this seems to be advantageous at least for `Cuda` but we should benchmark this a little better and also possibly extend to other backends.