### PR TITLE
nvcc_wrapper: suppress duplicates of GPU architecture and RDC flags

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -67,6 +67,11 @@ shared_versioned_libraries=""
 
 # Does the User set the architecture
 arch_set=0
+arch_flag=""
+
+# Does the user set RDC?
+rdc_set=0
+rdc_flag=""
 
 # Does the user overwrite the host compiler
 ccbin_set=0
@@ -190,8 +195,34 @@ do
     host_only_args="$host_only_args $1 $2"
     shift
     ;;
+  # Handle nvcc args controlling whether to generated relocatable device code
+  --relocatable-device-code=*|-rdc=*)
+    if [ "$rdc_set" -eq 0 ]; then
+        rdc_set=1
+        rdc_flag="$1"
+        cuda_args="$cuda_args $rdc_flag"
+    elif [  "$rdc_flag" != "$1" ]; then
+        echo "RDC is being set twice with different flags, which is not handled"
+        echo "$rdc_flag"
+        echo "$1"
+        exit 1
+    fi
+    ;;
+  -rdc)
+    if [ "$rdc_set" -eq 0 ]; then
+        rdc_set=1
+        rdc_flag="$1 $2"
+        cuda_args="$cuda_args $rdc_flag"
+        shift
+    elif [ "$rdc_flag" = "$1 $2" ]; then
+        echo "RDC is being set twice with different flags, which is not handled"
+        echo "$rdc_flag"
+        echo "$1 $2"
+        exit 1
+    fi
+    ;;
   #Handle known nvcc args
-  --dryrun|--verbose|--keep|--keep-dir*|-G|--relocatable-device-code*|-lineinfo|-expt-extended-lambda|-expt-relaxed-constexpr|--resource-usage|-Xptxas*|--fmad*|--use_fast_math|--Wext-lambda-captures-this|-Wext-lambda-captures-this)
+  --dryrun|--verbose|--keep|--keep-dir*|-G|-lineinfo|-expt-extended-lambda|-expt-relaxed-constexpr|--resource-usage|-Xptxas*|--fmad*|--use_fast_math|--Wext-lambda-captures-this|-Wext-lambda-captures-this)
     cuda_args="$cuda_args $1"
     ;;
   #Handle more known nvcc args
@@ -199,11 +230,11 @@ do
     cuda_args="$cuda_args $1"
     ;;
   #Handle known nvcc args that have an argument
-  -rdc|-maxrregcount|--default-stream|-Xnvlink|--fmad|-cudart|--cudart|-include)
+  -maxrregcount|--default-stream|-Xnvlink|--fmad|-cudart|--cudart|-include)
     cuda_args="$cuda_args $1 $2"
     shift
     ;;
-  -rdc=*|-maxrregcount*|--maxrregcount*)
+  -maxrregcount*|--maxrregcount*)
     cuda_args="$cuda_args $1"
     ;;
   #Handle unsupported standard flags
@@ -323,19 +354,35 @@ do
     ;;
 
   #Handle -arch argument (if its not set use a default) this is the version with = sign
-  -arch*|-gencode*)
-    cuda_args="$cuda_args $1"
-    arch_set=1
+  -arch=*|-gencode=*)
+    if [ "$arch_set" -eq 0 ]; then
+        arch_set=1
+        arch_flag="$1"
+        cuda_args="$cuda_args $arch_flag"
+    elif [  "$arch_flag" != "$1" ]; then
+        echo "ARCH is being set twice with different flags, which is not handled"
+        echo "$arch_flag"
+        echo "$1"
+        exit 1
+    fi
+    ;;
+  #Handle -arch argument (if its not set use a default) this is the version without = sign
+  -arch|-gencode)
+    if [ "$arch_set" -eq 0 ]; then
+        arch_set=1
+        arch_flag="$1 $2"
+        cuda_args="$cuda_args $arch_flag"
+        shift
+    elif [ "$arch_flag" = "$1 $2" ]; then
+        echo "ARCH is being set twice with different flags, which is not handled"
+        echo "$arch_flag"
+        echo "$1 $2"
+        exit 1
+    fi
     ;;
   #Handle -code argument (if its not set use a default) this is the version with = sign
   -code*)
     cuda_args="$cuda_args $1"
-    ;;
-  #Handle -arch argument (if its not set use a default) this is the version without = sign
-  -arch|-gencode)
-    cuda_args="$cuda_args $1 $2"
-    arch_set=1
-    shift
     ;;
   #Handle -code argument (if its not set use a default) this is the version without = sign
   -code)


### PR DESCRIPTION
An application that uses Trilinos and also uses a library that directly has its CMake say `target_link_library(myLib PUBLIC kokkos)` can pick up repeated copies of compiler flags. For the most part, this is no concern. However, for unknown reasons, nvcc specifically rejects repetitions of a few key flags, even if they're identical. This spuriously breaks application builds, in a way that the fix is as yet unknown, and is expected to involve very deep CMake surgery.

Thus, modify `nvcc_wrapper` to explicitly process these arguments and ensure that if they're duplicated, they're identical and only presented once to the underlying `nvcc`