### PR TITLE
Fix CI on MI60

### DIFF
--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -83,7 +83,7 @@ namespace Impl {
 // The hip_parallel_launch_*_memory code is identical to the cuda code
 template <typename DriverType>
 __global__ static void hip_parallel_launch_constant_memory() {
-  const DriverType &driver = *(reinterpret_cast<const DriverType *__restrict__>(
+  const DriverType &driver = *(reinterpret_cast<const DriverType *>(
       kokkos_impl_hip_constant_memory_buffer));
 
   driver();
@@ -92,7 +92,7 @@ __global__ static void hip_parallel_launch_constant_memory() {
 template <typename DriverType, unsigned int maxTperB, unsigned int minBperSM>
 __global__ __launch_bounds__(
     maxTperB, minBperSM) static void hip_parallel_launch_constant_memory() {
-  const DriverType &driver = *(reinterpret_cast<const DriverType *__restrict__>(
+  const DriverType &driver = *(reinterpret_cast<const DriverType *>(
       kokkos_impl_hip_constant_memory_buffer));
 
   driver();
@@ -100,29 +100,31 @@ __global__ __launch_bounds__(
 
 template <class DriverType>
 __global__ static void hip_parallel_launch_local_memory(
-    const DriverType *__restrict__ driver) {
+    const DriverType *driver) {
   // FIXME_HIP driver() pass by copy
   driver->operator()();
 }
 
 template <class DriverType, unsigned int maxTperB, unsigned int minBperSM>
-__global__
-__launch_bounds__(maxTperB, minBperSM) static void hip_parallel_launch_local_memory(
-    const DriverType *__restrict__ driver) {
+__global__ __launch_bounds__(
+    maxTperB,
+    minBperSM) static void hip_parallel_launch_local_memory(const DriverType
+                                                                *driver) {
   // FIXME_HIP driver() pass by copy
   driver->operator()();
 }
 
 template <typename DriverType>
 __global__ static void hip_parallel_launch_global_memory(
-    const DriverType *__restrict__ driver) {
+    const DriverType *driver) {
   driver->operator()();
 }
 
 template <typename DriverType, unsigned int maxTperB, unsigned int minBperSM>
-__global__
-__launch_bounds__(maxTperB, minBperSM) static void hip_parallel_launch_global_memory(
-    const DriverType *__restrict__ driver) {
+__global__ __launch_bounds__(
+    maxTperB,
+    minBperSM) static void hip_parallel_launch_global_memory(const DriverType
+                                                                 *driver) {
   driver->operator()();
 }
 


### PR DESCRIPTION
Revert "Add restrict to DriverTypes to help compiler prove member variable reads do not alias w/ global writes"

This reverts commit 801be4b43cf4988fc3dda40b43f5189e68f1bfd8.

Related to https://github.com/kokkos/kokkos/issues/4772

cc; @arghdos 