### PR TITLE
Correctly identify current compilation pass (host or device) for HIP

### DIFF
--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -506,7 +506,7 @@ class HIP {
   //@{
 
   KOKKOS_INLINE_FUNCTION static int in_parallel() {
-#if defined(__HIP_ARCH__)
+#if defined(__HIP_DEVICE_COMPILE__)
     return true;
 #else
     return false;


### PR DESCRIPTION
According to [HIP porting guide](https://github.com/ROCm-Developer-Tools/HIP/blob/master/docs/markdown/hip_porting_guide.md#identifying-current-compilation-pass-host-or-device), there is no `__HIP_ARCH__` define. Instead, to identify whether the compiler is compiling code for host or device, define `__HIP_DEVICE_COMPILE__` should be used.