### PR TITLE
Print current call stack when calling `Kokkos::abort()` from the host

### DIFF
--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -42,11 +42,10 @@
 //@HEADER
 */
 
-#include <cstdio>
 #include <cstring>
 #include <cstdlib>
 
-#include <ostream>
+#include <iostream>
 #include <sstream>
 #include <iomanip>
 #include <stdexcept>
@@ -68,9 +67,9 @@ void throw_runtime_exception(const std::string &msg) {
   traceback_callstack(o);
   throw std::runtime_error(o.str());
 }
+
 void host_abort(const char *const message) {
-  fwrite(message, 1, strlen(message), stderr);
-  fflush(stderr);
+  std::cerr << message;
   ::abort();
 }
 

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -50,6 +50,7 @@
 #include <iomanip>
 #include <stdexcept>
 #include <impl/Kokkos_Error.hpp>
+#include <impl/Kokkos_Stacktrace.hpp>
 #include <Cuda/Kokkos_Cuda_Error.hpp>
 
 //----------------------------------------------------------------------------
@@ -70,6 +71,11 @@ void throw_runtime_exception(const std::string &msg) {
 
 void host_abort(const char *const message) {
   std::cerr << message;
+#ifdef KOKKOS_IMPL_ENABLE_STACKTRACE
+  std::cerr << "\nBacktrace:\n";
+  save_stacktrace();
+  print_demangled_saved_stacktrace(std::cerr);
+#endif
   ::abort();
 }
 

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -468,6 +468,7 @@ TEST(TEST_CATEGORY, complex_issue_3865) {
   TestBugPowAndLogComplex<TEST_EXECSPACE>();
 }
 
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET
 TEST(TEST_CATEGORY, complex_issue_3867) {
   ASSERT_EQ(Kokkos::pow(Kokkos::complex<double>(2., 1.), 3.),
             Kokkos::pow(Kokkos::complex<double>(2., 1.), 3));
@@ -523,6 +524,7 @@ TEST(TEST_CATEGORY, complex_issue_3867) {
 
 #undef CHECK_POW_COMPLEX_PROMOTION
 }
+#endif
 
 TEST(TEST_CATEGORY, complex_operations_arithmetic_types_overloads) {
 #define STATIC_ASSERT(cond) static_assert(cond, "")


### PR DESCRIPTION
Improve error message to help locate the problem without a debugger

Related to #4671 
IMO, it is arguable whether we should append the backtrace to the message give to `std::runtime_error`, but when calling `abort` we absolutely should do it.