### PR TITLE
Unorderedmap clear() should zero the size()

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -345,7 +345,8 @@ class UnorderedMap {
       const impl_value_type tmp = impl_value_type();
       Kokkos::deep_copy(m_values, tmp);
     }
-    { Kokkos::deep_copy(m_scalars, 0); }
+    Kokkos::deep_copy(m_scalars, 0);
+    m_size = 0;
   }
 
   KOKKOS_INLINE_FUNCTION constexpr bool is_allocated() const {
@@ -393,9 +394,9 @@ class UnorderedMap {
   ///
   /// This method has undefined behavior when erasable() is true.
   ///
-  /// Note that this is not a device function; it cannot be called in
+  /// Note that this is <i>not</i> a device function; it cannot be called in
   /// a parallel kernel.  The value is not stored as a variable; it
-  /// must be computed.
+  /// must be computed. m_size is a mutable cache of that value.
   size_type size() const {
     if (capacity() == 0u) return 0u;
     if (modified()) {

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -327,6 +327,22 @@ TEST(TEST_CATEGORY, UnorderedMap_valid_empty) {
   ASSERT_TRUE(n.is_allocated());
 }
 
+TEST(TEST_CATEGORY, UnorderedMap_clear_zero_size) {
+  using Map = Kokkos::UnorderedMap<int, void, Kokkos::DefaultHostExecutionSpace>;
+
+  Map m(11);
+  ASSERT_EQ(0u, m.size());
+
+  m.insert(2);
+  m.insert(3);
+  m.insert(5);
+  m.insert(7);
+  ASSERT_EQ(4u, m.size());
+
+  m.clear();
+  ASSERT_EQ(0u, m.size());
+}
+
 }  // namespace Test
 
 #endif  // KOKKOS_TEST_UNORDERED_MAP_HPP

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -328,7 +328,8 @@ TEST(TEST_CATEGORY, UnorderedMap_valid_empty) {
 }
 
 TEST(TEST_CATEGORY, UnorderedMap_clear_zero_size) {
-  using Map = Kokkos::UnorderedMap<int, void, Kokkos::DefaultHostExecutionSpace>;
+  using Map =
+      Kokkos::UnorderedMap<int, void, Kokkos::DefaultHostExecutionSpace>;
 
   Map m(11);
   ASSERT_EQ(0u, m.size());


### PR DESCRIPTION
Fix for issue #4128.

`UnorderedMap::m_size` is a cache of the size of the container (that is why is is marked `mutable`), which only gets updated when `size()` is called on a modified (indicated by the `m_scalars(modified_idx)` flag) map. This flag is only possibly set in `insert` and `erase` methods. `clear()` both clears out `m_scalars` (which effectively clears the `modified_idx` flag) and doesn't update the `m_size` value, hence the bug.

I did verify that if we always recalculate the size, the correct value of `0` is calculated.

























































