### PR TITLE
Fixes for `View::operator()()`

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -815,6 +815,7 @@ class View : public ViewTraits<DataType, Properties...> {
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(0 == Rank) && (R == Rank), reference_type>
       operator()() const {
+    KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((m_track, m_map))
     return m_map.reference();
   }
   //------------------------------

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -811,8 +811,12 @@ class View : public ViewTraits<DataType, Properties...> {
   //------------------------------
   // Rank 0 operator()
 
+  template <int R = Rank>
   KOKKOS_FORCEINLINE_FUNCTION
-  reference_type operator()() const { return m_map.reference(); }
+      std::enable_if_t<(0 == Rank) && (R == Rank), reference_type>
+      operator()() const {
+    return m_map.reference();
+  }
   //------------------------------
   // Rank 1 operator()
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -811,10 +811,9 @@ class View : public ViewTraits<DataType, Properties...> {
   //------------------------------
   // Rank 0 operator()
 
-  template <int R = Rank>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(0 == Rank) && (R == Rank), reference_type>
-      operator()() const {
+  template <int R            = Rank,
+            class /*Enable*/ = std::enable_if_t<(0 == Rank) && (R == Rank)>>
+  KOKKOS_FORCEINLINE_FUNCTION reference_type operator()() const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY((m_track, m_map))
     return m_map.reference();
   }

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -71,6 +71,7 @@ KOKKOS_INCLUDE_DIRECTORIES(${KOKKOS_SOURCE_DIR}/core/unit_test/category_files)
 
 SET(COMPILE_ONLY_SOURCES
   TestDetectionIdiom.cpp
+  TestViewOperatorParens.cpp
   TestInterOp.cpp
   TestTypeList.cpp
 )

--- a/core/unit_test/TestViewOperatorParens.cpp
+++ b/core/unit_test/TestViewOperatorParens.cpp
@@ -1,0 +1,130 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+
+#define STATIC_ASSERT(cond) static_assert(cond, "")
+
+// clang-format off
+template <class V> using access_view_operator_parens_0_args_t = decltype(std::declval<V const&>().operator()());
+template <class V> using access_view_operator_parens_1_args_t = decltype(std::declval<V const&>().operator()(0));
+template <class V> using access_view_operator_parens_2_args_t = decltype(std::declval<V const&>().operator()(0, 0));
+template <class V> using access_view_operator_parens_3_args_t = decltype(std::declval<V const&>().operator()(0, 0, 0));
+template <class V> using access_view_operator_parens_4_args_t = decltype(std::declval<V const&>().operator()(0, 0, 0, 0));
+template <class V> using access_view_operator_parens_5_args_t = decltype(std::declval<V const&>().operator()(0, 0, 0, 0, 0));
+template <class V> using access_view_operator_parens_6_args_t = decltype(std::declval<V const&>().operator()(0, 0, 0, 0, 0, 0));
+template <class V> using access_view_operator_parens_7_args_t = decltype(std::declval<V const&>().operator()(0, 0, 0, 0, 0, 0, 0));
+
+STATIC_ASSERT(( Kokkos::is_detected<access_view_operator_parens_0_args_t, Kokkos::View<int>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_0_args_t, Kokkos::View<int*>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_0_args_t, Kokkos::View<int**>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_0_args_t, Kokkos::View<int***>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_0_args_t, Kokkos::View<int****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_0_args_t, Kokkos::View<int*****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_0_args_t, Kokkos::View<int******>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_0_args_t, Kokkos::View<int*******>>::value));
+
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_1_args_t, Kokkos::View<int>>::value));
+STATIC_ASSERT(( Kokkos::is_detected<access_view_operator_parens_1_args_t, Kokkos::View<int*>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_1_args_t, Kokkos::View<int**>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_1_args_t, Kokkos::View<int***>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_1_args_t, Kokkos::View<int****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_1_args_t, Kokkos::View<int*****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_1_args_t, Kokkos::View<int******>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_1_args_t, Kokkos::View<int*******>>::value));
+
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_2_args_t, Kokkos::View<int>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_2_args_t, Kokkos::View<int*>>::value));
+STATIC_ASSERT(( Kokkos::is_detected<access_view_operator_parens_2_args_t, Kokkos::View<int**>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_2_args_t, Kokkos::View<int***>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_2_args_t, Kokkos::View<int****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_2_args_t, Kokkos::View<int*****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_2_args_t, Kokkos::View<int******>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_2_args_t, Kokkos::View<int*******>>::value));
+
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_3_args_t, Kokkos::View<int>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_3_args_t, Kokkos::View<int*>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_3_args_t, Kokkos::View<int**>>::value));
+STATIC_ASSERT(( Kokkos::is_detected<access_view_operator_parens_3_args_t, Kokkos::View<int***>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_3_args_t, Kokkos::View<int****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_3_args_t, Kokkos::View<int*****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_3_args_t, Kokkos::View<int******>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_3_args_t, Kokkos::View<int*******>>::value));
+
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_4_args_t, Kokkos::View<int>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_4_args_t, Kokkos::View<int*>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_4_args_t, Kokkos::View<int**>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_4_args_t, Kokkos::View<int***>>::value));
+STATIC_ASSERT(( Kokkos::is_detected<access_view_operator_parens_4_args_t, Kokkos::View<int****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_4_args_t, Kokkos::View<int*****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_4_args_t, Kokkos::View<int******>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_4_args_t, Kokkos::View<int*******>>::value));
+
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_5_args_t, Kokkos::View<int>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_5_args_t, Kokkos::View<int*>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_5_args_t, Kokkos::View<int**>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_5_args_t, Kokkos::View<int***>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_5_args_t, Kokkos::View<int****>>::value));
+STATIC_ASSERT(( Kokkos::is_detected<access_view_operator_parens_5_args_t, Kokkos::View<int*****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_5_args_t, Kokkos::View<int******>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_5_args_t, Kokkos::View<int*******>>::value));
+
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_6_args_t, Kokkos::View<int>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_6_args_t, Kokkos::View<int*>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_6_args_t, Kokkos::View<int**>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_6_args_t, Kokkos::View<int***>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_6_args_t, Kokkos::View<int****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_6_args_t, Kokkos::View<int*****>>::value));
+STATIC_ASSERT(( Kokkos::is_detected<access_view_operator_parens_6_args_t, Kokkos::View<int******>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_6_args_t, Kokkos::View<int*******>>::value));
+
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_7_args_t, Kokkos::View<int>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_7_args_t, Kokkos::View<int*>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_7_args_t, Kokkos::View<int**>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_7_args_t, Kokkos::View<int***>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_7_args_t, Kokkos::View<int****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_7_args_t, Kokkos::View<int*****>>::value));
+STATIC_ASSERT((!Kokkos::is_detected<access_view_operator_parens_7_args_t, Kokkos::View<int******>>::value));
+STATIC_ASSERT(( Kokkos::is_detected<access_view_operator_parens_7_args_t, Kokkos::View<int*******>>::value));
+// clang-format on


### PR DESCRIPTION
SFINAE away `View::operator()()` for non rank-0 views and check for memory access violations.

I will add tests for the memory access violation later as part of including the view label in the error message passed to `Kokkos::abort()`.

---

Before this PR
```C++
Kokkos::View<float**, Kokkos::HostSpace> v("v", 1, 2);
std::cout << ++v() << '\n';  // sigh...
```
compiles and prints `1`.
With the changes proposed it yields
```
error: no matching function for call to object of type 'Kokkos::View<float **, Kokkos::HostSpace>'
  std::cout << ++v() << '\n';  // sigh...
                 ^
<kokkos>/core/src/Kokkos_View.hpp:815:7: note: candidate template ignored: requirement '(0 == Rank) && (2 == Rank)' was not satisfied [with R = 2]
      operator()() const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:827:7: note: candidate function template not viable: requires single argument 'i0', but no arguments were provided
      operator()(const I0& i0) const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:838:7: note: candidate function template not viable: requires single argument 'i0', but no arguments were provided
      operator()(const I0& i0) const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:849:7: note: candidate function template not viable: requires single argument 'i0', but no arguments were provided
      operator()(const I0& i0) const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:896:7: note: candidate function template not viable: requires 2 arguments, but 0 were provided
      operator()(const I0& i0, const I1& i1) const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:907:7: note: candidate function template not viable: requires 2 arguments, but 0 were provided
      operator()(const I0& i0, const I1& i1) const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:918:7: note: candidate function template not viable: requires 2 arguments, but 0 were provided
      operator()(const I0& i0, const I1& i1) const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:929:7: note: candidate function template not viable: requires 2 arguments, but 0 were provided
      operator()(const I0& i0, const I1& i1) const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:940:7: note: candidate function template not viable: requires 2 arguments, but 0 were provided
      operator()(const I0& i0, const I1& i1) const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:951:7: note: candidate function template not viable: requires 2 arguments, but 0 were provided
      operator()(const I0& i0, const I1& i1) const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:965:7: note: candidate function template not viable: requires 3 arguments, but 0 were provided
      operator()(const I0& i0, const I1& i1, const I2& i2) const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:975:7: note: candidate function template not viable: requires 3 arguments, but 0 were provided
      operator()(const I0& i0, const I1& i1, const I2& i2) const {
      ^
<kokkos>/core/src/Kokkos_View.hpp:988:3: note: candidate function template not viable: requires 4 arguments, but 0 were provided
  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3) const {
  ^
<kokkos>/core/src/Kokkos_View.hpp:998:3: note: candidate function template not viable: requires 4 arguments, but 0 were provided
  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3) const {
  ^
<kokkos>/core/src/Kokkos_View.hpp:1011:3: note: candidate function template not viable: requires 5 arguments, but 0 were provided
  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
  ^
<kokkos>/core/src/Kokkos_View.hpp:1022:3: note: candidate function template not viable: requires 5 arguments, but 0 were provided
  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
  ^
<kokkos>/core/src/Kokkos_View.hpp:1037:3: note: candidate function template not viable: requires 6 arguments, but 0 were provided
  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
  ^
<kokkos>/core/src/Kokkos_View.hpp:1049:3: note: candidate function template not viable: requires 6 arguments, but 0 were provided
  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
  ^
<kokkos>/core/src/Kokkos_View.hpp:1064:3: note: candidate function template not viable: requires 7 arguments, but 0 were provided
  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
  ^
<kokkos>/core/src/Kokkos_View.hpp:1076:3: note: candidate function template not viable: requires 7 arguments, but 0 were provided
  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
  ^
<kokkos>/core/src/Kokkos_View.hpp:1091:3: note: candidate function template not viable: requires 8 arguments, but 0 were provided
  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
  ^
<kokkos>/core/src/Kokkos_View.hpp:1105:3: note: candidate function template not viable: requires 8 arguments, but 0 were provided
  operator()(const I0& i0, const I1& i1, const I2& i2, const I3& i3,
  ^