### PR TITLE
DynRankView: Provide methods to present data as a flat View of requested rank

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -436,8 +436,6 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   KOKKOS_INLINE_FUNCTION
   const view_type& ConstDownCast() const { return (const view_type&)(*this); }
 
-  view_type as_view() const { return view_type(data(), layout()); }
-
   Kokkos::View<DataType, Properties...> as_view_0() const {
     if (rank() != 0) {
       Kokkos::Impl::throw_runtime_exception(

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -436,6 +436,47 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   KOKKOS_INLINE_FUNCTION
   const view_type& ConstDownCast() const { return (const view_type&)(*this); }
 
+  KOKKOS_INLINE_FUNCTION
+  view_type as_view() const { return view_type(data(), layout()); }
+
+  KOKKOS_INLINE_FUNCTION
+  Kokkos::View<DataType> as_view_0() const {
+    return Kokkos::View<DataType>(data());
+  }
+  KOKKOS_INLINE_FUNCTION
+  Kokkos::View<DataType*> as_view_1() const {
+    return Kokkos::View<DataType*>(data(), extent(0));
+  }
+  KOKKOS_INLINE_FUNCTION
+  Kokkos::View<DataType**> as_view_2() const {
+    return Kokkos::View<DataType**>(data(), extent(0), extent(1));
+  }
+  KOKKOS_INLINE_FUNCTION
+  Kokkos::View<DataType***> as_view_3() const {
+    return Kokkos::View<DataType***>(data(), extent(0), extent(1), extent(2));
+  }
+  KOKKOS_INLINE_FUNCTION
+  Kokkos::View<DataType****> as_view_4() const {
+    return Kokkos::View<DataType****>(data(), extent(0), extent(1), extent(2),
+                                      extent(3));
+  }
+  KOKKOS_INLINE_FUNCTION
+  Kokkos::View<DataType*****> as_view_5() const {
+    return Kokkos::View<DataType*****>(data(), extent(0), extent(1), extent(2),
+                                       extent(3), extent(4));
+  }
+  KOKKOS_INLINE_FUNCTION
+  Kokkos::View<DataType******> as_view_6() const {
+    return Kokkos::View<DataType******>(data(), extent(0), extent(1), extent(2),
+                                        extent(3), extent(4), extent(5));
+  }
+  KOKKOS_INLINE_FUNCTION
+  Kokkos::View<DataType*******> as_view_7() const {
+    return Kokkos::View<DataType*******>(data(), extent(0), extent(1),
+                                         extent(2), extent(3), extent(4),
+                                         extent(5), extent(6));
+  }
+
   // Types below - at least the HostMirror requires the value_type, NOT the rank
   // 7 data_type of the traits
 

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -436,10 +436,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   KOKKOS_INLINE_FUNCTION
   const view_type& ConstDownCast() const { return (const view_type&)(*this); }
 
-  KOKKOS_INLINE_FUNCTION
   view_type as_view() const { return view_type(data(), layout()); }
 
-  KOKKOS_INLINE_FUNCTION
   Kokkos::View<DataType, Properties...> as_view_0() const {
     if (rank() != 0) {
       Kokkos::Impl::throw_runtime_exception(
@@ -447,7 +445,6 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
     }
     return Kokkos::View<DataType, Properties...>(data(), layout());
   }
-  KOKKOS_INLINE_FUNCTION
   Kokkos::View<DataType*, Properties...> as_view_1() const {
     if (rank() != 1) {
       Kokkos::Impl::throw_runtime_exception(
@@ -455,7 +452,6 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
     }
     return Kokkos::View<DataType*, Properties...>(data(), layout());
   }
-  KOKKOS_INLINE_FUNCTION
   Kokkos::View<DataType**, Properties...> as_view_2() const {
     if (rank() != 2) {
       Kokkos::Impl::throw_runtime_exception(
@@ -463,7 +459,6 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
     }
     return Kokkos::View<DataType**, Properties...>(data(), layout());
   }
-  KOKKOS_INLINE_FUNCTION
   Kokkos::View<DataType***, Properties...> as_view_3() const {
     if (rank() != 3) {
       Kokkos::Impl::throw_runtime_exception(
@@ -471,7 +466,6 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
     }
     return Kokkos::View<DataType***, Properties...>(data(), layout());
   }
-  KOKKOS_INLINE_FUNCTION
   Kokkos::View<DataType****, Properties...> as_view_4() const {
     if (rank() != 4) {
       Kokkos::Impl::throw_runtime_exception(
@@ -479,7 +473,6 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
     }
     return Kokkos::View<DataType****, Properties...>(data(), layout());
   }
-  KOKKOS_INLINE_FUNCTION
   Kokkos::View<DataType*****, Properties...> as_view_5() const {
     if (rank() != 5) {
       Kokkos::Impl::throw_runtime_exception(
@@ -487,7 +480,6 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
     }
     return Kokkos::View<DataType*****, Properties...>(data(), layout());
   }
-  KOKKOS_INLINE_FUNCTION
   Kokkos::View<DataType******, Properties...> as_view_6() const {
     if (rank() != 6) {
       Kokkos::Impl::throw_runtime_exception(
@@ -495,7 +487,6 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
     }
     return Kokkos::View<DataType******, Properties...>(data(), layout());
   }
-  KOKKOS_INLINE_FUNCTION
   Kokkos::View<DataType*******, Properties...> as_view_7() const {
     if (rank() != 7) {
       Kokkos::Impl::throw_runtime_exception(

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -440,41 +440,68 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   view_type as_view() const { return view_type(data(), layout()); }
 
   KOKKOS_INLINE_FUNCTION
-  Kokkos::View<DataType> as_view_0() const {
-    return Kokkos::View<DataType>(data());
+  Kokkos::View<DataType, Properties...> as_view_0() const {
+    if (rank() != 0) {
+      Kokkos::Impl::throw_runtime_exception(
+          "Converting DynRankView to a View of mis-matched rank");
+    }
+    return Kokkos::View<DataType, Properties...>(data(), layout());
   }
   KOKKOS_INLINE_FUNCTION
-  Kokkos::View<DataType*> as_view_1() const {
-    return Kokkos::View<DataType*>(data(), extent(0));
+  Kokkos::View<DataType*, Properties...> as_view_1() const {
+    if (rank() != 1) {
+      Kokkos::Impl::throw_runtime_exception(
+          "Converting DynRankView to a View of mis-matched rank");
+    }
+    return Kokkos::View<DataType*, Properties...>(data(), layout());
   }
   KOKKOS_INLINE_FUNCTION
-  Kokkos::View<DataType**> as_view_2() const {
-    return Kokkos::View<DataType**>(data(), extent(0), extent(1));
+  Kokkos::View<DataType**, Properties...> as_view_2() const {
+    if (rank() != 2) {
+      Kokkos::Impl::throw_runtime_exception(
+          "Converting DynRankView to a View of mis-matched rank");
+    }
+    return Kokkos::View<DataType**, Properties...>(data(), layout());
   }
   KOKKOS_INLINE_FUNCTION
-  Kokkos::View<DataType***> as_view_3() const {
-    return Kokkos::View<DataType***>(data(), extent(0), extent(1), extent(2));
+  Kokkos::View<DataType***, Properties...> as_view_3() const {
+    if (rank() != 3) {
+      Kokkos::Impl::throw_runtime_exception(
+          "Converting DynRankView to a View of mis-matched rank");
+    }
+    return Kokkos::View<DataType***, Properties...>(data(), layout());
   }
   KOKKOS_INLINE_FUNCTION
-  Kokkos::View<DataType****> as_view_4() const {
-    return Kokkos::View<DataType****>(data(), extent(0), extent(1), extent(2),
-                                      extent(3));
+  Kokkos::View<DataType****, Properties...> as_view_4() const {
+    if (rank() != 4) {
+      Kokkos::Impl::throw_runtime_exception(
+          "Converting DynRankView to a View of mis-matched rank");
+    }
+    return Kokkos::View<DataType****, Properties...>(data(), layout());
   }
   KOKKOS_INLINE_FUNCTION
-  Kokkos::View<DataType*****> as_view_5() const {
-    return Kokkos::View<DataType*****>(data(), extent(0), extent(1), extent(2),
-                                       extent(3), extent(4));
+  Kokkos::View<DataType*****, Properties...> as_view_5() const {
+    if (rank() != 5) {
+      Kokkos::Impl::throw_runtime_exception(
+          "Converting DynRankView to a View of mis-matched rank");
+    }
+    return Kokkos::View<DataType*****, Properties...>(data(), layout());
   }
   KOKKOS_INLINE_FUNCTION
-  Kokkos::View<DataType******> as_view_6() const {
-    return Kokkos::View<DataType******>(data(), extent(0), extent(1), extent(2),
-                                        extent(3), extent(4), extent(5));
+  Kokkos::View<DataType******, Properties...> as_view_6() const {
+    if (rank() != 6) {
+      Kokkos::Impl::throw_runtime_exception(
+          "Converting DynRankView to a View of mis-matched rank");
+    }
+    return Kokkos::View<DataType******, Properties...>(data(), layout());
   }
   KOKKOS_INLINE_FUNCTION
-  Kokkos::View<DataType*******> as_view_7() const {
-    return Kokkos::View<DataType*******>(data(), extent(0), extent(1),
-                                         extent(2), extent(3), extent(4),
-                                         extent(5), extent(6));
+  Kokkos::View<DataType*******, Properties...> as_view_7() const {
+    if (rank() != 7) {
+      Kokkos::Impl::throw_runtime_exception(
+          "Converting DynRankView to a View of mis-matched rank");
+    }
+    return Kokkos::View<DataType*******, Properties...>(data(), layout());
   }
 
   // Types below - at least the HostMirror requires the value_type, NOT the rank

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -1154,7 +1154,7 @@ class TestDynViewAPI {
     // Error checking test
     bool mismatch_throws = false;
     try {
-      auto v_copy = d.as_view_0();
+      auto v_copy = d.as_view_2();
     } catch (...) {
       mismatch_throws = true;
     }

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -970,107 +970,134 @@ class TestDynViewAPI {
 
     // Rank 0
     View0 v0 = d.as_view_0();
-    // Assign values after calling as_view_0() function under test to ensure aliasing
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA (int) { d() = 13; });
+    // Assign values after calling as_view_0() function under test to ensure
+    // aliasing
+    Kokkos::parallel_for(
+        1, KOKKOS_LAMBDA(int) { d() = 13; });
     ASSERT_EQ(v0.size(), d.size());
     ASSERT_EQ(v0.data(), d.data());
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA (int) {
-	if (d() != v0()) error_flag() = 1;
-      });
+    Kokkos::parallel_for(
+        1, KOKKOS_LAMBDA(int) {
+          if (d() != v0()) error_flag() = 1;
+        });
     ASSERT_EQ(error_flag(), 0);
 
     // Rank 1
     Kokkos::resize(d, 1);
 
     View1 v1 = d.as_view_1();
-    Kokkos::parallel_for(d.extent(0),
-			 KOKKOS_LAMBDA (int i0) { d(i0) = i0; });
+    Kokkos::parallel_for(
+        d.extent(0), KOKKOS_LAMBDA(int i0) { d(i0) = i0; });
     for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v1.extent(rank), d.extent(rank));
     ASSERT_EQ(v1.data(), d.data());
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA (int i0) {
-	if (d(i0) != v1(i0)) error_flag() = 1;
-      });
+    Kokkos::parallel_for(
+        1, KOKKOS_LAMBDA(int i0) {
+          if (d(i0) != v1(i0)) error_flag() = 1;
+        });
     ASSERT_EQ(error_flag(), 0);
 
     // Rank 2
     Kokkos::resize(d, 1, 2);
 
-    auto policy2 = Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0}, {d.extent(0), d.extent(1)});
+    auto policy2 = Kokkos::MDRangePolicy<Kokkos::Rank<2>>(
+        {0, 0}, {d.extent(0), d.extent(1)});
 
     View2 v2 = d.as_view_2();
-    Kokkos::parallel_for(policy2,
-			 KOKKOS_LAMBDA (int i0, int i1) { d(i0, i1) = i0 + 10*i1; });
+    Kokkos::parallel_for(
+        policy2, KOKKOS_LAMBDA(int i0, int i1) { d(i0, i1) = i0 + 10 * i1; });
     for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v2.extent(rank), d.extent(rank));
     ASSERT_EQ(v2.data(), d.data());
-    Kokkos::parallel_for(policy2, KOKKOS_LAMBDA (int i0, int i1) {
-	if (d(i0,i1) != v2(i0,i1)) error_flag() = 1;
-      });
+    Kokkos::parallel_for(
+        policy2, KOKKOS_LAMBDA(int i0, int i1) {
+          if (d(i0, i1) != v2(i0, i1)) error_flag() = 1;
+        });
     ASSERT_EQ(error_flag(), 0);
 
     // Rank 3
     Kokkos::resize(d, 1, 2, 3);
 
-    auto policy3 = Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0}, {d.extent(0), d.extent(1), d.extent(2)});
+    auto policy3 = Kokkos::MDRangePolicy<Kokkos::Rank<3>>(
+        {0, 0, 0}, {d.extent(0), d.extent(1), d.extent(2)});
 
     View3 v3 = d.as_view_3();
-    Kokkos::parallel_for(policy3,
-			 KOKKOS_LAMBDA (int i0, int i1, int i2) { d(i0, i1, i2) = i0 + 10*i1 + 100*i2; });
+    Kokkos::parallel_for(
+        policy3, KOKKOS_LAMBDA(int i0, int i1, int i2) {
+          d(i0, i1, i2) = i0 + 10 * i1 + 100 * i2;
+        });
     for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v3.extent(rank), d.extent(rank));
     ASSERT_EQ(v3.data(), d.data());
-    Kokkos::parallel_for(policy3, KOKKOS_LAMBDA (int i0, int i1, int i2) {
-	if (d(i0,i1,i2) != v3(i0,i1,i2)) error_flag() = 1;
-      });
+    Kokkos::parallel_for(
+        policy3, KOKKOS_LAMBDA(int i0, int i1, int i2) {
+          if (d(i0, i1, i2) != v3(i0, i1, i2)) error_flag() = 1;
+        });
     ASSERT_EQ(error_flag(), 0);
 
     // Rank 4
     Kokkos::resize(d, 1, 2, 3, 4);
 
-    auto policy4 = Kokkos::MDRangePolicy<Kokkos::Rank<4>>({0,0,0,0}, {d.extent(0), d.extent(1), d.extent(2), d.extent(3)});
+    auto policy4 = Kokkos::MDRangePolicy<Kokkos::Rank<4>>(
+        {0, 0, 0, 0}, {d.extent(0), d.extent(1), d.extent(2), d.extent(3)});
 
     View4 v4 = d.as_view_4();
-    Kokkos::parallel_for(policy4,
-			 KOKKOS_LAMBDA (int i0, int i1, int i2, int i3) { d(i0, i1, i2, i3) = i0 + 10*i1 + 100*i2 + 1000*i3; });
+    Kokkos::parallel_for(
+        policy4, KOKKOS_LAMBDA(int i0, int i1, int i2, int i3) {
+          d(i0, i1, i2, i3) = i0 + 10 * i1 + 100 * i2 + 1000 * i3;
+        });
     for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v4.extent(rank), d.extent(rank));
     ASSERT_EQ(v4.data(), d.data());
-    Kokkos::parallel_for(policy4, KOKKOS_LAMBDA (int i0, int i1, int i2, int i3) {
-	if (d(i0,i1,i2,i3) != v4(i0,i1,i2,i3)) error_flag() = 1;
-      });
+    Kokkos::parallel_for(
+        policy4, KOKKOS_LAMBDA(int i0, int i1, int i2, int i3) {
+          if (d(i0, i1, i2, i3) != v4(i0, i1, i2, i3)) error_flag() = 1;
+        });
     ASSERT_EQ(error_flag(), 0);
 
     // Rank 5
     Kokkos::resize(d, 1, 2, 3, 4, 5);
 
-    auto policy5 = Kokkos::MDRangePolicy<Kokkos::Rank<5>>({0,0,0,0,0}, {d.extent(0), d.extent(1), d.extent(2), d.extent(3), d.extent(4)});
+    auto policy5 = Kokkos::MDRangePolicy<Kokkos::Rank<5>>(
+        {0, 0, 0, 0, 0},
+        {d.extent(0), d.extent(1), d.extent(2), d.extent(3), d.extent(4)});
 
     View5 v5 = d.as_view_5();
-    Kokkos::parallel_for(policy5,
-			 KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4) { d(i0, i1, i2, i3, i4) = i0 + 10*i1 + 100*i2 + 1000*i3 + 10000*i4; });
+    Kokkos::parallel_for(
+        policy5, KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4) {
+          d(i0, i1, i2, i3, i4) =
+              i0 + 10 * i1 + 100 * i2 + 1000 * i3 + 10000 * i4;
+        });
     for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v5.extent(rank), d.extent(rank));
     ASSERT_EQ(v5.data(), d.data());
-    Kokkos::parallel_for(policy5, KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4) {
-	if (d(i0,i1,i2,i3,i4) != v5(i0,i1,i2,i3,i4)) error_flag() = 1;
-      });
+    Kokkos::parallel_for(
+        policy5, KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4) {
+          if (d(i0, i1, i2, i3, i4) != v5(i0, i1, i2, i3, i4)) error_flag() = 1;
+        });
     ASSERT_EQ(error_flag(), 0);
 
     // Rank 6
     Kokkos::resize(d, 1, 2, 3, 4, 5, 6);
 
-    auto policy6 = Kokkos::MDRangePolicy<Kokkos::Rank<6>>({0,0,0,0,0,0}, {d.extent(0), d.extent(1), d.extent(2), d.extent(3), d.extent(4), d.extent(5)});
+    auto policy6 = Kokkos::MDRangePolicy<Kokkos::Rank<6>>(
+        {0, 0, 0, 0, 0, 0}, {d.extent(0), d.extent(1), d.extent(2), d.extent(3),
+                             d.extent(4), d.extent(5)});
 
     View6 v6 = d.as_view_6();
-    Kokkos::parallel_for(policy6,
-			 KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4, int i5) { d(i0, i1, i2, i3, i4, i5) = i0 + 10*i1 + 100*i2 + 1000*i3 + 10000*i4 + 100000*i5; });
+    Kokkos::parallel_for(
+        policy6, KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5) {
+          d(i0, i1, i2, i3, i4, i5) =
+              i0 + 10 * i1 + 100 * i2 + 1000 * i3 + 10000 * i4 + 100000 * i5;
+        });
     for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v6.extent(rank), d.extent(rank));
     ASSERT_EQ(v6.data(), d.data());
-    Kokkos::parallel_for(policy6, KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4, int i5) {
-	if (d(i0,i1,i2,i3,i4,i5) != v6(i0,i1,i2,i3,i4,i5)) error_flag() = 1;
-      });
+    Kokkos::parallel_for(
+        policy6, KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5) {
+          if (d(i0, i1, i2, i3, i4, i5) != v6(i0, i1, i2, i3, i4, i5))
+            error_flag() = 1;
+        });
     ASSERT_EQ(error_flag(), 0);
 
     // Rank 7
@@ -1078,17 +1105,28 @@ class TestDynViewAPI {
 
     // MDRangePolicy only accepts Rank < 7
 #if 0
-    auto policy7 = Kokkos::MDRangePolicy<Kokkos::Rank<7>>({0,0,0,0,0,0,0}, {d.extent(0), d.extent(1), d.extent(2), d.extent(3), d.extent(4), d.extent(5), d.extent(6)});
+    auto policy7 = Kokkos::MDRangePolicy<Kokkos::Rank<7>>(
+        {0, 0, 0, 0, 0, 0, 0},
+        {d.extent(0), d.extent(1), d.extent(2), d.extent(3), d.extent(4),
+         d.extent(5), d.extent(6)});
 
     View7 v7 = d.as_view_7();
-    Kokkos::parallel_for(policy7,
-			 KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4, int i5, int i6) { d(i0, i1, i2, i3, i4, i5, i6) = i0 + 10*i1 + 100*i2 + 1000*i3 + 10000*i4 + 100000*i5 + 1000000*i6; });
+    Kokkos::parallel_for(
+        policy7,
+        KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5, int i6) {
+          d(i0, i1, i2, i3, i4, i5, i6) = i0 + 10 * i1 + 100 * i2 + 1000 * i3 +
+                                          10000 * i4 + 100000 * i5 +
+                                          1000000 * i6;
+        });
     for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v7.extent(rank), d.extent(rank));
     ASSERT_EQ(v7.data(), d.data());
-    Kokkos::parallel_for(policy7, KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4, int i5, int i6) {
-	if (d(i0,i1,i2,i3,i4,i5,i6) != v7(i0,i1,i2,i3,i4,i5,i6)) error_flag() = 1;
-      });
+    Kokkos::parallel_for(
+        policy7,
+        KOKKOS_LAMBDA(int i0, int i1, int i2, int i3, int i4, int i5, int i6) {
+          if (d(i0, i1, i2, i3, i4, i5, i6) != v7(i0, i1, i2, i3, i4, i5, i6))
+            error_flag() = 1;
+        });
     ASSERT_EQ(error_flag(), 0);
 #endif
 
@@ -1096,7 +1134,7 @@ class TestDynViewAPI {
     bool mismatch_throws = false;
     try {
       v0 = d.as_view_0();
-    } catch(...) {
+    } catch (...) {
       mismatch_throws = true;
     }
     ASSERT_TRUE(mismatch_throws);
@@ -1221,7 +1259,7 @@ class TestDynViewAPI {
     hView0 hx, hy, hz;
 
     ASSERT_TRUE(Kokkos::is_dyn_rank_view<dView0>::value);
-    ASSERT_FALSE(Kokkos::is_dyn_rank_view<Kokkos::View<double> >::value);
+    ASSERT_FALSE(Kokkos::is_dyn_rank_view<Kokkos::View<double>>::value);
 
     ASSERT_EQ(dx.data(), nullptr);  // Okay with UVM
     ASSERT_EQ(dy.data(), nullptr);  // Okay with UVM

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -971,10 +971,10 @@ class TestDynViewAPI {
     // Rank 0
     View0 v0 = d.as_view_0();
     // Assign values after calling as_view_0() function under test to ensure aliasing
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA (int i) { d() = 13; });
+    Kokkos::parallel_for(1, KOKKOS_LAMBDA (int) { d() = 13; });
     ASSERT_EQ(v0.size(), d.size());
     ASSERT_EQ(v0.data(), d.data());
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA (int i) {
+    Kokkos::parallel_for(1, KOKKOS_LAMBDA (int) {
 	if (d() != v0()) error_flag() = 1;
       });
     ASSERT_EQ(error_flag(), 0);
@@ -985,7 +985,7 @@ class TestDynViewAPI {
     View1 v1 = d.as_view_1();
     Kokkos::parallel_for(d.extent(0),
 			 KOKKOS_LAMBDA (int i0) { d(i0) = i0; });
-    for (int rank = 0; rank < d.rank(); ++rank)
+    for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v1.extent(rank), d.extent(rank));
     ASSERT_EQ(v1.data(), d.data());
     Kokkos::parallel_for(1, KOKKOS_LAMBDA (int i0) {
@@ -1001,7 +1001,7 @@ class TestDynViewAPI {
     View2 v2 = d.as_view_2();
     Kokkos::parallel_for(policy2,
 			 KOKKOS_LAMBDA (int i0, int i1) { d(i0, i1) = i0 + 10*i1; });
-    for (int rank = 0; rank < d.rank(); ++rank)
+    for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v2.extent(rank), d.extent(rank));
     ASSERT_EQ(v2.data(), d.data());
     Kokkos::parallel_for(policy2, KOKKOS_LAMBDA (int i0, int i1) {
@@ -1017,7 +1017,7 @@ class TestDynViewAPI {
     View3 v3 = d.as_view_3();
     Kokkos::parallel_for(policy3,
 			 KOKKOS_LAMBDA (int i0, int i1, int i2) { d(i0, i1, i2) = i0 + 10*i1 + 100*i2; });
-    for (int rank = 0; rank < d.rank(); ++rank)
+    for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v3.extent(rank), d.extent(rank));
     ASSERT_EQ(v3.data(), d.data());
     Kokkos::parallel_for(policy3, KOKKOS_LAMBDA (int i0, int i1, int i2) {
@@ -1033,7 +1033,7 @@ class TestDynViewAPI {
     View4 v4 = d.as_view_4();
     Kokkos::parallel_for(policy4,
 			 KOKKOS_LAMBDA (int i0, int i1, int i2, int i3) { d(i0, i1, i2, i3) = i0 + 10*i1 + 100*i2 + 1000*i3; });
-    for (int rank = 0; rank < d.rank(); ++rank)
+    for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v4.extent(rank), d.extent(rank));
     ASSERT_EQ(v4.data(), d.data());
     Kokkos::parallel_for(policy4, KOKKOS_LAMBDA (int i0, int i1, int i2, int i3) {
@@ -1049,7 +1049,7 @@ class TestDynViewAPI {
     View5 v5 = d.as_view_5();
     Kokkos::parallel_for(policy5,
 			 KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4) { d(i0, i1, i2, i3, i4) = i0 + 10*i1 + 100*i2 + 1000*i3 + 10000*i4; });
-    for (int rank = 0; rank < d.rank(); ++rank)
+    for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v5.extent(rank), d.extent(rank));
     ASSERT_EQ(v5.data(), d.data());
     Kokkos::parallel_for(policy5, KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4) {
@@ -1065,7 +1065,7 @@ class TestDynViewAPI {
     View6 v6 = d.as_view_6();
     Kokkos::parallel_for(policy6,
 			 KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4, int i5) { d(i0, i1, i2, i3, i4, i5) = i0 + 10*i1 + 100*i2 + 1000*i3 + 10000*i4 + 100000*i5; });
-    for (int rank = 0; rank < d.rank(); ++rank)
+    for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v6.extent(rank), d.extent(rank));
     ASSERT_EQ(v6.data(), d.data());
     Kokkos::parallel_for(policy6, KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4, int i5) {
@@ -1083,7 +1083,7 @@ class TestDynViewAPI {
     View7 v7 = d.as_view_7();
     Kokkos::parallel_for(policy7,
 			 KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4, int i5, int i6) { d(i0, i1, i2, i3, i4, i5, i6) = i0 + 10*i1 + 100*i2 + 1000*i3 + 10000*i4 + 100000*i5 + 1000000*i6; });
-    for (int rank = 0; rank < d.rank(); ++rank)
+    for (unsigned int rank = 0; rank < d.rank(); ++rank)
       ASSERT_EQ(v7.extent(rank), d.extent(rank));
     ASSERT_EQ(v7.data(), d.data());
     Kokkos::parallel_for(policy7, KOKKOS_LAMBDA (int i0, int i1, int i2, int i3, int i4, int i5, int i6) {

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -965,7 +965,8 @@ class TestDynViewAPI {
   static void run_test_as_view() {
     Kokkos::View<int, Kokkos::HostSpace> error_flag_host("error_flag");
     error_flag_host() = 0;
-    auto error_flag = Kokkos::create_mirror_view_and_copy(DeviceType(), error_flag_host);
+    auto error_flag =
+        Kokkos::create_mirror_view_and_copy(DeviceType(), error_flag_host);
 
     dView0 d("d");
 
@@ -993,7 +994,8 @@ class TestDynViewAPI {
     // Rank 1
     Kokkos::resize(d, 1);
 
-    auto policy1 = Kokkos::RangePolicy<DeviceType>(DeviceType(), 0, d.extent(0));
+    auto policy1 =
+        Kokkos::RangePolicy<DeviceType>(DeviceType(), 0, d.extent(0));
 
     View1 v1 = d.as_view_1();
     Kokkos::parallel_for(
@@ -1145,9 +1147,9 @@ class TestDynViewAPI {
         });
     Kokkos::deep_copy(error_flag_host, error_flag);
     ASSERT_EQ(error_flag_host(), 0);
-#endif // MDRangePolict Rank < 7
+#endif  // MDRangePolict Rank < 7
 
-#endif // defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+#endif  // defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 
     // Error checking test
     bool mismatch_throws = false;

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -972,6 +972,14 @@ class TestDynViewAPI {
     View7 v7a = d.as_view();
     View7 v7b = d.as_view_7();
 
+    bool mismatch_throws = false;
+    try {
+      v0 = d.as_view_0();
+    } catch(...) {
+      mismatch_throws = true;
+    }
+    ASSERT_TRUE(mismatch_throws);
+
     ASSERT_EQ(v7a.extent(0), d.extent(0));
     ASSERT_EQ(v7a.extent(1), d.extent(1));
     ASSERT_EQ(v7a.extent(2), d.extent(2));

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -717,6 +717,7 @@ class TestDynViewAPI {
     run_test_subview();
     run_test_subview_strided();
     run_test_vector();
+    run_test_as_view();
   }
 
   static void run_operator_test_rank12345() {
@@ -954,6 +955,38 @@ class TestDynViewAPI {
       ASSERT_EQ(a_h.rank(), a_d.rank());
       ASSERT_EQ(a_org(5), a_h3(5));
     }
+  }
+
+  static void run_test_as_view() {
+    dView0 d("d", 5);
+
+    View1 v1 = d.as_view_1();
+    ASSERT_EQ(v1.extent(0), d.extent(0));
+
+    Kokkos::resize(d);  // 0-rank
+
+    View0 v0 = d.as_view_0();
+    ASSERT_EQ(v0.size(), d.size());
+
+    Kokkos::resize(d, 1, 2, 3, 4, 5, 6, 7);
+    View7 v7a = d.as_view();
+    View7 v7b = d.as_view_7();
+
+    ASSERT_EQ(v7a.extent(0), d.extent(0));
+    ASSERT_EQ(v7a.extent(1), d.extent(1));
+    ASSERT_EQ(v7a.extent(2), d.extent(2));
+    ASSERT_EQ(v7a.extent(3), d.extent(3));
+    ASSERT_EQ(v7a.extent(4), d.extent(4));
+    ASSERT_EQ(v7a.extent(5), d.extent(5));
+    ASSERT_EQ(v7a.extent(6), d.extent(6));
+
+    ASSERT_EQ(v7b.extent(0), d.extent(0));
+    ASSERT_EQ(v7b.extent(1), d.extent(1));
+    ASSERT_EQ(v7b.extent(2), d.extent(2));
+    ASSERT_EQ(v7b.extent(3), d.extent(3));
+    ASSERT_EQ(v7b.extent(4), d.extent(4));
+    ASSERT_EQ(v7b.extent(5), d.extent(5));
+    ASSERT_EQ(v7b.extent(6), d.extent(6));
   }
 
   static void run_test_scalar() {


### PR DESCRIPTION
This allows use of the standard 3-argument `deep_copy` of `View` arguments, rather than jumping through the hoops of #4059 to add such overloads directly for `DynRankView`