### PR TITLE
Add Kokkos::create_mirror[_view] WithoutInitializing for Container types

### DIFF
--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -340,6 +340,9 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
   size_t chunk_size() const noexcept { return m_chunk_size; }
 
   KOKKOS_INLINE_FUNCTION
+  size_t chunk_max() const noexcept { return m_chunk_max; }
+
+  KOKKOS_INLINE_FUNCTION
   size_t size() const noexcept {
     size_t extent_0 =
         *reinterpret_cast<const size_t*>(m_chunks_host + m_chunk_max + 1);
@@ -422,7 +425,7 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
     if (nullptr == *ch)
 #endif
     {
-      // Verify that allocation of the requested chunk in in progress.
+      // Verify that allocation of the requested chunk is in progress.
 
       // The allocated chunk counter is m_chunks[ m_chunk_max ]
       const uintptr_t n =
@@ -525,9 +528,10 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
    *  A maximum size is required in order to allocate a
    *  chunk-pointer array.
    */
-  explicit inline DynamicView(const std::string& arg_label,
-                              const unsigned min_chunk_size,
-                              const unsigned max_extent)
+  template <class... Prop>
+  DynamicView(const Kokkos::Impl::ViewCtorProp<Prop...>& arg_prop,
+              const unsigned min_chunk_size,
+              const unsigned max_extent)
       :  // The chunk size is guaranteed to be a power of two
         m_chunk_shift(Kokkos::Impl::integral_power_of_two_that_contains(
             min_chunk_size))  // div ceil(log2(min_chunk_size))
@@ -540,20 +544,30 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
         m_chunk_size(2 << (m_chunk_shift - 1)) {
     m_chunks = device_accessor(m_chunk_max, m_chunk_size);
 
+    const std::string& label =
+        static_cast<Kokkos::Impl::ViewCtorProp<void, std::string> const&>(
+            arg_prop)
+            .value;
+
     if (device_accessor::template IsAccessibleFrom<host_space>::value) {
-      m_chunks.template allocate_with_destroy<device_space>(arg_label);
+      m_chunks.template allocate_with_destroy<device_space>(label);
       m_chunks.initialize();
       m_chunks_host =
           device_accessor::template create_mirror<host_space>(m_chunks);
     } else {
-      m_chunks.allocate_device(arg_label);
+      m_chunks.allocate_device(label);
       m_chunks_host =
           device_accessor::template create_mirror<host_space>(m_chunks);
       m_chunks_host.template allocate_with_destroy<device_space>(
-          arg_label, m_chunks.get_ptr());
+          label, m_chunks.get_ptr());
       m_chunks_host.initialize();
       m_chunks_host.deep_copy_to(m_chunks);
     }
+  }
+
+  DynamicView(const std::string& arg_label, const unsigned min_chunk_size,
+              const unsigned max_extent)
+      : DynamicView(Kokkos::view_alloc(arg_label), min_chunk_size, max_extent) {
   }
 };
 
@@ -562,10 +576,168 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
 
 namespace Kokkos {
 
-template <class T, class... P>
+namespace Impl {
+
+// Deduce Mirror Types
+template <class Space, class T, class... P>
+struct MirrorDynamicViewType {
+  // The incoming view_type
+  using src_view_type = typename Kokkos::Experimental::DynamicView<T, P...>;
+  // The memory space for the mirror view
+  using memory_space = typename Space::memory_space;
+  // Check whether it is the same memory space
+  enum {
+    is_same_memspace =
+        std::is_same<memory_space, typename src_view_type::memory_space>::value
+  };
+  // The array_layout
+  using array_layout = typename src_view_type::array_layout;
+  // The data type (we probably want it non-const since otherwise we can't even
+  // deep_copy to it.)
+  using data_type = typename src_view_type::non_const_data_type;
+  // The destination view type if it is not the same memory space
+  using dest_view_type =
+      Kokkos::Experimental::DynamicView<data_type, array_layout, Space>;
+  // If it is the same memory_space return the existing view_type
+  // This will also keep the unmanaged trait if necessary
+  using view_type = typename std::conditional<is_same_memspace, src_view_type,
+                                              dest_view_type>::type;
+};
+}  // namespace Impl
+
+namespace Impl {
+template <class T, class... P, class... I>
 inline typename Kokkos::Experimental::DynamicView<T, P...>::HostMirror
-create_mirror_view(const Kokkos::Experimental::DynamicView<T, P...>& src) {
+create_mirror(const Kokkos::Experimental::DynamicView<T, P...>& src,
+              const I&... arg_prop) {
+  return typename Kokkos::Experimental::DynamicView<T, P...>::HostMirror(
+      Kokkos::view_alloc(arg_prop...,
+                         std::string(src.label()).append("_mirror")),
+      src.chunk_size(), src.chunk_max() * src.chunk_size());
+}
+
+template <class Space, class T, class... P, class... I>
+inline typename Kokkos::Impl::MirrorDynamicViewType<Space, T, P...>::view_type
+create_mirror(const Space&,
+              const Kokkos::Experimental::DynamicView<T, P...>& src,
+              const I&... arg_prop) {
+  return
+      typename Kokkos::Impl::MirrorDynamicViewType<Space, T, P...>::view_type(
+          Kokkos::view_alloc(arg_prop...,
+                             std::string(src.label()).append("_mirror")),
+          src.chunk_size(), src.chunk_max() * src.chunk_size());
+}
+}  // namespace Impl
+
+// Create a mirror in host space
+template <class T, class... P>
+inline auto create_mirror(
+    const Kokkos::Experimental::DynamicView<T, P...>& src) {
+  return Impl::create_mirror(src);
+}
+
+template <class T, class... P>
+inline auto create_mirror(
+    Kokkos::Impl::WithoutInitializing_t wi,
+    const Kokkos::Experimental::DynamicView<T, P...>& src) {
+  return Impl::create_mirror(src, wi);
+}
+
+// Create a mirror in a new space
+template <class Space, class T, class... P>
+inline auto create_mirror(
+    const Space& space, const Kokkos::Experimental::DynamicView<T, P...>& src) {
+  return Impl::create_mirror(space, src);
+}
+
+template <class Space, class T, class... P>
+typename Kokkos::Impl::MirrorDynamicViewType<Space, T, P...>::view_type
+create_mirror(Kokkos::Impl::WithoutInitializing_t wi, const Space& space,
+              const Kokkos::Experimental::DynamicView<T, P...>& src) {
+  return Impl::create_mirror(space, src, wi);
+}
+
+namespace Impl {
+template <class T, class... P, class... I>
+inline std::enable_if_t<
+    (std::is_same<
+         typename Kokkos::Experimental::DynamicView<T, P...>::memory_space,
+         typename Kokkos::Experimental::DynamicView<
+             T, P...>::HostMirror::memory_space>::value &&
+     std::is_same<
+         typename Kokkos::Experimental::DynamicView<T, P...>::data_type,
+         typename Kokkos::Experimental::DynamicView<
+             T, P...>::HostMirror::data_type>::value),
+    typename Kokkos::Experimental::DynamicView<T, P...>::HostMirror>
+create_mirror_view(
+    const typename Kokkos::Experimental::DynamicView<T, P...>& src,
+    const I&...) {
   return src;
+}
+
+template <class T, class... P, class... I>
+inline std::enable_if_t<
+    !(std::is_same<
+          typename Kokkos::Experimental::DynamicView<T, P...>::memory_space,
+          typename Kokkos::Experimental::DynamicView<
+              T, P...>::HostMirror::memory_space>::value &&
+      std::is_same<
+          typename Kokkos::Experimental::DynamicView<T, P...>::data_type,
+          typename Kokkos::Experimental::DynamicView<
+              T, P...>::HostMirror::data_type>::value),
+    typename Kokkos::Experimental::DynamicView<T, P...>::HostMirror>
+create_mirror_view(const Kokkos::Experimental::DynamicView<T, P...>& src,
+                   const I&... arg_prop) {
+  return Kokkos::create_mirror(arg_prop..., src);
+}
+
+template <class Space, class T, class... P, class... I>
+inline std::enable_if_t<
+    Impl::MirrorDynamicViewType<Space, T, P...>::is_same_memspace,
+    typename Kokkos::Impl::MirrorDynamicViewType<Space, T, P...>::view_type>
+create_mirror_view(const Space&,
+                   const Kokkos::Experimental::DynamicView<T, P...>& src,
+                   const I&...) {
+  return src;
+}
+
+template <class Space, class T, class... P, class... I>
+std::enable_if_t<
+    !Impl::MirrorDynamicViewType<Space, T, P...>::is_same_memspace,
+    typename Kokkos::Impl::MirrorDynamicViewType<Space, T, P...>::view_type>
+create_mirror_view(const Space& space,
+                   const Kokkos::Experimental::DynamicView<T, P...>& src,
+                   const I&... arg_prop) {
+  return Kokkos::create_mirror(arg_prop..., space, src);
+}
+}  // namespace Impl
+
+// Create a mirror view in host space
+template <class T, class... P>
+inline auto create_mirror_view(
+    const typename Kokkos::Experimental::DynamicView<T, P...>& src) {
+  return Impl::create_mirror_view(src);
+}
+
+template <class T, class... P>
+inline auto create_mirror_view(
+    Kokkos::Impl::WithoutInitializing_t wi,
+    const typename Kokkos::Experimental::DynamicView<T, P...>& src) {
+  return Impl::create_mirror_view(src, wi);
+}
+
+// Create a mirror in a new space
+template <class Space, class T, class... P>
+inline auto create_mirror_view(
+    const Space& space, const Kokkos::Experimental::DynamicView<T, P...>& src) {
+  return Impl::create_mirror_view(space, src);
+}
+
+template <class Space, class T, class... P>
+inline auto create_mirror_view(
+    Kokkos::Impl::WithoutInitializing_t wi, const Space& space,
+    const Kokkos::Experimental::DynamicView<T, P...>& src) {
+  return Impl::create_mirror_view(space, src, wi);
 }
 
 template <class T, class... DP, class... SP>

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -41,7 +41,6 @@ template <typename iType,
 using IndexRange = Kokkos::Array<iType, 2>;
 
 using index_list_type = std::initializer_list<int64_t>;
-using range_type      = std::pair<int64_t, int64_t>;
 
 //  template <typename iType,
 //    typename std::enable_if< std::is_integral<iType>::value &&
@@ -1109,33 +1108,6 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   explicit inline OffsetView(
       const Label& arg_label,
       typename std::enable_if<Kokkos::Impl::is_view_label<Label>::value,
-                              const range_type>::type range0,
-      const range_type range1 = KOKKOS_INVALID_INDEX_RANGE,
-      const range_type range2 = KOKKOS_INVALID_INDEX_RANGE,
-      const range_type range3 = KOKKOS_INVALID_INDEX_RANGE,
-      const range_type range4 = KOKKOS_INVALID_INDEX_RANGE,
-      const range_type range5 = KOKKOS_INVALID_INDEX_RANGE,
-      const range_type range6 = KOKKOS_INVALID_INDEX_RANGE,
-      const range_type range7 = KOKKOS_INVALID_INDEX_RANGE
-
-      )
-      : OffsetView(
-            Kokkos::Impl::ViewCtorProp<std::string>(arg_label),
-            typename traits::array_layout(range0.second - range0.first + 1,
-                                          range1.second - range1.first + 1,
-                                          range2.second - range2.first + 1,
-                                          range3.second - range3.first + 1,
-                                          range4.second - range4.first + 1,
-                                          range5.second - range5.first + 1,
-                                          range6.second - range6.first + 1,
-                                          range7.second - range7.first + 1),
-            {range0.first, range1.first, range2.first, range3.first,
-             range4.first, range5.first, range6.first, range7.first}) {}
-
-  template <typename Label>
-  explicit inline OffsetView(
-      const Label& arg_label,
-      typename std::enable_if<Kokkos::Impl::is_view_label<Label>::value,
                               const index_list_type>::type range0,
       const index_list_type range1 = KOKKOS_INVALID_INDEX_RANGE,
       const index_list_type range2 = KOKKOS_INVALID_INDEX_RANGE,
@@ -1143,15 +1115,22 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
       const index_list_type range4 = KOKKOS_INVALID_INDEX_RANGE,
       const index_list_type range5 = KOKKOS_INVALID_INDEX_RANGE,
       const index_list_type range6 = KOKKOS_INVALID_INDEX_RANGE,
-      const index_list_type range7 = KOKKOS_INVALID_INDEX_RANGE)
-      : OffsetView(arg_label, range_type(range0.begin()[0], range0.begin()[1]),
-                   range_type(range1.begin()[0], range1.begin()[1]),
-                   range_type(range2.begin()[0], range2.begin()[1]),
-                   range_type(range3.begin()[0], range3.begin()[1]),
-                   range_type(range4.begin()[0], range4.begin()[1]),
-                   range_type(range5.begin()[0], range5.begin()[1]),
-                   range_type(range6.begin()[0], range6.begin()[1]),
-                   range_type(range7.begin()[0], range7.begin()[1])) {}
+      const index_list_type range7 = KOKKOS_INVALID_INDEX_RANGE
+
+      )
+      : OffsetView(Kokkos::Impl::ViewCtorProp<std::string>(arg_label),
+                   typename traits::array_layout(
+                       range0.begin()[1] - range0.begin()[0] + 1,
+                       range1.begin()[1] - range1.begin()[0] + 1,
+                       range2.begin()[1] - range2.begin()[0] + 1,
+                       range3.begin()[1] - range3.begin()[0] + 1,
+                       range4.begin()[1] - range4.begin()[0] + 1,
+                       range5.begin()[1] - range5.begin()[0] + 1,
+                       range6.begin()[1] - range6.begin()[0] + 1,
+                       range7.begin()[1] - range7.begin()[0] + 1),
+                   {range0.begin()[0], range1.begin()[0], range2.begin()[0],
+                    range3.begin()[0], range4.begin()[0], range5.begin()[0],
+                    range6.begin()[0], range7.begin()[0]}) {}
 
   template <class... P>
   explicit KOKKOS_INLINE_FUNCTION OffsetView(

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1132,6 +1132,27 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
             {range0.first, range1.first, range2.first, range3.first,
              range4.first, range5.first, range6.first, range7.first}) {}
 
+  template <typename Label>
+  explicit inline OffsetView(
+      const Label& arg_label,
+      typename std::enable_if<Kokkos::Impl::is_view_label<Label>::value,
+                              const index_list_type>::type range0,
+      const index_list_type range1 = KOKKOS_INVALID_INDEX_RANGE,
+      const index_list_type range2 = KOKKOS_INVALID_INDEX_RANGE,
+      const index_list_type range3 = KOKKOS_INVALID_INDEX_RANGE,
+      const index_list_type range4 = KOKKOS_INVALID_INDEX_RANGE,
+      const index_list_type range5 = KOKKOS_INVALID_INDEX_RANGE,
+      const index_list_type range6 = KOKKOS_INVALID_INDEX_RANGE,
+      const index_list_type range7 = KOKKOS_INVALID_INDEX_RANGE)
+      : OffsetView(arg_label, range_type(range0.begin()[0], range0.begin()[1]),
+                   range_type(range1.begin()[0], range1.begin()[1]),
+                   range_type(range2.begin()[0], range2.begin()[1]),
+                   range_type(range3.begin()[0], range3.begin()[1]),
+                   range_type(range4.begin()[0], range4.begin()[1]),
+                   range_type(range5.begin()[0], range5.begin()[1]),
+                   range_type(range6.begin()[0], range6.begin()[1]),
+                   range_type(range7.begin()[0], range7.begin()[1])) {}
+
   template <class... P>
   explicit KOKKOS_INLINE_FUNCTION OffsetView(
       const Kokkos::Impl::ViewCtorProp<P...>& arg_prop,

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -41,6 +41,7 @@ template <typename iType,
 using IndexRange = Kokkos::Array<iType, 2>;
 
 using index_list_type = std::initializer_list<int64_t>;
+using range_type      = std::pair<int64_t, int64_t>;
 
 //  template <typename iType,
 //    typename std::enable_if< std::is_integral<iType>::value &&
@@ -1108,29 +1109,28 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
   explicit inline OffsetView(
       const Label& arg_label,
       typename std::enable_if<Kokkos::Impl::is_view_label<Label>::value,
-                              const index_list_type>::type range0,
-      const index_list_type range1 = KOKKOS_INVALID_INDEX_RANGE,
-      const index_list_type range2 = KOKKOS_INVALID_INDEX_RANGE,
-      const index_list_type range3 = KOKKOS_INVALID_INDEX_RANGE,
-      const index_list_type range4 = KOKKOS_INVALID_INDEX_RANGE,
-      const index_list_type range5 = KOKKOS_INVALID_INDEX_RANGE,
-      const index_list_type range6 = KOKKOS_INVALID_INDEX_RANGE,
-      const index_list_type range7 = KOKKOS_INVALID_INDEX_RANGE
+                              const range_type>::type range0,
+      const range_type range1 = KOKKOS_INVALID_INDEX_RANGE,
+      const range_type range2 = KOKKOS_INVALID_INDEX_RANGE,
+      const range_type range3 = KOKKOS_INVALID_INDEX_RANGE,
+      const range_type range4 = KOKKOS_INVALID_INDEX_RANGE,
+      const range_type range5 = KOKKOS_INVALID_INDEX_RANGE,
+      const range_type range6 = KOKKOS_INVALID_INDEX_RANGE,
+      const range_type range7 = KOKKOS_INVALID_INDEX_RANGE
 
       )
-      : OffsetView(Kokkos::Impl::ViewCtorProp<std::string>(arg_label),
-                   typename traits::array_layout(
-                       range0.begin()[1] - range0.begin()[0] + 1,
-                       range1.begin()[1] - range1.begin()[0] + 1,
-                       range2.begin()[1] - range2.begin()[0] + 1,
-                       range3.begin()[1] - range3.begin()[0] + 1,
-                       range4.begin()[1] - range4.begin()[0] + 1,
-                       range5.begin()[1] - range5.begin()[0] + 1,
-                       range6.begin()[1] - range6.begin()[0] + 1,
-                       range7.begin()[1] - range7.begin()[0] + 1),
-                   {range0.begin()[0], range1.begin()[0], range2.begin()[0],
-                    range3.begin()[0], range4.begin()[0], range5.begin()[0],
-                    range6.begin()[0], range7.begin()[0]}) {}
+      : OffsetView(
+            Kokkos::Impl::ViewCtorProp<std::string>(arg_label),
+            typename traits::array_layout(range0.second - range0.first + 1,
+                                          range1.second - range1.first + 1,
+                                          range2.second - range2.first + 1,
+                                          range3.second - range3.first + 1,
+                                          range4.second - range4.first + 1,
+                                          range5.second - range5.first + 1,
+                                          range6.second - range6.first + 1,
+                                          range7.second - range7.first + 1),
+            {range0.first, range1.first, range2.first, range3.first,
+             range4.first, range5.first, range6.first, range7.first}) {}
 
   template <class... P>
   explicit KOKKOS_INLINE_FUNCTION OffsetView(

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -45,7 +45,9 @@
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_DualView.hpp>
+#include <Kokkos_DynamicView.hpp>
 #include <Kokkos_DynRankView.hpp>
+#include <Kokkos_OffsetView.hpp>
 #include <Kokkos_ScatterView.hpp>
 
 #include <../../core/unit_test/tools/include/ToolTestingUtilities.hpp>
@@ -180,4 +182,93 @@ TEST(TEST_CATEGORY, resize_realloc_no_alloc_scatterview) {
       });
   ASSERT_TRUE(success);
   listen_tool_events(Config::DisableAll());
+}
+
+TEST(TEST_CATEGORY, create_mirror_no_init_dynrankview) {
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableKernels());
+  Kokkos::DynRankView<int, Kokkos::DefaultExecutionSpace> device_view(
+      "device view", 10);
+  Kokkos::DynRankView<int, Kokkos::HostSpace> host_view("host view", 10);
+
+  auto success = validate_absence(
+      [&]() {
+        auto mirror_device =
+            Kokkos::create_mirror(Kokkos::WithoutInitializing, device_view);
+        auto mirror_host =
+            Kokkos::create_mirror(Kokkos::WithoutInitializing,
+                                  Kokkos::DefaultExecutionSpace{}, host_view);
+        auto mirror_device_view = Kokkos::create_mirror_view(
+            Kokkos::WithoutInitializing, device_view);
+        auto mirror_host_view = Kokkos::create_mirror_view(
+            Kokkos::WithoutInitializing, Kokkos::DefaultExecutionSpace{},
+            host_view);
+      },
+      [&](BeginParallelForEvent) {
+        return MatchDiagnostic{true, {"Found begin event"}};
+      },
+      [&](EndParallelForEvent) {
+        return MatchDiagnostic{true, {"Found end event"}};
+      });
+  ASSERT_TRUE(success);
+}
+
+TEST(TEST_CATEGORY, create_mirror_no_init_offsetview) {
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableKernels());
+  Kokkos::Experimental::OffsetView<int*, Kokkos::DefaultExecutionSpace>
+      device_view("device view", {0, 10});
+  Kokkos::Experimental::OffsetView<int*, Kokkos::HostSpace> host_view(
+      "host view", {0, 10});
+
+  auto success = validate_absence(
+      [&]() {
+        auto mirror_device =
+            Kokkos::create_mirror(Kokkos::WithoutInitializing, device_view);
+        auto mirror_host =
+            Kokkos::create_mirror(Kokkos::WithoutInitializing,
+                                  Kokkos::DefaultExecutionSpace{}, host_view);
+        auto mirror_device_view = Kokkos::create_mirror_view(
+            Kokkos::WithoutInitializing, device_view);
+        auto mirror_host_view = Kokkos::create_mirror_view(
+            Kokkos::WithoutInitializing, Kokkos::DefaultExecutionSpace{},
+            host_view);
+      },
+      [&](BeginParallelForEvent) {
+        return MatchDiagnostic{true, {"Found begin event"}};
+      },
+      [&](EndParallelForEvent) {
+        return MatchDiagnostic{true, {"Found end event"}};
+      });
+  ASSERT_TRUE(success);
+}
+
+TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableKernels());
+  Kokkos::Experimental::DynamicView<int*, Kokkos::DefaultExecutionSpace>
+      device_view("device view", 2, 10);
+  Kokkos::Experimental::DynamicView<int*, Kokkos::HostSpace> host_view(
+      "host view", 2, 10);
+
+  auto success = validate_absence(
+      [&]() {
+        auto mirror_device =
+            Kokkos::create_mirror(Kokkos::WithoutInitializing, device_view);
+        auto mirror_host =
+            Kokkos::create_mirror(Kokkos::WithoutInitializing,
+                                  Kokkos::DefaultExecutionSpace{}, host_view);
+        auto mirror_device_view = Kokkos::create_mirror_view(
+            Kokkos::WithoutInitializing, device_view);
+        auto mirror_host_view = Kokkos::create_mirror_view(
+            Kokkos::WithoutInitializing, Kokkos::DefaultExecutionSpace{},
+            host_view);
+      },
+      [&](BeginParallelForEvent) {
+        return MatchDiagnostic{true, {"Found begin event"}};
+      },
+      [&](EndParallelForEvent) {
+        return MatchDiagnostic{true, {"Found end event"}};
+      });
+  ASSERT_TRUE(success);
 }

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -243,6 +243,8 @@ TEST(TEST_CATEGORY, create_mirror_no_init_offsetview) {
   ASSERT_TRUE(success);
 }
 
+// FIXME OPENMPTARGET
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());
@@ -272,3 +274,4 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
       });
   ASSERT_TRUE(success);
 }
+#endif


### PR DESCRIPTION
Related to #4794, in continuation of #4486.

`StaticCrsGraph` also provides `create_mirror[_view]` but with somewhat different semantics so I decided to omit it here.