### PR TITLE
Fix typo using CUDA_VERSION macro

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -60,7 +60,7 @@ half_t cast_to_half(half_t val) { return val; }
 // CUDA before 11.1 only has the half <-> float conversions marked host device
 // So we will largely convert to float on the host for conversion
 // But still call the correct functions on the device
-#if (CUDA_VERSION < 11100)
+#if (CUDA_VERSION < 11010)
 
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(float val) { return half_t(__float2half(val)); }
@@ -313,7 +313,7 @@ KOKKOS_INLINE_FUNCTION
 #endif
 
 /************************** bhalf conversions *********************************/
-#if CUDA_VERSION >= 11000 && CUDA_VERISON < 11200
+#if CUDA_VERSION >= 11000 && CUDA_VERSION < 11020
 KOKKOS_INLINE_FUNCTION
 bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
 
@@ -438,9 +438,9 @@ KOKKOS_INLINE_FUNCTION
     cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(cast_from_bhalf<unsigned long long>(val));
 }
-#endif  // CUDA_VERSION >= 11000 && CUDA_VERISON < 11200
+#endif  // CUDA_VERSION >= 11000 && CUDA_VERSION < 11020
 
-#if CUDA_VERISON >= 11200
+#if CUDA_VERSION >= 11020
 KOKKOS_INLINE_FUNCTION
 bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
 KOKKOS_INLINE_FUNCTION
@@ -521,7 +521,7 @@ KOKKOS_INLINE_FUNCTION
     cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(cast_from_bhalf<unsigned long long>(val));
 }
-#endif  // CUDA_VERSION >= 11200
+#endif  // CUDA_VERSION >= 11020
 }  // namespace Experimental
 
 #if (CUDA_VERSION >= 11000)

--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -50,7 +50,7 @@
 #include <Kokkos_Half.hpp>
 #include <Kokkos_NumericTraits.hpp>  // reduction_identity
 
-#if CUDA_VERSION >= 11020
+#if CUDA_VERSION >= 11000
 #include <cuda_bf16.h>
 #endif
 
@@ -264,44 +264,44 @@ half_t cast_to_half(unsigned long val) {
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, float>::value, T>
 cast_from_half(half_t val) {
-  return __half2float(val);
+  return __half2float(__half(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, double>::value, T>
 cast_from_half(half_t val) {
-  return __half2double(val);
+  return static_cast<double>(__half2float(__half(val)));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, short>::value, T>
 cast_from_half(half_t val) {
-  return __half2short_rz(val);
+  return __half2short_rz(__half(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned short>::value, T>
     cast_from_half(half_t val) {
-  return __half2ushort_rz(val);
+  return __half2ushort_rz(__half(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, int>::value, T>
 cast_from_half(half_t val) {
-  return __half2int_rz(val);
+  return __half2int_rz(__half(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, unsigned int>::value, T>
 cast_from_half(half_t val) {
-  return __half2uint_rz(val);
+  return __half2uint_rz(__half(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long long>::value, T>
 cast_from_half(half_t val) {
-  return __half2ll_rz(val);
+  return __half2ll_rz(__half(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned long long>::value, T>
     cast_from_half(half_t val) {
-  return __half2ull_rz(val);
+  return __half2ull_rz(__half(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long>::value, T>
@@ -317,7 +317,10 @@ KOKKOS_INLINE_FUNCTION
 #endif
 
 /************************** bhalf conversions *********************************/
-#if CUDA_VERSION >= 11000 && CUDA_VERSION < 11020
+// Go in this branch if CUDA version is >= 11.0.0 and less than 11.1.0 or if the
+// architecture is not Ampere
+#if CUDA_VERSION >= 11000 && \
+    (CUDA_VERSION < 11010 || !defined(KOKKOS_ARCH_AMPERE))
 KOKKOS_INLINE_FUNCTION
 bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
 
@@ -442,9 +445,10 @@ KOKKOS_INLINE_FUNCTION
     cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(cast_from_bhalf<unsigned long long>(val));
 }
-#endif  // CUDA_VERSION >= 11000 && CUDA_VERSION < 11020
+#endif  // CUDA_VERSION >= 11000 && CUDA_VERSION < 11010
 
-#if CUDA_VERSION >= 11020
+#if CUDA_VERSION >= 11010 && \
+    ((defined(KOKKOS_ARCH_AMPERE80) || defined(KOKKOS_ARCH_AMPERE86)))
 KOKKOS_INLINE_FUNCTION
 bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
 KOKKOS_INLINE_FUNCTION
@@ -475,44 +479,44 @@ bhalf_t cast_to_bhalf(unsigned long val) {
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, float>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return __bfloat162float(val);
+  return __bfloat162float(__nv_bfloat16(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, double>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return __bfloat162double(val);
+  return static_cast<double>(__bfloat162float(__nv_bfloat16(val)));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, short>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return __bfloat162short_rz(val);
+  return __bfloat162short_rz(__nv_bfloat16(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned short>::value, T>
     cast_from_bhalf(bhalf_t val) {
-  return __bfloat162ushort_rz(val);
+  return __bfloat162ushort_rz(__nv_bfloat16(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, int>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return __bfloat162int_rz(val);
+  return __bfloat162int_rz(__nv_bfloat16(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, unsigned int>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return __bfloat162uint_rz(val);
+  return __bfloat162uint_rz(__nv_bfloat16(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long long>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return __bfloat162ll_rz(val);
+  return __bfloat162ll_rz(__nv_bfloat16(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned long long>::value, T>
     cast_from_bhalf(bhalf_t val) {
-  return __bfloat162ull_rz(val);
+  return __bfloat162ull_rz(__nv_bfloat16(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long>::value, T>
@@ -525,7 +529,7 @@ KOKKOS_INLINE_FUNCTION
     cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(cast_from_bhalf<unsigned long long>(val));
 }
-#endif  // CUDA_VERSION >= 11020
+#endif  // CUDA_VERSION >= 11010
 }  // namespace Experimental
 
 #if (CUDA_VERSION >= 11000)

--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -50,6 +50,10 @@
 #include <Kokkos_Half.hpp>
 #include <Kokkos_NumericTraits.hpp>  // reduction_identity
 
+#if CUDA_VERSION >= 11020
+#include <cuda_bf16.h>
+#endif
+
 namespace Kokkos {
 namespace Experimental {
 


### PR DESCRIPTION
This PR fixes two kinds of typo in `core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp`. First, there are places we wrote `CUDA_VERISON` instead of `CUDA_VERSION`. Second, we have code that is enable only if `CUDA_VERSION >= 11200`, i.e., the code is enabled for CUDA 11.20. That doesn't make sense, so I changed the condition to `CUDA_VERSION >= 11020`