### PR TITLE
[WIP] Implementation Sketch: Standardized facilities for lazy evaluation

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -119,7 +119,6 @@ bool eventSetsEqual(const EventSet& l, const EventSet& r) {
          l.declare_optimization_goal == r.declare_optimization_goal;
 }
 
-
 enum class MayRequireGlobalFencing : bool { No, Yes };
 template <typename Callback, typename... Args>
 inline void invoke_kokkosp_callback(
@@ -135,7 +134,8 @@ inline void invoke_kokkosp_callback(
              .requires_global_fencing)) {
       Kokkos::fence();
     }
-    //(*callback)(std::forward<typename LazyEvaluator<Args>::value_type>(LazyEvaluator<Args>::get(args))...);
+    //(*callback)(std::forward<typename
+    // LazyEvaluator<Args>::value_type>(LazyEvaluator<Args>::get(args))...);
     (*callback)(lazily_evaluate(args)...);
   }
 }
@@ -145,24 +145,24 @@ bool profileLibraryLoaded() {
                                        Experimental::no_profiling);
 }
 
-void beginParallelFor(const Kokkos::Tools::Experimental::LazilyEvaluatable<const std::string>& kernelPrefix, const uint32_t devID,
-                      uint64_t* kernelID) {
+void beginParallelFor(const Kokkos::Tools::Experimental::LazilyEvaluatable<
+                          const std::string>& kernelPrefix,
+                      const uint32_t devID, uint64_t* kernelID) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
-      Experimental::current_callbacks.begin_parallel_for, kernelPrefix,
-      devID, kernelID);
+      Experimental::current_callbacks.begin_parallel_for, kernelPrefix, devID,
+      kernelID);
 #ifdef KOKKOS_ENABLE_TUNING
   if (Kokkos::tune_internals()) {
     auto context_id = Experimental::get_new_context_id();
     Experimental::begin_context(context_id);
-    /**
+
     Experimental::VariableValue contextValues[] = {
         Experimental::make_variable_value(
-            Experimental::kernel_name_context_variable_id, kernelPrefix),
+            Experimental::kernel_name_context_variable_id, kernelPrefix()),
         Experimental::make_variable_value(
             Experimental::kernel_type_context_variable_id, "parallel_for")};
     Experimental::set_input_values(context_id, 2, contextValues);
-    */
   }
 #endif
 }
@@ -197,6 +197,27 @@ void endParallelFor(const uint64_t kernelID) {
   }
 #endif
 }
+void beginParallelScan(const Kokkos::Tools::Experimental::LazilyEvaluatable<
+                           const std::string>& kernelPrefix,
+                       const uint32_t devID, uint64_t* kernelID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::Yes,
+      Experimental::current_callbacks.begin_parallel_scan, kernelPrefix, devID,
+      kernelID);
+#ifdef KOKKOS_ENABLE_TUNING
+  if (Kokkos::tune_internals()) {
+    auto context_id = Experimental::get_new_context_id();
+    Experimental::begin_context(context_id);
+
+    Experimental::VariableValue contextValues[] = {
+        Experimental::make_variable_value(
+            Experimental::kernel_name_context_variable_id, kernelPrefix()),
+        Experimental::make_variable_value(
+            Experimental::kernel_type_context_variable_id, "parallel_scan")};
+    Experimental::set_input_values(context_id, 2, contextValues);
+  }
+#endif
+}
 
 void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
                        uint64_t* kernelID) {
@@ -225,6 +246,28 @@ void endParallelScan(const uint64_t kernelID) {
 #ifdef KOKKOS_ENABLE_TUNING
   if (Kokkos::tune_internals()) {
     Experimental::end_context(Experimental::get_current_context_id());
+  }
+#endif
+}
+
+void beginParallelReduce(const Kokkos::Tools::Experimental::LazilyEvaluatable<
+                             const std::string>& kernelPrefix,
+                         const uint32_t devID, uint64_t* kernelID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::Yes,
+      Experimental::current_callbacks.begin_parallel_reduce, kernelPrefix,
+      devID, kernelID);
+#ifdef KOKKOS_ENABLE_TUNING
+  if (Kokkos::tune_internals()) {
+    auto context_id = Experimental::get_new_context_id();
+    Experimental::begin_context(context_id);
+
+    Experimental::VariableValue contextValues[] = {
+        Experimental::make_variable_value(
+            Experimental::kernel_name_context_variable_id, kernelPrefix()),
+        Experimental::make_variable_value(
+            Experimental::kernel_type_context_variable_id, "parallel_reduce")};
+    Experimental::set_input_values(context_id, 2, contextValues);
   }
 #endif
 }

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -118,6 +118,8 @@ bool eventSetsEqual(const EventSet& l, const EventSet& r) {
          l.request_output_values == r.request_output_values &&
          l.declare_optimization_goal == r.declare_optimization_goal;
 }
+
+
 enum class MayRequireGlobalFencing : bool { No, Yes };
 template <typename Callback, typename... Args>
 inline void invoke_kokkosp_callback(
@@ -133,13 +135,36 @@ inline void invoke_kokkosp_callback(
              .requires_global_fencing)) {
       Kokkos::fence();
     }
-    (*callback)(std::forward<Args>(args)...);
+    //(*callback)(std::forward<typename LazyEvaluator<Args>::value_type>(LazyEvaluator<Args>::get(args))...);
+    (*callback)(lazily_evaluate(args)...);
   }
 }
 }  // namespace Experimental
 bool profileLibraryLoaded() {
   return !Experimental::eventSetsEqual(Experimental::current_callbacks,
                                        Experimental::no_profiling);
+}
+
+void beginParallelFor(const Kokkos::Tools::Experimental::LazilyEvaluatable<const std::string>& kernelPrefix, const uint32_t devID,
+                      uint64_t* kernelID) {
+  Experimental::invoke_kokkosp_callback(
+      Experimental::MayRequireGlobalFencing::Yes,
+      Experimental::current_callbacks.begin_parallel_for, kernelPrefix,
+      devID, kernelID);
+#ifdef KOKKOS_ENABLE_TUNING
+  if (Kokkos::tune_internals()) {
+    auto context_id = Experimental::get_new_context_id();
+    Experimental::begin_context(context_id);
+    /**
+    Experimental::VariableValue contextValues[] = {
+        Experimental::make_variable_value(
+            Experimental::kernel_name_context_variable_id, kernelPrefix),
+        Experimental::make_variable_value(
+            Experimental::kernel_type_context_variable_id, "parallel_for")};
+    Experimental::set_input_values(context_id, 2, contextValues);
+    */
+  }
+#endif
 }
 
 void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -53,6 +53,7 @@
 #include <map>
 #include <string>
 #include <type_traits>
+#include <functional>
 namespace Kokkos {
 
 // forward declaration


### PR DESCRIPTION
Candidate answer to https://github.com/kokkos/kokkos/issues/4152.

Right now, all throughout Kokkos, often incorrectly, we implement guards for "only calculate this argument to a function of the tooling subsystem if a callback is set." See [this](https://github.com/kokkos/kokkos/blob/master/core/src/impl/Kokkos_Profiling.hpp#L486-L496) for an example of this done wrong, we currently only check if a profile library is loaded, rather than checking that the callback for begin_parallel_for is set (in practice this hasn't mattered much, though it likely will, soon).

To me, the obvious fix for this is to use something to the effect of a promise/future, and handle argument calculation in exactly one place. I propose [here](https://github.com/kokkos/kokkos/blob/master/core/src/impl/Kokkos_Profiling.cpp#L136) for the location. I implement this by adding something called a LazilyEvaluatable, which when invoked calculates a value based on a lambda. `invoke_kokkosp_callback` now forwards arguments that are raw arguments, but invokes LazilyEvaluatables passed to it. This achieves the goals.

Concerns:

1) Does this add overhead? We'll need to measure. But what's happening here is very cheap, a lambda is just a struct that initializes members based on its capture clause. So in these examples, we're constructing a struct containing a reference to a std::string, that's quite cheap. 
2) Handling cases of multiple callbacks needing the same future value. This actually happens, [here](https://github.com/kokkos/kokkos/compare/develop...DavidPoliakoff:feature/lazily-evaluate?expand=1#diff-706bc3e14f4ac802ad28b5bf2f78b3eeeaaac4762cbe1616e00bbd9b48c23e31R153) and [here](https://github.com/kokkos/kokkos/compare/develop...DavidPoliakoff:feature/lazily-evaluate?expand=1#diff-706bc3e14f4ac802ad28b5bf2f78b3eeeaaac4762cbe1616e00bbd9b48c23e31R162) both evaluate the same stuff. I think we could extend these facilities to support this pretty easily, but for this implementation sketch I'm not doing so
3) "But now I have two instances of beginParallelFor." Yep, and that really sucks. The plan would be to use 4.0 to refactor this stuff so that the futures are used consistently. But until 4.0 we will be adding maintenance overhead

Gains

1) We stop leaving guns to our own heads in terms of software quality. Right now it would be so easy to accidentally evaluate something in an inopportune time, the fact that we've done this as correctly as we have is a bit of a miracle
2) Standardization. This is the biggy for me. Right now every time we look at the problem of not adding overhead to Tools, we re-solve the same problems. I'd like to say "the way you guard yourself from calculating an expensive value is to use something std::future-y."

Anyway, let me know what you think

edit: reduced Godbolt, to show the core of what's happening here: https://godbolt.org/z/PGh4hvbMc