### PR TITLE
OpenMPTarget: Update the size_type 

### DIFF
--- a/core/src/Kokkos_OpenMPTargetSpace.hpp
+++ b/core/src/Kokkos_OpenMPTargetSpace.hpp
@@ -136,7 +136,7 @@ class OpenMPTargetSpace {
  public:
   //! Tag this class as a kokkos memory space
   using memory_space = OpenMPTargetSpace;
-  using size_type    = size_t;
+  using size_type    = unsigned;
 
   /// \typedef execution_space
   /// \brief Default execution space for this memory space.


### PR DESCRIPTION
The PR updates the `size_type` used as the index from `size_t` to `unsigned`. This improves the performance with the llvm compiler. 