### PR TITLE
Do not bother with CMake policy CMP0074

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -27,7 +27,7 @@ When configuring your project just set:
   -DKokkos_ROOT=${kokkos_install_prefix} \
   -DCMAKE_CXX_COMPILER=${compiler_used_to_build_kokkos}
 ````
-Note: You may need the following if using some versions of CMake (e.g. 3.12):
+Note: You may need the following if your project requires a minimum CMake version older than 3.12:
 ````cmake
 cmake_policy(SET CMP0074 NEW)
 ````

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,6 @@ set(Kokkos_VERSION_PATCH 99)
 set(Kokkos_VERSION "${Kokkos_VERSION_MAJOR}.${Kokkos_VERSION_MINOR}.${Kokkos_VERSION_PATCH}")
 math(EXPR KOKKOS_VERSION "${Kokkos_VERSION_MAJOR} * 10000 + ${Kokkos_VERSION_MINOR} * 100 + ${Kokkos_VERSION_PATCH}")
 
-MESSAGE(STATUS "Setting policy CMP0074 to use <Package>_ROOT variables")
-CMAKE_POLICY(SET CMP0074 NEW)
-
 # Load either the real TriBITS or a TriBITS wrapper
 # for certain utility functions that are universal (like GLOBAL_SET)
 INCLUDE(${KOKKOS_SRC_PATH}/cmake/fake_tribits.cmake)

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -224,12 +224,6 @@ MACRO(kokkos_import_tpl NAME)
     SET(TPL_IMPORTED_NAME Kokkos::${NAME})
   ENDIF()
 
-  # Even though this policy gets set in the top-level CMakeLists.txt,
-  # I have still been getting errors about ROOT variables being ignored
-  # I'm not sure if this is a scope issue - but make sure
-  # the policy is set before we do any find_package calls
-  CMAKE_POLICY(SET CMP0074 NEW)
-
   IF (KOKKOS_ENABLE_${NAME})
     #Tack on a TPL here to make sure we avoid using anyone else's find
     FIND_PACKAGE(TPL${NAME} REQUIRED MODULE)

--- a/example/build_cmake_installed/CMakeLists.txt
+++ b/example/build_cmake_installed/CMakeLists.txt
@@ -6,12 +6,6 @@ cmake_minimum_required(VERSION 3.16)
 # Kokkos flags will only apply to C++ files
 project(Example CXX Fortran)
 
-# You need this for using Kokkos_ROOT variable
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.12.0")
-  message(STATUS "Setting policy CMP0074 to use <Package>_ROOT variables")
-  cmake_policy(SET CMP0074 NEW)
-endif()
-
 # Look for an installed Kokkos
 find_package(Kokkos REQUIRED)
 

--- a/example/build_cmake_installed_different_compiler/CMakeLists.txt
+++ b/example/build_cmake_installed_different_compiler/CMakeLists.txt
@@ -6,10 +6,6 @@ cmake_minimum_required(VERSION 3.16)
 # Kokkos flags will only apply to C++ files
 project(Example CXX Fortran)
 
-# You need this for using Kokkos_ROOT variable
-message(STATUS "Setting policy CMP0074 to use <Package>_ROOT variables")
-cmake_policy(SET CMP0074 NEW)
-
 # Look for an installed Kokkos but force using the compiler launcher
 # to ensure that targets depending on Kokkos use the same compiler
 # as when kokkos was installed, e.g. if kokkos was built with


### PR DESCRIPTION
Documentation is available [here](https://cmake.org/cmake/help/v3.16/policy/CMP0074.html)
In short we do not need to set it since we require a minimum CMake version of 3.16