### PR TITLE
Disable fedora icpc CI temporarily

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -11,14 +11,14 @@ jobs:
         cmake_build_type: ['Release', 'Debug']
         openmp: ['ON']
         include:
-          - distro: 'fedora:intel'
-            cxx: 'icpc'
-            cmake_build_type: 'Release'
-            openmp: 'ON'
-          - distro: 'fedora:intel'
-            cxx: 'icpc'
-            cmake_build_type: 'Debug'
-            openmp: 'ON'
+#          - distro: 'fedora:intel'
+#            cxx: 'icpc'
+#            cmake_build_type: 'Release'
+#            openmp: 'ON'
+#          - distro: 'fedora:intel'
+#            cxx: 'icpc'
+#            cmake_build_type: 'Debug'
+#            openmp: 'ON'
           - distro: 'fedora:intel'
             cxx: 'icpx'
             cmake_build_type: 'Release'


### PR DESCRIPTION
Currently, CI is failing due to problems with `icpc` on `fedora:latest`. This pull request disables these checks until https://github.com/kokkos/ci-containers/issues/24 is resolved.