### PR TITLE
[Trilinos only] Keep quoted compiler flags when passing to Trilinos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,8 +206,13 @@ ENDIF()
 IF (KOKKOS_HAS_TRILINOS)
   # Overwrite the old flags at the top-level
   # Because Tribits doesn't use lists, it uses spaces for the list of CXX flags
-  # we have to match the annoying behavior
-  STRING(REPLACE ";" " " KOKKOSCORE_COMPILE_OPTIONS "${KOKKOS_COMPILE_OPTIONS}")
+  # we have to match the annoying behavior, also we have to preserve quotes
+  # which needs another workaround.
+  SET(KOKKOS_COMPILE_OPTIONS_TMP)
+  FOREACH(OPTION ${KOKKOS_COMPILE_OPTIONS})
+    LIST(APPEND KOKKOS_COMPILE_OPTIONS_TMP \"${OPTION}\")
+  ENDFOREACH()
+  STRING(REPLACE ";" " " KOKKOSCORE_COMPILE_OPTIONS "${KOKKOS_COMPILE_OPTIONS_TMP}")
   LIST(APPEND KOKKOS_ALL_COMPILE_OPTIONS ${KOKKOS_COMPILE_OPTIONS})
   IF (KOKKOS_ENABLE_CUDA)
     LIST(APPEND KOKKOS_ALL_COMPILE_OPTIONS ${KOKKOS_CUDA_OPTIONS})


### PR DESCRIPTION
For `SYCL` we need compiler flags that contain quotes when using the AOT compiler (which is currently required on some platforms due to compiler issues with the AOT compiler). These quotes seem to get stripped when passing them to `Trilinos`. It seems that simply quoting all flags individually seems to work around the issue but I'm happy if someone has better suggestions.

@ndellingwood Can you please check if building Trilinos with this works?