### PR TITLE
adding KOKKOS_FORCEINLINE_FUNCTION to constbitset constructors

### DIFF
--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -317,14 +317,18 @@ class ConstBitset {
   enum { block_shift = Kokkos::Impl::integral_power_of_two(block_size) };
 
  public:
+  KOKKOS_FORCEINLINE_FUNCTION
   ConstBitset() : m_size(0) {}
 
+  KOKKOS_FORCEINLINE_FUNCTION
   ConstBitset(Bitset<Device> const& rhs)
       : m_size(rhs.m_size), m_blocks(rhs.m_blocks) {}
 
+  KOKKOS_FORCEINLINE_FUNCTION
   ConstBitset(ConstBitset<Device> const& rhs)
       : m_size(rhs.m_size), m_blocks(rhs.m_blocks) {}
 
+  KOKKOS_FORCEINLINE_FUNCTION
   ConstBitset<Device>& operator=(Bitset<Device> const& rhs) {
     this->m_size   = rhs.m_size;
     this->m_blocks = rhs.m_blocks;
@@ -332,6 +336,7 @@ class ConstBitset {
     return *this;
   }
 
+  KOKKOS_FORCEINLINE_FUNCTION
   ConstBitset<Device>& operator=(ConstBitset<Device> const& rhs) {
     this->m_size   = rhs.m_size;
     this->m_blocks = rhs.m_blocks;

--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -317,18 +317,18 @@ class ConstBitset {
   enum { block_shift = Kokkos::Impl::integral_power_of_two(block_size) };
 
  public:
-  KOKKOS_FORCEINLINE_FUNCTION
+  KOKKOS_FUNCTION
   ConstBitset() : m_size(0) {}
 
-  KOKKOS_FORCEINLINE_FUNCTION
+  KOKKOS_FUNCTION
   ConstBitset(Bitset<Device> const& rhs)
       : m_size(rhs.m_size), m_blocks(rhs.m_blocks) {}
 
-  KOKKOS_FORCEINLINE_FUNCTION
+  KOKKOS_FUNCTION
   ConstBitset(ConstBitset<Device> const& rhs)
       : m_size(rhs.m_size), m_blocks(rhs.m_blocks) {}
 
-  KOKKOS_FORCEINLINE_FUNCTION
+  KOKKOS_FUNCTION
   ConstBitset<Device>& operator=(Bitset<Device> const& rhs) {
     this->m_size   = rhs.m_size;
     this->m_blocks = rhs.m_blocks;
@@ -336,7 +336,7 @@ class ConstBitset {
     return *this;
   }
 
-  KOKKOS_FORCEINLINE_FUNCTION
+  KOKKOS_FUNCTION
   ConstBitset<Device>& operator=(ConstBitset<Device> const& rhs) {
     this->m_size   = rhs.m_size;
     this->m_blocks = rhs.m_blocks;


### PR DESCRIPTION
Adding KOKKOS_FORCEDINLINE_FUNCTION to the ConstBitset constructors to allow for use on device and to match the bitset. Used in https://github.com/kokkos/kokkos/pull/4135 