### PR TITLE
Deprecate TeamPolicy::vector_length_max() and TeamPolicy::verify_requested_vector_length()

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -207,12 +207,16 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     return internal_team_size_recommended<closure_type>(f);
   }
 
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
   inline static int vector_length_max() { return Impl::CudaTraits::WarpSize; }
 
+  inline int vector_size_max() const { return Impl::CudaTraits::WarpSize; }
+
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use verify_requested_vector_size() instead!")
   inline static int verify_requested_vector_length(
       int requested_vector_length) {
     int test_vector_length =
-        std::min(requested_vector_length, vector_length_max());
+        std::min(requested_vector_length, vector_size_max());
 
     // Allow only power-of-two vector_length
     if (!(is_integral_power_of_two(test_vector_length))) {
@@ -227,6 +231,9 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     }
 
     return test_vector_length;
+  }
+  inline int verify_requested_vector_size(int requested_vector_size) const {
+    return verify_requested_vector_length(int requested_vector_size);
   }
 
   inline static int scratch_size_max(int level) {
@@ -287,8 +294,8 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
         m_team_size(team_size_request),
         m_vector_length(
             (vector_length_request > 0)
-                ? verify_requested_vector_length(vector_length_request)
-                : verify_requested_vector_length(1)),
+                ? verify_requested_vector_size(vector_length_request)
+                : verify_requested_vector_size(1)),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_chunk_size(Impl::CudaTraits::WarpSize),

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -216,7 +216,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
   inline static int verify_requested_vector_length(
       int requested_vector_length) {
     int test_vector_length =
-        std::min(requested_vector_length, vector_size_max());
+        std::min(requested_vector_length, vector_length_max());
 
     // Allow only power-of-two vector_length
     if (!(is_integral_power_of_two(test_vector_length))) {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -237,8 +237,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
   }
 #endif
   inline int verify_requested_vector_size(int requested_vector_size) const {
-    int test_vector_length =
-        std::min(requested_vector_size, vector_length_max());
+    int test_vector_length = std::min(requested_vector_size, vector_size_max());
 
     // Allow only power-of-two vector_length
     if (!(is_integral_power_of_two(test_vector_length))) {

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -164,12 +164,15 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
 
   inline bool impl_auto_vector_length() const { return m_tune_vector_length; }
   inline bool impl_auto_team_size() const { return m_tune_team_size; }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
   inline static int vector_length_max() {
     return ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
   }
+#endif
   inline int vector_size_max() const { return Impl::CudaTraits::WarpSize; }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   KOKKOS_DEPRECATED_WITH_COMMENT("Use verify_requested_vector_size() instead!")
   static int verify_requested_vector_length(int requested_vector_length) {
     int test_vector_length =
@@ -190,8 +193,25 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
 
     return test_vector_length;
   }
+#endif
   int verify_requested_vector_size(int requested_vector_size) {
-    return verify_requested_vector_length(requested_vector_size);
+    int test_vector_length =
+        std::min(requested_vector_size, vector_length_max());
+
+    // Allow only power-of-two vector_length
+    if (!(is_integral_power_of_two(test_vector_length))) {
+      int test_pow2           = 1;
+      int constexpr warp_size = Experimental::Impl::HIPTraits::WarpSize;
+      while (test_pow2 < warp_size) {
+        test_pow2 <<= 1;
+        if (test_pow2 > test_vector_length) {
+          break;
+        }
+      }
+      test_vector_length = test_pow2 >> 1;
+    }
+
+    return test_vector_length;
   }
 
   static int scratch_size_max(int level) {

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -164,13 +164,16 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
 
   inline bool impl_auto_vector_length() const { return m_tune_vector_length; }
   inline bool impl_auto_team_size() const { return m_tune_team_size; }
-  static int vector_length_max() {
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
+  inline static int vector_length_max() {
     return ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
   }
+  inline int vector_size_max() const { return Impl::CudaTraits::WarpSize; }
 
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use verify_requested_vector_size() instead!")
   static int verify_requested_vector_length(int requested_vector_length) {
     int test_vector_length =
-        std::min(requested_vector_length, vector_length_max());
+        std::min(requested_vector_length, vector_size_max());
 
     // Allow only power-of-two vector_length
     if (!(is_integral_power_of_two(test_vector_length))) {
@@ -186,6 +189,9 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
     }
 
     return test_vector_length;
+  }
+  int verify_requested_vector_size(int requested_vector_size) {
+    return verify_requested_vector_length(requested_vector_size);
   }
 
   static int scratch_size_max(int level) {
@@ -238,8 +244,8 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
         m_team_size(team_size_request),
         m_vector_length(
             (vector_length_request > 0)
-                ? verify_requested_vector_length(vector_length_request)
-                : (verify_requested_vector_length(1))),
+                ? verify_requested_vector_size(vector_length_request)
+                : (verify_requested_vector_size(1))),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_chunk_size(::Kokkos::Experimental::Impl::HIPTraits::WarpSize),

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -173,7 +173,7 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
   KOKKOS_DEPRECATED_WITH_COMMENT("Use verify_requested_vector_size() instead!")
   static int verify_requested_vector_length(int requested_vector_length) {
     int test_vector_length =
-        std::min(requested_vector_length, vector_size_max());
+        std::min(requested_vector_length, vector_length_max());
 
     // Allow only power-of-two vector_length
     if (!(is_integral_power_of_two(test_vector_length))) {

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -170,7 +170,9 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
     return ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
   }
 #endif
-  inline int vector_size_max() const { return Impl::CudaTraits::WarpSize; }
+  inline int vector_size_max() const {
+    return ::Kokkos::Experimental::Impl::HIPTraits::WarpSize;
+  }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   KOKKOS_DEPRECATED_WITH_COMMENT("Use verify_requested_vector_size() instead!")
@@ -195,8 +197,7 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
   }
 #endif
   int verify_requested_vector_size(int requested_vector_size) {
-    int test_vector_length =
-        std::min(requested_vector_size, vector_length_max());
+    int test_vector_length = std::min(requested_vector_size, vector_size_max());
 
     // Allow only power-of-two vector_length
     if (!(is_integral_power_of_two(test_vector_length))) {

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -370,7 +370,9 @@ class TeamPolicyInternal : public Impl::PolicyTraits<Properties...> {
    */
   inline bool impl_auto_vector_length() const;
 
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
   static int vector_length_max();
+  int vector_size_max() const;
 
   KOKKOS_INLINE_FUNCTION int impl_vector_length() const;
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -370,8 +370,10 @@ class TeamPolicyInternal : public Impl::PolicyTraits<Properties...> {
    */
   inline bool impl_auto_vector_length() const;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
   static int vector_length_max();
+#endif
   int vector_size_max() const;
 
   KOKKOS_INLINE_FUNCTION int impl_vector_length() const;

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -780,7 +780,9 @@ class TeamPolicyInternal<Kokkos::Experimental::HPX, Properties...>
     return 1;
   }
 
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
   static int vector_length_max() { return 1; }
+  int vector_size_max() const { return 1; }
 
   inline int impl_vector_length() noexcept { return 1; }
   inline bool impl_auto_team_size() noexcept { return false; }

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -780,8 +780,10 @@ class TeamPolicyInternal<Kokkos::Experimental::HPX, Properties...>
     return 1;
   }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
   static int vector_length_max() { return 1; }
+#endif
   int vector_size_max() const { return 1; }
 
   inline int impl_vector_length() noexcept { return 1; }

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -329,10 +329,12 @@ class TeamPolicyInternal<Kokkos::Serial, Properties...>
   }
 
   inline int impl_vector_length() const { return 1; }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
   static int vector_length_max() {
     return 1024;
   }  // Use arbitrary large number, is meant as a vectorizable length
+#endif
   int vector_size_max() const {
     return 1024;
   }  // Use arbitrary large number, is meant as a vectorizable length

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -329,7 +329,11 @@ class TeamPolicyInternal<Kokkos::Serial, Properties...>
   }
 
   inline int impl_vector_length() const { return 1; }
-  inline static int vector_length_max() {
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
+  static int vector_length_max() {
+    return 1024;
+  }  // Use arbitrary large number, is meant as a vectorizable length
+  int vector_size_max() const {
     return 1024;
   }  // Use arbitrary large number, is meant as a vectorizable length
 

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -441,7 +441,6 @@ class TeamSizeTuner : public ExtendableTunerMixin<TeamSizeTuner> {
                 Kokkos::TeamPolicy<Properties...>& policy,
                 const Functor& functor, const TagType& tag,
                 ViableConfigurationCalculator calc) {
-    using PolicyType           = Kokkos::TeamPolicy<Properties...>;
     auto initial_vector_length = policy.impl_vector_length();
     if (initial_vector_length < 1) {
       policy.impl_set_vector_length(1);

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -473,7 +473,7 @@ class TeamSizeTuner : public ExtendableTunerMixin<TeamSizeTuner> {
      */
     SpaceDescription space_description;
 
-    auto max_vector_length = PolicyType::vector_length_max();
+    auto max_vector_length = policy.vector_size_max();
     std::vector<int64_t> allowed_vector_lengths;
 
     if (policy.impl_auto_vector_length()) {  // case 1 or 2

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -122,7 +122,11 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
     return team_size_recommended(f, t);
   }
 
-  inline static int vector_length_max() {
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
+  static int vector_length_max() {
+    return 1024;
+  }  // Use arbitrary large number, is meant as a vectorizable length
+  int vector_size_max() const {
     return 1024;
   }  // Use arbitrary large number, is meant as a vectorizable length
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -122,10 +122,12 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
     return team_size_recommended(f, t);
   }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
   static int vector_length_max() {
     return 1024;
   }  // Use arbitrary large number, is meant as a vectorizable length
+#endif
   int vector_size_max() const {
     return 1024;
   }  // Use arbitrary large number, is meant as a vectorizable length

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -1016,10 +1016,16 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget, Properties...>
         m_chunk_size(0) {
     init(league_size_request, team_size_request, 1);
   }
-  inline static size_t vector_length_max() {
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
+  static int vector_length_max() {
     return 32; /* TODO: this is bad. Need logic that is compiler and backend
                   aware */
   }
+  int vector_size_max() const {
+    return 32; /* TODO: this is bad. Need logic that is compiler and backend
+                  aware */
+  }
+
   inline int team_alloc() const { return m_team_alloc; }
   inline int team_iter() const { return m_team_iter; }
 

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -1016,11 +1016,13 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget, Properties...>
         m_chunk_size(0) {
     init(league_size_request, team_size_request, 1);
   }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
   static int vector_length_max() {
     return 32; /* TODO: this is bad. Need logic that is compiler and backend
                   aware */
   }
+#endif
   int vector_size_max() const {
     return 32; /* TODO: this is bad. Need logic that is compiler and backend
                   aware */

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -129,11 +129,14 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
   }
   inline bool impl_auto_vector_length() const { return m_tune_vector_length; }
   inline bool impl_auto_team_size() const { return m_tune_team_size; }
-  static int vector_length_max() {
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
+  static int vector_length_max() { return 1; }
+  int vector_size_max() const {
     // FIXME_SYCL provide a reasonable value
     return 1;
   }
 
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use verify_request_vector_size() instead!")
   static int verify_requested_vector_length(int requested_vector_length) {
     int test_vector_length =
         std::min(requested_vector_length, vector_length_max());
@@ -151,6 +154,10 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
     }
 
     return test_vector_length;
+  }
+
+  int verify_requested_vector_size(int requested_vector_size) const {
+    return verify_requested_vector_length(requested_vector_size);
   }
 
   static int scratch_size_max(int level) {
@@ -202,8 +209,8 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
         m_team_size(team_size_request),
         m_vector_length(
             (vector_length_request > 0)
-                ? verify_requested_vector_length(vector_length_request)
-                : (verify_requested_vector_length(1))),
+                ? verify_requested_vector_size(vector_length_request)
+                : (verify_requested_vector_size(1))),
         m_team_scratch_size{0, 0},
         m_thread_scratch_size{0, 0},
         m_chunk_size(0),

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -674,10 +674,12 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
     return team_size_recommended(f, t);
   }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
   static int vector_length_max() {
     return 1024;
   }  // Use arbitrary large number, is meant as a vectorizable length
+#endif
   int vector_size_max() const {
     return 1024;
   }  // Use arbitrary large number, is meant as a vectorizable length

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -674,7 +674,11 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
     return team_size_recommended(f, t);
   }
 
-  inline static int vector_length_max() {
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use vector_size_max() instead!")
+  static int vector_length_max() {
+    return 1024;
+  }  // Use arbitrary large number, is meant as a vectorizable length
+  int vector_size_max() const {
     return 1024;
   }  // Use arbitrary large number, is meant as a vectorizable length
 


### PR DESCRIPTION
`TeamPolicy::vector_length_max` can not be static for `SYCL`, see https://github.com/kokkos/kokkos/pull/4183#discussion_r676609718. In an attempt to work around this, this pull request provides the same functionality as `TeamPolicy::vector_length_max()` and `TeamPolicy::verify_requested_vector_length()` in `TeamPolicy::vector_size_max()` and `TeamPolicy::verify_requested_vector_size()` as non-static member functions.

Of course, I'm open to other solutions.