### PR TITLE
Fix up compiling SYCL without NDEBUG

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Abort.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Abort.hpp
@@ -47,6 +47,7 @@
 
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_SYCL)
+#include <CL/sycl.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/example/build_cmake_in_tree/cmake_example.cpp
+++ b/example/build_cmake_in_tree/cmake_example.cpp
@@ -47,7 +47,7 @@
 
 int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);
-  Kokkos::DefaultExecutionSpace::print_configuration(std::cout);
+  Kokkos::DefaultExecutionSpace{}.print_configuration(std::cout);
 
   if (argc < 2) {
     fprintf(stderr, "Usage: %s [<kokkos_options>] <size>\n", argv[0]);


### PR DESCRIPTION
Fixes  #4679. Drive-by fix in `example/build_cmake_in_tree/cmake_example.cpp`: `print_configuration` is supposed to be a non-static member function.