### PR TITLE
nvcc_wrapper: fix errors in argument handling

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -214,7 +214,7 @@ do
         rdc_flag="$1 $2"
         cuda_args="$cuda_args $rdc_flag"
         shift
-    elif [ "$rdc_flag" = "$1 $2" ]; then
+    elif [ "$rdc_flag" != "$1 $2" ]; then
         echo "RDC is being set twice with different flags, which is not handled"
         echo "$rdc_flag"
         echo "$1 $2"
@@ -373,7 +373,7 @@ do
         arch_flag="$1 $2"
         cuda_args="$cuda_args $arch_flag"
         shift
-    elif [ "$arch_flag" = "$1 $2" ]; then
+    elif [ "$arch_flag" != "$1 $2" ]; then
         echo "ARCH is being set twice with different flags, which is not handled"
         echo "$arch_flag"
         echo "$1 $2"

--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -222,7 +222,7 @@ do
     fi
     ;;
   #Handle known nvcc args
-  --dryrun|--verbose|--keep|--keep-dir*|-G|-lineinfo|-expt-extended-lambda|-expt-relaxed-constexpr|--resource-usage|-Xptxas*|--fmad*|--use_fast_math|--Wext-lambda-captures-this|-Wext-lambda-captures-this)
+  --dryrun|--verbose|--keep|--keep-dir*|-G|-lineinfo|-expt-extended-lambda|-expt-relaxed-constexpr|--resource-usage|-Xptxas*|--fmad=*|--use_fast_math|--Wext-lambda-captures-this|-Wext-lambda-captures-this)
     cuda_args="$cuda_args $1"
     ;;
   #Handle more known nvcc args
@@ -230,12 +230,12 @@ do
     cuda_args="$cuda_args $1"
     ;;
   #Handle known nvcc args that have an argument
+  -maxrregcount=*|--maxrregcount=*)
+    cuda_args="$cuda_args $1"
+    ;;
   -maxrregcount|--default-stream|-Xnvlink|--fmad|-cudart|--cudart|-include)
     cuda_args="$cuda_args $1 $2"
     shift
-    ;;
-  -maxrregcount*|--maxrregcount*)
-    cuda_args="$cuda_args $1"
     ;;
   #Handle unsupported standard flags
   --std=c++1y|-std=c++1y|--std=gnu++1y|-std=gnu++1y|--std=c++1z|-std=c++1z|--std=gnu++1z|-std=gnu++1z|--std=c++2a|-std=c++2a)


### PR DESCRIPTION
Correction for #3968 and potential misparsing of `--foo=bar` style arguments relative to their `--foo bar` forms