### PR TITLE
Fixed invocation of tools init callbacks

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -457,10 +457,9 @@ void initialize(const std::string& profileLibrary) {
 #ifdef KOKKOS_ENABLE_LIBDL
   void* firstProfileLibrary = nullptr;
 
-  if (profileLibrary.empty())
-  {
-      invoke_init_callbacks();
-      return;
+  if (profileLibrary.empty()) {
+    invoke_init_callbacks();
+    return;
   }
 
   char* envProfileLibrary = const_cast<char*>(profileLibrary.c_str());


### PR DESCRIPTION
- Fixes scenario where `Kokkos::Tools::Experimental::set_init_callback` is configured before `Kokkos::initialize(...)` and there is no library loaded from environment, e.g.:

```cpp
extern "C"
void init_library(const int loadSeq, const uint64_t interfaceVer,
                  const uint32_t devInfoCount, void* deviceInfo) {
    // ...
}

int main()
{
    Kokkos::Tools::Experimental::set_init_callback(&init_library);
    Kokkos::initialize();
    // ...
    Kokkos::finalize();
}
```

Will also apply to: 

- `Experimental::current_callbacks.request_tool_settings`
- `Experimental::current_callbacks.provide_tool_programming_interface`

when the @DavidPoliakoff remembers to create set callback functions for those features ;)