### PR TITLE
Make sure messages in Kokkos::abort are newline terminated

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -290,7 +290,7 @@ class BinSort {
     const size_t values_len = values_range_end - values_range_begin;
     if (len != values_len) {
       Kokkos::abort(
-          "BinSort::sort: values range length != permutation vector length");
+          "BinSort::sort: values range length != permutation vector length\n");
     }
 
     scratch_view_type sorted_values(

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -280,7 +280,7 @@ KOKKOS_INLINE_FUNCTION void dyn_rank_view_verify_operator_bounds(
   if (static_cast<iType0>(rank) > op_rank) {
     Kokkos::abort(
         "DynRankView Bounds Checking Error: Need at least rank arguments to "
-        "the operator()");
+        "the operator()\n");
   }
 
   if (!dyn_rank_view_verify_operator_bounds<0>(rank, map, args...)) {
@@ -294,7 +294,7 @@ KOKKOS_INLINE_FUNCTION void dyn_rank_view_verify_operator_bounds(
     Kokkos::Impl::throw_runtime_exception(std::string(buffer));
 #else
     (void)tracker;
-    Kokkos::abort("DynRankView bounds error");
+    Kokkos::abort("DynRankView bounds error\n");
 #endif
   }
 }
@@ -1520,7 +1520,7 @@ subdynrankview(const Kokkos::DynRankView<D, P...>& src, Args... args) {
   {
     Kokkos::abort(
         "subdynrankview: num of args must be >= rank of the source "
-        "DynRankView");
+        "DynRankView\n");
   }
 
   using metafcn =

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -292,7 +292,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
     KOKKOS_FORCEINLINE_FUNCTION static void check() {
       Kokkos::abort(
           "Kokkos::DynamicView ERROR: attempt to access inaccessible memory "
-          "space");
+          "space\n");
     };
   };
 
@@ -442,7 +442,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
           *reinterpret_cast<uintptr_t volatile*>(m_chunks + m_chunk_max);
 
       if (n <= ic) {
-        Kokkos::abort("Kokkos::DynamicView array bounds error");
+        Kokkos::abort("Kokkos::DynamicView array bounds error\n");
       }
 
       // Allocation of this chunk is in progress
@@ -468,7 +468,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
         m_chunk_shift;  // New total number of chunks needed for resize
 
     if (m_chunk_max < NC) {
-      Kokkos::abort("DynamicView::resize_serial exceeded maximum size");
+      Kokkos::abort("DynamicView::resize_serial exceeded maximum size\n");
     }
 
     // *m_chunks[m_chunk_max] stores the current number of chunks being used

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -118,7 +118,7 @@ KOKKOS_INLINE_FUNCTION void offsetview_verify_operator_bounds(
     if (tracker.has_record()) {
       Kokkos::Impl::operator_bounds_error_on_device(map);
     } else {
-      Kokkos::abort("OffsetView bounds error");
+      Kokkos::abort("OffsetView bounds error\n");
     }
 #endif
   }
@@ -149,7 +149,7 @@ void runtime_check_rank_host(const size_t rank_dynamic, const size_t rank,
     message += "The number of offsets provided ( " +
                std::to_string(numOffsets) +
                " ) must equal the dynamic rank ( " +
-               std::to_string(rank_dynamic) + " ).";
+               std::to_string(rank_dynamic) + " ).\n";
     isBad = true;
   }
 
@@ -162,7 +162,8 @@ void runtime_check_rank_device(const size_t rank_dynamic, const size_t rank,
                                const index_list_type minIndices) {
   if (rank_dynamic != rank) {
     Kokkos::abort(
-        "The full rank of an OffsetView must be the same as the dynamic rank.");
+        "The full rank of an OffsetView must be the same as the dynamic "
+        "rank.\n");
   }
   size_t numOffsets = 0;
   for (size_t i = 0; i < minIndices.size(); ++i) {
@@ -171,7 +172,7 @@ void runtime_check_rank_device(const size_t rank_dynamic, const size_t rank,
   if (numOffsets != rank) {
     Kokkos::abort(
         "The number of offsets provided to an OffsetView constructor must "
-        "equal the dynamic rank.");
+        "equal the dynamic rank.\n");
   }
 }
 }  // namespace Impl
@@ -1024,23 +1025,23 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
     if (begins.size() != Rank)
       Kokkos::abort(
           "Kokkos::Experimental::OffsetView ERROR: for unmanaged "
-          "OffsetView: begins has bad Rank");
+          "OffsetView: begins has bad Rank\n");
     if (ends.size() != Rank)
       Kokkos::abort(
           "Kokkos::Experimental::OffsetView ERROR: for unmanaged "
-          "OffsetView: ends has bad Rank");
+          "OffsetView: ends has bad Rank\n");
 
     for (size_t i = 0; i != begins.size(); ++i) {
       switch (check_subtraction(at(ends, i), at(begins, i))) {
         case subtraction_failure::negative:
           Kokkos::abort(
               "Kokkos::Experimental::OffsetView ERROR: for unmanaged "
-              "OffsetView: bad range");
+              "OffsetView: bad range\n");
           break;
         case subtraction_failure::overflow:
           Kokkos::abort(
               "Kokkos::Experimental::OffsetView ERROR: for unmanaged "
-              "OffsetView: range overflows");
+              "OffsetView: range overflows\n");
           break;
         default: break;
       }

--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -163,7 +163,7 @@ class vector : public DualView<Scalar*, LayoutLeft, Arg1Type> {
     DV::sync_host();
     DV::modify_host();
     if (it < begin() || it > end())
-      Kokkos::abort("Kokkos::vector::insert : invalid insert iterator");
+      Kokkos::abort("Kokkos::vector::insert : invalid insert iterator\n");
     if (count == 0) return it;
     ptrdiff_t start = std::distance(begin(), it);
     auto org_size   = size();
@@ -194,7 +194,7 @@ class vector : public DualView<Scalar*, LayoutLeft, Arg1Type> {
     DV::sync_host();
     DV::modify_host();
     if (it < begin() || it > end())
-      Kokkos::abort("Kokkos::vector::insert : invalid insert iterator");
+      Kokkos::abort("Kokkos::vector::insert : invalid insert iterator\n");
 
     bool resized = false;
     if ((size() == 0) && (it == begin())) {

--- a/core/perf_test/test_mempool.cpp
+++ b/core/perf_test/test_mempool.cpp
@@ -269,13 +269,13 @@ int main(int argc, char* argv[]) {
     Kokkos::Timer timer;
 
     if (!functor.test_fill()) {
-      Kokkos::abort("fill ");
+      Kokkos::abort("fill \n");
     }
 
     auto t0 = timer.seconds();
 
     if (!functor.test_alloc_dealloc()) {
-      Kokkos::abort("alloc/dealloc ");
+      Kokkos::abort("alloc/dealloc \n");
     }
 
     auto t1              = timer.seconds();

--- a/core/perf_test/test_taskdag.cpp
+++ b/core/perf_test/test_taskdag.cpp
@@ -123,7 +123,7 @@ struct TestFib {
         // High priority to retire this branch.
         Kokkos::respawn(this, fib_all, Kokkos::TaskPriority::High);
       } else {
-        Kokkos::abort("Failed nested task spawn (allocation)");
+        Kokkos::abort("Failed nested task spawn (allocation)\n");
       }
     }
   }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -245,7 +245,7 @@ CudaInternalDevices::CudaInternalDevices() {
   if (m_cudaDevCount > MAXIMUM_DEVICE_COUNT) {
     Kokkos::abort(
         "Sorry, you have more GPUs per node than we thought anybody would ever "
-        "have. Please report this to github.com/kokkos/kokkos.");
+        "have. Please report this to github.com/kokkos/kokkos.\n");
   }
   for (int i = 0; i < m_cudaDevCount; ++i) {
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceProperties(m_cudaProp + i, i));

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -651,7 +651,8 @@ __device__ void cuda_intra_block_reduce_scan(
   // Must have power of two thread count
 
   if (BlockSizeMask & blockDim.y) {
-    Kokkos::abort("Cuda::cuda_intra_block_scan requires power-of-two blockDim");
+    Kokkos::abort(
+        "Cuda::cuda_intra_block_scan requires power-of-two blockDim\n");
   }
 
 #define BLOCK_REDUCE_STEP(R, TD, S)                          \
@@ -800,7 +801,7 @@ __device__ bool cuda_single_inter_block_reduce_scan2(
   if (BlockSizeMask & blockDim.y) {
     Kokkos::abort(
         "Cuda::cuda_single_inter_block_reduce_scan requires power-of-two "
-        "blockDim");
+        "blockDim\n");
   }
 
   const integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /

--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -94,7 +94,7 @@ class UniqueToken<Cuda, UniqueTokenScope::Global> {
 
     if (result.first < 0) {
       Kokkos::abort(
-          "UniqueToken<Cuda> failure to acquire tokens, no tokens available");
+          "UniqueToken<Cuda> failure to acquire tokens, no tokens available\n");
     }
 
     return result.first;

--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -266,7 +266,7 @@ class ViewDataHandle<
     if (0 == r) {
       Kokkos::abort(
           "Cuda const random access View using Cuda texture memory requires "
-          "Kokkos to allocate the View's memory");
+          "Kokkos to allocate the View's memory\n");
     }
 #endif
 
@@ -275,7 +275,7 @@ class ViewDataHandle<
 #else
     (void)arg_tracker;
     Kokkos::Impl::cuda_abort(
-        "Cannot create Cuda texture object from within a Cuda kernel");
+        "Cannot create Cuda texture object from within a Cuda kernel\n");
     return handle_type();
 #endif
   }

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -88,7 +88,7 @@ HIPInternalDevices::HIPInternalDevices() {
   if (m_hipDevCount > MAXIMUM_DEVICE_COUNT) {
     Kokkos::abort(
         "Sorry, you have more GPUs per node than we thought anybody would ever "
-        "have. Please report this to github.com/kokkos/kokkos.");
+        "have. Please report this to github.com/kokkos/kokkos.\n");
   }
   for (int i = 0; i < m_hipDevCount; ++i) {
     KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDeviceProperties(m_hipProp + i, i));

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -413,7 +413,7 @@ __device__ bool hip_single_inter_block_reduce_scan_impl(
   if (BlockSizeMask & blockDim.y) {
     Kokkos::abort(
         "HIP::hip_single_inter_block_reduce_scan requires power-of-two "
-        "blockDim");
+        "blockDim\n");
   }
 
   integral_nonzero_constant<size_type, ValueTraits::StaticValueSize /

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -92,7 +92,7 @@ class UniqueToken<HIP, UniqueTokenScope::Global> {
 
     if (result.first < 0) {
       Kokkos::abort(
-          "UniqueToken<HIP> failure to acquire tokens, no tokens available");
+          "UniqueToken<HIP> failure to acquire tokens, no tokens available\n");
     }
 
     return result.first;

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -104,7 +104,7 @@ constexpr To checked_narrow_cast(From arg) {
       (is_different_signedness &&
        is_less_than_value_initialized_variable(arg) !=
            is_less_than_value_initialized_variable(ret))) {
-    Kokkos::abort("unsafe narrowing conversion");
+    Kokkos::abort("unsafe narrowing conversion\n");
   }
   return ret;
 }
@@ -375,7 +375,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
              static_cast<int>(properties.max_threads));
       Kokkos::abort(
           "ExecSpace Error: MDRange tile dims exceed maximum number "
-          "of threads per block - choose smaller tile dims");
+          "of threads per block - choose smaller tile dims\n");
     }
   }
 };

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -72,7 +72,7 @@ struct ArrayBoundsCheck<Integral, true> {
       s += " < 0";
       Kokkos::Impl::throw_runtime_exception(s);
 #else
-      Kokkos::abort("Kokkos::Array: negative index in device code");
+      Kokkos::abort("Kokkos::Array: negative index in device code\n");
 #endif
     }
     ArrayBoundsCheck<Integral, false>(i, N);
@@ -91,7 +91,7 @@ struct ArrayBoundsCheck<Integral, false> {
       s += std::to_string(N);
       Kokkos::Impl::throw_runtime_exception(s);
 #else
-      Kokkos::abort("Kokkos::Array: index >= size");
+      Kokkos::abort("Kokkos::Array: index >= size\n");
 #endif
     }
   }
@@ -180,7 +180,7 @@ struct Array<T, 0, Proxy> {
     static_assert(
         (std::is_integral<iType>::value || std::is_enum<iType>::value),
         "Must be integer argument");
-    Kokkos::abort("Unreachable code");
+    Kokkos::abort("Unreachable code\n");
     return *reinterpret_cast<pointer>(-1);
   }
 
@@ -189,7 +189,7 @@ struct Array<T, 0, Proxy> {
     static_assert(
         (std::is_integral<iType>::value || std::is_enum<iType>::value),
         "Must be integer argument");
-    Kokkos::abort("Unreachable code");
+    Kokkos::abort("Unreachable code\n");
     return *reinterpret_cast<const_pointer>(-1);
   }
 

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -212,7 +212,7 @@ template <typename DstMemorySpace, typename SrcMemorySpace>
 struct verify_space<DstMemorySpace, SrcMemorySpace, false> {
   KOKKOS_FUNCTION static void check() {
     Kokkos::abort(
-        "Kokkos::View ERROR: attempt to access inaccessible memory space");
+        "Kokkos::View ERROR: attempt to access inaccessible memory space\n");
   };
 };
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -215,7 +215,8 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
 
     if (m_granularity > 0) {
       if (!Impl::is_integral_power_of_two(m_granularity))
-        Kokkos::abort("RangePolicy blocking granularity must be power of two");
+        Kokkos::abort(
+            "RangePolicy blocking granularity must be power of two\n");
     }
 
     int64_t new_chunk_size = 1;

--- a/core/src/Kokkos_Future.hpp
+++ b/core/src/Kokkos_Future.hpp
@@ -428,7 +428,7 @@ class BasicFuture {
   KOKKOS_INLINE_FUNCTION
   const typename Impl::TaskResult<ValueType>::reference_type get() const {
     if (nullptr == m_task) {
-      Kokkos::abort("Kokkos:::Future::get ERROR: is_null()");
+      Kokkos::abort("Kokkos:::Future::get ERROR: is_null()\n");
     }
     return Impl::TaskResult<ValueType>::get(m_task);
   }

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -618,7 +618,7 @@ class UniqueToken<HPX, UniqueTokenScope::Instance> {
       if (result.first < 0) {
         ::Kokkos::abort(
             "UniqueToken<HPX> failure to acquire tokens, no tokens "
-            "available");
+            "available\n");
       }
       return result.first;
     }
@@ -836,7 +836,7 @@ class TeamPolicyInternal<Kokkos::Experimental::HPX, Properties...>
 
     if (m_chunk_size > 0) {
       if (!Impl::is_integral_power_of_two(m_chunk_size))
-        Kokkos::abort("TeamPolicy blocking granularity must be power of two");
+        Kokkos::abort("TeamPolicy blocking granularity must be power of two\n");
     } else {
       int new_chunk_size = 1;
       while (new_chunk_size * 4 * Kokkos::Experimental::HPX::concurrency() <

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -502,7 +502,7 @@ class MemoryPool {
     if (size_t(1LU << m_max_block_size_lg2) < alloc_size) {
       Kokkos::abort(
           "Kokkos MemoryPool allocation request exceeded specified maximum "
-          "allocation size");
+          "allocation size\n");
     }
 
     if (0 == alloc_size) return nullptr;
@@ -773,7 +773,7 @@ class MemoryPool {
     }
 
     if (!ok_contains || !ok_block_aligned || !ok_dealloc_once) {
-      Kokkos::abort("Kokkos MemoryPool::deallocate given erroneous pointer");
+      Kokkos::abort("Kokkos MemoryPool::deallocate given erroneous pointer\n");
     }
   }
   // end deallocate

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -490,7 +490,7 @@ struct FunctorTeamShmemSize<FunctorType, true, true> {
   static inline size_t value(const FunctorType& /*f*/, int /*team_size*/) {
     Kokkos::abort(
         "Functor with both team_shmem_size and shmem_size defined is "
-        "not allowed");
+        "not allowed\n");
     return 0;
   }
 };

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -370,7 +370,7 @@ class TeamPolicyInternal<Kokkos::Serial, Properties...>
         m_league_size(league_size_request),
         m_chunk_size(32) {
     if (team_size_request > 1)
-      Kokkos::abort("Kokkos::abort: Requested Team Size is too large!");
+      Kokkos::abort("Kokkos::abort: Requested Team Size is too large!\n");
   }
 
   TeamPolicyInternal(const execution_space& space, int league_size_request,

--- a/core/src/Kokkos_TaskScheduler.hpp
+++ b/core/src/Kokkos_TaskScheduler.hpp
@@ -377,7 +377,7 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
                                          Kokkos::Impl::MemoryScopeDevice());
           if (q != static_cast<queue_type const*>(t->m_queue)) {
             Kokkos::abort(
-                "Kokkos when_all Futures must be in the same scheduler");
+                "Kokkos when_all Futures must be in the same scheduler\n");
           }
         }
       }
@@ -466,7 +466,7 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
           // if ( m_queue != static_cast< BasicTaskScheduler const * >(
           // arg_f.m_task->m_scheduler )->m_queue ) {
           //  Kokkos::abort("Kokkos when_all Futures must be in the same
-          //  scheduler" );
+          //  scheduler\n" );
           //}
           // Increment reference count to track subsequent assignment.
           // This increment likely has to be SeqCst

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -104,7 +104,7 @@ void runtime_check_rank_device(const size_t dyn_rank, const bool is_void_spec,
     if (num_passed_args != dyn_rank && is_void_spec) {
       Kokkos::abort(
           "Number of arguments passed to Kokkos::View() constructor must match "
-          "the dynamic rank of the view.");
+          "the dynamic rank of the view.\n");
     }
   }
 }
@@ -1817,7 +1817,7 @@ class View : public ViewTraits<DataType, Properties...> {
     if (is_layout_stride) {
       Kokkos::abort(
           "Kokkos::View::shmem_size(extents...) doesn't work with "
-          "LayoutStride. Pass a LayoutStride object instead");
+          "LayoutStride. Pass a LayoutStride object instead\n");
     }
     const size_t num_passed_args = Impl::count_valid_integers(
         arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7);

--- a/core/src/Kokkos_WorkGraphPolicy.hpp
+++ b/core/src/Kokkos_WorkGraphPolicy.hpp
@@ -100,7 +100,7 @@ class WorkGraphPolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
 
     if ((N <= j) || (END_TOKEN != atomic_exchange(ready_queue + j, w))) {
       // ERROR: past the end of queue or did not replace END_TOKEN
-      Kokkos::abort("WorkGraphPolicy push_work error");
+      Kokkos::abort("WorkGraphPolicy push_work error\n");
     }
 
     memory_fence();

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -289,7 +289,8 @@ class UniqueToken<OpenMP, UniqueTokenScope::Instance> {
 
     if (result.first < 0) {
       ::Kokkos::abort(
-          "UniqueToken<OpenMP> failure to acquire tokens, no tokens available");
+          "UniqueToken<OpenMP> failure to acquire tokens, no tokens "
+          "available\n");
     }
 
     return result.first;

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -157,7 +157,7 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
     m_league_size = league_size_request;
 
     if (team_size_request > team_max)
-      Kokkos::abort("Kokkos::abort: Requested Team Size is too large!");
+      Kokkos::abort("Kokkos::abort: Requested Team Size is too large!\n");
     m_team_size = team_size_request < team_max ? team_size_request : team_max;
 
     // Round team size up to a multiple of 'team_gain'
@@ -333,7 +333,7 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
 
     if (m_chunk_size > 0) {
       if (!Impl::is_integral_power_of_two(m_chunk_size))
-        Kokkos::abort("TeamPolicy blocking granularity must be power of two");
+        Kokkos::abort("TeamPolicy blocking granularity must be power of two\n");
     }
 
     int new_chunk_size = 1;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -1287,7 +1287,7 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenMPTarget, Properties...>
 
     if (m_chunk_size > 0) {
       if (!Impl::is_integral_power_of_two(m_chunk_size))
-        Kokkos::abort("TeamPolicy blocking granularity must be power of two");
+        Kokkos::abort("TeamPolicy blocking granularity must be power of two\n");
     }
 
     int new_chunk_size = 1;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -479,7 +479,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
         ParReduceSpecialize::template execute_array<TagType, 32>(
             m_functor, m_policy, m_result_ptr, m_result_ptr_on_device);
       } else {
-        Kokkos::abort("array reduction length must be <= 32");
+        Kokkos::abort("array reduction length must be <= 32\n");
       }
     } else {
       // This loop handles the basic scalar reduction.
@@ -1041,7 +1041,7 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
     if ((shmem_size_L0 + shmem_size_L1) > 0) {
       Kokkos::abort(
           "OpenMPTarget: Scratch memory is not supported in `parallel_reduce` "
-          "over functors with init/join.");
+          "over functors with init/join.\n");
     }
 
     const auto nteams = league_size;
@@ -1222,7 +1222,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         ParReduceSpecialize::template execute_array<32>(
             m_functor, m_policy, m_result_ptr, m_result_ptr_on_device);
       } else {
-        Kokkos::abort("array reduction length must be <= 32");
+        Kokkos::abort("array reduction length must be <= 32\n");
       }
     } else {
       ParReduceSpecialize::template execute_array<1>(

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Task.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Task.cpp
@@ -99,7 +99,7 @@ TaskExec<Kokkos::Experimental::OpenMPTarget>::TaskExec(
 
 void TaskExec<Kokkos::Experimental::OpenMPTarget>::team_barrier_impl() const {
   if (m_team_exec->scratch_reduce_size() < int(2 * sizeof(int64_t))) {
-    Kokkos::abort("TaskQueue<OpenMPTarget> scratch_reduce memory too small");
+    Kokkos::abort("TaskQueue<OpenMPTarget> scratch_reduce memory too small\n");
   }
 
   // Use team shared memory to synchronize.
@@ -145,7 +145,7 @@ void TaskQueueSpecialization<Kokkos::Experimental::OpenMPTarget>::execute(
   // const int team_size = PoolExec::pool_size(1); // Threads per NUMA
 
   if (8 < team_size) {
-    Kokkos::abort("TaskQueue<OpenMPTarget> unsupported team size");
+    Kokkos::abort("TaskQueue<OpenMPTarget> unsupported team size\n");
   }
 
 #pragma omp parallel

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_UniqueToken.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_UniqueToken.hpp
@@ -95,7 +95,7 @@ class UniqueToken<OpenMPTarget, UniqueTokenScope::Global> {
     if (result.first < 0) {
       Kokkos::abort(
           "UniqueToken<OpenMPTarget> failure to acquire tokens, no tokens "
-          "available");
+          "available\n");
     }
 
     return result.first;

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -252,7 +252,7 @@ class SYCLTeamMember {
     const auto base_data          = static_cast<Type*>(m_team_reduce);
     if (static_cast<int>(n_active_subgroups * sizeof(Type)) >
         m_team_reduce_size)
-      Kokkos::abort("Not implemented!");
+      Kokkos::abort("Not implemented!\n");
 
     const auto group_id = sg.get_group_id()[0];
     if (id_in_sg == sub_group_range - 1) base_data[group_id] = value;

--- a/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
@@ -97,7 +97,8 @@ class UniqueToken<SYCL, UniqueTokenScope::Global> {
 
     if (result.first < 0) {
       Kokkos::abort(
-          "UniqueToken<SYCL> failure to acquire tokens, no tokens available");
+          "UniqueToken<SYCL> failure to acquire tokens, no tokens "
+          "available\n");
     }
 
     return result.first;

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -702,7 +702,7 @@ class UniqueToken<Threads, UniqueTokenScope::Instance> {
       if (result.first < 0) {
         ::Kokkos::abort(
             "UniqueToken<Threads> failure to acquire tokens, no tokens "
-            "available");
+            "available\n");
       }
       return result.first;
     }

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -589,7 +589,7 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
     m_league_size = league_size_request;
 
     if (team_size_request > team_max)
-      Kokkos::abort("Kokkos::abort: Requested Team Size is too large!");
+      Kokkos::abort("Kokkos::abort: Requested Team Size is too large!\n");
 
     m_team_size = team_size_request < team_max ? team_size_request : team_max;
 
@@ -811,7 +811,7 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
 
     if (m_chunk_size > 0) {
       if (!Impl::is_integral_power_of_two(m_chunk_size))
-        Kokkos::abort("TeamPolicy blocking granularity must be power of two");
+        Kokkos::abort("TeamPolicy blocking granularity must be power of two\n");
     }
 
     int new_chunk_size = 1;

--- a/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -333,7 +333,7 @@ KOKKOS_INLINE_FUNCTION T atomic_fetch_oper(
   return return_val;
 #elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL)
   // FIXME_SYCL
-  Kokkos::abort("Not implemented!");
+  Kokkos::abort("Not implemented!\n");
   (void)op;
   (void)dest;
   (void)val;

--- a/core/src/impl/Kokkos_MemoryPoolAllocator.hpp
+++ b/core/src/impl/Kokkos_MemoryPoolAllocator.hpp
@@ -100,7 +100,7 @@ class MemoryPoolAllocator {
   pointer allocate(size_t n) {
     void* rv = m_pool.allocate(n * sizeof(T));
     if (rv == nullptr) {
-      Kokkos::abort("Kokkos MemoryPool allocator failed to allocate memory");
+      Kokkos::abort("Kokkos MemoryPool allocator failed to allocate memory\n");
     }
     return reinterpret_cast<T*>(rv);
   }

--- a/core/src/impl/Kokkos_MultipleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_MultipleTaskQueue.hpp
@@ -221,7 +221,7 @@ struct MultipleTaskQueueTeamEntry {
           !task_queue_traits::ready_queue_insertion_may_fail &&
               std::is_void<_always_void>::value,
           void*>::type = nullptr) {
-    Kokkos::abort("should be unreachable!");
+    Kokkos::abort("should be unreachable!\n");
   }
 
   template <class _always_void = void>

--- a/core/src/impl/Kokkos_Serial_Task.hpp
+++ b/core/src/impl/Kokkos_Serial_Task.hpp
@@ -224,7 +224,7 @@ class TaskQueueSpecializationConstrained<
         // and all tasks waiting on this task are updated.
         queue->complete(task);
       } else if (0 != queue->m_ready_count) {
-        Kokkos::abort("TaskQueue<Serial>::execute ERROR: ready_count");
+        Kokkos::abort("TaskQueue<Serial>::execute ERROR: ready_count\n");
       }
     }
   }

--- a/core/src/impl/Kokkos_TaskBase.hpp
+++ b/core/src/impl/Kokkos_TaskBase.hpp
@@ -206,7 +206,7 @@ class TaskBase {
     if (lock != Kokkos::Impl::desul_atomic_exchange(
                     &m_next, dep, Kokkos::Impl::MemoryOrderSeqCst(),
                     Kokkos::Impl::MemoryScopeDevice())) {
-      Kokkos::abort("TaskScheduler ERROR: resetting task dependence");
+      Kokkos::abort("TaskScheduler ERROR: resetting task dependence\n");
     }
     if (nullptr != dep) {
       // The future may be destroyed upon returning from this call

--- a/core/src/impl/Kokkos_TaskQueueMultiple.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMultiple.hpp
@@ -138,7 +138,8 @@ class TaskQueueMultiple : public TaskQueue<ExecSpace, MemorySpace> {
     auto* const end_tag = reinterpret_cast<TaskBase*>(TaskBase::EndTag);
 
     if (m_other_queues == nullptr) {
-      Kokkos::abort("attempted to steal task before queues were initialized!");
+      Kokkos::abort(
+          "attempted to steal task before queues were initialized!\n");
     }
 
     // Loop by priority and then type, and then team

--- a/core/src/impl/Kokkos_TaskQueue_impl.hpp
+++ b/core/src/impl/Kokkos_TaskQueue_impl.hpp
@@ -87,13 +87,14 @@ TaskQueue<ExecSpace, MemorySpace>::~TaskQueue() {
   for (int i = 0; i < NumQueue; ++i) {
     for (int j = 0; j < 2; ++j) {
       if (m_ready[i][j] != (task_root_type *)task_root_type::EndTag) {
-        Kokkos::abort("TaskQueue::~TaskQueue ERROR: has ready tasks");
+        Kokkos::abort("TaskQueue::~TaskQueue ERROR: has ready tasks\n");
       }
     }
   }
 
   if (0 != m_ready_count) {
-    Kokkos::abort("TaskQueue::~TaskQueue ERROR: has ready or executing tasks");
+    Kokkos::abort(
+        "TaskQueue::~TaskQueue ERROR: has ready or executing tasks\n");
   }
 }
 
@@ -130,7 +131,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::decrement(
     queue->deallocate(task, t.m_alloc_size);
   } else if (count <= 1) {
     Kokkos::abort(
-        "TaskScheduler task has negative reference count or is incomplete");
+        "TaskScheduler task has negative reference count or is incomplete\n");
   }
 }
 
@@ -192,7 +193,7 @@ KOKKOS_FUNCTION bool TaskQueue<ExecSpace, MemorySpace>::push_task(
 
   if (zero != next) {
     Kokkos::abort(
-        "TaskQueue::push_task ERROR: already a member of another queue");
+        "TaskQueue::push_task ERROR: already a member of another queue\n");
   }
 
   // store the head of the queue
@@ -370,7 +371,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::schedule_runnable(
     respawn = true;
   } else {
     // Task in Complete state
-    Kokkos::abort("TaskQueue::schedule_runnable ERROR: task is complete");
+    Kokkos::abort("TaskQueue::schedule_runnable ERROR: task is complete\n");
   }
 
   //----------------------------------------
@@ -483,7 +484,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::schedule_aggregate(
     // Task in Waiting state
   } else if (lock == t.m_wait) {
     // Task in Complete state
-    Kokkos::abort("TaskQueue::schedule_aggregate ERROR: task is complete");
+    Kokkos::abort("TaskQueue::schedule_aggregate ERROR: task is complete\n");
   }
 
   //----------------------------------------
@@ -569,7 +570,7 @@ KOKKOS_FUNCTION void TaskQueue<ExecSpace, MemorySpace>::reschedule(
   if (lock != Kokkos::Impl::desul_atomic_exchange(
                   &task->m_next, zero, Kokkos::Impl::MemoryOrderSeqCst(),
                   Kokkos::Impl::MemoryScopeDevice())) {
-    Kokkos::abort("TaskScheduler::respawn ERROR: already respawned");
+    Kokkos::abort("TaskScheduler::respawn ERROR: already respawned\n");
   }
 }
 

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -658,7 +658,7 @@ struct SubviewExtents {
   template <size_t... DimArgs, class... Args>
   KOKKOS_FORCEINLINE_FUNCTION void error(const ViewDimension<DimArgs...>&,
                                          Args...) const {
-    Kokkos::abort("Kokkos::subview bounds error");
+    Kokkos::abort("Kokkos::subview bounds error\n");
   }
 #endif
 
@@ -1131,7 +1131,7 @@ struct ViewOffset<
     if (rhs.m_stride.S0 != 1) {
       Kokkos::abort(
           "Kokkos::Impl::ViewOffset assignment of LayoutLeft from LayoutStride "
-          " requires stride == 1");
+          " requires stride == 1\n");
     }
   }
 
@@ -1452,7 +1452,7 @@ struct ViewOffset<
     if (rhs.m_stride.S0 != 1) {
       Kokkos::abort(
           "Kokkos::Impl::ViewOffset assignment of LayoutLeft from LayoutStride "
-          "requires stride == 1");
+          "requires stride == 1\n");
     }
   }
 
@@ -2127,7 +2127,7 @@ struct ViewOffset<
                                                 : rhs.m_stride.S7)))))) != 1) {
       Kokkos::abort(
           "Kokkos::Impl::ViewOffset assignment of LayoutRight from "
-          "LayoutStride requires right-most stride == 1");
+          "LayoutStride requires right-most stride == 1\n");
     }
   }
 
@@ -2754,7 +2754,7 @@ struct ViewDataHandle<
     if (reinterpret_cast<uintptr_t>(arg_data_ptr) % Impl::MEMORY_ALIGNMENT) {
       Kokkos::abort(
           "Assigning NonAligned View or Pointer to Kokkos::View with Aligned "
-          "attribute");
+          "attribute\n");
     }
     return handle_type(arg_data_ptr);
   }
@@ -2765,7 +2765,7 @@ struct ViewDataHandle<
         Impl::MEMORY_ALIGNMENT) {
       Kokkos::abort(
           "Assigning NonAligned View or Pointer to Kokkos::View with Aligned "
-          "attribute");
+          "attribute\n");
     }
     return handle_type(arg_data_ptr + offset);
   }
@@ -2799,7 +2799,7 @@ struct ViewDataHandle<
     if (reinterpret_cast<uintptr_t>(arg_data_ptr) % Impl::MEMORY_ALIGNMENT) {
       Kokkos::abort(
           "Assigning NonAligned View or Pointer to Kokkos::View with Aligned "
-          "attribute");
+          "attribute\n");
     }
     return (value_type*)(arg_data_ptr);
   }
@@ -2810,7 +2810,7 @@ struct ViewDataHandle<
         Impl::MEMORY_ALIGNMENT) {
       Kokkos::abort(
           "Assigning NonAligned View or Pointer to Kokkos::View with Aligned "
-          "attribute");
+          "attribute\n");
     }
     return (value_type*)(arg_data_ptr + offset);
   }
@@ -3526,7 +3526,7 @@ class ViewMapping<
       if (!assignable)
         Kokkos::abort(
             "View Assignment: trying to assign runtime dimension to non "
-            "matching compile time dimension.");
+            "matching compile time dimension.\n");
     }
     dst.m_impl_offset = dst_offset_type(src.m_impl_offset);
     dst.m_impl_handle = Kokkos::Impl::ViewDataHandle<DstTraits>::assign(
@@ -3679,7 +3679,7 @@ class ViewMapping<
       if (!assignable)
         Kokkos::abort(
             "View Assignment: trying to assign runtime dimension to non "
-            "matching compile time dimension.");
+            "matching compile time dimension.\n");
     }
     dst.m_impl_offset = dst_offset_type(src.m_impl_offset);
     dst.m_impl_handle = Kokkos::Impl::ViewDataHandle<DstTraits>::assign(
@@ -3915,7 +3915,7 @@ struct OperatorBoundsErrorOnDevice;
 template <class MapType>
 struct OperatorBoundsErrorOnDevice<MapType, false> {
   KOKKOS_INLINE_FUNCTION
-  static void run(MapType const&) { Kokkos::abort("View bounds error"); }
+  static void run(MapType const&) { Kokkos::abort("View bounds error\n"); }
 };
 
 template <class MapType>
@@ -3936,7 +3936,8 @@ struct OperatorBoundsErrorOnDevice<MapType, true> {
     for (char const* p2 = label; (*p2 != '\0') && (p < end); ++p, ++p2) {
       *p = *p2;
     }
-    *p = '\0';
+    *p     = '\n';
+    *(++p) = '\0';
     Kokkos::abort(msg);
   }
 };
@@ -3953,7 +3954,7 @@ template <class Map>
 KOKKOS_FUNCTION
     std::enable_if_t<!is_detected<printable_label_typedef_t, Map>::value>
     operator_bounds_error_on_device(Map const&) {
-  Kokkos::abort("View bounds error");
+  Kokkos::abort("View bounds error\n");
 }
 
 template <class Map>
@@ -3988,7 +3989,7 @@ KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(
     if (tracker.m_tracker.has_record()) {
       operator_bounds_error_on_device(map);
     } else {
-      Kokkos::abort("View bounds error");
+      Kokkos::abort("View bounds error\n");
     }
 #endif
   }

--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -98,7 +98,7 @@ struct LoadStoreFunctor {
   void operator()(int) const {
     T old = Kokkos::atomic_load(&data());
     if (old != i0)
-      Kokkos::abort("Kokkos Atomic Load didn't get the right value");
+      Kokkos::abort("Kokkos Atomic Load didn't get the right value\n");
     Kokkos::atomic_store(&data(), i1);
     Kokkos::atomic_assign(&data(), old);
   }

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -491,7 +491,8 @@ struct Functor_TestHalfOperators {
 
     // if (h_lhs != tmp_lhs) {
     //  printf("tmp_lhs = %f, h_lhs = %f\n", __half2float(tmp_lhs),
-    //  __half2float(h_lhs)); Kokkos::abort("Error in half_t prefix operators");
+    //  __half2float(h_lhs)); Kokkos::abort("Error in half_t prefix
+    //  operators\n");
     //}
 
     actual_lhs(POSTFIX_INC)   = cast_from_half<double>(tmp_lhs++);
@@ -503,7 +504,7 @@ struct Functor_TestHalfOperators {
     // if (h_lhs != tmp_lhs) {
     //  printf("tmp_lhs = %f, h_lhs = %f\n", __half2float(tmp_lhs),
     //  __half2float(h_lhs)); Kokkos::abort("Error in half_t postfix
-    //  operators");
+    //  operators\n");
     //}
 
     tmp_lhs = h_lhs;
@@ -883,14 +884,14 @@ struct Functor_TestHalfOperators {
     half_tmp = cast_from_half<float>(h_lhs);
     tmp_ptr  = &(tmp_lhs = half_tmp);
     if (tmp_ptr != &tmp_lhs)
-      Kokkos::abort("Error in half_t address-of operator");
+      Kokkos::abort("Error in half_t address-of operator\n");
     actual_lhs(AO_IMPL_HALF)   = cast_from_half<double>(*tmp_ptr);
     expected_lhs(AO_IMPL_HALF) = d_lhs;
 
     tmp2_lhs = h_lhs;
     tmp_ptr  = &(tmp_lhs = tmp2_lhs);
     if (tmp_ptr != &tmp_lhs)
-      Kokkos::abort("Error in half_t address-of operator");
+      Kokkos::abort("Error in half_t address-of operator\n");
     actual_lhs(AO_HALF_T)   = cast_from_half<double>(tmp_ptr[0]);
     expected_lhs(AO_HALF_T) = d_lhs;
 

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -525,7 +525,7 @@ struct TestMemoryPoolHuge<
               , ptrs(i) );
 #endif
       if (!ptrs(i)) {
-        Kokkos::abort("TestMemoryPoolHuge");
+        Kokkos::abort("TestMemoryPoolHuge\n");
         ++err;
       }
     }

--- a/core/unit_test/TestTaskScheduler.hpp
+++ b/core/unit_test/TestTaskScheduler.hpp
@@ -130,7 +130,7 @@ struct TestFib {
         );
 #endif
 
-        Kokkos::abort("TestFib insufficient memory");
+        Kokkos::abort("TestFib insufficient memory\n");
       }
     }
   }

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2114,7 +2114,7 @@ struct TestUnmanagedSubviewReset {
     for (int i = 0; i < int(a.extent(0)); ++i) {
       sub_a.assign_data(&a(i, 0, 0, 0));
       if (&sub_a(1, 1, 1) != &a(i, 1, 1, 1)) {
-        Kokkos::abort("TestUnmanagedSubviewReset");
+        Kokkos::abort("TestUnmanagedSubviewReset\n");
       }
     }
   }

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -47,7 +47,7 @@
 
 namespace Test {
 
-__global__ void test_abort() { Kokkos::abort("test_abort"); }
+__global__ void test_abort() { Kokkos::abort("test_abort\n"); }
 
 __global__ void test_cuda_spaces_int_value(int *ptr) {
   if (*ptr == 42) {

--- a/core/unit_test/hip/TestHIP_ScanUnit.cpp
+++ b/core/unit_test/hip/TestHIP_ScanUnit.cpp
@@ -67,7 +67,7 @@ __global__ void start_intra_block_scan()
   if (values[i] != ((i + 2) * (i + 1)) / 2) {
     printf("Value for %d should be %d but is %d\n", i, ((i + 2) * (i + 1)) / 2,
            values[i]);
-    Kokkos::abort("Test for intra_block_reduce_scan failed!");
+    Kokkos::abort("Test for intra_block_reduce_scan failed!\n");
   }
 }
 

--- a/core/unit_test/hip/TestHIP_Spaces.cpp
+++ b/core/unit_test/hip/TestHIP_Spaces.cpp
@@ -47,7 +47,7 @@
 
 namespace Test {
 
-__global__ void test_abort() { Kokkos::abort("test_abort"); }
+__global__ void test_abort() { Kokkos::abort("test_abort\n"); }
 
 __global__ void test_hip_spaces_int_value(int *ptr) {
   if (*ptr == 42) {


### PR DESCRIPTION
I noticed that some error messages are hard to read because the error message is not terminated by a newline.