### PR TITLE
Make sure reduction array is valid before exiting team_reduction/scan

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -218,7 +218,7 @@ class SYCLTeamMember {
     m_item.barrier(sycl::access::fence_space::local_space);
 
     reducer.reference() = reduction_array[0];
-    // Make sure that the reduction array hasn't been modified in the mean time.
+    // Make sure that the reduction array hasn't been modified in the meantime.
     m_item.barrier(sycl::access::fence_space::local_space);
   }
 
@@ -300,7 +300,7 @@ class SYCLTeamMember {
       m_item.barrier();  // Wait for atomic
       intermediate += base_data[n_active_subgroups - 1];
     }
-    // Make sure that the reduction array hasn't been modified in the mean time.
+    // Make sure that the reduction array hasn't been modified in the meantime.
     m_item.barrier(sycl::access::fence_space::local_space);
 
     return intermediate;

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -218,6 +218,8 @@ class SYCLTeamMember {
     m_item.barrier(sycl::access::fence_space::local_space);
 
     reducer.reference() = reduction_array[0];
+    // Make sure that the reduction array hasn't been modified in the mean time.
+    m_item.barrier(sycl::access::fence_space::local_space);
   }
 
   //--------------------------------------------------------------------------
@@ -298,6 +300,8 @@ class SYCLTeamMember {
       m_item.barrier();  // Wait for atomic
       intermediate += base_data[n_active_subgroups - 1];
     }
+    // Make sure that the reduction array hasn't been modified in the mean time.
+    m_item.barrier(sycl::access::fence_space::local_space);
 
     return intermediate;
   }


### PR DESCRIPTION
Apparently, #4314 exposes some race condition in the CI. This pull request makes sure that the reduction array hasn't been reused before existing the respective functions and this seems to be enough to make the tests pass multiple times.