### PR TITLE
Fix abort with HIP backend for ROCm 5.0.2 and beyond

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Abort.hpp
+++ b/core/src/HIP/Kokkos_HIP_Abort.hpp
@@ -57,14 +57,8 @@ namespace Impl {
 // directive to the optimizer.
 [[noreturn]] __device__ __attribute__((noinline)) inline void hip_abort(
     char const *msg) {
-#ifdef NDEBUG
-  (void)msg;
-#else
-  // disable printf on release builds, as it has a non-trivial performance
-  // impact
-  printf("Aborting with message `%s'.\n", msg);
-#endif
-  abort();
+  const char empty[] = "";
+  __assert_fail(msg, empty, 0, empty);
   // This loop is never executed. It's intended to suppress warnings that the
   // function returns, even though it does not. This is necessary because
   // abort() is not marked as [[noreturn]], even though it does not return.

--- a/core/unit_test/TestAbort.hpp
+++ b/core/unit_test/TestAbort.hpp
@@ -119,7 +119,7 @@ void test_abort_from_device() {
   } else {
     TestAbortCausingAbnormalProgramTerminationAndPrinting<ExecutionSpace>();
   }
-#elif defined(KOKKOS_ENABLE_HIP)  // FIXME_HIP
+#elif defined(KOKKOS_ENABLE_HIP)  // FIXME_HIP fixed from ROCm 5.0.2
   if (std::is_same<ExecutionSpace, Kokkos::Experimental::HIP>::value) {
     TestAbortCausingAbnormalProgramTerminationButIgnoringErrorMessage<
         ExecutionSpace>();


### PR DESCRIPTION
The error message provided to `Kokkos::abort` was not printed when called on the device-side.
The changes proposed (using `__assert_fail` instead of `printf` followed by `abort`) seem to do the charm with ROCm 5.0.2
Unfortunately there is no "native" macro we can use to guard the workaround in the unit tests so I just added a comment.  We could in principle do that at configuration time but I was a bit hesitant because it is hacky and we haven't done it for any of the toolchains yet.