### PR TITLE
Address deprecations warnings with newest SYCL compiler release

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
@@ -63,8 +63,8 @@ struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
     auto event = exec_space.impl_internal_space_instance()->m_queue->memset(
         dst.data(), 0,
         dst.size() * sizeof(typename View<DT, DP...>::value_type));
-    exec_space.impl_internal_space_instance()->m_queue->submit_barrier(
-        std::vector<sycl::event>{event});
+    exec_space.impl_internal_space_instance()
+        ->m_queue->ext_oneapi_submit_barrier(std::vector<sycl::event>{event});
   }
 
   ZeroMemset(const View<DT, DP...>& dst,

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
@@ -97,7 +97,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
       cgh.parallel_for<FunctorWrapperRangePolicyParallelFor<Functor, Policy>>(
           range, f);
     });
-    q.submit_barrier(std::vector<sycl::event>{parallel_for_event});
+    q.ext_oneapi_submit_barrier(std::vector<sycl::event>{parallel_for_event});
 
     return parallel_for_event;
   }
@@ -257,7 +257,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
                 .exec_range();
           });
         });
-    q.submit_barrier(std::vector<sycl::event>{parallel_for_event});
+    q.ext_oneapi_submit_barrier(std::vector<sycl::event>{parallel_for_event});
 
     return parallel_for_event;
   }

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -251,7 +251,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                            &results_ptr[0]);
         });
       });
-      q.submit_barrier(std::vector<sycl::event>{parallel_reduce_event});
+      q.ext_oneapi_submit_barrier(
+          std::vector<sycl::event>{parallel_reduce_event});
       last_reduction_event = parallel_reduce_event;
     }
 
@@ -324,7 +325,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                   static_cast<const FunctorType&>(functor), n_wgroups <= 1);
             });
       });
-      q.submit_barrier(std::vector<sycl::event>{parallel_reduce_event});
+      q.ext_oneapi_submit_barrier(
+          std::vector<sycl::event>{parallel_reduce_event});
 
       last_reduction_event = parallel_reduce_event;
 
@@ -525,7 +527,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                            &results_ptr[0]);
         });
       });
-      q.submit_barrier(std::vector<sycl::event>{parallel_reduce_event});
+      q.ext_oneapi_submit_barrier(
+          std::vector<sycl::event>{parallel_reduce_event});
       last_reduction_event = parallel_reduce_event;
     }
 
@@ -605,13 +608,14 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
               n_wgroups <= 1 && item.get_group_linear_id() == 0);
         });
       });
-      q.submit_barrier(std::vector<sycl::event>{parallel_reduce_event});
+      q.ext_oneapi_submit_barrier(
+          std::vector<sycl::event>{parallel_reduce_event});
 
       // FIXME_SYCL this is likely not necessary, see above
       auto deep_copy_event =
           q.memcpy(results_ptr, results_ptr2,
                    sizeof(*m_result_ptr) * value_count * n_wgroups);
-      q.submit_barrier(std::vector<sycl::event>{deep_copy_event});
+      q.ext_oneapi_submit_barrier(std::vector<sycl::event>{deep_copy_event});
       last_reduction_event = deep_copy_event;
 
       first_run = false;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -196,7 +196,7 @@ class ParallelScanSYCLBase {
             if (global_id < size) global_mem[global_id] = local_value;
           });
     });
-    q.submit_barrier(std::vector<sycl::event>{local_scans});
+    q.ext_oneapi_submit_barrier(std::vector<sycl::event>{local_scans});
 
     if (n_wgroups > 1) {
       scan_internal(q, functor, group_results, n_wgroups);
@@ -210,7 +210,8 @@ class ParallelScanSYCLBase {
                                 &group_results[item.get_group_linear_id()]);
             });
       });
-      q.submit_barrier(std::vector<sycl::event>{update_with_group_results});
+      q.ext_oneapi_submit_barrier(
+          std::vector<sycl::event>{update_with_group_results});
     }
   }
 
@@ -240,7 +241,8 @@ class ParallelScanSYCLBase {
         global_mem[id] = update;
       });
     });
-    q.submit_barrier(std::vector<sycl::event>{initialize_global_memory});
+    q.ext_oneapi_submit_barrier(
+        std::vector<sycl::event>{initialize_global_memory});
 
     // Perform the actual exclusive scan
     scan_internal(q, functor, m_scratch_space, len);
@@ -259,7 +261,8 @@ class ParallelScanSYCLBase {
         global_mem[global_id] = update;
       });
     });
-    q.submit_barrier(std::vector<sycl::event>{update_global_results});
+    q.ext_oneapi_submit_barrier(
+        std::vector<sycl::event>{update_global_results});
     return update_global_results;
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -480,7 +480,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
               sycl::range<2>(m_team_size, m_vector_size)),
           lambda);
     });
-    q.submit_barrier(std::vector<sycl::event>{parallel_for_event});
+    q.ext_oneapi_submit_barrier(std::vector<sycl::event>{parallel_for_event});
     return parallel_for_event;
   }
 
@@ -677,7 +677,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                &results_ptr[0]);
             });
       });
-      q.submit_barrier(std::vector<sycl::event>{parallel_reduce_event});
+      q.ext_oneapi_submit_barrier(
+          std::vector<sycl::event>{parallel_reduce_event});
       last_reduction_event = parallel_reduce_event;
     }
 
@@ -783,7 +784,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                 sycl::range<2>(m_team_size, m_vector_size)),
             lambda);
       });
-      q.submit_barrier(std::vector<sycl::event>{parallel_reduce_event});
+      q.ext_oneapi_submit_barrier(
+          std::vector<sycl::event>{parallel_reduce_event});
       last_reduction_event = parallel_reduce_event;
 
       first_run = false;

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -65,7 +65,7 @@ void DeepCopyAsyncSYCL(const Kokkos::Experimental::SYCL& instance, void* dst,
                        const void* src, size_t n) {
   auto event =
       instance.impl_internal_space_instance()->m_queue->memcpy(dst, src, n);
-  instance.impl_internal_space_instance()->m_queue->submit_barrier(
+  instance.impl_internal_space_instance()->m_queue->ext_oneapi_submit_barrier(
       std::vector<sycl::event>{event});
 }
 

--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -36,8 +36,8 @@ RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSIO
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
 ENV SYCL_DIR=/opt/sycl
-RUN SYCL_VERSION=20210903 && \
-    SYCL_URL=https://github.com/intel/llvm/archive/sycl-nightly && \
+RUN SYCL_VERSION=2021-09 && \
+    SYCL_URL=https://github.com/intel/llvm/archive/ && \
     SYCL_ARCHIVE=${SYCL_VERSION}.tar.gz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${SYCL_URL}/${SYCL_ARCHIVE} && \


### PR DESCRIPTION
I have seen the deprecations warnings addressed in this pull request for a while now with the compiler versions I normally work with but have waited for a good opportunity to address them. The release of [oneAPI 2022.1](https://www.intel.com/content/www/us/en/developer/tools/oneapi/toolkits.html?cid=em&source=elo&campid=iags_WW_iagsoapi2_EN_2021_2022.1%20Release_C-MKA-22972_T-MKA-28700&content=iags_WW_iagsoapi2_EMN_EN_2021_2022.1%20Release%20General_C-MKA-22972_T-MKA-28700&elq_cid=5941422&em_id=75722&elqrid=166ffb916bb445698c2ad7c54699305a&elqcampid=48558&erpm_id=8997301) seemed appropriate. It turns out that only `submit_barrier` needed to be renamed. This specific change originates from https://github.com/intel/llvm/pull/4432 which was merged on 09/08/2021.