### PR TITLE
MD Team Policies Implementation

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -431,6 +431,98 @@ struct ThreadVectorRangeBoundariesStruct<iType, CudaTeamMember> {
       : start(arg_begin), end(arg_end) {}
 };
 
+template <Kokkos::Iterate Direction, size_t Rank, typename iType>
+struct MDTeamThreadRangeBoundariesStruct<Direction, Rank, iType,
+                                         CudaTeamMember> {
+  static_assert(2 <= Rank, "Rank must be at least 2");
+  static_assert(Rank <= 8, "Rank must be at most 8");
+  static_assert(Direction == Kokkos::Iterate::Left ||
+                    Direction == Kokkos::Iterate::Right,
+                "Direction must be Left or Right");
+
+  static constexpr Kokkos::Iterate direction = Direction;
+  static constexpr size_t rank               = Rank;
+  using index_type                           = iType;
+  using team_member_type                     = CudaTeamMember;
+
+  template <typename... Ns>
+  KOKKOS_INLINE_FUNCTION constexpr explicit MDTeamThreadRangeBoundariesStruct(
+      CudaTeamMember const& member, Ns&&... ns)
+      : thread(member), threadDims{static_cast<iType>(ns)...} {
+    static_assert(sizeof...(ns) == Rank, "Number of ns must equal Rank");
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  MDTeamThreadRangeBoundariesStruct(team_member_type const& member,
+                                    const iType (&array)[Rank])
+      : thread(member) {
+    std::copy(&array[0], &array[Rank], &threadDims[0]);
+  }
+
+  team_member_type const& thread;
+  iType threadDims[Rank];
+};
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType>
+struct MDThreadVectorRangeBoundariesStruct<OuterDirection, InnerDirection, Rank,
+                                           iType, CudaTeamMember> {
+  static constexpr Kokkos::Iterate outer_direction = OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction = InnerDirection;
+  static constexpr size_t rank                     = Rank;
+  using index_type                                 = iType;
+  using team_member_type                           = CudaTeamMember;
+
+  static_assert(2 <= Rank, "Rank must be at least 2");
+  static_assert(Rank <= 8, "Rank must be at most 8");
+  static_assert(OuterDirection == Kokkos::Iterate::Left ||
+                    OuterDirection == Kokkos::Iterate::Right,
+                "OuterDirection must be Left or Right");
+  static_assert(InnerDirection == Kokkos::Iterate::Left ||
+                    InnerDirection == Kokkos::Iterate::Right,
+                "InnerDirection must be Left or Right");
+
+  template <typename... Ns>
+  KOKKOS_INLINE_FUNCTION constexpr explicit MDThreadVectorRangeBoundariesStruct(
+      team_member_type const& tm, Ns&&... ns)
+      : team_member(tm), taskDims{static_cast<iType>(ns)...} {
+    static_assert(sizeof...(ns) == Rank, "Number of ns must equal Rank");
+  }
+
+  team_member_type const& team_member;
+  iType const taskDims[Rank];
+};
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType>
+struct MDTeamVectorRangeBoundariesStruct<OuterDirection, InnerDirection, Rank,
+                                         iType, CudaTeamMember> {
+  static constexpr Kokkos::Iterate outer_direction = OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction = InnerDirection;
+  static constexpr size_t rank                     = Rank;
+  using index_type                                 = iType;
+  using team_member_type                           = CudaTeamMember;
+
+  static_assert(2 <= Rank, "Rank must be at least 2");
+  static_assert(Rank <= 8, "Rank must be at most 8");
+  static_assert(OuterDirection == Kokkos::Iterate::Left ||
+                    OuterDirection == Kokkos::Iterate::Right,
+                "OuterDirection must be Left or Right");
+  static_assert(InnerDirection == Kokkos::Iterate::Left ||
+                    InnerDirection == Kokkos::Iterate::Right,
+                "InnerDirection must be Left or Right");
+
+  template <typename... Ns>
+  KOKKOS_INLINE_FUNCTION constexpr explicit MDTeamVectorRangeBoundariesStruct(
+      team_member_type const& tm, Ns&&... ns)
+      : team_member(tm), taskDims{static_cast<iType>(ns)...} {
+    static_assert(sizeof...(ns) == Rank, "Number of ns must equal Rank");
+  }
+
+  team_member_type const& team_member;
+  iType const taskDims[Rank];
+};
+
 }  // namespace Impl
 
 template <typename iType>
@@ -484,6 +576,92 @@ ThreadVectorRange(const Impl::CudaTeamMember& thread, iType1 arg_begin,
   using iType = typename std::common_type<iType1, iType2>::type;
   return Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::CudaTeamMember>(
       thread, iType(arg_begin), iType(arg_end));
+}
+
+template <Kokkos::Iterate Direction, typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDTeamThreadRange(
+    Impl::CudaTeamMember const& member, Ns&&... ns) {
+  using execution_space = typename Impl::CudaTeamMember::execution_space;
+  using array_layout    = typename execution_space::array_layout;
+  static constexpr Kokkos::Iterate outer_direction =
+      Direction == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : Direction;
+  using iType = std::common_type_t<Ns...>;
+
+  return Impl::MDTeamThreadRangeBoundariesStruct<outer_direction, sizeof...(ns),
+                                                 iType, Impl::CudaTeamMember>(
+      member, static_cast<Ns&&>(ns)...);
+}
+
+template <typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDTeamThreadRange(
+    Impl::CudaTeamMember const& member, Ns&&... ns) {
+  return MDTeamThreadRange<Kokkos::Iterate::Default>(member,
+                                                     static_cast<Ns&&>(ns)...);
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDThreadVectorRange(
+    Impl::CudaTeamMember const& member, Ns&&... ns) {
+  using execution_space = typename Impl::CudaTeamMember::execution_space;
+  using array_layout    = typename execution_space::array_layout;
+  static constexpr Kokkos::Iterate outer_direction =
+      OuterDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction =
+      InnerDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : InnerDirection;
+  using iType = std::common_type_t<Ns...>;
+
+  return Impl::MDThreadVectorRangeBoundariesStruct<
+      outer_direction, inner_direction, sizeof...(ns), iType,
+      Impl::CudaTeamMember>(member, static_cast<Ns&&>(ns)...);
+}
+
+template <typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDThreadVectorRange(
+    Impl::CudaTeamMember const& member, Ns&&... ns) {
+  return MDThreadVectorRange<Kokkos::Iterate::Default,
+                             Kokkos::Iterate::Default>(
+      member, static_cast<Ns&&>(ns)...);
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDTeamVectorRange(
+    Impl::CudaTeamMember const& member, Ns&&... ns) {
+  using execution_space = typename Impl::CudaTeamMember::execution_space;
+  using array_layout    = typename execution_space::array_layout;
+  static constexpr Kokkos::Iterate outer_direction =
+      OuterDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction =
+      InnerDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : InnerDirection;
+  using iType = std::common_type_t<Ns...>;
+
+  return Impl::MDTeamVectorRangeBoundariesStruct<outer_direction,
+                                                 inner_direction, sizeof...(ns),
+                                                 iType, Impl::CudaTeamMember>(
+      member, static_cast<Ns&&>(ns)...);
+}
+
+template <typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDTeamVectorRange(
+    Impl::CudaTeamMember const& member, Ns&&... ns) {
+  return MDTeamVectorRange<Kokkos::Iterate::Default, Kokkos::Iterate::Default>(
+      member, static_cast<Ns&&>(ns)...);
 }
 
 KOKKOS_INLINE_FUNCTION
@@ -898,6 +1076,338 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure>::value_type;
   value_type dummy;
   parallel_scan(loop_boundaries, closure, Kokkos::Sum<value_type>(dummy));
+}
+
+template <size_t RemainingRank>
+struct ParallelForMDTeamThreadRangeCudaImpl {
+ private:
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void next_rank(
+      Boundaries const& boundaries, Closure const& closure,
+      typename Boundaries::index_type i) {
+    if (i >= 0) {
+      auto newClosure = [i, &closure](auto... is) { closure(i, is...); };
+      ParallelForMDTeamThreadRangeCudaImpl<RemainingRank -
+                                           1>::parallel_for_impl(boundaries,
+                                                                 newClosure);
+    }
+  }
+
+ public:
+  static constexpr size_t remaining_rank = RemainingRank;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
+      Boundaries const& boundaries, Closure const& closure) {
+    using index_type        = typename Boundaries::index_type;
+    using signed_index_type = std::make_signed_t<index_type>;
+
+    (void)boundaries;
+    (void)closure;
+
+#ifdef __CUDA_ARCH__
+    auto currentRank = Boundaries::rank - RemainingRank;
+
+    signed_index_type offsetThreadIdx = (currentRank) ? 0 : threadIdx.y;
+    signed_index_type offsetBlockDim  = (currentRank) ? 1 : blockDim.y;
+
+    if (Boundaries::direction == Kokkos::Iterate::Right) {
+      for (signed_index_type i = offsetThreadIdx;
+           i < boundaries.threadDims[currentRank]; i += offsetBlockDim) {
+        next_rank(boundaries, closure, i);
+      }
+    }
+
+    if (Boundaries::direction == Kokkos::Iterate::Left) {
+      for (signed_index_type i =
+               boundaries.threadDims[currentRank] - offsetThreadIdx - 1;
+           i >= 0;) {
+        next_rank(boundaries, closure, i);
+        i -= offsetBlockDim;
+      }
+    }
+#endif
+  }
+};
+
+template <>
+struct ParallelForMDTeamThreadRangeCudaImpl<0> {
+  static constexpr size_t remaining_rank = 0;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(Boundaries const&,
+                                                       Closure const& closure) {
+    closure();
+  }
+};
+
+template <Kokkos::Iterate Direction, size_t Rank, typename iType,
+          typename Closure>
+KOKKOS_INLINE_FUNCTION void parallel_for(
+    Impl::MDTeamThreadRangeBoundariesStruct<
+        Direction, Rank, iType, Impl::CudaTeamMember> const& loop_boundaries,
+    Closure const& closure) {
+  ParallelForMDTeamThreadRangeCudaImpl<Rank>::parallel_for_impl(loop_boundaries,
+                                                                closure);
+}
+
+template <Kokkos::Iterate Direction, size_t RemainingRank>
+struct ParallelForMDThreadVectorRangeCudaImpl {
+ private:
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void next_rank(
+      Boundaries const& boundaries, Closure const& closure,
+      typename Boundaries::index_type i) {
+    auto newClosure = [i, &closure](auto... is) { closure(i, is...); };
+    ParallelForMDThreadVectorRangeCudaImpl<
+        Boundaries::inner_direction,
+        RemainingRank - 1>::parallel_for_impl(boundaries, newClosure);
+  }
+
+ public:
+  static constexpr Kokkos::Iterate direction = Direction;
+  static constexpr size_t remaining_rank     = RemainingRank;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
+      Boundaries const& boundaries, Closure const& closure) {
+    using index_type        = typename Boundaries::index_type;
+    using signed_index_type = std::make_signed_t<index_type>;
+
+    (void)boundaries;
+    (void)closure;
+#ifdef __CUDA_ARCH__
+
+    auto currentRank = Boundaries::rank - RemainingRank;
+
+    signed_index_type offsetThreadIdx = (currentRank) ? 0 : threadIdx.x;
+    signed_index_type offsetBlockDim  = (currentRank) ? 1 : blockDim.x;
+
+    if (Direction == Kokkos::Iterate::Right) {
+      for (signed_index_type i = offsetThreadIdx;
+           i < boundaries.taskDims[currentRank]; i += offsetBlockDim) {
+        next_rank(boundaries, closure, i);
+      }
+    }
+
+    if (Direction == Kokkos::Iterate::Left) {
+      for (signed_index_type i =
+               boundaries.taskDims[currentRank] - offsetThreadIdx - 1;
+           i >= 0;) {
+        next_rank(boundaries, closure, i);
+        i -= offsetBlockDim;
+      }
+    }
+
+    __syncwarp(blockDim.x == 32
+                   ? 0xffffffff
+                   : ((1 << blockDim.x) - 1)
+                         << (threadIdx.y % (32 / blockDim.x)) * blockDim.x);
+#endif
+  }
+};
+
+template <Kokkos::Iterate Direction>
+struct ParallelForMDThreadVectorRangeCudaImpl<Direction, 0> {
+  static constexpr Kokkos::Iterate direction = Direction;
+  static constexpr size_t remaining_rank     = 0;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(Boundaries const&,
+                                                       Closure const& closure) {
+    closure();
+  }
+};
+
+template <Kokkos::Iterate outer_direction, Kokkos::Iterate inner_direction,
+          size_t Rank, typename iType, typename Closure>
+KOKKOS_INLINE_FUNCTION void parallel_for(
+    Impl::MDThreadVectorRangeBoundariesStruct<
+        outer_direction, inner_direction, Rank, iType,
+        Impl::CudaTeamMember> const& boundaries,
+    Closure const& closure) {
+  static_assert(outer_direction == Kokkos::Iterate::Left ||
+                    outer_direction == Kokkos::Iterate::Right,
+                "outer_direction must be Left or Right");
+  static_assert(inner_direction == Kokkos::Iterate::Left ||
+                    inner_direction == Kokkos::Iterate::Right,
+                "inner_direction must be Left or Right");
+
+  ParallelForMDThreadVectorRangeCudaImpl<outer_direction,
+                                         Rank>::parallel_for_impl(boundaries,
+                                                                  closure);
+}
+
+template <Kokkos::Iterate Direction, size_t RemainingRank>
+struct ParallelForMDTeamVectorRangeCudaImpl {
+ private:
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void next_rank(
+      Boundaries const& boundaries, Closure const& closure,
+      typename Boundaries::index_type i) {
+    auto newClosure = [i, &closure](auto... is) { closure(i, is...); };
+    ParallelForMDTeamVectorRangeCudaImpl<Boundaries::inner_direction,
+                                         RemainingRank -
+                                             1>::parallel_for_impl(boundaries,
+                                                                   newClosure);
+  }
+
+ public:
+  static constexpr Kokkos::Iterate direction = Direction;
+  static constexpr size_t remaining_rank     = RemainingRank;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
+      Boundaries const& boundaries, Closure const& closure) {
+    using index_type        = typename Boundaries::index_type;
+    using signed_index_type = std::make_signed_t<index_type>;
+
+    (void)boundaries;
+    (void)closure;
+#ifdef __CUDA_ARCH__
+
+    auto currentRank = Boundaries::rank - RemainingRank;
+
+    signed_index_type offsetThreadIdxX = (currentRank) ? 0 : threadIdx.x;
+    signed_index_type offsetThreadIdxY = (currentRank) ? 0 : threadIdx.y;
+    signed_index_type offsetBlockDimX  = (currentRank) ? 1 : blockDim.x;
+    signed_index_type offsetBlockDimY  = (currentRank) ? 1 : blockDim.y;
+
+    auto threadOffset = offsetThreadIdxY * offsetBlockDimX + offsetThreadIdxX;
+
+    if (Direction == Kokkos::Iterate::Right) {
+      for (signed_index_type i = threadOffset;
+           i < boundaries.taskDims[currentRank];
+           i += offsetBlockDimX * offsetBlockDimY) {
+        next_rank(boundaries, closure, i);
+      }
+    }
+
+    if (Direction == Kokkos::Iterate::Left) {
+      for (signed_index_type i =
+               boundaries.taskDims[currentRank] - threadOffset - 1;
+           i >= 0;) {
+        next_rank(boundaries, closure, i);
+        i -= offsetBlockDimX * offsetBlockDimY;
+      }
+    }
+#endif
+  }
+};
+
+template <Kokkos::Iterate Direction>
+struct ParallelForMDTeamVectorRangeCudaImpl<Direction, 0> {
+  static constexpr Kokkos::Iterate direction = Direction;
+  static constexpr size_t remaining_rank     = 0;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(Boundaries const&,
+                                                       Closure const& closure) {
+    closure();
+  }
+};
+
+template <Kokkos::Iterate outer_direction, Kokkos::Iterate inner_direction,
+          size_t Rank, typename iType, typename Closure>
+KOKKOS_INLINE_FUNCTION void parallel_for(
+    Impl::MDTeamVectorRangeBoundariesStruct<
+        outer_direction, inner_direction, Rank, iType,
+        Impl::CudaTeamMember> const& boundaries,
+    Closure const& closure) {
+  static_assert(outer_direction == Kokkos::Iterate::Left ||
+                    outer_direction == Kokkos::Iterate::Right,
+                "outer_direction must be Left or Right");
+  static_assert(inner_direction == Kokkos::Iterate::Left ||
+                    inner_direction == Kokkos::Iterate::Right,
+                "inner_direction must be Left or Right");
+
+  ParallelForMDTeamVectorRangeCudaImpl<outer_direction,
+                                       Rank>::parallel_for_impl(boundaries,
+                                                                closure);
+}
+
+template <Kokkos::Iterate Direction, size_t Rank, typename iType,
+          typename Closure, typename Reducer>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<Reducer>::value>
+parallel_reduce(
+    Impl::MDTeamThreadRangeBoundariesStruct<
+        Direction, Rank, iType, Impl::CudaTeamMember> const& boundaries,
+    Closure const& closure, Reducer const& reducer) {
+  typename Reducer::value_type value;
+  reducer.init(value);
+
+  parallel_for(boundaries, [&](auto... is) { closure(is..., value); });
+
+  boundaries.thread.team_reduce(reducer, value);
+}
+
+template <Kokkos::Iterate Direction, size_t Rank, typename iType,
+          typename Closure, typename ValueType>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
+parallel_reduce(
+    Impl::MDTeamThreadRangeBoundariesStruct<
+        Direction, Rank, iType, Impl::CudaTeamMember> const& boundaries,
+    Closure const& closure, ValueType& result) {
+  Kokkos::Sum<ValueType> reducer(result);
+
+  parallel_reduce(boundaries, closure, reducer);
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Closure, typename Reducer>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<Reducer>::value>
+parallel_reduce(Impl::MDThreadVectorRangeBoundariesStruct<
+                    OuterDirection, InnerDirection, Rank, iType,
+                    Impl::CudaTeamMember> const& boundaries,
+                Closure const& closure, Reducer const& reducer) {
+  typename Reducer::value_type value;
+  reducer.init(value);
+
+  parallel_for(boundaries,
+               [&](auto... is) { closure(is..., reducer.reference()); });
+
+  Impl::CudaTeamMember::vector_reduce(reducer);
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Closure, typename ValueType>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
+parallel_reduce(Impl::MDThreadVectorRangeBoundariesStruct<
+                    OuterDirection, InnerDirection, Rank, iType,
+                    Impl::CudaTeamMember> const& boundaries,
+                Closure const& closure, ValueType& result) {
+  result = ValueType();
+  Sum<ValueType> reducer(result);
+
+  parallel_reduce(boundaries, closure, reducer);
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Closure, typename Reducer>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<Reducer>::value>
+parallel_reduce(Impl::MDTeamVectorRangeBoundariesStruct<
+                    OuterDirection, InnerDirection, Rank, iType,
+                    Impl::CudaTeamMember> const& boundaries,
+                Closure const& closure, Reducer const& reducer) {
+  typename Reducer::value_type value;
+  reducer.init(value);
+
+  parallel_for(boundaries, [&](auto... is) { closure(is..., value); });
+
+  boundaries.team_member.vector_reduce(reducer, value);
+  boundaries.team_member.team_reduce(reducer, value);
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Closure, typename ValueType>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
+parallel_reduce(Impl::MDTeamVectorRangeBoundariesStruct<
+                    OuterDirection, InnerDirection, Rank, iType,
+                    Impl::CudaTeamMember> const& boundaries,
+                Closure const& closure, ValueType& result) {
+  Sum<ValueType> reducer(result);
+
+  parallel_reduce(boundaries, closure, reducer);
 }
 
 }  // namespace Kokkos

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -1099,15 +1099,14 @@ struct ParallelForMDTeamThreadRangeCudaImpl {
   template <typename Boundaries, typename Closure>
   KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
       Boundaries const& boundaries, Closure const& closure) {
-    using index_type        = typename Boundaries::index_type;
-    using signed_index_type = std::make_signed_t<index_type>;
-
     (void)boundaries;
     (void)closure;
 
 #ifdef __CUDA_ARCH__
-    auto currentRank = Boundaries::rank - RemainingRank;
+    using index_type        = typename Boundaries::index_type;
+    using signed_index_type = std::make_signed_t<index_type>;
 
+    auto currentRank                  = Boundaries::rank - RemainingRank;
     signed_index_type offsetThreadIdx = (currentRank) ? 0 : threadIdx.y;
     signed_index_type offsetBlockDim  = (currentRank) ? 1 : blockDim.y;
 
@@ -1171,15 +1170,14 @@ struct ParallelForMDThreadVectorRangeCudaImpl {
   template <typename Boundaries, typename Closure>
   KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
       Boundaries const& boundaries, Closure const& closure) {
+    (void)boundaries;
+    (void)closure;
+
+#ifdef __CUDA_ARCH__
     using index_type        = typename Boundaries::index_type;
     using signed_index_type = std::make_signed_t<index_type>;
 
-    (void)boundaries;
-    (void)closure;
-#ifdef __CUDA_ARCH__
-
-    auto currentRank = Boundaries::rank - RemainingRank;
-
+    auto currentRank                  = Boundaries::rank - RemainingRank;
     signed_index_type offsetThreadIdx = (currentRank) ? 0 : threadIdx.x;
     signed_index_type offsetBlockDim  = (currentRank) ? 1 : blockDim.x;
 
@@ -1259,15 +1257,14 @@ struct ParallelForMDTeamVectorRangeCudaImpl {
   template <typename Boundaries, typename Closure>
   KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
       Boundaries const& boundaries, Closure const& closure) {
+    (void)boundaries;
+    (void)closure;
+
+#ifdef __CUDA_ARCH__
     using index_type        = typename Boundaries::index_type;
     using signed_index_type = std::make_signed_t<index_type>;
 
-    (void)boundaries;
-    (void)closure;
-#ifdef __CUDA_ARCH__
-
-    auto currentRank = Boundaries::rank - RemainingRank;
-
+    auto currentRank                   = Boundaries::rank - RemainingRank;
     signed_index_type offsetThreadIdxX = (currentRank) ? 0 : threadIdx.x;
     signed_index_type offsetThreadIdxY = (currentRank) ? 0 : threadIdx.y;
     signed_index_type offsetBlockDimX  = (currentRank) ? 1 : blockDim.x;

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -1115,15 +1115,14 @@ struct ParallelForMDTeamThreadRangeHIPImpl {
   template <typename Boundaries, typename Closure>
   KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
       Boundaries const& boundaries, Closure const& closure) {
-    using index_type        = typename Boundaries::index_type;
-    using signed_index_type = std::make_signed_t<index_type>;
-
     (void)boundaries;
     (void)closure;
 
 #ifdef __HIP_DEVICE_COMPILE__
-    auto currentRank = Boundaries::rank - RemainingRank;
+    using index_type        = typename Boundaries::index_type;
+    using signed_index_type = std::make_signed_t<index_type>;
 
+    auto currentRank                  = Boundaries::rank - RemainingRank;
     signed_index_type offsetThreadIdx = (currentRank) ? 0 : threadIdx.y;
     signed_index_type offsetBlockDim  = (currentRank) ? 1 : blockDim.y;
 
@@ -1188,13 +1187,13 @@ struct ParallelForMDThreadVectorRangeHIPImpl {
   template <typename Boundaries, typename Closure>
   KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
       Boundaries const& boundaries, Closure const& closure) {
-    using index_type        = typename Boundaries::index_type;
-    using signed_index_type = std::make_signed_t<index_type>;
-
     (void)boundaries;
     (void)closure;
 
 #ifdef __HIP_DEVICE_COMPILE__
+    using index_type        = typename Boundaries::index_type;
+    using signed_index_type = std::make_signed_t<index_type>;
+
     auto currentRank = Boundaries::rank - RemainingRank;
 
     signed_index_type offsetThreadIdx = (currentRank) ? 0 : threadIdx.x;
@@ -1271,15 +1270,14 @@ struct ParallelForMDTeamVectorRangeHIPImpl {
   template <typename Boundaries, typename Closure>
   KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
       Boundaries const& boundaries, Closure const& closure) {
-    using index_type        = typename Boundaries::index_type;
-    using signed_index_type = std::make_signed_t<index_type>;
-
     (void)boundaries;
     (void)closure;
 
 #ifdef __HIP_DEVICE_COMPILE__
-    auto currentRank = Boundaries::rank - RemainingRank;
+    using index_type        = typename Boundaries::index_type;
+    using signed_index_type = std::make_signed_t<index_type>;
 
+    auto currentRank                   = Boundaries::rank - RemainingRank;
     signed_index_type offsetThreadIdxX = (currentRank) ? 0 : threadIdx.x;
     signed_index_type offsetThreadIdxY = (currentRank) ? 0 : threadIdx.y;
     signed_index_type offsetBlockDimX  = (currentRank) ? 1 : blockDim.x;

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -773,6 +773,105 @@ struct ThreadVectorRangeBoundariesStruct {
       : start(static_cast<index_type>(arg_begin)), end(arg_end) {}
 };
 
+template <Kokkos::Iterate Direction, size_t Rank, typename iType,
+          typename TeamMemberType>
+struct MDTeamThreadRangeBoundariesStruct {
+  static_assert(2 <= Rank, "Rank must be at least 2");
+  static_assert(Rank <= 8, "Rank must be at most 8");
+  static_assert(Direction == Kokkos::Iterate::Left ||
+                    Direction == Kokkos::Iterate::Right,
+                "Direction must be Left or Right");
+
+  static constexpr Kokkos::Iterate direction = Direction;
+  static constexpr size_t rank               = Rank;
+  using index_type                           = iType;
+  using team_member_type                     = TeamMemberType;
+
+  template <typename... Ns>
+  KOKKOS_INLINE_FUNCTION constexpr explicit MDTeamThreadRangeBoundariesStruct(
+      TeamMemberType const& member, Ns&&... ns)
+      : thread(member), threadDims{static_cast<iType>(ns)...} {
+    static_assert(sizeof...(ns) == Rank, "Number of ns must equal Rank");
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  MDTeamThreadRangeBoundariesStruct(TeamMemberType const& member,
+                                    const iType (&array)[Rank])
+      : thread(member) {
+    std::copy(&array[0], &array[Rank], &threadDims[0]);
+  }
+
+  TeamMemberType const& thread;
+  iType threadDims[Rank];
+};
+
+template <typename T>
+struct IsMDTeamThreadRangeBoundariesStruct : std::false_type {};
+
+template <Kokkos::Iterate Direction, size_t Rank, typename iType,
+          typename TeamMemberType>
+struct IsMDTeamThreadRangeBoundariesStruct<
+    MDTeamThreadRangeBoundariesStruct<Direction, Rank, iType, TeamMemberType>>
+    : std::true_type {};
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename TeamMemberType>
+struct MDThreadVectorRangeBoundariesStruct {
+  static constexpr Kokkos::Iterate outer_direction = OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction = InnerDirection;
+  static constexpr size_t rank                     = Rank;
+  using index_type                                 = iType;
+  using team_member_type                           = TeamMemberType;
+
+  static_assert(2 <= Rank, "Rank must be at least 2");
+  static_assert(Rank <= 8, "Rank must be at most 8");
+  static_assert(OuterDirection == Kokkos::Iterate::Left ||
+                    OuterDirection == Kokkos::Iterate::Right,
+                "OuterDirection must be Left or Right");
+  static_assert(InnerDirection == Kokkos::Iterate::Left ||
+                    InnerDirection == Kokkos::Iterate::Right,
+                "InnerDirection must be Left or Right");
+
+  template <typename... Ns>
+  KOKKOS_INLINE_FUNCTION constexpr explicit MDThreadVectorRangeBoundariesStruct(
+      TeamMemberType const& tm, Ns&&... ns)
+      : team_member(tm), taskDims{static_cast<iType>(ns)...} {
+    static_assert(sizeof...(ns) == Rank, "Number of ns must equal Rank");
+  }
+
+  TeamMemberType const& team_member;
+  iType const taskDims[Rank];
+};
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename TeamMemberType>
+struct MDTeamVectorRangeBoundariesStruct {
+  static constexpr Kokkos::Iterate outer_direction = OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction = InnerDirection;
+  static constexpr size_t rank                     = Rank;
+  using index_type                                 = iType;
+  using team_member_type                           = TeamMemberType;
+
+  static_assert(2 <= Rank, "Rank must be at least 2");
+  static_assert(Rank <= 8, "Rank must be at most 8");
+  static_assert(OuterDirection == Kokkos::Iterate::Left ||
+                    OuterDirection == Kokkos::Iterate::Right,
+                "OuterDirection must be Left or Right");
+  static_assert(InnerDirection == Kokkos::Iterate::Left ||
+                    InnerDirection == Kokkos::Iterate::Right,
+                "InnerDirection must be Left or Right");
+
+  template <typename... Ns>
+  KOKKOS_INLINE_FUNCTION constexpr explicit MDTeamVectorRangeBoundariesStruct(
+      TeamMemberType const& tm, Ns&&... ns)
+      : team_member(tm), taskDims{static_cast<iType>(ns)...} {
+    static_assert(sizeof...(ns) == Rank, "Number of ns must equal Rank");
+  }
+
+  TeamMemberType const& team_member;
+  iType const taskDims[Rank];
+};
+
 template <class TeamMemberType>
 struct ThreadSingleStruct {
   const TeamMemberType& team_member;

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -893,6 +893,92 @@ Impl::VectorSingleStruct<Impl::ThreadsExecTeamMember> PerThread(
     const Impl::ThreadsExecTeamMember& thread) {
   return Impl::VectorSingleStruct<Impl::ThreadsExecTeamMember>(thread);
 }
+
+template <Kokkos::Iterate Direction, typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDTeamThreadRange(
+    Impl::ThreadsExecTeamMember const& member, Ns&&... ns) {
+  using execution_space = typename Impl::ThreadsExecTeamMember::execution_space;
+  using array_layout    = typename execution_space::array_layout;
+  static constexpr Kokkos::Iterate outer_direction =
+      Direction == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : Direction;
+  using iType = std::common_type_t<Ns...>;
+
+  return Impl::MDTeamThreadRangeBoundariesStruct<
+      outer_direction, sizeof...(ns), iType, Impl::ThreadsExecTeamMember>(
+      member, static_cast<Ns&&>(ns)...);
+}
+
+template <typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDTeamThreadRange(
+    Impl::ThreadsExecTeamMember const& member, Ns&&... ns) {
+  return MDTeamThreadRange<Kokkos::Iterate::Default>(member,
+                                                     static_cast<Ns&&>(ns)...);
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDThreadVectorRange(
+    Impl::ThreadsExecTeamMember const& member, Ns&&... ns) {
+  using execution_space = typename Impl::ThreadsExecTeamMember::execution_space;
+  using array_layout    = typename execution_space::array_layout;
+  static constexpr Kokkos::Iterate outer_direction =
+      OuterDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction =
+      InnerDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : InnerDirection;
+  using iType = std::common_type_t<Ns...>;
+
+  return Impl::MDThreadVectorRangeBoundariesStruct<
+      outer_direction, inner_direction, sizeof...(ns), iType,
+      Impl::ThreadsExecTeamMember>(member, static_cast<Ns&&>(ns)...);
+}
+
+template <typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDThreadVectorRange(
+    Impl::ThreadsExecTeamMember const& member, Ns&&... ns) {
+  return MDThreadVectorRange<Kokkos::Iterate::Default,
+                             Kokkos::Iterate::Default>(
+      member, static_cast<Ns&&>(ns)...);
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDTeamVectorRange(
+    Impl::ThreadsExecTeamMember const& member, Ns&&... ns) {
+  using execution_space = typename Impl::ThreadsExecTeamMember::execution_space;
+  using array_layout    = typename execution_space::array_layout;
+  static constexpr Kokkos::Iterate outer_direction =
+      OuterDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction =
+      InnerDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : InnerDirection;
+  using iType = std::common_type_t<Ns...>;
+
+  return Impl::MDTeamVectorRangeBoundariesStruct<
+      outer_direction, inner_direction, sizeof...(ns), iType,
+      Impl::ThreadsExecTeamMember>(member, static_cast<Ns&&>(ns)...);
+}
+
+template <typename... Ns>
+KOKKOS_INLINE_FUNCTION auto MDTeamVectorRange(
+    Impl::ThreadsExecTeamMember const& member, Ns&&... ns) {
+  return MDTeamVectorRange<Kokkos::Iterate::Default, Kokkos::Iterate::Default>(
+      member, static_cast<Ns&&>(ns)...);
+}
+
 }  // namespace Kokkos
 
 namespace Kokkos {
@@ -1095,6 +1181,136 @@ KOKKOS_INLINE_FUNCTION
        i += loop_boundaries.increment) {
     lambda(i, scan_val, true);
   }
+}
+
+template <Kokkos::Iterate direction, size_t Rank, typename iType,
+          typename Closure>
+KOKKOS_INLINE_FUNCTION auto parallel_for(
+    Impl::MDTeamThreadRangeBoundariesStruct<direction, Rank, iType,
+                                            Impl::ThreadsExecTeamMember> const&
+        loop_boundaries,
+    Closure const& closure) {
+  ParallelForMDTeamThreadRangeHostImpl<Rank>::parallel_for_impl(loop_boundaries,
+                                                                closure);
+}
+
+template <Kokkos::Iterate outer_direction, Kokkos::Iterate inner_direction,
+          size_t Rank, typename iType, typename Closure>
+KOKKOS_INLINE_FUNCTION auto parallel_for(
+    Impl::MDThreadVectorRangeBoundariesStruct<
+        outer_direction, inner_direction, Rank, iType,
+        Impl::ThreadsExecTeamMember> const& boundaries,
+    Closure const& closure) {
+  static_assert(outer_direction == Kokkos::Iterate::Left ||
+                    outer_direction == Kokkos::Iterate::Right,
+                "outer_direction must be Left or Right");
+  static_assert(inner_direction == Kokkos::Iterate::Left ||
+                    inner_direction == Kokkos::Iterate::Right,
+                "inner_direction must be Left or Right");
+
+  ParallelForMDThreadVectorRangeHostImpl<outer_direction,
+                                         Rank>::parallel_for_impl(boundaries,
+                                                                  closure);
+}
+
+template <Kokkos::Iterate outer_direction, Kokkos::Iterate inner_direction,
+          size_t Rank, typename iType, typename Closure>
+KOKKOS_INLINE_FUNCTION auto parallel_for(
+    Impl::MDTeamVectorRangeBoundariesStruct<
+        outer_direction, inner_direction, Rank, iType,
+        Impl::ThreadsExecTeamMember> const& boundaries,
+    Closure const& closure) {
+  static_assert(outer_direction == Kokkos::Iterate::Left ||
+                    outer_direction == Kokkos::Iterate::Right,
+                "outer_direction must be Left or Right");
+  static_assert(inner_direction == Kokkos::Iterate::Left ||
+                    inner_direction == Kokkos::Iterate::Right,
+                "inner_direction must be Left or Right");
+
+  ParallelForMDTeamVectorRangeHostImpl<outer_direction,
+                                       Rank>::parallel_for_impl(boundaries,
+                                                                closure);
+}
+
+template <Kokkos::Iterate Direction, size_t Rank, typename iType,
+          typename Closure, typename Reducer>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<Reducer>::value>
+parallel_reduce(
+    Impl::MDTeamThreadRangeBoundariesStruct<
+        Direction, Rank, iType, Impl::ThreadsExecTeamMember> const& boundaries,
+    Closure const& closure, Reducer const& reducer) {
+  typename Reducer::value_type value;
+  reducer.init(value);
+
+  parallel_for(boundaries, [&](auto... is) { closure(is..., value); });
+
+  boundaries.thread.team_reduce(reducer, value);
+}
+
+template <Kokkos::Iterate Direction, size_t Rank, typename iType,
+          typename Closure, typename ValueType>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
+parallel_reduce(
+    Impl::MDTeamThreadRangeBoundariesStruct<
+        Direction, Rank, iType, Impl::ThreadsExecTeamMember> const& boundaries,
+    Closure const& closure, ValueType& result) {
+  Sum<ValueType> reducer(result);
+  reducer.init(result);
+
+  parallel_reduce(boundaries, closure, reducer);
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Closure, typename Reducer>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<Reducer>::value>
+parallel_reduce(Impl::MDThreadVectorRangeBoundariesStruct<
+                    OuterDirection, InnerDirection, Rank, iType,
+                    Impl::ThreadsExecTeamMember> const& boundaries,
+                Closure const& closure, Reducer const& reducer) {
+  typename Reducer::value_type value;
+  reducer.init(value);
+
+  parallel_for(boundaries, [&](auto... is) { closure(is..., value); });
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Closure, typename ValueType>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
+parallel_reduce(Impl::MDThreadVectorRangeBoundariesStruct<
+                    OuterDirection, InnerDirection, Rank, iType,
+                    Impl::ThreadsExecTeamMember> const& boundaries,
+                Closure const& closure, ValueType& result) {
+  result = ValueType();
+
+  parallel_for(boundaries, [&](auto... is) { closure(is..., result); });
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Closure, typename Reducer>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<Reducer>::value>
+parallel_reduce(Impl::MDTeamVectorRangeBoundariesStruct<
+                    OuterDirection, InnerDirection, Rank, iType,
+                    Impl::ThreadsExecTeamMember> const& boundaries,
+                Closure const& closure, Reducer const& reducer) {
+  typename Reducer::value_type value;
+  reducer.init(value);
+
+  parallel_for(boundaries, [&](auto... is) { closure(is..., value); });
+
+  boundaries.team_member.team_reduce(reducer, value);
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Closure, typename ValueType>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
+parallel_reduce(Impl::MDTeamVectorRangeBoundariesStruct<
+                    OuterDirection, InnerDirection, Rank, iType,
+                    Impl::ThreadsExecTeamMember> const& boundaries,
+                Closure const& closure, ValueType& result) {
+  Sum<ValueType> reducer(result);
+  reducer.init(result);
+
+  parallel_reduce(boundaries, closure, reducer);
 }
 
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -880,36 +880,6 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
   }
 }
 
-template <Kokkos::Iterate direction, typename iType, typename TeamMemberType,
-          typename Closure>
-KOKKOS_INLINE_FUNCTION void operator_impl(
-    Impl::MDTeamThreadRangeBoundariesStruct<
-        direction, 2, iType, TeamMemberType> const& loop_boundaries,
-    Closure const& closure,
-    typename std::enable_if<
-        Impl::is_host_thread_team_member<TeamMemberType>::value>::type const** =
-        nullptr) {
-  if (direction == Kokkos::Iterate::Right) {
-    for (iType i = 0; i < loop_boundaries.threadDims[0]; ++i) {
-      for (iType j = 0; j < loop_boundaries.threadDims[1]; ++j) {
-        closure(i, j);
-      }
-    }
-  } else if (direction == Kokkos::Iterate::Left) {
-    for (iType i = loop_boundaries.threadDims[0]; i > 0;) {
-      --i;
-      auto l = [&](auto&& j) { closure(i, j); };
-      for (iType j = 0; j < loop_boundaries.threadDims[1]; ++j) {
-        closure(i, j);
-      }
-    }
-  } else {
-    Kokkos::abort(
-        "direction must be either Kokkos::Iterate::Left or "
-        "Kokkos::Iterator::Right");
-  }
-}
-
 template <size_t RemainingRank>
 struct ParallelForMDTeamThreadRangeHostImpl {
  private:

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -491,18 +491,10 @@ class HostThreadTeamMember {
   //--------------------------------------------------------------------------
 
   template <typename T>
-<<<<<<< HEAD
   KOKKOS_INLINE_FUNCTION void team_broadcast(T& value,
                                              const int source_team_rank) const
       noexcept {
     KOKKOS_IF_ON_HOST((if (1 < m_data.m_team_size) {
-=======
-  KOKKOS_INLINE_FUNCTION void team_broadcast(
-      T& value, const int source_team_rank) const noexcept
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-  {
-    if (1 < m_data.m_team_size) {
->>>>>>> MD Team Policies Impl
       T volatile* const shared_value = (T*)m_data.team_reduce();
 
       // Don't overwrite shared memory until all threads arrive
@@ -529,19 +521,11 @@ class HostThreadTeamMember {
   //--------------------------------------------------------------------------
 
   template <class Closure, typename T>
-<<<<<<< HEAD
   KOKKOS_INLINE_FUNCTION void team_broadcast(Closure const& f, T& value,
                                              const int source_team_rank) const
       noexcept {
     KOKKOS_IF_ON_HOST((
         T volatile* const shared_value = (T*)m_data.team_reduce();
-=======
-  KOKKOS_INLINE_FUNCTION void team_broadcast(
-      Closure const& f, T& value, const int source_team_rank) const noexcept
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-  {
-    T volatile* const shared_value = (T*)m_data.team_reduce();
->>>>>>> MD Team Policies Impl
 
         // Don't overwrite shared memory until all threads arrive
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -128,6 +128,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
         QuadPrecisionMath
         ExecSpacePartitioning
         MathematicalSpecialFunctions
+        MDTeamParallelism
         )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -74,7 +74,7 @@ struct FillFlattenedIndex {
 struct FillConstant {
   explicit FillConstant(int initValue_) : initValue(initValue_) {}
 
-  int operator()(int n0, int n1, int n2) const { return initValue; }
+  int operator()(int, int, int) const { return initValue; }
 
   int initValue;
 };
@@ -87,9 +87,9 @@ struct TestMDTeamParallelFor {
   template <typename HostViewType, typename FillFunctor>
   static void check_result_3D(HostViewType h_view,
                               FillFunctor const& fillFunctor) {
-    for (int i = 0; i < h_view.extent(0); ++i) {
-      for (int j = 0; j < h_view.extent(1); ++j) {
-        for (int k = 0; k < h_view.extent(2); ++k) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
           EXPECT_EQ(h_view(i, j, k), fillFunctor(i, j, k));
         }
       }
@@ -130,10 +130,10 @@ struct TestMDTeamParallelFor {
 
   template <typename HostViewType, typename FillFunctor>
   static void check_result_4D(HostViewType h_view, FillFunctor& fillFunctor) {
-    for (int i = 0; i < h_view.extent(0); ++i) {
-      for (int j = 0; j < h_view.extent(1); ++j) {
-        for (int k = 0; k < h_view.extent(2); ++k) {
-          for (int l = 0; l < h_view.extent(3); ++l) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          for (size_t l = 0; l < h_view.extent(3); ++l) {
             EXPECT_EQ(h_view(i, j, k, l), fillFunctor(i, j, k, l));
           }
         }
@@ -177,11 +177,11 @@ struct TestMDTeamParallelFor {
 
   template <typename HostViewType, typename FillFunctor>
   static void check_result_5D(HostViewType h_view, FillFunctor& fillFunctor) {
-    for (int i = 0; i < h_view.extent(0); ++i) {
-      for (int j = 0; j < h_view.extent(1); ++j) {
-        for (int k = 0; k < h_view.extent(2); ++k) {
-          for (int l = 0; l < h_view.extent(3); ++l) {
-            for (int m = 0; m < h_view.extent(4); ++m) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          for (size_t l = 0; l < h_view.extent(3); ++l) {
+            for (size_t m = 0; m < h_view.extent(4); ++m) {
               EXPECT_EQ(h_view(i, j, k, l, m), fillFunctor(i, j, k, l, m));
             }
           }
@@ -228,12 +228,12 @@ struct TestMDTeamParallelFor {
 
   template <typename HostViewType, typename FillFunctor>
   static void check_result_6D(HostViewType h_view, FillFunctor& fillFunctor) {
-    for (int i = 0; i < h_view.extent(0); ++i) {
-      for (int j = 0; j < h_view.extent(1); ++j) {
-        for (int k = 0; k < h_view.extent(2); ++k) {
-          for (int l = 0; l < h_view.extent(3); ++l) {
-            for (int m = 0; m < h_view.extent(4); ++m) {
-              for (int n = 0; n < h_view.extent(5); ++n) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          for (size_t l = 0; l < h_view.extent(3); ++l) {
+            for (size_t m = 0; m < h_view.extent(4); ++m) {
+              for (size_t n = 0; n < h_view.extent(5); ++n) {
                 EXPECT_EQ(h_view(i, j, k, l, m, n),
                           fillFunctor(i, j, k, l, m, n));
               }
@@ -284,13 +284,13 @@ struct TestMDTeamParallelFor {
 
   template <typename HostViewType, typename FillFunctor>
   static void check_result_7D(HostViewType h_view, FillFunctor& fillFunctor) {
-    for (int i = 0; i < h_view.extent(0); ++i) {
-      for (int j = 0; j < h_view.extent(1); ++j) {
-        for (int k = 0; k < h_view.extent(2); ++k) {
-          for (int l = 0; l < h_view.extent(3); ++l) {
-            for (int m = 0; m < h_view.extent(4); ++m) {
-              for (int n = 0; n < h_view.extent(5); ++n) {
-                for (int o = 0; o < h_view.extent(6); ++o) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          for (size_t l = 0; l < h_view.extent(3); ++l) {
+            for (size_t m = 0; m < h_view.extent(4); ++m) {
+              for (size_t n = 0; n < h_view.extent(5); ++n) {
+                for (size_t o = 0; o < h_view.extent(6); ++o) {
                   EXPECT_EQ(h_view(i, j, k, l, m, n, o),
                             fillFunctor(i, j, k, l, m, n, o));
                 }
@@ -343,14 +343,14 @@ struct TestMDTeamParallelFor {
 
   template <typename HostViewType, typename FillFunctor>
   static void check_result_8D(HostViewType h_view, FillFunctor& fillFunctor) {
-    for (int i = 0; i < h_view.extent(0); ++i) {
-      for (int j = 0; j < h_view.extent(1); ++j) {
-        for (int k = 0; k < h_view.extent(2); ++k) {
-          for (int l = 0; l < h_view.extent(3); ++l) {
-            for (int m = 0; m < h_view.extent(4); ++m) {
-              for (int n = 0; n < h_view.extent(5); ++n) {
-                for (int o = 0; o < h_view.extent(6); ++o) {
-                  for (int p = 0; p < h_view.extent(7); ++p) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          for (size_t l = 0; l < h_view.extent(3); ++l) {
+            for (size_t m = 0; m < h_view.extent(4); ++m) {
+              for (size_t n = 0; n < h_view.extent(5); ++n) {
+                for (size_t o = 0; o < h_view.extent(6); ++o) {
+                  for (size_t p = 0; p < h_view.extent(7); ++p) {
                     EXPECT_EQ(h_view(i, j, k, l, m, n, o, p),
                               fillFunctor(i, j, k, l, m, n, o, p));
                   }
@@ -859,7 +859,6 @@ struct TestMDTeamParallelReduce {
   static void test_parallel_reduce_for_3D_MDTeamThreadRange(
       int* dims, const int initValue) {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -907,7 +906,6 @@ struct TestMDTeamParallelReduce {
   static void test_parallel_reduce_for_4D_MDTeamThreadRange(
       int* dims, const int initValue) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -957,7 +955,6 @@ struct TestMDTeamParallelReduce {
   static void test_parallel_reduce_for_5D_MDTeamThreadRange(
       int* dims, const int initValue) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1008,7 +1005,6 @@ struct TestMDTeamParallelReduce {
   static void test_parallel_reduce_for_6D_MDTeamThreadRange(
       int* dims, const int initValue) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1063,7 +1059,6 @@ struct TestMDTeamParallelReduce {
   static void test_parallel_reduce_for_4D_MDThreadVectorRange(
       int* dims, const int initValue) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1123,7 +1118,6 @@ struct TestMDTeamParallelReduce {
   static void test_parallel_reduce_for_5D_MDThreadVectorRange(
       int* dims, const int initValue) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1185,7 +1179,6 @@ struct TestMDTeamParallelReduce {
   static void test_parallel_reduce_for_6D_MDThreadVectorRange(
       int* dims, const int initValue) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1249,7 +1242,6 @@ struct TestMDTeamParallelReduce {
   static void test_parallel_reduce_for_4D_MDTeamVectorRange(
       int* dims, const int initValue) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1304,7 +1296,6 @@ struct TestMDTeamParallelReduce {
   static void test_parallel_reduce_for_5D_MDTeamVectorRange(
       int* dims, const int initValue) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1360,7 +1351,6 @@ struct TestMDTeamParallelReduce {
   static void test_parallel_reduce_for_6D_MDTeamVectorRange(
       int* dims, const int initValue) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
-    using HostViewType = typename ViewType::HostMirror;
 
     int leagueSize = dims[0];
     int n0         = dims[1];

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -1,0 +1,1682 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+
+namespace MDTeamParallelism {
+
+struct FillFlattenedIndex {
+  explicit FillFlattenedIndex(int n0, int n1, int n2, int n3 = 1, int n4 = 1,
+                              int n5 = 1, int n6 = 1, int n7 = 1)
+      : initValue{n0, n1, n2, n3, n4, n5, n6, n7} {}
+
+  KOKKOS_INLINE_FUNCTION
+  int operator()(int n0, int n1, int n2, int n3 = 0, int n4 = 0, int n5 = 0,
+                 int n6 = 0, int n7 = 0) const {
+    return ((((((n7 * initValue[7] + n6) * initValue[6] + n5) * initValue[5] +
+               n4) *
+                  initValue[4] +
+              n3) *
+                 initValue[3] +
+             n2) *
+                initValue[2] +
+            n1) *
+               initValue[1] +
+           n0;
+  }
+
+  int initValue[8];
+};
+
+struct FillConstant {
+  explicit FillConstant(int initValue_) : initValue(initValue_) {}
+
+  int operator()(int n0, int n1, int n2) const { return initValue; }
+
+  int initValue;
+};
+
+template <typename ExecSpace>
+struct TestMDTeamParallelFor {
+  using DataType = int;
+  using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_3D(HostViewType h_view,
+                              FillFunctor const& fillFunctor) {
+    for (int i = 0; i < h_view.extent(0); ++i) {
+      for (int j = 0; j < h_view.extent(1); ++j) {
+        for (int k = 0; k < h_view.extent(2); ++k) {
+          EXPECT_EQ(h_view(i, j, k), fillFunctor(i, j, k));
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_3D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+
+    ViewType v("v", leagueSize, n0, n1);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange = Kokkos::MDTeamThreadRange<Direction>(team, n0, n1);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j) {
+            v(leagueRank, i, j) += fillFlattenedIndex(leagueRank, i, j);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_3D(h_view, fillFlattenedIndex);
+  }
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_4D(HostViewType h_view, FillFunctor& fillFunctor) {
+    for (int i = 0; i < h_view.extent(0); ++i) {
+      for (int j = 0; j < h_view.extent(1); ++j) {
+        for (int k = 0; k < h_view.extent(2); ++k) {
+          for (int l = 0; l < h_view.extent(3); ++l) {
+            EXPECT_EQ(h_view(i, j, k, l), fillFunctor(i, j, k, l));
+          }
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_4D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
+            v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_4D(h_view, fillFlattenedIndex);
+  }
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_5D(HostViewType h_view, FillFunctor& fillFunctor) {
+    for (int i = 0; i < h_view.extent(0); ++i) {
+      for (int j = 0; j < h_view.extent(1); ++j) {
+        for (int k = 0; k < h_view.extent(2); ++k) {
+          for (int l = 0; l < h_view.extent(3); ++l) {
+            for (int m = 0; m < h_view.extent(4); ++m) {
+              EXPECT_EQ(h_view(i, j, k, l, m), fillFunctor(i, j, k, l, m));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_5D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2, n3);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j, int k, int l) {
+            v(leagueRank, i, j, k, l) +=
+                fillFlattenedIndex(leagueRank, i, j, k, l);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_5D(h_view, fillFlattenedIndex);
+  }
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_6D(HostViewType h_view, FillFunctor& fillFunctor) {
+    for (int i = 0; i < h_view.extent(0); ++i) {
+      for (int j = 0; j < h_view.extent(1); ++j) {
+        for (int k = 0; k < h_view.extent(2); ++k) {
+          for (int l = 0; l < h_view.extent(3); ++l) {
+            for (int m = 0; m < h_view.extent(4); ++m) {
+              for (int n = 0; n < h_view.extent(5); ++n) {
+                EXPECT_EQ(h_view(i, j, k, l, m, n),
+                          fillFunctor(i, j, k, l, m, n));
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_6D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2, n3, n4);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m) {
+                v(leagueRank, i, j, k, l, m) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_6D(h_view, fillFlattenedIndex);
+  }
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_7D(HostViewType h_view, FillFunctor& fillFunctor) {
+    for (int i = 0; i < h_view.extent(0); ++i) {
+      for (int j = 0; j < h_view.extent(1); ++j) {
+        for (int k = 0; k < h_view.extent(2); ++k) {
+          for (int l = 0; l < h_view.extent(3); ++l) {
+            for (int m = 0; m < h_view.extent(4); ++m) {
+              for (int n = 0; n < h_view.extent(5); ++n) {
+                for (int o = 0; o < h_view.extent(6); ++o) {
+                  EXPECT_EQ(h_view(i, j, k, l, m, n, o),
+                            fillFunctor(i, j, k, l, m, n, o));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_7D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange = Kokkos::MDTeamThreadRange<Direction>(team, n0, n1,
+                                                                n2, n3, n4, n5);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m, int n) {
+                v(leagueRank, i, j, k, l, m, n) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_7D(h_view, fillFlattenedIndex);
+  }
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_8D(HostViewType h_view, FillFunctor& fillFunctor) {
+    for (int i = 0; i < h_view.extent(0); ++i) {
+      for (int j = 0; j < h_view.extent(1); ++j) {
+        for (int k = 0; k < h_view.extent(2); ++k) {
+          for (int l = 0; l < h_view.extent(3); ++l) {
+            for (int m = 0; m < h_view.extent(4); ++m) {
+              for (int n = 0; n < h_view.extent(5); ++n) {
+                for (int o = 0; o < h_view.extent(6); ++o) {
+                  for (int p = 0; p < h_view.extent(7); ++p) {
+                    EXPECT_EQ(h_view(i, j, k, l, m, n, o, p),
+                              fillFunctor(i, j, k, l, m, n, o, p));
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_8D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+    int n6         = dims[7];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
+                                          n6);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange = Kokkos::MDTeamThreadRange<Direction>(
+              team, n0, n1, n2, n3, n4, n5, n6);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m, int n, int o) {
+                v(leagueRank, i, j, k, l, m, n, o) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_8D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_4D_MDThreadVectorRange(int* dims,
+                                                       const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto teamRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2);
+
+          Kokkos::parallel_for(teamThreadRange, [=](int i) {
+            Kokkos::parallel_for(teamRange, [=](int j, int k) {
+              v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
+            });
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_4D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_5D_MDThreadVectorRange(int* dims,
+                                                       const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto teamRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3);
+
+          Kokkos::parallel_for(teamThreadRange, [=](int i) {
+            Kokkos::parallel_for(teamRange, [=](int j, int k, int l) {
+              v(leagueRank, i, j, k, l) +=
+                  fillFlattenedIndex(leagueRank, i, j, k, l);
+            });
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_5D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_6D_MDThreadVectorRange(int* dims,
+                                                       const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto teamRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3, n4);
+
+          Kokkos::parallel_for(teamThreadRange, [=](int i) {
+            Kokkos::parallel_for(teamRange, [=](int j, int k, int l, int m) {
+              v(leagueRank, i, j, k, l, m) +=
+                  fillFlattenedIndex(leagueRank, i, j, k, l, m);
+            });
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_6D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_7D_MDThreadVectorRange(int* dims,
+                                                       const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto teamRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3, n4, n5);
+
+          Kokkos::parallel_for(teamThreadRange, [=](int i) {
+            Kokkos::parallel_for(
+                teamRange, [=](int j, int k, int l, int m, int n) {
+                  v(leagueRank, i, j, k, l, m, n) +=
+                      fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
+                });
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_7D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_8D_MDThreadVectorRange(int* dims,
+                                                       const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+    int n6         = dims[7];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
+                                          n6);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto teamRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3, n4, n5, n6);
+
+          Kokkos::parallel_for(teamThreadRange, [=](int i) {
+            Kokkos::parallel_for(
+                teamRange, [=](int j, int k, int l, int m, int n, int o) {
+                  v(leagueRank, i, j, k, l, m, n, o) +=
+                      fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+                });
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_8D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_3D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+
+    ViewType v("v", leagueSize, n0, n1);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(team,
+                                                                        n0, n1);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j) {
+            v(leagueRank, i, j) += fillFlattenedIndex(leagueRank, i, j);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_3D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_4D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
+            v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_4D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_5D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j, int k, int l) {
+            v(leagueRank, i, j, k, l) +=
+                fillFlattenedIndex(leagueRank, i, j, k, l);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_5D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_6D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3, n4);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m) {
+                v(leagueRank, i, j, k, l, m) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_6D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_7D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3, n4, n5);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m, int n) {
+                v(leagueRank, i, j, k, l, m, n) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_7D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_8D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+    int n6         = dims[7];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
+                                          n6);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3, n4, n5, n6);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m, int n, int o) {
+                v(leagueRank, i, j, k, l, m, n, o) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_8D(h_view, fillFlattenedIndex);
+  }
+};
+
+template <typename ExecSpace>
+struct TestMDTeamParallelReduce {
+  using DataType = int;
+  using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_3D_MDTeamThreadRange(
+      int* dims, const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+
+    ViewType v("v", leagueSize, n0, n1);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {leagueSize, n0, n1}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k) {
+          v(i, j, k) = fillFlattenedIndex(i, j, k);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          Kokkos::parallel_reduce(
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1),
+              [=](const int& i, const int& j, int& threadSum) {
+                threadSum += v(leagueRank, i, j);
+              },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 - 1);
+    int numValues   = (leagueSize * n0 * n1);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_4D_MDTeamThreadRange(
+      int* dims, const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<Kokkos::Rank<4>>({0, 0, 0, 0},
+                                               {leagueSize, n0, n1, n2}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
+          v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          Kokkos::parallel_reduce(
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2),
+              [=](const int& i, const int& j, const int& k, int& threadSum) {
+                threadSum += v(leagueRank, i, j, k);
+              },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_5D_MDTeamThreadRange(
+      int* dims, const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<Kokkos::Rank<5>>({0, 0, 0, 0, 0},
+                                               {leagueSize, n0, n1, n2, n3}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m) {
+          v(i, j, k, l, m) = fillFlattenedIndex(i, j, k, l, m);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          Kokkos::parallel_reduce(
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2, n3),
+              [=](const int& i, const int& j, const int& k, const int& l,
+                  int& threadSum) { threadSum += v(leagueRank, i, j, k, l); },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_6D_MDTeamThreadRange(
+      int* dims, const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<Kokkos::Rank<6>>(
+            {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m, const int n) {
+          v(i, j, k, l, m, n) = fillFlattenedIndex(i, j, k, l, m, n);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          Kokkos::parallel_reduce(
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2, n3, n4),
+              [=](const int& i, const int& j, const int& k, const int& l,
+                  const int& m, int& threadSum) {
+                threadSum += v(leagueRank, i, j, k, l, m);
+              },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 * n4 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3 * n4);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_4D_MDThreadVectorRange(
+      int* dims, const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<Kokkos::Rank<4>>({0, 0, 0, 0},
+                                               {leagueSize, n0, n1, n2}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
+          v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto threadVectorRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2);
+
+          Kokkos::parallel_for(teamThreadRange, [=, &teamSum](const int& i) {
+            int threadSum = 0;
+            Kokkos::parallel_reduce(
+                threadVectorRange,
+                [=](const int& j, const int& k, int& vectorSum) {
+                  vectorSum += v(leagueRank, i, j, k);
+                },
+                threadSum);
+
+            teamSum += threadSum;
+          });
+
+          leagueSum += teamSum;
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_5D_MDThreadVectorRange(
+      int* dims, const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<Kokkos::Rank<5>>({0, 0, 0, 0, 0},
+                                               {leagueSize, n0, n1, n2, n3}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m) {
+          v(i, j, k, l, m) = fillFlattenedIndex(i, j, k, l, m);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto threadVectorRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3);
+
+          Kokkos::parallel_for(teamThreadRange, [=, &teamSum](const int& i) {
+            int threadSum = 0;
+            Kokkos::parallel_reduce(
+                threadVectorRange,
+                [=](const int& j, const int& k, const int& l, int& vectorSum) {
+                  vectorSum += v(leagueRank, i, j, k, l);
+                },
+                threadSum);
+
+            teamSum += threadSum;
+          });
+
+          leagueSum += teamSum;
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_6D_MDThreadVectorRange(
+      int* dims, const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<Kokkos::Rank<6>>(
+            {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m, const int n) {
+          v(i, j, k, l, m, n) = fillFlattenedIndex(i, j, k, l, m, n);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto threadVectorRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3, n4);
+
+          Kokkos::parallel_for(teamThreadRange, [=, &teamSum](const int& i) {
+            int threadSum = 0;
+            Kokkos::parallel_reduce(
+                threadVectorRange,
+                [=](const int& j, const int& k, const int& l, const int& m,
+                    int& vectorSum) {
+                  vectorSum += v(leagueRank, i, j, k, l, m);
+                },
+                threadSum);
+
+            teamSum += threadSum;
+          });
+
+          leagueSum += teamSum;
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 * n4 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3 * n4);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_4D_MDTeamVectorRange(
+      int* dims, const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<Kokkos::Rank<4>>({0, 0, 0, 0},
+                                               {leagueSize, n0, n1, n2}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
+          v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamVectorRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2);
+
+          Kokkos::parallel_reduce(
+              teamVectorRange,
+              [=](const int& i, const int& j, const int& k, int& vectorSum) {
+                vectorSum += v(leagueRank, i, j, k);
+              },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_5D_MDTeamVectorRange(
+      int* dims, const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<Kokkos::Rank<5>>({0, 0, 0, 0, 0},
+                                               {leagueSize, n0, n1, n2, n3}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m) {
+          v(i, j, k, l, m) = fillFlattenedIndex(i, j, k, l, m);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamVectorRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3);
+
+          Kokkos::parallel_reduce(
+              teamVectorRange,
+              [=](const int& i, const int& j, const int& k, const int& l,
+                  int& vectorSum) { vectorSum += v(leagueRank, i, j, k, l); },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_6D_MDTeamVectorRange(
+      int* dims, const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<Kokkos::Rank<6>>(
+            {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m, const int n) {
+          v(i, j, k, l, m, n) = fillFlattenedIndex(i, j, k, l, m, n);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamVectorRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3, n4);
+
+          Kokkos::parallel_reduce(
+              teamVectorRange,
+              [=](const int& i, const int& j, const int& k, const int& l,
+                  const int& m, int& vectorSum) {
+                vectorSum += v(leagueRank, i, j, k, l, m);
+              },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 * n4 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3 * n4);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+};
+
+}  // namespace MDTeamParallelism
+
+}  // namespace Test
+
+/*--------------------------------------------------------------------------*/
+
+namespace Test {
+
+constexpr auto Left  = Kokkos::Iterate::Left;
+constexpr auto Right = Kokkos::Iterate::Right;
+
+TEST(TEST_CATEGORY, MDTeamParallelFor) {
+  using namespace MDTeamParallelism;
+  // int dims[] = {16, 16, 16, 16, 16, 16, 16, 16};
+  int dims[]          = {4, 4, 4, 4, 4, 4, 4, 4};
+  const int initValue = 5;
+
+  {
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamThreadRange<Right>(dims, initValue);
+  }
+
+  {
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDThreadVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDThreadVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDThreadVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDThreadVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDThreadVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDThreadVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDThreadVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDThreadVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDThreadVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDThreadVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDThreadVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDThreadVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDThreadVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDThreadVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDThreadVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDThreadVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDThreadVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDThreadVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDThreadVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDThreadVectorRange<Right, Right>(dims, initValue);
+  }
+
+  {
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamVectorRange<Right, Right>(dims, initValue);
+  }
+}
+
+TEST(TEST_CATEGORY, MDTeamParallelReduce) {
+  using namespace MDTeamParallelism;
+  // int dims[] = {16, 16, 16, 16, 16, 16, 16, 16};
+  int dims[]          = {4, 4, 4, 4, 4, 4, 4, 4};
+  const int initValue = 5;
+
+  {
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_3D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_3D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamThreadRange<Right>(dims, initValue);
+  }
+
+  {
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Left, Left>(dims,
+                                                                    initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Left, Right>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Right, Left>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Right, Right>(
+            dims, initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Left, Left>(dims,
+                                                                    initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Left, Right>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Right, Left>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Right, Right>(
+            dims, initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Left, Left>(dims,
+                                                                    initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Left, Right>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Right, Left>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Right, Right>(
+            dims, initValue);
+  }
+
+  {
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Left, Left>(dims,
+                                                                  initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Left, Right>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Right, Left>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Right, Right>(dims,
+                                                                    initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Left, Left>(dims,
+                                                                  initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Left, Right>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Right, Left>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Right, Right>(dims,
+                                                                    initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Left, Left>(dims,
+                                                                  initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Left, Right>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Right, Left>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Right, Right>(dims,
+                                                                    initValue);
+  }
+}
+
+}  // namespace Test

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -869,7 +869,8 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {leagueSize, n0, n1}),
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>>({0, 0, 0},
+                                                          {leagueSize, n0, n1}),
         KOKKOS_LAMBDA(const int i, const int j, const int k) {
           v(i, j, k) = fillFlattenedIndex(i, j, k);
         });
@@ -917,8 +918,8 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<Kokkos::Rank<4>>({0, 0, 0, 0},
-                                               {leagueSize, n0, n1, n2}),
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
+            {0, 0, 0, 0}, {leagueSize, n0, n1, n2}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
           v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
         });
@@ -967,8 +968,8 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<Kokkos::Rank<5>>({0, 0, 0, 0, 0},
-                                               {leagueSize, n0, n1, n2, n3}),
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>>(
+            {0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
                       const int m) {
           v(i, j, k, l, m) = fillFlattenedIndex(i, j, k, l, m);
@@ -1018,7 +1019,7 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<Kokkos::Rank<6>>(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
             {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
                       const int m, const int n) {
@@ -1070,8 +1071,8 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<Kokkos::Rank<4>>({0, 0, 0, 0},
-                                               {leagueSize, n0, n1, n2}),
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
+            {0, 0, 0, 0}, {leagueSize, n0, n1, n2}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
           v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
         });
@@ -1130,8 +1131,8 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<Kokkos::Rank<5>>({0, 0, 0, 0, 0},
-                                               {leagueSize, n0, n1, n2, n3}),
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>>(
+            {0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
                       const int m) {
           v(i, j, k, l, m) = fillFlattenedIndex(i, j, k, l, m);
@@ -1192,7 +1193,7 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<Kokkos::Rank<6>>(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
             {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
                       const int m, const int n) {
@@ -1253,8 +1254,8 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<Kokkos::Rank<4>>({0, 0, 0, 0},
-                                               {leagueSize, n0, n1, n2}),
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
+            {0, 0, 0, 0}, {leagueSize, n0, n1, n2}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
           v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
         });
@@ -1308,8 +1309,8 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<Kokkos::Rank<5>>({0, 0, 0, 0, 0},
-                                               {leagueSize, n0, n1, n2, n3}),
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>>(
+            {0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
                       const int m) {
           v(i, j, k, l, m) = fillFlattenedIndex(i, j, k, l, m);
@@ -1364,7 +1365,7 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<Kokkos::Rank<6>>(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
             {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
                       const int m, const int n) {

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -858,7 +858,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_3D_MDTeamThreadRange(
       int* dims, const int initValue) {
-    using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
+    using ViewType = typename Kokkos::View<DataType***, ExecSpace>;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -905,7 +905,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_4D_MDTeamThreadRange(
       int* dims, const int initValue) {
-    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -954,7 +954,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_5D_MDTeamThreadRange(
       int* dims, const int initValue) {
-    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1004,7 +1004,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_6D_MDTeamThreadRange(
       int* dims, const int initValue) {
-    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1058,7 +1058,7 @@ struct TestMDTeamParallelReduce {
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_4D_MDThreadVectorRange(
       int* dims, const int initValue) {
-    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1117,7 +1117,7 @@ struct TestMDTeamParallelReduce {
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_5D_MDThreadVectorRange(
       int* dims, const int initValue) {
-    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1178,7 +1178,7 @@ struct TestMDTeamParallelReduce {
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_6D_MDThreadVectorRange(
       int* dims, const int initValue) {
-    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1241,7 +1241,7 @@ struct TestMDTeamParallelReduce {
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_4D_MDTeamVectorRange(
       int* dims, const int initValue) {
-    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1295,7 +1295,7 @@ struct TestMDTeamParallelReduce {
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_5D_MDTeamVectorRange(
       int* dims, const int initValue) {
-    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1350,7 +1350,7 @@ struct TestMDTeamParallelReduce {
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_6D_MDTeamVectorRange(
       int* dims, const int initValue) {
-    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
     int leagueSize = dims[0];
     int n0         = dims[1];
@@ -1419,7 +1419,8 @@ constexpr auto Right = Kokkos::Iterate::Right;
 TEST(TEST_CATEGORY, MDTeamParallelFor) {
   using namespace MDTeamParallelism;
   // int dims[] = {16, 16, 16, 16, 16, 16, 16, 16};
-  int dims[]          = {4, 4, 4, 4, 4, 4, 4, 4};
+  int dims[] = {4, 4, 4, 4, 4, 4, 4, 4};
+
   const int initValue = 5;
 
   {
@@ -1556,7 +1557,7 @@ TEST(TEST_CATEGORY, MDTeamParallelFor) {
     TestMDTeamParallelFor<TEST_EXECSPACE>::
         test_parallel_for_8D_MDTeamVectorRange<Right, Right>(dims, initValue);
   }
-}
+}  // namespace Test
 
 TEST(TEST_CATEGORY, MDTeamParallelReduce) {
   using namespace MDTeamParallelism;


### PR DESCRIPTION
Motivation: #3385 

Implementation for MD TeamPolicy for Serial, CUDA, HIP and Threads backends. This also includes infrastructures and tests needed for all backends.
This adds parallel_for and parallel_reduce support for MDTeamThreadRange, MDThreadVectorRange and MDTeamVectorRange.

Added in directional supports:
- MDTeamThreadRange is single directional
- MDThreadVectorRange and MDTeamVectorRange have outer and inner directions

@nliber 