### PR TITLE
Kokkos_Macros: Fix disable of KOKKOS_DEPRECATED for older intel compi…

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -539,7 +539,7 @@
 // intel error #2651: attribute does not apply to any entity
 // using <deprecated_type> KOKKOS_DEPRECATED = ...
 #if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS) && !defined(__NVCC__) && \
-    (KOKKOS_COMPILER_INTEL <= 1900)
+    (KOKKOS_COMPILER_INTEL > 1900)
 #define KOKKOS_DEPRECATED [[deprecated]]
 #define KOKKOS_DEPRECATED_WITH_COMMENT(comment) [[deprecated(comment)]]
 #else


### PR DESCRIPTION
…lers

Fixes mistaken macro check in #4465 to disable KOKKOS_DEPRECATED macro
for intel compilers v. 17, 18, 19