### PR TITLE
Half_t fixes for belos and initial reduction support

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -139,19 +139,16 @@ class alignas(4) half_t {
   impl_type val;
 
  public:
-  // Default constructor - initializes val to 0
-  // noexcept - adds compile time check to ensure exceptions are not thrown
-  // default  - has the compiler define the implicit default constructor even
-  //            though other constructors are present
-  KOKKOS_DEFAULTED_FUNCTION
-  half_t() noexcept = default;
+  KOKKOS_FUNCTION
+  half_t() : val(0.0F) {}
 
   // Copy constructors
   KOKKOS_DEFAULTED_FUNCTION
   half_t(const half_t&) noexcept = default;
 
   KOKKOS_INLINE_FUNCTION
-  half_t(const volatile half_t& rhs) : val(const_cast<impl_type&>(rhs.val)) {}
+  half_t(const volatile half_t& rhs)
+      : val(const_cast<const impl_type&>(rhs.val)) {}
 
   // Don't support implicit conversion back to impl_type.
   // impl_type is a storage only type on host.
@@ -492,7 +489,7 @@ class alignas(4) half_t {
     // "warning: implicit dereference will not access object of type ‘volatile
     // __half’ in statement"
     auto val_ref = const_cast<impl_type&>(val);
-    val_ref      = __float2half(__half2float(const_cast<impl_type&>(val)) /
+    val_ref = __float2half(__half2float(const_cast<const impl_type&>(val)) /
                            __half2float(rhs.val));
 #endif
     return *this;
@@ -527,7 +524,7 @@ class alignas(4) half_t {
 #ifdef __CUDA_ARCH__
     lhs.val += rhs.val;
 #else
-    lhs.val      = __float2half(__half2float(lhs.val) + __half2float(rhs.val));
+    lhs.val = __float2half(__half2float(lhs.val) + __half2float(rhs.val));
 #endif
     return lhs;
   }
@@ -552,7 +549,7 @@ class alignas(4) half_t {
 #ifdef __CUDA_ARCH__
     lhs.val -= rhs.val;
 #else
-    lhs.val      = __float2half(__half2float(lhs.val) - __half2float(rhs.val));
+    lhs.val = __float2half(__half2float(lhs.val) - __half2float(rhs.val));
 #endif
     return lhs;
   }
@@ -577,7 +574,7 @@ class alignas(4) half_t {
 #ifdef __CUDA_ARCH__
     lhs.val *= rhs.val;
 #else
-    lhs.val      = __float2half(__half2float(lhs.val) * __half2float(rhs.val));
+    lhs.val = __float2half(__half2float(lhs.val) * __half2float(rhs.val));
 #endif
     return lhs;
   }
@@ -602,7 +599,7 @@ class alignas(4) half_t {
 #ifdef __CUDA_ARCH__
     lhs.val /= rhs.val;
 #else
-    lhs.val      = __float2half(__half2float(lhs.val) / __half2float(rhs.val));
+    lhs.val = __float2half(__half2float(lhs.val) / __half2float(rhs.val));
 #endif
     return lhs;
   }
@@ -711,11 +708,11 @@ class alignas(4) half_t {
   friend bool operator==(const volatile half_t& lhs,
                          const volatile half_t& rhs) {
 #ifdef __CUDA_ARCH__
-    return static_cast<bool>(const_cast<impl_type&>(lhs.val) ==
-                             const_cast<impl_type&>(rhs.val));
+    return static_cast<bool>(const_cast<const impl_type&>(lhs.val) ==
+                             const_cast<const impl_type&>(rhs.val));
 #else
-    return __half2float(const_cast<impl_type&>(lhs.val)) ==
-           __half2float(const_cast<impl_type&>(rhs.val));
+    return __half2float(const_cast<const impl_type&>(lhs.val)) ==
+           __half2float(const_cast<const impl_type&>(rhs.val));
 #endif
   }
 
@@ -723,11 +720,11 @@ class alignas(4) half_t {
   friend bool operator!=(const volatile half_t& lhs,
                          const volatile half_t& rhs) {
 #ifdef __CUDA_ARCH__
-    return static_cast<bool>(const_cast<impl_type&>(lhs.val) !=
-                             const_cast<impl_type&>(rhs.val));
+    return static_cast<bool>(const_cast<const impl_type&>(lhs.val) !=
+                             const_cast<const impl_type&>(rhs.val));
 #else
-    return __half2float(const_cast<impl_type&>(lhs.val)) !=
-           __half2float(const_cast<impl_type&>(rhs.val));
+    return __half2float(const_cast<const impl_type&>(lhs.val)) !=
+           __half2float(const_cast<const impl_type&>(rhs.val));
 #endif
   }
 
@@ -735,11 +732,11 @@ class alignas(4) half_t {
   friend bool operator<(const volatile half_t& lhs,
                         const volatile half_t& rhs) {
 #ifdef __CUDA_ARCH__
-    return static_cast<bool>(const_cast<impl_type&>(lhs.val) <
-                             const_cast<impl_type&>(rhs.val));
+    return static_cast<bool>(const_cast<const impl_type&>(lhs.val) <
+                             const_cast<const impl_type&>(rhs.val));
 #else
-    return __half2float(const_cast<impl_type&>(lhs.val)) <
-           __half2float(const_cast<impl_type&>(rhs.val));
+    return __half2float(const_cast<const impl_type&>(lhs.val)) <
+           __half2float(const_cast<const impl_type&>(rhs.val));
 #endif
   }
 
@@ -747,11 +744,11 @@ class alignas(4) half_t {
   friend bool operator>(const volatile half_t& lhs,
                         const volatile half_t& rhs) {
 #ifdef __CUDA_ARCH__
-    return static_cast<bool>(const_cast<impl_type&>(lhs.val) >
-                             const_cast<impl_type&>(rhs.val));
+    return static_cast<bool>(const_cast<const impl_type&>(lhs.val) >
+                             const_cast<const impl_type&>(rhs.val));
 #else
-    return __half2float(const_cast<impl_type&>(lhs.val)) >
-           __half2float(const_cast<impl_type&>(rhs.val));
+    return __half2float(const_cast<const impl_type&>(lhs.val)) >
+           __half2float(const_cast<const impl_type&>(rhs.val));
 #endif
   }
 
@@ -759,11 +756,11 @@ class alignas(4) half_t {
   friend bool operator<=(const volatile half_t& lhs,
                          const volatile half_t& rhs) {
 #ifdef __CUDA_ARCH__
-    return static_cast<bool>(const_cast<impl_type&>(lhs.val) <=
-                             const_cast<impl_type&>(rhs.val));
+    return static_cast<bool>(const_cast<const impl_type&>(lhs.val) <=
+                             const_cast<const impl_type&>(rhs.val));
 #else
-    return __half2float(const_cast<impl_type&>(lhs.val)) <=
-           __half2float(const_cast<impl_type&>(rhs.val));
+    return __half2float(const_cast<const impl_type&>(lhs.val)) <=
+           __half2float(const_cast<const impl_type&>(rhs.val));
 #endif
   }
 
@@ -771,11 +768,11 @@ class alignas(4) half_t {
   friend bool operator>=(const volatile half_t& lhs,
                          const volatile half_t& rhs) {
 #ifdef __CUDA_ARCH__
-    return static_cast<bool>(const_cast<impl_type&>(lhs.val) >=
-                             const_cast<impl_type&>(rhs.val));
+    return static_cast<bool>(const_cast<const impl_type&>(lhs.val) >=
+                             const_cast<const impl_type&>(rhs.val));
 #else
-    return __half2float(const_cast<impl_type&>(lhs.val)) >=
-           __half2float(const_cast<impl_type&>(rhs.val));
+    return __half2float(const_cast<const impl_type&>(lhs.val)) >=
+           __half2float(const_cast<const impl_type&>(rhs.val));
 #endif
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -372,8 +372,8 @@ class alignas(4) half_t {
     impl_type new_val = cast_to_half(rhs).val;
 #ifdef __CUDA_ARCH__
 #if (CUDA_VERSION < 10000)
-    volatile float* lhs = (float*)val_ptr;
-    val                 = __float2half(lhs[0]);
+    volatile float* new_lhs = (float*)&new_val;
+    val                     = __float2half(new_lhs[0]);
 #else
     Kokkos::atomic_store(val_ptr, *((uint16_t*)&new_val));
 #endif  // CUDA_VERSION

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -51,6 +51,7 @@
     !(defined(KOKKOS_ARCH_KEPLER) || defined(KOKKOS_ARCH_MAXWELL50) ||  \
       defined(KOKKOS_ARCH_MAXWELL52))
 #include <cuda_fp16.h>
+#include <iostream>  // istream & ostream for extraction and insertion ops
 
 #ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
 // Make sure no one else tries to define half_t
@@ -682,6 +683,19 @@ class half_t {
 #else
     return __half2float(val) >= __half2float(rhs.val);
 #endif
+  }
+
+  // Insertion and extraction operators
+  friend std::ostream& operator<<(std::ostream& os, const half_t& x) {
+    os << static_cast<float>(x);
+    return os;
+  }
+
+  friend std::istream& operator>>(std::istream& is, half_t& x) {
+    float s_x;
+    is >> s_x;
+    x = static_cast<half_t>(s_x);
+    return is;
   }
 };
 

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -55,7 +55,6 @@
 #include <string>
 #include <Kokkos_NumericTraits.hpp>  // reduction_identity
 #include <Kokkos_Atomic.hpp>         // Kokkos::atomic_store
-#include <impl/Kokkos_Error.hpp>     // Kokkos::abort
 
 #ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
 // Make sure no one else tries to define half_t
@@ -228,66 +227,94 @@ class alignas(4) half_t {
 
   // Atomics
   KOKKOS_FUNCTION
-  void atomic_add(const volatile half_t src) volatile {
-#ifdef __CUDA_ARCH__
+  void atomic_add(const volatile half_t src) const volatile {
+    // Kokkos::atomic_store and atomicAdd not available on cuda < 10
 #if (CUDA_VERSION < 10000)
-    volatile float* lhs = (float*)&val;
-    volatile float* rhs = (float*)&src.val;
-    *lhs                = __half2float(val);
-    *rhs                = __half2float(src.val);
-    val                 = __float2half(lhs[0] + rhs[0]);
+    volatile float* lhs =
+        reinterpret_cast<float*>(const_cast<impl_type*>(&val));
+    volatile float* rhs =
+        reinterpret_cast<float*>(const_cast<impl_type*>(&src.val));
+    *lhs                        = __half2float(const_cast<impl_type&>(val));
+    *rhs                        = __half2float(const_cast<impl_type&>(src.val));
+    const_cast<impl_type&>(val) = __float2half(lhs[0] + rhs[0]);
 #else
+#ifdef __CUDA_ARCH__
     // Cuda 10 supports __half volatile stores but not volatile arithmetic
     // operands so we use atomicAdd for cuda 10.0 instead.
     atomicAdd(const_cast<impl_type*>(&val),
               const_cast<const impl_type&>(src.val));
-#endif  // CUDA_VERSION
 #else
     // 32bit arithmetic on host followed by 16bit atomic store.
-    uint16_t* val_ptr = (uint16_t*)const_cast<impl_type*>(&val);
-    const impl_type new_val =
+    uint16_t* val_ptr =
+        reinterpret_cast<uint16_t*>(const_cast<impl_type*>(&val));
+    impl_type new_val =
         __float2half(__half2float(const_cast<impl_type&>(val)) +
                      __half2float(const_cast<const impl_type&>(src.val)));
-    __atomic_store_n(val_ptr, *((uint16_t*)&new_val), __ATOMIC_RELAXED);
-#endif
+    Kokkos::atomic_store(val_ptr, *(reinterpret_cast<uint16_t*>(&new_val)));
+#endif  // __CUDA_ARCH__
+#endif  // CUDA_VERSION
   }
 
   KOKKOS_FUNCTION
-  void atomic_mul(const volatile half_t src) volatile {
-#ifdef __CUDA_ARCH__
+  void atomic_mul(const volatile half_t src) const volatile {
+    // Kokkos::atomic_store not available on cuda  < 10
 #if (CUDA_VERSION < 10000)
-    volatile float* lhs = (float*)&val;
-    volatile float* rhs = (float*)&src.val;
-    *lhs                = __half2float(val);
-    *rhs                = __half2float(src.val);
-    val                 = __float2half(lhs[0] * rhs[0]);
+    volatile float* lhs =
+        reinterpret_cast<float*>(const_cast<impl_type*>(&val));
+    volatile float* rhs =
+        reinterpret_cast<float*>(const_cast<impl_type*>(&src.val));
+    *lhs                        = __half2float(const_cast<impl_type&>(val));
+    *rhs                        = __half2float(const_cast<impl_type&>(src.val));
+    const_cast<impl_type&>(val) = __float2half(lhs[0] * rhs[0]);
 #else
-    // static volatile unsigned mutex = 0; // TODO: this should not be a class
-    // member. while (mutex == 1) ; mutex = 1; val = const_cast<impl_type&>(val)
-    // * const_cast<const impl_type&>(src.val); mutex = 0;
-
-    // TODO: this will not work when alignas(4) is removed.
-    // volatile float* lhs = (float*)&val;
-    // volatile float* rhs = (float*)&src.val;
-    // *lhs = __half2float(val);
-    // *rhs = __half2float(src.val);
-    // lhs[0] *= rhs[0];
-    // val = __float2half(*lhs);
-
-    // 16 bit arithmetic on device follow by 16bit atomic store.
-    uint16_t* val_ptr = (uint16_t*)const_cast<impl_type*>(&val);
-    const impl_type new_val =
+#ifdef __CUDA_ARCH__
+    // 16 bit arithmetic on device followed by 16bit atomic store.
+    uint16_t* val_ptr =
+        reinterpret_cast<uint16_t*>(const_cast<impl_type*>(&val));
+    impl_type new_val =
         const_cast<impl_type&>(val) * const_cast<const impl_type&>(src.val);
-    Kokkos::atomic_store(val_ptr, *((uint16_t*)&new_val));
-#endif  // CUDA_VERSION
+    Kokkos::atomic_store(val_ptr, *(reinterpret_cast<uint16_t*>(&new_val)));
 #else
     // 32bit arithmetic on host followed by 16bit atomic store.
-    uint16_t* val_ptr = (uint16_t*)const_cast<impl_type*>(&val);
-    const impl_type new_val =
+    uint16_t* val_ptr =
+        reinterpret_cast<uint16_t*>(const_cast<impl_type*>(&val));
+    impl_type new_val =
         __float2half(__half2float(const_cast<impl_type&>(val)) *
                      __half2float(const_cast<const impl_type&>(src.val)));
-    __atomic_store_n(val_ptr, *((uint16_t*)&new_val), __ATOMIC_RELAXED);
-#endif
+    Kokkos::atomic_store(val_ptr, *(reinterpret_cast<uint16_t*>(&new_val)));
+#endif  // __CUDA_ARCH__
+#endif  // CUDA_VERSION
+  }
+
+  KOKKOS_FUNCTION
+  void atomic_div(const volatile half_t src) const volatile {
+    // Kokkos::atomic_store not available on cuda < 10
+#if (CUDA_VERSION < 10000)
+    volatile float* lhs =
+        reinterpret_cast<float*>(const_cast<impl_type*>(&val));
+    volatile float* rhs =
+        reinterpret_cast<float*>(const_cast<impl_type*>(&src.val));
+    *lhs                        = __half2float(const_cast<impl_type&>(val));
+    *rhs                        = __half2float(const_cast<impl_type&>(src.val));
+    const_cast<impl_type&>(val) = __float2half(lhs[0] / rhs[0]);
+#else
+#ifdef __CUDA_ARCH__
+    // 16 bit arithmetic on device followed by 16bit atomic store.
+    uint16_t* val_ptr =
+        reinterpret_cast<uint16_t*>(const_cast<impl_type*>(&val));
+    impl_type new_val =
+        const_cast<impl_type&>(val) * const_cast<const impl_type&>(src.val);
+    Kokkos::atomic_store(val_ptr, *(reinterpret_cast<uint16_t*>(&new_val)));
+#else
+    // 32bit arithmetic on host followed by 16bit atomic store.
+    uint16_t* val_ptr =
+        reinterpret_cast<uint16_t*>(const_cast<impl_type*>(&val));
+    impl_type new_val =
+        __float2half(__half2float(const_cast<impl_type&>(val)) /
+                     __half2float(const_cast<const impl_type&>(src.val)));
+    Kokkos::atomic_store(val_ptr, *(reinterpret_cast<uint16_t*>(&new_val)));
+#endif  // __CUDA_ARCH__
+#endif  // CUDA_VERSION
   }
 
   // Unary operators
@@ -303,7 +330,7 @@ class alignas(4) half_t {
   }
 
   KOKKOS_FUNCTION
-  half_t operator-() const {
+  half_t operator-() const volatile {
     half_t tmp = *this;
 #ifdef __CUDA_ARCH__
     tmp.val = -tmp.val;
@@ -368,18 +395,21 @@ class alignas(4) half_t {
 
   template <class T>
   KOKKOS_FUNCTION void operator=(T rhs) volatile {
-    uint16_t* val_ptr = (uint16_t*)const_cast<impl_type*>(&val);
     impl_type new_val = cast_to_half(rhs).val;
+#if (CUDA_VERSION < 10000)  // Kokkos::atomic_store not available on cuda < 10
+    volatile float* rhs_float =
+        reinterpret_cast<float*>(const_cast<impl_type*>(&rhs.val));
+    *rhs_float                  = __half2float(new_val);
+    const_cast<impl_type&>(val) = __float2half(rhs_float[0]);
+#else
+    uint16_t* val_ptr =
+        reinterpret_cast<uint16_t*>(const_cast<impl_type*>(&val));
 #ifdef __CUDA_ARCH__
-#if (CUDA_VERSION < 10000)
-    volatile float* new_lhs = (float*)&new_val;
-    val                     = __float2half(new_lhs[0]);
+    Kokkos::atomic_store(val_ptr, *(reinterpret_cast<uint16_t*>(&new_val)));
 #else
-    Kokkos::atomic_store(val_ptr, *((uint16_t*)&new_val));
+    Kokkos::atomic_store(val_ptr, *(reinterpret_cast<uint16_t*>(&new_val)));
+#endif  // __CUDA_ARCH__
 #endif  // CUDA_VERSION
-#else
-    __atomic_store_n(val_ptr, *((uint16_t*)&new_val), __ATOMIC_RELAXED);
-#endif
   }
 
   // Compound operators
@@ -388,18 +418,18 @@ class alignas(4) half_t {
 #ifdef __CUDA_ARCH__
     val += rhs.val;
 #else
-    val = __float2half(__half2float(val) + __half2float(rhs.val));
+    val     = __float2half(__half2float(val) + __half2float(rhs.val));
 #endif
     return *this;
   }
 
   KOKKOS_FUNCTION
-  volatile half_t& operator+=(const volatile half_t rhs) volatile {
+  volatile half_t operator+=(const volatile half_t rhs) volatile {
     atomic_add(rhs);
     return *this;
   }
 
-  // Compund operators: upcast overloads for +=
+  // Compound operators: upcast overloads for +=
   template <class T>
   KOKKOS_FUNCTION std::enable_if_t<
       std::is_same<T, float>::value || std::is_same<T, double>::value, T> friend
@@ -427,26 +457,14 @@ class alignas(4) half_t {
 #ifdef __CUDA_ARCH__
     val -= rhs.val;
 #else
-    val = __float2half(__half2float(val) - __half2float(rhs.val));
+    val     = __float2half(__half2float(val) - __half2float(rhs.val));
 #endif
     return *this;
   }
 
   KOKKOS_FUNCTION
-  volatile half_t& operator-=(half_t rhs) volatile {
-#ifdef __CUDA_ARCH__
-    // Cuda 10 supports __half volatile stores but not volatile arithmetic
-    // operands. Cast away volatile-ness of val for arithmetic but not for store
-    // location.
-    val = const_cast<impl_type&>(val) - rhs.val;
-#else
-    // Use non-volatile val_ref to suppress:
-    // "warning: implicit dereference will not access object of type ‘volatile
-    // __half’ in statement"
-    auto val_ref = const_cast<impl_type&>(val);
-    val_ref      = __float2half(__half2float(const_cast<impl_type&>(val)) -
-                           __half2float(rhs.val));
-#endif
+  volatile half_t operator-=(const volatile half_t rhs) volatile {
+    atomic_add(-rhs);
     return *this;
   }
 
@@ -478,13 +496,13 @@ class alignas(4) half_t {
 #ifdef __CUDA_ARCH__
     val *= rhs.val;
 #else
-    val          = __float2half(__half2float(val) * __half2float(rhs.val));
+    val     = __float2half(__half2float(val) * __half2float(rhs.val));
 #endif
     return *this;
   }
 
   KOKKOS_FUNCTION
-  volatile half_t& operator*=(const volatile half_t rhs) volatile {
+  volatile half_t operator*=(const volatile half_t rhs) volatile {
     atomic_mul(rhs);
     return *this;
   }
@@ -517,26 +535,14 @@ class alignas(4) half_t {
 #ifdef __CUDA_ARCH__
     val /= rhs.val;
 #else
-    val          = __float2half(__half2float(val) / __half2float(rhs.val));
+    val     = __float2half(__half2float(val) / __half2float(rhs.val));
 #endif
     return *this;
   }
 
   KOKKOS_FUNCTION
-  volatile half_t& operator/=(half_t rhs) volatile {
-#ifdef __CUDA_ARCH__
-    // Cuda 10 supports __half volatile stores but not volatile arithmetic
-    // operands. Cast away volatile-ness of val for arithmetic but not for store
-    // location.
-    val = const_cast<impl_type&>(val) / rhs.val;
-#else
-    // Use non-volatile val_ref to suppress:
-    // "warning: implicit dereference will not access object of type ‘volatile
-    // __half’ in statement"
-    auto val_ref = const_cast<impl_type&>(val);
-    val_ref = __float2half(__half2float(const_cast<const impl_type&>(val)) /
-                           __half2float(rhs.val));
-#endif
+  volatile half_t operator/=(const volatile half_t rhs) volatile {
+    atomic_div(rhs);
     return *this;
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Half.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half.hpp
@@ -685,6 +685,78 @@ class half_t {
 #endif
   }
 
+  KOKKOS_FUNCTION
+  friend bool operator==(const volatile half_t& lhs,
+                         const volatile half_t& rhs) {
+#ifdef __CUDA_ARCH__
+    return static_cast<bool>(const_cast<impl_type&>(lhs.val) ==
+                             const_cast<impl_type&>(rhs.val));
+#else
+    return __half2float(const_cast<impl_type&>(lhs.val)) ==
+           __half2float(const_cast<impl_type&>(rhs.val));
+#endif
+  }
+
+  KOKKOS_FUNCTION
+  friend bool operator!=(const volatile half_t& lhs,
+                         const volatile half_t& rhs) {
+#ifdef __CUDA_ARCH__
+    return static_cast<bool>(const_cast<impl_type&>(lhs.val) !=
+                             const_cast<impl_type&>(rhs.val));
+#else
+    return __half2float(const_cast<impl_type&>(lhs.val)) !=
+           __half2float(const_cast<impl_type&>(rhs.val));
+#endif
+  }
+
+  KOKKOS_FUNCTION
+  friend bool operator<(const volatile half_t& lhs,
+                        const volatile half_t& rhs) {
+#ifdef __CUDA_ARCH__
+    return static_cast<bool>(const_cast<impl_type&>(lhs.val) <
+                             const_cast<impl_type&>(rhs.val));
+#else
+    return __half2float(const_cast<impl_type&>(lhs.val)) <
+           __half2float(const_cast<impl_type&>(rhs.val));
+#endif
+  }
+
+  KOKKOS_FUNCTION
+  friend bool operator>(const volatile half_t& lhs,
+                        const volatile half_t& rhs) {
+#ifdef __CUDA_ARCH__
+    return static_cast<bool>(const_cast<impl_type&>(lhs.val) >
+                             const_cast<impl_type&>(rhs.val));
+#else
+    return __half2float(const_cast<impl_type&>(lhs.val)) >
+           __half2float(const_cast<impl_type&>(rhs.val));
+#endif
+  }
+
+  KOKKOS_FUNCTION
+  friend bool operator<=(const volatile half_t& lhs,
+                         const volatile half_t& rhs) {
+#ifdef __CUDA_ARCH__
+    return static_cast<bool>(const_cast<impl_type&>(lhs.val) <=
+                             const_cast<impl_type&>(rhs.val));
+#else
+    return __half2float(const_cast<impl_type&>(lhs.val)) <=
+           __half2float(const_cast<impl_type&>(rhs.val));
+#endif
+  }
+
+  KOKKOS_FUNCTION
+  friend bool operator>=(const volatile half_t& lhs,
+                         const volatile half_t& rhs) {
+#ifdef __CUDA_ARCH__
+    return static_cast<bool>(const_cast<impl_type&>(lhs.val) >=
+                             const_cast<impl_type&>(rhs.val));
+#else
+    return __half2float(const_cast<impl_type&>(lhs.val)) >=
+           __half2float(const_cast<impl_type&>(rhs.val));
+#endif
+  }
+
   // Insertion and extraction operators
   friend std::ostream& operator<<(std::ostream& os, const half_t& x) {
     os << static_cast<float>(x);

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -45,6 +45,7 @@
 #ifndef KOKKOS_PARALLEL_REDUCE_HPP
 #define KOKKOS_PARALLEL_REDUCE_HPP
 
+#include <Kokkos_Half.hpp>
 #include <Kokkos_NumericTraits.hpp>
 #include <Kokkos_View.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
@@ -91,8 +92,21 @@ struct Sum {
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const { dest += src; }
 
+#if !KOKKOS_HALF_T_IS_FLOAT
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
+  void join(volatile Experimental::half_t& dest,
+            const volatile Experimental::half_t& src) const {
+    dest.atomic_add(src);
+  }
+#endif
+
+  template <
+      class T                = value_type,
+      std::enable_if_t<!std::is_same<T, Experimental::half_t>::value ||
+                           std::is_same<Experimental::half_t, float>::value,
+                       bool> = true>
+  KOKKOS_INLINE_FUNCTION void join(volatile T& dest,
+                                   const volatile T& src) const {
     dest += src;
   }
 
@@ -136,8 +150,21 @@ struct Prod {
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const { dest *= src; }
 
+#if !KOKKOS_HALF_T_IS_FLOAT
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
+  void join(volatile Experimental::half_t& dest,
+            const volatile Experimental::half_t& src) const {
+    dest.atomic_mul(src);
+  }
+#endif
+
+  template <
+      class T                = value_type,
+      std::enable_if_t<!std::is_same<T, Experimental::half_t>::value ||
+                           std::is_same<Experimental::half_t, float>::value,
+                       bool> = true>
+  KOKKOS_INLINE_FUNCTION void join(volatile T& dest,
+                                   const volatile T& src) const {
     dest *= src;
   }
 

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -92,21 +92,8 @@ struct Sum {
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const { dest += src; }
 
-#if !KOKKOS_HALF_T_IS_FLOAT
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile Experimental::half_t& dest,
-            const volatile Experimental::half_t& src) const {
-    dest.atomic_add(src);
-  }
-#endif
-
-  template <
-      class T                = value_type,
-      std::enable_if_t<!std::is_same<T, Experimental::half_t>::value ||
-                           std::is_same<Experimental::half_t, float>::value,
-                       bool> = true>
-  KOKKOS_INLINE_FUNCTION void join(volatile T& dest,
-                                   const volatile T& src) const {
+  KOKKOS_INLINE_FUNCTION void join(volatile value_type& dest,
+                                   const volatile value_type& src) const {
     dest += src;
   }
 
@@ -150,21 +137,8 @@ struct Prod {
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const { dest *= src; }
 
-#if !KOKKOS_HALF_T_IS_FLOAT
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile Experimental::half_t& dest,
-            const volatile Experimental::half_t& src) const {
-    dest.atomic_mul(src);
-  }
-#endif
-
-  template <
-      class T                = value_type,
-      std::enable_if_t<!std::is_same<T, Experimental::half_t>::value ||
-                           std::is_same<Experimental::half_t, float>::value,
-                       bool> = true>
-  KOKKOS_INLINE_FUNCTION void join(volatile T& dest,
-                                   const volatile T& src) const {
+  KOKKOS_INLINE_FUNCTION void join(volatile value_type& dest,
+                                   const volatile value_type& src) const {
     dest *= src;
   }
 

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -270,6 +270,88 @@ enum OP_TESTS {
 };
 
 template <class view_type>
+struct Functor_TestHalfVolatileOperators {
+  volatile half_t h_lhs, h_rhs;
+  view_type actual_lhs, expected_lhs;
+  double d_lhs, d_rhs;
+  Functor_TestHalfVolatileOperators(volatile half_t lhs = half_t(0),
+                                    volatile half_t rhs = half_t(0))
+      : h_lhs(lhs), h_rhs(rhs) {
+    actual_lhs   = view_type("actual_lhs", N_OP_TESTS);
+    expected_lhs = view_type("expected_lhs", N_OP_TESTS);
+    d_lhs        = cast_from_half<double>(h_lhs);
+    d_rhs        = cast_from_half<double>(h_rhs);
+    if (std::is_same<view_type, ViewTypeHost>::value) {
+      auto run_on_host = *this;
+      run_on_host(0);
+    } else {
+      Kokkos::parallel_for("Test::Functor_TestHalfVolatileOperators",
+                           Kokkos::RangePolicy<ExecutionSpace>(0, 1), *this);
+    }
+  }
+
+  KOKKOS_FUNCTION
+  void operator()(int) const {
+    volatile half_t tmp_lhs;
+
+    // Initialze output views to catch missing test invocations
+    for (int i = 0; i < N_OP_TESTS; ++i) {
+      actual_lhs(i)   = 1;
+      expected_lhs(i) = -1;
+    }
+
+    tmp_lhs              = h_lhs;
+    actual_lhs(ASSIGN)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(ASSIGN) = d_lhs;
+
+    actual_lhs(LT)   = h_lhs < h_rhs;
+    expected_lhs(LT) = d_lhs < d_rhs;
+
+    actual_lhs(LE)   = h_lhs <= h_rhs;
+    expected_lhs(LE) = d_lhs <= d_rhs;
+
+    actual_lhs(NEQ)   = h_lhs != h_rhs;
+    expected_lhs(NEQ) = d_lhs != d_rhs;
+
+    actual_lhs(GT)   = h_lhs > h_rhs;
+    expected_lhs(GT) = d_lhs > d_rhs;
+
+    actual_lhs(GE)   = h_lhs >= h_rhs;
+    expected_lhs(GE) = d_lhs >= d_rhs;
+
+    actual_lhs(EQ)   = h_lhs == h_rhs;
+    expected_lhs(EQ) = d_lhs == d_rhs;
+
+    // cast away volatile on lhs to supress:
+    // warning: implicit dereference will not access object of type ‘volatile
+    // Kokkos::Experimental::half_t’ in statement
+    tmp_lhs = h_lhs;
+    const_cast<half_t&>(tmp_lhs) += h_rhs;
+    actual_lhs(CADD_H_H)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CADD_H_H) = d_lhs;
+    expected_lhs(CADD_H_H) += d_rhs;
+
+    tmp_lhs = h_lhs;
+    const_cast<half_t&>(tmp_lhs) -= h_rhs;
+    actual_lhs(CSUB_H_H)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CSUB_H_H) = d_lhs;
+    expected_lhs(CSUB_H_H) -= d_rhs;
+
+    tmp_lhs = h_lhs;
+    const_cast<half_t&>(tmp_lhs) *= h_rhs;
+    actual_lhs(CMUL_H_H)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CMUL_H_H) = d_lhs;
+    expected_lhs(CMUL_H_H) *= d_rhs;
+
+    tmp_lhs = h_lhs;
+    const_cast<half_t&>(tmp_lhs) /= h_rhs;
+    actual_lhs(CDIV_H_H)   = cast_from_half<double>(tmp_lhs);
+    expected_lhs(CDIV_H_H) = d_lhs;
+    expected_lhs(CDIV_H_H) /= d_rhs;
+  }
+};
+
+template <class view_type>
 struct Functor_TestHalfOperators {
   half_t h_lhs, h_rhs;
   double d_lhs, d_rhs;
@@ -840,8 +922,34 @@ void __test_half_operators(half_t h_lhs, half_t h_rhs) {
                 epsilon);
   }
 
+  // Test partial volatile support
+  volatile half_t _h_lhs = h_lhs;
+  volatile half_t _h_rhs = h_rhs;
+  Functor_TestHalfVolatileOperators<ViewType> f_volatile_device(_h_lhs, _h_rhs);
+  Functor_TestHalfVolatileOperators<ViewTypeHost> f_volatile_host(_h_lhs,
+                                                                  _h_rhs);
+
+  ExecutionSpace().fence();
+  Kokkos::deep_copy(f_device_actual_lhs, f_device.actual_lhs);
+  Kokkos::deep_copy(f_device_expected_lhs, f_device.expected_lhs);
+  for (int op_test = 0; op_test < N_OP_TESTS; op_test++) {
+    // printf("op_test = %d\n", op_test);
+    if (op_test == ASSIGN || op_test == LT || op_test == LE || op_test == NEQ ||
+        op_test == EQ || op_test == GT || op_test == GE ||
+        op_test == CADD_H_H || op_test == CSUB_H_H || op_test == CMUL_H_H ||
+        op_test == CDIV_H_H) {
+      ASSERT_NEAR(f_device_actual_lhs(op_test), f_device_expected_lhs(op_test),
+                  epsilon);
+      ASSERT_NEAR(f_host.actual_lhs(op_test), f_host.expected_lhs(op_test),
+                  epsilon);
+    }
+  }
+
+  // is_trivially_copyable is false with the addition of explicit
+  // copy constructors that are required for supporting reductions
+  // ASSERT_TRUE(std::is_trivially_copyable<half_t>::value);
+
   // Check whether half_t is trivially copyable
-  ASSERT_TRUE(std::is_trivially_copyable<half_t>::value);
   constexpr size_t n       = 2;
   constexpr size_t n_bytes = sizeof(half_t) * n;
   const half_t h_arr0 = half_t(0x89ab), h_arr1 = half_t(0xcdef);
@@ -870,15 +978,6 @@ void test_half_operators() {
     // TODO: __test_half_operators(h_lhs + cast_to_half(i + 1), half_t(0));
     // TODO: __test_half_operators(half_t(0), h_rhs + cast_to_half(i));
   }
-  // Test volatile support
-  volatile half_t _h_lhs = h_lhs;
-  volatile half_t _h_rhs = h_rhs;
-  ASSERT_TRUE(_h_lhs < _h_rhs);
-  ASSERT_TRUE(_h_lhs <= _h_rhs);
-  ASSERT_TRUE(_h_lhs != _h_rhs);
-  ASSERT_FALSE(_h_lhs > _h_rhs);
-  ASSERT_FALSE(_h_lhs >= _h_rhs);
-  ASSERT_FALSE(_h_lhs == _h_rhs);
 }
 
 TEST(TEST_CATEGORY, half_operators) { test_half_operators(); }

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -870,7 +870,15 @@ void test_half_operators() {
     // TODO: __test_half_operators(h_lhs + cast_to_half(i + 1), half_t(0));
     // TODO: __test_half_operators(half_t(0), h_rhs + cast_to_half(i));
   }
-  // TODO: __test_half_operators(0, 0);
+  // Test volatile support
+  volatile half_t _h_lhs = h_lhs;
+  volatile half_t _h_rhs = h_rhs;
+  ASSERT_TRUE(_h_lhs < _h_rhs);
+  ASSERT_TRUE(_h_lhs <= _h_rhs);
+  ASSERT_TRUE(_h_lhs != _h_rhs);
+  ASSERT_FALSE(_h_lhs > _h_rhs);
+  ASSERT_FALSE(_h_lhs >= _h_rhs);
+  ASSERT_FALSE(_h_lhs == _h_rhs);
 }
 
 TEST(TEST_CATEGORY, half_operators) { test_half_operators(); }

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -322,29 +322,26 @@ struct Functor_TestHalfVolatileOperators {
     actual_lhs(EQ)   = h_lhs == h_rhs;
     expected_lhs(EQ) = d_lhs == d_rhs;
 
-    // cast away volatile on lhs to supress:
-    // warning: implicit dereference will not access object of type ‘volatile
-    // Kokkos::Experimental::half_t’ in statement
     tmp_lhs = h_lhs;
-    const_cast<half_t&>(tmp_lhs) += h_rhs;
+    tmp_lhs += h_rhs;
     actual_lhs(CADD_H_H)   = cast_from_half<double>(tmp_lhs);
     expected_lhs(CADD_H_H) = d_lhs;
     expected_lhs(CADD_H_H) += d_rhs;
 
     tmp_lhs = h_lhs;
-    const_cast<half_t&>(tmp_lhs) -= h_rhs;
+    tmp_lhs -= h_rhs;
     actual_lhs(CSUB_H_H)   = cast_from_half<double>(tmp_lhs);
     expected_lhs(CSUB_H_H) = d_lhs;
     expected_lhs(CSUB_H_H) -= d_rhs;
 
     tmp_lhs = h_lhs;
-    const_cast<half_t&>(tmp_lhs) *= h_rhs;
+    tmp_lhs *= h_rhs;
     actual_lhs(CMUL_H_H)   = cast_from_half<double>(tmp_lhs);
     expected_lhs(CMUL_H_H) = d_lhs;
     expected_lhs(CMUL_H_H) *= d_rhs;
 
     tmp_lhs = h_lhs;
-    const_cast<half_t&>(tmp_lhs) /= h_rhs;
+    tmp_lhs /= h_rhs;
     actual_lhs(CDIV_H_H)   = cast_from_half<double>(tmp_lhs);
     expected_lhs(CDIV_H_H) = d_lhs;
     expected_lhs(CDIV_H_H) /= d_rhs;

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -296,7 +296,9 @@ struct TestReducers {
     Scalar reference_sum = 0;
 
     for (int i = 0; i < N; i++) {
-      h_values(i) = (Scalar)(rand() % 100);
+      int denom =
+          std::is_same<Scalar, Kokkos::Experimental::half_t>::value ? 10 : 100;
+      h_values(i) = (Scalar)(rand() % denom);
       reference_sum += h_values(i);
     }
     Kokkos::deep_copy(values, h_values);

--- a/core/unit_test/TestReducers_d.hpp
+++ b/core/unit_test/TestReducers_d.hpp
@@ -64,4 +64,9 @@ TEST(TEST_CATEGORY, reducers_struct) {
   TestReducers<array_reduce<float, 7>, TEST_EXECSPACE>::test_sum(1031);
 #endif
 }
+
+TEST(TEST_CATEGORY, reducers_half_t) {
+  TestReducers<Kokkos::Experimental::half_t, TEST_EXECSPACE>::execute_basic();
+}
+
 }  // namespace Test

--- a/core/unit_test/TestReducers_d.hpp
+++ b/core/unit_test/TestReducers_d.hpp
@@ -66,7 +66,16 @@ TEST(TEST_CATEGORY, reducers_struct) {
 }
 
 TEST(TEST_CATEGORY, reducers_half_t) {
-  TestReducers<Kokkos::Experimental::half_t, TEST_EXECSPACE>::execute_basic();
+  TestReducers<Kokkos::Experimental::half_t, TEST_EXECSPACE>::test_sum(10);
+  TestReducers<Kokkos::Experimental::half_t, TEST_EXECSPACE>::test_sum(101);
+  TestReducers<Kokkos::Experimental::half_t, TEST_EXECSPACE>::test_sum(202);
+  TestReducers<Kokkos::Experimental::half_t, TEST_EXECSPACE>::test_sum(303);
+
+  TestReducers<Kokkos::Experimental::half_t, TEST_EXECSPACE>::test_prod(5);
+  TestReducers<Kokkos::Experimental::half_t, TEST_EXECSPACE>::test_prod(10);
+  TestReducers<Kokkos::Experimental::half_t, TEST_EXECSPACE>::test_prod(15);
+  TestReducers<Kokkos::Experimental::half_t, TEST_EXECSPACE>::test_prod(20);
+  TestReducers<Kokkos::Experimental::half_t, TEST_EXECSPACE>::test_prod(25);
 }
 
 }  // namespace Test


### PR DESCRIPTION
- Add half_t insertion and extraction ops
- Support volatile half_t comparisons
- Start adding reduction support for half_t

Belos needs these changes for running some tests with their solvers.