### PR TITLE
[ci skip] Set OMP_MAX_ACTIVE_LEVELS=1 for OpenMP builds

### DIFF
--- a/scripts/testing_scripts/test_all_sandia
+++ b/scripts/testing_scripts/test_all_sandia
@@ -636,6 +636,7 @@ fi
 export OMP_NUM_THREADS=8
 export OMP_PROC_BIND=spread
 export OMP_PLACES=cores
+export OMP_MAX_ACTIVE_LEVELS=1
 
 declare -i NUM_RESULTS_TO_KEEP=7
 


### PR DESCRIPTION
Required for partition_master tests, addresses kokkos/kokkos#4960