### PR TITLE
[3.5] Fix bash syntax error cherrypick #4524

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -99,7 +99,7 @@ first_xcompiler_arg=1
 if [[ -z ${NVCC_WRAPPER_TMPDIR+x} ]]; then
   temp_dir=${TMPDIR:-/tmp}
 else
-  temp_dir=${NVCC_WRAPPER_TMPDIR+x}
+  temp_dir=${NVCC_WRAPPER_TMPDIR}
 fi
 
 # optimization flag added as a command-line argument


### PR DESCRIPTION
Fix bash syntax error in nvcc_wrapper with NVCC_WRAPPER_TMPDIR

(cherry picked from commit d94cc8da9af13b32e318624fb41dc1ec60129aec)