### PR TITLE
Fix for Kokkos::vector::insert into empty vector with begin and end iterators

### DIFF
--- a/containers/unit_tests/TestVector.hpp
+++ b/containers/unit_tests/TestVector.hpp
@@ -172,6 +172,23 @@ struct test_vector_insert {
       run_test(a);
       check_test(a, size);
     }
+    { test_vector_insert_into_empty(size); }
+  }
+
+  void test_vector_insert_into_empty(const size_t size) {
+    using Vector = Kokkos::vector<Scalar, Device>;
+    {
+      Vector a;
+      Vector b(size);
+      a.insert(a.begin(), b.begin(), b.end());
+      ASSERT_EQ(a.size(), size);
+    }
+
+    {
+      Vector c;
+      c.insert(c.begin(), size, Scalar{});
+      ASSERT_EQ(c.size(), size);
+    }
   }
 };
 


### PR DESCRIPTION
This is primarily a fix for issue #4975.

In vector::insert(iterator, InputIterator, InputIterator):
Changed the out of range check on it to use std::less, as one
cannot portably perform ordered pointer comparisons on pointers
that aren't pointing inside the same array (to a first approximation).

Removed the special case when inserting into an empty vector,
as it was incorrect (see issue #4975) and has no real performance
gain (unlike this special case in insert(it, count, val)).

Removed the special case when inserting zero elements, as there
is no need to hand optimize for this rare case, as it falls out
of the general algorithm anyway.

In vector::insert(it, count, val):

Changed the out of range check to use std::less

In TestVector.hpp:
Added tests for the above