### PR TITLE
Use different kernels for 2D and 3D in tutorial/06_simple_mdrangepolicy

### DIFF
--- a/example/tutorial/06_simple_mdrangepolicy/simple_mdrangepolicy.cpp
+++ b/example/tutorial/06_simple_mdrangepolicy/simple_mdrangepolicy.cpp
@@ -61,24 +61,18 @@
 
 // Simple functor for computing/storing the product of indices in a View v
 template <class ViewType>
-struct MDFunctor {
+struct MDFunctor2D {
   using value_type = long;
 
   ViewType v;
   size_t size;
 
-  MDFunctor(const ViewType& v_, const size_t size_) : v(v_), size(size_) {}
+  MDFunctor2D(const ViewType& v_, const size_t size_) : v(v_), size(size_) {}
 
   // 2D case - used by parallel_for
   KOKKOS_INLINE_FUNCTION
   void operator()(const int i, const int j) const {
     v(i, j) = i * j;  // compute the product of indices
-  }
-
-  // 3D case - used by parallel_for
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const int i, const int j, const int k) const {
-    v(i, j, k) = i * j * k;  // compute the product of indices
   }
 
   // 2D case - reduction
@@ -87,6 +81,22 @@ struct MDFunctor {
     if (v(i, j) != i * j) {
       incorrect_count += 1;
     }
+  }
+};
+
+template <class ViewType>
+struct MDFunctor3D {
+  using value_type = long;
+
+  ViewType v;
+  size_t size;
+
+  MDFunctor3D(const ViewType& v_, const size_t size_) : v(v_), size(size_) {}
+
+  // 3D case - used by parallel_for
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i, const int j, const int k) const {
+    v(i, j, k) = i * j * k;  // compute the product of indices
   }
 
   // 3D case - reduction
@@ -170,11 +180,12 @@ int main(int argc, char* argv[]) {
     ViewType_2D v2("v2", n, n);
 
     // Execute parallel_for with rank 2 MDRangePolicy
-    Kokkos::parallel_for("md2d", mdpolicy_2d, MDFunctor<ViewType_2D>(v2, n));
+    Kokkos::parallel_for("md2d", mdpolicy_2d, MDFunctor2D<ViewType_2D>(v2, n));
 
     // Check results with a parallel_reduce using the MDRangePolicy
     Kokkos::parallel_reduce("md2dredux", mdpolicy_2d,
-                            MDFunctor<ViewType_2D>(v2, n), incorrect_count_2d);
+                            MDFunctor2D<ViewType_2D>(v2, n),
+                            incorrect_count_2d);
 
     printf("Rank 2 MDRangePolicy incorrect count: %ld\n",
            incorrect_count_2d);  // should be 0
@@ -194,11 +205,12 @@ int main(int argc, char* argv[]) {
     ViewType_3D v3("v3", n, n, n);
 
     // Execute parallel_for with rank 3 MDRangePolicy
-    Kokkos::parallel_for("md3d", mdpolicy_3d, MDFunctor<ViewType_3D>(v3, n));
+    Kokkos::parallel_for("md3d", mdpolicy_3d, MDFunctor3D<ViewType_3D>(v3, n));
 
     // Check results with a parallel_reduce using the MDRangePolicy
     Kokkos::parallel_reduce("md3dredux", mdpolicy_3d,
-                            MDFunctor<ViewType_3D>(v3, n), incorrect_count_3d);
+                            MDFunctor3D<ViewType_3D>(v3, n),
+                            incorrect_count_3d);
 
     printf("Rank 3 MDRangePolicy incorrect count: %ld\n",
            incorrect_count_3d);  // should be 0


### PR DESCRIPTION
I was running into `static_assert` for an OMPT build for `tutorial/06_simple_mdrangepolicy` where a functor has two call operators: one for 2D, the other for 3D, and both access `Kokkos::Views` (2D and 3D resp.).
Splitting the functor should fix that.