### PR TITLE
Backport bit manipulation facility from C++20 standard library header `<bit>`

### DIFF
--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -1,0 +1,158 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_BIT_MANIPULATION_HPP
+#define KOKKOS_BIT_MANIPULATION_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_NumericTraits.hpp>
+
+namespace Kokkos::Impl {
+
+template <class T>
+KOKKOS_FUNCTION constexpr int countl_zero_fallback(T x) {
+  // From Hacker's Delight (2nd edition) section 5-3
+  unsigned int y = 0;
+  using ::Kokkos::Experimental::digits_v;
+  int n = digits_v<T>;
+  int c = digits_v<T> / 2;
+  do {
+    y = x >> c;
+    if (y != 0) {
+      n -= c;
+      x = y;
+    }
+    c >>= 1;
+  } while (c != 0);
+  return n - static_cast<int>(x);
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr int countr_zero_fallback(T x) {
+  using ::Kokkos::Experimental::digits_v;
+  return digits_v<T> - countl_zero_fallback(static_cast<T>(
+                           static_cast<T>(~x) & static_cast<T>(x - 1)));
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr int popcount_fallback(T x) {
+  int c = 0;
+  for (; x != 0; x &= x - 1) {
+    ++c;
+  }
+  return c;
+}
+
+template <class T>
+inline constexpr bool is_standard_unsigned_integer_type_v =
+    std::is_same_v<T, unsigned char> || std::is_same_v<T, unsigned short> ||
+    std::is_same_v<T, unsigned int> || std::is_same_v<T, unsigned long> ||
+    std::is_same_v<T, unsigned long long>;
+
+}  // namespace Kokkos::Impl
+
+namespace Kokkos {
+
+//<editor-fold desc="[bit.count], counting">
+template <class T>
+KOKKOS_FUNCTION constexpr std::enable_if_t<
+    Impl::is_standard_unsigned_integer_type_v<T>, int>
+countl_zero(T x) noexcept {
+  using ::Kokkos::Experimental::digits_v;
+  if (x == 0) return digits_v<T>;
+  // TODO use compiler intrinsics when available
+  return Impl::countl_zero_fallback(x);
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr std::enable_if_t<
+    Impl::is_standard_unsigned_integer_type_v<T>, int>
+countl_one(T x) noexcept {
+  using ::Kokkos::Experimental::digits_v;
+  using ::Kokkos::Experimental::finite_max_v;
+  if (x == finite_max_v<T>) return digits_v<T>;
+  return countl_zero(static_cast<T>(~x));
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr std::enable_if_t<
+    Impl::is_standard_unsigned_integer_type_v<T>, int>
+countr_zero(T x) noexcept {
+  using ::Kokkos::Experimental::digits_v;
+  if (x == 0) return digits_v<T>;
+  // TODO use compiler intrinsics when available
+  return Impl::countr_zero_fallback(x);
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr std::enable_if_t<
+    Impl::is_standard_unsigned_integer_type_v<T>, int>
+countr_one(T x) noexcept {
+  using ::Kokkos::Experimental::digits_v;
+  using ::Kokkos::Experimental::finite_max_v;
+  if (x == finite_max_v<T>) return digits_v<T>;
+  return countr_zero(static_cast<T>(~x));
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr std::enable_if_t<
+    Impl::is_standard_unsigned_integer_type_v<T>, int>
+popcount(T x) noexcept {
+  if (x == 0) return 0;
+  // TODO use compiler intrinsics when available
+  return Impl::popcount_fallback(x);
+}
+//</editor-fold>
+
+//<editor-fold desc="[bit.pow.two], integral powers of 2">
+template <class T>
+KOKKOS_FUNCTION constexpr std::enable_if_t<
+    Impl::is_standard_unsigned_integer_type_v<T>, bool>
+has_single_bit(T x) noexcept {
+  return x != 0 && (((x & (x - 1)) == 0));
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr std::enable_if_t<
+    Impl::is_standard_unsigned_integer_type_v<T>, T>
+bit_ceil(T x) noexcept {
+  if (x <= 1) return 1;
+  using ::Kokkos::Experimental::digits_v;
+  return T{1} << (digits_v<T> - countl_zero(static_cast<T>(x - 1)));
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr std::enable_if_t<
+    Impl::is_standard_unsigned_integer_type_v<T>, T>
+bit_floor(T x) noexcept {
+  if (x == 0) return 0;
+  using ::Kokkos::Experimental::digits_v;
+  return T{1} << (digits_v<T> - 1 - countl_zero(x));
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr std::enable_if_t<
+    Impl::is_standard_unsigned_integer_type_v<T>, T>
+bit_width(T x) noexcept {
+  if (x == 0) return 0;
+  using ::Kokkos::Experimental::digits_v;
+  return digits_v<T> - countl_zero(x);
+}
+//</editor-fold>
+
+}  // namespace Kokkos
+
+#endif

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -53,6 +53,7 @@
 #include <Kokkos_MathematicalFunctions.hpp>
 #include <Kokkos_MathematicalSpecialFunctions.hpp>
 #include <Kokkos_NumericTraits.hpp>
+#include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_MemoryPool.hpp>
 #include <Kokkos_Array.hpp>
 #include <Kokkos_View.hpp>

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -75,6 +75,7 @@ SET(COMPILE_ONLY_SOURCES
   TestArray.cpp
   TestCreateMirror.cpp
   TestDetectionIdiom.cpp
+  TestBitManipulation.cpp
   TestInterOp.cpp
   TestStringManipulation.cpp
   TestVersionMacros.cpp

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -112,6 +112,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     # file. That then exceeded the shell command line max length.
     set(${Tag}_SOURCES1A)
     foreach(Name
+        BitManipulationBuiltins
         AtomicOperations_int
         AtomicOperations_unsignedint
         AtomicOperations_longint

--- a/core/unit_test/TestBitManipulation.cpp
+++ b/core/unit_test/TestBitManipulation.cpp
@@ -1,0 +1,333 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_BitManipulation.hpp>
+
+struct X {
+  constexpr bool did_not_match() { return true; }
+};
+
+#define TEST_BIT_MANIPULATION(FUNC)                     \
+  constexpr X test_##FUNC(...) { return {}; }           \
+  static_assert(test_##FUNC((unsigned char)0));         \
+  static_assert(test_##FUNC((unsigned short)0));        \
+  static_assert(test_##FUNC((unsigned int)0));          \
+  static_assert(test_##FUNC((unsigned long)0));         \
+  static_assert(test_##FUNC((unsigned long long)0));    \
+  static_assert(test_##FUNC((bool)0).did_not_match());  \
+  static_assert(test_##FUNC((int)0).did_not_match());   \
+  static_assert(test_##FUNC((float)0).did_not_match()); \
+  static_assert(test_##FUNC((void*)0).did_not_match())
+
+//<editor-fold desc="[bit.count]">
+template <class UInt>
+constexpr auto test_countl_zero(UInt x) -> decltype(Kokkos::countl_zero(x)) {
+  using Kokkos::countl_zero;
+
+  static_assert(noexcept(countl_zero(x)));
+  static_assert(std::is_same_v<decltype(countl_zero(x)), int>);
+
+  constexpr auto dig = Kokkos::Experimental::digits_v<UInt>;
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+
+  static_assert(countl_zero(UInt(0)) == dig);
+  static_assert(countl_zero(UInt(1)) == dig - 1);
+  static_assert(countl_zero(UInt(2)) == dig - 2);
+  static_assert(countl_zero(UInt(3)) == dig - 2);
+  static_assert(countl_zero(UInt(4)) == dig - 3);
+  static_assert(countl_zero(UInt(5)) == dig - 3);
+  static_assert(countl_zero(UInt(6)) == dig - 3);
+  static_assert(countl_zero(UInt(7)) == dig - 3);
+  static_assert(countl_zero(UInt(8)) == dig - 4);
+  static_assert(countl_zero(UInt(9)) == dig - 4);
+  static_assert(countl_zero(UInt(127)) == dig - 7);
+  static_assert(countl_zero(UInt(128)) == dig - 8);
+  static_assert(countl_zero(max) == 0);
+
+  return true;
+}
+
+TEST_BIT_MANIPULATION(countl_zero);
+
+template <class UInt>
+constexpr auto test_countl_one(UInt x) -> decltype(Kokkos::countl_one(x)) {
+  using Kokkos::countl_one;
+
+  static_assert(noexcept(countl_one(x)));
+  static_assert(std::is_same_v<decltype(countl_one(x)), int>);
+
+  constexpr auto dig = Kokkos::Experimental::digits_v<UInt>;
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+
+  static_assert(countl_one(UInt(0)) == 0);
+  static_assert(countl_one(UInt(1)) == 0);
+  static_assert(countl_one(UInt(2)) == 0);
+  static_assert(countl_one(UInt(3)) == 0);
+  static_assert(countl_one(UInt(4)) == 0);
+  static_assert(countl_one(UInt(5)) == 0);
+  static_assert(countl_one(UInt(6)) == 0);
+  static_assert(countl_one(UInt(7)) == 0);
+  static_assert(countl_one(UInt(8)) == 0);
+  static_assert(countl_one(UInt(9)) == 0);
+  static_assert(countl_one(UInt(100)) == 0);
+  static_assert(countl_one(max) == dig);
+  static_assert(countl_one(UInt(max - 1)) == dig - 1);
+  static_assert(countl_one(UInt(max - 2)) == dig - 2);
+  static_assert(countl_one(UInt(max - 3)) == dig - 2);
+  static_assert(countl_one(UInt(max - 4)) == dig - 3);
+  static_assert(countl_one(UInt(max - 5)) == dig - 3);
+  static_assert(countl_one(UInt(max - 6)) == dig - 3);
+  static_assert(countl_one(UInt(max - 7)) == dig - 3);
+  static_assert(countl_one(UInt(max - 8)) == dig - 4);
+  static_assert(countl_one(UInt(max - 9)) == dig - 4);
+  static_assert(countl_one(UInt(max - 126)) == dig - 7);
+  static_assert(countl_one(UInt(max - 127)) == dig - 7);
+  static_assert(countl_one(UInt(max - 128)) == dig - 8);
+  static_assert(countl_one(UInt(UInt(1) << (dig - 1))) == 1);
+  static_assert(countl_one(UInt(UInt(3) << (dig - 2))) == 2);
+  static_assert(countl_one(UInt(UInt(7) << (dig - 3))) == 3);
+  static_assert(countl_one(UInt(UInt(255) << (dig - 8))) == 8);
+
+  return true;
+}
+
+TEST_BIT_MANIPULATION(countl_one);
+
+template <class UInt>
+constexpr auto test_countr_zero(UInt x) -> decltype(Kokkos::countr_zero(x)) {
+  using Kokkos::countr_zero;
+
+  static_assert(noexcept(countr_zero(x)));
+  static_assert(std::is_same_v<decltype(countr_zero(x)), int>);
+
+  constexpr auto dig = Kokkos::Experimental::digits_v<UInt>;
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+
+  static_assert(countr_zero(UInt(0)) == dig);
+  static_assert(countr_zero(UInt(1)) == 0);
+  static_assert(countr_zero(UInt(2)) == 1);
+  static_assert(countr_zero(UInt(3)) == 0);
+  static_assert(countr_zero(UInt(4)) == 2);
+  static_assert(countr_zero(UInt(5)) == 0);
+  static_assert(countr_zero(UInt(6)) == 1);
+  static_assert(countr_zero(UInt(7)) == 0);
+  static_assert(countr_zero(UInt(8)) == 3);
+  static_assert(countr_zero(UInt(9)) == 0);
+  static_assert(countr_zero(UInt(126)) == 1);
+  static_assert(countr_zero(UInt(127)) == 0);
+  static_assert(countr_zero(UInt(128)) == 7);
+  static_assert(countr_zero(UInt(129)) == 0);
+  static_assert(countr_zero(UInt(130)) == 1);
+  static_assert(countr_zero(max) == 0);
+
+  return true;
+}
+
+TEST_BIT_MANIPULATION(countr_zero);
+
+template <class UInt>
+constexpr auto test_countr_one(UInt x) -> decltype(Kokkos::countr_one(x)) {
+  using Kokkos::countr_one;
+
+  static_assert(noexcept(countr_one(x)));
+  static_assert(std::is_same_v<decltype(countr_one(x)), int>);
+
+  constexpr auto dig = Kokkos::Experimental::digits_v<UInt>;
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+
+  static_assert(countr_one(UInt(0)) == 0);
+  static_assert(countr_one(UInt(1)) == 1);
+  static_assert(countr_one(UInt(2)) == 0);
+  static_assert(countr_one(UInt(3)) == 2);
+  static_assert(countr_one(UInt(4)) == 0);
+  static_assert(countr_one(UInt(5)) == 1);
+  static_assert(countr_one(UInt(6)) == 0);
+  static_assert(countr_one(UInt(7)) == 3);
+  static_assert(countr_one(UInt(8)) == 0);
+  static_assert(countr_one(UInt(9)) == 1);
+  static_assert(countr_one(UInt(126)) == 0);
+  static_assert(countr_one(UInt(127)) == 7);
+  static_assert(countr_one(UInt(128)) == 0);
+  static_assert(countr_one(UInt(max - 1)) == 0);
+  static_assert(countr_one(max) == dig);
+
+  return true;
+}
+
+TEST_BIT_MANIPULATION(countr_one);
+
+template <class UInt>
+constexpr auto test_popcount(UInt x) -> decltype(Kokkos::popcount(x)) {
+  using Kokkos::popcount;
+
+  static_assert(noexcept(popcount(x)));
+  static_assert(std::is_same_v<decltype(popcount(x)), int>);
+
+  constexpr auto dig = Kokkos::Experimental::digits_v<UInt>;
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+
+  static_assert(popcount(UInt(0)) == 0);
+  static_assert(popcount(UInt(1)) == 1);
+  static_assert(popcount(UInt(2)) == 1);
+  static_assert(popcount(UInt(3)) == 2);
+  static_assert(popcount(UInt(4)) == 1);
+  static_assert(popcount(UInt(5)) == 2);
+  static_assert(popcount(UInt(6)) == 2);
+  static_assert(popcount(UInt(7)) == 3);
+  static_assert(popcount(UInt(8)) == 1);
+  static_assert(popcount(UInt(9)) == 2);
+  static_assert(popcount(UInt(127)) == 7);
+  static_assert(popcount(max) == dig);
+  static_assert(popcount(UInt(max - 1)) == dig - 1);
+
+  return true;
+}
+
+TEST_BIT_MANIPULATION(popcount);
+//</editor-fold>
+
+//<editor-fold desc="[bit.pow.two]">
+template <class UInt>
+constexpr auto test_has_single_bit(UInt x)
+    -> decltype(Kokkos::has_single_bit(x)) {
+  using Kokkos::has_single_bit;
+
+  static_assert(noexcept(has_single_bit(x)));
+  static_assert(std::is_same_v<decltype(has_single_bit(x)), bool>);
+
+  static_assert(!has_single_bit(UInt(0)));
+  static_assert(has_single_bit(UInt(1)));
+  static_assert(has_single_bit(UInt(2)));
+  static_assert(!has_single_bit(UInt(3)));
+  static_assert(has_single_bit(UInt(4)));
+  static_assert(!has_single_bit(UInt(5)));
+  static_assert(!has_single_bit(UInt(6)));
+  static_assert(!has_single_bit(UInt(7)));
+  static_assert(has_single_bit(UInt(8)));
+  static_assert(!has_single_bit(UInt(9)));
+
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+  static_assert(!has_single_bit(max));
+  constexpr UInt one = 1;
+  static_assert(has_single_bit(UInt(one << 0)));
+  static_assert(has_single_bit(UInt(one << 1)));
+  static_assert(has_single_bit(UInt(one << 2)));
+  static_assert(has_single_bit(UInt(one << 3)));
+  static_assert(has_single_bit(UInt(one << 4)));
+  static_assert(has_single_bit(UInt(one << 5)));
+  static_assert(has_single_bit(UInt(one << 6)));
+  static_assert(has_single_bit(UInt(one << 7)));
+
+  return true;
+}
+
+TEST_BIT_MANIPULATION(has_single_bit);
+
+template <class UInt>
+constexpr auto test_bit_floor(UInt x) -> decltype(Kokkos::bit_floor(x)) {
+  using Kokkos::bit_floor;
+
+  static_assert(noexcept(bit_floor(x)));
+  static_assert(std::is_same_v<decltype(bit_floor(x)), UInt>);
+
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+
+  static_assert(bit_floor(UInt(0)) == 0);
+  static_assert(bit_floor(UInt(1)) == 1);
+  static_assert(bit_floor(UInt(2)) == 2);
+  static_assert(bit_floor(UInt(3)) == 2);
+  static_assert(bit_floor(UInt(4)) == 4);
+  static_assert(bit_floor(UInt(5)) == 4);
+  static_assert(bit_floor(UInt(6)) == 4);
+  static_assert(bit_floor(UInt(7)) == 4);
+  static_assert(bit_floor(UInt(8)) == 8);
+  static_assert(bit_floor(UInt(9)) == 8);
+  static_assert(bit_floor(UInt(125)) == 64);
+  static_assert(bit_floor(UInt(126)) == 64);
+  static_assert(bit_floor(UInt(127)) == 64);
+  static_assert(bit_floor(UInt(128)) == 128);
+  static_assert(bit_floor(UInt(129)) == 128);
+  static_assert(bit_floor(max) == UInt(max - (max >> 1)));
+
+  return true;
+}
+
+TEST_BIT_MANIPULATION(bit_floor);
+
+template <class UInt>
+constexpr auto test_bit_ceil(UInt x) -> decltype(Kokkos::bit_ceil(x)) {
+  using Kokkos::bit_ceil;
+
+  static_assert(noexcept(bit_ceil(x)));
+  static_assert(std::is_same_v<decltype(bit_ceil(x)), UInt>);
+
+  static_assert(bit_ceil(UInt(0)) == 1);
+  static_assert(bit_ceil(UInt(1)) == 1);
+  static_assert(bit_ceil(UInt(2)) == 2);
+  static_assert(bit_ceil(UInt(3)) == 4);
+  static_assert(bit_ceil(UInt(4)) == 4);
+  static_assert(bit_ceil(UInt(5)) == 8);
+  static_assert(bit_ceil(UInt(6)) == 8);
+  static_assert(bit_ceil(UInt(7)) == 8);
+  static_assert(bit_ceil(UInt(8)) == 8);
+  static_assert(bit_ceil(UInt(9)) == 16);
+  static_assert(bit_ceil(UInt(60)) == 64);
+  static_assert(bit_ceil(UInt(61)) == 64);
+  static_assert(bit_ceil(UInt(62)) == 64);
+  static_assert(bit_ceil(UInt(63)) == 64);
+  static_assert(bit_ceil(UInt(64)) == 64);
+  static_assert(bit_ceil(UInt(65)) == 128);
+  static_assert(bit_ceil(UInt(66)) == 128);
+  static_assert(bit_ceil(UInt(67)) == 128);
+  static_assert(bit_ceil(UInt(68)) == 128);
+  static_assert(bit_ceil(UInt(69)) == 128);
+
+  return true;
+}
+
+TEST_BIT_MANIPULATION(bit_ceil);
+
+template <class UInt>
+constexpr auto test_bit_width(UInt x) -> decltype(Kokkos::bit_width(x)) {
+  using Kokkos::bit_width;
+
+  static_assert(noexcept(bit_width(x)));
+  static_assert(std::is_same_v<decltype(bit_width(x)), UInt>);
+
+  constexpr auto dig = Kokkos::Experimental::digits_v<UInt>;
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+
+  static_assert(bit_width(UInt(0)) == 0);
+  static_assert(bit_width(UInt(1)) == 1);
+  static_assert(bit_width(UInt(2)) == 2);
+  static_assert(bit_width(UInt(3)) == 2);
+  static_assert(bit_width(UInt(4)) == 3);
+  static_assert(bit_width(UInt(5)) == 3);
+  static_assert(bit_width(UInt(6)) == 3);
+  static_assert(bit_width(UInt(7)) == 3);
+  static_assert(bit_width(UInt(8)) == 4);
+  static_assert(bit_width(UInt(9)) == 4);
+
+  static_assert(bit_width(UInt(max - 1)) == dig);
+  static_assert(bit_width(max) == dig);
+
+  return true;
+}
+
+TEST_BIT_MANIPULATION(bit_width);
+//</editor-fold>
+
+#undef TEST_BIT_MANIPULATION

--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -198,7 +198,11 @@ void test_bit_manip_countr_zero() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_countr_zero) {
-  test_bit_manip_countr_zero<unsigned char>();
+#if defined(KOKKOS_ENABLE_SYCL) && \
+    !defined(KOKKOS_ARCH_INTEL_GPU)  // FIXME_SYCL returns wrong result
+  if (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
+#endif
+    test_bit_manip_countr_zero<unsigned char>();
   test_bit_manip_countr_zero<unsigned short>();
   test_bit_manip_countr_zero<unsigned int>();
   test_bit_manip_countr_zero<unsigned long>();
@@ -232,7 +236,11 @@ void test_bit_manip_countr_one() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_countr_one) {
-  test_bit_manip_countr_one<unsigned char>();
+#if defined(KOKKOS_ENABLE_SYCL) && \
+    !defined(KOKKOS_ARCH_INTEL_GPU)  // FIXME_SYCL returns wrong result
+  if (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
+#endif
+    test_bit_manip_countr_one<unsigned char>();
   test_bit_manip_countr_one<unsigned short>();
   test_bit_manip_countr_one<unsigned int>();
   test_bit_manip_countr_one<unsigned long>();

--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -1,0 +1,419 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+
+// clang-format off
+template <class>
+struct type_helper;
+#define DEFINE_TYPE_NAME(T) \
+template <> struct type_helper<T> { static char const * name() { return #T; } };
+DEFINE_TYPE_NAME(unsigned char)
+DEFINE_TYPE_NAME(unsigned short)
+DEFINE_TYPE_NAME(unsigned int)
+DEFINE_TYPE_NAME(unsigned long)
+DEFINE_TYPE_NAME(unsigned long long)
+#undef DEFINE_TYPE_NAME
+// clang-format on
+
+#define DEFINE_BIT_MANIPULATION_FUNCTION_EVAL(FUNC)   \
+  struct BitManipFunction_##FUNC {                    \
+    template <class T>                                \
+    static KOKKOS_FUNCTION auto eval_constexpr(T x) { \
+      return Kokkos::FUNC(x);                         \
+    }                                                 \
+    template <class T>                                \
+    static KOKKOS_FUNCTION auto eval_builtin(T x) {   \
+      return Kokkos::Experimental::FUNC##_builtin(x); \
+    }                                                 \
+    static char const* name() { return #FUNC; }       \
+  }
+
+DEFINE_BIT_MANIPULATION_FUNCTION_EVAL(countl_zero);
+DEFINE_BIT_MANIPULATION_FUNCTION_EVAL(countl_one);
+DEFINE_BIT_MANIPULATION_FUNCTION_EVAL(countr_zero);
+DEFINE_BIT_MANIPULATION_FUNCTION_EVAL(countr_one);
+DEFINE_BIT_MANIPULATION_FUNCTION_EVAL(popcount);
+DEFINE_BIT_MANIPULATION_FUNCTION_EVAL(has_single_bit);
+DEFINE_BIT_MANIPULATION_FUNCTION_EVAL(bit_ceil);
+DEFINE_BIT_MANIPULATION_FUNCTION_EVAL(bit_floor);
+DEFINE_BIT_MANIPULATION_FUNCTION_EVAL(bit_width);
+
+template <class Space, class Func, class Arg, std::size_t N>
+struct TestBitManipFunction {
+  Arg val_[N];
+  TestBitManipFunction(const Arg (&val)[N]) {
+    std::copy(val, val + N, val_);
+    run();
+  }
+  void run() const {
+    int errors = 0;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, N), *this, errors);
+    ASSERT_EQ(errors, 0) << "Failed check no error for " << Func::name() << "("
+                         << type_helper<Arg>::name() << ")";
+  }
+  KOKKOS_FUNCTION void operator()(int i, int& e) const {
+    if (Func::eval_builtin(val_[i]) != Func::eval_constexpr(val_[i])) {
+      ++e;
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "value at %x which is %d was expected to be %d\n", (unsigned)val_[i],
+          (int)Func::eval_builtin(val_[i]), (int)Func::eval_constexpr(val_[i]));
+    }
+  }
+};
+
+template <class Space, class... Func, class Arg, std::size_t N>
+void do_test_bit_manip_function(const Arg (&x)[N]) {
+  (void)std::initializer_list<int>{
+      (TestBitManipFunction<Space, Func, Arg, N>(x), 0)...};
+}
+
+#define TEST_BIT_MANIP_FUNCTION(FUNC) \
+  do_test_bit_manip_function<TEST_EXECSPACE, BitManipFunction_##FUNC>
+
+template <class UInt>
+void test_bit_manip_countl_zero() {
+  using Kokkos::Experimental::countl_zero_builtin;
+  static_assert(noexcept(countl_zero_builtin(UInt())));
+  static_assert(std::is_same_v<decltype(countl_zero_builtin(UInt())), int>);
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+  TEST_BIT_MANIP_FUNCTION(countl_zero)
+  ({
+      UInt(0),
+      UInt(1),
+      UInt(2),
+      UInt(3),
+      UInt(4),
+      UInt(5),
+      UInt(6),
+      UInt(7),
+      UInt(8),
+      UInt(9),
+      UInt(127),
+      UInt(128),
+      UInt(max),
+  });
+}
+
+TEST(TEST_CATEGORY, bit_manip_countl_zero) {
+  test_bit_manip_countl_zero<unsigned char>();
+  test_bit_manip_countl_zero<unsigned short>();
+  test_bit_manip_countl_zero<unsigned int>();
+  test_bit_manip_countl_zero<unsigned long>();
+  test_bit_manip_countl_zero<unsigned long long>();
+}
+
+template <class UInt>
+void test_bit_manip_countl_one() {
+  using Kokkos::Experimental::countl_one_builtin;
+  static_assert(noexcept(countl_one_builtin(UInt())));
+  static_assert(std::is_same_v<decltype(countl_one_builtin(UInt())), int>);
+  constexpr auto dig = Kokkos::Experimental::digits_v<UInt>;
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+  TEST_BIT_MANIP_FUNCTION(countl_one)
+  ({
+      // clang-format off
+      UInt(0),
+      UInt(1),
+      UInt(2),
+      UInt(3),
+      UInt(4),
+      UInt(5),
+      UInt(6),
+      UInt(7),
+      UInt(8),
+      UInt(9),
+      UInt(100),
+      UInt(127),
+      UInt(128),
+      UInt(max),
+      UInt(max - 1),
+      UInt(max - 2),
+      UInt(max - 3),
+      UInt(max - 4),
+      UInt(max - 5),
+      UInt(max - 6),
+      UInt(max - 7),
+      UInt(max - 8),
+      UInt(max - 9),
+      UInt(max - 126),
+      UInt(max - 127),
+      UInt(max - 128),
+      UInt(UInt(1) << (dig - 1)),
+      UInt(UInt(3) << (dig - 2)),
+      UInt(UInt(7) << (dig - 3)),
+      UInt(UInt(255) << (dig - 8)),
+      // clang-format on
+  });
+}
+
+TEST(TEST_CATEGORY, bit_manip_countl_one) {
+  test_bit_manip_countl_one<unsigned char>();
+  test_bit_manip_countl_one<unsigned short>();
+  test_bit_manip_countl_one<unsigned int>();
+  test_bit_manip_countl_one<unsigned long>();
+  test_bit_manip_countl_one<unsigned long long>();
+}
+
+template <class UInt>
+void test_bit_manip_countr_zero() {
+  using Kokkos::Experimental::countr_zero_builtin;
+  static_assert(noexcept(countr_zero_builtin(UInt())));
+  static_assert(std::is_same_v<decltype(countr_zero_builtin(UInt())), int>);
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+  TEST_BIT_MANIP_FUNCTION(countr_zero)
+  ({
+      UInt(0),
+      UInt(1),
+      UInt(2),
+      UInt(3),
+      UInt(4),
+      UInt(5),
+      UInt(6),
+      UInt(7),
+      UInt(8),
+      UInt(9),
+      UInt(126),
+      UInt(127),
+      UInt(128),
+      UInt(129),
+      UInt(130),
+      UInt(max),
+  });
+}
+
+TEST(TEST_CATEGORY, bit_manip_countr_zero) {
+  test_bit_manip_countr_zero<unsigned char>();
+  test_bit_manip_countr_zero<unsigned short>();
+  test_bit_manip_countr_zero<unsigned int>();
+  test_bit_manip_countr_zero<unsigned long>();
+  test_bit_manip_countr_zero<unsigned long long>();
+}
+
+template <class UInt>
+void test_bit_manip_countr_one() {
+  using Kokkos::Experimental::countr_one_builtin;
+  static_assert(noexcept(countr_one_builtin(UInt())));
+  static_assert(std::is_same_v<decltype(countr_one_builtin(UInt())), int>);
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+  TEST_BIT_MANIP_FUNCTION(countr_one)
+  ({
+      UInt(0),
+      UInt(1),
+      UInt(2),
+      UInt(3),
+      UInt(4),
+      UInt(5),
+      UInt(6),
+      UInt(7),
+      UInt(8),
+      UInt(9),
+      UInt(126),
+      UInt(127),
+      UInt(128),
+      UInt(max - 1),
+      UInt(max),
+  });
+}
+
+TEST(TEST_CATEGORY, bit_manip_countr_one) {
+  test_bit_manip_countr_one<unsigned char>();
+  test_bit_manip_countr_one<unsigned short>();
+  test_bit_manip_countr_one<unsigned int>();
+  test_bit_manip_countr_one<unsigned long>();
+  test_bit_manip_countr_one<unsigned long long>();
+}
+
+template <class UInt>
+void test_bit_manip_popcount() {
+  using Kokkos::Experimental::popcount_builtin;
+  static_assert(noexcept(popcount_builtin(UInt())));
+  static_assert(std::is_same_v<decltype(popcount_builtin(UInt())), int>);
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+  TEST_BIT_MANIP_FUNCTION(popcount)
+  ({
+      UInt(0),
+      UInt(1),
+      UInt(2),
+      UInt(3),
+      UInt(4),
+      UInt(5),
+      UInt(6),
+      UInt(7),
+      UInt(8),
+      UInt(9),
+      UInt(127),
+      UInt(max),
+      UInt(max - 1),
+  });
+}
+
+TEST(TEST_CATEGORY, bit_manip_popcount) {
+  test_bit_manip_popcount<unsigned char>();
+  test_bit_manip_popcount<unsigned short>();
+  test_bit_manip_popcount<unsigned int>();
+  test_bit_manip_popcount<unsigned long>();
+  test_bit_manip_popcount<unsigned long long>();
+}
+
+template <class UInt>
+void test_bit_manip_has_single_bit() {
+  using Kokkos::Experimental::has_single_bit_builtin;
+  static_assert(noexcept(has_single_bit_builtin(UInt())));
+  static_assert(std::is_same_v<decltype(has_single_bit_builtin(UInt())), bool>);
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+  constexpr UInt one = 1;
+  TEST_BIT_MANIP_FUNCTION(has_single_bit)
+  ({
+      // clang-format off
+      UInt(0),
+      UInt(1),
+      UInt(2),
+      UInt(3),
+      UInt(4),
+      UInt(5),
+      UInt(6),
+      UInt(7),
+      UInt(8),
+      UInt(9),
+      UInt(max),
+      UInt(one << 0),
+      UInt(one << 1),
+      UInt(one << 2),
+      UInt(one << 3),
+      UInt(one << 4),
+      UInt(one << 5),
+      UInt(one << 6),
+      UInt(one << 7),
+      // clang-format on
+  });
+}
+
+TEST(TEST_CATEGORY, bit_manip_has_single_bit) {
+  test_bit_manip_has_single_bit<unsigned char>();
+  test_bit_manip_has_single_bit<unsigned short>();
+  test_bit_manip_has_single_bit<unsigned int>();
+  test_bit_manip_has_single_bit<unsigned long>();
+  test_bit_manip_has_single_bit<unsigned long long>();
+}
+
+template <class UInt>
+void test_bit_manip_bit_floor() {
+  using Kokkos::Experimental::bit_floor_builtin;
+  static_assert(noexcept(bit_floor_builtin(UInt())));
+  static_assert(std::is_same_v<decltype(bit_floor_builtin(UInt())), UInt>);
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+  TEST_BIT_MANIP_FUNCTION(bit_floor)
+  ({
+      UInt(0),
+      UInt(1),
+      UInt(2),
+      UInt(3),
+      UInt(4),
+      UInt(5),
+      UInt(6),
+      UInt(7),
+      UInt(8),
+      UInt(9),
+      UInt(125),
+      UInt(126),
+      UInt(127),
+      UInt(128),
+      UInt(129),
+      UInt(max),
+  });
+}
+
+TEST(TEST_CATEGORY, bit_manip_bit_floor) {
+  test_bit_manip_bit_floor<unsigned char>();
+  test_bit_manip_bit_floor<unsigned short>();
+  test_bit_manip_bit_floor<unsigned int>();
+  test_bit_manip_bit_floor<unsigned long>();
+  test_bit_manip_bit_floor<unsigned long long>();
+}
+
+template <class UInt>
+void test_bit_manip_bit_ceil() {
+  using Kokkos::Experimental::bit_ceil_builtin;
+  static_assert(noexcept(bit_ceil_builtin(UInt())));
+  static_assert(std::is_same_v<decltype(bit_ceil_builtin(UInt())), UInt>);
+  TEST_BIT_MANIP_FUNCTION(bit_ceil)
+  ({
+      // clang-format off
+      UInt(0),
+      UInt(1),
+      UInt(2),
+      UInt(3),
+      UInt(4),
+      UInt(5),
+      UInt(6),
+      UInt(7),
+      UInt(8),
+      UInt(9),
+      UInt(60),
+      UInt(61),
+      UInt(62),
+      UInt(63),
+      UInt(64),
+      UInt(65),
+      UInt(66),
+      UInt(67),
+      UInt(68),
+      UInt(69),
+      // clang-format on
+  });
+}
+
+TEST(TEST_CATEGORY, bit_manip_bit_ceil) {
+  test_bit_manip_bit_ceil<unsigned char>();
+  test_bit_manip_bit_ceil<unsigned short>();
+  test_bit_manip_bit_ceil<unsigned int>();
+  test_bit_manip_bit_ceil<unsigned long>();
+  test_bit_manip_bit_ceil<unsigned long long>();
+}
+
+template <class UInt>
+void test_bit_manip_bit_width() {
+  using Kokkos::Experimental::bit_width_builtin;
+  static_assert(noexcept(bit_width_builtin(UInt())));
+  static_assert(std::is_same_v<decltype(bit_width_builtin(UInt())), UInt>);
+  constexpr auto max = Kokkos::Experimental::finite_max_v<UInt>;
+  TEST_BIT_MANIP_FUNCTION(bit_width)
+  ({
+      UInt(0),
+      UInt(1),
+      UInt(2),
+      UInt(3),
+      UInt(4),
+      UInt(5),
+      UInt(6),
+      UInt(7),
+      UInt(8),
+      UInt(9),
+      UInt(max - 1),
+      UInt(max),
+  });
+}
+
+TEST(TEST_CATEGORY, bit_manip_bit_width) {
+  test_bit_manip_bit_width<unsigned char>();
+  test_bit_manip_bit_width<unsigned short>();
+  test_bit_manip_bit_width<unsigned int>();
+  test_bit_manip_bit_width<unsigned long>();
+  test_bit_manip_bit_width<unsigned long long>();
+}


### PR DESCRIPTION
~~Fix #3828~~

**See documentation in kokkos/kokkos-core-wiki#300**

* ~~Deprecate `Kokkos::log2(unsigned) -> int`~~ done in #4595
* ~~Provide alternative `Impl::bit_log2(UnsignedInteger) -> UnsignedInteger` for internal use only~~ withdrawn (might come back with it in a follow up PR)
* Backport bit manipulation facility from C++20 https://eel.is/c++draft/bit
* ~~Remove `Impl::bit_count(unsigned int)` in favor of `Experimental::popcount(UnsignedInteger) -> UnsignedInteger`~~ withdrawn (will propose in a follow up PR)

#### NOTES
* I have already implemented `[bit.rot]` and I intend to remove `Impl::rotate_right(unsigned, int) -> unsigned` in the `Bitset` implementation but I was planing to do that in a follow-up PR
* I intend to incrementally replace everything in `<impl/Kokkos_BitOps.hpp>` until we can get rid of the header
* I will also attempt to replace the `integral_power_of_two*` facility in `impl/Kokkos_Traits.hpp` but I would rather deal with it later
* I only used GCC built-in functions on the host-side for `Experimental::*_builtin` function templates.  We can specialize further and add Intel intrinsics and such later.