### PR TITLE
Implement desired fence behavior for view initialization

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1152,7 +1152,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
     Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
         prop_copy,
         Impl::DynRankDimTraits<typename traits::specialize>::
-            template createLayout<traits, P...>(arg_prop, arg_layout));
+            template createLayout<traits, P...>(arg_prop, arg_layout),
+        Impl::ViewCtorProp<P...>::has_execution_space);
 
 //------------------------------------------------------------
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1214,8 +1214,9 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
 #endif
     //------------------------------------------------------------
 
-    Kokkos::Impl::SharedAllocationRecord<>* record =
-        m_map.allocate_shared(prop_copy, arg_layout);
+    Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
+        prop_copy, arg_layout,
+        Kokkos::Impl::ViewCtorProp<P...>::has_execution_space);
 
     //------------------------------------------------------------
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1552,8 +1552,8 @@ class View : public ViewTraits<DataType, Properties...> {
 #endif
     //------------------------------------------------------------
 
-    Kokkos::Impl::SharedAllocationRecord<>* record =
-        m_map.allocate_shared(prop_copy, arg_layout);
+    Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
+        prop_copy, arg_layout, Impl::ViewCtorProp<P...>::has_execution_space);
 
 //------------------------------------------------------------
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2860,6 +2860,7 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
   size_t n;
   bool destroy;
   std::string name;
+  bool default_exec_space;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const size_t i) const {
@@ -2882,7 +2883,17 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
         ptr(arg_ptr),
         n(arg_n),
         destroy(false),
-        name(std::move(arg_name)) {}
+        name(std::move(arg_name)),
+        default_exec_space(false) {}
+
+  ViewValueFunctor(ValueType* const arg_ptr, size_t const arg_n,
+                   std::string arg_name)
+      : space(ExecSpace{}),
+        ptr(arg_ptr),
+        n(arg_n),
+        destroy(false),
+        name(std::move(arg_name)),
+        default_exec_space(true) {}
 
   template <typename Dummy = ValueType>
   std::enable_if_t<std::is_trivial<Dummy>::value &&
@@ -2947,7 +2958,8 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
       const Kokkos::Impl::ParallelFor<ViewValueFunctor, PolicyType> closure(
           *this, policy);
       closure.execute();
-      space.fence("Kokkos::Impl::ViewValueFunctor: View init/destroy fence");
+      if (default_exec_space || destroy)
+        space.fence("Kokkos::Impl::ViewValueFunctor: View init/destroy fence");
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);
       }
@@ -2970,6 +2982,7 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
   ValueType* ptr;
   size_t n;
   std::string name;
+  bool default_exec_space;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const size_t i) const { ptr[i] = ValueType(); }
@@ -2981,6 +2994,10 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
   ViewValueFunctor(ExecSpace const& arg_space, ValueType* const arg_ptr,
                    size_t const arg_n, std::string arg_name)
       : space(arg_space), ptr(arg_ptr), n(arg_n), name(std::move(arg_name)) {}
+
+  ViewValueFunctor(ValueType* const arg_ptr, size_t const arg_n,
+                   std::string arg_name)
+      : space(ExecSpace{}), ptr(arg_ptr), n(arg_n), name(std::move(arg_name)) {}
 
   template <typename Dummy = ValueType>
   std::enable_if_t<std::is_trivial<Dummy>::value &&
@@ -3041,8 +3058,10 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
       const Kokkos::Impl::ParallelFor<ViewValueFunctor, PolicyType> closure(
           *this, PolicyType(0, n));
       closure.execute();
-      space.fence(
-          "Kokkos::Impl::ViewValueFunctor: Fence after setting values in view");
+      if (default_exec_space)
+        space.fence(
+            "Kokkos::Impl::ViewValueFunctor: Fence after setting values in "
+            "view");
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);
       }
@@ -3331,7 +3350,8 @@ class ViewMapping<
   template <class... P>
   Kokkos::Impl::SharedAllocationRecord<>* allocate_shared(
       Kokkos::Impl::ViewCtorProp<P...> const& arg_prop,
-      typename Traits::array_layout const& arg_layout) {
+      typename Traits::array_layout const& arg_layout,
+      bool execution_space_specified) {
     using alloc_prop = Kokkos::Impl::ViewCtorProp<P...>;
 
     using execution_space = typename alloc_prop::execution_space;
@@ -3374,11 +3394,17 @@ class ViewMapping<
       // Assume destruction is only required when construction is requested.
       // The ViewValueFunctor has both value construction and destruction
       // operators.
-      record->m_destroy = functor_type(
-          static_cast<Kokkos::Impl::ViewCtorProp<void, execution_space> const&>(
-              arg_prop)
-              .value,
-          (value_type*)m_impl_handle, m_impl_offset.span(), alloc_name);
+      if (execution_space_specified) {
+        record->m_destroy = functor_type(
+            static_cast<
+                Kokkos::Impl::ViewCtorProp<void, execution_space> const&>(
+                arg_prop)
+                .value,
+            (value_type*)m_impl_handle, m_impl_offset.span(), alloc_name);
+      } else {
+        record->m_destroy = functor_type((value_type*)m_impl_handle,
+                                         m_impl_offset.span(), alloc_name);
+      }
 
       // Construct values
       record->m_destroy.construct_shared_allocation();

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2993,11 +2993,19 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
 
   ViewValueFunctor(ExecSpace const& arg_space, ValueType* const arg_ptr,
                    size_t const arg_n, std::string arg_name)
-      : space(arg_space), ptr(arg_ptr), n(arg_n), name(std::move(arg_name)) {}
+      : space(arg_space),
+        ptr(arg_ptr),
+        n(arg_n),
+        name(std::move(arg_name)),
+        default_exec_space(false) {}
 
   ViewValueFunctor(ValueType* const arg_ptr, size_t const arg_n,
                    std::string arg_name)
-      : space(ExecSpace{}), ptr(arg_ptr), n(arg_n), name(std::move(arg_name)) {}
+      : space(ExecSpace{}),
+        ptr(arg_ptr),
+        n(arg_n),
+        name(std::move(arg_name)),
+        default_exec_space(true) {}
 
   template <typename Dummy = ValueType>
   std::enable_if_t<std::is_trivial<Dummy>::value &&

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2922,6 +2922,8 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);
       }
+      if (default_exec_space)
+        space.fence("Kokkos::Impl::ViewValueFunctor: View init/destroy fence");
     } else {
       parallel_for_implementation(false);
     }
@@ -3035,6 +3037,8 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);
       }
+      if (default_exec_space)
+        space.fence("Kokkos::Impl::ViewValueFunctor: View init/destroy fence");
     } else {
       parallel_for_implementation();
     }

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -198,6 +198,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
       ViewResize
       View_64bit
       WorkGraph
+      WithoutInitializing
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
@@ -265,7 +266,6 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
       SubView_c12
       SubView_c13
       SubView_c14
-      WithoutInitializing
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -172,7 +172,7 @@ TEST(TEST_CATEGORY, view_alloc_int) {
   using view_type = Kokkos::View<int*, TEST_EXECSPACE>;
   view_type outer_view;
 
-  auto success = validate_absence(
+  auto success = validate_existence(
       [&]() {
         view_type inner_view("bla", 8);
         // Avoid testing the destructor

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -96,3 +96,187 @@ TEST(TEST_CATEGORY, resize_realloc_no_alloc) {
   ASSERT_TRUE(success);
   listen_tool_events(Config::DisableAll());
 }
+
+namespace {
+struct NonTriviallyCopyable {
+  KOKKOS_FUNCTION NonTriviallyCopyable() {}
+  KOKKOS_FUNCTION NonTriviallyCopyable(const NonTriviallyCopyable&) {}
+};
+}  // namespace
+
+TEST(TEST_CATEGORY, view_alloc) {
+#ifdef KOKKOS_ENABLE_CUDA
+  if (std::is_same<typename TEST_EXECSPACE::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
+#endif
+
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableFences());
+  using view_type = Kokkos::View<NonTriviallyCopyable*, TEST_EXECSPACE>;
+  view_type outer_view;
+
+  if (Kokkos::Impl::MemorySpaceAccess<typename TEST_EXECSPACE::memory_space,
+                                      Kokkos::HostSpace>::accessible) {
+    auto success = validate_event_set(
+        [&]() {
+          view_type inner_view(Kokkos::view_alloc("bla"), 8);
+          // Avoid testing the destructor
+          outer_view = inner_view;
+        },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "Kokkos::Impl::ViewValueFunctor: View init/destroy fence") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; });
+    ASSERT_TRUE(success);
+  } else {
+    auto success = validate_event_set(
+        [&]() {
+          view_type inner_view(Kokkos::view_alloc("bla"), 8);
+          // Avoid testing the destructor
+          outer_view = inner_view;
+        },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "fence after copying header from HostSpace") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "Kokkos::Impl::ViewValueFunctor: View init/destroy fence") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; });
+    ASSERT_TRUE(success);
+  }
+  listen_tool_events(Config::DisableAll());
+}
+
+TEST(TEST_CATEGORY, view_alloc_exec_space) {
+#ifdef KOKKOS_ENABLE_CUDA
+  if (std::is_same<typename TEST_EXECSPACE::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
+#endif
+
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableFences());
+  using view_type = Kokkos::View<NonTriviallyCopyable*, TEST_EXECSPACE>;
+  view_type outer_view;
+
+  if (Kokkos::Impl::MemorySpaceAccess<typename TEST_EXECSPACE::memory_space,
+                                      Kokkos::HostSpace>::accessible) {
+    auto success = validate_event_set([&]() {
+      view_type inner_view(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
+      // Avoid testing the destructor
+      outer_view = inner_view;
+    });
+    ASSERT_TRUE(success);
+  } else {
+    auto success = validate_event_set(
+        [&]() {
+          view_type inner_view(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
+          // Avoid testing the destructor
+          outer_view = inner_view;
+        },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "fence after copying header from HostSpace") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; });
+    ASSERT_TRUE(success);
+  }
+  listen_tool_events(Config::DisableAll());
+}
+
+TEST(TEST_CATEGORY, view_alloc_int) {
+#ifdef KOKKOS_ENABLE_CUDA
+  if (std::is_same<typename TEST_EXECSPACE::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
+#endif
+
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableFences());
+  using view_type = Kokkos::View<int*, TEST_EXECSPACE>;
+  view_type outer_view;
+
+  if (Kokkos::Impl::MemorySpaceAccess<typename TEST_EXECSPACE::memory_space,
+                                      Kokkos::HostSpace>::accessible) {
+    auto success = validate_event_set([&]() {
+      view_type inner_view("bla", 8);
+      // Avoid testing the destructor
+      outer_view = inner_view;
+    });
+    ASSERT_TRUE(success);
+  } else {
+    auto success = validate_event_set(
+        [&]() {
+          view_type inner_view("bla", 8);
+          // Avoid testing the destructor
+          outer_view = inner_view;
+        },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "fence after copying header from HostSpace") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; });
+    ASSERT_TRUE(success);
+  }
+  listen_tool_events(Config::DisableAll());
+}
+
+TEST(TEST_CATEGORY, view_alloc_exec_space_int) {
+#ifdef KOKKOS_ENABLE_CUDA
+  if (std::is_same<typename TEST_EXECSPACE::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
+#endif
+
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableFences());
+  using view_type = Kokkos::View<int*, TEST_EXECSPACE>;
+  view_type outer_view;
+
+  if (Kokkos::Impl::MemorySpaceAccess<typename TEST_EXECSPACE::memory_space,
+                                      Kokkos::HostSpace>::accessible) {
+    auto success = validate_event_set([&]() {
+      view_type inner_view(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
+      // Avoid testing the destructor
+      outer_view = inner_view;
+    });
+    ASSERT_TRUE(success);
+  } else {
+    auto success = validate_event_set(
+        [&]() {
+          view_type inner_view(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
+          // Avoid testing the destructor
+          outer_view = inner_view;
+        },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "fence after copying header from HostSpace") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; });
+    ASSERT_TRUE(success);
+  }
+  listen_tool_events(Config::DisableAll());
+}

--- a/core/unit_test/tools/include/ToolTestingUtilities.hpp
+++ b/core/unit_test/tools/include/ToolTestingUtilities.hpp
@@ -1300,6 +1300,24 @@ bool validate_absence(const Lambda& lam, const Matchers... matchers) {
   return true;
 }
 
+template <class Lambda, class Matcher>
+bool validate_existence(const Lambda& lam, const Matcher matcher) {
+  // First, erase events from previous invocations
+  found_events.clear();
+  // Invoke the lambda (this will populate found_events, via tooling)
+  lam();
+  // compare the found events against the expected ones
+  for (const auto& event : found_events) {
+    MatchDiagnostic match = check_presence_of(event, matcher);
+
+    if (match.success) return true;
+  }
+  std::cout << "Test failure: Didn't encounter wanted events" << std::endl;
+  for (const auto& p_event : found_events)
+    std::cout << p_event->descriptor() << std::endl;
+  return false;
+}
+
 }  // namespace Tools
 }  // namespace Test
 }  // namespace Kokkos


### PR DESCRIPTION
Fixes #4697 (I already documented the behavior in the Wiki).
Note that `ZeroMemset` branch currently doesn't call any Kokkos `fence` already no matter if we are providing an execution space or not. The `Kokkos::View` initialization already only fenced the given (or default) execution space and this pull request only removes the fence if an execution space is explicitly specified.