### PR TITLE
Fix potential ambiguous specialization in is_CONCEPT macro

### DIFF
--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -148,21 +148,20 @@ struct LaunchBounds {
 
 namespace Kokkos {
 
-#define KOKKOS_IMPL_IS_CONCEPT(CONCEPT)                                    \
-  template <typename T>                                                    \
-  struct is_##CONCEPT {                                                    \
-   private:                                                                \
-    template <typename U>                                                  \
-    using have_t = typename std::is_base_of<typename U::CONCEPT, U>::type; \
-    template <typename U>                                                  \
-    using have_type_t =                                                    \
-        typename std::is_base_of<typename U::CONCEPT##_type, U>::type;     \
-                                                                           \
-   public:                                                                 \
-    static constexpr bool value =                                          \
-        detected_or_t<std::false_type, have_t, T>::value ||                \
-        detected_or_t<std::false_type, have_type_t, T>::value;             \
-    constexpr operator bool() const noexcept { return value; }             \
+#define KOKKOS_IMPL_IS_CONCEPT(CONCEPT)                        \
+  template <typename T>                                        \
+  struct is_##CONCEPT {                                        \
+   private:                                                    \
+    template <typename U>                                      \
+    using have_t = typename U::CONCEPT;                        \
+    template <typename U>                                      \
+    using have_type_t = typename U::CONCEPT##_type;            \
+                                                               \
+   public:                                                     \
+    static constexpr bool value =                              \
+        std::is_base_of<detected_t<have_t, T>, T>::value ||    \
+        std::is_base_of<detected_t<have_type_t, T>, T>::value; \
+    constexpr operator bool() const noexcept { return value; } \
   };
 
 // Public concept:


### PR DESCRIPTION
Looking at our concept macro, I realized that there is a potential for running into an ambiguous specialization if both `CONCEPT` and `CONCEPT_type` are provided as aliases, see https://godbolt.org/z/Y8E1Khq64.
I took the opportunity to also update the detection to using `is_detected`.