### PR TITLE
Do not mess with `M_PI` macro

### DIFF
--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -50,10 +50,6 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_ErrorReporter.hpp>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 namespace Test {
 
 // Just save the data in the report.  Informative text goes in the
@@ -174,7 +170,8 @@ struct ErrorReporterDriver : public ErrorReporterDriverBase<DeviceType> {
   KOKKOS_INLINE_FUNCTION
   void operator()(const int work_idx) const {
     if (driver_base::error_condition(work_idx)) {
-      double val = M_PI * static_cast<double>(work_idx);
+      double val =
+          Kokkos::Experimental::pi_v<double> * static_cast<double>(work_idx);
       typename driver_base::report_type report = {work_idx, -2 * work_idx, val};
       driver_base::m_errorReporter.add_report(work_idx, report);
     }
@@ -200,7 +197,8 @@ struct ErrorReporterDriverUseLambda
         Kokkos::RangePolicy<execution_space>(0, test_size),
         KOKKOS_CLASS_LAMBDA(const int work_idx) {
           if (driver_base::error_condition(work_idx)) {
-            double val = M_PI * static_cast<double>(work_idx);
+            double val = Kokkos::Experimental::pi_v<double> *
+                         static_cast<double>(work_idx);
             typename driver_base::report_type report = {work_idx, -2 * work_idx,
                                                         val};
             driver_base::m_errorReporter.add_report(work_idx, report);
@@ -224,7 +222,8 @@ struct ErrorReporterDriverNativeOpenMP
 #pragma omp parallel for
     for (int work_idx = 0; work_idx < test_size; ++work_idx) {
       if (driver_base::error_condition(work_idx)) {
-        double val = M_PI * static_cast<double>(work_idx);
+        double val =
+            Kokkos::Experimental::pi_v<double> * static_cast<double>(work_idx);
         typename driver_base::report_type report = {work_idx, -2 * work_idx,
                                                     val};
         driver_base::m_errorReporter.add_report(work_idx, report);

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -54,10 +54,6 @@
 #include <Kokkos_NumericTraits.hpp>
 #include <Kokkos_Complex.hpp>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 namespace Kokkos {
 namespace Experimental {
 

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -49,6 +49,7 @@
 #include <cmath>
 #include <algorithm>
 #include <type_traits>
+#include <Kokkos_MathematicalConstants.hpp>
 #include <Kokkos_MathematicalFunctions.hpp>
 #include <Kokkos_NumericTraits.hpp>
 #include <Kokkos_Complex.hpp>
@@ -124,6 +125,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erf(
   using Kokkos::Experimental::exp;
   using Kokkos::Experimental::fabs;
   using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::sin;
 
   using CmplxType = Kokkos::complex<RealType>;
@@ -136,7 +138,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erf(
   const RealType eh    = 0.606530659712633;
   const RealType ef    = 0.778800783071405;
   // const RealType tol   = 1.0e-13;
-  const RealType pi = M_PI;
+  constexpr auto pi = pi_v<RealType>;
 
   CmplxType cans;
 
@@ -302,6 +304,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erfcx(
   using Kokkos::Experimental::fabs;
   using Kokkos::Experimental::infinity;
   using Kokkos::Experimental::isinf;
+  using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::sin;
 
   using CmplxType = Kokkos::complex<RealType>;
@@ -314,7 +317,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erfcx(
   const RealType eh    = 0.606530659712633;
   const RealType ef    = 0.778800783071405;
   // const RealType tol   = 1.0e-13;
-  const RealType pi = M_PI;
+  constexpr auto pi = pi_v<RealType>;
 
   CmplxType cans;
 
@@ -490,10 +493,11 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_j0(const CmplxType& z,
   //         bw_start  --- Starting point for backward recurrence
   // Output:  cbj0      --- J0(z)
   using Kokkos::Experimental::fabs;
+  using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
 
   CmplxType cbj0;
-  const RealType pi    = M_PI;
+  constexpr auto pi    = pi_v<RealType>;
   const RealType a[12] = {
       -0.703125e-01,           0.112152099609375e+00,   -0.5725014209747314e+00,
       0.6074042001273483e+01,  -0.1100171402692467e+03, 0.3038090510922384e+04,
@@ -579,12 +583,13 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y0(const CmplxType& z,
   //    Output:  cby0      --- Y0(z)
   using Kokkos::Experimental::fabs;
   using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
 
   auto const inf = infinity<RealType>::value;
 
   CmplxType cby0, cbj0;
-  const RealType pi    = M_PI;
+  constexpr auto pi    = pi_v<RealType>;
   const RealType el    = 0.57721566490153286060651209008240;
   const RealType a[12] = {
       -0.703125e-01,           0.112152099609375e+00,   -0.5725014209747314e+00,
@@ -679,10 +684,11 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_j1(const CmplxType& z,
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbj1      --- J1(z)
   using Kokkos::Experimental::fabs;
+  using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
 
   CmplxType cbj1;
-  const RealType pi     = M_PI;
+  constexpr auto pi     = pi_v<RealType>;
   const RealType a1[12] = {0.1171875e+00,          -0.144195556640625e+00,
                            0.6765925884246826e+00, -0.6883914268109947e+01,
                            0.1215978918765359e+03, -0.3302272294480852e+04,
@@ -772,12 +778,13 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y1(const CmplxType& z,
   //    Output:  cby1      --- Y1(z)
   using Kokkos::Experimental::fabs;
   using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
 
   auto const inf = infinity<RealType>::value;
 
   CmplxType cby1, cbj0, cbj1, cby0;
-  const RealType pi     = M_PI;
+  constexpr auto pi     = pi_v<RealType>;
   const RealType el     = 0.57721566490153286060651209008240;
   const RealType a1[12] = {0.1171875e+00,          -0.144195556640625e+00,
                            0.6765925884246826e+00, -0.6883914268109947e+01,
@@ -875,7 +882,8 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_i0(const CmplxType& z,
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbi0      --- I0(z)
   CmplxType cbi0;
-  const RealType pi    = M_PI;
+  using Kokkos::Experimental::pi_v;
+  constexpr auto pi    = pi_v<RealType>;
   const RealType a[12] = {0.125,
                           7.03125e-2,
                           7.32421875e-2,
@@ -947,12 +955,13 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k0(const CmplxType& z,
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbk0      --- K0(z)
   using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
 
   auto const inf = infinity<RealType>::value;
 
   CmplxType cbk0, cbi0;
-  const RealType pi = M_PI;
+  constexpr auto pi = pi_v<RealType>;
   const RealType el = 0.57721566490153286060651209008240;
 
   RealType a0  = Kokkos::abs(z);
@@ -1020,7 +1029,8 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_i1(const CmplxType& z,
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbi1      --- I1(z)
   CmplxType cbi1;
-  const RealType pi    = M_PI;
+  using Kokkos::Experimental::pi_v;
+  constexpr auto pi    = pi_v<RealType>;
   const RealType b[12] = {-0.375,
                           -1.171875e-1,
                           -1.025390625e-1,
@@ -1093,12 +1103,13 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k1(const CmplxType& z,
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbk1      --- K1(z)
   using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
 
   auto const inf = infinity<RealType>::value;
 
   CmplxType cbk0, cbi0, cbk1, cbi1;
-  const RealType pi = M_PI;
+  constexpr auto pi = pi_v<RealType>;
   const RealType el = 0.57721566490153286060651209008240;
 
   RealType a0  = Kokkos::abs(z);
@@ -1163,11 +1174,12 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h10(const CmplxType& z) {
   //(Wiley, 1996).
   using RealType = typename CmplxType::value_type;
   using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::pi_v;
 
   auto const inf = infinity<RealType>::value;
 
   CmplxType ch10, cbk0, cbj0, cby0;
-  const RealType pi = M_PI;
+  constexpr auto pi = pi_v<RealType>;
   CmplxType ci      = CmplxType(0.0, 1.0);
 
   if ((z.real() == 0.0) && (z.imag() == 0.0)) {
@@ -1193,11 +1205,12 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h11(const CmplxType& z) {
   //(Wiley, 1996).
   using RealType = typename CmplxType::value_type;
   using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::pi_v;
 
   auto const inf = infinity<RealType>::value;
 
   CmplxType ch11, cbk1, cbj1, cby1;
-  const RealType pi = M_PI;
+  constexpr auto pi = pi_v<RealType>;
   CmplxType ci      = CmplxType(0.0, 1.0);
 
   if ((z.real() == 0.0) && (z.imag() == 0.0)) {
@@ -1223,11 +1236,12 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h20(const CmplxType& z) {
   //(Wiley, 1996).
   using RealType = typename CmplxType::value_type;
   using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::pi_v;
 
   auto const inf = infinity<RealType>::value;
 
   CmplxType ch20, cbk0, cbj0, cby0;
-  const RealType pi = M_PI;
+  constexpr auto pi = pi_v<RealType>;
   CmplxType ci      = CmplxType(0.0, 1.0);
 
   if ((z.real() == 0.0) && (z.imag() == 0.0)) {
@@ -1253,11 +1267,12 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h21(const CmplxType& z) {
   //(Wiley, 1996).
   using RealType = typename CmplxType::value_type;
   using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::pi_v;
 
   auto const inf = infinity<RealType>::value;
 
   CmplxType ch21, cbk1, cbj1, cby1;
-  const RealType pi = M_PI;
+  constexpr auto pi = pi_v<RealType>;
   CmplxType ci      = CmplxType(0.0, 1.0);
 
   if ((z.real() == 0.0) && (z.imag() == 0.0)) {

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -126,8 +126,8 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erf(
 
   using CmplxType = Kokkos::complex<RealType>;
 
-  auto const inf = infinity<RealType>::value;
-  auto const tol = epsilon<RealType>::value;
+  constexpr auto inf = infinity<RealType>::value;
+  constexpr auto tol = epsilon<RealType>::value;
 
   const RealType fnorm = 1.12837916709551;
   const RealType gnorm = 0.564189583547756;
@@ -305,8 +305,8 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erfcx(
 
   using CmplxType = Kokkos::complex<RealType>;
 
-  auto const inf = infinity<RealType>::value;
-  auto const tol = epsilon<RealType>::value;
+  constexpr auto inf = infinity<RealType>::value;
+  constexpr auto tol = epsilon<RealType>::value;
 
   const RealType fnorm = 1.12837916709551;
   const RealType gnorm = 0.564189583547756;
@@ -582,7 +582,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y0(const CmplxType& z,
   using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
 
-  auto const inf = infinity<RealType>::value;
+  constexpr auto inf = infinity<RealType>::value;
 
   CmplxType cby0, cbj0;
   constexpr auto pi    = pi_v<RealType>;
@@ -777,7 +777,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y1(const CmplxType& z,
   using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
 
-  auto const inf = infinity<RealType>::value;
+  constexpr auto inf = infinity<RealType>::value;
 
   CmplxType cby1, cbj0, cbj1, cby0;
   constexpr auto pi     = pi_v<RealType>;
@@ -954,7 +954,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k0(const CmplxType& z,
   using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
 
-  auto const inf = infinity<RealType>::value;
+  constexpr auto inf = infinity<RealType>::value;
 
   CmplxType cbk0, cbi0;
   constexpr auto pi = pi_v<RealType>;
@@ -1102,7 +1102,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k1(const CmplxType& z,
   using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
 
-  auto const inf = infinity<RealType>::value;
+  constexpr auto inf = infinity<RealType>::value;
 
   CmplxType cbk0, cbi0, cbk1, cbi1;
   constexpr auto pi = pi_v<RealType>;
@@ -1172,7 +1172,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h10(const CmplxType& z) {
   using Kokkos::Experimental::infinity;
   using Kokkos::Experimental::pi_v;
 
-  auto const inf = infinity<RealType>::value;
+  constexpr auto inf = infinity<RealType>::value;
 
   CmplxType ch10, cbk0, cbj0, cby0;
   constexpr auto pi = pi_v<RealType>;
@@ -1203,7 +1203,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h11(const CmplxType& z) {
   using Kokkos::Experimental::infinity;
   using Kokkos::Experimental::pi_v;
 
-  auto const inf = infinity<RealType>::value;
+  constexpr auto inf = infinity<RealType>::value;
 
   CmplxType ch11, cbk1, cbj1, cby1;
   constexpr auto pi = pi_v<RealType>;
@@ -1234,7 +1234,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h20(const CmplxType& z) {
   using Kokkos::Experimental::infinity;
   using Kokkos::Experimental::pi_v;
 
-  auto const inf = infinity<RealType>::value;
+  constexpr auto inf = infinity<RealType>::value;
 
   CmplxType ch20, cbk0, cbj0, cby0;
   constexpr auto pi = pi_v<RealType>;
@@ -1265,7 +1265,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h21(const CmplxType& z) {
   using Kokkos::Experimental::infinity;
   using Kokkos::Experimental::pi_v;
 
-  auto const inf = infinity<RealType>::value;
+  constexpr auto inf = infinity<RealType>::value;
 
   CmplxType ch21, cbk1, cbj1, cby1;
   constexpr auto pi = pi_v<RealType>;

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -577,6 +577,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y0(const CmplxType& z,
   //                           argument regions
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cby0      --- Y0(z)
+  using Kokkos::Experimental::egamma_v;
   using Kokkos::Experimental::fabs;
   using Kokkos::Experimental::infinity;
   using Kokkos::Experimental::pi_v;
@@ -586,7 +587,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y0(const CmplxType& z,
 
   CmplxType cby0, cbj0;
   constexpr auto pi    = pi_v<RealType>;
-  const RealType el    = 0.57721566490153286060651209008240;
+  constexpr auto el    = egamma_v<RealType>;
   const RealType a[12] = {
       -0.703125e-01,           0.112152099609375e+00,   -0.5725014209747314e+00,
       0.6074042001273483e+01,  -0.1100171402692467e+03, 0.3038090510922384e+04,
@@ -772,6 +773,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y1(const CmplxType& z,
   //                           argument regions
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cby1      --- Y1(z)
+  using Kokkos::Experimental::egamma_v;
   using Kokkos::Experimental::fabs;
   using Kokkos::Experimental::infinity;
   using Kokkos::Experimental::pi_v;
@@ -781,7 +783,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y1(const CmplxType& z,
 
   CmplxType cby1, cbj0, cbj1, cby0;
   constexpr auto pi     = pi_v<RealType>;
-  const RealType el     = 0.57721566490153286060651209008240;
+  constexpr auto el     = egamma_v<RealType>;
   const RealType a1[12] = {0.1171875e+00,          -0.144195556640625e+00,
                            0.6765925884246826e+00, -0.6883914268109947e+01,
                            0.1215978918765359e+03, -0.3302272294480852e+04,
@@ -950,6 +952,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k0(const CmplxType& z,
   //                           argument regions
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbk0      --- K0(z)
+  using Kokkos::Experimental::egamma_v;
   using Kokkos::Experimental::infinity;
   using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
@@ -958,7 +961,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k0(const CmplxType& z,
 
   CmplxType cbk0, cbi0;
   constexpr auto pi = pi_v<RealType>;
-  const RealType el = 0.57721566490153286060651209008240;
+  constexpr auto el = egamma_v<RealType>;
 
   RealType a0  = Kokkos::abs(z);
   CmplxType ci = CmplxType(0.0, 1.0);
@@ -1098,6 +1101,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k1(const CmplxType& z,
   //                           argument regions
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbk1      --- K1(z)
+  using Kokkos::Experimental::egamma_v;
   using Kokkos::Experimental::infinity;
   using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::pow;
@@ -1106,7 +1110,7 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k1(const CmplxType& z,
 
   CmplxType cbk0, cbi0, cbk1, cbi1;
   constexpr auto pi = pi_v<RealType>;
-  const RealType el = 0.57721566490153286060651209008240;
+  constexpr auto el = egamma_v<RealType>;
 
   RealType a0  = Kokkos::abs(z);
   CmplxType ci = CmplxType(0.0, 1.0);

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -299,6 +299,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erfcx(
   using Kokkos::Experimental::exp;
   using Kokkos::Experimental::fabs;
   using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::inv_sqrtpi_v;
   using Kokkos::Experimental::isinf;
   using Kokkos::Experimental::pi_v;
   using Kokkos::Experimental::sin;
@@ -309,7 +310,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erfcx(
   constexpr auto tol = epsilon<RealType>::value;
 
   const RealType fnorm = 1.12837916709551;
-  const RealType gnorm = 0.564189583547756;
+  constexpr auto gnorm = inv_sqrtpi_v<RealType>;
   const RealType eh    = 0.606530659712633;
   const RealType ef    = 0.778800783071405;
   // const RealType tol   = 1.0e-13;


### PR DESCRIPTION
Prefer math constants (#4519) in special math functions implementation
Do not define `M_PI` if it is not defined.
