### PR TITLE
Test with nvcc -Werror

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -343,7 +343,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=Release \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \
-                                -DCMAKE_CXX_FLAGS=-Werror \
+                                -DCMAKE_CXX_FLAGS=-Werror --Werror=all-warnings -Xcudafe --diag_suppress=3159 \
                                 -DCMAKE_CXX_STANDARD=17 \
                                 -DKokkos_INSTALL_TESTING=ON \
                               .. && \

--- a/tpls/gtest/gtest/gtest-all.cc
+++ b/tpls/gtest/gtest/gtest-all.cc
@@ -4278,37 +4278,6 @@ void ReportInvalidTestSuiteType(const char* test_suite_name,
 }
 }  // namespace internal
 
-namespace {
-
-// A predicate that checks the test name of a TestInfo against a known
-// value.
-//
-// This is used for implementation of the TestSuite class only.  We put
-// it in the anonymous namespace to prevent polluting the outer
-// namespace.
-//
-// TestNameIs is copyable.
-class TestNameIs {
- public:
-  // Constructor.
-  //
-  // TestNameIs has NO default constructor.
-  explicit TestNameIs(const char* name)
-      : name_(name) {}
-#if defined(__EDG__)
-#pragma diag_suppress declared_but_not_referenced
-#endif
-  // Returns true if and only if the test name of test_info matches name_.
-  bool operator()(const TestInfo * test_info) const {
-    return test_info && test_info->name() == name_;
-  }
-
- private:
-  std::string name_;
-};
-
-}  // namespace
-
 namespace internal {
 
 // This method expands all parameterized tests registered with macros TEST_P


### PR DESCRIPTION
Follow-up to #4735. Since we now have the ability to test for `nvcc`'s `-Werror`, we should also use it in our CI which is what this pull request does. 