### PR TITLE
Deprecate `Kokkos::is_reducer_type`

### DIFF
--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -1410,7 +1410,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const FunctorType &arg_functor, Policy arg_policy,
       const ViewType &arg_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void *>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
@@ -1548,7 +1548,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       const FunctorType &arg_functor, MDRangePolicy arg_policy,
       const ViewType &arg_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void *>::type = nullptr)
       : m_functor(arg_functor),
         m_mdr_policy(arg_policy),
@@ -2118,7 +2118,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       const FunctorType &arg_functor, const Policy &arg_policy,
       const ViewType &arg_result,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void *>::type = nullptr)
       : m_functor(arg_functor),
         m_league(arg_policy.league_size()),

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -54,6 +54,7 @@
 
 namespace Kokkos {
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 template <class T, class Enable = void>
 struct is_reducer_type {
   enum { value = 0 };
@@ -66,6 +67,7 @@ struct is_reducer_type<
            typename std::remove_cv<typename T::reducer>::type>::value>::type> {
   enum { value = 1 };
 };
+#endif
 
 template <class Scalar, class Space>
 struct Sum {

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1275,7 +1275,7 @@ struct ParallelReduceReturnValue<
     typename std::enable_if<!Kokkos::is_view<ReturnType>::value &&
                             (!std::is_array<ReturnType>::value &&
                              !std::is_pointer<ReturnType>::value) &&
-                            !Kokkos::is_reducer_type<ReturnType>::value>::type,
+                            !Kokkos::is_reducer<ReturnType>::value>::type,
     ReturnType, FunctorType> {
   using return_type =
       Kokkos::View<ReturnType, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>;
@@ -1312,7 +1312,7 @@ struct ParallelReduceReturnValue<
 
 template <class ReturnType, class FunctorType>
 struct ParallelReduceReturnValue<
-    typename std::enable_if<Kokkos::is_reducer_type<ReturnType>::value>::type,
+    typename std::enable_if<Kokkos::is_reducer<ReturnType>::value>::type,
     ReturnType, FunctorType> {
   using return_type  = ReturnType;
   using reducer_type = ReturnType;

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -55,18 +55,9 @@
 namespace Kokkos {
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
-template <class T, class Enable = void>
-struct is_reducer_type {
-  enum { value = 0 };
-};
-
 template <class T>
-struct is_reducer_type<
-    T, typename std::enable_if<std::is_same<
-           typename std::remove_cv<T>::type,
-           typename std::remove_cv<typename T::reducer>::type>::value>::type> {
-  enum { value = 1 };
-};
+using is_reducer_type KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::is_reducer instead!") = Kokkos::is_reducer<T>;
 #endif
 
 template <class Scalar, class Space>

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -585,7 +585,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const FunctorType& arg_functor, const Policy& arg_policy,
       const HostViewType& arg_result_view,
       typename std::enable_if<Kokkos::is_view<HostViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
@@ -883,7 +883,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       const FunctorType& arg_functor, const MDRangePolicy& arg_policy,
       const HostViewType& arg_result_view,
       typename std::enable_if<Kokkos::is_view<HostViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void*>::type = nullptr)
       : m_functor(arg_functor),
         m_mdr_policy(arg_policy),
@@ -1071,7 +1071,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       const FunctorType& arg_functor, const Policy& arg_policy,
       const ViewType& arg_result,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -387,7 +387,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const FunctorType& arg_functor, Policy arg_policy,
       const ViewType& arg_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void*>::type = nullptr)
       : m_instance(t_openmp_instance),
         m_functor(arg_functor),
@@ -543,7 +543,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       const FunctorType& arg_functor, MDRangePolicy arg_policy,
       const ViewType& arg_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void*>::type = nullptr)
       : m_instance(t_openmp_instance),
         m_functor(arg_functor),
@@ -1133,7 +1133,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       const FunctorType& arg_functor, const Policy& arg_policy,
       const ViewType& arg_result,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void*>::type = nullptr)
       : m_instance(t_openmp_instance),
         m_functor(arg_functor),

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -1403,12 +1403,10 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
  */
 
 template <typename iType, class Lambda, typename ValueType>
-KOKKOS_INLINE_FUNCTION
-    std::enable_if_t<!Kokkos::is_reducer_type<ValueType>::value>
-    parallel_reduce(
-        const Impl::TeamThreadRangeBoundariesStruct<
-            iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
-        const Lambda& lambda, ValueType& result) {
+KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
+parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
+                    iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
+                const Lambda& lambda, ValueType& result) {
   // FIXME_OPENMPTARGET - Make sure that if its an array reduction, number of
   // elements in the array <= 32. For reduction we allocate, 16 bytes per
   // element in the scratch space, hence, 16*32 = 512.
@@ -1448,12 +1446,10 @@ KOKKOS_INLINE_FUNCTION
 // and crashes. We should try this with every new compiler
 // This is the variant we actually wanted to write
 template <typename iType, class Lambda, typename ReducerType>
-KOKKOS_INLINE_FUNCTION
-    std::enable_if_t<Kokkos::is_reducer_type<ReducerType>::value>
-    parallel_reduce(
-        const Impl::TeamThreadRangeBoundariesStruct<
-            iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
-        const Lambda& lambda, ReducerType result) {
+KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
+parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
+                    iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
+                const Lambda& lambda, ReducerType result) {
   using ValueType = typename ReducerType::value_type;
 
 #pragma omp declare reduction(                                               \
@@ -1483,12 +1479,10 @@ KOKKOS_INLINE_FUNCTION
 }
 #else
 template <typename iType, class Lambda, typename ReducerType>
-KOKKOS_INLINE_FUNCTION
-    std::enable_if_t<Kokkos::is_reducer_type<ReducerType>::value>
-    parallel_reduce(
-        const Impl::TeamThreadRangeBoundariesStruct<
-            iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
-        const Lambda& lambda, ReducerType result) {
+KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
+parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
+                    iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
+                const Lambda& lambda, ReducerType result) {
   using ValueType = typename ReducerType::value_type;
 
   // FIXME_OPENMPTARGET - Make sure that if its an array reduction, number of
@@ -1678,12 +1672,10 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
 }
 
 template <typename iType, class Lambda, typename ReducerType>
-KOKKOS_INLINE_FUNCTION
-    std::enable_if_t<Kokkos::is_reducer_type<ReducerType>::value>
-    parallel_reduce(
-        const Impl::ThreadVectorRangeBoundariesStruct<
-            iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
-        const Lambda& lambda, ReducerType const& result) {
+KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
+parallel_reduce(const Impl::ThreadVectorRangeBoundariesStruct<
+                    iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
+                const Lambda& lambda, ReducerType const& result) {
   using ValueType = typename ReducerType::value_type;
 
 #pragma omp declare reduction(                                               \
@@ -1827,12 +1819,10 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
 
 #if !defined(KOKKOS_IMPL_HIERARCHICAL_REDUCERS_WORKAROUND)
 template <typename iType, class Lambda, typename ReducerType>
-KOKKOS_INLINE_FUNCTION
-    std::enable_if_t<Kokkos::is_reducer_type<ReducerType>::value>
-    parallel_reduce(
-        const Impl::TeamVectorRangeBoundariesStruct<
-            iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
-        const Lambda& lambda, ReducerType const& result) {
+KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
+parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
+                    iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
+                const Lambda& lambda, ReducerType const& result) {
   using ValueType = typename ReducerType::value_type;
 
   // FIXME_OPENMPTARGET - Make sure that if its an array reduction, number of
@@ -1863,12 +1853,10 @@ KOKKOS_INLINE_FUNCTION
 }
 #else
 template <typename iType, class Lambda, typename ReducerType>
-KOKKOS_INLINE_FUNCTION
-    std::enable_if_t<Kokkos::is_reducer_type<ReducerType>::value>
-    parallel_reduce(
-        const Impl::TeamVectorRangeBoundariesStruct<
-            iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
-        const Lambda& lambda, ReducerType const& result) {
+KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
+parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
+                    iType, Impl::OpenMPTargetExecTeamMember>& loop_boundaries,
+                const Lambda& lambda, ReducerType const& result) {
   using ValueType = typename ReducerType::value_type;
 
   // FIXME_OPENMPTARGET - Make sure that if its an array reduction, number of

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -129,7 +129,7 @@ struct ParallelReduceSpecialize {
     constexpr int FunctorHasJoin =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
                               FunctorType>::has_join_member_function;
-    constexpr int UseReducerType = is_reducer_type<ReducerType>::value;
+    constexpr int UseReducerType = is_reducer<ReducerType>::value;
 
     std::stringstream error_message;
     error_message << "Error: Invalid Specialization " << FunctorHasJoin << ' '
@@ -431,7 +431,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   static constexpr int HasJoin =
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, Policy,
                             FunctorType>::has_join_member_function;
-  static constexpr int UseReducer = is_reducer_type<ReducerType>::value;
+  static constexpr int UseReducer = is_reducer<ReducerType>::value;
   static constexpr int IsArray    = std::is_pointer<reference_type>::value;
 
   using ParReduceSpecialize =
@@ -489,7 +489,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const FunctorType& arg_functor, Policy& arg_policy,
       const ViewType& arg_result_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void*>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
@@ -1189,7 +1189,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   static constexpr int HasJoin =
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, Policy,
                             FunctorType>::has_join_member_function;
-  static constexpr int UseReducer = is_reducer_type<ReducerType>::value;
+  static constexpr int UseReducer = is_reducer<ReducerType>::value;
   static constexpr int IsArray    = std::is_pointer<reference_type>::value;
 
   using ParReduceSpecialize =
@@ -1240,7 +1240,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       const FunctorType& arg_functor, const Policy& arg_policy,
       const ViewType& arg_result,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void*>::type = nullptr)
       : m_result_ptr_on_device(
             MemorySpaceAccess<Kokkos::Experimental::OpenMPTargetSpace,

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_MDRange.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_MDRange.hpp
@@ -461,7 +461,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, Policy,
                               FunctorType>::has_join_member_function
   };
-  enum { UseReducer = is_reducer_type<ReducerType>::value };
+  enum { UseReducer = is_reducer<ReducerType>::value };
 
   const pointer_type m_result_ptr;
   const FunctorType m_functor;
@@ -483,7 +483,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       const FunctorType& arg_functor, Policy arg_policy,
       const ViewType& arg_result_view,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void*>::type = NULL)
       : m_result_ptr(arg_result_view.data()),
         m_functor(arg_functor),

--- a/core/src/Threads/Kokkos_Threads_Parallel.hpp
+++ b/core/src/Threads/Kokkos_Threads_Parallel.hpp
@@ -515,7 +515,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       const FunctorType &arg_functor, const Policy &arg_policy,
       const HostViewType &arg_result_view,
       typename std::enable_if<Kokkos::is_view<HostViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void *>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(arg_policy),
@@ -671,7 +671,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       const FunctorType &arg_functor, const MDRangePolicy &arg_policy,
       const HostViewType &arg_result_view,
       typename std::enable_if<Kokkos::is_view<HostViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void *>::type = nullptr)
       : m_functor(arg_functor),
         m_mdr_policy(arg_policy),
@@ -824,7 +824,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       const FunctorType &arg_functor, const Policy &arg_policy,
       const ViewType &arg_result,
       typename std::enable_if<Kokkos::is_view<ViewType>::value &&
-                                  !Kokkos::is_reducer_type<ReducerType>::value,
+                                  !Kokkos::is_reducer<ReducerType>::value,
                               void *>::type = nullptr)
       : m_functor(arg_functor),
         m_policy(fix_policy(arg_policy)),


### PR DESCRIPTION
Rational: obscure duplicate functionality

Haven't found any usage in Trilinos.  I suggest we deprecate/remove.