### PR TITLE
Only use GCC pragma for GCC

### DIFF
--- a/core/src/desul/atomics/Generic.hpp
+++ b/core/src/desul/atomics/Generic.hpp
@@ -10,8 +10,10 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_ATOMICS_GENERIC_HPP_
 
 #include <type_traits>
+#if defined(__GNUC__) && (!defined(__clang__))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
 #include "desul/atomics/Common.hpp"
 #include "desul/atomics/Compare_Exchange.hpp"
 #include "desul/atomics/Lock_Array.hpp"
@@ -713,5 +715,7 @@ DESUL_INLINE_FUNCTION bool atomic_compare_exchange_weak(T* const dest,
 #include <desul/atomics/GCC.hpp>
 #include <desul/atomics/HIP.hpp>
 #include <desul/atomics/OpenMP.hpp>
+#if defined(__GNUC__) && (!defined(__clang__))
 #pragma GCC diagnostic pop
+#endif
 #endif


### PR DESCRIPTION
This avoids a warning with MSVC