### PR TITLE
Fixes constexpr errors with frounding-math on gcc < 10.

### DIFF
--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -51,7 +51,6 @@
 #include <cmath>
 #include <cstdint>
 #include <type_traits>
-#include <limits>
 
 namespace Kokkos {
 namespace Experimental {
@@ -142,9 +141,9 @@ template <> struct digits_helper<double> { static constexpr int value = DBL_MANT
 template <> struct digits_helper<long double> { static constexpr int value = LDBL_MANT_DIG; };
 template <class> struct digits10_helper {};
 template <> struct digits10_helper<bool> { static constexpr int value = 0; };
-
+constexpr double log10_2 = 8*643L/2136; // The fraction 643/2136 approximates log10(2) to 7 significant digits. Follows gcc impl
 #define DIGITS10_HELPER_INTEGRAL(TYPE) \
-template <> struct digits10_helper<TYPE> { static constexpr int value = std::numeric_limits<TYPE>::digits10; };
+template <> struct digits10_helper<TYPE> { static constexpr int value = digits_helper<TYPE>::value * log10_2; };
 DIGITS10_HELPER_INTEGRAL(char)
 DIGITS10_HELPER_INTEGRAL(signed char)
 DIGITS10_HELPER_INTEGRAL(unsigned char)

--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -141,7 +141,7 @@ template <> struct digits_helper<double> { static constexpr int value = DBL_MANT
 template <> struct digits_helper<long double> { static constexpr int value = LDBL_MANT_DIG; };
 template <class> struct digits10_helper {};
 template <> struct digits10_helper<bool> { static constexpr int value = 0; };
-constexpr double log10_2 = 8*643L/2136; // The fraction 643/2136 approximates log10(2) to 7 significant digits. Follows gcc impl
+constexpr int log10_2 = 8*643L/2136; // The fraction 643/2136 approximates log10(2) to 7 significant digits. Follows gcc impl
 #define DIGITS10_HELPER_INTEGRAL(TYPE) \
 template <> struct digits10_helper<TYPE> { static constexpr int value = digits_helper<TYPE>::value * log10_2; };
 DIGITS10_HELPER_INTEGRAL(char)

--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -141,7 +141,7 @@ template <> struct digits_helper<double> { static constexpr int value = DBL_MANT
 template <> struct digits_helper<long double> { static constexpr int value = LDBL_MANT_DIG; };
 template <class> struct digits10_helper {};
 template <> struct digits10_helper<bool> { static constexpr int value = 0; };
-constexpr int log10_2 = 8*643L/2136; // The fraction 643/2136 approximates log10(2) to 7 significant digits. Follows gcc impl
+constexpr double log10_2 = 2.41;
 #define DIGITS10_HELPER_INTEGRAL(TYPE) \
 template <> struct digits10_helper<TYPE> { static constexpr int value = digits_helper<TYPE>::value * log10_2; };
 DIGITS10_HELPER_INTEGRAL(char)

--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -51,6 +51,7 @@
 #include <cmath>
 #include <cstdint>
 #include <type_traits>
+#include <limits>
 
 namespace Kokkos {
 namespace Experimental {
@@ -141,9 +142,9 @@ template <> struct digits_helper<double> { static constexpr int value = DBL_MANT
 template <> struct digits_helper<long double> { static constexpr int value = LDBL_MANT_DIG; };
 template <class> struct digits10_helper {};
 template <> struct digits10_helper<bool> { static constexpr int value = 0; };
-constexpr double log10_2 = 2.41;
+
 #define DIGITS10_HELPER_INTEGRAL(TYPE) \
-template <> struct digits10_helper<TYPE> { static constexpr int value = digits_helper<TYPE>::value * log10_2; };
+template <> struct digits10_helper<TYPE> { static constexpr int value = std::numeric_limits<TYPE>::digits10; };
 DIGITS10_HELPER_INTEGRAL(char)
 DIGITS10_HELPER_INTEGRAL(signed char)
 DIGITS10_HELPER_INTEGRAL(unsigned char)

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -310,7 +310,7 @@ class MultidimensionalSparseTuningProblem {
   // Not declared as static constexpr to work around the following compiler bug
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96862
   // where a floating-point expression cannot be constexpr under -frounding-math
-  double const tuning_step = tuning_max / max_space_dimension_size;
+  double tuning_step = tuning_max / max_space_dimension_size;
 
   using StoredProblemSpace =
       typename Impl::MapTypeConverter<ProblemSpaceInput>::type;

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -306,7 +306,7 @@ class MultidimensionalSparseTuningProblem {
   static constexpr size_t max_space_dimension_size = MaxDimensionSize;
   static constexpr double tuning_min               = 0.0;
   static constexpr double tuning_max               = 0.999;
-  double tuning_step = tuning_max / max_space_dimension_size;
+  double const tuning_step = tuning_max / max_space_dimension_size;
 
   using StoredProblemSpace =
       typename Impl::MapTypeConverter<ProblemSpaceInput>::type;

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -306,6 +306,10 @@ class MultidimensionalSparseTuningProblem {
   static constexpr size_t max_space_dimension_size = MaxDimensionSize;
   static constexpr double tuning_min               = 0.0;
   static constexpr double tuning_max               = 0.999;
+
+  // Not declared as static constexpr to work around the following compiler bug
+  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96862
+  // where a floating-point expression cannot be constexpr under -frounding-math
   double const tuning_step = tuning_max / max_space_dimension_size;
 
   using StoredProblemSpace =

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -306,7 +306,7 @@ class MultidimensionalSparseTuningProblem {
   static constexpr size_t max_space_dimension_size = MaxDimensionSize;
   static constexpr double tuning_min               = 0.0;
   static constexpr double tuning_max               = 0.999;
-  static constexpr double tuning_step = tuning_max / max_space_dimension_size;
+  double tuning_step = tuning_max / max_space_dimension_size;
 
   using StoredProblemSpace =
       typename Impl::MapTypeConverter<ProblemSpaceInput>::type;


### PR DESCRIPTION
Use std::numeric_limits digits10 instead of bespoke version
https://github.com/trilinos/Trilinos/issues/9056
https://github.com/kokkos/kokkos/issues/4267