### PR TITLE
Deprecate `partition_master`, `validate_partition`

### DIFF
--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -378,15 +378,17 @@ class HPX {
     return std::vector<HPX>();
   }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   template <typename F>
-  static void partition_master(F const &, int requested_num_partitions = 0,
-                               int = 0) {
+  KOKKOS_DEPRECATED static void partition_master(
+      F const &, int requested_num_partitions = 0, int = 0) {
     if (requested_num_partitions > 1) {
       Kokkos::abort(
           "Kokkos::Experimental::HPX::partition_master: can't partition an "
           "HPX instance\n");
     }
   }
+#endif
 
   static int concurrency();
   static void impl_initialize(int thread_count);

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -129,14 +129,17 @@ class OpenMP {
   /// This is a no-op on OpenMP since a non default instance cannot be created
   static OpenMP create_instance(...);
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   /// \brief Partition the default instance and call 'f' on each new 'master'
   /// thread
   ///
   /// Func is a functor with the following signiture
   ///   void( int partition_id, int num_partitions )
   template <typename F>
-  static void partition_master(F const& f, int requested_num_partitions = 0,
-                               int requested_partition_size = 0);
+  KOKKOS_DEPRECATED static void partition_master(
+      F const& f, int requested_num_partitions = 0,
+      int requested_partition_size = 0);
+#endif
 
   // use UniqueToken
   static int concurrency();

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
@@ -66,6 +66,7 @@ int g_openmp_hardware_max_threads = 1;
 __thread int t_openmp_hardware_id            = 0;
 __thread Impl::OpenMPExec *t_openmp_instance = nullptr;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 void OpenMPExec::validate_partition(const int nthreads, int &num_partitions,
                                     int &partition_size) {
   if (nthreads == 1) {
@@ -117,6 +118,7 @@ void OpenMPExec::validate_partition(const int nthreads, int &num_partitions,
     }
   }
 }
+#endif
 
 void OpenMPExec::verify_is_master(const char *const label) {
   if (!t_openmp_instance) {

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -90,8 +90,11 @@ class OpenMPExec {
 
   void clear_thread_data();
 
-  static void validate_partition(const int nthreads, int& num_partitions,
-                                 int& partition_size);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+  KOKKOS_DEPRECATED static void validate_partition(const int nthreads,
+                                                   int& num_partitions,
+                                                   int& partition_size);
+#endif
 
  private:
   OpenMPExec(int arg_pool_size)
@@ -105,7 +108,9 @@ class OpenMPExec {
   HostThreadTeamData* m_pool[MAX_THREAD_COUNT];
 
  public:
-  static void verify_is_master(const char* const);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+  KOKKOS_DEPRECATED static void verify_is_master(const char* const);
+#endif
 
   void resize_thread_data(size_t pool_reduce_bytes, size_t team_reduce_bytes,
                           size_t team_shared_bytes, size_t thread_local_bytes);
@@ -163,9 +168,10 @@ inline bool OpenMP::is_asynchronous(OpenMP const& /*instance*/) noexcept {
   return false;
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 template <typename F>
-void OpenMP::partition_master(F const& f, int num_partitions,
-                              int partition_size) {
+KOKKOS_DEPRECATED void OpenMP::partition_master(F const& f, int num_partitions,
+                                                int partition_size) {
 #if _OPENMP >= 201511
   if (omp_get_max_active_levels() > 1) {
 #else
@@ -216,6 +222,7 @@ void OpenMP::partition_master(F const& f, int num_partitions,
     f(0, 1);
   }
 }
+#endif
 
 namespace Experimental {
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Exec.hpp
@@ -108,9 +108,7 @@ class OpenMPExec {
   HostThreadTeamData* m_pool[MAX_THREAD_COUNT];
 
  public:
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
-  KOKKOS_DEPRECATED static void verify_is_master(const char* const);
-#endif
+  static void verify_is_master(const char* const);
 
   void resize_thread_data(size_t pool_reduce_bytes, size_t team_reduce_bytes,
                           size_t team_shared_bytes, size_t thread_local_bytes);

--- a/core/unit_test/openmp/TestOpenMP_PartitionMaster.cpp
+++ b/core/unit_test/openmp/TestOpenMP_PartitionMaster.cpp
@@ -50,6 +50,7 @@
 
 namespace Test {
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 TEST(openmp, partition_master) {
   using Mutex = Kokkos::Experimental::MasterLock<Kokkos::OpenMP>;
 
@@ -128,5 +129,6 @@ TEST(openmp, partition_master) {
   Kokkos::OpenMP::partition_master(master, 8, 8);
   ASSERT_EQ(errors, 0);
 }
+#endif
 
 }  // namespace Test


### PR DESCRIPTION
Deprecate mentioned functions in preparation for their removal (see https://github.com/kokkos/kokkos/pull/4119).
___
This was briefly discussed at [Kokkos Developer Meeting](https://github.com/kokkos/internal-documents/blob/master/meeting-notes/2022-01-26.md#deprecation-schedule) - please complain if you feel like voting is required.