### PR TITLE
Fixes for query_device example

### DIFF
--- a/example/query_device/query_device.cpp
+++ b/example/query_device/query_device.cpp
@@ -84,7 +84,6 @@ int main(int argc, char** argv) {
   }
 
   Kokkos::print_configuration(msg);
-  ;
 
   msg << "}" << std::endl;
 

--- a/example/query_device/query_device.cpp
+++ b/example/query_device/query_device.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
   msg << "MPI rank(" << mpi_rank << ") ";
 
 #endif
-
+  Kokkos::initialize(argc, argv);
   msg << "{" << std::endl;
 
   if (Kokkos::hwloc::available()) {
@@ -83,14 +83,13 @@ int main(int argc, char** argv) {
         << std::endl;
   }
 
-#if defined(KOKKOS_ENABLE_CUDA)
-  Kokkos::Cuda::print_configuration(msg);
-#endif
+  Kokkos::print_configuration(msg);
+  ;
 
   msg << "}" << std::endl;
 
   std::cout << msg.str();
-
+  Kokkos::finalize();
 #if defined(USE_MPI)
 
   MPI_Finalize();


### PR DESCRIPTION
Solves https://github.com/kokkos/kokkos/issues/4167

Turns out we needed two things, actually.

1) Change Kokkos::[subcomponent]::print_configuration to Kokkos::print_configuration
2) The metadata only gets initialized when Kokkos::initialize is called, which this example didn't