### PR TITLE
Avoid CUDA warnings in TestMinMaxClamp

### DIFF
--- a/core/unit_test/TestMinMaxClamp.hpp
+++ b/core/unit_test/TestMinMaxClamp.hpp
@@ -61,8 +61,8 @@ struct PairIntCompareFirst {
   int second;
 
  private:
-  friend constexpr bool operator<(PairIntCompareFirst const& lhs,
-                                  PairIntCompareFirst const& rhs) {
+  friend KOKKOS_FUNCTION constexpr bool operator<(
+      PairIntCompareFirst const& lhs, PairIntCompareFirst const& rhs) {
     return lhs.first < rhs.first;
   }
 };


### PR DESCRIPTION
We get warnings when `constexpr` support is not enabled for `CUDA`.