### PR TITLE
Cleanup Desul SYCL atomics

### DIFF
--- a/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2019, Lawrence Livermore National Security, LLC
 and DESUL project contributors. See the COPYRIGHT file for details.
 Source: https://github.com/desul/desul
@@ -8,30 +8,30 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #ifndef DESUL_ATOMICS_COMPARE_EXCHANGE_SYCL_HPP_
 #define DESUL_ATOMICS_COMPARE_EXCHANGE_SYCL_HPP_
-#include "desul/atomics/Common.hpp"
-#include "desul/atomics/SYCLConversions.hpp"
+
 #include <CL/sycl.hpp>
 
+#include "desul/atomics/Common.hpp"
+#include "desul/atomics/SYCLConversions.hpp"
 
 #ifdef DESUL_HAVE_SYCL_ATOMICS
 
 namespace desul {
 
-template<class MemoryOrder, class MemoryScope>
+template <class MemoryOrder, class MemoryScope>
 inline void atomic_thread_fence(MemoryOrder, MemoryScope) {
-  Impl::sycl_sync_and_atomics::atomic_fence(Impl::DesulToSYCLMemoryOrder<MemoryOrder>::value,
-                                            Impl::DesulToSYCLMemoryScope<MemoryScope>::value);
+  Impl::sycl_sync_and_atomics::atomic_fence(
+      Impl::DesulToSYCLMemoryOrder<MemoryOrder>::value,
+      Impl::DesulToSYCLMemoryScope<MemoryScope>::value);
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
 typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
-  static_assert(sizeof(unsigned int) == 4, "this function assumes an unsigned int is 32-bit");
-  Impl::sycl_atomic_ref<
-    unsigned int,
-    MemoryOrder,
-    MemoryScope>
-  dest_ref(*reinterpret_cast<unsigned int*>(dest));
+  static_assert(sizeof(unsigned int) == 4,
+                "this function assumes an unsigned int is 32-bit");
+  Impl::sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> dest_ref(
+      *reinterpret_cast<unsigned int*>(dest));
   dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare),
                                    *reinterpret_cast<unsigned int*>(&value));
   return compare;
@@ -39,45 +39,44 @@ typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
 template <typename T, class MemoryOrder, class MemoryScope>
 typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
-  static_assert(sizeof(unsigned long long int) == 8, "this function assumes an unsigned long long  is 64-bit");
-  Impl::sycl_atomic_ref<
-    unsigned long long int,
-    MemoryOrder,
-    MemoryScope>
-  dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+  static_assert(sizeof(unsigned long long int) == 8,
+                "this function assumes an unsigned long long  is 64-bit");
+  Impl::sycl_atomic_ref<unsigned long long int, MemoryOrder, MemoryScope> dest_ref(
+      *reinterpret_cast<unsigned long long int*>(dest));
   dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned long long int*>(&compare),
                                    *reinterpret_cast<unsigned long long int*>(&value));
   return compare;
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
-typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(
-    T* const dest, T value, MemoryOrder, MemoryScope) {
-  static_assert(sizeof(unsigned int) == 4, "this function assumes an unsigned int is 32-bit");
-  Impl::sycl_atomic_ref<
-    unsigned int,
-    MemoryOrder,
-    MemoryScope>
-  dest_ref(*reinterpret_cast<unsigned int*>(dest));
+typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(T* const dest,
+                                                                 T value,
+                                                                 MemoryOrder,
+                                                                 MemoryScope) {
+  static_assert(sizeof(unsigned int) == 4,
+                "this function assumes an unsigned int is 32-bit");
+  Impl::sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> dest_ref(
+      *reinterpret_cast<unsigned int*>(dest));
   unsigned int return_val = dest_ref.exchange(*reinterpret_cast<unsigned int*>(&value));
   return reinterpret_cast<T&>(return_val);
 }
 template <typename T, class MemoryOrder, class MemoryScope>
-typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(
-    T* const dest, T value, MemoryOrder, MemoryScope) {
-  static_assert(sizeof(unsigned long long int) == 8, "this function assumes an unsigned long long  is 64-bit");
-  Impl::sycl_atomic_ref<
-    unsigned long long int,
-    MemoryOrder,
-    MemoryScope>
-  dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(T* const dest,
+                                                                 T value,
+                                                                 MemoryOrder,
+                                                                 MemoryScope) {
+  static_assert(sizeof(unsigned long long int) == 8,
+                "this function assumes an unsigned long long  is 64-bit");
+  Impl::sycl_atomic_ref<unsigned long long int, MemoryOrder, MemoryScope> dest_ref(
+      *reinterpret_cast<unsigned long long int*>(dest));
   unsigned long long int return_val =
       dest_ref.exchange(reinterpret_cast<unsigned long long int&>(value));
   return reinterpret_cast<T&>(return_val);
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
-typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type atomic_compare_exchange(
+typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type
+atomic_compare_exchange(
     T* const /*dest*/, T compare, T /*value*/, MemoryOrder, MemoryScope) {
   // FIXME_SYCL not implemented
   assert(false);
@@ -92,7 +91,7 @@ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type atomic_ex
   return value;
 }
 
-}
+}  // namespace desul
 
 #endif
 #endif

--- a/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -19,21 +19,20 @@ namespace desul {
 
 template<class MemoryOrder, class MemoryScope>
 inline void atomic_thread_fence(MemoryOrder, MemoryScope) {
-  DESUL_SYCL_NAMESPACE::atomic_fence(DesulToSYCLMemoryOrder<MemoryOrder>::value,
-                                     DesulToSYCLMemoryScope<MemoryScope>::value);
+  Impl::sycl_sync_and_atomics::atomic_fence(Impl::DesulToSYCLMemoryOrder<MemoryOrder>::value,
+                                            Impl::DesulToSYCLMemoryScope<MemoryScope>::value);
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
 typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
   static_assert(sizeof(unsigned int) == 4, "this function assumes an unsigned int is 32-bit");
-  DESUL_SYCL_NAMESPACE::atomic_ref<
-    unsigned int, 
-    DesulToSYCLMemoryOrder<MemoryOrder>::value, 
-    DesulToSYCLMemoryScope<MemoryScope>::value, 
-    sycl::access::address_space::global_device_space> 
+  Impl::sycl_atomic_ref<
+    unsigned int,
+    MemoryOrder,
+    MemoryScope>
   dest_ref(*reinterpret_cast<unsigned int*>(dest));
-  dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare), 
+  dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare),
                                    *reinterpret_cast<unsigned int*>(&value));
   return compare;
 }
@@ -41,11 +40,10 @@ template <typename T, class MemoryOrder, class MemoryScope>
 typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
   static_assert(sizeof(unsigned long long int) == 8, "this function assumes an unsigned long long  is 64-bit");
-  DESUL_SYCL_NAMESPACE::atomic_ref<
-    unsigned long long int, 
-    DesulToSYCLMemoryOrder<MemoryOrder>::value,
-    DesulToSYCLMemoryScope<MemoryScope>::value, 
-    sycl::access::address_space::global_device_space> 
+  Impl::sycl_atomic_ref<
+    unsigned long long int,
+    MemoryOrder,
+    MemoryScope>
   dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
   dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned long long int*>(&compare),
                                    *reinterpret_cast<unsigned long long int*>(&value));
@@ -56,11 +54,10 @@ template <typename T, class MemoryOrder, class MemoryScope>
 typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(
     T* const dest, T value, MemoryOrder, MemoryScope) {
   static_assert(sizeof(unsigned int) == 4, "this function assumes an unsigned int is 32-bit");
-  DESUL_SYCL_NAMESPACE::atomic_ref<
-    unsigned int, 
-    DesulToSYCLMemoryOrder<MemoryOrder>::value, 
-    DesulToSYCLMemoryScope<MemoryScope>::value,  
-    sycl::access::address_space::global_device_space> 
+  Impl::sycl_atomic_ref<
+    unsigned int,
+    MemoryOrder,
+    MemoryScope>
   dest_ref(*reinterpret_cast<unsigned int*>(dest));
   unsigned int return_val = dest_ref.exchange(*reinterpret_cast<unsigned int*>(&value));
   return reinterpret_cast<T&>(return_val);
@@ -69,11 +66,10 @@ template <typename T, class MemoryOrder, class MemoryScope>
 typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(
     T* const dest, T value, MemoryOrder, MemoryScope) {
   static_assert(sizeof(unsigned long long int) == 8, "this function assumes an unsigned long long  is 64-bit");
-  DESUL_SYCL_NAMESPACE::atomic_ref<
+  Impl::sycl_atomic_ref<
     unsigned long long int,
-    DesulToSYCLMemoryOrder<MemoryOrder>::value,
-    DesulToSYCLMemoryScope<MemoryScope>::value,
-    sycl::access::address_space::global_device_space>
+    MemoryOrder,
+    MemoryScope>
   dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
   unsigned long long int return_val =
       dest_ref.exchange(reinterpret_cast<unsigned long long int&>(value));
@@ -85,7 +81,7 @@ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type atomic_co
     T* const /*dest*/, T compare, T /*value*/, MemoryOrder, MemoryScope) {
   // FIXME_SYCL not implemented
   assert(false);
-  return compare;  
+  return compare;
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>

--- a/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -9,10 +9,12 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef DESUL_ATOMICS_COMPARE_EXCHANGE_SYCL_HPP_
 #define DESUL_ATOMICS_COMPARE_EXCHANGE_SYCL_HPP_
 
-#include <CL/sycl.hpp>
-
-#include "desul/atomics/Common.hpp"
+// clang-format off
 #include "desul/atomics/SYCLConversions.hpp"
+#include "desul/atomics/Common.hpp"
+
+#include <CL/sycl.hpp>
+// clang-format on
 
 #ifdef DESUL_HAVE_SYCL_ATOMICS
 

--- a/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -42,7 +42,7 @@ template <typename T, class MemoryOrder, class MemoryScope>
 typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
   static_assert(sizeof(unsigned long long int) == 8,
-                "this function assumes an unsigned long long  is 64-bit");
+                "this function assumes an unsigned long long is 64-bit");
   Impl::sycl_atomic_ref<unsigned long long int, MemoryOrder, MemoryScope> dest_ref(
       *reinterpret_cast<unsigned long long int*>(dest));
   dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned long long int*>(&compare),
@@ -68,7 +68,7 @@ typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(T* const dest,
                                                                  MemoryOrder,
                                                                  MemoryScope) {
   static_assert(sizeof(unsigned long long int) == 8,
-                "this function assumes an unsigned long long  is 64-bit");
+                "this function assumes an unsigned long long is 64-bit");
   Impl::sycl_atomic_ref<unsigned long long int, MemoryOrder, MemoryScope> dest_ref(
       *reinterpret_cast<unsigned long long int*>(dest));
   unsigned long long int return_val =

--- a/core/src/desul/atomics/Macros.hpp
+++ b/core/src/desul/atomics/Macros.hpp
@@ -34,11 +34,6 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #ifdef SYCL_LANGUAGE_VERSION
 #define DESUL_HAVE_SYCL_ATOMICS
-#ifdef __clang__
-#define DESUL_SYCL_NAMESPACE sycl::ONEAPI
-#else
-#define DESUL_SYCL_NAMESPACE sycl
-#endif
 #endif
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(__SYCL_DEVICE_ONLY__)

--- a/core/src/desul/atomics/SYCL.hpp
+++ b/core/src/desul/atomics/SYCL.hpp
@@ -9,114 +9,48 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_ATOMICS_SYCL_HPP_
 
 #ifdef DESUL_HAVE_SYCL_ATOMICS
+
 #include "desul/atomics/Common.hpp"
 
 namespace desul {
-namespace Impl {
-template<class T>
-struct is_sycl_atomic_type {
-  static constexpr bool value = std::is_same<T, int>::value ||
-                                std::is_same<T, unsigned int>::value ||
-				std::is_same<T, long>::value ||
-				std::is_same<T, unsigned long>::value ||
-				std::is_same<T, long long>::value ||
-                                std::is_same<T, unsigned long long int>::value ||
-				std::is_same<T, float>::value ||
-				std::is_same<T, double>::value;
-};
-} // Impl
 
-// Atomic Add
-template<class T, class MemoryOrder/*, class MemoryScope*/>
-inline
-typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
-atomic_fetch_add(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  Impl::sycl_atomic_ref<
-    T,
-    MemoryOrder,
-    MemoryScopeDevice>
-  dest_ref(*dest);
-  return dest_ref.fetch_add(val);
-}
+#define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, TYPE)                        \
+  template <class MemoryOrder, class MemoryScope>                            \
+  TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScope) { \
+    Impl::sycl_atomic_ref<TYPE, MemoryOrder, MemoryScope> dest_ref(*dest);   \
+    return dest_ref.fetch_##OPER(val);                                       \
+  }
 
-// Atomic Sub
-template<class T, class MemoryOrder/*, class MemoryScope*/>
-inline
-typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
-atomic_fetch_sub(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  Impl::sycl_atomic_ref<
-    T,
-    MemoryOrder,
-    MemoryScopeDevice>
-  dest_ref(*dest);
-  return dest_ref.fetch_sub(val);
-}
+#define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(OPER) \
+  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, int)           \
+  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, unsigned int)  \
+  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, long)          \
+  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, unsigned long) \
+  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, long long)     \
+  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, unsigned long long)
 
-// Atomic Max
-template<class T, class MemoryOrder/*, class MemoryScope*/>
-inline
-typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
-atomic_fetch_max(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  Impl::sycl_atomic_ref<
-    T,
-    MemoryOrder,
-    MemoryScopeDevice>
-  dest_ref(*dest);
-  return dest_ref.fetch_max(val);
-}
+#define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(OPER) \
+  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, float)               \
+  DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, double)
 
-// Atomic Min
-template<class T, class MemoryOrder/*, class MemoryScope*/>
-inline
-typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
-atomic_fetch_min(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  Impl::sycl_atomic_ref<
-    T,
-    MemoryOrder,
-    MemoryScopeDevice>
-  dest_ref(*dest);
-  return dest_ref.fetch_min(val);
-}
+DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(add)
+DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(sub)
+DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(and)
+DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(or)
+DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(xor)
+DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(min)
+DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(max)
 
-// Atomic And
-template<class T, class MemoryOrder/*, class MemoryScope*/>
-inline
-typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
-atomic_fetch_and(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  Impl::sycl_atomic_ref<
-    T,
-    MemoryOrder,
-    MemoryScopeDevice>
-  dest_ref(*dest);
-  return dest_ref.fetch_and(val);
-}
+DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(add)
+DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(sub)
+DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(min)
+DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT(max)
 
-// Atomic XOR
-template<class T, class MemoryOrder/*, class MemoryScope*/>
-inline
-typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
-atomic_fetch_xor(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  Impl::sycl_atomic_ref<
-    T,
-    MemoryOrder,
-    MemoryScopeDevice>
-  dest_ref(*dest);
-  return dest_ref.fetch_xor(val);
-}
+#undef DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_FLOATING_POINT
+#undef DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL
+#undef DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER
 
-// Atomic OR
-template<class T, class MemoryOrder/*, class MemoryScope*/>
-inline
-typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
-atomic_fetch_or(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  Impl::sycl_atomic_ref<
-    T,
-    MemoryOrder,
-    MemoryScopeDevice>
-  dest_ref(*dest);
-  return dest_ref.fetch_or(val);
-}
+}  // namespace desul
 
-} // desul
 #endif  // DESUL_HAVE_SYCL_ATOMICS
 #endif  // DESUL_ATOMICS_SYCL_HPP_

--- a/core/src/desul/atomics/SYCL.hpp
+++ b/core/src/desul/atomics/SYCL.hpp
@@ -17,11 +17,16 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 namespace desul {
 
-#define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, TYPE)                        \
-  template <class MemoryOrder, class MemoryScope>                            \
-  TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScope) { \
-    Impl::sycl_atomic_ref<TYPE, MemoryOrder, MemoryScope> dest_ref(*dest);   \
-    return dest_ref.fetch_##OPER(val);                                       \
+#define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, TYPE)                              \
+  template <class MemoryOrder>                                                     \
+  TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeDevice) { \
+    Impl::sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeDevice> dest_ref(*dest);   \
+    return dest_ref.fetch_##OPER(val);                                             \
+  }                                                                                \
+  template <class MemoryOrder>                                                     \
+  TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeCore) {   \
+    Impl::sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeCore> dest_ref(*dest);     \
+    return dest_ref.fetch_##OPER(val);                                             \
   }
 
 #define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(OPER) \

--- a/core/src/desul/atomics/SYCL.hpp
+++ b/core/src/desul/atomics/SYCL.hpp
@@ -52,20 +52,6 @@ atomic_fetch_sub(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   return dest_ref.fetch_sub(val);
 }
 
-// Atomic Inc
-template<class MemoryOrder/*, class MemoryScope*/>
-inline
-unsigned int atomic_fetch_inc(unsigned int* dest, unsigned int val, MemoryOrder memory_order, MemoryScopeDevice memory_scope) {
-  return atomic_fetch_add(dest, val, memory_order, memory_scope);
-}
-
-// Atomic Dec
-template<class MemoryOrder/*, class MemoryScope*/>
-inline
-unsigned int atomic_fetch_dec(unsigned int* dest, unsigned int val, MemoryOrder memory_order, MemoryScopeDevice memory_scope) {
-  return atomic_fetch_sub(dest, val, memory_order, memory_scope);
-}
-
 // Atomic Max
 template<class T, class MemoryOrder/*, class MemoryScope*/>
 inline

--- a/core/src/desul/atomics/SYCL.hpp
+++ b/core/src/desul/atomics/SYCL.hpp
@@ -31,25 +31,23 @@ template<class T, class MemoryOrder/*, class MemoryScope*/>
 inline
 typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
 atomic_fetch_add(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  DESUL_SYCL_NAMESPACE::atomic_ref<
-    T, 
-    DesulToSYCLMemoryOrder<MemoryOrder>::value, 
-    DesulToSYCLMemoryScope<MemoryScopeDevice>::value,  
-    sycl::access::address_space::global_device_space> 
+  Impl::sycl_atomic_ref<
+    T,
+    MemoryOrder,
+    MemoryScopeDevice>
   dest_ref(*dest);
   return dest_ref.fetch_add(val);
 }
 
-// Atomic Sub 
+// Atomic Sub
 template<class T, class MemoryOrder/*, class MemoryScope*/>
 inline
 typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
 atomic_fetch_sub(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  DESUL_SYCL_NAMESPACE::atomic_ref<
+  Impl::sycl_atomic_ref<
     T,
-    DesulToSYCLMemoryOrder<MemoryOrder>::value,
-    DesulToSYCLMemoryScope<MemoryScopeDevice>::value,
-    sycl::access::address_space::global_device_space>
+    MemoryOrder,
+    MemoryScopeDevice>
   dest_ref(*dest);
   return dest_ref.fetch_sub(val);
 }
@@ -73,11 +71,10 @@ template<class T, class MemoryOrder/*, class MemoryScope*/>
 inline
 typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
 atomic_fetch_max(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  DESUL_SYCL_NAMESPACE::atomic_ref<
+  Impl::sycl_atomic_ref<
     T,
-    DesulToSYCLMemoryOrder<MemoryOrder>::value,
-    DesulToSYCLMemoryScope<MemoryScopeDevice>::value,
-    sycl::access::address_space::global_device_space>
+    MemoryOrder,
+    MemoryScopeDevice>
   dest_ref(*dest);
   return dest_ref.fetch_max(val);
 }
@@ -87,11 +84,10 @@ template<class T, class MemoryOrder/*, class MemoryScope*/>
 inline
 typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
 atomic_fetch_min(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  DESUL_SYCL_NAMESPACE::atomic_ref<
+  Impl::sycl_atomic_ref<
     T,
-    DesulToSYCLMemoryOrder<MemoryOrder>::value,
-    DesulToSYCLMemoryScope<MemoryScopeDevice>::value,
-    sycl::access::address_space::global_device_space>
+    MemoryOrder,
+    MemoryScopeDevice>
   dest_ref(*dest);
   return dest_ref.fetch_min(val);
 }
@@ -101,11 +97,10 @@ template<class T, class MemoryOrder/*, class MemoryScope*/>
 inline
 typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
 atomic_fetch_and(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  DESUL_SYCL_NAMESPACE::atomic_ref<
+  Impl::sycl_atomic_ref<
     T,
-    DesulToSYCLMemoryOrder<MemoryOrder>::value,
-    DesulToSYCLMemoryScope<MemoryScopeDevice>::value,
-    sycl::access::address_space::global_device_space>
+    MemoryOrder,
+    MemoryScopeDevice>
   dest_ref(*dest);
   return dest_ref.fetch_and(val);
 }
@@ -115,11 +110,10 @@ template<class T, class MemoryOrder/*, class MemoryScope*/>
 inline
 typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
 atomic_fetch_xor(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  DESUL_SYCL_NAMESPACE::atomic_ref<
+  Impl::sycl_atomic_ref<
     T,
-    DesulToSYCLMemoryOrder<MemoryOrder>::value,
-    DesulToSYCLMemoryScope<MemoryScopeDevice>::value,
-    sycl::access::address_space::global_device_space>
+    MemoryOrder,
+    MemoryScopeDevice>
   dest_ref(*dest);
   return dest_ref.fetch_xor(val);
 }
@@ -129,11 +123,10 @@ template<class T, class MemoryOrder/*, class MemoryScope*/>
 inline
 typename std::enable_if<Impl::is_sycl_atomic_type<T>::value,T>::type
 atomic_fetch_or(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  DESUL_SYCL_NAMESPACE::atomic_ref<
+  Impl::sycl_atomic_ref<
     T,
-    DesulToSYCLMemoryOrder<MemoryOrder>::value,
-    DesulToSYCLMemoryScope<MemoryScopeDevice>::value,
-    sycl::access::address_space::global_device_space>
+    MemoryOrder,
+    MemoryScopeDevice>
   dest_ref(*dest);
   return dest_ref.fetch_or(val);
 }

--- a/core/src/desul/atomics/SYCL.hpp
+++ b/core/src/desul/atomics/SYCL.hpp
@@ -10,7 +10,10 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #ifdef DESUL_HAVE_SYCL_ATOMICS
 
+// clang-format off
+#include "desul/atomics/SYCLConversions.hpp"
 #include "desul/atomics/Common.hpp"
+// clang-format on
 
 namespace desul {
 

--- a/core/src/desul/atomics/SYCLConversions.hpp
+++ b/core/src/desul/atomics/SYCLConversions.hpp
@@ -66,35 +66,20 @@ struct DesulToSYCLMemoryScope<MemoryScopeSystem> {
   static constexpr sycl_memory_scope value = sycl_memory_scope::system;
 };
 
-// NOTE valid atomic address spaces are
-//   * access::address_space::global_space
-//   * access::address_space::local_space
-//   * access::address_space::global_device_space
-// below is an attempt to map memory scope to an address space
-template <class MemoryScope>
-struct DesulMemoryScopeToSYCLAdressSpace;
-template <>
-struct DesulMemoryScopeToSYCLAdressSpace<MemoryScopeCore> {
-  static constexpr sycl::access::address_space value =
-      sycl::access::address_space::local_space;
-};
-template <>
-struct DesulMemoryScopeToSYCLAdressSpace<MemoryScopeDevice> {
-  static constexpr sycl::access::address_space value =
-      sycl::access::address_space::global_device_space;
-};
-template <>
-struct DesulMemoryScopeToSYCLAdressSpace<MemoryScopeSystem> {
-  static constexpr sycl::access::address_space value =
-      sycl::access::address_space::global_space;
-};
-
 template <class T, class MemoryOrder, class MemoryScope>
 using sycl_atomic_ref = sycl_sync_and_atomics::atomic_ref<
     T,
     DesulToSYCLMemoryOrder<MemoryOrder>::value,
     DesulToSYCLMemoryScope<MemoryScope>::value,
-    DesulMemoryScopeToSYCLAdressSpace<MemoryScope>::value>;
+    // FIXME In SYCL 2020 Specification (revision 3) the class template atomic_ref has
+    // its trailing (non-type) template parameter defaulted to
+    // access::address_space::generic_space, but in currently available implementations
+    // a/ the template parameter has no default template argument, and b/ the
+    // generic_space enumerator is not a valid address space (only global_space,
+    // local_space, and global_space are).  Worse it is not yet defined as part of the
+    // access::address_space enumerator list.
+    // Here we arbitrarily elected to use global_device_space as a temporary workaround.
+    sycl::access::address_space::global_device_space>;
 
 }  // namespace Impl
 }  // namespace desul

--- a/core/src/desul/atomics/SYCLConversions.hpp
+++ b/core/src/desul/atomics/SYCLConversions.hpp
@@ -78,8 +78,8 @@ using sycl_atomic_ref = sycl_sync_and_atomics::atomic_ref<
     // generic_space enumerator is not a valid address space (only global_space,
     // local_space, and global_space are).  Worse it is not yet defined as part of the
     // access::address_space enumerator list.
-    // Here we arbitrarily elected to use global_device_space as a temporary workaround.
-    sycl::access::address_space::global_device_space>;
+    // Here we arbitrarily elected to use global_space as a temporary workaround.
+    sycl::access::address_space::global_space>;
 
 }  // namespace Impl
 }  // namespace desul

--- a/core/src/desul/atomics/SYCLConversions.hpp
+++ b/core/src/desul/atomics/SYCLConversions.hpp
@@ -9,9 +9,12 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef DESUL_ATOMICS_SYCL_CONVERSIONS_HPP_
 #define DESUL_ATOMICS_SYCL_CONVERSIONS_HPP_
 #ifdef DESUL_HAVE_SYCL_ATOMICS
-#include <CL/sycl.hpp>
 
+// clang-format off
 #include "desul/atomics/Common.hpp"
+
+#include <CL/sycl.hpp>
+// clang-format on
 
 namespace desul {
 namespace Impl {

--- a/core/src/desul/atomics/SYCLConversions.hpp
+++ b/core/src/desul/atomics/SYCLConversions.hpp
@@ -9,50 +9,69 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef DESUL_ATOMICS_SYCL_CONVERSIONS_HPP_
 #define DESUL_ATOMICS_SYCL_CONVERSIONS_HPP_
 #ifdef DESUL_HAVE_SYCL_ATOMICS
-#include "desul/atomics/Common.hpp"
 #include <CL/sycl.hpp>
 
+#include "desul/atomics/Common.hpp"
+
 namespace desul {
+namespace Impl {
 
-template<class MemoryOrder>
+#ifdef __clang__
+namespace sycl_sync_and_atomics = ::sycl::ONEAPI;
+#else
+namespace sycl_sync_and_atomics = ::sycl;
+#endif
+
+using sycl_memory_order = sycl_sync_and_atomics::memory_order;
+using sycl_memory_scope = sycl_sync_and_atomics::memory_scope;
+
+template <class MemoryOrder>
 struct DesulToSYCLMemoryOrder;
-template<>
+template <>
 struct DesulToSYCLMemoryOrder<MemoryOrderSeqCst> {
-  static constexpr DESUL_SYCL_NAMESPACE::memory_order value = DESUL_SYCL_NAMESPACE::memory_order::seq_cst;
+  static constexpr sycl_memory_order value = sycl_memory_order::seq_cst;
 };
-template<>
+template <>
 struct DesulToSYCLMemoryOrder<MemoryOrderAcquire> {
-  static constexpr DESUL_SYCL_NAMESPACE::memory_order value = DESUL_SYCL_NAMESPACE::memory_order::acquire;
+  static constexpr sycl_memory_order value = sycl_memory_order::acquire;
 };
-template<>
+template <>
 struct DesulToSYCLMemoryOrder<MemoryOrderRelease> {
-  static constexpr DESUL_SYCL_NAMESPACE::memory_order value = DESUL_SYCL_NAMESPACE::memory_order::release;
+  static constexpr sycl_memory_order value = sycl_memory_order::release;
 };
-template<>
+template <>
 struct DesulToSYCLMemoryOrder<MemoryOrderAcqRel> {
-  static constexpr DESUL_SYCL_NAMESPACE::memory_order value = DESUL_SYCL_NAMESPACE::memory_order::acq_rel;
+  static constexpr sycl_memory_order value = sycl_memory_order::acq_rel;
 };
-template<>
+template <>
 struct DesulToSYCLMemoryOrder<MemoryOrderRelaxed> {
-  static constexpr DESUL_SYCL_NAMESPACE::memory_order value = DESUL_SYCL_NAMESPACE::memory_order::relaxed;
+  static constexpr sycl_memory_order value = sycl_memory_order::relaxed;
 };
 
-template<class MemoryScope>
+template <class MemoryScope>
 struct DesulToSYCLMemoryScope;
-template<>
+template <>
 struct DesulToSYCLMemoryScope<MemoryScopeCore> {
-  static constexpr DESUL_SYCL_NAMESPACE::memory_scope value = DESUL_SYCL_NAMESPACE::memory_scope::work_group;
+  static constexpr sycl_memory_scope value = sycl_memory_scope::work_group;
 };
-template<>
+template <>
 struct DesulToSYCLMemoryScope<MemoryScopeDevice> {
-  static constexpr DESUL_SYCL_NAMESPACE::memory_scope value = DESUL_SYCL_NAMESPACE::memory_scope::device;
+  static constexpr sycl_memory_scope value = sycl_memory_scope::device;
 };
-template<>
+template <>
 struct DesulToSYCLMemoryScope<MemoryScopeSystem> {
-  static constexpr DESUL_SYCL_NAMESPACE::memory_scope value = DESUL_SYCL_NAMESPACE::memory_scope::system;
+  static constexpr sycl_memory_scope value = sycl_memory_scope::system;
 };
 
-}
+template <class T, class MemoryOrder, class MemoryScope>
+using sycl_atomic_ref =
+    sycl_sync_and_atomics::atomic_ref<T,
+                                      DesulToSYCLMemoryOrder<MemoryOrder>::value,
+                                      DesulToSYCLMemoryScope<MemoryScope>::value,
+                                      sycl::access::address_space::global_device_space>;
+
+}  // namespace Impl
+}  // namespace desul
 
 #endif
 #endif

--- a/core/src/desul/atomics/SYCLConversions.hpp
+++ b/core/src/desul/atomics/SYCLConversions.hpp
@@ -63,12 +63,35 @@ struct DesulToSYCLMemoryScope<MemoryScopeSystem> {
   static constexpr sycl_memory_scope value = sycl_memory_scope::system;
 };
 
+// NOTE valid atomic address spaces are
+//   * access::address_space::global_space
+//   * access::address_space::local_space
+//   * access::address_space::global_device_space
+// below is an attempt to map memory scope to an address space
+template <class MemoryScope>
+struct DesulMemoryScopeToSYCLAdressSpace;
+template <>
+struct DesulMemoryScopeToSYCLAdressSpace<MemoryScopeCore> {
+  static constexpr sycl::access::address_space value =
+      sycl::access::address_space::local_space;
+};
+template <>
+struct DesulMemoryScopeToSYCLAdressSpace<MemoryScopeDevice> {
+  static constexpr sycl::access::address_space value =
+      sycl::access::address_space::global_device_space;
+};
+template <>
+struct DesulMemoryScopeToSYCLAdressSpace<MemoryScopeSystem> {
+  static constexpr sycl::access::address_space value =
+      sycl::access::address_space::global_space;
+};
+
 template <class T, class MemoryOrder, class MemoryScope>
-using sycl_atomic_ref =
-    sycl_sync_and_atomics::atomic_ref<T,
-                                      DesulToSYCLMemoryOrder<MemoryOrder>::value,
-                                      DesulToSYCLMemoryScope<MemoryScope>::value,
-                                      sycl::access::address_space::global_device_space>;
+using sycl_atomic_ref = sycl_sync_and_atomics::atomic_ref<
+    T,
+    DesulToSYCLMemoryOrder<MemoryOrder>::value,
+    DesulToSYCLMemoryScope<MemoryScope>::value,
+    DesulMemoryScopeToSYCLAdressSpace<MemoryScope>::value>;
 
 }  // namespace Impl
 }  // namespace desul


### PR DESCRIPTION
* Defer more atomic fetch operations to SYCL (was limited to device scope)
* General cleanup
* Apply clang-format
