### PR TITLE
Improve fencing behavior in SYCL backend

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
@@ -61,10 +61,13 @@ struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
     auto event = exec_space.impl_internal_space_instance()->m_queue->memset(
         dst.data(), 0,
         dst.size() * sizeof(typename View<DT, DP...>::value_type));
-    // FIXME_SYCL this should rather be
-    // exec_space.impl_internal_space_instance()->m_queue->submit_barrier();
-    // but that gives currently a segfault using the CUDA backend
+    // FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
+    exec_space.impl_internal_space_instance()->m_queue->submit_barrier(
+        sycl::vector_class<sycl::event>{event});
+#else
     Experimental::Impl::SYCLInternal::fence(event);
+#endif
   }
 
   ZeroMemset(const View<DT, DP...>& dst,

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -292,14 +292,15 @@ size_t SYCLInternal::USMObjectMem<Kind>::reserve(size_t n) {
 
 template <sycl::usm::alloc Kind>
 void SYCLInternal::USMObjectMem<Kind>::reset() {
-  assert(m_size == 0);
-
   if (m_data) {
+    // This implies a fence since this class is not copyable
+    // and deallocating implies a fence across all registered queues.
     using Record = Kokkos::Impl::SharedAllocationRecord<AllocationSpace, void>;
     Record::decrement(Record::get_record(m_data));
 
     m_capacity = 0;
     m_data     = nullptr;
+    m_size     = 0;
   }
   m_q.reset();
 }

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -99,29 +99,6 @@ class SYCLInternal {
   template <sycl::usm::alloc Kind>
   class USMObjectMem {
    public:
-    class Deleter {
-     public:
-      Deleter() = default;
-      explicit Deleter(USMObjectMem* mem) : m_mem(mem) {}
-
-      template <typename T>
-      void operator()(T* p) const noexcept {
-        assert(m_mem);
-        assert(sizeof(T) == m_mem->size());
-
-        if constexpr (sycl::usm::alloc::device == Kind)
-          // Only skipping the dtor on trivially copyable types
-          static_assert(std::is_trivially_copyable_v<T>);
-        else
-          p->~T();
-
-        m_mem->m_size = 0;
-      }
-
-     private:
-      USMObjectMem* m_mem = nullptr;
-    };
-
     void reset();
 
     void reset(sycl::queue q) {
@@ -162,15 +139,13 @@ class SYCLInternal {
     // not an implicit-lifetime nor trivially-copyable type, but presumably much
     // faster because we can use USM device memory
     template <typename T>
-    std::unique_ptr<T, Deleter> memcpy_from(const T& t) {
+    T* memcpy_from(const T& t) {
       reserve(sizeof(T));
       sycl::event memcopied = m_q->memcpy(m_data, std::addressof(t), sizeof(T));
       fence(memcopied);
 
-      std::unique_ptr<T, Deleter> ptr(reinterpret_cast<T*>(m_data),
-                                      Deleter(this));
       m_size = sizeof(T);
-      return ptr;
+      return reinterpret_cast<T*>(m_data);
     }
 
     // This will copy-constuct an object T into memory held by this object
@@ -179,15 +154,14 @@ class SYCLInternal {
     //
     // Note:  This will not work with USM device memory
     template <typename T>
-    std::unique_ptr<T, Deleter> copy_construct_from(const T& t) {
+    T* copy_construct_from(const T& t) {
       static_assert(Kind != sycl::usm::alloc::device,
                     "Cannot copy construct into USM device memory");
 
       reserve(sizeof(T));
 
-      std::unique_ptr<T, Deleter> ptr(new (m_data) T(t), Deleter(this));
       m_size = sizeof(T);
-      return ptr;
+      return new (m_data) T(t);
     }
 
    public:
@@ -198,13 +172,15 @@ class SYCLInternal {
     // or
     //
     // performs copy construction (for other USM memory types) and returns a
-    // unique_ptr<T, ...>
+    // reference to the copied object.
     template <typename T>
-    std::unique_ptr<T, Deleter> copy_from(const T& t) {
+    T& copy_from(const T& t) {
+      fence(last_event);
+      m_size = 0;
       if constexpr (sycl::usm::alloc::device == Kind)
-        return memcpy_from(t);
+        return *memcpy_from(t);
       else
-        return copy_construct_from(t);
+        return *copy_construct_from(t);
     }
 
    private:
@@ -242,24 +218,36 @@ class SYCLInternal {
         return move_assign_to(t);
     }
 
+    void register_event(sycl::event event) {
+      assert(
+          last_event.get_info<sycl::info::event::command_execution_status>() ==
+          sycl::info::event_command_status::complete);
+      last_event = event;
+    }
+
    private:
     // USMObjectMem class invariants
     // All four expressions below must evaluate to true:
     //
-    //  !m_data == !m_capacity
-    //  m_q || !m_data
-    //  m_data || !m_size
-    //  m_size <= m_capacity
+    //  (m_data == nullptr) == (m_capacity == 0)
+    //     (m_q != nullopt) || (m_data == nullptr)
+    //  (m_data != nullptr) || (m_size == 0)
+    //               m_size <= m_capacity
     //
     //  The above invariants mean that:
     //  if m_size != 0 then m_data != 0
     //  if m_data != 0 then m_capacity != 0 && m_q != nullopt
     //  if m_data == 0 then m_capacity == 0
+    //
+    //  m_size != 0 implies that there might be an active kernel using this
+    //  object. The status of that kernel can be queried using last_event. if
+    //  m_size == 0 then last_event is completed
 
     std::optional<sycl::queue> m_q;
     void* m_data      = nullptr;
     size_t m_size     = 0;  // sizeof(T) iff m_data points to live T
     size_t m_capacity = 0;
+    sycl::event last_event;
   };
 
   // An indirect kernel is one where the functor to be executed is explicitly
@@ -315,20 +303,24 @@ class SYCLFunctionWrapper<Functor, Storage, true> {
   SYCLFunctionWrapper(const Functor& functor, Storage&) : m_functor(functor) {}
 
   const Functor& get_functor() const { return m_functor; }
+
+  static void register_event(Storage&, sycl::event){};
 };
 
 template <typename Functor, typename Storage>
 class SYCLFunctionWrapper<Functor, Storage, false> {
-  std::unique_ptr<Functor,
-                  Experimental::Impl::SYCLInternal::IndirectKernelMem::Deleter>
-      m_kernelFunctorPtr;
+  Functor& m_kernelFunctorPtr;
 
  public:
   SYCLFunctionWrapper(const Functor& functor, Storage& storage)
       : m_kernelFunctorPtr(storage.copy_from(functor)) {}
 
   std::reference_wrapper<const Functor> get_functor() const {
-    return {*m_kernelFunctorPtr};
+    return {m_kernelFunctorPtr};
+  }
+
+  static void register_event(Storage& storage, sycl::event event) {
+    storage.register_event(event);
   }
 };
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -309,14 +309,14 @@ class SYCLFunctionWrapper<Functor, Storage, true> {
 
 template <typename Functor, typename Storage>
 class SYCLFunctionWrapper<Functor, Storage, false> {
-  Functor& m_kernelFunctorPtr;
+  const Functor& m_kernelFunctor;
 
  public:
   SYCLFunctionWrapper(const Functor& functor, Storage& storage)
-      : m_kernelFunctorPtr(storage.copy_from(functor)) {}
+      : m_kernelFunctor(storage.copy_from(functor)) {}
 
   std::reference_wrapper<const Functor> get_functor() const {
-    return {m_kernelFunctorPtr};
+    return {m_kernelFunctor};
   }
 
   static void register_event(Storage& storage, sycl::event event) {

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -229,15 +229,15 @@ class SYCLInternal {
     // USMObjectMem class invariants
     // All four expressions below must evaluate to true:
     //
-    //  (m_data == nullptr) == (m_capacity == 0)
-    //     (m_q != nullopt) || (m_data == nullptr)
-    //  (m_data != nullptr) || (m_size == 0)
-    //               m_size <= m_capacity
+    //  !m_data == (m_capacity == 0)
+    //      m_q || !m_data
+    //   m_data || (m_size == 0)
+    //   m_size <= m_capacity
     //
     //  The above invariants mean that:
-    //  if m_size != 0 then m_data != 0
-    //  if m_data != 0 then m_capacity != 0 && m_q != nullopt
-    //  if m_data == 0 then m_capacity == 0
+    //  if m_size != 0 then m_data != nullptr
+    //  if m_data != nullptr then m_capacity != 0 && m_q != nullopt
+    //  if m_data == nullptr then m_capacity == 0
     //
     //  m_size != 0 implies that there might be an active kernel using this
     //  object. The status of that kernel can be queried using last_event. if

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -175,7 +175,7 @@ class SYCLInternal {
     // reference to the copied object.
     template <typename T>
     T& copy_from(const T& t) {
-      fence(last_event);
+      fence(m_last_event);
       m_size = 0;
       if constexpr (sycl::usm::alloc::device == Kind)
         return *memcpy_from(t);
@@ -219,10 +219,10 @@ class SYCLInternal {
     }
 
     void register_event(sycl::event event) {
-      assert(
-          last_event.get_info<sycl::info::event::command_execution_status>() ==
-          sycl::info::event_command_status::complete);
-      last_event = event;
+      assert(m_last_event
+                 .get_info<sycl::info::event::command_execution_status>() ==
+             sycl::info::event_command_status::complete);
+      m_last_event = event;
     }
 
    private:
@@ -240,14 +240,14 @@ class SYCLInternal {
     //  if m_data == nullptr then m_capacity == 0
     //
     //  m_size != 0 implies that there might be an active kernel using this
-    //  object. The status of that kernel can be queried using last_event. if
-    //  m_size == 0 then last_event is completed
+    //  object. The status of that kernel can be queried using m_last_event. if
+    //  m_size == 0 then m_last_event is completed
 
     std::optional<sycl::queue> m_q;
     void* m_data      = nullptr;
     size_t m_size     = 0;  // sizeof(T) iff m_data points to live T
     size_t m_capacity = 0;
-    sycl::event last_event;
+    sycl::event m_last_event;
   };
 
   // An indirect kernel is one where the functor to be executed is explicitly

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
@@ -82,8 +82,12 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
           functor(WorkTag(), id);
       });
     });
-
+    // FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
     q.submit_barrier(sycl::vector_class<sycl::event>{parallel_for_event});
+#else
+    space.fence();
+#endif
 
     return parallel_for_event;
   }
@@ -236,8 +240,12 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
             .exec_range();
       });
     });
-
+    // FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
     q.submit_barrier(sycl::vector_class<sycl::event>{parallel_for_event});
+#else
+    m_space.fence();
+#endif
 
     return parallel_for_event;
   }

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -178,8 +178,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
  private:
   template <typename PolicyType, typename Functor, typename Reducer>
-  void sycl_direct_launch(const PolicyType& policy, const Functor& functor,
-                          const Reducer& reducer) const {
+  sycl::event sycl_direct_launch(const PolicyType& policy,
+                                 const Functor& functor,
+                                 const Reducer& reducer) const {
     using ReducerConditional =
         Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
                            FunctorType, ReducerType>;
@@ -217,11 +218,13 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     value_type* device_accessible_result_ptr =
         m_result_ptr_device_accessible ? m_result_ptr : nullptr;
 
+    sycl::event last_reduction_event;
+
     // If size<=1 we only call init(), the functor and possibly final once
     // working with the global scratch memory but don't copy back to
     // m_result_ptr yet.
     if (size <= 1) {
-      q.submit([&](sycl::handler& cgh) {
+      auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         const auto begin = policy.begin();
         cgh.single_task([=]() {
           const auto& selected_reducer = ReducerConditional::select(
@@ -243,7 +246,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                            &results_ptr[0]);
         });
       });
-      space.fence();
+      q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
+      last_reduction_event = parallel_reduce_event;
     }
 
     // Otherwise, we perform a reduction on the values in all workgroups
@@ -255,7 +259,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       auto n_wgroups = ((size + values_per_thread - 1) / values_per_thread +
                         wgroup_size - 1) /
                        wgroup_size;
-      q.submit([&](sycl::handler& cgh) {
+      auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         sycl::accessor<value_type, 1, sycl::access::mode::read_write,
                        sycl::access::target::local>
             local_mem(sycl::range<1>(wgroup_size) * std::max(value_count, 1u),
@@ -315,7 +319,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                   static_cast<const FunctorType&>(functor), n_wgroups <= 1);
             });
       });
-      space.fence();
+      q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
+      last_reduction_event = parallel_reduce_event;
 
       first_run = false;
       size      = n_wgroups;
@@ -331,6 +336,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
           sizeof(*m_result_ptr) * value_count);
       space.fence();
     }
+
+    return last_reduction_event;
   }
 
  public:
@@ -347,8 +354,10 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     const auto reducer_wrapper = Experimental::Impl::make_sycl_function_wrapper(
         m_reducer, indirectReducerMem);
 
-    sycl_direct_launch(m_policy, functor_wrapper.get_functor(),
-                       reducer_wrapper.get_functor());
+    sycl::event event = sycl_direct_launch(
+        m_policy, functor_wrapper.get_functor(), reducer_wrapper.get_functor());
+    functor_wrapper.register_event(indirectKernelMem, event);
+    reducer_wrapper.register_event(indirectReducerMem, event);
   }
 
  private:
@@ -426,8 +435,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
  private:
   template <typename PolicyType, typename Functor, typename Reducer>
-  void sycl_direct_launch(const PolicyType& policy, const Functor& functor,
-                          const Reducer& reducer) const {
+  sycl::event sycl_direct_launch(const PolicyType& policy,
+                                 const Functor& functor,
+                                 const Reducer& reducer) const {
     using ReducerConditional =
         Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
                            FunctorType, ReducerType>;
@@ -472,11 +482,13 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     value_type* device_accessible_result_ptr =
         m_result_ptr_device_accessible ? m_result_ptr : nullptr;
 
+    sycl::event last_reduction_event;
+
     // If size<=1 we only call init(), the functor and possibly final once
     // working with the global scratch memory but don't copy back to
     // m_result_ptr yet.
     if (size <= 1) {
-      q.submit([&](sycl::handler& cgh) {
+      auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         cgh.single_task([=]() {
           const auto& selected_reducer = ReducerConditional::select(
               static_cast<const FunctorType&>(functor),
@@ -498,7 +510,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                            &results_ptr[0]);
         });
       });
-      m_space.fence();
+      q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
+      last_reduction_event = parallel_reduce_event;
     }
 
     // Otherwise, we perform a reduction on the values in all workgroups
@@ -507,8 +520,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     // value.
     bool first_run = true;
     while (size > 1) {
-      auto n_wgroups = (size + wgroup_size - 1) / wgroup_size;
-      q.submit([&](sycl::handler& cgh) {
+      auto n_wgroups             = (size + wgroup_size - 1) / wgroup_size;
+      auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         sycl::accessor<value_type, 1, sycl::access::mode::read_write,
                        sycl::access::target::local>
             local_mem(sycl::range<1>(wgroup_size) * std::max(value_count, 1u),
@@ -577,14 +590,14 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
               n_wgroups <= 1 && item.get_group_linear_id() == 0);
         });
       });
-      m_space.fence();
+      q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
 
       // FIXME_SYCL this is likely not necessary, see above
-      Kokkos::Impl::DeepCopy<Kokkos::Experimental::SYCLDeviceUSMSpace,
-                             Kokkos::Experimental::SYCLDeviceUSMSpace>(
-          m_space, results_ptr, results_ptr2,
-          sizeof(*m_result_ptr) * value_count * n_wgroups);
-      m_space.fence();
+      auto deep_copy_event =
+          q.memcpy(results_ptr, results_ptr2,
+                   sizeof(*m_result_ptr) * value_count * n_wgroups);
+      q.submit_barrier(sycl::vector_class<sycl::event>{deep_copy_event});
+      last_reduction_event = deep_copy_event;
 
       first_run = false;
       size      = n_wgroups;
@@ -600,6 +613,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           sizeof(*m_result_ptr) * value_count);
       m_space.fence();
     }
+
+    return last_reduction_event;
   }
 
  public:
@@ -621,8 +636,10 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     const auto reducer_wrapper = Experimental::Impl::make_sycl_function_wrapper(
         m_reducer, indirectReducerMem);
 
-    sycl_direct_launch(m_policy, functor_wrapper.get_functor(),
-                       reducer_wrapper.get_functor());
+    sycl::event event = sycl_direct_launch(
+        m_policy, functor_wrapper.get_functor(), reducer_wrapper.get_functor());
+    functor_wrapper.register_event(indirectKernelMem, event);
+    reducer_wrapper.register_event(indirectReducerMem, event);
   }
 
  private:

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -246,7 +246,12 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                            &results_ptr[0]);
         });
       });
+      // FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
       q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
+#else
+      space.fence();
+#endif
       last_reduction_event = parallel_reduce_event;
     }
 
@@ -319,7 +324,13 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                   static_cast<const FunctorType&>(functor), n_wgroups <= 1);
             });
       });
+// FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
       q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
+#else
+      space.fence();
+#endif
+
       last_reduction_event = parallel_reduce_event;
 
       first_run = false;
@@ -510,7 +521,12 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                            &results_ptr[0]);
         });
       });
+      // FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
       q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
+#else
+      m_space.fence();
+#endif
       last_reduction_event = parallel_reduce_event;
     }
 
@@ -590,13 +606,23 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
               n_wgroups <= 1 && item.get_group_linear_id() == 0);
         });
       });
+// FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
       q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
+#else
+      m_space.fence();
+#endif
 
       // FIXME_SYCL this is likely not necessary, see above
       auto deep_copy_event =
           q.memcpy(results_ptr, results_ptr2,
                    sizeof(*m_result_ptr) * value_count * n_wgroups);
+      // FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
       q.submit_barrier(sycl::vector_class<sycl::event>{deep_copy_event});
+#else
+      m_space.fence();
+#endif
       last_reduction_event = deep_copy_event;
 
       first_run = false;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -148,7 +148,12 @@ class ParallelScanSYCLBase {
                              &local_mem[local_id]);
           });
     });
+    // FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
     q.submit_barrier(sycl::vector_class<sycl::event>{local_scans});
+#else
+    m_policy.space().fence();
+#endif
 
     if (n_wgroups > 1) scan_internal(q, functor, group_results, n_wgroups);
 
@@ -162,8 +167,13 @@ class ParallelScanSYCLBase {
                                &group_results[item.get_group_linear_id()]);
                        });
     });
+    // FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
     q.submit_barrier(
         sycl::vector_class<sycl::event>{update_with_group_results});
+#else
+    m_policy.space().fence();
+#endif
   }
 
   template <typename Functor>
@@ -192,7 +202,12 @@ class ParallelScanSYCLBase {
         ValueOps::copy(functor, &global_mem[id], &update);
       });
     });
+    // FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
     q.submit_barrier(sycl::vector_class<sycl::event>{initialize_global_memory});
+#else
+    space.fence();
+#endif
 
     // Perform the actual exclusive scan
     scan_internal(q, functor, m_scratch_space, len);
@@ -211,7 +226,12 @@ class ParallelScanSYCLBase {
         ValueOps::copy(functor, &global_mem[global_id], &update);
       });
     });
+// FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
     q.submit_barrier(sycl::vector_class<sycl::event>{update_global_results});
+#else
+    space.fence();
+#endif
     return update_global_results;
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -90,13 +90,11 @@ class ParallelScanSYCLBase {
     auto n_wgroups               = (size + wgroup_size - 1) / wgroup_size;
     pointer_type group_results   = global_mem + size;
 
-    q.submit([&](sycl::handler& cgh) {
+    auto local_scans = q.submit([&](sycl::handler& cgh) {
       sycl::accessor<value_type, 1, sycl::access::mode::read_write,
                      sycl::access::target::local>
           local_mem(sycl::range<1>(wgroup_size), cgh);
 
-      // FIXME_SYCL we get wrong results without this, not sure why
-      sycl::stream out(1, 1, cgh);
       cgh.parallel_for(
           sycl::nd_range<1>(n_wgroups * wgroup_size, wgroup_size),
           [=](sycl::nd_item<1> item) {
@@ -150,11 +148,11 @@ class ParallelScanSYCLBase {
                              &local_mem[local_id]);
           });
     });
+    q.submit_barrier(sycl::vector_class<sycl::event>{local_scans});
 
     if (n_wgroups > 1) scan_internal(q, functor, group_results, n_wgroups);
-    m_policy.space().fence();
 
-    q.submit([&](sycl::handler& cgh) {
+    auto update_with_group_results = q.submit([&](sycl::handler& cgh) {
       cgh.parallel_for(sycl::nd_range<1>(n_wgroups * wgroup_size, wgroup_size),
                        [=](sycl::nd_item<1> item) {
                          const auto global_id = item.get_global_linear_id();
@@ -164,11 +162,12 @@ class ParallelScanSYCLBase {
                                &group_results[item.get_group_linear_id()]);
                        });
     });
-    m_policy.space().fence();
+    q.submit_barrier(
+        sycl::vector_class<sycl::event>{update_with_group_results});
   }
 
   template <typename Functor>
-  void sycl_direct_launch(const Functor& functor) const {
+  sycl::event sycl_direct_launch(const Functor& functor) const {
     // Convenience references
     const Kokkos::Experimental::SYCL& space = m_policy.space();
     Kokkos::Experimental::Impl::SYCLInternal& instance =
@@ -178,7 +177,7 @@ class ParallelScanSYCLBase {
     const std::size_t len = m_policy.end() - m_policy.begin();
 
     // Initialize global memory
-    q.submit([&](sycl::handler& cgh) {
+    auto initialize_global_memory = q.submit([&](sycl::handler& cgh) {
       auto global_mem = m_scratch_space;
       auto begin      = m_policy.begin();
       cgh.parallel_for(sycl::range<1>(len), [=](sycl::item<1> item) {
@@ -193,13 +192,13 @@ class ParallelScanSYCLBase {
         ValueOps::copy(functor, &global_mem[id], &update);
       });
     });
-    space.fence();
+    q.submit_barrier(sycl::vector_class<sycl::event>{initialize_global_memory});
 
     // Perform the actual exclusive scan
     scan_internal(q, functor, m_scratch_space, len);
 
     // Write results to global memory
-    q.submit([&](sycl::handler& cgh) {
+    auto update_global_results = q.submit([&](sycl::handler& cgh) {
       auto global_mem = m_scratch_space;
       cgh.parallel_for(sycl::range<1>(len), [=](sycl::item<1> item) {
         auto global_id = item.get_id();
@@ -212,7 +211,8 @@ class ParallelScanSYCLBase {
         ValueOps::copy(functor, &global_mem[global_id], &update);
       });
     });
-    space.fence();
+    q.submit_barrier(sycl::vector_class<sycl::event>{update_global_results});
+    return update_global_results;
   }
 
  public:
@@ -251,7 +251,8 @@ class ParallelScanSYCLBase {
     const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper(
         m_functor, indirectKernelMem);
 
-    sycl_direct_launch(functor_wrapper.get_functor());
+    sycl::event event = sycl_direct_launch(functor_wrapper.get_functor());
+    functor_wrapper.register_event(indirectKernelMem, event);
     post_functor();
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -377,14 +377,15 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   int m_scratch_size[2];
 
   template <typename Functor>
-  void sycl_direct_launch(const Policy& policy, const Functor& functor) const {
+  sycl::event sycl_direct_launch(const Policy& policy,
+                                 const Functor& functor) const {
     // Convenience references
     const Kokkos::Experimental::SYCL& space = policy.space();
     Kokkos::Experimental::Impl::SYCLInternal& instance =
         *space.impl_internal_space_instance();
     sycl::queue& q = *instance.m_queue;
 
-    q.submit([&](sycl::handler& cgh) {
+    auto parallel_for_event = q.submit([&](sycl::handler& cgh) {
       // FIXME_SYCL accessors seem to need a size greater than zero at least for
       // host queues
       sycl::accessor<char, 1, sycl::access::mode::read_write,
@@ -415,7 +416,8 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
               functor(work_tag(), team_member);
           });
     });
-    space.fence();
+    q.submit_barrier(sycl::vector_class<sycl::event>{parallel_for_event});
+    return parallel_for_event;
   }
 
  public:
@@ -430,7 +432,9 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     const auto functor_wrapper = Experimental::Impl::make_sycl_function_wrapper(
         m_functor, indirectKernelMem);
 
-    sycl_direct_launch(m_policy, functor_wrapper.get_functor());
+    sycl::event event =
+        sycl_direct_launch(m_policy, functor_wrapper.get_functor());
+    functor_wrapper.register_event(indirectKernelMem, event);
   }
 
   ParallelFor(FunctorType const& arg_functor, Policy const& arg_policy)
@@ -516,8 +520,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   const size_type m_vector_size;
 
   template <typename PolicyType, typename Functor, typename Reducer>
-  void sycl_direct_launch(const PolicyType& policy, const Functor& functor,
-                          const Reducer& reducer) const {
+  sycl::event sycl_direct_launch(const PolicyType& policy,
+                                 const Functor& functor,
+                                 const Reducer& reducer) const {
     using ReducerConditional =
         Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
                            FunctorType, ReducerType>;
@@ -552,11 +557,13 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     value_type* device_accessible_result_ptr =
         m_result_ptr_device_accessible ? m_result_ptr : nullptr;
 
+    sycl::event last_reduction_event;
+
     // If size<=1 we only call init(), the functor and possibly final once
     // working with the global scratch memory but don't copy back to
     // m_result_ptr yet.
     if (size <= 1) {
-      q.submit([&](sycl::handler& cgh) {
+      auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         // FIXME_SYCL accessors seem to need a size greater than zero at least
         // for host queues
         sycl::accessor<char, 1, sycl::access::mode::read_write,
@@ -596,7 +603,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                &results_ptr[0]);
             });
       });
-      space.fence();
+      q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
+      last_reduction_event = parallel_reduce_event;
     }
 
     // Otherwise, we perform a reduction on the values in all workgroups
@@ -605,8 +613,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     // value.
     bool first_run = true;
     while (size > 1) {
-      auto n_wgroups = (size + wgroup_size - 1) / wgroup_size;
-      q.submit([&](sycl::handler& cgh) {
+      auto n_wgroups             = (size + wgroup_size - 1) / wgroup_size;
+      auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         sycl::accessor<value_type, 1, sycl::access::mode::read_write,
                        sycl::access::target::local>
             local_mem(sycl::range<1>(wgroup_size) * std::max(value_count, 1u),
@@ -671,7 +679,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   n_wgroups <= 1 && item.get_group_linear_id() == 0);
             });
       });
-      space.fence();
+      q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
+      last_reduction_event = parallel_reduce_event;
 
       first_run = false;
       size      = n_wgroups;
@@ -687,6 +696,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
           sizeof(*m_result_ptr) * value_count);
       space.fence();
     }
+
+    return last_reduction_event;
   }
 
  public:
@@ -703,8 +714,10 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     const auto reducer_wrapper = Experimental::Impl::make_sycl_function_wrapper(
         m_reducer, indirectReducerMem);
 
-    sycl_direct_launch(m_policy, functor_wrapper.get_functor(),
-                       reducer_wrapper.get_functor());
+    sycl::event event = sycl_direct_launch(
+        m_policy, functor_wrapper.get_functor(), reducer_wrapper.get_functor());
+    functor_wrapper.register_event(indirectKernelMem, event);
+    reducer_wrapper.register_event(indirectReducerMem, event);
   }
 
  private:

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -416,7 +416,12 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
               functor(work_tag(), team_member);
           });
     });
+// FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
     q.submit_barrier(sycl::vector_class<sycl::event>{parallel_for_event});
+#else
+    space.fence();
+#endif
     return parallel_for_event;
   }
 
@@ -603,7 +608,12 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                &results_ptr[0]);
             });
       });
+      // FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
       q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
+#else
+      space.fence();
+#endif
       last_reduction_event = parallel_reduce_event;
     }
 
@@ -679,7 +689,12 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   n_wgroups <= 1 && item.get_group_linear_id() == 0);
             });
       });
+      // FIXME_SYCL remove guard once implemented for SYCL+CUDA
+#ifdef KOKKOS_ARCH_INTEL_GEN
       q.submit_barrier(sycl::vector_class<sycl::event>{parallel_reduce_event});
+#else
+      space.fence();
+#endif
       last_reduction_event = parallel_reduce_event;
 
       first_run = false;


### PR DESCRIPTION
Rebased on top of #4089 (and thus #3940).

Currently, we are fencing after every kernel call and this is required for the current `USMObjectMem` to work properly. On the other hand, this is not the intended behavior. `parallel_for` should not fence, `parallel_reduce` only if the result pointer is host accessible and similarly for `parallel_scan`.
The kernels still need to run in the right order so we need to submit barriers instead (but this doesn't work for the `CUDA` backend in `SYCL` so we need to fall back to the current behavior in that case).

For `USMObjectMem` this implies that we must allow the underlying data to be accessed until the kernel is finished (which doesn't align with the lifetime of the wrapper object). We must only make sure that the kernel has run when the data in `USMObjectMem` is reused. Hence, we allow that class for an event to be registered we can wait for.
Since the data is accessible for a longer time than the lifetime of the wrapper, doing anything in the destructor doesn't make any sense. Since it doesn't really make sense for an object captured by `USMObjectMem` to have a destructor that has a notable effect, getting rid of the `Deleter` struct (and the `std::unique_ptr` seems sensible.

Since we only have one `USMObjectMem` object (or two for reductions), this pull request still implies that we fence the corresponding `sycl::queue` when calling a second kernel. This could be mitigated by allowing more such objects that we can cycle through. I would leave this for later, though.

[`d3869b8` (#4088)](https://github.com/kokkos/kokkos/pull/4088/commits/d3869b89a823699935b35875c3a8806e54222c4d) and [`f1c9b58` (#4088)](https://github.com/kokkos/kokkos/pull/4088/commits/f1c9b58a4c9d56a8f2b4ff7384a60c5ac14cf91e) are the relevant commits here.