### PR TITLE
Deprecate Kokkos::Profiling::ProfilingSection::{getName,getSectionID}

### DIFF
--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -58,7 +58,7 @@ class ProfilingSection {
  public:
   ProfilingSection(ProfilingSection const&) = delete;
   ProfilingSection& operator=(ProfilingSection const&) = delete;
-  
+
   ProfilingSection(const std::string& sectionName)
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
       : secName(sectionName)

--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -56,9 +56,13 @@ namespace Profiling {
 
 class ProfilingSection {
  public:
-  ProfilingSection(const std::string& sectionName) : secName(sectionName) {
+  ProfilingSection(const std::string& sectionName)
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+      : secName(sectionName)
+#endif
+  {
     if (Kokkos::Profiling::profileLibraryLoaded()) {
-      Kokkos::Profiling::createProfileSection(secName, &secID);
+      Kokkos::Profiling::createProfileSection(sectionName, &secID);
     }
   }
 
@@ -87,7 +91,9 @@ class ProfilingSection {
 #endif
 
  protected:
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   const std::string secName;
+#endif
   uint32_t secID;
 };
 

--- a/core/src/Kokkos_Profiling_ProfileSection.hpp
+++ b/core/src/Kokkos_Profiling_ProfileSection.hpp
@@ -80,9 +80,11 @@ class ProfilingSection {
     }
   }
 
-  std::string getName() { return secName; }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+  KOKKOS_DEPRECATED std::string getName() { return secName; }
 
-  uint32_t getSectionID() { return secID; }
+  KOKKOS_DEPRECATED uint32_t getSectionID() { return secID; }
+#endif
 
  protected:
   const std::string secName;


### PR DESCRIPTION
Rational:  These accessors are pointless.  There is nothing really useful that can be done with them.