### PR TITLE
[WIP] Thread safety tests

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -330,6 +330,7 @@ if(Kokkos_ENABLE_OPENMPTARGET)
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_AtomicOperations_complexdouble.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Crs.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_LocalDeepCopy.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_MultiThreadsTeam.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Other.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamReductionScan.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamScan.cpp
@@ -446,6 +447,14 @@ if(Kokkos_ENABLE_SERIAL)
 endif()
 
 if(Kokkos_ENABLE_THREADS)
+  # FIXME_THREAD doesn't work because kernels can only be launch from the master
+  # thread
+  list(REMOVE_ITEM Threads_SOURCES
+    ${CMAKE_CURRENT_BINARY_DIR}/threads/TestThreads_MultiThreadsRange.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/threads/TestThreads_MultiThreadsMDRange.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/threads/TestThreads_MultiThreadsTeam.cpp
+  )
+
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_Threads
     SOURCES ${Threads_SOURCES}

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -125,6 +125,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
         MDRange_b
         MDRange_c
         MultiThreadsRange
+        MultiThreadsMDRange
         HostSharedPtr
         HostSharedPtrAccessOnDevice
         QuadPrecisionMath

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -126,6 +126,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
         MDRange_c
         MultiThreadsRange
         MultiThreadsMDRange
+        MultiThreadsTeam
         HostSharedPtr
         HostSharedPtrAccessOnDevice
         QuadPrecisionMath

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -124,6 +124,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
         MDRange_a
         MDRange_b
         MDRange_c
+        MultiThreadsRange
         HostSharedPtr
         HostSharedPtrAccessOnDevice
         QuadPrecisionMath

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -30,6 +30,9 @@ IF(NOT GTest_FOUND)  # fallback to internal gtest
   ENDIF()
 ENDIF()
 
+find_package(Threads REQUIRED)
+target_link_libraries(kokkos_gtest Threads::Threads)
+
 #
 # Define Incremental Testing Feature Levels
 # Define Device name mappings (i.e. what comes after Kokkos:: for the ExecSpace)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -454,6 +454,14 @@ if(Kokkos_ENABLE_THREADS)
 endif()
 
 if (Kokkos_ENABLE_OPENMP)
+  # FIXME_OPENMP doesn't work because kernels can only be launch from the master
+  # thread
+  list(REMOVE_ITEM OpenMP_SOURCES
+    ${CMAKE_CURRENT_BINARY_DIR}/openmp/TestOpenMP_MultiThreadsRange.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmp/TestOpenMP_MultiThreadsMDRange.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmp/TestOpenMP_MultiThreadsTeam.cpp
+  )
+
   set(OpenMP_EXTRA_SOURCES
     openmp/TestOpenMP_Task.cpp
   )

--- a/core/unit_test/TestMultiThreadsMDRange.hpp
+++ b/core/unit_test/TestMultiThreadsMDRange.hpp
@@ -1,0 +1,153 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_TEST_MultiThreadsMDRange_HPP
+#define KOKKOS_TEST_MultiThreadsMDRange_HPP
+
+#include <Kokkos_Core.hpp>
+
+#include <thread>
+
+namespace Test {
+namespace {
+template <typename ExecSpace>
+struct TestMultiThreadsMDRange {
+  using value_type = int;
+
+  using view_type = Kokkos::View<value_type **, ExecSpace>;
+
+  struct VerifyInitTag {};
+  struct ResetTag {};
+  struct VerifyResetTag {};
+  struct OffsetTag {};
+  struct VerifyOffsetTag {};
+
+  int M;
+  int N;
+  view_type results;
+  view_type results_scan;
+
+  TestMultiThreadsMDRange(size_t const M_, size_t const N_)
+      : M(M_),
+        N(N_),
+        results(Kokkos::view_alloc(Kokkos::WithoutInitializing, "results"), M,
+                N),
+        results_scan(
+            Kokkos::view_alloc(Kokkos::WithoutInitializing, "results_scan"), M,
+            N) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(int const i, int j) const { results(i, j) = i + j; }
+
+  void check_result_for() {
+    auto results_host =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), results);
+    for (int i = 0; i < M; ++i) {
+      for (int j = 0; j < N; ++j) {
+        ASSERT_EQ(results_host(i, j), i + j);
+      }
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(int const i, int const j, value_type &lsum) const {
+    lsum += results(i, j);
+  }
+};
+}  // namespace
+
+TEST(TEST_CATEGORY, multiple_mdrange_for) {
+  size_t const M_0 = 10000;
+  size_t const M_1 = 2 * M_0;
+  size_t const N   = 2;
+  TestMultiThreadsMDRange<TEST_EXECSPACE> mdrange_0(M_0, N);
+  TestMultiThreadsMDRange<TEST_EXECSPACE> mdrange_1(M_1, N);
+  using range_type = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<N>>;
+  auto f_0         = [&]() {
+    range_type range({0, 0}, {M_0, N});
+    Kokkos::parallel_for(range, mdrange_0);
+  };
+  auto f_1 = [&]() {
+    range_type range({0, 0}, {M_1, N});
+    Kokkos::parallel_for(range, mdrange_1);
+  };
+
+  std::thread t_0(f_0);
+  std::thread t_1(f_1);
+  t_0.join();
+  t_1.join();
+
+  mdrange_0.check_result_for();
+  mdrange_1.check_result_for();
+}
+
+TEST(TEST_CATEGORY, multiple_mdrange_reduce) {
+  size_t constexpr M_0 = 10000;
+  size_t constexpr M_1 = 2 * M_0;
+  size_t constexpr N   = 2;
+  int total_0          = 0;
+  int total_1          = 0;
+  int ref_0            = ((M_0 - 1) * M_0 + M_0 * (M_0 + 1)) / 2;
+  int ref_1            = ((M_1 - 1) * M_1 + M_1 * (M_1 + 1)) / 2;
+  TestMultiThreadsMDRange<TEST_EXECSPACE> mdrange_0(M_0, N);
+  TestMultiThreadsMDRange<TEST_EXECSPACE> mdrange_1(M_1, N);
+  using range_type = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<N>>;
+  range_type range_0({0, 0}, {M_0, N});
+  range_type range_1({0, 0}, {M_1, N});
+  Kokkos::parallel_for(range_0, mdrange_0);
+  Kokkos::parallel_for(range_1, mdrange_1);
+  auto f_0 = [&]() { Kokkos::parallel_reduce(range_0, mdrange_0, total_0); };
+  auto f_1 = [&]() { Kokkos::parallel_reduce(range_1, mdrange_1, total_1); };
+
+  std::thread t_0(f_0);
+  std::thread t_1(f_1);
+  t_0.join();
+  t_1.join();
+
+  ASSERT_EQ(total_0, ref_0);
+  ASSERT_EQ(total_1, ref_1);
+}
+}  // namespace Test
+
+#endif

--- a/core/unit_test/TestMultiThreadsRange.hpp
+++ b/core/unit_test/TestMultiThreadsRange.hpp
@@ -1,0 +1,181 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_TEST_MultiThreadsRange_HPP
+#define KOKKOS_TEST_MultiThreadsRange_HPP
+
+#include <Kokkos_Core.hpp>
+
+#include <thread>
+
+namespace Test {
+namespace {
+template <typename ExecSpace>
+struct TestMultiThreadsRange {
+  using value_type = int;
+
+  using view_type = Kokkos::View<value_type *, ExecSpace>;
+
+  struct VerifyInitTag {};
+  struct ResetTag {};
+  struct VerifyResetTag {};
+  struct OffsetTag {};
+  struct VerifyOffsetTag {};
+
+  int N;
+  view_type results;
+  view_type results_scan;
+
+  TestMultiThreadsRange(size_t const N_)
+      : N(N_),
+        results(Kokkos::view_alloc(Kokkos::WithoutInitializing, "results"), N),
+        results_scan(
+            Kokkos::view_alloc(Kokkos::WithoutInitializing, "results_scan"),
+            N) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(int const i) const { results(i) = i; }
+
+  void check_result_for() {
+    auto results_host =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), results);
+    for (int i = 0; i < N; ++i) ASSERT_EQ(results_host(i), i);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(int const i, value_type &update) const {
+    update += results(i);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(int const i, value_type &update, bool last_pass) const {
+    update += results(i);
+    if (last_pass) {
+      results_scan(i) = update;
+    }
+  }
+};
+
+}  // namespace
+
+TEST(TEST_CATEGORY, multiple_range_for) {
+  size_t const N_0 = 10000;
+  size_t const N_1 = 2 * N_0;
+  TestMultiThreadsRange<TEST_EXECSPACE> range_0(N_0);
+  TestMultiThreadsRange<TEST_EXECSPACE> range_1(N_1);
+  auto f_0 = [&]() {
+    Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, N_0), range_0);
+  };
+  auto f_1 = [&]() {
+    Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, N_1), range_1);
+  };
+  std::thread t_0(f_0);
+  std::thread t_1(f_1);
+  t_0.join();
+  t_1.join();
+
+  range_0.check_result_for();
+  range_1.check_result_for();
+}
+
+TEST(TEST_CATEGORY, multiple_range_reduce) {
+  size_t const N_0 = 10000;
+  size_t const N_1 = 2 * N_0;
+  int total_0      = 0;
+  int total_1      = 0;
+  int ref_0        = (N_0 - 1) * N_0 / 2;
+  int ref_1        = (N_1 - 1) * N_1 / 2;
+  TestMultiThreadsRange<TEST_EXECSPACE> range_0(N_0);
+  TestMultiThreadsRange<TEST_EXECSPACE> range_1(N_1);
+  Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, N_0), range_0);
+  Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, N_1), range_1);
+
+  auto f_0 = [&]() {
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<TEST_EXECSPACE>(0, N_0),
+                            range_0, total_0);
+  };
+  auto f_1 = [&]() {
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<TEST_EXECSPACE>(0, N_1),
+                            range_1, total_1);
+  };
+  std::thread t_0(f_0);
+  std::thread t_1(f_1);
+  t_0.join();
+  t_1.join();
+
+  ASSERT_EQ(total_0, ref_0);
+  ASSERT_EQ(total_1, ref_1);
+}
+
+TEST(TEST_CATEGORY, multiple_range_scan) {
+  size_t const N_0 = 10000;
+  size_t const N_1 = 2 * N_0;
+  int total_0      = 0;
+  int total_1      = 0;
+  int ref_0        = (N_0 - 1) * N_0 / 2;
+  int ref_1        = (N_1 - 1) * N_1 / 2;
+  TestMultiThreadsRange<TEST_EXECSPACE> range_0(N_0);
+  TestMultiThreadsRange<TEST_EXECSPACE> range_1(N_1);
+  Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, N_0), range_0);
+  Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, N_1), range_1);
+
+  auto f_0 = [&]() {
+    Kokkos::parallel_scan(Kokkos::RangePolicy<TEST_EXECSPACE>(0, N_0), range_0,
+                          total_0);
+  };
+  auto f_1 = [&]() {
+    Kokkos::parallel_scan(Kokkos::RangePolicy<TEST_EXECSPACE>(0, N_1), range_1,
+                          total_1);
+  };
+  std::thread t_0(f_0);
+  std::thread t_1(f_1);
+  t_0.join();
+  t_1.join();
+
+  ASSERT_EQ(total_0, ref_0);
+  ASSERT_EQ(total_1, ref_1);
+}
+}  // namespace Test
+
+#endif

--- a/core/unit_test/TestMultiThreadsTeam.hpp
+++ b/core/unit_test/TestMultiThreadsTeam.hpp
@@ -1,0 +1,174 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_TEST_MultiThreadsTeam_HPP
+#define KOKKOS_TEST_MultiThreadsTeam_HPP
+
+#include <Kokkos_Core.hpp>
+
+#include <thread>
+
+namespace Test {
+namespace {
+template <typename ExecSpace>
+struct TestMultiThreadsTeam {
+  using value_type = int;
+
+  using view_type = Kokkos::View<value_type *, ExecSpace>;
+
+  struct VerifyInitTag {};
+  struct ResetTag {};
+  struct VerifyResetTag {};
+  struct OffsetTag {};
+  struct VerifyOffsetTag {};
+
+  int N;
+  int team_size;
+  view_type results;
+  view_type results_scan;
+
+  TestMultiThreadsTeam(int const N_, int const team_size_)
+      : N(N_),
+        team_size(team_size_),
+        results(Kokkos::view_alloc(Kokkos::WithoutInitializing, "results"), N) {
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(
+      typename Kokkos::TeamPolicy<ExecSpace>::member_type const team) const {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, team_size),
+                         [&](int const i) {
+                           int const j = team.league_rank() * team_size + i;
+                           results(j)  = j;
+                         });
+  }
+
+  void check_result_for() {
+    auto results_host =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), results);
+    for (int i = 0; i < N; ++i) ASSERT_EQ(results_host(i), i);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(
+      typename Kokkos::TeamPolicy<ExecSpace>::member_type const team,
+      value_type &update) const {
+    value_type tmp = 0;
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(team, team_size),
+        [&](int const i, value_type &innerUpdate) {
+          int const j = team.league_rank() * team_size + i;
+          innerUpdate += results(j);
+        },
+        tmp);
+
+    if (team.team_rank() == 0) {
+      update += tmp;
+    }
+  }
+};
+}  // namespace
+
+TEST(TEST_CATEGORY, multiple_team_for) {
+  int const N_0       = 100000;
+  int const N_1       = 2 * N_0;
+  int const team_size = 1;
+  TestMultiThreadsTeam<TEST_EXECSPACE> range_0(N_0, team_size);
+  TestMultiThreadsTeam<TEST_EXECSPACE> range_1(N_1, team_size);
+  auto f_0 = [&]() {
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<TEST_EXECSPACE>(N_0 / team_size, team_size),
+        range_0);
+  };
+  auto f_1 = [&]() {
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<TEST_EXECSPACE>(N_1 / team_size, team_size),
+        range_1);
+  };
+  std::thread t_0(f_0);
+  std::thread t_1(f_1);
+  t_0.join();
+  t_1.join();
+
+  range_0.check_result_for();
+  range_1.check_result_for();
+}
+
+TEST(TEST_CATEGORY, multiple_team_reduce) {
+  size_t const N_0    = 10;
+  size_t const N_1    = 2 * N_0;
+  int total_0         = 0;
+  int total_1         = 0;
+  int const team_size = 1;
+  int ref_0           = (N_0 - 1) * N_0 / 2;
+  int ref_1           = (N_1 - 1) * N_1 / 2;
+  TestMultiThreadsTeam<TEST_EXECSPACE> range_0(N_0 / team_size, team_size);
+  TestMultiThreadsTeam<TEST_EXECSPACE> range_1(N_1 / team_size, team_size);
+  auto f_0 = [&]() {
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<TEST_EXECSPACE>(N_0 / team_size, team_size),
+        range_0);
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<TEST_EXECSPACE>(N_0 / team_size, team_size), range_0,
+        total_0);
+  };
+  auto f_1 = [&]() {
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<TEST_EXECSPACE>(N_1 / team_size, team_size),
+        range_1);
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<TEST_EXECSPACE>(N_1 / team_size, team_size), range_1,
+        total_1);
+  };
+  std::thread t_0(f_0);
+  std::thread t_1(f_1);
+  t_0.join();
+  t_1.join();
+
+  ASSERT_EQ(total_0, ref_0);
+  ASSERT_EQ(total_1, ref_1);
+}
+}  // namespace Test
+
+#endif


### PR DESCRIPTION
This PR adds tests that launch kernels from `std::thread` in order to check basic thread safety. The tests cover:
 - `parallel_for` for `Range`, `MDRange`, and `Team`
 - `parallel_reduce` for `Range`, `MDRange`, and `Team`
 - `parallel_scan` for `Range`
 
The tests are disabled for OpenMP. With the `OpenMP` backend, we cannot launch a kernel from `std::thread`. This is because only the master thread can launch a kernel (possible fix #4119).


I've opened the PR to trigger the CI. It's not ready for review yet.