### PR TITLE
Use DPC++ broadcast extension in SYCL team_broadcast

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -111,15 +111,8 @@ class SYCLTeamMember {
   template <class ValueType>
   KOKKOS_INLINE_FUNCTION void team_broadcast(ValueType& val,
                                              const int thread_id) const {
-    // Wait for shared data write until all threads arrive here
-    m_item.barrier(sycl::access::fence_space::local_space);
-    if (m_item.get_local_id(1) == 0 &&
-        static_cast<int>(m_item.get_local_id(0)) == thread_id) {
-      *static_cast<ValueType*>(m_team_reduce) = val;
-    }
-    // Wait for shared data read until root thread writes
-    m_item.barrier(sycl::access::fence_space::local_space);
-    val = *static_cast<ValueType*>(m_team_reduce);
+    val = sycl::ONEAPI::broadcast(m_item.get_group(), val,
+                                  sycl::id<2>(thread_id, 0));
   }
 
   template <class Closure, class ValueType>


### PR DESCRIPTION
DPC++ offers an extension that exactly does what we want, see https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/GroupAlgorithms/SYCL_INTEL_group_algorithms.asciidoc, avoiding some explicit barriers on our side.