### PR TITLE
Fix Clang-Format job

### DIFF
--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -127,7 +127,7 @@ class Threads {
   //! \name Space-specific functions
   //@{
 
-  /** 
+  /**
    *  Teams of threads are distributed as evenly as possible across
    *  the requested number of numa regions and cores per numa region.
    *  A team will not be split across a numa region.


### PR DESCRIPTION
fixes #4583 

Removes trailing whitespace (that is causing Clang-Format job to fail).