### PR TITLE
Deprecate Kokkos_TaskPolicy.hpp

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -530,6 +530,18 @@
 #endif
 #define KOKKOS_DEPRECATED_TRAILING_ATTRIBUTE
 
+#ifdef _MSC_VER
+#define KOKKOS_STRINGIZE_HELPER(x) #x
+#define KOKKOS_STRINGIZE(x) KOKKOS_STRINGIZE_HELPER(x)
+#define KOKKOS_DO_PRAGMA(x) __pragma(x)
+#define KOKKOS_WARNING(desc) \
+  KOKKOS_DO_PRAGMA(          \
+      message(__FILE__ "(" KOKKOS_STRINGIZE(__LINE__) ") : warning: " #desc))
+#else
+#define KOKKOS_DO_PRAGMA(x) _Pragma(#x)
+#define KOKKOS_WARNING(desc) KOKKOS_DO_PRAGMA(message(#desc))
+#endif
+
 // DJS 05/28/2019: Bugfix: Issue 2155
 // Use KOKKOS_ENABLE_CUDA_LDG_INTRINSIC to avoid memory leak in RandomAccess
 // View

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -530,13 +530,14 @@
 #endif
 #define KOKKOS_DEPRECATED_TRAILING_ATTRIBUTE
 
+#define KOKKOS_IMPL_STRINGIFY(x) #x
+#define KOKKOS_IMPL_TOSTRING(x) KOKKOS_IMPL_STRINGIFY(x)
+
 #ifdef _MSC_VER
-#define KOKKOS_STRINGIZE_HELPER(x) #x
-#define KOKKOS_STRINGIZE(x) KOKKOS_STRINGIZE_HELPER(x)
 #define KOKKOS_DO_PRAGMA(x) __pragma(x)
 #define KOKKOS_WARNING(desc) \
-  KOKKOS_DO_PRAGMA(          \
-      message(__FILE__ "(" KOKKOS_STRINGIZE(__LINE__) ") : warning: " #desc))
+  KOKKOS_DO_PRAGMA(message(  \
+      __FILE__ "(" KOKKOS_IMPL_TOSTRING(__LINE__) ") : warning: " #desc))
 #else
 #define KOKKOS_DO_PRAGMA(x) _Pragma(#x)
 #define KOKKOS_WARNING(desc) KOKKOS_DO_PRAGMA(message(#desc))

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -534,13 +534,13 @@
 #define KOKKOS_IMPL_TOSTRING(x) KOKKOS_IMPL_STRINGIFY(x)
 
 #ifdef _MSC_VER
-#define KOKKOS_DO_PRAGMA(x) __pragma(x)
-#define KOKKOS_WARNING(desc) \
-  KOKKOS_DO_PRAGMA(message(  \
+#define KOKKOS_IMPL_DO_PRAGMA(x) __pragma(x)
+#define KOKKOS_IMPL_WARNING(desc) \
+  KOKKOS_IMPL_DO_PRAGMA(message(  \
       __FILE__ "(" KOKKOS_IMPL_TOSTRING(__LINE__) ") : warning: " #desc))
 #else
-#define KOKKOS_DO_PRAGMA(x) _Pragma(#x)
-#define KOKKOS_WARNING(desc) KOKKOS_DO_PRAGMA(message(#desc))
+#define KOKKOS_IMPL_DO_PRAGMA(x) _Pragma(#x)
+#define KOKKOS_IMPL_WARNING(desc) KOKKOS_IMPL_DO_PRAGMA(message(#desc))
 #endif
 
 // DJS 05/28/2019: Bugfix: Issue 2155

--- a/core/src/Kokkos_TaskPolicy.hpp
+++ b/core/src/Kokkos_TaskPolicy.hpp
@@ -43,5 +43,9 @@
 */
 
 // For backward compatibility:
+#include <Kokkos_Macros.hpp>
+
+KOKKOS_WARNING(
+    "This file is deprecated. Use <Kokkos_TaskScheduler.hpp> instead.")
 
 #include <Kokkos_TaskScheduler.hpp>

--- a/core/src/Kokkos_TaskPolicy.hpp
+++ b/core/src/Kokkos_TaskPolicy.hpp
@@ -45,7 +45,7 @@
 // For backward compatibility:
 #include <Kokkos_Macros.hpp>
 
-KOKKOS_WARNING(
+KOKKOS_IMPL_WARNING(
     "This file is deprecated. Use <Kokkos_TaskScheduler.hpp> instead.")
 
 #include <Kokkos_TaskScheduler.hpp>

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -218,8 +218,6 @@ KOKKOS_IMPL_ABORT_NORETURN KOKKOS_INLINE_FUNCTION void abort(
 
 #if !defined(NDEBUG) || defined(KOKKOS_ENFORCE_CONTRACTS) || \
     defined(KOKKOS_ENABLE_DEBUG)
-#define KOKKOS_IMPL_STRINGIFY(x) #x
-#define KOKKOS_IMPL_TOSTRING(x) KOKKOS_IMPL_STRINGIFY(x)
 #define KOKKOS_EXPECTS(...)                                                    \
   {                                                                            \
     if (!bool(__VA_ARGS__)) {                                                  \


### PR DESCRIPTION
Addressing https://github.com/kokkos/kokkos/pull/3978#discussion_r627829910 we wanted to deprecate this header. Since it requires defining some more preprocessor macros (differing between architectures) I decided to split this up into its own pull request.