### PR TITLE
algorithms: fix intel failure #4424

### DIFF
--- a/algorithms/src/std_algorithms/modifying_sequence_ops/Kokkos_ModifyingSequenceOperationsSet2.hpp
+++ b/algorithms/src/std_algorithms/modifying_sequence_ops/Kokkos_ModifyingSequenceOperationsSet2.hpp
@@ -106,7 +106,16 @@ struct StdReverseFunctor {
 
   KOKKOS_FUNCTION
   void operator()(index_type i) const {
+    // the swap below is doing the same thing, but
+    // for Intel 18.0.5 does not work.
+    // But putting the impl directly here, it works.
+#ifdef KOKKOS_COMPILER_INTEL
+    typename InputIterator::value_type tmp = std::move(m_first[i]);
+    m_first[i]                            = std::move(m_last[-i - 1]);
+    m_last[-i - 1]			  = std::move(tmp);
+#else
     ::Kokkos::Experimental::swap(m_first[i], m_last[-i - 1]);
+#endif
   }
 
   StdReverseFunctor(InputIterator first, InputIterator last)

--- a/algorithms/src/std_algorithms/modifying_sequence_ops/Kokkos_ModifyingSequenceOperationsSet2.hpp
+++ b/algorithms/src/std_algorithms/modifying_sequence_ops/Kokkos_ModifyingSequenceOperationsSet2.hpp
@@ -111,8 +111,8 @@ struct StdReverseFunctor {
     // But putting the impl directly here, it works.
 #ifdef KOKKOS_COMPILER_INTEL
     typename InputIterator::value_type tmp = std::move(m_first[i]);
-    m_first[i]                            = std::move(m_last[-i - 1]);
-    m_last[-i - 1]			  = std::move(tmp);
+    m_first[i]                             = std::move(m_last[-i - 1]);
+    m_last[-i - 1]                         = std::move(tmp);
 #else
     ::Kokkos::Experimental::swap(m_first[i], m_last[-i - 1]);
 #endif


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/4424
Another instance of `swap` creating a problem for Intel, similarly to what we observed in the [other PR](https://github.com/kokkos/kokkos/pull/4441).
I looked at it more closely, and it seemed to be more sensitive to "strided views". Not sure why, since the swap is operating on individual elements. 