### PR TITLE
Fix commented tests in TestEventCorrectness.hpp

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -262,20 +262,23 @@ SharedAllocationRecord<void, void> SharedAllocationRecord<
 
 SharedAllocationRecord<Kokkos::Experimental::HIPSpace,
                        void>::~SharedAllocationRecord() {
-  const char* label = nullptr;
+  std::string label;
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     SharedAllocationHeader header;
     Kokkos::Experimental::HIP exec;
-    Kokkos::Impl::DeepCopy<Kokkos::Experimental::HIPSpace, HostSpace>(
+    Kokkos::Impl::DeepCopy<HostSpace, Kokkos::Experimental::HIPSpace,
+                           Kokkos::Experimental::HIP>(
         exec, &header, RecordBase::m_alloc_ptr, sizeof(SharedAllocationHeader));
     exec.fence(
         "SharedAllocationRecord<Kokkos::Experimental::HIPSpace, "
-        "void>::~SharedAllocationRecord(): fence after copying header from "
+        "void>::~SharedAllocationRecord(): fence after copying header to "
         "HostSpace");
+    // FIXME Why is this deep copy necessary?
     label = header.label();
   }
   auto alloc_size = SharedAllocationRecord<void, void>::m_alloc_size;
-  m_space.deallocate(label, SharedAllocationRecord<void, void>::m_alloc_ptr,
+  m_space.deallocate(label.c_str(),
+                     SharedAllocationRecord<void, void>::m_alloc_ptr,
                      alloc_size, (alloc_size - sizeof(SharedAllocationHeader)));
 }
 

--- a/core/unit_test/tools/TestEventCorrectness.hpp
+++ b/core/unit_test/tools/TestEventCorrectness.hpp
@@ -442,13 +442,9 @@ TEST(kokkosp, raw_allocation) {
         if (alloc.ptr != free.ptr) {
           return MatchDiagnostic{false, {"No match on pointers"}};
         }
-        /**
-         * Note: this is broken in develop, need to fix in a followup
-         *
         if (free.name != "dogs") {
           return MatchDiagnostic{false, {"No match on free name"}};
         }
-        */
         if (free.size != 1000) {
           return MatchDiagnostic{false, {"No match on free size"}};
         }
@@ -477,14 +473,9 @@ TEST(kokkosp, view) {
         if (alloc.ptr != free.ptr) {
           return MatchDiagnostic{false, {"No match on pointers"}};
         }
-        /**
-         * Note: this is broken in develop, need to fix in a followup
-         *
         if (free.name != "dogs") {
           return MatchDiagnostic{false, {"No match on free name"}};
         }
-        */
-
         if (free.size != 1000 * sizeof(float)) {
           return MatchDiagnostic{false, {"No match on free size"}};
         }


### PR DESCRIPTION
Admittedly, it's not entirely clear to me why copying the string fixes the problem but the changes should have a fairly minimal impact.