### PR TITLE
Tune Occupancy Requests

### DIFF
--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -173,7 +173,6 @@ KOKKOS_IMPL_IS_CONCEPT(memory_traits)
 KOKKOS_IMPL_IS_CONCEPT(execution_space)
 KOKKOS_IMPL_IS_CONCEPT(execution_policy)
 KOKKOS_IMPL_IS_CONCEPT(array_layout)
-KOKKOS_IMPL_IS_CONCEPT(occupancy_control)
 KOKKOS_IMPL_IS_CONCEPT(reducer)
 namespace Experimental {
 KOKKOS_IMPL_IS_CONCEPT(work_item_property)

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -173,6 +173,7 @@ KOKKOS_IMPL_IS_CONCEPT(memory_traits)
 KOKKOS_IMPL_IS_CONCEPT(execution_space)
 KOKKOS_IMPL_IS_CONCEPT(execution_policy)
 KOKKOS_IMPL_IS_CONCEPT(array_layout)
+KOKKOS_IMPL_IS_CONCEPT(occupancy_control)
 KOKKOS_IMPL_IS_CONCEPT(reducer)
 namespace Experimental {
 KOKKOS_IMPL_IS_CONCEPT(work_item_property)

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -138,9 +138,10 @@ inline void parallel_for(
         nullptr) {
   uint64_t kpID = 0;
 
-  ExecPolicy inner_policy = policy;
-  Kokkos::Tools::Impl::begin_parallel_for(inner_policy, functor, str, kpID);
-
+  ExecPolicy policy_copy = policy;
+  auto response =
+  Kokkos::Tools::Impl::begin_parallel_for(policy_copy, functor, str, kpID);
+  auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelFor<FunctorType, ExecPolicy> closure(functor, inner_policy);
   Kokkos::Impl::shared_allocation_tracking_enable();
@@ -162,15 +163,16 @@ inline void parallel_for(const size_t work_count, const FunctorType& functor,
 
   policy execution_policy = policy(0, work_count);
 
+  auto response =
   Kokkos::Tools::Impl::begin_parallel_for(execution_policy, functor, str, kpID);
-
+  auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
-  Impl::ParallelFor<FunctorType, policy> closure(functor, execution_policy);
+  Impl::ParallelFor<FunctorType, policy> closure(functor, inner_policy);
   Kokkos::Impl::shared_allocation_tracking_enable();
 
   closure.execute();
 
-  Kokkos::Tools::Impl::end_parallel_for(execution_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::end_parallel_for(inner_policy, functor, str, kpID);
 }
 
 template <class ExecPolicy, class FunctorType>
@@ -368,9 +370,9 @@ inline void parallel_scan(
         Kokkos::Impl::is_execution_policy<ExecutionPolicy>::value>::type* =
         nullptr) {
   uint64_t kpID                = 0;
-  ExecutionPolicy inner_policy = policy;
-  Kokkos::Tools::Impl::begin_parallel_scan(inner_policy, functor, str, kpID);
-
+  ExecutionPolicy policy_copy = policy;
+  auto response = Kokkos::Tools::Impl::begin_parallel_scan(policy_copy, functor, str, kpID);
+  auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelScan<FunctorType, ExecutionPolicy> closure(functor,
                                                            inner_policy);
@@ -392,15 +394,16 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
 
   uint64_t kpID = 0;
   policy execution_policy(0, work_count);
-  Kokkos::Tools::Impl::begin_parallel_scan(execution_policy, functor, str,
+  auto response = Kokkos::Tools::Impl::begin_parallel_scan(execution_policy, functor, str,
                                            kpID);
+  auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
-  Impl::ParallelScan<FunctorType, policy> closure(functor, execution_policy);
+  Impl::ParallelScan<FunctorType, policy> closure(functor, inner_policy);
   Kokkos::Impl::shared_allocation_tracking_enable();
 
   closure.execute();
 
-  Kokkos::Tools::Impl::end_parallel_scan(execution_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::end_parallel_scan(inner_policy, functor, str, kpID);
 }
 
 template <class ExecutionPolicy, class FunctorType>
@@ -428,9 +431,9 @@ inline void parallel_scan(
         Kokkos::Impl::is_execution_policy<ExecutionPolicy>::value>::type* =
         nullptr) {
   uint64_t kpID                = 0;
-  ExecutionPolicy inner_policy = policy;
-  Kokkos::Tools::Impl::begin_parallel_scan(inner_policy, functor, str, kpID);
-
+  ExecutionPolicy policy_copy = policy;
+  auto response = Kokkos::Tools::Impl::begin_parallel_scan(policy_copy, functor, str, kpID);
+  auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelScanWithTotal<FunctorType, ExecutionPolicy, ReturnType> closure(
       functor, inner_policy, return_value);
@@ -455,17 +458,17 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
 
   policy execution_policy(0, work_count);
   uint64_t kpID = 0;
-  Kokkos::Tools::Impl::begin_parallel_scan(execution_policy, functor, str,
+  auto response = Kokkos::Tools::Impl::begin_parallel_scan(execution_policy, functor, str,
                                            kpID);
-
+  auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelScanWithTotal<FunctorType, policy, ReturnType> closure(
-      functor, execution_policy, return_value);
+      functor, inner_policy, return_value);
   Kokkos::Impl::shared_allocation_tracking_enable();
 
   closure.execute();
 
-  Kokkos::Tools::Impl::end_parallel_scan(execution_policy, functor, str, kpID);
+  Kokkos::Tools::Impl::end_parallel_scan(inner_policy, functor, str, kpID);
 
   execution_space().fence();
 }

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -139,6 +139,7 @@ inline void parallel_for(
   uint64_t kpID = 0;
 
   ExecPolicy policy_copy = policy;
+  /** Request a tuned policy from the tools subsystem */
   auto response =
       Kokkos::Tools::Impl::begin_parallel_for(policy_copy, functor, str, kpID);
   auto inner_policy = response.policy;
@@ -163,6 +164,7 @@ inline void parallel_for(const size_t work_count, const FunctorType& functor,
 
   policy execution_policy = policy(0, work_count);
 
+  /** Request a tuned policy from the tools subsystem */
   auto response     = Kokkos::Tools::Impl::begin_parallel_for(execution_policy,
                                                           functor, str, kpID);
   auto inner_policy = response.policy;
@@ -371,6 +373,7 @@ inline void parallel_scan(
         nullptr) {
   uint64_t kpID               = 0;
   ExecutionPolicy policy_copy = policy;
+  /** Request a tuned policy from the tools subsystem */
   auto response =
       Kokkos::Tools::Impl::begin_parallel_scan(policy_copy, functor, str, kpID);
   auto inner_policy = response.policy;
@@ -395,6 +398,7 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
 
   uint64_t kpID = 0;
   policy execution_policy(0, work_count);
+  /** Request a tuned policy from the tools subsystem */
   auto response     = Kokkos::Tools::Impl::begin_parallel_scan(execution_policy,
                                                            functor, str, kpID);
   auto inner_policy = response.policy;
@@ -433,6 +437,7 @@ inline void parallel_scan(
         nullptr) {
   uint64_t kpID               = 0;
   ExecutionPolicy policy_copy = policy;
+  /** Request a tuned policy from the tools subsystem */
   auto response =
       Kokkos::Tools::Impl::begin_parallel_scan(policy_copy, functor, str, kpID);
   auto inner_policy = response.policy;
@@ -459,7 +464,8 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
   using policy = Kokkos::RangePolicy<execution_space>;
 
   policy execution_policy(0, work_count);
-  uint64_t kpID     = 0;
+  uint64_t kpID = 0;
+  /** Request a tuned policy from the tools subsystem */
   auto response     = Kokkos::Tools::Impl::begin_parallel_scan(execution_policy,
                                                            functor, str, kpID);
   auto inner_policy = response.policy;

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -140,7 +140,7 @@ inline void parallel_for(
 
   ExecPolicy policy_copy = policy;
   auto response =
-  Kokkos::Tools::Impl::begin_parallel_for(policy_copy, functor, str, kpID);
+      Kokkos::Tools::Impl::begin_parallel_for(policy_copy, functor, str, kpID);
   auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelFor<FunctorType, ExecPolicy> closure(functor, inner_policy);
@@ -163,8 +163,8 @@ inline void parallel_for(const size_t work_count, const FunctorType& functor,
 
   policy execution_policy = policy(0, work_count);
 
-  auto response =
-  Kokkos::Tools::Impl::begin_parallel_for(execution_policy, functor, str, kpID);
+  auto response     = Kokkos::Tools::Impl::begin_parallel_for(execution_policy,
+                                                          functor, str, kpID);
   auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelFor<FunctorType, policy> closure(functor, inner_policy);
@@ -369,9 +369,10 @@ inline void parallel_scan(
     typename std::enable_if<
         Kokkos::Impl::is_execution_policy<ExecutionPolicy>::value>::type* =
         nullptr) {
-  uint64_t kpID                = 0;
+  uint64_t kpID               = 0;
   ExecutionPolicy policy_copy = policy;
-  auto response = Kokkos::Tools::Impl::begin_parallel_scan(policy_copy, functor, str, kpID);
+  auto response =
+      Kokkos::Tools::Impl::begin_parallel_scan(policy_copy, functor, str, kpID);
   auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelScan<FunctorType, ExecutionPolicy> closure(functor,
@@ -394,8 +395,8 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
 
   uint64_t kpID = 0;
   policy execution_policy(0, work_count);
-  auto response = Kokkos::Tools::Impl::begin_parallel_scan(execution_policy, functor, str,
-                                           kpID);
+  auto response     = Kokkos::Tools::Impl::begin_parallel_scan(execution_policy,
+                                                           functor, str, kpID);
   auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelScan<FunctorType, policy> closure(functor, inner_policy);
@@ -430,9 +431,10 @@ inline void parallel_scan(
     typename std::enable_if<
         Kokkos::Impl::is_execution_policy<ExecutionPolicy>::value>::type* =
         nullptr) {
-  uint64_t kpID                = 0;
+  uint64_t kpID               = 0;
   ExecutionPolicy policy_copy = policy;
-  auto response = Kokkos::Tools::Impl::begin_parallel_scan(policy_copy, functor, str, kpID);
+  auto response =
+      Kokkos::Tools::Impl::begin_parallel_scan(policy_copy, functor, str, kpID);
   auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelScanWithTotal<FunctorType, ExecutionPolicy, ReturnType> closure(
@@ -457,9 +459,9 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
   using policy = Kokkos::RangePolicy<execution_space>;
 
   policy execution_policy(0, work_count);
-  uint64_t kpID = 0;
-  auto response = Kokkos::Tools::Impl::begin_parallel_scan(execution_policy, functor, str,
-                                           kpID);
+  uint64_t kpID     = 0;
+  auto response     = Kokkos::Tools::Impl::begin_parallel_scan(execution_policy,
+                                                           functor, str, kpID);
   auto inner_policy = response.policy;
   Kokkos::Impl::shared_allocation_tracking_disable();
   Impl::ParallelScanWithTotal<FunctorType, policy, ReturnType> closure(

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -857,8 +857,7 @@ struct ParallelReduceAdaptor {
     uint64_t kpID = 0;
 
     PolicyType policy_copy = policy;
-    auto response = 
-    Kokkos::Tools::Impl::begin_parallel_reduce<
+    auto response          = Kokkos::Tools::Impl::begin_parallel_reduce<
         typename return_value_adapter::reducer_type>(policy_copy, functor,
                                                      label, kpID);
     auto& inner_policy = response.policy;

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -856,11 +856,12 @@ struct ParallelReduceAdaptor {
                              ReturnType& return_value) {
     uint64_t kpID = 0;
 
-    PolicyType inner_policy = policy;
+    PolicyType policy_copy = policy;
+    auto response = 
     Kokkos::Tools::Impl::begin_parallel_reduce<
-        typename return_value_adapter::reducer_type>(inner_policy, functor,
+        typename return_value_adapter::reducer_type>(policy_copy, functor,
                                                      label, kpID);
-
+    auto& inner_policy = response.policy;
     Kokkos::Impl::shared_allocation_tracking_disable();
 #ifdef KOKKOS_IMPL_NEED_FUNCTOR_WRAPPER
     Impl::ParallelReduce<typename functor_adaptor::functor_type, PolicyType,

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -857,7 +857,8 @@ struct ParallelReduceAdaptor {
     uint64_t kpID = 0;
 
     PolicyType policy_copy = policy;
-    auto response          = Kokkos::Tools::Impl::begin_parallel_reduce<
+    /** Request a tuned policy from the tools subsystem */
+    auto response = Kokkos::Tools::Impl::begin_parallel_reduce<
         typename return_value_adapter::reducer_type>(policy_copy, functor,
                                                      label, kpID);
     auto& inner_policy = response.policy;

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -75,6 +75,8 @@ VariableValue make_variable_value(size_t, int64_t);
 VariableValue make_variable_value(size_t, double);
 SetOrRange make_candidate_range(double lower, double upper, double step,
                                 bool openLower, bool openUpper);
+    SetOrRange make_candidate_range(int64_t lower, int64_t upper, int64_t step,
+                                    bool openLower, bool openUpper);
 size_t get_new_context_id();
 void begin_context(size_t context_id);
 void end_context(size_t context_id);
@@ -523,7 +525,7 @@ class TeamSizeTuner : public ExtendableTunerMixin<TeamSizeTuner> {
   }
 
   template <typename... Properties>
-  void tune(Kokkos::TeamPolicy<Properties...>& policy) {
+  auto tune(Kokkos::TeamPolicy<Properties...>& policy) {
     if (Kokkos::Tools::Experimental::have_tuning_tool()) {
       auto configuration = tuner.begin();
       auto team_size     = std::get<1>(configuration);
@@ -533,6 +535,7 @@ class TeamSizeTuner : public ExtendableTunerMixin<TeamSizeTuner> {
         policy.impl_set_vector_length(vector_length);
       }
     }
+    return policy;
   }
   void end() {
     if (Kokkos::Tools::Experimental::have_tuning_tool()) {
@@ -542,6 +545,102 @@ class TeamSizeTuner : public ExtendableTunerMixin<TeamSizeTuner> {
 
   TunerType get_tuner() const { return tuner; }
 };
+namespace Impl {
+   template<class T>
+   struct tuning_type_for;
+
+    template<>
+    struct tuning_type_for<double> {
+        static constexpr Kokkos::Tools::Experimental::ValueType value = Kokkos::Tools::Experimental::ValueType::kokkos_value_double;
+        static double get(const Kokkos::Tools::Experimental::VariableValue& value) {
+           return value.value.double_value;
+        }
+    };
+    template<>
+    struct tuning_type_for<int64_t> {
+        static constexpr Kokkos::Tools::Experimental::ValueType value = Kokkos::Tools::Experimental::ValueType::kokkos_value_int64;
+        static int64_t get(const Kokkos::Tools::Experimental::VariableValue& value) {
+            return value.value.int_value;
+        }
+    };
+}
+template<class Bound>
+class SingleDimensionalRangeTuner{
+
+    size_t id;
+    size_t context;
+    using tuning_util = Impl::tuning_type_for<Bound>;
+
+    Bound default_value;
+
+public:
+    SingleDimensionalRangeTuner() = default;
+    SingleDimensionalRangeTuner(const std::string& name, Kokkos::Tools::Experimental::StatisticalCategory category, Bound default_val, Bound lower, Bound upper, Bound step = (Bound)0) {
+        default_value = default_val;
+      Kokkos::Tools::Experimental::VariableInfo info;
+      info.category = category;
+      info.candidates = make_candidate_range(static_cast<Bound>(lower), static_cast<Bound>(upper), static_cast<Bound>(step), false, false);
+      info.valueQuantity = Kokkos::Tools::Experimental::CandidateValueType::kokkos_value_range;
+      info.type = tuning_util::value;
+      id = Kokkos::Tools::Experimental::declare_output_type(name, info);
+    }
+
+    Bound begin() {
+        context = Kokkos::Tools::Experimental::get_new_context_id();
+        Kokkos::Tools::Experimental::begin_context(context);
+        auto tuned_value = Kokkos::Tools::Experimental::make_variable_value(id, default_value);
+        Kokkos::Tools::Experimental::request_output_values(context, 1, &tuned_value);
+        return tuning_util::get(tuned_value);
+    }
+
+    void end() {
+        Kokkos::Tools::Experimental::end_context(context);
+    }
+
+    template<typename Functor>
+    void with_tuned_value(Functor& func){
+        func(begin());
+        end();
+    }
+};
+
+class RangePolicyOccupancyTuner {
+private:
+    using TunerType = SingleDimensionalRangeTuner<int64_t>;
+    TunerType tuner;
+
+public:
+    RangePolicyOccupancyTuner()        = default;
+    RangePolicyOccupancyTuner& operator=(const RangePolicyOccupancyTuner& other) = default;
+    RangePolicyOccupancyTuner(const RangePolicyOccupancyTuner& other)            = default;
+    RangePolicyOccupancyTuner& operator=(RangePolicyOccupancyTuner&& other) = default;
+    RangePolicyOccupancyTuner(RangePolicyOccupancyTuner&& other)            = default;
+    template <typename ViableConfigurationCalculator, typename Functor,
+            typename TagType, typename... Properties>
+    RangePolicyOccupancyTuner(const std::string& name,
+                  Kokkos::RangePolicy<Properties...>& policy,
+                  const Functor& functor, const TagType& tag,
+                  ViableConfigurationCalculator calc) : tuner(TunerType(name, Kokkos::Tools::Experimental::StatisticalCategory::kokkos_value_ratio, 72, 0, 100, 1)){
+    }
+
+    template <typename... Properties>
+    auto tune(Kokkos::RangePolicy<Properties...>& policy) {
+        if (Kokkos::Tools::Experimental::have_tuning_tool()) {
+            auto occupancy = tuner.begin();
+            return Kokkos::Experimental::prefer(policy, Kokkos::Experimental::DesiredOccupancy(occupancy));
+
+        }
+        return Kokkos::Experimental::prefer(policy, Kokkos::Experimental::DesiredOccupancy(100));
+    }
+    void end() {
+        if (Kokkos::Tools::Experimental::have_tuning_tool()) {
+            tuner.end();
+        }
+    }
+
+    TunerType get_tuner() const { return tuner; }
+};
+
 
 namespace Impl {
 
@@ -596,11 +695,12 @@ struct MDRangeTuner : public ExtendableTunerMixin<MDRangeTuner<MDRangeRank>> {
     policy.impl_change_tile_size({std::get<Indices>(tuple)...});
   }
   template <typename... Properties>
-  void tune(Kokkos::MDRangePolicy<Properties...>& policy) {
+  auto tune(Kokkos::MDRangePolicy<Properties...>& policy) {
     if (Kokkos::Tools::Experimental::have_tuning_tool()) {
       auto configuration = tuner.begin();
       set_policy_tile(policy, configuration, std::make_index_sequence<rank>{});
     }
+    return policy;
   }
   void end() {
     if (Kokkos::Tools::Experimental::have_tuning_tool()) {

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -75,6 +75,10 @@ struct MaximizeOccupancy {
   explicit MaximizeOccupancy() = default;
 };
 
+struct TunedOccupancy {
+    explicit TunedOccupancy() = default;
+};
+
 // </editor-fold> end Occupancy control user interface }}}1
 //==============================================================================
 

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -75,8 +75,8 @@ struct MaximizeOccupancy {
   explicit MaximizeOccupancy() = default;
 };
 
-struct TunedOccupancy {
-    explicit TunedOccupancy() = default;
+struct TuneOccupancy {
+    explicit TuneOccupancy() = default;
 };
 
 // </editor-fold> end Occupancy control user interface }}}1
@@ -110,7 +110,8 @@ struct OccupancyControlTrait : TraitSpecificationBase<OccupancyControlTrait> {
   using trait_matches_specification = std::integral_constant<
       bool,
       std::is_same<T, Kokkos::Experimental::DesiredOccupancy>::value ||
-          std::is_same<T, Kokkos::Experimental::MaximizeOccupancy>::value>;
+          std::is_same<T, Kokkos::Experimental::MaximizeOccupancy>::value ||
+            std::is_same<T, Kokkos::Experimental::TuneOccupancy>::value>;
 };
 
 // </editor-fold> end Occupancy control trait specification }}}1
@@ -166,6 +167,40 @@ struct OccupancyControlPolicyMixin<Kokkos::Experimental::DesiredOccupancy,
   }
 };
 
+        template <class AnalyzeNextTrait>
+        struct OccupancyControlPolicyMixin<Kokkos::Experimental::TuneOccupancy,
+                AnalyzeNextTrait> : AnalyzeNextTrait {
+            using base_t = AnalyzeNextTrait;
+            //using occupancy_control = Kokkos::Experimental::TuneOccupancy;
+            static constexpr bool experimental_contains_desired_occupancy = true;
+
+            // Treat this as private, but make it public so that MSVC will still treat
+            // this as a standard layout class and make it the right size: storage for a
+            // stateful desired occupancy
+            //   private:
+            //occupancy_control m_desired_occupancy = occupancy_control{};
+
+            OccupancyControlPolicyMixin() = default;
+
+            // Converting constructor
+            // Just rely on the convertibility of occupancy_control to transfer the data
+            template<class Other>
+            OccupancyControlPolicyMixin(ExecPolicyTraitsWithDefaults <Other> const &other)
+                    : base_t(other)
+                      /**,m_desired_occupancy(other.impl_get_occupancy_control())*/ {}
+
+            // Converting assignment operator
+            // Just rely on the convertibility of occupancy_control to transfer the data
+            template<class Other>
+            OccupancyControlPolicyMixin &operator=(
+                    ExecPolicyTraitsWithDefaults <Other> const &other) {
+                *static_cast<base_t *>(this) = other;
+                /**this->impl_set_desired_occupancy(
+                        occupancy_control{other.impl_get_occupancy_control()});*/
+                return *this;
+            }
+        };
+
 template <class AnalyzeNextTrait>
 struct OccupancyControlPolicyMixin<Kokkos::Experimental::MaximizeOccupancy,
                                    AnalyzeNextTrait> : AnalyzeNextTrait {
@@ -203,6 +238,14 @@ constexpr auto prefer(Policy const& p, MaximizeOccupancy) {
                                                              MaximizeOccupancy>;
   return new_policy_t{p};
 }
+        template <typename Policy>
+        constexpr auto prefer(Policy const& p, TuneOccupancy) {
+            static_assert(Kokkos::is_execution_policy<Policy>::value, "");
+            using new_policy_t =
+            Kokkos::Impl::OccupancyControlTrait::policy_with_trait<Policy,
+                    TuneOccupancy>;
+            return new_policy_t{p};
+        }
 
 // </editor-fold> end User interface }}}1
 //==============================================================================

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -76,7 +76,7 @@ struct MaximizeOccupancy {
 };
 
 struct TuneOccupancy {
-    explicit TuneOccupancy() = default;
+  explicit TuneOccupancy() = default;
 };
 
 // </editor-fold> end Occupancy control user interface }}}1
@@ -111,7 +111,7 @@ struct OccupancyControlTrait : TraitSpecificationBase<OccupancyControlTrait> {
       bool,
       std::is_same<T, Kokkos::Experimental::DesiredOccupancy>::value ||
           std::is_same<T, Kokkos::Experimental::MaximizeOccupancy>::value ||
-            std::is_same<T, Kokkos::Experimental::TuneOccupancy>::value>;
+          std::is_same<T, Kokkos::Experimental::TuneOccupancy>::value>;
 };
 
 // </editor-fold> end Occupancy control trait specification }}}1
@@ -167,39 +167,39 @@ struct OccupancyControlPolicyMixin<Kokkos::Experimental::DesiredOccupancy,
   }
 };
 
-        template <class AnalyzeNextTrait>
-        struct OccupancyControlPolicyMixin<Kokkos::Experimental::TuneOccupancy,
-                AnalyzeNextTrait> : AnalyzeNextTrait {
-            using base_t = AnalyzeNextTrait;
-            //using occupancy_control = Kokkos::Experimental::TuneOccupancy;
-            static constexpr bool experimental_contains_desired_occupancy = true;
+template <class AnalyzeNextTrait>
+struct OccupancyControlPolicyMixin<Kokkos::Experimental::TuneOccupancy,
+                                   AnalyzeNextTrait> : AnalyzeNextTrait {
+  using base_t = AnalyzeNextTrait;
+  // using occupancy_control = Kokkos::Experimental::TuneOccupancy;
+  static constexpr bool experimental_contains_desired_occupancy = true;
 
-            // Treat this as private, but make it public so that MSVC will still treat
-            // this as a standard layout class and make it the right size: storage for a
-            // stateful desired occupancy
-            //   private:
-            //occupancy_control m_desired_occupancy = occupancy_control{};
+  // Treat this as private, but make it public so that MSVC will still treat
+  // this as a standard layout class and make it the right size: storage for a
+  // stateful desired occupancy
+  //   private:
+  // occupancy_control m_desired_occupancy = occupancy_control{};
 
-            OccupancyControlPolicyMixin() = default;
+  OccupancyControlPolicyMixin() = default;
 
-            // Converting constructor
-            // Just rely on the convertibility of occupancy_control to transfer the data
-            template<class Other>
-            OccupancyControlPolicyMixin(ExecPolicyTraitsWithDefaults <Other> const &other)
-                    : base_t(other)
-                      /**,m_desired_occupancy(other.impl_get_occupancy_control())*/ {}
+  // Converting constructor
+  // Just rely on the convertibility of occupancy_control to transfer the data
+  template <class Other>
+  OccupancyControlPolicyMixin(ExecPolicyTraitsWithDefaults<Other> const& other)
+      : base_t(other)
+  /**,m_desired_occupancy(other.impl_get_occupancy_control())*/ {}
 
-            // Converting assignment operator
-            // Just rely on the convertibility of occupancy_control to transfer the data
-            template<class Other>
-            OccupancyControlPolicyMixin &operator=(
-                    ExecPolicyTraitsWithDefaults <Other> const &other) {
-                *static_cast<base_t *>(this) = other;
-                /**this->impl_set_desired_occupancy(
-                        occupancy_control{other.impl_get_occupancy_control()});*/
-                return *this;
-            }
-        };
+  // Converting assignment operator
+  // Just rely on the convertibility of occupancy_control to transfer the data
+  template <class Other>
+  OccupancyControlPolicyMixin& operator=(
+      ExecPolicyTraitsWithDefaults<Other> const& other) {
+    *static_cast<base_t*>(this) = other;
+    /**this->impl_set_desired_occupancy(
+            occupancy_control{other.impl_get_occupancy_control()});*/
+    return *this;
+  }
+};
 
 template <class AnalyzeNextTrait>
 struct OccupancyControlPolicyMixin<Kokkos::Experimental::MaximizeOccupancy,
@@ -238,14 +238,14 @@ constexpr auto prefer(Policy const& p, MaximizeOccupancy) {
                                                              MaximizeOccupancy>;
   return new_policy_t{p};
 }
-        template <typename Policy>
-        constexpr auto prefer(Policy const& p, TuneOccupancy) {
-            static_assert(Kokkos::is_execution_policy<Policy>::value, "");
-            using new_policy_t =
-            Kokkos::Impl::OccupancyControlTrait::policy_with_trait<Policy,
-                    TuneOccupancy>;
-            return new_policy_t{p};
-        }
+template <typename Policy>
+constexpr auto prefer(Policy const& p, TuneOccupancy) {
+  static_assert(Kokkos::is_execution_policy<Policy>::value, "");
+  using new_policy_t =
+      Kokkos::Impl::OccupancyControlTrait::policy_with_trait<Policy,
+                                                             TuneOccupancy>;
+  return new_policy_t{p};
+}
 
 // </editor-fold> end User interface }}}1
 //==============================================================================

--- a/core/unit_test/default/TestDefaultDeviceDevelop.cpp
+++ b/core/unit_test/default/TestDefaultDeviceDevelop.cpp
@@ -48,35 +48,41 @@
 #include <Kokkos_Core.hpp>
 
 #include <TestDefaultDeviceType_Category.hpp>
-struct TF{
-    KOKKOS_FUNCTION void operator()(const int) const {}
+struct TF {
+  KOKKOS_FUNCTION void operator()(const int) const {}
 };
 namespace Test {
 
-    TEST(defaultdevicetype, development_test) {
+TEST(defaultdevicetype, development_test) {
+  Kokkos::RangePolicy<> pol(0, 10000);
+  auto next_pol =
+      Kokkos::Experimental::prefer(pol, Kokkos::Experimental::TuneOccupancy{});
+  TF f;
+  using namespace Kokkos::Tools::Experimental;
+  VariableInfo info;
+  info.category      = StatisticalCategory::kokkos_value_categorical;
+  info.type          = ValueType::kokkos_value_int64;
+  info.valueQuantity = CandidateValueType::kokkos_value_unbounded;
+  size_t id          = declare_input_type("dogggo", info);
+  auto ctx           = get_new_context_id();
+  auto v             = make_variable_value(id, int64_t(1));
+  begin_context(ctx);
+  set_input_values(ctx, 1, &v);
+  Kokkos::Tools::Experimental::RangePolicyOccupancyTuner tuner(
+      "dogs", next_pol, f, Kokkos::ParallelForTag{},
+      Kokkos::Tools::Impl::Impl::SimpleTeamSizeCalculator{});
 
-        Kokkos::RangePolicy<> pol(0, 10000);
-        auto next_pol = Kokkos::Experimental::prefer(pol, Kokkos::Experimental::TuneOccupancy{});
-        TF f;
-        using namespace Kokkos::Tools::Experimental;
-        VariableInfo info;
-        info.category= StatisticalCategory::kokkos_value_categorical;
-        info.type = ValueType::kokkos_value_int64;
-        info.valueQuantity = CandidateValueType::kokkos_value_unbounded;
-        size_t id = declare_input_type("dogggo", info);
-        auto ctx = get_new_context_id();
-        auto v = make_variable_value(id, int64_t(1));
-        begin_context(ctx);
-        set_input_values(ctx, 1, &v);
-        Kokkos::Tools::Experimental::RangePolicyOccupancyTuner tuner("dogs", next_pol, f, Kokkos::ParallelForTag{}, Kokkos::Tools::Impl::Impl::SimpleTeamSizeCalculator{});
-
-        for(int x =0 ; x<10000; ++x) {
-            //auto nexter_pol = tuner.tune(next_pol);
-            //usleep(10 * abs(33 - nexter_pol.impl_get_desired_occupancy().value()));
-            //tuner.end();
-            Kokkos::parallel_for("puppies", Kokkos::Experimental::prefer(Kokkos::RangePolicy<>(0,1), Kokkos::Experimental::TuneOccupancy{}), KOKKOS_LAMBDA(int i){});
-        }
-        end_context(ctx);
-    }
+  for (int x = 0; x < 10000; ++x) {
+    // auto nexter_pol = tuner.tune(next_pol);
+    // usleep(10 * abs(33 - nexter_pol.impl_get_desired_occupancy().value()));
+    // tuner.end();
+    Kokkos::parallel_for(
+        "puppies",
+        Kokkos::Experimental::prefer(Kokkos::RangePolicy<>(0, 1),
+                                     Kokkos::Experimental::TuneOccupancy{}),
+        KOKKOS_LAMBDA(int i){});
+  }
+  end_context(ctx);
+}
 
 }  // namespace Test

--- a/core/unit_test/default/TestDefaultDeviceDevelop.cpp
+++ b/core/unit_test/default/TestDefaultDeviceDevelop.cpp
@@ -48,13 +48,35 @@
 #include <Kokkos_Core.hpp>
 
 #include <TestDefaultDeviceType_Category.hpp>
-
+struct TF{
+    KOKKOS_FUNCTION void operator()(const int) const {}
+};
 namespace Test {
 
     TEST(defaultdevicetype, development_test) {
 
         Kokkos::RangePolicy<> pol(0, 10000);
-        auto next_pol = Kokkos::Experimental::require(pol, Kokkos::Experimental::MaximizeOccupancy{});
+        auto next_pol = Kokkos::Experimental::prefer(pol, Kokkos::Experimental::TuneOccupancy{});
+        TF f;
+        using namespace Kokkos::Tools::Experimental;
+        VariableInfo info;
+        info.category= StatisticalCategory::kokkos_value_categorical;
+        info.type = ValueType::kokkos_value_int64;
+        info.valueQuantity = CandidateValueType::kokkos_value_unbounded;
+        size_t id = declare_input_type("dogggo", info);
+        auto ctx = get_new_context_id();
+        auto v = make_variable_value(id, int64_t(1));
+        begin_context(ctx);
+        set_input_values(ctx, 1, &v);
+        Kokkos::Tools::Experimental::RangePolicyOccupancyTuner tuner("dogs", next_pol, f, Kokkos::ParallelForTag{}, Kokkos::Tools::Impl::Impl::SimpleTeamSizeCalculator{});
+
+        for(int x =0 ; x<10000; ++x) {
+            //auto nexter_pol = tuner.tune(next_pol);
+            //usleep(10 * abs(33 - nexter_pol.impl_get_desired_occupancy().value()));
+            //tuner.end();
+            Kokkos::parallel_for("puppies", Kokkos::Experimental::prefer(Kokkos::RangePolicy<>(0,1), Kokkos::Experimental::TuneOccupancy{}), KOKKOS_LAMBDA(int i){});
+        }
+        end_context(ctx);
     }
 
 }  // namespace Test

--- a/core/unit_test/default/TestDefaultDeviceDevelop.cpp
+++ b/core/unit_test/default/TestDefaultDeviceDevelop.cpp
@@ -51,6 +51,10 @@
 
 namespace Test {
 
-TEST(defaultdevicetype, development_test) {}
+    TEST(defaultdevicetype, development_test) {
+
+        Kokkos::RangePolicy<> pol(0, 10000);
+        auto next_pol = Kokkos::Experimental::require(pol, Kokkos::Experimental::MaximizeOccupancy{});
+    }
 
 }  // namespace Test


### PR DESCRIPTION
So this PR is a bit big, it turns out that tuning occupancy is different than tuning other things. The end goal we're achieving here is to allow a user to say "please modify the occupancy of this kernel until you find the optimal result." It's used exactly how you use the other Occupancy request things

```c++
auto policy_with_tuning = 
  Kokkos::Experimental::prefer(
  SomeRangePolicy, Kokkos::Experimental::TuneOccupancy{});
```

When you build with `KOKKOS_ENABLE_TUNING`, run with `--kokkos-tune-internals`, and pass `policy_with_tuning` into a parallel_x`, the autotuning system will tune it.

You'll notice that this PR is _huge_ relative to recent Tuning PR's, and it's worth discussing why. A tuned TeamPolicy has the same type before and after tuning. Ditto MDRangePolicy. However, a RangePolicy with no occupancy set is a RangePolicy<Space>, while a tuned RangePolicy is a RangePolicy<Space, TagSayingImTuned>. This means that the tuning workflow has to change. 

In the past, parallel patterns passed a policy to the Tools subsystem by reference, which mutated the policy. Now, the tools subsystem returns a response on begin_parallel_x, which includes a policy that is then used in the actual functor execution.

I'll leave comments inline to clarify some things