### PR TITLE
Minimal sample of RangePolicy tuning

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -497,9 +497,11 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
         CudaParallelLaunch<ParallelFor,
                            LaunchBounds>::get_cuda_func_attributes();
     const int block_size =
-        Kokkos::Impl::cuda_get_opt_block_size<FunctorType, LaunchBounds>(
-            m_policy.space().impl_internal_space_instance(), attr, m_functor, 1,
-            0, 0);
+      m_policy.impl_const_additional_data().block_size > 0
+            ? m_policy.impl_const_additional_data().block_size
+            : Kokkos::Impl::cuda_get_opt_block_size<FunctorType, LaunchBounds>(
+                  m_policy.space().impl_internal_space_instance(), attr,
+                  m_functor, 1, 0, 0);
     KOKKOS_ASSERT(block_size > 0);
     dim3 block(1, block_size, 1);
     dim3 grid(

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -497,7 +497,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
         CudaParallelLaunch<ParallelFor,
                            LaunchBounds>::get_cuda_func_attributes();
     const int block_size =
-      m_policy.impl_const_additional_data().block_size > 0
+        m_policy.impl_const_additional_data().block_size > 0
             ? m_policy.impl_const_additional_data().block_size
             : Kokkos::Impl::cuda_get_opt_block_size<FunctorType, LaunchBounds>(
                   m_policy.space().impl_internal_space_instance(), attr,

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -65,6 +65,23 @@ struct ChunkSize {
   ChunkSize(int value_) : value(value_) {}
 };
 
+class Cuda;  // forward decl
+namespace Impl {
+
+struct EmptyBackendData {};
+struct BlocksizeBackendData {
+  int block_size = -1;
+};
+template <typename>
+struct BackendData {
+  using type = EmptyBackendData;
+};
+template <>
+struct BackendData<Cuda> {
+  using type = BlocksizeBackendData;
+};
+
+}  // namespace Impl
 /** \brief  Execution policy for work over a range of an integral type.
  *
  * Valid template argument options:
@@ -97,7 +114,9 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   typename traits::index_type m_end;
   typename traits::index_type m_granularity;
   typename traits::index_type m_granularity_mask;
-
+  using additional_data =
+      typename Impl::BackendData<typename traits::execution_space>::type;
+  additional_data m_additional_data;
   template <class... OtherProperties>
   friend class RangePolicy;
 
@@ -238,6 +257,10 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
    *
    *  Typically used to partition a range over a group of threads.
    */
+  additional_data& impl_additional_data() { return m_additional_data; }
+  const additional_data& impl_const_additional_data() const {
+    return m_additional_data;
+  }
   struct WorkRange {
     using work_tag    = typename RangePolicy<Properties...>::work_tag;
     using member_type = typename RangePolicy<Properties...>::member_type;

--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -51,6 +51,7 @@
 #include <KokkosExp_MDRangePolicy.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
 
+#include <iostream>
 #include <array>
 #include <utility>
 #include <tuple>
@@ -74,6 +75,8 @@ void request_output_values(size_t, size_t,
 VariableValue make_variable_value(size_t, int64_t);
 VariableValue make_variable_value(size_t, double);
 SetOrRange make_candidate_range(double lower, double upper, double step,
+                                bool openLower, bool openUpper);
+SetOrRange make_candidate_range(int64_t lower, int64_t upper, int64_t step,
                                 bool openLower, bool openUpper);
 size_t get_new_context_id();
 void begin_context(size_t context_id);
@@ -615,13 +618,85 @@ struct MDRangeTuner : public ExtendableTunerMixin<MDRangeTuner<MDRangeRank>> {
   TunerType get_tuner() const { return tuner; }
 };
 
+namespace Impl {
+template <class>
+struct DirectlyTunableType {
+  using type                  = std::false_type;
+  constexpr static bool value = false;
+  constexpr static Kokkos::Tools::Experimental::ValueType tag =
+      Kokkos::Tools::Experimental::ValueType::kokkos_value_int64;
+  template <class Choice>
+  static std::vector<int64_t>& pick_vector(std::vector<int64_t>& indices,
+                                           std::vector<Choice>&) {
+    return indices;
+  }
+};
+
+template <>
+struct DirectlyTunableType<int64_t> {
+  using type                  = std::true_type;
+  static constexpr bool value = true;
+  constexpr static Kokkos::Tools::Experimental::ValueType tag =
+      Kokkos::Tools::Experimental::ValueType::kokkos_value_int64;
+  static int64_t translate(
+      const Kokkos::Tools::Experimental::VariableValue& in) {
+    return in.value.int_value;
+  }
+  template <class Choice>
+  static std::vector<Choice>& pick_vector(std::vector<int64_t>&,
+                                          std::vector<Choice>& choices) {
+    return choices;
+  }
+};
+template <>
+struct DirectlyTunableType<double> {
+  using type                  = std::true_type;
+  static constexpr bool value = true;
+  constexpr static Kokkos::Tools::Experimental::ValueType tag =
+      Kokkos::Tools::Experimental::ValueType::kokkos_value_double;
+  static double translate(
+      const Kokkos::Tools::Experimental::VariableValue& in) {
+    return in.value.double_value;
+  }
+  template <class Choice>
+  static std::vector<Choice>& pick_vector(std::vector<int64_t>&,
+                                          std::vector<Choice>& choices) {
+    return choices;
+  }
+};
+
+template <typename Choice>
+const Choice& tuning_select(std::false_type, size_t context,
+                            size_t tuning_variable_id, const Choice&,
+                            const std::vector<Choice>& choices) {
+  VariableValue value = make_variable_value(tuning_variable_id, int64_t(0));
+  request_output_values(context, 1, &value);
+  return choices[value.value.int_value];
+}
+template <typename Choice>
+const Choice tuning_select(std::true_type, size_t context,
+                           size_t tuning_variable_id,
+                           const Choice& default_value,
+                           const std::vector<Choice>&) {
+  VariableValue value = make_variable_value(tuning_variable_id, default_value);
+  request_output_values(context, 1, &value);
+  return Impl::DirectlyTunableType<Choice>::translate(value);
+}
+
+}  // namespace Impl
+
 template <class Choice>
 struct CategoricalTuner {
   using choice_list = std::vector<Choice>;
   choice_list choices;
   size_t context;
   size_t tuning_variable_id;
-  CategoricalTuner(std::string name, choice_list m_choices)
+  Choice default_value;
+  /** Note DZP: needed, but unfortunate, due to BlockSizeTuner. Code refactoring
+   * to avoid need for this would be good
+   */
+  CategoricalTuner() = default;
+  CategoricalTuner(std::string name, choice_list m_choices, const Choice& def)
       : choices(m_choices) {
     std::vector<int64_t> indices;
     for (typename decltype(choices)::size_type x = 0; x < choices.size(); ++x) {
@@ -631,15 +706,21 @@ struct CategoricalTuner {
     info.category      = StatisticalCategory::kokkos_value_categorical;
     info.valueQuantity = CandidateValueType::kokkos_value_set;
     info.type          = ValueType::kokkos_value_int64;
-    info.candidates    = make_candidate_set(indices.size(), indices.data());
+    auto& vec =
+        Impl::DirectlyTunableType<Choice>::pick_vector(indices, m_choices);
+    info.candidates    = make_candidate_set(indices.size(), vec.data());
     tuning_variable_id = declare_output_type(name, info);
+    default_value      = def;
   }
-  const Choice& begin() {
+  CategoricalTuner(std::string name, choice_list m_choices)
+      : CategoricalTuner(name, m_choices, m_choices[0]) {}
+
+  const auto begin() {
     context = get_new_context_id();
     begin_context(context);
-    VariableValue value = make_variable_value(tuning_variable_id, int64_t(0));
-    request_output_values(context, 1, &value);
-    return choices[value.value.int_value];
+    return Impl::tuning_select(
+        typename Impl::DirectlyTunableType<Choice>::type{}, context,
+        tuning_variable_id, default_value, choices);
   }
   void end() { end_context(context); }
 };
@@ -649,6 +730,12 @@ auto make_categorical_tuner(std::string name, std::vector<Choice> choices)
     -> CategoricalTuner<Choice> {
   return CategoricalTuner<Choice>(name, choices);
 }
+template <typename Choice>
+auto make_categorical_tuner(std::string name, std::vector<Choice> choices,
+                            Choice default_value) -> CategoricalTuner<Choice> {
+  return CategoricalTuner<Choice>(name, choices, default_value);
+}
+
 struct BlockSizeTuner {
   CategoricalTuner<int64_t> tuner;
 
@@ -690,6 +777,7 @@ struct BlockSizeTuner {
   }
   void end() { tuner.end(); }
 };
+
 }  // namespace Experimental
 }  // namespace Tools
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -57,7 +57,7 @@ namespace Kokkos {
 class Cuda;
 namespace Experimental {
 class HIP;
-} // namespace Experimental
+}  // namespace Experimental
 
 namespace Tools {
 
@@ -74,7 +74,8 @@ class IsTunableRangePolicy<
     typename std::enable_if<std::is_same<typename Kokkos::RangePolicy<
                                              Properties...>::execution_space,
                                          Kokkos::Cuda>::value,
-                            void>::type> : public std::false_type {}; // TODO: change to true when CUDA supported
+                            void>::type> : public std::false_type {
+};  // TODO: change to true when CUDA supported
 
 template <class... Properties>
 class IsTunableRangePolicy<
@@ -179,20 +180,18 @@ struct SimpleTeamSizeCalculator {
                                      exec_space>;
     return driver::max_tile_size_product(policy, functor);
   }
-    template <typename Functor, typename Tag, template <class...> class Policy,
+  template <typename Functor, typename Tag, template <class...> class Policy,
             class... Traits>
-  int64_t range_max_block_size(const Policy<Traits...>&,
-                               const Functor&, const Tag&) const {
+  int64_t range_max_block_size(const Policy<Traits...>&, const Functor&,
+                               const Tag&) const {
     return 1;
   }
   template <typename Functor, typename Tag, template <class...> class Policy,
             class... Traits>
-  int64_t range_opt_block_size(const Policy<Traits...>&,
-                               const Functor&, const Tag&) const {
+  int64_t range_opt_block_size(const Policy<Traits...>&, const Functor&,
+                               const Tag&) const {
     return 1;
-  
-}
-
+  }
 };
 
 // when we have a complex reducer, we need to pass an
@@ -228,33 +227,30 @@ struct ComplexReducerSizeCalculator {
         Kokkos::Impl::ParallelReduce<Functor, Policy, ReducerType, exec_space>;
     return driver::max_tile_size_product(policy, functor);
   }
-template <typename Functor, typename Tag, template <class...> class Policy,
+  template <typename Functor, typename Tag, template <class...> class Policy,
             class... Traits>
-  int64_t range_opt_block_size(const Policy<Traits...>&,
-                               const Functor&, const Tag&) const {
-
+  int64_t range_opt_block_size(const Policy<Traits...>&, const Functor&,
+                               const Tag&) const {
     return 1;
   }
-template <typename Functor, typename Tag, template <class...> class Policy,
+  template <typename Functor, typename Tag, template <class...> class Policy,
             class... Traits>
-  int64_t range_max_block_size(const Policy<Traits...>&,
-                               const Functor&, const Tag&) const {
+  int64_t range_max_block_size(const Policy<Traits...>&, const Functor&,
+                               const Tag&) const {
+    /**
+        // CUDA version, doesn't work
+        using traits = Kokkos::Impl::PolicyTraits<Traits...>;
 
-/**
-    // CUDA version, doesn't work
-    using traits = Kokkos::Impl::PolicyTraits<Traits...>;
-
-    cudaFuncAttributes attr = Kokkos::Tools::Impl::get_cuda_func_attributes<
-        typename DriverFor<Tag>::template type<Functor, Policy<Traits...>,
-                                               Kokkos::Cuda, ReducerType>,
-        typename Policy<Traits...>::launch_bounds>();
-    const int block_size =
-        Kokkos::Impl::cuda_get_max_block_size<Functor,
-                                              typename traits::launch_bounds>(
-            policy.space().impl_internal_space_instance(), attr, functor, 1, 0,
-            0);
-    return block_size;
- */
+        cudaFuncAttributes attr = Kokkos::Tools::Impl::get_cuda_func_attributes<
+            typename DriverFor<Tag>::template type<Functor, Policy<Traits...>,
+                                                   Kokkos::Cuda, ReducerType>,
+            typename Policy<Traits...>::launch_bounds>();
+        const int block_size =
+            Kokkos::Impl::cuda_get_max_block_size<Functor,
+                                                  typename
+       traits::launch_bounds>( policy.space().impl_internal_space_instance(),
+       attr, functor, 1, 0, 0); return block_size;
+     */
     return 1;
   }
 };

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -54,6 +54,11 @@
 
 namespace Kokkos {
 
+class Cuda;
+namespace Experimental {
+class HIP;
+} // namespace Experimental
+
 namespace Tools {
 
 namespace Experimental {
@@ -69,7 +74,7 @@ class IsTunableRangePolicy<
     typename std::enable_if<std::is_same<typename Kokkos::RangePolicy<
                                              Properties...>::execution_space,
                                          Kokkos::Cuda>::value,
-                            void>::type> : public std::true_type {};
+                            void>::type> : public std::false_type {}; // TODO: change to true when CUDA supported
 
 template <class... Properties>
 class IsTunableRangePolicy<
@@ -86,8 +91,6 @@ template <int Rank>
 using MDRangeTuningMap =
     std::map<std::string, Kokkos::Tools::Experimental::MDRangeTuner<Rank>>;
 
-template <int Rank>
-static MDRangeTuningMap<Rank> mdrange_tuners;
 template <int Rank>
 static MDRangeTuningMap<Rank> mdrange_tuners;
 
@@ -230,8 +233,6 @@ template <typename Functor, typename Tag, template <class...> class Policy,
   int64_t range_opt_block_size(const Policy<Traits...>&,
                                const Functor&, const Tag&) const {
 
-    (void)policy;
-    (void)functor;
     return 1;
   }
 template <typename Functor, typename Tag, template <class...> class Policy,
@@ -254,8 +255,6 @@ template <typename Functor, typename Tag, template <class...> class Policy,
             0);
     return block_size;
  */
-    (void)policy;
-    (void)functor;
     return 1;
   }
 };

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -60,6 +60,25 @@ namespace Experimental {
 
 namespace Impl {
 
+template <class, class = void>
+struct IsTunableRangePolicy : public std::false_type {};
+
+template <class... Properties>
+class IsTunableRangePolicy<
+    Kokkos::RangePolicy<Properties...>,
+    typename std::enable_if<std::is_same<typename Kokkos::RangePolicy<
+                                             Properties...>::execution_space,
+                                         Kokkos::Cuda>::value,
+                            void>::type> : public std::true_type {};
+
+template <class... Properties>
+class IsTunableRangePolicy<
+    Kokkos::RangePolicy<Properties...>,
+    typename std::enable_if<std::is_same<typename Kokkos::RangePolicy<
+                                             Properties...>::execution_space,
+                                         Kokkos::Experimental::HIP>::value,
+                            void>::type> : public std::false_type {
+};  // TODO: change to true when HIP supported
 static std::map<std::string, Kokkos::Tools::Experimental::TeamSizeTuner>
     team_tuners;
 
@@ -69,7 +88,16 @@ using MDRangeTuningMap =
 
 template <int Rank>
 static MDRangeTuningMap<Rank> mdrange_tuners;
+template <int Rank>
+static MDRangeTuningMap<Rank> mdrange_tuners;
 
+using BlockSizeTuner = Kokkos::Tools::Experimental::BlockSizeTuner;
+
+template <class>
+using BlockSizeTunerMap = std::map<std::string, BlockSizeTuner>;
+
+template <class Space>
+static BlockSizeTunerMap<Space> block_size_tuners;
 // For any policies without a tuning implementation, with a reducer
 template <class ReducerType, class ExecPolicy, class Functor, typename TagType>
 void tune_policy(const size_t, const std::string&, ExecPolicy&, const Functor&,
@@ -100,7 +128,23 @@ void tune_policy(const size_t, const std::string&, ExecPolicy&, const Functor&,
  */
 
 namespace Impl {
-
+template <class Tag>
+struct DriverFor;
+template <>
+struct DriverFor<Kokkos::ParallelForTag> {
+  template <class A, class B, class C>
+  using type = Kokkos::Impl::ParallelFor<A, B, C>;
+};
+template <>
+struct DriverFor<Kokkos::ParallelScanTag> {
+  template <class A, class B, class C>
+  using type = Kokkos::Impl::ParallelScan<A, B, C>;
+};
+template <>
+struct DriverFor<Kokkos::ParallelReduceTag> {
+  template <class A, class B, class C, class D = Kokkos::InvalidType>
+  using type = Kokkos::Impl::ParallelReduce<A, B, D, C>;
+};
 struct SimpleTeamSizeCalculator {
   template <typename Policy, typename Functor, typename Tag>
   int get_max_team_size(const Policy& policy, const Functor& functor,
@@ -132,6 +176,20 @@ struct SimpleTeamSizeCalculator {
                                      exec_space>;
     return driver::max_tile_size_product(policy, functor);
   }
+    template <typename Functor, typename Tag, template <class...> class Policy,
+            class... Traits>
+  int64_t range_max_block_size(const Policy<Traits...>&,
+                               const Functor&, const Tag&) const {
+    return 1;
+  }
+  template <typename Functor, typename Tag, template <class...> class Policy,
+            class... Traits>
+  int64_t range_opt_block_size(const Policy<Traits...>&,
+                               const Functor&, const Tag&) const {
+    return 1;
+  
+}
+
 };
 
 // when we have a complex reducer, we need to pass an
@@ -166,6 +224,39 @@ struct ComplexReducerSizeCalculator {
     using driver =
         Kokkos::Impl::ParallelReduce<Functor, Policy, ReducerType, exec_space>;
     return driver::max_tile_size_product(policy, functor);
+  }
+template <typename Functor, typename Tag, template <class...> class Policy,
+            class... Traits>
+  int64_t range_opt_block_size(const Policy<Traits...>&,
+                               const Functor&, const Tag&) const {
+
+    (void)policy;
+    (void)functor;
+    return 1;
+  }
+template <typename Functor, typename Tag, template <class...> class Policy,
+            class... Traits>
+  int64_t range_max_block_size(const Policy<Traits...>&,
+                               const Functor&, const Tag&) const {
+
+/**
+    // CUDA version, doesn't work
+    using traits = Kokkos::Impl::PolicyTraits<Traits...>;
+
+    cudaFuncAttributes attr = Kokkos::Tools::Impl::get_cuda_func_attributes<
+        typename DriverFor<Tag>::template type<Functor, Policy<Traits...>,
+                                               Kokkos::Cuda, ReducerType>,
+        typename Policy<Traits...>::launch_bounds>();
+    const int block_size =
+        Kokkos::Impl::cuda_get_max_block_size<Functor,
+                                              typename traits::launch_bounds>(
+            policy.space().impl_internal_space_instance(), attr, functor, 1, 0,
+            0);
+    return block_size;
+ */
+    (void)policy;
+    (void)functor;
+    return 1;
   }
 };
 
@@ -251,7 +342,56 @@ void tune_policy(const size_t /**tuning_context*/, const std::string& label_in,
                 candidate_policy.impl_auto_vector_length());
       });
 }
+template <class ReducerType, class Functor, class TagType, class... Properties>
+void tune_range_policy(const size_t /**tuning_context*/,
+                       const std::string& label_in,
+                       Kokkos::RangePolicy<Properties...>& policy,
+                       const Functor& functor, const TagType& tag,
+                       std::true_type) {
+  generic_tune_policy<Experimental::BlockSizeTuner, ReducerType>(
+      label_in, block_size_tuners<Kokkos::Cuda>, policy, functor, tag,
+      [](const Kokkos::RangePolicy<Properties...>&) { return true; });
+}
+template <class Functor, class TagType, class... Properties>
+void tune_range_policy(const size_t /**tuning_context*/,
+                       const std::string& label_in,
+                       Kokkos::RangePolicy<Properties...>& policy,
+                       const Functor& functor, const TagType& tag,
+                       std::true_type) {
+  generic_tune_policy<Experimental::BlockSizeTuner>(
+      label_in, block_size_tuners<Kokkos::Cuda>, policy, functor, tag,
+      [](const Kokkos::RangePolicy<Properties...>&) { return true; });
+}
+template <class ReducerType, class Functor, class TagType, class... Properties>
+void tune_range_policy(const size_t, const std::string&,
+                       Kokkos::RangePolicy<Properties...>&, const Functor&,
+                       const TagType&, std::false_type) {}
+template <class Functor, class TagType, class... Properties>
+void tune_range_policy(const size_t, const std::string&,
+                       Kokkos::RangePolicy<Properties...>&, const Functor&,
+                       const TagType&, std::false_type) {}
+// tune a RangePolicy, with reducer
+template <class ReducerType, class Functor, class TagType, class... Properties>
+void tune_policy(const size_t tuning_context, const std::string& label_in,
+                 Kokkos::RangePolicy<Properties...>& policy,
+                 const Functor& functor, const TagType& tag) {
+  using is_tunable =
+      typename IsTunableRangePolicy<Kokkos::RangePolicy<Properties...>>::type;
+  tune_range_policy<ReducerType>(tuning_context, label_in, policy, functor, tag,
+                                 is_tunable{});
+}
+// RangePolicy, without reducer
+template <class Functor, class TagType, class... Properties>
+void tune_policy(const size_t tuning_context, const std::string& label_in,
+                 Kokkos::RangePolicy<Properties...>& policy,
+                 const Functor& functor, const TagType& tag
 
+) {
+  using is_tunable =
+      typename IsTunableRangePolicy<Kokkos::RangePolicy<Properties...>>::type;
+  tune_range_policy(tuning_context, label_in, policy, functor, tag,
+                    is_tunable{});
+}
 // tune a MDRangePolicy, without reducer
 template <class Functor, class TagType, class... Properties>
 void tune_policy(const size_t /**tuning_context*/, const std::string& label_in,
@@ -341,7 +481,58 @@ void report_policy_results(const size_t /**tuning_context*/,
                 candidate_policy.impl_auto_vector_length());
       });
 }
+template <class ReducerType, class Functor, class TagType, class... Properties>
+void report_range_results(const size_t /**tuning_context*/,
+                          const std::string& label_in,
+                          Kokkos::RangePolicy<Properties...>& policy,
+                          const Functor& functor, const TagType& tag,
+                          std::true_type) {
+  generic_report_results<Experimental::BlockSizeTuner, ReducerType>(
+      label_in, block_size_tuners<Kokkos::Cuda>, policy, functor, tag,
+      [](const Kokkos::RangePolicy<Properties...>&) { return true; });
+}
+template <class Functor, class TagType, class... Properties>
+void report_range_results(const size_t /**tuning_context*/,
+                          const std::string& label_in,
+                          Kokkos::RangePolicy<Properties...>& policy,
+                          const Functor& functor, const TagType& tag,
+                          std::true_type) {
+  generic_report_results<Experimental::BlockSizeTuner>(
+      label_in, block_size_tuners<Kokkos::Cuda>, policy, functor, tag,
+      [](const Kokkos::RangePolicy<Properties...>&) { return true; });
+}
+template <class ReducerType, class Functor, class TagType, class... Properties>
+void report_range_results(const size_t, const std::string&,
+                          Kokkos::RangePolicy<Properties...>&, const Functor&,
+                          const TagType&, std::false_type) {}
+template <class Functor, class TagType, class... Properties>
+void report_range_results(const size_t, const std::string&,
+                          Kokkos::RangePolicy<Properties...>&, const Functor&,
+                          const TagType&, std::false_type) {}
+// tune a RangePolicy, with reducer
+template <class ReducerType, class Functor, class TagType, class... Properties>
+void report_policy_results(const size_t tuning_context,
+                           const std::string& label_in,
+                           Kokkos::RangePolicy<Properties...>& policy,
+                           const Functor& functor, const TagType& tag) {
+  using is_tunable =
+      typename IsTunableRangePolicy<Kokkos::RangePolicy<Properties...>>::type;
+  report_range_results<ReducerType>(tuning_context, label_in, policy, functor,
+                                    tag, is_tunable{});
+}
+// RangePolicy, without reducer
+template <class Functor, class TagType, class... Properties>
+void report_policy_results(const size_t tuning_context,
+                           const std::string& label_in,
+                           Kokkos::RangePolicy<Properties...>& policy,
+                           const Functor& functor, const TagType& tag
 
+) {
+  using is_tunable =
+      typename IsTunableRangePolicy<Kokkos::RangePolicy<Properties...>>::type;
+  report_range_results(tuning_context, label_in, policy, functor, tag,
+                       is_tunable{});
+}
 // report results for an MDRangePolicy
 template <class Functor, class TagType, class... Properties>
 void report_policy_results(const size_t /**tuning_context*/,


### PR DESCRIPTION
So, in #4494 , it's proving really hard to polish that one up, so I'm making this PR instead. As of now, this is non-functional, somebody will have to take if over after I split.

The design for RangePolicy tuning needs some kind of tuner. In this case, I'm picking a CategoricalTuner, selecting amongst int block sizes. It also needs some way for a tuned policy to influence the block size we actually run with, I show this [here](https://github.com/kokkos/kokkos/compare/develop...DavidPoliakoff:minimal-rangepolicy-pr?expand=1#diff-99024452757b67f0dea936c050017c64f4ec289c2fac1a463689b39e653891edR500), but it also needs to happen for HIP, and for Reduce and Scan in CUDA.

What's missing, and what keeps killing these PR's, is the ability for us to ask "what is the max block size for a functor" from within Tools. I introduced Kokkos_Tools_Generic.hpp (partially) to "remove the dependency of backends on Kokkos Tools." What I missed is that backends include Kokkos_Parallel.hpp, which includes Kokkos_Tools_Generic.hpp. So CUDA includes Parallel includes Tools_Generic, which makes it hard for Tools_Generic to include CUDA. In other cases (TeamPolicy), the policy itself provided the team size deduction data, so this wasn't as much of a problem. So, we have a rats nest of include files making this difficult. 

Anyway, if you find a way around that, replace the [stubs like these](https://github.com/kokkos/kokkos/compare/develop...DavidPoliakoff:minimal-rangepolicy-pr?expand=1#diff-90269b706a5bcf0b17a7082383089bcac66eb8dc0293ce1c8b19963bbb6c3daeR183-R194) with proper versions, and you'll see autotuning. Also important: as you add support in a backend for this functionality, you'll need to remember to [change these](https://github.com/kokkos/kokkos/compare/develop...DavidPoliakoff:minimal-rangepolicy-pr?expand=1#diff-90269b706a5bcf0b17a7082383089bcac66eb8dc0293ce1c8b19963bbb6c3daeR77), while those inherit from "false_type" you won't see any autotuning.

The good news is that this PR can merge without harming anything, so somebody could drive this to production (should be a short drive), merge it, and then in a follow-on people could add support for whatever backend they want.