### PR TITLE
Hotfix SYCL to use in-order queues

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -88,7 +88,11 @@ void SYCLInternal::initialize(const sycl::device& d) {
       Kokkos::Impl::throw_runtime_exception(
           "There was an asynchronous SYCL error!\n");
   };
-  initialize(sycl::queue{d, exception_handler});
+  // FIXME_SYCL using an in-order queue here should not be necessary since we
+  // are using submit_barrier for managing kernel dependencies but this seems to
+  // be required as a hot fix for now.
+  initialize(
+      sycl::queue{d, exception_handler, sycl::property::queue::in_order()});
 }
 
 // FIXME_SYCL

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -158,7 +158,8 @@ struct TestNumericTraits {
     using Kokkos::Experimental::reciprocal_overflow_threshold;
     auto const inv = 1 / reciprocal_overflow_threshold<T>::value;
     if (inv + inv == inv && inv != 0) {
-      printf("inverse of reciprocal overflow threshold is inf\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "inverse of reciprocal overflow threshold is inf\n");
       ++e;
     }
     use_on_device();


### PR DESCRIPTION
Using in-order queues should not be necessary since we are using `submit_barrier` for managing kernel dependencies but this seems to be required as a hotfix with recent compilers. I will investigate more but want to allow people to confidently use `develop` with recent compiler releases as quickly as possible again.