### PR TITLE
Fix using external SYCL queues in tests

### DIFF
--- a/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
@@ -52,13 +52,16 @@ namespace Test {
 // Test whether allocations survive Kokkos initialize/finalize if done via Raw
 // SYCL.
 TEST(sycl, raw_sycl_interop) {
-  sycl::default_selector device_selector;
-  sycl::queue queue(device_selector);
-  constexpr int n = 100;
-  int* p          = sycl::malloc_device<int>(n, queue);
-
   Kokkos::InitArguments arguments{-1, -1, -1, false};
   Kokkos::initialize(arguments);
+
+  Kokkos::Experimental::SYCL default_space;
+  sycl::context default_context = default_space.sycl_context();
+
+  sycl::default_selector device_selector;
+  sycl::queue queue(default_context, device_selector);
+  constexpr int n = 100;
+  int* p          = sycl::malloc_device<int>(n, queue);
   {
     TEST_EXECSPACE space(queue);
     Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged>> v(p, n);

--- a/core/unit_test/sycl/TestSYCL_TeamScratchStreams.cpp
+++ b/core/unit_test/sycl/TestSYCL_TeamScratchStreams.cpp
@@ -101,11 +101,18 @@ void sycl_queue_scratch_test(
     int N, int T, int M_base,
     Kokkos::View<int64_t, Kokkos::Experimental::SYCLDeviceUSMSpace> counter) {
   constexpr int K = 4;
-  std::array<sycl::queue, K> queue;
+  Kokkos::Experimental::SYCL default_space;
+  sycl::context default_context = default_space.sycl_context();
+
+  sycl::default_selector device_selector;
+  sycl::queue queue(default_context, device_selector);
+
   std::array<Kokkos::Experimental::SYCL, K> sycl;
   for (int i = 0; i < K; i++) {
-    sycl[i] = Kokkos::Experimental::SYCL(queue[i]);
+    sycl[i] = Kokkos::Experimental::SYCL(
+        sycl::queue(default_context, device_selector));
   }
+
   // Test that growing scratch size in subsequent calls doesn't crash things
 #if defined(KOKKOS_ENABLE_OPENMP)
 #pragma omp parallel


### PR DESCRIPTION
With #4273, we implicitly call a `sycl::memcpy` using a `sycl::queue` that cannot necessarily access the memory it's called for. This seems to be an issue with Intel GPUs but not with Nvidia GPUs. https://github.com/intel/llvm/pull/2805 is related.

The fix is to make sure new (external) `sycl::queue`s always use the `sycl::context` created by the default execution space's `sycl::queue`.