### PR TITLE
Change instruction order when initializing tool_arguments from unset_string_option

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -71,10 +71,10 @@ namespace Kokkos {
 
 namespace Tools {
 
-InitArguments tool_arguments;
-
 const std::string InitArguments::unset_string_option = {
     "kokkos_tools_impl_unset_option"};
+
+InitArguments tool_arguments;
 
 namespace Impl {
 void parse_command_line_arguments(int& narg, char* arg[],


### PR DESCRIPTION
This resolves the issue reported here: [All tests segfault on Power9 ](https://github.com/kokkos/kokkos/issues/4589).


