### PR TITLE
Provide valid default team size for SYCL

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -647,30 +647,28 @@ IF(KOKKOS_ENABLE_CUDA AND NOT CUDA_ARCH_ALREADY_SPECIFIED)
   ENDIF()
 ENDIF()
 
-IF (KOKKOS_ENABLE_CUDA)
- #Regardless of version, make sure we define the general architecture name
- IF (KOKKOS_ARCH_KEPLER30 OR KOKKOS_ARCH_KEPLER32 OR KOKKOS_ARCH_KEPLER35 OR KOKKOS_ARCH_KEPLER37)
-   SET(KOKKOS_ARCH_KEPLER ON)
- ENDIF()
+#Regardless of version, make sure we define the general architecture name
+IF (KOKKOS_ARCH_KEPLER30 OR KOKKOS_ARCH_KEPLER32 OR KOKKOS_ARCH_KEPLER35 OR KOKKOS_ARCH_KEPLER37)
+  SET(KOKKOS_ARCH_KEPLER ON)
+ENDIF()
 
- #Regardless of version, make sure we define the general architecture name
- IF (KOKKOS_ARCH_MAXWELL50 OR KOKKOS_ARCH_MAXWELL52 OR KOKKOS_ARCH_MAXWELL53)
-   SET(KOKKOS_ARCH_MAXWELL ON)
- ENDIF()
+#Regardless of version, make sure we define the general architecture name
+IF (KOKKOS_ARCH_MAXWELL50 OR KOKKOS_ARCH_MAXWELL52 OR KOKKOS_ARCH_MAXWELL53)
+  SET(KOKKOS_ARCH_MAXWELL ON)
+ENDIF()
 
- #Regardless of version, make sure we define the general architecture name
- IF (KOKKOS_ARCH_PASCAL60 OR KOKKOS_ARCH_PASCAL61)
-   SET(KOKKOS_ARCH_PASCAL ON)
- ENDIF()
+#Regardless of version, make sure we define the general architecture name
+IF (KOKKOS_ARCH_PASCAL60 OR KOKKOS_ARCH_PASCAL61)
+  SET(KOKKOS_ARCH_PASCAL ON)
+ENDIF()
 
-  #Regardless of version, make sure we define the general architecture name
-  IF (KOKKOS_ARCH_VOLTA70 OR KOKKOS_ARCH_VOLTA72)
-    SET(KOKKOS_ARCH_VOLTA ON)
-  ENDIF()
+#Regardless of version, make sure we define the general architecture name
+IF (KOKKOS_ARCH_VOLTA70 OR KOKKOS_ARCH_VOLTA72)
+  SET(KOKKOS_ARCH_VOLTA ON)
+ENDIF()
 
-  IF (KOKKOS_ARCH_AMPERE80 OR KOKKOS_ARCH_AMPERE86)
-    SET(KOKKOS_ARCH_AMPERE ON)
-  ENDIF()
+IF (KOKKOS_ARCH_AMPERE80 OR KOKKOS_ARCH_AMPERE86)
+  SET(KOKKOS_ARCH_AMPERE ON)
 ENDIF()
 
 #CMake verbose is kind of pointless

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -330,10 +330,21 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
         (space().impl_internal_space_instance()->m_maxShmemPerBlock -
          2 * sizeof(double) - m_team_scratch_size[0]) /
         (sizeof(double) + m_thread_scratch_size[0]);
+    // FIXME_SYCL Avoid requesting to many registers on NVIDIA GPUs.
+#if defined(KOKKOS_ARCH_KEPLER) || defined(KOKKOS_ARCH_MAXWELL) || \
+    defined(KOKKOS_ARCH_PASCAL) || defined(KOKKOS_ARCH_VOLTA) ||   \
+    defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+    return std::min<int>(
+               {m_space.impl_internal_space_instance()->m_maxWorkgroupSize,
+                max_threads_for_memory, 256}) /
+           impl_vector_length();
+
+#else
     return std::min<int>(
                m_space.impl_internal_space_instance()->m_maxWorkgroupSize,
                max_threads_for_memory) /
            impl_vector_length();
+#endif
   }
 
   template <class FunctorType>

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -364,19 +364,13 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
   template <class FunctorType>
   int internal_team_size_recommended_for(const FunctorType& f) const {
     // FIXME_SYCL improve
-    const int max_team_size_half = internal_team_size_max_for(f) / 2;
-    int power_of_two             = 1;
-    while (power_of_two <= max_team_size_half) power_of_two <<= 1;
-    return power_of_two;
+    return 1 << Kokkos::log2(internal_team_size_max_for(f));
   }
 
   template <class FunctorType>
   int internal_team_size_recommended_reduce(const FunctorType& f) const {
     // FIXME_SYCL improve
-    const int max_team_size_half = internal_team_size_max_reduce(f) / 2;
-    int power_of_two             = 1;
-    while (power_of_two <= max_team_size_half) power_of_two <<= 1;
-    return power_of_two;
+    return 1 << Kokkos::log2(internal_team_size_max_reduce(f));
   }
 };
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -330,21 +330,17 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
         (space().impl_internal_space_instance()->m_maxShmemPerBlock -
          2 * sizeof(double) - m_team_scratch_size[0]) /
         (sizeof(double) + m_thread_scratch_size[0]);
-    // FIXME_SYCL Avoid requesting to many registers on NVIDIA GPUs.
+    return std::min<int>({
+             int(m_space.impl_internal_space_instance()->m_maxWorkgroupSize),
+      // FIXME_SYCL Avoid requesting to many registers on NVIDIA GPUs.
 #if defined(KOKKOS_ARCH_KEPLER) || defined(KOKKOS_ARCH_MAXWELL) || \
     defined(KOKKOS_ARCH_PASCAL) || defined(KOKKOS_ARCH_VOLTA) ||   \
     defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
-    return std::min<int>(
-               {m_space.impl_internal_space_instance()->m_maxWorkgroupSize,
-                max_threads_for_memory, 256}) /
-           impl_vector_length();
-
-#else
-    return std::min<int>(
-               m_space.impl_internal_space_instance()->m_maxWorkgroupSize,
-               max_threads_for_memory) /
-           impl_vector_length();
+                 256,
 #endif
+                 max_threads_for_memory
+           }) /
+           impl_vector_length();
   }
 
   template <class FunctorType>

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -497,7 +497,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
                            .impl_internal_space_instance()
                            ->m_team_scratch_mutex) {
     // FIXME_SYCL optimize
-    if (m_team_size < 0) m_team_size = 32;
+    if (m_team_size < 0) m_team_size = m_policy.team_size_recommended(arg_functor, ParallelForTag{});
 
     m_shmem_begin = (sizeof(double) * (m_team_size + 2));
     m_shmem_size =
@@ -813,7 +813,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
  private:
   void initialize() {
     // FIXME_SYCL optimize
-    if (m_team_size < 0) m_team_size = 32;
+    if (m_team_size < 0) m_team_size = m_policy.team_size_recommended(m_functor, ParallelReduceTag{});
     // Must be a power of two greater than two, get the one not bigger than the
     // requested one.
     if ((m_team_size & m_team_size - 1) || m_team_size < 2) {
@@ -847,7 +847,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       Kokkos::Impl::throw_runtime_exception(out.str());
     }
 
-    if (m_team_size > m_policy.team_size_max(m_functor, ParallelForTag{}))
+    if (m_team_size > m_policy.team_size_max(m_functor, ParallelReduceTag{}))
       Kokkos::Impl::throw_runtime_exception(
           "Kokkos::Impl::ParallelFor<SYCL> requested too large team size.");
   }

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -375,13 +375,13 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
   template <class FunctorType>
   int internal_team_size_recommended_for(const FunctorType& f) const {
     // FIXME_SYCL improve
-    return 1 << Kokkos::log2(internal_team_size_max_for(f));
+    return 1 << Kokkos::Impl::int_log2(internal_team_size_max_for(f));
   }
 
   template <class FunctorType>
   int internal_team_size_recommended_reduce(const FunctorType& f) const {
     // FIXME_SYCL improve
-    return 1 << Kokkos::log2(internal_team_size_max_reduce(f));
+    return 1 << Kokkos::Impl::int_log2(internal_team_size_max_reduce(f));
   }
 };
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -330,7 +330,7 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
         (space().impl_internal_space_instance()->m_maxShmemPerBlock -
          2 * sizeof(double) - m_team_scratch_size[0]) /
         (sizeof(double) + m_thread_scratch_size[0]);
-    return std::min<int>({
+    return std::min({
              int(m_space.impl_internal_space_instance()->m_maxWorkgroupSize),
       // FIXME_SYCL Avoid requesting to many registers on NVIDIA GPUs.
 #if defined(KOKKOS_ARCH_KEPLER) || defined(KOKKOS_ARCH_MAXWELL) || \
@@ -362,9 +362,16 @@ class TeamPolicyInternal<Kokkos::Experimental::SYCL, Properties...>
          2 * sizeof(double) - m_team_scratch_size[0]) /
         (sizeof(double) + sizeof(value_type) * value_count +
          m_thread_scratch_size[0]);
-    return std::min<int>(
-               m_space.impl_internal_space_instance()->m_maxWorkgroupSize,
-               max_threads_for_memory) /
+    return std::min<int>({
+             int(m_space.impl_internal_space_instance()->m_maxWorkgroupSize),
+      // FIXME_SYCL Avoid requesting to many registers on NVIDIA GPUs.
+#if defined(KOKKOS_ARCH_KEPLER) || defined(KOKKOS_ARCH_MAXWELL) || \
+    defined(KOKKOS_ARCH_PASCAL) || defined(KOKKOS_ARCH_VOLTA) ||   \
+    defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+                 256,
+#endif
+                 max_threads_for_memory
+           }) /
            impl_vector_length();
   }
 

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -337,7 +337,7 @@ void impl_test_local_deepcopy_teampolicy_rank_5(const int N) {
   // FIXME_SYCL improve default team_size
 #if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
-    team_policy = 512;
+    team_size = 512;
 #endif
   Kokkos::parallel_for(
       team_policy(N, team_size), KOKKOS_LAMBDA(const member_type& teamMember) {
@@ -411,7 +411,7 @@ void impl_test_local_deepcopy_teampolicy_rank_6(const int N) {
   // FIXME_SYCL improve default team_size
 #if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
-    team_policy = 512;
+    team_size = 512;
 #endif
   Kokkos::parallel_for(
       team_policy(N, team_size), KOKKOS_LAMBDA(const member_type& teamMember) {
@@ -482,7 +482,7 @@ void impl_test_local_deepcopy_teampolicy_rank_7(const int N) {
   // FIXME_SYCL improve default team_size
 #if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
-    team_policy = 512;
+    team_size = 512;
 #endif
   Kokkos::parallel_for(
       team_policy(N, team_size), KOKKOS_LAMBDA(const member_type& teamMember) {

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -334,7 +334,12 @@ void impl_test_local_deepcopy_teampolicy_rank_5(const int N) {
 
   // Deep Copy
   Kokkos::parallel_for(
+  // FIXME_SYCL improve default team_size
+#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
+      team_policy(N, 512),
+#else
       team_policy(N, Kokkos::AUTO),
+#endif
       KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc =
@@ -403,7 +408,12 @@ void impl_test_local_deepcopy_teampolicy_rank_6(const int N) {
 
   // Deep Copy
   Kokkos::parallel_for(
+  // FIXME_SYCL improve default team_size
+#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
+      team_policy(N, 512),
+#else
       team_policy(N, Kokkos::AUTO),
+#endif
       KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc = Kokkos::subview(A, 1, lid, Kokkos::ALL(), Kokkos::ALL(),
@@ -469,7 +479,12 @@ void impl_test_local_deepcopy_teampolicy_rank_7(const int N) {
 
   // Deep Copy
   Kokkos::parallel_for(
+  // FIXME_SYCL improve default team_size
+#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
+      team_policy(N, 512),
+#else
       team_policy(N, Kokkos::AUTO),
+#endif
       KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc = Kokkos::subview(

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -333,14 +333,14 @@ void impl_test_local_deepcopy_teampolicy_rank_5(const int N) {
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
   // Deep Copy
-  Kokkos::parallel_for(
+  auto team_size = Kokkos::AUTO;
   // FIXME_SYCL improve default team_size
 #if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-      team_policy(N, 512),
-#else
-      team_policy(N, Kokkos::AUTO),
+  if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
+    team_policy = 512;
 #endif
-      KOKKOS_LAMBDA(const member_type& teamMember) {
+  Kokkos::parallel_for(
+      team_policy(N, team_size), KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc =
             Kokkos::subview(A, 1, 1, lid, Kokkos::ALL(), Kokkos::ALL(),
@@ -407,14 +407,14 @@ void impl_test_local_deepcopy_teampolicy_rank_6(const int N) {
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
   // Deep Copy
-  Kokkos::parallel_for(
+  auto team_size = Kokkos::AUTO;
   // FIXME_SYCL improve default team_size
 #if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-      team_policy(N, 512),
-#else
-      team_policy(N, Kokkos::AUTO),
+  if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
+    team_policy = 512;
 #endif
-      KOKKOS_LAMBDA(const member_type& teamMember) {
+  Kokkos::parallel_for(
+      team_policy(N, team_size), KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc = Kokkos::subview(A, 1, lid, Kokkos::ALL(), Kokkos::ALL(),
                                       Kokkos::ALL(), Kokkos::ALL(),
@@ -478,14 +478,14 @@ void impl_test_local_deepcopy_teampolicy_rank_7(const int N) {
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
   // Deep Copy
-  Kokkos::parallel_for(
+  auto team_size = Kokkos::AUTO;
   // FIXME_SYCL improve default team_size
 #if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-      team_policy(N, 512),
-#else
-      team_policy(N, Kokkos::AUTO),
+  if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
+    team_policy = 512;
 #endif
-      KOKKOS_LAMBDA(const member_type& teamMember) {
+  Kokkos::parallel_for(
+      team_policy(N, team_size), KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc = Kokkos::subview(
             A, lid, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(),

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -333,14 +333,9 @@ void impl_test_local_deepcopy_teampolicy_rank_5(const int N) {
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
   // Deep Copy
-  team_policy policy(N, Kokkos::AUTO);
-  // FIXME_SYCL improve default team_size
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
-    policy = team_policy(N, 512);
-#endif
   Kokkos::parallel_for(
-      policy, KOKKOS_LAMBDA(const member_type& teamMember) {
+      team_policy(N, Kokkos::AUTO),
+      KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc =
             Kokkos::subview(A, 1, 1, lid, Kokkos::ALL(), Kokkos::ALL(),
@@ -407,14 +402,9 @@ void impl_test_local_deepcopy_teampolicy_rank_6(const int N) {
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
   // Deep Copy
-  team_policy policy(N, Kokkos::AUTO);
-  // FIXME_SYCL improve default team_size
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
-    policy = team_policy(N, 512);
-#endif
   Kokkos::parallel_for(
-      policy, KOKKOS_LAMBDA(const member_type& teamMember) {
+      team_policy(N, Kokkos::AUTO),
+      KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc = Kokkos::subview(A, 1, lid, Kokkos::ALL(), Kokkos::ALL(),
                                       Kokkos::ALL(), Kokkos::ALL(),
@@ -478,14 +468,9 @@ void impl_test_local_deepcopy_teampolicy_rank_7(const int N) {
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
   // Deep Copy
-  team_policy policy(N, Kokkos::AUTO);
-  // FIXME_SYCL improve default team_size
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
-    policy = team_policy(N, 512);
-#endif
   Kokkos::parallel_for(
-      policy, KOKKOS_LAMBDA(const member_type& teamMember) {
+      team_policy(N, Kokkos::AUTO),
+      KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc = Kokkos::subview(
             A, lid, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(),

--- a/core/unit_test/TestLocalDeepCopy.hpp
+++ b/core/unit_test/TestLocalDeepCopy.hpp
@@ -333,14 +333,14 @@ void impl_test_local_deepcopy_teampolicy_rank_5(const int N) {
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
   // Deep Copy
-  auto team_size = Kokkos::AUTO;
+  team_policy policy(N, Kokkos::AUTO);
   // FIXME_SYCL improve default team_size
 #if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
-    team_size = 512;
+    policy = team_policy(N, 512);
 #endif
   Kokkos::parallel_for(
-      team_policy(N, team_size), KOKKOS_LAMBDA(const member_type& teamMember) {
+      policy, KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc =
             Kokkos::subview(A, 1, 1, lid, Kokkos::ALL(), Kokkos::ALL(),
@@ -407,14 +407,14 @@ void impl_test_local_deepcopy_teampolicy_rank_6(const int N) {
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
   // Deep Copy
-  auto team_size = Kokkos::AUTO;
+  team_policy policy(N, Kokkos::AUTO);
   // FIXME_SYCL improve default team_size
 #if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
-    team_size = 512;
+    policy = team_policy(N, 512);
 #endif
   Kokkos::parallel_for(
-      team_policy(N, team_size), KOKKOS_LAMBDA(const member_type& teamMember) {
+      policy, KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc = Kokkos::subview(A, 1, lid, Kokkos::ALL(), Kokkos::ALL(),
                                       Kokkos::ALL(), Kokkos::ALL(),
@@ -478,14 +478,14 @@ void impl_test_local_deepcopy_teampolicy_rank_7(const int N) {
   using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
   // Deep Copy
-  auto team_size = Kokkos::AUTO;
+  team_policy policy(N, Kokkos::AUTO);
   // FIXME_SYCL improve default team_size
 #if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
   if (std::is_same<ExecSpace, Kokkos::Experimental::SYCL>::value)
-    team_size = 512;
+    policy = team_policy(N, 512);
 #endif
   Kokkos::parallel_for(
-      team_policy(N, team_size), KOKKOS_LAMBDA(const member_type& teamMember) {
+      policy, KOKKOS_LAMBDA(const member_type& teamMember) {
         int lid = teamMember.league_rank();  // returns a number between 0 and N
         auto subSrc = Kokkos::subview(
             A, lid, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(),

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -465,14 +465,8 @@ class TestScanTeam {
     functor_type functor;
 
     policy_type team_exec(nteam, 1);
-// FIXME_SYCL avoid using too many registers on CUDA devices
-#ifdef KOKKOS_ENABLE_SYCL
-    const auto team_size = std::min<int>(
-        team_exec.team_size_max(functor, Kokkos::ParallelReduceTag()), 512);
-#else
     const auto team_size =
         team_exec.team_size_max(functor, Kokkos::ParallelReduceTag());
-#endif
     team_exec = policy_type(nteam, team_size);
 
     for (unsigned i = 0; i < Repeat; ++i) {


### PR DESCRIPTION
Looking at the `KokkosKernels` tests, I ran across a case where the default team_size of 32 would exceed the maximum group size eligible for the kernel. This pull request uses `team_size_recommended` instead and this, in turn, is computed as the maximum power of two not exceeding `team_size_max`.
The computation of both `team_size_recommended` and `team_size_max` probably is still not ideal but certainly an improvement. Any help or suggestions are of course welcome.