### PR TITLE
Replace EXPECT_TRUE where sensible

### DIFF
--- a/algorithms/unit_tests/TestRandomAccessIterator.cpp
+++ b/algorithms/unit_tests/TestRandomAccessIterator.cpp
@@ -206,28 +206,28 @@ TEST_F(random_access_iterator_test, operatorsSet4) {
   auto it4 = KE::Impl::RandomAccessIterator<static_view_t>(m_static_view, 4);
   auto it5 = KE::Impl::RandomAccessIterator<dyn_view_t>(m_dynamic_view, 4);
   auto it6 = KE::Impl::RandomAccessIterator<strided_view_t>(m_strided_view, 4);
-  EXPECT_TRUE(it1 != it4);
-  EXPECT_TRUE(it2 != it5);
-  EXPECT_TRUE(it3 != it6);
-  EXPECT_TRUE(it1 < it4);
-  EXPECT_TRUE(it2 < it5);
-  EXPECT_TRUE(it3 < it6);
-  EXPECT_TRUE(it1 <= it4);
-  EXPECT_TRUE(it2 <= it5);
-  EXPECT_TRUE(it3 <= it6);
+  EXPECT_NE(it1, it4);
+  EXPECT_NE(it2, it5);
+  EXPECT_NE(it3, it6);
+  EXPECT_LT(it1, it4);
+  EXPECT_LT(it2, it5);
+  EXPECT_LT(it3, it6);
+  EXPECT_LE(it1, it4);
+  EXPECT_LE(it2, it5);
+  EXPECT_LE(it3, it6);
 
   auto it7 = KE::Impl::RandomAccessIterator<static_view_t>(m_static_view, 3);
   auto it8 = KE::Impl::RandomAccessIterator<dyn_view_t>(m_dynamic_view, 3);
   auto it9 = KE::Impl::RandomAccessIterator<strided_view_t>(m_strided_view, 3);
-  EXPECT_TRUE(it1 == it7);
-  EXPECT_TRUE(it2 == it8);
-  EXPECT_TRUE(it3 == it9);
-  EXPECT_TRUE(it1 >= it7);
-  EXPECT_TRUE(it2 >= it8);
-  EXPECT_TRUE(it3 >= it9);
-  EXPECT_TRUE(it4 > it7);
-  EXPECT_TRUE(it5 > it8);
-  EXPECT_TRUE(it6 > it9);
+  EXPECT_EQ(it1, it7);
+  EXPECT_EQ(it2, it8);
+  EXPECT_EQ(it3, it9);
+  EXPECT_GE(it1, it7);
+  EXPECT_GE(it2, it8);
+  EXPECT_GE(it3, it9);
+  EXPECT_GT(it4, it7);
+  EXPECT_GT(it5, it8);
+  EXPECT_GT(it6, it9);
 }
 
 TEST_F(random_access_iterator_test, assignment_operator) {

--- a/algorithms/unit_tests/TestStdAlgorithmsAdjacentDifference.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsAdjacentDifference.cpp
@@ -185,7 +185,7 @@ void verify_data(TestViewType test_view, GoldViewType gold) {
   const auto gold_h = create_mirror_view_and_copy(Kokkos::HostSpace(), gold);
 
   for (std::size_t i = 0; i < test_view.extent(0); ++i) {
-    EXPECT_TRUE(gold_h(i) == test_view_dc_h(i));
+    EXPECT_EQ(gold_h(i), test_view_dc_h(i));
   }
 }
 
@@ -225,7 +225,7 @@ void run_single_scenario(const InfoType& scenario_info,
     auto res1 = KE::adjacent_difference(exespace(), KE::cbegin(view_from),
                                         KE::cend(view_from),
                                         KE::begin(view_dest), args...);
-    EXPECT_TRUE(res1 == KE::end(view_dest));
+    EXPECT_EQ(res1, KE::end(view_dest));
     verify_data(view_dest, gold);
   }
 
@@ -235,7 +235,7 @@ void run_single_scenario(const InfoType& scenario_info,
     auto res2 = KE::adjacent_difference(
         "label", exespace(), KE::cbegin(view_from), KE::cend(view_from),
         KE::begin(view_dest), args...);
-    EXPECT_TRUE(res2 == KE::end(view_dest));
+    EXPECT_EQ(res2, KE::end(view_dest));
     verify_data(view_dest, gold);
   }
 
@@ -244,7 +244,7 @@ void run_single_scenario(const InfoType& scenario_info,
         create_view<ValueType>(Tag{}, view_ext, "adj_diff_dest_view");
     auto res3 =
         KE::adjacent_difference(exespace(), view_from, view_dest, args...);
-    EXPECT_TRUE(res3 == KE::end(view_dest));
+    EXPECT_EQ(res3, KE::end(view_dest));
     verify_data(view_dest, gold);
   }
 
@@ -253,7 +253,7 @@ void run_single_scenario(const InfoType& scenario_info,
         create_view<ValueType>(Tag{}, view_ext, "adj_diff_dest_view");
     auto res4 = KE::adjacent_difference("label", exespace(), view_from,
                                         view_dest, args...);
-    EXPECT_TRUE(res4 == KE::end(view_dest));
+    EXPECT_EQ(res4, KE::end(view_dest));
     verify_data(view_dest, gold);
   }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsAdjacentFind.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsAdjacentFind.cpp
@@ -257,7 +257,7 @@ void verify(DiffType my_diff, ViewType view, Args... args) {
       my_std_adjacent_find(KE::cbegin(view_h), KE::cend(view_h), args...);
   const auto std_diff = std_r - KE::cbegin(view_h);
 
-  EXPECT_TRUE(my_diff == std_diff);
+  EXPECT_EQ(my_diff, std_diff);
 }
 
 template <class Tag, class ValueType, class InfoType, class... Args>

--- a/algorithms/unit_tests/TestStdAlgorithmsCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCopyIf.cpp
@@ -165,49 +165,49 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
   }
 
   else if (name == "one-element-a") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(0));
   }
 
   else if (name == "one-element-b") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(2));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(2));
   }
 
   else if (name == "two-elements-a") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(2));
-    EXPECT_TRUE(view_test_h(1) == static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(2));
+    EXPECT_EQ(view_test_h(1), static_cast<value_type>(0));
   }
 
   else if (name == "two-elements-b") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(2));
-    EXPECT_TRUE(view_test_h(1) == static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(2));
+    EXPECT_EQ(view_test_h(1), static_cast<value_type>(0));
   }
 
   else if (name == "small-a") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(-4));
-    EXPECT_TRUE(view_test_h(1) == static_cast<value_type>(-2));
-    EXPECT_TRUE(view_test_h(2) == static_cast<value_type>(0));
-    EXPECT_TRUE(view_test_h(3) == static_cast<value_type>(2));
-    EXPECT_TRUE(view_test_h(4) == static_cast<value_type>(4));
-    EXPECT_TRUE(view_test_h(5) == static_cast<value_type>(0));
-    EXPECT_TRUE(view_test_h(6) == static_cast<value_type>(0));
-    EXPECT_TRUE(view_test_h(7) == static_cast<value_type>(0));
-    EXPECT_TRUE(view_test_h(8) == static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(-4));
+    EXPECT_EQ(view_test_h(1), static_cast<value_type>(-2));
+    EXPECT_EQ(view_test_h(2), static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(3), static_cast<value_type>(2));
+    EXPECT_EQ(view_test_h(4), static_cast<value_type>(4));
+    EXPECT_EQ(view_test_h(5), static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(6), static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(7), static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(8), static_cast<value_type>(0));
   }
 
   else if (name == "small-b") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(22));
-    EXPECT_TRUE(view_test_h(1) == static_cast<value_type>(-12));
-    EXPECT_TRUE(view_test_h(2) == static_cast<value_type>(22));
-    EXPECT_TRUE(view_test_h(3) == static_cast<value_type>(-12));
-    EXPECT_TRUE(view_test_h(4) == static_cast<value_type>(22));
-    EXPECT_TRUE(view_test_h(5) == static_cast<value_type>(-12));
-    EXPECT_TRUE(view_test_h(6) == static_cast<value_type>(22));
-    EXPECT_TRUE(view_test_h(7) == static_cast<value_type>(-12));
-    EXPECT_TRUE(view_test_h(8) == static_cast<value_type>(22));
-    EXPECT_TRUE(view_test_h(9) == static_cast<value_type>(-12));
-    EXPECT_TRUE(view_test_h(10) == static_cast<value_type>(22));
-    EXPECT_TRUE(view_test_h(11) == static_cast<value_type>(-12));
-    EXPECT_TRUE(view_test_h(12) == static_cast<value_type>(22));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(22));
+    EXPECT_EQ(view_test_h(1), static_cast<value_type>(-12));
+    EXPECT_EQ(view_test_h(2), static_cast<value_type>(22));
+    EXPECT_EQ(view_test_h(3), static_cast<value_type>(-12));
+    EXPECT_EQ(view_test_h(4), static_cast<value_type>(22));
+    EXPECT_EQ(view_test_h(5), static_cast<value_type>(-12));
+    EXPECT_EQ(view_test_h(6), static_cast<value_type>(22));
+    EXPECT_EQ(view_test_h(7), static_cast<value_type>(-12));
+    EXPECT_EQ(view_test_h(8), static_cast<value_type>(22));
+    EXPECT_EQ(view_test_h(9), static_cast<value_type>(-12));
+    EXPECT_EQ(view_test_h(10), static_cast<value_type>(22));
+    EXPECT_EQ(view_test_h(11), static_cast<value_type>(-12));
+    EXPECT_EQ(view_test_h(12), static_cast<value_type>(22));
   }
 
   else if (name == "medium" || name == "large") {
@@ -220,13 +220,13 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
     std::size_t count = 0;
     for (std::size_t i = 0; i < view_from_h.extent(0); ++i) {
       if (pred(view_from_h(i))) {
-        EXPECT_TRUE(view_test_h(count++) == view_from_h(i));
+        EXPECT_EQ(view_test_h(count++), view_from_h(i));
       }
     }
     // all other entries of test view should be zero
     for (; count < view_test_h.extent(0); ++count) {
       // std::cout << count << '\n';
-      EXPECT_TRUE(view_test_h(count) == value_type(0));
+      EXPECT_EQ(view_test_h(count), value_type(0));
     }
   }
 
@@ -255,7 +255,7 @@ void run_single_scenario(const InfoType& scenario_info) {
     auto rit       = KE::copy_if(exespace(), KE::cbegin(view_from),
                            KE::cend(view_from), KE::begin(view_dest), pred);
     verify_data(name, view_from, view_dest, pred);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + n));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + n));
   }
 
   {
@@ -264,7 +264,7 @@ void run_single_scenario(const InfoType& scenario_info) {
     auto rit       = KE::copy_if("label", exespace(), KE::cbegin(view_from),
                            KE::cend(view_from), KE::begin(view_dest), pred);
     verify_data(name, view_from, view_dest, pred);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + n));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + n));
   }
 
   {
@@ -272,7 +272,7 @@ void run_single_scenario(const InfoType& scenario_info) {
     auto view_dest = create_view<ValueType>(Tag{}, view_ext, "copy_if_dest");
     auto rit       = KE::copy_if(exespace(), view_from, view_dest, pred);
     verify_data(name, view_from, view_dest, pred);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + n));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + n));
   }
 
   {
@@ -280,7 +280,7 @@ void run_single_scenario(const InfoType& scenario_info) {
     auto view_dest = create_view<ValueType>(Tag{}, view_ext, "copy_if_dest");
     auto rit = KE::copy_if("label", exespace(), view_from, view_dest, pred);
     verify_data(name, view_from, view_dest, pred);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + n));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + n));
   }
 
   Kokkos::fence();

--- a/algorithms/unit_tests/TestStdAlgorithmsCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCopyIf.cpp
@@ -220,7 +220,8 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
     std::size_t count = 0;
     for (std::size_t i = 0; i < view_from_h.extent(0); ++i) {
       if (pred(view_from_h(i))) {
-        EXPECT_EQ(view_test_h(count++), view_from_h(i));
+        EXPECT_EQ(view_test_h(count), view_from_h(i));
+        count++;
       }
     }
     // all other entries of test view should be zero

--- a/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
@@ -181,7 +181,7 @@ void verify_data(ViewType1 data_view,  // contains data
       //           << gold_h(i) << " " << test_view_h(i) << " "
       //           << std::abs(gold_h(i) - test_view_h(i)) << std::endl;
       if (std::is_same<gold_view_value_type, int>::value) {
-        EXPECT_TRUE(gold_h(i) == test_view_h(i));
+        EXPECT_EQ(gold_h(i), test_view_h(i));
       } else {
         const auto error = std::abs(gold_h(i) - test_view_h(i));
         if (error > 1e-10) {
@@ -189,7 +189,7 @@ void verify_data(ViewType1 data_view,  // contains data
                     << " " << gold_h(i) << " " << test_view_h(i) << " "
                     << std::abs(gold_h(i) - test_view_h(i)) << std::endl;
         }
-        EXPECT_TRUE(error < 1e-10);
+        EXPECT_LT(error, 1e-10);
       }
     }
   }
@@ -247,7 +247,7 @@ void run_single_scenario_default_op(const InfoType& scenario_info,
     auto r = KE::exclusive_scan(exespace(), KE::cbegin(view_from),
                                 KE::cend(view_from), KE::begin(view_dest),
                                 init_value);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, default_op());
   }
 
@@ -256,14 +256,14 @@ void run_single_scenario_default_op(const InfoType& scenario_info,
     auto r = KE::exclusive_scan("label", exespace(), KE::cbegin(view_from),
                                 KE::cend(view_from), KE::begin(view_dest),
                                 init_value);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, default_op());
   }
 
   {
     fill_zero(view_dest);
     auto r = KE::exclusive_scan(exespace(), view_from, view_dest, init_value);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, default_op());
   }
 
@@ -271,7 +271,7 @@ void run_single_scenario_default_op(const InfoType& scenario_info,
     fill_zero(view_dest);
     auto r = KE::exclusive_scan("label", exespace(), view_from, view_dest,
                                 init_value);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, default_op());
   }
 
@@ -297,7 +297,7 @@ void run_single_scenario_custom_op(const InfoType& scenario_info,
     auto r = KE::exclusive_scan(exespace(), KE::cbegin(view_from),
                                 KE::cend(view_from), KE::begin(view_dest),
                                 init_value, bop);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, bop);
   }
 
@@ -306,7 +306,7 @@ void run_single_scenario_custom_op(const InfoType& scenario_info,
     auto r = KE::exclusive_scan("label", exespace(), KE::cbegin(view_from),
                                 KE::cend(view_from), KE::begin(view_dest),
                                 init_value, bop);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, bop);
   }
 
@@ -314,7 +314,7 @@ void run_single_scenario_custom_op(const InfoType& scenario_info,
     fill_zero(view_dest);
     auto r =
         KE::exclusive_scan(exespace(), view_from, view_dest, init_value, bop);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, bop);
   }
 
@@ -322,7 +322,7 @@ void run_single_scenario_custom_op(const InfoType& scenario_info,
     fill_zero(view_dest);
     auto r = KE::exclusive_scan("label", exespace(), view_from, view_dest,
                                 init_value, bop);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, bop);
   }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsFindEnd.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsFindEnd.cpp
@@ -312,7 +312,7 @@ void run_single_scenario(const InfoType& scenario_info, std::size_t seq_ext,
     const auto mydiff  = myrit - KE::cbegin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
     // std::cout << "result : " << mydiff << " " << stddiff << std::endl;
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
@@ -321,21 +321,21 @@ void run_single_scenario(const InfoType& scenario_info, std::size_t seq_ext,
                      KE::cbegin(s_view), KE::cend(s_view), args...);
     const auto mydiff  = myrit - KE::cbegin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
     auto myrit         = KE::find_end(exespace(), view, s_view, args...);
     const auto mydiff  = myrit - KE::begin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
     auto myrit = KE::find_end("label", exespace(), view, s_view, args...);
     const auto mydiff  = myrit - KE::begin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   Kokkos::fence();

--- a/algorithms/unit_tests/TestStdAlgorithmsFindFirstOf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsFindFirstOf.cpp
@@ -231,7 +231,7 @@ void run_single_scenario(const InfoType& scenario_info, std::size_t seq_ext,
                           KE::cbegin(s_view), KE::cend(s_view), args...);
     const auto mydiff  = myrit - KE::cbegin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
@@ -240,21 +240,21 @@ void run_single_scenario(const InfoType& scenario_info, std::size_t seq_ext,
                           KE::cbegin(s_view), KE::cend(s_view), args...);
     const auto mydiff  = myrit - KE::cbegin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
     auto myrit         = KE::find_first_of(exespace(), view, s_view, args...);
     const auto mydiff  = myrit - KE::begin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
     auto myrit = KE::find_first_of("label", exespace(), view, s_view, args...);
     const auto mydiff  = myrit - KE::begin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   Kokkos::fence();

--- a/algorithms/unit_tests/TestStdAlgorithmsInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsInclusiveScan.cpp
@@ -195,7 +195,7 @@ void verify_data(ViewType1 data_view,  // contains data
       //           << std::abs(gold_h(i) - test_view_h(i)) << std::endl;
 
       if (std::is_same<gold_view_value_type, int>::value) {
-        EXPECT_TRUE(gold_h(i) == test_view_h(i));
+        EXPECT_EQ(gold_h(i), test_view_h(i));
       } else {
         const auto error = std::abs(gold_h(i) - test_view_h(i));
         if (error > 1e-10) {
@@ -203,7 +203,7 @@ void verify_data(ViewType1 data_view,  // contains data
                     << " " << gold_h(i) << " " << test_view_h(i) << " "
                     << std::abs(gold_h(i) - test_view_h(i)) << std::endl;
         }
-        EXPECT_TRUE(error < 1e-10);
+        EXPECT_LT(error, 1e-10);
       }
     }
     // std::cout << " last el: " << test_view_h(ext-1) << std::endl;
@@ -258,7 +258,7 @@ void run_single_scenario_default_op(const InfoType& scenario_info) {
     fill_zero(view_dest);
     auto r = KE::inclusive_scan(exespace(), KE::cbegin(view_from),
                                 KE::cend(view_from), KE::begin(view_dest));
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, default_op());
   }
 
@@ -266,21 +266,21 @@ void run_single_scenario_default_op(const InfoType& scenario_info) {
     fill_zero(view_dest);
     auto r = KE::inclusive_scan("label", exespace(), KE::cbegin(view_from),
                                 KE::cend(view_from), KE::begin(view_dest));
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, default_op());
   }
 
   {
     fill_zero(view_dest);
     auto r = KE::inclusive_scan(exespace(), view_from, view_dest);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, default_op());
   }
 
   {
     fill_zero(view_dest);
     auto r = KE::inclusive_scan("label", exespace(), view_from, view_dest);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, default_op());
   }
 
@@ -313,7 +313,7 @@ void run_single_scenario_custom_op(const InfoType& scenario_info, BinaryOp bop,
     auto r = KE::inclusive_scan(exespace(), KE::cbegin(view_from),
                                 KE::cend(view_from), KE::begin(view_dest), bop,
                                 args...);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, bop, args...);
   }
 
@@ -322,14 +322,14 @@ void run_single_scenario_custom_op(const InfoType& scenario_info, BinaryOp bop,
     auto r = KE::inclusive_scan("label", exespace(), KE::cbegin(view_from),
                                 KE::cend(view_from), KE::begin(view_dest), bop,
                                 args...);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, bop, args...);
   }
 
   {
     fill_zero(view_dest);
     auto r = KE::inclusive_scan(exespace(), view_from, view_dest, bop, args...);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, bop, args...);
   }
 
@@ -337,7 +337,7 @@ void run_single_scenario_custom_op(const InfoType& scenario_info, BinaryOp bop,
     fill_zero(view_dest);
     auto r = KE::inclusive_scan("label", exespace(), view_from, view_dest, bop,
                                 args...);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, bop, args...);
   }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsIsSortedUntil.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsIsSortedUntil.cpp
@@ -175,10 +175,10 @@ void run_single_scenario(const InfoType& scenario_info) {
       KE::is_sorted_until("label", exespace(), KE::begin(view), KE::end(view));
   auto r3 = KE::is_sorted_until(exespace(), view);
   auto r4 = KE::is_sorted_until("label", exespace(), view);
-  EXPECT_TRUE(r1 == gold);
-  EXPECT_TRUE(r2 == gold);
-  EXPECT_TRUE(r3 == gold);
-  EXPECT_TRUE(r4 == gold);
+  EXPECT_EQ(r1, gold);
+  EXPECT_EQ(r2, gold);
+  EXPECT_EQ(r3, gold);
+  EXPECT_EQ(r4, gold);
 
 #if not defined KOKKOS_ENABLE_OPENMPTARGET
   CustomLessThanComparator<ValueType, ValueType> comp;
@@ -190,10 +190,10 @@ void run_single_scenario(const InfoType& scenario_info) {
   auto r8 = KE::is_sorted_until("label", exespace(), view, comp);
 #endif
 
-  EXPECT_TRUE(r1 == gold);
-  EXPECT_TRUE(r2 == gold);
-  EXPECT_TRUE(r3 == gold);
-  EXPECT_TRUE(r4 == gold);
+  EXPECT_EQ(r1, gold);
+  EXPECT_EQ(r2, gold);
+  EXPECT_EQ(r3, gold);
+  EXPECT_EQ(r4, gold);
 
   Kokkos::fence();
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsMinMaxElementOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsMinMaxElementOps.cpp
@@ -228,39 +228,39 @@ template <class ViewType>
 void test_max_element_trivial_data(ViewType view) {
   /* if we pass empty range, should return last */
   auto result = KE::max_element(exespace(), KE::cbegin(view), KE::cbegin(view));
-  EXPECT_TRUE(result == KE::cbegin(view));
+  EXPECT_EQ(result, KE::cbegin(view));
 
   /* if we pass empty range, should return last */
   auto it0     = KE::cbegin(view) + 3;
   auto it1     = it0;
   auto result2 = KE::max_element(exespace(), it0, it1);
-  EXPECT_TRUE(result2 == it1);
+  EXPECT_EQ(result2, it1);
 }
 
 template <class ViewType>
 void test_min_element_trivial_data(ViewType view) {
   /* if we pass empty range, should return last */
   auto result = KE::min_element(exespace(), KE::cbegin(view), KE::cbegin(view));
-  EXPECT_TRUE(result == KE::cbegin(view));
+  EXPECT_EQ(result, KE::cbegin(view));
 
   /* if we pass empty range, should return last */
   auto it0     = KE::cbegin(view) + 3;
   auto it1     = it0;
   auto result2 = KE::min_element(exespace(), it0, it1);
-  EXPECT_TRUE(result2 == it1);
+  EXPECT_EQ(result2, it1);
 }
 
 template <class ViewType>
 void test_minmax_element_empty_range(ViewType view) {
   auto result =
       KE::minmax_element(exespace(), KE::cbegin(view), KE::cbegin(view));
-  EXPECT_TRUE(result.first == KE::cbegin(view));
-  EXPECT_TRUE(result.second == KE::cbegin(view));
+  EXPECT_EQ(result.first, KE::cbegin(view));
+  EXPECT_EQ(result.second, KE::cbegin(view));
   auto it0     = KE::cbegin(view) + 3;
   auto it1     = it0;
   auto result2 = KE::minmax_element(exespace(), it0, it1);
-  EXPECT_TRUE(result2.first == it1);
-  EXPECT_TRUE(result2.second == it1);
+  EXPECT_EQ(result2.first, it1);
+  EXPECT_EQ(result2.second, it1);
 }
 
 template <class ViewType>

--- a/algorithms/unit_tests/TestStdAlgorithmsMismatch.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsMismatch.cpp
@@ -150,10 +150,10 @@ void run_single_scenario(ViewType view1, ViewType view2,
     const auto my_diff12 = my_res1.second - f2;
     const auto my_diff21 = my_res2.first - f1;
     const auto my_diff22 = my_res2.second - f2;
-    EXPECT_TRUE(my_diff11 == std_diff1);
-    EXPECT_TRUE(my_diff12 == std_diff2);
-    EXPECT_TRUE(my_diff21 == std_diff1);
-    EXPECT_TRUE(my_diff22 == std_diff2);
+    EXPECT_EQ(my_diff11, std_diff1);
+    EXPECT_EQ(my_diff12, std_diff2);
+    EXPECT_EQ(my_diff21, std_diff1);
+    EXPECT_EQ(my_diff22, std_diff2);
   }
 
   {
@@ -164,10 +164,10 @@ void run_single_scenario(ViewType view1, ViewType view2,
     const auto my_diff12 = my_res1.second - KE::begin(view2);
     const auto my_diff21 = my_res2.first - KE::begin(view1);
     const auto my_diff22 = my_res2.second - KE::begin(view2);
-    EXPECT_TRUE(my_diff11 == std_diff1);
-    EXPECT_TRUE(my_diff12 == std_diff2);
-    EXPECT_TRUE(my_diff21 == std_diff1);
-    EXPECT_TRUE(my_diff22 == std_diff2);
+    EXPECT_EQ(my_diff11, std_diff1);
+    EXPECT_EQ(my_diff12, std_diff2);
+    EXPECT_EQ(my_diff21, std_diff1);
+    EXPECT_EQ(my_diff22, std_diff2);
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
@@ -81,14 +81,14 @@ TEST(std_algorithms_mod_ops_test, move) {
 
   // move constr
   MyMovableType b(std::move(a));
-  EXPECT_TRUE(b.m_value == 11);
-  EXPECT_TRUE(a.m_value == -2);
+  EXPECT_EQ(b.m_value, 11);
+  EXPECT_EQ(a.m_value, -2);
 
   // move assign
   MyMovableType c;
   c = std::move(b);
-  EXPECT_TRUE(c.m_value == 11);
-  EXPECT_TRUE(b.m_value == -4);
+  EXPECT_EQ(c.m_value, 11);
+  EXPECT_EQ(b.m_value, -4);
 }
 
 template <class ViewType>
@@ -126,8 +126,8 @@ TEST(std_algorithms_mod_ops_test, swap) {
     int a = 1;
     int b = 2;
     KE::swap(a, b);
-    EXPECT_TRUE(a == 2);
-    EXPECT_TRUE(b == 1);
+    EXPECT_EQ(a, 2);
+    EXPECT_EQ(b, 1);
   }
 
   {
@@ -180,17 +180,17 @@ void test_iter_swap(ViewType view) {
   using value_type = typename ViewType::value_type;
   auto a_dc        = create_deep_copyable_compatible_clone(view);
   auto a_h         = create_mirror_view_and_copy(Kokkos::HostSpace(), a_dc);
-  EXPECT_TRUE(view.extent(0) == 10);
-  EXPECT_TRUE(a_h(0) == value_type(3));
-  EXPECT_TRUE(a_h(1) == value_type(1));
-  EXPECT_TRUE(a_h(2) == value_type(2));
-  EXPECT_TRUE(a_h(3) == value_type(0));
-  EXPECT_TRUE(a_h(4) == value_type(6));
-  EXPECT_TRUE(a_h(5) == value_type(5));
-  EXPECT_TRUE(a_h(6) == value_type(4));
-  EXPECT_TRUE(a_h(7) == value_type(7));
-  EXPECT_TRUE(a_h(8) == value_type(8));
-  EXPECT_TRUE(a_h(9) == value_type(9));
+  EXPECT_EQ(view.extent(0), 10);
+  EXPECT_EQ(a_h(0), value_type(3));
+  EXPECT_EQ(a_h(1), value_type(1));
+  EXPECT_EQ(a_h(2), value_type(2));
+  EXPECT_EQ(a_h(3), value_type(0));
+  EXPECT_EQ(a_h(4), value_type(6));
+  EXPECT_EQ(a_h(5), value_type(5));
+  EXPECT_EQ(a_h(6), value_type(4));
+  EXPECT_EQ(a_h(7), value_type(7));
+  EXPECT_EQ(a_h(8), value_type(8));
+  EXPECT_EQ(a_h(9), value_type(9));
 }
 
 TEST(std_algorithms_mod_ops_test, iter_swap_static_view) {

--- a/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsModOps.cpp
@@ -180,7 +180,7 @@ void test_iter_swap(ViewType view) {
   using value_type = typename ViewType::value_type;
   auto a_dc        = create_deep_copyable_compatible_clone(view);
   auto a_h         = create_mirror_view_and_copy(Kokkos::HostSpace(), a_dc);
-  EXPECT_EQ(view.extent(0), 10);
+  EXPECT_EQ(view.extent_int(0), 10);
   EXPECT_EQ(a_h(0), value_type(3));
   EXPECT_EQ(a_h(1), value_type(1));
   EXPECT_EQ(a_h(2), value_type(2));

--- a/algorithms/unit_tests/TestStdAlgorithmsModSeqOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsModSeqOps.cpp
@@ -390,16 +390,16 @@ void test_swap_ranges(ViewType view) {
   parallel_for(ext, cp_func_a_t(view, checkViewA));
   auto cvA_h =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), checkViewA);
-  EXPECT_TRUE(cvA_h(0) == 0);
-  EXPECT_TRUE(cvA_h(1) == 1);
-  EXPECT_TRUE(cvA_h(2) == 99);
-  EXPECT_TRUE(cvA_h(3) == 98);
-  EXPECT_TRUE(cvA_h(4) == 97);
-  EXPECT_TRUE(cvA_h(5) == 96);
-  EXPECT_TRUE(cvA_h(6) == 6);
-  EXPECT_TRUE(cvA_h(7) == 7);
-  EXPECT_TRUE(cvA_h(8) == 8);
-  EXPECT_TRUE(cvA_h(9) == 9);
+  EXPECT_EQ(cvA_h(0), 0);
+  EXPECT_EQ(cvA_h(1), 1);
+  EXPECT_EQ(cvA_h(2), 99);
+  EXPECT_EQ(cvA_h(3), 98);
+  EXPECT_EQ(cvA_h(4), 97);
+  EXPECT_EQ(cvA_h(5), 96);
+  EXPECT_EQ(cvA_h(6), 6);
+  EXPECT_EQ(cvA_h(7), 7);
+  EXPECT_EQ(cvA_h(8), 8);
+  EXPECT_EQ(cvA_h(9), 9);
 
   /* check viewB */
   static_view_type checkViewB("tmpB");
@@ -407,16 +407,16 @@ void test_swap_ranges(ViewType view) {
   Kokkos::parallel_for(ext, cp_func_b_t(viewB, checkViewB));
   auto cvB_h =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), checkViewB);
-  EXPECT_TRUE(cvB_h(0) == 100);
-  EXPECT_TRUE(cvB_h(1) == 2);
-  EXPECT_TRUE(cvB_h(2) == 3);
-  EXPECT_TRUE(cvB_h(3) == 4);
-  EXPECT_TRUE(cvB_h(4) == 5);
-  EXPECT_TRUE(cvB_h(5) == 95);
-  EXPECT_TRUE(cvB_h(6) == 94);
-  EXPECT_TRUE(cvB_h(7) == 93);
-  EXPECT_TRUE(cvB_h(8) == 92);
-  EXPECT_TRUE(cvB_h(9) == 91);
+  EXPECT_EQ(cvB_h(0), 100);
+  EXPECT_EQ(cvB_h(1), 2);
+  EXPECT_EQ(cvB_h(2), 3);
+  EXPECT_EQ(cvB_h(3), 4);
+  EXPECT_EQ(cvB_h(4), 5);
+  EXPECT_EQ(cvB_h(5), 95);
+  EXPECT_EQ(cvB_h(6), 94);
+  EXPECT_EQ(cvB_h(7), 93);
+  EXPECT_EQ(cvB_h(8), 92);
+  EXPECT_EQ(cvB_h(9), 91);
 }
 
 TEST_F(std_algorithms_mod_seq_ops_test, swap_ranges) {

--- a/algorithms/unit_tests/TestStdAlgorithmsNumerics.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsNumerics.cpp
@@ -260,8 +260,8 @@ void run_and_check_transform_reduce_default(ViewType1 first_view,
   const auto r2 = KE::transform_reduce(
       "MYLABEL", ExecutionSpace(), KE::cbegin(first_view),
       KE::cbegin(first_view), KE::cbegin(second_view), init_value);
-  EXPECT_TRUE(r1 == init_value);
-  EXPECT_TRUE(r2 == init_value);
+  EXPECT_EQ(r1, init_value);
+  EXPECT_EQ(r2, init_value);
 
   // non-trivial cases
   const auto r3 = KE::transform_reduce(ExecutionSpace(), KE::cbegin(first_view),
@@ -277,10 +277,10 @@ void run_and_check_transform_reduce_default(ViewType1 first_view,
   const auto r6 = KE::transform_reduce("MYLABEL", ExecutionSpace(), first_view,
                                        second_view, init_value);
 
-  EXPECT_TRUE(r3 == result_value);
-  EXPECT_TRUE(r4 == result_value);
-  EXPECT_TRUE(r5 == result_value);
-  EXPECT_TRUE(r6 == result_value);
+  EXPECT_EQ(r3, result_value);
+  EXPECT_EQ(r4, result_value);
+  EXPECT_EQ(r5, result_value);
+  EXPECT_EQ(r6, result_value);
 }
 
 TEST_F(std_algorithms_numerics_test,
@@ -363,8 +363,8 @@ void run_and_check_transform_reduce_overloadA(ViewType1 first_view,
                            KE::cbegin(first_view), KE::cbegin(second_view),
                            init_value, std::forward<Args>(args)...);
 
-  EXPECT_TRUE(r1 == init_value);
-  EXPECT_TRUE(r2 == init_value);
+  EXPECT_EQ(r1, init_value);
+  EXPECT_EQ(r2, init_value);
 
   // non trivial cases
   const auto r3 = KE::transform_reduce(
@@ -382,10 +382,10 @@ void run_and_check_transform_reduce_overloadA(ViewType1 first_view,
       KE::transform_reduce("MYLABEL", ExecutionSpace(), first_view, second_view,
                            init_value, std::forward<Args>(args)...);
 
-  EXPECT_TRUE(r3 == result_value);
-  EXPECT_TRUE(r4 == result_value);
-  EXPECT_TRUE(r5 == result_value);
-  EXPECT_TRUE(r6 == result_value);
+  EXPECT_EQ(r3, result_value);
+  EXPECT_EQ(r4, result_value);
+  EXPECT_EQ(r5, result_value);
+  EXPECT_EQ(r6, result_value);
 }
 
 TEST_F(std_algorithms_numerics_test,
@@ -482,8 +482,8 @@ void run_and_check_transform_reduce_overloadB(ViewType view,
                                        KE::cbegin(view), KE::cbegin(view),
                                        init_value, std::forward<Args>(args)...);
 
-  EXPECT_TRUE(r1 == init_value);
-  EXPECT_TRUE(r2 == init_value);
+  EXPECT_EQ(r1, init_value);
+  EXPECT_EQ(r2, init_value);
 
   // non trivial
   const auto r3 =
@@ -499,10 +499,10 @@ void run_and_check_transform_reduce_overloadB(ViewType view,
   const auto r6 = KE::transform_reduce("MYLABEL", ExecutionSpace(), view,
                                        init_value, std::forward<Args>(args)...);
 
-  EXPECT_TRUE(r3 == result_value);
-  EXPECT_TRUE(r4 == result_value);
-  EXPECT_TRUE(r5 == result_value);
-  EXPECT_TRUE(r6 == result_value);
+  EXPECT_EQ(r3, result_value);
+  EXPECT_EQ(r4, result_value);
+  EXPECT_EQ(r5, result_value);
+  EXPECT_EQ(r6, result_value);
 }
 
 TEST_F(std_algorithms_numerics_test,
@@ -556,8 +556,8 @@ void run_and_check_reduce_overloadA(ViewType view, ValueType non_trivial_result,
       KE::reduce(ExecutionSpace(), KE::cbegin(view), KE::cbegin(view));
   const auto r2 = KE::reduce("MYLABEL", ExecutionSpace(), KE::cbegin(view),
                              KE::cbegin(view));
-  EXPECT_TRUE(r1 == trivial_result);
-  EXPECT_TRUE(r2 == trivial_result);
+  EXPECT_EQ(r1, trivial_result);
+  EXPECT_EQ(r2, trivial_result);
 
   // non trivial cases
   const auto r3 =
@@ -567,10 +567,10 @@ void run_and_check_reduce_overloadA(ViewType view, ValueType non_trivial_result,
   const auto r5 = KE::reduce(ExecutionSpace(), view);
   const auto r6 = KE::reduce("MYLABEL", ExecutionSpace(), view);
 
-  EXPECT_TRUE(r3 == non_trivial_result);
-  EXPECT_TRUE(r4 == non_trivial_result);
-  EXPECT_TRUE(r5 == non_trivial_result);
-  EXPECT_TRUE(r6 == non_trivial_result);
+  EXPECT_EQ(r3, non_trivial_result);
+  EXPECT_EQ(r4, non_trivial_result);
+  EXPECT_EQ(r5, non_trivial_result);
+  EXPECT_EQ(r6, non_trivial_result);
 }
 
 TEST_F(std_algorithms_numerics_test,
@@ -612,8 +612,8 @@ void run_and_check_reduce_overloadB(ViewType view, ValueType result_value,
                              KE::cbegin(view), init_value);
   const auto r2 = KE::reduce("MYLABEL", ExecutionSpace(), KE::cbegin(view),
                              KE::cbegin(view), init_value);
-  EXPECT_TRUE(r1 == init_value);
-  EXPECT_TRUE(r2 == init_value);
+  EXPECT_EQ(r1, init_value);
+  EXPECT_EQ(r2, init_value);
 
   // non trivial cases
   const auto r3 = KE::reduce(ExecutionSpace(), KE::cbegin(view), KE::cend(view),
@@ -623,10 +623,10 @@ void run_and_check_reduce_overloadB(ViewType view, ValueType result_value,
   const auto r5 = KE::reduce(ExecutionSpace(), view, init_value);
   const auto r6 = KE::reduce("MYLABEL", ExecutionSpace(), view, init_value);
 
-  EXPECT_TRUE(r3 == result_value);
-  EXPECT_TRUE(r4 == result_value);
-  EXPECT_TRUE(r5 == result_value);
-  EXPECT_TRUE(r6 == result_value);
+  EXPECT_EQ(r3, result_value);
+  EXPECT_EQ(r4, result_value);
+  EXPECT_EQ(r5, result_value);
+  EXPECT_EQ(r6, result_value);
 }
 
 TEST_F(std_algorithms_numerics_test,
@@ -662,8 +662,8 @@ void run_and_check_reduce_overloadC(ViewType view, ValueType result_value,
                              KE::cbegin(view), init_value, joiner);
   const auto r2 = KE::reduce("MYLABEL", ExecutionSpace(), KE::cbegin(view),
                              KE::cbegin(view), init_value, joiner);
-  EXPECT_TRUE(r1 == init_value);
-  EXPECT_TRUE(r2 == init_value);
+  EXPECT_EQ(r1, init_value);
+  EXPECT_EQ(r2, init_value);
 
   // non trivial cases
   const auto r3 = KE::reduce(ExecutionSpace(), KE::cbegin(view), KE::cend(view),
@@ -674,10 +674,10 @@ void run_and_check_reduce_overloadC(ViewType view, ValueType result_value,
   const auto r6 =
       KE::reduce("MYLABEL", ExecutionSpace(), view, init_value, joiner);
 
-  EXPECT_TRUE(r3 == result_value);
-  EXPECT_TRUE(r4 == result_value);
-  EXPECT_TRUE(r5 == result_value);
-  EXPECT_TRUE(r6 == result_value);
+  EXPECT_EQ(r3, result_value);
+  EXPECT_EQ(r4, result_value);
+  EXPECT_EQ(r5, result_value);
+  EXPECT_EQ(r6, result_value);
 }
 
 TEST_F(std_algorithms_numerics_test,

--- a/algorithms/unit_tests/TestStdAlgorithmsPartitionCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsPartitionCopy.cpp
@@ -160,12 +160,12 @@ void verify_data(const std::string& name, ResultType my_result,
   const std::size_t my_diff_true = my_result.first - KE::begin(view_dest_true);
   const std::size_t my_diff_false =
       my_result.second - KE::begin(view_dest_false);
-  EXPECT_TRUE(std_diff_true == my_diff_true);
-  EXPECT_TRUE(std_diff_false == my_diff_false);
+  EXPECT_EQ(std_diff_true, my_diff_true);
+  EXPECT_EQ(std_diff_false, my_diff_false);
 
   auto view_dest_true_h = create_host_space_copy(view_dest_true);
   for (std::size_t i = 0; i < std_diff_true; ++i) {
-    EXPECT_TRUE(std_vec_true[i] == view_dest_true_h(i));
+    EXPECT_EQ(std_vec_true[i], view_dest_true_h(i));
     // std::cout << "i= " << i << " "
     // 	      << " std_true = " << std_vec_true[i] << " "
     // 	      << " mine     = " << view_dest_true_h(i) << '\n';
@@ -173,45 +173,45 @@ void verify_data(const std::string& name, ResultType my_result,
 
   auto view_dest_false_h = create_host_space_copy(view_dest_false);
   for (std::size_t i = 0; i < std_diff_false; ++i) {
-    EXPECT_TRUE(std_vec_false[i] == view_dest_false_h(i));
+    EXPECT_EQ(std_vec_false[i], view_dest_false_h(i));
     // std::cout << "i= " << i << " "
     // 	      << " std_false = " << std_vec_false[i] << " "
     // 	      << " mine     = " << view_dest_false_h(i) << '\n';
   }
 
   if (name == "empty") {
-    EXPECT_TRUE(my_diff_true == 0);
-    EXPECT_TRUE(my_diff_false == 0);
+    EXPECT_EQ(my_diff_true, 0);
+    EXPECT_EQ(my_diff_false, 0);
   }
 
   else if (name == "one-element-a") {
-    EXPECT_TRUE(my_diff_true == 0);
-    EXPECT_TRUE(my_diff_false == 1);
+    EXPECT_EQ(my_diff_true, 0);
+    EXPECT_EQ(my_diff_false, 1);
   }
 
   else if (name == "one-element-b") {
-    EXPECT_TRUE(my_diff_true == 1);
-    EXPECT_TRUE(my_diff_false == 0);
+    EXPECT_EQ(my_diff_true, 1);
+    EXPECT_EQ(my_diff_false, 0);
   }
 
   else if (name == "two-elements-a") {
-    EXPECT_TRUE(my_diff_true == 1);
-    EXPECT_TRUE(my_diff_false == 1);
+    EXPECT_EQ(my_diff_true, 1);
+    EXPECT_EQ(my_diff_false, 1);
   }
 
   else if (name == "two-elements-b") {
-    EXPECT_TRUE(my_diff_true == 1);
-    EXPECT_TRUE(my_diff_false == 1);
+    EXPECT_EQ(my_diff_true, 1);
+    EXPECT_EQ(my_diff_false, 1);
   }
 
   else if (name == "small-b") {
-    EXPECT_TRUE(my_diff_true == 13);
-    EXPECT_TRUE(my_diff_false == 0);
+    EXPECT_EQ(my_diff_true, 13);
+    EXPECT_EQ(my_diff_false, 0);
   }
 
   else if (name == "small-c") {
-    EXPECT_TRUE(my_diff_true == 0);
-    EXPECT_TRUE(my_diff_false == 15);
+    EXPECT_EQ(my_diff_true, 0);
+    EXPECT_EQ(my_diff_false, 15);
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsPartitionCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsPartitionCopy.cpp
@@ -180,38 +180,38 @@ void verify_data(const std::string& name, ResultType my_result,
   }
 
   if (name == "empty") {
-    EXPECT_EQ(my_diff_true, 0);
-    EXPECT_EQ(my_diff_false, 0);
+    EXPECT_EQ(my_diff_true, 0u);
+    EXPECT_EQ(my_diff_false, 0u);
   }
 
   else if (name == "one-element-a") {
-    EXPECT_EQ(my_diff_true, 0);
-    EXPECT_EQ(my_diff_false, 1);
+    EXPECT_EQ(my_diff_true, 0u);
+    EXPECT_EQ(my_diff_false, 1u);
   }
 
   else if (name == "one-element-b") {
-    EXPECT_EQ(my_diff_true, 1);
-    EXPECT_EQ(my_diff_false, 0);
+    EXPECT_EQ(my_diff_true, 1u);
+    EXPECT_EQ(my_diff_false, 0u);
   }
 
   else if (name == "two-elements-a") {
-    EXPECT_EQ(my_diff_true, 1);
-    EXPECT_EQ(my_diff_false, 1);
+    EXPECT_EQ(my_diff_true, 1u);
+    EXPECT_EQ(my_diff_false, 1u);
   }
 
   else if (name == "two-elements-b") {
-    EXPECT_EQ(my_diff_true, 1);
-    EXPECT_EQ(my_diff_false, 1);
+    EXPECT_EQ(my_diff_true, 1u);
+    EXPECT_EQ(my_diff_false, 1u);
   }
 
   else if (name == "small-b") {
-    EXPECT_EQ(my_diff_true, 13);
-    EXPECT_EQ(my_diff_false, 0);
+    EXPECT_EQ(my_diff_true, 13u);
+    EXPECT_EQ(my_diff_false, 0u);
   }
 
   else if (name == "small-c") {
-    EXPECT_EQ(my_diff_true, 0);
-    EXPECT_EQ(my_diff_false, 15);
+    EXPECT_EQ(my_diff_true, 0u);
+    EXPECT_EQ(my_diff_false, 15u);
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsPartitioningOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsPartitioningOps.cpp
@@ -180,15 +180,15 @@ TEST_F(std_algorithms_partitioning_test, is_partitioned_trivial) {
   IsNegativeFunctor<value_type> p;
   const auto result1 = KE::is_partitioned(exespace(), KE::cbegin(m_static_view),
                                           KE::cbegin(m_static_view), p);
-  EXPECT_EQ(true, result1);
+  EXPECT_TRUE(result1);
 
   const auto result2 = KE::is_partitioned(
       exespace(), KE::cbegin(m_dynamic_view), KE::cbegin(m_dynamic_view), p);
-  EXPECT_EQ(true, result2);
+  EXPECT_TRUE(result2);
 
   const auto result3 = KE::is_partitioned(
       exespace(), KE::cbegin(m_strided_view), KE::cbegin(m_strided_view), p);
-  EXPECT_EQ(true, result3);
+  EXPECT_TRUE(result3);
 }
 
 TEST_F(std_algorithms_partitioning_test, is_partitioned_accepting_iterators) {

--- a/algorithms/unit_tests/TestStdAlgorithmsRemove.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRemove.cpp
@@ -147,12 +147,12 @@ void verify_data(ViewTypeData view_data_h, ViewTypeTest view_test,
   // check that returned iterators are correct
   const std::size_t std_diff = std_result - KE::begin(view_data_h);
   const std::size_t my_diff  = my_result - KE::begin(view_test);
-  EXPECT_TRUE(std_diff == my_diff);
+  EXPECT_EQ(std_diff, my_diff);
 
   // check the actual data after algo has been applied
   auto view_test_h = create_host_space_copy(view_test);
   for (std::size_t i = 0; i < my_diff; ++i) {
-    EXPECT_TRUE(view_test_h(i) == view_data_h[i]);
+    EXPECT_EQ(view_test_h(i), view_data_h[i]);
     // std::cout << "i= " << i << " "
     // 	      << "mine: " << view_test_h(i) << " "
     // 	      << "std: " << view_data_h(i)

--- a/algorithms/unit_tests/TestStdAlgorithmsRemoveCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRemoveCopy.cpp
@@ -165,12 +165,12 @@ void verify_data(ViewFromType view_from, ViewDestType view_dest,
   // check that returned iterators are correct
   const std::size_t std_diff = std_result - gold_dest_std.begin();
   const std::size_t my_diff  = my_result - KE::begin(view_dest);
-  EXPECT_TRUE(std_diff == my_diff);
+  EXPECT_EQ(std_diff, my_diff);
 
   // check the actual data after algo has been applied
   auto view_dest_h = create_host_space_copy(view_dest);
   for (std::size_t i = 0; i < my_diff; ++i) {
-    EXPECT_TRUE(view_dest_h(i) == gold_dest_std[i]);
+    EXPECT_EQ(view_dest_h(i), gold_dest_std[i]);
     // std::cout << "i= " << i << " "
     // 	      << "mine: " << view_dest_h(i) << " "
     // 	      << "std: " << gold_dest_std[i]

--- a/algorithms/unit_tests/TestStdAlgorithmsRemoveCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRemoveCopyIf.cpp
@@ -149,12 +149,12 @@ void verify_data(ViewTypeFrom view_from, ViewTypeDest view_dest,
   // check that returned iterators are correct
   const std::size_t std_diff = std_result - gold_dest_std.begin();
   const std::size_t my_diff  = my_result - KE::begin(view_dest);
-  EXPECT_TRUE(std_diff == my_diff);
+  EXPECT_EQ(std_diff, my_diff);
 
   // check the actual data after algo has been applied
   auto view_dest_h = create_host_space_copy(view_dest);
   for (std::size_t i = 0; i < my_diff; ++i) {
-    EXPECT_TRUE(view_dest_h(i) == gold_dest_std[i]);
+    EXPECT_EQ(view_dest_h(i), gold_dest_std[i]);
     // std::cout << "i= " << i << " "
     // 	      << "mine: " << view_dest_h(i) << " "
     // 	      << "std: " << gold_dest_std[i]

--- a/algorithms/unit_tests/TestStdAlgorithmsRemoveIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRemoveIf.cpp
@@ -142,12 +142,12 @@ void verify_data(ViewTypeData view_data_h, ViewTypeTest view_test,
   // check that returned iterators are correct
   const std::size_t std_diff = std_result - KE::begin(view_data_h);
   const std::size_t my_diff  = my_result - KE::begin(view_test);
-  EXPECT_TRUE(std_diff == my_diff);
+  EXPECT_EQ(std_diff, my_diff);
 
   // check the actual data after algo has been applied
   auto view_test_h = create_host_space_copy(view_test);
   for (std::size_t i = 0; i < my_diff; ++i) {
-    EXPECT_TRUE(view_test_h(i) == view_data_h[i]);
+    EXPECT_EQ(view_test_h(i), view_data_h[i]);
     // std::cout << "i= " << i << " "
     // 	      << "mine: " << view_test_h(i) << " "
     // 	      << "std: " << view_data_h(i)

--- a/algorithms/unit_tests/TestStdAlgorithmsReplace.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsReplace.cpp
@@ -134,30 +134,30 @@ void verify_data(const std::string& name, ViewType1 test_view,
   }
 
   else if (name == "one-element-a") {
-    EXPECT_TRUE(view_h(0) == ValueType{1});
+    EXPECT_EQ(view_h(0), ValueType{1});
   }
 
   else if (name == "one-element-b") {
-    EXPECT_TRUE(view_h(0) == new_value);
+    EXPECT_EQ(view_h(0), new_value);
   }
 
   else if (name == "two-elements-a") {
-    EXPECT_TRUE(view_h(0) == ValueType{1});
-    EXPECT_TRUE(view_h(1) == new_value);
+    EXPECT_EQ(view_h(0), ValueType{1});
+    EXPECT_EQ(view_h(1), new_value);
   }
 
   else if (name == "two-elements-b") {
-    EXPECT_TRUE(view_h(0) == new_value);
-    EXPECT_TRUE(view_h(1) == ValueType{-1});
+    EXPECT_EQ(view_h(0), new_value);
+    EXPECT_EQ(view_h(1), ValueType{-1});
   }
 
   else if (name == "small-a") {
     for (std::size_t i = 0; i < view_h.extent(0); ++i) {
       if (i == 0 || i == 3 || i == 5 || i == 6) {
-        EXPECT_TRUE(view_h(i) == new_value);
+        EXPECT_EQ(view_h(i), new_value);
       } else {
         const auto gold = ValueType{-5} + static_cast<ValueType>(i + 1);
-        EXPECT_TRUE(view_h(i) == gold);
+        EXPECT_EQ(view_h(i), gold);
       }
     }
   }
@@ -165,9 +165,9 @@ void verify_data(const std::string& name, ViewType1 test_view,
   else if (name == "small-b") {
     for (std::size_t i = 0; i < view_h.extent(0); ++i) {
       if (i < 4) {
-        EXPECT_TRUE(view_h(i) == ValueType{-1});
+        EXPECT_EQ(view_h(i), ValueType{-1});
       } else {
-        EXPECT_TRUE(view_h(i) == new_value);
+        EXPECT_EQ(view_h(i), new_value);
       }
     }
   }
@@ -175,9 +175,9 @@ void verify_data(const std::string& name, ViewType1 test_view,
   else if (name == "medium" || name == "large") {
     for (std::size_t i = 0; i < view_h.extent(0); ++i) {
       if (i % 2 == 0) {
-        EXPECT_TRUE(view_h(i) == ValueType{-1});
+        EXPECT_EQ(view_h(i), ValueType{-1});
       } else {
-        EXPECT_TRUE(view_h(i) == new_value);
+        EXPECT_EQ(view_h(i), new_value);
       }
     }
   }

--- a/algorithms/unit_tests/TestStdAlgorithmsReplaceCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsReplaceCopy.cpp
@@ -142,40 +142,40 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
   }
 
   else if (name == "one-element-a") {
-    EXPECT_TRUE(view_from_h(0) == ValueType{1});
-    EXPECT_TRUE(view_test_h(0) == view_from_h(0));
+    EXPECT_EQ(view_from_h(0), ValueType{1});
+    EXPECT_EQ(view_test_h(0), view_from_h(0));
   }
 
   else if (name == "one-element-b") {
-    EXPECT_TRUE(view_from_h(0) == ValueType{2});
-    EXPECT_TRUE(view_test_h(0) == new_value);
+    EXPECT_EQ(view_from_h(0), ValueType{2});
+    EXPECT_EQ(view_test_h(0), new_value);
   }
 
   else if (name == "two-elements-a") {
-    EXPECT_TRUE(view_from_h(0) == ValueType{1});
-    EXPECT_TRUE(view_from_h(1) == ValueType{2});
+    EXPECT_EQ(view_from_h(0), ValueType{1});
+    EXPECT_EQ(view_from_h(1), ValueType{2});
 
-    EXPECT_TRUE(view_test_h(0) == view_from_h(0));
-    EXPECT_TRUE(view_test_h(1) == new_value);
+    EXPECT_EQ(view_test_h(0), view_from_h(0));
+    EXPECT_EQ(view_test_h(1), new_value);
   }
 
   else if (name == "two-elements-b") {
-    EXPECT_TRUE(view_from_h(0) == ValueType{2});
-    EXPECT_TRUE(view_from_h(1) == ValueType{-1});
+    EXPECT_EQ(view_from_h(0), ValueType{2});
+    EXPECT_EQ(view_from_h(1), ValueType{-1});
 
-    EXPECT_TRUE(view_test_h(0) == new_value);
-    EXPECT_TRUE(view_test_h(1) == view_from_h(1));
+    EXPECT_EQ(view_test_h(0), new_value);
+    EXPECT_EQ(view_test_h(1), view_from_h(1));
   }
 
   else if (name == "small-a") {
     for (std::size_t i = 0; i < view_test_h.extent(0); ++i) {
       if (i == 0 || i == 3 || i == 5 || i == 6) {
-        EXPECT_TRUE(view_from_h(i) == ValueType{2});
-        EXPECT_TRUE(view_test_h(i) == new_value);
+        EXPECT_EQ(view_from_h(i), ValueType{2});
+        EXPECT_EQ(view_test_h(i), new_value);
       } else {
         const auto gold = ValueType{-5} + static_cast<ValueType>(i + 1);
-        EXPECT_TRUE(view_from_h(i) == gold);
-        EXPECT_TRUE(view_test_h(i) == gold);
+        EXPECT_EQ(view_from_h(i), gold);
+        EXPECT_EQ(view_test_h(i), gold);
       }
     }
   }
@@ -183,11 +183,11 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
   else if (name == "small-b") {
     for (std::size_t i = 0; i < view_test_h.extent(0); ++i) {
       if (i < 4) {
-        EXPECT_TRUE(view_from_h(i) == ValueType{-1});
-        EXPECT_TRUE(view_test_h(i) == view_from_h(i));
+        EXPECT_EQ(view_from_h(i), ValueType{-1});
+        EXPECT_EQ(view_test_h(i), view_from_h(i));
       } else {
-        EXPECT_TRUE(view_from_h(i) == ValueType{2});
-        EXPECT_TRUE(view_test_h(i) == new_value);
+        EXPECT_EQ(view_from_h(i), ValueType{2});
+        EXPECT_EQ(view_test_h(i), new_value);
       }
     }
   }
@@ -195,11 +195,11 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
   else if (name == "medium" || name == "large") {
     for (std::size_t i = 0; i < view_test_h.extent(0); ++i) {
       if (i % 2 == 0) {
-        EXPECT_TRUE(view_from_h(i) == ValueType{-1});
-        EXPECT_TRUE(view_test_h(i) == view_from_h(i));
+        EXPECT_EQ(view_from_h(i), ValueType{-1});
+        EXPECT_EQ(view_test_h(i), view_from_h(i));
       } else {
-        EXPECT_TRUE(view_from_h(i) == ValueType{2});
-        EXPECT_TRUE(view_test_h(i) == new_value);
+        EXPECT_EQ(view_from_h(i), ValueType{2});
+        EXPECT_EQ(view_test_h(i), new_value);
       }
     }
   }
@@ -232,7 +232,7 @@ void run_single_scenario(const InfoType& scenario_info) {
         KE::replace_copy(exespace(), KE::cbegin(view_from), KE::cend(view_from),
                          KE::begin(view_dest), old_value, new_value);
     verify_data(name, view_from, view_dest, new_value);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   {
@@ -245,7 +245,7 @@ void run_single_scenario(const InfoType& scenario_info) {
                                 KE::cend(view_from), KE::begin(view_dest),
                                 old_value, new_value);
     verify_data(name, view_from, view_dest, new_value);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   {
@@ -257,7 +257,7 @@ void run_single_scenario(const InfoType& scenario_info) {
     auto rit = KE::replace_copy(exespace(), view_from, view_dest, old_value,
                                 new_value);
     verify_data(name, view_from, view_dest, new_value);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   {
@@ -269,7 +269,7 @@ void run_single_scenario(const InfoType& scenario_info) {
     auto rit = KE::replace_copy("label", exespace(), view_from, view_dest,
                                 old_value, new_value);
     verify_data(name, view_from, view_dest, new_value);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   Kokkos::fence();

--- a/algorithms/unit_tests/TestStdAlgorithmsReplaceCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsReplaceCopyIf.cpp
@@ -142,40 +142,40 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
   }
 
   else if (name == "one-element-a") {
-    EXPECT_TRUE(view_from_h(0) == ValueType{1});
-    EXPECT_TRUE(view_test_h(0) == view_from_h(0));
+    EXPECT_EQ(view_from_h(0), ValueType{1});
+    EXPECT_EQ(view_test_h(0), view_from_h(0));
   }
 
   else if (name == "one-element-b") {
-    EXPECT_TRUE(view_from_h(0) == ValueType{2});
-    EXPECT_TRUE(view_test_h(0) == new_value);
+    EXPECT_EQ(view_from_h(0), ValueType{2});
+    EXPECT_EQ(view_test_h(0), new_value);
   }
 
   else if (name == "two-elements-a") {
-    EXPECT_TRUE(view_from_h(0) == ValueType{1});
-    EXPECT_TRUE(view_from_h(1) == ValueType{2});
+    EXPECT_EQ(view_from_h(0), ValueType{1});
+    EXPECT_EQ(view_from_h(1), ValueType{2});
 
-    EXPECT_TRUE(view_test_h(0) == view_from_h(0));
-    EXPECT_TRUE(view_test_h(1) == new_value);
+    EXPECT_EQ(view_test_h(0), view_from_h(0));
+    EXPECT_EQ(view_test_h(1), new_value);
   }
 
   else if (name == "two-elements-b") {
-    EXPECT_TRUE(view_from_h(0) == ValueType{2});
-    EXPECT_TRUE(view_from_h(1) == ValueType{-1});
+    EXPECT_EQ(view_from_h(0), ValueType{2});
+    EXPECT_EQ(view_from_h(1), ValueType{-1});
 
-    EXPECT_TRUE(view_test_h(0) == new_value);
-    EXPECT_TRUE(view_test_h(1) == view_from_h(1));
+    EXPECT_EQ(view_test_h(0), new_value);
+    EXPECT_EQ(view_test_h(1), view_from_h(1));
   }
 
   else if (name == "small-a") {
     for (std::size_t i = 0; i < view_test_h.extent(0); ++i) {
       if (i == 0 || i == 3 || i == 5 || i == 6) {
-        EXPECT_TRUE(view_from_h(i) == ValueType{2});
-        EXPECT_TRUE(view_test_h(i) == new_value);
+        EXPECT_EQ(view_from_h(i), ValueType{2});
+        EXPECT_EQ(view_test_h(i), new_value);
       } else {
         const auto gold = ValueType{-5} + static_cast<ValueType>(i + 1);
-        EXPECT_TRUE(view_from_h(i) == gold);
-        EXPECT_TRUE(view_test_h(i) == gold);
+        EXPECT_EQ(view_from_h(i), gold);
+        EXPECT_EQ(view_test_h(i), gold);
       }
     }
   }
@@ -183,11 +183,11 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
   else if (name == "small-b") {
     for (std::size_t i = 0; i < view_test_h.extent(0); ++i) {
       if (i < 4) {
-        EXPECT_TRUE(view_from_h(i) == ValueType{-1});
-        EXPECT_TRUE(view_test_h(i) == view_from_h(i));
+        EXPECT_EQ(view_from_h(i), ValueType{-1});
+        EXPECT_EQ(view_test_h(i), view_from_h(i));
       } else {
-        EXPECT_TRUE(view_from_h(i) == ValueType{2});
-        EXPECT_TRUE(view_test_h(i) == new_value);
+        EXPECT_EQ(view_from_h(i), ValueType{2});
+        EXPECT_EQ(view_test_h(i), new_value);
       }
     }
   }
@@ -195,11 +195,11 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
   else if (name == "medium" || name == "large") {
     for (std::size_t i = 0; i < view_test_h.extent(0); ++i) {
       if (i % 2 == 0) {
-        EXPECT_TRUE(view_from_h(i) == ValueType{-1});
-        EXPECT_TRUE(view_test_h(i) == view_from_h(i));
+        EXPECT_EQ(view_from_h(i), ValueType{-1});
+        EXPECT_EQ(view_test_h(i), view_from_h(i));
       } else {
-        EXPECT_TRUE(view_from_h(i) == ValueType{2});
-        EXPECT_TRUE(view_test_h(i) == new_value);
+        EXPECT_EQ(view_from_h(i), ValueType{2});
+        EXPECT_EQ(view_test_h(i), new_value);
       }
     }
   }
@@ -239,7 +239,7 @@ void run_single_scenario(const InfoType& scenario_info) {
                                    KE::cend(view_from), KE::begin(view_dest),
                                    pred_type(), new_value);
     verify_data(name, view_from, view_dest, new_value);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   {
@@ -250,7 +250,7 @@ void run_single_scenario(const InfoType& scenario_info) {
                                    KE::cend(view_from), KE::begin(view_dest),
                                    pred_type(), new_value);
     verify_data(name, view_from, view_dest, new_value);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   {
@@ -260,7 +260,7 @@ void run_single_scenario(const InfoType& scenario_info) {
     auto rit = KE::replace_copy_if(exespace(), view_from, view_dest,
                                    pred_type(), new_value);
     verify_data(name, view_from, view_dest, new_value);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   {
@@ -270,7 +270,7 @@ void run_single_scenario(const InfoType& scenario_info) {
     auto rit = KE::replace_copy_if("label", exespace(), view_from, view_dest,
                                    pred_type(), new_value);
     verify_data(name, view_from, view_dest, new_value);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   Kokkos::fence();

--- a/algorithms/unit_tests/TestStdAlgorithmsReplaceIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsReplaceIf.cpp
@@ -168,7 +168,7 @@ void verify_data(ViewType1 data_view,  // contains data
       // 		<< data_view_dc(i) << " "
       // 		<< data_view_h(i) << " "
       // 		<< test_view_h(i) << std::endl;
-      EXPECT_TRUE(data_view_h(i) == test_view_h(i));
+      EXPECT_EQ(data_view_h(i), test_view_h(i));
     }
   }
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsReverse.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsReverse.cpp
@@ -107,7 +107,7 @@ void verify_data(ViewType1 test_view, ViewType2 orig_view) {
 
   const std::size_t ext = test_view.extent(0);
   for (std::size_t i = 0; i < ext; ++i) {
-    EXPECT_TRUE(tv_h(i) == ov_h(ext - i - 1));
+    EXPECT_EQ(tv_h(i), ov_h(ext - i - 1));
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsRotate.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRotate.cpp
@@ -166,13 +166,13 @@ void verify_data(ResultIt result_it, ViewType view, ViewHostType data_view_host,
   // make sure results match
   const auto my_diff  = result_it - KE::begin(view);
   const auto std_diff = std_rit - KE::begin(data_view_host);
-  EXPECT_TRUE(my_diff == std_diff);
+  EXPECT_EQ(my_diff, std_diff);
 
   // check views match
   auto view_h           = create_host_space_copy(view);
   const std::size_t ext = view_h.extent(0);
   for (std::size_t i = 0; i < ext; ++i) {
-    EXPECT_TRUE(view_h(i) == data_view_host[i]);
+    EXPECT_EQ(view_h(i), data_view_host[i]);
     // std::cout << "i= " << i << " "
     // 	      << "mine: " << view_h(i) << " "
     // 	      << "std: " << data_view_host(i)

--- a/algorithms/unit_tests/TestStdAlgorithmsRotateCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRotateCopy.cpp
@@ -169,7 +169,7 @@ void verify_data(ViewTypeFrom view_from, ViewTypeTest view_test,
                    std_gold_h.begin());
 
   for (std::size_t i = 0; i < ext; ++i) {
-    EXPECT_TRUE(view_test_h(i) == std_gold_h[i]);
+    EXPECT_EQ(view_test_h(i), std_gold_h[i]);
     // std::cout << "i= " << i << " "
     // 	      << "from: " << view_from_h(i) << " "
     // 	      << "mine: " << view_test_h(i) << " "
@@ -207,7 +207,7 @@ void run_single_scenario(const InfoType& scenario_info,
     auto rit  = KE::rotate_copy(exespace(), KE::cbegin(view_from), n_it,
                                KE::cend(view_from), KE::begin(view_dest));
     verify_data(view_from, view_dest, rotation_point);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   {
@@ -217,7 +217,7 @@ void run_single_scenario(const InfoType& scenario_info,
     auto rit = KE::rotate_copy("label", exespace(), KE::cbegin(view_from), n_it,
                                KE::cend(view_from), KE::begin(view_dest));
     verify_data(view_from, view_dest, rotation_point);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   {
@@ -226,7 +226,7 @@ void run_single_scenario(const InfoType& scenario_info,
     auto rit =
         KE::rotate_copy(exespace(), view_from, rotation_point, view_dest);
     verify_data(view_from, view_dest, rotation_point);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   {
@@ -235,7 +235,7 @@ void run_single_scenario(const InfoType& scenario_info,
     auto rit = KE::rotate_copy("label", exespace(), view_from, rotation_point,
                                view_dest);
     verify_data(view_from, view_dest, rotation_point);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + view_ext));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + view_ext));
   }
 
   Kokkos::fence();

--- a/algorithms/unit_tests/TestStdAlgorithmsSearch.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsSearch.cpp
@@ -289,7 +289,7 @@ void run_single_scenario(const InfoType& scenario_info, std::size_t seq_ext,
                             KE::cbegin(s_view), KE::cend(s_view), args...);
     const auto mydiff = myrit - KE::cbegin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
@@ -298,21 +298,21 @@ void run_single_scenario(const InfoType& scenario_info, std::size_t seq_ext,
                    KE::cbegin(s_view), KE::cend(s_view), args...);
     const auto mydiff  = myrit - KE::cbegin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
     auto myrit         = KE::search(exespace(), view, s_view, args...);
     const auto mydiff  = myrit - KE::begin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
     auto myrit         = KE::search("label", exespace(), view, s_view, args...);
     const auto mydiff  = myrit - KE::begin(view);
     const auto stddiff = stdrit - KE::cbegin(view_h);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   Kokkos::fence();

--- a/algorithms/unit_tests/TestStdAlgorithmsSearch_n.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsSearch_n.cpp
@@ -233,26 +233,26 @@ void run_single_scenario(const InfoType& scenario_info, std::size_t count,
     auto myrit = KE::search_n(exespace(), KE::cbegin(view), KE::cend(view),
                               count, value, args...);
     const auto mydiff = myrit - KE::cbegin(view);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
     auto myrit        = KE::search_n("label", exespace(), KE::cbegin(view),
                               KE::cend(view), count, value, args...);
     const auto mydiff = myrit - KE::cbegin(view);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
     auto myrit = KE::search_n("label", exespace(), view, count, value, args...);
     const auto mydiff = myrit - KE::begin(view);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   {
     auto myrit        = KE::search_n(exespace(), view, count, value, args...);
     const auto mydiff = myrit - KE::begin(view);
-    EXPECT_TRUE(mydiff == stddiff);
+    EXPECT_EQ(mydiff, stddiff);
   }
 
   Kokkos::fence();

--- a/algorithms/unit_tests/TestStdAlgorithmsShiftLeft.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsShiftLeft.cpp
@@ -133,12 +133,12 @@ void verify_data(ResultIt result_it, ViewType view, ViewHostType data_view_host,
   // make sure results match
   const auto my_diff  = result_it - KE::begin(view);
   const auto std_diff = std_rit - KE::begin(data_view_host);
-  EXPECT_TRUE(my_diff == std_diff);
+  EXPECT_EQ(my_diff, std_diff);
 
   // check views match
   auto view_h = create_host_space_copy(view);
   for (std::size_t i = 0; i < (std::size_t)my_diff; ++i) {
-    EXPECT_TRUE(view_h(i) == data_view_host[i]);
+    EXPECT_EQ(view_h(i), data_view_host[i]);
     // std::cout << "i= " << i << " "
     // 	      << "mine: " << view_h(i) << " "
     // 	      << "std: " << data_view_host(i)

--- a/algorithms/unit_tests/TestStdAlgorithmsShiftRight.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsShiftRight.cpp
@@ -131,14 +131,14 @@ void verify_data(ResultIt result_it, ViewType view, ViewHostType data_view_host,
   // make sure results match
   const auto my_diff  = KE::end(view) - result_it;
   const auto std_diff = KE::end(data_view_host) - std_rit;
-  EXPECT_TRUE(my_diff == std_diff);
+  EXPECT_EQ(my_diff, std_diff);
 
   // check views match
   auto view_h = create_host_space_copy(view);
   auto it1    = KE::cbegin(view_h);
   auto it2    = KE::cbegin(data_view_host);
   for (std::size_t i = 0; i < (std::size_t)my_diff; ++i) {
-    EXPECT_TRUE(it1[i] == it2[i]);
+    EXPECT_EQ(it1[i], it2[i]);
     // std::cout << "i= " << i << " "
     // 	      << "mine: " << it1[i] << " "
     // 	      << "std:  " << it2[i]

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
@@ -195,7 +195,7 @@ void verify_data(ViewType1 data_view,  // contains data
       //           << std::abs(gold_h(i) - test_view_h(i)) << std::endl;
 
       if (std::is_same<gold_view_value_type, int>::value) {
-        EXPECT_TRUE(gold_h(i) == test_view_h(i));
+        EXPECT_EQ(gold_h(i), test_view_h(i));
       } else {
         const auto error = std::abs(gold_h(i) - test_view_h(i));
         if (error > 1e-10) {
@@ -203,7 +203,7 @@ void verify_data(ViewType1 data_view,  // contains data
                     << " " << gold_h(i) << " " << test_view_h(i) << " "
                     << std::abs(gold_h(i) - test_view_h(i)) << std::endl;
         }
-        EXPECT_TRUE(error < 1e-10);
+        EXPECT_LT(error, 1e-10);
       }
     }
     // std::cout << " last el: " << test_view_h(test_view_h.extent(0)-1) <<
@@ -257,7 +257,7 @@ void run_single_scenario(const InfoType& scenario_info, ValueType init_value,
     auto r = KE::transform_exclusive_scan(
         exespace(), KE::cbegin(view_from), KE::cend(view_from),
         KE::begin(view_dest), init_value, bop, uop);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, bop, uop);
   }
 
@@ -266,7 +266,7 @@ void run_single_scenario(const InfoType& scenario_info, ValueType init_value,
     auto r = KE::transform_exclusive_scan(
         "label", exespace(), KE::cbegin(view_from), KE::cend(view_from),
         KE::begin(view_dest), init_value, bop, uop);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, bop, uop);
   }
 
@@ -274,7 +274,7 @@ void run_single_scenario(const InfoType& scenario_info, ValueType init_value,
     fill_zero(view_dest);
     auto r = KE::transform_exclusive_scan(exespace(), view_from, view_dest,
                                           init_value, bop, uop);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, bop, uop);
   }
 
@@ -282,7 +282,7 @@ void run_single_scenario(const InfoType& scenario_info, ValueType init_value,
     fill_zero(view_dest);
     auto r = KE::transform_exclusive_scan("label", exespace(), view_from,
                                           view_dest, init_value, bop, uop);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, init_value, bop, uop);
   }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformInclusiveScan.cpp
@@ -207,7 +207,7 @@ void verify_data(ViewType1 data_view,  // contains data
       //           << std::abs(gold_h(i) - test_view_h(i)) << std::endl;
 
       if (std::is_same<gold_view_value_type, int>::value) {
-        EXPECT_TRUE(gold_h(i) == test_view_h(i));
+        EXPECT_EQ(gold_h(i), test_view_h(i));
       } else {
         const auto error = std::abs(gold_h(i) - test_view_h(i));
         if (error > 1e-10) {
@@ -215,7 +215,7 @@ void verify_data(ViewType1 data_view,  // contains data
                     << " " << gold_h(i) << " " << test_view_h(i) << " "
                     << std::abs(gold_h(i) - test_view_h(i)) << std::endl;
         }
-        EXPECT_TRUE(error < 1e-10);
+        EXPECT_LT(error, 1e-10);
       }
     }
     // std::cout << " last el: " << test_view_h(test_view_h.extent(0)-1) <<
@@ -282,7 +282,7 @@ void run_single_scenario(const InfoType& scenario_info,
     auto r = KE::transform_inclusive_scan(exespace(), KE::cbegin(view_from),
                                           KE::cend(view_from),
                                           KE::begin(view_dest), args...);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, args...);
   }
 
@@ -291,7 +291,7 @@ void run_single_scenario(const InfoType& scenario_info,
     auto r = KE::transform_inclusive_scan(
         "label", exespace(), KE::cbegin(view_from), KE::cend(view_from),
         KE::begin(view_dest), args...);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, args...);
   }
 
@@ -299,7 +299,7 @@ void run_single_scenario(const InfoType& scenario_info,
     fill_zero(view_dest);
     auto r =
         KE::transform_inclusive_scan(exespace(), view_from, view_dest, args...);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, args...);
   }
 
@@ -307,7 +307,7 @@ void run_single_scenario(const InfoType& scenario_info,
     fill_zero(view_dest);
     auto r = KE::transform_inclusive_scan("label", exespace(), view_from,
                                           view_dest, args...);
-    EXPECT_TRUE(r == KE::end(view_dest));
+    EXPECT_EQ(r, KE::end(view_dest));
     verify_data(view_from, view_dest, args...);
   }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformUnaryOp.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformUnaryOp.cpp
@@ -88,7 +88,7 @@ void verify_data(ViewTypeFrom view_from, ViewTypeTest view_test) {
       create_mirror_view_and_copy(Kokkos::HostSpace(), view_from_dc);
 
   for (std::size_t i = 0; i < view_test_h.extent(0); ++i) {
-    EXPECT_TRUE(view_test_h(i) == view_from_h(i) + value_type(1));
+    EXPECT_EQ(view_test_h(i), view_from_h(i) + value_type(1));
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsUnique.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsUnique.cpp
@@ -187,7 +187,7 @@ void verify_data(const std::string& name, ResultIt my_result_it,
   //
   const auto std_diff = (std::size_t)(std_r - KE::begin(data_v_h));
   const auto my_diff  = (std::size_t)(my_result_it - KE::begin(view_test));
-  EXPECT_TRUE(my_diff == std_diff);
+  EXPECT_EQ(my_diff, std_diff);
 
   //
   // check the data in the view
@@ -200,14 +200,14 @@ void verify_data(const std::string& name, ResultIt my_result_it,
     // 		<< " my  = " << view_test_h(i) << " "
     // 		<< " std = " << data_v_h(i)
     // 		<< '\n';
-    EXPECT_TRUE(view_test_h(i) == data_v_h(i));
+    EXPECT_EQ(view_test_h(i), data_v_h(i));
   }
 
   if (name == "medium-b") {
     using value_type = typename ViewType1::value_type;
-    EXPECT_TRUE(my_diff == (std::size_t)2);
-    EXPECT_TRUE(view_test_h(0) == (value_type)22);
-    EXPECT_TRUE(view_test_h(1) == (value_type)44);
+    EXPECT_EQ(my_diff, (std::size_t)2);
+    EXPECT_EQ(view_test_h(0), (value_type)22);
+    EXPECT_EQ(view_test_h(1), (value_type)44);
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsUniqueCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsUniqueCopy.cpp
@@ -204,51 +204,51 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
   }
 
   else if (name == "one-element-a") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(1));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(1));
   }
 
   else if (name == "one-element-b") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(2));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(2));
   }
 
   else if (name == "two-elements-a") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(1));
-    EXPECT_TRUE(view_test_h(1) == static_cast<value_type>(2));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(1));
+    EXPECT_EQ(view_test_h(1), static_cast<value_type>(2));
   }
 
   else if (name == "two-elements-b") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(2));
-    EXPECT_TRUE(view_test_h(1) == static_cast<value_type>(-1));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(2));
+    EXPECT_EQ(view_test_h(1), static_cast<value_type>(-1));
   }
 
   else if (name == "small-a") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(0));
-    EXPECT_TRUE(view_test_h(1) == static_cast<value_type>(1));
-    EXPECT_TRUE(view_test_h(2) == static_cast<value_type>(2));
-    EXPECT_TRUE(view_test_h(3) == static_cast<value_type>(3));
-    EXPECT_TRUE(view_test_h(4) == static_cast<value_type>(4));
-    EXPECT_TRUE(view_test_h(5) == static_cast<value_type>(5));
-    EXPECT_TRUE(view_test_h(6) == static_cast<value_type>(6));
-    EXPECT_TRUE(view_test_h(7) == static_cast<value_type>(0));
-    EXPECT_TRUE(view_test_h(8) == static_cast<value_type>(0));
-    EXPECT_TRUE(view_test_h(9) == static_cast<value_type>(0));
-    EXPECT_TRUE(view_test_h(10) == static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(1), static_cast<value_type>(1));
+    EXPECT_EQ(view_test_h(2), static_cast<value_type>(2));
+    EXPECT_EQ(view_test_h(3), static_cast<value_type>(3));
+    EXPECT_EQ(view_test_h(4), static_cast<value_type>(4));
+    EXPECT_EQ(view_test_h(5), static_cast<value_type>(5));
+    EXPECT_EQ(view_test_h(6), static_cast<value_type>(6));
+    EXPECT_EQ(view_test_h(7), static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(8), static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(9), static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(10), static_cast<value_type>(0));
   }
 
   else if (name == "small-b") {
-    EXPECT_TRUE(view_test_h(0) == static_cast<value_type>(1));
-    EXPECT_TRUE(view_test_h(1) == static_cast<value_type>(2));
-    EXPECT_TRUE(view_test_h(2) == static_cast<value_type>(3));
-    EXPECT_TRUE(view_test_h(3) == static_cast<value_type>(4));
-    EXPECT_TRUE(view_test_h(4) == static_cast<value_type>(5));
-    EXPECT_TRUE(view_test_h(5) == static_cast<value_type>(6));
-    EXPECT_TRUE(view_test_h(6) == static_cast<value_type>(8));
-    EXPECT_TRUE(view_test_h(7) == static_cast<value_type>(9));
-    EXPECT_TRUE(view_test_h(8) == static_cast<value_type>(8));
-    EXPECT_TRUE(view_test_h(9) == static_cast<value_type>(0));
-    EXPECT_TRUE(view_test_h(10) == static_cast<value_type>(0));
-    EXPECT_TRUE(view_test_h(11) == static_cast<value_type>(0));
-    EXPECT_TRUE(view_test_h(12) == static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(0), static_cast<value_type>(1));
+    EXPECT_EQ(view_test_h(1), static_cast<value_type>(2));
+    EXPECT_EQ(view_test_h(2), static_cast<value_type>(3));
+    EXPECT_EQ(view_test_h(3), static_cast<value_type>(4));
+    EXPECT_EQ(view_test_h(4), static_cast<value_type>(5));
+    EXPECT_EQ(view_test_h(5), static_cast<value_type>(6));
+    EXPECT_EQ(view_test_h(6), static_cast<value_type>(8));
+    EXPECT_EQ(view_test_h(7), static_cast<value_type>(9));
+    EXPECT_EQ(view_test_h(8), static_cast<value_type>(8));
+    EXPECT_EQ(view_test_h(9), static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(10), static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(11), static_cast<value_type>(0));
+    EXPECT_EQ(view_test_h(12), static_cast<value_type>(0));
   }
 
   else if (name == "medium" || name == "large") {
@@ -260,7 +260,7 @@ void verify_data(const std::string& name, ViewTypeFrom view_from,
     (void)std_r;
 
     for (std::size_t i = 0; i < view_from_h.extent(0); ++i) {
-      EXPECT_TRUE(view_test_h(i) == tmp[i]);
+      EXPECT_EQ(view_test_h(i), tmp[i]);
     }
   }
 
@@ -303,7 +303,7 @@ void run_single_scenario(const InfoType& scenario_info, Args... args) {
         KE::unique_copy(exespace(), KE::cbegin(view_from), KE::cend(view_from),
                         KE::begin(view_dest), args...);
     verify_data(name, view_from, view_dest, args...);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + n));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + n));
   }
 
   {
@@ -313,7 +313,7 @@ void run_single_scenario(const InfoType& scenario_info, Args... args) {
         KE::unique_copy("label", exespace(), KE::cbegin(view_from),
                         KE::cend(view_from), KE::begin(view_dest), args...);
     verify_data(name, view_from, view_dest, args...);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + n));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + n));
   }
 
   {
@@ -321,7 +321,7 @@ void run_single_scenario(const InfoType& scenario_info, Args... args) {
         create_view<ValueType>(Tag{}, view_ext, "unique_copy_dest");
     auto rit = KE::unique_copy(exespace(), view_from, view_dest, args...);
     verify_data(name, view_from, view_dest, args...);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + n));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + n));
   }
 
   {
@@ -330,7 +330,7 @@ void run_single_scenario(const InfoType& scenario_info, Args... args) {
     auto rit =
         KE::unique_copy("label", exespace(), view_from, view_dest, args...);
     verify_data(name, view_from, view_dest, args...);
-    EXPECT_TRUE(rit == (KE::begin(view_dest) + n));
+    EXPECT_EQ(rit, (KE::begin(view_dest) + n));
   }
 
   Kokkos::fence();

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -259,11 +259,11 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val0 = host_view(i, 0);
       auto val1 = host_view(i, 1);
       auto val2 = host_view(i, 2);
-      EXPECT_TRUE(std::fabs((val0 - 65536.0) / 65536.0) < 1e-14)
+      EXPECT_LT(std::fabs((val0 - 65536.0) / 65536.0), 1e-14)
           << "Data differs at index " << i;
-      EXPECT_TRUE(std::fabs((val1 - 256.0) / 256.0) < 1e-14)
+      EXPECT_LT(std::fabs((val1 - 256.0) / 256.0), 1e-14)
           << "Data differs at index " << i;
-      EXPECT_TRUE(std::fabs((val2 - 1.0) / 1.0) < 1e-14)
+      EXPECT_LT(std::fabs((val2 - 1.0) / 1.0), 1e-14)
           << "Data differs at index " << i;
     }
   }
@@ -282,9 +282,9 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val2 = host_view(i, 2);
       if (i >= std::get<0>(subRangeDim0) && i < std::get<1>(subRangeDim0)) {
         // is in subview
-        EXPECT_TRUE(std::fabs((val0 - 65536.0) / 65536.0) < 1e-14);
-        EXPECT_TRUE(std::fabs((val1 - 256.0) / 256.0) < 1e-14);
-        EXPECT_TRUE(std::fabs((val2 - 1.0) / 1.0) < 1e-14);
+        EXPECT_LT(std::fabs((val0 - 65536.0) / 65536.0), 1e-14);
+        EXPECT_LT(std::fabs((val1 - 256.0) / 256.0), 1e-14);
+        EXPECT_LT(std::fabs((val2 - 1.0) / 1.0), 1e-14);
       } else {
         // is outside of subview
         EXPECT_NEAR(val0, NumberType(1), 1e-14)
@@ -362,11 +362,11 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val0 = host_view(i, 0);
       auto val1 = host_view(i, 1);
       auto val2 = host_view(i, 2);
-      EXPECT_TRUE(std::fabs((val0 - 4.0) / 4.0) < 1e-14)
+      EXPECT_LT(std::fabs((val0 - 4.0) / 4.0), 1e-14)
           << "Data differs at index " << i;
-      EXPECT_TRUE(std::fabs((val1 - 2.0) / 2.0) < 1e-14)
+      EXPECT_LT(std::fabs((val1 - 2.0) / 2.0), 1e-14)
           << "Data differs at index " << i;
-      EXPECT_TRUE(std::fabs((val2 - 1.0) / 1.0) < 1e-14)
+      EXPECT_LT(std::fabs((val2 - 1.0) / 1.0), 1e-14)
           << "Data differs at index " << i;
     }
   }
@@ -385,11 +385,11 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val2 = host_view(i, 2);
       if (i >= std::get<0>(subRangeDim0) && i < std::get<1>(subRangeDim0)) {
         // is in subview
-        EXPECT_TRUE(std::fabs((val0 - 4.0) / 4.0) < 1e-14)
+        EXPECT_LT(std::fabs((val0 - 4.0) / 4.0), 1e-14)
             << "Data differs at index " << i;
-        EXPECT_TRUE(std::fabs((val1 - 2.0) / 2.0) < 1e-14)
+        EXPECT_LT(std::fabs((val1 - 2.0) / 2.0), 1e-14)
             << "Data differs at index " << i;
-        EXPECT_TRUE(std::fabs((val2 - 1.0) / 1.0) < 1e-14)
+        EXPECT_LT(std::fabs((val2 - 1.0) / 1.0), 1e-14)
             << "Data differs at index " << i;
       } else {
         // is outside of subview
@@ -467,11 +467,11 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val0 = host_view(i, 0);
       auto val1 = host_view(i, 1);
       auto val2 = host_view(i, 2);
-      EXPECT_TRUE(std::fabs((val0 - 16.0) / 16.0) < 1e-14)
+      EXPECT_LT(std::fabs((val0 - 16.0) / 16.0), 1e-14)
           << "Data differs at index " << i;
-      EXPECT_TRUE(std::fabs((val1 - 8.0) / 8.0) < 1e-14)
+      EXPECT_LT(std::fabs((val1 - 8.0) / 8.0), 1e-14)
           << "Data differs at index " << i;
-      EXPECT_TRUE(std::fabs((val2 - 4.0) / 4.0) < 1e-14)
+      EXPECT_LT(std::fabs((val2 - 4.0) / 4.0), 1e-14)
           << "Data differs at index " << i;
     }
   }
@@ -490,11 +490,11 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val2 = host_view(i, 2);
       if (i >= std::get<0>(subRangeDim0) && i < std::get<1>(subRangeDim0)) {
         // is in subview
-        EXPECT_TRUE(std::fabs((val0 - 16.0) / 16.0) < 1e-14)
+        EXPECT_LT(std::fabs((val0 - 16.0) / 16.0), 1e-14)
             << "Data differs at index " << i;
-        EXPECT_TRUE(std::fabs((val1 - 8.0) / 8.0) < 1e-14)
+        EXPECT_LT(std::fabs((val1 - 8.0) / 8.0), 1e-14)
             << "Data differs at index " << i;
-        EXPECT_TRUE(std::fabs((val2 - 4.0) / 4.0) < 1e-14)
+        EXPECT_LT(std::fabs((val2 - 4.0) / 4.0), 1e-14)
             << "Data differs at index " << i;
       } else {
         // is outside of subview

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -259,12 +259,10 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val0 = host_view(i, 0);
       auto val1 = host_view(i, 1);
       auto val2 = host_view(i, 2);
-      EXPECT_LT(std::fabs((val0 - 65536.0) / 65536.0), 1e-14)
+      EXPECT_NEAR(val0, 65536.0, 1e-14 * 65536.0)
           << "Data differs at index " << i;
-      EXPECT_LT(std::fabs((val1 - 256.0) / 256.0), 1e-14)
-          << "Data differs at index " << i;
-      EXPECT_LT(std::fabs((val2 - 1.0) / 1.0), 1e-14)
-          << "Data differs at index " << i;
+      EXPECT_NEAR(val1, 256.0, 1e-14 * 256.0) << "Data differs at index " << i;
+      EXPECT_NEAR(val2, 1.0, 1e-14 * 1.0) << "Data differs at index " << i;
     }
   }
 
@@ -282,9 +280,9 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val2 = host_view(i, 2);
       if (i >= std::get<0>(subRangeDim0) && i < std::get<1>(subRangeDim0)) {
         // is in subview
-        EXPECT_LT(std::fabs((val0 - 65536.0) / 65536.0), 1e-14);
-        EXPECT_LT(std::fabs((val1 - 256.0) / 256.0), 1e-14);
-        EXPECT_LT(std::fabs((val2 - 1.0) / 1.0), 1e-14);
+        EXPECT_NEAR(val0, 65536.0, 1e-14 * 65536.0);
+        EXPECT_NEAR(val1, 256.0, 1e-14 * 256.0);
+        EXPECT_NEAR(val2, 1.0, 1e-14 * 1.0);
       } else {
         // is outside of subview
         EXPECT_NEAR(val0, NumberType(1), 1e-14)
@@ -362,12 +360,9 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val0 = host_view(i, 0);
       auto val1 = host_view(i, 1);
       auto val2 = host_view(i, 2);
-      EXPECT_LT(std::fabs((val0 - 4.0) / 4.0), 1e-14)
-          << "Data differs at index " << i;
-      EXPECT_LT(std::fabs((val1 - 2.0) / 2.0), 1e-14)
-          << "Data differs at index " << i;
-      EXPECT_LT(std::fabs((val2 - 1.0) / 1.0), 1e-14)
-          << "Data differs at index " << i;
+      EXPECT_NEAR(val0, 4.0, 1e-14 * 4.0) << "Data differs at index " << i;
+      EXPECT_NEAR(val1, 2.0, 1e-14 * 2.0) << "Data differs at index " << i;
+      EXPECT_NEAR(val2, 1.0, 1e-14 * 1.0) << "Data differs at index " << i;
     }
   }
 
@@ -385,12 +380,9 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val2 = host_view(i, 2);
       if (i >= std::get<0>(subRangeDim0) && i < std::get<1>(subRangeDim0)) {
         // is in subview
-        EXPECT_LT(std::fabs((val0 - 4.0) / 4.0), 1e-14)
-            << "Data differs at index " << i;
-        EXPECT_LT(std::fabs((val1 - 2.0) / 2.0), 1e-14)
-            << "Data differs at index " << i;
-        EXPECT_LT(std::fabs((val2 - 1.0) / 1.0), 1e-14)
-            << "Data differs at index " << i;
+        EXPECT_NEAR(val0, 4.0, 1e-14 * 4.0) << "Data differs at index " << i;
+        EXPECT_NEAR(val1, 2.0, 1e-14 * 2.0) << "Data differs at index " << i;
+        EXPECT_NEAR(val2, 1.0, 1e-14 * 1.0) << "Data differs at index " << i;
       } else {
         // is outside of subview
         EXPECT_NEAR(val0, NumberType(999999), 1e-14)
@@ -467,12 +459,9 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val0 = host_view(i, 0);
       auto val1 = host_view(i, 1);
       auto val2 = host_view(i, 2);
-      EXPECT_LT(std::fabs((val0 - 16.0) / 16.0), 1e-14)
-          << "Data differs at index " << i;
-      EXPECT_LT(std::fabs((val1 - 8.0) / 8.0), 1e-14)
-          << "Data differs at index " << i;
-      EXPECT_LT(std::fabs((val2 - 4.0) / 4.0), 1e-14)
-          << "Data differs at index " << i;
+      EXPECT_NEAR(val0, 16.0, 1e-14 * 16.0) << "Data differs at index " << i;
+      EXPECT_NEAR(val1, 8.0, 1e-14 * 8.0) << "Data differs at index " << i;
+      EXPECT_NEAR(val2, 4.0, 1e-14 * 4.0) << "Data differs at index " << i;
     }
   }
 
@@ -490,12 +479,9 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       auto val2 = host_view(i, 2);
       if (i >= std::get<0>(subRangeDim0) && i < std::get<1>(subRangeDim0)) {
         // is in subview
-        EXPECT_LT(std::fabs((val0 - 16.0) / 16.0), 1e-14)
-            << "Data differs at index " << i;
-        EXPECT_LT(std::fabs((val1 - 8.0) / 8.0), 1e-14)
-            << "Data differs at index " << i;
-        EXPECT_LT(std::fabs((val2 - 4.0) / 4.0), 1e-14)
-            << "Data differs at index " << i;
+        EXPECT_NEAR(val0, 16.0, 1e-14 * 16.0) << "Data differs at index " << i;
+        EXPECT_NEAR(val1, 8.0, 1e-14 * 8.0) << "Data differs at index " << i;
+        EXPECT_NEAR(val2, 4.0, 1e-14 * 4.0) << "Data differs at index " << i;
       } else {
         // is outside of subview
         EXPECT_NEAR(val0, NumberType(0), 1e-14)

--- a/core/unit_test/TestMinMaxClamp.hpp
+++ b/core/unit_test/TestMinMaxClamp.hpp
@@ -76,16 +76,16 @@ TEST(TEST_CATEGORY, max) {
 
   int a = 1;
   int b = 2;
-  EXPECT_TRUE(KE::max(a, b) == 2);
+  EXPECT_EQ(KE::max(a, b), 2);
 
   a = 3;
   b = 1;
-  EXPECT_TRUE(KE::max(a, b) == 3);
+  EXPECT_EQ(KE::max(a, b), 3);
 
   STATIC_ASSERT(KE::max(1, 2) == 2);
   STATIC_ASSERT(KE::max(1, 2, ::Test::Greater<int>{}) == 1);
 
-  EXPECT_TRUE(KE::max({3.f, -1.f, 0.f}) == 3.f);
+  EXPECT_EQ(KE::max({3.f, -1.f, 0.f}), 3.f);
 
   STATIC_ASSERT(KE::max({3, -1, 0}) == 3);
   STATIC_ASSERT(KE::max({3, -1, 0}, ::Test::Greater<int>{}) == -1);
@@ -140,16 +140,16 @@ TEST(TEST_CATEGORY, min) {
 
   int a = 1;
   int b = 2;
-  EXPECT_TRUE(KE::min(a, b) == 1);
+  EXPECT_EQ(KE::min(a, b), 1);
 
   a = 3;
   b = 2;
-  EXPECT_TRUE(KE::min(a, b) == 2);
+  EXPECT_EQ(KE::min(a, b), 2);
 
   STATIC_ASSERT(KE::min(3.f, 2.f) == 2.f);
   STATIC_ASSERT(KE::min(3.f, 2.f, ::Test::Greater<int>{}) == 3.f);
 
-  EXPECT_TRUE(KE::min({3.f, -1.f, 0.f}) == -1.f);
+  EXPECT_EQ(KE::min({3.f, -1.f, 0.f}), -1.f);
 
   STATIC_ASSERT(KE::min({3, -1, 0}) == -1);
   STATIC_ASSERT(KE::min({3, -1, 0}, ::Test::Greater<int>{}) == 3);
@@ -203,14 +203,14 @@ TEST(TEST_CATEGORY, minmax) {
   int a         = 1;
   int b         = 2;
   const auto& r = KE::minmax(a, b);
-  EXPECT_TRUE(r.first == 1);
-  EXPECT_TRUE(r.second == 2);
+  EXPECT_EQ(r.first, 1);
+  EXPECT_EQ(r.second, 2);
 
   a              = 3;
   b              = 2;
   const auto& r2 = KE::minmax(a, b);
-  EXPECT_TRUE(r2.first == 2);
-  EXPECT_TRUE(r2.second == 3);
+  EXPECT_EQ(r2.first, 2);
+  EXPECT_EQ(r2.second, 3);
 
   STATIC_ASSERT((Kokkos::pair<float, float>(KE::minmax(3.f, 2.f)) ==
                  Kokkos::make_pair(2.f, 3.f)));
@@ -218,7 +218,7 @@ TEST(TEST_CATEGORY, minmax) {
       (Kokkos::pair<float, float>(KE::minmax(
            3.f, 2.f, ::Test::Greater<int>{})) == Kokkos::make_pair(3.f, 2.f)));
 
-  EXPECT_TRUE(KE::minmax({3.f, -1.f, 0.f}) == Kokkos::make_pair(-1.f, 3.f));
+  EXPECT_EQ(KE::minmax({3.f, -1.f, 0.f}), Kokkos::make_pair(-1.f, 3.f));
 
   STATIC_ASSERT(KE::minmax({3, -1, 0}) == Kokkos::make_pair(-1, 3));
   STATIC_ASSERT(KE::minmax({3, -1, 0}, ::Test::Greater<int>{}) ==
@@ -283,22 +283,22 @@ TEST(TEST_CATEGORY, clamp) {
   int b         = 2;
   int c         = 19;
   const auto& r = KE::clamp(a, b, c);
-  EXPECT_TRUE(&r == &b);
-  EXPECT_TRUE(r == b);
+  EXPECT_EQ(&r, &b);
+  EXPECT_EQ(r, b);
 
   a              = 5;
   b              = -2;
   c              = 3;
   const auto& r2 = KE::clamp(a, b, c);
-  EXPECT_TRUE(&r2 == &c);
-  EXPECT_TRUE(r2 == c);
+  EXPECT_EQ(&r2, &c);
+  EXPECT_EQ(r2, c);
 
   a              = 5;
   b              = -2;
   c              = 7;
   const auto& r3 = KE::clamp(a, b, c);
-  EXPECT_TRUE(&r3 == &a);
-  EXPECT_TRUE(r3 == a);
+  EXPECT_EQ(&r3, &a);
+  EXPECT_EQ(r3, a);
 }
 
 template <class ViewType>

--- a/core/unit_test/TestRealloc.hpp
+++ b/core/unit_test/TestRealloc.hpp
@@ -71,81 +71,81 @@ void impl_testRealloc() {
     using view_type = Kokkos::View<int*, DeviceType>;
     view_type view_1d("view_1d", sizes[0]);
     const int* oldPointer = view_1d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_1d, sizes[0]);
     const int* newPointer = view_1d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int**, DeviceType>;
     view_type view_2d("view_2d", sizes[0], sizes[1]);
     const int* oldPointer = view_2d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_2d, sizes[0], sizes[1]);
     const int* newPointer = view_2d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int***, DeviceType>;
     view_type view_3d("view_3d", sizes[0], sizes[1], sizes[2]);
     const int* oldPointer = view_3d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_3d, sizes[0], sizes[1], sizes[2]);
     const int* newPointer = view_3d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int****, DeviceType>;
     view_type view_4d("view_4d", sizes[0], sizes[1], sizes[2], sizes[3]);
     const int* oldPointer = view_4d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_4d, sizes[0], sizes[1], sizes[2], sizes[3]);
     const int* newPointer = view_4d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int*****, DeviceType>;
     view_type view_5d("view_5d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4]);
     const int* oldPointer = view_5d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_5d, sizes[0], sizes[1], sizes[2], sizes[3],
                      sizes[4]);
     const int* newPointer = view_5d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int******, DeviceType>;
     view_type view_6d("view_6d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5]);
     const int* oldPointer = view_6d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_6d, sizes[0], sizes[1], sizes[2], sizes[3],
                      sizes[4], sizes[5]);
     const int* newPointer = view_6d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int*******, DeviceType>;
     view_type view_7d("view_7d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5], sizes[6]);
     const int* oldPointer = view_7d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_7d, sizes[0], sizes[1], sizes[2], sizes[3],
                      sizes[4], sizes[5], sizes[6]);
     const int* newPointer = view_7d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int********, DeviceType>;
     view_type view_8d("view_8d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5], sizes[6], sizes[7]);
     const int* oldPointer = view_8d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_8d, sizes[0], sizes[1], sizes[2], sizes[3],
                      sizes[4], sizes[5], sizes[6], sizes[7]);
     const int* newPointer = view_8d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
 }
 

--- a/core/unit_test/TestResize.hpp
+++ b/core/unit_test/TestResize.hpp
@@ -71,81 +71,81 @@ void impl_testResize() {
     using view_type = Kokkos::View<int*, DeviceType>;
     view_type view_1d("view_1d", sizes[0]);
     const int* oldPointer = view_1d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     resize_dispatch(Tag{}, view_1d, sizes[0]);
     const int* newPointer = view_1d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int**, DeviceType>;
     view_type view_2d("view_2d", sizes[0], sizes[1]);
     const int* oldPointer = view_2d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     resize_dispatch(Tag{}, view_2d, sizes[0], sizes[1]);
     const int* newPointer = view_2d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int***, DeviceType>;
     view_type view_3d("view_3d", sizes[0], sizes[1], sizes[2]);
     const int* oldPointer = view_3d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     resize_dispatch(Tag{}, view_3d, sizes[0], sizes[1], sizes[2]);
     const int* newPointer = view_3d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int****, DeviceType>;
     view_type view_4d("view_4d", sizes[0], sizes[1], sizes[2], sizes[3]);
     const int* oldPointer = view_4d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     resize_dispatch(Tag{}, view_4d, sizes[0], sizes[1], sizes[2], sizes[3]);
     const int* newPointer = view_4d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int*****, DeviceType>;
     view_type view_5d("view_5d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4]);
     const int* oldPointer = view_5d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     resize_dispatch(Tag{}, view_5d, sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4]);
     const int* newPointer = view_5d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int******, DeviceType>;
     view_type view_6d("view_6d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5]);
     const int* oldPointer = view_6d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     resize_dispatch(Tag{}, view_6d, sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5]);
     const int* newPointer = view_6d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int*******, DeviceType>;
     view_type view_7d("view_7d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5], sizes[6]);
     const int* oldPointer = view_7d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     resize_dispatch(Tag{}, view_7d, sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5], sizes[6]);
     const int* newPointer = view_7d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int********, DeviceType>;
     view_type view_8d("view_8d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5], sizes[6], sizes[7]);
     const int* oldPointer = view_8d.data();
-    EXPECT_TRUE(oldPointer != nullptr);
+    EXPECT_NE(oldPointer, nullptr);
     resize_dispatch(Tag{}, view_8d, sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5], sizes[6], sizes[7]);
     const int* newPointer = view_8d.data();
-    EXPECT_TRUE(oldPointer == newPointer);
+    EXPECT_EQ(oldPointer, newPointer);
   }
   // Resize without initialization: check if data preserved
   {
@@ -156,7 +156,7 @@ void impl_testResize() {
     Kokkos::deep_copy(view_1d, 111);
     Kokkos::deep_copy(h_view_1d_old, view_1d);
     resize_dispatch(Tag{}, view_1d, 2 * sizes[0]);
-    EXPECT_TRUE(view_1d.extent(0) == 2 * sizes[0]);
+    EXPECT_EQ(view_1d.extent(0), 2 * sizes[0]);
     typename view_type::HostMirror h_view_1d =
         Kokkos::create_mirror_view(view_1d);
     Kokkos::deep_copy(h_view_1d, view_1d);
@@ -167,7 +167,7 @@ void impl_testResize() {
         break;
       }
     }
-    EXPECT_TRUE(test == true);
+    EXPECT_EQ(test, true);
   }
   {
     using view_type = Kokkos::View<int**, DeviceType>;
@@ -177,7 +177,7 @@ void impl_testResize() {
     Kokkos::deep_copy(view_2d, 222);
     Kokkos::deep_copy(h_view_2d_old, view_2d);
     resize_dispatch(Tag{}, view_2d, 2 * sizes[0], sizes[1]);
-    EXPECT_TRUE(view_2d.extent(0) == 2 * sizes[0]);
+    EXPECT_EQ(view_2d.extent(0), 2 * sizes[0]);
     typename view_type::HostMirror h_view_2d =
         Kokkos::create_mirror_view(view_2d);
     Kokkos::deep_copy(h_view_2d, view_2d);
@@ -190,7 +190,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_TRUE(test == true);
+    EXPECT_EQ(test, true);
   }
   {
     using view_type = Kokkos::View<int***, DeviceType>;
@@ -200,7 +200,7 @@ void impl_testResize() {
     Kokkos::deep_copy(view_3d, 333);
     Kokkos::deep_copy(h_view_3d_old, view_3d);
     resize_dispatch(Tag{}, view_3d, 2 * sizes[0], sizes[1], sizes[2]);
-    EXPECT_TRUE(view_3d.extent(0) == 2 * sizes[0]);
+    EXPECT_EQ(view_3d.extent(0), 2 * sizes[0]);
     typename view_type::HostMirror h_view_3d =
         Kokkos::create_mirror_view(view_3d);
     Kokkos::deep_copy(h_view_3d, view_3d);
@@ -215,7 +215,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_TRUE(test == true);
+    EXPECT_EQ(test, true);
   }
   {
     using view_type = Kokkos::View<int****, DeviceType>;
@@ -225,7 +225,7 @@ void impl_testResize() {
     Kokkos::deep_copy(view_4d, 444);
     Kokkos::deep_copy(h_view_4d_old, view_4d);
     resize_dispatch(Tag{}, view_4d, 2 * sizes[0], sizes[1], sizes[2], sizes[3]);
-    EXPECT_TRUE(view_4d.extent(0) == 2 * sizes[0]);
+    EXPECT_EQ(view_4d.extent(0), 2 * sizes[0]);
     typename view_type::HostMirror h_view_4d =
         Kokkos::create_mirror_view(view_4d);
     Kokkos::deep_copy(h_view_4d, view_4d);
@@ -242,7 +242,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_TRUE(test == true);
+    EXPECT_EQ(test, true);
   }
   {
     using view_type = Kokkos::View<int*****, DeviceType>;
@@ -254,7 +254,7 @@ void impl_testResize() {
     Kokkos::deep_copy(h_view_5d_old, view_5d);
     resize_dispatch(Tag{}, view_5d, 2 * sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4]);
-    EXPECT_TRUE(view_5d.extent(0) == 2 * sizes[0]);
+    EXPECT_EQ(view_5d.extent(0), 2 * sizes[0]);
     typename view_type::HostMirror h_view_5d =
         Kokkos::create_mirror_view(view_5d);
     Kokkos::deep_copy(h_view_5d, view_5d);
@@ -274,7 +274,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_TRUE(test == true);
+    EXPECT_EQ(test, true);
   }
   {
     using view_type = Kokkos::View<int******, DeviceType>;
@@ -286,7 +286,7 @@ void impl_testResize() {
     Kokkos::deep_copy(h_view_6d_old, view_6d);
     resize_dispatch(Tag{}, view_6d, 2 * sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5]);
-    EXPECT_TRUE(view_6d.extent(0) == 2 * sizes[0]);
+    EXPECT_EQ(view_6d.extent(0), 2 * sizes[0]);
     typename view_type::HostMirror h_view_6d =
         Kokkos::create_mirror_view(view_6d);
     Kokkos::deep_copy(h_view_6d, view_6d);
@@ -308,7 +308,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_TRUE(test == true);
+    EXPECT_EQ(test, true);
   }
   {
     using view_type = Kokkos::View<int*******, DeviceType>;
@@ -320,7 +320,7 @@ void impl_testResize() {
     Kokkos::deep_copy(h_view_7d_old, view_7d);
     resize_dispatch(Tag{}, view_7d, 2 * sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5], sizes[6]);
-    EXPECT_TRUE(view_7d.extent(0) == 2 * sizes[0]);
+    EXPECT_EQ(view_7d.extent(0), 2 * sizes[0]);
     typename view_type::HostMirror h_view_7d =
         Kokkos::create_mirror_view(view_7d);
     Kokkos::deep_copy(h_view_7d, view_7d);
@@ -344,7 +344,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_TRUE(test == true);
+    EXPECT_EQ(test, true);
   }
   {
     using view_type = Kokkos::View<int********, DeviceType>;
@@ -356,7 +356,7 @@ void impl_testResize() {
     Kokkos::deep_copy(h_view_8d_old, view_8d);
     resize_dispatch(Tag{}, view_8d, 2 * sizes[0], sizes[1], sizes[2], sizes[3],
                     sizes[4], sizes[5], sizes[6], sizes[7]);
-    EXPECT_TRUE(view_8d.extent(0) == 2 * sizes[0]);
+    EXPECT_EQ(view_8d.extent(0), 2 * sizes[0]);
     typename view_type::HostMirror h_view_8d =
         Kokkos::create_mirror_view(view_8d);
     Kokkos::deep_copy(h_view_8d, view_8d);
@@ -382,7 +382,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_TRUE(test == true);
+    EXPECT_EQ(test, true);
   }
 }
 

--- a/core/unit_test/TestResize.hpp
+++ b/core/unit_test/TestResize.hpp
@@ -167,7 +167,7 @@ void impl_testResize() {
         break;
       }
     }
-    EXPECT_EQ(test, true);
+    EXPECT_TRUE(test);
   }
   {
     using view_type = Kokkos::View<int**, DeviceType>;
@@ -190,7 +190,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_EQ(test, true);
+    EXPECT_TRUE(test);
   }
   {
     using view_type = Kokkos::View<int***, DeviceType>;
@@ -215,7 +215,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_EQ(test, true);
+    EXPECT_TRUE(test);
   }
   {
     using view_type = Kokkos::View<int****, DeviceType>;
@@ -242,7 +242,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_EQ(test, true);
+    EXPECT_TRUE(test);
   }
   {
     using view_type = Kokkos::View<int*****, DeviceType>;
@@ -274,7 +274,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_EQ(test, true);
+    EXPECT_TRUE(test);
   }
   {
     using view_type = Kokkos::View<int******, DeviceType>;
@@ -308,7 +308,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_EQ(test, true);
+    EXPECT_TRUE(test);
   }
   {
     using view_type = Kokkos::View<int*******, DeviceType>;
@@ -344,7 +344,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_EQ(test, true);
+    EXPECT_TRUE(test);
   }
   {
     using view_type = Kokkos::View<int********, DeviceType>;

--- a/core/unit_test/TestResize.hpp
+++ b/core/unit_test/TestResize.hpp
@@ -382,7 +382,7 @@ void impl_testResize() {
         }
       }
     }
-    EXPECT_EQ(test, true);
+    EXPECT_TRUE(test);
   }
 }
 


### PR DESCRIPTION
While looking at #4887, I noted all the instances of using `ASSERT_TRUE` where we have more suitable replacements that print more information upon failure.