### PR TITLE
Obviate join(volatile) in reducers by preloading values

### DIFF
--- a/algorithms/src/std_algorithms/Kokkos_PartitioningOperations.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_PartitioningOperations.hpp
@@ -132,12 +132,6 @@ struct StdPartitionCopyScalar {
     false_count_ = other.false_count_;
   }
 
-  KOKKOS_FUNCTION
-  void operator=(const volatile StdPartitionCopyScalar& other) volatile {
-    true_count_  = other.true_count_;
-    false_count_ = other.false_count_;
-  }
-
   // this is needed for
   // OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp:699:21: error: no viable
   // overloaded '=' m_returnvalue = 0;

--- a/algorithms/src/std_algorithms/Kokkos_PartitioningOperations.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_PartitioningOperations.hpp
@@ -193,8 +193,7 @@ struct StdPartitionCopyFunctor {
   }
 
   KOKKOS_FUNCTION
-  void join(volatile value_type& update,
-            volatile const value_type& input) const {
+  void join(value_type& update, const value_type& input) const {
     update.true_count_ += input.true_count_;
     update.false_count_ += input.false_count_;
   }

--- a/algorithms/src/std_algorithms/Kokkos_ReducerWithArbitraryJoinerNoNeutralElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ReducerWithArbitraryJoinerNoNeutralElement.hpp
@@ -91,11 +91,6 @@ struct ReducerWithArbitraryJoinerNoNeutralElement {
   }
 
   KOKKOS_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    dest.val = m_joiner(dest.val, src.val);
-  }
-
-  KOKKOS_FUNCTION
   void init(value_type& val) const {
     // I cannot call reduction_identity, so need to default this
     val = {};

--- a/algorithms/src/std_algorithms/Kokkos_ValueWrapperForNoNeutralElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ValueWrapperForNoNeutralElement.hpp
@@ -63,12 +63,6 @@ struct ValueWrapperForNoNeutralElement {
     val        = rhs.val;
     is_initial = rhs.is_initial;
   }
-
-  KOKKOS_FUNCTION
-  void operator=(const volatile ValueWrapperForNoNeutralElement& rhs) volatile {
-    val        = rhs.val;
-    is_initial = rhs.is_initial;
-  }
 };
 
 }  // namespace Impl

--- a/algorithms/src/std_algorithms/numeric/Kokkos_ExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/numeric/Kokkos_ExclusiveScan.hpp
@@ -97,8 +97,7 @@ struct ExclusiveScanDefaultFunctor {
   }
 
   KOKKOS_FUNCTION
-  void join(volatile value_type& update,
-            volatile const value_type& input) const {
+  void join(value_type& update, const value_type& input) const {
     if (update.is_initial) {
       update.val        = input.val;
       update.is_initial = false;
@@ -155,8 +154,7 @@ struct TransformExclusiveScanFunctor {
   }
 
   KOKKOS_FUNCTION
-  void join(volatile value_type& update,
-            volatile const value_type& input) const {
+  void join(value_type& update, const value_type& input) const {
     if (update.is_initial) {
       update.val = input.val;
     } else {

--- a/algorithms/src/std_algorithms/numeric/Kokkos_InclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/numeric/Kokkos_InclusiveScan.hpp
@@ -89,8 +89,7 @@ struct InclusiveScanDefaultFunctor {
   }
 
   KOKKOS_FUNCTION
-  void join(volatile value_type& update,
-            volatile const value_type& input) const {
+  void join(value_type& update, const value_type& input) const {
     if (update.is_initial) {
       update.val = input.val;
     } else {
@@ -137,8 +136,7 @@ struct TransformInclusiveScanNoInitValueFunctor {
   }
 
   KOKKOS_FUNCTION
-  void join(volatile value_type& update,
-            volatile const value_type& input) const {
+  void join(value_type& update, const value_type& input) const {
     if (update.is_initial) {
       update.val = input.val;
     } else {
@@ -189,8 +187,7 @@ struct TransformInclusiveScanWithInitValueFunctor {
   }
 
   KOKKOS_FUNCTION
-  void join(volatile value_type& update,
-            volatile const value_type& input) const {
+  void join(value_type& update, const value_type& input) const {
     if (update.is_initial) {
       update.val = input.val;
     } else {

--- a/algorithms/src/std_algorithms/numeric/Kokkos_Reduce.hpp
+++ b/algorithms/src/std_algorithms/numeric/Kokkos_Reduce.hpp
@@ -62,12 +62,6 @@ struct StdReduceDefaultJoinFunctor {
   constexpr ValueType operator()(const ValueType& a, const ValueType& b) const {
     return a + b;
   }
-
-  KOKKOS_FUNCTION
-  constexpr ValueType operator()(const volatile ValueType& a,
-                                 const volatile ValueType& b) const {
-    return a + b;
-  }
 };
 
 template <class IteratorType, class ReducerType>

--- a/algorithms/src/std_algorithms/numeric/Kokkos_TransformReduce.hpp
+++ b/algorithms/src/std_algorithms/numeric/Kokkos_TransformReduce.hpp
@@ -73,12 +73,6 @@ struct StdTranformReduceDefaultJoinFunctor {
   constexpr ValueType operator()(const ValueType& a, const ValueType& b) const {
     return a + b;
   }
-
-  KOKKOS_FUNCTION
-  constexpr ValueType operator()(const volatile ValueType& a,
-                                 const volatile ValueType& b) const {
-    return a + b;
-  }
 };
 
 template <class IteratorType, class ReducerType, class TransformType>

--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -98,16 +98,6 @@ struct RandomProperties {
     max = add.max > max ? add.max : max;
     return *this;
   }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator+=(const volatile RandomProperties& add) volatile {
-    count += add.count;
-    mean += add.mean;
-    variance += add.variance;
-    covariance += add.covariance;
-    min = add.min < min ? add.min : min;
-    max = add.max > max ? add.max : max;
-  }
 };
 
 // FIXME_OPENMPTARGET: Need this for OpenMPTarget because contra to the standard

--- a/algorithms/unit_tests/TestStdAlgorithmsNumerics.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsNumerics.cpp
@@ -97,29 +97,6 @@ struct CustomValueType {
     return this->value == other.value;
   }
 
-  //
-  // volatile overloads needed for the kokkos reductions
-  //
-  // note the void return
-  KOKKOS_INLINE_FUNCTION
-  void operator+=(const volatile CustomValueType& other) volatile {
-    this->value += other.value;
-  }
-
-  // note the void return
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const CustomValueType& other) volatile {
-    this->value = other.value;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  CustomValueType operator+(const volatile CustomValueType& other) const
-      volatile {
-    CustomValueType result;
-    result.value = this->value + other.value;
-    return result;
-  }
-
  private:
   value_type value = {};
 };

--- a/containers/performance_tests/TestGlobal2LocalIds.hpp
+++ b/containers/performance_tests/TestGlobal2LocalIds.hpp
@@ -140,9 +140,7 @@ struct find_test {
   void init(value_type& v) const { v = 0; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dst, volatile value_type const& src) const {
-    dst += src;
-  }
+  void join(value_type& dst, value_type const& src) const { dst += src; }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(size_type i, value_type& num_errors) const {

--- a/containers/performance_tests/TestUnorderedMapPerformance.hpp
+++ b/containers/performance_tests/TestUnorderedMapPerformance.hpp
@@ -147,7 +147,7 @@ struct UnorderedMapTest {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dst, const volatile value_type& src) const {
+  void join(value_type& dst, const value_type& src) const {
     dst.failed_count += src.failed_count;
     dst.max_list = src.max_list < dst.max_list ? dst.max_list : src.max_list;
   }

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -300,11 +300,6 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, DeviceType,
     Kokkos::atomic_add(&dest, src);
   }
 
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile ValueType& dest, const volatile ValueType& src) const {
-    Kokkos::atomic_add(&dest, src);
-  }
-
   KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
     this->join(value, rhs);
   }
@@ -386,11 +381,6 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, DeviceType,
     atomic_prod(&dest, src);
   }
 
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile ValueType& dest, const volatile ValueType& src) const {
-    atomic_prod(&dest, src);
-  }
-
   KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
     atomic_prod(&value, rhs);
   }
@@ -457,11 +447,6 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, DeviceType,
     atomic_min(dest, src);
   }
 
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile ValueType& dest, const volatile ValueType& src) const {
-    atomic_min(dest, src);
-  }
-
   KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
     this->join(value, rhs);
   }
@@ -525,11 +510,6 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, DeviceType,
 
   KOKKOS_INLINE_FUNCTION
   void join(ValueType& dest, const ValueType& src) const {
-    atomic_max(dest, src);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile ValueType& dest, const volatile ValueType& src) const {
     atomic_max(dest, src);
   }
 

--- a/containers/src/Kokkos_StaticCrsGraph.hpp
+++ b/containers/src/Kokkos_StaticCrsGraph.hpp
@@ -471,8 +471,7 @@ struct StaticCrsGraphMaximumEntry {
   void init(value_type& update) const { update = 0; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& update,
-            volatile const value_type& input) const {
+  void join(value_type& update, const value_type& input) const {
     if (update < input) update = input;
   }
 };

--- a/containers/src/impl/Kokkos_Bitset_impl.hpp
+++ b/containers/src/impl/Kokkos_Bitset_impl.hpp
@@ -86,9 +86,7 @@ struct BitsetCount {
   void init(value_type& count) const { count = 0u; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& count, const volatile size_type& incr) const {
-    count += incr;
-  }
+  void join(value_type& count, const size_type& incr) const { count += incr; }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(size_type i, value_type& count) const {

--- a/containers/unit_tests/TestBitset.hpp
+++ b/containers/unit_tests/TestBitset.hpp
@@ -75,9 +75,7 @@ struct TestBitset {
   void init(value_type& v) const { v = 0; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dst, const volatile value_type& src) const {
-    dst += src;
-  }
+  void join(value_type& dst, const value_type& src) const { dst += src; }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(uint32_t i, value_type& v) const {
@@ -116,9 +114,7 @@ struct TestBitsetTest {
   void init(value_type& v) const { v = 0; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dst, const volatile value_type& src) const {
-    dst += src;
-  }
+  void join(value_type& dst, const value_type& src) const { dst += src; }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(uint32_t i, value_type& v) const {
@@ -148,9 +144,7 @@ struct TestBitsetAny {
   void init(value_type& v) const { v = 0; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dst, const volatile value_type& src) const {
-    dst += src;
-  }
+  void join(value_type& dst, const value_type& src) const { dst += src; }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(uint32_t i, value_type& v) const {

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -108,8 +108,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 7> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   const volatile value_type& input) {
+  static void join(value_type& update, const value_type& input) {
     update |= input;
   }
 
@@ -193,8 +192,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 6> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   const volatile value_type& input) {
+  static void join(value_type& update, const value_type& input) {
     update |= input;
   }
 
@@ -275,8 +273,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 5> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   const volatile value_type& input) {
+  static void join(value_type& update, const value_type& input) {
     update |= input;
   }
 
@@ -370,8 +367,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 4> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   const volatile value_type& input) {
+  static void join(value_type& update, const value_type& input) {
     update |= input;
   }
 
@@ -445,8 +441,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 3> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   const volatile value_type& input) {
+  static void join(value_type& update, const value_type& input) {
     update |= input;
   }
 
@@ -543,8 +538,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 2> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   const volatile value_type& input) {
+  static void join(value_type& update, const value_type& input) {
     update |= input;
   }
 
@@ -623,8 +617,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 1> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   const volatile value_type& input) {
+  static void join(value_type& update, const value_type& input) {
     update |= input;
   }
 

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -87,8 +87,7 @@ struct TestInsert {
   void init(value_type &failed_count) const { failed_count = 0; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type &failed_count,
-            const volatile value_type &count) const {
+  void join(value_type &failed_count, const value_type &count) const {
     failed_count += count;
   }
 
@@ -156,9 +155,7 @@ struct TestFind {
   static void init(value_type &dst) { dst = 0; }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type &dst, const volatile value_type &src) {
-    dst += src;
-  }
+  static void join(value_type &dst, const value_type &src) { dst += src; }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(typename execution_space::size_type i,

--- a/core/perf_test/PerfTestBlasKernels.hpp
+++ b/core/perf_test/PerfTestBlasKernels.hpp
@@ -72,8 +72,7 @@ struct Dot {
   void operator()(int i, value_type& update) const { update += X[i] * Y[i]; }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   const volatile value_type& source) {
+  static void join(value_type& update, const value_type& source) {
     update += source;
   }
 
@@ -105,8 +104,7 @@ struct DotSingle {
   }
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   const volatile value_type& source) {
+  static void join(value_type& update, const value_type& source) {
     update += source;
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -74,8 +74,7 @@ struct CudaJoinFunctor {
   using value_type = Type;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   volatile const value_type& input) {
+  static void join(value_type& update, const value_type& input) {
     update += input;
   }
 };

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -69,8 +69,7 @@ struct HIPJoinFunctor {
   using value_type = Type;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   volatile const value_type& input) {
+  static void join(value_type& update, const value_type& input) {
     update += input;
   }
 };

--- a/core/src/Kokkos_Crs.hpp
+++ b/core/src/Kokkos_Crs.hpp
@@ -213,8 +213,7 @@ class CrsRowMapFromCounts {
   KOKKOS_INLINE_FUNCTION
   void init(value_type& update) const { update = 0; }
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& update,
-            const volatile value_type& input) const {
+  void join(value_type& update, const value_type& input) const {
     update += input;
   }
   using self_type = CrsRowMapFromCounts<InCounts, OutRowMap>;

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -244,8 +244,8 @@ namespace Kokkos {
 ///                     value_type& update,
 ///                     const bool final_pass) const;
 ///   void init (value_type& update) const;
-///   void join (volatile value_type& update,
-//               volatile const value_type& input) const
+///   void join (value_type& update,
+//               const value_type& input) const
 /// };
 /// \endcode
 ///
@@ -275,7 +275,7 @@ namespace Kokkos {
 ///   void init (value_type& update) const {
 ///     update = 0;
 ///   }
-///   void join (volatile value_type& update, volatile const value_type& input)
+///   void join (value_type& update, const value_type& input)
 ///   const {
 ///     update += input;
 ///   }
@@ -313,7 +313,7 @@ namespace Kokkos {
 ///   void init (value_type& update) const {
 ///     update = 0;
 ///   }
-///   void join (volatile value_type& update, volatile const value_type& input)
+///   void join (value_type& update, const value_type& input)
 ///   const {
 ///     update += input;
 ///   }
@@ -360,7 +360,7 @@ namespace Kokkos {
 ///   void init (value_type& update) const {
 ///     update = 0;
 ///   }
-///   void join (volatile value_type& update, volatile const value_type& input)
+///   void join (value_type& update, const value_type& input)
 ///   const {
 ///     update += input;
 ///   }

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1719,8 +1719,8 @@ struct ParallelReduceFence {
  *    using value_type = <podType>;
  *    void operator()( <intType> iwork , <podType> & update ) const ;
  *    void init( <podType> & update ) const ;
- *    void join( volatile       <podType> & update ,
- *               volatile const <podType> & input ) const ;
+ *    void join(       <podType> & update ,
+ *               const <podType> & input ) const ;
  *
  *    void final( <podType> & update ) const ;
  *  };
@@ -1735,8 +1735,8 @@ struct ParallelReduceFence {
  *    using value_type = <podType>[];
  *    void operator()( <intType> , <podType> update[] ) const ;
  *    void init( <podType> update[] ) const ;
- *    void join( volatile       <podType> update[] ,
- *               volatile const <podType> input[] ) const ;
+ *    void join(       <podType> update[] ,
+ *               const <podType> input[] ) const ;
  *
  *    void final( <podType> update[] ) const ;
  *  };

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -409,12 +409,6 @@ struct ValLocScalar {
     val = rhs.val;
     loc = rhs.loc;
   }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const volatile ValLocScalar& rhs) volatile {
-    val = rhs.val;
-    loc = rhs.loc;
-  }
 };
 
 template <class Scalar, class Index, class Space>
@@ -520,12 +514,6 @@ struct MinMaxScalar {
     min_val = rhs.min_val;
     max_val = rhs.max_val;
   }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const volatile MinMaxScalar& rhs) volatile {
-    min_val = rhs.min_val;
-    max_val = rhs.max_val;
-  }
 };
 
 template <class Scalar, class Space>
@@ -586,14 +574,6 @@ struct MinMaxLocScalar {
 
   KOKKOS_INLINE_FUNCTION
   void operator=(const MinMaxLocScalar& rhs) {
-    min_val = rhs.min_val;
-    min_loc = rhs.min_loc;
-    max_val = rhs.max_val;
-    max_loc = rhs.max_loc;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const volatile MinMaxLocScalar& rhs) volatile {
     min_val = rhs.min_val;
     min_loc = rhs.min_loc;
     max_val = rhs.max_val;
@@ -1030,11 +1010,6 @@ struct FirstLocScalar {
 
   KOKKOS_INLINE_FUNCTION
   void operator=(const FirstLocScalar& rhs) { min_loc_true = rhs.min_loc_true; }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const volatile FirstLocScalar& rhs) volatile {
-    min_loc_true = rhs.min_loc_true;
-  }
 };
 
 template <class Index, class Space>
@@ -1093,11 +1068,6 @@ struct LastLocScalar {
 
   KOKKOS_INLINE_FUNCTION
   void operator=(const LastLocScalar& rhs) { max_loc_true = rhs.max_loc_true; }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const volatile LastLocScalar& rhs) volatile {
-    max_loc_true = rhs.max_loc_true;
-  }
 };
 
 template <class Index, class Space>
@@ -1153,12 +1123,6 @@ struct StdIsPartScalar {
 
   KOKKOS_INLINE_FUNCTION
   void operator=(const StdIsPartScalar& rhs) {
-    min_loc_false = rhs.min_loc_false;
-    max_loc_true  = rhs.max_loc_true;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const volatile StdIsPartScalar& rhs) volatile {
     min_loc_false = rhs.min_loc_false;
     max_loc_true  = rhs.max_loc_true;
   }
@@ -1226,11 +1190,6 @@ struct StdPartPointScalar {
 
   KOKKOS_INLINE_FUNCTION
   void operator=(const StdPartPointScalar& rhs) {
-    min_loc_false = rhs.min_loc_false;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const volatile StdPartPointScalar& rhs) volatile {
     min_loc_false = rhs.min_loc_false;
   }
 };

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -93,11 +93,6 @@ struct Sum {
   void join(value_type& dest, const value_type& src) const { dest += src; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    dest += src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
     val = reduction_identity<value_type>::sum();
   }
@@ -136,11 +131,6 @@ struct Prod {
   // Required
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const { dest *= src; }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    dest *= src;
-  }
 
   KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
@@ -185,11 +175,6 @@ struct Min {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    if (src < dest) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
     val = reduction_identity<value_type>::min();
   }
@@ -228,11 +213,6 @@ struct Max {
   // Required
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const {
-    if (src > dest) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
     if (src > dest) dest = src;
   }
 
@@ -279,11 +259,6 @@ struct LAnd {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    dest = dest && src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
     val = reduction_identity<value_type>::land();
   }
@@ -322,11 +297,6 @@ struct LOr {
   // Required
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const {
-    dest = dest || src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
     dest = dest || src;
   }
 
@@ -373,11 +343,6 @@ struct BAnd {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    dest = dest & src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
     val = reduction_identity<value_type>::band();
   }
@@ -416,11 +381,6 @@ struct BOr {
   // Required
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const {
-    dest = dest | src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
     dest = dest | src;
   }
 
@@ -489,11 +449,6 @@ struct MinLoc {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    if (src.val < dest.val) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
     val.val = reduction_identity<scalar_type>::min();
     val.loc = reduction_identity<index_type>::min();
@@ -537,11 +492,6 @@ struct MaxLoc {
   // Required
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const {
-    if (src.val > dest.val) dest = src;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
     if (src.val > dest.val) dest = src;
   }
 
@@ -605,16 +555,6 @@ struct MinMax {
   // Required
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const {
-    if (src.min_val < dest.min_val) {
-      dest.min_val = src.min_val;
-    }
-    if (src.max_val > dest.max_val) {
-      dest.max_val = src.max_val;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
     if (src.min_val < dest.min_val) {
       dest.min_val = src.min_val;
     }
@@ -700,18 +640,6 @@ struct MinMaxLoc {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    if (src.min_val < dest.min_val) {
-      dest.min_val = src.min_val;
-      dest.min_loc = src.min_loc;
-    }
-    if (src.max_val > dest.max_val) {
-      dest.max_val = src.max_val;
-      dest.max_loc = src.max_loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
     val.max_val = reduction_identity<scalar_type>::max();
     val.min_val = reduction_identity<scalar_type>::min();
@@ -764,15 +692,6 @@ struct MaxFirstLoc {
   // Required
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const {
-    if (dest.val < src.val) {
-      dest = src;
-    } else if (!(src.val < dest.val)) {
-      dest.loc = (src.loc < dest.loc) ? src.loc : dest.loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
     if (dest.val < src.val) {
       dest = src;
     } else if (!(src.val < dest.val)) {
@@ -840,15 +759,6 @@ struct MaxFirstLocCustomComparator {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    if (m_comp(dest.val, src.val)) {
-      dest = src;
-    } else if (!m_comp(src.val, dest.val)) {
-      dest.loc = (src.loc < dest.loc) ? src.loc : dest.loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
     val.val = reduction_identity<scalar_type>::max();
     val.loc = reduction_identity<index_type>::min();
@@ -895,15 +805,6 @@ struct MinFirstLoc {
   // Required
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const {
-    if (src.val < dest.val) {
-      dest = src;
-    } else if (!(dest.val < src.val)) {
-      dest.loc = (src.loc < dest.loc) ? src.loc : dest.loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
     if (src.val < dest.val) {
       dest = src;
     } else if (!(dest.val < src.val)) {
@@ -971,15 +872,6 @@ struct MinFirstLocCustomComparator {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    if (m_comp(src.val, dest.val)) {
-      dest = src;
-    } else if (!m_comp(dest.val, src.val)) {
-      dest.loc = (src.loc < dest.loc) ? src.loc : dest.loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
     val.val = reduction_identity<scalar_type>::min();
     val.loc = reduction_identity<index_type>::min();
@@ -1027,23 +919,6 @@ struct MinMaxFirstLastLoc {
   // Required
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const {
-    if (src.min_val < dest.min_val) {
-      dest.min_val = src.min_val;
-      dest.min_loc = src.min_loc;
-    } else if (!(dest.min_val < src.min_val)) {
-      dest.min_loc = (src.min_loc < dest.min_loc) ? src.min_loc : dest.min_loc;
-    }
-
-    if (dest.max_val < src.max_val) {
-      dest.max_val = src.max_val;
-      dest.max_loc = src.max_loc;
-    } else if (!(src.max_val < dest.max_val)) {
-      dest.max_loc = (src.max_loc > dest.max_loc) ? src.max_loc : dest.max_loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
     if (src.min_val < dest.min_val) {
       dest.min_val = src.min_val;
       dest.min_loc = src.min_loc;
@@ -1129,23 +1004,6 @@ struct MinMaxFirstLastLocCustomComparator {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    if (m_comp(src.min_val, dest.min_val)) {
-      dest.min_val = src.min_val;
-      dest.min_loc = src.min_loc;
-    } else if (!m_comp(dest.min_val, src.min_val)) {
-      dest.min_loc = (src.min_loc < dest.min_loc) ? src.min_loc : dest.min_loc;
-    }
-
-    if (m_comp(dest.max_val, src.max_val)) {
-      dest.max_val = src.max_val;
-      dest.max_loc = src.max_loc;
-    } else if (!m_comp(src.max_val, dest.max_val)) {
-      dest.max_loc = (src.max_loc > dest.max_loc) ? src.max_loc : dest.max_loc;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
     val.max_val = ::Kokkos::reduction_identity<scalar_type>::max();
     val.min_val = ::Kokkos::reduction_identity<scalar_type>::min();
@@ -1212,13 +1070,6 @@ struct FirstLoc {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    dest.min_loc_true = (src.min_loc_true < dest.min_loc_true)
-                            ? src.min_loc_true
-                            : dest.min_loc_true;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
     val.min_loc_true = ::Kokkos::reduction_identity<index_type>::min();
   }
@@ -1276,13 +1127,6 @@ struct LastLoc {
   // Required
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const {
-    dest.max_loc_true = (src.max_loc_true > dest.max_loc_true)
-                            ? src.max_loc_true
-                            : dest.max_loc_true;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
     dest.max_loc_true = (src.max_loc_true > dest.max_loc_true)
                             ? src.max_loc_true
                             : dest.max_loc_true;
@@ -1361,17 +1205,6 @@ struct StdIsPartitioned {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    dest.max_loc_true = (dest.max_loc_true < src.max_loc_true)
-                            ? src.max_loc_true
-                            : dest.max_loc_true;
-
-    dest.min_loc_false = (dest.min_loc_false < src.min_loc_false)
-                             ? dest.min_loc_false
-                             : src.min_loc_false;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const {
     val.max_loc_true  = ::Kokkos::reduction_identity<index_type>::max();
     val.min_loc_false = ::Kokkos::reduction_identity<index_type>::min();
@@ -1433,13 +1266,6 @@ struct StdPartitionPoint {
   // Required
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const {
-    dest.min_loc_false = (dest.min_loc_false < src.min_loc_false)
-                             ? dest.min_loc_false
-                             : src.min_loc_false;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
     dest.min_loc_false = (dest.min_loc_false < src.min_loc_false)
                              ? dest.min_loc_false
                              : src.min_loc_false;

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -263,7 +263,7 @@ class ThreadsExecTeamMember {
          type* const local_value = ((type*)m_exec->scratch_memory());
 
          // Set this thread's contribution
-         if (team_rank() != team_size() - 1)* local_value = contribution;
+         if (team_rank() != team_size() - 1) *local_value = contribution;
 
          // Fence to make sure the base team member has access:
          memory_fence();

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -252,48 +252,48 @@ class ThreadsExecTeamMember {
                   const typename ReducerType::value_type contribution) const {
     KOKKOS_IF_ON_DEVICE(((void)reducer; (void)contribution;))
 
-    KOKKOS_IF_ON_HOST(
-        (using value_type = typename ReducerType::value_type;
-         // Make sure there is enough scratch space:
-         using type = typename if_c<sizeof(value_type) < TEAM_REDUCE_SIZE,
-                                    value_type, void>::type;
+    KOKKOS_IF_ON_HOST((
+        using value_type = typename ReducerType::value_type;
+        // Make sure there is enough scratch space:
+        using type = typename if_c<sizeof(value_type) < TEAM_REDUCE_SIZE,
+                                   value_type, void>::type;
 
-         if (nullptr == m_exec) return;
+        if (nullptr == m_exec) return;
 
-         type* const local_value = ((type*)m_exec->scratch_memory());
+        type* const local_value = ((type*)m_exec->scratch_memory());
 
-         // Set this thread's contribution
-         if (team_rank() != team_size() - 1) *local_value = contribution;
+        // Set this thread's contribution
+        if (team_rank() != team_size() - 1) { *local_value = contribution; }
 
-         // Fence to make sure the base team member has access:
-         memory_fence();
+        // Fence to make sure the base team member has access:
+        memory_fence();
 
-         if (team_fan_in()) {
-           // The last thread to synchronize returns true, all other threads
-           // wait for team_fan_out()
-           type* const team_value = ((type*)m_team_base[0]->scratch_memory());
+        if (team_fan_in()) {
+          // The last thread to synchronize returns true, all other threads
+          // wait for team_fan_out()
+          type* const team_value = ((type*)m_team_base[0]->scratch_memory());
 
-           *team_value = contribution;
-           // Join to the team value:
-           for (int i = 1; i < m_team_size; ++i) {
-             reducer.join(*team_value,
-                          *((type*)m_team_base[i]->scratch_memory()));
-           }
+          *team_value = contribution;
+          // Join to the team value:
+          for (int i = 1; i < m_team_size; ++i) {
+            reducer.join(*team_value,
+                         *((type*)m_team_base[i]->scratch_memory()));
+          }
 
-           // Team base thread may "lap" member threads so copy out to their
-           // local value.
-           for (int i = 1; i < m_team_size; ++i) {
-             *((type*)m_team_base[i]->scratch_memory()) = *team_value;
-           }
+          // Team base thread may "lap" member threads so copy out to their
+          // local value.
+          for (int i = 1; i < m_team_size; ++i) {
+            *((type*)m_team_base[i]->scratch_memory()) = *team_value;
+          }
 
-           // Fence to make sure all team members have access
-           memory_fence();
-         }
+          // Fence to make sure all team members have access
+          memory_fence();
+        }
 
-         team_fan_out();
+        team_fan_out();
 
-         // Value was changed by the team base
-         reducer.reference() = *local_value;))
+        // Value was changed by the team base
+        reducer.reference() = *local_value;))
   }
 
   /** \brief  Intra-team exclusive prefix sum with team_rank() ordering

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -293,7 +293,7 @@ class ThreadsExecTeamMember {
          team_fan_out();
 
          // Value was changed by the team base
-         reducer.reference() = *((type volatile const*)local_value);))
+         reducer.reference() = *local_value;))
   }
 
   /** \brief  Intra-team exclusive prefix sum with team_rank() ordering

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -264,14 +264,6 @@ struct CombinedReducerImpl<std::integer_sequence<size_t, Idxs...>, Space,
             src.template get<Idxs, typename Reducers::value_type>())...);
   }
 
-  KOKKOS_FUNCTION void join(value_type volatile& dest,
-                            value_type const volatile& src) const noexcept {
-    emulate_fold_comma_operator(
-        this->CombinedReducerStorageImpl<Idxs, Reducers>::_join(
-            dest.template get<Idxs, typename Reducers::value_type>(),
-            src.template get<Idxs, typename Reducers::value_type>())...);
-  }
-
   KOKKOS_FUNCTION constexpr void init(value_type& dest) const noexcept {
     emulate_fold_comma_operator(
         this->CombinedReducerStorageImpl<Idxs, Reducers>::_init(

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -437,7 +437,7 @@ struct FunctorAnalysis {
     KOKKOS_INLINE_FUNCTION static void join(F const* const f, ValueType* dst,
                                             ValueType const* src) {
       volatile_preload(src, 1);
-      f->join(*const_cast<ValueType*>(dst), *const_cast<const ValueType*>(src));
+      f->join(*dst, *src);
     }
   };
 
@@ -454,7 +454,7 @@ struct FunctorAnalysis {
     KOKKOS_INLINE_FUNCTION static void join(F const* const f, ValueType* dst,
                                             ValueType const* src) {
       volatile_preload(src, value_count(*f));
-      f->join(const_cast<ValueType*>(dst), const_cast<const ValueType*>(src));
+      f->join(dst, src);
     }
   };
 
@@ -482,8 +482,7 @@ struct FunctorAnalysis {
     KOKKOS_INLINE_FUNCTION static void join(F const* const f, ValueType* dst,
                                             ValueType const* src) {
       volatile_preload(src, 1);
-      f->join(WTag(), *const_cast<ValueType*>(dst),
-              *const_cast<const ValueType*>(src));
+      f->join(WTag(), *dst, *src);
     }
   };
 
@@ -508,8 +507,7 @@ struct FunctorAnalysis {
     KOKKOS_INLINE_FUNCTION static void join(F const* const f, ValueType* dst,
                                             ValueType const* src) {
       volatile_preload(src, value_count(*f));
-      f->join(WTag(), const_cast<ValueType*>(dst),
-              const_cast<const ValueType*>(src));
+      f->join(WTag(), dst, src);
     }
   };
 
@@ -521,9 +519,7 @@ struct FunctorAnalysis {
                                             ValueType const* src) {
       const int n = FunctorAnalysis::value_count(*f);
       volatile_preload(src, n);
-      auto nv_dst = const_cast<ValueType*>(dst);
-      auto nv_src = const_cast<const ValueType*>(src);
-      for (int i = 0; i < n; ++i) nv_dst[i] += nv_src[i];
+      for (int i = 0; i < n; ++i) dst[i] += src[i];
     }
   };
 

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -90,10 +90,10 @@ struct DeduceFunctorPatternInterface<ParallelScanWithTotal<
   using type = FunctorPatternInterface::SCAN;
 };
 
+#if defined(__CUDA_ARCH__)
 template <typename T>
 KOKKOS_INLINE_FUNCTION void volatile_preload(const volatile T* src,
                                              size_t count) {
-#if defined(__CUDA_ARCH__)
   // Ensure that subsequent code in this thread that may do
   // non-`volatile` loads through `src` will not see stale
   // non-coherent values in the cache by forcing `volatile` loads to
@@ -106,8 +106,11 @@ KOKKOS_INLINE_FUNCTION void volatile_preload(const volatile T* src,
   }
 
   __threadfence();
-#endif
 }
+#else
+template <typename T>
+KOKKOS_INLINE_FUNCTION void volatile_preload(const volatile T*, size_t) {}
+#endif
 
 /** \brief  Query Functor and execution policy argument tag for value type.
  *

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -90,6 +90,25 @@ struct DeduceFunctorPatternInterface<ParallelScanWithTotal<
   using type = FunctorPatternInterface::SCAN;
 };
 
+template <typename T>
+KOKKOS_INLINE_FUNCTION void volatile_preload(const volatile T* src,
+                                             size_t count) {
+#if defined(__CUDA_ARCH__)
+  // Ensure that subsequent code in this thread that may do
+  // non-`volatile` loads through `src` will not see stale
+  // non-coherent values in the cache by forcing `volatile` loads to
+  // precede it
+  auto ct         = reinterpret_cast<const volatile char*>(src);
+  unsigned char c = 0;
+  for (size_t i = 0; i < count * sizeof(T); ++i) {
+    c += ct[i];  // I'd rather avoid the addition, but this quiets the unused
+                 // variable warning about `c`
+  }
+
+  __threadfence();
+#endif
+}
+
 /** \brief  Query Functor and execution policy argument tag for value type.
  *
  *  If 'value_type' is not explicitly declared in the functor
@@ -403,37 +422,35 @@ struct FunctorAnalysis {
 
   template <class F>
   struct has_join_no_tag_function<F, /*is_array*/ false> {
-    using vref_type  = volatile ValueType&;
-    using cvref_type = const volatile ValueType&;
+    using ref_type  = ValueType&;
+    using cref_type = const ValueType&;
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(vref_type,
-                                                             cvref_type) const);
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(ref_type,
+                                                             cref_type) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(vref_type,
-                                                          cvref_type));
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(ref_type, cref_type));
 
-    KOKKOS_INLINE_FUNCTION static void join(F const* const f,
-                                            ValueType volatile* dst,
-                                            ValueType volatile const* src) {
-      f->join(*dst, *src);
+    KOKKOS_INLINE_FUNCTION static void join(F const* const f, ValueType* dst,
+                                            ValueType const* src) {
+      volatile_preload(src, 1);
+      f->join(*const_cast<ValueType*>(dst), *const_cast<const ValueType*>(src));
     }
   };
 
   template <class F>
   struct has_join_no_tag_function<F, /*is_array*/ true> {
-    using vref_type  = volatile ValueType*;
-    using cvref_type = const volatile ValueType*;
+    using ref_type  = ValueType*;
+    using cref_type = const ValueType*;
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(vref_type,
-                                                             cvref_type) const);
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(ref_type,
+                                                             cref_type) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(vref_type,
-                                                          cvref_type));
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(ref_type, cref_type));
 
-    KOKKOS_INLINE_FUNCTION static void join(F const* const f,
-                                            ValueType volatile* dst,
-                                            ValueType volatile const* src) {
-      f->join(dst, src);
+    KOKKOS_INLINE_FUNCTION static void join(F const* const f, ValueType* dst,
+                                            ValueType const* src) {
+      volatile_preload(src, value_count(*f));
+      f->join(const_cast<ValueType*>(dst), const_cast<const ValueType*>(src));
     }
   };
 
@@ -442,53 +459,53 @@ struct FunctorAnalysis {
 
   template <class F>
   struct has_join_tag_function<F, /*is_array*/ false> {
-    using vref_type  = volatile ValueType&;
-    using cvref_type = const volatile ValueType&;
+    using ref_type  = ValueType&;
+    using cref_type = const ValueType&;
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, vref_type,
-                                                             cvref_type) const);
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, ref_type,
+                                                             cref_type) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, vref_type,
-                                                          cvref_type));
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, ref_type,
+                                                          cref_type));
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
-                                                             vref_type,
-                                                             cvref_type) const);
+                                                             ref_type,
+                                                             cref_type) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
-                                                          vref_type,
-                                                          cvref_type));
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&, ref_type,
+                                                          cref_type));
 
-    KOKKOS_INLINE_FUNCTION static void join(F const* const f,
-                                            ValueType volatile* dst,
-                                            ValueType volatile const* src) {
-      f->join(WTag(), *dst, *src);
+    KOKKOS_INLINE_FUNCTION static void join(F const* const f, ValueType* dst,
+                                            ValueType const* src) {
+      volatile_preload(src, 1);
+      f->join(WTag(), *const_cast<ValueType*>(dst),
+              *const_cast<const ValueType*>(src));
     }
   };
 
   template <class F>
   struct has_join_tag_function<F, /*is_array*/ true> {
-    using vref_type  = volatile ValueType*;
-    using cvref_type = const volatile ValueType*;
+    using ref_type  = ValueType*;
+    using cref_type = const ValueType*;
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, vref_type,
-                                                             cvref_type) const);
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag, ref_type,
+                                                             cref_type) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, vref_type,
-                                                          cvref_type));
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag, ref_type,
+                                                          cref_type));
 
     KOKKOS_INLINE_FUNCTION static void enable_if(void (F::*)(WTag const&,
-                                                             vref_type,
-                                                             cvref_type) const);
+                                                             ref_type,
+                                                             cref_type) const);
 
-    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&,
-                                                          vref_type,
-                                                          cvref_type));
+    KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&, ref_type,
+                                                          cref_type));
 
-    KOKKOS_INLINE_FUNCTION static void join(F const* const f,
-                                            ValueType volatile* dst,
-                                            ValueType volatile const* src) {
-      f->join(WTag(), dst, src);
+    KOKKOS_INLINE_FUNCTION static void join(F const* const f, ValueType* dst,
+                                            ValueType const* src) {
+      volatile_preload(src, value_count(*f));
+      f->join(WTag(), const_cast<ValueType*>(dst),
+              const_cast<const ValueType*>(src));
     }
   };
 
@@ -496,11 +513,13 @@ struct FunctorAnalysis {
   struct DeduceJoinNoTag {
     enum : bool { value = false };
 
-    KOKKOS_INLINE_FUNCTION static void join(F const* const f,
-                                            ValueType volatile* dst,
-                                            ValueType volatile const* src) {
+    KOKKOS_INLINE_FUNCTION static void join(F const* const f, ValueType* dst,
+                                            ValueType const* src) {
       const int n = FunctorAnalysis::value_count(*f);
-      for (int i = 0; i < n; ++i) dst[i] += src[i];
+      volatile_preload(src, n);
+      auto nv_dst = const_cast<ValueType*>(dst);
+      auto nv_src = const_cast<const ValueType*>(src);
+      for (int i = 0; i < n; ++i) nv_dst[i] += nv_src[i];
     }
   };
 
@@ -816,8 +835,7 @@ struct FunctorAnalysis {
     }
 
     KOKKOS_INLINE_FUNCTION
-    void join(ValueType volatile* dst, ValueType volatile const* src) const
-        noexcept {
+    void join(ValueType* dst, ValueType const* src) const noexcept {
       DeduceJoin<>::join(m_functor, dst, src);
     }
 

--- a/core/unit_test/TestAtomicViews.hpp
+++ b/core/unit_test/TestAtomicViews.hpp
@@ -73,8 +73,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 1> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type& update,
-                   const volatile value_type& input) {
+  static void join(value_type& update, const value_type& input) {
     update |= input;
   }
 

--- a/core/unit_test/TestCXX11.hpp
+++ b/core/unit_test/TestCXX11.hpp
@@ -216,8 +216,7 @@ struct FunctorReduceTest {
   void init(value_type& update) const { update = 0.0; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& update,
-            volatile value_type const& input) const {
+  void join(value_type& update, value_type const& input) const {
     update += input;
   }
 };

--- a/core/unit_test/TestFunctorAnalysis.hpp
+++ b/core/unit_test/TestFunctorAnalysis.hpp
@@ -61,7 +61,7 @@ struct TestFunctorAnalysis_03 {
   void operator()(int, value_type&) const {}
 
   KOKKOS_INLINE_FUNCTION
-  void join(value_type volatile&, value_type const volatile&) const {}
+  void join(value_type&, value_type const&) const {}
 
   KOKKOS_INLINE_FUNCTION static void init(value_type&) {}
 };

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -3904,10 +3904,6 @@ struct TestMDRange_ReduceScalar {
     void operator=(const volatile Scalar &src) volatile {
       for (int i = 0; i < 4; i++) v[i] = src.v[i];
     }
-    KOKKOS_INLINE_FUNCTION
-    void operator+=(const volatile Scalar &src) volatile {
-      for (int i = 0; i < 4; i++) v[i] += src.v[i];
-    }
   };
 
   static void test_scalar_reduce(const int N0, const int N1) {

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -3900,10 +3900,6 @@ struct TestMDRange_ReduceScalar {
     void operator+=(const Scalar &src) {
       for (int i = 0; i < 4; i++) v[i] += src.v[i];
     }
-    KOKKOS_INLINE_FUNCTION
-    void operator=(const volatile Scalar &src) volatile {
-      for (int i = 0; i < 4; i++) v[i] = src.v[i];
-    }
   };
 
   static void test_scalar_reduce(const int N0, const int N1) {

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -78,8 +78,7 @@ struct TestMDRange_ReduceArray_2D {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile scalar_type dst[],
-            const volatile scalar_type src[]) const {
+  void join(scalar_type dst[], const scalar_type src[]) const {
     for (unsigned i = 0; i < value_count; ++i) {
       dst[i] += src[i];
     }
@@ -167,8 +166,7 @@ struct TestMDRange_ReduceArray_3D {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile scalar_type dst[],
-            const volatile scalar_type src[]) const {
+  void join(scalar_type dst[], const scalar_type src[]) const {
     for (unsigned i = 0; i < value_count; ++i) {
       dst[i] += src[i];
     }

--- a/core/unit_test/TestNonTrivialScalarTypes.hpp
+++ b/core/unit_test/TestNonTrivialScalarTypes.hpp
@@ -83,37 +83,6 @@ struct my_complex {
   }
 
   KOKKOS_INLINE_FUNCTION
-  my_complex &operator=(const volatile my_complex &src) {
-    re    = src.re;
-    im    = src.im;
-    dummy = src.dummy;
-    return *this;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  volatile my_complex &operator=(const my_complex &src) volatile {
-    re    = src.re;
-    im    = src.im;
-    dummy = src.dummy;
-    return *this;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  volatile my_complex &operator=(const volatile my_complex &src) volatile {
-    re    = src.re;
-    im    = src.im;
-    dummy = src.dummy;
-    return *this;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  my_complex(const volatile my_complex &src) {
-    re    = src.re;
-    im    = src.im;
-    dummy = src.dummy;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   my_complex(const double &val) {
     re    = val;
     im    = 0.0;
@@ -129,23 +98,7 @@ struct my_complex {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator+=(const volatile my_complex &src) volatile {
-    re += src.re;
-    im += src.im;
-    dummy += src.dummy;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   my_complex operator+(const my_complex &src) {
-    my_complex tmp = *this;
-    tmp.re += src.re;
-    tmp.im += src.im;
-    tmp.dummy += src.dummy;
-    return tmp;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  my_complex operator+(const volatile my_complex &src) volatile {
     my_complex tmp = *this;
     tmp.re += src.re;
     tmp.im += src.im;
@@ -161,15 +114,6 @@ struct my_complex {
     im            = im_tmp;
     dummy *= src.dummy;
     return *this;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator*=(const volatile my_complex &src) volatile {
-    double re_tmp = re * src.re - im * src.im;
-    double im_tmp = re * src.im + im * src.re;
-    re            = re_tmp;
-    im            = im_tmp;
-    dummy *= src.dummy;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -229,12 +173,6 @@ struct array_reduce {
     return *this;
   }
 
-  KOKKOS_INLINE_FUNCTION
-  array_reduce &operator=(const volatile array_reduce &src) {
-    for (int i = 0; i < N; i++) data[i] = src.data[i];
-    return *this;
-  }
-
   KOKKOS_INLINE_FUNCTION  // add operator
       array_reduce &
       operator=(const scalar_t val) {
@@ -253,11 +191,6 @@ struct array_reduce {
       operator+=(const array_reduce &src) {
     for (int i = 0; i < N; i++) data[i] += src.data[i];
     return *this;
-  }
-  KOKKOS_INLINE_FUNCTION  // volatile add operator
-      void
-      operator+=(const volatile array_reduce &src) volatile {
-    for (int i = 0; i < N; i++) data[i] += src.data[i];
   }
   KOKKOS_INLINE_FUNCTION  // add operator
       array_reduce
@@ -278,11 +211,6 @@ struct array_reduce {
       operator*=(const array_reduce &src) {
     for (int i = 0; i < N; i++) data[i] *= src.data[i];
     return *this;
-  }
-  KOKKOS_INLINE_FUNCTION  // volatile add operator
-      void
-      operator*=(const volatile array_reduce &src) volatile {
-    for (int i = 0; i < N; i++) data[i] *= src.data[i];
   }
   KOKKOS_INLINE_FUNCTION  // add operator
       array_reduce
@@ -321,28 +249,25 @@ struct point_t {
   point_t(const point_t &val) : x(val.x), y(val.y), z(val.z){};
 
   KOKKOS_FUNCTION
-  point_t(const volatile point_t &val) : x(val.x), y(val.y), z(val.z){};
-
-  KOKKOS_FUNCTION
   point_t(const int rhs) { x = y = z = static_cast<uint8_t>(rhs); }
 
   KOKKOS_FUNCTION
   explicit operator int() const { return static_cast<int>(x + y + z); }
 
   KOKKOS_FUNCTION
-  bool operator==(const volatile point_t rhs) const volatile {
+  bool operator==(const point_t rhs) const {
     return (x == rhs.x && y == rhs.y && z == rhs.z);
   }
 
   KOKKOS_FUNCTION
-  void operator=(point_t rhs) volatile {
+  void operator=(point_t rhs) {
     x = rhs.x;
     y = rhs.y;
     z = rhs.z;
   }
 
   KOKKOS_FUNCTION
-  volatile point_t operator+=(const volatile point_t rhs) volatile {
+  point_t operator+=(const point_t rhs) {
     x += rhs.x;
     y += rhs.y;
     z += rhs.z;

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -82,7 +82,7 @@ class ReduceFunctor {
   */
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dst, const volatile value_type& src) const {
+  void join(value_type& dst, const value_type& src) const {
     dst.value[0] += src.value[0];
     dst.value[1] += src.value[1];
     dst.value[2] += src.value[2];
@@ -129,8 +129,7 @@ class ReduceFunctorFinalTag {
   ReduceFunctorFinalTag(const size_type arg_nwork) : nwork(arg_nwork) {}
 
   KOKKOS_INLINE_FUNCTION
-  void join(const ReducerTag, volatile value_type& dst,
-            const volatile value_type& src) const {
+  void join(const ReducerTag, value_type& dst, const value_type& src) const {
     dst.value[0] += src.value[0];
     dst.value[1] += src.value[1];
     dst.value[2] += src.value[2];
@@ -174,7 +173,7 @@ class RuntimeReduceFunctor {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile ScalarType dst[], const volatile ScalarType src[]) const {
+  void join(ScalarType dst[], const ScalarType src[]) const {
     for (unsigned i = 0; i < value_count; ++i) dst[i] += src[i];
   }
 
@@ -218,7 +217,7 @@ class RuntimeReduceMinMax {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile ScalarType dst[], const volatile ScalarType src[]) const {
+  void join(ScalarType dst[], const ScalarType src[]) const {
     for (unsigned i = 0; i < value_count; ++i) {
       dst[i] = i % 2 ? (dst[i] < src[i] ? dst[i] : src[i])   // min
                      : (dst[i] > src[i] ? dst[i] : src[i]);  // max

--- a/core/unit_test/TestReduceCombinatorical.hpp
+++ b/core/unit_test/TestReduceCombinatorical.hpp
@@ -73,11 +73,6 @@ struct AddPlus {
   KOKKOS_INLINE_FUNCTION
   void join(value_type& dest, const value_type& src) const { dest += src + 1; }
 
-  KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& dest, const volatile value_type& src) const {
-    dest += src + 1;
-  }
-
   // Optional.
   KOKKOS_INLINE_FUNCTION
   void init(value_type& val) const { val = value_type(); }
@@ -195,9 +190,7 @@ struct FunctorScalarJoin<0> {
   void operator()(const int& i, double& update) const { update += i; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile double& dst, const volatile double& update) const {
-    dst += update;
-  }
+  void join(double& dst, const double& update) const { dst += update; }
 };
 
 template <>
@@ -214,9 +207,7 @@ struct FunctorScalarJoin<1> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile double& dst, const volatile double& update) const {
-    dst += update;
-  }
+  void join(double& dst, const double& update) const { dst += update; }
 };
 
 template <int ISTEAM>
@@ -232,9 +223,7 @@ struct FunctorScalarJoinFinal<0> {
   void operator()(const int& i, double& update) const { update += i; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile double& dst, const volatile double& update) const {
-    dst += update;
-  }
+  void join(double& dst, const double& update) const { dst += update; }
 
   KOKKOS_INLINE_FUNCTION
   void final(double& update) const { result() = update; }
@@ -254,9 +243,7 @@ struct FunctorScalarJoinFinal<1> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile double& dst, const volatile double& update) const {
-    dst += update;
-  }
+  void join(double& dst, const double& update) const { dst += update; }
 
   KOKKOS_INLINE_FUNCTION
   void final(double& update) const { result() = update; }
@@ -275,9 +262,7 @@ struct FunctorScalarJoinInit<0> {
   void operator()(const int& i, double& update) const { update += i; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile double& dst, const volatile double& update) const {
-    dst += update;
-  }
+  void join(double& dst, const double& update) const { dst += update; }
 
   KOKKOS_INLINE_FUNCTION
   void init(double& update) const { update = 0.0; }
@@ -297,9 +282,7 @@ struct FunctorScalarJoinInit<1> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile double& dst, const volatile double& update) const {
-    dst += update;
-  }
+  void join(double& dst, const double& update) const { dst += update; }
 
   KOKKOS_INLINE_FUNCTION
   void init(double& update) const { update = 0.0; }
@@ -318,9 +301,7 @@ struct FunctorScalarJoinFinalInit<0> {
   void operator()(const int& i, double& update) const { update += i; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile double& dst, const volatile double& update) const {
-    dst += update;
-  }
+  void join(double& dst, const double& update) const { dst += update; }
 
   KOKKOS_INLINE_FUNCTION
   void final(double& update) const { result() = update; }
@@ -343,9 +324,7 @@ struct FunctorScalarJoinFinalInit<1> {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile double& dst, const volatile double& update) const {
-    dst += update;
-  }
+  void join(double& dst, const double& update) const { dst += update; }
 
   KOKKOS_INLINE_FUNCTION
   void final(double& update) const { result() = update; }
@@ -379,7 +358,7 @@ struct Functor2 {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile double dst[], const volatile double src[]) const {
+  void join(double dst[], const double src[]) const {
     for (unsigned i = 0; i < value_count; ++i) dst[i] += src[i];
   }
 };

--- a/core/unit_test/TestScan.hpp
+++ b/core/unit_test/TestScan.hpp
@@ -88,8 +88,7 @@ struct TestScan {
   void init(value_type& update) const { update = 0; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type& update,
-            volatile const value_type& input) const {
+  void join(value_type& update, const value_type& input) const {
     update += input;
   }
 

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -295,7 +295,7 @@ class ReduceTeamFunctor {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join(volatile value_type &dst, const volatile value_type &src) const {
+  void join(value_type &dst, const value_type &src) const {
     dst.value[0] += src.value[0];
     dst.value[1] += src.value[1];
     dst.value[2] += src.value[2];
@@ -394,8 +394,7 @@ class ScanTeamFunctor {
   void init(value_type &error) const { error = 0; }
 
   KOKKOS_INLINE_FUNCTION
-  void join(value_type volatile &error,
-            value_type volatile const &input) const {
+  void join(value_type &error, value_type const &input) const {
     if (input) error = 1;
   }
 
@@ -403,8 +402,7 @@ class ScanTeamFunctor {
     using value_type = int64_t;
 
     KOKKOS_INLINE_FUNCTION
-    void join(value_type volatile &dst,
-              value_type volatile const &input) const {
+    void join(value_type &dst, value_type const &input) const {
       if (dst < input) dst = input;
     }
   };

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -155,12 +155,6 @@ struct long_wrapper {
   }
 
   KOKKOS_FUNCTION
-  friend void operator+=(volatile long_wrapper& lhs,
-                         const volatile long_wrapper& rhs) {
-    lhs.value += rhs.value;
-  }
-
-  KOKKOS_FUNCTION
   void operator=(const long_wrapper& other) { value = other.value; }
 
   KOKKOS_FUNCTION

--- a/core/unit_test/TestTeamTeamSize.hpp
+++ b/core/unit_test/TestTeamTeamSize.hpp
@@ -64,14 +64,6 @@ class MyArray {
   void operator=(const MyArray& src) {
     for (int i = 0; i < N; i++) values[i] = src.values[i];
   }
-  KOKKOS_INLINE_FUNCTION
-  void operator+=(const volatile MyArray& src) volatile {
-    for (int i = 0; i < N; i++) values[i] += src.values[i];
-  }
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const volatile MyArray& src) volatile {
-    for (int i = 0; i < N; i++) values[i] = src.values[i];
-  }
 };
 
 template <class T, int N, class PolicyType, int S>

--- a/core/unit_test/TestTeamVectorRange.hpp
+++ b/core/unit_test/TestTeamVectorRange.hpp
@@ -79,37 +79,6 @@ struct my_complex {
   }
 
   KOKKOS_INLINE_FUNCTION
-  my_complex& operator=(const volatile my_complex& src) {
-    re    = src.re;
-    im    = src.im;
-    dummy = src.dummy;
-    return *this;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  volatile my_complex& operator=(const my_complex& src) volatile {
-    re    = src.re;
-    im    = src.im;
-    dummy = src.dummy;
-    return *this;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  volatile my_complex& operator=(const volatile my_complex& src) volatile {
-    re    = src.re;
-    im    = src.im;
-    dummy = src.dummy;
-    return *this;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  my_complex(const volatile my_complex& src) {
-    re    = src.re;
-    im    = src.im;
-    dummy = src.dummy;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   my_complex(const double& val) {
     re    = val;
     im    = 0.0;
@@ -125,23 +94,7 @@ struct my_complex {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator+=(const volatile my_complex& src) volatile {
-    re += src.re;
-    im += src.im;
-    dummy += src.dummy;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   my_complex operator+(const my_complex& src) {
-    my_complex tmp = *this;
-    tmp.re += src.re;
-    tmp.im += src.im;
-    tmp.dummy += src.dummy;
-    return tmp;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  my_complex operator+(const volatile my_complex& src) volatile {
     my_complex tmp = *this;
     tmp.re += src.re;
     tmp.im += src.im;
@@ -157,15 +110,6 @@ struct my_complex {
     im            = im_tmp;
     dummy *= src.dummy;
     return *this;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator*=(const volatile my_complex& src) volatile {
-    double re_tmp = re * src.re - im * src.im;
-    double im_tmp = re * src.im + im * src.re;
-    re            = re_tmp;
-    im            = im_tmp;
-    dummy *= src.dummy;
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -104,8 +104,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 8> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type &update,
-                   const volatile value_type &input) {
+  static void join(value_type &update, const value_type &input) {
     update |= input;
   }
 
@@ -200,8 +199,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 7> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type &update,
-                   const volatile value_type &input) {
+  static void join(value_type &update, const value_type &input) {
     update |= input;
   }
 
@@ -278,8 +276,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 6> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type &update,
-                   const volatile value_type &input) {
+  static void join(value_type &update, const value_type &input) {
     update |= input;
   }
 
@@ -354,8 +351,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 5> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type &update,
-                   const volatile value_type &input) {
+  static void join(value_type &update, const value_type &input) {
     update |= input;
   }
 
@@ -442,8 +438,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 4> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type &update,
-                   const volatile value_type &input) {
+  static void join(value_type &update, const value_type &input) {
     update |= input;
   }
 
@@ -512,8 +507,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 3> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type &update,
-                   const volatile value_type &input) {
+  static void join(value_type &update, const value_type &input) {
     update |= input;
   }
 
@@ -605,8 +599,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 2> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type &update,
-                   const volatile value_type &input) {
+  static void join(value_type &update, const value_type &input) {
     update |= input;
   }
 
@@ -681,8 +674,7 @@ struct TestViewOperator_LeftAndRight<DataType, DeviceType, 1> {
   using value_type = int;
 
   KOKKOS_INLINE_FUNCTION
-  static void join(volatile value_type &update,
-                   const volatile value_type &input) {
+  static void join(value_type &update, const value_type &input) {
     update |= input;
   }
 

--- a/core/unit_test/cuda/TestCuda_ReducerViewSizeLimit.cpp
+++ b/core/unit_test/cuda/TestCuda_ReducerViewSizeLimit.cpp
@@ -77,14 +77,6 @@ struct ArrayReduceFunctor {
     }
   }
 
-  KOKKOS_INLINE_FUNCTION void join(volatile value_type update,
-                                   const volatile value_type source) const {
-    const int numVecs = value_count;
-    for (int j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
-  }
-
   KOKKOS_INLINE_FUNCTION void join(value_type update,
                                    const value_type source) const {
     const int numVecs = value_count;

--- a/core/unit_test/incremental/Test14_MDRangeReduce.hpp
+++ b/core/unit_test/incremental/Test14_MDRangeReduce.hpp
@@ -71,12 +71,6 @@ struct MyComplex {
     _re += src._re;
     _im += src._im;
   }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator+=(const volatile MyComplex& src) volatile {
-    _re += src._re;
-    _im += src._im;
-  }
 };
 
 template <class ExecSpace>


### PR DESCRIPTION
The purpose of using the `volatile` qualifier for operations used in reductions was that on CUDA it ensured a cache-coherent read. If we ensure that the values present in cache reflect the results of a coherent load [1], then the operations themselves need not be concerned with coherent access.

[1] Specifically: Any previously-present values that have since become stale because of concurrent writes by other threads, but were not invalidated because of the lack of cache coherence, are either updated or evicted

Fixes #4077, #1554