### PR TITLE
Kokkos_Cuda.hpp: Fix shadow warning with cuda/11.0

### DIFF
--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -279,12 +279,13 @@ class CudaSpaceInitializer : public ExecSpaceInitializerBase {
 
 template <class DT, class... DP>
 struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
-  ZeroMemset(const Kokkos::Cuda& exec_space, const View<DT, DP...>& dst,
+  ZeroMemset(const Kokkos::Cuda& exec_space_instance,
+             const View<DT, DP...>& dst,
              typename View<DT, DP...>::const_value_type&) {
     CUDA_SAFE_CALL(cudaMemsetAsync(
         dst.data(), 0,
         dst.size() * sizeof(typename View<DT, DP...>::value_type),
-        exec_space.cuda_stream()));
+        exec_space_instance.cuda_stream()));
   }
 
   ZeroMemset(const View<DT, DP...>& dst,


### PR DESCRIPTION
The shadow warning triggered -Werror compilation errors in cuda/11.0 nightly builds for example with configuration:
```
$KOKKOS_PATH/generate_makefile.bash --with-devices=Cuda,Serial --arch=SNB,Volta70 --compiler=$KOKKOS_PATH/bin/nvcc_wrapper --cxxflags="-O3 -Wall -Wunused-parameter -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wuninitialized " --cxxstandard="17" --kokkos-path=$KOKKOS_PATH --with-cuda-options=enable_lambda  --no-examples
```