### PR TITLE
Fix running parallel_reduce with TeamPolicy for large ranges

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -1822,7 +1822,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   inline void execute() {
-    const bool do_work         = m_league_size > 0 && m_team_size > 0;
+    const bool is_empty_range  = m_league_size == 0 || m_team_size == 0;
     const bool need_device_set = ReduceFunctorHasInit<FunctorType>::value ||
                                  ReduceFunctorHasFinal<FunctorType>::value ||
                                  !m_result_ptr_host_accessible ||
@@ -1830,7 +1830,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                  Policy::is_graph_kernel::value ||
 #endif
                                  !std::is_same<ReducerType, InvalidType>::value;
-    if (do_work || need_device_set) {
+    if (!is_empty_range || need_device_set) {
       const int block_count =
           UseShflReduction ? std::min(m_league_size, size_type(1024 * 32))
                            : std::min(int(m_league_size), m_team_size);
@@ -1849,7 +1849,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       dim3 grid(block_count, 1, 1);
       const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
 
-      if (!do_work
+      if (is_empty_range
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
           || Kokkos::Impl::CudaInternal::cuda_use_serial_execution()
 #endif

--- a/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel.hpp
@@ -1456,7 +1456,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   }
 
   inline void execute() {
-    const int nwork = m_policy.m_num_tiles;
+    const auto nwork = m_policy.m_num_tiles;
     if (nwork) {
       int block_size = m_policy.m_prod_tile_dims;
       // CONSTRAINT: Algorithm requires block_size >= product of tile dimensions
@@ -1822,7 +1822,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   inline void execute() {
-    const int nwork            = m_league_size * m_team_size;
+    const auto nwork =
+        static_cast<typename Policy::index_type>(m_league_size) * m_team_size;
     const bool need_device_set = ReduceFunctorHasInit<FunctorType>::value ||
                                  ReduceFunctorHasFinal<FunctorType>::value ||
                                  !m_result_ptr_host_accessible ||
@@ -2331,7 +2332,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
   }
 
   inline void execute() {
-    const int nwork = m_policy.end() - m_policy.begin();
+    const auto nwork = m_policy.end() - m_policy.begin();
     if (nwork) {
       enum { GridMaxComputeCapability_2x = 0x0ffff };
 
@@ -2618,7 +2619,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
   inline void execute() {
-    const int nwork = m_policy.end() - m_policy.begin();
+    const auto nwork = m_policy.end() - m_policy.begin();
     if (nwork) {
       enum { GridMaxComputeCapability_2x = 0x0ffff };
 

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -336,7 +336,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   inline void execute() {
     using ClosureType = ParallelReduce<FunctorType, Policy, ReducerType,
                                        Kokkos::Experimental::HIP>;
-    const int nwork   = m_policy.m_num_tiles;
+    const auto nwork  = m_policy.m_num_tiles;
     if (nwork) {
       int block_size = m_policy.m_prod_tile_dims;
       // CONSTRAINT: Algorithm requires block_size >= product of tile dimensions

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -839,13 +839,12 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   inline void execute() {
-    const auto nwork =
-        static_cast<typename Policy::index_type>(m_league_size) * m_team_size;
+    const bool do_work         = m_league_size > 0 && m_team_size > 0;
     const bool need_device_set = ReduceFunctorHasInit<FunctorType>::value ||
                                  ReduceFunctorHasFinal<FunctorType>::value ||
                                  !m_result_ptr_host_accessible ||
                                  !std::is_same<ReducerType, InvalidType>::value;
-    if ((nwork > 0) || need_device_set) {
+    if (do_work || need_device_set) {
       const int block_count =
           UseShflReduction
               ? std::min(
@@ -864,7 +863,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
       dim3 block(m_vector_size, m_team_size, 1);
       dim3 grid(block_count, 1, 1);
-      if (nwork == 0) {
+      if (!do_work) {
         block = dim3(1, 1, 1);
         grid  = dim3(1, 1, 1);
       }

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -839,12 +839,12 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   inline void execute() {
-    const bool do_work         = m_league_size > 0 && m_team_size > 0;
+    const bool is_empty_range  = m_league_size == 0 || m_team_size == 0;
     const bool need_device_set = ReduceFunctorHasInit<FunctorType>::value ||
                                  ReduceFunctorHasFinal<FunctorType>::value ||
                                  !m_result_ptr_host_accessible ||
                                  !std::is_same<ReducerType, InvalidType>::value;
-    if (do_work || need_device_set) {
+    if (!is_empty_range || need_device_set) {
       const int block_count =
           UseShflReduction
               ? std::min(
@@ -863,7 +863,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
       dim3 block(m_vector_size, m_team_size, 1);
       dim3 grid(block_count, 1, 1);
-      if (!do_work) {
+      if (is_empty_range) {
         block = dim3(1, 1, 1);
         grid  = dim3(1, 1, 1);
       }

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -839,7 +839,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   inline void execute() {
-    const int nwork            = m_league_size * m_team_size;
+    const auto nwork =
+        static_cast<typename Policy::index_type>(m_league_size) * m_team_size;
     const bool need_device_set = ReduceFunctorHasInit<FunctorType>::value ||
                                  ReduceFunctorHasFinal<FunctorType>::value ||
                                  !m_result_ptr_host_accessible ||

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -1041,7 +1041,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   inline void execute() const {
     enum { is_dynamic = std::is_same<SchedTag, Kokkos::Dynamic>::value };
 
-    if (m_policy.league_size() * m_policy.team_size() == 0) {
+    if (m_policy.league_size() == 0 || m_policy.team_size() == 0) {
       if (m_result_ptr) {
         ValueInit::init(ReducerConditional::select(m_functor, m_reducer),
                         m_result_ptr);

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -223,8 +223,7 @@ void SYCLInternal::finalize() {
   m_queue.reset();
 }
 
-void* SYCLInternal::scratch_space(
-    const Kokkos::Experimental::SYCL::size_type size) {
+void* SYCLInternal::scratch_space(const std::size_t size) {
   const size_type sizeScratchGrain =
       sizeof(Kokkos::Experimental::SYCL::size_type);
   if (verify_is_initialized("scratch_space") &&
@@ -250,8 +249,7 @@ void* SYCLInternal::scratch_space(
   return m_scratchSpace;
 }
 
-void* SYCLInternal::scratch_flags(
-    const Kokkos::Experimental::SYCL::size_type size) {
+void* SYCLInternal::scratch_flags(const std::size_t size) {
   const size_type sizeScratchGrain =
       sizeof(Kokkos::Experimental::SYCL::size_type);
   if (verify_is_initialized("scratch_flags") &&

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -66,8 +66,8 @@ class SYCLInternal {
   SYCLInternal& operator=(SYCLInternal&&) = delete;
   SYCLInternal(SYCLInternal&&)            = delete;
 
-  void* scratch_space(const size_type size);
-  void* scratch_flags(const size_type size);
+  void* scratch_space(const std::size_t size);
+  void* scratch_flags(const std::size_t size);
   void* resize_team_scratch_space(std::int64_t bytes,
                                   bool force_shrink = false);
 
@@ -79,9 +79,9 @@ class SYCLInternal {
   uint64_t m_maxShmemPerBlock = 0;
 
   uint32_t* m_scratchConcurrentBitset = nullptr;
-  size_type m_scratchSpaceCount       = 0;
+  std::size_t m_scratchSpaceCount     = 0;
   size_type* m_scratchSpace           = nullptr;
-  size_type m_scratchFlagsCount       = 0;
+  std::size_t m_scratchFlagsCount     = 0;
   size_type* m_scratchFlags           = nullptr;
   // mutex to access shared memory
   mutable std::mutex m_mutexScratchSpace;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -588,7 +588,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
     // FIXME_SYCL optimize
     const size_t wgroup_size = m_team_size * m_vector_size;
-    std::size_t size         = m_league_size * m_team_size * m_vector_size;
+    std::size_t size = std::size_t(m_league_size) * m_team_size * m_vector_size;
     const auto init_size =
         std::max<std::size_t>((size + wgroup_size - 1) / wgroup_size, 1);
     const unsigned int value_count =

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -95,7 +95,6 @@ struct TestTeamReduceLarge {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const member_t& t, uint64_t& update) const {
-    const uint64_t i = t.league_rank();
     Kokkos::single(Kokkos::PerTeam(t), [&]() { update++; });
   }
 

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -85,21 +85,20 @@ TEST(TEST_CATEGORY, team_reduce) {
 
 template <typename ExecutionSpace>
 struct TestTeamReduceLarge {
-  using team_policy_t =
-      Kokkos::TeamPolicy<Kokkos::IndexType<uint64_t>, ExecutionSpace>;
-  using member_t = typename team_policy_t::member_type;
+  using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
+  using member_t      = typename team_policy_t::member_type;
 
-  uint64_t m_range;
+  int m_range;
 
-  TestTeamReduceLarge(const uint64_t range) : m_range(range) {}
+  TestTeamReduceLarge(const int range) : m_range(range) {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const member_t& t, uint64_t& update) const {
+  void operator()(const member_t& t, int& update) const {
     Kokkos::single(Kokkos::PerTeam(t), [&]() { update++; });
   }
 
   void run() {
-    uint64_t result = 0;
+    int result = 0;
     Kokkos::parallel_reduce(team_policy_t(m_range, Kokkos::AUTO), *this,
                             result);
     EXPECT_EQ(m_range, result);
@@ -107,8 +106,8 @@ struct TestTeamReduceLarge {
 };
 
 TEST(TEST_CATEGORY, team_reduce_large) {
-  std::vector<uint64_t> ranges{(2LU << 23) - 1, 2LU << 23, (2LU << 24),
-                               (2LU << 24) + 1};
+  std::vector<int> ranges{(2LU << 23) - 1, 2LU << 23, (2LU << 24),
+                          (2LU << 24) + 1};
   for (const auto range : ranges) {
     TestTeamReduceLarge<TEST_EXECSPACE> test(range);
     test.run();

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -107,7 +107,7 @@ struct TestTeamReduceLarge {
 
 TEST(TEST_CATEGORY, team_reduce_large) {
   std::vector<int> ranges{(2LU << 23) - 1, 2LU << 23, (2LU << 24),
-                          (2LU << 24) + 1};
+                          (2LU << 24) + 1, 1LU << 29};
   for (const auto range : ranges) {
     TestTeamReduceLarge<TEST_EXECSPACE> test(range);
     test.run();


### PR DESCRIPTION
Fixes #4531. Specifically, the lines
```
const auto nwork = static_cast<typename Policy::index_type>(m_league_size) * m_team_size;
```
fix the issue (for `CUDA` and `HIP`). The other changes to the types of `nwork` are just for consistency.
