### PR TITLE
Avoid allocations in resize and realloc

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -394,7 +394,7 @@ ENDIF()
 
 IF (KOKKOS_ENABLE_SYCL)
   COMPILER_SPECIFIC_FLAGS(
-    DEFAULT -fsycl
+    DEFAULT -fsycl -fno-sycl-id-queries-fit-in-int
   )
   COMPILER_SPECIFIC_OPTIONS(
     DEFAULT -fsycl-unnamed-lambda

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -877,8 +877,19 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                const size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG) {
-    ::Kokkos::realloc(d_view, n0, n1, n2, n3, n4, n5, n6, n7);
-    h_view = create_mirror_view(d_view);
+    const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
+    bool sizeMismatch           = false;
+    for (unsigned int dim = 0; dim < h_view.rank_dynamic; ++dim)
+      if (new_extents[dim] != h_view.extent(dim)) {
+        sizeMismatch = true;
+        break;
+      }
+
+    if (sizeMismatch) {
+      ::Kokkos::realloc(d_view, n0, n1, n2, n3, n4, n5, n6, n7);
+      h_view = create_mirror_view(d_view);
+    } else
+      ::Kokkos::deep_copy(d_view, typename t_dev::value_type{});
 
     /* Reset dirty flags */
     if (modified_flags.data() == nullptr) {
@@ -899,38 +910,33 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
               const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
               const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
               const size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG) {
+    const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
+    bool sizeMismatch           = false;
+    for (unsigned int dim = 0; dim < h_view.rank_dynamic; ++dim)
+      if (new_extents[dim] != h_view.extent(dim)) {
+        sizeMismatch = true;
+        break;
+      }
+
     if (modified_flags.data() == nullptr) {
       modified_flags = t_modified_flags("DualView::modified_flags");
     }
     if (modified_flags(1) >= modified_flags(0)) {
       /* Resize on Device */
-      ::Kokkos::resize(d_view, n0, n1, n2, n3, n4, n5, n6, n7);
-      h_view = create_mirror_view(d_view);
+      if (sizeMismatch) {
+        ::Kokkos::resize(d_view, n0, n1, n2, n3, n4, n5, n6, n7);
+        h_view = create_mirror_view(d_view);
+      }
 
       /* Mark Device copy as modified */
       modified_flags(1) = modified_flags(1) + 1;
 
     } else {
       /* Realloc on Device */
-
-      ::Kokkos::realloc(d_view, n0, n1, n2, n3, n4, n5, n6, n7);
-
-      const bool sizeMismatch =
-          (h_view.extent(0) != n0) || (h_view.extent(1) != n1) ||
-          (h_view.extent(2) != n2) || (h_view.extent(3) != n3) ||
-          (h_view.extent(4) != n4) || (h_view.extent(5) != n5) ||
-          (h_view.extent(6) != n6) || (h_view.extent(7) != n7);
-      if (sizeMismatch)
+      if (sizeMismatch) {
         ::Kokkos::resize(h_view, n0, n1, n2, n3, n4, n5, n6, n7);
-
-      t_host temp_view = create_mirror_view(d_view);
-
-      /* Remap on Host */
-      Kokkos::deep_copy(temp_view, h_view);
-
-      h_view = temp_view;
-
-      d_view = create_mirror_view(typename t_dev::execution_space(), h_view);
+        d_view = create_mirror_view(typename t_dev::execution_space(), h_view);
+      }
 
       /* Mark Host copy as modified */
       modified_flags(0) = modified_flags(0) + 1;

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2125,20 +2125,15 @@ inline void resize(DynRankView<T, P...>& v,
   static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
                 "Can only resize managed views");
 
-  const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
-  const bool sizeMismatch     = Impl::size_mismatch(v, v.rank(), new_extents);
+  drview_type v_resized(v.label(), n0, n1, n2, n3, n4, n5, n6, n7);
 
-  if (sizeMismatch) {
-    drview_type v_resized(v.label(), n0, n1, n2, n3, n4, n5, n6, n7);
+  Kokkos::Impl::DynRankViewRemap<drview_type, drview_type>(v_resized, v);
 
-    Kokkos::Impl::DynRankViewRemap<drview_type, drview_type>(v_resized, v);
-
-    v = v_resized;
-  }
+  v = v_resized;
 }
 
-/** \brief  Resize a view without copying old data to new data at the
- * corresponding indices. */
+/** \brief  Resize a view with copying old data to new data at the corresponding
+ * indices. */
 template <class T, class... P>
 inline void realloc(DynRankView<T, P...>& v,
                     const size_t n0 = KOKKOS_INVALID_INDEX,
@@ -2154,16 +2149,10 @@ inline void realloc(DynRankView<T, P...>& v,
   static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
                 "Can only realloc managed views");
 
-  const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
-  const bool sizeMismatch     = Impl::size_mismatch(v, v.rank(), new_extents);
+  const std::string label = v.label();
 
-  if (sizeMismatch) {
-    const std::string label = v.label();
-
-    v = drview_type();  // Deallocate first, if the only view to allocation
-    v = drview_type(label, n0, n1, n2, n3, n4, n5, n6, n7);
-  } else
-    Kokkos::deep_copy(v, typename drview_type::value_type{});
+  v = drview_type();  // Deallocate first, if the only view to allocation
+  v = drview_type(label, n0, n1, n2, n3, n4, n5, n6, n7);
 }
 
 }  // namespace Kokkos

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2126,12 +2126,7 @@ inline void resize(DynRankView<T, P...>& v,
                 "Can only resize managed views");
 
   const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
-  bool sizeMismatch           = false;
-  for (unsigned int dim = 0; dim < v.rank(); ++dim)
-    if (new_extents[dim] != v.extent(dim)) {
-      sizeMismatch = true;
-      break;
-    }
+  const bool sizeMismatch     = Impl::size_mismatch(v, v.rank(), new_extents);
 
   if (sizeMismatch) {
     drview_type v_resized(v.label(), n0, n1, n2, n3, n4, n5, n6, n7);
@@ -2160,12 +2155,7 @@ inline void realloc(DynRankView<T, P...>& v,
                 "Can only realloc managed views");
 
   const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
-  bool sizeMismatch           = false;
-  for (unsigned int dim = 0; dim < v.rank(); ++dim)
-    if (new_extents[dim] != v.extent(dim)) {
-      sizeMismatch = true;
-      break;
-    }
+  const bool sizeMismatch     = Impl::size_mismatch(v, v.rank(), new_extents);
 
   if (sizeMismatch) {
     const std::string label = v.label();

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2981,12 +2981,14 @@ inline void resize(Kokkos::View<T, P...>& v,
   static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
                 "Can only resize managed views");
 
-  view_type v_resized(v.label(), layout);
+  if (v.layout() != layout) {
+    view_type v_resized(v.label(), layout);
 
-  Kokkos::Impl::ViewRemap<view_type, view_type>(v_resized, v);
-  Kokkos::fence("Kokkos::resize(View)");
+    Kokkos::Impl::ViewRemap<view_type, view_type>(v_resized, v);
+    Kokkos::fence("Kokkos::resize(View)");
 
-  v = v_resized;
+    v = v_resized;
+  }
 }
 
 /** \brief  Resize a view with discarding old data. */

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2876,6 +2876,19 @@ inline void deep_copy(
 
 namespace Kokkos {
 
+namespace Impl {
+template <typename ViewType>
+bool size_mismatch(const ViewType& view, unsigned int max_extent,
+                   const size_t new_extents[8]) {
+  for (unsigned int dim = 0; dim < max_extent; ++dim)
+    if (new_extents[dim] != view.extent(dim)) {
+      return true;
+    }
+  return false;
+}
+
+}  // namespace Impl
+
 /** \brief  Resize a view with copying old data to new data at the corresponding
  * indices. */
 template <class T, class... P>
@@ -2905,12 +2918,7 @@ resize(Kokkos::View<T, P...>& v, const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
   // has enough space.
 
   const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
-  bool sizeMismatch           = false;
-  for (unsigned int dim = 0; dim < v.rank_dynamic; ++dim)
-    if (new_extents[dim] != v.extent(dim)) {
-      sizeMismatch = true;
-      break;
-    }
+  const bool sizeMismatch = Impl::size_mismatch(v, v.rank_dynamic, new_extents);
 
   if (sizeMismatch) {
     view_type v_resized(v.label(), n0, n1, n2, n3, n4, n5, n6, n7);
@@ -2952,12 +2960,7 @@ resize(const I& arg_prop, Kokkos::View<T, P...>& v,
   // has enough space.
 
   const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
-  bool sizeMismatch           = false;
-  for (unsigned int dim = 0; dim < v.rank_dynamic; ++dim)
-    if (new_extents[dim] != v.extent(dim)) {
-      sizeMismatch = true;
-      break;
-    }
+  const bool sizeMismatch = Impl::size_mismatch(v, v.rank_dynamic, new_extents);
 
   if (sizeMismatch) {
     view_type v_resized(view_alloc(v.label(), std::forward<const I>(arg_prop)),
@@ -3048,12 +3051,7 @@ realloc(Kokkos::View<T, P...>& v,
                 "Can only realloc managed views");
 
   const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
-  bool sizeMismatch           = false;
-  for (unsigned int dim = 0; dim < v.rank_dynamic; ++dim)
-    if (new_extents[dim] != v.extent(dim)) {
-      sizeMismatch = true;
-      break;
-    }
+  const bool sizeMismatch = Impl::size_mismatch(v, v.rank_dynamic, new_extents);
 
   if (sizeMismatch) {
     const std::string label = v.label();

--- a/core/src/Kokkos_Layout.hpp
+++ b/core/src/Kokkos_Layout.hpp
@@ -88,6 +88,16 @@ struct LayoutLeft {
                                 size_t N3 = 0, size_t N4 = 0, size_t N5 = 0,
                                 size_t N6 = 0, size_t N7 = 0)
       : dimension{N0, N1, N2, N3, N4, N5, N6, N7} {}
+
+  friend bool operator==(const LayoutLeft& left, const LayoutLeft& right) {
+    for (unsigned int rank = 0; rank < ARRAY_LAYOUT_MAX_RANK; ++rank)
+      if (left.dimension[rank] != right.dimension[rank]) return false;
+    return true;
+  }
+
+  friend bool operator!=(const LayoutLeft& left, const LayoutLeft& right) {
+    return !(left == right);
+  }
 };
 
 //----------------------------------------------------------------------------
@@ -122,6 +132,16 @@ struct LayoutRight {
                                  size_t N3 = 0, size_t N4 = 0, size_t N5 = 0,
                                  size_t N6 = 0, size_t N7 = 0)
       : dimension{N0, N1, N2, N3, N4, N5, N6, N7} {}
+
+  friend bool operator==(const LayoutRight& left, const LayoutRight& right) {
+    for (unsigned int rank = 0; rank < ARRAY_LAYOUT_MAX_RANK; ++rank)
+      if (left.dimension[rank] != right.dimension[rank]) return false;
+    return true;
+  }
+
+  friend bool operator!=(const LayoutRight& left, const LayoutRight& right) {
+    return !(left == right);
+  }
 };
 
 //----------------------------------------------------------------------------
@@ -183,6 +203,18 @@ struct LayoutStride {
                                   size_t S7 = 0)
       : dimension{N0, N1, N2, N3, N4, N5, N6, N7}, stride{S0, S1, S2, S3,
                                                           S4, S5, S6, S7} {}
+
+  friend bool operator==(const LayoutStride& left, const LayoutStride& right) {
+    for (unsigned int rank = 0; rank < ARRAY_LAYOUT_MAX_RANK; ++rank)
+      if (left.dimension[rank] != right.dimension[rank] ||
+          left.stride[rank] != right.stride[rank])
+        return false;
+    return true;
+  }
+
+  friend bool operator!=(const LayoutStride& left, const LayoutStride& right) {
+    return !(left == right);
+  }
 };
 
 // ===================================================================================
@@ -257,6 +289,16 @@ struct LayoutTiled {
                                  size_t argN4 = 0, size_t argN5 = 0,
                                  size_t argN6 = 0, size_t argN7 = 0)
       : dimension{argN0, argN1, argN2, argN3, argN4, argN5, argN6, argN7} {}
+
+  friend bool operator==(const LayoutTiled& left, const LayoutTiled& right) {
+    for (unsigned int rank = 0; rank < ARRAY_LAYOUT_MAX_RANK; ++rank)
+      if (left.dimension[rank] != right.dimension[rank]) return false;
+    return true;
+  }
+
+  friend bool operator!=(const LayoutTiled& left, const LayoutTiled& right) {
+    return !(left == right);
+  }
 };
 
 }  // namespace Experimental


### PR DESCRIPTION
Fixes #4193.

`resize()` and `realloc` always create new objects even if the extents requested are the same as the container already has. In some way, this is a continuation of https://github.com/kokkos/kokkos/pull/916 that already does this optimization for `Kokkos::resize(Kokkos::View, ...)`.
However, I believe that we need to check `dynamic_rank` instead of `Rank` (or `rank`) since we only care about the dynamic extents anyway and comparing the static extents with the requested ones would always fail (if the static rank is greater than 0).
For `resize` we don't do anything if the extents already match but we call Kokkos::deep_copy for `realloc` to preserve the current behavior. This should of course change when we add the `AllocateWithoutInitializing` overloads.