### PR TITLE
Deprecate array reductions with pointer return types

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -597,7 +597,7 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 // intel error #2651: attribute does not apply to any entity
 // using <deprecated_type> KOKKOS_DEPRECATED = ...
 #if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS) && !defined(__NVCC__) && \
-    (KOKKOS_COMPILER_INTEL > 1900)
+    (!defined(KOKKOS_COMPILER_INTEL) || KOKKOS_COMPILER_INTEL > 1900)
 #define KOKKOS_DEPRECATED [[deprecated]]
 #define KOKKOS_DEPRECATED_WITH_COMMENT(comment) [[deprecated(comment)]]
 #else

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -124,7 +124,12 @@ struct TestMDRange_ReduceArray_2D {
       parallel_for(range_init, functor);  // Init the view to 3's
 
       double sums[array_size];
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+      double *sums_ptr = sums;
+      parallel_reduce(range, functor, sums_ptr);
+#else
       parallel_reduce(range, functor, sums);
+#endif
 
       // Check output
       // printf("Array Reduce result. N0 = %d  N1 = %d  N0*N1 = %d  sums[0] =


### PR DESCRIPTION
Fixes #4208. Drive-by change fixes the deprecation macro to also work for non-`Intel` compilers.