### PR TITLE
Don't use [[deprecated]] for nvcc

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -529,7 +529,7 @@
 #define KOKKOS_DEPRECATED_TRAILING_ATTRIBUTE
 #endif
 
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
+#if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS) && !defined(__NVCC__)
 #define KOKKOS_DEPRECATED [[deprecated]]
 #define KOKKOS_DEPRECATED_WITH_COMMENT(comment) [[deprecated(comment)]]
 #else


### PR DESCRIPTION
`nvcc` versions prior to 11.0 complain with
```
warning: attribute does not apply to any entity
```
and later versions don't print anything at all up on encountering `[[deprecated]]`, see https://godbolt.org/z/Ps61j17ah. To make the compiler output less verbose for older `nvcc` releases, this pull request simply disables `KOKKOS_DEPRECATED*` altogether.
