### PR TITLE
algorithms: remove unused kokkos::exp::move

### DIFF
--- a/algorithms/src/Kokkos_StdAlgorithms.hpp
+++ b/algorithms/src/Kokkos_StdAlgorithms.hpp
@@ -55,7 +55,7 @@
 // distance
 #include <std_algorithms/Kokkos_Distance.hpp>
 
-// move, swap, iter_swap
+// swap, iter_swap
 #include "std_algorithms/Kokkos_ModifyingOperations.hpp"
 
 // find, find_if, find_if_not

--- a/algorithms/src/std_algorithms/Kokkos_ModifyingOperations.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ModifyingOperations.hpp
@@ -52,12 +52,6 @@
 namespace Kokkos {
 namespace Experimental {
 
-// move
-template <typename T>
-KOKKOS_INLINE_FUNCTION std::remove_reference_t<T>&& move(T&& t) {
-  return static_cast<std::remove_reference_t<T>&&>(t);
-}
-
 // swap
 template <class T>
 KOKKOS_INLINE_FUNCTION void swap(T& a, T& b) noexcept {

--- a/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
@@ -76,17 +76,17 @@ struct MyMovableType {
 
 TEST(std_algorithms_mod_ops_test, move) {
   MyMovableType a;
-  using move_t = decltype(KE::move(a));
+  using move_t = decltype(std::move(a));
   static_assert(std::is_rvalue_reference<move_t>::value, "");
 
   // move constr
-  MyMovableType b(KE::move(a));
+  MyMovableType b(std::move(a));
   EXPECT_TRUE(b.m_value == 11);
   EXPECT_TRUE(a.m_value == -2);
 
   // move assign
   MyMovableType c;
-  c = KE::move(b);
+  c = std::move(b);
   EXPECT_TRUE(c.m_value == 11);
   EXPECT_TRUE(b.m_value == -4);
 }
@@ -98,9 +98,9 @@ struct StdAlgoModSeqOpsTestMove {
   KOKKOS_INLINE_FUNCTION
   void operator()(const int index) const {
     typename ViewType::value_type a{11};
-    using move_t = decltype(KE::move(a));
+    using move_t = decltype(std::move(a));
     static_assert(std::is_rvalue_reference<move_t>::value, "");
-    m_view(index) = KE::move(a);
+    m_view(index) = std::move(a);
   }
 
   StdAlgoModSeqOpsTestMove(ViewType view) : m_view(view) {}


### PR DESCRIPTION
I think it was forgotten there but we only use `std::move` inside algorithms's implementation