### PR TITLE
OpenMPTarget: Update LLVM version in the OpenMPTarget docker.

### DIFF
--- a/scripts/docker/Dockerfile.openmptarget
+++ b/scripts/docker/Dockerfile.openmptarget
@@ -38,7 +38,7 @@ RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSIO
     rm ${CMAKE_SCRIPT}
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
-ARG LLVM_VERSION=llvmorg-13.0.0
+ARG LLVM_VERSION=llvmorg-13.0.1-rc3
 ENV LLVM_DIR=/opt/llvm
 RUN LLVM_URL=https://github.com/llvm/llvm-project/archive &&\
     LLVM_ARCHIVE=${LLVM_VERSION}.tar.gz &&\


### PR DESCRIPTION
This PR updates the llvm version used in our CI testing for the OpenMPTarget backend to llvm/13.0.1. 
This fixes the build issue we had with llvm/13.0.0 . 