### PR TITLE
Skip some CI tests when using CUDA 11.6

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -367,12 +367,12 @@ pipeline {
                         }
                     }
                 }
-                stage('CUDA-10.1-NVCC-DEBUG') {
+                stage('CUDA-11.6-NVCC-DEBUG') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.nvcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:10.1-devel'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.6.0-devel-ubuntu20.04'
                             label 'nvidia-docker && volta'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -604,7 +604,9 @@ CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_CONSTANT(long double, max_exponent10);
 
 // Workaround compiler issue error: expression must have a constant value
 // See kokkos/kokkos#4574
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC
+// There is the same bug with CUDA 11.6
+// FIXME_NVHPC FIXME_CUDA
+#if !defined(KOKKOS_COMPILER_NVHPC) && (CUDA_VERSION < 11060)
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(float, quiet_NaN);
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, quiet_NaN);
 CHECK_NAN_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, quiet_NaN);


### PR DESCRIPTION
With CUDA 11.6, we hit https://github.com/kokkos/kokkos/issues/4574 This PR skips the tests and move one of our CI image to CUDA 11.6.0. We still have `CUDA-10.1-Clang-Tidy` so we still have some coverage of CUDA 10.1