### PR TITLE
Suppress CUDA RDC warning about stack size

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -366,6 +366,9 @@ IF (KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE)
     Clang  -fcuda-rdc
     NVIDIA --relocatable-device-code=true
   )
+  COMPILER_SPECIFIC_LINK_OPTIONS(
+    NVIDIA -Xnvlink --suppress-stack-size-warning
+  )
 ENDIF()
 
 # Clang needs mcx16 option enabled for Windows atomic functions


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/2039. It's still debatable if we rather have downstream code deal with it or if we only want to apply it in the test suite instead.