### PR TITLE
Only fence in SYCL parallel_reduce for non-device-accessible result_ptr

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -352,10 +352,10 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   }
 
  private:
-  FunctorType m_functor;
-  Policy m_policy;
-  ReducerType m_reducer;
-  pointer_type m_result_ptr;
+  const FunctorType m_functor;
+  const Policy m_policy;
+  const ReducerType m_reducer;
+  const pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
 };
 
@@ -626,11 +626,11 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   }
 
  private:
-  FunctorType m_functor;
-  BarePolicy m_policy;
+  const FunctorType m_functor;
+  const BarePolicy m_policy;
   const Kokkos::Experimental::SYCL& m_space;
-  ReducerType m_reducer;
-  pointer_type m_result_ptr;
+  const ReducerType m_reducer;
+  const pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
 };
 


### PR DESCRIPTION
Based on top of https://github.com/kokkos/kokkos/pull/3940. Only https://github.com/kokkos/kokkos/commit/0523bcae4742b5c7e579fca13ae08214b7010cea is relevant.

Before this, we also fenced for device-accessible result_ptr.