### PR TITLE
Cleanup unnecessary `#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST` guards

### DIFF
--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -357,7 +357,6 @@ void test_offsetview_unmanaged_construction() {
     ASSERT_EQ(bb, ii);
   }
 
-#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
   {
     using offset_view_type = Kokkos::Experimental::OffsetView<Scalar*, Device>;
 
@@ -397,7 +396,6 @@ void test_offsetview_unmanaged_construction() {
     ASSERT_THROW(offset_view_type(&s, {0, 0, 0}, {1, 1, 1}),
                  std::runtime_error);
   }
-#endif  // KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
 }
 
 template <typename Scalar, typename Device>

--- a/core/src/Kokkos_TaskScheduler.hpp
+++ b/core/src/Kokkos_TaskScheduler.hpp
@@ -646,16 +646,6 @@ typename Scheduler::template future_type_for_functor<
   using task_type =
       typename scheduler_type::template runnable_task_type<FunctorType>;
 
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST) && \
-    defined(KOKKOS_ENABLE_CUDA)
-
-  // This doesn't work with clang cuda
-  // static_assert(
-  //    !std::is_same<Kokkos::Cuda, typename Scheduler::execution_space>::value,
-  //    "Error calling Kokkos::task_spawn for Cuda space within Host code");
-
-#endif
-
   static_assert(TaskEnum == Impl::TaskType::TaskTeam ||
                     TaskEnum == Impl::TaskType::TaskSingle,
                 "Kokkos task_spawn requires TaskTeam or TaskSingle");

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Task.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Task.cpp
@@ -95,8 +95,6 @@ TaskExec<Kokkos::Experimental::OpenMPTarget>::TaskExec(
   Kokkos::memory_fence();
 }
 
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-
 void TaskExec<Kokkos::Experimental::OpenMPTarget>::team_barrier_impl() const {
   if (m_team_exec->scratch_reduce_size() < int(2 * sizeof(int64_t))) {
     Kokkos::abort("TaskQueue<OpenMPTarget> scratch_reduce memory too small");
@@ -124,8 +122,6 @@ void TaskExec<Kokkos::Experimental::OpenMPTarget>::team_barrier_impl() const {
     if (1000 < m_sync_step) m_sync_step = 0;
   }
 }
-
-#endif
 
 //----------------------------------------------------------------------------
 

--- a/core/src/impl/Kokkos_Spinwait.cpp
+++ b/core/src/impl/Kokkos_Spinwait.cpp
@@ -43,7 +43,6 @@
 */
 
 #include <Kokkos_Macros.hpp>
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
 
 #include <Kokkos_Atomic.hpp>
 #include <impl/Kokkos_Spinwait.hpp>
@@ -135,7 +134,3 @@ void host_thread_yield(const uint32_t i, const WaitMode mode) {
 
 }  // namespace Impl
 }  // namespace Kokkos
-
-#else
-void KOKKOS_CORE_SRC_IMPL_SPINWAIT_PREVENT_LINK_ERROR() {}
-#endif

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3906,8 +3906,6 @@ inline void view_error_operator_bounds(char* buf, int len, const MapType& map,
   view_error_operator_bounds<R + 1>(buf + n, len - n, map, args...);
 }
 
-#if !defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-
 /* Check #3: is the View managed as determined by the MemoryTraits? */
 template <class MapType, bool is_managed = (MapType::is_managed != 0)>
 struct OperatorBoundsErrorOnDevice;
@@ -3962,8 +3960,6 @@ KOKKOS_FUNCTION
     operator_bounds_error_on_device(Map const& map) {
   OperatorBoundsErrorOnDevice<Map>::run(map);
 }
-
-#endif  // ! defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
 
 template <class MemorySpace, class ViewType, class MapType, class... Args>
 KOKKOS_INLINE_FUNCTION void view_verify_operator_bounds(

--- a/core/unit_test/TestSharedAlloc.hpp
+++ b/core/unit_test/TestSharedAlloc.hpp
@@ -65,7 +65,6 @@ struct SharedAllocDestroy {
 
 template <class MemorySpace, class ExecutionSpace>
 void test_shared_alloc() {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
   using Header     = const Kokkos::Impl::SharedAllocationHeader;
   using Tracker    = Kokkos::Impl::SharedAllocationTracker;
   using RecordBase = Kokkos::Impl::SharedAllocationRecord<void, void>;
@@ -231,8 +230,6 @@ void test_shared_alloc() {
 
     ASSERT_EQ(destroy_count, 1);
   }
-
-#endif /* #if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST ) */
 }
 
 TEST(TEST_CATEGORY, impl_shared_alloc) {


### PR DESCRIPTION
Related to #4660 
We are trying to get rid of guarding code with `KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_*` macros.
Most of the changes are "mechanical", replacing
```C++
#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
<host code>
#else
<device code>
#endif
```
by
```C++
KOKKOS_IF_HOST(<host code>)
KOKKOS_IF_DEVICE(<device code>)
```
This PR propose changes that are not following this pattern.  The intent is to offload potentially controversial(?) changes from the main PR and make life of reviewers a bit easier.