### PR TITLE
Allow Kokkos::create_mirror* to be used with WithoutInitializing

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -923,8 +923,10 @@ class Random_XorShift64_Pool {
     state_ = state_data_type("Kokkos::Random_XorShift64::state", num_states_,
                              padding_);
 
-    typename state_data_type::HostMirror h_state = create_mirror_view(state_);
-    typename locks_type::HostMirror h_lock       = create_mirror_view(locks_);
+    typename state_data_type::HostMirror h_state =
+        Kokkos::create_mirror_view(Kokkos::WithoutInitializing, state_);
+    typename locks_type::HostMirror h_lock =
+        Kokkos::create_mirror_view(Kokkos::WithoutInitializing, locks_);
 
     // Execute on the HostMirror's default execution space.
     Random_XorShift64<typename state_data_type::HostMirror::execution_space>
@@ -1175,9 +1177,12 @@ class Random_XorShift1024_Pool {
     state_ = state_data_type("Kokkos::Random_XorShift1024::state", num_states_);
     p_ = int_view_type("Kokkos::Random_XorShift1024::p", num_states_, padding_);
 
-    typename state_data_type::HostMirror h_state = create_mirror_view(state_);
-    typename locks_type::HostMirror h_lock       = create_mirror_view(locks_);
-    typename int_view_type::HostMirror h_p       = create_mirror_view(p_);
+    typename state_data_type::HostMirror h_state =
+        Kokkos::create_mirror_view(Kokkos::WithoutInitializing, state_);
+    typename locks_type::HostMirror h_lock =
+        Kokkos::create_mirror_view(Kokkos::WithoutInitializing, locks_);
+    typename int_view_type::HostMirror h_p =
+        Kokkos::create_mirror_view(Kokkos::WithoutInitializing, p_);
 
     // Execute on the HostMirror's default execution space.
     Random_XorShift64<typename state_data_type::HostMirror::execution_space>

--- a/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
@@ -170,8 +170,8 @@ struct UnorderedMapHistogram {
   }
 
   void print_length(std::ostream& out) {
-    host_histogram_view host_copy = create_mirror_view(m_length);
-    Kokkos::deep_copy(host_copy, m_length);
+    host_histogram_view host_copy =
+        create_mirror_view_and_copy(Kokkos::HostSpace{}, m_length);
 
     for (int i = 0, size = host_copy.extent(0); i < size; ++i) {
       out << host_copy[i] << " , ";
@@ -180,8 +180,8 @@ struct UnorderedMapHistogram {
   }
 
   void print_distance(std::ostream& out) {
-    host_histogram_view host_copy = create_mirror_view(m_distance);
-    Kokkos::deep_copy(host_copy, m_distance);
+    host_histogram_view host_copy =
+        create_mirror_view_and_copy(Kokkos::HostSpace{}, m_distance);
 
     for (int i = 0, size = host_copy.extent(0); i < size; ++i) {
       out << host_copy[i] << " , ";
@@ -190,8 +190,8 @@ struct UnorderedMapHistogram {
   }
 
   void print_block_distance(std::ostream& out) {
-    host_histogram_view host_copy = create_mirror_view(m_block_distance);
-    Kokkos::deep_copy(host_copy, m_block_distance);
+    host_histogram_view host_copy =
+        create_mirror_view_and_copy(Kokkos::HostSpace{}, m_block_distance);
 
     for (int i = 0, size = host_copy.extent(0); i < size; ++i) {
       out << host_copy[i] << " , ";

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3056,8 +3056,7 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
     v = view_type();  // Deallocate first, if the only view to allocation
     v = view_type(view_alloc(label, arg_prop...), n0, n1, n2, n3, n4, n5, n6,
                   n7);
-  } else if (!Kokkos::Impl::has_condition<
-                 void, Kokkos::Impl::is_without_initializing, I...>::value)
+  } else if (!Kokkos::Impl::has_type<Impl::WithoutInitializing_t, I...>::value)
     Kokkos::deep_copy(v, typename view_type::value_type{});
 }
 

--- a/core/src/Kokkos_Crs.hpp
+++ b/core/src/Kokkos_Crs.hpp
@@ -224,8 +224,8 @@ class CrsRowMapFromCounts {
     using closure_type = Kokkos::Impl::ParallelScan<self_type, policy_type>;
     closure_type closure(*this, policy_type(0, m_in.size() + 1));
     closure.execute();
-    auto last_value = Kokkos::create_mirror_view(m_last_value);
-    Kokkos::deep_copy(last_value, m_last_value);
+    auto last_value =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, m_last_value);
     return last_value();
   }
 };

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -67,10 +67,6 @@ struct is_view_ctor_property<AllowPadding_t> : public std::true_type {};
 template <>
 struct is_view_ctor_property<NullSpace_t> : public std::true_type {};
 
-template <typename T>
-struct is_without_initializing
-    : std::is_same<T, Kokkos::Impl::WithoutInitializing_t> {};
-
 //----------------------------------------------------------------------------
 /**\brief Whether a type can be used for a view label */
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -757,7 +757,9 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_KokkosP
     SOURCES
+    UnitTestMainInit.cpp
     tools/TestEventCorrectness.cpp
+    tools/TestWithoutInitializing.cpp
     tools/TestProfilingSection.cpp
   )
   if(KOKKOS_ENABLE_LIBDL)

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -892,8 +892,8 @@ struct TestViewMirror {
     for (int i = 0; i < 10; i++) {
       a_h(i) = (double)i;
     }
-    auto a_d = Kokkos::create_mirror_view(DeviceType(), a_h,
-                                          Kokkos::WithoutInitializing);
+    auto a_d = Kokkos::create_mirror_view(Kokkos::WithoutInitializing,
+                                          DeviceType(), a_h);
 
     int equal_ptr_h_d = (a_h.data() == a_d.data()) ? 1 : 0;
     constexpr int is_same_memspace =

--- a/core/unit_test/tools/TestCInterface.c
+++ b/core/unit_test/tools/TestCInterface.c
@@ -1,2 +1,2 @@
 #include <impl/Kokkos_Profiling_C_Interface.h>
-int main(){}
+int main() {}

--- a/core/unit_test/tools/TestWithoutInitializing.cpp
+++ b/core/unit_test/tools/TestWithoutInitializing.cpp
@@ -42,7 +42,36 @@
 //@HEADER
 */
 
-#include <iostream>
-#include "Kokkos_Core.hpp"
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
 
-#include <tools/TestEventCorrectness.hpp>
+#include "include/ToolTestingUtilities.hpp"
+
+TEST(kokkosp, create_mirror_no_init) {
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableKernels());
+  Kokkos::View<int*, Kokkos::DefaultExecutionSpace> device_view("device view",
+                                                                10);
+  Kokkos::View<int*, Kokkos::HostSpace> host_view("host view", 10);
+
+  auto success = validate_absence(
+      [&]() {
+        auto mirror_device =
+            Kokkos::create_mirror(Kokkos::WithoutInitializing, device_view);
+        auto mirror_host =
+            Kokkos::create_mirror(Kokkos::WithoutInitializing,
+                                  Kokkos::DefaultExecutionSpace{}, host_view);
+        auto mirror_device_view = Kokkos::create_mirror_view(
+            Kokkos::WithoutInitializing, device_view);
+        auto mirror_host_view = Kokkos::create_mirror_view(
+            Kokkos::WithoutInitializing, Kokkos::DefaultExecutionSpace{},
+            host_view);
+      },
+      [&](BeginParallelForEvent) {
+        return MatchDiagnostic{true, {"Found begin event"}};
+      },
+      [&](EndParallelForEvent) {
+        return MatchDiagnostic{true, {"Found end event"}};
+      });
+  ASSERT_TRUE(success);
+}

--- a/core/unit_test/tools/include/ToolTestingUtilities.hpp
+++ b/core/unit_test/tools/include/ToolTestingUtilities.hpp
@@ -97,7 +97,7 @@ using event_vector = std::vector<EventBasePtr>;
  * Should be replaced with a fold in C++17
  */
 
-bool are_valid() { return true; }
+inline bool are_valid() { return true; }
 
 /**
  * @brief Recursive reduction to check whether any pointer in a set is null
@@ -265,8 +265,8 @@ struct invoke_helper {
  * @param events the vector containing our events
  * @return MatchDiagnostic success if we scanned all events, failure otherwise
  */
-MatchDiagnostic check_match(event_vector::size_type events_scanned,
-                            const event_vector& events) {
+inline MatchDiagnostic check_match(event_vector::size_type events_scanned,
+                                   const event_vector& events) {
   return (events_scanned == events.size())
              ? MatchDiagnostic{true}
              : MatchDiagnostic{false, {"Wrong number of events encountered"}};
@@ -973,7 +973,7 @@ static uint64_t last_kernel_id;
 static uint32_t last_section_id;
 
 /** Subscribes to all of the requested callbacks */
-void set_tool_events_impl(const ToolValidatorConfiguration& config) {
+static void set_tool_events_impl(const ToolValidatorConfiguration& config) {
   Kokkos::Tools::Experimental::pause_tools();  // remove all events
   if (config.profiling.kernels) {
     Kokkos::Tools::Experimental::set_begin_parallel_for_callback(
@@ -1256,7 +1256,9 @@ auto get_event_set(const Lambda& lam) {
   return events;
 }
 
-MatchDiagnostic check_presence_of(const EventBasePtr&) { return {false}; }
+inline MatchDiagnostic check_presence_of(const EventBasePtr&) {
+  return {false};
+}
 template <class Matcher, class... Matchers>
 MatchDiagnostic check_presence_of(const EventBasePtr& event, const Matcher& m,
                                   Matchers&&... args) {


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/4259. For the moment, I only considered the overloads for `Kokkos::View` and not yet the other `View`-like containers.