### PR TITLE
Add KOKKOS_COMPILER_NVCPP macro, disable quiet_NaN and signaling_NaN

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -188,7 +188,7 @@
 #endif
 
 #if defined(__NVCOMPILER)
-#define KOKKOS_COMPILER_NVCPP                              \
+#define KOKKOS_COMPILER_NVHPC                              \
   __NVCOMPILER_MAJOR__ * 100 + __NVCOMPILER_MINOR__ * 10 + \
       __NVCOMPILER_PATCHLEVEL__
 #endif

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -187,6 +187,12 @@
 #endif
 #endif
 
+#if defined(__NVCOMPILER)
+#define KOKKOS_COMPILER_NVCPP                              \
+  __NVCOMPILER_MAJOR__ * 100 + __NVCOMPILER_MINOR__ * 10 + \
+      __NVCOMPILER_PATCHLEVEL__
+#endif
+
 #if defined(_MSC_VER) && !defined(KOKKOS_COMPILER_INTEL)
 #define KOKKOS_COMPILER_MSVC _MSC_VER
 #endif

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -589,12 +589,16 @@ CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_CONSTANT(long double, max_exponent10);
                     std::numeric_limits<T>::TRAIT(),                           \
                 "")
 
+// Workaround compiler issue error: expression must have a constant value
+// See kokkos/kokkos#4574
+#ifndef KOKKOS_COMPILER_NVCPP
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(float, quiet_NaN);
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, quiet_NaN);
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, quiet_NaN);
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(float, signaling_NaN);
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, signaling_NaN);
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, signaling_NaN);
+#endif
 
 #undef CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION
 

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -591,7 +591,7 @@ CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_CONSTANT(long double, max_exponent10);
 
 // Workaround compiler issue error: expression must have a constant value
 // See kokkos/kokkos#4574
-#ifndef KOKKOS_COMPILER_NVCPP
+#ifndef KOKKOS_COMPILER_NVHPC
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(float, quiet_NaN);
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, quiet_NaN);
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, quiet_NaN);


### PR DESCRIPTION
Disable quiet_NaN and signaling_NaN with nvc++ due to compiler issue
during static_assert check "error: expression must have a constant value"
See kokkos/kokkos#4574