### PR TITLE
Fix a bug when using HIP atomic with Kokkos::Complex

### DIFF
--- a/core/src/desul/atomics/Compare_Exchange_HIP.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_HIP.hpp
@@ -179,8 +179,8 @@ DESUL_INLINE_FUNCTION __device__
   // This is a way to avoid dead lock in a warp or wave front
   T return_val;
   int done = 0;
-  unsigned int active = DESUL_IMPL_BALLOT_MASK(1);
-  unsigned int done_active = 0;
+  unsigned long long int active = DESUL_IMPL_BALLOT_MASK(1);
+  unsigned long long int done_active = 0;
   while (active != done_active) {
     if (!done) {
       if (Impl::lock_address_hip((void*)dest, scope)) {
@@ -208,8 +208,8 @@ DESUL_INLINE_FUNCTION __device__
   // This is a way to avoid dead lock in a warp or wave front
   T return_val;
   int done = 0;
-  unsigned int active = DESUL_IMPL_BALLOT_MASK(1);
-  unsigned int done_active = 0;
+  unsigned long long int active = DESUL_IMPL_BALLOT_MASK(1);
+  unsigned long long int done_active = 0;
   while (active != done_active) {
     if (!done) {
       if (Impl::lock_address_hip((void*)dest, scope)) {

--- a/core/src/desul/atomics/Generic.hpp
+++ b/core/src/desul/atomics/Generic.hpp
@@ -238,8 +238,8 @@ atomic_fetch_oper(const Oper& op,
   T return_val;
   int done = 0;
 #ifdef __HIPCC__
-  unsigned int active = DESUL_IMPL_BALLOT_MASK(1);
-  unsigned int done_active = 0;
+  unsigned long long int active = DESUL_IMPL_BALLOT_MASK(1);
+  unsigned long long int done_active = 0;
   while (active != done_active) {
     if (!done) {
       if (Impl::lock_address_hip((void*)dest, scope)) {
@@ -305,8 +305,8 @@ atomic_oper_fetch(const Oper& op,
   T return_val;
   int done = 0;
 #ifdef __HIPCC__
-  unsigned int active = DESUL_IMPL_BALLOT_MASK(1);
-  unsigned int done_active = 0;
+  unsigned long long int active = DESUL_IMPL_BALLOT_MASK(1);
+  unsigned long long int done_active = 0;
   while (active != done_active) {
     if (!done) {
       if (Impl::lock_address_hip((void*)dest, scope)) {

--- a/core/unit_test/TestAtomics.hpp
+++ b/core/unit_test/TestAtomics.hpp
@@ -540,8 +540,6 @@ TEST(TEST_CATEGORY, atomics) {
 
 // FIXME_SYCL atomics for large types to be implemented
 #ifndef KOKKOS_ENABLE_SYCL
-  // FIXME_HIP HIP doesn't yet support atomics for >64bit types properly
-#ifndef KOKKOS_ENABLE_HIP
   ASSERT_TRUE(
       (TestAtomic::Loop<Kokkos::complex<double>, TEST_EXECSPACE>(1, 1)));
   ASSERT_TRUE(
@@ -564,7 +562,6 @@ TEST(TEST_CATEGORY, atomics) {
       (TestAtomic::Loop<TestAtomic::SuperScalar<4>, TEST_EXECSPACE>(100, 2)));
   ASSERT_TRUE(
       (TestAtomic::Loop<TestAtomic::SuperScalar<4>, TEST_EXECSPACE>(100, 3)));
-#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
__ballot returns an `unsigned long long int` in HIP and not an `unsigned int` like in CUDA. With this PR, all the tests are enabled for HIP.