### PR TITLE
Do not append stacktrace to the message when throwing a `std::runtime_error`

### DIFF
--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -59,7 +59,13 @@
 namespace Kokkos {
 namespace Impl {
 void traceback_callstack(std::ostream &msg) {
+#ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
+  msg << "\nBacktrace:\n";
+  save_stacktrace();
+  print_demangled_saved_stacktrace(msg);
+#else
   msg << "\nTraceback functionality not available\n";
+#endif
 }
 
 void throw_runtime_exception(const std::string &msg) {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -69,10 +69,7 @@ void traceback_callstack(std::ostream &msg) {
 }
 
 void throw_runtime_exception(const std::string &msg) {
-  std::ostringstream o;
-  o << msg;
-  traceback_callstack(o);
-  throw std::runtime_error(o.str());
+  throw std::runtime_error(msg);
 }
 
 void host_abort(const char *const message) {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -59,7 +59,7 @@
 namespace Kokkos {
 namespace Impl {
 void traceback_callstack(std::ostream &msg) {
-  msg << std::endl << "Traceback functionality not available" << std::endl;
+  msg << "\nTraceback functionality not available\n";
 }
 
 void throw_runtime_exception(const std::string &msg) {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -77,11 +77,7 @@ void throw_runtime_exception(const std::string &msg) {
 
 void host_abort(const char *const message) {
   std::cerr << message;
-#ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
-  std::cerr << "\nBacktrace:\n";
-  save_stacktrace();
-  print_demangled_saved_stacktrace(std::cerr);
-#endif
+  traceback_callstack(std::cerr);
   ::abort();
 }
 

--- a/core/unit_test/TestCTestDevice.cpp
+++ b/core/unit_test/TestCTestDevice.cpp
@@ -24,12 +24,12 @@ int unsetenv(const char *name) { return _putenv_s(name, ""); }
 
 // Needed because https://github.com/google/googletest/issues/952 has not been
 // resolved
-#define EXPECT_THROW_WITH_MESSAGE(stmt, etype, whatstring) \
-  EXPECT_THROW(                                            \
-      try { stmt; } catch (const etype &ex) {              \
-        EXPECT_EQ(whatstring, std::string(ex.what()));     \
-        throw;                                             \
-      },                                                   \
+#define EXPECT_THROW_WITH_MESSAGE(stmt, etype, whatstring)      \
+  EXPECT_THROW(                                                 \
+      try { stmt; } catch (const etype &ex) {                   \
+        EXPECT_EQ(std::string(ex.what()).find(whatstring), 0u); \
+        throw;                                                  \
+      },                                                        \
       etype)
 
 class ctest_environment : public ::testing::Test {
@@ -80,54 +80,43 @@ TEST_F(ctest_environment, invalid_rank) {
   EXPECT_THROW_WITH_MESSAGE(
       Kokkos::Impl::get_ctest_gpu("10"), std::runtime_error,
       "Error: local rank 10 is outside the bounds of resource groups provided "
-      "by"
-      " CTest. Raised by Kokkos::Impl::get_ctest_gpu().\nTraceback "
-      "functionality"
-      " not available\n");
+      "by CTest.");
 }
 
 TEST_F(ctest_environment, no_type_str) {
   EXPECT_THROW_WITH_MESSAGE(
       Kokkos::Impl::get_ctest_gpu("0"), std::runtime_error,
       "Error: CTEST_RESOURCE_GROUP_0 is not specified. Raised by "
-      "Kokkos::Impl::get_ctest_gpu().\nTraceback functionality not "
-      "available\n");
+      "Kokkos::Impl::get_ctest_gpu().");
 }
 
 TEST_F(ctest_environment, missing_type) {
   EXPECT_THROW_WITH_MESSAGE(
       Kokkos::Impl::get_ctest_gpu("1"), std::runtime_error,
       "Error: device type 'gpus' not included in CTEST_RESOURCE_GROUP_1. "
-      "Raised "
-      "by Kokkos::Impl::get_ctest_gpu().\nTraceback functionality not available"
-      "\n");
+      "Raised by Kokkos::Impl::get_ctest_gpu().");
   EXPECT_THROW_WITH_MESSAGE(
       Kokkos::Impl::get_ctest_gpu("2"), std::runtime_error,
       "Error: device type 'gpus' not included in CTEST_RESOURCE_GROUP_2. "
-      "Raised "
-      "by Kokkos::Impl::get_ctest_gpu().\nTraceback functionality not available"
-      "\n");
+      "Raised by Kokkos::Impl::get_ctest_gpu().");
 }
 
 TEST_F(ctest_environment, no_id_str) {
   EXPECT_THROW_WITH_MESSAGE(
       Kokkos::Impl::get_ctest_gpu("3"), std::runtime_error,
       "Error: CTEST_RESOURCE_GROUP_3_GPUS is not specified. Raised by "
-      "Kokkos::Impl::get_ctest_gpu().\nTraceback functionality not "
-      "available\n");
+      "Kokkos::Impl::get_ctest_gpu().");
 }
 
 TEST_F(ctest_environment, invalid_id_str) {
   EXPECT_THROW_WITH_MESSAGE(
       Kokkos::Impl::get_ctest_gpu("4"), std::runtime_error,
       "Error: invalid value of CTEST_RESOURCE_GROUP_4_GPUS: 'id:2'. Raised by "
-      "Kokkos::Impl::get_ctest_gpu().\nTraceback functionality not "
-      "available\n");
+      "Kokkos::Impl::get_ctest_gpu().");
   EXPECT_THROW_WITH_MESSAGE(
       Kokkos::Impl::get_ctest_gpu("5"), std::runtime_error,
       "Error: invalid value of CTEST_RESOURCE_GROUP_5_GPUS: 'slots:1,id:2'. "
-      "Raised by Kokkos::Impl::get_ctest_gpu().\nTraceback functionality not "
-      "available\n");
+      "Raised by Kokkos::Impl::get_ctest_gpu().");
 }
 
 TEST_F(ctest_environment, good) {


### PR DESCRIPTION
We used to include the call stack in the error message when throwing a runtime exception but it looks like we accidentally unconditionally disabled the functionality in the refactor #2226

**EDIT** decided to strip the stacktrace from the error message since it can be obtained on the user side when handling the error