### PR TITLE
Drop `KOKKOS_ARCH_HIP` macro when using generated GNU makefiles

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -1180,25 +1180,21 @@ endif
 ifeq ($(KOKKOS_INTERNAL_USE_HIP), 1)
   # Lets start with adding architecture defines
   ifeq ($(KOKKOS_INTERNAL_USE_ARCH_VEGA900), 1)
-    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_HIP 900")
     tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VEGA900")
     tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VEGA")
     KOKKOS_INTERNAL_HIP_ARCH_FLAG := --amdgpu-target=gfx900
   endif
   ifeq ($(KOKKOS_INTERNAL_USE_ARCH_VEGA906), 1)
-    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_HIP 906")
     tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VEGA906")
     tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VEGA")
     KOKKOS_INTERNAL_HIP_ARCH_FLAG := --amdgpu-target=gfx906
   endif
   ifeq ($(KOKKOS_INTERNAL_USE_ARCH_VEGA908), 1)
-    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_HIP 908")
     tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VEGA908")
     tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VEGA")
     KOKKOS_INTERNAL_HIP_ARCH_FLAG := --amdgpu-target=gfx908
   endif
   ifeq ($(KOKKOS_INTERNAL_USE_ARCH_VEGA90A), 1)
-    tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_HIP 90A")
     tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VEGA90A")
     tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_VEGA")
     KOKKOS_INTERNAL_HIP_ARCH_FLAG := --amdgpu-target=gfx90a


### PR DESCRIPTION
Rational: the macro is not defined in CMake builds.  this was an oversight on our part

Spotted in the review of #4782 