### PR TITLE
[BUG] avoid creating a host copy of the reducer

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -201,7 +201,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
         Kokkos::Impl::FunctorValueJoin<ReducerTypeFwd, WorkTagFwd>;
     using ValueOps = Kokkos::Impl::FunctorValueOps<FunctorType, WorkTag>;
 
-    auto selected_reducer = ReducerConditional::select(functor, reducer);
+    auto& selected_reducer = ReducerConditional::select(functor, reducer);
 
     // Convenience references
     const Kokkos::Experimental::SYCL& space = policy.space();

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -201,7 +201,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
         Kokkos::Impl::FunctorValueJoin<ReducerTypeFwd, WorkTagFwd>;
     using ValueOps = Kokkos::Impl::FunctorValueOps<FunctorType, WorkTag>;
 
-    auto& selected_reducer = ReducerConditional::select(functor, reducer);
+    const auto& selected_reducer = ReducerConditional::select(functor, reducer);
 
     // Convenience references
     const Kokkos::Experimental::SYCL& space = policy.space();


### PR DESCRIPTION
Not much more to say than the title - we tracked down an unnecessary copy of the reducer inside `ParallelReduce`.