### PR TITLE
[HIP] Fix issue w/ static initialization of function attributes

### DIFF
--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -200,6 +200,8 @@ struct DeduceHIPLaunchMechanism {
                  : (default_launch_mechanism));
 };
 
+template <typename DriverType, typename LaunchBounds,
+          HIPLaunchMechanism LaunchMechanism>
 struct HIPParallelLaunchKernelFuncData {
   static unsigned int get_scratch_size(
       hipFuncAttributes const &hip_func_attributes) {
@@ -229,6 +231,9 @@ template <typename DriverType, unsigned int MaxThreadsPerBlock,
 struct HIPParallelLaunchKernelFunc<
     DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
     HIPLaunchMechanism::LocalMemory> {
+  using base_t = HIPParallelLaunchKernelFuncData<
+      DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
+      HIPLaunchMechanism::LocalMemory>;
   static auto get_kernel_func() {
     return hip_parallel_launch_local_memory<DriverType, MaxThreadsPerBlock,
                                             MinBlocksPerSM>;
@@ -237,12 +242,11 @@ struct HIPParallelLaunchKernelFunc<
   static constexpr auto default_launchbounds() { return false; }
 
   static auto get_scratch_size() {
-    return HIPParallelLaunchKernelFuncData::get_scratch_size(
-        get_hip_func_attributes());
+    return base_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return HIPParallelLaunchKernelFuncData::get_hip_func_attributes(
+    return base_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };
@@ -250,6 +254,9 @@ struct HIPParallelLaunchKernelFunc<
 template <typename DriverType>
 struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
                                    HIPLaunchMechanism::LocalMemory> {
+  using base_t =
+      HIPParallelLaunchKernelFuncData<DriverType, Kokkos::LaunchBounds<0, 0>,
+                                      HIPLaunchMechanism::LocalMemory>;
   static auto get_kernel_func() {
     return HIPParallelLaunchKernelFunc<
         DriverType, Kokkos::LaunchBounds<HIPTraits::MaxThreadsPerBlock, 1>,
@@ -259,12 +266,11 @@ struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
   static constexpr auto default_launchbounds() { return true; }
 
   static auto get_scratch_size() {
-    return HIPParallelLaunchKernelFuncData::get_scratch_size(
-        get_hip_func_attributes());
+    return base_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return HIPParallelLaunchKernelFuncData::get_hip_func_attributes(
+    return base_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };
@@ -275,6 +281,9 @@ template <typename DriverType, unsigned int MaxThreadsPerBlock,
 struct HIPParallelLaunchKernelFunc<
     DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
     HIPLaunchMechanism::GlobalMemory> {
+  using base_t = HIPParallelLaunchKernelFuncData<
+      DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
+      HIPLaunchMechanism::GlobalMemory>;
   static auto get_kernel_func() {
     return hip_parallel_launch_global_memory<DriverType, MaxThreadsPerBlock,
                                              MinBlocksPerSM>;
@@ -283,12 +292,11 @@ struct HIPParallelLaunchKernelFunc<
   static constexpr auto default_launchbounds() { return false; }
 
   static auto get_scratch_size() {
-    return HIPParallelLaunchKernelFuncData::get_scratch_size(
-        get_hip_func_attributes());
+    return base_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return HIPParallelLaunchKernelFuncData::get_hip_func_attributes(
+    return base_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };
@@ -296,6 +304,9 @@ struct HIPParallelLaunchKernelFunc<
 template <typename DriverType>
 struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
                                    HIPLaunchMechanism::GlobalMemory> {
+  using base_t =
+      HIPParallelLaunchKernelFuncData<DriverType, Kokkos::LaunchBounds<0, 0>,
+                                      HIPLaunchMechanism::GlobalMemory>;
   static auto get_kernel_func() {
     return hip_parallel_launch_global_memory<DriverType>;
   }
@@ -303,12 +314,11 @@ struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
   static constexpr auto default_launchbounds() { return true; }
 
   static auto get_scratch_size() {
-    return HIPParallelLaunchKernelFuncData::get_scratch_size(
-        get_hip_func_attributes());
+    return base_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return HIPParallelLaunchKernelFuncData::get_hip_func_attributes(
+    return base_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };
@@ -319,6 +329,9 @@ template <typename DriverType, unsigned int MaxThreadsPerBlock,
 struct HIPParallelLaunchKernelFunc<
     DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
     HIPLaunchMechanism::ConstantMemory> {
+  using base_t = HIPParallelLaunchKernelFuncData<
+      DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
+      HIPLaunchMechanism::ConstantMemory>;
   static auto get_kernel_func() {
     return hip_parallel_launch_constant_memory<DriverType, MaxThreadsPerBlock,
                                                MinBlocksPerSM>;
@@ -327,12 +340,11 @@ struct HIPParallelLaunchKernelFunc<
   static constexpr auto default_launchbounds() { return false; }
 
   static auto get_scratch_size() {
-    return HIPParallelLaunchKernelFuncData::get_scratch_size(
-        get_hip_func_attributes());
+    return base_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return HIPParallelLaunchKernelFuncData::get_hip_func_attributes(
+    return base_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };
@@ -340,18 +352,20 @@ struct HIPParallelLaunchKernelFunc<
 template <typename DriverType>
 struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
                                    HIPLaunchMechanism::ConstantMemory> {
+  using base_t =
+      HIPParallelLaunchKernelFuncData<DriverType, Kokkos::LaunchBounds<0, 0>,
+                                      HIPLaunchMechanism::ConstantMemory>;
   static auto get_kernel_func() {
     return hip_parallel_launch_constant_memory<DriverType>;
   }
   static constexpr auto default_launchbounds() { return true; }
 
   static auto get_scratch_size() {
-    return HIPParallelLaunchKernelFuncData::get_scratch_size(
-        get_hip_func_attributes());
+    return base_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return HIPParallelLaunchKernelFuncData::get_hip_func_attributes(
+    return base_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -231,7 +231,7 @@ template <typename DriverType, unsigned int MaxThreadsPerBlock,
 struct HIPParallelLaunchKernelFunc<
     DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
     HIPLaunchMechanism::LocalMemory> {
-  using base_t = HIPParallelLaunchKernelFuncData<
+  using funcdata_t = HIPParallelLaunchKernelFuncData<
       DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
       HIPLaunchMechanism::LocalMemory>;
   static auto get_kernel_func() {
@@ -242,11 +242,11 @@ struct HIPParallelLaunchKernelFunc<
   static constexpr auto default_launchbounds() { return false; }
 
   static auto get_scratch_size() {
-    return base_t::get_scratch_size(get_hip_func_attributes());
+    return funcdata_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return base_t::get_hip_func_attributes(
+    return funcdata_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };
@@ -254,7 +254,7 @@ struct HIPParallelLaunchKernelFunc<
 template <typename DriverType>
 struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
                                    HIPLaunchMechanism::LocalMemory> {
-  using base_t =
+  using funcdata_t =
       HIPParallelLaunchKernelFuncData<DriverType, Kokkos::LaunchBounds<0, 0>,
                                       HIPLaunchMechanism::LocalMemory>;
   static auto get_kernel_func() {
@@ -266,11 +266,11 @@ struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
   static constexpr auto default_launchbounds() { return true; }
 
   static auto get_scratch_size() {
-    return base_t::get_scratch_size(get_hip_func_attributes());
+    return funcdata_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return base_t::get_hip_func_attributes(
+    return funcdata_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };
@@ -281,7 +281,7 @@ template <typename DriverType, unsigned int MaxThreadsPerBlock,
 struct HIPParallelLaunchKernelFunc<
     DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
     HIPLaunchMechanism::GlobalMemory> {
-  using base_t = HIPParallelLaunchKernelFuncData<
+  using funcdata_t = HIPParallelLaunchKernelFuncData<
       DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
       HIPLaunchMechanism::GlobalMemory>;
   static auto get_kernel_func() {
@@ -292,11 +292,11 @@ struct HIPParallelLaunchKernelFunc<
   static constexpr auto default_launchbounds() { return false; }
 
   static auto get_scratch_size() {
-    return base_t::get_scratch_size(get_hip_func_attributes());
+    return funcdata_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return base_t::get_hip_func_attributes(
+    return funcdata_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };
@@ -304,7 +304,7 @@ struct HIPParallelLaunchKernelFunc<
 template <typename DriverType>
 struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
                                    HIPLaunchMechanism::GlobalMemory> {
-  using base_t =
+  using funcdata_t =
       HIPParallelLaunchKernelFuncData<DriverType, Kokkos::LaunchBounds<0, 0>,
                                       HIPLaunchMechanism::GlobalMemory>;
   static auto get_kernel_func() {
@@ -314,11 +314,11 @@ struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
   static constexpr auto default_launchbounds() { return true; }
 
   static auto get_scratch_size() {
-    return base_t::get_scratch_size(get_hip_func_attributes());
+    return funcdata_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return base_t::get_hip_func_attributes(
+    return funcdata_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };
@@ -329,7 +329,7 @@ template <typename DriverType, unsigned int MaxThreadsPerBlock,
 struct HIPParallelLaunchKernelFunc<
     DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
     HIPLaunchMechanism::ConstantMemory> {
-  using base_t = HIPParallelLaunchKernelFuncData<
+  using funcdata_t = HIPParallelLaunchKernelFuncData<
       DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
       HIPLaunchMechanism::ConstantMemory>;
   static auto get_kernel_func() {
@@ -340,11 +340,11 @@ struct HIPParallelLaunchKernelFunc<
   static constexpr auto default_launchbounds() { return false; }
 
   static auto get_scratch_size() {
-    return base_t::get_scratch_size(get_hip_func_attributes());
+    return funcdata_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return base_t::get_hip_func_attributes(
+    return funcdata_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };
@@ -352,7 +352,7 @@ struct HIPParallelLaunchKernelFunc<
 template <typename DriverType>
 struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
                                    HIPLaunchMechanism::ConstantMemory> {
-  using base_t =
+  using funcdata_t =
       HIPParallelLaunchKernelFuncData<DriverType, Kokkos::LaunchBounds<0, 0>,
                                       HIPLaunchMechanism::ConstantMemory>;
   static auto get_kernel_func() {
@@ -361,11 +361,11 @@ struct HIPParallelLaunchKernelFunc<DriverType, Kokkos::LaunchBounds<0, 0>,
   static constexpr auto default_launchbounds() { return true; }
 
   static auto get_scratch_size() {
-    return base_t::get_scratch_size(get_hip_func_attributes());
+    return funcdata_t::get_scratch_size(get_hip_func_attributes());
   }
 
   static hipFuncAttributes get_hip_func_attributes() {
-    return base_t::get_hip_func_attributes(
+    return funcdata_t::get_hip_func_attributes(
         reinterpret_cast<void const *>(get_kernel_func()));
   }
 };

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -564,6 +564,7 @@ if(Kokkos_ENABLE_HIP)
       hip/TestHIPHostPinned_ViewMapping_b.cpp
       hip/TestHIPHostPinned_ViewMapping_subview.cpp
       hip/TestHIP_AsyncLauncher.cpp
+      hip/TestHIP_BlocksizeDeduction.cpp
   )
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_HIPInterOpInit

--- a/core/unit_test/hip/TestHIP_BlocksizeDeduction.cpp
+++ b/core/unit_test/hip/TestHIP_BlocksizeDeduction.cpp
@@ -1,0 +1,99 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+#include <TestHIP_Category.hpp>
+
+namespace Test {
+
+struct TestNone {
+  Kokkos::View<size_t*, TEST_EXECSPACE> view;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i) const { view(i) = i; }
+
+  TestNone() { view = Kokkos::View<size_t*, TEST_EXECSPACE>("dummy", 1); }
+};
+
+struct TestSpiller {
+  Kokkos::View<size_t*, TEST_EXECSPACE> view;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i) const {
+    size_t array[1000] = {0};
+    // and update flag
+    size_t value = 0;
+    for (int ii = i; ii < 1000; ++ii) {
+      array[ii] = value;
+      value += ii;
+    }
+    for (int ii = i; ii < 1000; ++ii) {
+      value *= array[ii];
+    }
+    Kokkos::atomic_add(&view[0], value);
+  }
+
+  TestSpiller() { view = Kokkos::View<size_t*, TEST_EXECSPACE>("dummy", 1); }
+};
+
+TEST(hip, preferred_blocksize_deduction) {
+  using execution_space =
+      typename Kokkos::Impl::FunctorPolicyExecutionSpace<TestSpiller,
+                                                         void>::execution_space;
+  using policy = Kokkos::RangePolicy<execution_space>;
+
+  {
+    using DriverType = Kokkos::Impl::ParallelFor<TestNone, policy>;
+    ASSERT_TRUE(Kokkos::Experimental::Impl::HIPParallelLaunch<
+                    DriverType>::get_scratch_size() == 0);
+  }
+
+  {
+    using DriverType = Kokkos::Impl::ParallelFor<TestSpiller, policy>;
+    ASSERT_TRUE(Kokkos::Experimental::Impl::HIPParallelLaunch<
+                    DriverType>::get_scratch_size() > 0);
+  }
+}
+
+}  // namespace Test


### PR DESCRIPTION
Fix issue w/ static initialization of function attributes on unspecialized type and add test.

This was a fun one to debug.  Basically, on line 214 (https://github.com/kokkos/kokkos/compare/develop...arghdos:fix_launch_mechs?expand=1#diff-078df6e850082d467d9c91f0888ce3b7b5f5f0fcde51bc91a00845ec6dd9bfb0R214), we use a static initialization of the function attributes to "cache" them.  However, this means that we will only get the function attributes for first kernel function pointer passed in.  This means that on subsequent calls we will get (e.g.,) incorrect `localSizeBytes`, which results in an incorrect launch bound determination at runtime. 