### PR TITLE
Enable atomics on Windows-LLVM.

### DIFF
--- a/core/src/Kokkos_Atomic.hpp
+++ b/core/src/Kokkos_Atomic.hpp
@@ -131,9 +131,9 @@ KOKKOS_INLINE_FUNCTION T desul_atomic_compare_exchange(
 
 #if defined(KOKKOS_ENABLE_CUDA)
 #define KOKKOS_ENABLE_CUDA_ATOMICS
+#endif
 #if defined(KOKKOS_COMPILER_CLANG)
 #define KOKKOS_ENABLE_GNU_ATOMICS
-#endif
 #endif
 
 #else  // _WIN32

--- a/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
@@ -196,8 +196,13 @@ inline int atomic_fetch_add(volatile int* const dest, const int val) {
 }
 #endif
 
+#ifdef _WIN32
+inline long long int atomic_fetch_add(volatile long long int* const dest,
+                                 const long long int val) {
+#else
 inline long int atomic_fetch_add(volatile long int* const dest,
                                  const long int val) {
+#endif
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);
 #endif

--- a/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
@@ -107,8 +107,13 @@ inline int atomic_fetch_or(volatile int* const dest, const int val) {
   return __sync_fetch_and_or(dest, val);
 }
 
+#ifdef _WIN32
+inline long long int atomic_fetch_or(volatile long long int* const dest,
+                                const long long int val) {
+#else
 inline long int atomic_fetch_or(volatile long int* const dest,
                                 const long int val) {
+#endif
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);
 #endif

--- a/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
@@ -171,8 +171,13 @@ inline int atomic_fetch_sub(volatile int* const dest, const int val) {
   return __sync_fetch_and_sub(dest, val);
 }
 
+#ifdef _WIN32
+inline long long int atomic_fetch_sub(volatile long long int* const dest,
+                                 const long long int val) {
+#else
 inline long int atomic_fetch_sub(volatile long int* const dest,
                                  const long int val) {
+#endif
 #if defined(KOKKOS_ENABLE_RFO_PREFETCH)
   _mm_prefetch((const char*)dest, _MM_HINT_ET0);
 #endif


### PR DESCRIPTION
Fixes #4029.

As per commit:

kokkos/core/src/Kokkos_Atomic.hpp: If clang is defined, enable GNU_ATOMICS independent of CUDA.

kokkos/core/src/impl/Kokkos_Atomic_Exchange.hpp: Fixes for Windows, where the 64-bit integer is long long, not long.