### PR TITLE
Improve Kokkos::abort() for SYCL

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Abort.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Abort.hpp
@@ -51,8 +51,13 @@
 namespace Kokkos {
 namespace Impl {
 
-inline void sycl_abort(char const *msg) {
+inline void sycl_abort(char const* msg) {
+#ifdef NDEBUG
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Aborting with message %s.\n", msg);
+#else
+  const char* empty = " ";
+  __assert_fail(msg, empty, 0, empty);
+#endif
 }
 
 }  // namespace Impl


### PR DESCRIPTION
https://github.com/intel/llvm/blob/87e9fa7a4d9f130381b679d8c3d44d91c9ab455d/sycl/doc/Assert.md is related.
Using `const char* empty = "";` gives garbage but a whitespace works reasonably well with output like
```
 :0:  : global id: [7,0,0], local id: [0,0,0] Assertion `bla` failed.
```
The improvement basically is to also print the thread indices `Kokkos::abort()` is invoked from in `Debug` mode (which also helps to see workgroup sizes chosen by the SYCL implementation). Although backends are allowed to abort kernel execution and indicate failure, in my experience tests still run correctly after introducing dummy `Kokkos::abort()` calls. Future implementation might change that but this seems to be as much as we can do from our side at the moment.

`__assert_fail()` is only available if `NDEBUG` is not defined.