### PR TITLE
Unique token improvement

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -998,19 +998,6 @@ void CudaSpaceInitializer::print_configuration(std::ostream &msg,
 
 }  // namespace Kokkos
 
-namespace Kokkos {
-namespace Experimental {
-
-UniqueToken<Kokkos::Cuda, Kokkos::Experimental::UniqueTokenScope::Global>::
-    UniqueToken(Kokkos::Cuda const &)
-    : m_locks(Kokkos::View<uint32_t *, Kokkos::CudaSpace>(
-          "Kokkos::UniqueToken::m_locks",
-          Kokkos::Impl::CudaInternal::singleton().m_maxConcurrency)),
-      m_count(Kokkos::Impl::CudaInternal::singleton().m_maxConcurrency) {}
-
-}  // namespace Experimental
-}  // namespace Kokkos
-
 #else
 
 void KOKKOS_CORE_SRC_CUDA_IMPL_PREVENT_LINK_ERROR() {}

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -1003,8 +1003,9 @@ namespace Experimental {
 
 UniqueToken<Kokkos::Cuda, Kokkos::Experimental::UniqueTokenScope::Global>::
     UniqueToken(Kokkos::Cuda const &)
-    : m_buffer(
-          Kokkos::Impl::CudaInternal::singleton().m_scratchConcurrentBitset),
+    : m_locks(Kokkos::View<uint32_t *, Kokkos::CudaSpace>(
+          "Kokkos::UniqueToken::m_locks",
+          Kokkos::Impl::CudaInternal::singleton().m_maxConcurrency)),
       m_count(Kokkos::Impl::CudaInternal::singleton().m_maxConcurrency) {}
 
 }  // namespace Experimental

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -302,8 +302,7 @@ void CudaInternal::print_configuration(std::ostream &s) const {
 //----------------------------------------------------------------------------
 
 CudaInternal::~CudaInternal() {
-  if (m_stream || m_scratchSpace || m_scratchFlags || m_scratchUnified ||
-      m_scratchConcurrentBitset) {
+  if (m_stream || m_scratchSpace || m_scratchFlags || m_scratchUnified) {
     std::cerr << "Kokkos::Cuda ERROR: Failed to call Kokkos::Cuda::finalize()"
               << std::endl;
   }
@@ -323,7 +322,6 @@ CudaInternal::~CudaInternal() {
   m_scratchSpace            = nullptr;
   m_scratchFlags            = nullptr;
   m_scratchUnified          = nullptr;
-  m_scratchConcurrentBitset = nullptr;
   m_stream                  = nullptr;
   for (int i = 0; i < m_n_team_scratch; ++i) {
     m_team_scratch_current_size[i] = 0;
@@ -501,11 +499,6 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream,
                            sizeof(uint32_t) * buffer_bound);
 
       Record::increment(r);
-
-      m_scratchConcurrentBitset = reinterpret_cast<uint32_t *>(r->data());
-
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemset(m_scratchConcurrentBitset, 0,
-                                            sizeof(uint32_t) * buffer_bound));
     }
     //----------------------------------
 
@@ -732,7 +725,6 @@ void CudaInternal::finalize() {
     RecordCuda::decrement(RecordCuda::get_record(m_scratchFlags));
     RecordCuda::decrement(RecordCuda::get_record(m_scratchSpace));
     RecordHost::decrement(RecordHost::get_record(m_scratchUnified));
-    RecordCuda::decrement(RecordCuda::get_record(m_scratchConcurrentBitset));
     if (m_scratchFunctorSize > 0)
       RecordCuda::decrement(RecordCuda::get_record(m_scratchFunctor));
 
@@ -744,20 +736,19 @@ void CudaInternal::finalize() {
     if (m_manage_stream && m_stream != nullptr)
       KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(m_stream));
 
-    m_cudaDev                 = -1;
-    m_multiProcCount          = 0;
-    m_maxWarpCount            = 0;
-    m_maxBlock                = {0, 0, 0};
-    m_maxSharedWords          = 0;
-    m_scratchSpaceCount       = 0;
-    m_scratchFlagsCount       = 0;
-    m_scratchUnifiedCount     = 0;
-    m_streamCount             = 0;
-    m_scratchSpace            = nullptr;
-    m_scratchFlags            = nullptr;
-    m_scratchUnified          = nullptr;
-    m_scratchConcurrentBitset = nullptr;
-    m_stream                  = nullptr;
+    m_cudaDev             = -1;
+    m_multiProcCount      = 0;
+    m_maxWarpCount        = 0;
+    m_maxBlock            = {0, 0, 0};
+    m_maxSharedWords      = 0;
+    m_scratchSpaceCount   = 0;
+    m_scratchFlagsCount   = 0;
+    m_scratchUnifiedCount = 0;
+    m_streamCount         = 0;
+    m_scratchSpace        = nullptr;
+    m_scratchFlags        = nullptr;
+    m_scratchUnified      = nullptr;
+    m_stream              = nullptr;
     for (int i = 0; i < m_n_team_scratch; ++i) {
       m_team_scratch_current_size[i] = 0;
       m_team_scratch_ptr[i]          = nullptr;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -115,7 +115,6 @@ class CudaInternal {
   mutable size_type* m_scratchFlags;
   mutable size_type* m_scratchUnified;
   mutable size_type* m_scratchFunctor;
-  uint32_t* m_scratchConcurrentBitset;
   cudaStream_t m_stream;
   uint32_t m_instance_id;
   bool m_manage_stream;
@@ -183,7 +182,6 @@ class CudaInternal {
         m_scratchFlags(nullptr),
         m_scratchUnified(nullptr),
         m_scratchFunctor(nullptr),
-        m_scratchConcurrentBitset(nullptr),
         m_stream(nullptr),
         m_instance_id(
             Kokkos::Tools::Experimental::Impl::idForInstance<Kokkos::Cuda>(

--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -51,7 +51,6 @@
 #include <Kokkos_CudaSpace.hpp>
 #include <Kokkos_UniqueToken.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
-#include <impl/Kokkos_ConcurrentBitset.hpp>
 
 namespace Kokkos {
 namespace Experimental {

--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -65,9 +65,13 @@ class UniqueToken<Cuda, UniqueTokenScope::Global> {
   using execution_space = Cuda;
   using size_type       = int32_t;
 
-  explicit UniqueToken(execution_space const& = execution_space())
+  explicit UniqueToken()
       : m_locks(Kokkos::View<uint32_t*, Kokkos::CudaSpace>(
             "Kokkos::UniqueToken::m_locks", Kokkos::Cuda().concurrency())) {}
+  explicit UniqueToken(execution_space const& exec)
+      : m_locks(Kokkos::View<uint32_t*, Kokkos::CudaSpace>(
+            Kokkos::view_alloc(exec, "Kokkos::UniqueToken::m_locks"),
+            Kokkos::Cuda().concurrency())) {}
 
   KOKKOS_DEFAULTED_FUNCTION
   UniqueToken(const UniqueToken&) = default;
@@ -150,12 +154,17 @@ template <>
 class UniqueToken<Cuda, UniqueTokenScope::Instance>
     : public UniqueToken<Cuda, UniqueTokenScope::Global> {
  public:
+  explicit UniqueToken() : UniqueToken<Cuda, UniqueTokenScope::Global>() {}
   explicit UniqueToken(execution_space const& arg = execution_space())
       : UniqueToken<Cuda, UniqueTokenScope::Global>(arg) {}
 
-  UniqueToken(size_type max_size, execution_space const& = execution_space()) {
+  UniqueToken(size_type max_size) {
     m_locks = Kokkos::View<uint32_t*, Kokkos::CudaSpace>(
         "Kokkos::UniqueToken::m_locks", max_size);
+  }
+  UniqueToken(size_type max_size, execution_space const& exec) {
+    m_locks = Kokkos::View<uint32_t*, Kokkos::CudaSpace>(
+        Kokkos::view_alloc(exec, "Kokkos::UniqueToken::m_locks"), max_size);
   }
 };
 

--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -66,12 +66,10 @@ class UniqueToken<Cuda, UniqueTokenScope::Global> {
   using size_type       = int32_t;
 
   explicit UniqueToken()
-      : m_locks(Kokkos::View<uint32_t*, Kokkos::CudaSpace>(
-            "Kokkos::UniqueToken::m_locks", Kokkos::Cuda().concurrency())) {}
+      : m_locks("Kokkos::UniqueToken::m_locks", Kokkos::Cuda().concurrency()) {}
   explicit UniqueToken(execution_space const& exec)
-      : m_locks(Kokkos::View<uint32_t*, Kokkos::CudaSpace>(
-            Kokkos::view_alloc(exec, "Kokkos::UniqueToken::m_locks"),
-            Kokkos::Cuda().concurrency())) {}
+      : m_locks(Kokkos::view_alloc(exec, "Kokkos::UniqueToken::m_locks"),
+                Kokkos::Cuda().concurrency()) {}
 
   KOKKOS_DEFAULTED_FUNCTION
   UniqueToken(const UniqueToken&) = default;

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -152,25 +152,24 @@ void HIPInternal::print_configuration(std::ostream &s) const {
 //----------------------------------------------------------------------------
 
 HIPInternal::~HIPInternal() {
-  if (m_scratchSpace || m_scratchFlags || m_scratchConcurrentBitset) {
+  if (m_scratchSpace || m_scratchFlags) {
     std::cerr << "Kokkos::Experimental::HIP ERROR: Failed to call "
                  "Kokkos::Experimental::HIP::finalize()"
               << std::endl;
     std::cerr.flush();
   }
 
-  m_hipDev                  = -1;
-  m_hipArch                 = -1;
-  m_multiProcCount          = 0;
-  m_maxWarpCount            = 0;
-  m_maxSharedWords          = 0;
-  m_maxShmemPerBlock        = 0;
-  m_scratchSpaceCount       = 0;
-  m_scratchFlagsCount       = 0;
-  m_scratchSpace            = nullptr;
-  m_scratchFlags            = nullptr;
-  m_scratchConcurrentBitset = nullptr;
-  m_stream                  = nullptr;
+  m_hipDev            = -1;
+  m_hipArch           = -1;
+  m_multiProcCount    = 0;
+  m_maxWarpCount      = 0;
+  m_maxSharedWords    = 0;
+  m_maxShmemPerBlock  = 0;
+  m_scratchSpaceCount = 0;
+  m_scratchFlagsCount = 0;
+  m_scratchSpace      = nullptr;
+  m_scratchFlags      = nullptr;
+  m_stream            = nullptr;
 }
 
 int HIPInternal::verify_is_initialized(const char *const label) const {
@@ -306,11 +305,6 @@ void HIPInternal::initialize(int hip_device_id, hipStream_t stream,
                                          sizeof(uint32_t) * buffer_bound);
 
       Record::increment(r);
-
-      m_scratchConcurrentBitset = reinterpret_cast<uint32_t *>(r->data());
-
-      KOKKOS_IMPL_HIP_SAFE_CALL(hipMemset(m_scratchConcurrentBitset, 0,
-                                          sizeof(uint32_t) * buffer_bound));
     }
     //----------------------------------
 
@@ -430,7 +424,6 @@ void HIPInternal::finalize() {
 
     RecordHIP::decrement(RecordHIP::get_record(m_scratchFlags));
     RecordHIP::decrement(RecordHIP::get_record(m_scratchSpace));
-    RecordHIP::decrement(RecordHIP::get_record(m_scratchConcurrentBitset));
 
     if (m_team_scratch_current_size > 0)
       Kokkos::kokkos_free<Kokkos::Experimental::HIPSpace>(m_team_scratch_ptr);
@@ -449,7 +442,6 @@ void HIPInternal::finalize() {
     m_scratchFlagsCount         = 0;
     m_scratchSpace              = nullptr;
     m_scratchFlags              = nullptr;
-    m_scratchConcurrentBitset   = nullptr;
     m_stream                    = nullptr;
     m_team_scratch_current_size = 0;
     m_team_scratch_ptr          = nullptr;

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -120,9 +120,8 @@ class HIPInternal {
   std::size_t m_scratchSpaceCount = 0;
   std::size_t m_scratchFlagsCount = 0;
 
-  size_type *m_scratchSpace           = nullptr;
-  size_type *m_scratchFlags           = nullptr;
-  uint32_t *m_scratchConcurrentBitset = nullptr;
+  size_type *m_scratchSpace = nullptr;
+  size_type *m_scratchFlags = nullptr;
 
   hipDeviceProp_t m_deviceProp;
 

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -45,9 +45,12 @@
 #ifndef KOKKOS_HIP_UNIQUE_TOKEN_HPP
 #define KOKKOS_HIP_UNIQUE_TOKEN_HPP
 
-#include <impl/Kokkos_ConcurrentBitset.hpp>
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_HIP
+
 #include <Kokkos_HIP_Space.hpp>
 #include <Kokkos_UniqueToken.hpp>
+#include <impl/Kokkos_SharedAlloc.hpp>
 
 namespace Kokkos {
 namespace Experimental {
@@ -56,7 +59,7 @@ namespace Experimental {
 template <>
 class UniqueToken<HIP, UniqueTokenScope::Global> {
  protected:
-  uint32_t volatile* m_buffer;
+  View<uint32_t*, HIPSpace> m_locks;
   uint32_t m_count;
 
  public:
@@ -64,8 +67,9 @@ class UniqueToken<HIP, UniqueTokenScope::Global> {
   using size_type       = int32_t;
 
   explicit UniqueToken(execution_space const& = execution_space())
-      : m_buffer(Impl::HIPInternal::singleton().m_scratchConcurrentBitset),
-        m_count(HIP::concurrency()) {}
+      : m_locks(View<uint32_t*, HIPSpace>("Kokkos::UniqueToken::m_locks",
+                                          HIP().concurrency())),
+        m_count(HIP().concurrency()){};
 
   KOKKOS_DEFAULTED_FUNCTION
   UniqueToken(const UniqueToken&) = default;
@@ -86,44 +90,55 @@ class UniqueToken<HIP, UniqueTokenScope::Global> {
   /// \brief acquire value such that 0 <= value < size()
   KOKKOS_INLINE_FUNCTION
   size_type acquire() const {
-    const Kokkos::pair<int, int> result =
-        Kokkos::Impl::concurrent_bitset::acquire_bounded(
-            m_buffer, m_count, Kokkos::Impl::clock_tic() % m_count);
-
-    if (result.first < 0) {
-      Kokkos::abort(
-          "UniqueToken<HIP> failure to acquire tokens, no tokens available");
-    }
-
-    return result.first;
+    KOKKOS_IF_ON_DEVICE(
+        int idx = blockIdx.x * (blockDim.x * blockDim.y) +
+                  threadIdx.y * blockDim.x + threadIdx.x;
+        idx = idx % m_count; unsigned int active = __ballot(1);
+        unsigned int done_active = 0; bool done = false;
+        while (active != done_active) {
+          if (!done) {
+            desul::atomic_thread_fence(desul::MemoryOrderAcquire(),
+                                       desul::MemoryScopeDevice());
+            if (Kokkos::atomic_compare_exchange(&m_locks(idx), 0, 1) == 0) {
+              done = true;
+            } else {
+              idx += blockDim.y * blockDim.x + 1;
+              idx = idx % m_count;
+            }
+          }
+          done_active = __ballot(done ? 1 : 0);
+        } return idx;)
+    KOKKOS_IF_ON_HOST(return 0;)
   }
 
   /// \brief release an acquired value
   KOKKOS_INLINE_FUNCTION
-  void release(size_type i) const noexcept {
-    Kokkos::Impl::concurrent_bitset::release(m_buffer, i);
+  void release(size_type idx) const noexcept {
+    desul::atomic_thread_fence(desul::MemoryOrderAcquire(),
+                               desul::MemoryScopeDevice());
+    (void)Kokkos::atomic_exchange(&m_locks(idx), 0);
   }
 };
 
 template <>
 class UniqueToken<HIP, UniqueTokenScope::Instance>
     : public UniqueToken<HIP, UniqueTokenScope::Global> {
+ private:
   View<uint32_t*, HIPSpace> m_buffer_view;
 
  public:
   explicit UniqueToken(execution_space const& arg = execution_space())
       : UniqueToken<HIP, UniqueTokenScope::Global>(arg) {}
 
-  UniqueToken(size_type max_size, execution_space const& = execution_space())
-      : m_buffer_view(
-            "UniqueToken::m_buffer_view",
-            ::Kokkos::Impl::concurrent_bitset::buffer_bound(max_size)) {
-    m_buffer = m_buffer_view.data();
-    m_count  = max_size;
+  UniqueToken(size_type max_size, execution_space const& = execution_space()) {
+    m_locks =
+        View<uint32_t*, HIPSpace>("Kokkos::UniqueToken::m_locks", max_size);
+    m_count = max_size;
   }
 };
 
 }  // namespace Experimental
 }  // namespace Kokkos
 
-#endif
+#endif  // KOKKOS_ENABLE_HIP
+#endif  // KOKKOS_HIP_UNIQUE_TOKEN_HPP

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -97,8 +97,12 @@ class UniqueToken<HIP, UniqueTokenScope::Global> {
         unsigned int done_active = 0; bool done = false;
         while (active != done_active) {
           if (!done) {
+#ifdef KOKKOS_ENABLE_IMPL_DESUL_ATOMICS
             desul::atomic_thread_fence(desul::MemoryOrderAcquire(),
                                        desul::MemoryScopeDevice());
+#else
+            Kokkos::memory_fence();
+#endif
             if (Kokkos::atomic_compare_exchange(&m_locks(idx), 0, 1) == 0) {
               done = true;
             } else {
@@ -114,8 +118,12 @@ class UniqueToken<HIP, UniqueTokenScope::Global> {
   /// \brief release an acquired value
   KOKKOS_INLINE_FUNCTION
   void release(size_type idx) const noexcept {
-    desul::atomic_thread_fence(desul::MemoryOrderAcquire(),
+#ifdef KOKKOS_ENABLE_IMPL_DESUL_ATOMICS
+    desul::atomic_thread_fence(desul::MemoryOrderRelease(),
                                desul::MemoryScopeDevice());
+#else
+    Kokkos::memory_fence();
+#endif
     (void)Kokkos::atomic_exchange(&m_locks(idx), 0);
   }
 };

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -64,9 +64,13 @@ class UniqueToken<HIP, UniqueTokenScope::Global> {
   using execution_space = HIP;
   using size_type       = int32_t;
 
-  explicit UniqueToken(execution_space const& = execution_space())
+  explicit UniqueToken()
       : m_locks(View<uint32_t*, HIPSpace>("Kokkos::UniqueToken::m_locks",
                                           HIP().concurrency())) {}
+  explicit UniqueToken(execution_space const& exec)
+      : m_locks(View<uint32_t*, HIPSpace>(
+            Kokkos::view_alloc(exec, "Kokkos::UniqueToken::m_locks"),
+            HIP().concurrency())) {}
 
   KOKKOS_DEFAULTED_FUNCTION
   UniqueToken(const UniqueToken&) = default;
@@ -144,12 +148,17 @@ template <>
 class UniqueToken<HIP, UniqueTokenScope::Instance>
     : public UniqueToken<HIP, UniqueTokenScope::Global> {
  public:
-  explicit UniqueToken(execution_space const& arg = execution_space())
+  explicit UniqueToken() : UniqueToken<HIP, UniqueTokenScope::Global>() {}
+  explicit UniqueToken(execution_space const& arg)
       : UniqueToken<HIP, UniqueTokenScope::Global>(arg) {}
 
-  UniqueToken(size_type max_size, execution_space const& = execution_space()) {
+  UniqueToken(size_type max_size) {
     m_locks =
         View<uint32_t*, HIPSpace>("Kokkos::UniqueToken::m_locks", max_size);
+  }
+  UniqueToken(size_type max_size, execution_space const& exec) {
+    m_locks = View<uint32_t*, HIPSpace>(
+        Kokkos::view_alloc(exec, "Kokkos::UniqueToken::m_locks"), max_size);
   }
 };
 

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -50,9 +50,18 @@
 #include <impl/Kokkos_SharedAlloc.hpp>
 
 namespace Kokkos {
+
+namespace Impl {
+Kokkos::View<uint32_t*, Kokkos::Experimental::HIPSpace>
+hip_global_unique_token_locks(bool deallocate = false);
+}
+
 namespace Experimental {
 
 // both global and instance Unique Tokens are implemented in the same way
+// the global version has one shared static lock array underneath
+// but it can't be a static member variable since we need to acces it on device
+// and we share the implementation with the instance version
 template <>
 class UniqueToken<HIP, UniqueTokenScope::Global> {
  protected:
@@ -62,14 +71,21 @@ class UniqueToken<HIP, UniqueTokenScope::Global> {
   using execution_space = HIP;
   using size_type       = int32_t;
 
-  explicit UniqueToken()
-      : m_locks(View<uint32_t*, HIPSpace>("Kokkos::UniqueToken::m_locks",
-                                          HIP().concurrency())) {}
-  explicit UniqueToken(execution_space const& exec)
-      : m_locks(View<uint32_t*, HIPSpace>(
-            Kokkos::view_alloc(exec, "Kokkos::UniqueToken::m_locks"),
-            HIP().concurrency())) {}
+  explicit UniqueToken(execution_space const& = HIP())
+      : m_locks(Kokkos::Impl::hip_global_unique_token_locks()) {}
 
+ protected:
+  // These are constructors for the Instance version
+  UniqueToken(size_type max_size) {
+    m_locks = Kokkos::View<uint32_t*, HIPSpace>("Kokkos::UniqueToken::m_locks",
+                                                max_size);
+  }
+  UniqueToken(size_type max_size, execution_space const& exec) {
+    m_locks = Kokkos::View<uint32_t*, HIPSpace>(
+        Kokkos::view_alloc(exec, "Kokkos::UniqueToken::m_locks"), max_size);
+  }
+
+ public:
   KOKKOS_DEFAULTED_FUNCTION
   UniqueToken(const UniqueToken&) = default;
 
@@ -146,18 +162,19 @@ template <>
 class UniqueToken<HIP, UniqueTokenScope::Instance>
     : public UniqueToken<HIP, UniqueTokenScope::Global> {
  public:
-  explicit UniqueToken() : UniqueToken<HIP, UniqueTokenScope::Global>() {}
+  // The instance version will forward to protected constructor which creates
+  // a lock array per instance
+  explicit UniqueToken()
+      : UniqueToken<HIP, UniqueTokenScope::Global>(
+            Kokkos::Experimental::HIP().concurrency()) {}
   explicit UniqueToken(execution_space const& arg)
-      : UniqueToken<HIP, UniqueTokenScope::Global>(arg) {}
-
-  UniqueToken(size_type max_size) {
-    m_locks =
-        View<uint32_t*, HIPSpace>("Kokkos::UniqueToken::m_locks", max_size);
-  }
-  UniqueToken(size_type max_size, execution_space const& exec) {
-    m_locks = View<uint32_t*, HIPSpace>(
-        Kokkos::view_alloc(exec, "Kokkos::UniqueToken::m_locks"), max_size);
-  }
+      : UniqueToken<HIP, UniqueTokenScope::Global>(
+            Kokkos::Experimental::HIP().concurrency(), arg) {}
+  UniqueToken(size_type max_size)
+      : UniqueToken<HIP, UniqueTokenScope::Global>(max_size) {}
+  UniqueToken(size_type max_size,
+              execution_space const& arg = execution_space())
+      : UniqueToken<HIP, UniqueTokenScope::Global>(max_size, arg) {}
 };
 
 }  // namespace Experimental

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -45,8 +45,6 @@
 #ifndef KOKKOS_HIP_UNIQUE_TOKEN_HPP
 #define KOKKOS_HIP_UNIQUE_TOKEN_HPP
 
-#include <Kokkos_Macros.hpp>
-
 #include <Kokkos_HIP_Space.hpp>
 #include <Kokkos_UniqueToken.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -89,10 +89,10 @@ class UniqueToken<HIP, UniqueTokenScope::Global> {
   size_type impl_acquire() const {
     int idx = blockIdx.x * (blockDim.x * blockDim.y) +
               threadIdx.y * blockDim.x + threadIdx.x;
-    idx                      = idx % size();
-    unsigned int active      = __ballot(1);
-    unsigned int done_active = 0;
-    bool done                = false;
+    idx                            = idx % size();
+    unsigned long long active      = __ballot(1);
+    unsigned long long done_active = 0;
+    bool done                      = false;
     while (active != done_active) {
       if (!done) {
         // Using m_locks(idx) fails self containment test of Kokkos_HIP.hpp

--- a/core/src/Kokkos_UniqueToken.hpp
+++ b/core/src/Kokkos_UniqueToken.hpp
@@ -59,8 +59,8 @@ enum class UniqueTokenScope : int { Instance, Global };
 ///
 /// This object should behave like a ref-counted object, so that when the last
 /// instance is destroy resources are free if needed
-template <typename ExecutionSpace,
-          UniqueTokenScope = UniqueTokenScope::Instance>
+template <typename ExecutionSpace = Kokkos::DefaultExecutionSpace,
+          UniqueTokenScope        = UniqueTokenScope::Instance>
 class UniqueToken {
  public:
   using execution_space = ExecutionSpace;


### PR DESCRIPTION
Align interface with other Kokkos interfaces which default the execution space. 

This also removes the usage of bitset in favor of using straight up int arrays as locks for UniqueToken in HIP and CUDA. 
As a consequence atomic conflicts are vastly reduced, and also by default you are getting much better aligned indicies within a warp, improving data access patterns in common usecases. 

Here is a performance example:
```c++
#include<Kokkos_Core.hpp>

int main(int argc, char* argv[]) {
  Kokkos::initialize(argc,argv);
  {
     int N = (argc>1) ? atoi(argv[1]) : 30000;
     int R = (argc>2) ? atoi(argv[2]) : 1;


     Kokkos::Experimental::UniqueToken<> token;
     Kokkos::View<double*> a("A",token.size());

     auto f1 = KOKKOS_LAMBDA(int) {
       int idx = token.acquire();
       for(int r=0; r<R; r++)
         a(idx) += a(idx)+1;
       Kokkos::memory_fence();
       token.release(idx);
     };
     auto f2 = KOKKOS_LAMBDA(int i) {
       int idx = i % a.extent(0);
       for(int r=0; r<R; r++)
         a(idx) += a(idx)+1;
       Kokkos::memory_fence();
     };

     Kokkos::parallel_for(N, f1);
     Kokkos::parallel_for(N, f2);
     Kokkos::fence();

     Kokkos::Timer timer;
     Kokkos::parallel_for(N, f1);
     Kokkos::fence();
     double time1 = timer.seconds();
     timer.reset();
     Kokkos::parallel_for(N, f2);
     Kokkos::fence();
     double time2 = timer.seconds();

     printf("%lf %lf\n",time1*1.e6, time2*1.e6);
  }
  Kokkos::finalize();
}
```

Prior to the change:
A100: 
```
bash-4.2$ ./test.cuda 30000 1
1823.098000 16.880000
bash-4.2$ ./test.cuda 30000000 1
152508.359000 207.732000
```
MI100:
```
// MI100
bash-4.2$ ./test.host 30000 1
1585.862000 25.080000
bash-4.2$ ./test.host 30000000 1
495600.250000 357.516000
```

Post change:
A100
```
bash-4.2$ ./test.cuda 30000 1
17.940000 14.940000
bash-4.2$ ./test.cuda 30000000 1
836.698000 370.924000
```

MI100
```
bash-4.2$ ./test.host 30000 1
26.680000 24.060000
bash-4.2$ ./test.host 30000000 1
958.009000 353.497000
```
