### PR TITLE
add bool specialization for reduction_identity

### DIFF
--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -353,6 +353,30 @@ struct reduction_identity<signed char> {
 };
 
 template <>
+struct reduction_identity<bool> {
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool sum() {
+    return static_cast<bool>(false);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool prod() {
+    return static_cast<bool>(true);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool max() { return false; }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool min() { return true; }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool bor() {
+    return static_cast<bool>(false);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool band() {
+    return static_cast<bool>(true);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool lor() {
+    return static_cast<bool>(false);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool land() {
+    return static_cast<bool>(true);
+  }
+};
+
+template <>
 struct reduction_identity<short> {
   KOKKOS_FORCEINLINE_FUNCTION constexpr static short sum() {
     return static_cast<short>(0);


### PR DESCRIPTION
The following code:

```
#include "Kokkos_Core.hpp"

int main(int argc, char** argv) {
  Kokkos::initialize(argc, argv);
  const int size = 5;

  bool res;
  Kokkos::parallel_reduce(
    Kokkos::RangePolicy<>(0, size), 
    KOKKOS_LAMBDA(const int& i, bool& update) {
      update = true;
  }, Kokkos::LAnd<bool>(res) );
  assert(res==true);
  return 0;
}
```

built with kokkos@develop (113e11ed) failed during compilation with the following error:

```
install/include/Kokkos_Parallel_Reduce.hpp:287:11: error: implicit instantiation of undefined template 'Kokkos::reduction_identity<bool>'
    val = reduction_identity<value_type>::land();
```

This PR adds the `bool` template specialization for `reduction_identity` and allows compiling and running the given code without error.

`core/unit_test/TestReducers.hpp` was extended, and `core/unit_test/TestReducers_e.hpp` added, to test the `bool` type.  In a build with the `CUDA` backend enabled all tests are passing; which appears to include the new tests:

```
$ grep reducers_bool Testing/Temporary/LastTest.log 
[ RUN      ] serial.reducers_bool
[       OK ] serial.reducers_bool (0 ms)
[ RUN      ] cuda.reducers_bool
[       OK ] cuda.reducers_bool (1 ms)
```
