### PR TITLE
Fix pre-Volta build.

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp
@@ -105,8 +105,7 @@ class UniqueToken<Cuda, UniqueTokenScope::Global> {
   size_type size() const noexcept { return m_locks.extent(0); }
 
  private:
-  KOKKOS_INLINE_FUNCTION
-  size_type impl_acquire() const {
+  __device__ size_type impl_acquire() const {
     int idx = blockIdx.x * (blockDim.x * blockDim.y) +
               threadIdx.y * blockDim.x + threadIdx.x;
     idx = idx % size();

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -103,7 +103,8 @@ class UniqueToken<HIP, UniqueTokenScope::Global> {
   size_type size() const noexcept { return m_locks.extent(0); }
 
  private:
-  __device__ size_type impl_acquire() const {
+  // FIXME_HIP
+  KOKKOS_INLINE_FUNCTION size_type impl_acquire() const {
     int idx = blockIdx.x * (blockDim.x * blockDim.y) +
               threadIdx.y * blockDim.x + threadIdx.x;
     idx                            = idx % size();

--- a/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
+++ b/core/src/HIP/Kokkos_HIP_UniqueToken.hpp
@@ -103,8 +103,7 @@ class UniqueToken<HIP, UniqueTokenScope::Global> {
   size_type size() const noexcept { return m_locks.extent(0); }
 
  private:
-  KOKKOS_INLINE_FUNCTION
-  size_type impl_acquire() const {
+  __device__ size_type impl_acquire() const {
     int idx = blockIdx.x * (blockDim.x * blockDim.y) +
               threadIdx.y * blockDim.x + threadIdx.x;
     idx                            = idx % size();


### PR DESCRIPTION
the UniqueToken impl_acquire function should be device only in HIP/CUDA
since it uses raw CUDA/HIP calls in it.