### PR TITLE
Implement `Kokkos::Experimental::{min,max,minmax}(std::initializer_list)`

### DIFF
--- a/core/src/Kokkos_MinMaxClamp.hpp
+++ b/core/src/Kokkos_MinMaxClamp.hpp
@@ -48,6 +48,8 @@
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Pair.hpp>
 
+#include <initializer_list>
+
 namespace Kokkos {
 namespace Experimental {
 
@@ -79,6 +81,31 @@ constexpr KOKKOS_INLINE_FUNCTION const T& max(const T& a, const T& b,
   return comp(a, b) ? b : a;
 }
 
+template <class T>
+KOKKOS_INLINE_FUNCTION constexpr T max(std::initializer_list<T> ilist) {
+  auto first      = ilist.begin();
+  auto const last = ilist.end();
+  auto result     = *first;
+  if (first == last) return result;
+  while (++first != last) {
+    if (*first > result) result = *first;
+  }
+  return result;
+}
+
+template <class T, class Compare>
+KOKKOS_INLINE_FUNCTION constexpr T max(std::initializer_list<T> ilist,
+                                       Compare comp) {
+  auto first      = ilist.begin();
+  auto const last = ilist.end();
+  auto result     = *first;
+  if (first == last) return result;
+  while (++first != last) {
+    if (comp(result, *first)) result = *first;
+  }
+  return result;
+}
+
 // min
 template <class T>
 constexpr KOKKOS_INLINE_FUNCTION const T& min(const T& a, const T& b) {
@@ -89,6 +116,31 @@ template <class T, class ComparatorType>
 constexpr KOKKOS_INLINE_FUNCTION const T& min(const T& a, const T& b,
                                               ComparatorType comp) {
   return comp(b, a) ? b : a;
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION constexpr T min(std::initializer_list<T> ilist) {
+  auto first      = ilist.begin();
+  auto const last = ilist.end();
+  auto result     = *first;
+  if (first == last) return result;
+  while (++first != last) {
+    if (*first < result) result = *first;
+  }
+  return result;
+}
+
+template <class T, class Compare>
+KOKKOS_INLINE_FUNCTION constexpr T min(std::initializer_list<T> ilist,
+                                       Compare comp) {
+  auto first      = ilist.begin();
+  auto const last = ilist.end();
+  auto result     = *first;
+  if (first == last) return result;
+  while (++first != last) {
+    if (comp(*first, result)) result = *first;
+  }
+  return result;
 }
 
 // minmax
@@ -103,6 +155,34 @@ constexpr KOKKOS_INLINE_FUNCTION auto minmax(const T& a, const T& b,
                                              ComparatorType comp) {
   using return_t = ::Kokkos::pair<const T&, const T&>;
   return comp(b, a) ? return_t{b, a} : return_t{a, b};
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION constexpr Kokkos::pair<T, T> minmax(
+    std::initializer_list<T> ilist) {
+  auto first      = ilist.begin();
+  auto const last = ilist.end();
+  Kokkos::pair<T, T> result{*first, *first};
+  if (first == last) return result;
+  while (++first != last) {
+    if (*first < result.first) result.first = *first;
+    if (*first > result.second) result.second = *first;
+  }
+  return result;
+}
+
+template <class T, class Compare>
+KOKKOS_INLINE_FUNCTION constexpr Kokkos::pair<T, T> minmax(
+    std::initializer_list<T> ilist, Compare comp) {
+  auto first      = ilist.begin();
+  auto const last = ilist.end();
+  Kokkos::pair<T, T> result{*first, *first};
+  if (first == last) return result;
+  while (++first != last) {
+    if (comp(*first, result.first)) result.first = *first;
+    if (comp(result.second, *first)) result.second = *first;
+  }
+  return result;
 }
 
 }  // namespace Experimental

--- a/core/src/Kokkos_MinMaxClamp.hpp
+++ b/core/src/Kokkos_MinMaxClamp.hpp
@@ -88,7 +88,7 @@ KOKKOS_INLINE_FUNCTION constexpr T max(std::initializer_list<T> ilist) {
   auto result     = *first;
   if (first == last) return result;
   while (++first != last) {
-    if (*first > result) result = *first;
+    if (result < *first) result = *first;
   }
   return result;
 }
@@ -166,7 +166,7 @@ KOKKOS_INLINE_FUNCTION constexpr Kokkos::pair<T, T> minmax(
   if (first == last) return result;
   while (++first != last) {
     if (*first < result.first) result.first = *first;
-    if (*first > result.second) result.second = *first;
+    if (result.second < *first) result.second = *first;
   }
   return result;
 }

--- a/core/src/Kokkos_MinMaxClamp.hpp
+++ b/core/src/Kokkos_MinMaxClamp.hpp
@@ -162,11 +162,30 @@ KOKKOS_INLINE_FUNCTION constexpr Kokkos::pair<T, T> minmax(
     std::initializer_list<T> ilist) {
   auto first      = ilist.begin();
   auto const last = ilist.end();
+  auto next       = first;
   Kokkos::pair<T, T> result{*first, *first};
-  if (first == last) return result;
+  if (first == last || ++next == last) return result;
+  if (*next < *first)
+    result.first = *next;
+  else
+    result.second = *next;
+  first = next;
   while (++first != last) {
-    if (*first < result.first) result.first = *first;
-    if (result.second < *first) result.second = *first;
+    if (++next == last) {
+      if (*first < result.first)
+        result.first = *first;
+      else if (!(*first < result.second))
+        result.second = *first;
+      break;
+    }
+    if (*next < *first) {
+      if (*next < result.first) result.first = *next;
+      if (!(*first < result.second)) result.second = *first;
+    } else {
+      if (*first < result.first) result.first = *first;
+      if (!(*next < result.second)) result.second = *next;
+    }
+    first = next;
   }
   return result;
 }
@@ -176,11 +195,30 @@ KOKKOS_INLINE_FUNCTION constexpr Kokkos::pair<T, T> minmax(
     std::initializer_list<T> ilist, Compare comp) {
   auto first      = ilist.begin();
   auto const last = ilist.end();
+  auto next       = first;
   Kokkos::pair<T, T> result{*first, *first};
-  if (first == last) return result;
+  if (first == last || ++next == last) return result;
+  if (comp(*next, *first))
+    result.first = *next;
+  else
+    result.second = *next;
+  first = next;
   while (++first != last) {
-    if (comp(*first, result.first)) result.first = *first;
-    if (comp(result.second, *first)) result.second = *first;
+    if (++next == last) {
+      if (comp(*first, result.first))
+        result.first = *first;
+      else if (!comp(*first, result.second))
+        result.second = *first;
+      break;
+    }
+    if (comp(*next, *first)) {
+      if (comp(*next, result.first)) result.first = *next;
+      if (!comp(*first, result.second)) result.second = *first;
+    } else {
+      if (comp(*first, result.first)) result.first = *first;
+      if (!comp(*next, result.second)) result.second = *next;
+    }
+    first = next;
   }
   return result;
 }

--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -326,8 +326,8 @@ struct pair<T1&, T2> {
 
 //! Equality operator for Kokkos::pair.
 template <class T1, class T2>
-KOKKOS_FORCEINLINE_FUNCTION bool operator==(const pair<T1, T2>& lhs,
-                                            const pair<T1, T2>& rhs) {
+KOKKOS_FORCEINLINE_FUNCTION constexpr bool operator==(const pair<T1, T2>& lhs,
+                                                      const pair<T1, T2>& rhs) {
   return lhs.first == rhs.first && lhs.second == rhs.second;
 }
 

--- a/core/unit_test/TestMinMaxClamp.hpp
+++ b/core/unit_test/TestMinMaxClamp.hpp
@@ -55,6 +55,17 @@ struct Greater {
     return lhs > rhs;
   }
 };
+
+struct PairIntCompareFirst {
+  int first;
+  int second;
+
+ private:
+  friend constexpr bool operator<(PairIntCompareFirst const& lhs,
+                                  PairIntCompareFirst const& rhs) {
+    return lhs.first < rhs.first;
+  }
+};
 }  // namespace Test
 
 // ----------------------------------------------------------
@@ -78,6 +89,16 @@ TEST(TEST_CATEGORY, max) {
 
   STATIC_ASSERT(KE::max({3, -1, 0}) == 3);
   STATIC_ASSERT(KE::max({3, -1, 0}, ::Test::Greater<int>{}) == -1);
+
+  STATIC_ASSERT(KE::max({
+                            ::Test::PairIntCompareFirst{255, 0},
+                            ::Test::PairIntCompareFirst{255, 1},
+                            ::Test::PairIntCompareFirst{0, 2},
+                            ::Test::PairIntCompareFirst{0, 3},
+                            ::Test::PairIntCompareFirst{255, 4},
+                            ::Test::PairIntCompareFirst{0, 5},
+                        })
+                    .second == 0);  // leftmost element
 }
 
 template <class ViewType>
@@ -132,6 +153,16 @@ TEST(TEST_CATEGORY, min) {
 
   STATIC_ASSERT(KE::min({3, -1, 0}) == -1);
   STATIC_ASSERT(KE::min({3, -1, 0}, ::Test::Greater<int>{}) == 3);
+
+  STATIC_ASSERT(KE::min({
+                            ::Test::PairIntCompareFirst{255, 0},
+                            ::Test::PairIntCompareFirst{255, 1},
+                            ::Test::PairIntCompareFirst{0, 2},
+                            ::Test::PairIntCompareFirst{0, 3},
+                            ::Test::PairIntCompareFirst{255, 4},
+                            ::Test::PairIntCompareFirst{0, 5},
+                        })
+                    .second == 2);  // leftmost element
 }
 
 template <class ViewType>
@@ -192,6 +223,25 @@ TEST(TEST_CATEGORY, minmax) {
   STATIC_ASSERT(KE::minmax({3, -1, 0}) == Kokkos::make_pair(-1, 3));
   STATIC_ASSERT(KE::minmax({3, -1, 0}, ::Test::Greater<int>{}) ==
                 Kokkos::make_pair(3, -1));
+
+  STATIC_ASSERT(KE::minmax({
+                               ::Test::PairIntCompareFirst{255, 0},
+                               ::Test::PairIntCompareFirst{255, 1},
+                               ::Test::PairIntCompareFirst{0, 2},
+                               ::Test::PairIntCompareFirst{0, 3},
+                               ::Test::PairIntCompareFirst{255, 4},
+                               ::Test::PairIntCompareFirst{0, 5},
+                           })
+                    .first.second == 2);  // leftmost
+  STATIC_ASSERT(KE::minmax({
+                               ::Test::PairIntCompareFirst{255, 0},
+                               ::Test::PairIntCompareFirst{255, 1},
+                               ::Test::PairIntCompareFirst{0, 2},
+                               ::Test::PairIntCompareFirst{0, 3},
+                               ::Test::PairIntCompareFirst{255, 4},
+                               ::Test::PairIntCompareFirst{0, 5},
+                           })
+                    .second.second == 4);  // rightmost
 }
 
 template <class ViewType>

--- a/core/unit_test/TestMinMaxClamp.hpp
+++ b/core/unit_test/TestMinMaxClamp.hpp
@@ -45,6 +45,18 @@
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 
+// FIXME C++17
+#define STATIC_ASSERT(cond) static_assert(cond, "");
+
+namespace Test {
+template <class T>
+struct Greater {
+  KOKKOS_FUNCTION constexpr bool operator()(T const& lhs, T const& rhs) {
+    return lhs > rhs;
+  }
+};
+}  // namespace Test
+
 // ----------------------------------------------------------
 // test max()
 // ----------------------------------------------------------
@@ -58,6 +70,14 @@ TEST(TEST_CATEGORY, max) {
   a = 3;
   b = 1;
   EXPECT_TRUE(KE::max(a, b) == 3);
+
+  STATIC_ASSERT(KE::max(1, 2) == 2);
+  STATIC_ASSERT(KE::max(1, 2, ::Test::Greater<int>{}) == 1);
+
+  EXPECT_TRUE(KE::max({3.f, -1.f, 0.f}) == 3.f);
+
+  STATIC_ASSERT(KE::max({3, -1, 0}) == 3);
+  STATIC_ASSERT(KE::max({3, -1, 0}, ::Test::Greater<int>{}) == -1);
 }
 
 template <class ViewType>
@@ -104,6 +124,14 @@ TEST(TEST_CATEGORY, min) {
   a = 3;
   b = 2;
   EXPECT_TRUE(KE::min(a, b) == 2);
+
+  STATIC_ASSERT(KE::min(3.f, 2.f) == 2.f);
+  STATIC_ASSERT(KE::min(3.f, 2.f, ::Test::Greater<int>{}) == 3.f);
+
+  EXPECT_TRUE(KE::min({3.f, -1.f, 0.f}) == -1.f);
+
+  STATIC_ASSERT(KE::min({3, -1, 0}) == -1);
+  STATIC_ASSERT(KE::min({3, -1, 0}, ::Test::Greater<int>{}) == 3);
 }
 
 template <class ViewType>
@@ -152,6 +180,18 @@ TEST(TEST_CATEGORY, minmax) {
   const auto& r2 = KE::minmax(a, b);
   EXPECT_TRUE(r2.first == 2);
   EXPECT_TRUE(r2.second == 3);
+
+  STATIC_ASSERT((Kokkos::pair<float, float>(KE::minmax(3.f, 2.f)) ==
+                 Kokkos::make_pair(2.f, 3.f)));
+  STATIC_ASSERT(
+      (Kokkos::pair<float, float>(KE::minmax(
+           3.f, 2.f, ::Test::Greater<int>{})) == Kokkos::make_pair(3.f, 2.f)));
+
+  EXPECT_TRUE(KE::minmax({3.f, -1.f, 0.f}) == Kokkos::make_pair(-1.f, 3.f));
+
+  STATIC_ASSERT(KE::minmax({3, -1, 0}) == Kokkos::make_pair(-1, 3));
+  STATIC_ASSERT(KE::minmax({3, -1, 0}, ::Test::Greater<int>{}) ==
+                Kokkos::make_pair(3, -1));
 }
 
 template <class ViewType>


### PR DESCRIPTION
Rational: reviewed some code downstream that was doing things like `min(a, min(b, c)`

Make sure you see the drib-by fixing of a defect in `operator==` for `Kokkos::pair<T1, T2>` that was missing the `constexpr` specifier.
About the overloads I am adding, I just followed closely the design of `std::{min,max,minmax}` (see https://eel.is/c++draft/alg.min.max)