### PR TITLE
Fix TestDetectionIdiom.cpp test inclusion for Trilinos/TriBITS

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -65,8 +65,11 @@ KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 KOKKOS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
 KOKKOS_INCLUDE_DIRECTORIES(${KOKKOS_SOURCE_DIR}/core/unit_test/category_files)
 
-add_executable(TestCompileOnly TestDetectionIdiom.cpp)
-target_link_libraries(TestCompileOnly PRIVATE Kokkos::kokkos)
+KOKKOS_ADD_EXECUTABLE(
+  TestCompileOnly
+  SOURCES
+  TestDetectionIdiom.cpp
+)
 
 foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
   # Because there is always an exception to the rule


### PR DESCRIPTION
The TestDetectionIdiom test inclusion caused configuration errors in Trilinos nightly builds:

```
CMake Error at kokkos/core/unit_test/CMakeLists.txt:68 (add_executable):
  Target "TestCompileOnly" links to target "Kokkos::kokkos" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
```

Replacing test inclusion with `KOKKOS_ADD_EXECUTABLE_AND_TEST` resolved the issue for me in Trilinos and standalone Kokkos builds.