### PR TITLE
Silence warnings about dynamic class in memcpy for HIP launch

### DIFF
--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -435,7 +435,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
     // Copy functor (synchronously) to staging buffer in pinned host memory
     unsigned long *staging = hip_instance->constantMemHostStaging;
-    memcpy(staging, driver, sizeof(DriverType));
+    std::memcpy((void *)staging, (void *)driver, sizeof(DriverType));
 
     // Copy functor asynchronously from there to constant memory on the device
     KOKKOS_IMPL_HIP_SAFE_CALL(hipMemcpyToSymbolAsync(


### PR DESCRIPTION
Silences warnings to the effect of:

>./lammps/lib/kokkos/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp:437:21: warning: source of this 'memcpy' call is a pointer to class containing a dynamic class 'PairZBLKokkos<Kokkos::Serial>'; vtable pointer will be copied [-Wdynamic-class-memaccess]

and brings it into alignment w/ the memcpy that happens below in the non-constant launcher.

Change-Id: I71615caccaf2bb08c77cb8c258b82fdd0d4e7d63