### PR TITLE
Use synchronous Memcpy when using DeepCopy

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -91,9 +91,7 @@ static std::atomic<int> num_uvm_allocations(0);
 }  // namespace
 
 void DeepCopyCuda(void *dst, const void *src, size_t n) {
-  cudaStream_t s = cuda_get_deep_copy_stream();
-  KOKKOS_IMPL_CUDA_SAFE_CALL(
-      cudaMemcpyAsync(dst, src, n, cudaMemcpyDefault, s));
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemcpy(dst, src, n, cudaMemcpyDefault));
 }
 
 void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -74,8 +74,7 @@ hipStream_t get_deep_copy_stream() {
 }  // namespace
 
 void DeepCopyHIP(void* dst, void const* src, size_t n) {
-  hipStream_t s = get_deep_copy_stream();
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipMemcpyAsync(dst, src, n, hipMemcpyDefault, s));
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipMemcpyAsync(dst, src, n, hipMemcpyDefault));
 }
 
 void DeepCopyAsyncHIP(const Kokkos::Experimental::HIP& instance, void* dst,


### PR DESCRIPTION
Partial revert of https://github.com/kokkos/kokkos/pull/4349 because it causes bugs into downstream apps. See https://github.com/kokkos/kokkos/issues/4903 
