### PR TITLE
Replace deprecated sycl::ONEAPI namespace w/ sycl::ext::oneapi

### DIFF
--- a/core/src/desul/atomics/Macros.hpp
+++ b/core/src/desul/atomics/Macros.hpp
@@ -35,8 +35,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifdef SYCL_LANGUAGE_VERSION
 #define DESUL_HAVE_SYCL_ATOMICS
 #ifdef __clang__
-#define DESUL_SYCL_NAMESPACE sycl::ONEAPI
-#else
+#define DESUL_SYCL_NAMESPACE sycl::ext::oneapi
+#elseg
 #define DESUL_SYCL_NAMESPACE sycl
 #endif
 #endif

--- a/core/src/desul/atomics/Macros.hpp
+++ b/core/src/desul/atomics/Macros.hpp
@@ -36,7 +36,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_HAVE_SYCL_ATOMICS
 #ifdef __clang__
 #define DESUL_SYCL_NAMESPACE sycl::ext::oneapi
-#elseg
+#else
 #define DESUL_SYCL_NAMESPACE sycl
 #endif
 #endif

--- a/core/src/impl/Kokkos_Memory_Fence.hpp
+++ b/core/src/impl/Kokkos_Memory_Fence.hpp
@@ -58,8 +58,8 @@ void memory_fence() {
 #elif defined(__HIP_DEVICE_COMPILE__)
   __threadfence();
 #elif defined(KOKKOS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__)
-  sycl::ONEAPI::atomic_fence(sycl::ONEAPI::memory_order::acq_rel,
-                             sycl::ONEAPI::memory_scope::device);
+  sycl::ext::oneapi::atomic_fence(sycl::ext::oneapi::memory_order::acq_rel,
+                             sycl::ext::oneapi::memory_scope::device);
 #elif defined(KOKKOS_ENABLE_ASM) && defined(KOKKOS_ENABLE_ISA_X86_64)
   asm volatile("mfence" ::: "memory");
 #elif defined(KOKKOS_ENABLE_GNU_ATOMICS) || \

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -65,7 +65,7 @@ void sink(Args&&... args) {
 #define KOKKOS_IMPL_DO_NOT_USE_PRINTF(format, ...)                \
   do {                                                            \
     const __attribute__((opencl_constant)) char fmt[] = (format); \
-    sycl::ONEAPI::experimental::printf(fmt, ##__VA_ARGS__);       \
+    sycl::ext::oneapi::experimental::printf(fmt, ##__VA_ARGS__);       \
   } while (0)
 #endif
 #endif


### PR DESCRIPTION
`sycl::ONEAPI` doesn't exist on the tip of the `sycl` branch, it's been replaced with `sycl::ext::oneapi`.