### PR TITLE
algorithms: remove volatile from unit tests

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsCompileOnly.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCompileOnly.cpp
@@ -61,12 +61,6 @@ struct TrivialBinaryFunctor {
   ValueType operator()(const ValueType &a, const ValueType &b) const {
     return (a + b);
   }
-
-  KOKKOS_INLINE_FUNCTION
-  ValueType operator()(const volatile ValueType &a,
-                       const volatile ValueType &b) const {
-    return (a + b);
-  }
 };
 
 template <class ValueType>
@@ -100,12 +94,6 @@ struct TrivialComparator {
   bool operator()(const ValueType &a, const ValueType &b) const {
     return a > b;
   }
-
-  KOKKOS_INLINE_FUNCTION
-  bool operator()(const volatile ValueType &a,
-                  const volatile ValueType &b) const {
-    return a > b;
-  }
 };
 
 template <class ValueType>
@@ -118,12 +106,6 @@ template <class ValueType>
 struct TrivialReduceJoinFunctor {
   KOKKOS_FUNCTION
   ValueType operator()(const ValueType &a, const ValueType &b) const {
-    return a + b;
-  }
-
-  KOKKOS_FUNCTION
-  ValueType operator()(const volatile ValueType &a,
-                       const volatile ValueType &b) const {
     return a + b;
   }
 };

--- a/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
@@ -209,24 +209,12 @@ struct MultiplyFunctor {
   ValueType operator()(const ValueType& a, const ValueType& b) const {
     return (a * b);
   }
-
-  KOKKOS_INLINE_FUNCTION
-  ValueType operator()(const volatile ValueType& a,
-                       const volatile ValueType& b) const {
-    return (a * b);
-  }
 };
 
 template <class ValueType>
 struct SumFunctor {
   KOKKOS_INLINE_FUNCTION
   ValueType operator()(const ValueType& a, const ValueType& b) const {
-    return (a + b);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  ValueType operator()(const volatile ValueType& a,
-                       const volatile ValueType& b) const {
     return (a + b);
   }
 };

--- a/algorithms/unit_tests/TestStdAlgorithmsHelperFunctors.hpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsHelperFunctors.hpp
@@ -157,12 +157,6 @@ struct CustomLessThanComparator {
   }
 
   KOKKOS_INLINE_FUNCTION
-  bool operator()(const volatile ValueType1& a,
-                  const volatile ValueType1& b) const {
-    return a < b;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   CustomLessThanComparator() {}
 };
 

--- a/algorithms/unit_tests/TestStdAlgorithmsInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsInclusiveScan.cpp
@@ -224,24 +224,12 @@ struct MultiplyFunctor {
   ValueType operator()(const ValueType& a, const ValueType& b) const {
     return (a * b);
   }
-
-  KOKKOS_INLINE_FUNCTION
-  ValueType operator()(const volatile ValueType& a,
-                       const volatile ValueType& b) const {
-    return (a * b);
-  }
 };
 
 template <class ValueType>
 struct SumFunctor {
   KOKKOS_INLINE_FUNCTION
   ValueType operator()(const ValueType& a, const ValueType& b) const {
-    return (a + b);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  ValueType operator()(const volatile ValueType& a,
-                       const volatile ValueType& b) const {
     return (a + b);
   }
 };

--- a/algorithms/unit_tests/TestStdAlgorithmsNumerics.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsNumerics.cpp
@@ -70,12 +70,6 @@ struct SumJoinFunctor {
   ValueType operator()(const ValueType& a, const ValueType& b) const {
     return a + b;
   }
-
-  KOKKOS_INLINE_FUNCTION
-  ValueType operator()(const volatile ValueType& a,
-                       const volatile ValueType& b) const {
-    return a + b;
-  }
 };
 
 struct std_algorithms_numerics_test : public ::testing::Test {

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
@@ -223,12 +223,6 @@ struct SumBinaryFunctor {
   ValueType operator()(const ValueType& a, const ValueType& b) const {
     return (a + b);
   }
-
-  KOKKOS_INLINE_FUNCTION
-  ValueType operator()(const volatile ValueType& a,
-                       const volatile ValueType& b) const {
-    return (a + b);
-  }
 };
 
 std::string value_type_to_string(int) { return "int"; }

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformInclusiveScan.cpp
@@ -235,12 +235,6 @@ struct SumBinaryFunctor {
   ValueType operator()(const ValueType& a, const ValueType& b) const {
     return (a + b);
   }
-
-  KOKKOS_INLINE_FUNCTION
-  ValueType operator()(const volatile ValueType& a,
-                       const volatile ValueType& b) const {
-    return (a + b);
-  }
 };
 
 std::string value_type_to_string(int) { return "int"; }


### PR DESCRIPTION
Cleanup of volatile qualifier in unit tests of std algorithms following #4931 