### PR TITLE
Implement SYCL::print_configuration

### DIFF
--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -113,7 +113,7 @@ class SYCL {
   void fence() const;
 
   /// \brief Print configuration information to the given output stream.
-  static void print_configuration(std::ostream&, const bool detail = false);
+  void print_configuration(std::ostream&, const bool detail = false);
 
   /// \brief Free any resources being consumed by the device.
   static void impl_finalize();
@@ -131,12 +131,10 @@ class SYCL {
     sycl::device get_device() const;
 
     friend std::ostream& operator<<(std::ostream& os, const SYCLDevice& that) {
-      return that.info(os);
+      return SYCL::info(os, that.m_device);
     }
 
    private:
-    std::ostream& info(std::ostream& os) const;
-
     sycl::device m_device;
   };
 
@@ -154,6 +152,8 @@ class SYCL {
   }
 
  private:
+  static std::ostream& info(std::ostream& os, const sycl::device& device);
+
   Kokkos::Impl::HostSharedPtr<Impl::SYCLInternal> m_space_instance;
 };
 

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -131,7 +131,7 @@ class SYCL {
     sycl::device get_device() const;
 
     friend std::ostream& operator<<(std::ostream& os, const SYCLDevice& that) {
-      return SYCL::info(os, that.m_device);
+      return SYCL::impl_sycl_info(os, that.m_device);
     }
 
    private:
@@ -152,7 +152,8 @@ class SYCL {
   }
 
  private:
-  static std::ostream& info(std::ostream& os, const sycl::device& device);
+  static std::ostream& impl_sycl_info(std::ostream& os,
+                                      const sycl::device& device);
 
   Kokkos::Impl::HostSharedPtr<Impl::SYCLInternal> m_space_instance;
 };

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -105,6 +105,11 @@ bool SYCL::impl_is_initialized() {
 
 void SYCL::impl_finalize() { Impl::SYCLInternal::singleton().finalize(); }
 
+void SYCL::print_configuration(std::ostream& s, const bool detailed) {
+  s << "macro  KOKKOS_ENABLE_SYCL : defined" << '\n';
+  if (detailed) SYCL::info(s, m_space_instance->m_queue->get_device());
+}
+
 void SYCL::fence() const {
   Impl::SYCLInternal::fence(*m_space_instance->m_queue);
 }
@@ -143,119 +148,117 @@ void SYCL::impl_initialize(SYCL::SYCLDevice d) {
   Impl::SYCLInternal::singleton().initialize(d.get_device());
 }
 
-std::ostream& SYCL::SYCLDevice::info(std::ostream& os) const {
+std::ostream& SYCL::info(std::ostream& os, const sycl::device& device) {
   using namespace sycl::info;
-  return os << "Name: " << m_device.get_info<device::name>()
-            << "\nDriver Version: "
-            << m_device.get_info<device::driver_version>()
-            << "\nIs Host: " << m_device.is_host()
-            << "\nIs CPU: " << m_device.is_cpu()
-            << "\nIs GPU: " << m_device.is_gpu()
-            << "\nIs Accelerator: " << m_device.is_accelerator()
-            << "\nVendor Id: " << m_device.get_info<device::vendor_id>()
+  return os << "Name: " << device.get_info<device::name>()
+            << "\nDriver Version: " << device.get_info<device::driver_version>()
+            << "\nIs Host: " << device.is_host()
+            << "\nIs CPU: " << device.is_cpu()
+            << "\nIs GPU: " << device.is_gpu()
+            << "\nIs Accelerator: " << device.is_accelerator()
+            << "\nVendor Id: " << device.get_info<device::vendor_id>()
             << "\nMax Compute Units: "
-            << m_device.get_info<device::max_compute_units>()
+            << device.get_info<device::max_compute_units>()
             << "\nMax Work Item Dimensions: "
-            << m_device.get_info<device::max_work_item_dimensions>()
+            << device.get_info<device::max_work_item_dimensions>()
             << "\nMax Work Group Size: "
-            << m_device.get_info<device::max_work_group_size>()
+            << device.get_info<device::max_work_group_size>()
             << "\nPreferred Vector Width Char: "
-            << m_device.get_info<device::preferred_vector_width_char>()
+            << device.get_info<device::preferred_vector_width_char>()
             << "\nPreferred Vector Width Short: "
-            << m_device.get_info<device::preferred_vector_width_short>()
+            << device.get_info<device::preferred_vector_width_short>()
             << "\nPreferred Vector Width Int: "
-            << m_device.get_info<device::preferred_vector_width_int>()
+            << device.get_info<device::preferred_vector_width_int>()
             << "\nPreferred Vector Width Long: "
-            << m_device.get_info<device::preferred_vector_width_long>()
+            << device.get_info<device::preferred_vector_width_long>()
             << "\nPreferred Vector Width Float: "
-            << m_device.get_info<device::preferred_vector_width_float>()
+            << device.get_info<device::preferred_vector_width_float>()
             << "\nPreferred Vector Width Double: "
-            << m_device.get_info<device::preferred_vector_width_double>()
+            << device.get_info<device::preferred_vector_width_double>()
             << "\nPreferred Vector Width Half: "
-            << m_device.get_info<device::preferred_vector_width_half>()
+            << device.get_info<device::preferred_vector_width_half>()
             << "\nNative Vector Width Char: "
-            << m_device.get_info<device::native_vector_width_char>()
+            << device.get_info<device::native_vector_width_char>()
             << "\nNative Vector Width Short: "
-            << m_device.get_info<device::native_vector_width_short>()
+            << device.get_info<device::native_vector_width_short>()
             << "\nNative Vector Width Int: "
-            << m_device.get_info<device::native_vector_width_int>()
+            << device.get_info<device::native_vector_width_int>()
             << "\nNative Vector Width Long: "
-            << m_device.get_info<device::native_vector_width_long>()
+            << device.get_info<device::native_vector_width_long>()
             << "\nNative Vector Width Float: "
-            << m_device.get_info<device::native_vector_width_float>()
+            << device.get_info<device::native_vector_width_float>()
             << "\nNative Vector Width Double: "
-            << m_device.get_info<device::native_vector_width_double>()
+            << device.get_info<device::native_vector_width_double>()
             << "\nNative Vector Width Half: "
-            << m_device.get_info<device::native_vector_width_half>()
-            << "\nAddress Bits: " << m_device.get_info<device::address_bits>()
-            << "\nImage Support: " << m_device.get_info<device::image_support>()
+            << device.get_info<device::native_vector_width_half>()
+            << "\nAddress Bits: " << device.get_info<device::address_bits>()
+            << "\nImage Support: " << device.get_info<device::image_support>()
             << "\nMax Mem Alloc Size: "
-            << m_device.get_info<device::max_mem_alloc_size>()
+            << device.get_info<device::max_mem_alloc_size>()
             << "\nMax Read Image Args: "
-            << m_device.get_info<device::max_read_image_args>()
+            << device.get_info<device::max_read_image_args>()
             << "\nImage2d Max Width: "
-            << m_device.get_info<device::image2d_max_width>()
+            << device.get_info<device::image2d_max_width>()
             << "\nImage2d Max Height: "
-            << m_device.get_info<device::image2d_max_height>()
+            << device.get_info<device::image2d_max_height>()
             << "\nImage3d Max Width: "
-            << m_device.get_info<device::image3d_max_width>()
+            << device.get_info<device::image3d_max_width>()
             << "\nImage3d Max Height: "
-            << m_device.get_info<device::image3d_max_height>()
+            << device.get_info<device::image3d_max_height>()
             << "\nImage3d Max Depth: "
-            << m_device.get_info<device::image3d_max_depth>()
+            << device.get_info<device::image3d_max_depth>()
             << "\nImage Max Buffer Size: "
-            << m_device.get_info<device::image_max_buffer_size>()
+            << device.get_info<device::image_max_buffer_size>()
             << "\nImage Max Array Size: "
-            << m_device.get_info<device::image_max_array_size>()
-            << "\nMax Samplers: " << m_device.get_info<device::max_samplers>()
+            << device.get_info<device::image_max_array_size>()
+            << "\nMax Samplers: " << device.get_info<device::max_samplers>()
             << "\nMax Parameter Size: "
-            << m_device.get_info<device::max_parameter_size>()
+            << device.get_info<device::max_parameter_size>()
             << "\nMem Base Addr Align: "
-            << m_device.get_info<device::mem_base_addr_align>()
+            << device.get_info<device::mem_base_addr_align>()
             << "\nGlobal Cache Mem Line Size: "
-            << m_device.get_info<device::global_mem_cache_line_size>()
+            << device.get_info<device::global_mem_cache_line_size>()
             << "\nGlobal Mem Cache Size: "
-            << m_device.get_info<device::global_mem_cache_size>()
+            << device.get_info<device::global_mem_cache_size>()
             << "\nGlobal Mem Size: "
-            << m_device.get_info<device::global_mem_size>()
+            << device.get_info<device::global_mem_size>()
             << "\nMax Constant Buffer Size: "
-            << m_device.get_info<device::max_constant_buffer_size>()
+            << device.get_info<device::max_constant_buffer_size>()
             << "\nMax Constant Args: "
-            << m_device.get_info<device::max_constant_args>()
-            << "\nLocal Mem Size: "
-            << m_device.get_info<device::local_mem_size>()
+            << device.get_info<device::max_constant_args>()
+            << "\nLocal Mem Size: " << device.get_info<device::local_mem_size>()
             << "\nError Correction Support: "
-            << m_device.get_info<device::error_correction_support>()
+            << device.get_info<device::error_correction_support>()
             << "\nHost Unified Memory: "
-            << m_device.get_info<device::host_unified_memory>()
+            << device.get_info<device::host_unified_memory>()
             << "\nProfiling Timer Resolution: "
-            << m_device.get_info<device::profiling_timer_resolution>()
+            << device.get_info<device::profiling_timer_resolution>()
             << "\nIs Endian Little: "
-            << m_device.get_info<device::is_endian_little>()
-            << "\nIs Available: " << m_device.get_info<device::is_available>()
+            << device.get_info<device::is_endian_little>()
+            << "\nIs Available: " << device.get_info<device::is_available>()
             << "\nIs Compiler Available: "
-            << m_device.get_info<device::is_compiler_available>()
+            << device.get_info<device::is_compiler_available>()
             << "\nIs Linker Available: "
-            << m_device.get_info<device::is_linker_available>()
+            << device.get_info<device::is_linker_available>()
             << "\nQueue Profiling: "
-            << m_device.get_info<device::queue_profiling>()
+            << device.get_info<device::queue_profiling>()
             << "\nBuilt In Kernels: "
             << Container<std::vector<std::string>>(
-                   m_device.get_info<device::built_in_kernels>())
-            << "\nVendor: " << m_device.get_info<device::vendor>()
-            << "\nProfile: " << m_device.get_info<device::profile>()
-            << "\nVersion: " << m_device.get_info<device::version>()
+                   device.get_info<device::built_in_kernels>())
+            << "\nVendor: " << device.get_info<device::vendor>()
+            << "\nProfile: " << device.get_info<device::profile>()
+            << "\nVersion: " << device.get_info<device::version>()
             << "\nExtensions: "
             << Container<std::vector<std::string>>(
-                   m_device.get_info<device::extensions>())
+                   device.get_info<device::extensions>())
             << "\nPrintf Buffer Size: "
-            << m_device.get_info<device::printf_buffer_size>()
+            << device.get_info<device::printf_buffer_size>()
             << "\nPreferred Interop User Sync: "
-            << m_device.get_info<device::preferred_interop_user_sync>()
+            << device.get_info<device::preferred_interop_user_sync>()
             << "\nPartition Max Sub Devices: "
-            << m_device.get_info<device::partition_max_sub_devices>()
+            << device.get_info<device::partition_max_sub_devices>()
             << "\nReference Count: "
-            << m_device.get_info<device::reference_count>() << '\n';
+            << device.get_info<device::reference_count>() << '\n';
 }
 
 namespace Impl {

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -107,7 +107,8 @@ void SYCL::impl_finalize() { Impl::SYCLInternal::singleton().finalize(); }
 
 void SYCL::print_configuration(std::ostream& s, const bool detailed) {
   s << "macro  KOKKOS_ENABLE_SYCL : defined" << '\n';
-  if (detailed) SYCL::info(s, m_space_instance->m_queue->get_device());
+  if (detailed)
+    SYCL::impl_sycl_info(s, m_space_instance->m_queue->get_device());
 }
 
 void SYCL::fence() const {
@@ -148,7 +149,8 @@ void SYCL::impl_initialize(SYCL::SYCLDevice d) {
   Impl::SYCLInternal::singleton().initialize(d.get_device());
 }
 
-std::ostream& SYCL::info(std::ostream& os, const sycl::device& device) {
+std::ostream& SYCL::impl_sycl_info(std::ostream& os,
+                                   const sycl::device& device) {
   using namespace sycl::info;
   return os << "Name: " << device.get_info<device::name>()
             << "\nDriver Version: " << device.get_info<device::driver_version>()

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -298,15 +298,13 @@ void SYCLSpaceInitializer::fence() {
 }
 
 void SYCLSpaceInitializer::print_configuration(std::ostream& msg,
-                                               const bool /*detail*/) {
+                                               const bool detail) {
   msg << "Devices:" << std::endl;
   msg << "  KOKKOS_ENABLE_SYCL: ";
   msg << "yes" << std::endl;
 
   msg << "\nRuntime Configuration:" << std::endl;
-  // FIXME_SYCL not implemented
-  std::abort();
-  // Experimental::SYCL::print_configuration(msg, detail);
+  Experimental::SYCL{}.print_configuration(msg, detail);
 }
 
 }  // namespace Impl


### PR DESCRIPTION
Trilinos needs this and we haven't actually implemented it yet although we had an `SYCLDevice::info` that would fulfill similar functionality that I am just using. To combine the implementation I pulled it outside of `SYCLDevice` (but still in `SYCL`) as a private static member function (since I don't see a reason to actually store an `SYCLDevice` as of now).
Also, we are not looping over all possible devices but just the one that is used by the current object so I decided to make `print_configuration` non-static (similar to `OpenMPTarget`). I remember @crtrott saying that it's fine for `OpenMPTarget` but I am happy to discuss if we want something else.