### PR TITLE
Return input argument if no GPUs werde detected in get_gpu

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -284,8 +284,8 @@ int g_sycl_space_factory_initialized =
     Kokkos::Impl::initialize_space_factory<SYCLSpaceInitializer>("170_SYCL");
 
 void SYCLSpaceInitializer::initialize(const InitArguments& args) {
-  // If there are no GPUs return whatever else we can run on if no specific GPU is
-  // requested.
+  // If there are no GPUs return whatever else we can run on if no specific GPU
+  // is requested.
   const auto num_gpus =
       sycl::device::get_devices(sycl::info::device_type::gpu).size();
   int use_gpu = num_gpus == 0 ? args.device_id : Kokkos::Impl::get_gpu(args);

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -284,7 +284,11 @@ int g_sycl_space_factory_initialized =
     Kokkos::Impl::initialize_space_factory<SYCLSpaceInitializer>("170_SYCL");
 
 void SYCLSpaceInitializer::initialize(const InitArguments& args) {
-  int use_gpu = Kokkos::Impl::get_gpu(args);
+  // If there a no GPUs return whatever else we can run on if no specific GPU is
+  // requested.
+  const auto num_gpus =
+      sycl::device::get_devices(sycl::info::device_type::gpu).size();
+  int use_gpu = num_gpus == 0 ? args.device_id : Kokkos::Impl::get_gpu(args);
 
   if (std::is_same<Kokkos::Experimental::SYCL,
                    Kokkos::DefaultExecutionSpace>::value ||

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -284,7 +284,7 @@ int g_sycl_space_factory_initialized =
     Kokkos::Impl::initialize_space_factory<SYCLSpaceInitializer>("170_SYCL");
 
 void SYCLSpaceInitializer::initialize(const InitArguments& args) {
-  // If there a no GPUs return whatever else we can run on if no specific GPU is
+  // If there are no GPUs return whatever else we can run on if no specific GPU is
   // requested.
   const auto num_gpus =
       sycl::device::get_devices(sycl::info::device_type::gpu).size();

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -247,6 +247,7 @@ int get_gpu(const InitArguments& args) {
     return num_devices;
 #endif
   }(args.ndevices);
+  if (ndevices == 0) return use_gpu;
   const int skip_device = args.skip_device;
 
   // if the exact device is not set, but ndevices was given, assign round-robin

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -247,7 +247,6 @@ int get_gpu(const InitArguments& args) {
     return num_devices;
 #endif
   }(args.ndevices);
-  if (ndevices == 0) return use_gpu;
   const int skip_device = args.skip_device;
 
   // if the exact device is not set, but ndevices was given, assign round-robin


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/4621. @jczhang07 Can you please take a look if this works for you?

Essentially, the changes here are only relevant for the SYCL backend. If a specific device is requested (id>=0) we still error out if there are no GPUs. If that is not the case (id<0), we use the default selector to run on a host queue if no GPUs are detected. This (intended) behavior is not changed here but we have `use_gpu` return the input argument when no GPU is detected (instead of assigning GPU 0 which doesn't exist in that case).