### PR TITLE
Missing include in cuda_compute_capability.cc

### DIFF
--- a/cmake/compile_tests/cuda_compute_capability.cc
+++ b/cmake/compile_tests/cuda_compute_capability.cc
@@ -43,6 +43,7 @@
 */
 
 #include <iostream>
+#include <cuda_runtime_api.h>
 
 int main() {
   cudaDeviceProp device_properties;


### PR DESCRIPTION
I am not sure how this has been working without including `cuda_runtime_api.h`