### PR TITLE
Update OpenMPTarget CI testing to llvm/14.

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -1103,7 +1103,7 @@ endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_OPENMPTARGET), 1)
   ifeq ($(KOKKOS_INTERNAL_COMPILER_CLANG), 1)
-    KOKKOS_INTERNAL_CUDA_ARCH_FLAG=-fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target -march
+    KOKKOS_INTERNAL_CUDA_ARCH_FLAG=-fopenmp-targets=nvptx64 -Xopenmp-target -march
   endif
   KOKKOS_INTERNAL_USE_CUDA_ARCH = 1
 endif

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -533,7 +533,7 @@ IF (KOKKOS_ENABLE_OPENMPTARGET)
   IF (CLANG_CUDA_ARCH)
     STRING(REPLACE "sm_" "cc" NVHPC_CUDA_ARCH ${CLANG_CUDA_ARCH})
     COMPILER_SPECIFIC_FLAGS(
-      Clang -Xopenmp-target -march=${CLANG_CUDA_ARCH} -fopenmp-targets=nvptx64-nvidia-cuda
+      Clang -Xopenmp-target -march=${CLANG_CUDA_ARCH} -fopenmp-targets=nvptx64
       XL    -qtgtarch=${KOKKOS_CUDA_ARCH_FLAG}
       NVHPC -gpu=${NVHPC_CUDA_ARCH}
     )

--- a/scripts/docker/Dockerfile.openmptarget
+++ b/scripts/docker/Dockerfile.openmptarget
@@ -38,7 +38,7 @@ RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSIO
     rm ${CMAKE_SCRIPT}
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
-ARG LLVM_VERSION=llvmorg-13.0.1-rc3
+ARG LLVM_VERSION=llvmorg-14.0.0
 ENV LLVM_DIR=/opt/llvm
 RUN LLVM_URL=https://github.com/llvm/llvm-project/archive &&\
     LLVM_ARCHIVE=${LLVM_VERSION}.tar.gz &&\


### PR DESCRIPTION
The PR updates the dockerfile for OpenMPTarget to use llvm/14 release versions.
It also updates `Makefile.kokkos` and `kokkos_arch.cmake` to use the update nvptx flags. 