### PR TITLE
CMake modules findtplthreads

### DIFF
--- a/cmake/Modules/FindTPLTHREADS.cmake
+++ b/cmake/Modules/FindTPLTHREADS.cmake
@@ -1,5 +1,5 @@
 INCLUDE(FindPackageHandleStandardArgs)
-INCLUDE("${CMAKE_SOURCE_DIR}/cmake/tpls/FindTPLPthread.cmake")
+INCLUDE("${CMAKE_CURRENT_SOURCE_DIR}/cmake/tpls/FindTPLPthread.cmake")
 
 IF (TARGET Threads::Threads)
   SET(FOUND_THREADS TRUE)


### PR DESCRIPTION
When `kokkos` is included as a subdirectory via CMake, look for `FindTPLPthread` relative to the location of the `kokkos` directory, not the top level project directory.