### PR TITLE
Cuda: Adding implementation to use cudaFuncCachePreferEqual when needed.

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -242,6 +242,25 @@ inline size_t get_shmem_per_sm_prefer_l1(cudaDeviceProp const& properties) {
     return 0;
   }() * 1024;
 }
+
+// Assuming !cudaFuncSetCacheConfig(MyKernel, cudaFuncCachePreferL1) this
+// routine lists the approximate size for 50% cache size based on Cuda occupance
+// calculator spreadsheet.
+inline size_t get_shmem_per_sm_prefer_equal(cudaDeviceProp const& properties) {
+  int const compute_capability = properties.major * 10 + properties.minor;
+  return [compute_capability]() {
+    switch (compute_capability) {
+      case 70:
+      case 80: return 64;
+      case 86: return 96;
+      case 75: return 32;
+      default:
+        Kokkos::Impl::throw_runtime_exception(
+            "Unknown device in cuda block size deduction");
+    }
+    return 0;
+  }() * 1024;
+}
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -243,34 +243,6 @@ inline size_t get_shmem_per_sm_prefer_l1(cudaDeviceProp const& properties) {
   }() * 1024;
 }
 
-// Assuming cudaFuncSetCacheConfig(MyKernel, cudaFuncCachePreferEqual) this
-// routine lists the approximate size for 50% cache size based on Cuda occupance
-// calculator spreadsheet.
-inline size_t get_shmem_per_sm_prefer_equal(cudaDeviceProp const& properties) {
-  int const compute_capability = properties.major * 10 + properties.minor;
-  return [compute_capability]() {
-    switch (compute_capability) {
-      case 30:
-      case 32:
-      case 35:
-      case 37:
-      case 50:
-      case 53:
-      case 60:
-      case 62:
-      case 52:
-      case 61: return 0;
-      case 70:
-      case 80: return 64;
-      case 86: return 96;
-      case 75: return 32;
-      default:
-        Kokkos::Impl::throw_runtime_exception(
-            "Unknown device in cuda block size deduction");
-    }
-    return 0;
-  }() * 1024;
-}
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -243,13 +243,23 @@ inline size_t get_shmem_per_sm_prefer_l1(cudaDeviceProp const& properties) {
   }() * 1024;
 }
 
-// Assuming !cudaFuncSetCacheConfig(MyKernel, cudaFuncCachePreferL1) this
+// Assuming cudaFuncSetCacheConfig(MyKernel, cudaFuncCachePreferEqual) this
 // routine lists the approximate size for 50% cache size based on Cuda occupance
 // calculator spreadsheet.
 inline size_t get_shmem_per_sm_prefer_equal(cudaDeviceProp const& properties) {
   int const compute_capability = properties.major * 10 + properties.minor;
   return [compute_capability]() {
     switch (compute_capability) {
+      case 30:
+      case 32:
+      case 35:
+      case 37:
+      case 50:
+      case 53:
+      case 60:
+      case 62:
+      case 52:
+      case 61: return 0;
       case 70:
       case 80: return 64;
       case 86: return 96;

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -167,7 +167,7 @@ inline void configure_shmem_preference(KernelFuncPtr const& func,
 #ifndef KOKKOS_ARCH_KEPLER
   // On Kepler the L1 has no benefit since it doesn't cache reads
   auto set_cache_config = [&] {
-    CUDA_SAFE_CALL(cudaFuncSetCacheConfig(
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncSetCacheConfig(
         func, (prefer_shmem == 0)
                   ? cudaFuncCachePreferL1
                   : (prefer_shmem == 1) ? cudaFuncCachePreferEqual
@@ -207,7 +207,7 @@ modify_launch_configuration_if_desired_occupancy_is_specified(
 
   if (dynamic_shmem > shmem) {
     shmem        = dynamic_shmem;
-    prefer_shmem = 2;
+    prefer_shmem = 0;
   }
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -196,7 +196,7 @@ inline void configure_shmem_preference(KernelFuncPtr const& func,
 template <class Policy>
 std::enable_if_t<Policy::experimental_contains_desired_occupancy>
 modify_launch_configuration_if_desired_occupancy_is_specified(
-    dim3 const& grid, Policy const& policy, cudaDeviceProp const& properties,
+    dim3 const&, Policy const& policy, cudaDeviceProp const& properties,
     cudaFuncAttributes const& attributes, dim3 const& block, int& shmem,
     CachePreference& prefer_shmem) {
   int const block_size        = block.x * block.y * block.z;
@@ -222,7 +222,7 @@ modify_launch_configuration_if_desired_occupancy_is_specified(
 template <class Policy>
 std::enable_if_t<!Policy::experimental_contains_desired_occupancy>
 modify_launch_configuration_if_desired_occupancy_is_specified(
-    dim3 const& grid, Policy const& policy, cudaDeviceProp const& properties,
+    dim3 const& grid, Policy const&, cudaDeviceProp const& properties,
     cudaFuncAttributes const& attributes, dim3 const& block, int& shmem,
     CachePreference& prefer_shmem) {
   // Calculate maximum number of blocks that can simultaneously run on a SM

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -242,9 +242,6 @@ modify_launch_configuration_if_desired_occupancy_is_specified(
   int const regs_per_thread = attributes.numRegs;
   int const max_blocks_regs = regs_per_sm / (regs_per_thread * block_size);
 
-  // Set active_blocks to be the maximum of the two.
-  int const active_blocks = std::max({max_blocks_threads, max_blocks_regs});
-
   // Returns approximately half of the configurable cache size.
   size_t const shmem_per_sm_prefer_equal =
       get_shmem_per_sm_prefer_equal(properties);

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -231,17 +231,6 @@ modify_launch_configuration_if_desired_occupancy_is_specified(
     Policy const&, cudaDeviceProp const& properties,
     cudaFuncAttributes const& attributes, dim3 const& block, int& shmem,
     int& prefer_shmem) {
-  // Calculate maximum number of blocks that can simultaneously run on a SM
-  // based on the block size requested.
-  int const block_size   = block.x * block.y * block.z;
-  int max_blocks_threads = properties.maxThreadsPerMultiProcessor / block_size;
-
-  // Calculate the maximum number of blocks that can simultaneously run based on
-  // the number of registers.
-  int const regs_per_sm     = properties.regsPerMultiprocessor;
-  int const regs_per_thread = attributes.numRegs;
-  int const max_blocks_regs = regs_per_sm / (regs_per_thread * block_size);
-
   // Returns approximately half of the configurable cache size.
   size_t const shmem_per_sm_prefer_equal =
       get_shmem_per_sm_prefer_equal(properties);

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -86,6 +86,15 @@ inline __device__ T* kokkos_impl_cuda_shared_memory() {
 
 namespace Kokkos {
 namespace Impl {
+// CachePreferences during kernel launch.
+// KokkosCachePreferL1 = 0 - cudaFuncCachePreferL1
+// KokkosCachePreferShared = 1 - cudaFuncCachePreferShared
+// KokkosCachePreferEqual = 2 - cudaFuncCachePreferEqual
+enum CachePreference {
+  KokkosCachePreferL1     = 0,
+  KokkosCachePreferShared = 1,
+  KokkosCachePreferEqual  = 2
+};
 
 //----------------------------------------------------------------------------
 // See section B.17 of Cuda C Programming Guide Version 3.2
@@ -165,13 +174,15 @@ template <class DriverType, class LaunchBounds, class KernelFuncPtr>
 inline void configure_shmem_preference(KernelFuncPtr const& func,
                                        int prefer_shmem) {
 #ifndef KOKKOS_ARCH_KEPLER
+
   // On Kepler the L1 has no benefit since it doesn't cache reads
   auto set_cache_config = [&] {
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncSetCacheConfig(
-        func, (prefer_shmem == 0)
+        func, (prefer_shmem == KokkosCachePreferL1)
                   ? cudaFuncCachePreferL1
-                  : (prefer_shmem == 1) ? cudaFuncCachePreferEqual
-                                        : cudaFuncCachePreferShared));
+                  : (prefer_shmem == KokkosCachePreferShared)
+                        ? cudaFuncCachePreferShared
+                        : cudaFuncCachePreferEqual));
     return prefer_shmem;
   };
   static bool cache_config_preference_cached = set_cache_config();
@@ -217,10 +228,6 @@ modify_launch_configuration_if_desired_occupancy_is_specified(
     Policy const&, cudaDeviceProp const& properties,
     cudaFuncAttributes const& attributes, dim3 const& block, int& shmem,
     int& prefer_shmem) {
-  // prefer_shmem = 0 - cudaFuncCachePreferL1
-  // prefer_shmem = 1 - cudaFuncCachePreferEqual
-  // prefer_shmem = 2 - cudaFuncCachePreferShared
-
   // Calculate maximum number of blocks that can simultaneously run on a SM
   // based on the block size requested.
   int const block_size   = block.x * block.y * block.z;
@@ -246,11 +253,11 @@ modify_launch_configuration_if_desired_occupancy_is_specified(
   // shared memory, set cudaFuncCachePreferL1, if it's greater than half set
   // cudaFuncCachePreferEqual else set cudaFuncCachePreferShared.
   if (dynamic_shmem / 2 > shmem)
-    prefer_shmem = 0;
+    prefer_shmem = KokkosCachePreferL1;
   else if (dynamic_shmem > shmem) {
-    prefer_shmem = 1;
+    prefer_shmem = KokkosCachePreferEqual;
   } else
-    prefer_shmem = 2;
+    prefer_shmem = KokkosCachePreferShared;
 }
 
 // </editor-fold> end Some helper functions for launch code readability }}}1

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -87,13 +87,13 @@ inline __device__ T* kokkos_impl_cuda_shared_memory() {
 namespace Kokkos {
 namespace Impl {
 // CachePreferences during kernel launch.
-// KokkosCachePreferL1 = 0 - cudaFuncCachePreferL1
-// KokkosCachePreferShared = 1 - cudaFuncCachePreferShared
-// KokkosCachePreferEqual = 2 - cudaFuncCachePreferEqual
-enum CachePreference {
-  KokkosCachePreferL1     = 0,
-  KokkosCachePreferShared = 1,
-  KokkosCachePreferEqual  = 2
+// CachePreferL1 = 0 - cudaFuncCachePreferL1
+// CachePreferShared = 1 - cudaFuncCachePreferShared
+// CachePreferEqual = 2 - cudaFuncCachePreferEqual
+enum class CachePreference {
+  CachePreferL1     = 0,
+  CachePreferShared = 1,
+  CachePreferEqual  = 2
 };
 
 //----------------------------------------------------------------------------
@@ -172,7 +172,7 @@ inline void check_shmem_request(CudaInternal const* cuda_instance, int shmem) {
 // KernelFuncPtr does not necessarily contain that type information.
 template <class DriverType, class LaunchBounds, class KernelFuncPtr>
 inline void configure_shmem_preference(KernelFuncPtr const& func,
-                                       int prefer_shmem) {
+                                       CachePreference prefer_shmem) {
 #ifndef KOKKOS_ARCH_KEPLER
 
   // On Kepler the L1 has no benefit since it doesn't cache reads
@@ -181,14 +181,12 @@ inline void configure_shmem_preference(KernelFuncPtr const& func,
   auto set_cache_config = [&] {
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncSetAttribute(
         func, cudaFuncAttributePreferredSharedMemoryCarveout,
-        (prefer_shmem == CachePreference::KokkosCachePreferL1)
+        (prefer_shmem == CachePreference::CachePreferL1)
             ? 25
-            : (prefer_shmem == CachePreference::KokkosCachePreferShared) ? 75
-                                                                         : 50));
-
+            : (prefer_shmem == CachePreference::CachePreferShared) ? 75 : 50));
     return prefer_shmem;
   };
-  static int cache_config_preference_cached = set_cache_config();
+  static CachePreference cache_config_preference_cached = set_cache_config();
   if (cache_config_preference_cached != prefer_shmem) {
     cache_config_preference_cached = set_cache_config();
   }
@@ -204,7 +202,7 @@ std::enable_if_t<Policy::experimental_contains_desired_occupancy>
 modify_launch_configuration_if_desired_occupancy_is_specified(
     Policy const& policy, cudaDeviceProp const& properties,
     cudaFuncAttributes const& attributes, dim3 const& block, int& shmem,
-    int& prefer_shmem) {
+    CachePreference& prefer_shmem) {
   int const block_size        = block.x * block.y * block.z;
   int const desired_occupancy = policy.impl_get_desired_occupancy().value();
 
@@ -221,7 +219,7 @@ modify_launch_configuration_if_desired_occupancy_is_specified(
 
   if (dynamic_shmem > shmem) {
     shmem        = dynamic_shmem;
-    prefer_shmem = 0;
+    prefer_shmem = CachePreference::CachePreferL1;
   }
 }
 
@@ -230,23 +228,37 @@ std::enable_if_t<!Policy::experimental_contains_desired_occupancy>
 modify_launch_configuration_if_desired_occupancy_is_specified(
     Policy const&, cudaDeviceProp const& properties,
     cudaFuncAttributes const& attributes, dim3 const& block, int& shmem,
-    int& prefer_shmem) {
+    CachePreference& prefer_shmem) {
+  // Calculate maximum number of blocks that can simultaneously run on a SM
+  // based on the block size requested.
+  int const block_size   = block.x * block.y * block.z;
+  int max_blocks_threads = properties.maxThreadsPerMultiProcessor / block_size;
+
+  // Calculate the maximum number of blocks that can simultaneously run based on
+  // the number of registers.
+  int const regs_per_sm     = properties.regsPerMultiprocessor;
+  int const regs_per_thread = attributes.numRegs;
+  int const max_blocks_regs = regs_per_sm / (regs_per_thread * block_size);
+
+  size_t const static_shmem   = attributes.sharedSizeBytes;
+  int const max_active_blocks = std::max(max_blocks_threads, max_blocks_regs);
+  size_t const max_shmem_mem  = max_active_blocks * (shmem + static_shmem);
+
   // Returns approximately half of the configurable cache size.
   size_t const shmem_per_sm_prefer_equal =
       get_shmem_per_sm_prefer_equal(properties);
   size_t const shmem_per_sm_prefer_l1 = get_shmem_per_sm_prefer_l1(properties);
-  size_t const static_shmem           = attributes.sharedSizeBytes;
 
   // If the addition of the requested shared memory and static shmem is smaller
   // than the preferred L1, set cudaFuncCachePreferL1. If it is smaller than the
   // preferred equal set cudaFuncCachePreferEqual else set
   // cudaFuncCacchePreferShared.
-  if (shmem_per_sm_prefer_l1 > shmem + static_shmem)
-    prefer_shmem = CachePreference::KokkosCachePreferL1;
-  else if (shmem_per_sm_prefer_equal > shmem + static_shmem) {
-    prefer_shmem = CachePreference::KokkosCachePreferEqual;
+  if (shmem_per_sm_prefer_l1 > max_shmem_mem)
+    prefer_shmem = CachePreference::CachePreferL1;
+  else if (shmem_per_sm_prefer_equal > max_shmem_mem) {
+    prefer_shmem = CachePreference::CachePreferEqual;
   } else
-    prefer_shmem = CachePreference::KokkosCachePreferShared;
+    prefer_shmem = CachePreference::CachePreferShared;
 }
 
 // </editor-fold> end Some helper functions for launch code readability }}}1
@@ -381,7 +393,7 @@ struct CudaParallelLaunchKernelInvoker<
 
   inline static void create_parallel_launch_graph_node(
       DriverType const& driver, dim3 const& grid, dim3 const& block, int shmem,
-      CudaInternal const* cuda_instance, int prefer_shmem) {
+      CudaInternal const* cuda_instance, CachePreference prefer_shmem) {
     //----------------------------------------
     auto const& graph = Impl::get_cuda_graph_from_kernel(driver);
     KOKKOS_EXPECTS(bool(graph));
@@ -473,7 +485,7 @@ struct CudaParallelLaunchKernelInvoker<
 
   inline static void create_parallel_launch_graph_node(
       DriverType const& driver, dim3 const& grid, dim3 const& block, int shmem,
-      CudaInternal const* cuda_instance, int prefer_shmem) {
+      CudaInternal const* cuda_instance, CachePreference prefer_shmem) {
     //----------------------------------------
     auto const& graph = Impl::get_cuda_graph_from_kernel(driver);
     KOKKOS_EXPECTS(bool(graph));
@@ -595,7 +607,7 @@ struct CudaParallelLaunchKernelInvoker<
 
   inline static void create_parallel_launch_graph_node(
       DriverType const& driver, dim3 const& grid, dim3 const& block, int shmem,
-      CudaInternal const* cuda_instance, int prefer_shmem) {
+      CudaInternal const* cuda_instance, CachePreference prefer_shmem) {
     // Just use global memory; coordinating through events to share constant
     // memory with the non-graph interface is not really reasonable since
     // events don't work with Graphs directly, and this would anyway require
@@ -642,7 +654,7 @@ struct CudaParallelLaunchImpl<
   inline static void launch_kernel(const DriverType& driver, const dim3& grid,
                                    const dim3& block, int shmem,
                                    const CudaInternal* cuda_instance,
-                                   int prefer_shmem) {
+                                   CachePreference prefer_shmem) {
     if (!Impl::is_empty_launch(grid, block)) {
       // Prevent multiple threads to simultaneously set the cache configuration
       // preference and launch the same kernel

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -122,7 +122,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
           1);
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          false);
+          CachePreference::CachePreferL1);
     } else if (RP::rank == 3) {
       const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1], m_rp.m_tile[2]);
       KOKKOS_ASSERT(block.x > 0);
@@ -140,7 +140,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          false);
+          CachePreference::CachePreferL1);
     } else if (RP::rank == 4) {
       // id0,id1 encoded within threadIdx.x; id2 to threadIdx.y; id3 to
       // threadIdx.z
@@ -159,7 +159,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          false);
+          CachePreference::CachePreferL1);
     } else if (RP::rank == 5) {
       // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4 to
       // threadIdx.z
@@ -176,7 +176,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          false);
+          CachePreference::CachePreferL1);
     } else if (RP::rank == 6) {
       // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4,id5 to
       // threadIdx.z
@@ -192,7 +192,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
                                      maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          false);
+          CachePreference::CachePreferL1);
     } else {
       Kokkos::abort("Kokkos::MDRange Error: Exceeded rank bounds with Cuda\n");
     }
@@ -406,7 +406,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem,
           m_policy.space().impl_internal_space_instance(),
-          false);  // copy to device and execute
+          CachePreference::CachePreferL1);  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
         if (m_result_ptr) {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -122,7 +122,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
           1);
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          CachePreference::CachePreferL1);
+          CachePreference::PreferL1);
     } else if (RP::rank == 3) {
       const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1], m_rp.m_tile[2]);
       KOKKOS_ASSERT(block.x > 0);
@@ -140,7 +140,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          CachePreference::CachePreferL1);
+          CachePreference::PreferL1);
     } else if (RP::rank == 4) {
       // id0,id1 encoded within threadIdx.x; id2 to threadIdx.y; id3 to
       // threadIdx.z
@@ -159,7 +159,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          CachePreference::CachePreferL1);
+          CachePreference::PreferL1);
     } else if (RP::rank == 5) {
       // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4 to
       // threadIdx.z
@@ -176,7 +176,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          CachePreference::CachePreferL1);
+          CachePreference::PreferL1);
     } else if (RP::rank == 6) {
       // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4,id5 to
       // threadIdx.z
@@ -192,7 +192,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
                                      maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          CachePreference::CachePreferL1);
+          CachePreference::PreferL1);
     } else {
       Kokkos::abort("Kokkos::MDRange Error: Exceeded rank bounds with Cuda\n");
     }
@@ -406,7 +406,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem,
           m_policy.space().impl_internal_space_instance(),
-          CachePreference::CachePreferL1);  // copy to device and execute
+          CachePreference::PreferL1);  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
         if (m_result_ptr) {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -136,7 +136,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 
     CudaParallelLaunch<ParallelFor, LaunchBounds>(
         *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),
-        false);
+        CachePreference::CachePreferL1);
   }
 
   ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
@@ -374,7 +374,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem,
           m_policy.space().impl_internal_space_instance(),
-          false);  // copy to device and execute
+          CachePreference::CachePreferL1);  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
         if (m_result_ptr) {
@@ -725,7 +725,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
         CudaParallelLaunch<ParallelScan, LaunchBounds>(
             *this, grid, block, shmem,
             m_policy.space().impl_internal_space_instance(),
-            false);  // copy to device and execute
+            CachePreference::CachePreferL1);  // copy to device and execute
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
       }
 #endif
@@ -733,7 +733,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
       CudaParallelLaunch<ParallelScan, LaunchBounds>(
           *this, grid, block, shmem,
           m_policy.space().impl_internal_space_instance(),
-          false);  // copy to device and execute
+          CachePreference::CachePreferL1);  // copy to device and execute
     }
   }
 
@@ -1042,13 +1042,13 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
         CudaParallelLaunch<ParallelScanWithTotal, LaunchBounds>(
             *this, grid, block, shmem,
             m_policy.space().impl_internal_space_instance(),
-            false);  // copy to device and execute
+            CachePreference::CachePreferL1);  // copy to device and execute
       }
       m_final = true;
       CudaParallelLaunch<ParallelScanWithTotal, LaunchBounds>(
           *this, grid, block, shmem,
           m_policy.space().impl_internal_space_instance(),
-          false);  // copy to device and execute
+          CachePreference::CachePreferL1);  // copy to device and execute
 
       const int size = Analysis::value_size(m_functor);
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -136,7 +136,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 
     CudaParallelLaunch<ParallelFor, LaunchBounds>(
         *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),
-        CachePreference::CachePreferL1);
+        CachePreference::PreferL1);
   }
 
   ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
@@ -374,7 +374,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem,
           m_policy.space().impl_internal_space_instance(),
-          CachePreference::CachePreferL1);  // copy to device and execute
+          CachePreference::PreferL1);  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
         if (m_result_ptr) {
@@ -725,7 +725,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
         CudaParallelLaunch<ParallelScan, LaunchBounds>(
             *this, grid, block, shmem,
             m_policy.space().impl_internal_space_instance(),
-            CachePreference::CachePreferL1);  // copy to device and execute
+            CachePreference::PreferL1);  // copy to device and execute
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
       }
 #endif
@@ -733,7 +733,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
       CudaParallelLaunch<ParallelScan, LaunchBounds>(
           *this, grid, block, shmem,
           m_policy.space().impl_internal_space_instance(),
-          CachePreference::CachePreferL1);  // copy to device and execute
+          CachePreference::PreferL1);  // copy to device and execute
     }
   }
 
@@ -1042,13 +1042,13 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
         CudaParallelLaunch<ParallelScanWithTotal, LaunchBounds>(
             *this, grid, block, shmem,
             m_policy.space().impl_internal_space_instance(),
-            CachePreference::CachePreferL1);  // copy to device and execute
+            CachePreference::PreferL1);  // copy to device and execute
       }
       m_final = true;
       CudaParallelLaunch<ParallelScanWithTotal, LaunchBounds>(
           *this, grid, block, shmem,
           m_policy.space().impl_internal_space_instance(),
-          CachePreference::CachePreferL1);  // copy to device and execute
+          CachePreference::PreferL1);  // copy to device and execute
 
       const int size = Analysis::value_size(m_functor);
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -548,7 +548,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     CudaParallelLaunch<ParallelFor, LaunchBounds>(
         *this, grid, block, shmem_size_total,
         m_policy.space().impl_internal_space_instance(),
-        true);  // copy to device and execute
+        CachePreference::CachePreferShared);  // copy to device and execute
   }
 
   ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
@@ -867,7 +867,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem_size_total,
           m_policy.space().impl_internal_space_instance(),
-          true);  // copy to device and execute
+          CachePreference::CachePreferShared);  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
         m_policy.space().fence(

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -548,7 +548,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     CudaParallelLaunch<ParallelFor, LaunchBounds>(
         *this, grid, block, shmem_size_total,
         m_policy.space().impl_internal_space_instance(),
-        CachePreference::CachePreferShared);  // copy to device and execute
+        CachePreference::PreferShared);  // copy to device and execute
   }
 
   ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
@@ -867,7 +867,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem_size_total,
           m_policy.space().impl_internal_space_instance(),
-          CachePreference::CachePreferShared);  // copy to device and execute
+          CachePreference::PreferShared);  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
         m_policy.space().fence(

--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -111,7 +111,7 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
 
     Kokkos::Impl::CudaParallelLaunch<Self>(
         *this, grid, block, shared, Cuda().impl_internal_space_instance(),
-        false);
+        CachePreference::CachePreferL1);
   }
 
   inline ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)

--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -111,7 +111,7 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
 
     Kokkos::Impl::CudaParallelLaunch<Self>(
         *this, grid, block, shared, Cuda().impl_internal_space_instance(),
-        CachePreference::CachePreferL1);
+        CachePreference::PreferL1);
   }
 
   inline ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -144,6 +144,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         QuadPrecisionMath
         ExecSpacePartitioning
         MathematicalSpecialFunctions
+        CudaCacheConfig
         )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/core/unit_test/TestCudaCacheConfig.hpp
+++ b/core/unit_test/TestCudaCacheConfig.hpp
@@ -46,9 +46,11 @@
 #include <Kokkos_Core.hpp>
 #include <iostream>
 
+// The following unit test is only valid for the CUDA backend.
+#if defined(KOKKOS_ENABLE_CUDA)
 namespace Test {
-using CachePreference = Kokkos::Impl::CachePreference;
 TEST(TEST_CATEGORY, cuda_cache_config) {
+  using CachePreference = Kokkos::Impl::CachePreference;
   CachePreference cache_config;
   cudaFuncAttributes attributes;
   cudaDeviceProp prop;
@@ -96,12 +98,9 @@ TEST(TEST_CATEGORY, cuda_cache_config) {
     ASSERT_EQ(cache_config, CachePreference::PreferEqual);
   }
   {
-    cudaFuncAttributes attributes;
     attributes.numRegs         = 32;
     attributes.sharedSizeBytes = 16;
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, 0);
-    shmem = 63000;
+    shmem                      = 63000;
 
     modify_launch_configuration_if_desired_occupancy_is_specified(
         grid, policy_t, prop, attributes, block, shmem, cache_config);
@@ -111,3 +110,5 @@ TEST(TEST_CATEGORY, cuda_cache_config) {
 }
 
 }  // namespace Test
+
+#endif

--- a/core/unit_test/TestCudaCacheConfig.hpp
+++ b/core/unit_test/TestCudaCacheConfig.hpp
@@ -46,65 +46,68 @@
 #include <Kokkos_Core.hpp>
 #include <iostream>
 
-namespace Test{
-    using CachePreference = Kokkos::Impl::CachePreference;
+namespace Test {
+using CachePreference = Kokkos::Impl::CachePreference;
 TEST(TEST_CATEGORY, cuda_cache_config) {
-        CachePreference cache_config;
-        cudaFuncAttributes attributes;
-        cudaDeviceProp prop;
-        cudaGetDeviceProperties(&prop, 0);
-        Kokkos::TeamPolicy<TEST_EXECSPACE> policy_t;
-        dim3 grid{14, 1, 1};
-        dim3 block{64, 10, 1};
+  CachePreference cache_config;
+  cudaFuncAttributes attributes;
+  cudaDeviceProp prop;
+  cudaGetDeviceProperties(&prop, 0);
+  Kokkos::TeamPolicy<TEST_EXECSPACE> policy_t;
+  dim3 grid{14, 1, 1};
+  dim3 block{64, 10, 1};
 
-        int shmem = 0;
+  int shmem = 0;
 
-        {
-            attributes.numRegs = 32;
-            attributes.sharedSizeBytes = 16;
+  {
+    attributes.numRegs         = 32;
+    attributes.sharedSizeBytes = 16;
 #if defined(KOKKOS_ARCH_VOLTA70)
-            shmem = 1000;
+    shmem = 1000;
 #elif defined(KOKKOS_ARCH_AMPERE80)
-            shmem = 10000;
+    shmem = 10000;
 #else
-            printf("The unit test is only defined for Volta70 and Ampere80 architectures.\n");
+    printf(
+        "The unit test is only defined for Volta70 and Ampere80 "
+        "architectures.\n");
 #endif
 
-            modify_launch_configuration_if_desired_occupancy_is_specified(
-                grid, policy_t, prop, attributes, block, shmem, cache_config);
+    modify_launch_configuration_if_desired_occupancy_is_specified(
+        grid, policy_t, prop, attributes, block, shmem, cache_config);
 
-            ASSERT_EQ(cache_config, CachePreference::PreferL1);
-        }
-        {
-            attributes.numRegs = 64;
-            attributes.sharedSizeBytes = 32;
+    ASSERT_EQ(cache_config, CachePreference::PreferL1);
+  }
+  {
+    attributes.numRegs         = 64;
+    attributes.sharedSizeBytes = 32;
 #if defined(KOKKOS_ARCH_VOLTA70)
-            shmem = 45000;
+    shmem = 45000;
 #elif defined(KOKKOS_ARCH_AMPERE80)
-            shmem = 55000;
+    shmem = 55000;
 #else
-            printf("The unit test is only defined for Volta70 and Ampere80 architectures.\n");
+    printf(
+        "The unit test is only defined for Volta70 and Ampere80 "
+        "architectures.\n");
 #endif
 
-            modify_launch_configuration_if_desired_occupancy_is_specified(
-                grid, policy_t, prop, attributes, block, shmem, cache_config);
+    modify_launch_configuration_if_desired_occupancy_is_specified(
+        grid, policy_t, prop, attributes, block, shmem, cache_config);
 
-            ASSERT_EQ(cache_config, CachePreference::PreferEqual);
-        }
-        {
-            cudaFuncAttributes attributes;
-            attributes.numRegs = 32;
-            attributes.sharedSizeBytes = 16;
-            cudaDeviceProp prop;
-            cudaGetDeviceProperties(&prop, 0);
-            shmem = 63000;
+    ASSERT_EQ(cache_config, CachePreference::PreferEqual);
+  }
+  {
+    cudaFuncAttributes attributes;
+    attributes.numRegs         = 32;
+    attributes.sharedSizeBytes = 16;
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, 0);
+    shmem = 63000;
 
-            modify_launch_configuration_if_desired_occupancy_is_specified(
-                grid, policy_t, prop, attributes, block, shmem, cache_config);
+    modify_launch_configuration_if_desired_occupancy_is_specified(
+        grid, policy_t, prop, attributes, block, shmem, cache_config);
 
-            ASSERT_EQ(cache_config, CachePreference::PreferShared);
-        }
-
+    ASSERT_EQ(cache_config, CachePreference::PreferShared);
+  }
 }
 
-} // namespace test
+}  // namespace Test

--- a/core/unit_test/TestCudaCacheConfig.hpp
+++ b/core/unit_test/TestCudaCacheConfig.hpp
@@ -1,0 +1,110 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+#include <iostream>
+
+namespace Test{
+    using CachePreference = Kokkos::Impl::CachePreference;
+TEST(TEST_CATEGORY, cuda_cache_config) {
+        CachePreference cache_config;
+        cudaFuncAttributes attributes;
+        cudaDeviceProp prop;
+        cudaGetDeviceProperties(&prop, 0);
+        Kokkos::TeamPolicy<TEST_EXECSPACE> policy_t;
+        dim3 grid{14, 1, 1};
+        dim3 block{64, 10, 1};
+
+        int shmem = 0;
+
+        {
+            attributes.numRegs = 32;
+            attributes.sharedSizeBytes = 16;
+#if defined(KOKKOS_ARCH_VOLTA70)
+            shmem = 1000;
+#elif defined(KOKKOS_ARCH_AMPERE80)
+            shmem = 10000;
+#else
+            printf("The unit test is only defined for Volta70 and Ampere80 architectures.\n");
+#endif
+
+            modify_launch_configuration_if_desired_occupancy_is_specified(
+                grid, policy_t, prop, attributes, block, shmem, cache_config);
+
+            ASSERT_EQ(cache_config, CachePreference::PreferL1);
+        }
+        {
+            attributes.numRegs = 64;
+            attributes.sharedSizeBytes = 32;
+#if defined(KOKKOS_ARCH_VOLTA70)
+            shmem = 45000;
+#elif defined(KOKKOS_ARCH_AMPERE80)
+            shmem = 55000;
+#else
+            printf("The unit test is only defined for Volta70 and Ampere80 architectures.\n");
+#endif
+
+            modify_launch_configuration_if_desired_occupancy_is_specified(
+                grid, policy_t, prop, attributes, block, shmem, cache_config);
+
+            ASSERT_EQ(cache_config, CachePreference::PreferEqual);
+        }
+        {
+            cudaFuncAttributes attributes;
+            attributes.numRegs = 32;
+            attributes.sharedSizeBytes = 16;
+            cudaDeviceProp prop;
+            cudaGetDeviceProperties(&prop, 0);
+            shmem = 63000;
+
+            modify_launch_configuration_if_desired_occupancy_is_specified(
+                grid, policy_t, prop, attributes, block, shmem, cache_config);
+
+            ASSERT_EQ(cache_config, CachePreference::PreferShared);
+        }
+
+}
+
+} // namespace test


### PR DESCRIPTION
The PR adds an option to use `cudaFuncCachePreferEqual` cache config option instead of always choosing `cudaFuncCachePreferShared`. 