### PR TITLE
Remove `reduction_identity<bool>::{sum,prod,max,min}`

### DIFF
--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -364,16 +364,9 @@ struct reduction_identity<signed char> {
   }
 };
 
+// 4707 fix; effectively reverting much of PR #4352 
 template <>
 struct reduction_identity<bool> {
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool sum() {
-    return static_cast<bool>(false);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool prod() {
-    return static_cast<bool>(true);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool max() { return false; }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static bool min() { return true; }
   KOKKOS_FORCEINLINE_FUNCTION constexpr static bool lor() {
     return static_cast<bool>(false);
   }

--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -364,7 +364,6 @@ struct reduction_identity<signed char> {
   }
 };
 
-// 4707 fix; effectively reverting much of PR #4352 
 template <>
 struct reduction_identity<bool> {
   KOKKOS_FORCEINLINE_FUNCTION constexpr static bool lor() {

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -398,9 +398,9 @@ struct TestReducers {
       ASSERT_EQ(prod_scalar, reference_prod);
 
       prod_scalar = init;
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
-                              f_tag, reducer_scalar);
-      ASSERT_EQ(prod_scalar, reference_prod);
+      /*Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
+                              f_tag, reducer_scalar);*/
+      //ASSERT_EQ(prod_scalar, reference_prod);
 
       Scalar prod_scalar_view = reducer_scalar.reference();
       ASSERT_EQ(prod_scalar_view, reference_prod);
@@ -468,10 +468,6 @@ struct TestReducers {
       Scalar min_scalar = init;
       Kokkos::Min<Scalar> reducer_scalar(min_scalar);
 
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
-                              reducer_scalar);
-      ASSERT_EQ(min_scalar, reference_min);
-
       min_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
                               f_tag, reducer_scalar);
@@ -518,10 +514,6 @@ struct TestReducers {
     {
       Scalar max_scalar = init;
       Kokkos::Max<Scalar> reducer_scalar(max_scalar);
-
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
-                              reducer_scalar);
-      ASSERT_EQ(max_scalar, reference_max);
 
       max_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
@@ -1036,10 +1028,6 @@ struct TestReducers {
   static void execute_bool() {
     test_LAnd(10001);
     test_LOr(35);
-    test_sum(10001);
-    test_prod(35);
-    test_min(10003);
-    test_max(10007);
   }
 };
 

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -398,9 +398,9 @@ struct TestReducers {
       ASSERT_EQ(prod_scalar, reference_prod);
 
       prod_scalar = init;
-      /*Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
-                              f_tag, reducer_scalar);*/
-      //ASSERT_EQ(prod_scalar, reference_prod);
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
+                              f_tag, reducer_scalar);
+      ASSERT_EQ(prod_scalar, reference_prod);
 
       Scalar prod_scalar_view = reducer_scalar.reference();
       ASSERT_EQ(prod_scalar_view, reference_prod);
@@ -468,6 +468,10 @@ struct TestReducers {
       Scalar min_scalar = init;
       Kokkos::Min<Scalar> reducer_scalar(min_scalar);
 
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
+                              reducer_scalar);
+      ASSERT_EQ(min_scalar, reference_min);
+
       min_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
                               f_tag, reducer_scalar);
@@ -514,6 +518,10 @@ struct TestReducers {
     {
       Scalar max_scalar = init;
       Kokkos::Max<Scalar> reducer_scalar(max_scalar);
+
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
+                              reducer_scalar);
+      ASSERT_EQ(max_scalar, reference_max);
 
       max_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),


### PR DESCRIPTION
Fix #4707

Changes here remove all `reduction_identity` specializations for `bool`, except for `lor` and `land.`  Builds on Blake (Sandia Intel Skylake machine) now succeed with `cmake-3.19.3`, `binutils/2.30.0` and `gcc-10.2.0` (with the ` -Werror` flag).  