### PR TITLE
Disable gcc-5.3.0 in CI temporarily

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -381,36 +381,6 @@ pipeline {
                         }
                     }
                 }
-                stage('GCC-5.3.0') {
-                    agent {
-                        dockerfile {
-                            filename 'Dockerfile.gcc'
-                            dir 'scripts/docker'
-                            label 'docker'
-                        }
-                    }
-                    environment {
-                        OMP_NUM_THREADS = 8
-                        OMP_PROC_BIND = 'true'
-                    }
-                    steps {
-                        sh '''rm -rf build && mkdir -p build && cd build && \
-                              cmake \
-                                -DCMAKE_BUILD_TYPE=Release \
-                                -DCMAKE_CXX_STANDARD=14 \
-                                -DCMAKE_CXX_FLAGS=-Werror \
-                                -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
-                                -DKokkos_ENABLE_DEPRECATED_CODE_3=ON \
-                                -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
-                                -DKokkos_ENABLE_TESTS=ON \
-                                -DKokkos_ENABLE_OPENMP=ON \
-                                -DKokkos_ENABLE_LIBDL=OFF \
-                                -DKokkos_ENABLE_LIBQUADMATH=ON \
-                                -DCMAKE_PREFIX_PATH=/usr/local/lib/gcc/x86_64-unknown-linux-gnu/5.3.0 \
-                              .. && \
-                              make -j8 && ctest --verbose && gcc -I$PWD/../core/src/ ../core/unit_test/tools/TestCInterface.c'''
-                    }
-                }
             }
         }
     }


### PR DESCRIPTION
All pull requests are currently failing because of problems in `gcc-5.3.0`. This pull request disables that CI check until we have a proper fix.