### PR TITLE
Use std::size_t for requested scratch allocations in GPU backends

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -620,8 +620,7 @@ Cuda::size_type *CudaInternal::scratch_space(const std::size_t size) const {
   return m_scratchSpace;
 }
 
-Cuda::size_type *CudaInternal::scratch_unified(
-    const Cuda::size_type size) const {
+Cuda::size_type *CudaInternal::scratch_unified(const std::size_t size) const {
   if (verify_is_initialized("scratch_unified") && m_scratchUnifiedSupported &&
       m_scratchUnifiedCount * sizeScratchGrain < size) {
     m_scratchUnifiedCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -573,7 +573,7 @@ Kokkos::Cuda::initialize WARNING: Cuda is allocating into UVMSpace by default
 using ScratchGrain = Cuda::size_type[Impl::CudaTraits::WarpSize];
 enum { sizeScratchGrain = sizeof(ScratchGrain) };
 
-Cuda::size_type *CudaInternal::scratch_flags(const Cuda::size_type size) const {
+Cuda::size_type *CudaInternal::scratch_flags(const std::size_t size) const {
   if (verify_is_initialized("scratch_flags") &&
       m_scratchFlagsCount * sizeScratchGrain < size) {
     m_scratchFlagsCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
@@ -598,7 +598,7 @@ Cuda::size_type *CudaInternal::scratch_flags(const Cuda::size_type size) const {
   return m_scratchFlags;
 }
 
-Cuda::size_type *CudaInternal::scratch_space(const Cuda::size_type size) const {
+Cuda::size_type *CudaInternal::scratch_space(const std::size_t size) const {
   if (verify_is_initialized("scratch_space") &&
       m_scratchSpaceCount * sizeScratchGrain < size) {
     m_scratchSpaceCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
@@ -644,8 +644,7 @@ Cuda::size_type *CudaInternal::scratch_unified(
   return m_scratchUnified;
 }
 
-Cuda::size_type *CudaInternal::scratch_functor(
-    const Cuda::size_type size) const {
+Cuda::size_type *CudaInternal::scratch_functor(const std::size_t size) const {
   if (verify_is_initialized("scratch_functor") && m_scratchFunctorSize < size) {
     m_scratchFunctorSize = size;
 
@@ -795,17 +794,17 @@ Cuda::size_type cuda_internal_maximum_shared_words() {
 }
 
 Cuda::size_type *cuda_internal_scratch_space(const Cuda &instance,
-                                             const Cuda::size_type size) {
+                                             const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_space(size);
 }
 
 Cuda::size_type *cuda_internal_scratch_flags(const Cuda &instance,
-                                             const Cuda::size_type size) {
+                                             const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_flags(size);
 }
 
 Cuda::size_type *cuda_internal_scratch_unified(const Cuda &instance,
-                                               const Cuda::size_type size) {
+                                               const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_unified(size);
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -104,10 +104,10 @@ class CudaInternal {
   cudaDeviceProp m_deviceProp;
 
   // Scratch Spaces for Reductions
-  mutable size_type m_scratchSpaceCount;
-  mutable size_type m_scratchFlagsCount;
-  mutable size_type m_scratchUnifiedCount;
-  mutable size_type m_scratchFunctorSize;
+  mutable std::size_t m_scratchSpaceCount;
+  mutable std::size_t m_scratchFlagsCount;
+  mutable std::size_t m_scratchUnifiedCount;
+  mutable std::size_t m_scratchFunctorSize;
 
   size_type m_scratchUnifiedSupported;
   size_type m_streamCount;
@@ -196,10 +196,10 @@ class CudaInternal {
   }
 
   // Resizing of reduction related scratch spaces
-  size_type* scratch_space(const size_type size) const;
-  size_type* scratch_flags(const size_type size) const;
-  size_type* scratch_unified(const size_type size) const;
-  size_type* scratch_functor(const size_type size) const;
+  size_type* scratch_space(const std::size_t size) const;
+  size_type* scratch_flags(const std::size_t size) const;
+  size_type* scratch_unified(const std::size_t size) const;
+  size_type* scratch_functor(const std::size_t size) const;
   uint32_t impl_get_instance_id() const;
   // Resizing of team level 1 scratch
   std::pair<void*, int> resize_team_scratch_space(std::int64_t bytes,

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -60,12 +60,12 @@ CudaSpace::size_type cuda_internal_maximum_shared_words();
 
 CudaSpace::size_type cuda_internal_maximum_concurrent_block_count();
 
-CudaSpace::size_type* cuda_internal_scratch_flags(
-    const Cuda&, const CudaSpace::size_type size);
-CudaSpace::size_type* cuda_internal_scratch_space(
-    const Cuda&, const CudaSpace::size_type size);
-CudaSpace::size_type* cuda_internal_scratch_unified(
-    const Cuda&, const CudaSpace::size_type size);
+CudaSpace::size_type* cuda_internal_scratch_flags(const Cuda&,
+                                                  const std::size_t size);
+CudaSpace::size_type* cuda_internal_scratch_space(const Cuda&,
+                                                  const std::size_t size);
+CudaSpace::size_type* cuda_internal_scratch_unified(const Cuda&,
+                                                    const std::size_t size);
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -324,7 +324,7 @@ using ScratchGrain =
 enum { sizeScratchGrain = sizeof(ScratchGrain) };
 
 Kokkos::Experimental::HIP::size_type *HIPInternal::scratch_space(
-    const Kokkos::Experimental::HIP::size_type size) {
+    const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&
       m_scratchSpaceCount * sizeScratchGrain < size) {
     m_scratchSpaceCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
@@ -348,7 +348,7 @@ Kokkos::Experimental::HIP::size_type *HIPInternal::scratch_space(
 }
 
 Kokkos::Experimental::HIP::size_type *HIPInternal::scratch_flags(
-    const Kokkos::Experimental::HIP::size_type size) {
+    const std::size_t size) {
   if (verify_is_initialized("scratch_flags") &&
       m_scratchFlagsCount * sizeScratchGrain < size) {
     m_scratchFlagsCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
@@ -486,12 +486,12 @@ Kokkos::Experimental::HIP::size_type hip_internal_maximum_grid_count() {
 }
 
 Kokkos::Experimental::HIP::size_type *hip_internal_scratch_space(
-    const HIP &instance, const HIP::size_type size) {
+    const HIP &instance, const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_space(size);
 }
 
 Kokkos::Experimental::HIP::size_type *hip_internal_scratch_flags(
-    const HIP &instance, const HIP::size_type size) {
+    const HIP &instance, const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_flags(size);
 }
 

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -76,9 +76,9 @@ HIP::size_type hip_internal_maximum_grid_count();
 HIP::size_type hip_internal_multiprocessor_count();
 
 HIP::size_type *hip_internal_scratch_space(const HIP &instance,
-                                           const HIP::size_type size);
+                                           const std::size_t size);
 HIP::size_type *hip_internal_scratch_flags(const HIP &instance,
-                                           const HIP::size_type size);
+                                           const std::size_t size);
 
 //----------------------------------------------------------------------------
 
@@ -117,8 +117,8 @@ class HIPInternal {
   mutable std::mutex m_mutexSharedMemory;
 
   // Scratch Spaces for Reductions
-  size_type m_scratchSpaceCount = 0;
-  size_type m_scratchFlagsCount = 0;
+  std::size_t m_scratchSpaceCount = 0;
+  std::size_t m_scratchFlagsCount = 0;
 
   size_type *m_scratchSpace           = nullptr;
   size_type *m_scratchFlags           = nullptr;
@@ -167,8 +167,8 @@ class HIPInternal {
   HIPInternal() = default;
 
   // Resizing of reduction related scratch spaces
-  size_type *scratch_space(const size_type size);
-  size_type *scratch_flags(const size_type size);
+  size_type *scratch_space(const std::size_t size);
+  size_type *scratch_flags(const std::size_t size);
   uint32_t impl_get_instance_id() const noexcept;
   // Resizing of team level 1 scratch
   void *resize_team_scratch_space(std::int64_t bytes,

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -223,8 +223,7 @@ void SYCLInternal::finalize() {
   m_queue.reset();
 }
 
-void* SYCLInternal::scratch_space(
-    const Kokkos::Experimental::SYCL::size_type size) {
+void* SYCLInternal::scratch_space(const std::size_t size) {
   const size_type sizeScratchGrain =
       sizeof(Kokkos::Experimental::SYCL::size_type);
   if (verify_is_initialized("scratch_space") &&
@@ -250,8 +249,7 @@ void* SYCLInternal::scratch_space(
   return m_scratchSpace;
 }
 
-void* SYCLInternal::scratch_flags(
-    const Kokkos::Experimental::SYCL::size_type size) {
+void* SYCLInternal::scratch_flags(const std::size_t size) {
   const size_type sizeScratchGrain =
       sizeof(Kokkos::Experimental::SYCL::size_type);
   if (verify_is_initialized("scratch_flags") &&

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -66,8 +66,8 @@ class SYCLInternal {
   SYCLInternal& operator=(SYCLInternal&&) = delete;
   SYCLInternal(SYCLInternal&&)            = delete;
 
-  void* scratch_space(const size_type size);
-  void* scratch_flags(const size_type size);
+  void* scratch_space(const std::size_t size);
+  void* scratch_flags(const std::size_t size);
   void* resize_team_scratch_space(std::int64_t bytes,
                                   bool force_shrink = false);
 
@@ -79,9 +79,9 @@ class SYCLInternal {
   uint64_t m_maxShmemPerBlock = 0;
 
   uint32_t* m_scratchConcurrentBitset = nullptr;
-  size_type m_scratchSpaceCount       = 0;
+  std::size_t m_scratchSpaceCount     = 0;
   size_type* m_scratchSpace           = nullptr;
-  size_type m_scratchFlagsCount       = 0;
+  std::size_t m_scratchFlagsCount     = 0;
   size_type* m_scratchFlags           = nullptr;
   // mutex to access shared memory
   mutable std::mutex m_mutexScratchSpace;


### PR DESCRIPTION
In https://github.com/kokkos/kokkos/pull/4532, it turned out that some test cases needed the allocation size for scratch space to be larger than `ExecutionSpace::size_type`. This pull request tries to make the change from `ExecutionSpace::size_type` to `std::size_t` more uniform across `CUDA`, `HIP` and `SYCL`.