### PR TITLE
Avoid C-style arrays in Kokkos_ScratchSpace.hpp

### DIFF
--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -69,8 +69,10 @@ class ScratchMemorySpace {
   enum { ALIGN = 8 };
 
  private:
-  mutable char* m_iter_L[2] = {nullptr, nullptr};
-  char* m_end_L[2]          = {nullptr, nullptr};
+  mutable char* m_iter_L0 = nullptr;
+  mutable char* m_iter_L1 = nullptr;
+  char* m_end_L0          = nullptr;
+  char* m_end_L1          = nullptr;
 
   mutable int m_multiplier    = 0;
   mutable int m_offset        = 0;
@@ -114,14 +116,15 @@ class ScratchMemorySpace {
                                                 const ptrdiff_t alignment,
                                                 int level = -1) const {
     if (level == -1) level = m_default_level;
-    char* previous            = m_iter_L[level];
-    const ptrdiff_t missalign = size_t(m_iter_L[level]) % alignment;
-    if (missalign) m_iter_L[level] += alignment - missalign;
+    auto& m_iter              = (level == 0) ? m_iter_L0 : m_iter_L1;
+    auto& m_end               = (level == 0) ? m_end_L0 : m_end_L1;
+    char* previous            = m_iter;
+    const ptrdiff_t missalign = size_t(m_iter) % alignment;
+    if (missalign) m_iter += alignment - missalign;
 
-    void* tmp = m_iter_L[level] + m_offset * (aligned ? size : align(size));
-    if (m_end_L[level] <
-        (m_iter_L[level] += (aligned ? size : align(size)) * m_multiplier)) {
-      m_iter_L[level] = previous;  // put it back like it was
+    void* tmp = m_iter + m_offset * (aligned ? size : align(size));
+    if (m_end < (m_iter += (aligned ? size : align(size)) * m_multiplier)) {
+      m_iter = previous;  // put it back like it was
 #ifdef KOKKOS_ENABLE_DEBUG
       // mfh 23 Jun 2015: printf call consumes 25 registers
       // in a CUDA build, so only print in debug mode.  The
@@ -129,7 +132,7 @@ class ScratchMemorySpace {
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "ScratchMemorySpace<...>::get_shmem: Failed to allocate "
           "%ld byte(s); remaining capacity is %ld byte(s)\n",
-          long(size), long(m_end_L[level] - m_iter_L[level]));
+          long(size), long(m_end - m_iter));
 #endif  // KOKKOS_ENABLE_DEBUG
       tmp = nullptr;
     }
@@ -145,8 +148,10 @@ class ScratchMemorySpace {
                                             const IntType& size_L0,
                                             void* ptr_L1           = nullptr,
                                             const IntType& size_L1 = 0)
-      : m_iter_L{(char*)ptr_L0, (char*)ptr_L1},
-        m_end_L{(char*)ptr_L0 + size_L0, (char*)ptr_L1 + size_L1},
+      : m_iter_L0((char*)ptr_L0),
+        m_iter_L1((char*)ptr_L1),
+        m_end_L0((char*)ptr_L0 + size_L0),
+        m_end_L1((char*)ptr_L1 + size_L1),
         m_multiplier(1),
         m_offset(0),
         m_default_level(0) {}

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1537,7 +1537,9 @@ struct TestTeamPolicyHandleByValue {
   using exec_space = ExecSpace;
   using mem_space  = typename ExecSpace::memory_space;
 
-  TestTeamPolicyHandleByValue() {
+  TestTeamPolicyHandleByValue() { test(); }
+
+  void test() {
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     const int M = 1, N = 1;
     Kokkos::View<scalar **, mem_space> a("a", M, N);

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -198,6 +198,10 @@ TEST(TEST_CATEGORY, team_broadcast_double) {
   }
 }
 
+TEST(TEST_CATEGORY, team_handle_by_value) {
+  { TestTeamPolicyHandleByValue<TEST_EXECSPACE>(); }
+}
+
 }  // namespace Test
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET


### PR DESCRIPTION
Alternative to #3956 and #3957 working around issues with Intel 18.

@ndellingwood Can you please confirm that this also fixes the issue for you?