### PR TITLE
Kokkos:  Fix SFINAE logic for create_mirror() for specialized types

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3302,8 +3302,8 @@ template <class T, class... P>
 std::enable_if_t<
     std::is_same<typename ViewTraits<T, P...>::specialize, void>::value,
     typename Kokkos::View<T, P...>::HostMirror>
-create_mirror(
-    Kokkos::Impl::WithoutInitializing_t wi, Kokkos::View<T, P...> const& v) {
+create_mirror(Kokkos::Impl::WithoutInitializing_t wi,
+              Kokkos::View<T, P...> const& v) {
   return Impl::create_mirror(v, wi);
 }
 
@@ -3312,8 +3312,7 @@ template <class Space, class T, class... P,
 std::enable_if_t<
     std::is_same<typename ViewTraits<T, P...>::specialize, void>::value,
     typename Impl::MirrorType<Space, T, P...>::view_type>
-create_mirror(
-    Space const& space, Kokkos::View<T, P...> const& v) {
+create_mirror(Space const& space, Kokkos::View<T, P...> const& v) {
   return Impl::create_mirror(space, v);
 }
 
@@ -3322,9 +3321,8 @@ template <class Space, class T, class... P,
 std::enable_if_t<
     std::is_same<typename ViewTraits<T, P...>::specialize, void>::value,
     typename Impl::MirrorType<Space, T, P...>::view_type>
-create_mirror(
-    Kokkos::Impl::WithoutInitializing_t wi, Space const& space,
-    Kokkos::View<T, P...> const& v) {
+create_mirror(Kokkos::Impl::WithoutInitializing_t wi, Space const& space,
+              Kokkos::View<T, P...> const& v) {
   return Impl::create_mirror(space, v, wi);
 }
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3299,21 +3299,30 @@ create_mirror(Kokkos::View<T, P...> const& v) {
 }
 
 template <class T, class... P>
-typename Kokkos::View<T, P...>::HostMirror create_mirror(
+std::enable_if_t<
+    std::is_same<typename ViewTraits<T, P...>::specialize, void>::value,
+    typename Kokkos::View<T, P...>::HostMirror>
+create_mirror(
     Kokkos::Impl::WithoutInitializing_t wi, Kokkos::View<T, P...> const& v) {
   return Impl::create_mirror(v, wi);
 }
 
-template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-typename Impl::MirrorType<Space, T, P...>::view_type create_mirror(
+template <class Space, class T, class... P>
+std::enable_if_t<
+    Kokkos::is_space<Space>::value &&
+    std::is_same<typename ViewTraits<T, P...>::specialize, void>::value,
+    typename Impl::MirrorType<Space, T, P...>::view_type>
+create_mirror(
     Space const& space, Kokkos::View<T, P...> const& v) {
   return Impl::create_mirror(space, v);
 }
 
-template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
-typename Impl::MirrorType<Space, T, P...>::view_type create_mirror(
+template <class Space, class T, class... P>
+std::enable_if_t<
+    Kokkos::is_space<Space>::value &&
+    std::is_same<typename ViewTraits<T, P...>::specialize, void>::value,
+    typename Impl::MirrorType<Space, T, P...>::view_type>
+create_mirror(
     Kokkos::Impl::WithoutInitializing_t wi, Space const& space,
     Kokkos::View<T, P...> const& v) {
   return Impl::create_mirror(space, v, wi);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3307,9 +3307,9 @@ create_mirror(
   return Impl::create_mirror(v, wi);
 }
 
-template <class Space, class T, class... P>
+template <class Space, class T, class... P,
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 std::enable_if_t<
-    Kokkos::is_space<Space>::value &&
     std::is_same<typename ViewTraits<T, P...>::specialize, void>::value,
     typename Impl::MirrorType<Space, T, P...>::view_type>
 create_mirror(
@@ -3317,9 +3317,9 @@ create_mirror(
   return Impl::create_mirror(space, v);
 }
 
-template <class Space, class T, class... P>
+template <class Space, class T, class... P,
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 std::enable_if_t<
-    Kokkos::is_space<Space>::value &&
     std::is_same<typename ViewTraits<T, P...>::specialize, void>::value,
     typename Impl::MirrorType<Space, T, P...>::view_type>
 create_mirror(


### PR DESCRIPTION
This reintroduces the SFINAE logic of only allowing the base implementations of
create_mirror() work where ViewTraits<>::specialize == void, to resolve
ambiguous overload errors in Sacado/Stokhos.  Goes along with changes in Sacado/Stokhos
to mirror the SFINAE logic here, as well as add overloads for Kokkos::Impl::WithoutInitializing_t.

This partially reverts changes in PR #4562, so its effects will have to be tested on the builds
giving rise to that PR.