### PR TITLE
Let `SharedAllocationHeader::get_header({void* -> void const*})`

### DIFF
--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -87,8 +87,8 @@ class SharedAllocationHeader {
   /* Given user memory get pointer to the header */
   KOKKOS_INLINE_FUNCTION static const SharedAllocationHeader* get_header(
       void const* alloc_ptr) {
-    return static_cast<SharedAllocationHeader const*>(static_cast<void const*>(
-        static_cast<char const*>(alloc_ptr) - sizeof(SharedAllocationHeader)));
+    return reinterpret_cast<SharedAllocationHeader const*>(
+        static_cast<char const*>(alloc_ptr) - sizeof(SharedAllocationHeader));
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -185,7 +185,7 @@ class SharedAllocationRecord<void, void> {
 
   /* User's memory begins at the end of the header */
   KOKKOS_INLINE_FUNCTION
-  void* data() const { return reinterpret_cast<void*>(m_alloc_ptr + 1); }
+  void* data() const { return static_cast<void*>(m_alloc_ptr + 1); }
 
   /* User's memory begins at the end of the header */
   size_t size() const { return m_alloc_size - sizeof(SharedAllocationHeader); }

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -86,9 +86,9 @@ class SharedAllocationHeader {
  public:
   /* Given user memory get pointer to the header */
   KOKKOS_INLINE_FUNCTION static const SharedAllocationHeader* get_header(
-      void* alloc_ptr) {
-    return reinterpret_cast<SharedAllocationHeader*>(
-        reinterpret_cast<char*>(alloc_ptr) - sizeof(SharedAllocationHeader));
+      void const* alloc_ptr) {
+    return static_cast<SharedAllocationHeader const*>(static_cast<void const*>(
+        static_cast<char const*>(alloc_ptr) - sizeof(SharedAllocationHeader)));
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3917,7 +3917,8 @@ struct OperatorBoundsErrorOnDevice<MapType, true> {
   KOKKOS_INLINE_FUNCTION
   static void run(MapType const& map) {
     SharedAllocationHeader const* const header =
-        SharedAllocationHeader::get_header((void*)(map.data()));
+        SharedAllocationHeader::get_header(
+            static_cast<void const*>(map.data()));
     char const* const label = header->label();
     enum { LEN = 128 };
     char msg[LEN];


### PR DESCRIPTION
Without these changes it I need to cast away the constness of the pointer when I attempt to retrieve the view labels.
I realized they was absolutely no reason to take a non-const pointer in `SharedAllocationHeader::get_header(void [const]*)`.