### PR TITLE
Provide Error if a previously initialized exec space gets reinit

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -126,8 +126,8 @@ class CudaInternal {
   mutable void* m_team_scratch_ptr[10];
   mutable std::atomic_int m_team_scratch_pool[10];
 
-  bool was_initialized = false;
-  bool was_finalized   = false;
+  bool m_was_initialized = false;
+  bool m_was_finalized   = false;
 
   // FIXME_CUDA: these want to be per-device, not per-stream...  use of 'static'
   //  here will break once there are multiple devices though

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -134,7 +134,8 @@ class HIPInternal {
   mutable void *m_team_scratch_ptr            = nullptr;
   mutable std::mutex m_team_scratch_mutex;
 
-  bool was_finalized = false;
+  bool m_was_finalized   = false;
+  bool m_was_initialized = false;
 
   // FIXME_HIP: these want to be per-device, not per-stream...  use of 'static'
   // here will break once there are multiple devices though

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -204,6 +204,8 @@ namespace Experimental {
 class HPX {
  private:
   static bool m_hpx_initialized;
+  static bool m_was_initialized;
+  static bool m_was_finalized;
   static std::atomic<uint32_t> m_next_instance_id;
   uint32_t m_instance_id = 0;
 

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -97,7 +97,9 @@ class SerialInternal {
                                size_t thread_local_bytes);
 
   HostThreadTeamData m_thread_team_data;
-  bool m_is_initialized = false;
+  bool m_is_initialized  = false;
+  bool m_was_initialized = false;
+  bool m_was_finalized   = false;
 };
 }  // namespace Impl
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -199,7 +199,8 @@ class SYCLInternal {
   using IndirectReducerMem = USMObjectMem<sycl::usm::alloc::shared>;
   IndirectReducerMem m_indirectReducerMem;
 
-  bool was_finalized = false;
+  bool m_was_finalized   = false;
+  bool m_was_initialized = false;
 
   static SYCLInternal& singleton();
 

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -107,6 +107,10 @@ class ThreadsExec {
   int m_pool_size;
   int m_pool_fan_size;
   int volatile m_pool_state;  ///< State for global synchronizations
+  // For now initialize and finalize are static functions in threads,
+  // so this needs to be static too
+  static bool m_was_initialized;
+  static bool m_was_finalized;
 
   // Members for dynamic scheduling
   // Which thread am I stealing from currently

--- a/core/unit_test/TestDefaultDeviceTypeInit.hpp
+++ b/core/unit_test/TestDefaultDeviceTypeInit.hpp
@@ -293,8 +293,13 @@ void check_correct_initialization(const Kokkos::InitArguments& argstruct) {
 
 // TODO: Add check whether correct number of threads are actually started.
 void test_no_arguments() {
+  Kokkos::finalize();
+  Kokkos::finalize();
   Kokkos::initialize();
   check_correct_initialization(Kokkos::InitArguments());
+  Kokkos::initialize();
+  check_correct_initialization(Kokkos::InitArguments());
+  Kokkos::finalize();
   Kokkos::finalize();
 }
 


### PR DESCRIPTION
This implements this for all backends except OpenMP which turns
out to require a larger overhaul.

The semantics are such that the following code is legal:

```c++
int main(int argc, char* argv[]) {
  Kokkos::finalize();
  Kokkos::finalize();
  Kokkos::initialize(argc,argv);
  Kokkos::initialize(argc,argv);
  Kokkos::finalize();
  Kokkos::finalize();
  // Would error out:
  // Kokkos::initialize();
}
```