### PR TITLE
Set L0 scratch to 32k to work around #4332

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -189,9 +189,11 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
   }
 
   static int scratch_size_max(int level) {
-    return (
-        level == 0 ? 1024 * 40 :  // FIXME_HIP arbitrarily setting this to 48kB
-            20 * 1024 * 1024);    // FIXME_HIP arbitrarily setting this to 20MB
+    // FIXME_HIP: can set actual limits once the API change discussed
+    // in https://github.com/kokkos/kokkos/issues/4338 is resolved
+    // until then, we leave these as arbitrary values that "fix" the failing
+    // test
+    return (level == 0 ? 1024 * 32 : 20 * 1024 * 1024);
   }
   inline void impl_set_vector_length(size_t size) { m_vector_length = size; }
   inline void impl_set_team_size(size_t size) { m_team_size = size; }


### PR DESCRIPTION
After discussing w/ @dalg24 -- we will set the max L0 scratch size on the HIP backend to 32KB to work around the test failures in https://github.com/kokkos/kokkos/issues/4338 until the new proposed API is finalized.

Change-Id: I44d5c68099fce712a1b76ab7965789add2e6a02f