### PR TITLE
Label all SYCL fences

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -132,15 +132,15 @@ void SYCLInternal::initialize(const sycl::queue& q) {
           Kokkos::Experimental::SYCLDeviceUSMSpace, void>;
       Record* const r =
           Record::allocate(Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
-                           "Kokkos::SYCL::InternalScratchBitset",
+                           "Kokkos::Experimental::SYCL::InternalScratchBitset",
                            sizeof(uint32_t) * buffer_bound);
       Record::increment(r);
       m_scratchConcurrentBitset = reinterpret_cast<uint32_t*>(r->data());
       auto event                = m_queue->memset(m_scratchConcurrentBitset, 0,
                                    sizeof(uint32_t) * buffer_bound);
       fence(event,
-            "SYCLInternal::initialize: fence after initializing "
-            "m_scratchConcurrentBitset",
+            "Kokkos::Experimental::SYCLInternal::initialize: fence after "
+            "initializing m_scratchConcurrentBitset",
             m_instance_id);
     }
 
@@ -168,7 +168,7 @@ void* SYCLInternal::resize_team_scratch_space(std::int64_t bytes,
     m_team_scratch_current_size = bytes;
     m_team_scratch_ptr =
         Kokkos::kokkos_malloc<Experimental::SYCLDeviceUSMSpace>(
-            "Kokkos::SYCLDeviceUSMSpace::TeamScratchMemory",
+            "Kokkos::Experimental::SYCLDeviceUSMSpace::TeamScratchMemory",
             m_team_scratch_current_size);
   }
   if ((bytes > m_team_scratch_current_size) ||
@@ -233,7 +233,7 @@ void* SYCLInternal::scratch_space(
 
     Record* const r =
         Record::allocate(Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
-                         "Kokkos::SYCL::InternalScratchSpace",
+                         "Kokkos::Experimental::SYCL::InternalScratchSpace",
                          (sizeScratchGrain * m_scratchSpaceCount));
 
     Record::increment(r);
@@ -260,7 +260,7 @@ void* SYCLInternal::scratch_flags(
 
     Record* const r =
         Record::allocate(Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
-                         "Kokkos::SYCL::InternalScratchFlags",
+                         "Kokkos::Experimental::SYCL::InternalScratchFlags",
                          (sizeScratchGrain * m_scratchFlagsCount));
 
     Record::increment(r);
@@ -269,7 +269,8 @@ void* SYCLInternal::scratch_flags(
   }
   m_queue->memset(m_scratchFlags, 0, m_scratchFlagsCount * sizeScratchGrain);
   fence(*m_queue,
-        "SYCLInternal::scratch_flags fence after initializing m_scratchFlags",
+        "Kokkos::Experimental::SYCLInternal::scratch_flags fence after "
+        "initializing m_scratchFlags",
         m_instance_id);
 
   return m_scratchFlags;
@@ -285,8 +286,8 @@ size_t SYCLInternal::USMObjectMem<Kind>::reserve(size_t n) {
     // First free what we have (in case malloc can reuse it)
     if (m_data) Record::decrement(Record::get_record(m_data));
 
-    Record* const r = Record::allocate(AllocationSpace(*m_q),
-                                       "Kokkos::SYCL::USMObjectMem", n);
+    Record* const r = Record::allocate(
+        AllocationSpace(*m_q), "Kokkos::Experimental::SYCL::USMObjectMem", n);
     Record::increment(r);
 
     m_data     = r->data();

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -138,13 +138,16 @@ void SYCLInternal::initialize(const sycl::queue& q) {
       m_scratchConcurrentBitset = reinterpret_cast<uint32_t*>(r->data());
       auto event                = m_queue->memset(m_scratchConcurrentBitset, 0,
                                    sizeof(uint32_t) * buffer_bound);
-      fence(event);
+      fence(event,
+            "SYCLInternal::initialize: fence after initializing "
+            "m_scratchConcurrentBitset",
+            m_instance_id);
     }
 
     m_maxShmemPerBlock =
         d.template get_info<sycl::info::device::local_mem_size>();
-    m_indirectKernelMem.reset(*m_queue);
-    m_indirectReducerMem.reset(*m_queue);
+    m_indirectKernelMem.reset(*m_queue, m_instance_id);
+    m_indirectReducerMem.reset(*m_queue, m_instance_id);
   } else {
     std::ostringstream msg;
     msg << "Kokkos::Experimental::SYCL::initialize(...) FAILED";
@@ -265,7 +268,9 @@ void* SYCLInternal::scratch_flags(
     m_scratchFlags = reinterpret_cast<size_type*>(r->data());
   }
   m_queue->memset(m_scratchFlags, 0, m_scratchFlagsCount * sizeScratchGrain);
-  fence(*m_queue);
+  fence(*m_queue,
+        "SYCLInternal::scratch_flags fence after initializing m_scratchFlags",
+        m_instance_id);
 
   return m_scratchFlags;
 }

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -146,7 +146,8 @@ class SYCLInternal {
     T* memcpy_from(const T& t) {
       reserve(sizeof(T));
       sycl::event memcopied = m_q->memcpy(m_data, std::addressof(t), sizeof(T));
-      fence(memcopied, "SYCLInternal::USMObject fence after copy",
+      fence(memcopied,
+            "Kokkos::Experimental::SYCLInternal::USMObject fence after copy",
             m_instance_id);
 
       m_size = sizeof(T);
@@ -181,7 +182,8 @@ class SYCLInternal {
     template <typename T>
     T& copy_from(const T& t) {
       fence(m_last_event,
-            "SYCLInternal::USMObject fence to wait for last event to finish",
+            "Kokkos::Experimental::SYCLInternal::USMObject fence to wait for "
+            "last event to finish",
             m_instance_id);
       m_size = 0;
       if constexpr (sycl::usm::alloc::device == Kind)
@@ -197,7 +199,8 @@ class SYCLInternal {
       assert(sizeof(T) == m_size);
 
       sycl::event memcopied = m_q->memcpy(std::addressof(t), m_data, sizeof(T));
-      fence(memcopied, "SYCLInternal::USMObject fence after copy",
+      fence(memcopied,
+            "Kokkos::Experimental::SYCLInternal::USMObject fence after copy",
             m_instance_id);
 
       return t;

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -291,21 +291,7 @@ class SYCLInternal {
   // (sycl::event and sycl::queue)
   template <typename WAT>
   static void fence_helper(WAT& wat, const std::string& name,
-                           uint32_t instance_id) {
-    Kokkos::Tools::Experimental::Impl::profile_fence_event<
-        Kokkos::Experimental::SYCL>(
-        name,
-        Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{instance_id},
-        [&]() {
-          try {
-            wat.wait_and_throw();
-          } catch (sycl::exception const& e) {
-            Kokkos::Impl::throw_runtime_exception(
-                std::string("There was a synchronous SYCL error:\n") +=
-                e.what());
-          }
-        });
-  }
+                           uint32_t instance_id);
 
  public:
   static void fence(sycl::queue& q, const std::string& name,

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -104,12 +104,14 @@ class SYCLInternal {
    public:
     void reset();
 
-    void reset(sycl::queue q) {
+    void reset(sycl::queue q, uint32_t instance_id) {
+      m_instance_id = instance_id;
       reset();
       m_q.emplace(std::move(q));
     }
     USMObjectMem() = default;
-    explicit USMObjectMem(sycl::queue q) noexcept : m_q(std::move(q)) {}
+    explicit USMObjectMem(sycl::queue q, uint32_t instance_id) noexcept
+        : m_q(std::move(q)), m_instance_id(instance_id) {}
 
     USMObjectMem(USMObjectMem const&) = delete;
     USMObjectMem(USMObjectMem&&)      = delete;
@@ -144,7 +146,8 @@ class SYCLInternal {
     T* memcpy_from(const T& t) {
       reserve(sizeof(T));
       sycl::event memcopied = m_q->memcpy(m_data, std::addressof(t), sizeof(T));
-      fence(memcopied);
+      fence(memcopied, "SYCLInternal::USMObject fence after copy",
+            m_instance_id);
 
       m_size = sizeof(T);
       return reinterpret_cast<T*>(m_data);
@@ -177,7 +180,9 @@ class SYCLInternal {
     // reference to the copied object.
     template <typename T>
     T& copy_from(const T& t) {
-      fence(m_last_event);
+      fence(m_last_event,
+            "SYCLInternal::USMObject fence to wait for last event to finish",
+            m_instance_id);
       m_size = 0;
       if constexpr (sycl::usm::alloc::device == Kind)
         return *memcpy_from(t);
@@ -192,7 +197,8 @@ class SYCLInternal {
       assert(sizeof(T) == m_size);
 
       sycl::event memcopied = m_q->memcpy(std::addressof(t), m_data, sizeof(T));
-      fence(memcopied);
+      fence(memcopied, "SYCLInternal::USMObject fence after copy",
+            m_instance_id);
 
       return t;
     }
@@ -250,6 +256,8 @@ class SYCLInternal {
     size_t m_size     = 0;  // sizeof(T) iff m_data points to live T
     size_t m_capacity = 0;
     sycl::event m_last_event;
+
+    uint32_t m_instance_id;
   };
 
   // An indirect kernel is one where the functor to be executed is explicitly
@@ -279,18 +287,32 @@ class SYCLInternal {
   // fence(...) takes any type with a .wait_and_throw() method
   // (sycl::event and sycl::queue)
   template <typename WAT>
-  static void fence_helper(WAT& wat) {
-    try {
-      wat.wait_and_throw();
-    } catch (sycl::exception const& e) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("There was a synchronous SYCL error:\n") += e.what());
-    }
+  static void fence_helper(WAT& wat, const std::string& name,
+                           uint32_t instance_id) {
+    Kokkos::Tools::Experimental::Impl::profile_fence_event<
+        Kokkos::Experimental::SYCL>(
+        name,
+        Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{instance_id},
+        [&]() {
+          try {
+            wat.wait_and_throw();
+          } catch (sycl::exception const& e) {
+            Kokkos::Impl::throw_runtime_exception(
+                std::string("There was a synchronous SYCL error:\n") +=
+                e.what());
+          }
+        });
   }
 
  public:
-  static void fence(sycl::queue& q) { fence_helper(q); }
-  static void fence(sycl::event& e) { fence_helper(e); }
+  static void fence(sycl::queue& q, const std::string& name,
+                    uint32_t instance_id) {
+    fence_helper(q, name, instance_id);
+  }
+  static void fence(sycl::event& e, const std::string& name,
+                    uint32_t instance_id) {
+    fence_helper(e, name, instance_id);
+  }
 };
 
 template <typename Functor, typename Storage,

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -59,10 +59,8 @@ namespace Impl {
 
 void DeepCopySYCL(void* dst, const void* src, size_t n) {
   Experimental::SYCL().fence("Kokkos::Impl::DeepCopySYCL: fence before memcpy");
-  auto event = Experimental::Impl::SYCLInternal::singleton().m_queue->memcpy(
-      dst, src, n);
-  // FIXME_SYCL This fence is unnamed
-  Experimental::Impl::SYCLInternal::fence(event);
+  Experimental::Impl::SYCLInternal::singleton().m_queue->memcpy(dst, src, n);
+  Experimental::SYCL().fence("Kokkos::Impl::DeepCopySYCL: fence after memcpy");
 }
 
 void DeepCopyAsyncSYCL(const Kokkos::Experimental::SYCL& instance, void* dst,
@@ -71,10 +69,9 @@ void DeepCopyAsyncSYCL(const Kokkos::Experimental::SYCL& instance, void* dst,
 }
 
 void DeepCopyAsyncSYCL(void* dst, const void* src, size_t n) {
-  auto event = Experimental::Impl::SYCLInternal::singleton().m_queue->memcpy(
-      dst, src, n);
-  // FIXME_SYCL This fence is unnamed
-  Experimental::Impl::SYCLInternal::fence(event);
+  Experimental::Impl::SYCLInternal::singleton().m_queue->memcpy(dst, src, n);
+  Experimental::SYCL().fence(
+      "Kokkos::Impl::DeepCopyAsyncSYCL: fence after memcpy");
 }
 
 }  // namespace Impl

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -109,8 +109,8 @@ class SYCLTeamMember {
   template <class ValueType>
   KOKKOS_INLINE_FUNCTION void team_broadcast(ValueType& val,
                                              const int thread_id) const {
-    val = sycl::group_broadcast(m_item.get_group(), val,
-                                sycl::id<2>(thread_id, 0));
+    val = sycl::ONEAPI::broadcast(m_item.get_group(), val,
+                                  sycl::id<2>(thread_id, 0));
   }
 
   template <class Closure, class ValueType>

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -109,8 +109,8 @@ class SYCLTeamMember {
   template <class ValueType>
   KOKKOS_INLINE_FUNCTION void team_broadcast(ValueType& val,
                                              const int thread_id) const {
-    val = sycl::ONEAPI::broadcast(m_item.get_group(), val,
-                                  sycl::id<2>(thread_id, 0));
+    val = sycl::group_broadcast(m_item.get_group(), val,
+                                sycl::id<2>(thread_id, 0));
   }
 
   template <class Closure, class ValueType>


### PR DESCRIPTION
Previously, the final level calling `fence` functions for `SYCL` didn't have labels. This pull request shifts the respective `Profiling` calls down. 
This requires that `USMObjectMem` needs another identifier for the `instance_id` to report its fences. Also, the static fence can't really use the lowest level function anymore since we don't store the instance id with the `queues`. I decided to just copy the fence implementation for this case duplicating a few lines of code. Note that this case was treated in the `Profiling` interface separately already.

I also noticed that we use `Kokkos::SYCL` or `Kokkos::Experimental::SYCL` rather inconsistently in strings so I went for the latter everywhere since the majority of cases already used `Kokkos::Experimental::SYCL`.