### PR TITLE
Use all dimensions of m_maxBlock in Cuda and HIP

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -301,7 +301,7 @@ CudaInternal::~CudaInternal() {
   m_cudaArch                = -1;
   m_multiProcCount          = 0;
   m_maxWarpCount            = 0;
-  m_maxBlock                = 0;
+  m_maxBlock                = {0, 0, 0};
   m_maxSharedWords          = 0;
   m_maxConcurrency          = 0;
   m_scratchSpaceCount       = 0;
@@ -433,7 +433,9 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream,
     //----------------------------------
     // Maximum number of blocks:
 
-    m_maxBlock = cudaProp.maxGridSize[0];
+    m_maxBlock[0] = cudaProp.maxGridSize[0];
+    m_maxBlock[1] = cudaProp.maxGridSize[1];
+    m_maxBlock[2] = cudaProp.maxGridSize[2];
 
     m_shmemPerSM       = cudaProp.sharedMemPerMultiprocessor;
     m_maxShmemPerBlock = cudaProp.sharedMemPerBlock;
@@ -735,7 +737,7 @@ void CudaInternal::finalize() {
     m_cudaDev                 = -1;
     m_multiProcCount          = 0;
     m_maxWarpCount            = 0;
-    m_maxBlock                = 0;
+    m_maxBlock                = {0, 0, 0};
     m_maxSharedWords          = 0;
     m_scratchSpaceCount       = 0;
     m_scratchFlagsCount       = 0;
@@ -786,7 +788,7 @@ Cuda::size_type cuda_internal_maximum_warp_count() {
   return CudaInternal::singleton().m_maxWarpCount;
 }
 
-Cuda::size_type cuda_internal_maximum_grid_count() {
+std::array<Cuda::size_type, 3> cuda_internal_maximum_grid_count() {
   return CudaInternal::singleton().m_maxBlock;
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -55,7 +55,7 @@ struct CudaTraits {
 
 CudaSpace::size_type cuda_internal_multiprocessor_count();
 CudaSpace::size_type cuda_internal_maximum_warp_count();
-CudaSpace::size_type cuda_internal_maximum_grid_count();
+std::array<CudaSpace::size_type, 3> cuda_internal_maximum_grid_count();
 CudaSpace::size_type cuda_internal_maximum_shared_words();
 
 CudaSpace::size_type cuda_internal_maximum_concurrent_block_count();
@@ -91,7 +91,7 @@ class CudaInternal {
   int m_cudaArch;
   unsigned m_multiProcCount;
   unsigned m_maxWarpCount;
-  unsigned m_maxBlock;
+  std::array<size_type, 3> m_maxBlock;
   unsigned m_maxSharedWords;
   uint32_t m_maxConcurrency;
   int m_shmemPerSM;
@@ -164,7 +164,7 @@ class CudaInternal {
         m_cudaArch(-1),
         m_multiProcCount(0),
         m_maxWarpCount(0),
-        m_maxBlock(0),
+        m_maxBlock({0, 0, 0}),
         m_maxSharedWords(0),
         m_maxConcurrency(0),
         m_shmemPerSM(0),

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -236,7 +236,9 @@ void HIPInternal::initialize(int hip_device_id, hipStream_t stream,
 
     //----------------------------------
     // Maximum number of blocks
-    m_maxBlock = hipProp.maxGridSize[0];
+    m_maxBlock[0] = hipProp.maxGridSize[0];
+    m_maxBlock[1] = hipProp.maxGridSize[1];
+    m_maxBlock[2] = hipProp.maxGridSize[2];
 
     // theoretically, we can get 40 WF's / CU, but only can sustain 32
     // see
@@ -413,7 +415,7 @@ void HIPInternal::finalize() {
     m_hipArch                   = -1;
     m_multiProcCount            = 0;
     m_maxWarpCount              = 0;
-    m_maxBlock                  = 0;
+    m_maxBlock                  = {0, 0, 0};
     m_maxSharedWords            = 0;
     m_maxShmemPerBlock          = 0;
     m_scratchSpaceCount         = 0;
@@ -481,7 +483,8 @@ Kokkos::Experimental::HIP::size_type hip_internal_maximum_warp_count() {
   return HIPInternal::singleton().m_maxWarpCount;
 }
 
-Kokkos::Experimental::HIP::size_type hip_internal_maximum_grid_count() {
+std::array<Kokkos::Experimental::HIP::size_type, 3>
+hip_internal_maximum_grid_count() {
   return HIPInternal::singleton().m_maxBlock;
 }
 

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -72,7 +72,7 @@ struct HIPTraits {
 //----------------------------------------------------------------------------
 
 HIP::size_type hip_internal_maximum_warp_count();
-HIP::size_type hip_internal_maximum_grid_count();
+std::array<HIP::size_type, 3> hip_internal_maximum_grid_count();
 HIP::size_type hip_internal_multiprocessor_count();
 
 HIP::size_type *hip_internal_scratch_space(const HIP &instance,
@@ -90,13 +90,13 @@ class HIPInternal {
  public:
   using size_type = ::Kokkos::Experimental::HIP::size_type;
 
-  int m_hipDev              = -1;
-  int m_hipArch             = -1;
-  unsigned m_multiProcCount = 0;
-  unsigned m_maxWarpCount   = 0;
-  unsigned m_maxBlock       = 0;
-  unsigned m_maxWavesPerCU  = 0;
-  unsigned m_maxSharedWords = 0;
+  int m_hipDev                        = -1;
+  int m_hipArch                       = -1;
+  unsigned m_multiProcCount           = 0;
+  unsigned m_maxWarpCount             = 0;
+  std::array<size_type, 3> m_maxBlock = {0, 0, 0};
+  unsigned m_maxWavesPerCU            = 0;
+  unsigned m_maxSharedWords           = 0;
   int m_regsPerSM;
   int m_shmemPerSM       = 0;
   int m_maxShmemPerBlock = 0;

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -84,17 +84,19 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     using ClosureType =
         ParallelFor<FunctorType, Policy, Kokkos::Experimental::HIP>;
     if (m_policy.m_num_tiles == 0) return;
-    array_index_type const maxblocks = static_cast<array_index_type>(
-        m_policy.space().impl_internal_space_instance()->m_maxBlock);
+    auto const maxblocks =
+        Kokkos::Experimental::Impl::hip_internal_maximum_grid_count();
     if (Policy::rank == 2) {
       dim3 const block(m_policy.m_tile[0], m_policy.m_tile[1], 1);
       dim3 const grid(
-          std::min((m_policy.m_upper[0] - m_policy.m_lower[0] + block.x - 1) /
-                       block.x,
-                   maxblocks),
-          std::min((m_policy.m_upper[1] - m_policy.m_lower[1] + block.y - 1) /
-                       block.y,
-                   maxblocks),
+          std::min<array_index_type>(
+              (m_policy.m_upper[0] - m_policy.m_lower[0] + block.x - 1) /
+                  block.x,
+              maxblocks[0]),
+          std::min<array_index_type>(
+              (m_policy.m_upper[1] - m_policy.m_lower[1] + block.y - 1) /
+                  block.y,
+              maxblocks[1]),
           1);
       Kokkos::Experimental::Impl::hip_parallel_launch<ClosureType,
                                                       LaunchBounds>(
@@ -104,15 +106,18 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       dim3 const block(m_policy.m_tile[0], m_policy.m_tile[1],
                        m_policy.m_tile[2]);
       dim3 const grid(
-          std::min((m_policy.m_upper[0] - m_policy.m_lower[0] + block.x - 1) /
-                       block.x,
-                   maxblocks),
-          std::min((m_policy.m_upper[1] - m_policy.m_lower[1] + block.y - 1) /
-                       block.y,
-                   maxblocks),
-          std::min((m_policy.m_upper[2] - m_policy.m_lower[2] + block.z - 1) /
-                       block.z,
-                   maxblocks));
+          std::min<array_index_type>(
+              (m_policy.m_upper[0] - m_policy.m_lower[0] + block.x - 1) /
+                  block.x,
+              maxblocks[0]),
+          std::min<array_index_type>(
+              (m_policy.m_upper[1] - m_policy.m_lower[1] + block.y - 1) /
+                  block.y,
+              maxblocks[1]),
+          std::min<array_index_type>(
+              (m_policy.m_upper[2] - m_policy.m_lower[2] + block.z - 1) /
+                  block.z,
+              maxblocks[2]));
       Kokkos::Experimental::Impl::hip_parallel_launch<ClosureType,
                                                       LaunchBounds>(
           *this, grid, block, 0,
@@ -123,15 +128,16 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
                        m_policy.m_tile[2], m_policy.m_tile[3]);
       dim3 const grid(
-          std::min(static_cast<uint32_t>(m_policy.m_tile_end[0] *
-                                         m_policy.m_tile_end[1]),
-                   static_cast<uint32_t>(maxblocks)),
-          std::min((m_policy.m_upper[2] - m_policy.m_lower[2] + block.y - 1) /
-                       block.y,
-                   maxblocks),
-          std::min((m_policy.m_upper[3] - m_policy.m_lower[3] + block.z - 1) /
-                       block.z,
-                   maxblocks));
+          std::min<array_index_type>(
+              m_policy.m_tile_end[0] * m_policy.m_tile_end[1], maxblocks[0]),
+          std::min<array_index_type>(
+              (m_policy.m_upper[2] - m_policy.m_lower[2] + block.y - 1) /
+                  block.y,
+              maxblocks[1]),
+          std::min<array_index_type>(
+              (m_policy.m_upper[3] - m_policy.m_lower[3] + block.z - 1) /
+                  block.z,
+              maxblocks[2]));
       Kokkos::Experimental::Impl::hip_parallel_launch<ClosureType,
                                                       LaunchBounds>(
           *this, grid, block, 0,
@@ -143,15 +149,14 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
                        m_policy.m_tile[2] * m_policy.m_tile[3],
                        m_policy.m_tile[4]);
       dim3 const grid(
-          std::min(static_cast<index_type>(m_policy.m_tile_end[0] *
-                                           m_policy.m_tile_end[1]),
-                   static_cast<index_type>(maxblocks)),
-          std::min(static_cast<index_type>(m_policy.m_tile_end[2] *
-                                           m_policy.m_tile_end[3]),
-                   static_cast<index_type>(maxblocks)),
-          std::min((m_policy.m_upper[4] - m_policy.m_lower[4] + block.z - 1) /
-                       block.z,
-                   maxblocks));
+          std::min<array_index_type>(
+              m_policy.m_tile_end[0] * m_policy.m_tile_end[1], maxblocks[0]),
+          std::min<array_index_type>(
+              m_policy.m_tile_end[2] * m_policy.m_tile_end[3], maxblocks[1]),
+          std::min<array_index_type>(
+              (m_policy.m_upper[4] - m_policy.m_lower[4] + block.z - 1) /
+                  block.z,
+              maxblocks[2]));
       Kokkos::Experimental::Impl::hip_parallel_launch<ClosureType,
                                                       LaunchBounds>(
           *this, grid, block, 0,
@@ -162,15 +167,13 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
                        m_policy.m_tile[2] * m_policy.m_tile[3],
                        m_policy.m_tile[4] * m_policy.m_tile[5]);
-      dim3 const grid(std::min(static_cast<index_type>(m_policy.m_tile_end[0] *
-                                                       m_policy.m_tile_end[1]),
-                               static_cast<index_type>(maxblocks)),
-                      std::min(static_cast<index_type>(m_policy.m_tile_end[2] *
-                                                       m_policy.m_tile_end[3]),
-                               static_cast<index_type>(maxblocks)),
-                      std::min(static_cast<index_type>(m_policy.m_tile_end[4] *
-                                                       m_policy.m_tile_end[5]),
-                               static_cast<index_type>(maxblocks)));
+      dim3 const grid(
+          std::min<array_index_type>(
+              m_policy.m_tile_end[0] * m_policy.m_tile_end[1], maxblocks[0]),
+          std::min<array_index_type>(
+              m_policy.m_tile_end[2] * m_policy.m_tile_end[3], maxblocks[1]),
+          std::min<array_index_type>(
+              m_policy.m_tile_end[4] * m_policy.m_tile_end[5], maxblocks[2]));
       Kokkos::Experimental::Impl::hip_parallel_launch<ClosureType,
                                                       LaunchBounds>(
           *this, grid, block, 0,

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -248,7 +248,7 @@ class TeamPolicyInternal<Kokkos::Experimental::HIP, Properties...>
     // Make sure league size is permissible
     if (league_size_ >=
         static_cast<int>(
-            ::Kokkos::Experimental::Impl::hip_internal_maximum_grid_count()))
+            ::Kokkos::Experimental::Impl::hip_internal_maximum_grid_count()[0]))
       Impl::throw_runtime_exception(
           "Requested too large league_size for TeamPolicy on HIP execution "
           "space.");

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -145,6 +145,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
         MDRange_d
         MDRange_e
         MDRange_f
+        MDRange_g
         NumericTraits
         Other
         RangePolicy

--- a/core/unit_test/TestMDRange_g.hpp
+++ b/core/unit_test/TestMDRange_g.hpp
@@ -1,0 +1,106 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+//#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+
+template <typename View>
+struct SumView {
+  const View m_view;
+  KOKKOS_FUNCTION void operator()(const int i, const int j, int& update) const {
+    update += m_view(i, j);
+  }
+
+  SumView(View view) : m_view(view) {}
+
+  int run() {
+    int sum_view = 0;
+    Kokkos::parallel_reduce(
+        Kokkos::MDRangePolicy<typename View::execution_space, Kokkos::Rank<2>>(
+            {0, 0}, {m_view.extent(0), m_view.extent(1)}),
+        *this, sum_view);
+    return sum_view;
+  }
+};
+
+template <typename ExecutionSpace>
+struct TestMDRangeLargeDeepCopy {
+  static void run() {
+    ExecutionSpace exec;
+    using MemorySpace       = typename ExecutionSpace::memory_space;
+    const int s             = 45;
+    const int step_sizes[2] = {1, 10000};
+    Kokkos::View<int**, MemorySpace> view("v", s * step_sizes[0],
+                                          (s + 1) * step_sizes[1]);
+    Kokkos::deep_copy(exec, view, 1);
+    for (int step = 2; step < view.extent_int(0); ++step) {
+      auto subview =
+          Kokkos::subview(view, std::make_pair(0, (step + 1) * step_sizes[0]),
+                          std::make_pair(0, (step + 2) * step_sizes[1]));
+      Kokkos::View<int**, MemorySpace> subview_copy(
+          "subview_copy", subview.extent(0), subview.extent(1));
+      Kokkos::deep_copy(TEST_EXECSPACE{}, subview_copy, subview);
+      exec.fence();
+
+      SumView<decltype(subview)> sum_subview(subview);
+      int total_subview = sum_subview.run();
+      SumView<decltype(subview_copy)> sum_subview_copy(subview_copy);
+      int total_subview_copy = sum_subview_copy.run();
+
+      ASSERT_EQ(total_subview, total_subview_copy);
+    }
+  }
+};
+
+// Check that deep_copy with a large range for a dimension different from the
+// first one works successfully. There was a problem with this in the Cuda
+// backend.
+TEST(TEST_CATEGORY, mdrange_large_deep_copy) {
+  TestMDRangeLargeDeepCopy<TEST_EXECSPACE>::run();
+}
+
+}  // namespace Test


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/4558. We use `m_maxBlock` not just as first argument for determining the grid sizes in `Cuda` and `HIP` and the correct values might differ between dimensions. Hence, this pull request stores all three values and uses them accordingly.