### PR TITLE
Replace volatile_load by Kokkos::atomic_load for SYCL

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -517,6 +517,8 @@ class UnorderedMap {
       // Continue searching the unordered list for this key,
       // list will only be appended during insert phase.
       // Need volatile_load as other threads may be appending.
+
+      // FIXME_SYCL replacement for memory_fence
 #ifdef KOKKOS_ENABLE_SYCL
       size_type curr = Kokkos::atomic_load(curr_ptr);
 #else
@@ -583,15 +585,26 @@ class UnorderedMap {
             new_index = index_hint;
             // Set key and value
             KOKKOS_NONTEMPORAL_PREFETCH_STORE(&m_keys[new_index]);
+// FIXME_SYCL replacement for memory_fence
+#ifdef KOKKOS_ENABLE_SYCL
+            Kokkos::atomic_store(&m_keys[new_index], k);
+#else
             m_keys[new_index] = k;
+#endif
 
             if (!is_set) {
               KOKKOS_NONTEMPORAL_PREFETCH_STORE(&m_values[new_index]);
+#ifdef KOKKOS_ENABLE_SYCL
+              Kokkos::atomic_store(&m_values[new_index], v);
+#else
               m_values[new_index] = v;
+#endif
             }
 
+#ifndef KOKKOS_ENABLE_SYCL
             // Do not proceed until key and value are updated in global memory
             memory_fence();
+#endif
           }
         } else if (failed_insert_ref) {
           not_done = false;

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -294,9 +294,7 @@ void test_deep_copy(uint32_t num_nodes) {
   }
 }
 
-// FIXME_SYCL wrong results on Nvidia GPUs but correct on Host and Intel GPUs
-// WORKAROUND MSVC
-#if !defined(_WIN32) && !defined(KOKKOS_ENABLE_SYCL)
+#if !defined(_WIN32)
 TEST(TEST_CATEGORY, UnorderedMap_insert) {
   for (int i = 0; i < 500; ++i) {
     test_insert<TEST_EXECSPACE>(100000, 90000, 100, true);


### PR DESCRIPTION
Fixes #4567. I'm not quite sure how `volatile_load` is supposed to work but replacing it with `Kokkos::atomic_load` seems sensible to me to avoid race conditions. The `bitset` test also failed for me on Intel hardware but this patch fixes that as well.

@brian-kelley Can you please check that this resolves #4567 for you?
