### PR TITLE
Mark throw_runtime_exception as [[noreturn]]

### DIFF
--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -67,12 +67,11 @@ namespace Impl {
 
 [[noreturn]] void host_abort(const char *const);
 
-void throw_runtime_exception(const std::string &);
+[[noreturn]] void throw_runtime_exception(const std::string &msg);
 
 void traceback_callstack(std::ostream &);
 
 std::string human_memory_size(size_t arg_bytes);
-void throw_runtime_exception(const std::string &msg);
 
 }  // namespace Impl
 


### PR DESCRIPTION
This quiets some compiler warnings about non-void functions not reaching a return.