### PR TITLE
Tell the user to delete CMakeCache.txt after creating a build folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 # Disable in-source builds to prevent source tree corruption.
 if( "${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}" )
-  message( FATAL_ERROR "FATAL: In-source builds are not allowed. You should create a separate directory for build files." )
+  message( FATAL_ERROR "FATAL: In-source builds are not allowed. You should create a separate directory for build files and delete CMakeCache.txt." )
 endif()
 
 # We want to determine if options are given with the wrong case


### PR DESCRIPTION
The current message can be confusing enough for users not familiar with cmake:

```
$ cmake .
CMake Error at CMakeLists.txt:4 (message):
  FATAL: In-source builds are not allowed.  You should create a separate
  directory for build files.


-- Configuring incomplete, errors occurred!

$ make build
$ cd build
$ cmake ..
CMake Error at CMakeLists.txt:4 (message):
  FATAL: In-source builds are not allowed.  You should create a separate
  directory for build files.


-- Configuring incomplete, errors occurred!
```

Deleting the `CMakeCache.txt` file fixes the problem:

```
$ rm CMakeCache.txt
$ cmake ..
-- Setting default Kokkos CXX standard to 14
-- The CXX compiler identification is Clang 11.1.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
[...]
```