### PR TITLE
Update base image for SYCL CI to 11.0-devel

### DIFF
--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -1,4 +1,4 @@
-ARG BASE=nvidia/cuda:10.2-devel
+ARG BASE=nvidia/cuda:11.0-devel
 FROM $BASE
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
We are running into problems building the current image, try if updating to a newer CUDA version build helps and works.