### PR TITLE
Drop noexcept specifier in defaulted `Kokkos::complex` default constructor

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -77,7 +77,7 @@ class
 
   //! Default constructor (initializes both real and imaginary parts to zero).
   KOKKOS_DEFAULTED_FUNCTION
-  complex() noexcept = default;
+  complex() = default;
 
   //! Copy constructor.
   KOKKOS_DEFAULTED_FUNCTION


### PR DESCRIPTION
Fixes #4376.

Tested d9187bb via nightly XL build number 51 and 9804013 via build number 52.