### PR TITLE
Deal with unused variables

### DIFF
--- a/containers/unit_tests/TestStaticCrsGraph.hpp
+++ b/containers/unit_tests/TestStaticCrsGraph.hpp
@@ -180,18 +180,12 @@ void run_test_graph3(size_t B, size_t N) {
 
   std::vector<size_t> sizes(LENGTH);
 
-  size_t total_length = 0;
-
   for (size_t i = 0; i < LENGTH; ++i) {
     sizes[i] = rand() % 1000;
   }
 
   sizes[1]    = N;
   sizes[1998] = N;
-
-  for (size_t i = 0; i < LENGTH; ++i) {
-    total_length += sizes[i];
-  }
 
   int C    = 0;
   dView dx = Kokkos::create_staticcrsgraph<dView>("test", sizes);

--- a/core/perf_test/PerfTestGramSchmidt.cpp
+++ b/core/perf_test/PerfTestGramSchmidt.cpp
@@ -231,7 +231,7 @@ void run_test_gramschmidt(int exp_beg, int exp_end, int num_trials,
 
     std::cout << label_gramschmidt << " , " << parallel_work_length << " , "
               << min_seconds << " , " << (min_seconds / parallel_work_length)
-              << std::endl;
+              << ", " << avg_seconds << std::endl;
   }
 }
 

--- a/core/perf_test/PerfTestHexGrad.cpp
+++ b/core/perf_test/PerfTestHexGrad.cpp
@@ -280,7 +280,7 @@ void run_test_hexgrad(int exp_beg, int exp_end, int num_trials,
 
     std::cout << label_hexgrad << " , " << parallel_work_length << " , "
               << min_seconds << " , " << (min_seconds / parallel_work_length)
-              << std::endl;
+              << avg_seconds << std::endl;
   }
 }
 


### PR DESCRIPTION
Recent dpcpp releases (clang development versions) complain about some variables being unused.