### PR TITLE
Add fallthrough comment so Sierra compiles with warnings as errors

### DIFF
--- a/containers/src/impl/Kokkos_Functional_impl.hpp
+++ b/containers/src/impl/Kokkos_Functional_impl.hpp
@@ -107,7 +107,9 @@ uint32_t MurmurHash3_x86_32(const void* key, int len, uint32_t seed) {
 
   switch (len & 3) {
     case 3: k1 ^= tail[2] << 16;
+      // fall through
     case 2: k1 ^= tail[1] << 8;
+      // fall through
     case 1:
       k1 ^= tail[0];
       k1 *= c1;


### PR DESCRIPTION
Allows us to use the pod_hash without getting build errors in "warnings are errors" mode.