### PR TITLE
Deprecate `Kokkos::Impl::is_view`

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -2123,13 +2123,16 @@ KOKKOS_INLINE_FUNCTION DeducedCommonPropsType<Views...> common_view_alloc_prop(
 
 }  // namespace Kokkos
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 namespace Kokkos {
 namespace Impl {
 
-using Kokkos::is_view;
+template <class T>
+using is_view KOKKOS_DEPRECATED = Kokkos::is_view<T>;
 
 } /* namespace Impl */
 } /* namespace Kokkos */
+#endif
 
 #include <impl/Kokkos_ViewUniformType.hpp>
 #include <impl/Kokkos_Atomic_View.hpp>

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -2128,7 +2128,8 @@ namespace Kokkos {
 namespace Impl {
 
 template <class T>
-using is_view KOKKOS_DEPRECATED = Kokkos::is_view<T>;
+using is_view KOKKOS_DEPRECATED_WITH_COMMENT("Use Kokkos::is_view instead!") =
+    Kokkos::is_view<T>;
 
 } /* namespace Impl */
 } /* namespace Kokkos */


### PR DESCRIPTION
Rational:  Seems to only be there for backward compatibility.  We don't want users to reach into `Kokkos::Impl::`.  Let us emit deprecation warnings so we can remove in upcoming releases.