### PR TITLE
Work around SYCL JIT compiler issues with static variables

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -109,7 +109,7 @@ class SYCLInternal {
         assert(m_mem);
         assert(sizeof(T) == m_mem->size());
 
-        if constexpr (sycl::usm::alloc::device == kind)
+        if constexpr (sycl::usm::alloc::device == Kind)
           // Only skipping the dtor on trivially copyable types
           static_assert(std::is_trivially_copyable_v<T>);
         else
@@ -121,8 +121,6 @@ class SYCLInternal {
      private:
       USMObjectMem* m_mem = nullptr;
     };
-
-    static constexpr sycl::usm::alloc kind = Kind;
 
     void reset();
 
@@ -182,7 +180,7 @@ class SYCLInternal {
     // Note:  This will not work with USM device memory
     template <typename T>
     std::unique_ptr<T, Deleter> copy_construct_from(const T& t) {
-      static_assert(kind != sycl::usm::alloc::device,
+      static_assert(Kind != sycl::usm::alloc::device,
                     "Cannot copy construct into USM device memory");
 
       reserve(sizeof(T));
@@ -203,7 +201,7 @@ class SYCLInternal {
     // unique_ptr<T, ...>
     template <typename T>
     std::unique_ptr<T, Deleter> copy_from(const T& t) {
-      if constexpr (sycl::usm::alloc::device == kind)
+      if constexpr (sycl::usm::alloc::device == Kind)
         return memcpy_from(t);
       else
         return copy_construct_from(t);
@@ -224,7 +222,7 @@ class SYCLInternal {
     // Returns a reference to t (helpful when debugging)
     template <typename T>
     T& move_assign_to(T& t) {
-      static_assert(kind != sycl::usm::alloc::device,
+      static_assert(Kind != sycl::usm::alloc::device,
                     "Cannot move_assign_to from USM device memory");
 
       assert(sizeof(T) == m_size);
@@ -238,7 +236,7 @@ class SYCLInternal {
     // Returns a reference to t (helpful when debugging)
     template <typename T>
     T& transfer_to(T& t) {
-      if constexpr (sycl::usm::alloc::device == kind)
+      if constexpr (sycl::usm::alloc::device == Kind)
         return memcpy_to(t);
       else
         return move_assign_to(t);

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -62,10 +62,10 @@ void sink(Args&&... args) {
     Kokkos::ImplSYCL::sink(__VA_ARGS__);   \
   } while (0)
 #else
-#define KOKKOS_IMPL_DO_NOT_USE_PRINTF(format, ...)                       \
-  do {                                                                   \
-    static const __attribute__((opencl_constant)) char fmt[] = (format); \
-    sycl::ONEAPI::experimental::printf(fmt, ##__VA_ARGS__);              \
+#define KOKKOS_IMPL_DO_NOT_USE_PRINTF(format, ...)                \
+  do {                                                            \
+    const __attribute__((opencl_constant)) char fmt[] = (format); \
+    sycl::ONEAPI::experimental::printf(fmt, ##__VA_ARGS__);       \
   } while (0)
 #endif
 #endif


### PR DESCRIPTION
We have been seeing SYCL compiler problems recently when using JIT mode. Compiling a debug version of the compiler revealed that these `static` variables are problematic and I don't see much of a reason for keeping them necessarily.
I still see
```
InvalidInstruction: Can't translate llvm instruction:
   fence seq_cst, !dbg !18492
 [Src: /scratch/llvm/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp:1720  ]
```
but that seems to be a different issue (possibly to be tackled later).