### PR TITLE
Replace FunctorValueTraits for Serial

### DIFF
--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -50,6 +50,7 @@
 #if defined(__HIPCC__)
 
 #include <HIP/Kokkos_HIP_Vectorization.hpp>
+#include <impl/Kokkos_FunctorAdapter.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -58,7 +58,6 @@
 
 #include <impl/Kokkos_Traits.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
-#include <impl/Kokkos_FunctorAdapter.hpp>
 
 #include <cstddef>
 #include <type_traits>

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -48,7 +48,6 @@
 #include <Kokkos_NumericTraits.hpp>
 #include <Kokkos_View.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
-#include <impl/Kokkos_FunctorAdapter.hpp>
 #include <impl/Kokkos_Tools_Generic.hpp>
 #include <type_traits>
 #include <iostream>
@@ -1917,14 +1916,15 @@ inline void parallel_reduce(
     const FunctorType& functor,
     typename std::enable_if<
         Kokkos::is_execution_policy<PolicyType>::value>::type* = nullptr) {
-  using ValueTraits = Kokkos::Impl::FunctorValueTraits<FunctorType, void>;
-  using value_type  = std::conditional_t<(ValueTraits::StaticValueSize != 0),
-                                        typename ValueTraits::value_type,
-                                        typename ValueTraits::pointer_type>;
+  using FunctorAnalysis =
+      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
+                            FunctorType>;
+  using value_type = std::conditional_t<(FunctorAnalysis::StaticValueSize != 0),
+                                        typename FunctorAnalysis::value_type,
+                                        typename FunctorAnalysis::pointer_type>;
 
   static_assert(
-      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
-                            FunctorType>::has_final_member_function,
+      FunctorAnalysis::has_final_member_function,
       "Calling parallel_reduce without either return value or final function.");
 
   using result_view_type =
@@ -1941,14 +1941,15 @@ inline void parallel_reduce(
     const PolicyType& policy, const FunctorType& functor,
     typename std::enable_if<
         Kokkos::is_execution_policy<PolicyType>::value>::type* = nullptr) {
-  using ValueTraits = Kokkos::Impl::FunctorValueTraits<FunctorType, void>;
-  using value_type  = std::conditional_t<(ValueTraits::StaticValueSize != 0),
-                                        typename ValueTraits::value_type,
-                                        typename ValueTraits::pointer_type>;
+  using FunctorAnalysis =
+      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
+                            FunctorType>;
+  using value_type = std::conditional_t<(FunctorAnalysis::StaticValueSize != 0),
+                                        typename FunctorAnalysis::value_type,
+                                        typename FunctorAnalysis::pointer_type>;
 
   static_assert(
-      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
-                            FunctorType>::has_final_member_function,
+      FunctorAnalysis::has_final_member_function,
       "Calling parallel_reduce without either return value or final function.");
 
   using result_view_type =
@@ -1965,15 +1966,15 @@ inline void parallel_reduce(const size_t& policy, const FunctorType& functor) {
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
-  using ValueTraits = Kokkos::Impl::FunctorValueTraits<FunctorType, void>;
-  using value_type  = std::conditional_t<(ValueTraits::StaticValueSize != 0),
-                                        typename ValueTraits::value_type,
-                                        typename ValueTraits::pointer_type>;
+  using FunctorAnalysis =
+      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, policy_type,
+                            FunctorType>;
+  using value_type = std::conditional_t<(FunctorAnalysis::StaticValueSize != 0),
+                                        typename FunctorAnalysis::value_type,
+                                        typename FunctorAnalysis::pointer_type>;
 
   static_assert(
-      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                            RangePolicy<>,
-                            FunctorType>::has_final_member_function,
+      FunctorAnalysis::has_final_member_function,
       "Calling parallel_reduce without either return value or final function.");
 
   using result_view_type =
@@ -1992,15 +1993,15 @@ inline void parallel_reduce(const std::string& label, const size_t& policy,
   using policy_type =
       typename Impl::ParallelReducePolicyType<void, size_t,
                                               FunctorType>::policy_type;
-  using ValueTraits = Kokkos::Impl::FunctorValueTraits<FunctorType, void>;
-  using value_type  = std::conditional_t<(ValueTraits::StaticValueSize != 0),
-                                        typename ValueTraits::value_type,
-                                        typename ValueTraits::pointer_type>;
+  using FunctorAnalysis =
+      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, policy_type,
+                            FunctorType>;
+  using value_type = std::conditional_t<(FunctorAnalysis::StaticValueSize != 0),
+                                        typename FunctorAnalysis::value_type,
+                                        typename FunctorAnalysis::pointer_type>;
 
   static_assert(
-      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                            RangePolicy<>,
-                            FunctorType>::has_final_member_function,
+      FunctorAnalysis::has_final_member_function,
       "Calling parallel_reduce without either return value or final function.");
 
   using result_view_type =

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -570,7 +570,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
             : pointer_type(
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
-    typename Analysis::template Reducer<> final_reducer(
+    typename Analysis::Reducer final_reducer(
         &ReducerConditional::select(m_functor, m_reducer));
 
     reference_type update = final_reducer.init(ptr);
@@ -665,7 +665,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
         pool_reduce_size, team_reduce_size, team_shared_size,
         thread_local_size);
 
-    typename Analysis::template Reducer<> final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(&m_functor);
 
     reference_type update = final_reducer.init(pointer_type(
         internal_instance->m_thread_team_data.pool_reduce_local()));
@@ -729,7 +729,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
         pool_reduce_size, team_reduce_size, team_shared_size,
         thread_local_size);
 
-    typename Analysis::template Reducer<> final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(&m_functor);
 
     reference_type update = final_reducer.init(pointer_type(
         internal_instance->m_thread_team_data.pool_reduce_local()));
@@ -868,7 +868,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
             : pointer_type(
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
-    typename Analysis::template Reducer<> final_reducer(
+    typename Analysis::Reducer final_reducer(
         &ReducerConditional::select(m_functor, m_reducer));
 
     reference_type update = final_reducer.init(ptr);
@@ -1056,7 +1056,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
             : pointer_type(
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
-    typename Analysis::template Reducer<> final_reducer(
+    typename Analysis::Reducer final_reducer(
         &ReducerConditional::select(m_functor, m_reducer));
 
     reference_type update = final_reducer.init(ptr);

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -64,7 +64,6 @@
 #include <Kokkos_MemoryTraits.hpp>
 #include <impl/Kokkos_HostThreadTeam.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
-#include <impl/Kokkos_FunctorAdapter.hpp>
 #include <impl/Kokkos_Tools.hpp>
 #include <impl/Kokkos_ExecSpaceInitializer.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
@@ -519,9 +518,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                          void>;
 
   using Analysis =
-      FunctorAnalysis<FunctorPatternInterface::REDUCE, Policy, FunctorType>;
-
-  using ValueInit = Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd>;
+      FunctorAnalysis<FunctorPatternInterface::REDUCE, Policy, ReducerTypeFwd>;
 
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
@@ -573,13 +570,14 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
             : pointer_type(
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
-    reference_type update =
-        ValueInit::init(ReducerConditional::select(m_functor, m_reducer), ptr);
+    typename Analysis::template Reducer<> final_reducer(
+        &ReducerConditional::select(m_functor, m_reducer));
+
+    reference_type update = final_reducer.init(ptr);
 
     this->template exec<WorkTag>(update);
 
-    Kokkos::Impl::FunctorFinal<ReducerTypeFwd, WorkTagFwd>::final(
-        ReducerConditional::select(m_functor, m_reducer), ptr);
+    final_reducer.final(ptr);
   }
 
   template <class HostViewType>
@@ -627,8 +625,6 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   using Analysis =
       FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType>;
 
-  using ValueInit = Kokkos::Impl::FunctorValueInit<FunctorType, WorkTag>;
-
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
 
@@ -669,10 +665,10 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
         pool_reduce_size, team_reduce_size, team_shared_size,
         thread_local_size);
 
-    reference_type update = ValueInit::init(
-        m_functor,
-        pointer_type(
-            internal_instance->m_thread_team_data.pool_reduce_local()));
+    typename Analysis::template Reducer<> final_reducer(&m_functor);
+
+    reference_type update = final_reducer.init(pointer_type(
+        internal_instance->m_thread_team_data.pool_reduce_local()));
 
     this->template exec<WorkTag>(update);
   }
@@ -691,8 +687,6 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
   using Analysis =
       FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType>;
-
-  using ValueInit = Kokkos::Impl::FunctorValueInit<FunctorType, WorkTag>;
 
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
@@ -735,10 +729,10 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
         pool_reduce_size, team_reduce_size, team_shared_size,
         thread_local_size);
 
-    reference_type update = ValueInit::init(
-        m_functor,
-        pointer_type(
-            internal_instance->m_thread_team_data.pool_reduce_local()));
+    typename Analysis::template Reducer<> final_reducer(&m_functor);
+
+    reference_type update = final_reducer.init(pointer_type(
+        internal_instance->m_thread_team_data.pool_reduce_local()));
 
     this->template exec<WorkTag>(update);
 
@@ -820,9 +814,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                          void>;
 
   using Analysis = FunctorAnalysis<FunctorPatternInterface::REDUCE,
-                                   MDRangePolicy, FunctorType>;
-
-  using ValueInit = Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd>;
+                                   MDRangePolicy, ReducerTypeFwd>;
 
   using pointer_type   = typename Analysis::pointer_type;
   using value_type     = typename Analysis::value_type;
@@ -876,13 +868,14 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
             : pointer_type(
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
-    reference_type update =
-        ValueInit::init(ReducerConditional::select(m_functor, m_reducer), ptr);
+    typename Analysis::template Reducer<> final_reducer(
+        &ReducerConditional::select(m_functor, m_reducer));
+
+    reference_type update = final_reducer.init(ptr);
 
     this->exec(update);
 
-    Kokkos::Impl::FunctorFinal<ReducerTypeFwd, WorkTagFwd>::final(
-        ReducerConditional::select(m_functor, m_reducer), ptr);
+    final_reducer.final(ptr);
   }
 
   template <class HostViewType>
@@ -998,9 +991,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
   using Policy = TeamPolicyInternal<Kokkos::Serial, Properties...>;
 
-  using Analysis =
-      FunctorAnalysis<FunctorPatternInterface::REDUCE, Policy, FunctorType>;
-
   using Member  = typename Policy::member_type;
   using WorkTag = typename Policy::work_tag;
 
@@ -1012,7 +1002,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
                          void>;
 
-  using ValueInit = Kokkos::Impl::FunctorValueInit<ReducerTypeFwd, WorkTagFwd>;
+  using Analysis =
+      FunctorAnalysis<FunctorPatternInterface::REDUCE, Policy, ReducerTypeFwd>;
 
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
@@ -1065,13 +1056,14 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
             : pointer_type(
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
-    reference_type update =
-        ValueInit::init(ReducerConditional::select(m_functor, m_reducer), ptr);
+    typename Analysis::template Reducer<> final_reducer(
+        &ReducerConditional::select(m_functor, m_reducer));
+
+    reference_type update = final_reducer.init(ptr);
 
     this->template exec<WorkTag>(internal_instance->m_thread_team_data, update);
 
-    Kokkos::Impl::FunctorFinal<ReducerTypeFwd, WorkTagFwd>::final(
-        ReducerConditional::select(m_functor, m_reducer), ptr);
+    final_reducer.final(ptr);
   }
 
   template <class ViewType>

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -50,6 +50,7 @@
 
 #include <Kokkos_Atomic.hpp>
 #include "Kokkos_OpenMPTarget_Abort.hpp"
+#include <impl/Kokkos_FunctorAdapter.hpp>
 
 // FIXME_OPENMPTARGET - Using this macro to implement a workaround for
 // hierarchical reducers. It avoids hitting the code path which we wanted to

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -533,6 +533,8 @@ KOKKOS_INLINE_FUNCTION constexpr auto make_wrapped_combined_functor(
   //----------------------------------------
 }
 
+template <typename FunctorType>
+using functor_has_value_t = typename FunctorType::value_type;
 }  // end namespace Impl
 
 //==============================================================================
@@ -569,6 +571,9 @@ auto parallel_reduce(std::string const& label, PolicyType const& policy,
       functor, space_type{}, returnType1, returnType2, returnTypes...);
 
   using combined_functor_type = decltype(combined_functor);
+  static_assert(
+      is_detected<Impl::functor_has_value_t, combined_functor_type>::value,
+      "value_type not properly detected");
   using reduce_adaptor_t =
       Impl::ParallelReduceAdaptor<PolicyType, combined_functor_type,
                                   combined_reducer_type>;

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -569,9 +569,6 @@ auto parallel_reduce(std::string const& label, PolicyType const& policy,
       functor, space_type{}, returnType1, returnType2, returnTypes...);
 
   using combined_functor_type = decltype(combined_functor);
-  /*  static_assert(
-        Impl::FunctorDeclaresValueType<combined_functor_type, void>::value,
-        "value_type not properly detected");*/
   using reduce_adaptor_t =
       Impl::ParallelReduceAdaptor<PolicyType, combined_functor_type,
                                   combined_reducer_type>;

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -569,9 +569,9 @@ auto parallel_reduce(std::string const& label, PolicyType const& policy,
       functor, space_type{}, returnType1, returnType2, returnTypes...);
 
   using combined_functor_type = decltype(combined_functor);
-  static_assert(
-      Impl::FunctorDeclaresValueType<combined_functor_type, void>::value,
-      "value_type not properly detected");
+  /*  static_assert(
+        Impl::FunctorDeclaresValueType<combined_functor_type, void>::value,
+        "value_type not properly detected");*/
   using reduce_adaptor_t =
       Impl::ParallelReduceAdaptor<PolicyType, combined_functor_type,
                                   combined_reducer_type>;

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -505,8 +505,11 @@ struct FunctorAnalysis {
   };
 
   template <class F>
-  struct DeduceJoinNoTag<F, decltype(has_join_no_tag_function<F>::enable_if(
-                                &F::join))>
+  struct DeduceJoinNoTag<
+      F, std::enable_if_t<is_reducer<F>::value || (!is_reducer<F>::value &&
+                                                   std::is_void<Tag>::value),
+                          decltype(has_join_no_tag_function<F>::enable_if(
+                              &F::join))>>
       : public has_join_no_tag_function<F> {
     enum : bool { value = true };
   };
@@ -515,7 +518,10 @@ struct FunctorAnalysis {
   struct DeduceJoin : public DeduceJoinNoTag<F> {};
 
   template <class F>
-  struct DeduceJoin<F, decltype(has_join_tag_function<F>::enable_if(&F::join))>
+  struct DeduceJoin<
+      F,
+      std::enable_if_t<!is_reducer<F>::value,
+                       decltype(has_join_tag_function<F>::enable_if(&F::join))>>
       : public has_join_tag_function<F> {
     enum : bool { value = true };
   };
@@ -596,8 +602,11 @@ struct FunctorAnalysis {
   };
 
   template <class F>
-  struct DeduceInitNoTag<F, decltype(has_init_no_tag_function<F>::enable_if(
-                                &F::init))>
+  struct DeduceInitNoTag<
+      F, std::enable_if_t<is_reducer<F>::value || (!is_reducer<F>::value &&
+                                                   std::is_void<Tag>::value),
+                          decltype(has_init_no_tag_function<F>::enable_if(
+                              &F::init))>>
       : public has_init_no_tag_function<F> {
     enum : bool { value = true };
   };
@@ -606,7 +615,10 @@ struct FunctorAnalysis {
   struct DeduceInit : public DeduceInitNoTag<F> {};
 
   template <class F>
-  struct DeduceInit<F, decltype(has_init_tag_function<F>::enable_if(&F::init))>
+  struct DeduceInit<
+      F,
+      std::enable_if_t<!is_reducer<F>::value,
+                       decltype(has_init_tag_function<F>::enable_if(&F::init))>>
       : public has_init_tag_function<F> {
     enum : bool { value = true };
   };
@@ -690,8 +702,11 @@ struct FunctorAnalysis {
   };
 
   template <class F>
-  struct DeduceFinalNoTag<F, decltype(has_final_no_tag_function<F>::enable_if(
-                                 &F::final))>
+  struct DeduceFinalNoTag<
+      F, std::enable_if_t<is_reducer<F>::value || (!is_reducer<F>::value &&
+                                                   std::is_void<Tag>::value),
+                          decltype(has_final_no_tag_function<F>::enable_if(
+                              &F::final))>>
       : public has_final_no_tag_function<F> {
     enum : bool { value = true };
   };
@@ -700,8 +715,9 @@ struct FunctorAnalysis {
   struct DeduceFinal : public DeduceFinalNoTag<F> {};
 
   template <class F>
-  struct DeduceFinal<F,
-                     decltype(has_final_tag_function<F>::enable_if(&F::final))>
+  struct DeduceFinal<F, std::enable_if_t<!is_reducer<F>::value,
+                                         decltype(has_final_tag_function<
+                                                  F>::enable_if(&F::final))>>
       : public has_final_tag_function<F> {
     enum : bool { value = true };
   };

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -446,19 +446,18 @@ struct FunctorAnalysis {
     using vref_type  = volatile ValueType&;
     using cvref_type = const volatile ValueType&;
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
-                                                             vref_type,
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, vref_type,
                                                              cvref_type) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, vref_type,
+                                                          cvref_type));
+
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              vref_type,
                                                              cvref_type) const);
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
                                                           vref_type,
-                                                          cvref_type));
-
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const, vref_type,
                                                           cvref_type));
 
     KOKKOS_INLINE_FUNCTION static void join(F const* const f,
@@ -473,19 +472,18 @@ struct FunctorAnalysis {
     using vref_type  = volatile ValueType*;
     using cvref_type = const volatile ValueType*;
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
-                                                             vref_type,
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, vref_type,
                                                              cvref_type) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, vref_type,
+                                                          cvref_type));
+
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              vref_type,
                                                              cvref_type) const);
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
                                                           vref_type,
-                                                          cvref_type));
-
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const, vref_type,
                                                           cvref_type));
 
     KOKKOS_INLINE_FUNCTION static void join(F const* const f,
@@ -555,16 +553,15 @@ struct FunctorAnalysis {
 
   template <class F>
   struct has_init_tag_function<F, /*is_array*/ false> {
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, ValueType&)
+                                                     const);
+
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              ValueType&) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
-                                                             ValueType&) const);
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, ValueType&));
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
-                                                          ValueType&));
-
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const,
                                                           ValueType&));
 
     KOKKOS_INLINE_FUNCTION static void init(F const* const f, ValueType* dst) {
@@ -574,16 +571,15 @@ struct FunctorAnalysis {
 
   template <class F>
   struct has_init_tag_function<F, /*is_array*/ true> {
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, ValueType*)
+                                                     const);
+
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              ValueType*) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
-                                                             ValueType*) const);
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, ValueType*));
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
-                                                          ValueType*));
-
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const,
                                                           ValueType*));
 
     KOKKOS_INLINE_FUNCTION static void init(F const* const f, ValueType* dst) {
@@ -651,16 +647,15 @@ struct FunctorAnalysis {
   // Has tag, not array
   template <class F>
   struct has_final_tag_function<F, /*is_array*/ false> {
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, ValueType&)
+                                                     const);
+
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              ValueType&) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
-                                                             ValueType&) const);
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, ValueType&));
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
-                                                          ValueType&));
-
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const,
                                                           ValueType&));
 
     KOKKOS_INLINE_FUNCTION static void final(F const* const f, ValueType* dst) {
@@ -671,16 +666,15 @@ struct FunctorAnalysis {
   // Has tag, is array
   template <class F>
   struct has_final_tag_function<F, /*is_array*/ true> {
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, ValueType*)
+                                                     const);
+
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              ValueType*) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
-                                                             ValueType*) const);
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, ValueType*));
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
-                                                          ValueType*));
-
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const,
                                                           ValueType*));
 
     KOKKOS_INLINE_FUNCTION static void final(F const* const f, ValueType* dst) {

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -798,10 +798,6 @@ struct FunctorAnalysis {
       return *dst;
     }
 
-    KOKKOS_INLINE_FUNCTION constexpr reference_type reference() const noexcept {
-      return Reducer::template ref<candidate_is_array>();
-    }
-
     KOKKOS_INLINE_FUNCTION constexpr int length() const noexcept {
       return Reducer::template len<candidate_is_array>();
     }

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -760,7 +760,6 @@ struct FunctorAnalysis {
                     !Kokkos::is_reducer<Functor>::value,
                 "Reducer must have a join member function!");
 
-  template <class MemorySpace = typename execution_space::memory_space>
   struct Reducer {
    private:
     Functor const* const m_functor;
@@ -782,7 +781,6 @@ struct FunctorAnalysis {
     using reducer        = Reducer;
     using value_type     = std::remove_const_t<FunctorAnalysis::value_type>;
     using pointer_type   = value_type*;
-    using memory_space   = MemorySpace;
     using reference_type = FunctorAnalysis::reference_type;
     using functor_type   = Functor;  // Adapts a functor
 

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -117,8 +117,7 @@ struct FunctorAnalysis {
   };
 
   template <typename P>
-  struct has_work_tag<P,
-                      typename std::is_same<typename P::work_tag, void>::type> {
+  struct has_work_tag<P, typename std::is_void<typename P::work_tag>::type> {
     using type = typename P::work_tag;
     using wtag = typename P::work_tag;
   };
@@ -137,7 +136,7 @@ struct FunctorAnalysis {
 
   template <typename T>
   struct has_execution_space<
-      T, typename std::is_same<typename T::execution_space, void>::type> {
+      T, typename std::is_void<typename T::execution_space>::type> {
     using type = typename T::execution_space;
     enum : bool { value = true };
   };
@@ -159,8 +158,8 @@ struct FunctorAnalysis {
   };
 
   template <typename F>
-  struct has_value_type<
-      F, typename std::is_same<typename F::value_type, void>::type> {
+  struct has_value_type<F,
+                        typename std::is_void<typename F::value_type>::type> {
     using type = typename F::value_type;
 
     static_assert(!std::is_reference<type>::value &&
@@ -176,7 +175,7 @@ struct FunctorAnalysis {
 
   template <typename F, typename P = PatternInterface,
             typename V = typename has_value_type<F>::type,
-            bool T     = std::is_same<Tag, void>::value>
+            bool T     = std::is_void<Tag>::value>
   struct deduce_value_type {
     using type = V;
   };
@@ -317,7 +316,7 @@ struct FunctorAnalysis {
   using candidate_type = typename deduce_value_type<Functor>::type;
 
   enum {
-    candidate_is_void  = std::is_same<candidate_type, void>::value,
+    candidate_is_void  = std::is_void<candidate_type>::value,
     candidate_is_array = std::rank<candidate_type>::value == 1
   };
 

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -61,6 +61,35 @@ struct FunctorPatternInterface {
   struct SCAN {};
 };
 
+template <typename T>
+struct DeduceFunctorPatternInterface;
+
+template <class FunctorType, class ExecPolicy, class ExecutionSpace>
+struct DeduceFunctorPatternInterface<
+    ParallelFor<FunctorType, ExecPolicy, ExecutionSpace>> {
+  using type = FunctorPatternInterface::FOR;
+};
+
+template <class FunctorType, class ExecPolicy, class ReducerType,
+          class ExecutionSpace>
+struct DeduceFunctorPatternInterface<
+    ParallelReduce<FunctorType, ExecPolicy, ReducerType, ExecutionSpace>> {
+  using type = FunctorPatternInterface::REDUCE;
+};
+
+template <class FunctorType, class ExecPolicy, class ExecutionSpace>
+struct DeduceFunctorPatternInterface<
+    ParallelScan<FunctorType, ExecPolicy, ExecutionSpace>> {
+  using type = FunctorPatternInterface::SCAN;
+};
+
+template <class FunctorType, class ExecPolicy, class ReturnType,
+          class ExecutionSpace>
+struct DeduceFunctorPatternInterface<ParallelScanWithTotal<
+    FunctorType, ExecPolicy, ReturnType, ExecutionSpace>> {
+  using type = FunctorPatternInterface::SCAN;
+};
+
 /** \brief  Query Functor and execution policy argument tag for value type.
  *
  *  If 'value_type' is not explicitly declared in the functor
@@ -285,6 +314,8 @@ struct FunctorAnalysis {
 
   //----------------------------------------
 
+  //  using candidate_type = typename FunctorValueTraits<Functor,
+  //  Tag>::value_type;
   using candidate_type = typename deduce_value_type<Functor>::type;
 
   enum {
@@ -302,6 +333,10 @@ struct FunctorAnalysis {
                                 Kokkos::DefaultExecutionSpace>::type>::type;
 
   using value_type = typename std::remove_extent<candidate_type>::type;
+  /*  static_assert(
+        std::is_same<typename FunctorValueTraits<Functor, Tag>::value_type,
+                     value_type>::value,
+        "");*/
 
   static_assert(!std::is_const<value_type>::value,
                 "Kokkos functor operator reduce argument cannot be const");
@@ -374,7 +409,7 @@ struct FunctorAnalysis {
     HAS_TAG_NOT_ARRAY = 3,
     HAS_TAG_IS_ARRAY  = 4,
     DEDUCED =
-        !std::is_same<PatternInterface, REDUCE>::value
+        std::is_same<PatternInterface, FOR>::value
             ? DISABLE
             : (std::is_same<Tag, void>::value
                    ? (candidate_is_array ? NO_TAG_IS_ARRAY : NO_TAG_NOT_ARRAY)
@@ -385,11 +420,11 @@ struct FunctorAnalysis {
   //----------------------------------------
   // parallel_reduce join operator
 
-  template <class F, INTERFACE>
-  struct has_join_function;
+  template <class F, bool is_array = candidate_is_array>
+  struct has_join_no_tag_function;
 
   template <class F>
-  struct has_join_function<F, NO_TAG_NOT_ARRAY> {
+  struct has_join_no_tag_function<F, /*is_array*/ false> {
     using vref_type  = volatile ValueType&;
     using cvref_type = const volatile ValueType&;
 
@@ -407,7 +442,7 @@ struct FunctorAnalysis {
   };
 
   template <class F>
-  struct has_join_function<F, NO_TAG_IS_ARRAY> {
+  struct has_join_no_tag_function<F, /*is_array*/ true> {
     using vref_type  = volatile ValueType*;
     using cvref_type = const volatile ValueType*;
 
@@ -424,23 +459,27 @@ struct FunctorAnalysis {
     }
   };
 
+  template <class F, bool is_array = candidate_is_array>
+  struct has_join_tag_function;
+
   template <class F>
-  struct has_join_function<F, HAS_TAG_NOT_ARRAY> {
+  struct has_join_tag_function<F, /*is_array*/ false> {
     using vref_type  = volatile ValueType&;
     using cvref_type = const volatile ValueType&;
-
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, vref_type,
-                                                             cvref_type) const);
-
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, vref_type,
-                                                          cvref_type));
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              vref_type,
                                                              cvref_type) const);
 
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
+                                                             vref_type,
+                                                             cvref_type) const);
+
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
                                                           vref_type,
+                                                          cvref_type));
+
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const, vref_type,
                                                           cvref_type));
 
     KOKKOS_INLINE_FUNCTION static void join(F const* const f,
@@ -451,22 +490,23 @@ struct FunctorAnalysis {
   };
 
   template <class F>
-  struct has_join_function<F, HAS_TAG_IS_ARRAY> {
+  struct has_join_tag_function<F, /*is_array*/ true> {
     using vref_type  = volatile ValueType*;
     using cvref_type = const volatile ValueType*;
-
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, vref_type,
-                                                             cvref_type) const);
-
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, vref_type,
-                                                          cvref_type));
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              vref_type,
                                                              cvref_type) const);
 
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
+                                                             vref_type,
+                                                             cvref_type) const);
+
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
                                                           vref_type,
+                                                          cvref_type));
+
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const, vref_type,
                                                           cvref_type));
 
     KOKKOS_INLINE_FUNCTION static void join(F const* const f,
@@ -476,8 +516,8 @@ struct FunctorAnalysis {
     }
   };
 
-  template <class F = Functor, INTERFACE = DEDUCED, typename = void>
-  struct DeduceJoin {
+  template <class F = Functor, typename = void>
+  struct DeduceJoinNoTag {
     enum : bool { value = false };
 
     KOKKOS_INLINE_FUNCTION static void join(F const* const f,
@@ -489,27 +529,28 @@ struct FunctorAnalysis {
   };
 
   template <class F>
-  struct DeduceJoin<F, DISABLE, void> {
-    enum : bool { value = false };
-
-    KOKKOS_INLINE_FUNCTION static void join(F const* const, ValueType volatile*,
-                                            ValueType volatile const*) {}
+  struct DeduceJoinNoTag<F, decltype(has_join_no_tag_function<F>::enable_if(
+                                &F::join))>
+      : public has_join_no_tag_function<F> {
+    enum : bool { value = true };
   };
 
-  template <class F, INTERFACE I>
-  struct DeduceJoin<F, I,
-                    decltype(has_join_function<F, I>::enable_if(&F::join))>
-      : public has_join_function<F, I> {
+  template <class F = Functor, typename = void>
+  struct DeduceJoin : public DeduceJoinNoTag<F> {};
+
+  template <class F>
+  struct DeduceJoin<F, decltype(has_join_tag_function<F>::enable_if(&F::join))>
+      : public has_join_tag_function<F> {
     enum : bool { value = true };
   };
 
   //----------------------------------------
 
-  template <class, INTERFACE>
-  struct has_init_function;
+  template <class, bool is_array = candidate_is_array>
+  struct has_init_no_tag_function;
 
   template <class F>
-  struct has_init_function<F, NO_TAG_NOT_ARRAY> {
+  struct has_init_no_tag_function<F, /*is_array*/ false> {
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(ValueType&) const);
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(ValueType&));
@@ -520,7 +561,7 @@ struct FunctorAnalysis {
   };
 
   template <class F>
-  struct has_init_function<F, NO_TAG_IS_ARRAY> {
+  struct has_init_no_tag_function<F, /*is_array*/ true> {
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(ValueType*) const);
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(ValueType*));
@@ -530,17 +571,21 @@ struct FunctorAnalysis {
     }
   };
 
-  template <class F>
-  struct has_init_function<F, HAS_TAG_NOT_ARRAY> {
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, ValueType&)
-                                                     const);
+  template <class, bool is_array = candidate_is_array>
+  struct has_init_tag_function;
 
+  template <class F>
+  struct has_init_tag_function<F, /*is_array*/ false> {
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              ValueType&) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, ValueType&));
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
+                                                             ValueType&) const);
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
+                                                          ValueType&));
+
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const,
                                                           ValueType&));
 
     KOKKOS_INLINE_FUNCTION static void init(F const* const f, ValueType* dst) {
@@ -549,16 +594,17 @@ struct FunctorAnalysis {
   };
 
   template <class F>
-  struct has_init_function<F, HAS_TAG_IS_ARRAY> {
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, ValueType*)
-                                                     const);
-
+  struct has_init_tag_function<F, /*is_array*/ true> {
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              ValueType*) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, ValueType*));
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
+                                                             ValueType*) const);
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
+                                                          ValueType*));
+
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const,
                                                           ValueType*));
 
     KOKKOS_INLINE_FUNCTION static void init(F const* const f, ValueType* dst) {
@@ -566,8 +612,8 @@ struct FunctorAnalysis {
     }
   };
 
-  template <class F = Functor, INTERFACE = DEDUCED, typename = void>
-  struct DeduceInit {
+  template <class F = Functor, typename = void>
+  struct DeduceInitNoTag {
     enum : bool { value = false };
 
     KOKKOS_INLINE_FUNCTION static void init(F const* const, ValueType* dst) {
@@ -576,27 +622,29 @@ struct FunctorAnalysis {
   };
 
   template <class F>
-  struct DeduceInit<F, DISABLE, void> {
-    enum : bool { value = false };
-
-    KOKKOS_INLINE_FUNCTION static void init(F const* const, ValueType*) {}
+  struct DeduceInitNoTag<F, decltype(has_init_no_tag_function<F>::enable_if(
+                                &F::init))>
+      : public has_init_no_tag_function<F> {
+    enum : bool { value = true };
   };
 
-  template <class F, INTERFACE I>
-  struct DeduceInit<F, I,
-                    decltype(has_init_function<F, I>::enable_if(&F::init))>
-      : public has_init_function<F, I> {
+  template <class F = Functor, typename = void>
+  struct DeduceInit : public DeduceInitNoTag<F> {};
+
+  template <class F>
+  struct DeduceInit<F, decltype(has_init_tag_function<F>::enable_if(&F::init))>
+      : public has_init_tag_function<F> {
     enum : bool { value = true };
   };
 
   //----------------------------------------
 
-  template <class, INTERFACE>
-  struct has_final_function;
+  template <class, bool is_array = candidate_is_array>
+  struct has_final_no_tag_function;
 
   // No tag, not array
   template <class F>
-  struct has_final_function<F, NO_TAG_NOT_ARRAY> {
+  struct has_final_no_tag_function<F, /*is_array*/ false> {
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(ValueType&) const);
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(ValueType&));
@@ -608,7 +656,7 @@ struct FunctorAnalysis {
 
   // No tag, is array
   template <class F>
-  struct has_final_function<F, NO_TAG_IS_ARRAY> {
+  struct has_final_no_tag_function<F, /*is_array*/ true> {
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(ValueType*) const);
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(ValueType*));
@@ -618,18 +666,22 @@ struct FunctorAnalysis {
     }
   };
 
+  template <class, bool is_array = candidate_is_array>
+  struct has_final_tag_function;
+
   // Has tag, not array
   template <class F>
-  struct has_final_function<F, HAS_TAG_NOT_ARRAY> {
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, ValueType&)
-                                                     const);
-
+  struct has_final_tag_function<F, /*is_array*/ false> {
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              ValueType&) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, ValueType&));
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
+                                                             ValueType&) const);
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
+                                                          ValueType&));
+
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const,
                                                           ValueType&));
 
     KOKKOS_INLINE_FUNCTION static void final(F const* const f, ValueType* dst) {
@@ -639,16 +691,17 @@ struct FunctorAnalysis {
 
   // Has tag, is array
   template <class F>
-  struct has_final_function<F, HAS_TAG_IS_ARRAY> {
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, ValueType*)
-                                                     const);
-
+  struct has_final_tag_function<F, /*is_array*/ true> {
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
                                                              ValueType*) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, ValueType*));
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const,
+                                                             ValueType*) const);
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
+                                                          ValueType*));
+
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const,
                                                           ValueType*));
 
     KOKKOS_INLINE_FUNCTION static void final(F const* const f, ValueType* dst) {
@@ -656,18 +709,28 @@ struct FunctorAnalysis {
     }
   };
 
-  template <class F = Functor, INTERFACE = DEDUCED, typename = void>
-  struct DeduceFinal {
+  template <class F = Functor, typename = void>
+  struct DeduceFinalNoTag {
     enum : bool { value = false };
 
     KOKKOS_INLINE_FUNCTION
     static void final(F const* const, ValueType*) {}
   };
 
-  template <class F, INTERFACE I>
-  struct DeduceFinal<F, I,
-                     decltype(has_final_function<F, I>::enable_if(&F::final))>
-      : public has_final_function<F, I> {
+  template <class F>
+  struct DeduceFinalNoTag<F, decltype(has_final_no_tag_function<F>::enable_if(
+                                 &F::final))>
+      : public has_final_no_tag_function<F> {
+    enum : bool { value = true };
+  };
+
+  template <class F = Functor, typename = void>
+  struct DeduceFinal : public DeduceFinalNoTag<F> {};
+
+  template <class F>
+  struct DeduceFinal<F,
+                     decltype(has_final_tag_function<F>::enable_if(&F::final))>
+      : public has_final_tag_function<F> {
     enum : bool { value = true };
   };
 
@@ -713,6 +776,11 @@ struct FunctorAnalysis {
   enum { has_init_member_function = DeduceInit<>::value };
   enum { has_final_member_function = DeduceFinal<>::value };
 
+  static_assert((Kokkos::is_reducer<Functor>::value &&
+                 has_join_member_function) ||
+                    !Kokkos::is_reducer<Functor>::value,
+                "Reducer must have a join member function!");
+
   template <class MemorySpace = typename execution_space::memory_space>
   struct Reducer {
    private:
@@ -750,13 +818,31 @@ struct FunctorAnalysis {
 
    public:
     using reducer        = Reducer;
-    using value_type     = FunctorAnalysis::value_type;
+    using value_type     = std::remove_const_t<FunctorAnalysis::value_type>;
+    using pointer_type   = value_type*;
     using memory_space   = MemorySpace;
     using reference_type = FunctorAnalysis::reference_type;
     using functor_type   = Functor;  // Adapts a functor
+    using special        = void;
 
     KOKKOS_INLINE_FUNCTION constexpr value_type* data() const noexcept {
       return m_result;
+    }
+
+    /*KOKKOS_INLINE_FUNCTION constexpr reference_type reference() const noexcept
+    { return Reducer::template ref<candidate_is_array>();
+    }*/
+
+    template <bool is_array = candidate_is_array>
+    KOKKOS_INLINE_FUNCTION static std::enable_if_t<is_array, reference_type>
+    reference(ValueType* dst) noexcept {
+      return dst;
+    }
+
+    template <bool is_array = candidate_is_array>
+    KOKKOS_INLINE_FUNCTION static std::enable_if_t<!is_array, reference_type>
+    reference(ValueType* dst) noexcept {
+      return *dst;
     }
 
     KOKKOS_INLINE_FUNCTION constexpr reference_type reference() const noexcept {
@@ -779,9 +865,18 @@ struct FunctorAnalysis {
       DeduceJoin<>::join(m_functor, dst, src);
     }
 
-    KOKKOS_INLINE_FUNCTION
-    void init(ValueType* dst) const noexcept {
+    template <bool is_array = candidate_is_array>
+    KOKKOS_INLINE_FUNCTION std::enable_if_t<is_array, reference_type> init(
+        ValueType* const dst) const noexcept {
       DeduceInit<>::init(m_functor, dst);
+      return dst;
+    }
+
+    template <bool is_array = candidate_is_array>
+    KOKKOS_INLINE_FUNCTION std::enable_if_t<!is_array, reference_type> init(
+        ValueType* const dst) const noexcept {
+      DeduceInit<>::init(m_functor, dst);
+      return *dst;
     }
 
     KOKKOS_INLINE_FUNCTION
@@ -798,8 +893,9 @@ struct FunctorAnalysis {
     using rebind = Reducer<S>;
 
     KOKKOS_INLINE_FUNCTION explicit constexpr Reducer(
-        Functor const* arg_functor = 0, ValueType* arg_value = nullptr) noexcept
-        : m_functor(arg_functor), m_result(arg_value) {}
+        Functor const* arg_functor =
+            0 /*, ValueType* arg_value = nullptr*/) noexcept
+        : m_functor(arg_functor), m_result(nullptr) {}
   };
 };
 

--- a/core/unit_test/TestFunctorAnalysis.hpp
+++ b/core/unit_test/TestFunctorAnalysis.hpp
@@ -75,7 +75,7 @@ void test_functor_analysis() {
                                     Kokkos::RangePolicy<ExecSpace>,
                                     decltype(c01)>;
 
-  using R01 = typename A01::template Reducer<typename ExecSpace::memory_space>;
+  using R01 = typename A01::Reducer;
 
   static_assert(std::is_same<typename A01::value_type, void>::value, "");
   static_assert(std::is_same<typename A01::pointer_type, void>::value, "");
@@ -94,7 +94,7 @@ void test_functor_analysis() {
   using A02 = Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::REDUCE,
       Kokkos::RangePolicy<ExecSpace>, decltype(c02)>;
-  using R02 = typename A02::template Reducer<typename ExecSpace::memory_space>;
+  using R02 = typename A02::Reducer;
 
   static_assert(std::is_same<typename A02::value_type, double>::value, "");
   static_assert(std::is_same<typename A02::pointer_type, double*>::value, "");
@@ -114,7 +114,7 @@ void test_functor_analysis() {
   using A03 = Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::REDUCE,
       Kokkos::RangePolicy<ExecSpace>, TestFunctorAnalysis_03>;
-  using R03 = typename A03::template Reducer<typename ExecSpace::memory_space>;
+  using R03 = typename A03::Reducer;
 
   static_assert(std::is_same<typename A03::value_type,
                              TestFunctorAnalysis_03::value_type>::value,


### PR DESCRIPTION
Part of #4663. I thought it's better to break out one of the simplest backends to discuss common changes for removing `Kokkos_FunctorAdapter.hpp`.