### PR TITLE
Remove threadfence in HIP reduction(s)

### DIFF
--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -147,14 +147,12 @@ struct HIPReductionsFunctor<FunctorType, ArgTag, true> {
     scalar_intra_block_reduction(functor, value, true,
                                  my_global_team_buffer_element, shared_elements,
                                  shared_team_buffer_elements);
-    __threadfence();
     __syncthreads();
 
     // Use the last block that is done to do the do the reduction across the
     // block
     __shared__ unsigned int num_teams_done;
     if (threadIdx.x + threadIdx.y == 0) {
-      __threadfence();
       num_teams_done = Kokkos::atomic_fetch_add(global_flags, 1) + 1;
     }
     bool is_last_block = false;
@@ -263,7 +261,6 @@ struct HIPReductionsFunctor<FunctorType, ArgTag, false> {
     // block
     __shared__ unsigned int num_teams_done;
     if (threadIdx.x + threadIdx.y == 0) {
-      __threadfence();
       num_teams_done = Kokkos::atomic_fetch_add(global_flags, 1) + 1;
     }
     bool is_last_block = false;
@@ -450,7 +447,6 @@ __device__ bool hip_single_inter_block_reduce_scan_impl(
   n_done = 0;
   __syncthreads();
   if (threadIdx.y == 0) {
-    __threadfence();
     n_done = 1 + atomicInc(global_flags, block_count - 1);
   }
   __syncthreads();

--- a/core/src/HIP/Kokkos_HIP_Shuffle_Reduce.hpp
+++ b/core/src/HIP/Kokkos_HIP_Shuffle_Reduce.hpp
@@ -163,7 +163,6 @@ __device__ inline bool hip_inter_block_shuffle_reduction(
   // One warp of last block performs inter block reduction through loading the
   // block values from global scratch_memory
   bool last_block = false;
-  __threadfence();
   __syncthreads();
   int constexpr warp_size = Kokkos::Experimental::Impl::HIPTraits::WarpSize;
   if (id < warp_size) {
@@ -180,7 +179,7 @@ __device__ inline bool hip_inter_block_shuffle_reduction(
       last_block = true;
       value      = neutral;
 
-      pointer_type const volatile global =
+      pointer_type const global =
           reinterpret_cast<pointer_type>(m_scratch_space);
 
       // Reduce all global values with splitting work over threads in one warp
@@ -286,7 +285,6 @@ __device__ inline bool hip_inter_block_shuffle_reduction(
   // block values from global scratch_memory
   bool last_block = false;
 
-  __threadfence();
   __syncthreads();
   int constexpr warp_size = Kokkos::Experimental::Impl::HIPTraits::WarpSize;
   if (id < warp_size) {
@@ -303,7 +301,7 @@ __device__ inline bool hip_inter_block_shuffle_reduction(
       last_block = true;
       reducer.init(value);
 
-      pointer_type const volatile global =
+      pointer_type const global =
           reinterpret_cast<pointer_type>(m_scratch_space);
 
       // Reduce all global values with splitting work over threads in one warp

--- a/core/src/HIP/Kokkos_HIP_Vectorization.hpp
+++ b/core/src/HIP/Kokkos_HIP_Vectorization.hpp
@@ -121,6 +121,8 @@ struct in_place_shfl_op {
       reinterpret_cast<shuffle_as_t*>(&out)[i] = self().do_shfl_op(
           reinterpret_cast<shuffle_as_t const*>(&val)[i], lane_or_delta, width);
     }
+    // FIXME_HIP - this fence should be removed once the hip-clang compiler
+    // properly supports fence semanics for shuffles
     __atomic_signal_fence(__ATOMIC_SEQ_CST);
   }
 };

--- a/core/src/HIP/Kokkos_HIP_Vectorization.hpp
+++ b/core/src/HIP/Kokkos_HIP_Vectorization.hpp
@@ -129,10 +129,6 @@ struct in_place_shfl_fn : in_place_shfl_op<in_place_shfl_fn> {
   template <class T>
   __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
                                                   int width) const noexcept {
-    // FIXME_HIP Not sure why there is a race condition here. Note that the
-    // problem was also found in the CUDA backend with CUDA clang
-    // (https://github.com/kokkos/kokkos/issues/941) but it seems more limited
-    // in CUDA clang.
     auto return_val = __shfl(val, lane, width);
     return return_val;
   }
@@ -147,10 +143,6 @@ struct in_place_shfl_up_fn : in_place_shfl_op<in_place_shfl_up_fn> {
   template <class T>
   __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
                                                   int width) const noexcept {
-    // FIXME_HIP Not sure why there is a race condition here. Note that the
-    // problem was also found in the CUDA backend with CUDA clang
-    // (https://github.com/kokkos/kokkos/issues/941) but it seems more limited
-    // in CUDA clang.
     auto return_val = __shfl_up(val, lane, width);
     return return_val;
   }
@@ -166,10 +158,6 @@ struct in_place_shfl_down_fn : in_place_shfl_op<in_place_shfl_down_fn> {
   template <class T>
   __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
                                                   int width) const noexcept {
-    // FIXME_HIP Not sure why there is a race condition here. Note that the
-    // problem was also found in the CUDA backend with CUDA clang
-    // (https://github.com/kokkos/kokkos/issues/941) but it seems more limited
-    // in CUDA clang.
     auto return_val = __shfl_down(val, lane, width);
     return return_val;
   }

--- a/core/src/HIP/Kokkos_HIP_Vectorization.hpp
+++ b/core/src/HIP/Kokkos_HIP_Vectorization.hpp
@@ -121,6 +121,7 @@ struct in_place_shfl_op {
       reinterpret_cast<shuffle_as_t*>(&out)[i] = self().do_shfl_op(
           reinterpret_cast<shuffle_as_t const*>(&val)[i], lane_or_delta, width);
     }
+    __atomic_signal_fence(__ATOMIC_SEQ_CST);
   }
 };
 
@@ -133,7 +134,6 @@ struct in_place_shfl_fn : in_place_shfl_op<in_place_shfl_fn> {
     // (https://github.com/kokkos/kokkos/issues/941) but it seems more limited
     // in CUDA clang.
     auto return_val = __shfl(val, lane, width);
-    __threadfence();
     return return_val;
   }
 };
@@ -152,7 +152,6 @@ struct in_place_shfl_up_fn : in_place_shfl_op<in_place_shfl_up_fn> {
     // (https://github.com/kokkos/kokkos/issues/941) but it seems more limited
     // in CUDA clang.
     auto return_val = __shfl_up(val, lane, width);
-    __threadfence();
     return return_val;
   }
 };
@@ -172,7 +171,6 @@ struct in_place_shfl_down_fn : in_place_shfl_op<in_place_shfl_down_fn> {
     // (https://github.com/kokkos/kokkos/issues/941) but it seems more limited
     // in CUDA clang.
     auto return_val = __shfl_down(val, lane, width);
-    __threadfence();
     return return_val;
   }
 };


### PR DESCRIPTION
Resolves long-standing race condition (and perf. issue) in reductions for the HIP backend.
Essentially what was happening was that for shuffle reductions of structures (i.e., https://github.com/kokkos/kokkos/blob/develop/core/src/HIP/Kokkos_HIP_Vectorization.hpp#L120), the compiler was improperly re-ordering memory operations ahead of the struct. 

Before this change, we would call __threadfence (which maps to an L1 flush of volatile lines, see BUFFER_WBINVL1_VOL in Sec. 12.14 of https://developer.amd.com/wp-content/resources/CDNA1_Shader_ISA_14December2020.pdf):  many times.  E.g.,  8 flushes (!) for shuffling a struct of 2 unsigned longs.  This had an ~30% perf degradation for a "fused" SpMV solver (i.e., 1 matrix, two vectors) I had been working on.

Replacing the fences & volatile with a simple signal fence to stop the compiler from improperly re-ordering works on my MI-100 system ROCm 4.2, 4.3, and 4.3.1 [all three pass 100% of tests].  The re-ordering issue itself actually goes away if we force use of the new pass manager (`-fno-legacy-pass-manager`), but this seems like it's masking the issue rather than solving it, hence the compiler barrier seems like a more robust solution until it is fully confirmed.