### PR TITLE
Error out for const scalar return type in reduction

### DIFF
--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1735,12 +1735,14 @@ struct ParallelReduceFence {
 template <class PolicyType, class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
                         !(Kokkos::is_view<ReturnType>::value ||
-                          Kokkos::is_reducer<ReturnType>::value)>
+                          Kokkos::is_reducer<ReturnType>::value ||
+                          std::is_pointer<ReturnType>::value)>
 parallel_reduce(const std::string& label, const PolicyType& policy,
                 const FunctorType& functor, ReturnType& return_value) {
-  static_assert(!std::is_const<ReturnType>::value,
-                "A const reduction result type is only allowed for a View or "
-                "reducer return type!");
+  static_assert(
+      !std::is_const<ReturnType>::value,
+      "A const reduction result type is only allowed for a View, pointer or "
+      "reducer return type!");
 
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       label, policy, functor, return_value);
@@ -1754,12 +1756,14 @@ parallel_reduce(const std::string& label, const PolicyType& policy,
 template <class PolicyType, class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
                         !(Kokkos::is_view<ReturnType>::value ||
-                          Kokkos::is_reducer<ReturnType>::value)>
+                          Kokkos::is_reducer<ReturnType>::value ||
+                          std::is_pointer<ReturnType>::value)>
 parallel_reduce(const PolicyType& policy, const FunctorType& functor,
                 ReturnType& return_value) {
-  static_assert(!std::is_const<ReturnType>::value,
-                "A const reduction result type is only allowed for a View or "
-                "reducer return type!");
+  static_assert(
+      !std::is_const<ReturnType>::value,
+      "A const reduction result type is only allowed for a View, pointer or "
+      "reducer return type!");
 
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       "", policy, functor, return_value);
@@ -1772,12 +1776,14 @@ parallel_reduce(const PolicyType& policy, const FunctorType& functor,
 
 template <class FunctorType, class ReturnType>
 inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
-                          Kokkos::is_reducer<ReturnType>::value)>
+                          Kokkos::is_reducer<ReturnType>::value ||
+                          std::is_pointer<ReturnType>::value)>
 parallel_reduce(const size_t& policy, const FunctorType& functor,
                 ReturnType& return_value) {
-  static_assert(!std::is_const<ReturnType>::value,
-                "A const reduction result type is only allowed for a View or "
-                "reducer return type!");
+  static_assert(
+      !std::is_const<ReturnType>::value,
+      "A const reduction result type is only allowed for a View, pointer or "
+      "reducer return type!");
 
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
@@ -1794,12 +1800,14 @@ parallel_reduce(const size_t& policy, const FunctorType& functor,
 
 template <class FunctorType, class ReturnType>
 inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
-                          Kokkos::is_reducer<ReturnType>::value)>
+                          Kokkos::is_reducer<ReturnType>::value ||
+                          std::is_pointer<ReturnType>::value)>
 parallel_reduce(const std::string& label, const size_t& policy,
                 const FunctorType& functor, ReturnType& return_value) {
-  static_assert(!std::is_const<ReturnType>::value,
-                "A const reduction result type is only allowed for a View or "
-                "reducer return type!");
+  static_assert(
+      !std::is_const<ReturnType>::value,
+      "A const reduction result type is only allowed for a View, pointer or "
+      "reducer return type!");
 
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
@@ -1818,7 +1826,8 @@ parallel_reduce(const std::string& label, const size_t& policy,
 template <class PolicyType, class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
                         (Kokkos::is_view<ReturnType>::value ||
-                         Kokkos::is_reducer<ReturnType>::value)>
+                         Kokkos::is_reducer<ReturnType>::value ||
+                         std::is_pointer<ReturnType>::value)>
 parallel_reduce(const std::string& label, const PolicyType& policy,
                 const FunctorType& functor, const ReturnType& return_value) {
   ReturnType return_value_impl = return_value;
@@ -1834,7 +1843,8 @@ parallel_reduce(const std::string& label, const PolicyType& policy,
 template <class PolicyType, class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
                         (Kokkos::is_view<ReturnType>::value ||
-                         Kokkos::is_reducer<ReturnType>::value)>
+                         Kokkos::is_reducer<ReturnType>::value ||
+                         std::is_pointer<ReturnType>::value)>
 parallel_reduce(const PolicyType& policy, const FunctorType& functor,
                 const ReturnType& return_value) {
   ReturnType return_value_impl = return_value;
@@ -1849,7 +1859,8 @@ parallel_reduce(const PolicyType& policy, const FunctorType& functor,
 
 template <class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_view<ReturnType>::value ||
-                        Kokkos::is_reducer<ReturnType>::value>
+                        Kokkos::is_reducer<ReturnType>::value ||
+                        std::is_pointer<ReturnType>::value>
 parallel_reduce(const size_t& policy, const FunctorType& functor,
                 const ReturnType& return_value) {
   using policy_type =
@@ -1867,7 +1878,8 @@ parallel_reduce(const size_t& policy, const FunctorType& functor,
 
 template <class FunctorType, class ReturnType>
 inline std::enable_if_t<Kokkos::is_view<ReturnType>::value ||
-                        Kokkos::is_reducer<ReturnType>::value>
+                        Kokkos::is_reducer<ReturnType>::value ||
+                        std::is_pointer<ReturnType>::value>
 parallel_reduce(const std::string& label, const size_t& policy,
                 const FunctorType& functor, const ReturnType& return_value) {
   using policy_type =

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1738,9 +1738,9 @@ inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
                           Kokkos::is_reducer<ReturnType>::value)>
 parallel_reduce(const std::string& label, const PolicyType& policy,
                 const FunctorType& functor, ReturnType& return_value) {
-  static_assert(
-      !std::is_const<ReturnType>::value,
-      "A const return type is only allowed for a View or reducer return type!");
+  static_assert(!std::is_const<ReturnType>::value,
+                "A const reduction result type is only allowed for a View or "
+                "reducer return type!");
 
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       label, policy, functor, return_value);
@@ -1757,9 +1757,9 @@ inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
                           Kokkos::is_reducer<ReturnType>::value)>
 parallel_reduce(const PolicyType& policy, const FunctorType& functor,
                 ReturnType& return_value) {
-  static_assert(
-      !std::is_const<ReturnType>::value,
-      "A const return type is only allowed for a View or reducer return type!");
+  static_assert(!std::is_const<ReturnType>::value,
+                "A const reduction result type is only allowed for a View or "
+                "reducer return type!");
 
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       "", policy, functor, return_value);
@@ -1775,13 +1775,14 @@ inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
                           Kokkos::is_reducer<ReturnType>::value)>
 parallel_reduce(const size_t& policy, const FunctorType& functor,
                 ReturnType& return_value) {
-  static_assert(
-      !std::is_const<ReturnType>::value,
-      "A const return type is only allowed for a View or reducer return type!");
+  static_assert(!std::is_const<ReturnType>::value,
+                "A const reduction result type is only allowed for a View or "
+                "reducer return type!");
 
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
+
   Impl::ParallelReduceAdaptor<policy_type, FunctorType, ReturnType>::execute(
       "", policy_type(0, policy), functor, return_value);
   Impl::ParallelReduceFence<typename policy_type::execution_space, ReturnType>::
@@ -1796,9 +1797,9 @@ inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
                           Kokkos::is_reducer<ReturnType>::value)>
 parallel_reduce(const std::string& label, const size_t& policy,
                 const FunctorType& functor, ReturnType& return_value) {
-  static_assert(
-      !std::is_const<ReturnType>::value,
-      "A const return type is only allowed for a View or reducer return type!");
+  static_assert(!std::is_const<ReturnType>::value,
+                "A const reduction result type is only allowed for a View or "
+                "reducer return type!");
 
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1733,10 +1733,15 @@ struct ParallelReduceFence {
 // ReturnValue is scalar or array: take by reference
 
 template <class PolicyType, class FunctorType, class ReturnType>
-inline typename std::enable_if<
-    Kokkos::is_execution_policy<PolicyType>::value>::type
+inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
+                        !(Kokkos::is_view<ReturnType>::value ||
+                          Kokkos::is_reducer<ReturnType>::value)>
 parallel_reduce(const std::string& label, const PolicyType& policy,
                 const FunctorType& functor, ReturnType& return_value) {
+  static_assert(
+      !std::is_const<ReturnType>::value,
+      "A const return type is only allowed for a View or reducer return type!");
+
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       label, policy, functor, return_value);
   Impl::ParallelReduceFence<typename PolicyType::execution_space, ReturnType>::
@@ -1747,10 +1752,15 @@ parallel_reduce(const std::string& label, const PolicyType& policy,
 }
 
 template <class PolicyType, class FunctorType, class ReturnType>
-inline typename std::enable_if<
-    Kokkos::is_execution_policy<PolicyType>::value>::type
+inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
+                        !(Kokkos::is_view<ReturnType>::value ||
+                          Kokkos::is_reducer<ReturnType>::value)>
 parallel_reduce(const PolicyType& policy, const FunctorType& functor,
                 ReturnType& return_value) {
+  static_assert(
+      !std::is_const<ReturnType>::value,
+      "A const return type is only allowed for a View or reducer return type!");
+
   Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
       "", policy, functor, return_value);
   Impl::ParallelReduceFence<typename PolicyType::execution_space, ReturnType>::
@@ -1761,8 +1771,14 @@ parallel_reduce(const PolicyType& policy, const FunctorType& functor,
 }
 
 template <class FunctorType, class ReturnType>
-inline void parallel_reduce(const size_t& policy, const FunctorType& functor,
-                            ReturnType& return_value) {
+inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
+                          Kokkos::is_reducer<ReturnType>::value)>
+parallel_reduce(const size_t& policy, const FunctorType& functor,
+                ReturnType& return_value) {
+  static_assert(
+      !std::is_const<ReturnType>::value,
+      "A const return type is only allowed for a View or reducer return type!");
+
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
@@ -1776,9 +1792,14 @@ inline void parallel_reduce(const size_t& policy, const FunctorType& functor,
 }
 
 template <class FunctorType, class ReturnType>
-inline void parallel_reduce(const std::string& label, const size_t& policy,
-                            const FunctorType& functor,
-                            ReturnType& return_value) {
+inline std::enable_if_t<!(Kokkos::is_view<ReturnType>::value ||
+                          Kokkos::is_reducer<ReturnType>::value)>
+parallel_reduce(const std::string& label, const size_t& policy,
+                const FunctorType& functor, ReturnType& return_value) {
+  static_assert(
+      !std::is_const<ReturnType>::value,
+      "A const return type is only allowed for a View or reducer return type!");
+
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
@@ -1794,8 +1815,9 @@ inline void parallel_reduce(const std::string& label, const size_t& policy,
 // ReturnValue as View or Reducer: take by copy to allow for inline construction
 
 template <class PolicyType, class FunctorType, class ReturnType>
-inline typename std::enable_if<
-    Kokkos::is_execution_policy<PolicyType>::value>::type
+inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
+                        (Kokkos::is_view<ReturnType>::value ||
+                         Kokkos::is_reducer<ReturnType>::value)>
 parallel_reduce(const std::string& label, const PolicyType& policy,
                 const FunctorType& functor, const ReturnType& return_value) {
   ReturnType return_value_impl = return_value;
@@ -1809,8 +1831,9 @@ parallel_reduce(const std::string& label, const PolicyType& policy,
 }
 
 template <class PolicyType, class FunctorType, class ReturnType>
-inline typename std::enable_if<
-    Kokkos::is_execution_policy<PolicyType>::value>::type
+inline std::enable_if_t<Kokkos::is_execution_policy<PolicyType>::value &&
+                        (Kokkos::is_view<ReturnType>::value ||
+                         Kokkos::is_reducer<ReturnType>::value)>
 parallel_reduce(const PolicyType& policy, const FunctorType& functor,
                 const ReturnType& return_value) {
   ReturnType return_value_impl = return_value;
@@ -1824,8 +1847,10 @@ parallel_reduce(const PolicyType& policy, const FunctorType& functor,
 }
 
 template <class FunctorType, class ReturnType>
-inline void parallel_reduce(const size_t& policy, const FunctorType& functor,
-                            const ReturnType& return_value) {
+inline std::enable_if_t<Kokkos::is_view<ReturnType>::value ||
+                        Kokkos::is_reducer<ReturnType>::value>
+parallel_reduce(const size_t& policy, const FunctorType& functor,
+                const ReturnType& return_value) {
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
@@ -1840,9 +1865,10 @@ inline void parallel_reduce(const size_t& policy, const FunctorType& functor,
 }
 
 template <class FunctorType, class ReturnType>
-inline void parallel_reduce(const std::string& label, const size_t& policy,
-                            const FunctorType& functor,
-                            const ReturnType& return_value) {
+inline std::enable_if_t<Kokkos::is_view<ReturnType>::value ||
+                        Kokkos::is_reducer<ReturnType>::value>
+parallel_reduce(const std::string& label, const size_t& policy,
+                const FunctorType& functor, const ReturnType& return_value) {
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;


### PR DESCRIPTION
Fixes #2090. This pull request also makes sure that we are calling the intended overload for `parallel_reduce`, i.e., the return value is only copied if the return type is a `View` or a reducer.