### PR TITLE
Kokkos:  Allow overloads of create_mirror_view_and_copy()

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3427,6 +3427,7 @@ create_mirror_view_and_copy(
     const Space&, const Kokkos::View<T, P...>& src,
     std::string const& name = "",
     typename std::enable_if<
+        std::is_same<typename ViewTraits<T, P...>::specialize, void>::value &&
         !Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* =
         nullptr) {
   using Mirror      = typename Impl::MirrorViewType<Space, T, P...>::view_type;

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3411,6 +3411,7 @@ create_mirror_view_and_copy(
     const Space&, const Kokkos::View<T, P...>& src,
     std::string const& name = "",
     typename std::enable_if<
+        std::is_same<typename ViewTraits<T, P...>::specialize, void>::value &&
         Impl::MirrorViewType<Space, T, P...>::is_same_memspace>::type* =
         nullptr) {
   (void)name;


### PR DESCRIPTION
The default implementation doesn't work with some Sacado/Stokhos scalar
types, so restrict it to ViewTraits::specialize == void as usual to
allow overloads in these packages.