### PR TITLE
Drop unused function `<anonymous>::cuda_launch_blocking`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -129,16 +129,6 @@ int cuda_kernel_arch() {
   return arch;
 }
 
-#ifdef KOKKOS_ENABLE_CUDA_UVM
-bool cuda_launch_blocking() {
-  const char *env = getenv("CUDA_LAUNCH_BLOCKING");
-
-  if (env == nullptr) return false;
-
-  return std::stoi(env);
-}
-#endif
-
 }  // namespace
 
 void cuda_device_synchronize(const std::string &name) {


### PR DESCRIPTION
Fix #4412 by removing the function that is unused and has internal linkage (defined in unnamed namespace in a source file)