### PR TITLE
Replace remaining unnamed fences for SYCL

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -184,7 +184,9 @@ void* SYCLInternal::resize_team_scratch_space(std::int64_t bytes,
 uint32_t SYCLInternal::impl_get_instance_id() const { return m_instance_id; }
 
 void SYCLInternal::finalize() {
-  SYCL().fence();
+  SYCLInternal::fence(*m_queue,
+                      "Kokkos::SYCLInternal::finalize: fence on finalization",
+                      m_instance_id);
   was_finalized = true;
 
   using RecordSYCL = Kokkos::Impl::SharedAllocationRecord<SYCLDeviceUSMSpace>;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -735,7 +735,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                              Kokkos::Experimental::SYCLDeviceUSMSpace>(
           space, m_result_ptr, results_ptr,
           sizeof(*m_result_ptr) * value_count);
-      space.fence();
+      space.fence(
+          "Kokkos::Impl::ParallelReduce<TeamPolicy,SYCL>: fence because "
+          "reduction can't access result storage location");
     }
 
     return last_reduction_event;


### PR DESCRIPTION
I checked by commenting all versions that don't take a `std::string` in `core/src`.