### PR TITLE
Cap vector size to kernel maximum for SYCL

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -462,13 +462,6 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   q.get_device(),
                   sycl::range<3>(m_team_size, m_vector_size, 1));
       auto final_vector_size = std::min<int>(m_vector_size, max_sg_size);
-      if (max_sg_size % final_vector_size != 0) {
-        std::stringstream out;
-        out << "The maximum subgroup size (" << max_sg_size
-            << ") for this kernel is not divisible by the vector_size ("
-            << final_vector_size << "). Choose a smaller vector_size!\n";
-        Kokkos::Impl::throw_runtime_exception(out.str());
-      }
       // FIXME_SYCL For some reason, explicitly enforcing the kernel bundle to
       // be used gives a runtime error.
       // cgh.use_kernel_bundle(kernel_bundle);
@@ -846,13 +839,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
             sycl::info::kernel_device_specific::max_sub_group_size>(
             q.get_device(), sycl::range<3>(m_team_size, m_vector_size, 1));
         auto final_vector_size = std::min<int>(m_vector_size, max_sg_size);
-        if (max_sg_size % final_vector_size != 0) {
-          std::stringstream out;
-          out << "The maximum subgroup size (" << max_sg_size
-              << ") for this kernel is not divisible by the vector_size ("
-              << final_vector_size << "). Choose a smaller vector_size!\n";
-          Kokkos::Impl::throw_runtime_exception(out.str());
-        }
         // FIXME_SYCL For some reason, explicitly enforcing the kernel bundle to
         // be used gives a runtime error.
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -448,7 +448,6 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
           functor_wrapper.get_functor()(work_tag(), team_member);
       };
 
-#if defined(__SYCL_COMPILER_VERSION) && __SYCL_COMPILER_VERSION > 20210903
       static sycl::kernel kernel = [&] {
         sycl::kernel_id functor_kernel_id =
             sycl::get_kernel_id<decltype(lambda)>();
@@ -462,22 +461,22 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
               .get_info<sycl::info::kernel_device_specific::max_sub_group_size>(
                   q.get_device(),
                   sycl::range<3>(m_team_size, m_vector_size, 1));
-      if (max_sg_size % m_vector_size != 0) {
+      auto final_vector_size = std::min<int>(m_vector_size, max_sg_size);
+      if (max_sg_size % final_vector_size != 0) {
         std::stringstream out;
         out << "The maximum subgroup size (" << max_sg_size
             << ") for this kernel is not divisible by the vector_size ("
-            << m_vector_size << "). Choose a smaller vector_size!\n";
+            << final_vector_size << "). Choose a smaller vector_size!\n";
         Kokkos::Impl::throw_runtime_exception(out.str());
       }
       // FIXME_SYCL For some reason, explicitly enforcing the kernel bundle to
       // be used gives a runtime error.
       // cgh.use_kernel_bundle(kernel_bundle);
-#endif
 
       cgh.parallel_for(
           sycl::nd_range<2>(
-              sycl::range<2>(m_team_size, m_league_size * m_vector_size),
-              sycl::range<2>(m_team_size, m_vector_size)),
+              sycl::range<2>(m_team_size, m_league_size * final_vector_size),
+              sycl::range<2>(m_team_size, final_vector_size)),
           lambda);
     });
     q.ext_oneapi_submit_barrier(std::vector<sycl::event>{parallel_for_event});
@@ -618,20 +617,11 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         *space.impl_internal_space_instance();
     sycl::queue& q = *instance.m_queue;
 
-    // FIXME_SYCL optimize
-    const size_t wgroup_size = m_team_size * m_vector_size;
-    std::size_t size = std::size_t(m_league_size) * m_team_size * m_vector_size;
-    const auto init_size =
-        std::max<std::size_t>((size + wgroup_size - 1) / wgroup_size, 1);
     const unsigned int value_count =
         FunctorValueTraits<ReducerTypeFwd, WorkTagFwd>::value_count(
             ReducerConditional::select(m_functor, m_reducer));
-    const auto results_ptr = static_cast<pointer_type>(instance.scratch_space(
-        sizeof(value_type) * std::max(value_count, 1u) * init_size));
-    value_type* device_accessible_result_ptr =
-        m_result_ptr_device_accessible ? m_result_ptr : nullptr;
-    auto scratch_flags = static_cast<unsigned int*>(
-        instance.scratch_flags(sizeof(unsigned int)));
+    std::size_t size = std::size_t(m_league_size) * m_team_size * m_vector_size;
+    value_type* results_ptr = nullptr;
 
     sycl::event last_reduction_event;
 
@@ -639,6 +629,11 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     // working with the global scratch memory but don't copy back to
     // m_result_ptr yet.
     if (size <= 1) {
+      results_ptr = static_cast<pointer_type>(instance.scratch_space(
+          sizeof(value_type) * std::max(value_count, 1u)));
+      value_type* device_accessible_result_ptr =
+          m_result_ptr_device_accessible ? m_result_ptr : nullptr;
+
       auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
         // FIXME_SYCL accessors seem to need a size greater than zero at least
         // for host queues
@@ -683,21 +678,14 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       q.ext_oneapi_submit_barrier(
           std::vector<sycl::event>{parallel_reduce_event});
       last_reduction_event = parallel_reduce_event;
-    }
-
-    // Otherwise, we perform a reduction on the values in all workgroups
-    // separately, write the workgroup results back to global memory and recurse
-    // until only one workgroup does the reduction and thus gets the final
-    // value.
-    if (size > 1) {
-      auto n_wgroups             = (size + wgroup_size - 1) / wgroup_size;
+    } else {
+      // Otherwise, (if the total range has more than one element) we perform a
+      // reduction on the values in all workgroups separately, write the
+      // workgroup results back to global memory and recurse until only one
+      // workgroup does the reduction and thus gets the final value.
       auto parallel_reduce_event = q.submit([&](sycl::handler& cgh) {
-        sycl::accessor<value_type, 1, sycl::access::mode::read_write,
-                       sycl::access::target::local>
-            local_mem(sycl::range<1>(wgroup_size) * std::max(value_count, 1u) +
-                          (sizeof(unsigned int) + sizeof(value_type) - 1) /
-                              sizeof(value_type),
-                      cgh);
+        auto scratch_flags = static_cast<unsigned int*>(
+            instance.scratch_flags(sizeof(unsigned int)));
 
         // FIXME_SYCL accessors seem to need a size greater than zero at least
         // for host queues
@@ -712,124 +700,143 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         const int scratch_size[2]  = {m_scratch_size[0], m_scratch_size[1]};
         char* const scratch_ptr[2] = {m_scratch_ptr[0], m_scratch_ptr[1]};
 
-        auto lambda = [=](sycl::nd_item<2> item) {
-          auto& num_teams_done = reinterpret_cast<unsigned int&>(
-              local_mem[wgroup_size * std::max(value_count, 1u)]);
-          const auto local_id          = item.get_local_linear_id();
-          const auto& functor          = functor_wrapper.get_functor();
-          const auto& selected_reducer = ReducerConditional::select(
-              static_cast<const FunctorType&>(functor),
-              static_cast<const ReducerType&>(reducer_wrapper.get_functor()));
+        auto team_reduction_factory = [&](sycl::accessor<
+                                              value_type, 1,
+                                              sycl::access::mode::read_write,
+                                              sycl::access::target::local>
+                                              local_mem,
+                                          value_type* results_ptr) mutable {
+          value_type* device_accessible_result_ptr =
+              m_result_ptr_device_accessible ? m_result_ptr : nullptr;
+          auto lambda = [=](sycl::nd_item<2> item) {
+            auto n_wgroups =
+                item.get_group_range()[0] * item.get_group_range()[1];
+            auto wgroup_size =
+                item.get_local_range()[0] * item.get_local_range()[1];
+            auto size = n_wgroups * wgroup_size;
 
-          if constexpr (FunctorValueTraits<ReducerTypeFwd,
-                                           WorkTagFwd>::StaticValueSize == 0) {
-            reference_type update = ValueInit::init(
-                selected_reducer, &local_mem[local_id * value_count]);
-            const member_type team_member(
-                team_scratch_memory_L0.get_pointer(), shmem_begin,
-                scratch_size[0],
-                scratch_ptr[1] + item.get_group(1) * scratch_size[1],
-                scratch_size[1], item);
-            if constexpr (std::is_same<WorkTag, void>::value)
-              functor(team_member, update);
-            else
-              functor(WorkTag(), team_member, update);
-            item.barrier(sycl::access::fence_space::local_space);
+            auto& num_teams_done = reinterpret_cast<unsigned int&>(
+                local_mem[wgroup_size * std::max(value_count, 1u)]);
+            const auto local_id          = item.get_local_linear_id();
+            const auto& functor          = functor_wrapper.get_functor();
+            const auto& selected_reducer = ReducerConditional::select(
+                static_cast<const FunctorType&>(functor),
+                static_cast<const ReducerType&>(reducer_wrapper.get_functor()));
 
-            SYCLReduction::workgroup_reduction<ValueJoin, ValueOps, WorkTag>(
-                item, local_mem.get_pointer(), results_ptr,
-                device_accessible_result_ptr, value_count, selected_reducer,
-                static_cast<const FunctorType&>(functor), false,
-                std::min<std::size_t>(size, item.get_local_range()[0] *
-                                                item.get_local_range()[1]));
-
-            if (local_id == 0) {
-              sycl::ext::oneapi::atomic_ref<
-                  unsigned, sycl::ext::oneapi::memory_order::relaxed,
-                  sycl::ext::oneapi::memory_scope::device,
-                  sycl::access::address_space::global_space>
-                  scratch_flags_ref(*scratch_flags);
-              num_teams_done = ++scratch_flags_ref;
-            }
-            sycl::group_barrier(item.get_group());
-            if (num_teams_done == n_wgroups) {
-              if (local_id >= n_wgroups)
-                ValueInit::init(selected_reducer,
-                                &local_mem[local_id * value_count]);
-              else {
-                ValueOps::copy(functor, &local_mem[local_id * value_count],
-                               &results_ptr[local_id * value_count]);
-                for (unsigned int id = local_id + wgroup_size; id < n_wgroups;
-                     id += wgroup_size) {
-                  ValueJoin::join(selected_reducer,
-                                  &local_mem[local_id * value_count],
-                                  &results_ptr[id * value_count]);
-                }
-              }
+            if constexpr (FunctorValueTraits<ReducerTypeFwd,
+                                             WorkTagFwd>::StaticValueSize ==
+                          0) {
+              reference_type update = ValueInit::init(
+                  selected_reducer, &local_mem[local_id * value_count]);
+              const member_type team_member(
+                  team_scratch_memory_L0.get_pointer(), shmem_begin,
+                  scratch_size[0],
+                  scratch_ptr[1] + item.get_group(1) * scratch_size[1],
+                  scratch_size[1], item);
+              if constexpr (std::is_same<WorkTag, void>::value)
+                functor(team_member, update);
+              else
+                functor(WorkTag(), team_member, update);
+              item.barrier(sycl::access::fence_space::local_space);
 
               SYCLReduction::workgroup_reduction<ValueJoin, ValueOps, WorkTag>(
                   item, local_mem.get_pointer(), results_ptr,
                   device_accessible_result_ptr, value_count, selected_reducer,
-                  static_cast<const FunctorType&>(functor), true,
-                  std::min(n_wgroups, item.get_local_range()[0] *
-                                          item.get_local_range()[1]));
-            }
-          } else {
-            value_type local_value;
-            reference_type update =
-                ValueInit::init(selected_reducer, &local_value);
-            const member_type team_member(
-                team_scratch_memory_L0.get_pointer(), shmem_begin,
-                scratch_size[0],
-                scratch_ptr[1] + item.get_group(1) * scratch_size[1],
-                scratch_size[1], item);
-            if constexpr (std::is_same<WorkTag, void>::value)
-              functor(team_member, update);
-            else
-              functor(WorkTag(), team_member, update);
+                  static_cast<const FunctorType&>(functor), false,
+                  std::min<std::size_t>(size, item.get_local_range()[0] *
+                                                  item.get_local_range()[1]));
 
-            SYCLReduction::workgroup_reduction<ValueJoin, WorkTag>(
-                item, local_mem.get_pointer(), local_value, results_ptr,
-                device_accessible_result_ptr, selected_reducer,
-                static_cast<const FunctorType&>(functor), false,
-                std::min<std::size_t>(size, item.get_local_range()[0] *
-                                                item.get_local_range()[1]));
-
-            if (local_id == 0) {
-              sycl::ext::oneapi::atomic_ref<
-                  unsigned, sycl::ext::oneapi::memory_order::relaxed,
-                  sycl::ext::oneapi::memory_scope::device,
-                  sycl::access::address_space::global_space>
-                  scratch_flags_ref(*scratch_flags);
-              num_teams_done = ++scratch_flags_ref;
-            }
-            item.barrier(sycl::access::fence_space::local_space);
-            if (num_teams_done == n_wgroups) {
-              if (local_id >= n_wgroups)
-                ValueInit::init(selected_reducer, &local_value);
-              else {
-                local_value = results_ptr[local_id];
-                for (unsigned int id = local_id + wgroup_size; id < n_wgroups;
-                     id += wgroup_size) {
-                  ValueJoin::join(selected_reducer, &local_value,
-                                  &results_ptr[id]);
-                }
+              if (local_id == 0) {
+                sycl::ext::oneapi::atomic_ref<
+                    unsigned, sycl::ext::oneapi::memory_order::relaxed,
+                    sycl::ext::oneapi::memory_scope::device,
+                    sycl::access::address_space::global_space>
+                    scratch_flags_ref(*scratch_flags);
+                num_teams_done = ++scratch_flags_ref;
               }
+              sycl::group_barrier(item.get_group());
+              if (num_teams_done == n_wgroups) {
+                if (local_id >= n_wgroups)
+                  ValueInit::init(selected_reducer,
+                                  &local_mem[local_id * value_count]);
+                else {
+                  ValueOps::copy(functor, &local_mem[local_id * value_count],
+                                 &results_ptr[local_id * value_count]);
+                  for (unsigned int id = local_id + wgroup_size; id < n_wgroups;
+                       id += wgroup_size) {
+                    ValueJoin::join(selected_reducer,
+                                    &local_mem[local_id * value_count],
+                                    &results_ptr[id * value_count]);
+                  }
+                }
+
+                SYCLReduction::workgroup_reduction<ValueJoin, ValueOps,
+                                                   WorkTag>(
+                    item, local_mem.get_pointer(), results_ptr,
+                    device_accessible_result_ptr, value_count, selected_reducer,
+                    static_cast<const FunctorType&>(functor), true,
+                    std::min(n_wgroups, item.get_local_range()[0] *
+                                            item.get_local_range()[1]));
+              }
+            } else {
+              value_type local_value;
+              reference_type update =
+                  ValueInit::init(selected_reducer, &local_value);
+              const member_type team_member(
+                  team_scratch_memory_L0.get_pointer(), shmem_begin,
+                  scratch_size[0],
+                  scratch_ptr[1] + item.get_group(1) * scratch_size[1],
+                  scratch_size[1], item);
+              if constexpr (std::is_same<WorkTag, void>::value)
+                functor(team_member, update);
+              else
+                functor(WorkTag(), team_member, update);
 
               SYCLReduction::workgroup_reduction<ValueJoin, WorkTag>(
                   item, local_mem.get_pointer(), local_value, results_ptr,
                   device_accessible_result_ptr, selected_reducer,
-                  static_cast<const FunctorType&>(functor), true,
-                  std::min(n_wgroups, item.get_local_range()[0] *
-                                          item.get_local_range()[1]));
+                  static_cast<const FunctorType&>(functor), false,
+                  std::min<std::size_t>(size, item.get_local_range()[0] *
+                                                  item.get_local_range()[1]));
+
+              if (local_id == 0) {
+                sycl::ext::oneapi::atomic_ref<
+                    unsigned, sycl::ext::oneapi::memory_order::relaxed,
+                    sycl::ext::oneapi::memory_scope::device,
+                    sycl::access::address_space::global_space>
+                    scratch_flags_ref(*scratch_flags);
+                num_teams_done = ++scratch_flags_ref;
+              }
+              item.barrier(sycl::access::fence_space::local_space);
+              if (num_teams_done == n_wgroups) {
+                if (local_id >= n_wgroups)
+                  ValueInit::init(selected_reducer, &local_value);
+                else {
+                  local_value = results_ptr[local_id];
+                  for (unsigned int id = local_id + wgroup_size; id < n_wgroups;
+                       id += wgroup_size) {
+                    ValueJoin::join(selected_reducer, &local_value,
+                                    &results_ptr[id]);
+                  }
+                }
+
+                SYCLReduction::workgroup_reduction<ValueJoin, WorkTag>(
+                    item, local_mem.get_pointer(), local_value, results_ptr,
+                    device_accessible_result_ptr, selected_reducer,
+                    static_cast<const FunctorType&>(functor), true,
+                    std::min(n_wgroups, item.get_local_range()[0] *
+                                            item.get_local_range()[1]));
+              }
             }
-          }
+          };
+          return lambda;
         };
 
-#if defined(__SYCL_COMPILER_VERSION) && __SYCL_COMPILER_VERSION > 20210903
+        auto dummy_reduction_lambda = team_reduction_factory({1, cgh}, nullptr);
+
         static sycl::kernel kernel = [&] {
           sycl::kernel_id functor_kernel_id =
-              sycl::get_kernel_id<decltype(lambda)>();
+              sycl::get_kernel_id<decltype(dummy_reduction_lambda)>();
           auto kernel_bundle =
               sycl::get_kernel_bundle<sycl::bundle_state::executable>(
                   q.get_context(), std::vector{functor_kernel_id});
@@ -838,26 +845,42 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         auto max_sg_size = kernel.get_info<
             sycl::info::kernel_device_specific::max_sub_group_size>(
             q.get_device(), sycl::range<3>(m_team_size, m_vector_size, 1));
-        if (max_sg_size % m_vector_size != 0) {
+        auto final_vector_size = std::min<int>(m_vector_size, max_sg_size);
+        if (max_sg_size % final_vector_size != 0) {
           std::stringstream out;
           out << "The maximum subgroup size (" << max_sg_size
               << ") for this kernel is not divisible by the vector_size ("
-              << m_vector_size << "). Choose a smaller vector_size!\n";
+              << final_vector_size << "). Choose a smaller vector_size!\n";
           Kokkos::Impl::throw_runtime_exception(out.str());
         }
         // FIXME_SYCL For some reason, explicitly enforcing the kernel bundle to
         // be used gives a runtime error.
 
-//     cgh.use_kernel_bundle(kernel_bundle);
-#endif
+        //     cgh.use_kernel_bundle(kernel_bundle);
+
+        auto wgroup_size = m_team_size * final_vector_size;
+        std::size_t size = std::size_t(m_league_size) * wgroup_size;
+        sycl::accessor<value_type, 1, sycl::access::mode::read_write,
+                       sycl::access::target::local>
+            local_mem(sycl::range<1>(wgroup_size) * std::max(value_count, 1u) +
+                          (sizeof(unsigned int) + sizeof(value_type) - 1) /
+                              sizeof(value_type),
+                      cgh);
+
+        const auto init_size =
+            std::max<std::size_t>((size + wgroup_size - 1) / wgroup_size, 1);
+        results_ptr = static_cast<pointer_type>(instance.scratch_space(
+            sizeof(value_type) * std::max(value_count, 1u) * init_size));
+
+        auto reduction_lambda = team_reduction_factory(local_mem, results_ptr);
 
         cgh.parallel_for(
             sycl::nd_range<2>(
                 sycl::range<2>(m_team_size, m_league_size * m_vector_size),
                 sycl::range<2>(m_team_size, m_vector_size)),
-            lambda);
+            reduction_lambda);
       });
-      last_reduction_event = q.ext_oneapi_submit_barrier(
+      last_reduction_event       = q.ext_oneapi_submit_barrier(
           std::vector<sycl::event>{parallel_reduce_event});
     }
 


### PR DESCRIPTION
Fixes #4573.
For SYCL, the maximum vector size depends on the kernel and the maximum reported by the device might not be supported for every kernel. So far, we just errored out in case we detected the vector size being too large. This pull request tries to cap the vector size to the maximum supported by the kernel instead.
This is easy enough for `parallel_for` since the kernel doesn't use the vector size explicitly (meaning that it's fine to retrieve from within the kernel) but for `parallel_reduce` allocations for the reductions actually depend on the total workgroup size. 
The idea here is to first build a kernel with dummy pointers for reduction results and temporary storage, use that one for querying the maximum vector size for the kernel, allocating temporary global and local space, and create the final kernel to be launched with these pointers.

The actual changes are not that large if you ignore whitespace changes.