### PR TITLE
WIP #4077: Try applying volatile_wrapper approach in the reduction/scan functor analysis implementations

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -427,6 +427,9 @@ struct CudaReductionsFunctor<FunctorType, false, false> {
       scalar_intra_block_reduction(
           functor, value, false, shared_team_buffer_elements + (blockDim.y - 1),
           shared_elements, shared_team_buffer_elements);
+
+      __threadfence();
+      __syncthreads();
     }
     return is_last_block;
   }

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -352,7 +352,7 @@ struct CudaReductionsFunctor<FunctorType, false, false> {
     __syncwarp(mask);
 
     for (int delta = skip_vector ? blockDim.x : 1; delta < width; delta *= 2) {
-      if (lane_id + delta < 32) {
+      if (lane_id + delta < 32 && (lane_id%(delta*2)==0)) {
         functor.join(value, value + delta);
       }
       __syncwarp(mask);

--- a/core/unit_test/TestReducers_d.hpp
+++ b/core/unit_test/TestReducers_d.hpp
@@ -65,6 +65,20 @@ TEST(TEST_CATEGORY, reducers_struct) {
 #endif
 }
 
+TEST(TEST_CATEGORY, reducers_int16_t) {
+  using ThisTestType = int16_t;
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(2);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(101);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(202);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(303);
+
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(5);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(10);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(15);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(20);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(25);
+}
+
 TEST(TEST_CATEGORY, reducers_half_t) {
   using ThisTestType = Kokkos::Experimental::half_t;
   TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(2);


### PR DESCRIPTION
This is a demonstration of applying the volatile_wrapper approach to CUDA reduction/scan implementation in the adapter class for the user-provided operation, rather than at the call sites.

The code modification involved is much simpler this way, though it does break at least one layer of abstraction boundary.

I consider this a demonstration, rather than something to be directly considered for integration right away