### PR TITLE
Deprecate `Experimental::MasterLock`

### DIFF
--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -53,7 +53,9 @@
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Utilities.hpp>
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 #include <Kokkos_MasterLock.hpp>
+#endif
 
 //----------------------------------------------------------------------------
 // Have assumed a 64bit build (8byte pointers) throughout the code base.

--- a/core/src/Kokkos_MasterLock.hpp
+++ b/core/src/Kokkos_MasterLock.hpp
@@ -47,6 +47,8 @@
 
 #include <Kokkos_Macros.hpp>
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+
 namespace Kokkos {
 namespace Experimental {
 
@@ -71,5 +73,7 @@ class MasterLock;
 
 }  // namespace Experimental
 }  // namespace Kokkos
+
+#endif
 
 #endif  // KOKKOS_MASTER_LOCK_HPP

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -213,6 +213,7 @@ void OpenMP::partition_master(F const& f, int num_partitions,
 
 namespace Experimental {
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 template <>
 class MasterLock<OpenMP> {
  public:
@@ -231,6 +232,7 @@ class MasterLock<OpenMP> {
  private:
   omp_lock_t m_lock;
 };
+#endif
 
 template <>
 class UniqueToken<OpenMP, UniqueTokenScope::Instance> {

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -378,15 +378,11 @@ if(Kokkos_ENABLE_PTHREAD)
 endif()
 
 if (Kokkos_ENABLE_OPENMP)
+  set(OpenMP_EXTRA_SOURCES
+    openmp/TestOpenMP_Task.cpp
+  )
   if (Kokkos_ENABLE_DEPRECATED_CODE_3)
-    set(OpenMP_EXTRA_SOURCES
-      openmp/TestOpenMP_PartitionMaster.cpp
-      openmp/TestOpenMP_Task.cpp
-    )
-  else ()
-    set(OpenMP_EXTRA_SOURCES
-      openmp/TestOpenMP_Task.cpp
-    )
+    list(APPEND OpenMP_EXTRA_SOURCES openmp/TestOpenMP_Task.cpp)
   endif ()
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_OpenMP

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -377,14 +377,23 @@ if(Kokkos_ENABLE_PTHREAD)
   )
 endif()
 
-if(Kokkos_ENABLE_OPENMP)
+if (Kokkos_ENABLE_OPENMP)
+  if (Kokkos_ENABLE_DEPRECATED_CODE_3)
+    set(OpenMP_EXTRA_SOURCES
+      openmp/TestOpenMP_PartitionMaster.cpp
+      openmp/TestOpenMP_Task.cpp
+    )
+  else ()
+    set(OpenMP_EXTRA_SOURCES
+      openmp/TestOpenMP_Task.cpp
+    )
+  endif ()
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_OpenMP
     SOURCES
     UnitTestMainInit.cpp
     ${OpenMP_SOURCES}
-    openmp/TestOpenMP_PartitionMaster.cpp
-    openmp/TestOpenMP_Task.cpp
+    ${OpenMP_EXTRA_SOURCES}
   )
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_OpenMPInterOp


### PR DESCRIPTION
(Re-open #3217)

The class template is only specialized for the OpenMP backend.
No one seems to know anything about it.
It is apparently not used anywhere.