### PR TITLE
Update SYCL UniqueToken avoiding bitset

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -171,16 +171,15 @@ class UniqueToken<Cuda, UniqueTokenScope::Instance>
  public:
   // The instance version will forward to protected constructor which creates
   // a lock array per instance
-  explicit UniqueToken()
+  UniqueToken()
       : UniqueToken<Cuda, UniqueTokenScope::Global>(
             Kokkos::Cuda().concurrency()) {}
   explicit UniqueToken(execution_space const& arg)
       : UniqueToken<Cuda, UniqueTokenScope::Global>(
             Kokkos::Cuda().concurrency(), arg) {}
-  UniqueToken(size_type max_size)
+  explicit UniqueToken(size_type max_size)
       : UniqueToken<Cuda, UniqueTokenScope::Global>(max_size) {}
-  UniqueToken(size_type max_size,
-              execution_space const& arg = execution_space())
+  UniqueToken(size_type max_size, execution_space const& arg)
       : UniqueToken<Cuda, UniqueTokenScope::Global>(max_size, arg) {}
 };
 

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -164,16 +164,15 @@ class UniqueToken<HIP, UniqueTokenScope::Instance>
  public:
   // The instance version will forward to protected constructor which creates
   // a lock array per instance
-  explicit UniqueToken()
+  UniqueToken()
       : UniqueToken<HIP, UniqueTokenScope::Global>(
             Kokkos::Experimental::HIP().concurrency()) {}
   explicit UniqueToken(execution_space const& arg)
       : UniqueToken<HIP, UniqueTokenScope::Global>(
             Kokkos::Experimental::HIP().concurrency(), arg) {}
-  UniqueToken(size_type max_size)
+  explicit UniqueToken(size_type max_size)
       : UniqueToken<HIP, UniqueTokenScope::Global>(max_size) {}
-  UniqueToken(size_type max_size,
-              execution_space const& arg = execution_space())
+  UniqueToken(size_type max_size, execution_space const& arg)
       : UniqueToken<HIP, UniqueTokenScope::Global>(max_size, arg) {}
 };
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -52,8 +52,7 @@ std::vector<std::optional<sycl::queue>*> SYCLInternal::all_queues;
 std::mutex SYCLInternal::mutex;
 
 SYCLInternal::~SYCLInternal() {
-  if (!was_finalized || m_scratchSpace || m_scratchFlags ||
-      m_scratchConcurrentBitset) {
+  if (!was_finalized || m_scratchSpace || m_scratchFlags) {
     std::cerr << "Kokkos::Experimental::SYCL ERROR: Failed to call "
                  "Kokkos::Experimental::SYCL::finalize()"
               << std::endl;
@@ -139,13 +138,6 @@ void SYCLInternal::initialize(const sycl::queue& q) {
                            "Kokkos::Experimental::SYCL::InternalScratchBitset",
                            sizeof(uint32_t) * buffer_bound);
       Record::increment(r);
-      m_scratchConcurrentBitset = reinterpret_cast<uint32_t*>(r->data());
-      auto event                = m_queue->memset(m_scratchConcurrentBitset, 0,
-                                   sizeof(uint32_t) * buffer_bound);
-      fence(event,
-            "Kokkos::Experimental::SYCLInternal::initialize: fence after "
-            "initializing m_scratchConcurrentBitset",
-            m_instance_id);
     }
 
     m_maxShmemPerBlock =
@@ -206,9 +198,6 @@ void SYCLInternal::finalize() {
   m_scratchSpace      = nullptr;
   m_scratchFlagsCount = 0;
   m_scratchFlags      = nullptr;
-
-  RecordSYCL::decrement(RecordSYCL::get_record(m_scratchConcurrentBitset));
-  m_scratchConcurrentBitset = nullptr;
 
   if (m_team_scratch_current_size > 0)
     Kokkos::kokkos_free<Kokkos::Experimental::SYCLDeviceUSMSpace>(

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -78,11 +78,10 @@ class SYCLInternal {
   uint32_t m_maxConcurrency   = 0;
   uint64_t m_maxShmemPerBlock = 0;
 
-  uint32_t* m_scratchConcurrentBitset = nullptr;
-  std::size_t m_scratchSpaceCount     = 0;
-  size_type* m_scratchSpace           = nullptr;
-  std::size_t m_scratchFlagsCount     = 0;
-  size_type* m_scratchFlags           = nullptr;
+  std::size_t m_scratchSpaceCount = 0;
+  size_type* m_scratchSpace       = nullptr;
+  std::size_t m_scratchFlagsCount = 0;
+  size_type* m_scratchFlags       = nullptr;
   // mutex to access shared memory
   mutable std::mutex m_mutexScratchSpace;
 

--- a/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
@@ -84,7 +84,8 @@ class UniqueToken<SYCL, UniqueTokenScope::Global> {
   UniqueToken(size_type max_size,
               execution_space const& arg = execution_space())
       : m_locks(Kokkos::View<uint32_t*, SYCLDeviceUSMSpace>(
-            "Kokkos::UniqueToken::m_locks", max_size)) {}
+            Kokkos::view_alloc(arg, "Kokkos::UniqueToken::m_locks"),
+            max_size)) {}
 
  private:
   /// \brief acquire value such that 0 <= value < size()

--- a/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
@@ -55,17 +55,14 @@ namespace Experimental {
 // both global and instance Unique Tokens are implemented in the same way
 template <>
 class UniqueToken<SYCL, UniqueTokenScope::Global> {
- protected:
-  uint32_t volatile* m_buffer;
-  uint32_t m_count;
+  Kokkos::View<uint32_t*, SYCLDeviceUSMSpace> m_locks;
 
  public:
   using execution_space = SYCL;
   using size_type       = int32_t;
 
-  explicit UniqueToken(execution_space const& = execution_space())
-      : m_buffer(Impl::SYCLInternal::singleton().m_scratchConcurrentBitset),
-        m_count(SYCL::concurrency()) {}
+  explicit UniqueToken(execution_space const& arg = execution_space())
+      : UniqueToken(SYCL().concurrency(), arg) {}
 
   KOKKOS_DEFAULTED_FUNCTION
   UniqueToken(const UniqueToken&) = default;
@@ -81,51 +78,77 @@ class UniqueToken<SYCL, UniqueTokenScope::Global> {
 
   /// \brief upper bound for acquired values, i.e. 0 <= value < size()
   KOKKOS_INLINE_FUNCTION
-  size_type size() const noexcept { return m_count; }
+  size_type size() const noexcept { return m_locks.extent(0); }
 
+ protected:
+  UniqueToken(size_type max_size,
+              execution_space const& arg = execution_space())
+      : m_locks(Kokkos::View<uint32_t*, SYCLDeviceUSMSpace>(
+            "Kokkos::UniqueToken::m_locks", max_size)) {}
+
+ private:
+  /// \brief acquire value such that 0 <= value < size()
+  KOKKOS_INLINE_FUNCTION
+  size_type impl_acquire() const {
+    auto item = sycl::ext::oneapi::experimental::this_nd_item<3>();
+    std::size_t threadIdx[3] = {item.get_local_id(2), item.get_local_id(1),
+                                item.get_local_id(0)};
+    std::size_t blockIdx[3]  = {item.get_group(2), item.get_group(1),
+                               item.get_group(0)};
+    std::size_t blockDim[3] = {item.get_local_range(2), item.get_local_range(1),
+                               item.get_local_range(0)};
+
+    int idx = (blockIdx[0] * (blockDim[0] * blockDim[1]) +
+               threadIdx[1] * blockDim[0] + threadIdx[0]) %
+              size();
+
+    while (Kokkos::atomic_compare_exchange(&m_locks(idx), 0, 1) == 1) {
+      idx += blockDim[1] * blockDim[0] + 1;
+      idx = idx % size();
+    }
+
+    // Make sure that all writes in the previous lock owner are visible to me
+#ifdef KOKKOS_ENABLE_IMPL_DESUL_ATOMICS
+    desul::atomic_thread_fence(desul::MemoryOrderAcquire(),
+                               desul::MemoryScopeDevice());
+#else
+    Kokkos::memory_fence();
+#endif
+    return idx;
+  }
+
+ public:
   /// \brief acquire value such that 0 <= value < size()
   KOKKOS_INLINE_FUNCTION
   size_type acquire() const {
-    const Kokkos::pair<int, int> result =
-        Kokkos::Impl::concurrent_bitset::acquire_bounded(
-            m_buffer, m_count
-#ifdef KOKKOS_ARCH_INTEL_GPU
-            ,
-            Kokkos::Impl::clock_tic() % m_count
-#endif
-        );
-
-    if (result.first < 0) {
-      Kokkos::abort(
-          "UniqueToken<SYCL> failure to acquire tokens, no tokens available");
-    }
-
-    return result.first;
+    KOKKOS_IF_ON_DEVICE(return impl_acquire();)
+    KOKKOS_IF_ON_HOST(return 0;)
   }
 
   /// \brief release an acquired value
   KOKKOS_INLINE_FUNCTION
-  void release(size_type i) const noexcept {
-    Kokkos::Impl::concurrent_bitset::release(m_buffer, i);
+  void release(size_type idx) const noexcept {
+    // Make sure my writes are visible to the next lock owner
+#ifdef KOKKOS_ENABLE_IMPL_DESUL_ATOMICS
+    desul::atomic_thread_fence(desul::MemoryOrderRelease(),
+                               desul::MemoryScopeDevice());
+#else
+    Kokkos::memory_fence();
+#endif
+    (void)Kokkos::atomic_exchange(&m_locks(idx), 0);
   }
 };
 
 template <>
 class UniqueToken<SYCL, UniqueTokenScope::Instance>
     : public UniqueToken<SYCL, UniqueTokenScope::Global> {
-  View<uint32_t*, SYCLDeviceUSMSpace> m_buffer_view;
-
  public:
   explicit UniqueToken(execution_space const& arg = execution_space())
       : UniqueToken<SYCL, UniqueTokenScope::Global>(arg) {}
 
-  UniqueToken(size_type max_size, execution_space const& = execution_space())
-      : m_buffer_view(
-            "UniqueToken::m_buffer_view",
-            ::Kokkos::Impl::concurrent_bitset::buffer_bound(max_size)) {
-    m_buffer = m_buffer_view.data();
-    m_count  = max_size;
-  }
+  UniqueToken(size_type max_size,
+              execution_space const& arg = execution_space())
+      : UniqueToken<SYCL, UniqueTokenScope::Global>(max_size, arg) {}
 };
 
 }  // namespace Experimental

--- a/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
@@ -90,6 +90,10 @@ class UniqueToken<SYCL, UniqueTokenScope::Global> {
 
  protected:
   // Constructors for the Instance version
+  UniqueToken(size_type max_size)
+      : m_locks(Kokkos::View<uint32_t*, SYCLDeviceUSMSpace>(
+            "Kokkos::UniqueToken::m_locks", max_size)) {}
+
   UniqueToken(size_type max_size, execution_space const& arg)
       : m_locks(Kokkos::View<uint32_t*, SYCLDeviceUSMSpace>(
             Kokkos::view_alloc(arg, "Kokkos::UniqueToken::m_locks"),
@@ -152,7 +156,11 @@ template <>
 class UniqueToken<SYCL, UniqueTokenScope::Instance>
     : public UniqueToken<SYCL, UniqueTokenScope::Global> {
  public:
-  explicit UniqueToken(execution_space const& arg = execution_space())
+  UniqueToken()
+      : UniqueToken<SYCL, UniqueTokenScope::Global>(
+            Kokkos::Experimental::SYCL().concurrency()) {}
+
+  explicit UniqueToken(execution_space const& arg)
       : UniqueToken<SYCL, UniqueTokenScope::Global>(
             Kokkos::Experimental::SYCL().concurrency(), arg) {}
 

--- a/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
@@ -165,8 +165,7 @@ class UniqueToken<SYCL, UniqueTokenScope::Instance>
             Kokkos::Experimental::SYCL().concurrency(), arg) {}
 
   explicit UniqueToken(size_type max_size)
-      : UniqueToken<SYCL, UniqueTokenScope::Global>(max_size,
-                                                    execution_space()) {}
+      : UniqueToken<SYCL, UniqueTokenScope::Global>(max_size) {}
 
   UniqueToken(size_type max_size, execution_space const& arg)
       : UniqueToken<SYCL, UniqueTokenScope::Global>(max_size, arg) {}

--- a/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
@@ -69,7 +69,7 @@ class UniqueToken<SYCL, UniqueTokenScope::Global> {
   using execution_space = SYCL;
   using size_type       = int32_t;
 
-  explicit UniqueToken(execution_space const& arg = execution_space())
+  explicit UniqueToken(execution_space const& = execution_space())
       : m_locks(Impl::sycl_global_unique_token_locks()) {}
 
   KOKKOS_DEFAULTED_FUNCTION


### PR DESCRIPTION
This corresponds to #4741. I see similar speed-ups.