### PR TITLE
Add workaround for SYCL team_broadcast

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -107,10 +107,26 @@ class SYCLTeamMember {
   //--------------------------------------------------------------------------
 
   template <class ValueType>
-  KOKKOS_INLINE_FUNCTION void team_broadcast(ValueType& val,
-                                             const int thread_id) const {
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_arithmetic_v<ValueType>>
+  team_broadcast(ValueType& val, const int thread_id) const {
     val = sycl::group_broadcast(m_item.get_group(), val,
                                 sycl::id<2>(thread_id, 0));
+  }
+
+  // FIXME_SYCL Remove this branch once the Intel oneAPI implementation is
+  // conforming to the SYCL2020 standard
+  template <class ValueType>
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<!std::is_arithmetic_v<ValueType>>
+  team_broadcast(ValueType& val, const int thread_id) const {
+    // Wait for shared data write until all threads arrive here
+    m_item.barrier(sycl::access::fence_space::local_space);
+    if (m_item.get_local_id(1) == 0 &&
+        static_cast<int>(m_item.get_local_id(0)) == thread_id) {
+      *static_cast<ValueType*>(m_team_reduce) = val;
+    }
+    // Wait for shared data read until root thread writes
+    m_item.barrier(sycl::access::fence_space::local_space);
+    val = *(static_cast<ValueType*>(m_team_reduce));
   }
 
   template <class Closure, class ValueType>


### PR DESCRIPTION
Despite `SYCL2020` not constraining sycl::group_broadcast` (https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_group_broadcast), the oneAPI implementation does, see https://github.com/intel/llvm/blob/f844f709820fd3b5fad008eb9d957334a8093ef7/sycl/include/CL/sycl/group_algorithm.hpp#L452-L499.
Apparently, we were only testing arithmetic types in `Kokkos` but `KokkosKernels` requires calling `team_broadcast` also for non-arithmetic types, thus failing at build time.

The implementation in this pull request as a workaround mirrors what we had previous to switching to `sycl::grou_broadcast`, see https://github.com/kokkos/kokkos/pull/4103/files, and this also largely matches what we have for `CUDA` and `SYCL` apart from the optimization for `group size` less or equal to `sub group` size.