### PR TITLE
Enable -fsycl-dead-args-optimization

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -394,7 +394,7 @@ ENDIF()
 
 IF (KOKKOS_ENABLE_SYCL)
   COMPILER_SPECIFIC_FLAGS(
-    DEFAULT -fsycl -fno-sycl-id-queries-fit-in-int
+    DEFAULT -fsycl -fno-sycl-id-queries-fit-in-int -fsycl-dead-args-optimization
   )
   COMPILER_SPECIFIC_OPTIONS(
     DEFAULT -fsycl-unnamed-lambda


### PR DESCRIPTION
https://intel.github.io/llvm-docs/UsersManual.html says
```
[...]
Enables (or disables) LLVM IR dead argument elimination pass to remove
unused arguments for the kernel functions before translation to SPIR-V.
Currently has effect only on spir64\* targets.
Disabled by default.
```
https://github.com/intel/llvm/pull/3004 is related.