### PR TITLE
[3.5] DynamicView: Fix deallocation extent cherrypick 4533

### DIFF
--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -173,7 +173,9 @@ struct ChunkedArrayManager {
     void execute() {
       // Destroy the array of chunk pointers.
       // Two entries beyond the max chunks are allocation counters.
-      for (unsigned i = 0; i < m_chunk_max; i++) {
+      uintptr_t const len =
+          *reinterpret_cast<uintptr_t*>(m_chunks + m_chunk_max);
+      for (unsigned i = 0; i < len; i++) {
         Space().deallocate(m_label.c_str(), m_chunks[i],
                            sizeof(value_type) * m_chunk_size);
       }


### PR DESCRIPTION
Resolves #4517: DynamicView: Fix deallocation extent

(cherry picked from commit 55aeec4968aa4db260f1213a4bfdaef47f1f6eaa)