### PR TITLE
Lock constant memory in Cuda/HIP kernel launch with a mutex

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -261,6 +261,7 @@ const CudaInternalDevices &CudaInternalDevices::singleton() {
 
 unsigned long *CudaInternal::constantMemHostStaging = nullptr;
 cudaEvent_t CudaInternal::constantMemReusable       = nullptr;
+std::mutex CudaInternal::constantMemMutex;
 
 //----------------------------------------------------------------------------
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -133,6 +133,7 @@ class CudaInternal {
   //  here will break once there are multiple devices though
   static unsigned long* constantMemHostStaging;
   static cudaEvent_t constantMemReusable;
+  static std::mutex constantMemMutex;
 
   static CudaInternal& singleton();
 

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -540,8 +540,9 @@ struct CudaParallelLaunchKernelInvoker<
                             dim3 const& block, int shmem,
                             CudaInternal const* cuda_instance) {
     // Wait until the previous kernel that uses the constant buffer is done
+    std::lock_guard<std::mutex> lock(CudaInternal::constantMemMutex);
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaEventSynchronize(cuda_instance->constantMemReusable));
+        cudaEventSynchronize(CudaInternal::constantMemReusable));
 
     // Copy functor (synchronously) to staging buffer in pinned host memory
     unsigned long* staging = cuda_instance->constantMemHostStaging;
@@ -558,7 +559,7 @@ struct CudaParallelLaunchKernelInvoker<
 
     // Record an event that says when the constant buffer can be reused
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaEventRecord(cuda_instance->constantMemReusable,
+        cudaEventRecord(CudaInternal::constantMemReusable,
                         cudaStream_t(cuda_instance->m_stream)));
   }
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -97,6 +97,7 @@ const HIPInternalDevices &HIPInternalDevices::singleton() {
 
 unsigned long *Impl::HIPInternal::constantMemHostStaging = nullptr;
 hipEvent_t Impl::HIPInternal::constantMemReusable        = nullptr;
+std::mutex Impl::HIPInternal::constantMemMutex;
 
 namespace Impl {
 

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -142,6 +142,7 @@ class HIPInternal {
   // here will break once there are multiple devices though
   static unsigned long *constantMemHostStaging;
   static hipEvent_t constantMemReusable;
+  static std::mutex constantMemMutex;
 
   static HIPInternal &singleton();
 


### PR DESCRIPTION
The constant memory used for kernel launches is shared between all `Cuda`/`HIP` execution space instances. We already guard the access to make sure that the last kernel using the constant memory has finished before copying the next one. This doesn't prevent (different) kernels submitted from independent threads to be copied to the constant memory in a conflict way. Note that we already have a mutex for the case that the same kernel is submitted from different threads.

This pull request adds another mutex that guards access to the constant memory globally.