### PR TITLE
Remove duplicate `KOKKOS_IMPL_{HOST,DEVICE}_FUNCTION` macro definitions with CUDA

### DIFF
--- a/core/src/setup/Kokkos_Setup_Cuda.hpp
+++ b/core/src/setup/Kokkos_Setup_Cuda.hpp
@@ -125,8 +125,6 @@
 #else
 #define KOKKOS_DEFAULTED_FUNCTION inline
 #endif
-#define KOKKOS_IMPL_HOST_FUNCTION __host__
-#define KOKKOS_IMPL_DEVICE_FUNCTION __device__
 
 #if (CUDA_VERSION >= 10000)
 #define KOKKOS_CUDA_ENABLE_GRAPHS


### PR DESCRIPTION
They are unconditionally defined here
https://github.com/dalg24/kokkos/blob/bdb84be146cb74c2d7bdfd15f108e3ee5bce19ba/core/src/setup/Kokkos_Setup_Cuda.hpp#L116-L117