### PR TITLE
Applying desul clang-format to Kokkos desul copy

### DIFF
--- a/core/src/desul/atomics/Atomic_Ref.hpp
+++ b/core/src/desul/atomics/Atomic_Ref.hpp
@@ -103,10 +103,10 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, false, false> {
   DESUL_FUNCTION bool compare_exchange_weak(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
     return compare_exchange_weak(expected,
-                          desired,
-                          order,
-                          cmpexch_failure_memory_order<_MemoryOrder>(),
-                          MemoryScope());
+                                 desired,
+                                 order,
+                                 cmpexch_failure_memory_order<_MemoryOrder>(),
+                                 MemoryScope());
   }
 
   template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
@@ -123,10 +123,10 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, false, false> {
   DESUL_FUNCTION bool compare_exchange_strong(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
     return compare_exchange_strong(expected,
-                            desired,
-                            order,
-                            cmpexch_failure_memory_order<_MemoryOrder>(),
-                            MemoryScope());
+                                   desired,
+                                   order,
+                                   cmpexch_failure_memory_order<_MemoryOrder>(),
+                                   MemoryScope());
   }
 };
 
@@ -195,10 +195,10 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, true, false> {
   DESUL_FUNCTION bool compare_exchange_weak(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
     return compare_exchange_weak(expected,
-                          desired,
-                          order,
-                          cmpexch_failure_memory_order<_MemoryOrder>(),
-                          MemoryScope());
+                                 desired,
+                                 order,
+                                 cmpexch_failure_memory_order<_MemoryOrder>(),
+                                 MemoryScope());
   }
 
   template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
@@ -215,10 +215,10 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, true, false> {
   DESUL_FUNCTION bool compare_exchange_strong(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
     return compare_exchange_strong(expected,
-                            desired,
-                            order,
-                            cmpexch_failure_memory_order<_MemoryOrder>(),
-                            MemoryScope());
+                                   desired,
+                                   order,
+                                   cmpexch_failure_memory_order<_MemoryOrder>(),
+                                   MemoryScope());
   }
 
   template <typename _MemoryOrder = MemoryOrder>
@@ -348,10 +348,10 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, false, true> {
   DESUL_FUNCTION bool compare_exchange_weak(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
     return compare_exchange_weak(expected,
-                          desired,
-                          order,
-                          cmpexch_failure_memory_order<_MemoryOrder>(),
-                          MemoryScope());
+                                 desired,
+                                 order,
+                                 cmpexch_failure_memory_order<_MemoryOrder>(),
+                                 MemoryScope());
   }
 
   template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
@@ -368,10 +368,10 @@ struct basic_atomic_ref<T, MemoryOrder, MemoryScope, false, true> {
   DESUL_FUNCTION bool compare_exchange_strong(
       T& expected, T desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
     return compare_exchange_strong(expected,
-                            desired,
-                            order,
-                            cmpexch_failure_memory_order<_MemoryOrder>(),
-                            MemoryScope());
+                                   desired,
+                                   order,
+                                   cmpexch_failure_memory_order<_MemoryOrder>(),
+                                   MemoryScope());
   }
 
   template <typename _MemoryOrder = MemoryOrder>
@@ -457,10 +457,10 @@ struct basic_atomic_ref<T*, MemoryOrder, MemoryScope, false, false> {
   DESUL_FUNCTION bool compare_exchange_weak(
       T*& expected, T* desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
     return compare_exchange_weak(expected,
-                          desired,
-                          order,
-                          cmpexch_failure_memory_order<_MemoryOrder>(),
-                          MemoryScope());
+                                 desired,
+                                 order,
+                                 cmpexch_failure_memory_order<_MemoryOrder>(),
+                                 MemoryScope());
   }
 
   template <typename SuccessMemoryOrder, typename FailureMemoryOrder>
@@ -477,10 +477,10 @@ struct basic_atomic_ref<T*, MemoryOrder, MemoryScope, false, false> {
   DESUL_FUNCTION bool compare_exchange_strong(
       T*& expected, T* desired, _MemoryOrder order = _MemoryOrder()) const noexcept {
     return compare_exchange_strong(expected,
-                            desired,
-                            order,
-                            cmpexch_failure_memory_order<_MemoryOrder>(),
-                            MemoryScope());
+                                   desired,
+                                   order,
+                                   cmpexch_failure_memory_order<_MemoryOrder>(),
+                                   MemoryScope());
   }
 
   template <typename _MemoryOrder = MemoryOrder>

--- a/core/src/desul/atomics/CUDA.hpp
+++ b/core/src/desul/atomics/CUDA.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2019, Lawrence Livermore National Security, LLC
 and DESUL project contributors. See the COPYRIGHT file for details.
 Source: https://github.com/desul/desul
@@ -23,78 +23,77 @@ SPDX-License-Identifier: (BSD-3-Clause)
     (!defined(__NVCC__) && !defined(DESUL_HAVE_CUDA_ATOMICS_ASM))
 namespace desul {
 namespace Impl {
-template<class T>
+template <class T>
 struct is_cuda_atomic_integer_type {
-  static constexpr bool value = std::is_same<T,int>::value ||
-                                std::is_same<T,unsigned int>::value ||
-                                std::is_same<T,unsigned long long int>::value;
+  static constexpr bool value = std::is_same<T, int>::value ||
+                                std::is_same<T, unsigned int>::value ||
+                                std::is_same<T, unsigned long long int>::value;
 };
 
-template<class T>
+template <class T>
 struct is_cuda_atomic_add_type {
   static constexpr bool value = is_cuda_atomic_integer_type<T>::value ||
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 600)
-                                std::is_same<T,double>::value || 
+                                std::is_same<T, double>::value ||
 #endif
-                                std::is_same<T,float>::value;
+                                std::is_same<T, float>::value;
 };
 
-template<class T>
+template <class T>
 struct is_cuda_atomic_sub_type {
-  static constexpr bool value = std::is_same<T,int>::value ||
-                                std::is_same<T,unsigned int>::value;
+  static constexpr bool value =
+      std::is_same<T, int>::value || std::is_same<T, unsigned int>::value;
 };
-} // Impl
+}  // namespace Impl
 
 // Atomic Add
-template<class T>
+template <class T>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value,T>::type
-atomic_fetch_add(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
-  return atomicAdd(dest,val);
+    typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value, T>::type
+    atomic_fetch_add(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
+  return atomicAdd(dest, val);
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value,T>::type
-atomic_fetch_add(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
+    typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value, T>::type
+    atomic_fetch_add(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
-  T return_val = atomicAdd(dest,val);
-  __threadfence();
-  return return_val;
-}
-
-template<class T, class MemoryOrder>
-__device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value,T>::type
-atomic_fetch_add(T* dest, T val, MemoryOrder, MemoryScopeCore) {
-  return atomic_fetch_add(dest,val,MemoryOrder(),MemoryScopeDevice());
-}
-
-
-// Atomic Sub 
-template<class T>
-__device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value,T>::type
-atomic_fetch_sub(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
-  return atomicSub(dest,val);
-}
-
-template<class T, class MemoryOrder>
-__device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value,T>::type
-atomic_fetch_sub(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
-  __threadfence();
-  T return_val = atomicSub(dest,val);
+  T return_val = atomicAdd(dest, val);
   __threadfence();
   return return_val;
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value,T>::type
-atomic_fetch_sub(T* dest, T val, MemoryOrder, MemoryScopeCore) {
-  return atomic_fetch_sub(dest,val,MemoryOrder(),MemoryScopeDevice());
+    typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value, T>::type
+    atomic_fetch_add(T* dest, T val, MemoryOrder, MemoryScopeCore) {
+  return atomic_fetch_add(dest, val, MemoryOrder(), MemoryScopeDevice());
+}
+
+// Atomic Sub
+template <class T>
+__device__ inline
+    typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value, T>::type
+    atomic_fetch_sub(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
+  return atomicSub(dest, val);
+}
+
+template <class T, class MemoryOrder>
+__device__ inline
+    typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value, T>::type
+    atomic_fetch_sub(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
+  __threadfence();
+  T return_val = atomicSub(dest, val);
+  __threadfence();
+  return return_val;
+}
+
+template <class T, class MemoryOrder>
+__device__ inline
+    typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value, T>::type
+    atomic_fetch_sub(T* dest, T val, MemoryOrder, MemoryScopeCore) {
+  return atomic_fetch_sub(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
 
 // Wrap around atomic add
@@ -203,337 +202,461 @@ __device__ inline
 }
 
 // Atomic Max
-template<class T>
+template <class T>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_max(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
-  return atomicMax(dest,val);
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_max(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
+  return atomicMax(dest, val);
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_max(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_max(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
-  T return_val = atomicMax(dest,val);
+  T return_val = atomicMax(dest, val);
   __threadfence();
   return return_val;
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_max(T* dest, T val, MemoryOrder, MemoryScopeCore) {
-  return atomic_fetch_max(dest,val,MemoryOrder(),MemoryScopeDevice());
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_max(T* dest, T val, MemoryOrder, MemoryScopeCore) {
+  return atomic_fetch_max(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
 
 // Atomic Min
-template<class T>
+template <class T>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_min(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
-  return atomicMin(dest,val);
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_min(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
+  return atomicMin(dest, val);
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_min(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_min(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
-  T return_val = atomicMin(dest,val);
+  T return_val = atomicMin(dest, val);
   __threadfence();
   return return_val;
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_min(T* dest, T val, MemoryOrder, MemoryScopeCore) {
-  return atomic_fetch_min(dest,val,MemoryOrder(),MemoryScopeDevice());
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_min(T* dest, T val, MemoryOrder, MemoryScopeCore) {
+  return atomic_fetch_min(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
 
 // Atomic And
-template<class T>
+template <class T>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_and(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
-  return atomicAnd(dest,val);
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_and(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
+  return atomicAnd(dest, val);
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_and(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_and(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
-  T return_val = atomicAnd(dest,val);
+  T return_val = atomicAnd(dest, val);
   __threadfence();
   return return_val;
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_and(T* dest, T val, MemoryOrder, MemoryScopeCore) {
-  return atomic_fetch_and(dest,val,MemoryOrder(),MemoryScopeDevice());
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_and(T* dest, T val, MemoryOrder, MemoryScopeCore) {
+  return atomic_fetch_and(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
 
 // Atomic XOR
-template<class T>
+template <class T>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_xor(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
-  return atomicXor(dest,val);
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_xor(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
+  return atomicXor(dest, val);
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_xor(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_xor(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
-  T return_val = atomicXor(dest,val);
+  T return_val = atomicXor(dest, val);
   __threadfence();
   return return_val;
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_xor(T* dest, T val, MemoryOrder, MemoryScopeCore) {
-  return atomic_fetch_xor(dest,val,MemoryOrder(),MemoryScopeDevice());
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_xor(T* dest, T val, MemoryOrder, MemoryScopeCore) {
+  return atomic_fetch_xor(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
 
 // Atomic OR
-template<class T>
+template <class T>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_or(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
-  return atomicOr(dest,val);
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_or(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
+  return atomicOr(dest, val);
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_or(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_or(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
-  T return_val = atomicOr(dest,val);
+  T return_val = atomicOr(dest, val);
   __threadfence();
   return return_val;
 }
 
-template<class T, class MemoryOrder>
+template <class T, class MemoryOrder>
 __device__ inline
-typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value,T>::type
-atomic_fetch_or(T* dest, T val, MemoryOrder, MemoryScopeCore) {
-  return atomic_fetch_or(dest,val,MemoryOrder(),MemoryScopeDevice());
+    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    atomic_fetch_or(T* dest, T val, MemoryOrder, MemoryScopeCore) {
+  return atomic_fetch_or(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
-} // desul
+}  // namespace desul
 #endif
 
 #if !defined(__NVCC__)
-// Functions defined as device functions in CUDA which don't exist in the GCC overload set
+// Functions defined as device functions in CUDA which don't exist in the GCC overload
+// set
 namespace desul {
 
 #if defined(DESUL_HAVE_CUDA_ATOMICS_ASM)
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(TYPE,ORDER,SCOPE) \
-    inline void atomic_add(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
-    (void) atomic_fetch_add(dest, val, order, scope); \
+#define DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(TYPE, ORDER, SCOPE)                      \
+  inline void atomic_add(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
+    (void)atomic_fetch_add(dest, val, order, scope);                             \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(int32_t,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(long,MemoryOrderRelaxed,MemoryScopeDevice); // only for ASM?
-  DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(unsigned long long,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(float,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(double,MemoryOrderRelaxed,MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(int32_t, MemoryOrderRelaxed, MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(long,
+                                MemoryOrderRelaxed,
+                                MemoryScopeDevice);  // only for ASM?
+DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(unsigned int, MemoryOrderRelaxed, MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(unsigned long long,
+                                MemoryOrderRelaxed,
+                                MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(float, MemoryOrderRelaxed, MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_ADD(double, MemoryOrderRelaxed, MemoryScopeDevice);
 
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(TYPE,ORDER,SCOPE) \
-    inline void atomic_sub(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
-    (void) atomic_fetch_sub(dest, val, order, scope); \
+#define DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(TYPE, ORDER, SCOPE)                      \
+  inline void atomic_sub(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
+    (void)atomic_fetch_sub(dest, val, order, scope);                             \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(int32_t,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(long,MemoryOrderRelaxed,MemoryScopeDevice); // only for ASM?
-  DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(float,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(double,MemoryOrderRelaxed,MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(int32_t, MemoryOrderRelaxed, MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(long,
+                                MemoryOrderRelaxed,
+                                MemoryScopeDevice);  // only for ASM?
+DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(unsigned int, MemoryOrderRelaxed, MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(float, MemoryOrderRelaxed, MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_SUB(double, MemoryOrderRelaxed, MemoryScopeDevice);
 
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_INC(TYPE,ORDER,SCOPE) \
-    inline void atomic_inc(TYPE* const dest, ORDER order, SCOPE scope) { \
-    (void) atomic_fetch_inc(dest, order, scope); \
+#define DESUL_IMPL_CUDA_HOST_ATOMIC_INC(TYPE, ORDER, SCOPE)            \
+  inline void atomic_inc(TYPE* const dest, ORDER order, SCOPE scope) { \
+    (void)atomic_fetch_inc(dest, order, scope);                        \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_INC(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice); // only for ASM?
+DESUL_IMPL_CUDA_HOST_ATOMIC_INC(unsigned int,
+                                MemoryOrderRelaxed,
+                                MemoryScopeDevice);  // only for ASM?
 
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_DEC(TYPE,ORDER,SCOPE) \
-    inline void atomic_dec(TYPE* const dest, ORDER order, SCOPE scope) { \
-    (void) atomic_fetch_dec(dest, order, scope); \
+#define DESUL_IMPL_CUDA_HOST_ATOMIC_DEC(TYPE, ORDER, SCOPE)            \
+  inline void atomic_dec(TYPE* const dest, ORDER order, SCOPE scope) { \
+    (void)atomic_fetch_dec(dest, order, scope);                        \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_DEC(unsigned,MemoryOrderRelaxed,MemoryScopeDevice); // only for ASM?
+DESUL_IMPL_CUDA_HOST_ATOMIC_DEC(unsigned,
+                                MemoryOrderRelaxed,
+                                MemoryScopeDevice);  // only for ASM?
 
-#endif // DESUL_HAVE_CUDA_ATOMICS_ASM
+#endif  // DESUL_HAVE_CUDA_ATOMICS_ASM
 
-#define DESUL_IMPL_CUDA_HOST_ATOMIC_INC_MOD(TYPE,ORDER,SCOPE) \
+#define DESUL_IMPL_CUDA_HOST_ATOMIC_INC_MOD(TYPE, ORDER, SCOPE)                      \
   inline TYPE atomic_fetch_inc_mod(TYPE* dest, TYPE val, ORDER order, SCOPE scope) { \
-  using cas_t = typename Impl::atomic_compare_exchange_type<sizeof(TYPE)>::type; \
-  cas_t oldval = reinterpret_cast<cas_t&>(*dest); \
-  cas_t assume = oldval; \
-  do { \
-    assume = oldval; \
-    TYPE newval = (reinterpret_cast<TYPE&>(assume) >= val) ? static_cast<TYPE>(0) : reinterpret_cast<TYPE&>(assume) + static_cast<TYPE>(1); \
-    oldval = desul::atomic_compare_exchange(reinterpret_cast<cas_t*>(dest), assume, reinterpret_cast<cas_t&>(newval), order, scope); \
-  } while (assume != oldval); \
-  return reinterpret_cast<TYPE&>(oldval); \
-}
-DESUL_IMPL_CUDA_HOST_ATOMIC_INC_MOD(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
-#define DESUL_IMPL_CUDA_HOST_ATOMIC_DEC_MOD(TYPE,ORDER,SCOPE) \
-    inline TYPE atomic_fetch_dec_mod(TYPE* dest, TYPE val, ORDER order, SCOPE scope) { \
-    using cas_t = typename Impl::atomic_compare_exchange_type<sizeof(TYPE)>::type; \
-    cas_t oldval = reinterpret_cast<cas_t&>(*dest); \
-    cas_t assume = oldval; \
-    do { \
-      assume = oldval; \
-      TYPE newval = ((reinterpret_cast<TYPE&>(assume) == static_cast<TYPE>(0)) | (reinterpret_cast<TYPE&>(assume) > val)) ? val : reinterpret_cast<TYPE&>(assume) - static_cast<TYPE>(1); \
-      oldval = desul::atomic_compare_exchange(reinterpret_cast<cas_t*>(dest), assume, reinterpret_cast<cas_t&>(newval), order, scope); \
-    } while (assume != oldval); \
-    return reinterpret_cast<TYPE&>(oldval); \
+    using cas_t = typename Impl::atomic_compare_exchange_type<sizeof(TYPE)>::type;   \
+    cas_t oldval = reinterpret_cast<cas_t&>(*dest);                                  \
+    cas_t assume = oldval;                                                           \
+    do {                                                                             \
+      assume = oldval;                                                               \
+      TYPE newval = (reinterpret_cast<TYPE&>(assume) >= val)                         \
+                        ? static_cast<TYPE>(0)                                       \
+                        : reinterpret_cast<TYPE&>(assume) + static_cast<TYPE>(1);    \
+      oldval = desul::atomic_compare_exchange(reinterpret_cast<cas_t*>(dest),        \
+                                              assume,                                \
+                                              reinterpret_cast<cas_t&>(newval),      \
+                                              order,                                 \
+                                              scope);                                \
+    } while (assume != oldval);                                                      \
+    return reinterpret_cast<TYPE&>(oldval);                                          \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_DEC_MOD(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
-
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_ADD(TYPE,ORDER,SCOPE) \
-    inline TYPE atomic_fetch_add(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
-      return Impl::atomic_fetch_oper(Impl::AddOper<TYPE, const TYPE>(),dest, val, order, scope); \
+DESUL_IMPL_CUDA_HOST_ATOMIC_INC_MOD(unsigned int,
+                                    MemoryOrderRelaxed,
+                                    MemoryScopeDevice);
+#define DESUL_IMPL_CUDA_HOST_ATOMIC_DEC_MOD(TYPE, ORDER, SCOPE)                      \
+  inline TYPE atomic_fetch_dec_mod(TYPE* dest, TYPE val, ORDER order, SCOPE scope) { \
+    using cas_t = typename Impl::atomic_compare_exchange_type<sizeof(TYPE)>::type;   \
+    cas_t oldval = reinterpret_cast<cas_t&>(*dest);                                  \
+    cas_t assume = oldval;                                                           \
+    do {                                                                             \
+      assume = oldval;                                                               \
+      TYPE newval = ((reinterpret_cast<TYPE&>(assume) == static_cast<TYPE>(0)) |     \
+                     (reinterpret_cast<TYPE&>(assume) > val))                        \
+                        ? val                                                        \
+                        : reinterpret_cast<TYPE&>(assume) - static_cast<TYPE>(1);    \
+      oldval = desul::atomic_compare_exchange(reinterpret_cast<cas_t*>(dest),        \
+                                              assume,                                \
+                                              reinterpret_cast<cas_t&>(newval),      \
+                                              order,                                 \
+                                              scope);                                \
+    } while (assume != oldval);                                                      \
+    return reinterpret_cast<TYPE&>(oldval);                                          \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_ADD(float,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_ADD(double,MemoryOrderRelaxed,MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_DEC_MOD(unsigned int,
+                                    MemoryOrderRelaxed,
+                                    MemoryScopeDevice);
 
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_SUB(TYPE,ORDER,SCOPE) \
-    inline TYPE atomic_fetch_sub(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
-      return Impl::atomic_fetch_oper(Impl::SubOper<TYPE, const TYPE>(),dest, val, order, scope); \
+#define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_ADD(TYPE, ORDER, SCOPE)                      \
+  inline TYPE atomic_fetch_add(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
+    return Impl::atomic_fetch_oper(                                                    \
+        Impl::AddOper<TYPE, const TYPE>(), dest, val, order, scope);                   \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_SUB(float,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_SUB(double,MemoryOrderRelaxed,MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_ADD(float, MemoryOrderRelaxed, MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_ADD(double, MemoryOrderRelaxed, MemoryScopeDevice);
 
-
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(TYPE,ORDER,SCOPE) \
-    inline TYPE atomic_fetch_max(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
-      return Impl::atomic_fetch_oper(Impl::MaxOper<TYPE, const TYPE>(), dest, val, order, scope); \
+#define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_SUB(TYPE, ORDER, SCOPE)                      \
+  inline TYPE atomic_fetch_sub(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
+    return Impl::atomic_fetch_oper(                                                    \
+        Impl::SubOper<TYPE, const TYPE>(), dest, val, order, scope);                   \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(int,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(long,MemoryOrderRelaxed,MemoryScopeDevice); // only for ASM?
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(unsigned long,MemoryOrderRelaxed,MemoryScopeDevice);
-//  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(unsigned long long,MemoryOrderRelaxed,MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_SUB(float, MemoryOrderRelaxed, MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_SUB(double, MemoryOrderRelaxed, MemoryScopeDevice);
 
-  #define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(TYPE,ORDER,SCOPE) \
-    inline TYPE atomic_fetch_min(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
-      return Impl::atomic_fetch_oper(Impl::MinOper<TYPE, const TYPE>(), dest, val, order, scope); \
+#define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(TYPE, ORDER, SCOPE)                      \
+  inline TYPE atomic_fetch_max(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
+    return Impl::atomic_fetch_oper(                                                    \
+        Impl::MaxOper<TYPE, const TYPE>(), dest, val, order, scope);                   \
   }
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(int,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(long,MemoryOrderRelaxed,MemoryScopeDevice); // only for ASM?
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(unsigned int,MemoryOrderRelaxed,MemoryScopeDevice);
-  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(unsigned long,MemoryOrderRelaxed,MemoryScopeDevice);
-//  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(unsigned long long,MemoryOrderRelaxed,MemoryScopeDevice);
-//  inline void atomic_fetch_max(int32_t* const dest, int32_t val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(int, MemoryOrderRelaxed, MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(long,
+                                      MemoryOrderRelaxed,
+                                      MemoryScopeDevice);  // only for ASM?
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(unsigned int,
+                                      MemoryOrderRelaxed,
+                                      MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(unsigned long,
+                                      MemoryOrderRelaxed,
+                                      MemoryScopeDevice);
+//  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MAX(unsigned long
+//  long,MemoryOrderRelaxed,MemoryScopeDevice);
+
+#define DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(TYPE, ORDER, SCOPE)                      \
+  inline TYPE atomic_fetch_min(TYPE* const dest, TYPE val, ORDER order, SCOPE scope) { \
+    return Impl::atomic_fetch_oper(                                                    \
+        Impl::MinOper<TYPE, const TYPE>(), dest, val, order, scope);                   \
+  }
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(int, MemoryOrderRelaxed, MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(long,
+                                      MemoryOrderRelaxed,
+                                      MemoryScopeDevice);  // only for ASM?
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(unsigned int,
+                                      MemoryOrderRelaxed,
+                                      MemoryScopeDevice);
+DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(unsigned long,
+                                      MemoryOrderRelaxed,
+                                      MemoryScopeDevice);
+//  DESUL_IMPL_CUDA_HOST_ATOMIC_FETCH_MIN(unsigned long
+//  long,MemoryOrderRelaxed,MemoryScopeDevice); inline void atomic_fetch_max(int32_t*
+//  const dest, int32_t val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
 
 }  // namespace desul
 
 // Functions defined int the GCC overload set but not in the device overload set
 namespace desul {
-  __device__ inline
-  unsigned long long atomic_fetch_add(unsigned long long* const dest, unsigned long long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::AddOper<unsigned long long, const unsigned long long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long long atomic_fetch_add(long long* const dest, long long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::AddOper<long long, const long long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_fetch_add(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::AddOper<long, const long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long long atomic_fetch_sub(long long* const dest, long long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::SubOper<long long, const long long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_fetch_sub(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::SubOper<long, const long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_fetch_max(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::MaxOper<long, const long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_fetch_min(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::MinOper<long, const long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_fetch_or(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::OrOper<long, const long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long long atomic_fetch_or(long long* const dest, long long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::OrOper<long long, const long long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_fetch_xor(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::XorOper<long, const long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long long atomic_fetch_xor(long long* const dest, long long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::XorOper<long long, const long long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_fetch_and(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::AndOper<long, const long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long long atomic_fetch_and(long long* const dest, long long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_fetch_oper(Impl::AndOper<long long, const long long>(), dest, val, order, scope);
-  }
+__device__ inline unsigned long long atomic_fetch_add(unsigned long long* const dest,
+                                                      unsigned long long val,
+                                                      MemoryOrderRelaxed order,
+                                                      MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::AddOper<unsigned long long, const unsigned long long>(),
+      dest,
+      val,
+      order,
+      scope);
+}
+__device__ inline long long atomic_fetch_add(long long* const dest,
+                                             long long val,
+                                             MemoryOrderRelaxed order,
+                                             MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::AddOper<long long, const long long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_fetch_add(long* const dest,
+                                        long val,
+                                        MemoryOrderRelaxed order,
+                                        MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::AddOper<long, const long>(), dest, val, order, scope);
+}
+__device__ inline long long atomic_fetch_sub(long long* const dest,
+                                             long long val,
+                                             MemoryOrderRelaxed order,
+                                             MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::SubOper<long long, const long long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_fetch_sub(long* const dest,
+                                        long val,
+                                        MemoryOrderRelaxed order,
+                                        MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::SubOper<long, const long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_fetch_max(long* const dest,
+                                        long val,
+                                        MemoryOrderRelaxed order,
+                                        MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::MaxOper<long, const long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_fetch_min(long* const dest,
+                                        long val,
+                                        MemoryOrderRelaxed order,
+                                        MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::MinOper<long, const long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_fetch_or(long* const dest,
+                                       long val,
+                                       MemoryOrderRelaxed order,
+                                       MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::OrOper<long, const long>(), dest, val, order, scope);
+}
+__device__ inline long long atomic_fetch_or(long long* const dest,
+                                            long long val,
+                                            MemoryOrderRelaxed order,
+                                            MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::OrOper<long long, const long long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_fetch_xor(long* const dest,
+                                        long val,
+                                        MemoryOrderRelaxed order,
+                                        MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::XorOper<long, const long>(), dest, val, order, scope);
+}
+__device__ inline long long atomic_fetch_xor(long long* const dest,
+                                             long long val,
+                                             MemoryOrderRelaxed order,
+                                             MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::XorOper<long long, const long long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_fetch_and(long* const dest,
+                                        long val,
+                                        MemoryOrderRelaxed order,
+                                        MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::AndOper<long, const long>(), dest, val, order, scope);
+}
+__device__ inline long long atomic_fetch_and(long long* const dest,
+                                             long long val,
+                                             MemoryOrderRelaxed order,
+                                             MemoryScopeDevice scope) {
+  return Impl::atomic_fetch_oper(
+      Impl::AndOper<long long, const long long>(), dest, val, order, scope);
+}
 
-
-  __device__ inline
-  unsigned long long atomic_add_fetch(unsigned long long* const dest, unsigned long long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_oper_fetch(Impl::AddOper<unsigned long long, const unsigned long long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long long atomic_add_fetch(long long* const dest, long long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_oper_fetch(Impl::AddOper<long long, const long long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_add_fetch(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_oper_fetch(Impl::AddOper<long, const long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long long atomic_sub_fetch(long long* const dest, long long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_oper_fetch(Impl::SubOper<long long, const long long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_sub_fetch(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_oper_fetch(Impl::SubOper<long, const long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long long atomic_or_fetch(long long* const dest, long long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_oper_fetch(Impl::OrOper<long long, const long long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_or_fetch(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_oper_fetch(Impl::OrOper<long, const long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long long atomic_xor_fetch(long long* const dest, long long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_oper_fetch(Impl::XorOper<long long, const long long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_xor_fetch(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_oper_fetch(Impl::XorOper<long, const long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long long atomic_and_fetch(long long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_oper_fetch(Impl::AndOper<long long, const long long>(), dest, val, order, scope);
-  }
-  __device__ inline
-  long atomic_and_fetch(long* const dest, long val, MemoryOrderRelaxed order, MemoryScopeDevice scope) {
-    return Impl::atomic_oper_fetch(Impl::AndOper<long, const long>(), dest, val, order, scope);
-  }
+__device__ inline unsigned long long atomic_add_fetch(unsigned long long* const dest,
+                                                      unsigned long long val,
+                                                      MemoryOrderRelaxed order,
+                                                      MemoryScopeDevice scope) {
+  return Impl::atomic_oper_fetch(
+      Impl::AddOper<unsigned long long, const unsigned long long>(),
+      dest,
+      val,
+      order,
+      scope);
+}
+__device__ inline long long atomic_add_fetch(long long* const dest,
+                                             long long val,
+                                             MemoryOrderRelaxed order,
+                                             MemoryScopeDevice scope) {
+  return Impl::atomic_oper_fetch(
+      Impl::AddOper<long long, const long long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_add_fetch(long* const dest,
+                                        long val,
+                                        MemoryOrderRelaxed order,
+                                        MemoryScopeDevice scope) {
+  return Impl::atomic_oper_fetch(
+      Impl::AddOper<long, const long>(), dest, val, order, scope);
+}
+__device__ inline long long atomic_sub_fetch(long long* const dest,
+                                             long long val,
+                                             MemoryOrderRelaxed order,
+                                             MemoryScopeDevice scope) {
+  return Impl::atomic_oper_fetch(
+      Impl::SubOper<long long, const long long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_sub_fetch(long* const dest,
+                                        long val,
+                                        MemoryOrderRelaxed order,
+                                        MemoryScopeDevice scope) {
+  return Impl::atomic_oper_fetch(
+      Impl::SubOper<long, const long>(), dest, val, order, scope);
+}
+__device__ inline long long atomic_or_fetch(long long* const dest,
+                                            long long val,
+                                            MemoryOrderRelaxed order,
+                                            MemoryScopeDevice scope) {
+  return Impl::atomic_oper_fetch(
+      Impl::OrOper<long long, const long long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_or_fetch(long* const dest,
+                                       long val,
+                                       MemoryOrderRelaxed order,
+                                       MemoryScopeDevice scope) {
+  return Impl::atomic_oper_fetch(
+      Impl::OrOper<long, const long>(), dest, val, order, scope);
+}
+__device__ inline long long atomic_xor_fetch(long long* const dest,
+                                             long long val,
+                                             MemoryOrderRelaxed order,
+                                             MemoryScopeDevice scope) {
+  return Impl::atomic_oper_fetch(
+      Impl::XorOper<long long, const long long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_xor_fetch(long* const dest,
+                                        long val,
+                                        MemoryOrderRelaxed order,
+                                        MemoryScopeDevice scope) {
+  return Impl::atomic_oper_fetch(
+      Impl::XorOper<long, const long>(), dest, val, order, scope);
+}
+__device__ inline long long atomic_and_fetch(long long* const dest,
+                                             long val,
+                                             MemoryOrderRelaxed order,
+                                             MemoryScopeDevice scope) {
+  return Impl::atomic_oper_fetch(
+      Impl::AndOper<long long, const long long>(), dest, val, order, scope);
+}
+__device__ inline long atomic_and_fetch(long* const dest,
+                                        long val,
+                                        MemoryOrderRelaxed order,
+                                        MemoryScopeDevice scope) {
+  return Impl::atomic_oper_fetch(
+      Impl::AndOper<long, const long>(), dest, val, order, scope);
+}
 }  // namespace desul
 #endif
 

--- a/core/src/desul/atomics/Common.hpp
+++ b/core/src/desul/atomics/Common.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2019, Lawrence Livermore National Security, LLC
 and DESUL project contributors. See the COPYRIGHT file for details.
 Source: https://github.com/desul/desul
@@ -8,10 +8,11 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #ifndef DESUL_ATOMICS_COMMON_HPP_
 #define DESUL_ATOMICS_COMMON_HPP_
-#include "desul/atomics/Macros.hpp"
-#include <cstdint>
 #include <atomic>
+#include <cstdint>
 #include <type_traits>
+
+#include "desul/atomics/Macros.hpp"
 
 namespace desul {
 struct alignas(16) Dummy16ByteValue {
@@ -137,20 +138,21 @@ using cmpexch_failure_memory_order =
     typename CmpExchFailureOrder<MemoryOrder>::memory_order;
 }  // namespace Impl
 
-}
+}  // namespace desul
 
-// We should in principle use std::numeric_limits, but that requires constexpr function support on device
-// Currently that is still considered experimetal on CUDA and sometimes not reliable.
+// We should in principle use std::numeric_limits, but that requires constexpr function
+// support on device Currently that is still considered experimetal on CUDA and
+// sometimes not reliable.
 namespace desul {
 namespace Impl {
-template<class T>
+template <class T>
 struct numeric_limits_max;
 
-template<>
+template <>
 struct numeric_limits_max<uint32_t> {
   static constexpr uint32_t value = 0xffffffffu;
 };
-template<>
+template <>
 struct numeric_limits_max<uint64_t> {
   static constexpr uint64_t value = 0xfffffffflu;
 };
@@ -172,30 +174,32 @@ DESUL_INLINE_FUNCTION bool atomic_is_lock_free() noexcept {
       ;
 }
 
-template<std::size_t N>
+template <std::size_t N>
 struct atomic_compare_exchange_type;
 
-template<>
+template <>
 struct atomic_compare_exchange_type<4> {
   using type = int32_t;
 };
 
-template<>
+template <>
 struct atomic_compare_exchange_type<8> {
   using type = int64_t;
 };
 
-template<>
+template <>
 struct atomic_compare_exchange_type<16> {
   using type = Dummy16ByteValue;
 };
 
-template<class T>
-struct dont_deduce_this_parameter { using type = T; };
+template <class T>
+struct dont_deduce_this_parameter {
+  using type = T;
+};
 
-template<class T>
+template <class T>
 using dont_deduce_this_parameter_t = typename dont_deduce_this_parameter<T>::type;
 
-}
-}
+}  // namespace Impl
+}  // namespace desul
 #endif

--- a/core/src/desul/atomics/Compare_Exchange.hpp
+++ b/core/src/desul/atomics/Compare_Exchange.hpp
@@ -9,9 +9,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef DESUL_ATOMICS_COMPARE_EXCHANGE_HPP_
 #define DESUL_ATOMICS_COMPARE_EXCHANGE_HPP_
 
-#include "desul/atomics/Macros.hpp"
-
 #include "desul/atomics/Compare_Exchange_ScopeCaller.hpp"
+#include "desul/atomics/Macros.hpp"
 
 #ifdef DESUL_HAVE_GCC_ATOMICS
 #include "desul/atomics/Compare_Exchange_GCC.hpp"

--- a/core/src/desul/atomics/Compare_Exchange_CUDA.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_CUDA.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2019, Lawrence Livermore National Security, LLC
 and DESUL project contributors. See the COPYRIGHT file for details.
 Source: https://github.com/desul/desul
@@ -40,7 +40,7 @@ __device__ inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeCore) {
 __device__ inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeCore) {
   __threadfence_block();
 }
-#if (__CUDA_ARCH__>=600) || !defined(__NVCC__)
+#if (__CUDA_ARCH__ >= 600) || !defined(__NVCC__)
 __device__ inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeNode) {
   __threadfence_system();
 }
@@ -55,19 +55,21 @@ __device__ inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeNode) {
 }
 #endif
 #endif
-}
+}  // namespace desul
 
-// Compare Exchange for PRE Volta, not supported with CLANG as CUDA compiler, since we do NOT have a way
-// of having the code included for clang only when the CC is smaller than 700
-// But on Clang the device side symbol list must be independent of __CUDA_ARCH__
+// Compare Exchange for PRE Volta, not supported with CLANG as CUDA compiler, since we
+// do NOT have a way of having the code included for clang only when the CC is smaller
+// than 700 But on Clang the device side symbol list must be independent of
+// __CUDA_ARCH__
 // FIXME temporary fix for https://github.com/kokkos/kokkos/issues/4390
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700) || \
-(!defined(__NVCC__) && defined(DESUL_CUDA_ARCH_IS_PRE_VOLTA) && 0)
+    (!defined(__NVCC__) && defined(DESUL_CUDA_ARCH_IS_PRE_VOLTA) && 0)
 namespace desul {
 template <typename T, class MemoryScope>
 __device__ typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrderRelaxed, MemoryScope) {
-  static_assert(sizeof(unsigned int) == 4, "this function assumes an unsigned int is 32-bit");
+  static_assert(sizeof(unsigned int) == 4,
+                "this function assumes an unsigned int is 32-bit");
   unsigned int return_val = atomicCAS(reinterpret_cast<unsigned int*>(dest),
                                       reinterpret_cast<unsigned int&>(compare),
                                       reinterpret_cast<unsigned int&>(value));
@@ -76,7 +78,8 @@ __device__ typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_excha
 template <typename T, class MemoryScope>
 __device__ typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrderRelaxed, MemoryScope) {
-  static_assert(sizeof(unsigned long long int) == 8, "this function assumes an unsigned long long  is 64-bit");
+  static_assert(sizeof(unsigned long long int) == 8,
+                "this function assumes an unsigned long long  is 64-bit");
   unsigned long long int return_val =
       atomicCAS(reinterpret_cast<unsigned long long int*>(dest),
                 reinterpret_cast<unsigned long long int&>(compare),
@@ -85,34 +88,41 @@ __device__ typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_excha
 }
 
 template <typename T, class MemoryScope>
-__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type atomic_compare_exchange(
+__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type
+atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrderRelease, MemoryScope) {
-  T return_val = atomic_compare_exchange(dest, compare, value, MemoryOrderRelaxed(), MemoryScope());
-  atomic_thread_fence(MemoryOrderRelease(),MemoryScope());
+  T return_val = atomic_compare_exchange(
+      dest, compare, value, MemoryOrderRelaxed(), MemoryScope());
+  atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
   return return_val;
 }
 
 template <typename T, class MemoryScope>
-__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type atomic_compare_exchange(
+__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type
+atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrderAcquire, MemoryScope) {
-  atomic_thread_fence(MemoryOrderAcquire(),MemoryScope());
-  T return_val = atomic_compare_exchange(dest, compare, value, MemoryOrderRelaxed(), MemoryScope());
+  atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
+  T return_val = atomic_compare_exchange(
+      dest, compare, value, MemoryOrderRelaxed(), MemoryScope());
   return return_val;
 }
 
 template <typename T, class MemoryScope>
-__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type atomic_compare_exchange(
+__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type
+atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrderAcqRel, MemoryScope) {
-  atomic_thread_fence(MemoryOrderAcquire(),MemoryScope());
-  T return_val = atomic_compare_exchange(dest, compare, value, MemoryOrderRelaxed(), MemoryScope());
-  atomic_thread_fence(MemoryOrderRelease(),MemoryScope());
+  atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
+  T return_val = atomic_compare_exchange(
+      dest, compare, value, MemoryOrderRelaxed(), MemoryScope());
+  atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
   return return_val;
 }
 
 template <typename T, class MemoryScope>
 __device__ typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(
     T* const dest, T value, MemoryOrderRelaxed, MemoryScope) {
-  static_assert(sizeof(unsigned int) == 4, "this function assumes an unsigned int is 32-bit");
+  static_assert(sizeof(unsigned int) == 4,
+                "this function assumes an unsigned int is 32-bit");
   unsigned int return_val = atomicExch(reinterpret_cast<unsigned int*>(dest),
                                        reinterpret_cast<unsigned int&>(value));
   return reinterpret_cast<T&>(return_val);
@@ -120,7 +130,8 @@ __device__ typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(
 template <typename T, class MemoryScope>
 __device__ typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(
     T* const dest, T value, MemoryOrderRelaxed, MemoryScope) {
-  static_assert(sizeof(unsigned long long int) == 8, "this function assumes an unsigned long long  is 64-bit");
+  static_assert(sizeof(unsigned long long int) == 8,
+                "this function assumes an unsigned long long  is 64-bit");
   unsigned long long int return_val =
       atomicExch(reinterpret_cast<unsigned long long int*>(dest),
                  reinterpret_cast<unsigned long long int&>(value));
@@ -128,27 +139,27 @@ __device__ typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(
 }
 
 template <typename T, class MemoryScope>
-__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type atomic_exchange(
-    T* const dest, T value, MemoryOrderRelease, MemoryScope) {
+__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type
+atomic_exchange(T* const dest, T value, MemoryOrderRelease, MemoryScope) {
   T return_val = atomic_exchange(dest, value, MemoryOrderRelaxed(), MemoryScope());
-  atomic_thread_fence(MemoryOrderRelease(),MemoryScope());
+  atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
   return reinterpret_cast<T&>(return_val);
 }
 
 template <typename T, class MemoryScope>
-__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type atomic_exchange(
-    T* const dest, T value, MemoryOrderAcquire, MemoryScope) {
-  atomic_thread_fence(MemoryOrderAcquire(),MemoryScope());
+__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type
+atomic_exchange(T* const dest, T value, MemoryOrderAcquire, MemoryScope) {
+  atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
   T return_val = atomic_exchange(dest, value, MemoryOrderRelaxed(), MemoryScope());
   return reinterpret_cast<T&>(return_val);
 }
 
 template <typename T, class MemoryScope>
-__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type atomic_exchange(
-    T* const dest, T value, MemoryOrderAcqRel, MemoryScope) {
-  atomic_thread_fence(MemoryOrderAcquire(),MemoryScope());
+__device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type
+atomic_exchange(T* const dest, T value, MemoryOrderAcqRel, MemoryScope) {
+  atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
   T return_val = atomic_exchange(dest, value, MemoryOrderRelaxed(), MemoryScope());
-  atomic_thread_fence(MemoryOrderRelease(),MemoryScope());
+  atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
   return reinterpret_cast<T&>(return_val);
 }
 }  // namespace desul
@@ -162,8 +173,8 @@ __device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type at
 // We simply can say DESUL proper doesn't support clang CUDA build pre Volta,
 // Kokkos has that knowledge and so I use it here, allowing in Kokkos to use
 // clang with pre Volta as CUDA compiler
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__>=700)) || \
-     (!defined(__NVCC__) && !defined(DESUL_CUDA_ARCH_IS_PRE_VOLTA))
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700)) || \
+    (!defined(__NVCC__) && !defined(DESUL_CUDA_ARCH_IS_PRE_VOLTA))
 #include <desul/atomics/cuda/CUDA_asm_exchange.hpp>
 #endif
 
@@ -174,42 +185,45 @@ namespace desul {
 template <typename T, class MemoryScope>
 __device__ typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(
     T* const dest, T value, MemoryOrderSeqCst, MemoryScope) {
-  atomic_thread_fence(MemoryOrderAcquire(),MemoryScope());
-  T return_val = atomic_exchange(dest,value,MemoryOrderRelaxed(),MemoryScope());
-  atomic_thread_fence(MemoryOrderRelease(),MemoryScope());
+  atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
+  T return_val = atomic_exchange(dest, value, MemoryOrderRelaxed(), MemoryScope());
+  atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
   return return_val;
 }
 template <typename T, class MemoryScope>
 __device__ typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(
     T* const dest, T value, MemoryOrderSeqCst, MemoryScope) {
-  atomic_thread_fence(MemoryOrderAcquire(),MemoryScope());
-  T return_val = atomic_exchange(dest,value,MemoryOrderRelaxed(),MemoryScope());
-  atomic_thread_fence(MemoryOrderRelease(),MemoryScope());
+  atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
+  T return_val = atomic_exchange(dest, value, MemoryOrderRelaxed(), MemoryScope());
+  atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
   return return_val;
 }
 template <typename T, class MemoryScope>
 __device__ typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrderSeqCst, MemoryScope) {
-  atomic_thread_fence(MemoryOrderAcquire(),MemoryScope());
-  T return_val = atomic_compare_exchange(dest,compare,value,MemoryOrderRelaxed(),MemoryScope());
-  atomic_thread_fence(MemoryOrderRelease(),MemoryScope());
+  atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
+  T return_val = atomic_compare_exchange(
+      dest, compare, value, MemoryOrderRelaxed(), MemoryScope());
+  atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
   return return_val;
 }
 template <typename T, class MemoryScope>
 __device__ typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrderSeqCst, MemoryScope) {
-  atomic_thread_fence(MemoryOrderAcquire(),MemoryScope());
-  T return_val = atomic_compare_exchange(dest,compare,value,MemoryOrderRelaxed(),MemoryScope());
-  atomic_thread_fence(MemoryOrderRelease(),MemoryScope());
+  atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
+  T return_val = atomic_compare_exchange(
+      dest, compare, value, MemoryOrderRelaxed(), MemoryScope());
+  atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
   return return_val;
 }
-}
+}  // namespace desul
 #endif
 
 #if defined(__CUDA_ARCH__) || !defined(__NVCC__)
 namespace desul {
 template <typename T, class MemoryOrder, class MemoryScope>
-__device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type atomic_compare_exchange(
+__device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type
+atomic_compare_exchange(
     T* const dest, T compare, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid dead lock in a warp or wave front
   T return_val;
@@ -220,12 +234,13 @@ __device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::typ
   while (active != done_active) {
     if (!done) {
       if (Impl::lock_address_cuda((void*)dest, scope)) {
-        if(std::is_same<MemoryOrder,MemoryOrderSeqCst>::value) atomic_thread_fence(MemoryOrderRelease(),scope);
-        atomic_thread_fence(MemoryOrderAcquire(),scope);
+        if (std::is_same<MemoryOrder, MemoryOrderSeqCst>::value)
+          atomic_thread_fence(MemoryOrderRelease(), scope);
+        atomic_thread_fence(MemoryOrderAcquire(), scope);
         return_val = *dest;
-        if(return_val == compare) {
+        if (return_val == compare) {
           *dest = value;
-          atomic_thread_fence(MemoryOrderRelease(),scope);
+          atomic_thread_fence(MemoryOrderRelease(), scope);
         }
         Impl::unlock_address_cuda((void*)dest, scope);
         done = 1;
@@ -236,8 +251,8 @@ __device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::typ
   return return_val;
 }
 template <typename T, class MemoryOrder, class MemoryScope>
-__device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type atomic_exchange(
-    T* const dest, T value, MemoryOrder, MemoryScope scope) {
+__device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::type
+atomic_exchange(T* const dest, T value, MemoryOrder, MemoryScope scope) {
   // This is a way to avoid dead lock in a warp or wave front
   T return_val;
   int done = 0;
@@ -247,11 +262,12 @@ __device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::typ
   while (active != done_active) {
     if (!done) {
       if (Impl::lock_address_cuda((void*)dest, scope)) {
-        if(std::is_same<MemoryOrder,MemoryOrderSeqCst>::value) atomic_thread_fence(MemoryOrderRelease(),scope);
-        atomic_thread_fence(MemoryOrderAcquire(),scope);
+        if (std::is_same<MemoryOrder, MemoryOrderSeqCst>::value)
+          atomic_thread_fence(MemoryOrderRelease(), scope);
+        atomic_thread_fence(MemoryOrderAcquire(), scope);
         return_val = *dest;
         *dest = value;
-        atomic_thread_fence(MemoryOrderRelease(),scope);
+        atomic_thread_fence(MemoryOrderRelease(), scope);
         Impl::unlock_address_cuda((void*)dest, scope);
         done = 1;
       }
@@ -260,9 +276,8 @@ __device__ typename std::enable_if<(sizeof(T) != 8) && (sizeof(T) != 4), T>::typ
   }
   return return_val;
 }
-}
+}  // namespace desul
 #endif
-
 
 #endif
 #endif

--- a/core/src/desul/atomics/Compare_Exchange_GCC.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_GCC.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2019, Lawrence Livermore National Security, LLC
 and DESUL project contributors. See the COPYRIGHT file for details.
 Source: https://github.com/desul/desul
@@ -18,39 +18,37 @@ SPDX-License-Identifier: (BSD-3-Clause)
 namespace desul {
 
 namespace Impl {
-template<class T>
+template <class T>
 struct atomic_exchange_available_gcc {
   constexpr static bool value =
 #ifndef DESUL_HAVE_LIBATOMIC
-    ((sizeof(T)==4 && alignof(T)==4) ||
+      ((sizeof(T) == 4 && alignof(T) == 4) ||
 #ifdef DESUL_HAVE_16BYTE_COMPARE_AND_SWAP
-     (sizeof(T)==16 && alignof(T)==16) ||
+       (sizeof(T) == 16 && alignof(T) == 16) ||
 #endif
-     (sizeof(T)==8 && alignof(T)==8)) &&
+       (sizeof(T) == 8 && alignof(T) == 8)) &&
 #endif
-    std::is_trivially_copyable<T>::value;
+      std::is_trivially_copyable<T>::value;
 };
-} //namespace Impl
+}  // namespace Impl
 
-#if defined(__clang__) && (__clang_major__>=7) && !defined(__APPLE__)
+#if defined(__clang__) && (__clang_major__ >= 7) && !defined(__APPLE__)
 // Disable warning for large atomics on clang 7 and up (checked with godbolt)
-// error: large atomic operation may incur significant performance penalty [-Werror,-Watomic-alignment]
-// https://godbolt.org/z/G7YhqhbG6
+// error: large atomic operation may incur significant performance penalty
+// [-Werror,-Watomic-alignment] https://godbolt.org/z/G7YhqhbG6
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Watomic-alignment"
 #endif
-template<class MemoryOrder, class MemoryScope>
+template <class MemoryOrder, class MemoryScope>
 void atomic_thread_fence(MemoryOrder, MemoryScope) {
   __atomic_thread_fence(GCCMemoryOrder<MemoryOrder>::value);
 }
 
 template <typename T, class MemoryOrder, class MemoryScope>
-std::enable_if_t<Impl::atomic_exchange_available_gcc<T>::value, T>
-atomic_exchange(
+std::enable_if_t<Impl::atomic_exchange_available_gcc<T>::value, T> atomic_exchange(
     T* dest, T value, MemoryOrder, MemoryScope) {
   T return_val;
-  __atomic_exchange(
-     dest, &value, &return_val, GCCMemoryOrder<MemoryOrder>::value);
+  __atomic_exchange(dest, &value, &return_val, GCCMemoryOrder<MemoryOrder>::value);
   return return_val;
 }
 
@@ -58,17 +56,19 @@ atomic_exchange(
 // Those two get handled separatly.
 template <typename T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<Impl::atomic_exchange_available_gcc<T>::value, T>
-atomic_compare_exchange(
-    T* dest, T compare, T value, MemoryOrder, MemoryScope) {
-  (void)__atomic_compare_exchange(
-      dest, &compare, &value, false, GCCMemoryOrder<MemoryOrder>::value, GCCMemoryOrder<MemoryOrder>::value);
+atomic_compare_exchange(T* dest, T compare, T value, MemoryOrder, MemoryScope) {
+  (void)__atomic_compare_exchange(dest,
+                                  &compare,
+                                  &value,
+                                  false,
+                                  GCCMemoryOrder<MemoryOrder>::value,
+                                  GCCMemoryOrder<MemoryOrder>::value);
   return compare;
 }
 
 template <typename T, class MemoryScope>
 std::enable_if_t<Impl::atomic_exchange_available_gcc<T>::value, T>
-atomic_compare_exchange(
-    T* dest, T compare, T value, MemoryOrderRelease, MemoryScope) {
+atomic_compare_exchange(T* dest, T compare, T value, MemoryOrderRelease, MemoryScope) {
   (void)__atomic_compare_exchange(
       dest, &compare, &value, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
   return compare;
@@ -76,14 +76,13 @@ atomic_compare_exchange(
 
 template <typename T, class MemoryScope>
 std::enable_if_t<Impl::atomic_exchange_available_gcc<T>::value, T>
-atomic_compare_exchange(
-    T* dest, T compare, T value, MemoryOrderAcqRel, MemoryScope) {
+atomic_compare_exchange(T* dest, T compare, T value, MemoryOrderAcqRel, MemoryScope) {
   (void)__atomic_compare_exchange(
       dest, &compare, &value, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
   return compare;
 }
 
-#if defined(__clang__) && (__clang_major__>=7) && !defined(__APPLE__)
+#if defined(__clang__) && (__clang_major__ >= 7) && !defined(__APPLE__)
 #pragma GCC diagnostic pop
 #endif
 }  // namespace desul

--- a/core/src/desul/atomics/Compare_Exchange_HIP.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_HIP.hpp
@@ -165,10 +165,10 @@ atomic_exchange(T* const dest, T value, MemoryOrderAcqRel, MemoryScope) {
 template <typename T, class MemoryScope>
 __device__ typename std::enable_if<sizeof(T) == 4 || sizeof(T) == 8, T>::type
 atomic_exchange(T* const dest, T value, MemoryOrderSeqCst, MemoryScope) {
-          atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
-            T return_val = atomic_exchange(dest, value, MemoryOrderRelaxed(), MemoryScope());
-              atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
-                return reinterpret_cast<T&>(return_val);
+  atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
+  T return_val = atomic_exchange(dest, value, MemoryOrderRelaxed(), MemoryScope());
+  atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
+  return reinterpret_cast<T&>(return_val);
 }
 
 template <typename T, class MemoryScope>

--- a/core/src/desul/atomics/Compare_Exchange_OpenMP.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_OpenMP.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2019, Lawrence Livermore National Security, LLC
 and DESUL project contributors. See the COPYRIGHT file for details.
 Source: https://github.com/desul/desul
@@ -7,9 +7,11 @@ SPDX-License-Identifier: (BSD-3-Clause)
 */
 #ifndef DESUL_ATOMICS_COMPARE_EXCHANGE_OPENMP_HPP_
 #define DESUL_ATOMICS_COMPARE_EXCHANGE_OPENMP_HPP_
-#include "desul/atomics/Common.hpp"
-#include <cstdio>
 #include <omp.h>
+
+#include <cstdio>
+
+#include "desul/atomics/Common.hpp"
 
 #ifdef DESUL_HAVE_OPENMP_ATOMICS
 namespace desul {
@@ -17,91 +19,93 @@ namespace desul {
 #if _OPENMP > 201800
 // atomic_thread_fence for Core Scope
 inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeCore) {
-  // There is no seq_cst flush in OpenMP, isn't it the same anyway for fence?
-  #pragma omp flush acq_rel
+// There is no seq_cst flush in OpenMP, isn't it the same anyway for fence?
+#pragma omp flush acq_rel
 }
 inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeCore) {
-  #pragma omp flush acq_rel
+#pragma omp flush acq_rel
 }
 inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeCore) {
-  #pragma omp flush release
+#pragma omp flush release
 }
 inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeCore) {
-  #pragma omp flush acquire
+#pragma omp flush acquire
 }
 // atomic_thread_fence for Device Scope
 inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeDevice) {
-  // There is no seq_cst flush in OpenMP, isn't it the same anyway for fence?
-  #pragma omp flush acq_rel
+// There is no seq_cst flush in OpenMP, isn't it the same anyway for fence?
+#pragma omp flush acq_rel
 }
 inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeDevice) {
-  #pragma omp flush acq_rel
+#pragma omp flush acq_rel
 }
 inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeDevice) {
-  #pragma omp flush release
+#pragma omp flush release
 }
 inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeDevice) {
-  #pragma omp flush acquire
+#pragma omp flush acquire
 }
 #else
 // atomic_thread_fence for Core Scope
 inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeCore) {
-  #pragma omp flush
+#pragma omp flush
 }
 inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeCore) {
-  #pragma omp flush
+#pragma omp flush
 }
 inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeCore) {
-  #pragma omp flush
+#pragma omp flush
 }
 inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeCore) {
-  #pragma omp flush
+#pragma omp flush
 }
 // atomic_thread_fence for Device Scope
 inline void atomic_thread_fence(MemoryOrderSeqCst, MemoryScopeDevice) {
-  #pragma omp flush
+#pragma omp flush
 }
 inline void atomic_thread_fence(MemoryOrderAcqRel, MemoryScopeDevice) {
-  #pragma omp flush
+#pragma omp flush
 }
 inline void atomic_thread_fence(MemoryOrderRelease, MemoryScopeDevice) {
-  #pragma omp flush
+#pragma omp flush
 }
 inline void atomic_thread_fence(MemoryOrderAcquire, MemoryScopeDevice) {
-  #pragma omp flush
+#pragma omp flush
 }
 #endif
 
 template <typename T, class MemoryOrder, class MemoryScope>
-T atomic_exchange(
-    T* dest, T value, MemoryOrder, MemoryScope) {
+T atomic_exchange(T* dest, T value, MemoryOrder, MemoryScope) {
   T return_val;
-  if(!std::is_same<MemoryOrder,MemoryOrderRelaxed>::value)
-    atomic_thread_fence(MemoryOrderAcquire(),MemoryScope());
+  if (!std::is_same<MemoryOrder, MemoryOrderRelaxed>::value)
+    atomic_thread_fence(MemoryOrderAcquire(), MemoryScope());
   T& x = *dest;
-  #pragma omp atomic capture
-  { return_val = x; x = value; }
-  if(!std::is_same<MemoryOrder,MemoryOrderRelaxed>::value)
-    atomic_thread_fence(MemoryOrderRelease(),MemoryScope());
+#pragma omp atomic capture
+  {
+    return_val = x;
+    x = value;
+  }
+  if (!std::is_same<MemoryOrder, MemoryOrderRelaxed>::value)
+    atomic_thread_fence(MemoryOrderRelease(), MemoryScope());
   return return_val;
 }
 
-// OpenMP doesn't have compare exchange, so we use build-ins and rely on testing that this works
-// Note that means we test this in OpenMPTarget offload regions!
+// OpenMP doesn't have compare exchange, so we use build-ins and rely on testing that
+// this works Note that means we test this in OpenMPTarget offload regions!
 template <typename T, class MemoryOrder, class MemoryScope>
-std::enable_if_t<Impl::atomic_always_lock_free(sizeof(T)),T> atomic_compare_exchange(
+std::enable_if_t<Impl::atomic_always_lock_free(sizeof(T)), T> atomic_compare_exchange(
     T* dest, T compare, T value, MemoryOrder, MemoryScope) {
   using cas_t = typename Impl::atomic_compare_exchange_type<sizeof(T)>::type;
-  cas_t retval = __sync_val_compare_and_swap(
-     reinterpret_cast<volatile cas_t*>(dest), 
-     reinterpret_cast<cas_t&>(compare), 
-     reinterpret_cast<cas_t&>(value));
+  cas_t retval = __sync_val_compare_and_swap(reinterpret_cast<volatile cas_t*>(dest),
+                                             reinterpret_cast<cas_t&>(compare),
+                                             reinterpret_cast<cas_t&>(value));
   return reinterpret_cast<T&>(retval);
 }
 
-#if defined(__clang__) && (__clang_major__>=7)
+#if defined(__clang__) && (__clang_major__ >= 7)
 // Disable warning for large atomics on clang 7 and up (checked with godbolt)
-// error: large atomic operation may incur significant performance penalty [-Werror,-Watomic-alignment]
+// error: large atomic operation may incur significant performance penalty
+// [-Werror,-Watomic-alignment]
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Watomic-alignment"
 #endif
@@ -130,7 +134,7 @@ atomic_compare_exchange(T* /*dest*/, T /*compare*/, T value, MemoryOrder, Memory
 }
 #pragma omp end declare variant
 
-#if defined(__clang__) && (__clang_major__>=7)
+#if defined(__clang__) && (__clang_major__ >= 7)
 #pragma GCC diagnostic pop
 #endif
 

--- a/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -41,7 +41,7 @@ typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
                           MemoryOrder,
                           MemoryScopeDevice,
                           sycl::access::address_space::local_space>
-    dest_ref(*reinterpret_cast<unsigned int*>(dest));
+        dest_ref(*reinterpret_cast<unsigned int*>(dest));
     dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare),
                                      *reinterpret_cast<unsigned int*>(&value));
     return compare;
@@ -50,7 +50,7 @@ typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
                           MemoryOrder,
                           MemoryScopeDevice,
                           sycl::access::address_space::global_space>
-    dest_ref(*reinterpret_cast<unsigned int*>(dest));
+        dest_ref(*reinterpret_cast<unsigned int*>(dest));
     dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare),
                                      *reinterpret_cast<unsigned int*>(&value));
     return compare;
@@ -67,7 +67,7 @@ typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
                           MemoryOrder,
                           MemoryScopeDevice,
                           sycl::access::address_space::local_space>
-    dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+        dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
     dest_ref.compare_exchange_strong(
         *reinterpret_cast<unsigned long long int*>(&compare),
         *reinterpret_cast<unsigned long long int*>(&value));
@@ -77,7 +77,7 @@ typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
                           MemoryOrder,
                           MemoryScopeDevice,
                           sycl::access::address_space::global_space>
-    dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+        dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
     dest_ref.compare_exchange_strong(
         *reinterpret_cast<unsigned long long int*>(&compare),
         *reinterpret_cast<unsigned long long int*>(&value));
@@ -98,7 +98,7 @@ typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(T* const dest,
                           MemoryOrder,
                           MemoryScopeDevice,
                           sycl::access::address_space::local_space>
-    dest_ref(*reinterpret_cast<unsigned int*>(dest));
+        dest_ref(*reinterpret_cast<unsigned int*>(dest));
     unsigned int return_val =
         dest_ref.exchange(*reinterpret_cast<unsigned int*>(&value));
     return reinterpret_cast<T&>(return_val);
@@ -107,7 +107,7 @@ typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(T* const dest,
                           MemoryOrder,
                           MemoryScopeDevice,
                           sycl::access::address_space::global_space>
-    dest_ref(*reinterpret_cast<unsigned int*>(dest));
+        dest_ref(*reinterpret_cast<unsigned int*>(dest));
     unsigned int return_val =
         dest_ref.exchange(*reinterpret_cast<unsigned int*>(&value));
     return reinterpret_cast<T&>(return_val);
@@ -126,7 +126,7 @@ typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(T* const dest,
                           MemoryOrder,
                           MemoryScopeDevice,
                           sycl::access::address_space::local_space>
-    dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+        dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
     unsigned long long int return_val =
         dest_ref.exchange(*reinterpret_cast<unsigned long long int*>(&value));
     return reinterpret_cast<T&>(return_val);
@@ -135,7 +135,7 @@ typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(T* const dest,
                           MemoryOrder,
                           MemoryScopeDevice,
                           sycl::access::address_space::global_space>
-    dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+        dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
     unsigned long long int return_val =
         dest_ref.exchange(*reinterpret_cast<unsigned long long int*>(&value));
     return reinterpret_cast<T&>(return_val);
@@ -151,7 +151,7 @@ typename std::enable_if<sizeof(T) == 4, T>::type atomic_compare_exchange(
                         MemoryOrder,
                         MemoryScope,
                         sycl::access::address_space::global_space>
-  dest_ref(*reinterpret_cast<unsigned int*>(dest));
+      dest_ref(*reinterpret_cast<unsigned int*>(dest));
   dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned int*>(&compare),
                                    *reinterpret_cast<unsigned int*>(&value));
   return compare;
@@ -165,7 +165,7 @@ typename std::enable_if<sizeof(T) == 8, T>::type atomic_compare_exchange(
                         MemoryOrder,
                         MemoryScope,
                         sycl::access::address_space::global_space>
-  dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+      dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
   dest_ref.compare_exchange_strong(*reinterpret_cast<unsigned long long int*>(&compare),
                                    *reinterpret_cast<unsigned long long int*>(&value));
   return compare;
@@ -182,7 +182,7 @@ typename std::enable_if<sizeof(T) == 4, T>::type atomic_exchange(T* const dest,
                         MemoryOrder,
                         MemoryScope,
                         sycl::access::address_space::global_space>
-  dest_ref(*reinterpret_cast<unsigned int*>(dest));
+      dest_ref(*reinterpret_cast<unsigned int*>(dest));
   unsigned int return_val = dest_ref.exchange(*reinterpret_cast<unsigned int*>(&value));
   return reinterpret_cast<T&>(return_val);
 }
@@ -197,7 +197,7 @@ typename std::enable_if<sizeof(T) == 8, T>::type atomic_exchange(T* const dest,
                         MemoryOrder,
                         MemoryScope,
                         sycl::access::address_space::global_space>
-  dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
+      dest_ref(*reinterpret_cast<unsigned long long int*>(dest));
   unsigned long long int return_val =
       dest_ref.exchange(reinterpret_cast<unsigned long long int&>(value));
   return reinterpret_cast<T&>(return_val);

--- a/core/src/desul/atomics/Compare_Exchange_Serial.hpp
+++ b/core/src/desul/atomics/Compare_Exchange_Serial.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2019, Lawrence Livermore National Security, LLC
 and DESUL project contributors. See the COPYRIGHT file for details.
 Source: https://github.com/desul/desul
@@ -10,13 +10,11 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #ifdef DESUL_HAVE_SERIAL_ATOMICS
 namespace desul {
-template<class MemoryScope>
-void atomic_thread_fence(MemoryOrderAcquire, MemoryScope) {
-}
+template <class MemoryScope>
+void atomic_thread_fence(MemoryOrderAcquire, MemoryScope) {}
 
-template<class MemoryScope>
-void atomic_thread_fence(MemoryOrderRelease, MemoryScope) {
-}
+template <class MemoryScope>
+void atomic_thread_fence(MemoryOrderRelease, MemoryScope) {}
 
 template <typename T, class MemoryScope>
 T atomic_compare_exchange(

--- a/core/src/desul/atomics/GCC.hpp
+++ b/core/src/desul/atomics/GCC.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2019, Lawrence Livermore National Security, LLC
 and DESUL project contributors. See the COPYRIGHT file for details.
 Source: https://github.com/desul/desul
@@ -10,7 +10,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #ifdef DESUL_HAVE_GCC_ATOMICS
 
-#include<type_traits>
+#include <type_traits>
 /*
 Built - in Function : type __atomic_add_fetch(type * ptr, type val, int memorder)
 Built - in Function : type __atomic_sub_fetch(type * ptr, type val, int memorder)
@@ -91,18 +91,19 @@ DESUL_GCC_INTEGRAL_OP_ATOMICS(MemoryOrderSeqCst, MemoryScopeDevice)
 DESUL_GCC_INTEGRAL_OP_ATOMICS(MemoryOrderSeqCst, MemoryScopeCore)
 
 template <typename T, class MemoryOrder, class MemoryScope>
-std::enable_if_t<!Impl::atomic_exchange_available_gcc<T>::value, T>
-atomic_exchange(T* const dest,
-                  Impl::dont_deduce_this_parameter_t<const T> val,
-                  MemoryOrder /*order*/,
-                  MemoryScope scope) {
+std::enable_if_t<!Impl::atomic_exchange_available_gcc<T>::value, T> atomic_exchange(
+    T* const dest,
+    Impl::dont_deduce_this_parameter_t<const T> val,
+    MemoryOrder /*order*/,
+    MemoryScope scope) {
   // Acquire a lock for the address
-  while (!Impl::lock_address((void*)dest, scope)) {}
+  while (!Impl::lock_address((void*)dest, scope)) {
+  }
 
-  atomic_thread_fence(MemoryOrderAcquire(),scope);
+  atomic_thread_fence(MemoryOrderAcquire(), scope);
   T return_val = *dest;
   *dest = val;
-  atomic_thread_fence(MemoryOrderRelease(),scope);
+  atomic_thread_fence(MemoryOrderRelease(), scope);
   Impl::unlock_address((void*)dest, scope);
   return return_val;
 }
@@ -110,18 +111,19 @@ atomic_exchange(T* const dest,
 template <typename T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<!Impl::atomic_exchange_available_gcc<T>::value, T>
 atomic_compare_exchange(T* const dest,
-                  Impl::dont_deduce_this_parameter_t<const T> compare,
-                  Impl::dont_deduce_this_parameter_t<const T> val,
-                  MemoryOrder /*order*/,
-                  MemoryScope scope) {
+                        Impl::dont_deduce_this_parameter_t<const T> compare,
+                        Impl::dont_deduce_this_parameter_t<const T> val,
+                        MemoryOrder /*order*/,
+                        MemoryScope scope) {
   // Acquire a lock for the address
-  while (!Impl::lock_address((void*)dest, scope)) {}
+  while (!Impl::lock_address((void*)dest, scope)) {
+  }
 
-  atomic_thread_fence(MemoryOrderAcquire(),scope);
+  atomic_thread_fence(MemoryOrderAcquire(), scope);
   T return_val = *dest;
-  if(return_val == compare) {
+  if (return_val == compare) {
     *dest = val;
-    atomic_thread_fence(MemoryOrderRelease(),scope);
+    atomic_thread_fence(MemoryOrderRelease(), scope);
   }
   Impl::unlock_address((void*)dest, scope);
   return return_val;

--- a/core/src/desul/atomics/HIP.hpp
+++ b/core/src/desul/atomics/HIP.hpp
@@ -109,7 +109,6 @@ DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP(dec_mod, unsigned int)
 #undef DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP_INTEGRAL
 #undef DESUL_IMPL_HIP_DEVICE_ATOMIC_FETCH_OP
 
-
 // 2/ host-side fallback implementation for atomic functions not provided by GCC
 
 #define DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_FUN(OP_LOWERCASE, OP_PASCAL_CASE, TYPE) \
@@ -177,7 +176,6 @@ DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_INCREMENT_DECREMENT(unsigned long long)
 
 #undef DESUL_IMPL_HIP_HOST_FALLBACK_ATOMIC_INCREMENT_DECREMENT
 
-
 // 3/ device-side fallback implementation for atomic functions defined in GCC overload
 // set
 
@@ -222,4 +220,3 @@ DESUL_IMPL_HIP_DEVICE_FALLBACK_ATOMIC_FUN(nand, Nand)
 
 #endif
 #endif
-

--- a/core/src/desul/atomics/Lock_Array.hpp
+++ b/core/src/desul/atomics/Lock_Array.hpp
@@ -57,17 +57,14 @@ inline void finalize_lock_arrays() {
 }
 template <typename MemoryScope>
 inline bool lock_address(void* ptr, MemoryScope ms) {
-  return 0 == atomic_exchange(host_locks__::get_host_lock_(ptr),
-                                      int32_t(1),
-                                      MemoryOrderSeqCst(),
-                                      ms);
+  return 0 ==
+         atomic_exchange(
+             host_locks__::get_host_lock_(ptr), int32_t(1), MemoryOrderSeqCst(), ms);
 }
 template <typename MemoryScope>
 void unlock_address(void* ptr, MemoryScope ms) {
-  (void)atomic_exchange(host_locks__::get_host_lock_(ptr),
-                                int32_t(0),
-                                MemoryOrderSeqCst(),
-                                ms);
+  (void)atomic_exchange(
+      host_locks__::get_host_lock_(ptr), int32_t(0), MemoryOrderSeqCst(), ms);
 }
 }  // namespace Impl
 }  // namespace desul

--- a/core/src/desul/atomics/Lock_Array_Cuda.hpp
+++ b/core/src/desul/atomics/Lock_Array_Cuda.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2019, Lawrence Livermore National Security, LLC
 and DESUL project contributors. See the COPYRIGHT file for details.
 Source: https://github.com/desul/desul
@@ -9,8 +9,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef DESUL_ATOMICS_LOCK_ARRAY_CUDA_HPP_
 #define DESUL_ATOMICS_LOCK_ARRAY_CUDA_HPP_
 
-#include "desul/atomics/Macros.hpp"
 #include "desul/atomics/Common.hpp"
+#include "desul/atomics/Macros.hpp"
 
 #ifdef DESUL_HAVE_CUDA_ATOMICS
 
@@ -23,7 +23,7 @@ namespace Impl {
 #define DESUL_IMPL_BALLOT_MASK(m, x) __ballot_sync(m, x)
 #define DESUL_IMPL_ACTIVEMASK __activemask()
 #else
-#define DESUL_IMPL_BALLOT_MASK(m, x) m==0?0:1
+#define DESUL_IMPL_BALLOT_MASK(m, x) m == 0 ? 0 : 1
 #define DESUL_IMPL_ACTIVEMASK 0
 #endif
 
@@ -32,14 +32,13 @@ namespace Impl {
 extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h;
 extern int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE_h;
 
-
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
 ///        valid, initialized arrays.
 ///
 /// This call is idempotent.
 /// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
 ///   snapshotted version while also linking against pure Desul
-template<typename /*AlwaysInt*/ = int>
+template <typename /*AlwaysInt*/ = int>
 void init_lock_arrays_cuda();
 
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
@@ -48,7 +47,7 @@ void init_lock_arrays_cuda();
 /// This call is idempotent.
 /// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
 ///   snappshotted version while also linking against pure Desul
-template<typename T = int>
+template <typename T = int>
 void finalize_lock_arrays_cuda();
 
 }  // namespace Impl
@@ -150,13 +149,12 @@ inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
       cudaMemcpyToSymbol(::desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_DEVICE,    \
                          &::desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h, \
                          sizeof(int32_t*));                                \
-      cudaMemcpyToSymbol(::desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_NODE,    \
-                         &::desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_NODE_h, \
+      cudaMemcpyToSymbol(::desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_NODE,      \
+                         &::desul::Impl::CUDA_SPACE_ATOMIC_LOCKS_NODE_h,   \
                          sizeof(int32_t*));                                \
     }                                                                      \
     ::desul::Impl::lock_array_copied = 1;                                  \
   }
-
 
 #endif /* defined( __CUDACC__ ) */
 

--- a/core/src/desul/atomics/Lock_Array_HIP.hpp
+++ b/core/src/desul/atomics/Lock_Array_HIP.hpp
@@ -38,7 +38,7 @@ extern int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE_h;
 /// This call is idempotent.
 /// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
 ///   snappshotted version while also linking against pure Desul
-template<typename T = int>
+template <typename T = int>
 void init_lock_arrays_hip();
 
 /// \brief After this call, the g_host_cuda_lock_arrays variable has
@@ -47,7 +47,7 @@ void init_lock_arrays_hip();
 /// This call is idempotent.
 /// The function is templated to make it a weak symbol to deal with Kokkos/RAJA
 ///   snappshotted version while also linking against pure Desul
-template<typename T = int>
+template <typename T = int>
 void finalize_lock_arrays_hip();
 }  // namespace Impl
 }  // namespace desul
@@ -145,17 +145,18 @@ inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
 /* It is critical that this code be a macro, so that it will
    capture the right address for g_device_hip_lock_arrays!
    putting this in an inline function will NOT do the right thing! */
-#define DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE()                               \
-  {                                                                               \
-    if (::desul::Impl::lock_array_copied == 0) {                                  \
-      (void) hipMemcpyToSymbol(HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE), \
-                        &::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,          \
-                        sizeof(int32_t*));                                        \
-      (void) hipMemcpyToSymbol(HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE),   \
-                        &::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE_h,            \
-                        sizeof(int32_t*));                                        \
-    }                                                                             \
-    ::desul::Impl::lock_array_copied = 1;                                         \
+#define DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE()                                   \
+  {                                                                                   \
+    if (::desul::Impl::lock_array_copied == 0) {                                      \
+      (void)hipMemcpyToSymbol(                                                        \
+          HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE),                   \
+          &::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,                            \
+          sizeof(int32_t*));                                                          \
+      (void)hipMemcpyToSymbol(HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE), \
+                              &::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE_h,          \
+                              sizeof(int32_t*));                                      \
+    }                                                                                 \
+    ::desul::Impl::lock_array_copied = 1;                                             \
   }
 
 #endif

--- a/core/src/desul/atomics/OpenMP.hpp
+++ b/core/src/desul/atomics/OpenMP.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2019, Lawrence Livermore National Security, LLC
 and DESUL project contributors. See the COPYRIGHT file for details.
 Source: https://github.com/desul/desul
@@ -10,6 +10,6 @@ SPDX-License-Identifier: (BSD-3-Clause)
 
 #ifdef DESUL_HAVE_OPENMP_ATOMICS
 
-#include<desul/atomics/openmp/OpenMP_40.hpp>
+#include <desul/atomics/openmp/OpenMP_40.hpp>
 #endif
 #endif


### PR DESCRIPTION
This applies clang 10 formatting to the Kokkos copy of desul using the format specifier from desul. 