### PR TITLE
Reorganize includes for Kokkos_Half.hpp

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -47,6 +47,7 @@
 
 #ifdef KOKKOS_IMPL_CUDA_HALF_TYPE_DEFINED
 
+#include <Kokkos_Half.hpp>
 #include <Kokkos_NumericTraits.hpp>  // reduction_identity
 
 namespace Kokkos {

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -50,11 +50,9 @@
 
 #include <Kokkos_Core_fwd.hpp>
 
-// Fundamental type description for half precision
-// Should not rely on other backend infrastructure
-#include <Kokkos_Half.hpp>
 #include <KokkosCore_Config_DeclareBackend.hpp>
 
+#include <Kokkos_Half.hpp>
 #include <Kokkos_AnonymousSpace.hpp>
 #include <Kokkos_LogicalSpaces.hpp>
 #include <Kokkos_Pair.hpp>

--- a/core/src/Kokkos_Half.hpp
+++ b/core/src/Kokkos_Half.hpp
@@ -50,12 +50,6 @@
 #include <iosfwd>  // istream & ostream for extraction and insertion ops
 #include <string>
 
-////////////////////////////////////////////////////////////////////////////////
-///////// Include special backend specific headers and impl types here /////////
-#include <Cuda/Kokkos_Cuda_Half_Impl_Type.hpp>
-#include <SYCL/Kokkos_SYCL_Half_Impl_Type.hpp>
-////////////////////////////////////////////////////////////////////////////////
-
 #ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
 
 // KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH: A macro to select which
@@ -913,14 +907,6 @@ cast_from_wrapper(const Kokkos::Experimental::bhalf_t& x) {
 }  // namespace Experimental
 }  // namespace Kokkos
 
-////////////////////////////////////////////////////////////////////////////////
-////// Include special backend specific cast routines and identities here //////
-#include <Cuda/Kokkos_Cuda_Half_Conversion.hpp>
-#include <SYCL/Kokkos_SYCL_Half_Conversion.hpp>
-////////////////////////////////////////////////////////////////////////////////
-
-// Potentially include special compiler specific versions here
-// e.g. for Intel
 #endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
 
 // If none of the above actually did anything and defined a half precision type

--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -47,6 +47,7 @@
 
 #ifdef KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
 
+#include <Kokkos_Half.hpp>
 #include <Kokkos_NumericTraits.hpp>  // reduction_identity
 
 namespace Kokkos {

--- a/core/src/decl/Kokkos_Declare_CUDA.hpp
+++ b/core/src/decl/Kokkos_Declare_CUDA.hpp
@@ -47,6 +47,8 @@
 
 #if defined(KOKKOS_ENABLE_CUDA)
 #include <Kokkos_Cuda.hpp>
+#include <Cuda/Kokkos_Cuda_Half_Impl_Type.hpp>
+#include <Cuda/Kokkos_Cuda_Half_Conversion.hpp>
 #include <Cuda/Kokkos_Cuda_Parallel.hpp>
 #include <Cuda/Kokkos_Cuda_KernelLaunch.hpp>
 #include <Cuda/Kokkos_Cuda_Instance.hpp>

--- a/core/src/decl/Kokkos_Declare_SYCL.hpp
+++ b/core/src/decl/Kokkos_Declare_SYCL.hpp
@@ -47,6 +47,8 @@
 
 #if defined(KOKKOS_ENABLE_SYCL)
 #include <Kokkos_SYCL.hpp>
+#include <SYCL/Kokkos_SYCL_Half_Impl_Type.hpp>
+#include <SYCL/Kokkos_SYCL_Half_Conversion.hpp>
 #include <SYCL/Kokkos_SYCL_DeepCopy.hpp>
 #include <SYCL/Kokkos_SYCL_MDRangePolicy.hpp>
 #include <SYCL/Kokkos_SYCL_Parallel_Range.hpp>

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -653,8 +653,9 @@ struct SubviewExtents {
 
          Kokkos::Impl::throw_runtime_exception(std::string(buffer));))
 
-    KOKKOS_IF_ON_DEVICE(
-        ((void)dim; Kokkos::abort("Kokkos::subview bounds error");))
+    KOKKOS_IF_ON_DEVICE(((void)dim;
+                         Kokkos::abort("Kokkos::subview bounds error");
+                         [](Args...) {}(args...);))
   }
 
 #else


### PR DESCRIPTION
Follow-up to #4650. Drive-by change to `core/src/impl/Kokkos_ViewMapping.hpp`to fix a warning.