### PR TITLE
Promote mathematical functions to `Kokkos` namespace

### DIFF
--- a/core/perf_test/PerfTestGramSchmidt.cpp
+++ b/core/perf_test/PerfTestGramSchmidt.cpp
@@ -69,7 +69,7 @@ struct InvNorm2 : public Kokkos::DotSingle<VectorView> {
 
   KOKKOS_INLINE_FUNCTION
   void final(value_type& result) const {
-    result = Kokkos::Experimental::sqrt(result);
+    result = Kokkos::sqrt(result);
     Rjj()  = result;
     inv()  = (0 < result) ? 1.0 / result : 0;
   }

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -217,7 +217,6 @@ class
   // Conditional noexcept, just in case RType throws on divide-by-zero
   constexpr KOKKOS_INLINE_FUNCTION complex& operator/=(
       const complex<RealType>& y) noexcept(noexcept(RealType{} / RealType{})) {
-    using Kokkos::Experimental::fabs;
     // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
     // If the real part is +/-Inf and the imaginary part is -/+Inf,
     // this won't change the result.
@@ -245,7 +244,6 @@ class
   constexpr KOKKOS_INLINE_FUNCTION complex& operator/=(
       const std::complex<RealType>& y) noexcept(noexcept(RealType{} /
                                                          RealType{})) {
-    using Kokkos::Experimental::fabs;
     // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
     // If the real part is +/-Inf and the imaginary part is -/+Inf,
     // this won't change the result.
@@ -706,8 +704,6 @@ KOKKOS_INLINE_FUNCTION constexpr Impl::promote_t<ArithmeticType> real(
 //! Constructs a complex number from magnitude and phase angle
 template <class T>
 KOKKOS_INLINE_FUNCTION complex<T> polar(const T& r, const T& theta = T()) {
-  using Kokkos::Experimental::cos;
-  using Kokkos::Experimental::sin;
   KOKKOS_EXPECTS(r >= 0);
   return complex<T>(r * cos(theta), r * sin(theta));
 }
@@ -715,15 +711,12 @@ KOKKOS_INLINE_FUNCTION complex<T> polar(const T& r, const T& theta = T()) {
 //! Absolute value (magnitude) of a complex number.
 template <class RealType>
 KOKKOS_INLINE_FUNCTION RealType abs(const complex<RealType>& x) {
-  using Kokkos::Experimental::hypot;
   return hypot(x.real(), x.imag());
 }
 
 //! Power of a complex number
 template <class T>
 KOKKOS_INLINE_FUNCTION complex<T> pow(const complex<T>& x, const T& y) {
-  using Kokkos::Experimental::atan2;
-  using Kokkos::Experimental::pow;
   T r     = abs(x);
   T theta = atan2(x.imag(), x.real());
   return polar(pow(r, y), y * theta);
@@ -737,8 +730,6 @@ KOKKOS_INLINE_FUNCTION complex<T> pow(const T& x, const complex<T>& y) {
 template <class T>
 KOKKOS_INLINE_FUNCTION complex<T> pow(const complex<T>& x,
                                       const complex<T>& y) {
-  using Kokkos::Experimental::log;
-
   return x == T() ? T() : exp(y * log(x));
 }
 
@@ -770,9 +761,6 @@ KOKKOS_INLINE_FUNCTION complex<Impl::promote_2_t<T, U>> pow(
 template <class RealType>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sqrt(
     const complex<RealType>& x) {
-  using Kokkos::Experimental::fabs;
-  using Kokkos::Experimental::sqrt;
-
   RealType r = x.real();
   RealType i = x.imag();
 
@@ -805,9 +793,6 @@ KOKKOS_INLINE_FUNCTION constexpr complex<Impl::promote_t<ArithmeticType>> conj(
 //! Exponential of a complex number.
 template <class RealType>
 KOKKOS_INLINE_FUNCTION complex<RealType> exp(const complex<RealType>& x) {
-  using Kokkos::Experimental::cos;
-  using Kokkos::Experimental::exp;
-  using Kokkos::Experimental::sin;
   return exp(x.real()) * complex<RealType>(cos(x.imag()), sin(x.imag()));
 }
 
@@ -815,8 +800,6 @@ KOKKOS_INLINE_FUNCTION complex<RealType> exp(const complex<RealType>& x) {
 template <class RealType>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> log(
     const complex<RealType>& x) {
-  using Kokkos::Experimental::atan2;
-  using Kokkos::Experimental::log;
   RealType phi = atan2(x.imag(), x.real());
   return Kokkos::complex<RealType>(log(abs(x)), phi);
 }
@@ -825,10 +808,6 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> log(
 template <class RealType>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sin(
     const complex<RealType>& x) {
-  using Kokkos::Experimental::cos;
-  using Kokkos::Experimental::cosh;
-  using Kokkos::Experimental::sin;
-  using Kokkos::Experimental::sinh;
   return Kokkos::complex<RealType>(sin(x.real()) * cosh(x.imag()),
                                    cos(x.real()) * sinh(x.imag()));
 }
@@ -837,10 +816,6 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sin(
 template <class RealType>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> cos(
     const complex<RealType>& x) {
-  using Kokkos::Experimental::cos;
-  using Kokkos::Experimental::cosh;
-  using Kokkos::Experimental::sin;
-  using Kokkos::Experimental::sinh;
   return Kokkos::complex<RealType>(cos(x.real()) * cosh(x.imag()),
                                    -sin(x.real()) * sinh(x.imag()));
 }
@@ -856,10 +831,6 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> tan(
 template <class RealType>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sinh(
     const complex<RealType>& x) {
-  using Kokkos::Experimental::cos;
-  using Kokkos::Experimental::cosh;
-  using Kokkos::Experimental::sin;
-  using Kokkos::Experimental::sinh;
   return Kokkos::complex<RealType>(sinh(x.real()) * cos(x.imag()),
                                    cosh(x.real()) * sin(x.imag()));
 }
@@ -868,10 +839,6 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sinh(
 template <class RealType>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> cosh(
     const complex<RealType>& x) {
-  using Kokkos::Experimental::cos;
-  using Kokkos::Experimental::cosh;
-  using Kokkos::Experimental::sin;
-  using Kokkos::Experimental::sinh;
   return Kokkos::complex<RealType>(cosh(x.real()) * cos(x.imag()),
                                    sinh(x.real()) * sin(x.imag()));
 }
@@ -902,9 +869,6 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> acosh(
 template <class RealType>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> atanh(
     const complex<RealType>& x) {
-  using Kokkos::Experimental::atan2;
-  using Kokkos::Experimental::log;
-
   const RealType i2 = x.imag() * x.imag();
   const RealType r  = RealType(1.0) - i2 - x.real() * x.real();
 
@@ -932,7 +896,6 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> asin(
 template <class RealType>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> acos(
     const complex<RealType>& x) {
-  using Kokkos::Experimental::acos;
   Kokkos::complex<RealType> t = asin(x);
   RealType pi_2               = acos(RealType(0.0));
   return Kokkos::complex<RealType>(pi_2 - t.real(), -t.imag());
@@ -942,8 +905,6 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> acos(
 template <class RealType>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> atan(
     const complex<RealType>& x) {
-  using Kokkos::Experimental::atan2;
-  using Kokkos::Experimental::log;
   const RealType r2 = x.real() * x.real();
   const RealType i  = RealType(1.0) - r2 - x.imag() * x.imag();
 
@@ -985,7 +946,6 @@ KOKKOS_INLINE_FUNCTION
     operator/(const complex<RealType1>& x,
               const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
                                                              RealType2{})) {
-  using Kokkos::Experimental::fabs;
   // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
   // If the real part is +/-Inf and the imaginary part is -/+Inf,
   // this won't change the result.

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -76,10 +76,13 @@ struct promote<float> {
 };
 template <class T>
 using promote_t = typename promote<T>::type;
-template <class T, class U>
+template <class T, class U,
+          bool = std::is_arithmetic<T>::value&& std::is_arithmetic<U>::value>
 struct promote_2 {
   using type = decltype(promote_t<T>() + promote_t<U>());
 };
+template <class T, class U>
+struct promote_2<T, U, false> {};
 template <class T, class U>
 using promote_2_t = typename promote_2<T, U>::type;
 }  // namespace Impl

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -100,6 +100,16 @@ using promote_2_t = typename promote_2<T, U>::type;
 #endif
 #endif
 
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_3)
+#define KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED( \
+    USING_DECLARATIONS_IN_EXPERIMENTAL_NAMESPACE)                      \
+  USING_DECLARATIONS_IN_EXPERIMENTAL_NAMESPACE
+#else
+#define KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED( \
+    USING_DECLARATIONS_IN_EXPERIMENTAL_NAMESPACE)                      \
+  /* nothing */
+#endif
+
 #define KOKKOS_IMPL_MATH_UNARY_FUNCTION(FUNC)                                 \
   KOKKOS_INLINE_FUNCTION float FUNC(float x) {                                \
     using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                         \
@@ -127,11 +137,12 @@ using promote_2_t = typename promote_2<T, U>::type;
     using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                         \
     return FUNC(static_cast<double>(x));                                      \
   }                                                                           \
-  namespace Experimental {                                                    \
-  using ::Kokkos::FUNC;                                                       \
-  using ::Kokkos::FUNC##f;                                                    \
-  using ::Kokkos::FUNC##l;                                                    \
-  }
+  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(              \
+      namespace Experimental {                                                \
+        using ::Kokkos::FUNC;                                                 \
+        using ::Kokkos::FUNC##f;                                              \
+        using ::Kokkos::FUNC##l;                                              \
+      });
 
 // isinf, isnan, and isinfinite do not work on Windows with CUDA with std::
 // getting warnings about calling host function in device function then
@@ -149,9 +160,8 @@ using promote_2_t = typename promote_2<T, U>::type;
   FUNC(T x) {                                                               \
     return ::FUNC(static_cast<double>(x));                                  \
   }                                                                         \
-  namespace Experimental {                                                  \
-  using ::Kokkos::FUNC;                                                     \
-  }
+  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(            \
+      namespace Experimental { using ::Kokkos::FUNC; })
 #else
 #define KOKKOS_IMPL_MATH_UNARY_PREDICATE(FUNC)                              \
   KOKKOS_INLINE_FUNCTION bool FUNC(float x) {                               \
@@ -172,10 +182,8 @@ using promote_2_t = typename promote_2<T, U>::type;
     using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                       \
     return FUNC(static_cast<double>(x));                                    \
   }                                                                         \
-  namespace Experimental {                                                  \
-  using ::Kokkos::FUNC;                                                     \
-  }
-
+  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(            \
+      namespace Experimental { using ::Kokkos::FUNC; })
 #endif
 
 #define KOKKOS_IMPL_MATH_BINARY_FUNCTION(FUNC)                          \
@@ -222,12 +230,12 @@ using promote_2_t = typename promote_2<T, U>::type;
     using std::FUNC;                                                    \
     return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));    \
   }                                                                     \
-  namespace Experimental {                                              \
-  using ::Kokkos::FUNC;                                                 \
-  using ::Kokkos::FUNC##f;                                              \
-  using ::Kokkos::FUNC##l;                                              \
-  }
-
+  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(        \
+      namespace Experimental {                                          \
+        using ::Kokkos::FUNC;                                           \
+        using ::Kokkos::FUNC##f;                                        \
+        using ::Kokkos::FUNC##l;                                        \
+      })
 // Basic operations
 KOKKOS_INLINE_FUNCTION int abs(int n) {
   using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::abs;
@@ -253,9 +261,8 @@ inline long double abs(long double x) {
   using std::abs;
   return abs(x);
 }
-namespace Experimental {
-using ::Kokkos::abs;
-}
+KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(
+    namespace Experimental { using ::Kokkos::abs; })
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(fabs)
 KOKKOS_IMPL_MATH_BINARY_FUNCTION(fmod)
 KOKKOS_IMPL_MATH_BINARY_FUNCTION(remainder)
@@ -274,11 +281,12 @@ KOKKOS_INLINE_FUNCTION float nanf(char const*) { return sycl::nan(0u); }
 KOKKOS_INLINE_FUNCTION double nan(char const*) { return sycl::nan(0ul); }
 #endif
 inline long double nanl(char const* arg) { return ::nanl(arg); }
-namespace Experimental {
-using ::Kokkos::nan;
-using ::Kokkos::nanf;
-using ::Kokkos::nanl;
-}  // namespace Experimental
+KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(
+    namespace Experimental {
+      using ::Kokkos::nan;
+      using ::Kokkos::nanf;
+      using ::Kokkos::nanl;
+    })
 // Power functions
 KOKKOS_IMPL_MATH_BINARY_FUNCTION(pow)
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(sqrt)
@@ -325,6 +333,7 @@ KOKKOS_IMPL_MATH_UNARY_PREDICATE(isfinite)
 KOKKOS_IMPL_MATH_UNARY_PREDICATE(isinf)
 KOKKOS_IMPL_MATH_UNARY_PREDICATE(isnan)
 
+#undef KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED
 #undef KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE
 #undef KOKKOS_IMPL_MATH_UNARY_FUNCTION
 #undef KOKKOS_IMPL_MATH_UNARY_PREDICATE

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -87,8 +87,6 @@ template <class T, class U>
 using promote_2_t = typename promote_2<T, U>::type;
 }  // namespace Impl
 
-namespace Experimental {
-
 // NOTE long double overloads are not available on the device
 
 #if defined(KOKKOS_ENABLE_SYCL)
@@ -128,6 +126,11 @@ namespace Experimental {
   FUNC(T x) {                                                                 \
     using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                         \
     return FUNC(static_cast<double>(x));                                      \
+  }                                                                           \
+  namespace Experimental {                                                    \
+  using ::Kokkos::FUNC;                                                       \
+  using ::Kokkos::FUNC##f;                                                    \
+  using ::Kokkos::FUNC##l;                                                    \
   }
 
 // isinf, isnan, and isinfinite do not work on Windows with CUDA with std::
@@ -145,6 +148,9 @@ namespace Experimental {
   KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral<T>::value, bool> \
   FUNC(T x) {                                                               \
     return ::FUNC(static_cast<double>(x));                                  \
+  }                                                                         \
+  namespace Experimental {                                                  \
+  using ::Kokkos::FUNC;                                                     \
   }
 #else
 #define KOKKOS_IMPL_MATH_UNARY_PREDICATE(FUNC)                              \
@@ -165,7 +171,11 @@ namespace Experimental {
   FUNC(T x) {                                                               \
     using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                       \
     return FUNC(static_cast<double>(x));                                    \
+  }                                                                         \
+  namespace Experimental {                                                  \
+  using ::Kokkos::FUNC;                                                     \
   }
+
 #endif
 
 #define KOKKOS_IMPL_MATH_BINARY_FUNCTION(FUNC)                          \
@@ -211,6 +221,11 @@ namespace Experimental {
     static_assert(std::is_same<Promoted, long double>::value, "");      \
     using std::FUNC;                                                    \
     return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));    \
+  }                                                                     \
+  namespace Experimental {                                              \
+  using ::Kokkos::FUNC;                                                 \
+  using ::Kokkos::FUNC##f;                                              \
+  using ::Kokkos::FUNC##l;                                              \
   }
 
 // Basic operations
@@ -238,6 +253,9 @@ inline long double abs(long double x) {
   using std::abs;
   return abs(x);
 }
+namespace Experimental {
+using ::Kokkos::abs;
+}
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(fabs)
 KOKKOS_IMPL_MATH_BINARY_FUNCTION(fmod)
 KOKKOS_IMPL_MATH_BINARY_FUNCTION(remainder)
@@ -256,6 +274,11 @@ KOKKOS_INLINE_FUNCTION float nanf(char const*) { return sycl::nan(0u); }
 KOKKOS_INLINE_FUNCTION double nan(char const*) { return sycl::nan(0ul); }
 #endif
 inline long double nanl(char const* arg) { return ::nanl(arg); }
+namespace Experimental {
+using ::Kokkos::nan;
+using ::Kokkos::nanf;
+using ::Kokkos::nanl;
+}  // namespace Experimental
 // Power functions
 KOKKOS_IMPL_MATH_BINARY_FUNCTION(pow)
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(sqrt)
@@ -307,7 +330,6 @@ KOKKOS_IMPL_MATH_UNARY_PREDICATE(isnan)
 #undef KOKKOS_IMPL_MATH_UNARY_PREDICATE
 #undef KOKKOS_IMPL_MATH_BINARY_FUNCTION
 
-}  // namespace Experimental
 }  // namespace Kokkos
 
 #endif

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -47,6 +47,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <cmath>
+#include <cstdlib>
 #include <type_traits>
 
 #ifdef KOKKOS_ENABLE_SYCL

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -62,12 +62,12 @@ template <class RealType>
 KOKKOS_INLINE_FUNCTION RealType expint1(RealType x) {
   // This function is a conversion of the corresponding Fortran program in
   // S. Zhang & J. Jin "Computation of Special Functions" (Wiley, 1996).
+  using Kokkos::exp;
+  using Kokkos::fabs;
+  using Kokkos::log;
+  using Kokkos::pow;
   using Kokkos::Experimental::epsilon;
-  using Kokkos::Experimental::exp;
-  using Kokkos::Experimental::fabs;
   using Kokkos::Experimental::infinity;
-  using Kokkos::Experimental::log;
-  using Kokkos::Experimental::pow;
 
   RealType e1;
 
@@ -116,12 +116,12 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erf(
   //      (3)  abs(z)>2 and 0<=x<=1 and abs(y)<6 - series, NBS Handbook, p. 299
   //      (4)  abs(z)>2 and 0<=x<=1 and abs(y)>=6 - asymptotic expansion
   //  Error condition: abs(z^2) > 670 is a fatal overflow error
-  using Kokkos::Experimental::cos;
+  using Kokkos::cos;
+  using Kokkos::exp;
+  using Kokkos::fabs;
+  using Kokkos::sin;
   using Kokkos::Experimental::epsilon;
-  using Kokkos::Experimental::exp;
-  using Kokkos::Experimental::fabs;
   using Kokkos::Experimental::infinity;
-  using Kokkos::Experimental::sin;
 
   using CmplxType = Kokkos::complex<RealType>;
 
@@ -293,13 +293,13 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erfcx(
   //      (3)  abs(z)>2 and 0<=x<=1 and abs(y)<6 - series, NBS Handbook, p. 299
   //      (4)  abs(z)>2 and 0<=x<=1 and abs(y)>=6 - asymptotic expansion
   // Error condition: abs(z^2) > 670 is a fatal overflow error when x<0
-  using Kokkos::Experimental::cos;
+  using Kokkos::cos;
+  using Kokkos::exp;
+  using Kokkos::fabs;
+  using Kokkos::isinf;
+  using Kokkos::sin;
   using Kokkos::Experimental::epsilon;
-  using Kokkos::Experimental::exp;
-  using Kokkos::Experimental::fabs;
   using Kokkos::Experimental::infinity;
-  using Kokkos::Experimental::isinf;
-  using Kokkos::Experimental::sin;
 
   using CmplxType = Kokkos::complex<RealType>;
 
@@ -486,8 +486,8 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_j0(const CmplxType& z,
   //                       argument regions
   //         bw_start  --- Starting point for backward recurrence
   // Output:  cbj0      --- J0(z)
-  using Kokkos::Experimental::fabs;
-  using Kokkos::Experimental::pow;
+  using Kokkos::fabs;
+  using Kokkos::pow;
 
   CmplxType cbj0;
   constexpr auto pi    = Kokkos::Experimental::pi_v<RealType>;
@@ -574,9 +574,9 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y0(const CmplxType& z,
   //                           argument regions
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cby0      --- Y0(z)
-  using Kokkos::Experimental::fabs;
+  using Kokkos::fabs;
+  using Kokkos::pow;
   using Kokkos::Experimental::infinity;
-  using Kokkos::Experimental::pow;
 
   constexpr auto inf = infinity<RealType>::value;
 
@@ -675,8 +675,8 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_j1(const CmplxType& z,
   //                           argument regions
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbj1      --- J1(z)
-  using Kokkos::Experimental::fabs;
-  using Kokkos::Experimental::pow;
+  using Kokkos::fabs;
+  using Kokkos::pow;
 
   CmplxType cbj1;
   constexpr auto pi     = Kokkos::Experimental::pi_v<RealType>;
@@ -767,9 +767,9 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y1(const CmplxType& z,
   //                           argument regions
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cby1      --- Y1(z)
-  using Kokkos::Experimental::fabs;
+  using Kokkos::fabs;
+  using Kokkos::pow;
   using Kokkos::Experimental::infinity;
-  using Kokkos::Experimental::pow;
 
   constexpr auto inf = infinity<RealType>::value;
 
@@ -943,8 +943,8 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k0(const CmplxType& z,
   //                           argument regions
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbk0      --- K0(z)
+  using Kokkos::pow;
   using Kokkos::Experimental::infinity;
-  using Kokkos::Experimental::pow;
 
   constexpr auto inf = infinity<RealType>::value;
 
@@ -1089,8 +1089,8 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k1(const CmplxType& z,
   //                           argument regions
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbk1      --- K1(z)
+  using Kokkos::pow;
   using Kokkos::Experimental::infinity;
-  using Kokkos::Experimental::pow;
 
   constexpr auto inf = infinity<RealType>::value;
 

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -114,7 +114,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erf(
   //      (1)  abs(z)<=2 - Power series, NBS Handbook, p. 298
   //      (2)  abs(z)>2 and x>1 - continued fraction, NBS Handbook, p. 298
   //      (3)  abs(z)>2 and 0<=x<=1 and abs(y)<6 - series, NBS Handbook, p. 299
-  //      (4)  abs(z)>2 and 0<=x<=1 and abs(y)>=6 - asymtotic expansion
+  //      (4)  abs(z)>2 and 0<=x<=1 and abs(y)>=6 - asymptotic expansion
   //  Error condition: abs(z^2) > 670 is a fatal overflow error
   using Kokkos::Experimental::cos;
   using Kokkos::Experimental::epsilon;
@@ -248,7 +248,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erf(
         if (z.real() < 0.0) cans = -cans;
       }       // end (abs(yp) < 6.0)
       else {  //(abs(YP)>=6.0)
-        // Asymtotic expansion for 0<=xp<=1 and abs(yp)>=6
+        // Asymptotic expansion for 0<=xp<=1 and abs(yp)>=6
         CmplxType rcz   = 0.5 / cz;
         CmplxType accum = CmplxType(1.0, 0.0);
         CmplxType term  = accum;
@@ -291,7 +291,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erfcx(
   //      (1)  abs(z)<=2 - Power series, NBS Handbook, p. 298
   //      (2)  abs(z)>2 and x>1 - continued fraction, NBS Handbook, p. 298
   //      (3)  abs(z)>2 and 0<=x<=1 and abs(y)<6 - series, NBS Handbook, p. 299
-  //      (4)  abs(z)>2 and 0<=x<=1 and abs(y)>=6 - asymtotic expansion
+  //      (4)  abs(z)>2 and 0<=x<=1 and abs(y)>=6 - asymptotic expansion
   // Error condition: abs(z^2) > 670 is a fatal overflow error when x<0
   using Kokkos::Experimental::cos;
   using Kokkos::Experimental::epsilon;
@@ -440,7 +440,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erfcx(
           cans = cz * (1.0 + w) + rcz * CmplxType(s1, s2) / pi;
       }       // end (abs(yp) < 6.0)
       else {  //(abs(YP)>=6.0)
-        // Asymtotic expansion for 0<=xp<=1 and abs(yp)>=6
+        // Asymptotic expansion for 0<=xp<=1 and abs(yp)>=6
         CmplxType rcz   = 0.5 / cz;
         CmplxType accum = CmplxType(1.0, 0.0);
         CmplxType term  = accum;

--- a/core/src/impl/Kokkos_BitOps.hpp
+++ b/core/src/impl/Kokkos_BitOps.hpp
@@ -152,15 +152,6 @@ unsigned integral_power_of_two_that_contains(const unsigned N) {
 }
 
 }  // namespace Impl
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
-
-KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION int log2(unsigned i) {
-  return Impl::int_log2(i);
-}
-
-#endif
-
 }  // namespace Kokkos
 
 #endif  // KOKKOS_BITOPS_HPP

--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -705,7 +705,6 @@ bool DivAtomicTest(T i0, T i1) {
   bool passed = true;
 
   using Kokkos::abs;
-  using std::abs;
   if (abs((resSerial - res) * 1.) > 1e-5) {
     passed = false;
 

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -385,7 +385,7 @@ struct TestMDRange_2D {
       parallel_reduce(
           "rank2-min-reducer", range,
           KOKKOS_LAMBDA(const int i, const int j, double &min_val) {
-            min_val = Kokkos::Experimental::fmin(v_in(i, j), min_val);
+            min_val = Kokkos::fmin(v_in(i, j), min_val);
           },
           reducer_scalar);
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -299,10 +299,10 @@ struct math_function_name;
   struct MathUnaryFunction_##FUNC {                                            \
     template <typename T>                                                      \
     static KOKKOS_FUNCTION auto eval(T x) {                                    \
-      static_assert(std::is_same<decltype(Kokkos::Experimental::FUNC((T)0)),   \
+      static_assert(std::is_same<decltype(Kokkos::FUNC((T)0)),                 \
                                  math_unary_function_return_type_t<T>>::value, \
                     "");                                                       \
-      return Kokkos::Experimental::FUNC(x);                                    \
+      return Kokkos::FUNC(x);                                                  \
     }                                                                          \
     template <typename T>                                                      \
     static auto eval_std(T x) {                                                \
@@ -376,10 +376,10 @@ DEFINE_UNARY_FUNCTION_EVAL(nearbyint, 2);
     template <typename T, typename U>                                    \
     static KOKKOS_FUNCTION auto eval(T x, U y) {                         \
       static_assert(                                                     \
-          std::is_same<decltype(Kokkos::Experimental::FUNC((T)0, (U)0)), \
+          std::is_same<decltype(Kokkos::FUNC((T)0, (U)0)),               \
                        math_binary_function_return_type_t<T, U>>::value, \
           "");                                                           \
-      return Kokkos::Experimental::FUNC(x, y);                           \
+      return Kokkos::FUNC(x, y);                                         \
     }                                                                    \
     template <typename T, typename U>                                    \
     static auto eval_std(T x, U y) {                                     \
@@ -898,7 +898,7 @@ struct TestAbsoluteValueFunction {
     ASSERT_EQ(errors, 0);
   }
   KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::Experimental::abs;
+    using Kokkos::abs;
     if (abs(1) != 1 || abs(-1) != 1) {
       ++e;
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed abs(int)\n");
@@ -926,8 +926,8 @@ struct TestAbsoluteValueFunction {
     }
 #endif
     // special values
-    using Kokkos::Experimental::isinf;
-    using Kokkos::Experimental::isnan;
+    using Kokkos::isinf;
+    using Kokkos::isnan;
     if (abs(-0.) != 0.
 #ifndef KOKKOS_IMPL_WORKAROUND_INTEL_LLVM_DEFAULT_FLOATING_POINT_MODEL
         || !isinf(abs(-INFINITY)) || !isnan(abs(-NAN))
@@ -962,7 +962,7 @@ struct TestIsNaN {
     ASSERT_EQ(errors, 0);
   }
   KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::Experimental::isnan;
+    using Kokkos::isnan;
     using Kokkos::Experimental::quiet_NaN;
     using Kokkos::Experimental::signaling_NaN;
     if (isnan(1) || isnan(INT_MAX)) {

--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -17,7 +17,7 @@ struct TestExponentialIntergral1Function {
   HostViewType h_ref;
 
   void testit() {
-    using Kokkos::Experimental::fabs;
+    using Kokkos::fabs;
     using Kokkos::Experimental::infinity;
 
     d_x      = ViewType("d_x", 15);


### PR DESCRIPTION
Move all math functions from `Kokkos::Experimental::` to `Kokkos::` namespace.
Provide using-declaration in the `Kokkos::Experimental::` namespace when deprecated code is enabled to ease the transition.

Deprecated function `log2(unsigned) -> int` is being removed.