### PR TITLE
OpenMPTarget: Access scratch_memory_space from OpenMPTarget space.

### DIFF
--- a/core/src/Kokkos_OpenMPTarget.hpp
+++ b/core/src/Kokkos_OpenMPTarget.hpp
@@ -124,6 +124,17 @@ class OpenMPTarget {
 };
 }  // namespace Experimental
 
+namespace Impl {
+template <>
+struct MemorySpaceAccess<
+    Kokkos::Experimental::OpenMPTargetSpace,
+    Kokkos::Experimental::OpenMPTarget::scratch_memory_space> {
+  enum : bool { assignable = false };
+  enum : bool { accessible = true };
+  enum : bool { deepcopy = false };
+};
+}  // namespace Impl
+
 namespace Tools {
 namespace Experimental {
 template <>

--- a/core/src/Kokkos_OpenMPTargetSpace.hpp
+++ b/core/src/Kokkos_OpenMPTargetSpace.hpp
@@ -113,14 +113,6 @@ struct MemorySpaceAccess<Kokkos::Experimental::OpenMPTargetSpace,
 };
 
 //----------------------------------------
-
-template <>
-struct MemorySpaceAccess<Kokkos::Experimental::OpenMPTargetSpace,
-                         Kokkos::Experimental::OpenMPTargetSpace> {
-  enum : bool { assignable = true };
-  enum : bool { accessible = true };
-  enum : bool { deepcopy = false };
-};
 }  // namespace Impl
 }  // namespace Kokkos
 


### PR DESCRIPTION
The PR adds the specialization for `MemorySpaceAccess` to access scratch space from OpenMPTarget space.
It also deletes the unused structure that checks for memory accesses when both the parameters are OpenMPTarget space.

