### PR TITLE
Avoid unused variables in Kokkos_Cuda_ReduceScan.hpp

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -192,27 +192,27 @@ __device__ bool cuda_inter_block_reduction(
         if (id + 1 < int(gridDim.x)) join(value, tmp);
       }
       unsigned int mask = __activemask();
-      int active        = __ballot_sync(mask, 1);
+      __syncwarp(mask);
       if (int(blockDim.x * blockDim.y) > 2) {
         value_type tmp = Kokkos::shfl_down(value, 2, 32);
         if (id + 2 < int(gridDim.x)) join(value, tmp);
       }
-      active += __ballot_sync(mask, 1);
+      __syncwarp(mask);
       if (int(blockDim.x * blockDim.y) > 4) {
         value_type tmp = Kokkos::shfl_down(value, 4, 32);
         if (id + 4 < int(gridDim.x)) join(value, tmp);
       }
-      active += __ballot_sync(mask, 1);
+      __syncwarp(mask);
       if (int(blockDim.x * blockDim.y) > 8) {
         value_type tmp = Kokkos::shfl_down(value, 8, 32);
         if (id + 8 < int(gridDim.x)) join(value, tmp);
       }
-      active += __ballot_sync(mask, 1);
+      __syncwarp(mask);
       if (int(blockDim.x * blockDim.y) > 16) {
         value_type tmp = Kokkos::shfl_down(value, 16, 32);
         if (id + 16 < int(gridDim.x)) join(value, tmp);
       }
-      active += __ballot_sync(mask, 1);
+      __syncwarp(mask);
     }
   }
   // The last block has in its thread=0 the global reduction value through
@@ -369,27 +369,27 @@ __device__ inline
         if (id + 1 < int(gridDim.x)) reducer.join(value, tmp);
       }
       unsigned int mask = __activemask();
-      int active        = __ballot_sync(mask, 1);
+      __syncwarp(mask);
       if (int(blockDim.x * blockDim.y) > 2) {
         value_type tmp = Kokkos::shfl_down(value, 2, 32);
         if (id + 2 < int(gridDim.x)) reducer.join(value, tmp);
       }
-      active += __ballot_sync(mask, 1);
+      __syncwarp(mask);
       if (int(blockDim.x * blockDim.y) > 4) {
         value_type tmp = Kokkos::shfl_down(value, 4, 32);
         if (id + 4 < int(gridDim.x)) reducer.join(value, tmp);
       }
-      active += __ballot_sync(mask, 1);
+      __syncwarp(mask);
       if (int(blockDim.x * blockDim.y) > 8) {
         value_type tmp = Kokkos::shfl_down(value, 8, 32);
         if (id + 8 < int(gridDim.x)) reducer.join(value, tmp);
       }
-      active += __ballot_sync(mask, 1);
+      __syncwarp(mask);
       if (int(blockDim.x * blockDim.y) > 16) {
         value_type tmp = Kokkos::shfl_down(value, 16, 32);
         if (id + 16 < int(gridDim.x)) reducer.join(value, tmp);
       }
-      active += __ballot_sync(mask, 1);
+      __syncwarp(mask);
     }
   }
 


### PR DESCRIPTION
Recent `clang` compilers complain about `active` not being used (and the tests also work with `__ballot_sync` removed). The calls were introduced in https://github.com/kokkos/kokkos/pull/948 for `clang` 4.0. Since we are still officially supporting that, it seems that we can't outright remove it yet (but maybe when we update the minimal `clang` version).
Anyway, I would assume that `__syncwarp` is sufficient here but we should check with `clang` 4.0.