### PR TITLE
If `CMAKE_CXX_COMPILER_LAUNCHER` is set , do not enable `kokkos_launch_compiler`

### DIFF
--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -37,9 +37,9 @@ IF(Kokkos_ENABLE_CUDA)
         PATHS           ${PROJECT_SOURCE_DIR}
         PATH_SUFFIXES   bin)
 
-    # check if compiler was set to nvcc_wrapper
+    # Check if compiler was set to nvcc_wrapper
     kokkos_internal_have_compiler_nvcc(${CMAKE_CXX_COMPILER})
-    # if launcher was found and nvcc_wrapper was not specified as
+    # If launcher was found and nvcc_wrapper was not specified as
     # compiler and `CMAKE_CXX_COMPILIER_LAUNCHER` is not set, set to use launcher.
     # Will ensure CMAKE_CXX_COMPILER is replaced by nvcc_wrapper
     IF(Kokkos_COMPILE_LAUNCHER AND NOT INTERNAL_HAVE_COMPILER_NVCC AND NOT KOKKOS_CXX_COMPILER_ID STREQUAL Clang)

--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -40,12 +40,13 @@ IF(Kokkos_ENABLE_CUDA)
     # check if compiler was set to nvcc_wrapper
     kokkos_internal_have_compiler_nvcc(${CMAKE_CXX_COMPILER})
     # if launcher was found and nvcc_wrapper was not specified as
-    # compiler AND `CMAKE_CXX_COMPILIER_LAUNCHER` is not set, set to use launcher. Will ensure CMAKE_CXX_COMPILER
-    # is replaced by nvcc_wrapper
-    IF(Kokkos_COMPILE_LAUNCHER AND NOT INTERNAL_HAVE_COMPILER_NVCC AND NOT
-       CMAKE_CXX_COMPILER_LAUNCHER AND NOT KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
-			MESSAGE(FATAL_ERROR "Cannot use CMAKE_CXX_COMPILER_LAUNCHER if the CMAKE_CXX_COMPILER is not able to compile CUDA code, i.e. nvcc_wrapper or
+    # compiler and `CMAKE_CXX_COMPILIER_LAUNCHER` is not set, set to use launcher.
+    # Will ensure CMAKE_CXX_COMPILER is replaced by nvcc_wrapper
+    IF(Kokkos_COMPILE_LAUNCHER AND NOT INTERNAL_HAVE_COMPILER_NVCC AND NOT KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+      IF(CMAKE_CXX_COMPILER_LAUNCHER)
+      MESSAGE(FATAL_ERROR "Cannot use CMAKE_CXX_COMPILER_LAUNCHER if the CMAKE_CXX_COMPILER is not able to compile CUDA code, i.e. nvcc_wrapper or
 clang++!")
+      ENDIF()
       # the first argument to launcher is always the C++ compiler defined by cmake
       # if the second argument matches the C++ compiler, it forwards the rest of the
       # args to nvcc_wrapper

--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -42,7 +42,8 @@ IF(Kokkos_ENABLE_CUDA)
     # if launcher was found and nvcc_wrapper was not specified as
     # compiler, set to use launcher. Will ensure CMAKE_CXX_COMPILER
     # is replaced by nvcc_wrapper
-    IF(Kokkos_COMPILE_LAUNCHER AND NOT INTERNAL_HAVE_COMPILER_NVCC AND NOT KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+    IF(Kokkos_COMPILE_LAUNCHER AND NOT INTERNAL_HAVE_COMPILER_NVCC AND NOT
+       CMAKE_CXX_COMPILER_LAUNCHER AND NOT KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
       # the first argument to launcher is always the C++ compiler defined by cmake
       # if the second argument matches the C++ compiler, it forwards the rest of the
       # args to nvcc_wrapper

--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -40,10 +40,12 @@ IF(Kokkos_ENABLE_CUDA)
     # check if compiler was set to nvcc_wrapper
     kokkos_internal_have_compiler_nvcc(${CMAKE_CXX_COMPILER})
     # if launcher was found and nvcc_wrapper was not specified as
-    # compiler, set to use launcher. Will ensure CMAKE_CXX_COMPILER
+    # compiler AND `CMAKE_CXX_COMPILIER_LAUNCHER` is not set, set to use launcher. Will ensure CMAKE_CXX_COMPILER
     # is replaced by nvcc_wrapper
     IF(Kokkos_COMPILE_LAUNCHER AND NOT INTERNAL_HAVE_COMPILER_NVCC AND NOT
        CMAKE_CXX_COMPILER_LAUNCHER AND NOT KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+			MESSAGE(FATAL_ERROR "Cannot use CMAKE_CXX_COMPILER_LAUNCHER if the CMAKE_CXX_COMPILER is not able to compile CUDA code, i.e. nvcc_wrapper or
+clang++!")
       # the first argument to launcher is always the C++ compiler defined by cmake
       # if the second argument matches the C++ compiler, it forwards the rest of the
       # args to nvcc_wrapper

--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -44,7 +44,7 @@ IF(Kokkos_ENABLE_CUDA)
     # Will ensure CMAKE_CXX_COMPILER is replaced by nvcc_wrapper
     IF(Kokkos_COMPILE_LAUNCHER AND NOT INTERNAL_HAVE_COMPILER_NVCC AND NOT KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
       IF(CMAKE_CXX_COMPILER_LAUNCHER)
-      MESSAGE(FATAL_ERROR "Cannot use CMAKE_CXX_COMPILER_LAUNCHER if the CMAKE_CXX_COMPILER is not able to compile CUDA code, i.e. nvcc_wrapper or
+       MESSAGE(FATAL_ERROR "Cannot use CMAKE_CXX_COMPILER_LAUNCHER if the CMAKE_CXX_COMPILER is not able to compile CUDA code, i.e. nvcc_wrapper or
 clang++!")
       ENDIF()
       # the first argument to launcher is always the C++ compiler defined by cmake


### PR DESCRIPTION
This PR adds another condition in setting `INTERNAL_USE_COMPILER_LAUNCHER` to prevent interaction with
`kokkos_launch_compiler` when `CMAKE_CXX_COMPILER_LAUNCHER` is set.  This change fixes #4821.