### PR TITLE
Fix compiler warnings with newest SYCL compiler

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -262,9 +262,6 @@ std::ostream& SYCL::impl_sycl_info(std::ostream& os,
             << device.get_info<device::is_linker_available>()
             << "\nQueue Profiling: "
             << device.get_info<device::queue_profiling>()
-            << "\nBuilt In Kernels: "
-            << Container<std::vector<std::string>>(
-                   device.get_info<device::built_in_kernels>())
             << "\nVendor: " << device.get_info<device::vendor>()
             << "\nProfile: " << device.get_info<device::profile>()
             << "\nVersion: " << device.get_info<device::version>()

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -375,10 +375,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                     false, std::min(size, wgroup_size));
 
                 if (local_id == 0) {
-                  sycl::ext::oneapi::atomic_ref<
-                      unsigned, sycl::ext::oneapi::memory_order::relaxed,
-                      sycl::ext::oneapi::memory_scope::device,
-                      sycl::access::address_space::global_space>
+                  sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                                   sycl::memory_scope::device,
+                                   sycl::access::address_space::global_space>
                       scratch_flags_ref(*scratch_flags);
                   num_teams_done[0] = ++scratch_flags_ref;
                 }
@@ -418,10 +417,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                     std::min(size, wgroup_size));
 
                 if (local_id == 0) {
-                  sycl::ext::oneapi::atomic_ref<
-                      unsigned, sycl::ext::oneapi::memory_order::relaxed,
-                      sycl::ext::oneapi::memory_scope::device,
-                      sycl::access::address_space::global_space>
+                  sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                                   sycl::memory_scope::device,
+                                   sycl::access::address_space::global_space>
                       scratch_flags_ref(*scratch_flags);
                   num_teams_done[0] = ++scratch_flags_ref;
                 }
@@ -702,10 +700,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                 std::min(size, wgroup_size));
 
             if (local_id == 0) {
-              sycl::ext::oneapi::atomic_ref<
-                  unsigned, sycl::ext::oneapi::memory_order::relaxed,
-                  sycl::ext::oneapi::memory_scope::device,
-                  sycl::access::address_space::global_space>
+              sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                               sycl::memory_scope::device,
+                               sycl::access::address_space::global_space>
                   scratch_flags_ref(*scratch_flags);
               num_teams_done[0] = ++scratch_flags_ref;
             }
@@ -746,10 +743,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                 std::min(size, wgroup_size));
 
             if (local_id == 0) {
-              sycl::ext::oneapi::atomic_ref<
-                  unsigned, sycl::ext::oneapi::memory_order::relaxed,
-                  sycl::ext::oneapi::memory_scope::device,
-                  sycl::access::address_space::global_space>
+              sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                               sycl::memory_scope::device,
+                               sycl::access::address_space::global_space>
                   scratch_flags_ref(*scratch_flags);
               num_teams_done[0] = ++scratch_flags_ref;
             }

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -730,10 +730,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                                 item.get_local_range()[1]));
 
                   if (local_id == 0) {
-                    sycl::ext::oneapi::atomic_ref<
-                        unsigned, sycl::ext::oneapi::memory_order::relaxed,
-                        sycl::ext::oneapi::memory_scope::device,
-                        sycl::access::address_space::global_space>
+                    sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                                     sycl::memory_scope::device,
+                                     sycl::access::address_space::global_space>
                         scratch_flags_ref(*scratch_flags);
                     num_teams_done = ++scratch_flags_ref;
                   }
@@ -779,10 +778,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                                 item.get_local_range()[1]));
 
                   if (local_id == 0) {
-                    sycl::ext::oneapi::atomic_ref<
-                        unsigned, sycl::ext::oneapi::memory_order::relaxed,
-                        sycl::ext::oneapi::memory_scope::device,
-                        sycl::access::address_space::global_space>
+                    sycl::atomic_ref<unsigned, sycl::memory_order::relaxed,
+                                     sycl::memory_scope::device,
+                                     sycl::access::address_space::global_space>
                         scratch_flags_ref(*scratch_flags);
                     num_teams_done = ++scratch_flags_ref;
                   }

--- a/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -27,131 +27,13 @@ inline void atomic_thread_fence(MemoryOrder, MemoryScope) {
       Impl::DesulToSYCLMemoryScope<MemoryScope, /*extended namespace*/ false>::value);
 }
 
-// FIXME_SYCL We need to either use generic_space or figure out how to check for the
-// correct adress space in a SYCL-portable way.
-#ifndef __NVPTX__
 template <typename T, class MemoryOrder, class MemoryScope>
 typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
   static_assert(sizeof(unsigned int) == 4,
                 "this function assumes an unsigned int is 32-bit");
-  auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<unsigned int>(dest);
-  if (l) {
-    Impl::sycl_atomic_ref<unsigned int,
-                          MemoryOrder,
-                          MemoryScopeDevice,
-                          sycl::access::address_space::local_space>
-        dest_ref(*reinterpret_cast<unsigned int*>(dest));
-    dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare),
-                                     *reinterpret_cast<unsigned int*>(&value));
-    return compare;
-  } else {
-    Impl::sycl_atomic_ref<unsigned int,
-                          MemoryOrder,
-                          MemoryScopeDevice,
-                          sycl::access::address_space::global_space>
-        dest_ref(*reinterpret_cast<unsigned int*>(dest));
-    dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare),
-                                     *reinterpret_cast<unsigned int*>(&value));
-    return compare;
-  }
-}
-template <typename T, class MemoryOrder, class MemoryScope>
-typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
-    T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
-  static_assert(sizeof(unsigned long long int) == 8,
-                "this function assumes an unsigned long long is 64-bit");
-  auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<unsigned long long int>(dest);
-  if (l) {
-    Impl::sycl_atomic_ref<unsigned long long int,
-                          MemoryOrder,
-                          MemoryScopeDevice,
-                          sycl::access::address_space::local_space>
-        dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
-    dest_ref.compare_exchange_strong(
-        *reinterpret_cast<unsigned long long int*>(&compare),
-        *reinterpret_cast<unsigned long long int*>(&value));
-    return compare;
-  } else {
-    Impl::sycl_atomic_ref<unsigned long long int,
-                          MemoryOrder,
-                          MemoryScopeDevice,
-                          sycl::access::address_space::global_space>
-        dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
-    dest_ref.compare_exchange_strong(
-        *reinterpret_cast<unsigned long long int*>(&compare),
-        *reinterpret_cast<unsigned long long int*>(&value));
-    return compare;
-  }
-}
-
-template <typename T, class MemoryOrder, class MemoryScope>
-typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(T* const dest,
-                                                                 T value,
-                                                                 MemoryOrder,
-                                                                 MemoryScope) {
-  static_assert(sizeof(unsigned int) == 4,
-                "this function assumes an unsigned int is 32-bit");
-  auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<unsigned int>(dest);
-  if (l) {
-    Impl::sycl_atomic_ref<unsigned int,
-                          MemoryOrder,
-                          MemoryScopeDevice,
-                          sycl::access::address_space::local_space>
-        dest_ref(*reinterpret_cast<unsigned int*>(dest));
-    unsigned int return_val =
-        dest_ref.exchange(*reinterpret_cast<unsigned int*>(&value));
-    return reinterpret_cast<T&>(return_val);
-  } else {
-    Impl::sycl_atomic_ref<unsigned int,
-                          MemoryOrder,
-                          MemoryScopeDevice,
-                          sycl::access::address_space::global_space>
-        dest_ref(*reinterpret_cast<unsigned int*>(dest));
-    unsigned int return_val =
-        dest_ref.exchange(*reinterpret_cast<unsigned int*>(&value));
-    return reinterpret_cast<T&>(return_val);
-  }
-}
-template <typename T, class MemoryOrder, class MemoryScope>
-typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(T* const dest,
-                                                                 T value,
-                                                                 MemoryOrder,
-                                                                 MemoryScope) {
-  static_assert(sizeof(unsigned long long int) == 8,
-                "this function assumes an unsigned long long is 64-bit");
-  auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<unsigned long long int>(dest);
-  if (l) {
-    Impl::sycl_atomic_ref<unsigned long long int,
-                          MemoryOrder,
-                          MemoryScopeDevice,
-                          sycl::access::address_space::local_space>
-        dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
-    unsigned long long int return_val =
-        dest_ref.exchange(*reinterpret_cast<unsigned long long int*>(&value));
-    return reinterpret_cast<T&>(return_val);
-  } else {
-    Impl::sycl_atomic_ref<unsigned long long int,
-                          MemoryOrder,
-                          MemoryScopeDevice,
-                          sycl::access::address_space::global_space>
-        dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
-    unsigned long long int return_val =
-        dest_ref.exchange(*reinterpret_cast<unsigned long long int*>(&value));
-    return reinterpret_cast<T&>(return_val);
-  }
-}
-#else
-template <typename T, class MemoryOrder, class MemoryScope>
-typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
-    T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
-  static_assert(sizeof(unsigned int) == 4,
-                "this function assumes an unsigned int is 32-bit");
-  Impl::sycl_atomic_ref<unsigned int,
-                        MemoryOrder,
-                        MemoryScope,
-                        sycl::access::address_space::global_space>
-      dest_ref(*reinterpret_cast<unsigned int*>(dest));
+  Impl::sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> dest_ref(
+      *reinterpret_cast<unsigned int*>(dest));
   dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare),
                                    *reinterpret_cast<unsigned int*>(&value));
   return compare;
@@ -161,11 +43,8 @@ typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope) {
   static_assert(sizeof(unsigned long long int) == 8,
                 "this function assumes an unsigned long long is 64-bit");
-  Impl::sycl_atomic_ref<unsigned long long int,
-                        MemoryOrder,
-                        MemoryScope,
-                        sycl::access::address_space::global_space>
-      dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+  Impl::sycl_atomic_ref<unsigned long long int, MemoryOrder, MemoryScope> dest_ref(
+      *reinterpret_cast<unsigned long long int*>(dest));
   dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned long long int*>(&compare),
                                    *reinterpret_cast<unsigned long long int*>(&value));
   return compare;
@@ -178,11 +57,8 @@ typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(T* const dest,
                                                                  MemoryScope) {
   static_assert(sizeof(unsigned int) == 4,
                 "this function assumes an unsigned int is 32-bit");
-  Impl::sycl_atomic_ref<unsigned int,
-                        MemoryOrder,
-                        MemoryScope,
-                        sycl::access::address_space::global_space>
-      dest_ref(*reinterpret_cast<unsigned int*>(dest));
+  Impl::sycl_atomic_ref<unsigned int, MemoryOrder, MemoryScope> dest_ref(
+      *reinterpret_cast<unsigned int*>(dest));
   unsigned int return_val = dest_ref.exchange(*reinterpret_cast<unsigned int*>(&value));
   return reinterpret_cast<T&>(return_val);
 }
@@ -193,16 +69,12 @@ typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(T* const dest,
                                                                  MemoryScope) {
   static_assert(sizeof(unsigned long long int) == 8,
                 "this function assumes an unsigned long long is 64-bit");
-  Impl::sycl_atomic_ref<unsigned long long int,
-                        MemoryOrder,
-                        MemoryScope,
-                        sycl::access::address_space::global_space>
-      dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+  Impl::sycl_atomic_ref<unsigned long long int, MemoryOrder, MemoryScope> dest_ref(
+      *reinterpret_cast<unsigned long long int*>(dest));
   unsigned long long int return_val =
       dest_ref.exchange(reinterpret_cast<unsigned long long int&>(value));
   return reinterpret_cast<T&>(return_val);
 }
-#endif
 
 template <typename T, class MemoryOrder, class MemoryScope>
 typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type

--- a/core/src/desul/atomics/SYCL.hpp
+++ b/core/src/desul/atomics/SYCL.hpp
@@ -17,69 +17,17 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 namespace desul {
 
-// FIXME_SYCL We need to either use generic_space or figure out how to check for the
-// correct adress space in a SYCL-portable way.
-#ifndef __NVPTX__
 #define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, TYPE)                              \
   template <class MemoryOrder>                                                     \
   TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeDevice) { \
-    auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<TYPE>(dest);                  \
-    if (l) {                                                                       \
-      Impl::sycl_atomic_ref<TYPE,                                                  \
-                            MemoryOrder,                                           \
-                            MemoryScopeDevice,                                     \
-                            sycl::access::address_space::local_space>              \
-          dest_ref(*dest);                                                         \
-      return dest_ref.fetch_##OPER(val);                                           \
-    } else {                                                                       \
-      Impl::sycl_atomic_ref<TYPE,                                                  \
-                            MemoryOrder,                                           \
-                            MemoryScopeDevice,                                     \
-                            sycl::access::address_space::global_space>             \
-          dest_ref(*dest);                                                         \
-      return dest_ref.fetch_##OPER(val);                                           \
-    }                                                                              \
-  }                                                                                \
-  template <class MemoryOrder>                                                     \
-  TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeCore) {   \
-    auto l = __SYCL_GenericCastToPtrExplicit_ToLocal<TYPE>(dest);                  \
-    if (l) {                                                                       \
-      Impl::sycl_atomic_ref<TYPE,                                                  \
-                            MemoryOrder,                                           \
-                            MemoryScopeDevice,                                     \
-                            sycl::access::address_space::local_space>              \
-          dest_ref(*dest);                                                         \
-      return dest_ref.fetch_##OPER(val);                                           \
-    } else {                                                                       \
-      Impl::sycl_atomic_ref<TYPE,                                                  \
-                            MemoryOrder,                                           \
-                            MemoryScopeDevice,                                     \
-                            sycl::access::address_space::global_space>             \
-          dest_ref(*dest);                                                         \
-      return dest_ref.fetch_##OPER(val);                                           \
-    }                                                                              \
-  }
-#else
-#define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, TYPE)                              \
-  template <class MemoryOrder>                                                     \
-  TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeDevice) { \
-    Impl::sycl_atomic_ref<TYPE,                                                    \
-                          MemoryOrder,                                             \
-                          MemoryScopeDevice,                                       \
-                          sycl::access::address_space::global_space>               \
-        dest_ref(*dest);                                                           \
+    Impl::sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeDevice> dest_ref(*dest);   \
     return dest_ref.fetch_##OPER(val);                                             \
   }                                                                                \
   template <class MemoryOrder>                                                     \
   TYPE atomic_fetch_##OPER(TYPE* dest, TYPE val, MemoryOrder, MemoryScopeCore) {   \
-    Impl::sycl_atomic_ref<TYPE,                                                    \
-                          MemoryOrder,                                             \
-                          MemoryScopeCore,                                         \
-                          sycl::access::address_space::global_space>               \
-        dest_ref(*dest);                                                           \
+    Impl::sycl_atomic_ref<TYPE, MemoryOrder, MemoryScopeCore> dest_ref(*dest);     \
     return dest_ref.fetch_##OPER(val);                                             \
   }
-#endif
 
 #define DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER_INTEGRAL(OPER) \
   DESUL_IMPL_SYCL_ATOMIC_FETCH_OPER(OPER, int)           \

--- a/core/src/desul/atomics/SYCLConversions.hpp
+++ b/core/src/desul/atomics/SYCLConversions.hpp
@@ -80,16 +80,20 @@ struct DesulToSYCLMemoryScope<MemoryScopeSystem, extended_namespace> {
       sycl_memory_scope<extended_namespace>::system;
 };
 
-template <class T,
-          class MemoryOrder,
-          class MemoryScope,
-          sycl::access::address_space AddressSpace>
-using sycl_atomic_ref =
-    sycl::ext::oneapi::atomic_ref<T,
-                                  DesulToSYCLMemoryOrder<MemoryOrder>::value,
-                                  DesulToSYCLMemoryScope<MemoryScope>::value,
-                                  AddressSpace>;
-
+// FIXME_SYCL generic_space isn't available yet for CUDA.
+#ifdef __NVPTX__
+template <class T, class MemoryOrder, class MemoryScope>
+using sycl_atomic_ref = sycl::atomic_ref<T,
+                                         DesulToSYCLMemoryOrder<MemoryOrder>::value,
+                                         DesulToSYCLMemoryScope<MemoryScope>::value,
+                                         sycl::access::address_space::global_space>;
+#else
+template <class T, class MemoryOrder, class MemoryScope>
+using sycl_atomic_ref = sycl::atomic_ref<T,
+                                         DesulToSYCLMemoryOrder<MemoryOrder>::value,
+                                         DesulToSYCLMemoryScope<MemoryScope>::value,
+                                         sycl::access::address_space::generic_space>;
+#endif
 }  // namespace Impl
 }  // namespace desul
 

--- a/core/src/impl/Kokkos_Memory_Fence.hpp
+++ b/core/src/impl/Kokkos_Memory_Fence.hpp
@@ -58,8 +58,7 @@ void memory_fence() {
 #elif defined(__HIP_DEVICE_COMPILE__)
   __threadfence();
 #elif defined(KOKKOS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__)
-  sycl::atomic_fence(sycl::ext::oneapi::memory_order::acq_rel,
-                     sycl::ext::oneapi::memory_scope::device);
+  sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::device);
 #elif defined(KOKKOS_ENABLE_ASM) && defined(KOKKOS_ENABLE_ISA_X86_64)
   asm volatile("mfence" ::: "memory");
 #elif defined(KOKKOS_ENABLE_GNU_ATOMICS) || \

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
@@ -93,8 +93,10 @@ TEST(sycl, raw_sycl_interop_context_2) {
   constexpr int n = 100;
 
   Kokkos::Experimental::SYCL space(queue);
-  Kokkos::View<int*, Kokkos::Experimental::SYCLDeviceUSMSpace> v("default_view",
-                                                                 n);
+  // FIXME_SYCL WithoutInitialing should not be necessary but works around a
+  // compiler regression
+  Kokkos::View<int*, Kokkos::Experimental::SYCLDeviceUSMSpace> v(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "default_view"), n);
   Kokkos::deep_copy(space, v, 5);
 
   auto* v_ptr = v.data();

--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -36,8 +36,8 @@ RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSIO
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
 ENV SYCL_DIR=/opt/sycl
-RUN SYCL_VERSION=2021-09 && \
-    SYCL_URL=https://github.com/intel/llvm/archive/ && \
+RUN SYCL_VERSION=20220112 && \
+    SYCL_URL=https://github.com/intel/llvm/archive/sycl-nightly && \
     SYCL_ARCHIVE=${SYCL_VERSION}.tar.gz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${SYCL_URL}/${SYCL_ARCHIVE} && \


### PR DESCRIPTION
The newest compiler drop introduces some more deprecation warnings.