### PR TITLE
Fix two xl issues

### DIFF
--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -99,6 +99,8 @@ KOKKOS_LINK_TPL(kokkoscore PUBLIC ROCM)
 
 # FIXME: We need a proper solution to figure out whether to enable
 #        libatomic
+# XL requires libatomic even for 64 bit CAS, most others only for 128
+# I (CT) had removed 128bit CAS from desul to not need libatomic.
 IF (KOKKOS_ENABLE_IMPL_DESUL_ATOMICS AND
     (KOKKOS_ENABLE_OPENMPTARGET OR (CMAKE_CXX_COMPILER_ID STREQUAL XLClang)))
   target_link_libraries(kokkoscore PUBLIC atomic)

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -100,7 +100,7 @@ KOKKOS_LINK_TPL(kokkoscore PUBLIC ROCM)
 # FIXME: We need a proper solution to figure out whether to enable
 #        libatomic
 IF (KOKKOS_ENABLE_IMPL_DESUL_ATOMICS AND
-    KOKKOS_ENABLE_OPENMPTARGET)
+    (KOKKOS_ENABLE_OPENMPTARGET OR (CMAKE_CXX_COMPILER_ID STREQUAL XLClang)))
   target_link_libraries(kokkoscore PUBLIC atomic)
 ENDIF()
 

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -198,7 +198,9 @@ struct TestNumericTraits<
 TEST(TEST_CATEGORY, numeric_traits_infinity) {
   TestNumericTraits<TEST_EXECSPACE, float, Infinity>();
   TestNumericTraits<TEST_EXECSPACE, double, Infinity>();
+#ifndef KOKKOS_COMPILER_IBM  // fails with XL 16.1.1 see issue #4100
   TestNumericTraits<TEST_EXECSPACE, long double, Infinity>();
+#endif
 }
 
 TEST(TEST_CATEGORY, numeric_traits_epsilon) {


### PR DESCRIPTION
This adds libatomic for XL which does require it for 64 bit compare exchange of complex<float> and turns of the infinity test for long double where it generates wrong answers: see #4100 