### PR TITLE
`kokkos_launch_compiler`: escape `$` character

### DIFF
--- a/bin/kokkos_launch_compiler
+++ b/bin/kokkos_launch_compiler
@@ -66,7 +66,7 @@ CXX_COMPILER=${1}
 shift
 
 # escape $
-target=("${@/\$/\\\$}")
+command=("${@/\$/\\\$}")
 
 # NOTE: in below, ${KOKKOS_COMPILER} is usually nvcc_wrapper
 #
@@ -86,9 +86,9 @@ target=("${@/\$/\\\$}")
 # results in this command being executed:
 #       ${KOKKOS_COMPILER} -c file.cpp -o file.o
 if [[ "${KOKKOS_DEPENDENCE}" -eq "0" || "${CXX_COMPILER}" != "${1}" ]]; then
-    debug-message ${target[*]}
+    debug-message ${command[*]}
     # the command does not depend on Kokkos so just execute the command w/o re-directing to ${KOKKOS_COMPILER}
-    eval ${target[*]}
+    eval ${command[*]}
 else
     # the executable is the C++ compiler, so we need to re-direct to ${KOKKOS_COMPILER}
     if [ ! -f "${KOKKOS_COMPILER}" ]; then
@@ -116,9 +116,9 @@ else
     fi
 
     # discard the compiler from the command
-    target=("${target[@]:1}")
+    command=("${command[@]:1}")
 
-    debug-message ${KOKKOS_COMPILER} ${target[*]}
+    debug-message ${KOKKOS_COMPILER} ${command[*]}
     # execute ${KOKKOS_COMPILER} (again, usually nvcc_wrapper)
-    ${KOKKOS_COMPILER} ${target[*]}
+    ${KOKKOS_COMPILER} ${command[*]}
 fi

--- a/bin/kokkos_launch_compiler
+++ b/bin/kokkos_launch_compiler
@@ -65,6 +65,9 @@ CXX_COMPILER=${1}
 # remove the expected C++ compiler from the arguments
 shift
 
+# escape $
+target=("${@/\$/\\\$}")
+
 # NOTE: in below, ${KOKKOS_COMPILER} is usually nvcc_wrapper
 #
 # after the above shifts, $1 is now the exe for the compile or link command, e.g.
@@ -83,9 +86,9 @@ shift
 # results in this command being executed:
 #       ${KOKKOS_COMPILER} -c file.cpp -o file.o
 if [[ "${KOKKOS_DEPENDENCE}" -eq "0" || "${CXX_COMPILER}" != "${1}" ]]; then
-    debug-message $@
+    debug-message ${target[*]}
     # the command does not depend on Kokkos so just execute the command w/o re-directing to ${KOKKOS_COMPILER}
-    eval $@
+    eval ${target[*]}
 else
     # the executable is the C++ compiler, so we need to re-direct to ${KOKKOS_COMPILER}
     if [ ! -f "${KOKKOS_COMPILER}" ]; then
@@ -113,9 +116,9 @@ else
     fi
 
     # discard the compiler from the command
-    shift
+    target=("${target[@]:1}")
 
-    debug-message ${KOKKOS_COMPILER} $@
+    debug-message ${KOKKOS_COMPILER} ${target[*]}
     # execute ${KOKKOS_COMPILER} (again, usually nvcc_wrapper)
-    ${KOKKOS_COMPILER} $@
+    ${KOKKOS_COMPILER} ${target[*]}
 fi


### PR DESCRIPTION
fixes #4687 