### PR TITLE
[WIP] Use SYCL subgroup reduction also for TeamPolicy

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -77,6 +77,7 @@ void subgroup_reduction(const sycl::nd_item<dim>& item,
     auto* tmp = sg.shuffle_down(local_mem, stride);
     if (id_in_sg < std::min(stride, max_index - stride))
       ValueJoin::join(selected_reducer, local_mem, tmp);
+    sg.barrier();
   }
 }
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -47,7 +47,7 @@
 
 #include <Kokkos_Parallel.hpp>
 
-#include <SYCL/Kokkos_SYCL_Parallel_Reduce.hpp>  // workgroup_reduction
+#include <SYCL/Kokkos_SYCL_Parallel_Reduce.hpp>  // workgroup_reduction_with_final
 #include <SYCL/Kokkos_SYCL_Team.hpp>
 
 namespace Kokkos {
@@ -721,7 +721,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
               }
               item.barrier(sycl::access::fence_space::local_space);
 
-              SYCLReduction::workgroup_reduction<ValueJoin, ValueOps, WorkTag>(
+              SYCLReduction::workgroup_reduction_with_final<ValueJoin, ValueOps,
+                                                            WorkTag>(
                   item, local_mem.get_pointer(), results_ptr,
                   device_accessible_result_ptr, value_count, selected_reducer,
                   static_cast<const FunctorType&>(functor),

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -142,10 +142,6 @@ class SYCLTeamMember {
     const int maximum_work_range =
         std::min<int>(m_team_reduce_size / sizeof(value_type), team_size());
 
-    int smaller_power_of_two = 1;
-    while ((smaller_power_of_two << 1) < maximum_work_range)
-      smaller_power_of_two <<= 1;
-
     const int idx        = team_rank();
     auto reduction_array = static_cast<value_type*>(m_team_reduce);
 
@@ -164,11 +160,17 @@ class SYCLTeamMember {
       m_item.barrier(sycl::access::fence_space::local_space);
     }
 
-    for (int stride = smaller_power_of_two; stride > 0; stride >>= 1) {
-      if (idx < stride && idx + stride < maximum_work_range)
-        reducer.join(reduction_array[idx], reduction_array[idx + stride]);
-      m_item.barrier(sycl::access::fence_space::local_space);
-    }
+    auto sg            = m_item.get_sub_group();
+    const int id_in_sg = sg.get_local_id()[0];
+    Kokkos::Impl::SYCLReduction::workgroup_reduction<
+        Kokkos::Impl::FunctorValueJoin<ReducerType, void>,
+        Kokkos::Impl::FunctorValueOps<ReducerType, void>>(
+        m_item, reduction_array, 1,
+        std::min<int>(sg.get_local_range()[0],
+                      maximum_work_range - idx + id_in_sg),
+        reducer, reducer);
+
+    m_item.barrier(sycl::access::fence_space::local_space);
     reducer.reference() = reduction_array[0];
     m_item.barrier(sycl::access::fence_space::local_space);
   }


### PR DESCRIPTION
In continuation of #3940. This implementation factors the subgroup reduction part out and reuses it in `TeamPolicy` for team reductions.