### PR TITLE
Replace std::unique_lock by std::lock_guard in HIP and SYCL

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -247,7 +247,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   size_type* m_scratch_flags;
   // Only let one Parallel/Scan modify the shared memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::unique_lock<std::mutex> m_shared_memory_lock;
+  std::lock_guard<std::mutex> m_shared_memory_lock;
 
   using DeviceIteratePattern = typename Kokkos::Impl::Reduce::DeviceIterateTile<
       Policy::rank, Policy, FunctorType, WorkTag, reference_type>;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -180,7 +180,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   size_type* m_scratch_flags = nullptr;
   // Only let one ParallelReduce/Scan modify the shared memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::unique_lock<std::mutex> m_shared_memory_lock;
+  std::lock_guard<std::mutex> m_shared_memory_lock;
 
   static bool constexpr UseShflReduction =
       static_cast<bool>(ValueTraits::StaticValueSize);
@@ -484,7 +484,7 @@ class ParallelScanHIPBase {
   int m_grid_x               = 0;
   // Only let one ParallelReduce/Scan modify the shared memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::unique_lock<std::mutex> m_shared_memory_lock;
+  std::lock_guard<std::mutex> m_shared_memory_lock;
 
  private:
   template <class TagType>

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -479,7 +479,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   int m_scratch_size[2];
   // Only let one ParallelFor/Reduce modify the team scratch memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::unique_lock<std::mutex> m_scratch_lock;
+  std::lock_guard<std::mutex> m_scratch_lock;
 
   template <typename TagType>
   __device__ inline
@@ -677,7 +677,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   const size_type m_vector_size;
   // Only let one ParallelFor/Reduce modify the team scratch memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::unique_lock<std::mutex> m_scratch_lock;
+  std::lock_guard<std::mutex> m_scratch_lock;
 
   template <class TagType>
   __device__ inline

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -131,7 +131,7 @@ void SYCL::impl_static_fence(const std::string& name) {
           GlobalDeviceSynchronization,
       [&]() {
         // guard accessing all_queues
-        std::lock_guard<std::mutex> lock(Impl::SYCLInternal::mutex);
+        std::scoped_lock<std::mutex> lock(Impl::SYCLInternal::mutex);
         for (auto& queue : Impl::SYCLInternal::all_queues) {
           try {
             (*queue)->wait_and_throw();

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -131,7 +131,7 @@ void SYCL::impl_static_fence(const std::string& name) {
           GlobalDeviceSynchronization,
       [&]() {
         // guard accessing all_queues
-        std::scoped_lock<std::mutex> lock(Impl::SYCLInternal::mutex);
+        std::scoped_lock lock(Impl::SYCLInternal::mutex);
         for (auto& queue : Impl::SYCLInternal::all_queues) {
           try {
             (*queue)->wait_and_throw();

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -111,7 +111,7 @@ void SYCLInternal::initialize(const sycl::queue& q) {
     m_queue = q;
     // guard pushing to all_queues
     {
-      std::lock_guard<std::mutex> lock(mutex);
+      std::scoped_lock<std::mutex> lock(mutex);
       all_queues.push_back(&m_queue);
     }
     const sycl::device& d = m_queue->get_device();
@@ -213,7 +213,7 @@ void SYCLInternal::finalize() {
   m_indirectReducerMem.reset();
   // guard erasing from all_queues
   {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock<std::mutex> lock(mutex);
     all_queues.erase(std::find(all_queues.begin(), all_queues.end(), &m_queue));
   }
   m_queue.reset();

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -111,7 +111,7 @@ void SYCLInternal::initialize(const sycl::queue& q) {
     m_queue = q;
     // guard pushing to all_queues
     {
-      std::scoped_lock<std::mutex> lock(mutex);
+      std::scoped_lock lock(mutex);
       all_queues.push_back(&m_queue);
     }
     const sycl::device& d = m_queue->get_device();
@@ -213,7 +213,7 @@ void SYCLInternal::finalize() {
   m_indirectReducerMem.reset();
   // guard erasing from all_queues
   {
-    std::scoped_lock<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
     all_queues.erase(std::find(all_queues.begin(), all_queues.end(), &m_queue));
   }
   m_queue.reset();

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -379,7 +379,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
   // Only let one Parallel/Scan modify the shared memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::unique_lock<std::mutex> m_shared_memory_lock;
+  std::lock_guard<std::mutex> m_shared_memory_lock;
 };
 
 template <class FunctorType, class ReducerType, class... Traits>
@@ -672,7 +672,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
   // Only let one Parallel/Scan modify the shared memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::unique_lock<std::mutex> m_shared_memory_lock;
+  std::lock_guard<std::mutex> m_shared_memory_lock;
 };
 
 }  // namespace Impl

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -379,7 +379,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
   // Only let one Parallel/Scan modify the shared memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::lock_guard<std::mutex> m_shared_memory_lock;
+  std::scoped_lock<std::mutex> m_shared_memory_lock;
 };
 
 template <class FunctorType, class ReducerType, class... Traits>
@@ -672,7 +672,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
   // Only let one Parallel/Scan modify the shared memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::lock_guard<std::mutex> m_shared_memory_lock;
+  std::scoped_lock<std::mutex> m_shared_memory_lock;
 };
 
 }  // namespace Impl

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -84,7 +84,7 @@ class ParallelScanSYCLBase {
 
   // Only let one Parallel/Scan modify the shared memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::lock_guard<std::mutex> m_shared_memory_lock;
+  std::scoped_lock<std::mutex> m_shared_memory_lock;
 
  private:
   template <typename Functor>

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -84,7 +84,7 @@ class ParallelScanSYCLBase {
 
   // Only let one Parallel/Scan modify the shared memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::unique_lock<std::mutex> m_shared_memory_lock;
+  std::lock_guard<std::mutex> m_shared_memory_lock;
 
  private:
   template <typename Functor>

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -398,7 +398,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   int m_scratch_size[2];
   // Only let one ParallelFor/Reduce modify the team scratch memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::unique_lock<std::mutex> m_scratch_lock;
+  std::lock_guard<std::mutex> m_scratch_lock;
 
   template <typename Functor>
   sycl::event sycl_direct_launch(const Policy& policy,
@@ -559,7 +559,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   const size_type m_vector_size;
   // Only let one ParallelFor/Reduce modify the team scratch memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::unique_lock<std::mutex> m_scratch_lock;
+  std::lock_guard<std::mutex> m_scratch_lock;
 
   template <typename PolicyType, typename Functor, typename Reducer>
   sycl::event sycl_direct_launch(const PolicyType& policy,

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -398,7 +398,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   int m_scratch_size[2];
   // Only let one ParallelFor/Reduce modify the team scratch memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::lock_guard<std::mutex> m_scratch_lock;
+  std::scoped_lock<std::mutex> m_scratch_lock;
 
   template <typename Functor>
   sycl::event sycl_direct_launch(const Policy& policy,
@@ -559,7 +559,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   const size_type m_vector_size;
   // Only let one ParallelFor/Reduce modify the team scratch memory. The
   // constructor acquires the mutex which is released in the destructor.
-  std::lock_guard<std::mutex> m_scratch_lock;
+  std::scoped_lock<std::mutex> m_scratch_lock;
 
   template <typename PolicyType, typename Functor, typename Reducer>
   sycl::event sycl_direct_launch(const PolicyType& policy,


### PR DESCRIPTION
As discussed in https://github.com/kokkos/kokkos/pull/4408#discussion_r729994077 and https://github.com/kokkos/kokkos/pull/3916#discussion_r605885333, we should be able to replace `std::unique_lock` with `std::lock_guard` which might be better suited since we only want to lock the respective mutexes once in the constructor and release the lock in the destructor. One caveat is that this makes the respective classes non-moveable and non-copyable.