### PR TITLE
CUDA Reductions: Fix data races reported by Nvidia compute-sanitizer

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -548,7 +548,9 @@ struct CudaReductionsFunctor<FunctorType, ArgTag, false, false> {
       }
       __syncwarp(mask);
     }
-    *value = *(value - lane_id);
+    if (lane_id != 0) {
+      *value = *(value - lane_id);
+    }
   }
 
   __device__ static inline void scalar_intra_block_reduction(

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -539,6 +539,9 @@ struct CudaReductionsFunctor<FunctorType, ArgTag, false, false> {
             : ((1 << width) - 1)
                   << ((threadIdx.y * blockDim.x + threadIdx.x) / width) * width;
     const int lane_id = (threadIdx.y * blockDim.x + threadIdx.x) % 32;
+
+    __syncwarp(mask);
+
     for (int delta = skip_vector ? blockDim.x : 1; delta < width; delta *= 2) {
       if (lane_id + delta < 32) {
         ValueJoin::join(functor, value, value + delta);


### PR DESCRIPTION
Detected with Nvidia's compute-sanitizer racecheck tool, with the tiny test case

```c++
#include <Kokkos_Core.hpp>
#include <cstdlib>
#include <iostream>

struct Sum {
  using value_type = double;

  KOKKOS_INLINE_FUNCTION
  void operator()(const int i, double& lsum) const {
    lsum += i;
  }
};

int main(int argc, char** argv)
{
  Kokkos::initialize(argc, argv);

  int n = std::atoi(argv[1]);
  std::cout << "Running with n = " << n << std::endl;
  {
    Kokkos::View<double*> v("foo", n);
    double val;
    Sum sum;
    Kokkos::parallel_reduce(n, sum, val);
    Kokkos::fence();
  }
  Kokkos::finalize();
  return 0;
}
```

Before this change:

```
$ compute-sanitizer --tool=racecheck ./redtest 1
========= COMPUTE-SANITIZER
Running with n = 1
========= WARNING: Race reported between Read access at 0xf10 in /scratch/pbmille/kokkos/install/cuda10/include/impl/Kokkos_FunctorAdapter.hpp:1571:Kokkos::Impl::CudaReductionsFunctor<Sum,void,bool=0,bool=0>::scalar_intra_warp_reduction(Sum const &,double*,bool,int)
=========     and Write access at 0x8a0 in /scratch/pbmille/kokkos/install/cuda10/include/Cuda/Kokkos_Cuda_ReduceScan.hpp:557:Kokkos::Impl::CudaReductionsFunctor<Sum,void,bool=0,bool=0>::scalar_intra_block_reduction(Sum const &,double,bool,double*,int,double*) [3968 hazards]
========= 
========= WARNING: Race reported between Read access at 0x11a0 in /scratch/pbmille/kokkos/install/cuda10/include/Cuda/Kokkos_Cuda_ReduceScan.hpp:548:Kokkos::Impl::CudaReductionsFunctor<Sum,void,bool=0,bool=0>::scalar_intra_warp_reduction(Sum const &,double*,bool,int)
=========     and Write access at 0x11d0 in /scratch/pbmille/kokkos/install/cuda10/include/Cuda/Kokkos_Cuda_ReduceScan.hpp:548:Kokkos::Impl::CudaReductionsFunctor<Sum,void,bool=0,bool=0>::scalar_intra_warp_reduction(Sum const &,double*,bool,int) [144 hazards]
========= 
========= WARNING: Race reported between Write access at 0x1180 in /scratch/pbmille/kokkos/install/cuda10/include/Cuda/Kokkos_Cuda_ReduceScan.hpp:572:Kokkos::Impl::CudaReductionsFunctor<Sum,void,bool=0,bool=0>::scalar_intra_block_reduction(Sum const &,double,bool,double*,int,double*)
=========     and Read access at 0x2d10 in /scratch/pbmille/kokkos/install/cuda10/include/Cuda/Kokkos_Cuda_Parallel_Range.hpp:321:_ZNK6Kokkos4Impl14ParallelReduceI3SumNS_11RangePolicyIJNS_4CudaEEEENS_11InvalidTypeES4_EclEv [4 hazards]
========= 
========= RACECHECK SUMMARY: 3 hazards displayed (0 errors, 3 warnings)
```

After this change, the first twp reports are eliminated:

```
$ compute-sanitizer --tool=racecheck --show-backtrace=yes ./redtest 1
========= COMPUTE-SANITIZER
Running with n = 1
========= WARNING: Race reported between Write access at 0x1180 in /scratch/pbmille/kokkos/install/cuda10/include/Cuda/Kokkos_Cuda_ReduceScan.hpp:577:Kokkos::Impl::CudaReductionsFunctor<Sum,void,bool=0,bool=0>::scalar_intra_block_reduction(Sum const &,double,bool,double*,int,double*)
=========     and Read access at 0x2d10 in /scratch/pbmille/kokkos/install/cuda10/include/Cuda/Kokkos_Cuda_Parallel_Range.hpp:321:_ZNK6Kokkos4Impl14ParallelReduceI3SumNS_11RangePolicyIJNS_4CudaEEEENS_11InvalidTypeES4_EclEv [4 hazards]
========= 
========= RACECHECK SUMMARY: 1 hazard displayed (0 errors, 1 warning)

```