### PR TITLE
Fix nextafter(0, 1.f) test for SYCL

### DIFF
--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -257,9 +257,10 @@ struct FloatingPointComparison {
 
     bool ar = absolute(fpv) < abs_tol;
     if (!ar) {
-#if !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_HIP)
-      printf("absolute value exceeds tolerance [|%e| > %e]\n", (double)fpv,
-             abs_tol);
+#if !defined(KOKKOS_ENABLE_HIP)
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "absolute value exceeds tolerance [|%e| > %e]\n", (double)fpv,
+          abs_tol);
 #endif
     }
 
@@ -281,9 +282,10 @@ struct FloatingPointComparison {
       double rel_diff = abs_diff / min_denom;
       bool ar         = rel_diff < rel_tol;
       if (!ar) {
-#if !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_HIP)
-        printf("relative difference exceeds tolerance [%e > %e]\n",
-               (double)rel_diff, rel_tol);
+#if !defined(KOKKOS_ENABLE_HIP)
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "relative difference exceeds tolerance [%e > %e]\n",
+            (double)rel_diff, rel_tol);
 #endif
       }
 
@@ -456,9 +458,10 @@ struct TestMathUnaryFunction : FloatingPointComparison {
     bool ar = compare(Func::eval(val_[i]), res_[i], Func::ulp_factor());
     if (!ar) {
       ++e;
-#if !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_HIP)
-      printf("value at %f which is %f was expected to be %f\n", (double)val_[i],
-             (double)Func::eval(val_[i]), (double)res_[i]);
+#if !defined(KOKKOS_ENABLE_HIP)
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "value at %f which is %f was expected to be %f\n", (double)val_[i],
+          (double)Func::eval(val_[i]), (double)res_[i]);
 #endif
     }
   }
@@ -495,10 +498,10 @@ struct TestMathBinaryFunction : FloatingPointComparison {
     bool ar = compare(Func::eval(val1_, val2_), res_, Func::ulp_factor());
     if (!ar) {
       ++e;
-#if !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_HIP)
-      printf("value at %f, %f which is %f was expected to be %f\n",
-             (double)val1_, (double)val2_, (double)Func::eval(val1_, val2_),
-             (double)res_);
+#if !defined(KOKKOS_ENABLE_HIP)
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "value at %f, %f which is %f was expected to be %f\n", (double)val1_,
+          (double)val2_, (double)Func::eval(val1_, val2_), (double)res_);
 #endif
     }
   }

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -257,11 +257,9 @@ struct FloatingPointComparison {
 
     bool ar = absolute(fpv) < abs_tol;
     if (!ar) {
-#if !defined(KOKKOS_ENABLE_HIP)
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "absolute value exceeds tolerance [|%e| > %e]\n", (double)fpv,
           abs_tol);
-#endif
     }
 
     return ar;
@@ -282,11 +280,9 @@ struct FloatingPointComparison {
       double rel_diff = abs_diff / min_denom;
       bool ar         = abs_diff == 0 || rel_diff < rel_tol;
       if (!ar) {
-#if !defined(KOKKOS_ENABLE_HIP)
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "relative difference exceeds tolerance [%e > %e]\n",
             (double)rel_diff, rel_tol);
-#endif
       }
 
       return ar;
@@ -458,11 +454,9 @@ struct TestMathUnaryFunction : FloatingPointComparison {
     bool ar = compare(Func::eval(val_[i]), res_[i], Func::ulp_factor());
     if (!ar) {
       ++e;
-#if !defined(KOKKOS_ENABLE_HIP)
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "value at %f which is %f was expected to be %f\n", (double)val_[i],
           (double)Func::eval(val_[i]), (double)res_[i]);
-#endif
     }
   }
 };
@@ -498,11 +492,9 @@ struct TestMathBinaryFunction : FloatingPointComparison {
     bool ar = compare(Func::eval(val1_, val2_), res_, Func::ulp_factor());
     if (!ar) {
       ++e;
-#if !defined(KOKKOS_ENABLE_HIP)
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "value at %f, %f which is %f was expected to be %f\n", (double)val1_,
           (double)val2_, (double)Func::eval(val1_, val2_), (double)res_);
-#endif
     }
   }
 };

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -280,7 +280,7 @@ struct FloatingPointComparison {
       double min_denom = static_cast<double>(
           absolute(rhs) < absolute(lhs) ? absolute(rhs) : absolute(lhs));
       double rel_diff = abs_diff / min_denom;
-      bool ar         = rel_diff < rel_tol;
+      bool ar         = abs_diff == 0 || rel_diff < rel_tol;
       if (!ar) {
 #if !defined(KOKKOS_ENABLE_HIP)
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(


### PR DESCRIPTION
Without this patch, the test for `nextafter(0, 1.f)` fails on Intel GPUs since the reciprocal of the smallest denominator is `inf` and `rel_diff  = 0 * inf =inf`. Checking that the absolute difference is zero helps here.
I also considered falling back to `compare_near_zero` if the values to compare are less than `eps*ulp` but that would be much larger than the values in consideration here (1.e-16 vs 4.9406564584e-324) but works, too.

Testing `abs_diff <= rel_tol * min_denom` would also work here with both sides being zero.

This pull request also enables printing for `SYCL` which was helpful (and it's easier to remove the restriction searching for the macro instead of KOKKOS_ENABLE_SYCL+printf in the next line). 
