### PR TITLE
Create KokkosExp_InterOp.hpp

### DIFF
--- a/core/src/KokkosExp_InterOp.hpp
+++ b/core/src/KokkosExp_InterOp.hpp
@@ -111,7 +111,8 @@ struct python_view_type {
                 "Error! python_view_type only supports Kokkos::View and "
                 "Kokkos::DynRankView");
 
-  using type = Kokkos::Impl::python_view_type_impl_t<typename ViewT::array_type>;
+  using type =
+      Kokkos::Impl::python_view_type_impl_t<typename ViewT::array_type>;
 };
 
 template <typename ViewT>

--- a/core/src/KokkosExp_InterOp.hpp
+++ b/core/src/KokkosExp_InterOp.hpp
@@ -1,0 +1,172 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_CORE_EXP_INTEROP_HPP
+#define KOKKOS_CORE_EXP_INTEROP_HPP
+
+#include <Kokkos_Core_fwd.hpp>
+#include <Kokkos_Layout.hpp>
+#include <Kokkos_MemoryTraits.hpp>
+#include <Kokkos_View.hpp>
+#include <Kokkos_DynRankView.hpp>
+#include <impl/Kokkos_Utilities.hpp>
+#include <type_traits>
+
+namespace Kokkos {
+namespace Experimental {
+namespace Impl {
+
+template <typename... T>
+using type_list = Kokkos::Impl::type_list<T...>;
+
+// ------------------------------------------------------------------ //
+//  concat_type_list combines types in multiple type_lists
+
+// default definition
+template <typename... T>
+struct concat_type_list {
+  using type = type_list<T...>;
+};
+
+// append to type_list
+template <typename... T, typename... Tail>
+struct concat_type_list<type_list<T...>, Tail...>
+    : concat_type_list<T..., Tail...> {};
+
+// combine consecutive type_lists
+template <typename... T, typename... U, typename... Tail>
+struct concat_type_list<type_list<T...>, type_list<U...>, Tail...>
+    : concat_type_list<type_list<T..., U...>, Tail...> {};
+
+// alias
+template <typename... T>
+using concat_type_list_t = typename concat_type_list<T...>::type;
+
+// ------------------------------------------------------------------ //
+//  gather filters out types which satisfy PredicateT<T>::Value = ValueT
+
+template <template <typename> class PredicateT, bool ValueT, typename... T>
+struct gather {
+  using type = concat_type_list_t<std::conditional_t<
+      PredicateT<T>::value == ValueT, concat_type_list_t<T>, type_list<>>...>;
+};
+
+template <template <typename> class PredicateT, bool ValueT, typename... T>
+using gather_t = typename gather<PredicateT, ValueT, T...>::type;
+
+// ------------------------------------------------------------------ //
+//  this is used to convert
+//      Kokkos::Device<ExecSpace, MemSpace> to MemSpace
+//
+template <typename Tp>
+struct device_memory_space {
+  using type = Tp;
+};
+
+template <typename ExecT, typename MemT>
+struct device_memory_space<Kokkos::Device<ExecT, MemT>> {
+  using type = MemT;
+};
+
+template <typename Tp>
+using device_memory_space_t = typename device_memory_space<Tp>::type;
+
+// ------------------------------------------------------------------ //
+//  this identifies the default memory trait
+//
+template <typename Tp>
+struct is_default_memory_trait : std::false_type {};
+
+template <>
+struct is_default_memory_trait<Kokkos::MemoryTraits<0>> : std::true_type {};
+
+// ------------------------------------------------------------------ //
+//  this is the impl version which takes a view and converts to python
+//  view type
+//
+template <typename, typename...>
+struct python_view_type;
+
+template <template <typename...> class ViewT, typename ValueT,
+          typename... Types>
+struct python_view_type<ViewT<ValueT>, type_list<Types...>> {
+  using type = ViewT<ValueT, device_memory_space_t<Types>...>;
+};
+
+template <template <typename...> class ViewT, typename ValueT,
+          typename... Types>
+struct python_view_type<ViewT<ValueT, Types...>>
+    : python_view_type<ViewT<ValueT>,
+                       gather_t<is_default_memory_trait, false, Types...>> {};
+
+template <typename... T>
+using python_view_type_t = typename python_view_type<T...>::type;
+
+}  // namespace Impl
+
+//--------------------------------------------------------------------------------------//
+//  this is used to extract the uniform type of a view
+//
+template <typename ViewT>
+struct python_view_type {
+  static_assert(Kokkos::is_view<std::decay_t<ViewT>>::value ||
+                    Kokkos::is_dyn_rank_view<std::decay_t<ViewT>>::value,
+                "Error! python_view_type only supports Kokkos::View and "
+                "Kokkos::DynRankView");
+
+  using type = Impl::python_view_type_t<typename ViewT::array_type>;
+};
+
+template <typename ViewT>
+using python_view_type_t = typename python_view_type<ViewT>::type;
+
+template <typename Tp>
+auto as_python_type(Tp&& _v) {
+  using cast_type = python_view_type_t<Tp>;
+  return static_cast<cast_type>(std::forward<Tp>(_v));
+}
+}  // namespace Experimental
+}  // namespace Kokkos
+
+#endif

--- a/core/src/KokkosExp_InterOp.hpp
+++ b/core/src/KokkosExp_InterOp.hpp
@@ -86,7 +86,7 @@ struct concat_type_list<type_list<T...>, type_list<U...>, Tail...>
 //  PredicateT<T>::value == ValueT
 
 template <template <typename> class PredicateT, typename TypeListT,
-          bool ValueT = false>
+          bool ValueT = true>
 struct filter_type_list;
 
 template <template <typename> class PredicateT, typename... T, bool ValueT>
@@ -96,7 +96,7 @@ struct filter_type_list<PredicateT, type_list<T...>, ValueT> {
                                             type_list<T>, type_list<>>...>;
 };
 
-template <template <typename> class PredicateT, typename T, bool ValueT = false>
+template <template <typename> class PredicateT, typename T, bool ValueT = true>
 using filter_type_list_t =
     typename filter_type_list<PredicateT, T, ValueT>::type;
 
@@ -142,9 +142,9 @@ struct python_view_type_impl<ViewT<ValueT>, type_list<Types...>> {
 template <template <typename...> class ViewT, typename ValueT,
           typename... Types>
 struct python_view_type_impl<ViewT<ValueT, Types...>>
-    : python_view_type_impl<
-          ViewT<ValueT>,
-          filter_type_list_t<is_default_memory_trait, type_list<Types...>>> {};
+    : python_view_type_impl<ViewT<ValueT>,
+                            filter_type_list_t<is_default_memory_trait,
+                                               type_list<Types...>, false>> {};
 
 template <typename... T>
 using python_view_type_impl_t = typename python_view_type_impl<T...>::type;

--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -118,6 +118,15 @@ enum : unsigned {
   MEMORY_ALIGNMENT_THRESHOLD = KOKKOS_MEMORY_ALIGNMENT_THRESHOLD
 };
 
+// ------------------------------------------------------------------ //
+//  this identifies the default memory trait
+//
+template <typename Tp>
+struct is_default_memory_trait : std::false_type {};
+
+template <>
+struct is_default_memory_trait<Kokkos::MemoryTraits<0>> : std::true_type {};
+
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -209,6 +209,54 @@ struct type_list_any<UnaryPred, type_list<>> : std::false_type {};
 // </editor-fold> end type_list_any }}}2
 //------------------------------------------------------------------------------
 
+//------------------------------------------------------------------------------
+// <editor-fold desc="concat_type_list"> {{{2
+//  concat_type_list combines types in multiple type_lists
+
+// forward declaration
+template <typename... T>
+struct concat_type_list;
+
+// alias
+template <typename... T>
+using concat_type_list_t = typename concat_type_list<T...>::type;
+
+// final instantiation
+template <typename... T>
+struct concat_type_list<type_list<T...>> {
+  using type = type_list<T...>;
+};
+
+// combine consecutive type_lists
+template <typename... T, typename... U, typename... Tail>
+struct concat_type_list<type_list<T...>, type_list<U...>, Tail...>
+    : concat_type_list<type_list<T..., U...>, Tail...> {};
+// </editor-fold> end concat_type_list }}}2
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// <editor-fold desc="filter_type_list"> {{{2
+//  filter_type_list generates type-list of types which satisfy
+//  PredicateT<T>::value == ValueT
+
+template <template <typename> class PredicateT, typename TypeListT,
+          bool ValueT = true>
+struct filter_type_list;
+
+template <template <typename> class PredicateT, typename... T, bool ValueT>
+struct filter_type_list<PredicateT, type_list<T...>, ValueT> {
+  using type =
+      concat_type_list_t<std::conditional_t<PredicateT<T>::value == ValueT,
+                                            type_list<T>, type_list<>>...>;
+};
+
+template <template <typename> class PredicateT, typename T, bool ValueT = true>
+using filter_type_list_t =
+    typename filter_type_list<PredicateT, T, ValueT>::type;
+
+// </editor-fold> end filter_type_list }}}2
+//------------------------------------------------------------------------------
+
 // </editor-fold> end type_list }}}1
 //==============================================================================
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -70,6 +70,7 @@ KOKKOS_ADD_EXECUTABLE(
   SOURCES
   TestDetectionIdiom.cpp
   TestInterOp.cpp
+  TestTypeList.cpp
 )
 
 foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -69,6 +69,7 @@ KOKKOS_ADD_EXECUTABLE(
   TestCompileOnly
   SOURCES
   TestDetectionIdiom.cpp
+  TestInterOp.cpp
 )
 
 foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)

--- a/core/unit_test/TestInterOp.cpp
+++ b/core/unit_test/TestInterOp.cpp
@@ -1,0 +1,155 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <KokkosExp_InterOp.hpp>
+
+// View
+static_assert(
+    std::is_same<
+        Kokkos::Experimental::python_view_type_t<Kokkos::View<double*>>,
+        Kokkos::View<double*, Kokkos::LayoutRight,
+                     typename Kokkos::DefaultExecutionSpace::memory_space>>::
+        value,
+    "Error! Unexpected python_view_type for: View");
+
+// DynRankView
+static_assert(
+    std::is_same<
+        Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<double>>,
+        Kokkos::DynRankView<
+            double, Kokkos::LayoutRight,
+            typename Kokkos::DefaultExecutionSpace::memory_space>>::value,
+    "Error! Unexpected python_view_type for: DynRankView");
+
+// View + Execution Space
+static_assert(
+    std::is_same<
+        Kokkos::Experimental::python_view_type_t<
+            Kokkos::View<double*, Kokkos::DefaultExecutionSpace>>,
+        Kokkos::View<double*, Kokkos::LayoutRight,
+                     typename Kokkos::DefaultExecutionSpace::memory_space>>::
+        value,
+    "Error! Unexpected python_view_type for: View + Execution Space");
+
+// DynRankView + Execution Space
+static_assert(
+    std::is_same<
+        Kokkos::Experimental::python_view_type_t<
+            Kokkos::DynRankView<double, Kokkos::DefaultExecutionSpace>>,
+        Kokkos::DynRankView<
+            double, Kokkos::LayoutRight,
+            typename Kokkos::DefaultExecutionSpace::memory_space>>::value,
+    "Error! Unexpected python_view_type for: DynRankView + Execution Space");
+
+// View + Memory space
+static_assert(std::is_same<Kokkos::Experimental::python_view_type_t<
+                               Kokkos::View<int64_t*, Kokkos::HostSpace>>,
+                           Kokkos::View<int64_t*, Kokkos::LayoutRight,
+                                        Kokkos::HostSpace>>::value,
+              "Error! Unexpected python_view_type for: View + Memory space");
+
+// DynRankView + Memory space
+static_assert(std::is_same<Kokkos::Experimental::python_view_type_t<
+                               Kokkos::DynRankView<int16_t, Kokkos::HostSpace>>,
+                           Kokkos::DynRankView<int16_t, Kokkos::LayoutRight,
+                                               Kokkos::HostSpace>>::value,
+              "Error! Unexpected python_view_type for: DynRankView + Memory space");
+
+// View + Layout + Execution space
+static_assert(
+    std::is_same<
+        Kokkos::Experimental::python_view_type_t<Kokkos::View<
+            int**, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace>>,
+        Kokkos::View<int**, Kokkos::LayoutLeft,
+                     typename Kokkos::DefaultExecutionSpace::memory_space>>::
+        value,
+    "Error! Unexpected python_view_type for: View + Layout + Execution space");
+
+// DynRankView + Layout + Execution space
+static_assert(
+    std::is_same<Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<
+                     int, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace>>,
+                 Kokkos::DynRankView<int, Kokkos::LayoutLeft,
+                                     typename Kokkos::DefaultExecutionSpace::
+                                         memory_space>>::value,
+    "Error! Unexpected python_view_type for: DynRankView + Layout + Execution space");
+
+// View + Layout + Memory Space
+static_assert(
+    std::is_same<
+        Kokkos::Experimental::python_view_type_t<
+            Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
+        Kokkos::View<uint32_t**, Kokkos::LayoutLeft, Kokkos::HostSpace>>::value,
+    "Error! Unexpected python_view_type for: View + Layout + Memory Space");
+
+// DynRankView + Layout + Memory Space
+static_assert(
+    std::is_same<
+        Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<
+            uint64_t, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
+        Kokkos::DynRankView<uint64_t, Kokkos::LayoutLeft, Kokkos::HostSpace>>::value,
+    "Error! Unexpected python_view_type for: DynRankView + Layout + Memory Space");
+
+// View + Layout + Execution space + Memory Trait
+static_assert(
+    std::is_same<
+        Kokkos::Experimental::python_view_type_t<Kokkos::View<
+            float***, Kokkos::LayoutLeft, Kokkos::DefaultHostExecutionSpace,
+            Kokkos::MemoryTraits<Kokkos::RandomAccess>>>,
+        Kokkos::View<float***, Kokkos::LayoutLeft,
+                     typename Kokkos::DefaultHostExecutionSpace::memory_space,
+                     Kokkos::MemoryTraits<Kokkos::RandomAccess>>>::value,
+    "Error! Unexpected python_view_type for: View + Layout + Execution space + Memory Trait");
+
+// DynRankView + Layout + Execution space  + Memory trait
+static_assert(
+    std::is_same<
+        Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<
+            float, Kokkos::LayoutLeft, Kokkos::DefaultHostExecutionSpace,
+            Kokkos::MemoryTraits<Kokkos::Atomic>>>,
+        Kokkos::DynRankView<
+            float, Kokkos::LayoutLeft,
+            typename Kokkos::DefaultHostExecutionSpace::memory_space,
+            Kokkos::MemoryTraits<Kokkos::Atomic>>>::value,
+    "Error! Unexpected python_view_type for: DynRankView + Layout + Execution space  + Memory trait");

--- a/core/unit_test/TestInterOp.cpp
+++ b/core/unit_test/TestInterOp.cpp
@@ -48,9 +48,9 @@
 static_assert(
     std::is_same<
         Kokkos::Experimental::python_view_type_t<Kokkos::View<double*>>,
-        Kokkos::View<double*, Kokkos::LayoutRight,
-                     typename Kokkos::DefaultExecutionSpace::memory_space>>::
-        value,
+        Kokkos::View<
+            double*, typename Kokkos::DefaultExecutionSpace::array_layout,
+            typename Kokkos::DefaultExecutionSpace::memory_space>>::value,
     "Error! Unexpected python_view_type for: View");
 
 // DynRankView
@@ -58,7 +58,7 @@ static_assert(
     std::is_same<
         Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<double>>,
         Kokkos::DynRankView<
-            double, Kokkos::LayoutRight,
+            double, typename Kokkos::DefaultExecutionSpace::array_layout,
             typename Kokkos::DefaultExecutionSpace::memory_space>>::value,
     "Error! Unexpected python_view_type for: DynRankView");
 
@@ -67,9 +67,9 @@ static_assert(
     std::is_same<
         Kokkos::Experimental::python_view_type_t<
             Kokkos::View<double*, Kokkos::DefaultExecutionSpace>>,
-        Kokkos::View<double*, Kokkos::LayoutRight,
-                     typename Kokkos::DefaultExecutionSpace::memory_space>>::
-        value,
+        Kokkos::View<
+            double*, typename Kokkos::DefaultExecutionSpace::array_layout,
+            typename Kokkos::DefaultExecutionSpace::memory_space>>::value,
     "Error! Unexpected python_view_type for: View + Execution Space");
 
 // DynRankView + Execution Space
@@ -78,7 +78,7 @@ static_assert(
         Kokkos::Experimental::python_view_type_t<
             Kokkos::DynRankView<double, Kokkos::DefaultExecutionSpace>>,
         Kokkos::DynRankView<
-            double, Kokkos::LayoutRight,
+            double, typename Kokkos::DefaultExecutionSpace::array_layout,
             typename Kokkos::DefaultExecutionSpace::memory_space>>::value,
     "Error! Unexpected python_view_type for: DynRankView + Execution Space");
 

--- a/core/unit_test/TestInterOp.cpp
+++ b/core/unit_test/TestInterOp.cpp
@@ -90,11 +90,12 @@ static_assert(std::is_same<Kokkos::Experimental::python_view_type_t<
               "Error! Unexpected python_view_type for: View + Memory space");
 
 // DynRankView + Memory space
-static_assert(std::is_same<Kokkos::Experimental::python_view_type_t<
-                               Kokkos::DynRankView<int16_t, Kokkos::HostSpace>>,
-                           Kokkos::DynRankView<int16_t, Kokkos::LayoutRight,
-                                               Kokkos::HostSpace>>::value,
-              "Error! Unexpected python_view_type for: DynRankView + Memory space");
+static_assert(
+    std::is_same<Kokkos::Experimental::python_view_type_t<
+                     Kokkos::DynRankView<int16_t, Kokkos::HostSpace>>,
+                 Kokkos::DynRankView<int16_t, Kokkos::LayoutRight,
+                                     Kokkos::HostSpace>>::value,
+    "Error! Unexpected python_view_type for: DynRankView + Memory space");
 
 // View + Layout + Execution space
 static_assert(
@@ -113,7 +114,8 @@ static_assert(
                  Kokkos::DynRankView<int, Kokkos::LayoutLeft,
                                      typename Kokkos::DefaultExecutionSpace::
                                          memory_space>>::value,
-    "Error! Unexpected python_view_type for: DynRankView + Layout + Execution space");
+    "Error! Unexpected python_view_type for: DynRankView + Layout + Execution "
+    "space");
 
 // View + Layout + Memory Space
 static_assert(
@@ -125,11 +127,12 @@ static_assert(
 
 // DynRankView + Layout + Memory Space
 static_assert(
-    std::is_same<
-        Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<
-            uint64_t, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
-        Kokkos::DynRankView<uint64_t, Kokkos::LayoutLeft, Kokkos::HostSpace>>::value,
-    "Error! Unexpected python_view_type for: DynRankView + Layout + Memory Space");
+    std::is_same<Kokkos::Experimental::python_view_type_t<Kokkos::DynRankView<
+                     uint64_t, Kokkos::LayoutLeft, Kokkos::HostSpace>>,
+                 Kokkos::DynRankView<uint64_t, Kokkos::LayoutLeft,
+                                     Kokkos::HostSpace>>::value,
+    "Error! Unexpected python_view_type for: DynRankView + Layout + Memory "
+    "Space");
 
 // View + Layout + Execution space + Memory Trait
 static_assert(
@@ -140,7 +143,8 @@ static_assert(
         Kokkos::View<float***, Kokkos::LayoutLeft,
                      typename Kokkos::DefaultHostExecutionSpace::memory_space,
                      Kokkos::MemoryTraits<Kokkos::RandomAccess>>>::value,
-    "Error! Unexpected python_view_type for: View + Layout + Execution space + Memory Trait");
+    "Error! Unexpected python_view_type for: View + Layout + Execution space + "
+    "Memory Trait");
 
 // DynRankView + Layout + Execution space  + Memory trait
 static_assert(
@@ -152,4 +156,5 @@ static_assert(
             float, Kokkos::LayoutLeft,
             typename Kokkos::DefaultHostExecutionSpace::memory_space,
             Kokkos::MemoryTraits<Kokkos::Atomic>>>::value,
-    "Error! Unexpected python_view_type for: DynRankView + Layout + Execution space  + Memory trait");
+    "Error! Unexpected python_view_type for: DynRankView + Layout + Execution "
+    "space  + Memory trait");

--- a/core/unit_test/TestTypeList.cpp
+++ b/core/unit_test/TestTypeList.cpp
@@ -1,0 +1,69 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <impl/Kokkos_Utilities.hpp>
+
+using TypeList2 = Kokkos::Impl::type_list<void, bool>;
+using TypeList3 = Kokkos::Impl::type_list<char, short, int>;
+using TypeList223 =
+    Kokkos::Impl::type_list<void, bool, void, bool, char, short, int>;
+using TypeList223Void   = Kokkos::Impl::type_list<void, void>;
+using TypeList223NoVoid = Kokkos::Impl::type_list<bool, bool, char, short, int>;
+
+// concat_type_list
+using ConcatTypeList2 = Kokkos::Impl::concat_type_list_t<TypeList2>;
+static_assert(std::is_same<TypeList2, ConcatTypeList2>::value);
+
+using ConcatTypeList223 =
+    Kokkos::Impl::concat_type_list_t<TypeList2, TypeList2, TypeList3>;
+static_assert(std::is_same<TypeList223, ConcatTypeList223>::value);
+
+// filter_type_list
+using FilterTypeList223Void =
+    Kokkos::Impl::filter_type_list_t<std::is_void, TypeList223>;
+static_assert(std::is_same<TypeList223Void, FilterTypeList223Void>::value);
+
+using FilterTypeList223NoVoid =
+    Kokkos::Impl::filter_type_list_t<std::is_void, TypeList223, false>;
+static_assert(std::is_same<TypeList223NoVoid, FilterTypeList223NoVoid>::value);

--- a/core/unit_test/TestTypeList.cpp
+++ b/core/unit_test/TestTypeList.cpp
@@ -53,17 +53,21 @@ using TypeList223NoVoid = Kokkos::Impl::type_list<bool, bool, char, short, int>;
 
 // concat_type_list
 using ConcatTypeList2 = Kokkos::Impl::concat_type_list_t<TypeList2>;
-static_assert(std::is_same<TypeList2, ConcatTypeList2>::value);
+static_assert(std::is_same<TypeList2, ConcatTypeList2>::value,
+              "concat_type_list of a single type_list failed");
 
 using ConcatTypeList223 =
     Kokkos::Impl::concat_type_list_t<TypeList2, TypeList2, TypeList3>;
-static_assert(std::is_same<TypeList223, ConcatTypeList223>::value);
+static_assert(std::is_same<TypeList223, ConcatTypeList223>::value,
+              "concat_type_list of three type_lists failed");
 
 // filter_type_list
 using FilterTypeList223Void =
     Kokkos::Impl::filter_type_list_t<std::is_void, TypeList223>;
-static_assert(std::is_same<TypeList223Void, FilterTypeList223Void>::value);
+static_assert(std::is_same<TypeList223Void, FilterTypeList223Void>::value,
+              "filter_type_list with predicate value==true failed");
 
 using FilterTypeList223NoVoid =
     Kokkos::Impl::filter_type_list_t<std::is_void, TypeList223, false>;
-static_assert(std::is_same<TypeList223NoVoid, FilterTypeList223NoVoid>::value);
+static_assert(std::is_same<TypeList223NoVoid, FilterTypeList223NoVoid>::value,
+              "filter_type_list with predicate value==false failed");


### PR DESCRIPTION
For the given user code:

```cpp
using view_type = Kokkos::View<double**, Kokkos::DefaultExecutionSpace>;

view_type generate_view(size_t);
void modify_view(view_type);
```

in order to pass an instance of `view_type` to/from python, the user needs to cast view type into a uniform type: `View<ValueT, LayoutT, MemorySpaceT, MemoryTraitsT>` where only `Kokkos::MemoryTraits<0>` can be omitted, e.g. `Kokkos::View<double**, Kokkos::Cuda>` needs to be cast to `Kokkos::View<double**, Kokkos::LayoutRight, Kokkos::CudaSpace>`.

Thus the following will compile with pybind11 but will fail at runtime:

```cpp
PYBIND11_MODULE(ex_generate, ex) {

  ex.def(
      "generate_view", 
      &generate_view);

  ex.def(
      "modify_view", 
      &modify_view);
}
```

by including `KokkosExp_InterOp.hpp`, the user can write the bindings like this such that the proper cast will be performed:

```cpp
#include <KokkosExp_InterOp.hpp>

PYBIND11_MODULE(ex_generate, ex) {

  ex.def(
      "generate_view",
      [](size_t n) {
        return Kokkos::Experimental::as_python_type(generate_view(n));
      });

  ex.def(
      "modify_view",
      [](Kokkos::Experimental::python_view_type_t<view_type> _v) {
        modify_view(_v);
      });
}
```