### PR TITLE
Fix intel hang

### DIFF
--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -2751,11 +2751,18 @@ struct TestMDRange_6D {
                            const int N3, const int N4, const int N5) {
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<128, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2774,11 +2781,18 @@ struct TestMDRange_6D {
 #endif
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2811,11 +2825,18 @@ struct TestMDRange_6D {
 
     // Test with reducers - scalar
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
 #ifdef KOKKOS_ENABLE_SYCL
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 2, 2, 2}});
@@ -2838,11 +2859,18 @@ struct TestMDRange_6D {
 
     // Test with reducers - scalar + label
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
 
 #ifdef KOKKOS_ENABLE_SYCL
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
@@ -2866,12 +2894,19 @@ struct TestMDRange_6D {
 
     // Test with reducers - scalar view
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
                                          Kokkos::IndexType<int>,
                                          Kokkos::LaunchBounds<512, 1>>;
+#endif
 #ifdef KOKKOS_ENABLE_SYCL
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 2, 2, 2}});
@@ -2899,11 +2934,18 @@ struct TestMDRange_6D {
     // Test Min reducer with lambda
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<128, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       range_type range({{1, 1, 1, 1, 1, 1}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 2, 2, 1}});
 
@@ -2936,12 +2978,19 @@ struct TestMDRange_6D {
 
     // Tagged operator test
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
+          Kokkos::IndexType<int>, InitTag>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
           Kokkos::IndexType<int>, InitTag>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2993,11 +3042,18 @@ struct TestMDRange_6D {
                         const int N4, const int N5) {
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<128, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3046,10 +3102,16 @@ struct TestMDRange_6D {
 #endif
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>>;
+#endif
       using point_type = typename range_type::point_type;
 
       range_type range(point_type{{0, 0, 0, 0, 0, 0}},
@@ -3082,11 +3144,18 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>, InitTag>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>, InitTag>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3137,11 +3206,18 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3182,12 +3258,19 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
+          Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3228,12 +3311,19 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Left, Iterate::Left>,
+          Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Left, Iterate::Left>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3274,12 +3364,19 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Left, Iterate::Right>,
+          Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Left, Iterate::Right>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3320,12 +3417,19 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Right, Iterate::Left>,
+          Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Right, Iterate::Left>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3366,12 +3470,19 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Right, Iterate::Right>,
+          Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Right, Iterate::Right>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3722,11 +3833,18 @@ struct TestMDRange_6D_NegIdx {
   static void test_6D_negidx(const int N0, const int N1, const int N2,
                              const int N3, const int N4, const int N5) {
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<256, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 


### PR DESCRIPTION
Use of Launchbounds within the MDRangePolicy rank 6 unit tests caused hangs with intel/{17,18,19} compilers
These changes workaround the issue by adding guards to only add the Launchbounds when intel is not compiler