### PR TITLE
Allow tools to set tool hook function pointers

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -72,109 +72,141 @@ void tool_invoked_fence(const uint32_t /* devID */) {
    */
   Kokkos::fence();
 }
-bool tool_set_event_hook(Kokkos::Tools::Experimental::ToolEventSetRequest request){
-    void* target = request.function_pointer;
-    switch(request.id){
-        case Kokkos_Tools_init_event:
-           Kokkos::Tools::Experimental::set_init_callback(*reinterpret_cast<initFunction*>(&target));
-           break;
-        case Kokkos_Tools_finalize_event:
-            Kokkos::Tools::Experimental::set_finalize_callback(*reinterpret_cast<finalizeFunction *>(&target));
-            break;
-        case Kokkos_Tools_parse_args_event:
-            Kokkos::Tools::Experimental::set_parse_args_callback(*reinterpret_cast<parseArgsFunction *>(&target));
-            break;
-        case Kokkos_Tools_print_help_event:
-            Kokkos::Tools::Experimental::set_print_help_callback(*reinterpret_cast<printHelpFunction *>(&target));
-            break;
-        case Kokkos_Tools_begin_parallel_for_event:
-            Kokkos::Tools::Experimental::set_begin_parallel_for_callback(*reinterpret_cast<beginFunction *>(&target));
-            break;
-        case Kokkos_Tools_end_parallel_for_event:
-            Kokkos::Tools::Experimental::set_end_parallel_for_callback(*reinterpret_cast<endFunction *>(&target));
-            break;
-        case Kokkos_Tools_begin_parallel_reduce_event:
-            Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(*reinterpret_cast<beginFunction *>(&target));
-            break;
-        case Kokkos_Tools_end_parallel_reduce_event:
-            Kokkos::Tools::Experimental::set_end_parallel_reduce_callback(*reinterpret_cast<endFunction *>(&target));
-            break;
-        case Kokkos_Tools_begin_parallel_scan_event:
-            Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(*reinterpret_cast<beginFunction *>(&target));
-            break;
-        case Kokkos_Tools_end_parallel_scan_event:
-            Kokkos::Tools::Experimental::set_end_parallel_scan_callback(*reinterpret_cast<endFunction *>(&target));
-            break;
-        case Kokkos_Tools_push_region_event:
-            Kokkos::Tools::Experimental::set_push_region_callback(*reinterpret_cast<pushFunction *>(&target));
-            break;
-        case Kokkos_Tools_pop_region_event:
-            Kokkos::Tools::Experimental::set_pop_region_callback(*reinterpret_cast<popFunction *>(&target));
-            break;
-        case Kokkos_Tools_allocate_data_event:
-            Kokkos::Tools::Experimental::set_allocate_data_callback(*reinterpret_cast<allocateDataFunction *>(&target));
-            break;
-        case Kokkos_Tools_deallocate_data_event:
-            Kokkos::Tools::Experimental::set_deallocate_data_callback(*reinterpret_cast<deallocateDataFunction *>(&target));
-            break;
-        case Kokkos_Tools_create_profile_section_event:
-            Kokkos::Tools::Experimental::set_create_profile_section_callback(*reinterpret_cast<createProfileSectionFunction *>(&target));
-            break;
-        case Kokkos_Tools_start_profile_section_event:
-            Kokkos::Tools::Experimental::set_start_profile_section_callback(*reinterpret_cast<startProfileSectionFunction *>(&target));
-            break;
-        case Kokkos_Tools_stop_profile_section_event:
-            Kokkos::Tools::Experimental::set_stop_profile_section_callback(*reinterpret_cast<stopProfileSectionFunction *>(&target));
-            break;
-        case Kokkos_Tools_destroy_profile_section_event:
-            Kokkos::Tools::Experimental::set_destroy_profile_section_callback(*reinterpret_cast<destroyProfileSectionFunction *>(&target));
-            break;
-        case Kokkos_Tools_profile_event_event:
-            Kokkos::Tools::Experimental::set_profile_event_callback(*reinterpret_cast<profileEventFunction *>(&target));
-            break;
-        case Kokkos_Tools_begin_deep_copy_event:
-            Kokkos::Tools::Experimental::set_begin_deep_copy_callback(*reinterpret_cast<beginDeepCopyFunction *>(&target));
-            break;
-        case Kokkos_Tools_end_deep_copy_event:
-            Kokkos::Tools::Experimental::set_end_deep_copy_callback(*reinterpret_cast<endDeepCopyFunction *>(&target));
-            break;
-        case Kokkos_Tools_begin_fence_event:
-            Kokkos::Tools::Experimental::set_begin_fence_callback(*reinterpret_cast<beginFenceFunction *>(&target));
-            break;
-        case Kokkos_Tools_end_fence_event:
-            Kokkos::Tools::Experimental::set_end_fence_callback(*reinterpret_cast<endFenceFunction *>(&target));
-            break;
-        case Kokkos_Tools_sync_dual_view_event:
-            Kokkos::Tools::Experimental::set_dual_view_sync_callback(*reinterpret_cast<dualViewSyncFunction *>(&target));
-            break;
-        case Kokkos_Tools_modify_dual_view_event:
-            Kokkos::Tools::Experimental::set_dual_view_modify_callback(*reinterpret_cast<dualViewModifyFunction *>(&target));
-            break;
-        case Kokkos_Tools_declare_metadata_event:
-            Kokkos::Tools::Experimental::set_declare_metadata_callback(*reinterpret_cast<declareMetadataFunction *>(&target));
-            break;
-        case Kokkos_Tools_declare_output_type_event:
-            Kokkos::Tools::Experimental::set_declare_output_type_callback(*reinterpret_cast<outputTypeDeclarationFunction *>(&target));
-            break;
-        case Kokkos_Tools_declare_input_type_event:
-            Kokkos::Tools::Experimental::set_declare_input_type_callback(*reinterpret_cast<inputTypeDeclarationFunction *>(&target));
-            break;
-        case Kokkos_Tools_request_output_values_event:
-            Kokkos::Tools::Experimental::set_request_output_values_callback(*reinterpret_cast<requestValueFunction *>(&target));
-            break;
-        case Kokkos_Tools_begin_tuning_context_event:
-            Kokkos::Tools::Experimental::set_begin_context_callback(*reinterpret_cast<contextBeginFunction *>(&target));
-            break;
-        case Kokkos_Tools_end_tuning_context_event:
-            Kokkos::Tools::Experimental::set_end_context_callback(*reinterpret_cast<contextEndFunction *>(&target));
-            break;
-        case Kokkos_Tools_declare_optimization_goal_event:
-            Kokkos::Tools::Experimental::set_declare_optimization_goal_callback(*reinterpret_cast<optimizationGoalDeclarationFunction *>(&target));
-            break;
-        default:
-            return false;
-    }
-    return true;
+bool tool_set_event_hook(
+    Kokkos::Tools::Experimental::ToolEventSetRequest request) {
+  void* target = request.function_pointer;
+  switch (request.id) {
+    case Kokkos_Tools_init_event:
+      Kokkos::Tools::Experimental::set_init_callback(
+          *reinterpret_cast<initFunction*>(&target));
+      break;
+    case Kokkos_Tools_finalize_event:
+      Kokkos::Tools::Experimental::set_finalize_callback(
+          *reinterpret_cast<finalizeFunction*>(&target));
+      break;
+    case Kokkos_Tools_parse_args_event:
+      Kokkos::Tools::Experimental::set_parse_args_callback(
+          *reinterpret_cast<parseArgsFunction*>(&target));
+      break;
+    case Kokkos_Tools_print_help_event:
+      Kokkos::Tools::Experimental::set_print_help_callback(
+          *reinterpret_cast<printHelpFunction*>(&target));
+      break;
+    case Kokkos_Tools_begin_parallel_for_event:
+      Kokkos::Tools::Experimental::set_begin_parallel_for_callback(
+          *reinterpret_cast<beginFunction*>(&target));
+      break;
+    case Kokkos_Tools_end_parallel_for_event:
+      Kokkos::Tools::Experimental::set_end_parallel_for_callback(
+          *reinterpret_cast<endFunction*>(&target));
+      break;
+    case Kokkos_Tools_begin_parallel_reduce_event:
+      Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(
+          *reinterpret_cast<beginFunction*>(&target));
+      break;
+    case Kokkos_Tools_end_parallel_reduce_event:
+      Kokkos::Tools::Experimental::set_end_parallel_reduce_callback(
+          *reinterpret_cast<endFunction*>(&target));
+      break;
+    case Kokkos_Tools_begin_parallel_scan_event:
+      Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(
+          *reinterpret_cast<beginFunction*>(&target));
+      break;
+    case Kokkos_Tools_end_parallel_scan_event:
+      Kokkos::Tools::Experimental::set_end_parallel_scan_callback(
+          *reinterpret_cast<endFunction*>(&target));
+      break;
+    case Kokkos_Tools_push_region_event:
+      Kokkos::Tools::Experimental::set_push_region_callback(
+          *reinterpret_cast<pushFunction*>(&target));
+      break;
+    case Kokkos_Tools_pop_region_event:
+      Kokkos::Tools::Experimental::set_pop_region_callback(
+          *reinterpret_cast<popFunction*>(&target));
+      break;
+    case Kokkos_Tools_allocate_data_event:
+      Kokkos::Tools::Experimental::set_allocate_data_callback(
+          *reinterpret_cast<allocateDataFunction*>(&target));
+      break;
+    case Kokkos_Tools_deallocate_data_event:
+      Kokkos::Tools::Experimental::set_deallocate_data_callback(
+          *reinterpret_cast<deallocateDataFunction*>(&target));
+      break;
+    case Kokkos_Tools_create_profile_section_event:
+      Kokkos::Tools::Experimental::set_create_profile_section_callback(
+          *reinterpret_cast<createProfileSectionFunction*>(&target));
+      break;
+    case Kokkos_Tools_start_profile_section_event:
+      Kokkos::Tools::Experimental::set_start_profile_section_callback(
+          *reinterpret_cast<startProfileSectionFunction*>(&target));
+      break;
+    case Kokkos_Tools_stop_profile_section_event:
+      Kokkos::Tools::Experimental::set_stop_profile_section_callback(
+          *reinterpret_cast<stopProfileSectionFunction*>(&target));
+      break;
+    case Kokkos_Tools_destroy_profile_section_event:
+      Kokkos::Tools::Experimental::set_destroy_profile_section_callback(
+          *reinterpret_cast<destroyProfileSectionFunction*>(&target));
+      break;
+    case Kokkos_Tools_profile_event_event:
+      Kokkos::Tools::Experimental::set_profile_event_callback(
+          *reinterpret_cast<profileEventFunction*>(&target));
+      break;
+    case Kokkos_Tools_begin_deep_copy_event:
+      Kokkos::Tools::Experimental::set_begin_deep_copy_callback(
+          *reinterpret_cast<beginDeepCopyFunction*>(&target));
+      break;
+    case Kokkos_Tools_end_deep_copy_event:
+      Kokkos::Tools::Experimental::set_end_deep_copy_callback(
+          *reinterpret_cast<endDeepCopyFunction*>(&target));
+      break;
+    case Kokkos_Tools_begin_fence_event:
+      Kokkos::Tools::Experimental::set_begin_fence_callback(
+          *reinterpret_cast<beginFenceFunction*>(&target));
+      break;
+    case Kokkos_Tools_end_fence_event:
+      Kokkos::Tools::Experimental::set_end_fence_callback(
+          *reinterpret_cast<endFenceFunction*>(&target));
+      break;
+    case Kokkos_Tools_sync_dual_view_event:
+      Kokkos::Tools::Experimental::set_dual_view_sync_callback(
+          *reinterpret_cast<dualViewSyncFunction*>(&target));
+      break;
+    case Kokkos_Tools_modify_dual_view_event:
+      Kokkos::Tools::Experimental::set_dual_view_modify_callback(
+          *reinterpret_cast<dualViewModifyFunction*>(&target));
+      break;
+    case Kokkos_Tools_declare_metadata_event:
+      Kokkos::Tools::Experimental::set_declare_metadata_callback(
+          *reinterpret_cast<declareMetadataFunction*>(&target));
+      break;
+    case Kokkos_Tools_declare_output_type_event:
+      Kokkos::Tools::Experimental::set_declare_output_type_callback(
+          *reinterpret_cast<outputTypeDeclarationFunction*>(&target));
+      break;
+    case Kokkos_Tools_declare_input_type_event:
+      Kokkos::Tools::Experimental::set_declare_input_type_callback(
+          *reinterpret_cast<inputTypeDeclarationFunction*>(&target));
+      break;
+    case Kokkos_Tools_request_output_values_event:
+      Kokkos::Tools::Experimental::set_request_output_values_callback(
+          *reinterpret_cast<requestValueFunction*>(&target));
+      break;
+    case Kokkos_Tools_begin_tuning_context_event:
+      Kokkos::Tools::Experimental::set_begin_context_callback(
+          *reinterpret_cast<contextBeginFunction*>(&target));
+      break;
+    case Kokkos_Tools_end_tuning_context_event:
+      Kokkos::Tools::Experimental::set_end_context_callback(
+          *reinterpret_cast<contextEndFunction*>(&target));
+      break;
+    case Kokkos_Tools_declare_optimization_goal_event:
+      Kokkos::Tools::Experimental::set_declare_optimization_goal_callback(
+          *reinterpret_cast<optimizationGoalDeclarationFunction*>(&target));
+      break;
+    default: return false;
+  }
+  return true;
 }
 }  // namespace Impl
 #ifdef KOKKOS_ENABLE_TUNING
@@ -540,146 +572,148 @@ void initialize(const std::string& profileLibrary) {
   void* firstProfileLibrary = nullptr;
 
   if (!profileLibrary.empty()) {
+    char* envProfileLibrary = const_cast<char*>(profileLibrary.c_str());
 
-  char* envProfileLibrary = const_cast<char*>(profileLibrary.c_str());
+    char* envProfileCopy =
+        (char*)malloc(sizeof(char) * (strlen(envProfileLibrary) + 1));
+    sprintf(envProfileCopy, "%s", envProfileLibrary);
 
-  char* envProfileCopy =
-      (char*)malloc(sizeof(char) * (strlen(envProfileLibrary) + 1));
-  sprintf(envProfileCopy, "%s", envProfileLibrary);
+    char* profileLibraryName = strtok(envProfileCopy, ";");
 
-  char* profileLibraryName = strtok(envProfileCopy, ";");
+    if ((profileLibraryName != nullptr) &&
+        (strcmp(profileLibraryName, "") != 0)) {
+      firstProfileLibrary = dlopen(profileLibraryName, RTLD_NOW | RTLD_GLOBAL);
 
-  if ((profileLibraryName != nullptr) &&
-      (strcmp(profileLibraryName, "") != 0)) {
-    firstProfileLibrary = dlopen(profileLibraryName, RTLD_NOW | RTLD_GLOBAL);
-
-    if (firstProfileLibrary == nullptr) {
-      std::cerr << "Error: Unable to load KokkosP library: "
-                << profileLibraryName << std::endl;
-      std::cerr << "dlopen(" << profileLibraryName
-                << ", RTLD_NOW | RTLD_GLOBAL) failed with " << dlerror()
-                << '\n';
-    } else {
+      if (firstProfileLibrary == nullptr) {
+        std::cerr << "Error: Unable to load KokkosP library: "
+                  << profileLibraryName << std::endl;
+        std::cerr << "dlopen(" << profileLibraryName
+                  << ", RTLD_NOW | RTLD_GLOBAL) failed with " << dlerror()
+                  << '\n';
+      } else {
 #ifdef KOKKOS_ENABLE_PROFILING_LOAD_PRINT
-      std::cout << "KokkosP: Library Loaded: " << profileLibraryName
-                << std::endl;
+        std::cout << "KokkosP: Library Loaded: " << profileLibraryName
+                  << std::endl;
 #endif
-      lookup_function(
-          firstProfileLibrary, "kokkosp_begin_parallel_scan",
-          Kokkos::Tools::Experimental::current_callbacks.begin_parallel_scan);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_begin_parallel_for",
-          Kokkos::Tools::Experimental::current_callbacks.begin_parallel_for);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_begin_parallel_reduce",
-          Kokkos::Tools::Experimental::current_callbacks.begin_parallel_reduce);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_end_parallel_scan",
-          Kokkos::Tools::Experimental::current_callbacks.end_parallel_scan);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_end_parallel_for",
-          Kokkos::Tools::Experimental::current_callbacks.end_parallel_for);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_end_parallel_reduce",
-          Kokkos::Tools::Experimental::current_callbacks.end_parallel_reduce);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_begin_parallel_scan",
+            Kokkos::Tools::Experimental::current_callbacks.begin_parallel_scan);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_begin_parallel_for",
+            Kokkos::Tools::Experimental::current_callbacks.begin_parallel_for);
+        lookup_function(firstProfileLibrary, "kokkosp_begin_parallel_reduce",
+                        Kokkos::Tools::Experimental::current_callbacks
+                            .begin_parallel_reduce);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_end_parallel_scan",
+            Kokkos::Tools::Experimental::current_callbacks.end_parallel_scan);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_end_parallel_for",
+            Kokkos::Tools::Experimental::current_callbacks.end_parallel_for);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_end_parallel_reduce",
+            Kokkos::Tools::Experimental::current_callbacks.end_parallel_reduce);
 
-      lookup_function(firstProfileLibrary, "kokkosp_init_library",
-                      Kokkos::Tools::Experimental::current_callbacks.init);
-      lookup_function(firstProfileLibrary, "kokkosp_finalize_library",
-                      Kokkos::Tools::Experimental::current_callbacks.finalize);
+        lookup_function(firstProfileLibrary, "kokkosp_init_library",
+                        Kokkos::Tools::Experimental::current_callbacks.init);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_finalize_library",
+            Kokkos::Tools::Experimental::current_callbacks.finalize);
 
-      lookup_function(
-          firstProfileLibrary, "kokkosp_push_profile_region",
-          Kokkos::Tools::Experimental::current_callbacks.push_region);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_pop_profile_region",
-          Kokkos::Tools::Experimental::current_callbacks.pop_region);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_allocate_data",
-          Kokkos::Tools::Experimental::current_callbacks.allocate_data);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_deallocate_data",
-          Kokkos::Tools::Experimental::current_callbacks.deallocate_data);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_push_profile_region",
+            Kokkos::Tools::Experimental::current_callbacks.push_region);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_pop_profile_region",
+            Kokkos::Tools::Experimental::current_callbacks.pop_region);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_allocate_data",
+            Kokkos::Tools::Experimental::current_callbacks.allocate_data);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_deallocate_data",
+            Kokkos::Tools::Experimental::current_callbacks.deallocate_data);
 
-      lookup_function(
-          firstProfileLibrary, "kokkosp_begin_deep_copy",
-          Kokkos::Tools::Experimental::current_callbacks.begin_deep_copy);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_end_deep_copy",
-          Kokkos::Tools::Experimental::current_callbacks.end_deep_copy);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_begin_fence",
-          Kokkos::Tools::Experimental::current_callbacks.begin_fence);
-      lookup_function(firstProfileLibrary, "kokkosp_end_fence",
-                      Kokkos::Tools::Experimental::current_callbacks.end_fence);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_dual_view_sync",
-          Kokkos::Tools::Experimental::current_callbacks.sync_dual_view);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_dual_view_modify",
-          Kokkos::Tools::Experimental::current_callbacks.modify_dual_view);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_begin_deep_copy",
+            Kokkos::Tools::Experimental::current_callbacks.begin_deep_copy);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_end_deep_copy",
+            Kokkos::Tools::Experimental::current_callbacks.end_deep_copy);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_begin_fence",
+            Kokkos::Tools::Experimental::current_callbacks.begin_fence);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_end_fence",
+            Kokkos::Tools::Experimental::current_callbacks.end_fence);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_dual_view_sync",
+            Kokkos::Tools::Experimental::current_callbacks.sync_dual_view);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_dual_view_modify",
+            Kokkos::Tools::Experimental::current_callbacks.modify_dual_view);
 
-      lookup_function(
-          firstProfileLibrary, "kokkosp_declare_metadata",
-          Kokkos::Tools::Experimental::current_callbacks.declare_metadata);
-      lookup_function(firstProfileLibrary, "kokkosp_create_profile_section",
-                      Kokkos::Tools::Experimental::current_callbacks
-                          .create_profile_section);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_start_profile_section",
-          Kokkos::Tools::Experimental::current_callbacks.start_profile_section);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_stop_profile_section",
-          Kokkos::Tools::Experimental::current_callbacks.stop_profile_section);
-      lookup_function(firstProfileLibrary, "kokkosp_destroy_profile_section",
-                      Kokkos::Tools::Experimental::current_callbacks
-                          .destroy_profile_section);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_declare_metadata",
+            Kokkos::Tools::Experimental::current_callbacks.declare_metadata);
+        lookup_function(firstProfileLibrary, "kokkosp_create_profile_section",
+                        Kokkos::Tools::Experimental::current_callbacks
+                            .create_profile_section);
+        lookup_function(firstProfileLibrary, "kokkosp_start_profile_section",
+                        Kokkos::Tools::Experimental::current_callbacks
+                            .start_profile_section);
+        lookup_function(firstProfileLibrary, "kokkosp_stop_profile_section",
+                        Kokkos::Tools::Experimental::current_callbacks
+                            .stop_profile_section);
+        lookup_function(firstProfileLibrary, "kokkosp_destroy_profile_section",
+                        Kokkos::Tools::Experimental::current_callbacks
+                            .destroy_profile_section);
 
-      lookup_function(
-          firstProfileLibrary, "kokkosp_profile_event",
-          Kokkos::Tools::Experimental::current_callbacks.profile_event);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_profile_event",
+            Kokkos::Tools::Experimental::current_callbacks.profile_event);
 #ifdef KOKKOS_ENABLE_TUNING
-      lookup_function(
-          firstProfileLibrary, "kokkosp_declare_output_type",
-          Kokkos::Tools::Experimental::current_callbacks.declare_output_type);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_declare_output_type",
+            Kokkos::Tools::Experimental::current_callbacks.declare_output_type);
 
-      lookup_function(
-          firstProfileLibrary, "kokkosp_declare_input_type",
-          Kokkos::Tools::Experimental::current_callbacks.declare_input_type);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_request_values",
-          Kokkos::Tools::Experimental::current_callbacks.request_output_values);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_end_context",
-          Kokkos::Tools::Experimental::current_callbacks.end_tuning_context);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_begin_context",
-          Kokkos::Tools::Experimental::current_callbacks.begin_tuning_context);
-      lookup_function(firstProfileLibrary, "kokkosp_declare_optimization_goal",
-                      Kokkos::Tools::Experimental::current_callbacks
-                          .declare_optimization_goal);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_declare_input_type",
+            Kokkos::Tools::Experimental::current_callbacks.declare_input_type);
+        lookup_function(firstProfileLibrary, "kokkosp_request_values",
+                        Kokkos::Tools::Experimental::current_callbacks
+                            .request_output_values);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_end_context",
+            Kokkos::Tools::Experimental::current_callbacks.end_tuning_context);
+        lookup_function(firstProfileLibrary, "kokkosp_begin_context",
+                        Kokkos::Tools::Experimental::current_callbacks
+                            .begin_tuning_context);
+        lookup_function(firstProfileLibrary,
+                        "kokkosp_declare_optimization_goal",
+                        Kokkos::Tools::Experimental::current_callbacks
+                            .declare_optimization_goal);
 #endif  // KOKKOS_ENABLE_TUNING
 
-      lookup_function(
-          firstProfileLibrary, "kokkosp_print_help",
-          Kokkos::Tools::Experimental::current_callbacks.print_help);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_parse_args",
-          Kokkos::Tools::Experimental::current_callbacks.parse_args);
-      lookup_function(firstProfileLibrary,
-                      "kokkosp_provide_tool_programming_interface",
-                      Kokkos::Tools::Experimental::current_callbacks
-                          .provide_tool_programming_interface);
-      lookup_function(
-          firstProfileLibrary, "kokkosp_request_tool_settings",
-          Kokkos::Tools::Experimental::current_callbacks.request_tool_settings);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_print_help",
+            Kokkos::Tools::Experimental::current_callbacks.print_help);
+        lookup_function(
+            firstProfileLibrary, "kokkosp_parse_args",
+            Kokkos::Tools::Experimental::current_callbacks.parse_args);
+        lookup_function(firstProfileLibrary,
+                        "kokkosp_provide_tool_programming_interface",
+                        Kokkos::Tools::Experimental::current_callbacks
+                            .provide_tool_programming_interface);
+        lookup_function(firstProfileLibrary, "kokkosp_request_tool_settings",
+                        Kokkos::Tools::Experimental::current_callbacks
+                            .request_tool_settings);
+      }
     }
-  }
 #else
   (void)profileLibrary;
 #endif  // KOKKOS_ENABLE_LIBDL
 #ifdef KOKKOS_ENABLE_LIBDL
-      free(envProfileCopy);
+    free(envProfileCopy);
 #endif
   }
   Experimental::invoke_kokkosp_callback(
@@ -695,7 +729,7 @@ void initialize(const std::string& profileLibrary) {
       &Experimental::tool_requirements);
 
   Experimental::ToolProgrammingInterface actions;
-  actions.fence = &Experimental::Impl::tool_invoked_fence;
+  actions.fence         = &Experimental::Impl::tool_invoked_fence;
   actions.set_tool_hook = &Experimental::Impl::tool_set_event_hook;
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
@@ -764,7 +798,7 @@ void initialize(const std::string& profileLibrary) {
   Experimental::no_profiling.declare_output_type   = nullptr;
   Experimental::no_profiling.request_output_values = nullptr;
   Experimental::no_profiling.end_tuning_context    = nullptr;
-}
+}  // namespace Tools
 
 void finalize() {
   // Make sure finalize calls happens only once
@@ -920,7 +954,8 @@ void set_declare_optimization_goal_callback(
     optimizationGoalDeclarationFunction callback) {
   current_callbacks.declare_optimization_goal = callback;
 }
-void set_provide_tool_programming_interface_callback(provideToolProgrammingInterfaceFunction callback) {
+void set_provide_tool_programming_interface_callback(
+    provideToolProgrammingInterfaceFunction callback) {
   current_callbacks.provide_tool_programming_interface = callback;
 }
 

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -594,7 +594,7 @@ void initialize(const std::string& profileLibrary) {
 #ifdef KOKKOS_ENABLE_PROFILING_LOAD_PRINT
         std::cout << "KokkosP: Library Loaded: " << profileLibraryName
                   << std::endl;
-#endif // KOKKOS_ENABLE_PROFILING_LOAD_PRINT
+#endif  // KOKKOS_ENABLE_PROFILING_LOAD_PRINT
         lookup_function(
             firstProfileLibrary, "kokkosp_begin_parallel_scan",
             Kokkos::Tools::Experimental::current_callbacks.begin_parallel_scan);
@@ -707,149 +707,149 @@ void initialize(const std::string& profileLibrary) {
         lookup_function(firstProfileLibrary, "kokkosp_request_tool_settings",
                         Kokkos::Tools::Experimental::current_callbacks
                             .request_tool_settings);
-      } // firstProfileLibrary not null
-    } // strcmp
+      }  // firstProfileLibrary not null
+    }    // strcmp
 #ifdef KOKKOS_ENABLE_LIBDL
-      free(envProfileCopy);
+    free(envProfileCopy);
 #endif
   }
 #else
   (void)profileLibrary;
 #endif  // KOKKOS_ENABLE_LIBDL
-    Experimental::invoke_kokkosp_callback(
-        Kokkos::Tools::Experimental::MayRequireGlobalFencing::No,
-        Kokkos::Tools::Experimental::current_callbacks.init, 0,
-        (uint64_t)KOKKOSP_INTERFACE_VERSION, (uint32_t)0, nullptr);
+  Experimental::invoke_kokkosp_callback(
+      Kokkos::Tools::Experimental::MayRequireGlobalFencing::No,
+      Kokkos::Tools::Experimental::current_callbacks.init, 0,
+      (uint64_t)KOKKOSP_INTERFACE_VERSION, (uint32_t)0, nullptr);
 
-    Experimental::tool_requirements.requires_global_fencing = true;
+  Experimental::tool_requirements.requires_global_fencing = true;
 
-    Experimental::invoke_kokkosp_callback(
-        Experimental::MayRequireGlobalFencing::No,
-        Experimental::current_callbacks.request_tool_settings, 1,
-        &Experimental::tool_requirements);
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.request_tool_settings, 1,
+      &Experimental::tool_requirements);
 
-    Experimental::ToolProgrammingInterface actions;
-    actions.fence         = &Experimental::Impl::tool_invoked_fence;
-    actions.set_tool_hook = &Experimental::Impl::tool_set_event_hook;
-    Experimental::invoke_kokkosp_callback(
-        Experimental::MayRequireGlobalFencing::No,
-        Experimental::current_callbacks.provide_tool_programming_interface, 2,
-        actions);
+  Experimental::ToolProgrammingInterface actions;
+  actions.fence         = &Experimental::Impl::tool_invoked_fence;
+  actions.set_tool_hook = &Experimental::Impl::tool_set_event_hook;
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.provide_tool_programming_interface, 2,
+      actions);
 
 #ifdef KOKKOS_ENABLE_TUNING
-    Experimental::VariableInfo kernel_name;
-    kernel_name.type = Experimental::ValueType::kokkos_value_string;
-    kernel_name.category =
-        Experimental::StatisticalCategory::kokkos_value_categorical;
-    kernel_name.valueQuantity =
-        Experimental::CandidateValueType::kokkos_value_unbounded;
+  Experimental::VariableInfo kernel_name;
+  kernel_name.type = Experimental::ValueType::kokkos_value_string;
+  kernel_name.category =
+      Experimental::StatisticalCategory::kokkos_value_categorical;
+  kernel_name.valueQuantity =
+      Experimental::CandidateValueType::kokkos_value_unbounded;
 
-    std::array<std::string, 4> candidate_values = {
-        "parallel_for",
-        "parallel_reduce",
-        "parallel_scan",
-        "parallel_copy",
-    };
+  std::array<std::string, 4> candidate_values = {
+      "parallel_for",
+      "parallel_reduce",
+      "parallel_scan",
+      "parallel_copy",
+  };
 
-    Experimental::SetOrRange kernel_type_variable_candidates =
-        Experimental::make_candidate_set(4, candidate_values.data());
+  Experimental::SetOrRange kernel_type_variable_candidates =
+      Experimental::make_candidate_set(4, candidate_values.data());
 
-    Experimental::kernel_name_context_variable_id =
-        Experimental::declare_input_type("kokkos.kernel_name", kernel_name);
+  Experimental::kernel_name_context_variable_id =
+      Experimental::declare_input_type("kokkos.kernel_name", kernel_name);
 
-    Experimental::VariableInfo kernel_type;
-    kernel_type.type = Experimental::ValueType::kokkos_value_string;
-    kernel_type.category =
-        Experimental::StatisticalCategory::kokkos_value_categorical;
-    kernel_type.valueQuantity =
-        Experimental::CandidateValueType::kokkos_value_set;
-    kernel_type.candidates = kernel_type_variable_candidates;
-    Experimental::kernel_type_context_variable_id =
-        Experimental::declare_input_type("kokkos.kernel_type", kernel_type);
+  Experimental::VariableInfo kernel_type;
+  kernel_type.type = Experimental::ValueType::kokkos_value_string;
+  kernel_type.category =
+      Experimental::StatisticalCategory::kokkos_value_categorical;
+  kernel_type.valueQuantity =
+      Experimental::CandidateValueType::kokkos_value_set;
+  kernel_type.candidates = kernel_type_variable_candidates;
+  Experimental::kernel_type_context_variable_id =
+      Experimental::declare_input_type("kokkos.kernel_type", kernel_type);
 
 #endif
 
-    Experimental::no_profiling.init     = nullptr;
-    Experimental::no_profiling.finalize = nullptr;
+  Experimental::no_profiling.init     = nullptr;
+  Experimental::no_profiling.finalize = nullptr;
 
-    Experimental::no_profiling.begin_parallel_for    = nullptr;
-    Experimental::no_profiling.begin_parallel_scan   = nullptr;
-    Experimental::no_profiling.begin_parallel_reduce = nullptr;
-    Experimental::no_profiling.end_parallel_scan     = nullptr;
-    Experimental::no_profiling.end_parallel_for      = nullptr;
-    Experimental::no_profiling.end_parallel_reduce   = nullptr;
+  Experimental::no_profiling.begin_parallel_for    = nullptr;
+  Experimental::no_profiling.begin_parallel_scan   = nullptr;
+  Experimental::no_profiling.begin_parallel_reduce = nullptr;
+  Experimental::no_profiling.end_parallel_scan     = nullptr;
+  Experimental::no_profiling.end_parallel_for      = nullptr;
+  Experimental::no_profiling.end_parallel_reduce   = nullptr;
 
-    Experimental::no_profiling.push_region     = nullptr;
-    Experimental::no_profiling.pop_region      = nullptr;
-    Experimental::no_profiling.allocate_data   = nullptr;
-    Experimental::no_profiling.deallocate_data = nullptr;
+  Experimental::no_profiling.push_region     = nullptr;
+  Experimental::no_profiling.pop_region      = nullptr;
+  Experimental::no_profiling.allocate_data   = nullptr;
+  Experimental::no_profiling.deallocate_data = nullptr;
 
-    Experimental::no_profiling.begin_deep_copy = nullptr;
-    Experimental::no_profiling.end_deep_copy   = nullptr;
+  Experimental::no_profiling.begin_deep_copy = nullptr;
+  Experimental::no_profiling.end_deep_copy   = nullptr;
 
-    Experimental::no_profiling.create_profile_section  = nullptr;
-    Experimental::no_profiling.start_profile_section   = nullptr;
-    Experimental::no_profiling.stop_profile_section    = nullptr;
-    Experimental::no_profiling.destroy_profile_section = nullptr;
+  Experimental::no_profiling.create_profile_section  = nullptr;
+  Experimental::no_profiling.start_profile_section   = nullptr;
+  Experimental::no_profiling.stop_profile_section    = nullptr;
+  Experimental::no_profiling.destroy_profile_section = nullptr;
 
-    Experimental::no_profiling.profile_event = nullptr;
+  Experimental::no_profiling.profile_event = nullptr;
 
-    Experimental::no_profiling.declare_input_type    = nullptr;
-    Experimental::no_profiling.declare_output_type   = nullptr;
-    Experimental::no_profiling.request_output_values = nullptr;
-    Experimental::no_profiling.end_tuning_context    = nullptr;
+  Experimental::no_profiling.declare_input_type    = nullptr;
+  Experimental::no_profiling.declare_output_type   = nullptr;
+  Experimental::no_profiling.request_output_values = nullptr;
+  Experimental::no_profiling.end_tuning_context    = nullptr;
+}
+
+void finalize() {
+  // Make sure finalize calls happens only once
+  static int is_finalized = 0;
+  if (is_finalized) return;
+  is_finalized = 1;
+
+  if (Experimental::current_callbacks.finalize != nullptr) {
+    Experimental::invoke_kokkosp_callback(
+        Experimental::MayRequireGlobalFencing::No,
+        Experimental::current_callbacks.finalize);
+
+    Experimental::pause_tools();
   }
-
-  void finalize() {
-    // Make sure finalize calls happens only once
-    static int is_finalized = 0;
-    if (is_finalized) return;
-    is_finalized = 1;
-
-    if (Experimental::current_callbacks.finalize != nullptr) {
-      Experimental::invoke_kokkosp_callback(
-          Experimental::MayRequireGlobalFencing::No,
-          Experimental::current_callbacks.finalize);
-
-      Experimental::pause_tools();
-    }
 #ifdef KOKKOS_ENABLE_TUNING
-    // clean up string candidate set
-    for (auto& metadata_pair : Experimental::variable_metadata) {
-      auto metadata = metadata_pair.second;
-      if ((metadata.type == Experimental::ValueType::kokkos_value_string) &&
-          (metadata.valueQuantity ==
-           Experimental::CandidateValueType::kokkos_value_set)) {
-        auto candidate_set = metadata.candidates.set;
-        delete[] candidate_set.values.string_value;
-      }
+  // clean up string candidate set
+  for (auto& metadata_pair : Experimental::variable_metadata) {
+    auto metadata = metadata_pair.second;
+    if ((metadata.type == Experimental::ValueType::kokkos_value_string) &&
+        (metadata.valueQuantity ==
+         Experimental::CandidateValueType::kokkos_value_set)) {
+      auto candidate_set = metadata.candidates.set;
+      delete[] candidate_set.values.string_value;
     }
+  }
 #endif
-  }
+}
 
-  void syncDualView(const std::string& label, const void* const ptr,
-                    bool to_device) {
-    Experimental::invoke_kokkosp_callback(
-        Experimental::MayRequireGlobalFencing::No,
-        Experimental::current_callbacks.sync_dual_view, label.c_str(), ptr,
-        to_device);
-  }
-  void modifyDualView(const std::string& label, const void* const ptr,
-                      bool on_device) {
-    Experimental::invoke_kokkosp_callback(
-        Experimental::MayRequireGlobalFencing::No,
-        Experimental::current_callbacks.modify_dual_view, label.c_str(), ptr,
-        on_device);
-  }
+void syncDualView(const std::string& label, const void* const ptr,
+                  bool to_device) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.sync_dual_view, label.c_str(), ptr,
+      to_device);
+}
+void modifyDualView(const std::string& label, const void* const ptr,
+                    bool on_device) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.modify_dual_view, label.c_str(), ptr,
+      on_device);
+}
 
-  void declareMetadata(const std::string& key, const std::string& value) {
-    Experimental::invoke_kokkosp_callback(
-        Experimental::MayRequireGlobalFencing::No,
-        Experimental::current_callbacks.declare_metadata, key.c_str(),
-        value.c_str());
-  }
+void declareMetadata(const std::string& key, const std::string& value) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::No,
+      Experimental::current_callbacks.declare_metadata, key.c_str(),
+      value.c_str());
+}
 
-}  // namespace Kokkos
+}  // namespace Tools
 
 namespace Tools {
 namespace Experimental {
@@ -1049,7 +1049,7 @@ SpaceHandle make_space_handle(const char* space_name) {
 }
 }  // namespace Profiling
 
-}  // namespace Tools
+}  // namespace Kokkos
 
 // Tuning
 

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -72,6 +72,110 @@ void tool_invoked_fence(const uint32_t /* devID */) {
    */
   Kokkos::fence();
 }
+bool tool_set_event_hook(Kokkos::Tools::Experimental::ToolEventSetRequest request){
+    void* target = request.function_pointer;
+    switch(request.id){
+        case Kokkos_Tools_init_event:
+           Kokkos::Tools::Experimental::set_init_callback(*reinterpret_cast<initFunction*>(&target));
+           break;
+        case Kokkos_Tools_finalize_event:
+            Kokkos::Tools::Experimental::set_finalize_callback(*reinterpret_cast<finalizeFunction *>(&target));
+            break;
+        case Kokkos_Tools_parse_args_event:
+            Kokkos::Tools::Experimental::set_parse_args_callback(*reinterpret_cast<parseArgsFunction *>(&target));
+            break;
+        case Kokkos_Tools_print_help_event:
+            Kokkos::Tools::Experimental::set_print_help_callback(*reinterpret_cast<printHelpFunction *>(&target));
+            break;
+        case Kokkos_Tools_begin_parallel_for_event:
+            Kokkos::Tools::Experimental::set_begin_parallel_for_callback(*reinterpret_cast<beginFunction *>(&target));
+            break;
+        case Kokkos_Tools_end_parallel_for_event:
+            Kokkos::Tools::Experimental::set_end_parallel_for_callback(*reinterpret_cast<endFunction *>(&target));
+            break;
+        case Kokkos_Tools_begin_parallel_reduce_event:
+            Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(*reinterpret_cast<beginFunction *>(&target));
+            break;
+        case Kokkos_Tools_end_parallel_reduce_event:
+            Kokkos::Tools::Experimental::set_end_parallel_reduce_callback(*reinterpret_cast<endFunction *>(&target));
+            break;
+        case Kokkos_Tools_begin_parallel_scan_event:
+            Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(*reinterpret_cast<beginFunction *>(&target));
+            break;
+        case Kokkos_Tools_end_parallel_scan_event:
+            Kokkos::Tools::Experimental::set_end_parallel_scan_callback(*reinterpret_cast<endFunction *>(&target));
+            break;
+        case Kokkos_Tools_push_region_event:
+            Kokkos::Tools::Experimental::set_push_region_callback(*reinterpret_cast<pushFunction *>(&target));
+            break;
+        case Kokkos_Tools_pop_region_event:
+            Kokkos::Tools::Experimental::set_pop_region_callback(*reinterpret_cast<popFunction *>(&target));
+            break;
+        case Kokkos_Tools_allocate_data_event:
+            Kokkos::Tools::Experimental::set_allocate_data_callback(*reinterpret_cast<allocateDataFunction *>(&target));
+            break;
+        case Kokkos_Tools_deallocate_data_event:
+            Kokkos::Tools::Experimental::set_deallocate_data_callback(*reinterpret_cast<deallocateDataFunction *>(&target));
+            break;
+        case Kokkos_Tools_create_profile_section_event:
+            Kokkos::Tools::Experimental::set_create_profile_section_callback(*reinterpret_cast<createProfileSectionFunction *>(&target));
+            break;
+        case Kokkos_Tools_start_profile_section_event:
+            Kokkos::Tools::Experimental::set_start_profile_section_callback(*reinterpret_cast<startProfileSectionFunction *>(&target));
+            break;
+        case Kokkos_Tools_stop_profile_section_event:
+            Kokkos::Tools::Experimental::set_stop_profile_section_callback(*reinterpret_cast<stopProfileSectionFunction *>(&target));
+            break;
+        case Kokkos_Tools_destroy_profile_section_event:
+            Kokkos::Tools::Experimental::set_destroy_profile_section_callback(*reinterpret_cast<destroyProfileSectionFunction *>(&target));
+            break;
+        case Kokkos_Tools_profile_event_event:
+            Kokkos::Tools::Experimental::set_profile_event_callback(*reinterpret_cast<profileEventFunction *>(&target));
+            break;
+        case Kokkos_Tools_begin_deep_copy_event:
+            Kokkos::Tools::Experimental::set_begin_deep_copy_callback(*reinterpret_cast<beginDeepCopyFunction *>(&target));
+            break;
+        case Kokkos_Tools_end_deep_copy_event:
+            Kokkos::Tools::Experimental::set_end_deep_copy_callback(*reinterpret_cast<endDeepCopyFunction *>(&target));
+            break;
+        case Kokkos_Tools_begin_fence_event:
+            Kokkos::Tools::Experimental::set_begin_fence_callback(*reinterpret_cast<beginFenceFunction *>(&target));
+            break;
+        case Kokkos_Tools_end_fence_event:
+            Kokkos::Tools::Experimental::set_end_fence_callback(*reinterpret_cast<endFenceFunction *>(&target));
+            break;
+        case Kokkos_Tools_sync_dual_view_event:
+            Kokkos::Tools::Experimental::set_dual_view_sync_callback(*reinterpret_cast<dualViewSyncFunction *>(&target));
+            break;
+        case Kokkos_Tools_modify_dual_view_event:
+            Kokkos::Tools::Experimental::set_dual_view_modify_callback(*reinterpret_cast<dualViewModifyFunction *>(&target));
+            break;
+        case Kokkos_Tools_declare_metadata_event:
+            Kokkos::Tools::Experimental::set_declare_metadata_callback(*reinterpret_cast<declareMetadataFunction *>(&target));
+            break;
+        case Kokkos_Tools_declare_output_type_event:
+            Kokkos::Tools::Experimental::set_declare_output_type_callback(*reinterpret_cast<outputTypeDeclarationFunction *>(&target));
+            break;
+        case Kokkos_Tools_declare_input_type_event:
+            Kokkos::Tools::Experimental::set_declare_input_type_callback(*reinterpret_cast<inputTypeDeclarationFunction *>(&target));
+            break;
+        case Kokkos_Tools_request_output_values_event:
+            Kokkos::Tools::Experimental::set_request_output_values_callback(*reinterpret_cast<requestValueFunction *>(&target));
+            break;
+        case Kokkos_Tools_begin_tuning_context_event:
+            Kokkos::Tools::Experimental::set_begin_context_callback(*reinterpret_cast<contextBeginFunction *>(&target));
+            break;
+        case Kokkos_Tools_end_tuning_context_event:
+            Kokkos::Tools::Experimental::set_end_context_callback(*reinterpret_cast<contextEndFunction *>(&target));
+            break;
+        case Kokkos_Tools_declare_optimization_goal_event:
+            Kokkos::Tools::Experimental::set_declare_optimization_goal_callback(*reinterpret_cast<optimizationGoalDeclarationFunction *>(&target));
+            break;
+        default:
+            return false;
+    }
+    return true;
+}
 }  // namespace Impl
 #ifdef KOKKOS_ENABLE_TUNING
 static size_t kernel_name_context_variable_id;
@@ -588,10 +692,11 @@ void initialize(const std::string& profileLibrary) {
 
   Experimental::ToolProgrammingInterface actions;
   actions.fence = &Experimental::Impl::tool_invoked_fence;
+  actions.set_tool_hook = &Experimental::Impl::tool_set_event_hook;
 
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
-      Experimental::current_callbacks.provide_tool_programming_interface, 1,
+      Experimental::current_callbacks.provide_tool_programming_interface, 2,
       actions);
 
 #ifdef KOKKOS_ENABLE_TUNING

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -539,7 +539,7 @@ void initialize(const std::string& profileLibrary) {
 #ifdef KOKKOS_ENABLE_LIBDL
   void* firstProfileLibrary = nullptr;
 
-  if (profileLibrary.empty()) return;
+  if (!profileLibrary.empty()) {
 
   char* envProfileLibrary = const_cast<char*>(profileLibrary.c_str());
 
@@ -678,6 +678,10 @@ void initialize(const std::string& profileLibrary) {
 #else
   (void)profileLibrary;
 #endif  // KOKKOS_ENABLE_LIBDL
+#ifdef KOKKOS_ENABLE_LIBDL
+      free(envProfileCopy);
+#endif
+  }
   Experimental::invoke_kokkosp_callback(
       Kokkos::Tools::Experimental::MayRequireGlobalFencing::No,
       Kokkos::Tools::Experimental::current_callbacks.init, 0,
@@ -693,7 +697,6 @@ void initialize(const std::string& profileLibrary) {
   Experimental::ToolProgrammingInterface actions;
   actions.fence = &Experimental::Impl::tool_invoked_fence;
   actions.set_tool_hook = &Experimental::Impl::tool_set_event_hook;
-
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::No,
       Experimental::current_callbacks.provide_tool_programming_interface, 2,
@@ -761,9 +764,6 @@ void initialize(const std::string& profileLibrary) {
   Experimental::no_profiling.declare_output_type   = nullptr;
   Experimental::no_profiling.request_output_values = nullptr;
   Experimental::no_profiling.end_tuning_context    = nullptr;
-#ifdef KOKKOS_ENABLE_LIBDL
-  free(envProfileCopy);
-#endif
 }
 
 void finalize() {
@@ -919,6 +919,9 @@ void set_begin_context_callback(contextBeginFunction callback) {
 void set_declare_optimization_goal_callback(
     optimizationGoalDeclarationFunction callback) {
   current_callbacks.declare_optimization_goal = callback;
+}
+void set_provide_tool_programming_interface_callback(provideToolProgrammingInterfaceFunction callback) {
+  current_callbacks.provide_tool_programming_interface = callback;
 }
 
 void pause_tools() {

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -594,7 +594,7 @@ void initialize(const std::string& profileLibrary) {
 #ifdef KOKKOS_ENABLE_PROFILING_LOAD_PRINT
         std::cout << "KokkosP: Library Loaded: " << profileLibraryName
                   << std::endl;
-#endif
+#endif // KOKKOS_ENABLE_PROFILING_LOAD_PRINT
         lookup_function(
             firstProfileLibrary, "kokkosp_begin_parallel_scan",
             Kokkos::Tools::Experimental::current_callbacks.begin_parallel_scan);
@@ -707,15 +707,15 @@ void initialize(const std::string& profileLibrary) {
         lookup_function(firstProfileLibrary, "kokkosp_request_tool_settings",
                         Kokkos::Tools::Experimental::current_callbacks
                             .request_tool_settings);
-      }
-    }
+      } // firstProfileLibrary not null
+    } // strcmp
+#ifdef KOKKOS_ENABLE_LIBDL
+      free(envProfileCopy);
+#endif
+  }
 #else
   (void)profileLibrary;
-}
 #endif  // KOKKOS_ENABLE_LIBDL
-#ifdef KOKKOS_ENABLE_LIBDL
-    free(envProfileCopy);
-#endif
     Experimental::invoke_kokkosp_callback(
         Kokkos::Tools::Experimental::MayRequireGlobalFencing::No,
         Kokkos::Tools::Experimental::current_callbacks.init, 0,
@@ -798,7 +798,7 @@ void initialize(const std::string& profileLibrary) {
     Experimental::no_profiling.declare_output_type   = nullptr;
     Experimental::no_profiling.request_output_values = nullptr;
     Experimental::no_profiling.end_tuning_context    = nullptr;
-  }  // namespace Tools
+  }
 
   void finalize() {
     // Make sure finalize calls happens only once

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -711,145 +711,145 @@ void initialize(const std::string& profileLibrary) {
     }
 #else
   (void)profileLibrary;
+}
 #endif  // KOKKOS_ENABLE_LIBDL
 #ifdef KOKKOS_ENABLE_LIBDL
     free(envProfileCopy);
 #endif
-  }
-  Experimental::invoke_kokkosp_callback(
-      Kokkos::Tools::Experimental::MayRequireGlobalFencing::No,
-      Kokkos::Tools::Experimental::current_callbacks.init, 0,
-      (uint64_t)KOKKOSP_INTERFACE_VERSION, (uint32_t)0, nullptr);
+    Experimental::invoke_kokkosp_callback(
+        Kokkos::Tools::Experimental::MayRequireGlobalFencing::No,
+        Kokkos::Tools::Experimental::current_callbacks.init, 0,
+        (uint64_t)KOKKOSP_INTERFACE_VERSION, (uint32_t)0, nullptr);
 
-  Experimental::tool_requirements.requires_global_fencing = true;
+    Experimental::tool_requirements.requires_global_fencing = true;
 
-  Experimental::invoke_kokkosp_callback(
-      Experimental::MayRequireGlobalFencing::No,
-      Experimental::current_callbacks.request_tool_settings, 1,
-      &Experimental::tool_requirements);
-
-  Experimental::ToolProgrammingInterface actions;
-  actions.fence         = &Experimental::Impl::tool_invoked_fence;
-  actions.set_tool_hook = &Experimental::Impl::tool_set_event_hook;
-  Experimental::invoke_kokkosp_callback(
-      Experimental::MayRequireGlobalFencing::No,
-      Experimental::current_callbacks.provide_tool_programming_interface, 2,
-      actions);
-
-#ifdef KOKKOS_ENABLE_TUNING
-  Experimental::VariableInfo kernel_name;
-  kernel_name.type = Experimental::ValueType::kokkos_value_string;
-  kernel_name.category =
-      Experimental::StatisticalCategory::kokkos_value_categorical;
-  kernel_name.valueQuantity =
-      Experimental::CandidateValueType::kokkos_value_unbounded;
-
-  std::array<std::string, 4> candidate_values = {
-      "parallel_for",
-      "parallel_reduce",
-      "parallel_scan",
-      "parallel_copy",
-  };
-
-  Experimental::SetOrRange kernel_type_variable_candidates =
-      Experimental::make_candidate_set(4, candidate_values.data());
-
-  Experimental::kernel_name_context_variable_id =
-      Experimental::declare_input_type("kokkos.kernel_name", kernel_name);
-
-  Experimental::VariableInfo kernel_type;
-  kernel_type.type = Experimental::ValueType::kokkos_value_string;
-  kernel_type.category =
-      Experimental::StatisticalCategory::kokkos_value_categorical;
-  kernel_type.valueQuantity =
-      Experimental::CandidateValueType::kokkos_value_set;
-  kernel_type.candidates = kernel_type_variable_candidates;
-  Experimental::kernel_type_context_variable_id =
-      Experimental::declare_input_type("kokkos.kernel_type", kernel_type);
-
-#endif
-
-  Experimental::no_profiling.init     = nullptr;
-  Experimental::no_profiling.finalize = nullptr;
-
-  Experimental::no_profiling.begin_parallel_for    = nullptr;
-  Experimental::no_profiling.begin_parallel_scan   = nullptr;
-  Experimental::no_profiling.begin_parallel_reduce = nullptr;
-  Experimental::no_profiling.end_parallel_scan     = nullptr;
-  Experimental::no_profiling.end_parallel_for      = nullptr;
-  Experimental::no_profiling.end_parallel_reduce   = nullptr;
-
-  Experimental::no_profiling.push_region     = nullptr;
-  Experimental::no_profiling.pop_region      = nullptr;
-  Experimental::no_profiling.allocate_data   = nullptr;
-  Experimental::no_profiling.deallocate_data = nullptr;
-
-  Experimental::no_profiling.begin_deep_copy = nullptr;
-  Experimental::no_profiling.end_deep_copy   = nullptr;
-
-  Experimental::no_profiling.create_profile_section  = nullptr;
-  Experimental::no_profiling.start_profile_section   = nullptr;
-  Experimental::no_profiling.stop_profile_section    = nullptr;
-  Experimental::no_profiling.destroy_profile_section = nullptr;
-
-  Experimental::no_profiling.profile_event = nullptr;
-
-  Experimental::no_profiling.declare_input_type    = nullptr;
-  Experimental::no_profiling.declare_output_type   = nullptr;
-  Experimental::no_profiling.request_output_values = nullptr;
-  Experimental::no_profiling.end_tuning_context    = nullptr;
-}  // namespace Tools
-
-void finalize() {
-  // Make sure finalize calls happens only once
-  static int is_finalized = 0;
-  if (is_finalized) return;
-  is_finalized = 1;
-
-  if (Experimental::current_callbacks.finalize != nullptr) {
     Experimental::invoke_kokkosp_callback(
         Experimental::MayRequireGlobalFencing::No,
-        Experimental::current_callbacks.finalize);
+        Experimental::current_callbacks.request_tool_settings, 1,
+        &Experimental::tool_requirements);
 
-    Experimental::pause_tools();
-  }
+    Experimental::ToolProgrammingInterface actions;
+    actions.fence         = &Experimental::Impl::tool_invoked_fence;
+    actions.set_tool_hook = &Experimental::Impl::tool_set_event_hook;
+    Experimental::invoke_kokkosp_callback(
+        Experimental::MayRequireGlobalFencing::No,
+        Experimental::current_callbacks.provide_tool_programming_interface, 2,
+        actions);
+
 #ifdef KOKKOS_ENABLE_TUNING
-  // clean up string candidate set
-  for (auto& metadata_pair : Experimental::variable_metadata) {
-    auto metadata = metadata_pair.second;
-    if ((metadata.type == Experimental::ValueType::kokkos_value_string) &&
-        (metadata.valueQuantity ==
-         Experimental::CandidateValueType::kokkos_value_set)) {
-      auto candidate_set = metadata.candidates.set;
-      delete[] candidate_set.values.string_value;
-    }
-  }
+    Experimental::VariableInfo kernel_name;
+    kernel_name.type = Experimental::ValueType::kokkos_value_string;
+    kernel_name.category =
+        Experimental::StatisticalCategory::kokkos_value_categorical;
+    kernel_name.valueQuantity =
+        Experimental::CandidateValueType::kokkos_value_unbounded;
+
+    std::array<std::string, 4> candidate_values = {
+        "parallel_for",
+        "parallel_reduce",
+        "parallel_scan",
+        "parallel_copy",
+    };
+
+    Experimental::SetOrRange kernel_type_variable_candidates =
+        Experimental::make_candidate_set(4, candidate_values.data());
+
+    Experimental::kernel_name_context_variable_id =
+        Experimental::declare_input_type("kokkos.kernel_name", kernel_name);
+
+    Experimental::VariableInfo kernel_type;
+    kernel_type.type = Experimental::ValueType::kokkos_value_string;
+    kernel_type.category =
+        Experimental::StatisticalCategory::kokkos_value_categorical;
+    kernel_type.valueQuantity =
+        Experimental::CandidateValueType::kokkos_value_set;
+    kernel_type.candidates = kernel_type_variable_candidates;
+    Experimental::kernel_type_context_variable_id =
+        Experimental::declare_input_type("kokkos.kernel_type", kernel_type);
+
 #endif
-}
 
-void syncDualView(const std::string& label, const void* const ptr,
-                  bool to_device) {
-  Experimental::invoke_kokkosp_callback(
-      Experimental::MayRequireGlobalFencing::No,
-      Experimental::current_callbacks.sync_dual_view, label.c_str(), ptr,
-      to_device);
-}
-void modifyDualView(const std::string& label, const void* const ptr,
-                    bool on_device) {
-  Experimental::invoke_kokkosp_callback(
-      Experimental::MayRequireGlobalFencing::No,
-      Experimental::current_callbacks.modify_dual_view, label.c_str(), ptr,
-      on_device);
-}
+    Experimental::no_profiling.init     = nullptr;
+    Experimental::no_profiling.finalize = nullptr;
 
-void declareMetadata(const std::string& key, const std::string& value) {
-  Experimental::invoke_kokkosp_callback(
-      Experimental::MayRequireGlobalFencing::No,
-      Experimental::current_callbacks.declare_metadata, key.c_str(),
-      value.c_str());
-}
+    Experimental::no_profiling.begin_parallel_for    = nullptr;
+    Experimental::no_profiling.begin_parallel_scan   = nullptr;
+    Experimental::no_profiling.begin_parallel_reduce = nullptr;
+    Experimental::no_profiling.end_parallel_scan     = nullptr;
+    Experimental::no_profiling.end_parallel_for      = nullptr;
+    Experimental::no_profiling.end_parallel_reduce   = nullptr;
 
-}  // namespace Tools
+    Experimental::no_profiling.push_region     = nullptr;
+    Experimental::no_profiling.pop_region      = nullptr;
+    Experimental::no_profiling.allocate_data   = nullptr;
+    Experimental::no_profiling.deallocate_data = nullptr;
+
+    Experimental::no_profiling.begin_deep_copy = nullptr;
+    Experimental::no_profiling.end_deep_copy   = nullptr;
+
+    Experimental::no_profiling.create_profile_section  = nullptr;
+    Experimental::no_profiling.start_profile_section   = nullptr;
+    Experimental::no_profiling.stop_profile_section    = nullptr;
+    Experimental::no_profiling.destroy_profile_section = nullptr;
+
+    Experimental::no_profiling.profile_event = nullptr;
+
+    Experimental::no_profiling.declare_input_type    = nullptr;
+    Experimental::no_profiling.declare_output_type   = nullptr;
+    Experimental::no_profiling.request_output_values = nullptr;
+    Experimental::no_profiling.end_tuning_context    = nullptr;
+  }  // namespace Tools
+
+  void finalize() {
+    // Make sure finalize calls happens only once
+    static int is_finalized = 0;
+    if (is_finalized) return;
+    is_finalized = 1;
+
+    if (Experimental::current_callbacks.finalize != nullptr) {
+      Experimental::invoke_kokkosp_callback(
+          Experimental::MayRequireGlobalFencing::No,
+          Experimental::current_callbacks.finalize);
+
+      Experimental::pause_tools();
+    }
+#ifdef KOKKOS_ENABLE_TUNING
+    // clean up string candidate set
+    for (auto& metadata_pair : Experimental::variable_metadata) {
+      auto metadata = metadata_pair.second;
+      if ((metadata.type == Experimental::ValueType::kokkos_value_string) &&
+          (metadata.valueQuantity ==
+           Experimental::CandidateValueType::kokkos_value_set)) {
+        auto candidate_set = metadata.candidates.set;
+        delete[] candidate_set.values.string_value;
+      }
+    }
+#endif
+  }
+
+  void syncDualView(const std::string& label, const void* const ptr,
+                    bool to_device) {
+    Experimental::invoke_kokkosp_callback(
+        Experimental::MayRequireGlobalFencing::No,
+        Experimental::current_callbacks.sync_dual_view, label.c_str(), ptr,
+        to_device);
+  }
+  void modifyDualView(const std::string& label, const void* const ptr,
+                      bool on_device) {
+    Experimental::invoke_kokkosp_callback(
+        Experimental::MayRequireGlobalFencing::No,
+        Experimental::current_callbacks.modify_dual_view, label.c_str(), ptr,
+        on_device);
+  }
+
+  void declareMetadata(const std::string& key, const std::string& value) {
+    Experimental::invoke_kokkosp_callback(
+        Experimental::MayRequireGlobalFencing::No,
+        Experimental::current_callbacks.declare_metadata, key.c_str(),
+        value.c_str());
+  }
+
+}  // namespace Kokkos
 
 namespace Tools {
 namespace Experimental {
@@ -1049,7 +1049,7 @@ SpaceHandle make_space_handle(const char* space_name) {
 }
 }  // namespace Profiling
 
-}  // namespace Kokkos
+}  // namespace Tools
 
 // Tuning
 

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -170,7 +170,7 @@ void set_declare_optimization_goal_callback(
     optimizationGoalDeclarationFunction callback);
 void set_end_context_callback(contextEndFunction callback);
 void set_begin_context_callback(contextBeginFunction callback);
-
+void set_provide_tool_programming_interface_callback(provideToolProgrammingInterfaceFunction callback);
 void pause_tools();
 void resume_tools();
 

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -170,7 +170,8 @@ void set_declare_optimization_goal_callback(
     optimizationGoalDeclarationFunction callback);
 void set_end_context_callback(contextEndFunction callback);
 void set_begin_context_callback(contextBeginFunction callback);
-void set_provide_tool_programming_interface_callback(provideToolProgrammingInterfaceFunction callback);
+void set_provide_tool_programming_interface_callback(
+    provideToolProgrammingInterfaceFunction callback);
 void pause_tools();
 void resume_tools();
 

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -135,52 +135,53 @@ typedef void (*Kokkos_Profiling_declareMetadataFunction)(const char*,
 typedef void (*Kokkos_Tools_toolInvokedFenceFunction)(const uint32_t);
 
 enum Kokkos_Tools_EventIds {
-    Kokkos_Tools_init_event = 0,
-    Kokkos_Tools_finalize_event,
-    Kokkos_Tools_parse_args_event,
-    Kokkos_Tools_print_help_event,
-    Kokkos_Tools_begin_parallel_for_event,
-    Kokkos_Tools_end_parallel_for_event,
-    Kokkos_Tools_begin_parallel_reduce_event,
-    Kokkos_Tools_end_parallel_reduce_event,
-    Kokkos_Tools_begin_parallel_scan_event,
-    Kokkos_Tools_end_parallel_scan_event,
-    Kokkos_Tools_push_region_event,
-    Kokkos_Tools_pop_region_event,
-    Kokkos_Tools_allocate_data_event,
-    Kokkos_Tools_deallocate_data_event,
-    Kokkos_Tools_create_profile_section_event,
-    Kokkos_Tools_start_profile_section_event,
-    Kokkos_Tools_stop_profile_section_event,
-    Kokkos_Tools_destroy_profile_section_event,
-    Kokkos_Tools_profile_event_event,
-    Kokkos_Tools_begin_deep_copy_event,
-    Kokkos_Tools_end_deep_copy_event,
-    Kokkos_Tools_begin_fence_event,
-    Kokkos_Tools_end_fence_event,
-    Kokkos_Tools_sync_dual_view_event,
-    Kokkos_Tools_modify_dual_view_event,
-    Kokkos_Tools_declare_metadata_event,
-    Kokkos_Tools_declare_output_type_event,
-    Kokkos_Tools_declare_input_type_event,
-    Kokkos_Tools_request_output_values_event,
-    Kokkos_Tools_begin_tuning_context_event,
-    Kokkos_Tools_end_tuning_context_event,
-    Kokkos_Tools_declare_optimization_goal_event
+  Kokkos_Tools_init_event = 0,
+  Kokkos_Tools_finalize_event,
+  Kokkos_Tools_parse_args_event,
+  Kokkos_Tools_print_help_event,
+  Kokkos_Tools_begin_parallel_for_event,
+  Kokkos_Tools_end_parallel_for_event,
+  Kokkos_Tools_begin_parallel_reduce_event,
+  Kokkos_Tools_end_parallel_reduce_event,
+  Kokkos_Tools_begin_parallel_scan_event,
+  Kokkos_Tools_end_parallel_scan_event,
+  Kokkos_Tools_push_region_event,
+  Kokkos_Tools_pop_region_event,
+  Kokkos_Tools_allocate_data_event,
+  Kokkos_Tools_deallocate_data_event,
+  Kokkos_Tools_create_profile_section_event,
+  Kokkos_Tools_start_profile_section_event,
+  Kokkos_Tools_stop_profile_section_event,
+  Kokkos_Tools_destroy_profile_section_event,
+  Kokkos_Tools_profile_event_event,
+  Kokkos_Tools_begin_deep_copy_event,
+  Kokkos_Tools_end_deep_copy_event,
+  Kokkos_Tools_begin_fence_event,
+  Kokkos_Tools_end_fence_event,
+  Kokkos_Tools_sync_dual_view_event,
+  Kokkos_Tools_modify_dual_view_event,
+  Kokkos_Tools_declare_metadata_event,
+  Kokkos_Tools_declare_output_type_event,
+  Kokkos_Tools_declare_input_type_event,
+  Kokkos_Tools_request_output_values_event,
+  Kokkos_Tools_begin_tuning_context_event,
+  Kokkos_Tools_end_tuning_context_event,
+  Kokkos_Tools_declare_optimization_goal_event
 };
 
 struct Kokkos_Tools_ToolEventSetRequest {
-    enum Kokkos_Tools_EventIds id;
-    void* function_pointer;
+  enum Kokkos_Tools_EventIds id;
+  void* function_pointer;
 };
 
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
-typedef bool(*Kokkos_Tools_setToolHookFunction)(struct Kokkos_Tools_ToolEventSetRequest);
+typedef bool (*Kokkos_Tools_setToolHookFunction)(
+    struct Kokkos_Tools_ToolEventSetRequest);
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Tools_functionPointer)();
 struct Kokkos_Tools_ToolProgrammingInterface {
   Kokkos_Tools_toolInvokedFenceFunction fence;
-    Kokkos_Tools_setToolHookFunction set_tool_hook;
+  Kokkos_Tools_setToolHookFunction set_tool_hook;
   // allow addition of more actions
   Kokkos_Tools_functionPointer padding[30];
 };
@@ -290,7 +291,6 @@ typedef void (*Kokkos_Tools_contextEndFunction)(
     const size_t, struct Kokkos_Tools_VariableValue);
 typedef void (*Kokkos_Tools_optimizationGoalDeclarationFunction)(
     const size_t, const struct Kokkos_Tools_OptimzationGoal goal);
-
 
 struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_initFunction init;

--- a/core/src/impl/Kokkos_Profiling_C_Interface.h
+++ b/core/src/impl/Kokkos_Profiling_C_Interface.h
@@ -54,7 +54,7 @@
 #include <stdbool.h>
 #endif
 
-#define KOKKOSP_INTERFACE_VERSION 20210225
+#define KOKKOSP_INTERFACE_VERSION 20210504
 
 // Profiling
 
@@ -134,12 +134,55 @@ typedef void (*Kokkos_Profiling_declareMetadataFunction)(const char*,
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Tools_toolInvokedFenceFunction)(const uint32_t);
 
+enum Kokkos_Tools_EventIds {
+    Kokkos_Tools_init_event = 0,
+    Kokkos_Tools_finalize_event,
+    Kokkos_Tools_parse_args_event,
+    Kokkos_Tools_print_help_event,
+    Kokkos_Tools_begin_parallel_for_event,
+    Kokkos_Tools_end_parallel_for_event,
+    Kokkos_Tools_begin_parallel_reduce_event,
+    Kokkos_Tools_end_parallel_reduce_event,
+    Kokkos_Tools_begin_parallel_scan_event,
+    Kokkos_Tools_end_parallel_scan_event,
+    Kokkos_Tools_push_region_event,
+    Kokkos_Tools_pop_region_event,
+    Kokkos_Tools_allocate_data_event,
+    Kokkos_Tools_deallocate_data_event,
+    Kokkos_Tools_create_profile_section_event,
+    Kokkos_Tools_start_profile_section_event,
+    Kokkos_Tools_stop_profile_section_event,
+    Kokkos_Tools_destroy_profile_section_event,
+    Kokkos_Tools_profile_event_event,
+    Kokkos_Tools_begin_deep_copy_event,
+    Kokkos_Tools_end_deep_copy_event,
+    Kokkos_Tools_begin_fence_event,
+    Kokkos_Tools_end_fence_event,
+    Kokkos_Tools_sync_dual_view_event,
+    Kokkos_Tools_modify_dual_view_event,
+    Kokkos_Tools_declare_metadata_event,
+    Kokkos_Tools_declare_output_type_event,
+    Kokkos_Tools_declare_input_type_event,
+    Kokkos_Tools_request_output_values_event,
+    Kokkos_Tools_begin_tuning_context_event,
+    Kokkos_Tools_end_tuning_context_event,
+    Kokkos_Tools_declare_optimization_goal_event
+};
+
+struct Kokkos_Tools_ToolEventSetRequest {
+    enum Kokkos_Tools_EventIds id;
+    void* function_pointer;
+};
+
+// NOLINTNEXTLINE(modernize-use-using): C compatibility
+typedef bool(*Kokkos_Tools_setToolHookFunction)(struct Kokkos_Tools_ToolEventSetRequest);
 // NOLINTNEXTLINE(modernize-use-using): C compatibility
 typedef void (*Kokkos_Tools_functionPointer)();
 struct Kokkos_Tools_ToolProgrammingInterface {
   Kokkos_Tools_toolInvokedFenceFunction fence;
+    Kokkos_Tools_setToolHookFunction set_tool_hook;
   // allow addition of more actions
-  Kokkos_Tools_functionPointer padding[31];
+  Kokkos_Tools_functionPointer padding[30];
 };
 
 struct Kokkos_Tools_ToolSettings {
@@ -247,6 +290,7 @@ typedef void (*Kokkos_Tools_contextEndFunction)(
     const size_t, struct Kokkos_Tools_VariableValue);
 typedef void (*Kokkos_Tools_optimizationGoalDeclarationFunction)(
     const size_t, const struct Kokkos_Tools_OptimzationGoal goal);
+
 
 struct Kokkos_Profiling_EventSet {
   Kokkos_Profiling_initFunction init;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -119,6 +119,8 @@ using provideToolProgrammingInterfaceFunction =
 using requestToolSettingsFunction = Kokkos_Tools_requestToolSettingsFunction;
 using ToolSettings                = Kokkos_Tools_ToolSettings;
 using ToolProgrammingInterface    = Kokkos_Tools_ToolProgrammingInterface;
+using ToolEventSetRequest = Kokkos_Tools_ToolEventSetRequest;
+using ToolEventIds = Kokkos_Tools_EventIds;
 }  // namespace Experimental
 using initFunction           = Kokkos_Profiling_initFunction;
 using finalizeFunction       = Kokkos_Profiling_finalizeFunction;

--- a/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -119,8 +119,8 @@ using provideToolProgrammingInterfaceFunction =
 using requestToolSettingsFunction = Kokkos_Tools_requestToolSettingsFunction;
 using ToolSettings                = Kokkos_Tools_ToolSettings;
 using ToolProgrammingInterface    = Kokkos_Tools_ToolProgrammingInterface;
-using ToolEventSetRequest = Kokkos_Tools_ToolEventSetRequest;
-using ToolEventIds = Kokkos_Tools_EventIds;
+using ToolEventSetRequest         = Kokkos_Tools_ToolEventSetRequest;
+using ToolEventIds                = Kokkos_Tools_EventIds;
 }  // namespace Experimental
 using initFunction           = Kokkos_Profiling_initFunction;
 using finalizeFunction       = Kokkos_Profiling_finalizeFunction;

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -715,6 +715,10 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
       kokkosprinter-tool SHARED
       SOURCES tools/printing-tool.cpp
     )
+    KOKKOS_ADD_TEST_LIBRARY(
+      kokkosadaptive-tool SHARED
+      SOURCES tools/adaptive-tool.cpp
+    )
 
     if((NOT (Kokkos_ENABLE_CUDA AND WIN32)) AND (NOT ("${KOKKOS_CXX_COMPILER_ID}" STREQUAL "Fujitsu")))
       TARGET_COMPILE_FEATURES(kokkosprinter-tool PUBLIC cxx_std_14)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -701,6 +701,11 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
       SOURCES
       tools/TestCategoricalTuner.cpp
     )
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+            UnitTest_ToolInvokedActions
+            SOURCES
+            tools/TestToolInvokedActions.cpp
+    )
   endif()
   if(NOT Kokkos_ENABLE_OPENMPTARGET)
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
@@ -714,10 +719,6 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
     KOKKOS_ADD_TEST_LIBRARY(
       kokkosprinter-tool SHARED
       SOURCES tools/printing-tool.cpp
-    )
-    KOKKOS_ADD_TEST_LIBRARY(
-      kokkosadaptive-tool SHARED
-      SOURCES tools/adaptive-tool.cpp
     )
 
     if((NOT (Kokkos_ENABLE_CUDA AND WIN32)) AND (NOT ("${KOKKOS_CXX_COMPILER_ID}" STREQUAL "Fujitsu")))

--- a/core/unit_test/tools/TestToolInvokedActions.cpp
+++ b/core/unit_test/tools/TestToolInvokedActions.cpp
@@ -1,0 +1,76 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+#include <Kokkos_Core.hpp>
+
+Kokkos::Tools::Experimental::ToolProgrammingInterface interface;
+
+struct SampleFunctor {
+    KOKKOS_FUNCTION void operator()(int) const {}
+};
+void next_cb (const char *, const uint32_t, uint64_t *) {
+    interface.fence(0);
+    std::cout << "Called the next callback\n";
+};
+
+int main(int argc, char *argv[]) {
+    /**
+     * Calling this function before initialize is necessary,
+     * intialize is what invokes the callback we're setting
+     */
+    Kokkos::Tools::Experimental::set_provide_tool_programming_interface_callback([](const unsigned int,
+                                                                                    Kokkos::Tools::Experimental::ToolProgrammingInterface
+                                                                                    provided_interface) {
+        interface = provided_interface;
+    });
+    Kokkos::initialize(argc, argv);
+    {
+        Kokkos::Tools::Experimental::set_begin_parallel_for_callback([](const char*, const uint32_t, uint64_t*){
+          interface.set_tool_hook({Kokkos_Tools_begin_parallel_for_event, reinterpret_cast<void*>(&next_cb)});
+        });
+        SampleFunctor samp;
+        Kokkos::parallel_for("dummy_kernel", Kokkos::RangePolicy<>(0,1), samp);
+        Kokkos::parallel_for("dummy_kernel", Kokkos::RangePolicy<>(0,1), samp);
+    }
+    Kokkos::finalize();
+}

--- a/core/unit_test/tools/TestToolInvokedActions.cpp
+++ b/core/unit_test/tools/TestToolInvokedActions.cpp
@@ -46,31 +46,32 @@
 Kokkos::Tools::Experimental::ToolProgrammingInterface interface;
 
 struct SampleFunctor {
-    KOKKOS_FUNCTION void operator()(int) const {}
+  KOKKOS_FUNCTION void operator()(int) const {}
 };
-void next_cb (const char *, const uint32_t, uint64_t *) {
-    interface.fence(0);
-    std::cout << "Called the next callback\n";
+void next_cb(const char *, const uint32_t, uint64_t *) {
+  interface.fence(0);
+  std::cout << "Called the next callback\n";
 };
 
 int main(int argc, char *argv[]) {
-    /**
-     * Calling this function before initialize is necessary,
-     * intialize is what invokes the callback we're setting
-     */
-    Kokkos::Tools::Experimental::set_provide_tool_programming_interface_callback([](const unsigned int,
-                                                                                    Kokkos::Tools::Experimental::ToolProgrammingInterface
-                                                                                    provided_interface) {
-        interface = provided_interface;
-    });
-    Kokkos::initialize(argc, argv);
-    {
-        Kokkos::Tools::Experimental::set_begin_parallel_for_callback([](const char*, const uint32_t, uint64_t*){
-          interface.set_tool_hook({Kokkos_Tools_begin_parallel_for_event, reinterpret_cast<void*>(&next_cb)});
+  /**
+   * Calling this function before initialize is necessary,
+   * intialize is what invokes the callback we're setting
+   */
+  Kokkos::Tools::Experimental::set_provide_tool_programming_interface_callback(
+      [](const unsigned int,
+         Kokkos::Tools::Experimental::ToolProgrammingInterface
+             provided_interface) { interface = provided_interface; });
+  Kokkos::initialize(argc, argv);
+  {
+    Kokkos::Tools::Experimental::set_begin_parallel_for_callback(
+        [](const char *, const uint32_t, uint64_t *) {
+          interface.set_tool_hook({Kokkos_Tools_begin_parallel_for_event,
+                                   reinterpret_cast<void *>(&next_cb)});
         });
-        SampleFunctor samp;
-        Kokkos::parallel_for("dummy_kernel", Kokkos::RangePolicy<>(0,1), samp);
-        Kokkos::parallel_for("dummy_kernel", Kokkos::RangePolicy<>(0,1), samp);
-    }
-    Kokkos::finalize();
+    SampleFunctor samp;
+    Kokkos::parallel_for("dummy_kernel", Kokkos::RangePolicy<>(0, 1), samp);
+    Kokkos::parallel_for("dummy_kernel", Kokkos::RangePolicy<>(0, 1), samp);
+  }
+  Kokkos::finalize();
 }

--- a/core/unit_test/tools/printing-tool.cpp
+++ b/core/unit_test/tools/printing-tool.cpp
@@ -1,4 +1,3 @@
-
 #include <inttypes.h>
 #include <iostream>
 


### PR DESCRIPTION
Suppose a person (call them @wrwilliams ), wanted to be able to change their tool hooks, because they're developing the Tally-Q tool which wants to do that. This PR adds this ability to the ToolProgrammingInterface struct. Basically there's a new struct containing an enum (which event to set) and a function pointer (void*, because C). So, "unset the begin parallel for event" would look like

```c++
interface.set_tool_hook({Kokkos_Tools_begin_parallel_for_event,
                                   reinterpret_cast<void *>(&next_cb)});
```

Where `interface` is an instance of ToolProgrammingInterface. The main concern I had here was backwards compatibility. Suppose the day after merging this we add another callback. If Tally-Q requests to set that new callback, in a version of Kokkos that doesn't support the callback, what happens? So I added a bool as a return value, if the user requests some unknown value we return false, otherwise we return true. Before we review this for quality I'd like a tool developer to let me know if this design does what they need.