### PR TITLE
Allow non-power-of-two team sizes for team reductions and scans

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -520,16 +520,16 @@ __device__ void cuda_intra_block_reduce_scan(
     const unsigned inner_mask =
         __ballot_sync(0xffffffff, (threadIdx.y < n_active_warps));
     if (threadIdx.y < n_active_warps) {
-      const bool is_full_warp =
+      const bool is_full_warp_inter =
           threadIdx.y < (blockDim.y >> CudaTraits::WarpIndexShift);
       const pointer_type tdata_inter =
           base_data +
-          value_count * (is_full_warp
+          value_count * (is_full_warp_inter
                              ? (threadIdx.y << CudaTraits::WarpIndexShift) +
                                    (CudaTraits::WarpSize - 1)
                              : blockDim.y - 1);
       const unsigned index_shift =
-          is_full_warp
+          is_full_warp_inter
               ? 0
               : blockDim.y - (threadIdx.y << CudaTraits::WarpIndexShift);
       const int rtid_inter = (threadIdx.y << CudaTraits::WarpIndexShift) +

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -479,7 +479,7 @@ __device__ void cuda_intra_block_reduce_scan(
                                pointer_type memory_start, int index_shift) {
     const auto join_ptr = TD - (value_count << S) + value_count * index_shift;
     if (((R + 1) & ((1 << (S + 1)) - 1)) == 0 && join_ptr >= memory_start) {
-      ValueJoin::join(functor, TD, join_ptr);
+      functor.join(TD, join_ptr);
     }
   };
 
@@ -489,7 +489,7 @@ __device__ void cuda_intra_block_reduce_scan(
     const auto N        = (1 << (S + 1));
     const auto join_ptr = TD - (value_count << S) + value_count * index_shift;
     if (R >= N && ((R + 1) & (N - 1)) == (N >> 1) && join_ptr >= memory_start) {
-      ValueJoin::join(functor, TD, join_ptr);
+      functor.join(TD, join_ptr);
     }
   };
 
@@ -590,7 +590,7 @@ __device__ void cuda_intra_block_reduce_scan(
     // Update with total from previous warps
     if (mapped_idx >= CudaTraits::WarpSize &&
         (mapped_idx & (CudaTraits::WarpSize - 1)) != (CudaTraits::WarpSize - 1))
-      ValueJoin::join(functor, tdata_intra, warp_start - value_count);
+      functor.join(tdata_intra, warp_start - value_count);
     __syncwarp(0xffffffff);
   }
 }

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -444,9 +444,8 @@ struct CudaReductionsFunctor<FunctorType, false, false> {
 //----------------------------------------------------------------------------
 /*
  *  Algorithmic constraints:
- *   (a) blockDim.y is a power of two
- *   (b) blockDim.y <= 1024
- *   (c) blockDim.x == blockDim.z == 1
+ *   (a) blockDim.y <= 1024
+ *   (b) blockDim.x == blockDim.z == 1
  */
 
 template <bool DoScan, class FunctorType>
@@ -455,93 +454,117 @@ __device__ void cuda_intra_block_reduce_scan(
     const typename FunctorType::pointer_type base_data) {
   using pointer_type = typename FunctorType::pointer_type;
 
-  const unsigned value_count   = functor.length();
-  const unsigned BlockSizeMask = blockDim.y - 1;
+  const unsigned value_count = functor.length();
+  const unsigned not_less_power_of_two =
+      (1 << (Impl::int_log2(blockDim.y - 1) + 1));
+  const unsigned BlockSizeMask = not_less_power_of_two - 1;
+  // There is at most one warp that is neither completely full or empty.
+  // For that warp, we shift all indices logically to the end and ignore join
+  // operations with unassigned indices in the warp when performing the intra
+  // warp reduction/scan.
+  const bool is_full_warp = (((threadIdx.y >> CudaTraits::WarpIndexShift) + 1)
+                             << CudaTraits::WarpIndexShift) <= blockDim.y;
 
-  // Must have power of two thread count
-
-  if (BlockSizeMask & blockDim.y) {
-    Kokkos::abort("Cuda::cuda_intra_block_scan requires power-of-two blockDim");
-  }
-
-#define BLOCK_REDUCE_STEP(R, TD, S)              \
-  if (!(R & ((1 << (S + 1)) - 1))) {             \
-    functor.join(TD, (TD - (value_count << S))); \
-  }
-
-#define BLOCK_SCAN_STEP(TD, N, S)                \
-  if (N == (1 << S)) {                           \
-    functor.join(TD, (TD - (value_count << S))); \
-  }
-
-  const unsigned rtid_intra      = threadIdx.y ^ BlockSizeMask;
+  const unsigned mapped_idx =
+      threadIdx.y + (is_full_warp ? 0
+                                  : (not_less_power_of_two - blockDim.y) &
+                                        (CudaTraits::WarpSize - 1));
   const pointer_type tdata_intra = base_data + value_count * threadIdx.y;
+  const pointer_type warp_start =
+      base_data + value_count * ((threadIdx.y >> CudaTraits::WarpIndexShift)
+                                 << CudaTraits::WarpIndexShift);
+
+  auto block_reduce_step = [&functor, value_count](
+                               int const R, pointer_type const TD, int const S,
+                               pointer_type memory_start, int index_shift) {
+    const auto join_ptr = TD - (value_count << S) + value_count * index_shift;
+    if (((R + 1) & ((1 << (S + 1)) - 1)) == 0 && join_ptr >= memory_start) {
+      ValueJoin::join(functor, TD, join_ptr);
+    }
+  };
+
+  auto block_scan_step = [&functor, value_count](
+                             int const R, pointer_type const TD, int const S,
+                             pointer_type memory_start, int index_shift) {
+    const auto N        = (1 << (S + 1));
+    const auto join_ptr = TD - (value_count << S) + value_count * index_shift;
+    if (R >= N && ((R + 1) & (N - 1)) == (N >> 1) && join_ptr >= memory_start) {
+      ValueJoin::join(functor, TD, join_ptr);
+    }
+  };
 
   {  // Intra-warp reduction:
     __syncwarp(0xffffffff);
-    BLOCK_REDUCE_STEP(rtid_intra, tdata_intra, 0)
+    block_reduce_step(mapped_idx, tdata_intra, 0, warp_start, 0);
     __syncwarp(0xffffffff);
-    BLOCK_REDUCE_STEP(rtid_intra, tdata_intra, 1)
+    block_reduce_step(mapped_idx, tdata_intra, 1, warp_start, 0);
     __syncwarp(0xffffffff);
-    BLOCK_REDUCE_STEP(rtid_intra, tdata_intra, 2)
+    block_reduce_step(mapped_idx, tdata_intra, 2, warp_start, 0);
     __syncwarp(0xffffffff);
-    BLOCK_REDUCE_STEP(rtid_intra, tdata_intra, 3)
+    block_reduce_step(mapped_idx, tdata_intra, 3, warp_start, 0);
     __syncwarp(0xffffffff);
-    BLOCK_REDUCE_STEP(rtid_intra, tdata_intra, 4)
+    block_reduce_step(mapped_idx, tdata_intra, 4, warp_start, 0);
     __syncwarp(0xffffffff);
   }
 
   __syncthreads();  // Wait for all warps to reduce
 
-  {  // Inter-warp reduce-scan by a single warp to avoid extra synchronizations
-    const unsigned rtid_inter = (threadIdx.y ^ BlockSizeMask)
-                                << CudaTraits::WarpIndexShift;
-
-    unsigned inner_mask = __ballot_sync(0xffffffff, (rtid_inter < blockDim.y));
-    if (rtid_inter < blockDim.y) {
+  // Inter-warp reduce-scan by a single warp to avoid extra synchronizations.
+  {
+    // There is at most one warp where the memory address to be used is not
+    // (CudaTraits::WarpSize - 1) away from the warp start adress. For the
+    // following reduction, we shift all indices logically to the end of the
+    // next power-of-two to the number of warps.
+    const unsigned n_active_warps =
+        ((blockDim.y - 1) >> CudaTraits::WarpIndexShift) + 1;
+    const unsigned inner_mask =
+        __ballot_sync(0xffffffff, (threadIdx.y < n_active_warps));
+    if (threadIdx.y < n_active_warps) {
+      const bool is_full_warp =
+          threadIdx.y < (blockDim.y >> CudaTraits::WarpIndexShift);
       const pointer_type tdata_inter =
-          base_data + value_count * (rtid_inter ^ BlockSizeMask);
+          base_data +
+          value_count * (is_full_warp
+                             ? (threadIdx.y << CudaTraits::WarpIndexShift) +
+                                   (CudaTraits::WarpSize - 1)
+                             : blockDim.y - 1);
+      const unsigned index_shift =
+          is_full_warp
+              ? 0
+              : blockDim.y - (threadIdx.y << CudaTraits::WarpIndexShift);
+      const int rtid_inter = (threadIdx.y << CudaTraits::WarpIndexShift) +
+                             (CudaTraits::WarpSize - 1) - index_shift;
 
       if ((1 << 5) < BlockSizeMask) {
         __syncwarp(inner_mask);
-        BLOCK_REDUCE_STEP(rtid_inter, tdata_inter, 5)
+        block_reduce_step(rtid_inter, tdata_inter, 5, base_data, index_shift);
       }
       if ((1 << 6) < BlockSizeMask) {
         __syncwarp(inner_mask);
-        BLOCK_REDUCE_STEP(rtid_inter, tdata_inter, 6)
+        block_reduce_step(rtid_inter, tdata_inter, 6, base_data, index_shift);
       }
       if ((1 << 7) < BlockSizeMask) {
         __syncwarp(inner_mask);
-        BLOCK_REDUCE_STEP(rtid_inter, tdata_inter, 7)
+        block_reduce_step(rtid_inter, tdata_inter, 7, base_data, index_shift);
       }
       if ((1 << 8) < BlockSizeMask) {
         __syncwarp(inner_mask);
-        BLOCK_REDUCE_STEP(rtid_inter, tdata_inter, 8)
+        block_reduce_step(rtid_inter, tdata_inter, 8, base_data, index_shift);
       }
       if ((1 << 9) < BlockSizeMask) {
         __syncwarp(inner_mask);
-        BLOCK_REDUCE_STEP(rtid_inter, tdata_inter, 9)
+        block_reduce_step(rtid_inter, tdata_inter, 9, base_data, index_shift);
       }
 
       if (DoScan) {
-        int n =
-            (rtid_inter & 32)
-                ? 32
-                : ((rtid_inter & 64)
-                       ? 64
-                       : ((rtid_inter & 128) ? 128
-                                             : ((rtid_inter & 256) ? 256 : 0)));
-
-        if (!(rtid_inter + n < blockDim.y)) n = 0;
-
         __syncwarp(inner_mask);
-        BLOCK_SCAN_STEP(tdata_inter, n, 8)
+        block_scan_step(rtid_inter, tdata_inter, 8, base_data, index_shift);
         __syncwarp(inner_mask);
-        BLOCK_SCAN_STEP(tdata_inter, n, 7)
+        block_scan_step(rtid_inter, tdata_inter, 7, base_data, index_shift);
         __syncwarp(inner_mask);
-        BLOCK_SCAN_STEP(tdata_inter, n, 6)
+        block_scan_step(rtid_inter, tdata_inter, 6, base_data, index_shift);
         __syncwarp(inner_mask);
-        BLOCK_SCAN_STEP(tdata_inter, n, 5)
+        block_scan_step(rtid_inter, tdata_inter, 5, base_data, index_shift);
       }
     }
   }
@@ -549,32 +572,27 @@ __device__ void cuda_intra_block_reduce_scan(
   __syncthreads();  // Wait for inter-warp reduce-scan to complete
 
   if (DoScan) {
-    int n =
-        (rtid_intra & 1)
-            ? 1
-            : ((rtid_intra & 2)
-                   ? 2
-                   : ((rtid_intra & 4)
-                          ? 4
-                          : ((rtid_intra & 8) ? 8
-                                              : ((rtid_intra & 16) ? 16 : 0))));
-
-    if (!(rtid_intra + n < blockDim.y)) n = 0;
+    block_scan_step(mapped_idx, tdata_intra, 4, warp_start, 0);
+    __threadfence_block();
     __syncwarp(0xffffffff);
-    BLOCK_SCAN_STEP(tdata_intra, n, 4) __threadfence_block();
+    block_scan_step(mapped_idx, tdata_intra, 3, warp_start, 0);
+    __threadfence_block();
     __syncwarp(0xffffffff);
-    BLOCK_SCAN_STEP(tdata_intra, n, 3) __threadfence_block();
+    block_scan_step(mapped_idx, tdata_intra, 2, warp_start, 0);
+    __threadfence_block();
     __syncwarp(0xffffffff);
-    BLOCK_SCAN_STEP(tdata_intra, n, 2) __threadfence_block();
+    block_scan_step(mapped_idx, tdata_intra, 1, warp_start, 0);
+    __threadfence_block();
     __syncwarp(0xffffffff);
-    BLOCK_SCAN_STEP(tdata_intra, n, 1) __threadfence_block();
+    block_scan_step(mapped_idx, tdata_intra, 0, warp_start, 0);
+    __threadfence_block();
     __syncwarp(0xffffffff);
-    BLOCK_SCAN_STEP(tdata_intra, n, 0) __threadfence_block();
+    // Update with total from previous warps
+    if (mapped_idx >= CudaTraits::WarpSize &&
+        (mapped_idx & (CudaTraits::WarpSize - 1)) != (CudaTraits::WarpSize - 1))
+      ValueJoin::join(functor, tdata_intra, warp_start - value_count);
     __syncwarp(0xffffffff);
   }
-
-#undef BLOCK_SCAN_STEP
-#undef BLOCK_REDUCE_STEP
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -310,7 +310,7 @@ __device__ void hip_intra_block_reduce_scan(
                                pointer_type memory_start, int index_shift) {
     const auto join_ptr = TD - (value_count << S) + value_count * index_shift;
     if (R > ((1 << S) - 1) && join_ptr >= memory_start) {
-      ValueJoin::join(functor, TD, join_ptr);
+      functor.join(TD, join_ptr);
     }
   };
 
@@ -397,8 +397,8 @@ __device__ void hip_intra_block_reduce_scan(
     if (threadIdx.y >= Experimental::Impl::HIPTraits::WarpSize &&
         !is_last_thread_in_warp) {
       const int offset_to_previous_warp_total = (threadIdx.y & (~WarpMask)) - 1;
-      ValueJoin::join(functor, base_data + value_count * threadIdx.y,
-                      base_data + value_count * offset_to_previous_warp_total);
+      functor.join(base_data + value_count * threadIdx.y,
+                   base_data + value_count * offset_to_previous_warp_total);
     }
   }
 }

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -305,44 +305,35 @@ __device__ void hip_intra_block_reduce_scan(
       (((threadIdx.y >> Experimental::Impl::HIPTraits::WarpIndexShift) + 1)
        << Experimental::Impl::HIPTraits::WarpIndexShift) <= blockDim.y;
 
-  const unsigned mapped_idx =
-      threadIdx.y + (is_full_warp
-                         ? 0
-                         : (not_less_power_of_two - blockDim.y) &
-                               (Experimental::Impl::HIPTraits::WarpSize - 1));
-
   auto block_reduce_step = [&functor, value_count](
                                int const R, pointer_type const TD, int const S,
                                pointer_type memory_start, int index_shift) {
     const auto join_ptr = TD - (value_count << S) + value_count * index_shift;
-    if (((R + 1) & ((1 << (S + 1)) - 1)) == 0 && join_ptr >= memory_start) {
-      ValueJoin::join(functor, TD, join_ptr);
-    }
-  };
-
-  auto block_scan_step = [&functor, value_count](
-                             int const R, pointer_type const TD, int const S,
-                             pointer_type memory_start, int index_shift) {
-    const auto N        = (1 << (S + 1));
-    const auto join_ptr = TD - (value_count << S) + value_count * index_shift;
-    if (R >= N && ((R + 1) & (N - 1)) == (N >> 1) && join_ptr >= memory_start) {
+    if (R > ((1 << S) - 1) && join_ptr >= memory_start) {
       ValueJoin::join(functor, TD, join_ptr);
     }
   };
 
   // Intra-warp reduction:
-  const pointer_type tdata_intra = base_data + value_count * threadIdx.y;
-  const pointer_type warp_start =
-      base_data +
-      value_count *
-          ((threadIdx.y >> Experimental::Impl::HIPTraits::WarpIndexShift)
-           << Experimental::Impl::HIPTraits::WarpIndexShift);
-  block_reduce_step(mapped_idx, tdata_intra, 0, warp_start, 0);
-  block_reduce_step(mapped_idx, tdata_intra, 1, warp_start, 0);
-  block_reduce_step(mapped_idx, tdata_intra, 2, warp_start, 0);
-  block_reduce_step(mapped_idx, tdata_intra, 3, warp_start, 0);
-  block_reduce_step(mapped_idx, tdata_intra, 4, warp_start, 0);
-  block_reduce_step(mapped_idx, tdata_intra, 5, warp_start, 0);
+  {
+    const unsigned mapped_idx =
+        threadIdx.y + (is_full_warp
+                           ? 0
+                           : (not_less_power_of_two - blockDim.y) &
+                                 (Experimental::Impl::HIPTraits::WarpSize - 1));
+    const pointer_type tdata_intra = base_data + value_count * threadIdx.y;
+    const pointer_type warp_start =
+        base_data +
+        value_count *
+            ((threadIdx.y >> Experimental::Impl::HIPTraits::WarpIndexShift)
+             << Experimental::Impl::HIPTraits::WarpIndexShift);
+    block_reduce_step(mapped_idx, tdata_intra, 0, warp_start, 0);
+    block_reduce_step(mapped_idx, tdata_intra, 1, warp_start, 0);
+    block_reduce_step(mapped_idx, tdata_intra, 2, warp_start, 0);
+    block_reduce_step(mapped_idx, tdata_intra, 3, warp_start, 0);
+    block_reduce_step(mapped_idx, tdata_intra, 4, warp_start, 0);
+    block_reduce_step(mapped_idx, tdata_intra, 5, warp_start, 0);
+  }
 
   __syncthreads();  // Wait for all warps to reduce
 
@@ -390,30 +381,25 @@ __device__ void hip_intra_block_reduce_scan(
       if ((1 << 10) < BlockSizeMask) {
         block_reduce_step(rtid_inter, tdata_inter, 10, base_data, index_shift);
       }
-
-      if (DoScan) {
-        block_scan_step(rtid_inter, tdata_inter, 9, base_data, index_shift);
-        block_scan_step(rtid_inter, tdata_inter, 8, base_data, index_shift);
-        block_scan_step(rtid_inter, tdata_inter, 7, base_data, index_shift);
-        block_scan_step(rtid_inter, tdata_inter, 6, base_data, index_shift);
-      }
     }
   }
 
   __syncthreads();  // Wait for inter-warp reduce-scan to complete
 
   if (DoScan) {
-    block_scan_step(mapped_idx, tdata_intra, 5, warp_start, 0);
-    block_scan_step(mapped_idx, tdata_intra, 4, warp_start, 0);
-    block_scan_step(mapped_idx, tdata_intra, 3, warp_start, 0);
-    block_scan_step(mapped_idx, tdata_intra, 2, warp_start, 0);
-    block_scan_step(mapped_idx, tdata_intra, 1, warp_start, 0);
-    block_scan_step(mapped_idx, tdata_intra, 0, warp_start, 0);
-    // Update with total from previous warps
-    if (mapped_idx >= Experimental::Impl::HIPTraits::WarpSize &&
-        (mapped_idx & (Experimental::Impl::HIPTraits::WarpSize - 1)) !=
-            (Experimental::Impl::HIPTraits::WarpSize - 1))
-      ValueJoin::join(functor, tdata_intra, warp_start - value_count);
+    // Update all the values for the respective warps (except for the last one)
+    // by adding from the last value of the previous warp.
+    const unsigned int WarpMask = Experimental::Impl::HIPTraits::WarpSize - 1;
+    const int is_last_thread_in_warp =
+        is_full_warp ? ((threadIdx.y & WarpMask) ==
+                        Experimental::Impl::HIPTraits::WarpSize - 1)
+                     : (threadIdx.y == blockDim.y - 1);
+    if (threadIdx.y >= Experimental::Impl::HIPTraits::WarpSize &&
+        !is_last_thread_in_warp) {
+      const int offset_to_previous_warp_total = (threadIdx.y & (~WarpMask)) - 1;
+      ValueJoin::join(functor, base_data + value_count * threadIdx.y,
+                      base_data + value_count * offset_to_previous_warp_total);
+    }
   }
 }
 

--- a/core/unit_test/TestTeamScan.hpp
+++ b/core/unit_test/TestTeamScan.hpp
@@ -92,18 +92,15 @@ struct TestTeamScan {
     N   = _N;
     a_d = view_type("a_d", M, N);
     a_r = view_type("a_r", M, N);
-    // Set team size explicitly to
-    // a) check whether this works in CPU backends with team_size > 1 and
-    // b) make sure we have a power of 2 and for GPU backends due to limitation
-    // of the scan algorithm implemented in CUDA etc.
-    int team_size = 1;
-    if (ExecutionSpace().concurrency() > 2) {
-      if (ExecutionSpace().concurrency() > 10000)
-        team_size = 128;
-      else
-        team_size = 3;
-    }
-    Kokkos::parallel_for(policy_type(M, team_size), *this);
+
+    // Set team size explicitly to check whether non-power-of-two team sizes ca
+    // be used.
+    if (ExecutionSpace().concurrency() > 10000)
+      Kokkos::parallel_for(policy_type(M, 127), *this);
+    else if (ExecutionSpace().concurrency() > 2)
+      Kokkos::parallel_for(policy_type(M, 3), *this);
+    else
+      Kokkos::parallel_for(policy_type(M, 1), *this);
 
     auto a_i = Kokkos::create_mirror_view(a_d);
     auto a_o = Kokkos::create_mirror_view(a_r);

--- a/core/unit_test/TestTeamScan.hpp
+++ b/core/unit_test/TestTeamScan.hpp
@@ -93,7 +93,7 @@ struct TestTeamScan {
     a_d = view_type("a_d", M, N);
     a_r = view_type("a_r", M, N);
 
-    // Set team size explicitly to check whether non-power-of-two team sizes ca
+    // Set team size explicitly to check whether non-power-of-two team sizes can
     // be used.
     if (ExecutionSpace().concurrency() > 10000)
       Kokkos::parallel_for(policy_type(M, 127), *this);


### PR DESCRIPTION
Fixes #4146. Basically, the idea is to shift all indices in a warp so that the last indices are used and ignore all contributions from indices that have not been mapped. Then, for the inter-warp algorithm, again shift all individual contributions to the end of the power-of-two range covered and again ignore contributions from unmapped indices.