### PR TITLE
SYCL RangePolicy: manually specify workgroup size through chunk size

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
@@ -56,7 +56,7 @@ struct FunctorWrapperRangePolicyParallelFor {
 
   void operator()(sycl::item<1> item) const {
     const typename Policy::index_type id = item.get_linear_id() + m_begin;
-    if constexpr (std::is_void<WorkTag>::value)
+    if constexpr (std::is_void_v<WorkTag>)
       m_functor_wrapper.get_functor()(id);
     else
       m_functor_wrapper.get_functor()(WorkTag(), id);
@@ -64,6 +64,27 @@ struct FunctorWrapperRangePolicyParallelFor {
 
   typename Policy::index_type m_begin;
   FunctorWrapper m_functor_wrapper;
+};
+
+// Same as above but for a user-provided workgroup size
+template <typename FunctorWrapper, typename Policy>
+struct FunctorWrapperRangePolicyParallelForCustom {
+  using WorkTag = typename Policy::work_tag;
+
+  void operator()(sycl::item<1> item) const {
+    const typename Policy::index_type id = item.get_linear_id();
+    if (id < m_work_size) {
+      const auto shifted_id = id + m_begin;
+      if constexpr (std::is_void_v<WorkTag>)
+        m_functor_wrapper.get_functor()(shifted_id);
+      else
+        m_functor_wrapper.get_functor()(WorkTag(), shifted_id);
+    }
+  }
+
+  typename Policy::index_type m_begin;
+  FunctorWrapper m_functor_wrapper;
+  typename Policy::index_type m_work_size;
 };
 }  // namespace Kokkos::Impl
 
@@ -74,9 +95,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
   using Policy = Kokkos::RangePolicy<Traits...>;
 
  private:
-  using Member       = typename Policy::member_type;
-  using WorkTag      = typename Policy::work_tag;
-  using LaunchBounds = typename Policy::launch_bounds;
+  using Member  = typename Policy::member_type;
+  using WorkTag = typename Policy::work_tag;
 
   const FunctorType m_functor;
   const Policy m_policy;
@@ -90,12 +110,29 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
     sycl::queue& q                          = space.sycl_queue();
 
     auto parallel_for_event = q.submit([&](sycl::handler& cgh) {
-      FunctorWrapperRangePolicyParallelFor<Functor, Policy> f{policy.begin(),
-                                                              functor};
-      sycl::range<1> range(policy.end() - policy.begin());
       cgh.depends_on(memcpy_event);
-      cgh.parallel_for<FunctorWrapperRangePolicyParallelFor<Functor, Policy>>(
-          range, f);
+      if (policy.chunk_size() <= 1) {
+        FunctorWrapperRangePolicyParallelFor<Functor, Policy> f{policy.begin(),
+                                                                functor};
+        sycl::range<1> range(policy.end() - policy.begin());
+        cgh.parallel_for<FunctorWrapperRangePolicyParallelFor<Functor, Policy>>(
+            range, f);
+      } else {
+        // Use the chunk size as workgroup size. We need to make sure that the
+        // range the kernel is launched with is a multiple of the workgroup
+        // size. Hence, we need to restrict the execution of the functor in the
+        // kernel to the actual range.
+        const auto actual_range = policy.end() - policy.begin();
+        const auto wgroup_size  = policy.chunk_size();
+        const auto launch_range =
+            (actual_range + wgroup_size - 1) / wgroup_size * wgroup_size;
+        FunctorWrapperRangePolicyParallelForCustom<Functor, Policy> f{
+            policy.begin(), functor, actual_range};
+        sycl::nd_range<1> range(launch_range, wgroup_size);
+        cgh.parallel_for<
+            FunctorWrapperRangePolicyParallelForCustom<Functor, Policy>>(range,
+                                                                         f);
+      }
     });
     q.ext_oneapi_submit_barrier(std::vector<sycl::event>{parallel_for_event});
 
@@ -140,7 +177,6 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
  private:
   using array_index_type = typename Policy::array_index_type;
   using index_type       = typename Policy::index_type;
-  using LaunchBounds     = typename Policy::launch_bounds;
   using WorkTag          = typename Policy::work_tag;
 
   const FunctorType m_functor;


### PR DESCRIPTION
In some cases, selecting a custom workgroup size gives significantly better performance than relying on the compiler to choose.