### PR TITLE
MD Team Policies Implementation for serial

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -794,13 +794,6 @@ struct MDTeamThreadRangeBoundariesStruct {
     static_assert(sizeof...(ns) == Rank, "Number of ns must equal Rank");
   }
 
-  KOKKOS_INLINE_FUNCTION
-  MDTeamThreadRangeBoundariesStruct(TeamMemberType const& member,
-                                    const iType (&array)[Rank])
-      : thread(member) {
-    std::copy(&array[0], &array[Rank], &threadDims[0]);
-  }
-
   TeamMemberType const& thread;
   iType threadDims[Rank];
 };

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -773,6 +773,105 @@ struct ThreadVectorRangeBoundariesStruct {
       : start(static_cast<index_type>(arg_begin)), end(arg_end) {}
 };
 
+template <Kokkos::Iterate Direction, size_t Rank, typename iType,
+          typename TeamMemberType>
+struct MDTeamThreadRangeBoundariesStruct {
+  static_assert(2 <= Rank, "Rank must be at least 2");
+  static_assert(Rank <= 8, "Rank must be at most 8");
+  static_assert(Direction == Kokkos::Iterate::Left ||
+                    Direction == Kokkos::Iterate::Right,
+                "Direction must be Left or Right");
+
+  static constexpr Kokkos::Iterate direction = Direction;
+  static constexpr size_t rank               = Rank;
+  using index_type                           = iType;
+  using team_member_type                     = TeamMemberType;
+
+  template <typename... Ns>
+  KOKKOS_INLINE_FUNCTION constexpr explicit MDTeamThreadRangeBoundariesStruct(
+      TeamMemberType const& member, Ns&&... ns)
+      : thread(member), threadDims{static_cast<iType>(ns)...} {
+    static_assert(sizeof...(ns) == Rank, "Number of ns must equal Rank");
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  MDTeamThreadRangeBoundariesStruct(TeamMemberType const& member,
+                                    const iType (&array)[Rank])
+      : thread(member) {
+    std::copy(&array[0], &array[Rank], &threadDims[0]);
+  }
+
+  TeamMemberType const& thread;
+  iType threadDims[Rank];
+};
+
+template <typename T>
+struct IsMDTeamThreadRangeBoundariesStruct : std::false_type {};
+
+template <Kokkos::Iterate Direction, size_t Rank, typename iType,
+          typename TeamMemberType>
+struct IsMDTeamThreadRangeBoundariesStruct<
+    MDTeamThreadRangeBoundariesStruct<Direction, Rank, iType, TeamMemberType>>
+    : std::true_type {};
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename TeamMemberType>
+struct MDThreadVectorRangeBoundariesStruct {
+  static constexpr Kokkos::Iterate outer_direction = OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction = InnerDirection;
+  static constexpr size_t rank                     = Rank;
+  using index_type                                 = iType;
+  using team_member_type                           = TeamMemberType;
+
+  static_assert(2 <= Rank, "Rank must be at least 2");
+  static_assert(Rank <= 8, "Rank must be at most 8");
+  static_assert(OuterDirection == Kokkos::Iterate::Left ||
+                    OuterDirection == Kokkos::Iterate::Right,
+                "OuterDirection must be Left or Right");
+  static_assert(InnerDirection == Kokkos::Iterate::Left ||
+                    InnerDirection == Kokkos::Iterate::Right,
+                "InnerDirection must be Left or Right");
+
+  template <typename... Ns>
+  KOKKOS_INLINE_FUNCTION constexpr explicit MDThreadVectorRangeBoundariesStruct(
+      TeamMemberType const& tm, Ns&&... ns)
+      : team_member(tm), taskDims{static_cast<iType>(ns)...} {
+    static_assert(sizeof...(ns) == Rank, "Number of ns must equal Rank");
+  }
+
+  TeamMemberType const& team_member;
+  iType const taskDims[Rank];
+};
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename TeamMemberType>
+struct MDTeamVectorRangeBoundariesStruct {
+  static constexpr Kokkos::Iterate outer_direction = OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction = InnerDirection;
+  static constexpr size_t rank                     = Rank;
+  using index_type                                 = iType;
+  using team_member_type                           = TeamMemberType;
+
+  static_assert(2 <= Rank, "Rank must be at least 2");
+  static_assert(Rank <= 8, "Rank must be at most 8");
+  static_assert(OuterDirection == Kokkos::Iterate::Left ||
+                    OuterDirection == Kokkos::Iterate::Right,
+                "OuterDirection must be Left or Right");
+  static_assert(InnerDirection == Kokkos::Iterate::Left ||
+                    InnerDirection == Kokkos::Iterate::Right,
+                "InnerDirection must be Left or Right");
+
+  template <typename... Ns>
+  KOKKOS_INLINE_FUNCTION constexpr explicit MDTeamVectorRangeBoundariesStruct(
+      TeamMemberType const& tm, Ns&&... ns)
+      : team_member(tm), taskDims{static_cast<iType>(ns)...} {
+    static_assert(sizeof...(ns) == Rank, "Number of ns must equal Rank");
+  }
+
+  TeamMemberType const& team_member;
+  iType const taskDims[Rank];
+};
+
 template <class TeamMemberType>
 struct ThreadSingleStruct {
   const TeamMemberType& team_member;

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -883,6 +883,14 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
 template <size_t RemainingRank>
 struct ParallelForMDTeamThreadRangeHostImpl {
  private:
+// Incorrect shadow warning in older gcc compilers, see
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67273
+// FIXME: These pragmas can be deleted for Kokkos 4 when GCC 7 becomes the
+// minimum requirement
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU <= 600)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
   template <typename Boundaries, typename Closure>
   KOKKOS_INLINE_FUNCTION static void next_rank(
       Boundaries const& boundaries, Closure const& closure,
@@ -891,6 +899,9 @@ struct ParallelForMDTeamThreadRangeHostImpl {
     ParallelForMDTeamThreadRangeHostImpl<RemainingRank - 1>::parallel_for_impl(
         boundaries, newClosure);
   }
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU <= 600)
+#pragma GCC diagnostic pop
+#endif
 
  public:
   static constexpr size_t remaining_rank = RemainingRank;
@@ -942,6 +953,14 @@ KOKKOS_INLINE_FUNCTION
 template <Kokkos::Iterate Direction, size_t RemainingRank>
 struct ParallelForMDThreadVectorRangeHostImpl {
  private:
+// Incorrect shadow warning in older gcc compilers, see
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67273
+// FIXME: These pragmas can be deleted for Kokkos 4 when GCC 7 becomes the
+// minimum requirement
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU <= 600)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
   template <typename Boundaries, typename Closure>
   KOKKOS_INLINE_FUNCTION static void next_rank(
       Boundaries const& boundaries, Closure const& closure,
@@ -951,6 +970,9 @@ struct ParallelForMDThreadVectorRangeHostImpl {
         Boundaries::inner_direction,
         RemainingRank - 1>::parallel_for_impl(boundaries, newClosure);
   }
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU <= 600)
+#pragma GCC diagnostic pop
+#endif
 
  public:
   static constexpr Kokkos::Iterate direction = Direction;
@@ -1147,6 +1169,14 @@ Impl::TeamThreadRangeBoundariesStruct<iType,Impl::HostThreadTeamMember<Space> >
   loop_boundaries.thread.team_reduce( reducer );
 }*/
 
+// Incorrect shadow warning in older gcc compilers, see
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67273
+// FIXME: These pragmas can be deleted for Kokkos 4 when GCC 7 becomes the
+// minimum requirement
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU <= 600)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
 template <Kokkos::Iterate Direction, size_t Rank, typename iType,
           typename Member, typename Closure, typename Reducer>
 KOKKOS_INLINE_FUNCTION
@@ -1176,6 +1206,13 @@ KOKKOS_INLINE_FUNCTION
 
   parallel_reduce(boundaries, closure, reducer);
 }
+// Incorrect shadow warning in older gcc compilers, see
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67273
+// FIXME: These pragmas can be deleted for Kokkos 4 when GCC 7 becomes the
+// minimum requirement
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU <= 600)
+#pragma GCC diagnostic pop
+#endif
 
 //----------------------------------------------------------------------------
 /** \brief  Inter-thread vector parallel_reduce.
@@ -1214,6 +1251,14 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<iType, Member>&
   }
 }
 
+// Incorrect shadow warning in older gcc compilers, see
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67273
+// FIXME: These pragmas can be deleted for Kokkos 4 when GCC 7 becomes the
+// minimum requirement
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU <= 600)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
 template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
           size_t Rank, typename iType, typename Member, typename Closure,
           typename Reducer>
@@ -1278,6 +1323,13 @@ KOKKOS_INLINE_FUNCTION
 
   parallel_reduce(boundaries, closure, reducer);
 }
+// Incorrect shadow warning in older gcc compilers, see
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67273
+// FIXME: These pragmas can be deleted for Kokkos 4 when GCC 7 becomes the
+// minimum requirement
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU <= 600)
+#pragma GCC diagnostic pop
+#endif
 
 //----------------------------------------------------------------------------
 

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -748,6 +748,103 @@ ThreadVectorRange(
       member, iType(arg_begin), iType(arg_end));
 }
 
+template <
+    Kokkos::Iterate Direction, typename Member, typename... Ns,
+    typename = std::enable_if_t<Impl::is_thread_team_member<Member>::value>>
+KOKKOS_INLINE_FUNCTION auto MDTeamThreadRange(Member const& member,
+                                              Ns&&... ns) {
+  using execution_space = typename Member::execution_space;
+  using array_layout    = typename execution_space::array_layout;
+  static constexpr Kokkos::Iterate outer_direction =
+      Direction == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : Direction;
+  using iType = std::common_type_t<Ns...>;
+
+  return Impl::MDTeamThreadRangeBoundariesStruct<outer_direction, sizeof...(ns),
+                                                 iType, Member>(
+      member, static_cast<Ns&&>(ns)...);
+}
+
+template <
+    typename Member, typename... Ns,
+    typename = std::enable_if_t<Impl::is_thread_team_member<Member>::value>>
+KOKKOS_INLINE_FUNCTION auto MDTeamThreadRange(Member const& member,
+                                              Ns&&... ns) {
+  return MDTeamThreadRange<Kokkos::Iterate::Default>(member,
+                                                     static_cast<Ns&&>(ns)...);
+}
+
+template <
+    Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+    typename Member, typename... Ns,
+    typename = std::enable_if_t<Impl::is_thread_team_member<Member>::value>>
+KOKKOS_INLINE_FUNCTION auto MDThreadVectorRange(Member const& member,
+                                                Ns&&... ns) {
+  using execution_space = typename Member::execution_space;
+  using array_layout    = typename execution_space::array_layout;
+  static constexpr Kokkos::Iterate outer_direction =
+      OuterDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction =
+      InnerDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : InnerDirection;
+  using iType = std::common_type_t<Ns...>;
+
+  return Impl::MDThreadVectorRangeBoundariesStruct<
+      outer_direction, inner_direction, sizeof...(ns), iType, Member>(
+      member, static_cast<Ns&&>(ns)...);
+}
+
+template <
+    typename Member, typename... Ns,
+    typename = std::enable_if_t<Impl::is_thread_team_member<Member>::value>>
+KOKKOS_INLINE_FUNCTION auto MDThreadVectorRange(Member const& member,
+                                                Ns&&... ns) {
+  return MDThreadVectorRange<Kokkos::Iterate::Default,
+                             Kokkos::Iterate::Default>(
+      member, static_cast<Ns&&>(ns)...);
+}
+
+template <
+    Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+    typename Member, typename... Ns,
+    typename = std::enable_if_t<Impl::is_thread_team_member<Member>::value>>
+KOKKOS_INLINE_FUNCTION auto MDTeamVectorRange(Member const& member,
+                                              Ns&&... ns) {
+  using execution_space = typename Member::execution_space;
+  using array_layout    = typename execution_space::array_layout;
+  static constexpr Kokkos::Iterate outer_direction =
+      OuterDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : OuterDirection;
+  static constexpr Kokkos::Iterate inner_direction =
+      InnerDirection == Kokkos::Iterate::Default
+          ? Kokkos::layout_iterate_type_selector<
+                array_layout>::outer_iteration_pattern
+          : InnerDirection;
+  using iType = std::common_type_t<Ns...>;
+
+  return Impl::MDTeamVectorRangeBoundariesStruct<
+      outer_direction, inner_direction, sizeof...(ns), iType, Member>(
+      member, static_cast<Ns&&>(ns)...);
+}
+
+template <
+    typename Member, typename... Ns,
+    typename = std::enable_if_t<Impl::is_thread_team_member<Member>::value>>
+KOKKOS_INLINE_FUNCTION auto MDTeamVectorRange(Member const& member,
+                                              Ns&&... ns) {
+  return MDTeamVectorRange<Kokkos::Iterate::Default, Kokkos::Iterate::Default>(
+      member, static_cast<Ns&&>(ns)...);
+}
+
 //----------------------------------------------------------------------------
 /** \brief  Inter-thread parallel_for.
  *
@@ -781,6 +878,208 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
        i += loop_boundaries.increment) {
     closure(i);
   }
+}
+
+template <size_t RemainingRank>
+struct ParallelForMDTeamThreadRangeHostImpl {
+ private:
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void next_rank(
+      Boundaries const& boundaries, Closure const& closure,
+      typename Boundaries::index_type i) {
+    auto newClosure = [i, &closure](auto... is) { closure(i, is...); };
+    ParallelForMDTeamThreadRangeHostImpl<RemainingRank - 1>::parallel_for_impl(
+        boundaries, newClosure);
+  }
+
+ public:
+  static constexpr size_t remaining_rank = RemainingRank;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
+      Boundaries const& boundaries, Closure const& closure) {
+    using index_type = typename Boundaries::index_type;
+    if (Boundaries::direction == Kokkos::Iterate::Right) {
+      for (index_type i = 0;
+           i < boundaries.threadDims[Boundaries::rank - RemainingRank]; ++i) {
+        next_rank(boundaries, closure, i);
+      }
+    }
+
+    if (Boundaries::direction == Kokkos::Iterate::Left) {
+      for (index_type i =
+               boundaries.threadDims[Boundaries::rank - RemainingRank];
+           i > 0;) {
+        next_rank(boundaries, closure, --i);
+      }
+    }
+  }
+};
+
+template <>
+struct ParallelForMDTeamThreadRangeHostImpl<0> {
+  static constexpr size_t remaining_rank = 0;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(Boundaries const&,
+                                                       Closure const& closure) {
+    closure();
+  }
+};
+
+template <Kokkos::Iterate direction, size_t Rank, typename iType,
+          typename TeamMemberType, typename Closure>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<Impl::is_host_thread_team_member<TeamMemberType>::value>
+    parallel_for(Impl::MDTeamThreadRangeBoundariesStruct<direction, Rank, iType,
+                                                         TeamMemberType> const&
+                     loop_boundaries,
+                 Closure const& closure) {
+  ParallelForMDTeamThreadRangeHostImpl<Rank>::parallel_for_impl(loop_boundaries,
+                                                                closure);
+}
+
+template <Kokkos::Iterate Direction, size_t RemainingRank>
+struct ParallelForMDThreadVectorRangeHostImpl {
+ private:
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void next_rank(
+      Boundaries const& boundaries, Closure const& closure,
+      typename Boundaries::index_type i) {
+    auto newClosure = [i, &closure](auto... is) { closure(i, is...); };
+    ParallelForMDThreadVectorRangeHostImpl<
+        Boundaries::inner_direction,
+        RemainingRank - 1>::parallel_for_impl(boundaries, newClosure);
+  }
+
+ public:
+  static constexpr Kokkos::Iterate direction = Direction;
+  static constexpr size_t remaining_rank     = RemainingRank;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
+      Boundaries const& boundaries, Closure const& closure) {
+    using index_type = typename Boundaries::index_type;
+
+    if (Direction == Kokkos::Iterate::Right) {
+      for (index_type i = 0;
+           i < boundaries.taskDims[Boundaries::rank - RemainingRank]; ++i) {
+        next_rank(boundaries, closure, i);
+      }
+    }
+
+    if (Direction == Kokkos::Iterate::Left) {
+      for (index_type i = boundaries.taskDims[Boundaries::rank - RemainingRank];
+           i > 0;) {
+        next_rank(boundaries, closure, --i);
+      }
+    }
+  }
+};
+
+template <Kokkos::Iterate Direction>
+struct ParallelForMDThreadVectorRangeHostImpl<Direction, 0> {
+  static constexpr Kokkos::Iterate direction = Direction;
+  static constexpr size_t remaining_rank     = 0;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(Boundaries const&,
+                                                       Closure const& closure) {
+    closure();
+  }
+};
+
+template <Kokkos::Iterate outer_direction, Kokkos::Iterate inner_direction,
+          size_t Rank, typename iType, typename Closure,
+          typename TeamMemberType>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<Impl::is_host_thread_team_member<TeamMemberType>::value>
+    parallel_for(Impl::MDThreadVectorRangeBoundariesStruct<
+                     outer_direction, inner_direction, Rank, iType,
+                     TeamMemberType> const& boundaries,
+                 Closure const& closure) {
+  static_assert(outer_direction == Kokkos::Iterate::Left ||
+                    outer_direction == Kokkos::Iterate::Right,
+                "outer_direction must be Left or Right");
+  static_assert(inner_direction == Kokkos::Iterate::Left ||
+                    inner_direction == Kokkos::Iterate::Right,
+                "inner_direction must be Left or Right");
+
+  ParallelForMDThreadVectorRangeHostImpl<outer_direction,
+                                         Rank>::parallel_for_impl(boundaries,
+                                                                  closure);
+}
+
+template <Kokkos::Iterate Direction, size_t RemainingRank>
+struct ParallelForMDTeamVectorRangeHostImpl {
+ private:
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void next_rank(
+      Boundaries const& boundaries, Closure const& closure,
+      typename Boundaries::index_type i) {
+    auto newClosure = [i, &closure](auto... iArgs) { closure(i, iArgs...); };
+    ParallelForMDTeamVectorRangeHostImpl<Boundaries::inner_direction,
+                                         RemainingRank -
+                                             1>::parallel_for_impl(boundaries,
+                                                                   newClosure);
+  }
+
+ public:
+  static constexpr Kokkos::Iterate direction = Direction;
+  static constexpr size_t remaining_rank     = RemainingRank;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(
+      Boundaries const& boundaries, Closure const& closure) {
+    using index_type = typename Boundaries::index_type;
+
+    if (Direction == Kokkos::Iterate::Right) {
+      for (index_type i = 0;
+           i < boundaries.taskDims[Boundaries::rank - RemainingRank]; ++i) {
+        next_rank(boundaries, closure, i);
+      }
+    }
+
+    if (Direction == Kokkos::Iterate::Left) {
+      for (index_type i = boundaries.taskDims[Boundaries::rank - RemainingRank];
+           i > 0;) {
+        next_rank(boundaries, closure, --i);
+      }
+    }
+  }
+};
+
+template <Kokkos::Iterate Direction>
+struct ParallelForMDTeamVectorRangeHostImpl<Direction, 0> {
+  static constexpr Kokkos::Iterate direction = Direction;
+  static constexpr size_t remaining_rank     = 0;
+
+  template <typename Boundaries, typename Closure>
+  KOKKOS_INLINE_FUNCTION static void parallel_for_impl(Boundaries const&,
+                                                       Closure const& closure) {
+    closure();
+  }
+};
+
+template <Kokkos::Iterate outer_direction, Kokkos::Iterate inner_direction,
+          size_t Rank, typename iType, typename Closure,
+          typename TeamMemberType>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<Impl::is_host_thread_team_member<TeamMemberType>::value>
+    parallel_for(Impl::MDTeamVectorRangeBoundariesStruct<
+                     outer_direction, inner_direction, Rank, iType,
+                     TeamMemberType> const& boundaries,
+                 Closure const& closure) {
+  static_assert(outer_direction == Kokkos::Iterate::Left ||
+                    outer_direction == Kokkos::Iterate::Right,
+                "outer_direction must be Left or Right");
+  static_assert(inner_direction == Kokkos::Iterate::Left ||
+                    inner_direction == Kokkos::Iterate::Right,
+                "inner_direction must be Left or Right");
+
+  ParallelForMDTeamVectorRangeHostImpl<outer_direction,
+                                       Rank>::parallel_for_impl(boundaries,
+                                                                closure);
 }
 
 //----------------------------------------------------------------------------
@@ -848,6 +1147,36 @@ Impl::TeamThreadRangeBoundariesStruct<iType,Impl::HostThreadTeamMember<Space> >
   loop_boundaries.thread.team_reduce( reducer );
 }*/
 
+template <Kokkos::Iterate Direction, size_t Rank, typename iType,
+          typename Member, typename Closure, typename Reducer>
+KOKKOS_INLINE_FUNCTION
+    typename std::enable_if_t<Kokkos::is_reducer<Reducer>::value &&
+                              Impl::is_host_thread_team_member<Member>::value>
+    parallel_reduce(Impl::MDTeamThreadRangeBoundariesStruct<
+                        Direction, Rank, iType, Member> const& boundaries,
+                    Closure const& closure, Reducer const& reducer) {
+  typename Reducer::value_type value;
+  reducer.init(value);
+
+  parallel_for(boundaries, [&](auto... is) { closure(is..., value); });
+
+  boundaries.thread.team_reduce(reducer, value);
+}
+
+template <Kokkos::Iterate Direction, size_t Rank, typename iType,
+          typename Member, typename Closure, typename ValueType>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<!Kokkos::is_reducer<ValueType>::value &&
+                     Impl::is_host_thread_team_member<Member>::value>
+    parallel_reduce(Impl::MDTeamThreadRangeBoundariesStruct<
+                        Direction, Rank, iType, Member> const& boundaries,
+                    Closure const& closure, ValueType& result) {
+  Sum<ValueType> reducer(result);
+  reducer.init(result);
+
+  parallel_reduce(boundaries, closure, reducer);
+}
+
 //----------------------------------------------------------------------------
 /** \brief  Inter-thread vector parallel_reduce.
  *
@@ -883,6 +1212,71 @@ parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<iType, Member>&
        i += loop_boundaries.increment) {
     lambda(i, reducer.reference());
   }
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Member, typename Closure,
+          typename Reducer>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<Kokkos::is_reducer<Reducer>::value &&
+                     Impl::is_host_thread_team_member<Member>::value>
+    parallel_reduce(Impl::MDThreadVectorRangeBoundariesStruct<
+                        OuterDirection, InnerDirection, Rank, iType,
+                        Member> const& boundaries,
+                    Closure const& closure, Reducer const& reducer) {
+  typename Reducer::value_type value;
+  reducer.init(value);
+
+  parallel_for(boundaries, [&](auto... is) { closure(is..., value); });
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Member, typename Closure,
+          typename ValueType>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<!Kokkos::is_reducer<ValueType>::value &&
+                     Impl::is_host_thread_team_member<Member>::value>
+    parallel_reduce(Impl::MDThreadVectorRangeBoundariesStruct<
+                        OuterDirection, InnerDirection, Rank, iType,
+                        Member> const& boundaries,
+                    Closure const& closure, ValueType& result) {
+  result = ValueType();
+
+  parallel_for(boundaries, [&](auto... is) { closure(is..., result); });
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Member, typename Closure,
+          typename Reducer>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<Kokkos::is_reducer<Reducer>::value &&
+                     Impl::is_host_thread_team_member<Member>::value>
+    parallel_reduce(Impl::MDTeamVectorRangeBoundariesStruct<
+                        OuterDirection, InnerDirection, Rank, iType,
+                        Member> const& boundaries,
+                    Closure const& closure, Reducer const& reducer) {
+  typename Reducer::value_type value;
+  reducer.init(value);
+
+  parallel_for(boundaries, [&](auto... is) { closure(is..., value); });
+
+  boundaries.team_member.team_reduce(reducer, value);
+}
+
+template <Kokkos::Iterate OuterDirection, Kokkos::Iterate InnerDirection,
+          size_t Rank, typename iType, typename Member, typename Closure,
+          typename ValueType>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<!Kokkos::is_reducer<ValueType>::value &&
+                     Impl::is_host_thread_team_member<Member>::value>
+    parallel_reduce(Impl::MDTeamVectorRangeBoundariesStruct<
+                        OuterDirection, InnerDirection, Rank, iType,
+                        Member> const& boundaries,
+                    Closure const& closure, ValueType& result) {
+  Sum<ValueType> reducer(result);
+  reducer.init(result);
+
+  parallel_reduce(boundaries, closure, reducer);
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -1017,7 +1017,7 @@ struct ParallelForMDTeamVectorRangeHostImpl {
   KOKKOS_INLINE_FUNCTION static void next_rank(
       Boundaries const& boundaries, Closure const& closure,
       typename Boundaries::index_type i) {
-    auto newClosure = [i, &closure](auto... iArgs) { closure(i, iArgs...); };
+    auto newClosure = [i, &closure](auto... is) { closure(i, is...); };
     ParallelForMDTeamVectorRangeHostImpl<Boundaries::inner_direction,
                                          RemainingRank -
                                              1>::parallel_for_impl(boundaries,

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -1035,6 +1035,14 @@ KOKKOS_INLINE_FUNCTION
 template <Kokkos::Iterate Direction, size_t RemainingRank>
 struct ParallelForMDTeamVectorRangeHostImpl {
  private:
+// Incorrect shadow warning in older gcc compilers, see
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67273
+// FIXME: These pragmas can be deleted for Kokkos 4 when GCC 7 becomes the
+// minimum requirement
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU <= 600)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
   template <typename Boundaries, typename Closure>
   KOKKOS_INLINE_FUNCTION static void next_rank(
       Boundaries const& boundaries, Closure const& closure,
@@ -1045,6 +1053,9 @@ struct ParallelForMDTeamVectorRangeHostImpl {
                                              1>::parallel_for_impl(boundaries,
                                                                    newClosure);
   }
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU <= 600)
+#pragma GCC diagnostic pop
+#endif
 
  public:
   static constexpr Kokkos::Iterate direction = Direction;

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -426,6 +426,7 @@ if(Kokkos_ENABLE_SERIAL)
     UnitTestMainInit.cpp
     ${Serial_SOURCES1}
     serial/TestSerial_Task.cpp
+    serial/TestSerial_MDTeamParallelism.cpp
   )
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_Serial2

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -1110,11 +1110,10 @@ struct TestMDTeamParallelReduce {
         mdRangePolicy,
         KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
                       const int k, const int l, const int m) {
-          Kokkos::parallel_for(
-              n5, KOKKOS_LAMBDA(const int n) {
-                v(leagueRank, i, j, k, l, m, n) =
-                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
-              });
+          for (int n = 0; n < n5; ++n) {
+            v(leagueRank, i, j, k, l, m, n) =
+                fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
+          }
         });
 
     int finalSum = 0;
@@ -1168,14 +1167,12 @@ struct TestMDTeamParallelReduce {
         mdRangePolicy,
         KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
                       const int k, const int l, const int m) {
-          Kokkos::parallel_for(
-              n5, KOKKOS_LAMBDA(const int n) {
-                Kokkos::parallel_for(
-                    n6, KOKKOS_LAMBDA(const int o) {
-                      v(leagueRank, i, j, k, l, m, n, o) =
-                          fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
-                    });
-              });
+          for (int n = 0; n < n5; ++n) {
+            for (int o = 0; o < n6; ++o) {
+              v(leagueRank, i, j, k, l, m, n, o) =
+                  fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+            }
+          }
         });
 
     int finalSum = 0;
@@ -1399,11 +1396,10 @@ struct TestMDTeamParallelReduce {
         mdRangePolicy,
         KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
                       const int k, const int l, const int m) {
-          Kokkos::parallel_for(
-              n5, KOKKOS_LAMBDA(const int n) {
-                v(leagueRank, i, j, k, l, m, n) =
-                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
-              });
+          for (int n = 0; n < n5; ++n) {
+            v(leagueRank, i, j, k, l, m, n) =
+                fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
+          }
         });
 
     int finalSum = 0;
@@ -1466,14 +1462,12 @@ struct TestMDTeamParallelReduce {
         mdRangePolicy,
         KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
                       const int k, const int l, const int m) {
-          Kokkos::parallel_for(
-              n5, KOKKOS_LAMBDA(const int n) {
-                Kokkos::parallel_for(
-                    n6, KOKKOS_LAMBDA(const int o) {
-                      v(leagueRank, i, j, k, l, m, n, o) =
-                          fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
-                    });
-              });
+          for (int n = 0; n < n5; ++n) {
+            for (int o = 0; o < n6; ++o) {
+              v(leagueRank, i, j, k, l, m, n, o) =
+                  fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+            }
+          }
         });
 
     int finalSum = 0;
@@ -1689,11 +1683,10 @@ struct TestMDTeamParallelReduce {
         mdRangePolicy,
         KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
                       const int k, const int l, const int m) {
-          Kokkos::parallel_for(
-              n5, KOKKOS_LAMBDA(const int n) {
-                v(leagueRank, i, j, k, l, m, n) =
-                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
-              });
+          for (int n = 0; n < n5; ++n) {
+            v(leagueRank, i, j, k, l, m, n) =
+                fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
+          }
         });
 
     int finalSum = 0;
@@ -1751,14 +1744,12 @@ struct TestMDTeamParallelReduce {
         mdRangePolicy,
         KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
                       const int k, const int l, const int m) {
-          Kokkos::parallel_for(
-              n5, KOKKOS_LAMBDA(const int n) {
-                Kokkos::parallel_for(
-                    n6, KOKKOS_LAMBDA(const int o) {
-                      v(leagueRank, i, j, k, l, m, n, o) =
-                          fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
-                    });
-              });
+          for (int n = 0; n < n5; ++n) {
+            for (int o = 0; o < n6; ++o) {
+              v(leagueRank, i, j, k, l, m, n, o) =
+                  fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+            }
+          }
         });
 
     int finalSum = 0;

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -858,15 +858,19 @@ struct TestMDTeamParallelReduce {
   using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
   template <typename F>
-  constexpr static auto get_expected_partial_sum(DimsType const& dims, size_t maxRank, F const& f, DimsType& indices, size_t rank) {
-    if(rank == maxRank) {
-      return f(indices[0], indices[1], indices[2], indices[3], indices[4], indices[5], indices[6], indices[7]);
-    } 
+  constexpr static auto get_expected_partial_sum(DimsType const& dims,
+                                                 size_t maxRank, F const& f,
+                                                 DimsType& indices,
+                                                 size_t rank) {
+    if (rank == maxRank) {
+      return f(indices[0], indices[1], indices[2], indices[3], indices[4],
+               indices[5], indices[6], indices[7]);
+    }
 
-    auto& index = indices[rank];
+    auto& index       = indices[rank];
     DataType accValue = 0;
-    for(index = 0; index < dims[rank]; ++index) {
-      accValue += get_expected_partial_sum(dims, maxRank, f, indices, rank+1);
+    for (index = 0; index < dims[rank]; ++index) {
+      accValue += get_expected_partial_sum(dims, maxRank, f, indices, rank + 1);
     }
 
     return accValue;

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -1103,12 +1103,13 @@ struct TestMDTeamParallelReduce {
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
+    auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
+        {0, 0, 0, 0, 0, 0}, {n0, n1, n2, n3, n4, n5});
 
     Kokkos::parallel_for(
         leagueSize, KOKKOS_LAMBDA(const int leagueRank) {
           Kokkos::parallel_for(
-              Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-                  {0, 0, 0, 0, 0, 0}, {n0, n1, n2, n3, n4, n5}),
+              mdRangePolicy,
               KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
                             const int m, const int n) {
                 v(leagueRank, i, j, k, l, m, n) =
@@ -1160,6 +1161,8 @@ struct TestMDTeamParallelReduce {
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
                                           n6);
+    auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
+        {0, 0, 0, 0, 0, 0}, {n1, n2, n3, n4, n5, n6});
 
     Kokkos::parallel_for(
         Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>>({0, 0},
@@ -1167,8 +1170,7 @@ struct TestMDTeamParallelReduce {
 
         KOKKOS_LAMBDA(const int leagueRank, const int i) {
           Kokkos::parallel_for(
-              Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-                  {0, 0, 0, 0, 0, 0}, {n1, n2, n3, n4, n5, n6}),
+              mdRangePolicy,
               KOKKOS_LAMBDA(const int j, const int k, const int l, const int m,
                             const int n, const int o) {
                 v(leagueRank, i, j, k, l, m, n, o) =
@@ -1390,12 +1392,13 @@ struct TestMDTeamParallelReduce {
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
+    auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
+        {0, 0, 0, 0, 0, 0}, {n0, n1, n2, n3, n4, n5});
 
     Kokkos::parallel_for(
         leagueSize, KOKKOS_LAMBDA(const int leagueRank) {
           Kokkos::parallel_for(
-              Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-                  {0, 0, 0, 0, 0, 0}, {n0, n1, n2, n3, n4, n5}),
+              mdRangePolicy,
               KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
                             const int m, const int n) {
                 v(leagueRank, i, j, k, l, m, n) =
@@ -1456,14 +1459,15 @@ struct TestMDTeamParallelReduce {
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
                                           n6);
+    auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
+        {0, 0, 0, 0, 0, 0}, {n1, n2, n3, n4, n5, n6});
 
     Kokkos::parallel_for(
         Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>>({0, 0},
                                                           {leagueSize, n0}),
         KOKKOS_LAMBDA(const int leagueRank, const int i) {
           Kokkos::parallel_for(
-              Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-                  {0, 0, 0, 0, 0, 0}, {n1, n2, n3, n4, n5, n6}),
+              mdRangePolicy,
               KOKKOS_LAMBDA(const int j, const int k, const int l, const int m,
                             const int n, const int o) {
                 v(leagueRank, i, j, k, l, m, n, o) =
@@ -1677,11 +1681,13 @@ struct TestMDTeamParallelReduce {
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
+    auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
+        {0, 0, 0, 0, 0, 0}, {n0, n1, n2, n3, n4, n5});
+
     Kokkos::parallel_for(
         leagueSize, KOKKOS_LAMBDA(const int leagueRank) {
           Kokkos::parallel_for(
-              Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-                  {0, 0, 0, 0, 0, 0}, {n0, n1, n2, n3, n4, n5}),
+              mdRangePolicy,
               KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
                             const int m, const int n) {
                 v(leagueRank, i, j, k, l, m, n) =
@@ -1737,14 +1743,15 @@ struct TestMDTeamParallelReduce {
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
                                           n6);
+    auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
+        {0, 0, 0, 0, 0, 0}, {n1, n2, n3, n4, n5, n6});
 
     Kokkos::parallel_for(
         Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>>({0, 0},
                                                           {leagueSize, n0}),
         KOKKOS_LAMBDA(const int leagueRank, const int i) {
           Kokkos::parallel_for(
-              Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-                  {0, 0, 0, 0, 0, 0}, {n1, n2, n3, n4, n5, n6}),
+              mdRangePolicy,
               KOKKOS_LAMBDA(const int j, const int k, const int l, const int m,
                             const int n, const int o) {
                 v(leagueRank, i, j, k, l, m, n, o) =

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -1790,7 +1790,7 @@ struct TestMDTeamParallelReduce {
 
     EXPECT_EQ(finalSum, expectedSum);
   }
-};  // namespace MDTeamParallelism
+};
 
 /*--------------------------------------------------------------------------*/
 

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -71,14 +71,6 @@ struct FillFlattenedIndex {
   int initValue[8];
 };
 
-struct FillConstant {
-  explicit FillConstant(int initValue_) : initValue(initValue_) {}
-
-  int operator()(int, int, int) const { return initValue; }
-
-  int initValue;
-};
-
 template <typename ExecSpace>
 struct TestMDTeamParallelFor {
   using DataType = int;
@@ -98,8 +90,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_3D_MDTeamThreadRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_3D_MDTeamThreadRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -108,7 +99,6 @@ struct TestMDTeamParallelFor {
     int n1         = dims[2];
 
     ViewType v("v", leagueSize, n0, n1);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
 
     Kokkos::parallel_for(
@@ -143,8 +133,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_4D_MDTeamThreadRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_4D_MDTeamThreadRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -154,7 +143,6 @@ struct TestMDTeamParallelFor {
     int n2         = dims[3];
 
     ViewType v("v", leagueSize, n0, n1, n2);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
@@ -192,8 +180,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_5D_MDTeamThreadRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_5D_MDTeamThreadRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -204,7 +191,6 @@ struct TestMDTeamParallelFor {
     int n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
 
     Kokkos::parallel_for(
@@ -246,8 +232,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_6D_MDTeamThreadRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_6D_MDTeamThreadRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -259,7 +244,6 @@ struct TestMDTeamParallelFor {
     int n4         = dims[5];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
 
     Kokkos::parallel_for(
@@ -304,8 +288,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_7D_MDTeamThreadRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_7D_MDTeamThreadRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -318,7 +301,6 @@ struct TestMDTeamParallelFor {
     int n5         = dims[6];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
 
     Kokkos::parallel_for(
@@ -365,8 +347,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_8D_MDTeamThreadRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_8D_MDTeamThreadRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -380,7 +361,6 @@ struct TestMDTeamParallelFor {
     int n6         = dims[7];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
                                           n6);
 
@@ -407,8 +387,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_4D_MDThreadVectorRange(DimsType const& dims,
-                                                       const int initValue) {
+  static void test_parallel_for_4D_MDThreadVectorRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -418,7 +397,6 @@ struct TestMDTeamParallelFor {
     int n2         = dims[3];
 
     ViewType v("v", leagueSize, n0, n1, n2);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
@@ -446,8 +424,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_5D_MDThreadVectorRange(DimsType const& dims,
-                                                       const int initValue) {
+  static void test_parallel_for_5D_MDThreadVectorRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -458,7 +435,6 @@ struct TestMDTeamParallelFor {
     int n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
 
     Kokkos::parallel_for(
@@ -487,8 +463,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_6D_MDThreadVectorRange(DimsType const& dims,
-                                                       const int initValue) {
+  static void test_parallel_for_6D_MDThreadVectorRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -500,7 +475,6 @@ struct TestMDTeamParallelFor {
     int n4         = dims[5];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
 
     Kokkos::parallel_for(
@@ -529,8 +503,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_7D_MDThreadVectorRange(DimsType const& dims,
-                                                       const int initValue) {
+  static void test_parallel_for_7D_MDThreadVectorRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -543,7 +516,6 @@ struct TestMDTeamParallelFor {
     int n5         = dims[6];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
 
     Kokkos::parallel_for(
@@ -573,8 +545,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_8D_MDThreadVectorRange(DimsType const& dims,
-                                                       const int initValue) {
+  static void test_parallel_for_8D_MDThreadVectorRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -588,7 +559,6 @@ struct TestMDTeamParallelFor {
     int n6         = dims[7];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
                                           n6);
 
@@ -619,8 +589,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_3D_MDTeamVectorRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_3D_MDTeamVectorRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -629,7 +598,6 @@ struct TestMDTeamParallelFor {
     int n1         = dims[2];
 
     ViewType v("v", leagueSize, n0, n1);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
 
     Kokkos::parallel_for(
@@ -654,8 +622,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_4D_MDTeamVectorRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_4D_MDTeamVectorRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -665,7 +632,6 @@ struct TestMDTeamParallelFor {
     int n2         = dims[3];
 
     ViewType v("v", leagueSize, n0, n1, n2);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
@@ -690,8 +656,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_5D_MDTeamVectorRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_5D_MDTeamVectorRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -702,7 +667,6 @@ struct TestMDTeamParallelFor {
     int n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
 
     Kokkos::parallel_for(
@@ -728,8 +692,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_6D_MDTeamVectorRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_6D_MDTeamVectorRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -741,7 +704,6 @@ struct TestMDTeamParallelFor {
     int n4         = dims[5];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
 
     Kokkos::parallel_for(
@@ -768,8 +730,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_7D_MDTeamVectorRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_7D_MDTeamVectorRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -782,7 +743,6 @@ struct TestMDTeamParallelFor {
     int n5         = dims[6];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
 
     Kokkos::parallel_for(
@@ -809,8 +769,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_8D_MDTeamVectorRange(DimsType const& dims,
-                                                     const int initValue) {
+  static void test_parallel_for_8D_MDTeamVectorRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
@@ -824,7 +783,6 @@ struct TestMDTeamParallelFor {
     int n6         = dims[7];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
                                           n6);
 
@@ -848,6 +806,67 @@ struct TestMDTeamParallelFor {
         Kokkos::DefaultHostExecutionSpace(), v);
 
     check_result_8D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_single_direction_test(DimsType const& dims) {
+    using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int n0         = dims[0];
+    int n1         = dims[1];
+    int n2         = dims[2];
+
+    ViewType v("v", n0, n1, n2);
+    FillFlattenedIndex fillFlattenedIndex(n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(1, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          auto teamRange =
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
+            v(i, j, k) += fillFlattenedIndex(i, j, k);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_3D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_double_direction_test(DimsType const& dims) {
+    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int n0 = dims[0];
+    int n1 = dims[1];
+    int n2 = dims[2];
+    int n3 = dims[3];
+
+    ViewType v("v", n0, n1, n2, n3);
+    FillFlattenedIndex fillFlattenedIndex(n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(1, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j, int k, int l) {
+            v(i, j, k, l) += fillFlattenedIndex(i, j, k, l);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_4D(h_view, fillFlattenedIndex);
   }
 };
 
@@ -885,7 +904,7 @@ struct TestMDTeamParallelReduce {
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_3D_MDTeamThreadRange(
-      DimsType const& dims, const int initValue) {
+      DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType***, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -893,7 +912,6 @@ struct TestMDTeamParallelReduce {
     int n1         = dims[2];
 
     ViewType v("v", leagueSize, n0, n1);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
 
     Kokkos::parallel_for(
@@ -930,7 +948,7 @@ struct TestMDTeamParallelReduce {
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_4D_MDTeamThreadRange(
-      DimsType const& dims, const int initValue) {
+      DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -939,7 +957,6 @@ struct TestMDTeamParallelReduce {
     int n2         = dims[3];
 
     ViewType v("v", leagueSize, n0, n1, n2);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
@@ -976,7 +993,7 @@ struct TestMDTeamParallelReduce {
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_5D_MDTeamThreadRange(
-      DimsType const& dims, const int initValue) {
+      DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -986,7 +1003,6 @@ struct TestMDTeamParallelReduce {
     int n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
 
     Kokkos::parallel_for(
@@ -1023,7 +1039,7 @@ struct TestMDTeamParallelReduce {
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_6D_MDTeamThreadRange(
-      DimsType const& dims, const int initValue) {
+      DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1034,7 +1050,6 @@ struct TestMDTeamParallelReduce {
     int n4         = dims[5];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
 
     Kokkos::parallel_for(
@@ -1074,7 +1089,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_4D_MDThreadVectorRange(
-      DimsType const& dims, const int initValue) {
+      DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1083,7 +1098,6 @@ struct TestMDTeamParallelReduce {
     int n2         = dims[3];
 
     ViewType v("v", leagueSize, n0, n1, n2);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
@@ -1130,7 +1144,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_5D_MDThreadVectorRange(
-      DimsType const& dims, const int initValue) {
+      DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1140,7 +1154,6 @@ struct TestMDTeamParallelReduce {
     int n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
 
     Kokkos::parallel_for(
@@ -1188,7 +1201,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_6D_MDThreadVectorRange(
-      DimsType const& dims, const int initValue) {
+      DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1199,7 +1212,6 @@ struct TestMDTeamParallelReduce {
     int n4         = dims[5];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
 
     Kokkos::parallel_for(
@@ -1248,7 +1260,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_4D_MDTeamVectorRange(
-      DimsType const& dims, const int initValue) {
+      DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1257,7 +1269,6 @@ struct TestMDTeamParallelReduce {
     int n2         = dims[3];
 
     ViewType v("v", leagueSize, n0, n1, n2);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
@@ -1299,7 +1310,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_5D_MDTeamVectorRange(
-      DimsType const& dims, const int initValue) {
+      DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1309,7 +1320,6 @@ struct TestMDTeamParallelReduce {
     int n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
 
     Kokkos::parallel_for(
@@ -1351,7 +1361,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_6D_MDTeamVectorRange(
-      DimsType const& dims, const int initValue) {
+      DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1362,7 +1372,6 @@ struct TestMDTeamParallelReduce {
     int n4         = dims[5];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
-    FillConstant fillConstant(initValue);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
 
     Kokkos::parallel_for(
@@ -1411,254 +1420,239 @@ constexpr auto Right = Kokkos::Iterate::Right;
 
 TEST(TEST_CATEGORY, MDTeamParallelFor) {
   using namespace MDTeamParallelism;
-  // int dims[] = {16, 16, 16, 16, 16, 16, 16, 16};
-  int dims[]          = {3, 5, 7, 11, 13, 17, 19, 23};
-  const int initValue = 5;
+  int dims[] = {3, 5, 7, 11, 13, 17, 19, 23};
 
   {
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_3D_MDTeamThreadRange<Left>(dims, initValue);
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_3D_MDTeamThreadRange<Right>(dims, initValue);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_3D_MDTeamThreadRange<Left>(dims);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_3D_MDTeamThreadRange<Right>(dims);
 
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_4D_MDTeamThreadRange<Left>(dims, initValue);
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_4D_MDTeamThreadRange<Right>(dims, initValue);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_4D_MDTeamThreadRange<Left>(dims);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_4D_MDTeamThreadRange<Right>(dims);
 
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_5D_MDTeamThreadRange<Left>(dims, initValue);
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_5D_MDTeamThreadRange<Right>(dims, initValue);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_5D_MDTeamThreadRange<Left>(dims);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_5D_MDTeamThreadRange<Right>(dims);
 
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_6D_MDTeamThreadRange<Left>(dims, initValue);
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_6D_MDTeamThreadRange<Right>(dims, initValue);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_6D_MDTeamThreadRange<Left>(dims);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_6D_MDTeamThreadRange<Right>(dims);
 
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_7D_MDTeamThreadRange<Left>(dims, initValue);
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_7D_MDTeamThreadRange<Right>(dims, initValue);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_7D_MDTeamThreadRange<Left>(dims);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_7D_MDTeamThreadRange<Right>(dims);
 
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_8D_MDTeamThreadRange<Left>(dims, initValue);
-    TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_8D_MDTeamThreadRange<Right>(dims, initValue);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_8D_MDTeamThreadRange<Left>(dims);
+    TestMDTeamParallelFor<
+        TEST_EXECSPACE>::test_parallel_for_8D_MDTeamThreadRange<Right>(dims);
   }
 
   {
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_4D_MDThreadVectorRange<Left, Left>(dims, initValue);
+        test_parallel_for_4D_MDThreadVectorRange<Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_4D_MDThreadVectorRange<Left, Right>(dims, initValue);
+        test_parallel_for_4D_MDThreadVectorRange<Left, Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_4D_MDThreadVectorRange<Right, Left>(dims, initValue);
+        test_parallel_for_4D_MDThreadVectorRange<Right, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_4D_MDThreadVectorRange<Right, Right>(dims, initValue);
+        test_parallel_for_4D_MDThreadVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_5D_MDThreadVectorRange<Left, Left>(dims, initValue);
+        test_parallel_for_5D_MDThreadVectorRange<Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_5D_MDThreadVectorRange<Left, Right>(dims, initValue);
+        test_parallel_for_5D_MDThreadVectorRange<Left, Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_5D_MDThreadVectorRange<Right, Left>(dims, initValue);
+        test_parallel_for_5D_MDThreadVectorRange<Right, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_5D_MDThreadVectorRange<Right, Right>(dims, initValue);
+        test_parallel_for_5D_MDThreadVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_6D_MDThreadVectorRange<Left, Left>(dims, initValue);
+        test_parallel_for_6D_MDThreadVectorRange<Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_6D_MDThreadVectorRange<Left, Right>(dims, initValue);
+        test_parallel_for_6D_MDThreadVectorRange<Left, Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_6D_MDThreadVectorRange<Right, Left>(dims, initValue);
+        test_parallel_for_6D_MDThreadVectorRange<Right, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_6D_MDThreadVectorRange<Right, Right>(dims, initValue);
+        test_parallel_for_6D_MDThreadVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_7D_MDThreadVectorRange<Left, Left>(dims, initValue);
+        test_parallel_for_7D_MDThreadVectorRange<Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_7D_MDThreadVectorRange<Left, Right>(dims, initValue);
+        test_parallel_for_7D_MDThreadVectorRange<Left, Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_7D_MDThreadVectorRange<Right, Left>(dims, initValue);
+        test_parallel_for_7D_MDThreadVectorRange<Right, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_7D_MDThreadVectorRange<Right, Right>(dims, initValue);
+        test_parallel_for_7D_MDThreadVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_8D_MDThreadVectorRange<Left, Left>(dims, initValue);
+        test_parallel_for_8D_MDThreadVectorRange<Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_8D_MDThreadVectorRange<Left, Right>(dims, initValue);
+        test_parallel_for_8D_MDThreadVectorRange<Left, Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_8D_MDThreadVectorRange<Right, Left>(dims, initValue);
+        test_parallel_for_8D_MDThreadVectorRange<Right, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_8D_MDThreadVectorRange<Right, Right>(dims, initValue);
+        test_parallel_for_8D_MDThreadVectorRange<Right, Right>(dims);
   }
 
   {
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_3D_MDTeamVectorRange<Left, Left>(dims, initValue);
+        test_parallel_for_3D_MDTeamVectorRange<Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_3D_MDTeamVectorRange<Left, Right>(dims, initValue);
+        test_parallel_for_3D_MDTeamVectorRange<Left, Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_3D_MDTeamVectorRange<Right, Left>(dims, initValue);
+        test_parallel_for_3D_MDTeamVectorRange<Right, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_3D_MDTeamVectorRange<Right, Right>(dims, initValue);
+        test_parallel_for_3D_MDTeamVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_4D_MDTeamVectorRange<Left, Left>(dims, initValue);
+        test_parallel_for_4D_MDTeamVectorRange<Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_4D_MDTeamVectorRange<Left, Right>(dims, initValue);
+        test_parallel_for_4D_MDTeamVectorRange<Left, Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_4D_MDTeamVectorRange<Right, Left>(dims, initValue);
+        test_parallel_for_4D_MDTeamVectorRange<Right, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_4D_MDTeamVectorRange<Right, Right>(dims, initValue);
+        test_parallel_for_4D_MDTeamVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_5D_MDTeamVectorRange<Left, Left>(dims, initValue);
+        test_parallel_for_5D_MDTeamVectorRange<Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_5D_MDTeamVectorRange<Left, Right>(dims, initValue);
+        test_parallel_for_5D_MDTeamVectorRange<Left, Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_5D_MDTeamVectorRange<Right, Left>(dims, initValue);
+        test_parallel_for_5D_MDTeamVectorRange<Right, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_5D_MDTeamVectorRange<Right, Right>(dims, initValue);
+        test_parallel_for_5D_MDTeamVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_6D_MDTeamVectorRange<Left, Left>(dims, initValue);
+        test_parallel_for_6D_MDTeamVectorRange<Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_6D_MDTeamVectorRange<Left, Right>(dims, initValue);
+        test_parallel_for_6D_MDTeamVectorRange<Left, Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_6D_MDTeamVectorRange<Right, Left>(dims, initValue);
+        test_parallel_for_6D_MDTeamVectorRange<Right, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_6D_MDTeamVectorRange<Right, Right>(dims, initValue);
+        test_parallel_for_6D_MDTeamVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_7D_MDTeamVectorRange<Left, Left>(dims, initValue);
+        test_parallel_for_7D_MDTeamVectorRange<Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_7D_MDTeamVectorRange<Left, Right>(dims, initValue);
+        test_parallel_for_7D_MDTeamVectorRange<Left, Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_7D_MDTeamVectorRange<Right, Left>(dims, initValue);
+        test_parallel_for_7D_MDTeamVectorRange<Right, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_7D_MDTeamVectorRange<Right, Right>(dims, initValue);
+        test_parallel_for_7D_MDTeamVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_8D_MDTeamVectorRange<Left, Left>(dims, initValue);
+        test_parallel_for_8D_MDTeamVectorRange<Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_8D_MDTeamVectorRange<Left, Right>(dims, initValue);
+        test_parallel_for_8D_MDTeamVectorRange<Left, Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_8D_MDTeamVectorRange<Right, Left>(dims, initValue);
+        test_parallel_for_8D_MDTeamVectorRange<Right, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::
-        test_parallel_for_8D_MDTeamVectorRange<Right, Right>(dims, initValue);
+        test_parallel_for_8D_MDTeamVectorRange<Right, Right>(dims);
+  }
+
+  {
+    TestMDTeamParallelFor<TEST_EXECSPACE>::test_parallel_single_direction_test<
+        Left>(dims);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::test_parallel_double_direction_test<
+        Left, Left>(dims);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::test_parallel_double_direction_test<
+        Left, Right>(dims);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::test_parallel_double_direction_test<
+        Right, Left>(dims);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::test_parallel_double_direction_test<
+        Right, Right>(dims);
   }
 }  // namespace Test
 
 TEST(TEST_CATEGORY, MDTeamParallelReduce) {
   using namespace MDTeamParallelism;
-  // int dims[] = {16, 16, 16, 16, 16, 16, 16, 16};
-  int dims[]          = {3, 5, 7, 11, 13, 17, 19, 23};
-  const int initValue = 5;
+  int dims[] = {3, 5, 7, 11, 13, 17, 19, 23};
 
   {
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_3D_MDTeamThreadRange<Left>(dims, initValue);
+        test_parallel_reduce_for_3D_MDTeamThreadRange<Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_3D_MDTeamThreadRange<Right>(dims, initValue);
+        test_parallel_reduce_for_3D_MDTeamThreadRange<Right>(dims);
 
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_4D_MDTeamThreadRange<Left>(dims, initValue);
+        test_parallel_reduce_for_4D_MDTeamThreadRange<Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_4D_MDTeamThreadRange<Right>(dims, initValue);
+        test_parallel_reduce_for_4D_MDTeamThreadRange<Right>(dims);
 
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_5D_MDTeamThreadRange<Left>(dims, initValue);
+        test_parallel_reduce_for_5D_MDTeamThreadRange<Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_5D_MDTeamThreadRange<Right>(dims, initValue);
+        test_parallel_reduce_for_5D_MDTeamThreadRange<Right>(dims);
 
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_6D_MDTeamThreadRange<Left>(dims, initValue);
+        test_parallel_reduce_for_6D_MDTeamThreadRange<Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_6D_MDTeamThreadRange<Right>(dims, initValue);
+        test_parallel_reduce_for_6D_MDTeamThreadRange<Right>(dims);
   }
 
   {
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_4D_MDThreadVectorRange<Left, Left>(dims,
-                                                                    initValue);
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Left, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_4D_MDThreadVectorRange<Left, Right>(dims,
-                                                                     initValue);
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Left, Right>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_4D_MDThreadVectorRange<Right, Left>(dims,
-                                                                     initValue);
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Right, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_4D_MDThreadVectorRange<Right, Right>(
-            dims, initValue);
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_5D_MDThreadVectorRange<Left, Left>(dims,
-                                                                    initValue);
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Left, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_5D_MDThreadVectorRange<Left, Right>(dims,
-                                                                     initValue);
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Left, Right>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_5D_MDThreadVectorRange<Right, Left>(dims,
-                                                                     initValue);
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Right, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_5D_MDThreadVectorRange<Right, Right>(
-            dims, initValue);
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_6D_MDThreadVectorRange<Left, Left>(dims,
-                                                                    initValue);
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Left, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_6D_MDThreadVectorRange<Left, Right>(dims,
-                                                                     initValue);
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Left, Right>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_6D_MDThreadVectorRange<Right, Left>(dims,
-                                                                     initValue);
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Right, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_6D_MDThreadVectorRange<Right, Right>(
-            dims, initValue);
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Right, Right>(dims);
   }
 
   {
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_4D_MDTeamVectorRange<Left, Left>(dims,
-                                                                  initValue);
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Left, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_4D_MDTeamVectorRange<Left, Right>(dims,
-                                                                   initValue);
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Left, Right>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_4D_MDTeamVectorRange<Right, Left>(dims,
-                                                                   initValue);
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Right, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_4D_MDTeamVectorRange<Right, Right>(dims,
-                                                                    initValue);
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_5D_MDTeamVectorRange<Left, Left>(dims,
-                                                                  initValue);
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Left, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_5D_MDTeamVectorRange<Left, Right>(dims,
-                                                                   initValue);
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Left, Right>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_5D_MDTeamVectorRange<Right, Left>(dims,
-                                                                   initValue);
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Right, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_5D_MDTeamVectorRange<Right, Right>(dims,
-                                                                    initValue);
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Right, Right>(dims);
 
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_6D_MDTeamVectorRange<Left, Left>(dims,
-                                                                  initValue);
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Left, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_6D_MDTeamVectorRange<Left, Right>(dims,
-                                                                   initValue);
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Left, Right>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_6D_MDTeamVectorRange<Right, Left>(dims,
-                                                                   initValue);
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Right, Left>(dims);
     TestMDTeamParallelReduce<TEST_EXECSPACE>::
-        test_parallel_reduce_for_6D_MDTeamVectorRange<Right, Right>(dims,
-                                                                    initValue);
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Right, Right>(dims);
   }
 }
 

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -1,0 +1,1674 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+
+namespace MDTeamParallelism {
+
+struct FillFlattenedIndex {
+  explicit FillFlattenedIndex(int n0, int n1, int n2, int n3 = 1, int n4 = 1,
+                              int n5 = 1, int n6 = 1, int n7 = 1)
+      : initValue{n0, n1, n2, n3, n4, n5, n6, n7} {}
+
+  KOKKOS_INLINE_FUNCTION
+  int operator()(int n0, int n1, int n2, int n3 = 0, int n4 = 0, int n5 = 0,
+                 int n6 = 0, int n7 = 0) const {
+    return ((((((n7 * initValue[7] + n6) * initValue[6] + n5) * initValue[5] +
+               n4) *
+                  initValue[4] +
+              n3) *
+                 initValue[3] +
+             n2) *
+                initValue[2] +
+            n1) *
+               initValue[1] +
+           n0;
+  }
+
+  int initValue[8];
+};
+
+struct FillConstant {
+  explicit FillConstant(int initValue_) : initValue(initValue_) {}
+
+  int operator()(int, int, int) const { return initValue; }
+
+  int initValue;
+};
+
+template <typename ExecSpace>
+struct TestMDTeamParallelFor {
+  using DataType = int;
+  using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_3D(HostViewType h_view,
+                              FillFunctor const& fillFunctor) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          EXPECT_EQ(h_view(i, j, k), fillFunctor(i, j, k));
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_3D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+
+    ViewType v("v", leagueSize, n0, n1);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange = Kokkos::MDTeamThreadRange<Direction>(team, n0, n1);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j) {
+            v(leagueRank, i, j) += fillFlattenedIndex(leagueRank, i, j);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_3D(h_view, fillFlattenedIndex);
+  }
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_4D(HostViewType h_view, FillFunctor& fillFunctor) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          for (size_t l = 0; l < h_view.extent(3); ++l) {
+            EXPECT_EQ(h_view(i, j, k, l), fillFunctor(i, j, k, l));
+          }
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_4D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
+            v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_4D(h_view, fillFlattenedIndex);
+  }
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_5D(HostViewType h_view, FillFunctor& fillFunctor) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          for (size_t l = 0; l < h_view.extent(3); ++l) {
+            for (size_t m = 0; m < h_view.extent(4); ++m) {
+              EXPECT_EQ(h_view(i, j, k, l, m), fillFunctor(i, j, k, l, m));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_5D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2, n3);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j, int k, int l) {
+            v(leagueRank, i, j, k, l) +=
+                fillFlattenedIndex(leagueRank, i, j, k, l);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_5D(h_view, fillFlattenedIndex);
+  }
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_6D(HostViewType h_view, FillFunctor& fillFunctor) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          for (size_t l = 0; l < h_view.extent(3); ++l) {
+            for (size_t m = 0; m < h_view.extent(4); ++m) {
+              for (size_t n = 0; n < h_view.extent(5); ++n) {
+                EXPECT_EQ(h_view(i, j, k, l, m, n),
+                          fillFunctor(i, j, k, l, m, n));
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_6D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2, n3, n4);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m) {
+                v(leagueRank, i, j, k, l, m) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_6D(h_view, fillFlattenedIndex);
+  }
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_7D(HostViewType h_view, FillFunctor& fillFunctor) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          for (size_t l = 0; l < h_view.extent(3); ++l) {
+            for (size_t m = 0; m < h_view.extent(4); ++m) {
+              for (size_t n = 0; n < h_view.extent(5); ++n) {
+                for (size_t o = 0; o < h_view.extent(6); ++o) {
+                  EXPECT_EQ(h_view(i, j, k, l, m, n, o),
+                            fillFunctor(i, j, k, l, m, n, o));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_7D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange = Kokkos::MDTeamThreadRange<Direction>(team, n0, n1,
+                                                                n2, n3, n4, n5);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m, int n) {
+                v(leagueRank, i, j, k, l, m, n) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_7D(h_view, fillFlattenedIndex);
+  }
+
+  template <typename HostViewType, typename FillFunctor>
+  static void check_result_8D(HostViewType h_view, FillFunctor& fillFunctor) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          for (size_t l = 0; l < h_view.extent(3); ++l) {
+            for (size_t m = 0; m < h_view.extent(4); ++m) {
+              for (size_t n = 0; n < h_view.extent(5); ++n) {
+                for (size_t o = 0; o < h_view.extent(6); ++o) {
+                  for (size_t p = 0; p < h_view.extent(7); ++p) {
+                    EXPECT_EQ(h_view(i, j, k, l, m, n, o, p),
+                              fillFunctor(i, j, k, l, m, n, o, p));
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_for_8D_MDTeamThreadRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+    int n6         = dims[7];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
+                                          n6);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange = Kokkos::MDTeamThreadRange<Direction>(
+              team, n0, n1, n2, n3, n4, n5, n6);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m, int n, int o) {
+                v(leagueRank, i, j, k, l, m, n, o) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_8D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_4D_MDThreadVectorRange(int* dims,
+                                                       const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto teamRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2);
+
+          Kokkos::parallel_for(teamThreadRange, [=](int i) {
+            Kokkos::parallel_for(teamRange, [=](int j, int k) {
+              v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
+            });
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_4D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_5D_MDThreadVectorRange(int* dims,
+                                                       const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto teamRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3);
+
+          Kokkos::parallel_for(teamThreadRange, [=](int i) {
+            Kokkos::parallel_for(teamRange, [=](int j, int k, int l) {
+              v(leagueRank, i, j, k, l) +=
+                  fillFlattenedIndex(leagueRank, i, j, k, l);
+            });
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_5D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_6D_MDThreadVectorRange(int* dims,
+                                                       const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto teamRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3, n4);
+
+          Kokkos::parallel_for(teamThreadRange, [=](int i) {
+            Kokkos::parallel_for(teamRange, [=](int j, int k, int l, int m) {
+              v(leagueRank, i, j, k, l, m) +=
+                  fillFlattenedIndex(leagueRank, i, j, k, l, m);
+            });
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_6D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_7D_MDThreadVectorRange(int* dims,
+                                                       const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto teamRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3, n4, n5);
+
+          Kokkos::parallel_for(teamThreadRange, [=](int i) {
+            Kokkos::parallel_for(
+                teamRange, [=](int j, int k, int l, int m, int n) {
+                  v(leagueRank, i, j, k, l, m, n) +=
+                      fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
+                });
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_7D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_8D_MDThreadVectorRange(int* dims,
+                                                       const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+    int n6         = dims[7];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
+                                          n6);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto teamRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3, n4, n5, n6);
+
+          Kokkos::parallel_for(teamThreadRange, [=](int i) {
+            Kokkos::parallel_for(
+                teamRange, [=](int j, int k, int l, int m, int n, int o) {
+                  v(leagueRank, i, j, k, l, m, n, o) +=
+                      fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+                });
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_8D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_3D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+
+    ViewType v("v", leagueSize, n0, n1);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(team,
+                                                                        n0, n1);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j) {
+            v(leagueRank, i, j) += fillFlattenedIndex(leagueRank, i, j);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_3D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_4D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
+            v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_4D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_5D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3);
+
+          Kokkos::parallel_for(teamRange, [=](int i, int j, int k, int l) {
+            v(leagueRank, i, j, k, l) +=
+                fillFlattenedIndex(leagueRank, i, j, k, l);
+          });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_5D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_6D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3, n4);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m) {
+                v(leagueRank, i, j, k, l, m) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_6D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_7D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3, n4, n5);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m, int n) {
+                v(leagueRank, i, j, k, l, m, n) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_7D(h_view, fillFlattenedIndex);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_for_8D_MDTeamVectorRange(int* dims,
+                                                     const int initValue) {
+    using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
+    using HostViewType = typename ViewType::HostMirror;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+    int n5         = dims[6];
+    int n6         = dims[7];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
+                                          n6);
+
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const TeamType& team) {
+          int leagueRank = team.league_rank();
+
+          auto teamRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3, n4, n5, n6);
+
+          Kokkos::parallel_for(
+              teamRange, [=](int i, int j, int k, int l, int m, int n, int o) {
+                v(leagueRank, i, j, k, l, m, n, o) +=
+                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+              });
+        });
+
+    HostViewType h_view = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), v);
+
+    check_result_8D(h_view, fillFlattenedIndex);
+  }
+};
+
+template <typename ExecSpace>
+struct TestMDTeamParallelReduce {
+  using DataType = int;
+  using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_3D_MDTeamThreadRange(
+      int* dims, const int initValue) {
+    using ViewType = typename Kokkos::View<DataType***, ExecSpace>;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+
+    ViewType v("v", leagueSize, n0, n1);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>>({0, 0, 0},
+                                                          {leagueSize, n0, n1}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k) {
+          v(i, j, k) = fillFlattenedIndex(i, j, k);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          Kokkos::parallel_reduce(
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1),
+              [=](const int& i, const int& j, int& threadSum) {
+                threadSum += v(leagueRank, i, j);
+              },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 - 1);
+    int numValues   = (leagueSize * n0 * n1);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_4D_MDTeamThreadRange(
+      int* dims, const int initValue) {
+    using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
+            {0, 0, 0, 0}, {leagueSize, n0, n1, n2}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
+          v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          Kokkos::parallel_reduce(
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2),
+              [=](const int& i, const int& j, const int& k, int& threadSum) {
+                threadSum += v(leagueRank, i, j, k);
+              },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_5D_MDTeamThreadRange(
+      int* dims, const int initValue) {
+    using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>>(
+            {0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m) {
+          v(i, j, k, l, m) = fillFlattenedIndex(i, j, k, l, m);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          Kokkos::parallel_reduce(
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2, n3),
+              [=](const int& i, const int& j, const int& k, const int& l,
+                  int& threadSum) { threadSum += v(leagueRank, i, j, k, l); },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_6D_MDTeamThreadRange(
+      int* dims, const int initValue) {
+    using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
+            {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m, const int n) {
+          v(i, j, k, l, m, n) = fillFlattenedIndex(i, j, k, l, m, n);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          Kokkos::parallel_reduce(
+              Kokkos::MDTeamThreadRange<Direction>(team, n0, n1, n2, n3, n4),
+              [=](const int& i, const int& j, const int& k, const int& l,
+                  const int& m, int& threadSum) {
+                threadSum += v(leagueRank, i, j, k, l, m);
+              },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 * n4 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3 * n4);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_4D_MDThreadVectorRange(
+      int* dims, const int initValue) {
+    using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
+            {0, 0, 0, 0}, {leagueSize, n0, n1, n2}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
+          v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto threadVectorRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2);
+
+          Kokkos::parallel_for(teamThreadRange, [=, &teamSum](const int& i) {
+            int threadSum = 0;
+            Kokkos::parallel_reduce(
+                threadVectorRange,
+                [=](const int& j, const int& k, int& vectorSum) {
+                  vectorSum += v(leagueRank, i, j, k);
+                },
+                threadSum);
+
+            teamSum += threadSum;
+          });
+
+          leagueSum += teamSum;
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_5D_MDThreadVectorRange(
+      int* dims, const int initValue) {
+    using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>>(
+            {0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m) {
+          v(i, j, k, l, m) = fillFlattenedIndex(i, j, k, l, m);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto threadVectorRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3);
+
+          Kokkos::parallel_for(teamThreadRange, [=, &teamSum](const int& i) {
+            int threadSum = 0;
+            Kokkos::parallel_reduce(
+                threadVectorRange,
+                [=](const int& j, const int& k, const int& l, int& vectorSum) {
+                  vectorSum += v(leagueRank, i, j, k, l);
+                },
+                threadSum);
+
+            teamSum += threadSum;
+          });
+
+          leagueSum += teamSum;
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_6D_MDThreadVectorRange(
+      int* dims, const int initValue) {
+    using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
+            {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m, const int n) {
+          v(i, j, k, l, m, n) = fillFlattenedIndex(i, j, k, l, m, n);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
+          auto threadVectorRange =
+              Kokkos::MDThreadVectorRange<OuterDirection, InnerDirection>(
+                  team, n1, n2, n3, n4);
+
+          Kokkos::parallel_for(teamThreadRange, [=, &teamSum](const int& i) {
+            int threadSum = 0;
+            Kokkos::parallel_reduce(
+                threadVectorRange,
+                [=](const int& j, const int& k, const int& l, const int& m,
+                    int& vectorSum) {
+                  vectorSum += v(leagueRank, i, j, k, l, m);
+                },
+                threadSum);
+
+            teamSum += threadSum;
+          });
+
+          leagueSum += teamSum;
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 * n4 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3 * n4);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_4D_MDTeamVectorRange(
+      int* dims, const int initValue) {
+    using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+
+    ViewType v("v", leagueSize, n0, n1, n2);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
+            {0, 0, 0, 0}, {leagueSize, n0, n1, n2}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
+          v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamVectorRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2);
+
+          Kokkos::parallel_reduce(
+              teamVectorRange,
+              [=](const int& i, const int& j, const int& k, int& vectorSum) {
+                vectorSum += v(leagueRank, i, j, k);
+              },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_5D_MDTeamVectorRange(
+      int* dims, const int initValue) {
+    using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>>(
+            {0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m) {
+          v(i, j, k, l, m) = fillFlattenedIndex(i, j, k, l, m);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamVectorRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3);
+
+          Kokkos::parallel_reduce(
+              teamVectorRange,
+              [=](const int& i, const int& j, const int& k, const int& l,
+                  int& vectorSum) { vectorSum += v(leagueRank, i, j, k, l); },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+
+  template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
+            Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
+  static void test_parallel_reduce_for_6D_MDTeamVectorRange(
+      int* dims, const int initValue) {
+    using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
+
+    int leagueSize = dims[0];
+    int n0         = dims[1];
+    int n1         = dims[2];
+    int n2         = dims[3];
+    int n3         = dims[4];
+    int n4         = dims[5];
+
+    ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
+    FillConstant fillConstant(initValue);
+    FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
+
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
+            {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4}),
+        KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
+                      const int m, const int n) {
+          v(i, j, k, l, m, n) = fillFlattenedIndex(i, j, k, l, m, n);
+        });
+
+    int finalSum = 0;
+
+    Kokkos::parallel_reduce(
+        Kokkos::TeamPolicy<ExecSpace>(leagueSize, Kokkos::AUTO),
+        KOKKOS_LAMBDA(TeamType const& team, int& leagueSum) {
+          auto leagueRank = team.league_rank();
+          int teamSum     = 0;
+
+          auto teamVectorRange =
+              Kokkos::MDTeamVectorRange<OuterDirection, InnerDirection>(
+                  team, n0, n1, n2, n3, n4);
+
+          Kokkos::parallel_reduce(
+              teamVectorRange,
+              [=](const int& i, const int& j, const int& k, const int& l,
+                  const int& m, int& vectorSum) {
+                vectorSum += v(leagueRank, i, j, k, l, m);
+              },
+              teamSum);
+
+          Kokkos::single(Kokkos::PerTeam(team),
+                         [&leagueSum, teamSum]() { leagueSum += teamSum; });
+        },
+        finalSum);
+
+    int firstValue  = 0;
+    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 * n4 - 1);
+    int numValues   = (leagueSize * n0 * n1 * n2 * n3 * n4);
+    int expectedSum = numValues * (firstValue + lastValue) / 2;
+
+    EXPECT_EQ(finalSum, expectedSum);
+  }
+};
+
+}  // namespace MDTeamParallelism
+
+}  // namespace Test
+
+/*--------------------------------------------------------------------------*/
+
+namespace Test {
+
+constexpr auto Left  = Kokkos::Iterate::Left;
+constexpr auto Right = Kokkos::Iterate::Right;
+
+TEST(TEST_CATEGORY, MDTeamParallelFor) {
+  using namespace MDTeamParallelism;
+  // int dims[] = {16, 16, 16, 16, 16, 16, 16, 16};
+  int dims[] = {4, 4, 4, 4, 4, 4, 4, 4};
+
+  const int initValue = 5;
+
+  {
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamThreadRange<Right>(dims, initValue);
+  }
+
+  {
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDThreadVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDThreadVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDThreadVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDThreadVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDThreadVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDThreadVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDThreadVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDThreadVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDThreadVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDThreadVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDThreadVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDThreadVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDThreadVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDThreadVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDThreadVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDThreadVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDThreadVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDThreadVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDThreadVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDThreadVectorRange<Right, Right>(dims, initValue);
+  }
+
+  {
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_3D_MDTeamVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_4D_MDTeamVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_5D_MDTeamVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_6D_MDTeamVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_7D_MDTeamVectorRange<Right, Right>(dims, initValue);
+
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamVectorRange<Left, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamVectorRange<Left, Right>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamVectorRange<Right, Left>(dims, initValue);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::
+        test_parallel_for_8D_MDTeamVectorRange<Right, Right>(dims, initValue);
+  }
+}  // namespace Test
+
+TEST(TEST_CATEGORY, MDTeamParallelReduce) {
+  using namespace MDTeamParallelism;
+  // int dims[] = {16, 16, 16, 16, 16, 16, 16, 16};
+  int dims[]          = {4, 4, 4, 4, 4, 4, 4, 4};
+  const int initValue = 5;
+
+  {
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_3D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_3D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamThreadRange<Right>(dims, initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamThreadRange<Left>(dims, initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamThreadRange<Right>(dims, initValue);
+  }
+
+  {
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Left, Left>(dims,
+                                                                    initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Left, Right>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Right, Left>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDThreadVectorRange<Right, Right>(
+            dims, initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Left, Left>(dims,
+                                                                    initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Left, Right>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Right, Left>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDThreadVectorRange<Right, Right>(
+            dims, initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Left, Left>(dims,
+                                                                    initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Left, Right>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Right, Left>(dims,
+                                                                     initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDThreadVectorRange<Right, Right>(
+            dims, initValue);
+  }
+
+  {
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Left, Left>(dims,
+                                                                  initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Left, Right>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Right, Left>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_MDTeamVectorRange<Right, Right>(dims,
+                                                                    initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Left, Left>(dims,
+                                                                  initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Left, Right>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Right, Left>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_MDTeamVectorRange<Right, Right>(dims,
+                                                                    initValue);
+
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Left, Left>(dims,
+                                                                  initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Left, Right>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Right, Left>(dims,
+                                                                   initValue);
+    TestMDTeamParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_MDTeamVectorRange<Right, Right>(dims,
+                                                                    initValue);
+  }
+}
+
+}  // namespace Test

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -82,6 +82,7 @@ struct FillConstant {
 template <typename ExecSpace>
 struct TestMDTeamParallelFor {
   using DataType = int;
+  using DimsType = int[8];
   using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
   template <typename HostViewType, typename FillFunctor>
@@ -97,7 +98,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_3D_MDTeamThreadRange(int* dims,
+  static void test_parallel_for_3D_MDTeamThreadRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -142,7 +143,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_4D_MDTeamThreadRange(int* dims,
+  static void test_parallel_for_4D_MDTeamThreadRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -191,7 +192,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_5D_MDTeamThreadRange(int* dims,
+  static void test_parallel_for_5D_MDTeamThreadRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -245,7 +246,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_6D_MDTeamThreadRange(int* dims,
+  static void test_parallel_for_6D_MDTeamThreadRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -303,7 +304,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_7D_MDTeamThreadRange(int* dims,
+  static void test_parallel_for_7D_MDTeamThreadRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -364,7 +365,7 @@ struct TestMDTeamParallelFor {
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
-  static void test_parallel_for_8D_MDTeamThreadRange(int* dims,
+  static void test_parallel_for_8D_MDTeamThreadRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -406,7 +407,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_4D_MDThreadVectorRange(int* dims,
+  static void test_parallel_for_4D_MDThreadVectorRange(DimsType const& dims,
                                                        const int initValue) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -445,7 +446,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_5D_MDThreadVectorRange(int* dims,
+  static void test_parallel_for_5D_MDThreadVectorRange(DimsType const& dims,
                                                        const int initValue) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -486,7 +487,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_6D_MDThreadVectorRange(int* dims,
+  static void test_parallel_for_6D_MDThreadVectorRange(DimsType const& dims,
                                                        const int initValue) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -528,7 +529,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_7D_MDThreadVectorRange(int* dims,
+  static void test_parallel_for_7D_MDThreadVectorRange(DimsType const& dims,
                                                        const int initValue) {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -572,7 +573,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_8D_MDThreadVectorRange(int* dims,
+  static void test_parallel_for_8D_MDThreadVectorRange(DimsType const& dims,
                                                        const int initValue) {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -618,7 +619,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_3D_MDTeamVectorRange(int* dims,
+  static void test_parallel_for_3D_MDTeamVectorRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -653,7 +654,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_4D_MDTeamVectorRange(int* dims,
+  static void test_parallel_for_4D_MDTeamVectorRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -689,7 +690,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_5D_MDTeamVectorRange(int* dims,
+  static void test_parallel_for_5D_MDTeamVectorRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -727,7 +728,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_6D_MDTeamVectorRange(int* dims,
+  static void test_parallel_for_6D_MDTeamVectorRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -767,7 +768,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_7D_MDTeamVectorRange(int* dims,
+  static void test_parallel_for_7D_MDTeamVectorRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -808,7 +809,7 @@ struct TestMDTeamParallelFor {
 
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
-  static void test_parallel_for_8D_MDTeamVectorRange(int* dims,
+  static void test_parallel_for_8D_MDTeamVectorRange(DimsType const& dims,
                                                      const int initValue) {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
@@ -853,11 +854,34 @@ struct TestMDTeamParallelFor {
 template <typename ExecSpace>
 struct TestMDTeamParallelReduce {
   using DataType = int;
+  using DimsType = int[8];
   using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+
+  template <typename F>
+  constexpr static auto get_expected_partial_sum(DimsType const& dims, size_t maxRank, F const& f, DimsType& indices, size_t rank) {
+    if(rank == maxRank) {
+      return f(indices[0], indices[1], indices[2], indices[3], indices[4], indices[5], indices[6], indices[7]);
+    } 
+
+    auto& index = indices[rank];
+    DataType accValue = 0;
+    for(index = 0; index < dims[rank]; ++index) {
+      accValue += get_expected_partial_sum(dims, maxRank, f, indices, rank+1);
+    }
+
+    return accValue;
+  }
+
+  template <typename F>
+  static DataType get_expected_sum(DimsType const& dims, size_t maxRank,
+                                   F const& f) {
+    DimsType indices = {};
+    return get_expected_partial_sum(dims, maxRank, f, indices, 0);
+  }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_3D_MDTeamThreadRange(
-      int* dims, const int initValue) {
+      DimsType const& dims, const int initValue) {
     using ViewType = typename Kokkos::View<DataType***, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -895,17 +919,14 @@ struct TestMDTeamParallelReduce {
         },
         finalSum);
 
-    int firstValue  = 0;
-    int lastValue   = (leagueSize * n0 * n1 - 1);
-    int numValues   = (leagueSize * n0 * n1);
-    int expectedSum = numValues * (firstValue + lastValue) / 2;
+    int expectedSum = get_expected_sum(dims, 3, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_4D_MDTeamThreadRange(
-      int* dims, const int initValue) {
+      DimsType const& dims, const int initValue) {
     using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -944,17 +965,14 @@ struct TestMDTeamParallelReduce {
         },
         finalSum);
 
-    int firstValue  = 0;
-    int lastValue   = (leagueSize * n0 * n1 * n2 - 1);
-    int numValues   = (leagueSize * n0 * n1 * n2);
-    int expectedSum = numValues * (firstValue + lastValue) / 2;
+    int expectedSum = get_expected_sum(dims, 4, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_5D_MDTeamThreadRange(
-      int* dims, const int initValue) {
+      DimsType const& dims, const int initValue) {
     using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -994,17 +1012,14 @@ struct TestMDTeamParallelReduce {
         },
         finalSum);
 
-    int firstValue  = 0;
-    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 - 1);
-    int numValues   = (leagueSize * n0 * n1 * n2 * n3);
-    int expectedSum = numValues * (firstValue + lastValue) / 2;
+    int expectedSum = get_expected_sum(dims, 5, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_6D_MDTeamThreadRange(
-      int* dims, const int initValue) {
+      DimsType const& dims, const int initValue) {
     using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1047,10 +1062,7 @@ struct TestMDTeamParallelReduce {
         },
         finalSum);
 
-    int firstValue  = 0;
-    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 * n4 - 1);
-    int numValues   = (leagueSize * n0 * n1 * n2 * n3 * n4);
-    int expectedSum = numValues * (firstValue + lastValue) / 2;
+    int expectedSum = get_expected_sum(dims, 6, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1058,7 +1070,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_4D_MDThreadVectorRange(
-      int* dims, const int initValue) {
+      DimsType const& dims, const int initValue) {
     using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1106,10 +1118,7 @@ struct TestMDTeamParallelReduce {
         },
         finalSum);
 
-    int firstValue  = 0;
-    int lastValue   = (leagueSize * n0 * n1 * n2 - 1);
-    int numValues   = (leagueSize * n0 * n1 * n2);
-    int expectedSum = numValues * (firstValue + lastValue) / 2;
+    int expectedSum = get_expected_sum(dims, 4, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1117,7 +1126,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_5D_MDThreadVectorRange(
-      int* dims, const int initValue) {
+      DimsType const& dims, const int initValue) {
     using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1167,10 +1176,7 @@ struct TestMDTeamParallelReduce {
         },
         finalSum);
 
-    int firstValue  = 0;
-    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 - 1);
-    int numValues   = (leagueSize * n0 * n1 * n2 * n3);
-    int expectedSum = numValues * (firstValue + lastValue) / 2;
+    int expectedSum = get_expected_sum(dims, 5, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1178,7 +1184,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_6D_MDThreadVectorRange(
-      int* dims, const int initValue) {
+      DimsType const& dims, const int initValue) {
     using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1230,10 +1236,7 @@ struct TestMDTeamParallelReduce {
         },
         finalSum);
 
-    int firstValue  = 0;
-    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 * n4 - 1);
-    int numValues   = (leagueSize * n0 * n1 * n2 * n3 * n4);
-    int expectedSum = numValues * (firstValue + lastValue) / 2;
+    int expectedSum = get_expected_sum(dims, 6, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1241,7 +1244,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_4D_MDTeamVectorRange(
-      int* dims, const int initValue) {
+      DimsType const& dims, const int initValue) {
     using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1284,10 +1287,7 @@ struct TestMDTeamParallelReduce {
         },
         finalSum);
 
-    int firstValue  = 0;
-    int lastValue   = (leagueSize * n0 * n1 * n2 - 1);
-    int numValues   = (leagueSize * n0 * n1 * n2);
-    int expectedSum = numValues * (firstValue + lastValue) / 2;
+    int expectedSum = get_expected_sum(dims, 4, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1295,7 +1295,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_5D_MDTeamVectorRange(
-      int* dims, const int initValue) {
+      DimsType const& dims, const int initValue) {
     using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1339,10 +1339,7 @@ struct TestMDTeamParallelReduce {
         },
         finalSum);
 
-    int firstValue  = 0;
-    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 - 1);
-    int numValues   = (leagueSize * n0 * n1 * n2 * n3);
-    int expectedSum = numValues * (firstValue + lastValue) / 2;
+    int expectedSum = get_expected_sum(dims, 5, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1350,7 +1347,7 @@ struct TestMDTeamParallelReduce {
   template <Kokkos::Iterate OuterDirection = Kokkos::Iterate::Default,
             Kokkos::Iterate InnerDirection = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_6D_MDTeamVectorRange(
-      int* dims, const int initValue) {
+      DimsType const& dims, const int initValue) {
     using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
     int leagueSize = dims[0];
@@ -1397,22 +1394,13 @@ struct TestMDTeamParallelReduce {
         },
         finalSum);
 
-    int firstValue  = 0;
-    int lastValue   = (leagueSize * n0 * n1 * n2 * n3 * n4 - 1);
-    int numValues   = (leagueSize * n0 * n1 * n2 * n3 * n4);
-    int expectedSum = numValues * (firstValue + lastValue) / 2;
+    int expectedSum = get_expected_sum(dims, 6, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
 };
 
-}  // namespace MDTeamParallelism
-
-}  // namespace Test
-
 /*--------------------------------------------------------------------------*/
-
-namespace Test {
 
 constexpr auto Left  = Kokkos::Iterate::Left;
 constexpr auto Right = Kokkos::Iterate::Right;
@@ -1420,8 +1408,7 @@ constexpr auto Right = Kokkos::Iterate::Right;
 TEST(TEST_CATEGORY, MDTeamParallelFor) {
   using namespace MDTeamParallelism;
   // int dims[] = {16, 16, 16, 16, 16, 16, 16, 16};
-  int dims[] = {4, 4, 4, 4, 4, 4, 4, 4};
-
+  int dims[]          = {3, 5, 7, 11, 13, 17, 19, 23};
   const int initValue = 5;
 
   {
@@ -1563,7 +1550,7 @@ TEST(TEST_CATEGORY, MDTeamParallelFor) {
 TEST(TEST_CATEGORY, MDTeamParallelReduce) {
   using namespace MDTeamParallelism;
   // int dims[] = {16, 16, 16, 16, 16, 16, 16, 16};
-  int dims[]          = {4, 4, 4, 4, 4, 4, 4, 4};
+  int dims[]          = {3, 5, 7, 11, 13, 17, 19, 23};
   const int initValue = 5;
 
   {
@@ -1671,4 +1658,5 @@ TEST(TEST_CATEGORY, MDTeamParallelReduce) {
   }
 }
 
+}  // namespace MDTeamParallelism
 }  // namespace Test

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -1104,14 +1104,14 @@ struct TestMDTeamParallelReduce {
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
     auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-        {0, 0, 0, 0, 0, 0}, {n0, n1, n2, n3, n4, n5});
+        {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4});
 
     Kokkos::parallel_for(
-        leagueSize, KOKKOS_LAMBDA(const int leagueRank) {
+        mdRangePolicy,
+        KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
+                      const int k, const int l, const int m) {
           Kokkos::parallel_for(
-              mdRangePolicy,
-              KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
-                            const int m, const int n) {
+              n5, KOKKOS_LAMBDA(const int n) {
                 v(leagueRank, i, j, k, l, m, n) =
                     fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
               });
@@ -1162,19 +1162,19 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
                                           n6);
     auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-        {0, 0, 0, 0, 0, 0}, {n1, n2, n3, n4, n5, n6});
+        {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4});
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>>({0, 0},
-                                                          {leagueSize, n0}),
-
-        KOKKOS_LAMBDA(const int leagueRank, const int i) {
+        mdRangePolicy,
+        KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
+                      const int k, const int l, const int m) {
           Kokkos::parallel_for(
-              mdRangePolicy,
-              KOKKOS_LAMBDA(const int j, const int k, const int l, const int m,
-                            const int n, const int o) {
-                v(leagueRank, i, j, k, l, m, n, o) =
-                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+              n5, KOKKOS_LAMBDA(const int n) {
+                Kokkos::parallel_for(
+                    n6, KOKKOS_LAMBDA(const int o) {
+                      v(leagueRank, i, j, k, l, m, n, o) =
+                          fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+                    });
               });
         });
 
@@ -1393,14 +1393,14 @@ struct TestMDTeamParallelReduce {
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
     auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-        {0, 0, 0, 0, 0, 0}, {n0, n1, n2, n3, n4, n5});
+        {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4});
 
     Kokkos::parallel_for(
-        leagueSize, KOKKOS_LAMBDA(const int leagueRank) {
+        mdRangePolicy,
+        KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
+                      const int k, const int l, const int m) {
           Kokkos::parallel_for(
-              mdRangePolicy,
-              KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
-                            const int m, const int n) {
+              n5, KOKKOS_LAMBDA(const int n) {
                 v(leagueRank, i, j, k, l, m, n) =
                     fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
               });
@@ -1460,18 +1460,19 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
                                           n6);
     auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-        {0, 0, 0, 0, 0, 0}, {n1, n2, n3, n4, n5, n6});
+        {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4});
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>>({0, 0},
-                                                          {leagueSize, n0}),
-        KOKKOS_LAMBDA(const int leagueRank, const int i) {
+        mdRangePolicy,
+        KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
+                      const int k, const int l, const int m) {
           Kokkos::parallel_for(
-              mdRangePolicy,
-              KOKKOS_LAMBDA(const int j, const int k, const int l, const int m,
-                            const int n, const int o) {
-                v(leagueRank, i, j, k, l, m, n, o) =
-                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+              n5, KOKKOS_LAMBDA(const int n) {
+                Kokkos::parallel_for(
+                    n6, KOKKOS_LAMBDA(const int o) {
+                      v(leagueRank, i, j, k, l, m, n, o) =
+                          fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+                    });
               });
         });
 
@@ -1682,14 +1683,14 @@ struct TestMDTeamParallelReduce {
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
     auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-        {0, 0, 0, 0, 0, 0}, {n0, n1, n2, n3, n4, n5});
+        {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4});
 
     Kokkos::parallel_for(
-        leagueSize, KOKKOS_LAMBDA(const int leagueRank) {
+        mdRangePolicy,
+        KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
+                      const int k, const int l, const int m) {
           Kokkos::parallel_for(
-              mdRangePolicy,
-              KOKKOS_LAMBDA(const int i, const int j, const int k, const int l,
-                            const int m, const int n) {
+              n5, KOKKOS_LAMBDA(const int n) {
                 v(leagueRank, i, j, k, l, m, n) =
                     fillFlattenedIndex(leagueRank, i, j, k, l, m, n);
               });
@@ -1744,18 +1745,19 @@ struct TestMDTeamParallelReduce {
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
                                           n6);
     auto mdRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>(
-        {0, 0, 0, 0, 0, 0}, {n1, n2, n3, n4, n5, n6});
+        {0, 0, 0, 0, 0, 0}, {leagueSize, n0, n1, n2, n3, n4});
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<2>>({0, 0},
-                                                          {leagueSize, n0}),
-        KOKKOS_LAMBDA(const int leagueRank, const int i) {
+        mdRangePolicy,
+        KOKKOS_LAMBDA(const int leagueRank, const int i, const int j,
+                      const int k, const int l, const int m) {
           Kokkos::parallel_for(
-              mdRangePolicy,
-              KOKKOS_LAMBDA(const int j, const int k, const int l, const int m,
-                            const int n, const int o) {
-                v(leagueRank, i, j, k, l, m, n, o) =
-                    fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+              n5, KOKKOS_LAMBDA(const int n) {
+                Kokkos::parallel_for(
+                    n6, KOKKOS_LAMBDA(const int o) {
+                      v(leagueRank, i, j, k, l, m, n, o) =
+                          fillFlattenedIndex(leagueRank, i, j, k, l, m, n, o);
+                    });
               });
         });
 
@@ -1788,7 +1790,7 @@ struct TestMDTeamParallelReduce {
 
     EXPECT_EQ(finalSum, expectedSum);
   }
-};
+};  // namespace MDTeamParallelism
 
 /*--------------------------------------------------------------------------*/
 

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -813,9 +813,9 @@ struct TestMDTeamParallelFor {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
     using HostViewType = typename ViewType::HostMirror;
 
-    int n0         = dims[0];
-    int n1         = dims[1];
-    int n2         = dims[2];
+    int n0 = dims[0];
+    int n1 = dims[1];
+    int n2 = dims[2];
 
     ViewType v("v", n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(n0, n1, n2);

--- a/core/unit_test/TestMDTeamParallelism.hpp
+++ b/core/unit_test/TestMDTeamParallelism.hpp
@@ -1560,6 +1560,8 @@ TEST(TEST_CATEGORY, MDTeamParallelFor) {
   {
     TestMDTeamParallelFor<TEST_EXECSPACE>::test_parallel_single_direction_test<
         Left>(dims);
+    TestMDTeamParallelFor<TEST_EXECSPACE>::test_parallel_single_direction_test<
+        Right>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::test_parallel_double_direction_test<
         Left, Left>(dims);
     TestMDTeamParallelFor<TEST_EXECSPACE>::test_parallel_double_direction_test<

--- a/core/unit_test/serial/TestSerial_MDTeamParallelism.cpp
+++ b/core/unit_test/serial/TestSerial_MDTeamParallelism.cpp
@@ -1,0 +1,47 @@
+
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <TestSerial_Category.hpp>
+#include <TestMDTeamParallelism.hpp>


### PR DESCRIPTION
Motivation: #3385 

Implementation for MD TeamPolicy for Serial backend. This includes infrastructures and tests needed for all backends.
This adds parallel_for and parallel_reduce support for MDTeamThreadRange, MDThreadVectorRange and MDTeamVectorRange.

Added in directional supports:
MDTeamThreadRange is single directional
MDThreadVectorRange and MDTeamVectorRange have outer and inner directions

@nliber 