### PR TITLE
Desul wrappers adding atomic_assign legacy function support

### DIFF
--- a/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
@@ -35,6 +35,9 @@ T atomic_load(T* const dest) { return desul::atomic_load(dest, desul::MemoryOrde
 template<class T> KOKKOS_INLINE_FUNCTION
 void atomic_store(T* const dest, desul::Impl::dont_deduce_this_parameter_t<const T> val) { return desul::atomic_store(dest, val, desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice()); }
 
+template<class T> KOKKOS_INLINE_FUNCTION
+void atomic_assign(T* const dest, desul::Impl::dont_deduce_this_parameter_t<const T> val) { atomic_store(dest,val); }
+
 KOKKOS_INLINE_FUNCTION
 void memory_fence() {
   desul::atomic_thread_fence(desul::MemoryOrderSeqCst(), desul::MemoryScopeDevice());

--- a/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
@@ -180,13 +180,14 @@ template<class T> KOKKOS_INLINE_FUNCTION
 T atomic_exchange(T* const dest, desul::Impl::dont_deduce_this_parameter_t<const T> val) { return desul::atomic_exchange(dest, val, desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice()); }
 
 template<class T> KOKKOS_INLINE_FUNCTION
-bool atomic_compare_exchange_strong(T* const dest, T& expected, const T desired) {
-  return desul::atomic_compare_exchange_strong(dest, expected, desired,
+bool atomic_compare_exchange_strong(T* const dest, desul::Impl::dont_deduce_this_parameter_t<const T> expected, desul::Impl::dont_deduce_this_parameter_t<const T> desired) {
+  T expected_ref = expected;
+  return desul::atomic_compare_exchange_strong(dest, expected_ref, desired,
                   desul::MemoryOrderRelaxed(), desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());
 }
 
 template<class T> KOKKOS_INLINE_FUNCTION
-T atomic_compare_exchange(T* const dest, const T compare, const T desired) {
+T atomic_compare_exchange(T* const dest, desul::Impl::dont_deduce_this_parameter_t<const T> compare, desul::Impl::dont_deduce_this_parameter_t<const T> desired) {
   return desul::atomic_compare_exchange(dest, compare, desired,
                   desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());
 }

--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -82,6 +82,51 @@ struct InitFunctor {
 };
 
 //---------------------------------------------------
+//--------------atomic_load/store/assign---------------------
+//---------------------------------------------------
+
+template <class T, class DEVICE_TYPE>
+struct LoadStoreFunctor {
+  using execution_space = DEVICE_TYPE;
+  using type            = Kokkos::View<T, execution_space>;
+
+  type data;
+  T i0;
+  T i1;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(int) const {
+    T old = Kokkos::atomic_load(&data());
+    if (old != i0)
+      Kokkos::abort("Kokkos Atomic Load didn't get the right value");
+    Kokkos::atomic_store(&data(), i1);
+    Kokkos::atomic_assign(&data(), old);
+  }
+  LoadStoreFunctor(T _i0, T _i1) : i0(_i0), i1(_i1) {}
+};
+
+template <class T, class DeviceType>
+bool LoadStoreAtomicTest(T i0, T i1) {
+  using execution_space = typename DeviceType::execution_space;
+  struct InitFunctor<T, execution_space> f_init(i0);
+  typename InitFunctor<T, execution_space>::type data("Data");
+  typename InitFunctor<T, execution_space>::h_type h_data("HData");
+
+  f_init.data = data;
+  Kokkos::parallel_for(1, f_init);
+  execution_space().fence();
+
+  struct LoadStoreFunctor<T, execution_space> f(i0, i1);
+
+  f.data = data;
+  Kokkos::parallel_for(1, f);
+
+  Kokkos::deep_copy(h_data, data);
+
+  return h_data() == i0;
+}
+
+//---------------------------------------------------
 //--------------atomic_fetch_max---------------------
 //---------------------------------------------------
 
@@ -954,6 +999,7 @@ bool AtomicOperationsTestIntegralType(int i0, int i1, int test) {
     case 10: return RShiftAtomicTest<T, DeviceType>((T)i0, (T)i1);
     case 11: return IncAtomicTest<T, DeviceType>((T)i0);
     case 12: return DecAtomicTest<T, DeviceType>((T)i0);
+    case 13: return LoadStoreAtomicTest<T, DeviceType>((T)i0, (T)i1);
   }
 
   return 0;
@@ -966,6 +1012,7 @@ bool AtomicOperationsTestNonIntegralType(int i0, int i1, int test) {
     case 2: return MinAtomicTest<T, DeviceType>((T)i0, (T)i1);
     case 3: return MulAtomicTest<T, DeviceType>((T)i0, (T)i1);
     case 4: return DivAtomicTest<T, DeviceType>((T)i0, (T)i1);
+    case 5: return LoadStoreAtomicTest<T, DeviceType>((T)i0, (T)i1);
   }
 
   return 0;

--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -84,7 +84,7 @@ struct InitFunctor {
 //---------------------------------------------------
 //--------------atomic_load/store/assign---------------------
 //---------------------------------------------------
-
+#ifdef KOKKOS_ENABLE_IMPL_DESUL_ATOMICS
 template <class T, class DEVICE_TYPE>
 struct LoadStoreFunctor {
   using execution_space = DEVICE_TYPE;
@@ -104,6 +104,7 @@ struct LoadStoreFunctor {
   }
   LoadStoreFunctor(T _i0, T _i1) : i0(_i0), i1(_i1) {}
 };
+#endif
 
 template <class T, class DeviceType>
 bool LoadStoreAtomicTest(T i0, T i1) {
@@ -116,10 +117,14 @@ bool LoadStoreAtomicTest(T i0, T i1) {
   Kokkos::parallel_for(1, f_init);
   execution_space().fence();
 
+#ifdef KOKKOS_ENABLE_DESUL_ATOMICS
   struct LoadStoreFunctor<T, execution_space> f(i0, i1);
 
   f.data = data;
   Kokkos::parallel_for(1, f);
+#else
+  h_data() = i1;
+#endif
 
   Kokkos::deep_copy(h_data, data);
 

--- a/core/unit_test/TestAtomicOperations_double.hpp
+++ b/core/unit_test/TestAtomicOperations_double.hpp
@@ -57,6 +57,8 @@ TEST(TEST_CATEGORY, atomic_operations_double) {
                  double, TEST_EXECSPACE>(start, end - i, 3)));
     ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestNonIntegralType<
                  double, TEST_EXECSPACE>(start, end - i, 4)));
+    ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestNonIntegralType<
+                 double, TEST_EXECSPACE>(start, end - i, 5)));
   }
 }
 }  // namespace Test

--- a/core/unit_test/TestAtomicOperations_float.hpp
+++ b/core/unit_test/TestAtomicOperations_float.hpp
@@ -57,6 +57,8 @@ TEST(TEST_CATEGORY, atomic_operations_float) {
                  float, TEST_EXECSPACE>(start, end - i, 3)));
     ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestNonIntegralType<
                  float, TEST_EXECSPACE>(start, end - i, 4)));
+    ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestNonIntegralType<
+                 float, TEST_EXECSPACE>(start, end - i, 5)));
   }
 }
 }  // namespace Test

--- a/core/unit_test/TestAtomicOperations_int.hpp
+++ b/core/unit_test/TestAtomicOperations_int.hpp
@@ -71,6 +71,8 @@ TEST(TEST_CATEGORY, atomic_operations_int) {
                  int, TEST_EXECSPACE>(start, end - i, 11)));
     ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
                  int, TEST_EXECSPACE>(start, end - i, 12)));
+    ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
+                 int, TEST_EXECSPACE>(start, end - i, 13)));
   }
 }
 }  // namespace Test

--- a/core/unit_test/TestAtomicOperations_longint.hpp
+++ b/core/unit_test/TestAtomicOperations_longint.hpp
@@ -71,6 +71,8 @@ TEST(TEST_CATEGORY, atomic_operations_long) {
                  long int, TEST_EXECSPACE>(start, end - i, 11)));
     ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
                  long int, TEST_EXECSPACE>(start, end - i, 12)));
+    ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
+                 long int, TEST_EXECSPACE>(start, end - i, 13)));
   }
 }
 }  // namespace Test

--- a/core/unit_test/TestAtomicOperations_longlongint.hpp
+++ b/core/unit_test/TestAtomicOperations_longlongint.hpp
@@ -71,6 +71,8 @@ TEST(TEST_CATEGORY, atomic_operations_longlong) {
                  long long int, TEST_EXECSPACE>(start, end - i, 11)));
     ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
                  long long int, TEST_EXECSPACE>(start, end - i, 12)));
+    ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
+                 long long int, TEST_EXECSPACE>(start, end - i, 13)));
   }
 }
 }  // namespace Test

--- a/core/unit_test/TestAtomicOperations_unsignedint.hpp
+++ b/core/unit_test/TestAtomicOperations_unsignedint.hpp
@@ -71,6 +71,8 @@ TEST(TEST_CATEGORY, atomic_operations_unsigned) {
                  unsigned int, TEST_EXECSPACE>(start, end - i, 11)));
     ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
                  unsigned int, TEST_EXECSPACE>(start, end - i, 12)));
+    ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
+                 unsigned int, TEST_EXECSPACE>(start, end - i, 13)));
   }
 }
 }  // namespace Test

--- a/core/unit_test/TestAtomicOperations_unsignedlongint.hpp
+++ b/core/unit_test/TestAtomicOperations_unsignedlongint.hpp
@@ -71,6 +71,8 @@ TEST(TEST_CATEGORY, atomic_operations_unsignedlong) {
                  unsigned long int, TEST_EXECSPACE>(start, end - i, 11)));
     ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
                  unsigned long int, TEST_EXECSPACE>(start, end - i, 12)));
+    ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestIntegralType<
+                 unsigned long int, TEST_EXECSPACE>(start, end - i, 13)));
   }
 }
 }  // namespace Test


### PR DESCRIPTION
atomic_assign is undocumented and unused in core so far, but used
downstream. It is in the Kokkos:: namespace