### PR TITLE
This makes the math function use the "C" interface for GCC 5

### DIFF
--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -91,7 +91,12 @@ namespace Experimental {
 #if defined(KOKKOS_ENABLE_SYCL)
 #define KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE sycl
 #else
+#if defined(KOKKOS_COMPILER_NVCC) && defined(__GNUC__) && (__GNUC__ < 6) && \
+    !defined(__clang__)
+#define KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE
+#else
 #define KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE std
+#endif
 #endif
 
 #define KOKKOS_IMPL_MATH_UNARY_FUNCTION(FUNC)                                 \


### PR DESCRIPTION
When compiling for CUDA with GCC 5 the std::functions don't have
the right markup, so you get all these warnings or errors about
calling pure host functions in our math functions.

Prior to GCC 6 you have to call for example fmin instead of std::fmin