### PR TITLE
Disable memset on A64FX and use parallel init instead

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1298,9 +1298,13 @@ inline std::enable_if_t<
 contiguous_fill_or_memset(
     const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
+// On A64FX memset seems to do the wrong thing with regards to first touch
+// leading to the significant performance issues
+#ifndef KOKKOS_ARCH_A64FX
   if (Impl::is_zero_byte(value))
     ZeroMemset<ExecutionSpace, DT, DP...>(exec_space, dst, value);
   else
+#endif
     contiguous_fill(exec_space, dst, value);
 }
 
@@ -1326,9 +1330,13 @@ contiguous_fill_or_memset(
   using ViewType        = View<DT, DP...>;
   using exec_space_type = typename ViewType::execution_space;
 
+// On A64FX memset seems to do the wrong thing with regards to first touch
+// leading to the significant performance issues
+#ifndef KOKKOS_ARCH_A64FX
   if (Impl::is_zero_byte(value))
     ZeroMemset<exec_space_type, DT, DP...>(dst, value);
   else
+#endif
     contiguous_fill(exec_space_type(), dst, value);
 }
 


### PR DESCRIPTION
This fixes performance issues related to 1st touch which do not seem to pop up on X86

On A64FX we get wrong first touch with memset, leading to bad performance.
Kokkos stream benchmark only get 180GB/s vs 600GB/s when doing parallel set zero.
This is with GCC.

We need to check other archs/OS combos where we may need to disable memset. 