### PR TITLE
Deprecate `log2(unsigned) -> int`

### DIFF
--- a/containers/src/Kokkos_Bitset.hpp
+++ b/containers/src/Kokkos_Bitset.hpp
@@ -270,7 +270,7 @@ class Bitset {
     block = Impl::rotate_right(block, offset);
     return (((!(scan_direction & BIT_SCAN_REVERSE)
                   ? Impl::bit_scan_forward(block)
-                  : ::Kokkos::log2(block)) +
+                  : Impl::int_log2(block)) +
              offset) &
             block_mask) +
            block_start;

--- a/core/src/impl/Kokkos_BitOps.hpp
+++ b/core/src/impl/Kokkos_BitOps.hpp
@@ -54,9 +54,10 @@
 #endif
 
 namespace Kokkos {
+namespace Impl {
 
 KOKKOS_FORCEINLINE_FUNCTION
-int log2(unsigned i) {
+int int_log2(unsigned i) {
   enum : int { shift = sizeof(unsigned) * CHAR_BIT - 1 };
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   return shift - __clz(i);
@@ -75,8 +76,6 @@ int log2(unsigned i) {
   return offset;
 #endif
 }
-
-namespace Impl {
 
 /**\brief  Find first zero bit.
  *
@@ -148,11 +147,20 @@ int bit_count(unsigned i) {
 
 KOKKOS_INLINE_FUNCTION
 unsigned integral_power_of_two_that_contains(const unsigned N) {
-  const unsigned i = Kokkos::log2(N);
+  const unsigned i = int_log2(N);
   return ((1u << i) < N) ? i + 1 : i;
 }
 
 }  // namespace Impl
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+
+KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION int log2(unsigned i) {
+  return Impl::int_log2(i);
+}
+
+#endif
+
 }  // namespace Kokkos
 
 #endif  // KOKKOS_BITOPS_HPP

--- a/core/src/impl/Kokkos_HostBarrier.cpp
+++ b/core/src/impl/Kokkos_HostBarrier.cpp
@@ -64,7 +64,7 @@ void HostBarrier::impl_backoff_wait_until_equal(
   unsigned count = 0u;
 
   while (!test_equal(ptr, v)) {
-    const int c = ::Kokkos::log2(++count);
+    const int c = int_log2(++count);
     if (!active_wait || c > log2_iterations_till_sleep) {
       std::this_thread::sleep_for(
           std::chrono::nanoseconds(c < 16 ? 256 * c : 4096));

--- a/core/src/impl/Kokkos_Spinwait.cpp
+++ b/core/src/impl/Kokkos_Spinwait.cpp
@@ -65,7 +65,7 @@ void host_thread_yield(const uint32_t i, const WaitMode mode) {
   static constexpr uint32_t sleep_limit = 1 << 13;
   static constexpr uint32_t yield_limit = 1 << 12;
 
-  const int c = Kokkos::log2(i);
+  const int c = int_log2(i);
 
   if (WaitMode::ROOT != mode) {
     if (sleep_limit < i) {


### PR DESCRIPTION
Fix #3828 