### PR TITLE
Loosen restriction for using built-in sycl::group_broadcast

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -109,8 +109,9 @@ class SYCLTeamMember {
   //--------------------------------------------------------------------------
 
   template <class ValueType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_arithmetic_v<ValueType>>
-  team_broadcast(ValueType& val, const int thread_id) const {
+  KOKKOS_INLINE_FUNCTION
+      std::enable_if_t<std::is_trivially_copyable_v<ValueType>>
+      team_broadcast(ValueType& val, const int thread_id) const {
     val = sycl::group_broadcast(m_item.get_group(), val,
                                 sycl::id<2>(thread_id, 0));
   }
@@ -118,8 +119,9 @@ class SYCLTeamMember {
   // FIXME_SYCL remove/adapt this overload once the Intel oneAPI implementation
   // is conforming to the SYCL2020 standard (allowing trivially-copyable types)
   template <class ValueType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<!std::is_arithmetic_v<ValueType>>
-  team_broadcast(ValueType& val, const int thread_id) const {
+  KOKKOS_INLINE_FUNCTION
+      std::enable_if_t<!std::is_trivially_copyable_v<ValueType>>
+      team_broadcast(ValueType& val, const int thread_id) const {
     // Wait for shared data write until all threads arrive here
     sycl::group_barrier(m_item.get_group());
     if (m_item.get_local_id(1) == 0 &&


### PR DESCRIPTION
After https://github.com/intel/llvm/pull/4910 has been merged, we can also use `sycl::group_broadcast` for `team_broadcast` for trivially-copyable types.
Fixes https://github.com/intel/llvm/issues/4717.