### PR TITLE
Fence Kokkos::resize()

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2963,6 +2963,7 @@ resize(Kokkos::View<T, P...>& v, const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
   view_type v_resized(v.label(), n0, n1, n2, n3, n4, n5, n6, n7);
 
   Kokkos::Impl::ViewRemap<view_type, view_type>(v_resized, v);
+  typename view_type::execution_space{}.fence();
 
   v = v_resized;
 }
@@ -3061,6 +3062,7 @@ resize(const I& arg_prop, Kokkos::View<T, P...>& v,
                       n0, n1, n2, n3, n4, n5, n6, n7);
 
   Kokkos::Impl::ViewRemap<view_type, view_type>(v_resized, v);
+  typename view_type::execution_space{}.fence();
 
   v = v_resized;
 }
@@ -3078,6 +3080,7 @@ inline void resize(Kokkos::View<T, P...>& v,
   view_type v_resized(v.label(), layout);
 
   Kokkos::Impl::ViewRemap<view_type, view_type>(v_resized, v);
+  typename view_type::execution_space{}.fence();
 
   v = v_resized;
 }


### PR DESCRIPTION
While working on improving the fencing behavior for the `SYCL` backend, I ran into problems with `Kokkos:resize()`. Without the fences, the view was deallocated before the copy kernel in `ViewRemap` ran. Thus, make sure that the copy is finished before calling the copy assignment operator.