### PR TITLE
Don't print output to std::cout for passing tests

### DIFF
--- a/algorithms/unit_tests/UnitTestMain.cpp
+++ b/algorithms/unit_tests/UnitTestMain.cpp
@@ -58,7 +58,7 @@ class MinimalistPrinter : public testing::EmptyTestEventListener {
       const testing::TestPartResult& test_part_result) override {
     switch (test_part_result.type()) {
       // If the test part succeeded, we don't need to do anything.
-      case TestPartResult::kSuccess: break;
+      case testing::TestPartResult::kSuccess: break;
       default: std::cout.rdbuf(sbuf); std::cout << buffer.str() << std::endl;
     }
     buffer.str(std::string());  // clears the buffer.

--- a/containers/performance_tests/TestMain.cpp
+++ b/containers/performance_tests/TestMain.cpp
@@ -60,7 +60,7 @@ class MinimalistPrinter : public testing::EmptyTestEventListener {
       const testing::TestPartResult& test_part_result) override {
     switch (test_part_result.type()) {
       // If the test part succeeded, we don't need to do anything.
-      case TestPartResult::kSuccess: break;
+      case testing::TestPartResult::kSuccess: break;
       default: std::cout.rdbuf(sbuf); std::cout << buffer.str() << std::endl;
     }
     buffer.str(std::string());  // clears the buffer.

--- a/containers/performance_tests/TestMain.cpp
+++ b/containers/performance_tests/TestMain.cpp
@@ -47,9 +47,43 @@
 
 #include <Kokkos_Core.hpp>
 
-int main(int argc, char *argv[]) {
+class MinimalistPrinter : public testing::EmptyTestEventListener {
+  // Called before a test starts.
+  void OnTestStart(const testing::TestInfo&) override {
+    buffer.str(std::string());  // clears the buffer.
+    sbuf = std::cout.rdbuf();
+    std::cout.rdbuf(buffer.rdbuf());
+  }
+
+  // Called after a failed assertion or a SUCCESS().
+  void OnTestPartResult(
+      const testing::TestPartResult& test_part_result) override {
+    switch (test_part_result.type()) {
+      // If the test part succeeded, we don't need to do anything.
+      case TestPartResult::kSuccess: break;
+      default: std::cout.rdbuf(sbuf); std::cout << buffer.str() << std::endl;
+    }
+    buffer.str(std::string());  // clears the buffer.
+    sbuf = std::cout.rdbuf();
+    std::cout.rdbuf(buffer.rdbuf());
+  }
+
+  // Called after a test ends.
+  void OnTestEnd(const testing::TestInfo&) override { std::cout.rdbuf(sbuf); }
+
+  std::stringstream buffer;
+  std::streambuf* sbuf;
+};
+
+int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+
+  ::testing::TestEventListeners& listeners =
+      ::testing::UnitTest::GetInstance()->listeners();
+  auto default_listener = listeners.Release(listeners.default_result_printer());
+  listeners.Append(new MinimalistPrinter);
+  listeners.Append(default_listener);
 
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();

--- a/containers/unit_tests/UnitTestMain.cpp
+++ b/containers/unit_tests/UnitTestMain.cpp
@@ -58,7 +58,7 @@ class MinimalistPrinter : public testing::EmptyTestEventListener {
       const testing::TestPartResult& test_part_result) override {
     switch (test_part_result.type()) {
       // If the test part succeeded, we don't need to do anything.
-      case TestPartResult::kSuccess: break;
+      case testing::TestPartResult::kSuccess: break;
       default: std::cout.rdbuf(sbuf); std::cout << buffer.str() << std::endl;
     }
     buffer.str(std::string());  // clears the buffer.

--- a/core/perf_test/PerfTestMain.cpp
+++ b/core/perf_test/PerfTestMain.cpp
@@ -78,7 +78,7 @@ class MinimalistPrinter : public testing::EmptyTestEventListener {
       const testing::TestPartResult& test_part_result) override {
     switch (test_part_result.type()) {
       // If the test part succeeded, we don't need to do anything.
-      case TestPartResult::kSuccess: break;
+      case testing::TestPartResult::kSuccess: break;
       default: std::cout.rdbuf(sbuf); std::cout << buffer.str() << std::endl;
     }
     buffer.str(std::string());  // clears the buffer.

--- a/core/perf_test/PerfTestMain.cpp
+++ b/core/perf_test/PerfTestMain.cpp
@@ -65,9 +65,43 @@ const char* command_line_arg(int k, char** input_args = nullptr) {
 
 }  // namespace Test
 
+class MinimalistPrinter : public testing::EmptyTestEventListener {
+  // Called before a test starts.
+  void OnTestStart(const testing::TestInfo&) override {
+    buffer.str(std::string());  // clears the buffer.
+    sbuf = std::cout.rdbuf();
+    std::cout.rdbuf(buffer.rdbuf());
+  }
+
+  // Called after a failed assertion or a SUCCESS().
+  void OnTestPartResult(
+      const testing::TestPartResult& test_part_result) override {
+    switch (test_part_result.type()) {
+      // If the test part succeeded, we don't need to do anything.
+      case TestPartResult::kSuccess: break;
+      default: std::cout.rdbuf(sbuf); std::cout << buffer.str() << std::endl;
+    }
+    buffer.str(std::string());  // clears the buffer.
+    sbuf = std::cout.rdbuf();
+    std::cout.rdbuf(buffer.rdbuf());
+  }
+
+  // Called after a test ends.
+  void OnTestEnd(const testing::TestInfo&) override { std::cout.rdbuf(sbuf); }
+
+  std::stringstream buffer;
+  std::streambuf* sbuf;
+};
+
 int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
   Kokkos::initialize(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+
+  ::testing::TestEventListeners& listeners =
+      ::testing::UnitTest::GetInstance()->listeners();
+  auto default_listener = listeners.Release(listeners.default_result_printer());
+  listeners.Append(new MinimalistPrinter);
+  listeners.Append(default_listener);
 
   (void)Test::command_line_num_args(argc);
   (void)Test::command_line_arg(0, argv);

--- a/core/unit_test/UnitTestMain.cpp
+++ b/core/unit_test/UnitTestMain.cpp
@@ -58,7 +58,7 @@ class MinimalistPrinter : public testing::EmptyTestEventListener {
       const testing::TestPartResult& test_part_result) override {
     switch (test_part_result.type()) {
       // If the test part succeeded, we don't need to do anything.
-      case TestPartResult::kSuccess: break;
+      case testing::TestPartResult::kSuccess: break;
       default: std::cout.rdbuf(sbuf); std::cout << buffer.str() << std::endl;
     }
     buffer.str(std::string());  // clears the buffer.

--- a/core/unit_test/UnitTestMain.cpp
+++ b/core/unit_test/UnitTestMain.cpp
@@ -45,7 +45,41 @@
 #include <gtest/gtest.h>
 #include <cstdlib>
 
-int main(int argc, char *argv[]) {
+class MinimalistPrinter : public testing::EmptyTestEventListener {
+  // Called before a test starts.
+  void OnTestStart(const testing::TestInfo&) override {
+    buffer.str(std::string());  // clears the buffer.
+    sbuf = std::cout.rdbuf();
+    std::cout.rdbuf(buffer.rdbuf());
+  }
+
+  // Called after a failed assertion or a SUCCESS().
+  void OnTestPartResult(
+      const testing::TestPartResult& test_part_result) override {
+    switch (test_part_result.type()) {
+      // If the test part succeeded, we don't need to do anything.
+      case TestPartResult::kSuccess: break;
+      default: std::cout.rdbuf(sbuf); std::cout << buffer.str() << std::endl;
+    }
+    buffer.str(std::string());  // clears the buffer.
+    sbuf = std::cout.rdbuf();
+    std::cout.rdbuf(buffer.rdbuf());
+  }
+
+  // Called after a test ends.
+  void OnTestEnd(const testing::TestInfo&) override { std::cout.rdbuf(sbuf); }
+
+  std::stringstream buffer;
+  std::streambuf* sbuf;
+};
+
+int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
+  ::testing::TestEventListeners& listeners =
+      ::testing::UnitTest::GetInstance()->listeners();
+  auto default_listener = listeners.Release(listeners.default_result_printer());
+  listeners.Append(new MinimalistPrinter);
+  listeners.Append(default_listener);
+
   return RUN_ALL_TESTS();
 }

--- a/core/unit_test/UnitTestMainInit.cpp
+++ b/core/unit_test/UnitTestMainInit.cpp
@@ -47,9 +47,42 @@
 
 #include <Kokkos_Core.hpp>
 
-int main(int argc, char *argv[]) {
+class MinimalistPrinter : public testing::EmptyTestEventListener {
+  // Called before a test starts.
+  void OnTestStart(const testing::TestInfo&) override {
+    buffer.str(std::string());  // clears the buffer.
+    sbuf = std::cout.rdbuf();
+    std::cout.rdbuf(buffer.rdbuf());
+  }
+
+  // Called after a failed assertion or a SUCCESS().
+  void OnTestPartResult(
+      const testing::TestPartResult& test_part_result) override {
+    switch (test_part_result.type()) {
+      // If the test part succeeded, we don't need to do anything.
+      case testing::TestPartResult::kSuccess: break;
+      default: std::cout.rdbuf(sbuf); std::cout << buffer.str() << std::endl;
+    }
+    buffer.str(std::string());  // clears the buffer.
+    sbuf = std::cout.rdbuf();
+    std::cout.rdbuf(buffer.rdbuf());
+  }
+
+  // Called after a test ends.
+  void OnTestEnd(const testing::TestInfo&) override { std::cout.rdbuf(sbuf); }
+
+  std::stringstream buffer;
+  std::streambuf* sbuf;
+};
+
+int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+  ::testing::TestEventListeners& listeners =
+      ::testing::UnitTest::GetInstance()->listeners();
+  auto default_listener = listeners.Release(listeners.default_result_printer());
+  listeners.Append(new MinimalistPrinter);
+  listeners.Append(default_listener);
 
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();

--- a/core/unit_test/standalone/UnitTestMainInit.cpp
+++ b/core/unit_test/standalone/UnitTestMainInit.cpp
@@ -88,7 +88,7 @@ class MinimalistPrinter : public testing::EmptyTestEventListener {
       const testing::TestPartResult& test_part_result) override {
     switch (test_part_result.type()) {
       // If the test part succeeded, we don't need to do anything.
-      case TestPartResult::kSuccess: break;
+      case testing::TestPartResult::kSuccess: break;
       default: std::cout.rdbuf(sbuf); std::cout << buffer.str() << std::endl;
     }
     buffer.str(std::string());  // clears the buffer.

--- a/core/unit_test/standalone/UnitTestMainInit.cpp
+++ b/core/unit_test/standalone/UnitTestMainInit.cpp
@@ -75,9 +75,43 @@
 #endif
 #include <TestReducers_d.hpp>
 
-int main(int argc, char *argv[]) {
+class MinimalistPrinter : public testing::EmptyTestEventListener {
+  // Called before a test starts.
+  void OnTestStart(const testing::TestInfo&) override {
+    buffer.str(std::string());  // clears the buffer.
+    sbuf = std::cout.rdbuf();
+    std::cout.rdbuf(buffer.rdbuf());
+  }
+
+  // Called after a failed assertion or a SUCCESS().
+  void OnTestPartResult(
+      const testing::TestPartResult& test_part_result) override {
+    switch (test_part_result.type()) {
+      // If the test part succeeded, we don't need to do anything.
+      case TestPartResult::kSuccess: break;
+      default: std::cout.rdbuf(sbuf); std::cout << buffer.str() << std::endl;
+    }
+    buffer.str(std::string());  // clears the buffer.
+    sbuf = std::cout.rdbuf();
+    std::cout.rdbuf(buffer.rdbuf());
+  }
+
+  // Called after a test ends.
+  void OnTestEnd(const testing::TestInfo&) override { std::cout.rdbuf(sbuf); }
+
+  std::stringstream buffer;
+  std::streambuf* sbuf;
+};
+
+int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+
+  ::testing::TestEventListeners& listeners =
+      ::testing::UnitTest::GetInstance()->listeners();
+  auto default_listener = listeners.Release(listeners.default_result_printer());
+  listeners.Append(new MinimalistPrinter);
+  listeners.Append(default_listener);
 
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();


### PR DESCRIPTION
Fixes #4463. All output to `std::cout` is only printed to the screen if the test fails. In that case, we print everything that has been submitted to `std::cout` since the last test.