### PR TITLE
Remove architecture flags in .jenkins for HIP backend

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -88,7 +88,6 @@ pipeline {
                                 -DKokkos_ENABLE_DEPRECATED_CODE_3=OFF \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_HIP=ON \
-                                -DKokkos_ARCH_VEGA906=ON \
                                 -DKokkos_ENABLE_OPENMP=ON \
                                 -DBUILD_NAME=${STAGE_NAME} \
                               -P cmake/KokkosCI.cmake'''
@@ -124,7 +123,6 @@ pipeline {
                                 -DKokkos_ENABLE_DEPRECATED_CODE_3=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_HIP=ON \
-                                -DKokkos_ARCH_VEGA906=ON \
                                 -DBUILD_NAME=${STAGE_NAME} \
                               -P cmake/KokkosCI.cmake'''
                     }


### PR DESCRIPTION
We have a mix MI60 and MI100 on our testing machines. Removing the architecture flags allows us to use all of our CI machines. 