### PR TITLE
OpenMPTarget: Update to LLVM/13 .

### DIFF
--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -1857,10 +1857,14 @@ TEST(TEST_CATEGORY, mathspecialfunc_expint1) {
   test.testit();
 }
 
+// FIXME_OPENMPTARGET: This unit test fails with a misaligned address error at
+// runtime with LLVM/13.
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 TEST(TEST_CATEGORY, mathspecialfunc_errorfunc) {
   TestComplexErrorFunction<TEST_EXECSPACE> test;
   test.testit();
 }
+#endif
 
 TEST(TEST_CATEGORY, mathspecialfunc_cbesselj0y0) {
   TestComplexBesselJ0Y0Function<TEST_EXECSPACE> test;

--- a/scripts/docker/Dockerfile.openmptarget
+++ b/scripts/docker/Dockerfile.openmptarget
@@ -62,4 +62,4 @@ RUN LLVM_URL=https://github.com/llvm/llvm-project/archive &&\
     make install && \
     rm -rf ${SCRATCH_DIR}
 ENV PATH=${LLVM_DIR}/bin:$PATH
-ENV LD_LIBARY_PATH=${LLVM_DIR}/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=${LLVM_DIR}/lib:$LD_LIBRARY_PATH

--- a/scripts/docker/Dockerfile.openmptarget
+++ b/scripts/docker/Dockerfile.openmptarget
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
         ccache \
         python3 \
         libelf-dev \
+        g++-multilib \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -37,9 +38,9 @@ RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSIO
     rm ${CMAKE_SCRIPT}
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
+ARG LLVM_VERSION=llvmorg-13.0.0
 ENV LLVM_DIR=/opt/llvm
-RUN LLVM_VERSION=887c7660bdf3f300bd1997dcfd7ace91787c0584 && \
-    LLVM_URL=https://github.com/llvm/llvm-project/archive &&\
+RUN LLVM_URL=https://github.com/llvm/llvm-project/archive &&\
     LLVM_ARCHIVE=${LLVM_VERSION}.tar.gz &&\
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${LLVM_URL}/${LLVM_ARCHIVE} && \
@@ -52,22 +53,13 @@ RUN LLVM_VERSION=887c7660bdf3f300bd1997dcfd7ace91787c0584 && \
       -DCMAKE_INSTALL_PREFIX=$LLVM_DIR \
       -DCMAKE_C_COMPILER=gcc \
       -DCMAKE_CXX_COMPILER=g++ \
-      -DLLVM_ENABLE_PROJECTS="clang;libcxx;libcxxabi;openmp" \
+      -DLLVM_ENABLE_PROJECTS="clang" \
+      -DLLVM_ENABLE_RUNTIMES="openmp" \
       -DCLANG_OPENMP_NVPTX_DEFAULT_ARCH=sm_70 \
       -DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES=70 \
     ../llvm && \
     make -j${NPROC} && \
     make install && \
-    rm -rf ../build/* && \
-    cmake \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=$LLVM_DIR \
-      -DCMAKE_C_COMPILER=$LLVM_DIR/bin/clang \
-      -DCMAKE_CXX_COMPILER=$LLVM_DIR/bin/clang++ \
-      -DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES=70 \
-    ../openmp && \
-    make -j${NPROC} && \
-    make install && \
-    echo "${LLVM_DIR}/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig && \
     rm -rf ${SCRATCH_DIR}
 ENV PATH=${LLVM_DIR}/bin:$PATH
+ENV LD_LIBARY_PATH=${LLVM_DIR}/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
The PR does the following 
1. Updates the CI testing for OpenMPTarget backend to use LLVM/13 .
2. Uses a single pass LLVM installation rather than a 2 pass installation.
3. It disables one unit test which fails correctness with LLVM/13 . 


The PR is dependent on #4456 to avoid a compile time error.
