### PR TITLE
Temporarily disable OPENMPTARGET-ROCm-4.2 build on Jenkins CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -133,6 +133,7 @@ pipeline {
                         }
                     }
                 }
+                /*
                 stage('OPENMPTARGET-ROCm-4.2') {
                     agent {
                         dockerfile {
@@ -175,6 +176,7 @@ pipeline {
                         }
                     }
                 }
+                */
                 stage('OPENMPTARGET-Clang') {
                     agent {
                         dockerfile {


### PR DESCRIPTION
The build times have dramatically increased this week (likely since we merged #4315) and the queue has become insane on ORNL's Jenkins server.  This PR temporarily disable that test while we investigate what happened and will do until we find a proper solution.