### PR TITLE
Reverting the OpenMP API check for omp_max_active_levels to use OpenMP4.5

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -167,7 +167,7 @@ inline bool OpenMP::is_asynchronous(OpenMP const& /*instance*/) noexcept {
 template <typename F>
 void OpenMP::partition_master(F const& f, int num_partitions,
                               int partition_size) {
-#if _OPENMP >= 201811
+#if _OPENMP >= 201511
   if (omp_get_max_active_levels() > 1) {
 #else
   if (omp_get_nested()) {


### PR DESCRIPTION
The PR aims to close #3142 . 