### PR TITLE
staticcsrgraph: use device type instead of execution space to construct views

### DIFF
--- a/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
+++ b/containers/src/impl/Kokkos_StaticCrsGraph_factory.hpp
@@ -114,15 +114,11 @@ namespace Kokkos {
 template <class StaticCrsGraphType, class InputSizeType>
 inline typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
     const std::string& label, const std::vector<InputSizeType>& input) {
-  using output_type = StaticCrsGraphType;
-  // using input_type = std::vector<InputSizeType>; // unused
-
+  using output_type  = StaticCrsGraphType;
   using entries_type = typename output_type::entries_type;
-
-  using work_type = View<typename output_type::size_type[],
-                         typename output_type::array_layout,
-                         typename output_type::execution_space,
-                         typename output_type::memory_traits>;
+  using work_type    = View<
+      typename output_type::size_type[], typename output_type::array_layout,
+      typename output_type::device_type, typename output_type::memory_traits>;
 
   output_type output;
 
@@ -161,10 +157,9 @@ inline typename StaticCrsGraphType::staticcrsgraph_type create_staticcrsgraph(
 
   static_assert(entries_type::rank == 1, "Graph entries view must be rank one");
 
-  using work_type = View<typename output_type::size_type[],
-                         typename output_type::array_layout,
-                         typename output_type::execution_space,
-                         typename output_type::memory_traits>;
+  using work_type = View<
+      typename output_type::size_type[], typename output_type::array_layout,
+      typename output_type::device_type, typename output_type::memory_traits>;
 
   output_type output;
 


### PR DESCRIPTION
Using the execution space to construct views internally can lead to issues when the staticcrsgraph itself is built using a non default memory space.
This leads to build failures in Tpetra on AMD.
Closes issue #3990.