### PR TITLE
Add structured binding support for `Kokkos::Array`

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -347,6 +347,9 @@ struct Array<T, KOKKOS_INVALID_INDEX, Array<>::strided> {
 }  // namespace Kokkos
 
 //<editor-fold desc="Support for structured binding">
+// guarding against bogus error 'specialization in different namespace' with
+// older GCC that do not support C++17 anyway
+#if !defined(KOKKOS_COMPILER_GNU) || (KOKKOS_COMPILER_GNU >= 710)
 template <class T, std::size_t N>
 struct std::tuple_size<Kokkos::Array<T, N>>
     : std::integral_constant<std::size_t, N> {};
@@ -355,6 +358,7 @@ template <std::size_t I, class T, std::size_t N>
 struct std::tuple_element<I, Kokkos::Array<T, N>> {
   using type = T;
 };
+#endif
 
 namespace Kokkos {
 

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -51,6 +51,7 @@
 
 #include <type_traits>
 #include <algorithm>
+#include <utility>
 #include <limits>
 #include <cstddef>
 
@@ -344,5 +345,40 @@ struct Array<T, KOKKOS_INVALID_INDEX, Array<>::strided> {
 };
 
 }  // namespace Kokkos
+
+//<editor-fold desc="Support for structured binding">
+template <class T, std::size_t N>
+struct std::tuple_size<Kokkos::Array<T, N>>
+    : std::integral_constant<std::size_t, N> {};
+
+template <std::size_t I, class T, std::size_t N>
+struct std::tuple_element<I, Kokkos::Array<T, N>> {
+  using type = T;
+};
+
+namespace Kokkos {
+
+template <std::size_t I, class T, std::size_t N>
+KOKKOS_FUNCTION constexpr T& get(Array<T, N>& a) noexcept {
+  return a[I];
+}
+
+template <std::size_t I, class T, std::size_t N>
+KOKKOS_FUNCTION constexpr T const& get(Array<T, N> const& a) noexcept {
+  return a[I];
+}
+
+template <std::size_t I, class T, std::size_t N>
+KOKKOS_FUNCTION constexpr T&& get(Array<T, N>&& a) noexcept {
+  return std::move(a[I]);
+}
+
+template <std::size_t I, class T, std::size_t N>
+KOKKOS_FUNCTION constexpr T const&& get(Array<T, N> const&& a) noexcept {
+  return std::move(a[I]);
+}
+
+}  // namespace Kokkos
+//</editor-fold>
 
 #endif /* #ifndef KOKKOS_ARRAY_HPP */

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -63,4 +63,22 @@ KOKKOS_FUNCTION constexpr bool test_array() {
 
 STATIC_ASSERT(test_array());
 
+#ifdef KOKKOS_ENABLE_CXX17
+KOKKOS_FUNCTION constexpr bool test_array_structured_binding_support() {
+  constexpr Kokkos::Array<float, 2> a{};
+  auto& [xr, yr] = a;
+  (void)xr;
+  (void)yr;
+  auto [x, y] = a;
+  (void)x;
+  (void)y;
+  auto const& [xcr, ycr] = a;
+  (void)xcr;
+  (void)ycr;
+  return true;
+}
+
+STATIC_ASSERT(test_array_structured_binding_support());
+#endif
+
 }  // namespace


### PR DESCRIPTION
Fix #4961 