### PR TITLE
Make sure `Kokkos::abort()` causes abnormal program termination when called on the host-side

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Error.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Error.hpp
@@ -71,12 +71,6 @@ void cuda_stream_synchronize(const cudaStream_t stream,
                                             const char* file = nullptr,
                                             const int line   = 0);
 
-#ifdef KOKKOS_ENABLE_CXX17
-#define KOKKOS_IMPL_FALLTHROUGH [[fallthrough]];
-#else
-#define KOKKOS_IMPL_FALLTHROUGH
-#endif
-
 inline void cuda_internal_safe_call(cudaError e, const char* name,
                                     const char* file = nullptr,
                                     const int line   = 0) {
@@ -86,21 +80,19 @@ inline void cuda_internal_safe_call(cudaError e, const char* name,
   // 3. Any other error code -> throw a runtime error.
   switch (e) {
     case cudaSuccess: break;
-    case cudaErrorIllegalAddress: KOKKOS_IMPL_FALLTHROUGH
-    case cudaErrorAssert: KOKKOS_IMPL_FALLTHROUGH
-    case cudaErrorHardwareStackError: KOKKOS_IMPL_FALLTHROUGH
-    case cudaErrorIllegalInstruction: KOKKOS_IMPL_FALLTHROUGH
-    case cudaErrorMisalignedAddress: KOKKOS_IMPL_FALLTHROUGH
-    case cudaErrorInvalidAddressSpace: KOKKOS_IMPL_FALLTHROUGH
-    case cudaErrorInvalidPc: KOKKOS_IMPL_FALLTHROUGH
+    case cudaErrorIllegalAddress:
+    case cudaErrorAssert:
+    case cudaErrorHardwareStackError:
+    case cudaErrorIllegalInstruction:
+    case cudaErrorMisalignedAddress:
+    case cudaErrorInvalidAddressSpace:
+    case cudaErrorInvalidPc:
     case cudaErrorLaunchFailure:
       cuda_internal_error_abort(e, name, file, line);
       break;
     default: cuda_internal_error_throw(e, name, file, line); break;
   }
 }
-
-#undef KOKKOS_IMPL_FALLTHROUGH
 
 #define KOKKOS_IMPL_CUDA_SAFE_CALL(call) \
   Kokkos::Impl::cuda_internal_safe_call(call, #call, __FILE__, __LINE__)

--- a/core/src/Cuda/Kokkos_Cuda_Error.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Error.hpp
@@ -63,16 +63,44 @@ void cuda_device_synchronize(const std::string& name);
 void cuda_stream_synchronize(const cudaStream_t stream,
                              const std::string& name);
 
-void cuda_internal_error_throw(cudaError e, const char* name,
-                               const char* file = nullptr, const int line = 0);
+[[noreturn]] void cuda_internal_error_throw(cudaError e, const char* name,
+                                            const char* file = nullptr,
+                                            const int line   = 0);
+
+[[noreturn]] void cuda_internal_error_abort(cudaError e, const char* name,
+                                            const char* file = nullptr,
+                                            const int line   = 0);
+
+#ifdef KOKKOS_ENABLE_CXX17
+#define KOKKOS_IMPL_FALLTHROUGH [[fallthrough]];
+#else
+#define KOKKOS_IMPL_FALLTHROUGH
+#endif
 
 inline void cuda_internal_safe_call(cudaError e, const char* name,
                                     const char* file = nullptr,
                                     const int line   = 0) {
-  if (cudaSuccess != e) {
-    cuda_internal_error_throw(e, name, file, line);
+  // 1. Success -> normal continuation.
+  // 2. Error codes for which, to continue using CUDA, the process must be
+  //    terminated and relaunched -> call abort on the host-side.
+  // 3. Any other error code -> throw a runtime error.
+  switch (e) {
+    case cudaSuccess: break;
+    case cudaErrorIllegalAddress: KOKKOS_IMPL_FALLTHROUGH
+    case cudaErrorAssert: KOKKOS_IMPL_FALLTHROUGH
+    case cudaErrorHardwareStackError: KOKKOS_IMPL_FALLTHROUGH
+    case cudaErrorIllegalInstruction: KOKKOS_IMPL_FALLTHROUGH
+    case cudaErrorMisalignedAddress: KOKKOS_IMPL_FALLTHROUGH
+    case cudaErrorInvalidAddressSpace: KOKKOS_IMPL_FALLTHROUGH
+    case cudaErrorInvalidPc: KOKKOS_IMPL_FALLTHROUGH
+    case cudaErrorLaunchFailure:
+      cuda_internal_error_abort(e, name, file, line);
+      break;
+    default: cuda_internal_error_throw(e, name, file, line); break;
   }
 }
+
+#undef KOKKOS_IMPL_FALLTHROUGH
 
 #define KOKKOS_IMPL_CUDA_SAFE_CALL(call) \
   Kokkos::Impl::cuda_internal_safe_call(call, #call, __FILE__, __LINE__)

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -184,6 +184,17 @@ void cuda_internal_error_throw(cudaError e, const char *name, const char *file,
   throw_runtime_exception(out.str());
 }
 
+void cuda_internal_error_abort(cudaError e, const char *name, const char *file,
+                               const int line) {
+  std::ostringstream out;
+  out << name << " error( " << cudaGetErrorName(e)
+      << "): " << cudaGetErrorString(e);
+  if (file) {
+    out << " " << file << ":" << line;
+  }
+  abort(out.str().c_str());
+}
+
 //----------------------------------------------------------------------------
 // Some significant cuda device properties:
 //

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -82,7 +82,7 @@ namespace Impl {
 #elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
 // HIP aborts
 #define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
-#elif defined(KOKKOS_ENABLE_SYCL)
+#elif defined(KOKKOS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__)
 // FIXME_SYCL SYCL doesn't abort
 #define KOKKOS_IMPL_ABORT_NORETURN
 #elif !defined(KOKKOS_ENABLE_OPENMPTARGET)
@@ -93,10 +93,16 @@ namespace Impl {
 #define KOKKOS_IMPL_ABORT_NORETURN
 #endif
 
+#ifdef KOKKOS_ENABLE_SYCL  // FIXME_SYCL
+#define KOKKOS_IMPL_ABORT_NORETURN_DEVICE
+#else
+#define KOKKOS_IMPL_ABORT_NORETURN_DEVICE KOKKOS_IMPL_ABORT_NORETURN
+#endif
+
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
     defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENMPTARGET)
-KOKKOS_IMPL_ABORT_NORETURN inline KOKKOS_IMPL_DEVICE_FUNCTION void device_abort(
-    const char *const msg) {
+KOKKOS_IMPL_ABORT_NORETURN_DEVICE inline KOKKOS_IMPL_DEVICE_FUNCTION void
+device_abort(const char *const msg) {
 #if defined(KOKKOS_ENABLE_CUDA)
   ::Kokkos::Impl::cuda_abort(msg);
 #elif defined(KOKKOS_ENABLE_HIP)

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -82,7 +82,7 @@ namespace Impl {
 #elif defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)
 // HIP aborts
 #define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
-#elif defined(KOKKOS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__)
+#elif defined(KOKKOS_ENABLE_SYCL)
 // FIXME_SYCL SYCL doesn't abort
 #define KOKKOS_IMPL_ABORT_NORETURN
 #elif !defined(KOKKOS_ENABLE_OPENMPTARGET)

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -104,7 +104,7 @@ KOKKOS_IMPL_ABORT_NORETURN inline KOKKOS_IMPL_DEVICE_FUNCTION void device_abort(
 #elif defined(KOKKOS_ENABLE_SYCL)
   ::Kokkos::Impl::sycl_abort(msg);
 #elif defined(KOKKOS_ENABLE_OPENMPTARGET)
-  // FIXME_OPENMPTARGET
+  printf("%s", msg);  // FIXME_OPENMPTARGET
 #else
 #error faulty logic
 #endif

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -175,6 +175,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
 
     SET(${Tag}_SOURCES2A)
     foreach(Name
+      Abort
       TeamBasic
       TeamReductionScan
       TeamScan

--- a/core/unit_test/TestAbort.hpp
+++ b/core/unit_test/TestAbort.hpp
@@ -1,0 +1,55 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+
+TEST(TEST_CATEGORY_DEATH, abort_from_host) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  char msg[] = "Goodbye cruel world";
+  EXPECT_DEATH({ Kokkos::abort(msg); }, msg);
+}
+

--- a/core/unit_test/TestAbort.hpp
+++ b/core/unit_test/TestAbort.hpp
@@ -78,26 +78,6 @@ void test_abort_causing_abnormal_program_termination_but_ignoring_message() {
 }
 
 template <class ExecutionSpace>
-void test_abort_throwing_exception_and_printing_to_stderr() {
-  ::testing::internal::CaptureStderr();
-  EXPECT_THROW(
-      {
-        Kokkos::parallel_for(
-            Kokkos::RangePolicy<ExecutionSpace>(0, 1),
-            KOKKOS_LAMBDA(int) { Kokkos::abort("is anyone listening?"); });
-        Kokkos::fence();
-      },
-      std::runtime_error);
-  auto const captured = ::testing::internal::GetCapturedStderr();
-  // FIXME use EXPECT_THAT(captured, ::testing::ContainsRegex(...) with gMock
-  EXPECT_PRED1(
-      [](std::string const& s) {
-        return std::regex_search(s, std::regex("is anyone listening?"));
-      },
-      captured);
-}
-
-template <class ExecutionSpace>
 void test_abort_causing_abnormal_program_termination_and_printing() {
   EXPECT_DEATH(
       {
@@ -135,13 +115,6 @@ void test_abort_from_device() {
   if (std::is_same<ExecutionSpace, Kokkos::Experimental::HIP>::value) {
     test_abort_causing_abnormal_program_termination_but_ignoring_message<
         ExecutionSpace>();
-  } else {
-    test_abort_causing_abnormal_program_termination_and_printing<
-        ExecutionSpace>();
-  }
-#elif defined(KOKKOS_ENABLE_CUDA)  // FIXME_CUDA
-  if (std::is_same<ExecutionSpace, Kokkos::Cuda>::value) {
-    test_abort_throwing_exception_and_printing_to_stderr<ExecutionSpace>();
   } else {
     test_abort_causing_abnormal_program_termination_and_printing<
         ExecutionSpace>();

--- a/core/unit_test/TestAbort.hpp
+++ b/core/unit_test/TestAbort.hpp
@@ -62,7 +62,9 @@ struct TestAbortPrintingToStdout {
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, 1), *this);
     Kokkos::fence();
     auto const captured = ::testing::internal::GetCapturedStdout();
-    EXPECT_EQ(captured, "move along nothing to see here");
+    EXPECT_TRUE(std::regex_search(captured,
+                                  std::regex("move along nothing to see here")))
+        << "here is what was printed to stdout \"" << captured << "\"";
   }
   KOKKOS_FUNCTION void operator()(int) const {
     Kokkos::abort("move along nothing to see here");

--- a/core/unit_test/TestAbort.hpp
+++ b/core/unit_test/TestAbort.hpp
@@ -47,6 +47,7 @@
 #include <regex>
 #include <Kokkos_Core.hpp>
 
+#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC
 TEST(TEST_CATEGORY_DEATH, abort_from_host) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
@@ -129,3 +130,4 @@ TEST(TEST_CATEGORY_DEATH, abort_from_device) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   test_abort_from_device<TEST_EXECSPACE>();
 }
+#endif


### PR DESCRIPTION
"Regularize" behavior of `Kokkos::abort` as much as currently possible:
* always causing abnormal program termination when called from the host-side (was previously ignored when OPENMPTARGET backend was enabled)
* call abort on the host-side at the next synchronization point with CUDA instead of throwing a runtime error