### PR TITLE
Use host-pinned memory for SYCL kernel memory

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -201,10 +201,10 @@ class SYCLInternal {
   // An indirect kernel is one where the functor to be executed is explicitly
   // copied to USM memory before being executed, to get around the
   // trivially copyable limitation of SYCL.
-  using IndirectKernelMem = USMObjectMem<sycl::usm::alloc::shared>;
+  using IndirectKernelMem = USMObjectMem<sycl::usm::alloc::host>;
   IndirectKernelMem m_indirectKernelMem;
 
-  using IndirectReducerMem = USMObjectMem<sycl::usm::alloc::shared>;
+  using IndirectReducerMem = USMObjectMem<sycl::usm::alloc::host>;
   IndirectReducerMem m_indirectReducerMem;
 
   bool was_finalized = false;


### PR DESCRIPTION
Related to #4596 and #4097.
For the AXPBY benchmark in #4018, I see the best performance on Intel GPUs storing the kernel in host-pinned memory.

We should evaluate this pull request together with #4596.