### PR TITLE
algorithms/unit_tests: Increase bhalf variance factor

### DIFF
--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -434,7 +434,7 @@ struct test_random_scalar {
 
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
       if (std::is_same<Scalar, Kokkos::Experimental::bhalf_t>::value) {
-        variance_factor = 15.01;
+        variance_factor = 15.07;
       }
 #endif
 


### PR DESCRIPTION
  - Some of the unit tests are failing in the "3-D histogram"
  with bhalf.

@masterleinad reported that some of the bhalf TestRandom tests are failing in this way. This PR increases the tolerance slightly to address the failures. I marked this as a bug but suspect this has more to do with the generation of random numbers.