### PR TITLE
Workaround compiler bug in definition of `reciprocal_overflow_threshold`

### DIFF
--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -135,20 +135,32 @@ template <> struct denorm_min_helper<float> { static constexpr float value = __F
 template <> struct denorm_min_helper<double> { static constexpr double value = __DBL_DENORM_MIN__; };
 template <> struct denorm_min_helper<long double> { static constexpr long double value = __LDBL_DENORM_MIN__; };
 #endif
+// GCC <10.3 is not able to evaluate T(1) / finite_max_v<T> at compile time when passing -frounding-math
+// https://godbolt.org/z/zj9svb1T7
+// Similar issue was reported on IBM Power without the compiler option
+#define KOKKOS_IMPL_WORKAROUND_CONSTANT_EXPRESSION_COMPILER_BUG
+#ifndef KOKKOS_IMPL_WORKAROUND_CONSTANT_EXPRESSION_COMPILER_BUG
 // NOTE see ?lamch routine from LAPACK that determines machine parameters for floating-point arithmetic
 template <class T>
 constexpr T safe_minimum(T /*ignored*/) {
-  constexpr auto one   = static_cast<T>(1);
-  constexpr auto eps   = epsilon_helper<T>::value;
-  constexpr auto tiny  = norm_min_helper<T>::value;
-  constexpr auto huge  = finite_max_helper<T>::value;
-  constexpr auto small = one / huge;
+  constexpr auto one  = static_cast<T>(1);
+  constexpr auto eps  = epsilon_helper<T>::value;
+  constexpr auto tiny = norm_min_helper<T>::value;
+  constexpr auto huge = finite_max_helper<T>::value;
+  constexpr auto small = one / huge;  // error: is not a constant expression
   return small >= tiny ? small * (one + eps) : tiny;
 }
 template <class> struct reciprocal_overflow_threshold_helper {};
 template <> struct reciprocal_overflow_threshold_helper<float> { static constexpr float value = safe_minimum(0.f); };
 template <> struct reciprocal_overflow_threshold_helper<double> { static constexpr double value = safe_minimum(0.); };
 template <> struct reciprocal_overflow_threshold_helper<long double> { static constexpr long double value = safe_minimum(0.l); };
+#else
+template <class> struct reciprocal_overflow_threshold_helper {};
+template <> struct reciprocal_overflow_threshold_helper<float> { static constexpr float value = norm_min_helper<float>::value; };  // OK for IEEE-754 floating-point numbers
+template <> struct reciprocal_overflow_threshold_helper<double> { static constexpr double value = norm_min_helper<double>::value; };
+template <> struct reciprocal_overflow_threshold_helper<long double> { static constexpr long double value = norm_min_helper<long double>::value; };
+#endif
+#undef KOKKOS_IMPL_WORKAROUND_CONSTANT_EXPRESSION_COMPILER_BUG
 template <class> struct quiet_NaN_helper {};
 template <> struct quiet_NaN_helper<float> { static constexpr float value = __builtin_nanf(""); };
 template <> struct quiet_NaN_helper<double> { static constexpr double value = __builtin_nan(""); };


### PR DESCRIPTION
Fix #4485 (`1 / norm_min_v<T>` cannot be evaluated at compile time)
Giving up and aliasing `reciprocal_overflow_threshold` to `norm_min` which is fine for IEEE-754 floating-point types

cc @mhoemmen 