### PR TITLE
Revert #4155: Deprecate ViewAllocateWithoutInitializing

### DIFF
--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -268,10 +268,8 @@ struct ViewCtorProp : public ViewCtorProp<void, P>... {
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 namespace Kokkos {
 
-/* For backward compatibility */
 namespace Impl {
 struct ViewAllocateWithoutInitializingBackwardCompat {};
 
@@ -292,13 +290,11 @@ struct ViewCtorProp<WithoutInitializing_t, std::string,
 };
 } /* namespace Impl */
 
-using ViewAllocateWithoutInitializing KOKKOS_DEPRECATED_WITH_COMMENT(
-    "Use Kokkos::view_alloc(Kokkos::WithoutInitializing, label) instead") =
+using ViewAllocateWithoutInitializing =
     Impl::ViewCtorProp<Impl::WithoutInitializing_t, std::string,
                        Impl::ViewAllocateWithoutInitializingBackwardCompat>;
 
 } /* namespace Kokkos */
-#endif
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
+++ b/core/unit_test/TestViewCtorPropEmbeddedDim.hpp
@@ -157,12 +157,10 @@ TEST(TEST_CATEGORY, viewctorprop_embedded_dim) {
   TestViewCtorProp_EmbeddedDim<TEST_EXECSPACE>::test_vcpt(2, 3);
 }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 TEST(TEST_CATEGORY,
      viewctorpop_view_allocate_without_initializing_backward_compatility) {
   using deprecated_view_alloc = Kokkos::ViewAllocateWithoutInitializing;
   Kokkos::View<int**, TEST_EXECSPACE> v(deprecated_view_alloc("v"), 5, 7);
 }
-#endif
 
 }  // namespace Test


### PR DESCRIPTION
As decided in https://github.com/kokkos/kokkos/pull/4155#issuecomment-884399219.