### PR TITLE
OpenMPTarget verify process fix

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
@@ -77,7 +77,7 @@ namespace Kokkos {
 namespace Impl {
 
 void OpenMPTargetExec::verify_is_process(const char* const label) {
-  if (omp_in_parallel()) {
+  if (omp_in_parallel() && (!omp_is_initial_device())) {
     std::string msg(label);
     msg.append(" ERROR: in parallel");
     Kokkos::Impl::throw_runtime_exception(msg);

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.cpp
@@ -77,9 +77,10 @@ namespace Kokkos {
 namespace Impl {
 
 void OpenMPTargetExec::verify_is_process(const char* const label) {
+  // Fails if the current task is in a parallel region or is not on the host.
   if (omp_in_parallel() && (!omp_is_initial_device())) {
     std::string msg(label);
-    msg.append(" ERROR: in parallel");
+    msg.append(" ERROR: in parallel or on device");
     Kokkos::Impl::throw_runtime_exception(msg);
   }
 }


### PR DESCRIPTION
The PR adds a check to `verify_is_process` routine which determines if the routine is being called on the host. 