### PR TITLE
Use the same flags in Makefile.kokkos for POWER7/8/9 as for CMake

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -942,18 +942,8 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_POWER8), 1)
   ifeq ($(KOKKOS_INTERNAL_COMPILER_PGI), 1)
 
   else
-    ifeq ($(KOKKOS_INTERNAL_COMPILER_XL), 1) 
-        KOKKOS_CXXFLAGS += -mcpu=power8 -mtune=power8
-        KOKKOS_LDFLAGS  += -mcpu=power8 -mtune=power8
-    else
-      ifeq ($(KOKKOS_INTERNAL_COMPILER_NVCC), 1)
-
-      else 
-        # Assume that this is a really a GNU compiler on P8.
-        KOKKOS_CXXFLAGS += -mcpu=power8 -mtune=power8
-        KOKKOS_LDFLAGS  += -mcpu=power8 -mtune=power8
-      endif
-    endif
+    KOKKOS_CXXFLAGS += -mcpu=power8 -mtune=power8
+    KOKKOS_LDFLAGS  += -mcpu=power8 -mtune=power8
   endif
 endif
 
@@ -963,18 +953,8 @@ ifeq ($(KOKKOS_INTERNAL_USE_ARCH_POWER9), 1)
   ifeq ($(KOKKOS_INTERNAL_COMPILER_PGI), 1)
 
   else
-    ifeq ($(KOKKOS_INTERNAL_COMPILER_XL), 1) 
-        KOKKOS_CXXFLAGS += -mcpu=power9 -mtune=power9
-        KOKKOS_LDFLAGS  += -mcpu=power9 -mtune=power9
-    else
-      ifeq ($(KOKKOS_INTERNAL_COMPILER_NVCC), 1)
-
-      else 
-        # Assume that this is a really a GNU compiler on P9
-        KOKKOS_CXXFLAGS += -mcpu=power9 -mtune=power9
-        KOKKOS_LDFLAGS  += -mcpu=power9 -mtune=power9
-      endif
-    endif
+    KOKKOS_CXXFLAGS += -mcpu=power9 -mtune=power9
+    KOKKOS_LDFLAGS  += -mcpu=power9 -mtune=power9
   endif
 endif
 


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/4247. Note that this is also the logic used for `Power7` already.