### PR TITLE
SYCL: Fix race conditions in TeamPolicy::parallel_reduce

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -74,19 +74,16 @@ void workgroup_reduction(sycl::nd_item<dim>& item,
   for (unsigned int i = 0; i < dim; ++i) wgroup_size *= item.get_local_range(i);
 
   // Perform the actual workgroup reduction in each subgroup
-  // separately. To achieve a better memory access pattern, we use
-  // sequential addressing and a reversed loop. If the workgroup
-  // size is 8, the first element contains all the values with
-  // index%4==0, after the second one the values with index%2==0 and
-  // after the third one index%1==0, i.e., all values.
+  // separately.
   auto sg                = item.get_sub_group();
   auto* result           = &local_mem[local_id * value_count];
   const auto id_in_sg    = sg.get_local_id()[0];
   const auto local_range = std::min(sg.get_local_range()[0], wgroup_size);
-  for (unsigned int stride = local_range / 2; stride > 0; stride >>= 1) {
-    auto* tmp = sg.shuffle_down(result, stride);
+  for (unsigned int stride = 1; stride < local_range; stride <<= 1) {
     if (id_in_sg + stride < local_range)
-      ValueJoin::join(selected_reducer, result, tmp);
+      ValueJoin::join(selected_reducer, result,
+                      &local_mem[(local_id + stride) * value_count]);
+    sg.barrier();
   }
   item.barrier(sycl::access::fence_space::local_space);
 
@@ -109,11 +106,14 @@ void workgroup_reduction(sycl::nd_item<dim>& item,
       if (id_in_sg + offset < n_subgroups)
         ValueJoin::join(selected_reducer, result_,
                         &local_mem[(id_in_sg + offset) * value_count]);
+    sg.barrier();
+
     // Then, we proceed as before.
-    for (unsigned int stride = local_range / 2; stride > 0; stride >>= 1) {
-      auto* tmp = sg.shuffle_down(result_, stride);
+    for (unsigned int stride = 1; stride < local_range; stride <<= 1) {
       if (id_in_sg + stride < n_subgroups)
-        ValueJoin::join(selected_reducer, result_, tmp);
+        ValueJoin::join(selected_reducer, result_,
+                        &local_mem[(id_in_sg + stride) * value_count]);
+      sg.barrier();
     }
 
     // Finally, we copy the workgroup results back to global memory

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -665,16 +665,11 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         const int scratch_size[2]  = {m_scratch_size[0], m_scratch_size[1]};
         void* const scratch_ptr[2] = {m_scratch_ptr[0], m_scratch_ptr[1]};
 
-        sycl::range<2> global =
-            first_run
-                ? sycl::range<2>(m_team_size, m_league_size * m_vector_size)
-                : sycl::range<2>(1, n_wgroups * wgroup_size);
-        sycl::range<2> local = first_run
-                                   ? sycl::range<2>(m_team_size, m_vector_size)
-                                   : sycl::range<2>(1, wgroup_size);
-
         cgh.parallel_for(
-            sycl::nd_range<2>(global, local), [=](sycl::nd_item<2> item) {
+            sycl::nd_range<2>(
+                sycl::range<2>(m_team_size, m_league_size * m_vector_size),
+                sycl::range<2>(m_team_size, m_vector_size)),
+            [=](sycl::nd_item<2> item) {
 #ifdef KOKKOS_ENABLE_DEBUG
               if (first_run && item.get_sub_group().get_local_range() %
                                        item.get_local_range(1) !=


### PR DESCRIPTION
Running on different GPUs revealed some more race conditions that should be fixed by this pull request.
There are some other minor changes along the way, like decreasing the number of threads launched after each reduction recursion, restricting an error check to the first iteration, and allowing non-power of two workgroup sizes.