### PR TITLE
Implement desired fence behavior for view initialization

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1152,7 +1152,8 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
     Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
         prop_copy,
         Impl::DynRankDimTraits<typename traits::specialize>::
-            template createLayout<traits, P...>(arg_prop, arg_layout));
+            template createLayout<traits, P...>(arg_prop, arg_layout),
+        Impl::ViewCtorProp<P...>::has_execution_space);
 
 //------------------------------------------------------------
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1214,8 +1214,9 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
 #endif
     //------------------------------------------------------------
 
-    Kokkos::Impl::SharedAllocationRecord<>* record =
-        m_map.allocate_shared(prop_copy, arg_layout);
+    Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
+        prop_copy, arg_layout,
+        Kokkos::Impl::ViewCtorProp<P...>::has_execution_space);
 
     //------------------------------------------------------------
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -98,6 +98,10 @@ class CudaSpace {
   ~CudaSpace()                               = default;
 
   /**\brief  Allocate untracked memory in the cuda space */
+  void* allocate(const Cuda& exec_space, const size_t arg_alloc_size) const;
+  void* allocate(const Cuda& exec_space, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const;
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
@@ -111,6 +115,11 @@ class CudaSpace {
  private:
   template <class, class, class, class>
   friend class Kokkos::Experimental::LogicalMemorySpace;
+  void* impl_allocate(const Cuda& exec_space, const char* arg_label,
+                      const size_t arg_alloc_size,
+                      const size_t arg_logical_size = 0,
+                      const Kokkos::Tools::SpaceHandle =
+                          Kokkos::Tools::make_space_handle(name())) const;
   void* impl_allocate(const char* arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,
                       const Kokkos::Tools::SpaceHandle =
@@ -181,6 +190,11 @@ class CudaUVMSpace {
   ~CudaUVMSpace()                                  = default;
 
   /**\brief  Allocate untracked memory in the cuda space */
+  void* allocate(const Cuda& exec_space, const size_t arg_alloc_size) const;
+  void* allocate(const Cuda& exec_space, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const;
+
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
@@ -255,6 +269,10 @@ class CudaHostPinnedSpace {
   ~CudaHostPinnedSpace()                                         = default;
 
   /**\brief  Allocate untracked memory in the space */
+  void* allocate(const Cuda&, const size_t arg_alloc_size) const;
+  void* allocate(const Cuda&, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const;
   void* allocate(const size_t arg_alloc_size) const;
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
                  const size_t arg_logical_size = 0) const;
@@ -575,6 +593,11 @@ class SharedAllocationRecord<Kokkos::CudaSpace, void>
   SharedAllocationRecord() = default;
 
   SharedAllocationRecord(
+      const Kokkos::Cuda& exec_space, const Kokkos::CudaSpace& arg_space,
+      const std::string& arg_label, const size_t arg_alloc_size,
+      const RecordBase::function_type arg_dealloc = &base_t::deallocate);
+
+  SharedAllocationRecord(
       const Kokkos::CudaSpace& arg_space, const std::string& arg_label,
       const size_t arg_alloc_size,
       const RecordBase::function_type arg_dealloc = &base_t::deallocate);
@@ -624,6 +647,11 @@ class SharedAllocationRecord<Kokkos::CudaUVMSpace, void>
  protected:
   ~SharedAllocationRecord();
   SharedAllocationRecord() = default;
+
+  SharedAllocationRecord(
+      const Kokkos::Cuda& exec_space, const Kokkos::CudaUVMSpace& arg_space,
+      const std::string& arg_label, const size_t arg_alloc_size,
+      const RecordBase::function_type arg_dealloc = &base_t::deallocate);
 
   SharedAllocationRecord(
       const Kokkos::CudaUVMSpace& arg_space, const std::string& arg_label,
@@ -677,9 +705,15 @@ class SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>
   SharedAllocationRecord() = default;
 
   SharedAllocationRecord(
+      const Kokkos::Cuda& exec_space,
       const Kokkos::CudaHostPinnedSpace& arg_space,
       const std::string& arg_label, const size_t arg_alloc_size,
-      const RecordBase::function_type arg_dealloc = &deallocate);
+      const RecordBase::function_type arg_dealloc = &base_t::deallocate);
+
+  SharedAllocationRecord(
+      const Kokkos::CudaHostPinnedSpace& arg_space,
+      const std::string& arg_label, const size_t arg_alloc_size,
+      const RecordBase::function_type arg_dealloc = &base_t::deallocate);
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -60,6 +60,7 @@
 #include <impl/Kokkos_Tools.hpp>
 
 #include "impl/Kokkos_HostSpace_deepcopy.hpp"
+#include <impl/Kokkos_MemorySpace.hpp>
 
 /*--------------------------------------------------------------------------*/
 
@@ -138,9 +139,25 @@ class HostSpace {
   explicit HostSpace(const AllocationMechanism&);
 
   /**\brief  Allocate untracked memory in the space */
-  void* allocate(const size_t arg_alloc_size) const;
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace& exec_space,
+                 const size_t arg_alloc_size) const {
+    return allocate(exec_space, "[unlabeled]", arg_alloc_size);
+  }
+  template <typename ExecutionSpace>
+  void* allocate(const ExecutionSpace& exec_space, const char* arg_label,
+                 const size_t arg_alloc_size,
+                 const size_t arg_logical_size = 0) const {
+    return impl_allocate(/*exec_space, */ arg_label, arg_alloc_size,
+                         arg_logical_size);
+  }
+  void* allocate(const size_t arg_alloc_size) const {
+    return allocate("[unlabeled]", arg_alloc_size);
+  }
   void* allocate(const char* arg_label, const size_t arg_alloc_size,
-                 const size_t arg_logical_size = 0) const;
+                 const size_t arg_logical_size = 0) const {
+    return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
+  }
 
   /**\brief  Deallocate untracked memory in the space */
   void deallocate(void* const arg_alloc_ptr, const size_t arg_alloc_size) const;
@@ -252,12 +269,41 @@ class SharedAllocationRecord<Kokkos::HostSpace, void>
       ;
   SharedAllocationRecord() = default;
 
+  template <typename ExecutionSpace>
+  SharedAllocationRecord(
+      const ExecutionSpace& exec_space, const Kokkos::HostSpace& arg_space,
+      const std::string& arg_label, const size_t arg_alloc_size,
+      const RecordBase::function_type arg_dealloc = &deallocate)
+      : base_t(
+#ifdef KOKKOS_ENABLE_DEBUG
+            &SharedAllocationRecord<Kokkos::HostSpace, void>::s_root_record,
+#endif
+            Impl::checked_allocation_with_header(exec_space, arg_space,
+                                                 arg_label, arg_alloc_size),
+            sizeof(SharedAllocationHeader) + arg_alloc_size, arg_dealloc,
+            arg_label),
+        m_space(arg_space) {
+    this->base_t::_fill_host_accessible_header_info(*RecordBase::m_alloc_ptr,
+                                                    arg_label);
+  }
+
   SharedAllocationRecord(
       const Kokkos::HostSpace& arg_space, const std::string& arg_label,
       const size_t arg_alloc_size,
       const RecordBase::function_type arg_dealloc = &deallocate);
 
  public:
+  template <typename ExecutionSpace>
+  KOKKOS_INLINE_FUNCTION static SharedAllocationRecord* allocate(
+      const ExecutionSpace& exec_space, const Kokkos::HostSpace& arg_space,
+      const std::string& arg_label, const size_t arg_alloc_size) {
+    KOKKOS_IF_ON_HOST(
+        (return new SharedAllocationRecord(exec_space, arg_space, arg_label,
+                                           arg_alloc_size);))
+    KOKKOS_IF_ON_DEVICE(((void)arg_space; (void)arg_label; (void)arg_alloc_size;
+                         return nullptr;))
+  }
+
   KOKKOS_INLINE_FUNCTION static SharedAllocationRecord* allocate(
       const Kokkos::HostSpace& arg_space, const std::string& arg_label,
       const size_t arg_alloc_size) {

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1552,8 +1552,8 @@ class View : public ViewTraits<DataType, Properties...> {
 #endif
     //------------------------------------------------------------
 
-    Kokkos::Impl::SharedAllocationRecord<>* record =
-        m_map.allocate_shared(prop_copy, arg_layout);
+    Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
+        prop_copy, arg_layout, Impl::ViewCtorProp<P...>::has_execution_space);
 
 //------------------------------------------------------------
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -162,15 +162,6 @@ HostSpace::HostSpace(const HostSpace::AllocationMechanism &arg_alloc_mech)
   }
 }
 
-void *HostSpace::allocate(const size_t arg_alloc_size) const {
-  return allocate("[unlabeled]", arg_alloc_size);
-}
-void *HostSpace::allocate(const char *arg_label, const size_t arg_alloc_size,
-                          const size_t
-
-                              arg_logical_size) const {
-  return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
-}
 void *HostSpace::impl_allocate(
     const char *arg_label, const size_t arg_alloc_size,
     const size_t arg_logical_size,

--- a/core/src/impl/Kokkos_MemorySpace.hpp
+++ b/core/src/impl/Kokkos_MemorySpace.hpp
@@ -78,6 +78,20 @@ SharedAllocationHeader *checked_allocation_with_header(MemorySpace const &space,
   return nullptr;  // unreachable
 }
 
+template <class ExecutionSpace, class MemorySpace>
+SharedAllocationHeader *checked_allocation_with_header(
+    ExecutionSpace const &exec_space, MemorySpace const &space,
+    std::string const &label, size_t alloc_size) {
+  try {
+    return reinterpret_cast<SharedAllocationHeader *>(space.allocate(
+        exec_space, label.c_str(), alloc_size + sizeof(SharedAllocationHeader),
+        alloc_size));
+  } catch (Kokkos::Experimental::RawMemoryAllocationFailure const &failure) {
+    safe_throw_allocation_with_header_failure(space.name(), label, failure);
+  }
+  return nullptr;  // unreachable
+}
+
 }  // end namespace Impl
 }  // end namespace Kokkos
 

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -302,6 +302,16 @@ template <class MemorySpace, class DestroyFunctor>
 class SharedAllocationRecord
     : public SharedAllocationRecord<MemorySpace, void> {
  private:
+  template <typename ExecutionSpace>
+  SharedAllocationRecord(const ExecutionSpace& exec_space,
+                         const MemorySpace& arg_space,
+                         const std::string& arg_label, const size_t arg_alloc)
+      /*  Allocate user memory as [ SharedAllocationHeader , user_memory ] */
+      : SharedAllocationRecord<MemorySpace, void>(
+            exec_space, arg_space, arg_label, arg_alloc,
+            &Kokkos::Impl::deallocate<MemorySpace, DestroyFunctor>),
+        m_destroy() {}
+
   SharedAllocationRecord(const MemorySpace& arg_space,
                          const std::string& arg_label, const size_t arg_alloc)
       /*  Allocate user memory as [ SharedAllocationHeader , user_memory ] */
@@ -325,6 +335,17 @@ class SharedAllocationRecord
       const size_t arg_alloc) {
     KOKKOS_IF_ON_HOST(
         (return new SharedAllocationRecord(arg_space, arg_label, arg_alloc);))
+    KOKKOS_IF_ON_DEVICE(
+        ((void)arg_space; (void)arg_label; (void)arg_alloc; return nullptr;))
+  }
+
+  template <typename ExecutionSpace>
+  KOKKOS_INLINE_FUNCTION static SharedAllocationRecord* allocate(
+      const ExecutionSpace& exec_space, const MemorySpace& arg_space,
+      const std::string& arg_label, const size_t arg_alloc) {
+    KOKKOS_IF_ON_HOST(
+        (return new SharedAllocationRecord(exec_space, arg_space, arg_label,
+                                           arg_alloc);))
     KOKKOS_IF_ON_DEVICE(
         ((void)arg_space; (void)arg_label; (void)arg_alloc; return nullptr;))
   }

--- a/core/src/impl/Kokkos_ViewArray.hpp
+++ b/core/src/impl/Kokkos_ViewArray.hpp
@@ -374,8 +374,13 @@ class ViewMapping<Traits, Kokkos::Array<>> {
         static_cast<Kokkos::Impl::ViewCtorProp<void, std::string> const &>(
             arg_prop)
             .value;
+    const execution_space &exec_space =
+        static_cast<Kokkos::Impl::ViewCtorProp<void, execution_space> const &>(
+            arg_prop)
+            .value;
     // Allocate memory from the memory space and create tracking record.
     record_type *const record = record_type::allocate(
+        exec_space,
         static_cast<Kokkos::Impl::ViewCtorProp<void, memory_space> const &>(
             arg_prop)
             .value,
@@ -388,13 +393,9 @@ class ViewMapping<Traits, Kokkos::Array<>> {
       if (alloc_prop::initialize) {
         // The functor constructs and destroys
         if (execution_space_specified)
-          record->m_destroy = functor_type(
-              static_cast<
-                  Kokkos::Impl::ViewCtorProp<void, execution_space> const &>(
-                  arg_prop)
-                  .value,
-              (pointer_type)m_impl_handle, m_impl_offset.span() * Array_N,
-              alloc_name);
+          record->m_destroy =
+              functor_type(exec_space, (pointer_type)m_impl_handle,
+                           m_impl_offset.span() * Array_N, alloc_name);
         else
           record->m_destroy =
               functor_type((pointer_type)m_impl_handle,

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -3378,9 +3378,14 @@ class ViewMapping<
         static_cast<Kokkos::Impl::ViewCtorProp<void, std::string> const&>(
             arg_prop)
             .value;
+    const execution_space& exec_space =
+        static_cast<Kokkos::Impl::ViewCtorProp<void, execution_space> const&>(
+            arg_prop)
+            .value;
     // Create shared memory tracking record with allocate memory from the memory
     // space
     record_type* const record = record_type::allocate(
+        exec_space,
         static_cast<Kokkos::Impl::ViewCtorProp<void, memory_space> const&>(
             arg_prop)
             .value,
@@ -3395,12 +3400,8 @@ class ViewMapping<
       // The ViewValueFunctor has both value construction and destruction
       // operators.
       if (execution_space_specified) {
-        record->m_destroy = functor_type(
-            static_cast<
-                Kokkos::Impl::ViewCtorProp<void, execution_space> const&>(
-                arg_prop)
-                .value,
-            (value_type*)m_impl_handle, m_impl_offset.span(), alloc_name);
+        record->m_destroy = functor_type(exec_space, (value_type*)m_impl_handle,
+                                         m_impl_offset.span(), alloc_name);
       } else {
         record->m_destroy = functor_type((value_type*)m_impl_handle,
                                          m_impl_offset.span(), alloc_name);

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2860,6 +2860,7 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
   size_t n;
   bool destroy;
   std::string name;
+  bool default_exec_space;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const size_t i) const {
@@ -2882,7 +2883,17 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
         ptr(arg_ptr),
         n(arg_n),
         destroy(false),
-        name(std::move(arg_name)) {}
+        name(std::move(arg_name)),
+        default_exec_space(false) {}
+
+  ViewValueFunctor(ValueType* const arg_ptr, size_t const arg_n,
+                   std::string arg_name)
+      : space(ExecSpace{}),
+        ptr(arg_ptr),
+        n(arg_n),
+        destroy(false),
+        name(std::move(arg_name)),
+        default_exec_space(true) {}
 
   template <typename Dummy = ValueType>
   std::enable_if_t<std::is_trivial<Dummy>::value &&
@@ -2947,7 +2958,8 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
       const Kokkos::Impl::ParallelFor<ViewValueFunctor, PolicyType> closure(
           *this, policy);
       closure.execute();
-      space.fence("Kokkos::Impl::ViewValueFunctor: View init/destroy fence");
+      if (default_exec_space || destroy)
+        space.fence("Kokkos::Impl::ViewValueFunctor: View init/destroy fence");
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);
       }
@@ -2970,6 +2982,7 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
   ValueType* ptr;
   size_t n;
   std::string name;
+  bool default_exec_space;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const size_t i) const { ptr[i] = ValueType(); }
@@ -2981,6 +2994,10 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
   ViewValueFunctor(ExecSpace const& arg_space, ValueType* const arg_ptr,
                    size_t const arg_n, std::string arg_name)
       : space(arg_space), ptr(arg_ptr), n(arg_n), name(std::move(arg_name)) {}
+
+  ViewValueFunctor(ValueType* const arg_ptr, size_t const arg_n,
+                   std::string arg_name)
+      : space(ExecSpace{}), ptr(arg_ptr), n(arg_n), name(std::move(arg_name)) {}
 
   template <typename Dummy = ValueType>
   std::enable_if_t<std::is_trivial<Dummy>::value &&
@@ -3041,8 +3058,10 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
       const Kokkos::Impl::ParallelFor<ViewValueFunctor, PolicyType> closure(
           *this, PolicyType(0, n));
       closure.execute();
-      space.fence(
-          "Kokkos::Impl::ViewValueFunctor: Fence after setting values in view");
+      if (default_exec_space)
+        space.fence(
+            "Kokkos::Impl::ViewValueFunctor: Fence after setting values in "
+            "view");
       if (Kokkos::Profiling::profileLibraryLoaded()) {
         Kokkos::Profiling::endParallelFor(kpID);
       }
@@ -3331,7 +3350,8 @@ class ViewMapping<
   template <class... P>
   Kokkos::Impl::SharedAllocationRecord<>* allocate_shared(
       Kokkos::Impl::ViewCtorProp<P...> const& arg_prop,
-      typename Traits::array_layout const& arg_layout) {
+      typename Traits::array_layout const& arg_layout,
+      bool execution_space_specified) {
     using alloc_prop = Kokkos::Impl::ViewCtorProp<P...>;
 
     using execution_space = typename alloc_prop::execution_space;
@@ -3374,11 +3394,17 @@ class ViewMapping<
       // Assume destruction is only required when construction is requested.
       // The ViewValueFunctor has both value construction and destruction
       // operators.
-      record->m_destroy = functor_type(
-          static_cast<Kokkos::Impl::ViewCtorProp<void, execution_space> const&>(
-              arg_prop)
-              .value,
-          (value_type*)m_impl_handle, m_impl_offset.span(), alloc_name);
+      if (execution_space_specified) {
+        record->m_destroy = functor_type(
+            static_cast<
+                Kokkos::Impl::ViewCtorProp<void, execution_space> const&>(
+                arg_prop)
+                .value,
+            (value_type*)m_impl_handle, m_impl_offset.span(), alloc_name);
+      } else {
+        record->m_destroy = functor_type((value_type*)m_impl_handle,
+                                         m_impl_offset.span(), alloc_name);
+      }
 
       // Construct values
       record->m_destroy.construct_shared_allocation();

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -198,6 +198,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
       ViewResize
       View_64bit
       WorkGraph
+      WithoutInitializing
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
@@ -265,7 +266,6 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
       SubView_c12
       SubView_c13
       SubView_c14
-      WithoutInitializing
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -96,3 +96,187 @@ TEST(TEST_CATEGORY, resize_realloc_no_alloc) {
   ASSERT_TRUE(success);
   listen_tool_events(Config::DisableAll());
 }
+
+namespace {
+struct NonTriviallyCopyable {
+  KOKKOS_FUNCTION NonTriviallyCopyable() {}
+  KOKKOS_FUNCTION NonTriviallyCopyable(const NonTriviallyCopyable&) {}
+};
+}  // namespace
+
+TEST(TEST_CATEGORY, view_alloc) {
+#ifdef KOKKOS_ENABLE_CUDA
+  if (std::is_same<typename TEST_EXECSPACE::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
+#endif
+
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableFences());
+  using view_type = Kokkos::View<NonTriviallyCopyable*, TEST_EXECSPACE>;
+  view_type outer_view;
+
+  if (Kokkos::Impl::MemorySpaceAccess<typename TEST_EXECSPACE::memory_space,
+                                      Kokkos::HostSpace>::accessible) {
+    auto success = validate_event_set(
+        [&]() {
+          view_type inner_view(Kokkos::view_alloc("bla"), 8);
+          // Avoid testing the destructor
+          outer_view = inner_view;
+        },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "Kokkos::Impl::ViewValueFunctor: View init/destroy fence") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; });
+    ASSERT_TRUE(success);
+  } else {
+    auto success = validate_event_set(
+        [&]() {
+          view_type inner_view(Kokkos::view_alloc("bla"), 8);
+          // Avoid testing the destructor
+          outer_view = inner_view;
+        },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "fence after copying header from HostSpace") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "Kokkos::Impl::ViewValueFunctor: View init/destroy fence") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; });
+    ASSERT_TRUE(success);
+  }
+  listen_tool_events(Config::DisableAll());
+}
+
+TEST(TEST_CATEGORY, view_alloc_exec_space) {
+#ifdef KOKKOS_ENABLE_CUDA
+  if (std::is_same<typename TEST_EXECSPACE::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
+#endif
+
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableFences());
+  using view_type = Kokkos::View<NonTriviallyCopyable*, TEST_EXECSPACE>;
+  view_type outer_view;
+
+  if (Kokkos::Impl::MemorySpaceAccess<typename TEST_EXECSPACE::memory_space,
+                                      Kokkos::HostSpace>::accessible) {
+    auto success = validate_event_set([&]() {
+      view_type inner_view(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
+      // Avoid testing the destructor
+      outer_view = inner_view;
+    });
+    ASSERT_TRUE(success);
+  } else {
+    auto success = validate_event_set(
+        [&]() {
+          view_type inner_view(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
+          // Avoid testing the destructor
+          outer_view = inner_view;
+        },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "fence after copying header from HostSpace") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; });
+    ASSERT_TRUE(success);
+  }
+  listen_tool_events(Config::DisableAll());
+}
+
+TEST(TEST_CATEGORY, view_alloc_int) {
+#ifdef KOKKOS_ENABLE_CUDA
+  if (std::is_same<typename TEST_EXECSPACE::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
+#endif
+
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableFences());
+  using view_type = Kokkos::View<int*, TEST_EXECSPACE>;
+  view_type outer_view;
+
+  if (Kokkos::Impl::MemorySpaceAccess<typename TEST_EXECSPACE::memory_space,
+                                      Kokkos::HostSpace>::accessible) {
+    auto success = validate_event_set([&]() {
+      view_type inner_view("bla", 8);
+      // Avoid testing the destructor
+      outer_view = inner_view;
+    });
+    ASSERT_TRUE(success);
+  } else {
+    auto success = validate_event_set(
+        [&]() {
+          view_type inner_view("bla", 8);
+          // Avoid testing the destructor
+          outer_view = inner_view;
+        },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "fence after copying header from HostSpace") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; });
+    ASSERT_TRUE(success);
+  }
+  listen_tool_events(Config::DisableAll());
+}
+
+TEST(TEST_CATEGORY, view_alloc_exec_space_int) {
+#ifdef KOKKOS_ENABLE_CUDA
+  if (std::is_same<typename TEST_EXECSPACE::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
+#endif
+
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableFences());
+  using view_type = Kokkos::View<int*, TEST_EXECSPACE>;
+  view_type outer_view;
+
+  if (Kokkos::Impl::MemorySpaceAccess<typename TEST_EXECSPACE::memory_space,
+                                      Kokkos::HostSpace>::accessible) {
+    auto success = validate_event_set([&]() {
+      view_type inner_view(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
+      // Avoid testing the destructor
+      outer_view = inner_view;
+    });
+    ASSERT_TRUE(success);
+  } else {
+    auto success = validate_event_set(
+        [&]() {
+          view_type inner_view(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
+          // Avoid testing the destructor
+          outer_view = inner_view;
+        },
+        [&](BeginFenceEvent event) {
+          if (event.descriptor().find(
+                  "fence after copying header from HostSpace") !=
+              std::string::npos)
+            return MatchDiagnostic{true};
+          return MatchDiagnostic{false, {"Expected fence not found"}};
+        },
+        [&](EndFenceEvent) { return MatchDiagnostic{true}; });
+    ASSERT_TRUE(success);
+  }
+  listen_tool_events(Config::DisableAll());
+}

--- a/core/unit_test/tools/include/ToolTestingUtilities.hpp
+++ b/core/unit_test/tools/include/ToolTestingUtilities.hpp
@@ -1300,6 +1300,24 @@ bool validate_absence(const Lambda& lam, const Matchers... matchers) {
   return true;
 }
 
+template <class Lambda, class Matcher>
+bool validate_existence(const Lambda& lam, const Matcher matcher) {
+  // First, erase events from previous invocations
+  found_events.clear();
+  // Invoke the lambda (this will populate found_events, via tooling)
+  lam();
+  // compare the found events against the expected ones
+  for (const auto& event : found_events) {
+    MatchDiagnostic match = check_presence_of(event, matcher);
+
+    if (match.success) return true;
+  }
+  std::cout << "Test failure: Didn't encounter wanted events" << std::endl;
+  for (const auto& p_event : found_events)
+    std::cout << p_event->descriptor() << std::endl;
+  return false;
+}
+
 }  // namespace Tools
 }  // namespace Test
 }  // namespace Kokkos


### PR DESCRIPTION
Based on #4823. This pull request allows allocating using a specific memory space. For `Cuda` it replaces a `cudaDeviceSynchronize` with a `cudaStreamSynchronize` (which could of course also be done already). As an alternative we could also use a dedicated stream (or the copy stream) instead of the one contained in the execution space passed.
Similar considerations hold for `SYCL` where we are always using a specific execution space instance/`sycl::queue` for memory allocations.

This is currently only implemented for the host memory space and the `Cuda` memory spaces and is mostly there for dicussion.