### PR TITLE
Fix a missing memory_fence for debug shared alloc code

### DIFF
--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -259,6 +259,9 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<
     while ((root_next = Kokkos::atomic_exchange(&arg_record->m_root->m_next,
                                                 zero)) == nullptr)
       ;
+    // We need a memory_fence() here so that the following update
+    // is properly sequenced
+    Kokkos::memory_fence();
 
     arg_record->m_next->m_prev = arg_record->m_prev;
 


### PR DESCRIPTION
Looks like there was a missing fence in the pure debug code
and that missing fence would make a SharedAlloc sanity check
fail on Power (and presumably ARM).

Fixes issue #4174