### PR TITLE
change windows.h include to lowercase to improve mingw compatibility

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -59,7 +59,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #else
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This PR changes a single instance of `Windows.h` to it's lowercase form. All other instances of `windows.h` includes are already lowercase with the exception of this one.

When building on Windows, a case-insensitive file-system is usually employed, but when cross-compiling on a Linux host for a Windows target case-senstive file-systems are more common. MinGW consistently uses lowercase names for all libraries and header files.