### PR TITLE
Fixup forward declare DynRankView in the interoperability header

### DIFF
--- a/core/src/KokkosExp_InterOp.hpp
+++ b/core/src/KokkosExp_InterOp.hpp
@@ -49,11 +49,14 @@
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_MemoryTraits.hpp>
 #include <Kokkos_View.hpp>
-#include <Kokkos_DynRankView.hpp>
 #include <impl/Kokkos_Utilities.hpp>
 #include <type_traits>
 
 namespace Kokkos {
+
+template <typename DataType, class... Properties>
+class DynRankView;  // forward declaration
+
 namespace Impl {
 
 // ------------------------------------------------------------------ //


### PR DESCRIPTION
Resolve #4109
Accidental introduction of a dependency from Core on KokkosContainers library
when including <Kokkos_DynRankView.hpp>

Co-Authored-By: Jonathan R. Madsen <jonathanrmadsen@gmail.com>