### PR TITLE
Revert m_iter_L, m_end_L changes to Kokkos_ScratchSpace

### DIFF
--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -198,6 +198,10 @@ TEST(TEST_CATEGORY, team_broadcast_double) {
   }
 }
 
+TEST(TEST_CATEGORY, team_handle_by_value) {
+  { TestTeamPolicyHandleByValue<TEST_EXECSPACE>(); }
+}
+
 }  // namespace Test
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET


### PR DESCRIPTION
Some changes of PR #3793 that removed code duplication in scratch
space code resulted in seg faults (when compiled with intel/18 compilers)
of executables utilizing hierarchical parallelism when the
team handle was passed by value rather than by reference and
accessing/writing to views within the lambda body

This PR reverts the changes that replaced
m_iter_L0, m_iter_L1, m_end_L0, m_iter_L1 by arrays
m_iter_L and m_end_L and adds a unit test that reproduced the issue