### PR TITLE
Abort stuck Jenkins CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -6,6 +6,11 @@ pipeline {
         CCACHE_MAXSIZE = '10G'
         CCACHE_CPP2 = 'true'
     }
+
+    options {
+        timeout(time: 6, unit: 'HOURS')
+    }
+
     stages {
         stage('Clang-Format') {
             agent {


### PR DESCRIPTION
Occasionally, a build job is stuck for unclear reasons (as happened yesterday) potentially clogging all the Jenkins infrastructure.
This pull request suggests the pipeline to fail if it hasn't finished within 6 hours which should be enough even if we need to build some docker container images.