### PR TITLE
Fence all registered SYCL queues before deallocating memory

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -195,6 +195,7 @@ void sycl_deallocate(const char* arg_label, void* const arg_alloc_ptr,
                                       reported_size);
   }
 
+  SYCL::impl_static_fence();
   sycl::free(arg_alloc_ptr, queue);
 }
 


### PR DESCRIPTION
Supersedes #4079. Without this, `Kokkos::resize()` would run into issues (deallocating memory before the copy kernel was finished) when trying to improve the fencing behavior of the `SYCL` backend.
We fence all `sycl::queue`s that can reasonably access the memory asynchronously that we are trying to deallocate.