### PR TITLE
Kokkos::resize always error out for mismatch in runtime rank

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2889,6 +2889,10 @@ bool size_mismatch(const ViewType& view, unsigned int max_extent,
     if (new_extents[dim] != view.extent(dim)) {
       return true;
     }
+  for (unsigned int dim = max_extent; dim < 8; ++dim)
+    if (new_extents[dim] != KOKKOS_IMPL_CTOR_DEFAULT_ARG) {
+      return true;
+    }
   return false;
 }
 


### PR DESCRIPTION
Should be close enough to fix https://github.com/kokkos/kokkos/issues/1714. The constructor of View errors out anyway and the error message shouldn't be too far off to deduce that the problem might come from another function calling the constructor (which is `resize` in the issue).

The changes here specifically make sure that we still error out if the dimensions given to `resize` match up to the run-time rank but are different after that. Previously, we were just ignoring the extra arguments.