### PR TITLE
[3.5] Fix disable of KOKKOS_DEPRECATED for older intel compilers cherry pick 4476

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -539,7 +539,7 @@
 // intel error #2651: attribute does not apply to any entity
 // using <deprecated_type> KOKKOS_DEPRECATED = ...
 #if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS) && !defined(__NVCC__) && \
-    (KOKKOS_COMPILER_INTEL <= 1900)
+    (KOKKOS_COMPILER_INTEL > 1900)
 #define KOKKOS_DEPRECATED [[deprecated]]
 #define KOKKOS_DEPRECATED_WITH_COMMENT(comment) [[deprecated(comment)]]
 #else


### PR DESCRIPTION
Kokkos_Macros: Fix disable of KOKKOS_DEPRECATED for older intel compi…

(cherry picked from commit 78f0bd57b5a8c297a6294204c70ca3826f043c4f)