### PR TITLE
Avoid hangs in the Threads backend

### DIFF
--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -129,8 +129,6 @@ class ThreadsExec {
   ThreadsExec(const ThreadsExec &);
   ThreadsExec &operator=(const ThreadsExec &);
 
-  static void execute_serial(void (*)(ThreadsExec &, const void *));
-
  public:
   KOKKOS_INLINE_FUNCTION int pool_size() const { return m_pool_size; }
   KOKKOS_INLINE_FUNCTION int pool_rank() const { return m_pool_rank; }

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -308,6 +308,7 @@ void HostSpace::impl_deallocate(
     const size_t arg_alloc_size, const size_t arg_logical_size,
     const Kokkos::Tools::SpaceHandle arg_handle) const {
   if (arg_alloc_ptr) {
+    Kokkos::fence("HostSpace::impl_deallocate before free");
     size_t reported_size =
         (arg_logical_size > 0) ? arg_logical_size : arg_alloc_size;
     if (Kokkos::Profiling::profileLibraryLoaded()) {

--- a/core/unit_test/TestSharedAlloc.hpp
+++ b/core/unit_test/TestSharedAlloc.hpp
@@ -115,14 +115,18 @@ void test_shared_alloc() {
     // RecordMemS::print_records( std::cout, s, true );
 #endif
 
-    Kokkos::parallel_for(range, [=](size_t i) {
+    // This must be a plain for-loop since deallocation (which can be triggered
+    // by RecordBase::decrement) fences all execution space instances. If this
+    // is a parallel_for, the test can hang with the parallel_for blocking
+    // waiting for itself to complete.
+    for (size_t i = range.begin(); i < range.end(); ++i) {
       while (nullptr !=
              (r[i] = static_cast<RecordMemS*>(RecordBase::decrement(r[i])))) {
 #ifdef KOKKOS_ENABLE_DEBUG
         if (r[i]->use_count() == 1) RecordBase::is_sane(r[i]);
 #endif
       }
-    });
+    }
 
     Kokkos::fence();
   }
@@ -156,14 +160,18 @@ void test_shared_alloc() {
     RecordBase::is_sane(r[0]);
 #endif
 
-    Kokkos::parallel_for(range, [=](size_t i) {
+    // This must be a plain for-loop since deallocation (which can be triggered
+    // by RecordBase::decrement) fences all execution space instances. If this
+    // is a parallel_for, the test can hang with the parallel_for blocking
+    // waiting for itself to complete.
+    for (size_t i = range.begin(); i < range.end(); ++i) {
       while (nullptr !=
              (r[i] = static_cast<RecordMemS*>(RecordBase::decrement(r[i])))) {
 #ifdef KOKKOS_ENABLE_DEBUG
         if (r[i]->use_count() == 1) RecordBase::is_sane(r[i]);
 #endif
       }
-    });
+    }
 
     Kokkos::fence();
 


### PR DESCRIPTION
This fixes the hangs seen in #4241 (after making deallocate fencing) by not using `execute_serial` for resizing the scratch space but doing that directly.
I'm not quite sure why using `execute_serial` is required or what its purpose is. Maybe, someone that is more familiar with the `Threads` backed can comment on it and tell me if this change is OK or not.
