### PR TITLE
Detect join member function with volatile-qualified arguments

### DIFF
--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -495,7 +495,6 @@ struct FunctorAnalysis {
     KOKKOS_INLINE_FUNCTION static void enable_if(void (*)(WTag const&, ref_type,
                                                           cref_type));
 
-
     KOKKOS_INLINE_FUNCTION static void join(F const* const f, ValueType* dst,
                                             ValueType const* src) {
       f->join(WTag(), *dst, *src);
@@ -528,7 +527,6 @@ struct FunctorAnalysis {
 
   template <class F>
   struct has_join_tag_function<F, true, /*is_array*/ false> {
-
 #ifdef KOKKOS_IMPL_LOVATILE
     using vref_type  = volatile ValueType&;
     using cvref_type = const volatile ValueType&;
@@ -596,11 +594,11 @@ struct FunctorAnalysis {
 
   template <class F>
   struct DeduceJoinNoTag<
-      F, std::enable_if_t<is_reducer<F>::value || (!is_reducer<F>::value &&
-                                                   std::is_void<Tag>::value),
-						 decltype(has_join_no_tag_function<F, false>::enable_if(
-                              &F::join))>>
-    : public has_join_no_tag_function<F, false> {
+      F, std::enable_if_t<
+             is_reducer<F>::value ||
+                 (!is_reducer<F>::value && std::is_void<Tag>::value),
+             decltype(has_join_no_tag_function<F, false>::enable_if(&F::join))>>
+      : public has_join_no_tag_function<F, false> {
     enum : bool { value = true };
   };
 
@@ -608,9 +606,9 @@ struct FunctorAnalysis {
   struct DeduceJoinNoTag<
       F, std::enable_if_t<is_reducer<F>::value || (!is_reducer<F>::value &&
                                                    std::is_void<Tag>::value),
-						 decltype(has_join_no_tag_function<F, true>::enable_if(
+                          decltype(has_join_no_tag_function<F, true>::enable_if(
                               &F::join))>>
-    : public has_join_no_tag_function<F, true> {
+      : public has_join_no_tag_function<F, true> {
     enum : bool { value = true };
   };
 
@@ -619,19 +617,19 @@ struct FunctorAnalysis {
 
   template <class F>
   struct DeduceJoin<
-      F,
-      std::enable_if_t<!is_reducer<F>::value,
-						 decltype(has_join_tag_function<F, false>::enable_if(&F::join))>>
-    : public has_join_tag_function<F, false> {
+      F, std::enable_if_t<!is_reducer<F>::value,
+                          decltype(has_join_tag_function<F, false>::enable_if(
+                              &F::join))>>
+      : public has_join_tag_function<F, false> {
     enum : bool { value = true };
   };
 
   template <class F>
   struct DeduceJoin<
-      F,
-      std::enable_if_t<!is_reducer<F>::value,
-						 decltype(has_join_tag_function<F, true>::enable_if(&F::join))>>
-    : public has_join_tag_function<F, true> {
+      F, std::enable_if_t<!is_reducer<F>::value,
+                          decltype(has_join_tag_function<F, true>::enable_if(
+                              &F::join))>>
+      : public has_join_tag_function<F, true> {
     enum : bool { value = true };
   };
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -75,6 +75,7 @@ SET(COMPILE_ONLY_SOURCES
   TestInterOp.cpp
   TestStringManipulation.cpp
   TestTypeList.cpp
+  TestJoinBackwardCompatibility.cpp
 )
 # TestInterOp has a dependency on containers
 IF(KOKKOS_HAS_TRILINOS)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -75,7 +75,6 @@ SET(COMPILE_ONLY_SOURCES
   TestInterOp.cpp
   TestStringManipulation.cpp
   TestTypeList.cpp
-  TestJoinBackwardCompatibility.cpp
 )
 # TestInterOp has a dependency on containers
 IF(KOKKOS_HAS_TRILINOS)
@@ -119,6 +118,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
         ExecutionSpace
         FunctorAnalysis
         Init
+        JoinBackwardCompatibility
         LocalDeepCopy
         MinMaxClamp
         MathematicalConstants

--- a/core/unit_test/TestJoinBackwardCompatibility.cpp
+++ b/core/unit_test/TestJoinBackwardCompatibility.cpp
@@ -80,7 +80,7 @@ struct ReducerWithJoinThatTakesVolatileQualifiedArgs {
 
 }  // namespace
 
-KOKKOS_FUNCTION void test_join_backward_compatibility() {
+void test_join_backward_compatibility() {
   MyValueType result;
   Kokkos::RangePolicy<> policy(0, 1);
   Kokkos::parallel_reduce(

--- a/core/unit_test/TestJoinBackwardCompatibility.cpp
+++ b/core/unit_test/TestJoinBackwardCompatibility.cpp
@@ -1,0 +1,93 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+
+struct MyValueType {};
+
+struct ReducerWithJoinThatTakesNonVolatileQualifiedArgs {
+  using reducer    = ReducerWithJoinThatTakesNonVolatileQualifiedArgs;
+  using value_type = MyValueType;
+  KOKKOS_FUNCTION void join(MyValueType &, MyValueType const &) const {}
+  KOKKOS_FUNCTION void operator()(int, MyValueType &) const {}
+  KOKKOS_FUNCTION
+  ReducerWithJoinThatTakesNonVolatileQualifiedArgs() {}
+};
+
+struct ReducerWithJoinThatTakesBothVolatileAndNonVolatileQualifiedArgs {
+  using reducer =
+      ReducerWithJoinThatTakesBothVolatileAndNonVolatileQualifiedArgs;
+  using value_type = MyValueType;
+  KOKKOS_FUNCTION void join(MyValueType &, MyValueType const &) const {}
+  KOKKOS_FUNCTION void join(MyValueType volatile &,
+                            MyValueType const volatile &) const {}
+  KOKKOS_FUNCTION void operator()(int, MyValueType &) const {}
+  KOKKOS_FUNCTION
+  ReducerWithJoinThatTakesBothVolatileAndNonVolatileQualifiedArgs() {}
+};
+
+struct ReducerWithJoinThatTakesVolatileQualifiedArgs {
+  using reducer    = ReducerWithJoinThatTakesVolatileQualifiedArgs;
+  using value_type = MyValueType;
+  KOKKOS_FUNCTION void join(MyValueType volatile &,
+                            MyValueType const volatile &) const {}
+  KOKKOS_FUNCTION void operator()(int, MyValueType &) const {}
+  KOKKOS_FUNCTION ReducerWithJoinThatTakesVolatileQualifiedArgs() {}
+};
+
+}  // namespace
+
+KOKKOS_FUNCTION void test_join_backward_compatibility() {
+  MyValueType result;
+  Kokkos::RangePolicy<> policy(0, 1);
+  Kokkos::parallel_reduce(
+      policy, ReducerWithJoinThatTakesVolatileQualifiedArgs{}, result);
+  Kokkos::parallel_reduce(
+      policy, ReducerWithJoinThatTakesBothVolatileAndNonVolatileQualifiedArgs{},
+      result);
+  Kokkos::parallel_reduce(
+      policy, ReducerWithJoinThatTakesNonVolatileQualifiedArgs{}, result);
+}

--- a/core/unit_test/TestJoinBackwardCompatibility.hpp
+++ b/core/unit_test/TestJoinBackwardCompatibility.hpp
@@ -47,24 +47,24 @@
 
 namespace Test {
 
-namespace {
+struct MyJoinBackCompatValueType {};
 
-struct MyValueType {};
-
-KOKKOS_FUNCTION void operator+=(MyValueType &, const MyValueType &) {
+KOKKOS_FUNCTION void operator+=(MyJoinBackCompatValueType &,
+                                const MyJoinBackCompatValueType &) {
   Kokkos::abort("FunctorAnalysis fell back to operator+=(non-volatile)");
 }
 
-KOKKOS_FUNCTION void operator+=(volatile MyValueType &,
-                                const volatile MyValueType &) {
+KOKKOS_FUNCTION void operator+=(volatile MyJoinBackCompatValueType &,
+                                const volatile MyJoinBackCompatValueType &) {
   Kokkos::abort("FunctorAnalysis fell back to operator+=(volatile)");
 }
 
 struct ReducerWithJoinThatTakesNonVolatileQualifiedArgs {
   using reducer    = ReducerWithJoinThatTakesNonVolatileQualifiedArgs;
-  using value_type = MyValueType;
-  KOKKOS_FUNCTION void join(MyValueType &, MyValueType const &) const {}
-  KOKKOS_FUNCTION void operator()(int, MyValueType &) const {}
+  using value_type = MyJoinBackCompatValueType;
+  KOKKOS_FUNCTION void join(MyJoinBackCompatValueType &,
+                            MyJoinBackCompatValueType const &) const {}
+  KOKKOS_FUNCTION void operator()(int, MyJoinBackCompatValueType &) const {}
   KOKKOS_FUNCTION
   ReducerWithJoinThatTakesNonVolatileQualifiedArgs() {}
 };
@@ -72,31 +72,30 @@ struct ReducerWithJoinThatTakesNonVolatileQualifiedArgs {
 struct ReducerWithJoinThatTakesBothVolatileAndNonVolatileQualifiedArgs {
   using reducer =
       ReducerWithJoinThatTakesBothVolatileAndNonVolatileQualifiedArgs;
-  using value_type = MyValueType;
-  KOKKOS_FUNCTION void join(MyValueType &, MyValueType const &) const {}
-  KOKKOS_FUNCTION void join(MyValueType volatile &,
-                            MyValueType const volatile &) const {
+  using value_type = MyJoinBackCompatValueType;
+  KOKKOS_FUNCTION void join(MyJoinBackCompatValueType &,
+                            MyJoinBackCompatValueType const &) const {}
+  KOKKOS_FUNCTION void join(MyJoinBackCompatValueType volatile &,
+                            MyJoinBackCompatValueType const volatile &) const {
     Kokkos::abort(
         "join overload taking non-volatile parameters should be selected");
   }
-  KOKKOS_FUNCTION void operator()(int, MyValueType &) const {}
+  KOKKOS_FUNCTION void operator()(int, MyJoinBackCompatValueType &) const {}
   KOKKOS_FUNCTION
   ReducerWithJoinThatTakesBothVolatileAndNonVolatileQualifiedArgs() {}
 };
 
 struct ReducerWithJoinThatTakesVolatileQualifiedArgs {
   using reducer    = ReducerWithJoinThatTakesVolatileQualifiedArgs;
-  using value_type = MyValueType;
-  KOKKOS_FUNCTION void join(MyValueType volatile &,
-                            MyValueType const volatile &) const {}
-  KOKKOS_FUNCTION void operator()(int, MyValueType &) const {}
+  using value_type = MyJoinBackCompatValueType;
+  KOKKOS_FUNCTION void join(MyJoinBackCompatValueType volatile &,
+                            MyJoinBackCompatValueType const volatile &) const {}
+  KOKKOS_FUNCTION void operator()(int, MyJoinBackCompatValueType &) const {}
   KOKKOS_FUNCTION ReducerWithJoinThatTakesVolatileQualifiedArgs() {}
 };
 
-}  // namespace
-
 void test_join_backward_compatibility() {
-  MyValueType result;
+  MyJoinBackCompatValueType result;
   Kokkos::RangePolicy<> policy(0, 1);
   Kokkos::parallel_reduce(
       policy, ReducerWithJoinThatTakesVolatileQualifiedArgs{}, result);

--- a/core/unit_test/TestJoinBackwardCompatibility.hpp
+++ b/core/unit_test/TestJoinBackwardCompatibility.hpp
@@ -52,11 +52,12 @@ namespace {
 struct MyValueType {};
 
 KOKKOS_FUNCTION void operator+=(MyValueType &, const MyValueType &) {
-  FAIL() << "FunctorAnalysis fell back to operator+=(non-volatile)";
+  Kokkos::abort("FunctorAnalysis fell back to operator+=(non-volatile)");
 }
 
-KOKKOS_FUNCTION void operator+=(volatile MyValueType &, const volatile MyValueType &) {
-  FAIL() << "FunctorAnalysis fell back to operator+=(volatile)";
+KOKKOS_FUNCTION void operator+=(volatile MyValueType &,
+                                const volatile MyValueType &) {
+  Kokkos::abort("FunctorAnalysis fell back to operator+=(volatile)");
 }
 
 struct ReducerWithJoinThatTakesNonVolatileQualifiedArgs {
@@ -75,7 +76,8 @@ struct ReducerWithJoinThatTakesBothVolatileAndNonVolatileQualifiedArgs {
   KOKKOS_FUNCTION void join(MyValueType &, MyValueType const &) const {}
   KOKKOS_FUNCTION void join(MyValueType volatile &,
                             MyValueType const volatile &) const {
-    FAIL() << "join overload taking non-volatile parameters should be selected";
+    Kokkos::abort(
+        "join overload taking non-volatile parameters should be selected");
   }
   KOKKOS_FUNCTION void operator()(int, MyValueType &) const {}
   KOKKOS_FUNCTION


### PR DESCRIPTION
Hotfix for #4931 
For backward compatibility, make sure that user-defined reducer that only had a `join` member function that takes arguments with the volatile type qualifier are not rejected.

Fixes: #4952, #4941