### PR TITLE
Fix a bug in CUDA scratch memory pool

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -676,7 +676,7 @@ std::pair<void *, int> CudaInternal::resize_team_scratch_space(
   int current_team_scratch = 0;
   int zero                 = 0;
   int one                  = 1;
-  while (m_team_scratch_pool[current_team_scratch].compare_exchange_weak(
+  while (!m_team_scratch_pool[current_team_scratch].compare_exchange_weak(
       zero, one, std::memory_order_release, std::memory_order_relaxed)) {
     current_team_scratch = (current_team_scratch + 1) % m_n_team_scratch;
   }


### PR DESCRIPTION
There is a bug when we try to acquire an object in the scratch memory pool. We basically do the opposite of what we want to do, if we can acquire a free object we mark it as busy and then, we try to acquire the next one. The loop exits when we find a busy object. The code is unique to CUDA and does not appear in HIP or SYCL.