### PR TITLE
Fix scratch lock array when using scratch level 1

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -1092,6 +1092,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         FunctorTeamShmemSize<FunctorType>::value(arg_functor, m_team_size);
     m_scratch_size[0] = m_shmem_size;
     m_scratch_size[1] = m_policy.scratch_size(1, m_team_size);
+    m_scratch_locks =
+        m_policy.space().impl_internal_space_instance()->m_scratch_locks;
     if (m_team_size <= 0) {
       m_scratch_ptr[1] = nullptr;
     } else {

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -1026,6 +1026,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         FunctorTeamShmemSize<FunctorType>::value(arg_functor, m_team_size);
     m_scratch_size[0] = m_shmem_size;
     m_scratch_size[1] = m_policy.scratch_size(1, m_team_size);
+    m_scratch_locks =
+        m_policy.space().impl_internal_space_instance()->m_scratch_locks;
     m_scratch_ptr[1] =
         m_team_size <= 0
             ? nullptr

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -849,6 +849,13 @@ struct TestScratchTeam {
         Functor(), result_type(&error_count));
     Kokkos::fence();
     ASSERT_EQ(error_count, 0);
+
+    Kokkos::parallel_reduce(
+        team_exec.set_scratch_size(1, Kokkos::PerTeam(team_scratch_size),
+                                   Kokkos::PerThread(thread_scratch_size)),
+        Functor(), Kokkos::Sum<typename Functor::value_type>(error_count));
+    Kokkos::fence();
+    ASSERT_EQ(error_count, 0);
   }
 };
 


### PR DESCRIPTION
This is a copy of #4869 to merge the changes into develop for fixing #4864 