### PR TITLE
Don't print SYCL device info in execution space intialization

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -115,7 +115,6 @@ void SYCLInternal::initialize(const sycl::queue& q) {
       all_queues.push_back(&m_queue);
     }
     const sycl::device& d = m_queue->get_device();
-    std::cout << SYCL::SYCLDevice(d) << '\n';
 
     m_maxWorkgroupSize =
         d.template get_info<sycl::info::device::max_work_group_size>();


### PR DESCRIPTION
At the moment, we are printing something like
```
Name: Tesla V100-PCIE-32GB
Driver Version: CUDA 11.0
Is Host: 0
Is CPU: 0
Is GPU: 1
Is Accelerator: 0
Vendor Id: 4318
Max Compute Units: 80
Max Work Item Dimensions: 3
Max Work Group Size: 1024
Preferred Vector Width Char: 1
Preferred Vector Width Short: 1
Preferred Vector Width Int: 1
Preferred Vector Width Long: 1
Preferred Vector Width Float: 1
Preferred Vector Width Double: 1
Preferred Vector Width Half: 0
Native Vector Width Char: 1
Native Vector Width Short: 1
Native Vector Width Int: 1
Native Vector Width Long: 1
Native Vector Width Float: 1
Native Vector Width Double: 1
Native Vector Width Half: 0
Address Bits: 64
Image Support: 1
Max Mem Alloc Size: 1073741824
Max Read Image Args: 128
Image2d Max Width: 131072
Image2d Max Height: 65536
Image3d Max Width: 16384
Image3d Max Height: 16384
Image3d Max Depth: 16384
Image Max Buffer Size: 32768
Image Max Array Size: 0
Max Samplers: 128
Max Parameter Size: 4000
Mem Base Addr Align: 4096
Global Cache Mem Line Size: 128
Global Mem Cache Size: 6291456
Global Mem Size: 34089730048
Local Mem Size: 49152
Error Correction Support: 1
Host Unified Memory: 0
Profiling Timer Resolution: 1000
Is Endian Little: 1
Is Available: 1
Is Compiler Available: 1
Is Linker Available: 1
Queue Profiling: 1
Built In Kernels: 0
Vendor: NVIDIA Corporation
Profile: CUDA
Version: 0.0
Extensions: 2
	cl_khr_fp64
	cl_khr_fp16
Printf Buffer Size: 1024
Preferred Interop User Sync: 1
Partition Max Sub Devices: 0
Reference Count: 1
```
every time an `SYCL` execution space is initialized. I think it's time to get rid of all this debug information now. We don't invoke `print_configuration` for any other backend during initialization.