### PR TITLE
Replace remaining occurences of 'typename std::...<>::type'

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -120,13 +120,13 @@ class BinSort {
     // If a Kokkos::View then can generate constant random access
     // otherwise can only use the constant type.
 
-    using src_view_type = typename std::conditional<
+    using src_view_type = std::conditional_t<
         Kokkos::is_view<SrcViewType>::value,
         Kokkos::View<typename SrcViewType::const_data_type,
                      typename SrcViewType::array_layout,
                      typename SrcViewType::device_type,
                      Kokkos::MemoryTraits<Kokkos::RandomAccess> >,
-        typename SrcViewType::const_type>::type;
+        typename SrcViewType::const_type>;
 
     using perm_view_type = typename PermuteViewType::const_type;
 
@@ -174,13 +174,13 @@ class BinSort {
   // If a Kokkos::View then can generate constant random access
   // otherwise can only use the constant type.
 
-  using const_rnd_key_view_type = typename std::conditional<
+  using const_rnd_key_view_type = std::conditional_t<
       Kokkos::is_view<KeyViewType>::value,
       Kokkos::View<typename KeyViewType::const_data_type,
                    typename KeyViewType::array_layout,
                    typename KeyViewType::device_type,
                    Kokkos::MemoryTraits<Kokkos::RandomAccess> >,
-      const_key_view_type>::type;
+      const_key_view_type>;
 
   using non_const_key_scalar = typename KeyViewType::non_const_value_type;
   using const_key_scalar     = typename KeyViewType::const_value_type;

--- a/algorithms/src/std_algorithms/Kokkos_ReducerWithArbitraryJoinerNoNeutralElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ReducerWithArbitraryJoinerNoNeutralElement.hpp
@@ -58,7 +58,7 @@ namespace Impl {
 
 template <class Scalar, class JoinerType, class Space = HostSpace>
 struct ReducerWithArbitraryJoinerNoNeutralElement {
-  using scalar_type = typename std::remove_cv<Scalar>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
 
  public:
   // Required

--- a/algorithms/unit_tests/TestStdReducers.cpp
+++ b/algorithms/unit_tests/TestStdReducers.cpp
@@ -115,9 +115,9 @@ auto run_min_or_max_test(ViewType view, StdReducersTestEnumOrder enValue) {
             << "\n";
 
   using view_value_type = typename ViewType::value_type;
-  using reducer_type    = typename std::conditional<
+  using reducer_type    = std::conditional_t<
       (flag == 0), Kokkos::MaxFirstLoc<view_value_type, IndexType, ExeSpace>,
-      Kokkos::MinFirstLoc<view_value_type, IndexType, ExeSpace> >::type;
+      Kokkos::MinFirstLoc<view_value_type, IndexType, ExeSpace> >;
   using reduction_value_type = typename reducer_type::value_type;
 
   reduction_value_type red_result;

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1105,17 +1105,14 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
     // to avoid duplicate class error.
     using alloc_prop = Kokkos::Impl::ViewCtorProp<
         P...,
-        typename std::conditional<alloc_prop_input::has_label,
-                                  std::integral_constant<unsigned, 0>,
-                                  typename std::string>::type,
-        typename std::conditional<
-            alloc_prop_input::has_memory_space,
-            std::integral_constant<unsigned, 1>,
-            typename traits::device_type::memory_space>::type,
-        typename std::conditional<
-            alloc_prop_input::has_execution_space,
-            std::integral_constant<unsigned, 2>,
-            typename traits::device_type::execution_space>::type>;
+        std::conditional_t<alloc_prop_input::has_label,
+                           std::integral_constant<unsigned, 0>, std::string>,
+        std::conditional_t<alloc_prop_input::has_memory_space,
+                           std::integral_constant<unsigned, 1>,
+                           typename traits::device_type::memory_space>,
+        std::conditional_t<alloc_prop_input::has_execution_space,
+                           std::integral_constant<unsigned, 2>,
+                           typename traits::device_type::execution_space>>;
 
     static_assert(traits::is_managed,
                   "View allocation constructor requires managed memory");
@@ -1441,22 +1438,21 @@ class ViewMapping<
       Args... args) {
     using DstType = ViewMapping<traits_type, typename traits_type::specialize>;
 
-    using DstDimType = typename std::conditional<
+    using DstDimType = std::conditional_t<
         (rank == 0), ViewDimension<>,
-        typename std::conditional<
+        std::conditional_t<
             (rank == 1), ViewDimension<0>,
-            typename std::conditional<
+            std::conditional_t<
                 (rank == 2), ViewDimension<0, 0>,
-                typename std::conditional<
+                std::conditional_t<
                     (rank == 3), ViewDimension<0, 0, 0>,
-                    typename std::conditional<
+                    std::conditional_t<
                         (rank == 4), ViewDimension<0, 0, 0, 0>,
-                        typename std::conditional<
+                        std::conditional_t<
                             (rank == 5), ViewDimension<0, 0, 0, 0, 0>,
-                            typename std::conditional<
+                            std::conditional_t<
                                 (rank == 6), ViewDimension<0, 0, 0, 0, 0, 0>,
-                                ViewDimension<0, 0, 0, 0, 0, 0, 0>>::type>::
-                            type>::type>::type>::type>::type>::type;
+                                ViewDimension<0, 0, 0, 0, 0, 0, 0>>>>>>>>;
 
     using dst_offset_type = ViewOffset<DstDimType, Kokkos::LayoutStride>;
     using dst_handle_type = typename DstType::handle_type;
@@ -1903,8 +1899,8 @@ struct MirrorDRViewType {
   using dest_view_type = Kokkos::DynRankView<data_type, array_layout, Space>;
   // If it is the same memory_space return the existsing view_type
   // This will also keep the unmanaged trait if necessary
-  using view_type = typename std::conditional<is_same_memspace, src_view_type,
-                                              dest_view_type>::type;
+  using view_type =
+      std::conditional_t<is_same_memspace, src_view_type, dest_view_type>;
 };
 
 template <class Space, class T, class... P>

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -598,8 +598,8 @@ struct MirrorDynamicViewType {
       Kokkos::Experimental::DynamicView<data_type, array_layout, Space>;
   // If it is the same memory_space return the existing view_type
   // This will also keep the unmanaged trait if necessary
-  using view_type = typename std::conditional<is_same_memspace, src_view_type,
-                                              dest_view_type>::type;
+  using view_type =
+      std::conditional_t<is_same_memspace, src_view_type, dest_view_type>;
 };
 }  // namespace Impl
 

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1192,17 +1192,14 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
     // to avoid duplicate class error.
     using alloc_prop = Kokkos::Impl::ViewCtorProp<
         P...,
-        typename std::conditional<alloc_prop_input::has_label,
-                                  std::integral_constant<unsigned, 0>,
-                                  typename std::string>::type,
-        typename std::conditional<
-            alloc_prop_input::has_memory_space,
-            std::integral_constant<unsigned, 1>,
-            typename traits::device_type::memory_space>::type,
-        typename std::conditional<
-            alloc_prop_input::has_execution_space,
-            std::integral_constant<unsigned, 2>,
-            typename traits::device_type::execution_space>::type>;
+        std::conditional_t<alloc_prop_input::has_label,
+                           std::integral_constant<unsigned, 0>, std::string>,
+        std::conditional_t<alloc_prop_input::has_memory_space,
+                           std::integral_constant<unsigned, 1>,
+                           typename traits::device_type::memory_space>,
+        std::conditional_t<alloc_prop_input::has_execution_space,
+                           std::integral_constant<unsigned, 2>,
+                           typename traits::device_type::execution_space>>;
 
     static_assert(traits::is_managed,
                   "OffsetView allocation constructor requires managed memory");
@@ -1871,8 +1868,8 @@ struct MirrorOffsetViewType {
       Kokkos::Experimental::OffsetView<data_type, array_layout, Space>;
   // If it is the same memory_space return the existing view_type
   // This will also keep the unmanaged trait if necessary
-  using view_type = typename std::conditional<is_same_memspace, src_view_type,
-                                              dest_view_type>::type;
+  using view_type =
+      std::conditional_t<is_same_memspace, src_view_type, dest_view_type>;
 };
 
 template <class Space, class T, class... P>

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -199,10 +199,9 @@ class UnorderedMapInsertResult {
 ///   <tt>Key</tt>.  The default will do a bitwise equality comparison.
 ///
 template <typename Key, typename Value,
-          typename Device = Kokkos::DefaultExecutionSpace,
-          typename Hasher = pod_hash<typename std::remove_const<Key>::type>,
-          typename EqualTo =
-              pod_equal_to<typename std::remove_const<Key>::type>>
+          typename Device  = Kokkos::DefaultExecutionSpace,
+          typename Hasher  = pod_hash<std::remove_const_t<Key>>,
+          typename EqualTo = pod_equal_to<std::remove_const_t<Key>>>
 class UnorderedMap {
  private:
   using host_mirror_space =
@@ -214,13 +213,13 @@ class UnorderedMap {
 
   // key_types
   using declared_key_type = Key;
-  using key_type          = typename std::remove_const<declared_key_type>::type;
-  using const_key_type    = typename std::add_const<key_type>::type;
+  using key_type          = std::remove_const_t<declared_key_type>;
+  using const_key_type    = std::add_const_t<key_type>;
 
   // value_types
   using declared_value_type = Value;
-  using value_type = typename std::remove_const<declared_value_type>::type;
-  using const_value_type = typename std::add_const<value_type>::type;
+  using value_type          = std::remove_const_t<declared_value_type>;
+  using const_value_type    = std::add_const_t<value_type>;
 
   using device_type     = Device;
   using execution_space = typename Device::execution_space;
@@ -776,9 +775,8 @@ class UnorderedMap {
   }
 
   template <typename SKey, typename SValue, typename SDevice>
-  std::enable_if_t<
-      std::is_same<typename std::remove_const<SKey>::type, key_type>::value &&
-      std::is_same<typename std::remove_const<SValue>::type, value_type>::value>
+  std::enable_if_t<std::is_same<std::remove_const_t<SKey>, key_type>::value &&
+                   std::is_same<std::remove_const_t<SValue>, value_type>::value>
   create_copy_view(
       UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo> const &src) {
     if (m_hash_lists.data() != src.m_hash_lists.data()) {

--- a/core/src/Cuda/Kokkos_Cuda_Atomic_Intrinsics.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Atomic_Intrinsics.hpp
@@ -548,8 +548,8 @@ DO__atomic_compare_exchange_simt_(4, 32)
                                     const type *desired, bool,
                                     int success_memorder,
                                     int failure_memorder) {
-  using R            = typename std::conditional<std::is_volatile<type>::value,
-                                      volatile uint32_t, uint32_t>::type;
+  using R = std::conditional_t<std::is_volatile<type>::value, volatile uint32_t,
+                               uint32_t>;
   auto const aligned = (R *)((intptr_t)ptr & ~(sizeof(uint32_t) - 1));
   auto const offset  = uint32_t((intptr_t)ptr & (sizeof(uint32_t) - 1)) * 8;
   auto const mask    = ((1 << sizeof(type) * 8) - 1) << offset;

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -184,10 +184,10 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   // offset rather than at every 4 byte word; such that, when the join is
   // performed, we have the correct data that was copied over in chunks of 4
   // bytes.
-  using word_size_type = typename std::conditional<
+  using word_size_type = std::conditional_t<
       sizeof(value_type) < sizeof(Kokkos::Cuda::size_type),
-      typename std::conditional<sizeof(value_type) == 2, int16_t, int8_t>::type,
-      Kokkos::Cuda::size_type>::type;
+      std::conditional_t<sizeof(value_type) == 2, int16_t, int8_t>,
+      Kokkos::Cuda::size_type>;
   using index_type   = typename Policy::index_type;
   using reducer_type = ReducerType;
 

--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -779,12 +779,12 @@ namespace Kokkos {
 // template<typename iType1, typename iType2>
 // KOKKOS_INLINE_FUNCTION
 // Impl::TeamThreadRangeBoundariesStruct
-//  < typename std::common_type<iType1,iType2>::type
+//  < std::common_type_t<iType1,iType2>
 //  , Impl::TaskExec< Kokkos::Cuda > >
 // TeamThreadRange( const Impl::TaskExec< Kokkos::Cuda > & thread
 //               , const iType1 & begin, const iType2 & end )
 //{
-//  using iType = typename std::common_type< iType1, iType2 >::type;
+//  using iType = std::common_type_t< iType1, iType2 >;
 //  return Impl::TeamThreadRangeBoundariesStruct< iType, Impl::TaskExec<
 //  Kokkos::Cuda > >(
 //           thread, iType(begin), iType(end) );

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -444,9 +444,9 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::CudaTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::CudaTeamMember>
 TeamThreadRange(const Impl::CudaTeamMember& thread, iType1 begin, iType2 end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamThreadRangeBoundariesStruct<iType, Impl::CudaTeamMember>(
       thread, iType(begin), iType(end));
 }
@@ -461,10 +461,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::CudaTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::CudaTeamMember>
 TeamVectorRange(const Impl::CudaTeamMember& thread, const iType1& begin,
                 const iType2& end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamVectorRangeBoundariesStruct<iType, Impl::CudaTeamMember>(
       thread, iType(begin), iType(end));
 }
@@ -479,10 +479,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::ThreadVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::CudaTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::CudaTeamMember>
 ThreadVectorRange(const Impl::CudaTeamMember& thread, iType1 arg_begin,
                   iType2 arg_end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::CudaTeamMember>(
       thread, iType(arg_begin), iType(arg_end));
 }

--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -222,12 +222,11 @@ class ViewDataHandle<
   using value_type  = typename Traits::const_value_type;
   using return_type = typename Traits::const_value_type;  // NOT a reference
 
-  using alias_type = typename std::conditional<
+  using alias_type = std::conditional_t<
       (sizeof(value_type) == 4), int,
-      typename std::conditional<
+      std::conditional_t<
           (sizeof(value_type) == 8), ::int2,
-          typename std::conditional<(sizeof(value_type) == 16), ::int4,
-                                    void>::type>::type>::type;
+          std::conditional_t<(sizeof(value_type) == 16), ::int4, void>>>;
 
 #if defined(KOKKOS_ENABLE_CUDA_LDG_INTRINSIC)
   using handle_type = Kokkos::Impl::CudaLDGFetch<value_type, alias_type>;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -201,9 +201,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
  public:
   __device__ inline void operator()() const {
-    using ReductionTag =
-        typename std::conditional<UseShflReduction, ShflReductionTag,
-                                  SHMEMReductionTag>::type;
+    using ReductionTag = std::conditional_t<UseShflReduction, ShflReductionTag,
+                                            SHMEMReductionTag>;
     run(ReductionTag{});
   }
 

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -421,9 +421,9 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::HIPTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::HIPTeamMember>
 TeamThreadRange(const Impl::HIPTeamMember& thread, iType1 begin, iType2 end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamThreadRangeBoundariesStruct<iType, Impl::HIPTeamMember>(
       thread, iType(begin), iType(end));
 }
@@ -438,10 +438,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::HIPTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::HIPTeamMember>
 TeamVectorRange(const Impl::HIPTeamMember& thread, const iType1& begin,
                 const iType2& end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamVectorRangeBoundariesStruct<iType, Impl::HIPTeamMember>(
       thread, iType(begin), iType(end));
 }
@@ -456,10 +456,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::ThreadVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::HIPTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::HIPTeamMember>
 ThreadVectorRange(const Impl::HIPTeamMember& thread, iType1 arg_begin,
                   iType2 arg_end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::HIPTeamMember>(
       thread, iType(arg_begin), iType(arg_end));
 }

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -116,12 +116,12 @@ struct Array {
 
  public:
   using reference       = T&;
-  using const_reference = typename std::add_const<T>::type&;
+  using const_reference = std::add_const_t<T>&;
   using size_type       = size_t;
   using difference_type = ptrdiff_t;
   using value_type      = T;
   using pointer         = T*;
-  using const_pointer   = typename std::add_const<T>::type*;
+  using const_pointer   = std::add_const_t<T>*;
 
   KOKKOS_INLINE_FUNCTION static constexpr size_type size() { return N; }
   KOKKOS_INLINE_FUNCTION static constexpr bool empty() { return false; }
@@ -158,12 +158,12 @@ template <class T, class Proxy>
 struct Array<T, 0, Proxy> {
  public:
   using reference       = T&;
-  using const_reference = typename std::add_const<T>::type&;
+  using const_reference = std::add_const_t<T>&;
   using size_type       = size_t;
   using difference_type = ptrdiff_t;
   using value_type      = T;
   using pointer         = T*;
-  using const_pointer   = typename std::add_const<T>::type*;
+  using const_pointer   = std::add_const_t<T>*;
 
   KOKKOS_INLINE_FUNCTION static constexpr size_type size() { return 0; }
   KOKKOS_INLINE_FUNCTION static constexpr bool empty() { return true; }
@@ -215,12 +215,12 @@ struct Array<T, KOKKOS_INVALID_INDEX, Array<>::contiguous> {
 
  public:
   using reference       = T&;
-  using const_reference = typename std::add_const<T>::type&;
+  using const_reference = std::add_const_t<T>&;
   using size_type       = size_t;
   using difference_type = ptrdiff_t;
   using value_type      = T;
   using pointer         = T*;
-  using const_pointer   = typename std::add_const<T>::type*;
+  using const_pointer   = std::add_const_t<T>*;
 
   KOKKOS_INLINE_FUNCTION constexpr size_type size() const { return m_size; }
   KOKKOS_INLINE_FUNCTION constexpr bool empty() const { return 0 != m_size; }
@@ -284,12 +284,12 @@ struct Array<T, KOKKOS_INVALID_INDEX, Array<>::strided> {
 
  public:
   using reference       = T&;
-  using const_reference = typename std::add_const<T>::type&;
+  using const_reference = std::add_const_t<T>&;
   using size_type       = size_t;
   using difference_type = ptrdiff_t;
   using value_type      = T;
   using pointer         = T*;
-  using const_pointer   = typename std::add_const<T>::type*;
+  using const_pointer   = std::add_const_t<T>*;
 
   KOKKOS_INLINE_FUNCTION constexpr size_type size() const { return m_size; }
   KOKKOS_INLINE_FUNCTION constexpr bool empty() const { return 0 != m_size; }

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -446,7 +446,7 @@ class
 template <class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION bool operator==(complex<RealType1> const& x,
                                        complex<RealType2> const& y) noexcept {
-  using common_type = typename std::common_type<RealType1, RealType2>::type;
+  using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y.real()) &&
          common_type(x.imag()) == common_type(y.imag());
 }
@@ -457,7 +457,7 @@ KOKKOS_INLINE_FUNCTION bool operator==(complex<RealType1> const& x,
 template <class RealType1, class RealType2>
 inline bool operator==(std::complex<RealType1> const& x,
                        complex<RealType2> const& y) noexcept {
-  using common_type = typename std::common_type<RealType1, RealType2>::type;
+  using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y.real()) &&
          common_type(x.imag()) == common_type(y.imag());
 }
@@ -466,7 +466,7 @@ inline bool operator==(std::complex<RealType1> const& x,
 template <class RealType1, class RealType2>
 inline bool operator==(complex<RealType1> const& x,
                        std::complex<RealType2> const& y) noexcept {
-  using common_type = typename std::common_type<RealType1, RealType2>::type;
+  using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y.real()) &&
          common_type(x.imag()) == common_type(y.imag());
 }
@@ -478,7 +478,7 @@ template <
     std::enable_if_t<std::is_convertible<RealType2, RealType1>::value, int> = 0>
 KOKKOS_INLINE_FUNCTION bool operator==(complex<RealType1> const& x,
                                        RealType2 const& y) noexcept {
-  using common_type = typename std::common_type<RealType1, RealType2>::type;
+  using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y) &&
          common_type(x.imag()) == common_type(0);
 }
@@ -490,7 +490,7 @@ template <
     std::enable_if_t<std::is_convertible<RealType1, RealType2>::value, int> = 0>
 KOKKOS_INLINE_FUNCTION bool operator==(RealType1 const& x,
                                        complex<RealType2> const& y) noexcept {
-  using common_type = typename std::common_type<RealType1, RealType2>::type;
+  using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x) == common_type(y.real()) &&
          common_type(0) == common_type(y.imag());
 }
@@ -499,7 +499,7 @@ KOKKOS_INLINE_FUNCTION bool operator==(RealType1 const& x,
 template <class RealType1, class RealType2>
 KOKKOS_INLINE_FUNCTION bool operator!=(complex<RealType1> const& x,
                                        complex<RealType2> const& y) noexcept {
-  using common_type = typename std::common_type<RealType1, RealType2>::type;
+  using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y.real()) ||
          common_type(x.imag()) != common_type(y.imag());
 }
@@ -508,7 +508,7 @@ KOKKOS_INLINE_FUNCTION bool operator!=(complex<RealType1> const& x,
 template <class RealType1, class RealType2>
 inline bool operator!=(std::complex<RealType1> const& x,
                        complex<RealType2> const& y) noexcept {
-  using common_type = typename std::common_type<RealType1, RealType2>::type;
+  using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y.real()) ||
          common_type(x.imag()) != common_type(y.imag());
 }
@@ -517,7 +517,7 @@ inline bool operator!=(std::complex<RealType1> const& x,
 template <class RealType1, class RealType2>
 inline bool operator!=(complex<RealType1> const& x,
                        std::complex<RealType2> const& y) noexcept {
-  using common_type = typename std::common_type<RealType1, RealType2>::type;
+  using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y.real()) ||
          common_type(x.imag()) != common_type(y.imag());
 }
@@ -529,7 +529,7 @@ template <
     std::enable_if_t<std::is_convertible<RealType2, RealType1>::value, int> = 0>
 KOKKOS_INLINE_FUNCTION bool operator!=(complex<RealType1> const& x,
                                        RealType2 const& y) noexcept {
-  using common_type = typename std::common_type<RealType1, RealType2>::type;
+  using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y) ||
          common_type(x.imag()) != common_type(0);
 }
@@ -541,7 +541,7 @@ template <
     std::enable_if_t<std::is_convertible<RealType1, RealType2>::value, int> = 0>
 KOKKOS_INLINE_FUNCTION bool operator!=(RealType1 const& x,
                                        complex<RealType2> const& y) noexcept {
-  using common_type = typename std::common_type<RealType1, RealType2>::type;
+  using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x) != common_type(y.real()) ||
          common_type(0) != common_type(y.imag());
 }
@@ -551,30 +551,26 @@ KOKKOS_INLINE_FUNCTION bool operator!=(RealType1 const& x,
 
 //! Binary + operator for complex complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator+(const complex<RealType1>& x,
-              const complex<RealType2>& y) noexcept {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(
-      x.real() + y.real(), x.imag() + y.imag());
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator+(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
+  return complex<std::common_type_t<RealType1, RealType2>>(x.real() + y.real(),
+                                                           x.imag() + y.imag());
 }
 
 //! Binary + operator for complex scalar.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator+(const complex<RealType1>& x, const RealType2& y) noexcept {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(
-      x.real() + y, x.imag());
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator+(const complex<RealType1>& x, const RealType2& y) noexcept {
+  return complex<std::common_type_t<RealType1, RealType2>>(x.real() + y,
+                                                           x.imag());
 }
 
 //! Binary + operator for scalar complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator+(const RealType1& x, const complex<RealType2>& y) noexcept {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(
-      x + y.real(), y.imag());
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator+(const RealType1& x, const complex<RealType2>& y) noexcept {
+  return complex<std::common_type_t<RealType1, RealType2>>(x + y.real(),
+                                                           y.imag());
 }
 
 //! Unary + operator for complex.
@@ -586,30 +582,26 @@ KOKKOS_INLINE_FUNCTION complex<RealType> operator+(
 
 //! Binary - operator for complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator-(const complex<RealType1>& x,
-              const complex<RealType2>& y) noexcept {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(
-      x.real() - y.real(), x.imag() - y.imag());
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator-(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
+  return complex<std::common_type_t<RealType1, RealType2>>(x.real() - y.real(),
+                                                           x.imag() - y.imag());
 }
 
 //! Binary - operator for complex scalar.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator-(const complex<RealType1>& x, const RealType2& y) noexcept {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(
-      x.real() - y, x.imag());
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator-(const complex<RealType1>& x, const RealType2& y) noexcept {
+  return complex<std::common_type_t<RealType1, RealType2>>(x.real() - y,
+                                                           x.imag());
 }
 
 //! Binary - operator for scalar complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator-(const RealType1& x, const complex<RealType2>& y) noexcept {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(
-      x - y.real(), -y.imag());
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator-(const RealType1& x, const complex<RealType2>& y) noexcept {
+  return complex<std::common_type_t<RealType1, RealType2>>(x - y.real(),
+                                                           -y.imag());
 }
 
 //! Unary - operator for complex.
@@ -621,11 +613,9 @@ KOKKOS_INLINE_FUNCTION complex<RealType> operator-(
 
 //! Binary * operator for complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator*(const complex<RealType1>& x,
-              const complex<RealType2>& y) noexcept {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator*(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
+  return complex<std::common_type_t<RealType1, RealType2>>(
       x.real() * y.real() - x.imag() * y.imag(),
       x.real() * y.imag() + x.imag() * y.real());
 }
@@ -639,9 +629,9 @@ KOKKOS_INLINE_FUNCTION
 /// std::complex's methods and nonmember functions are not marked as
 /// CUDA device functions.
 template <class RealType1, class RealType2>
-inline complex<typename std::common_type<RealType1, RealType2>::type> operator*(
+inline complex<std::common_type_t<RealType1, RealType2>> operator*(
     const std::complex<RealType1>& x, const complex<RealType2>& y) {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(
+  return complex<std::common_type_t<RealType1, RealType2>>(
       x.real() * y.real() - x.imag() * y.imag(),
       x.real() * y.imag() + x.imag() * y.real());
 }
@@ -651,11 +641,10 @@ inline complex<typename std::common_type<RealType1, RealType2>::type> operator*(
 /// This function exists because the compiler doesn't know that
 /// RealType and complex<RealType> commute with respect to operator*.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator*(const RealType1& x, const complex<RealType2>& y) noexcept {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(
-      x * y.real(), x * y.imag());
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator*(const RealType1& x, const complex<RealType2>& y) noexcept {
+  return complex<std::common_type_t<RealType1, RealType2>>(x * y.real(),
+                                                           x * y.imag());
 }
 
 /// \brief Binary * operator for RealType times complex.
@@ -663,11 +652,10 @@ KOKKOS_INLINE_FUNCTION
 /// This function exists because the compiler doesn't know that
 /// RealType and complex<RealType> commute with respect to operator*.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator*(const complex<RealType1>& y, const RealType2& x) noexcept {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(
-      x * y.real(), x * y.imag());
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator*(const complex<RealType1>& y, const RealType2& x) noexcept {
+  return complex<std::common_type_t<RealType1, RealType2>>(x * y.real(),
+                                                           x * y.imag());
 }
 
 //! Imaginary part of a complex number.
@@ -923,27 +911,23 @@ inline complex<RealType> exp(const std::complex<RealType>& c) {
 
 //! Binary operator / for complex and real numbers
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator/(const complex<RealType1>& x,
-              const RealType2& y) noexcept(noexcept(RealType1{} /
-                                                    RealType2{})) {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(
-      real(x) / y, imag(x) / y);
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator/(const complex<RealType1>& x,
+          const RealType2& y) noexcept(noexcept(RealType1{} / RealType2{})) {
+  return complex<std::common_type_t<RealType1, RealType2>>(real(x) / y,
+                                                           imag(x) / y);
 }
 
 //! Binary operator / for complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator/(const complex<RealType1>& x,
-              const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
-                                                             RealType2{})) {
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator/(const complex<RealType1>& x,
+          const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
+                                                         RealType2{})) {
   // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
   // If the real part is +/-Inf and the imaginary part is -/+Inf,
   // this won't change the result.
-  using common_real_type =
-      typename std::common_type<RealType1, RealType2>::type;
+  using common_real_type   = std::common_type_t<RealType1, RealType2>;
   const common_real_type s = fabs(real(y)) + fabs(imag(y));
 
   // If s is 0, then y is zero, so x/y == real(x)/0 + i*imag(x)/0.
@@ -965,12 +949,11 @@ KOKKOS_INLINE_FUNCTION
 
 //! Binary operator / for complex and real numbers
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION
-    complex<typename std::common_type<RealType1, RealType2>::type>
-    operator/(const RealType1& x,
-              const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
-                                                             RealType2{})) {
-  return complex<typename std::common_type<RealType1, RealType2>::type>(x) / y;
+KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
+operator/(const RealType1& x,
+          const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
+                                                         RealType2{})) {
+  return complex<std::common_type_t<RealType1, RealType2>>(x) / y;
 }
 
 template <class RealType>

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -270,8 +270,7 @@ struct is_device_helper<Device<ExecutionSpace, MemorySpace>> : std::true_type {
 }  // namespace Impl
 
 template <typename T>
-using is_device =
-    typename Impl::is_device_helper<typename std::remove_cv<T>::type>::type;
+using is_device = typename Impl::is_device_helper<std::remove_cv_t<T>>::type;
 
 //----------------------------------------------------------------------------
 
@@ -294,32 +293,26 @@ struct is_space {
   };
 
   template <typename U>
-  struct exe<U, typename std::conditional<true, void,
-                                          typename U::execution_space>::type>
+  struct exe<U, std::conditional_t<true, void, typename U::execution_space>>
       : std::is_same<U, typename U::execution_space>::type {
     using space = typename U::execution_space;
   };
 
   template <typename U>
-  struct mem<
-      U, typename std::conditional<true, void, typename U::memory_space>::type>
+  struct mem<U, std::conditional_t<true, void, typename U::memory_space>>
       : std::is_same<U, typename U::memory_space>::type {
     using space = typename U::memory_space;
   };
 
   template <typename U>
-  struct dev<
-      U, typename std::conditional<true, void, typename U::device_type>::type>
+  struct dev<U, std::conditional_t<true, void, typename U::device_type>>
       : std::is_same<U, typename U::device_type>::type {
     using space = typename U::device_type;
   };
 
-  using is_exe =
-      typename is_space<T>::template exe<typename std::remove_cv<T>::type>;
-  using is_mem =
-      typename is_space<T>::template mem<typename std::remove_cv<T>::type>;
-  using is_dev =
-      typename is_space<T>::template dev<typename std::remove_cv<T>::type>;
+  using is_exe = typename is_space<T>::template exe<std::remove_cv_t<T>>;
+  using is_mem = typename is_space<T>::template mem<std::remove_cv_t<T>>;
+  using is_dev = typename is_space<T>::template dev<std::remove_cv_t<T>>;
 
  public:
   static constexpr bool value = is_exe::value || is_mem::value || is_dev::value;
@@ -501,11 +494,11 @@ struct SpaceAccessibility {
   // to be able to access MemorySpace?
   // If same memory space or not accessible use the AccessSpace
   // else construct a device with execution space and memory space.
-  using space = typename std::conditional<
+  using space = std::conditional_t<
       std::is_same<typename AccessSpace::memory_space, MemorySpace>::value ||
           !exe_access::accessible,
       AccessSpace,
-      Kokkos::Device<typename AccessSpace::execution_space, MemorySpace>>::type;
+      Kokkos::Device<typename AccessSpace::execution_space, MemorySpace>>;
 };
 
 }  // namespace Kokkos

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1261,9 +1261,9 @@ inline void contiguous_fill(
   using ViewTypeFlat = Kokkos::View<
       typename ViewType::value_type*, Kokkos::LayoutRight,
       Kokkos::Device<typename ViewType::execution_space,
-                     typename std::conditional<ViewType::Rank == 0,
-                                               typename ViewType::memory_space,
-                                               Kokkos::AnonymousSpace>::type>,
+                     std::conditional_t<ViewType::Rank == 0,
+                                        typename ViewType::memory_space,
+                                        Kokkos::AnonymousSpace>>,
       Kokkos::MemoryTraits<0>>;
 
   ViewTypeFlat dst_flat(dst.data(), dst.size());
@@ -1423,9 +1423,10 @@ inline void deep_copy(
 
   // Lets call the right ViewFill functor based on integer space needed and
   // iteration type
-  using ViewTypeUniform = typename std::conditional<
-      ViewType::Rank == 0, typename ViewType::uniform_runtime_type,
-      typename ViewType::uniform_runtime_nomemspace_type>::type;
+  using ViewTypeUniform =
+      std::conditional_t<ViewType::Rank == 0,
+                         typename ViewType::uniform_runtime_type,
+                         typename ViewType::uniform_runtime_nomemspace_type>;
   if (dst.span() > static_cast<size_t>(std::numeric_limits<int>::max())) {
     if (iterate == Kokkos::Iterate::Right)
       Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutRight,
@@ -2507,10 +2508,10 @@ inline void deep_copy(
   } else if (dst.span_is_contiguous()) {
     Impl::contiguous_fill_or_memset(space, dst, value);
   } else {
-    using ViewTypeUniform = typename std::conditional<
+    using ViewTypeUniform = std::conditional_t<
         View<DT, DP...>::Rank == 0,
         typename View<DT, DP...>::uniform_runtime_type,
-        typename View<DT, DP...>::uniform_runtime_nomemspace_type>::type;
+        typename View<DT, DP...>::uniform_runtime_nomemspace_type>;
     Kokkos::Impl::ViewFill<ViewTypeUniform, typename dst_traits::array_layout,
                            ExecSpace>(dst, value, space);
   }
@@ -2552,10 +2553,10 @@ inline void deep_copy(
     if (dst.span_is_contiguous()) {
       Impl::contiguous_fill_or_memset(fill_exec_space(), dst, value);
     } else {
-      using ViewTypeUniform = typename std::conditional<
+      using ViewTypeUniform = std::conditional_t<
           View<DT, DP...>::Rank == 0,
           typename View<DT, DP...>::uniform_runtime_type,
-          typename View<DT, DP...>::uniform_runtime_nomemspace_type>::type;
+          typename View<DT, DP...>::uniform_runtime_nomemspace_type>;
       Kokkos::Impl::ViewFill<ViewTypeUniform, typename dst_traits::array_layout,
                              fill_exec_space>(dst, value, fill_exec_space());
     }
@@ -2826,8 +2827,8 @@ inline void deep_copy(
       Impl::view_copy(exec_space, dst, src);
     } else if (DstExecCanAccessSrc || SrcExecCanAccessDst) {
       using cpy_exec_space =
-          typename std::conditional<DstExecCanAccessSrc, dst_execution_space,
-                                    src_execution_space>::type;
+          std::conditional_t<DstExecCanAccessSrc, dst_execution_space,
+                             src_execution_space>;
       exec_space.fence(
           "Kokkos::deep_copy: view-to-view noncontiguous copy on space, pre "
           "copy");
@@ -3172,8 +3173,8 @@ struct MirrorViewType {
   using dest_view_type = Kokkos::View<data_type, array_layout, Space>;
   // If it is the same memory_space return the existsing view_type
   // This will also keep the unmanaged trait if necessary
-  using view_type = typename std::conditional<is_same_memspace, src_view_type,
-                                              dest_view_type>::type;
+  using view_type =
+      std::conditional_t<is_same_memspace, src_view_type, dest_view_type>;
 };
 
 template <class Space, class T, class... P>

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -808,7 +808,7 @@ KOKKOS_INLINE_FUNCTION_DELETED
 template <typename iType1, typename iType2, class TeamMemberType,
           class _never_use_this_overload>
 KOKKOS_INLINE_FUNCTION_DELETED Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, TeamMemberType>
+    std::common_type_t<iType1, iType2>, TeamMemberType>
 TeamThreadRange(const TeamMemberType&, const iType1& begin,
                 const iType2& end) = delete;
 
@@ -834,7 +834,7 @@ KOKKOS_INLINE_FUNCTION_DELETED
 template <typename iType1, typename iType2, class TeamMemberType,
           class _never_use_this_overload>
 KOKKOS_INLINE_FUNCTION_DELETED Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, TeamMemberType>
+    std::common_type_t<iType1, iType2>, TeamMemberType>
 TeamVectorRange(const TeamMemberType&, const iType1& begin,
                 const iType2& end) = delete;
 
@@ -853,7 +853,7 @@ KOKKOS_INLINE_FUNCTION_DELETED
 template <typename iType1, typename iType2, class TeamMemberType,
           class _never_use_this_overload>
 KOKKOS_INLINE_FUNCTION_DELETED Impl::ThreadVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, TeamMemberType>
+    std::common_type_t<iType1, iType2>, TeamMemberType>
 ThreadVectorRange(const TeamMemberType&, const iType1& arg_begin,
                   const iType2& arg_end) = delete;
 

--- a/core/src/Kokkos_Future.hpp
+++ b/core/src/Kokkos_Future.hpp
@@ -465,14 +465,13 @@ class ResolveFutureArgOrder {
   static_assert(!(Arg1_is_value && Arg2_is_value),
                 "Future cannot be given two value types");
 
-  using value_type = typename std::conditional<
-      Arg1_is_value, Arg1,
-      typename std::conditional<Arg2_is_value, Arg2, void>::type>::type;
+  using value_type =
+      std::conditional_t<Arg1_is_value, Arg1,
+                         std::conditional_t<Arg2_is_value, Arg2, void>>;
 
-  using execution_space = typename std::conditional<
+  using execution_space = typename std::conditional_t<
       Arg1_is_space, Arg1,
-      typename std::conditional<Arg2_is_space, Arg2,
-                                void>::type>::type::execution_space;
+      std::conditional_t<Arg2_is_space, Arg2, void>>::execution_space;
 
  public:
   using type = BasicFuture<value_type, TaskScheduler<execution_space>>;

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -225,7 +225,7 @@ class GraphNodeRef {
 
   template <
       class OtherKernel, class OtherPredecessor,
-      typename std::enable_if_t<
+      std::enable_if_t<
           // Not a copy/move constructor
           !std::is_same<GraphNodeRef, GraphNodeRef<execution_space, OtherKernel,
                                                    OtherPredecessor>>::value &&
@@ -353,8 +353,7 @@ class GraphNodeRef {
     // needs static assertion of constraint:
     //   DataParallelReductionFunctor<Functor, ReturnType>
 
-    using policy_t = typename std::remove_cv<
-        typename std::remove_reference<Policy>::type>::type;
+    using policy_t = std::remove_cv_t<std::remove_reference_t<Policy>>;
     static_assert(
         std::is_same<typename policy_t::execution_space,
                      execution_space>::value,
@@ -380,8 +379,8 @@ class GraphNodeRef {
 
     //----------------------------------------
     // This is a disaster, but I guess it's not a my disaster to fix right now
-    using return_type_remove_cvref = typename std::remove_cv<
-        typename std::remove_reference<ReturnType>::type>::type;
+    using return_type_remove_cvref =
+        std::remove_cv_t<std::remove_reference_t<ReturnType>>;
     static_assert(Kokkos::is_view<return_type_remove_cvref>::value ||
                       Kokkos::is_reducer<return_type_remove_cvref>::value,
                   "Output argument to parallel reduce in a graph must be a "

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -2129,10 +2129,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::HPXTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::HPXTeamMember>
 TeamThreadRange(const Impl::HPXTeamMember &thread, const iType1 &i_begin,
                 const iType2 &i_end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamThreadRangeBoundariesStruct<iType, Impl::HPXTeamMember>(
       thread, iType(i_begin), iType(i_end));
 }
@@ -2147,10 +2147,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::HPXTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::HPXTeamMember>
 TeamVectorRange(const Impl::HPXTeamMember &thread, const iType1 &i_begin,
                 const iType2 &i_end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamThreadRangeBoundariesStruct<iType, Impl::HPXTeamMember>(
       thread, iType(i_begin), iType(i_end));
 }
@@ -2165,10 +2165,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::ThreadVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::HPXTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::HPXTeamMember>
 ThreadVectorRange(const Impl::HPXTeamMember &thread, const iType1 &i_begin,
                   const iType2 &i_end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::HPXTeamMember>(
       thread, iType(i_begin), iType(i_end));
 }

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -204,13 +204,12 @@ struct HostMirror {
   };
 
  public:
-  using Space = typename std::conditional<
+  using Space = std::conditional_t<
       keep_exe && keep_mem, S,
-      typename std::conditional<
-          keep_mem,
-          Kokkos::Device<Kokkos::HostSpace::execution_space,
-                         typename S::memory_space>,
-          Kokkos::HostSpace>::type>::type;
+      std::conditional_t<keep_mem,
+                         Kokkos::Device<Kokkos::HostSpace::execution_space,
+                                        typename S::memory_space>,
+                         Kokkos::HostSpace>>;
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_LogicalSpaces.hpp
+++ b/core/src/Kokkos_LogicalSpaces.hpp
@@ -98,9 +98,9 @@ class LogicalMemorySpace {
   /// parallel using the View's default execution space).
 
   using execution_space =
-      typename std::conditional<std::is_void<DefaultBaseExecutionSpace>::value,
-                                typename BaseSpace::execution_space,
-                                DefaultBaseExecutionSpace>::type;
+      std::conditional_t<std::is_void<DefaultBaseExecutionSpace>::value,
+                         typename BaseSpace::execution_space,
+                         DefaultBaseExecutionSpace>;
 
   using device_type = Kokkos::Device<execution_space, memory_space>;
 

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -65,7 +65,7 @@ struct Sum {
  public:
   // Required
   using reducer    = Sum<Scalar, Space>;
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   using result_view_type = Kokkos::View<value_type, Space>;
 
@@ -105,7 +105,7 @@ struct Prod {
  public:
   // Required
   using reducer    = Prod<Scalar, Space>;
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   using result_view_type = Kokkos::View<value_type, Space>;
 
@@ -145,7 +145,7 @@ struct Min {
  public:
   // Required
   using reducer    = Min<Scalar, Space>;
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   using result_view_type = Kokkos::View<value_type, Space>;
 
@@ -187,7 +187,7 @@ struct Max {
  public:
   // Required
   using reducer    = Max<Scalar, Space>;
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   using result_view_type = Kokkos::View<value_type, Space>;
 
@@ -230,7 +230,7 @@ struct LAnd {
  public:
   // Required
   using reducer    = LAnd<Scalar, Space>;
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   using result_view_type = Kokkos::View<value_type, Space>;
 
@@ -271,7 +271,7 @@ struct LOr {
  public:
   // Required
   using reducer    = LOr<Scalar, Space>;
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   using result_view_type = Kokkos::View<value_type, Space>;
 
@@ -313,7 +313,7 @@ struct BAnd {
  public:
   // Required
   using reducer    = BAnd<Scalar, Space>;
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   using result_view_type = Kokkos::View<value_type, Space>;
 
@@ -355,7 +355,7 @@ struct BOr {
  public:
   // Required
   using reducer    = BOr<Scalar, Space>;
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   using result_view_type = Kokkos::View<value_type, Space>;
 
@@ -407,8 +407,8 @@ struct ValLocScalar {
 template <class Scalar, class Index, class Space>
 struct MinLoc {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -454,8 +454,8 @@ struct MinLoc {
 template <class Scalar, class Index, class Space>
 struct MaxLoc {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -512,7 +512,7 @@ struct MinMaxScalar {
 template <class Scalar, class Space>
 struct MinMax {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
 
  public:
   // Required
@@ -577,8 +577,8 @@ struct MinMaxLocScalar {
 template <class Scalar, class Index, class Space>
 struct MinMaxLoc {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -640,8 +640,8 @@ struct MinMaxLoc {
 template <class Scalar, class Index, class Space>
 struct MaxFirstLoc {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -695,8 +695,8 @@ struct MaxFirstLoc {
 template <class Scalar, class Index, class ComparatorType, class Space>
 struct MaxFirstLocCustomComparator {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -753,8 +753,8 @@ struct MaxFirstLocCustomComparator {
 template <class Scalar, class Index, class Space>
 struct MinFirstLoc {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -808,8 +808,8 @@ struct MinFirstLoc {
 template <class Scalar, class Index, class ComparatorType, class Space>
 struct MinFirstLocCustomComparator {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -866,8 +866,8 @@ struct MinFirstLocCustomComparator {
 template <class Scalar, class Index, class Space>
 struct MinMaxFirstLastLoc {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -932,8 +932,8 @@ struct MinMaxFirstLastLoc {
 template <class Scalar, class Index, class ComparatorType, class Space>
 struct MinMaxFirstLastLocCustomComparator {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -1008,7 +1008,7 @@ struct FirstLocScalar {
 template <class Index, class Space>
 struct FirstLoc {
  private:
-  using index_type = typename std::remove_cv<Index>::type;
+  using index_type = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -1066,7 +1066,7 @@ struct LastLocScalar {
 template <class Index, class Space>
 struct LastLoc {
  private:
-  using index_type = typename std::remove_cv<Index>::type;
+  using index_type = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -1127,7 +1127,7 @@ struct StdIsPartScalar {
 template <class Index, class Space>
 struct StdIsPartitioned {
  private:
-  using index_type = typename std::remove_cv<Index>::type;
+  using index_type = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -1193,7 +1193,7 @@ struct StdPartPointScalar {
 template <class Index, class Space>
 struct StdPartitionPoint {
  private:
-  using index_type = typename std::remove_cv<Index>::type;
+  using index_type = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -1287,7 +1287,7 @@ struct ParallelReduceReturnValue<
     std::enable_if_t<(std::is_array<ReturnType>::value ||
                       std::is_pointer<ReturnType>::value)>,
     ReturnType, FunctorType> {
-  using return_type = Kokkos::View<typename std::remove_const<ReturnType>::type,
+  using return_type = Kokkos::View<std::remove_const_t<ReturnType>,
                                    Kokkos::HostSpace, Kokkos::MemoryUnmanaged>;
 
   using reducer_type = InvalidType;

--- a/core/src/Kokkos_TaskScheduler.hpp
+++ b/core/src/Kokkos_TaskScheduler.hpp
@@ -145,7 +145,7 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
                   typename task_base::destroy_type /*arg_destroy*/,
                   FunctorType&& arg_functor) {
     using functor_future_type =
-        future_type_for_functor<typename std::decay<FunctorType>::type>;
+        future_type_for_functor<std::decay_t<FunctorType>>;
     using task_type =
         Impl::Task<BasicTaskScheduler, typename functor_future_type::value_type,
                    FunctorType>;
@@ -301,11 +301,9 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
   }
 
   template <int TaskEnum, typename DepFutureType, typename FunctorType>
-  KOKKOS_FUNCTION
-      future_type_for_functor<typename std::decay<FunctorType>::type>
-      spawn(
-          Impl::TaskPolicyWithPredecessor<TaskEnum, DepFutureType>&& arg_policy,
-          FunctorType&& arg_functor) {
+  KOKKOS_FUNCTION future_type_for_functor<std::decay_t<FunctorType>> spawn(
+      Impl::TaskPolicyWithPredecessor<TaskEnum, DepFutureType>&& arg_policy,
+      FunctorType&& arg_functor) {
     using task_type = runnable_task_type<FunctorType>;
     typename task_type::function_type const ptr = task_type::apply;
     typename task_type::destroy_type const dtor = task_type::destroy;
@@ -521,7 +519,7 @@ namespace Kokkos {
 
 template <class T, class Scheduler>
 Impl::TaskPolicyWithPredecessor<Impl::TaskType::TaskTeam,
-                                Kokkos::BasicFuture<T, Scheduler> >
+                                Kokkos::BasicFuture<T, Scheduler>>
     KOKKOS_INLINE_FUNCTION
     TaskTeam(Kokkos::BasicFuture<T, Scheduler> arg_future,
              TaskPriority arg_priority = TaskPriority::Regular) {
@@ -558,7 +556,7 @@ Impl::TaskPolicyWithScheduler<Kokkos::Impl::TaskType::TaskTeam, Scheduler,
 
 template <class T, class Scheduler>
 Impl::TaskPolicyWithPredecessor<Impl::TaskType::TaskSingle,
-                                Kokkos::BasicFuture<T, Scheduler> >
+                                Kokkos::BasicFuture<T, Scheduler>>
     KOKKOS_INLINE_FUNCTION
     TaskSingle(Kokkos::BasicFuture<T, Scheduler> arg_future,
                TaskPriority arg_priority = TaskPriority::Regular) {
@@ -601,8 +599,7 @@ Impl::TaskPolicyWithScheduler<Kokkos::Impl::TaskType::TaskSingle, Scheduler,
  */
 template <int TaskEnum, typename Scheduler, typename DepFutureType,
           typename FunctorType>
-typename Scheduler::template future_type_for_functor<
-    typename std::decay<FunctorType>::type>
+typename Scheduler::template future_type_for_functor<std::decay_t<FunctorType>>
 host_spawn(Impl::TaskPolicyWithScheduler<TaskEnum, Scheduler, DepFutureType>
                arg_policy,
            FunctorType&& arg_functor) {
@@ -633,8 +630,7 @@ host_spawn(Impl::TaskPolicyWithScheduler<TaskEnum, Scheduler, DepFutureType>
  */
 template <int TaskEnum, typename Scheduler, typename DepFutureType,
           typename FunctorType>
-typename Scheduler::template future_type_for_functor<
-    typename std::decay<FunctorType>::type>
+typename Scheduler::template future_type_for_functor<std::decay_t<FunctorType>>
     KOKKOS_INLINE_FUNCTION
     task_spawn(Impl::TaskPolicyWithScheduler<TaskEnum, Scheduler, DepFutureType>
                    arg_policy,

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -85,7 +85,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<Sum<Scalar, Space>> {
  public:
   // Required
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   // Required
   KOKKOS_INLINE_FUNCTION
@@ -106,7 +106,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<Prod<Scalar, Space>> {
  public:
   // Required
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   // Required
   KOKKOS_INLINE_FUNCTION
@@ -127,7 +127,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<Min<Scalar, Space>> {
  public:
   // Required
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   // Required
   KOKKOS_INLINE_FUNCTION
@@ -150,7 +150,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<Max<Scalar, Space>> {
  public:
   // Required
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   // Required
   KOKKOS_INLINE_FUNCTION
@@ -174,7 +174,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<LAnd<Scalar, Space>> {
  public:
   // Required
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   KOKKOS_INLINE_FUNCTION
   static void join(value_type& dest, const value_type& src) {
@@ -196,7 +196,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<LOr<Scalar, Space>> {
  public:
   // Required
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   using result_view_type = Kokkos::View<value_type, Space>;
 
@@ -221,7 +221,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<BAnd<Scalar, Space>> {
  public:
   // Required
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   // Required
   KOKKOS_INLINE_FUNCTION
@@ -244,7 +244,7 @@ template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<BOr<Scalar, Space>> {
  public:
   // Required
-  using value_type = typename std::remove_cv<Scalar>::type;
+  using value_type = std::remove_cv_t<Scalar>;
 
   // Required
   KOKKOS_INLINE_FUNCTION
@@ -266,8 +266,8 @@ struct OpenMPTargetReducerWrapper<BOr<Scalar, Space>> {
 template <class Scalar, class Index, class Space>
 struct OpenMPTargetReducerWrapper<MinLoc<Scalar, Index, Space>> {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -294,8 +294,8 @@ struct OpenMPTargetReducerWrapper<MinLoc<Scalar, Index, Space>> {
 template <class Scalar, class Index, class Space>
 struct OpenMPTargetReducerWrapper<MaxLoc<Scalar, Index, Space>> {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -321,7 +321,7 @@ struct OpenMPTargetReducerWrapper<MaxLoc<Scalar, Index, Space>> {
 template <class Scalar, class Space>
 struct OpenMPTargetReducerWrapper<MinMax<Scalar, Space>> {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
 
  public:
   // Required
@@ -358,8 +358,8 @@ struct OpenMPTargetReducerWrapper<MinMax<Scalar, Space>> {
 template <class Scalar, class Index, class Space>
 struct OpenMPTargetReducerWrapper<MinMaxLoc<Scalar, Index, Space>> {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -405,8 +405,8 @@ struct OpenMPTargetReducerWrapper<MinMaxLoc<Scalar, Index, Space>> {
 template <class Scalar, class Index, class Space>
 struct OpenMPTargetReducerWrapper<MaxFirstLoc<Scalar, Index, Space>> {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -448,8 +448,8 @@ struct OpenMPTargetReducerWrapper<MaxFirstLoc<Scalar, Index, Space>> {
 template <class Scalar, class Index, class Space>
 struct OpenMPTargetReducerWrapper<MinFirstLoc<Scalar, Index, Space>> {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -491,8 +491,8 @@ struct OpenMPTargetReducerWrapper<MinFirstLoc<Scalar, Index, Space>> {
 template <class Scalar, class Index, class Space>
 struct OpenMPTargetReducerWrapper<MinMaxFirstLastLoc<Scalar, Index, Space>> {
  private:
-  using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using scalar_type = std::remove_cv_t<Scalar>;
+  using index_type  = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -553,7 +553,7 @@ struct OpenMPTargetReducerWrapper<MinMaxFirstLastLoc<Scalar, Index, Space>> {
 template <class Index, class Space>
 struct OpenMPTargetReducerWrapper<FirstLoc<Index, Space>> {
  private:
-  using index_type = typename std::remove_cv<Index>::type;
+  using index_type = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -591,7 +591,7 @@ struct OpenMPTargetReducerWrapper<FirstLoc<Index, Space>> {
 template <class Index, class Space>
 struct OpenMPTargetReducerWrapper<LastLoc<Index, Space>> {
  private:
-  using index_type = typename std::remove_cv<Index>::type;
+  using index_type = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -629,7 +629,7 @@ struct OpenMPTargetReducerWrapper<LastLoc<Index, Space>> {
 template <class Index, class Space>
 struct OpenMPTargetReducerWrapper<StdIsPartitioned<Index, Space>> {
  private:
-  using index_type = typename std::remove_cv<Index>::type;
+  using index_type = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -676,7 +676,7 @@ struct OpenMPTargetReducerWrapper<StdIsPartitioned<Index, Space>> {
 template <class Index, class Space>
 struct OpenMPTargetReducerWrapper<StdPartitionPoint<Index, Space>> {
  private:
-  using index_type = typename std::remove_cv<Index>::type;
+  using index_type = std::remove_cv_t<Index>;
 
  public:
   // Required
@@ -835,9 +835,8 @@ class OpenMPTargetExecTeamMember {
   KOKKOS_INLINE_FUNCTION void team_broadcast(ValueType& value,
                                              int thread_id) const {
     // Make sure there is enough scratch space:
-    using type =
-        typename std::conditional<(sizeof(ValueType) < TEAM_REDUCE_SIZE),
-                                  ValueType, void>::type;
+    using type = std::conditional_t<(sizeof(ValueType) < TEAM_REDUCE_SIZE),
+                                    ValueType, void>;
     type* team_scratch =
         reinterpret_cast<type*>(static_cast<char*>(m_glb_scratch) +
                                 TEAM_REDUCE_SIZE * omp_get_team_num());
@@ -1314,11 +1313,10 @@ TeamThreadRange(const Impl::OpenMPTargetExecTeamMember& thread,
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type,
-    Impl::OpenMPTargetExecTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::OpenMPTargetExecTeamMember>
 TeamThreadRange(const Impl::OpenMPTargetExecTeamMember& thread,
                 const iType1& begin, const iType2& end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamThreadRangeBoundariesStruct<
       iType, Impl::OpenMPTargetExecTeamMember>(thread, iType(begin),
                                                iType(end));
@@ -1335,11 +1333,10 @@ ThreadVectorRange(const Impl::OpenMPTargetExecTeamMember& thread,
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::ThreadVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type,
-    Impl::OpenMPTargetExecTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::OpenMPTargetExecTeamMember>
 ThreadVectorRange(const Impl::OpenMPTargetExecTeamMember& thread,
                   const iType1& arg_begin, const iType2& arg_end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::ThreadVectorRangeBoundariesStruct<
       iType, Impl::OpenMPTargetExecTeamMember>(thread, iType(arg_begin),
                                                iType(arg_end));
@@ -1356,11 +1353,10 @@ TeamVectorRange(const Impl::OpenMPTargetExecTeamMember& thread,
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type,
-    Impl::OpenMPTargetExecTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::OpenMPTargetExecTeamMember>
 TeamVectorRange(const Impl::OpenMPTargetExecTeamMember& thread,
                 const iType1& arg_begin, const iType2& arg_end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamVectorRangeBoundariesStruct<
       iType, Impl::OpenMPTargetExecTeamMember>(thread, iType(arg_begin),
                                                iType(arg_end));

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -146,8 +146,8 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
   using PolicyType = Kokkos::RangePolicy<PolicyArgs...>;
   using TagType    = typename PolicyType::work_tag;
   using ReducerTypeFwd =
-      typename std::conditional<std::is_same<InvalidType, ReducerType>::value,
-                                FunctorType, ReducerType>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value,
+                         FunctorType, ReducerType>;
   using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
                                          PolicyType, ReducerTypeFwd>;
   using ReferenceType = typename Analysis::reference_type;
@@ -420,8 +420,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   using WorkRange = typename Policy::WorkRange;
 
   using ReducerTypeFwd =
-      typename std::conditional<std::is_same<InvalidType, ReducerType>::value,
-                                FunctorType, ReducerType>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value,
+                         FunctorType, ReducerType>;
   using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
                                          Policy, ReducerTypeFwd>;
 
@@ -836,8 +836,8 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
   using PolicyType = TeamPolicyInternal<PolicyArgs...>;
   using TagType    = typename PolicyType::work_tag;
   using ReducerTypeFwd =
-      typename std::conditional<std::is_same<InvalidType, ReducerType>::value,
-                                FunctorType, ReducerType>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value,
+                         FunctorType, ReducerType>;
   using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
                                          PolicyType, ReducerTypeFwd>;
 
@@ -1170,8 +1170,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   using WorkTag = typename Policy::work_tag;
   using Member  = typename Policy::member_type;
   using ReducerTypeFwd =
-      typename std::conditional<std::is_same<InvalidType, ReducerType>::value,
-                                FunctorType, ReducerType>::type;
+      std::conditional_t<std::is_same<InvalidType, ReducerType>::value,
+                         FunctorType, ReducerType>;
   using WorkTagFwd =
       std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
                          void>;

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -455,9 +455,9 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::SYCLTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::SYCLTeamMember>
 TeamThreadRange(const Impl::SYCLTeamMember& thread, iType1 begin, iType2 end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamThreadRangeBoundariesStruct<iType, Impl::SYCLTeamMember>(
       thread, iType(begin), iType(end));
 }
@@ -472,10 +472,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::SYCLTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::SYCLTeamMember>
 TeamVectorRange(const Impl::SYCLTeamMember& thread, const iType1& begin,
                 const iType2& end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>(
       thread, iType(begin), iType(end));
 }
@@ -490,10 +490,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::ThreadVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Impl::SYCLTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::SYCLTeamMember>
 ThreadVectorRange(const Impl::SYCLTeamMember& thread, iType1 arg_begin,
                   iType2 arg_end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>(
       thread, iType(arg_begin), iType(arg_end));
 }

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -826,11 +826,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type,
-    Impl::ThreadsExecTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::ThreadsExecTeamMember>
 TeamThreadRange(const Impl::ThreadsExecTeamMember& thread, const iType1& begin,
                 const iType2& end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamThreadRangeBoundariesStruct<iType,
                                                Impl::ThreadsExecTeamMember>(
       thread, iType(begin), iType(end));
@@ -848,11 +847,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type,
-    Impl::ThreadsExecTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::ThreadsExecTeamMember>
 TeamVectorRange(const Impl::ThreadsExecTeamMember& thread, const iType1& begin,
                 const iType2& end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamThreadRangeBoundariesStruct<iType,
                                                Impl::ThreadsExecTeamMember>(
       thread, iType(begin), iType(end));
@@ -870,11 +868,10 @@ KOKKOS_INLINE_FUNCTION
 
 template <typename iType1, typename iType2>
 KOKKOS_INLINE_FUNCTION Impl::ThreadVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type,
-    Impl::ThreadsExecTeamMember>
+    std::common_type_t<iType1, iType2>, Impl::ThreadsExecTeamMember>
 ThreadVectorRange(const Impl::ThreadsExecTeamMember& thread,
                   const iType1& arg_begin, const iType2& arg_end) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::ThreadVectorRangeBoundariesStruct<iType,
                                                  Impl::ThreadsExecTeamMember>(
       thread, iType(arg_begin), iType(arg_end));

--- a/core/src/desul/atomics/CUDA.hpp
+++ b/core/src/desul/atomics/CUDA.hpp
@@ -49,14 +49,14 @@ struct is_cuda_atomic_sub_type {
 // Atomic Add
 template <class T>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_add_type<T>::value, T>
     atomic_fetch_add(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
   return atomicAdd(dest, val);
 }
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_add_type<T>::value, T>
     atomic_fetch_add(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
   T return_val = atomicAdd(dest, val);
@@ -66,7 +66,7 @@ __device__ inline
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_add_type<T>::value, T>
     atomic_fetch_add(T* dest, T val, MemoryOrder, MemoryScopeCore) {
   return atomic_fetch_add(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
@@ -74,14 +74,14 @@ __device__ inline
 // Atomic Sub
 template <class T>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_sub_type<T>::value, T>
     atomic_fetch_sub(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
   return atomicSub(dest, val);
 }
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_sub_type<T>::value, T>
     atomic_fetch_sub(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
   T return_val = atomicSub(dest, val);
@@ -91,7 +91,7 @@ __device__ inline
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_sub_type<T>::value, T>
     atomic_fetch_sub(T* dest, T val, MemoryOrder, MemoryScopeCore) {
   return atomic_fetch_sub(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
@@ -153,14 +153,14 @@ __device__ inline unsigned int atomic_fetch_dec_mod(unsigned int* dest,
 // Atomic Inc
 template <typename T>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_add_type<T>::value, T>
     atomic_fetch_inc(T* dest, MemoryOrderRelaxed, MemoryScopeDevice) {
   return atomicAdd(dest, T(1));
 }
 
 template <typename T, typename MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_add_type<T>::value, T>
     atomic_fetch_inc(T* dest, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
   T return_val = atomicAdd(dest, T(1));
@@ -171,7 +171,7 @@ __device__ inline
 
 template <typename T, typename MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_add_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_add_type<T>::value, T>
     atomic_fetch_inc(T* dest, MemoryOrder, MemoryScopeCore) {
   return atomic_fetch_add(dest, T(1), MemoryOrder(), MemoryScopeDevice());
 }
@@ -179,14 +179,14 @@ __device__ inline
 // Atomic Dec
 template <typename T>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_sub_type<T>::value, T>
     atomic_fetch_dec(T* dest, MemoryOrderRelaxed, MemoryScopeDevice) {
   return atomicSub(dest, T(1));
 }
 
 template <typename T, typename MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_sub_type<T>::value, T>
     atomic_fetch_dec(T* dest, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
   T return_val = atomicSub(dest, T(1));
@@ -196,7 +196,7 @@ __device__ inline
 
 template <typename T, typename MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_sub_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_sub_type<T>::value, T>
     atomic_fetch_dec(T* dest, MemoryOrder, MemoryScopeCore) {
   return atomic_fetch_sub(dest, T(1), MemoryOrder(), MemoryScopeDevice());
 }
@@ -204,14 +204,14 @@ __device__ inline
 // Atomic Max
 template <class T>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_max(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
   return atomicMax(dest, val);
 }
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_max(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
   T return_val = atomicMax(dest, val);
@@ -221,7 +221,7 @@ __device__ inline
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_max(T* dest, T val, MemoryOrder, MemoryScopeCore) {
   return atomic_fetch_max(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
@@ -229,14 +229,14 @@ __device__ inline
 // Atomic Min
 template <class T>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_min(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
   return atomicMin(dest, val);
 }
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_min(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
   T return_val = atomicMin(dest, val);
@@ -246,7 +246,7 @@ __device__ inline
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_min(T* dest, T val, MemoryOrder, MemoryScopeCore) {
   return atomic_fetch_min(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
@@ -254,14 +254,14 @@ __device__ inline
 // Atomic And
 template <class T>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_and(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
   return atomicAnd(dest, val);
 }
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_and(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
   T return_val = atomicAnd(dest, val);
@@ -271,7 +271,7 @@ __device__ inline
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_and(T* dest, T val, MemoryOrder, MemoryScopeCore) {
   return atomic_fetch_and(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
@@ -279,14 +279,14 @@ __device__ inline
 // Atomic XOR
 template <class T>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_xor(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
   return atomicXor(dest, val);
 }
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_xor(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
   T return_val = atomicXor(dest, val);
@@ -296,7 +296,7 @@ __device__ inline
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_xor(T* dest, T val, MemoryOrder, MemoryScopeCore) {
   return atomic_fetch_xor(dest, val, MemoryOrder(), MemoryScopeDevice());
 }
@@ -304,14 +304,14 @@ __device__ inline
 // Atomic OR
 template <class T>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_or(T* dest, T val, MemoryOrderRelaxed, MemoryScopeDevice) {
   return atomicOr(dest, val);
 }
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_or(T* dest, T val, MemoryOrder, MemoryScopeDevice) {
   __threadfence();
   T return_val = atomicOr(dest, val);
@@ -321,7 +321,7 @@ __device__ inline
 
 template <class T, class MemoryOrder>
 __device__ inline
-    typename std::enable_if<Impl::is_cuda_atomic_integer_type<T>::value, T>::type
+    std::enable_if_t<Impl::is_cuda_atomic_integer_type<T>::value, T>
     atomic_fetch_or(T* dest, T val, MemoryOrder, MemoryScopeCore) {
   return atomic_fetch_or(dest, val, MemoryOrder(), MemoryScopeDevice());
 }

--- a/core/src/impl/KokkosExp_Host_IterateTile.hpp
+++ b/core/src/impl/KokkosExp_Host_IterateTile.hpp
@@ -1916,7 +1916,7 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
 
   RP const& m_rp;
   Functor const& m_func;
-  typename std::conditional<std::is_void<Tag>::value, int, Tag>::type m_tag;
+  std::conditional_t<std::is_void<Tag>::value, int, Tag> m_tag;
 };
 
 // For ParallelReduce
@@ -2334,7 +2334,7 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
   RP const& m_rp;
   Functor const& m_func;
   value_type& m_v;
-  typename std::conditional<std::is_void<Tag>::value, int, Tag>::type m_tag;
+  std::conditional_t<std::is_void<Tag>::value, int, Tag> m_tag;
 };
 
 // For ParallelReduce
@@ -2753,7 +2753,7 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
   RP const& m_rp;
   Functor const& m_func;
   value_type* m_v;
-  typename std::conditional<std::is_void<Tag>::value, int, Tag>::type m_tag;
+  std::conditional_t<std::is_void<Tag>::value, int, Tag> m_tag;
 };
 
 // ------------------------------------------------------------------ //

--- a/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
+++ b/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
@@ -378,12 +378,10 @@ KOKKOS_INTERNAL_INLINE_DEVICE_IF_CUDA_ARCH bool _atomic_compare_exchange_strong(
     std::enable_if_t<
         (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8 ||
          sizeof(T) == 16) &&
-            std::is_same<
-                typename MemoryOrderSuccess::memory_order,
-                typename std::remove_cv<MemoryOrderSuccess>::type>::value &&
-            std::is_same<
-                typename MemoryOrderFailure::memory_order,
-                typename std::remove_cv<MemoryOrderFailure>::type>::value,
+            std::is_same<typename MemoryOrderSuccess::memory_order,
+                         std::remove_cv_t<MemoryOrderSuccess>>::value &&
+            std::is_same<typename MemoryOrderFailure::memory_order,
+                         std::remove_cv_t<MemoryOrderFailure>>::value,
         void const**> = nullptr) {
   return __atomic_compare_exchange_n(dest, &compare, val, /* weak = */ false,
                                      MemoryOrderSuccess::gnu_constant,
@@ -397,12 +395,10 @@ KOKKOS_INTERNAL_INLINE_DEVICE_IF_CUDA_ARCH bool _atomic_compare_exchange_strong(
     std::enable_if_t<
         !(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
           sizeof(T) == 8 || sizeof(T) == 16) &&
-            std::is_same<
-                typename MemoryOrderSuccess::memory_order,
-                typename std::remove_cv<MemoryOrderSuccess>::type>::value &&
-            std::is_same<
-                typename MemoryOrderFailure::memory_order,
-                typename std::remove_cv<MemoryOrderFailure>::type>::value,
+            std::is_same<typename MemoryOrderSuccess::memory_order,
+                         std::remove_cv_t<MemoryOrderSuccess>>::value &&
+            std::is_same<typename MemoryOrderFailure::memory_order,
+                         std::remove_cv_t<MemoryOrderFailure>>::value,
         void const**> = nullptr) {
   return _atomic_compare_exchange_fallback(dest, compare, val, order_success,
                                            order_failure);

--- a/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
@@ -365,8 +365,7 @@ T atomic_fetch_add(volatile T* const dest, const T val) {
 #elif defined(KOKKOS_ENABLE_SERIAL_ATOMICS)
 
 template <typename T>
-T atomic_fetch_add(volatile T* const dest_v,
-                   typename std::add_const<T>::type val) {
+T atomic_fetch_add(volatile T* const dest_v, std::add_const_t<T> val) {
   T* dest  = const_cast<T*>(dest_v);
   T retval = *dest;
   *dest += val;

--- a/core/src/impl/Kokkos_Atomic_Load.hpp
+++ b/core/src/impl/Kokkos_Atomic_Load.hpp
@@ -72,25 +72,23 @@ namespace Impl {
 template <class T, class MemoryOrder>
 KOKKOS_INTERNAL_INLINE_DEVICE_IF_CUDA_ARCH T _atomic_load(
     T* ptr, MemoryOrder,
-    std::enable_if_t<
-        (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
-         sizeof(T) == 8) &&
-            std::is_same<typename MemoryOrder::memory_order,
-                         typename std::remove_cv<MemoryOrder>::type>::value,
-        void const**> = nullptr) {
+    std::enable_if_t<(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
+                      sizeof(T) == 8) &&
+                         std::is_same<typename MemoryOrder::memory_order,
+                                      std::remove_cv_t<MemoryOrder>>::value,
+                     void const**> = nullptr) {
   return __atomic_load_n(ptr, MemoryOrder::gnu_constant);
 }
 
 template <class T, class MemoryOrder>
 KOKKOS_INTERNAL_INLINE_DEVICE_IF_CUDA_ARCH T _atomic_load(
     T* ptr, MemoryOrder,
-    std::enable_if_t<
-        !(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
-          sizeof(T) == 8) &&
-            std::is_default_constructible<T>::value &&
-            std::is_same<typename MemoryOrder::memory_order,
-                         typename std::remove_cv<MemoryOrder>::type>::value,
-        void const**> = nullptr) {
+    std::enable_if_t<!(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
+                       sizeof(T) == 8) &&
+                         std::is_default_constructible<T>::value &&
+                         std::is_same<typename MemoryOrder::memory_order,
+                                      std::remove_cv_t<MemoryOrder>>::value,
+                     void const**> = nullptr) {
   T rv{};
   __atomic_load(ptr, &rv, MemoryOrder::gnu_constant);
   return rv;

--- a/core/src/impl/Kokkos_Atomic_Store.hpp
+++ b/core/src/impl/Kokkos_Atomic_Store.hpp
@@ -72,25 +72,23 @@ namespace Impl {
 template <class T, class MemoryOrder>
 KOKKOS_INTERNAL_INLINE_DEVICE_IF_CUDA_ARCH void _atomic_store(
     T* ptr, T val, MemoryOrder,
-    std::enable_if_t<
-        (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
-         sizeof(T) == 8) &&
-            std::is_same<typename MemoryOrder::memory_order,
-                         typename std::remove_cv<MemoryOrder>::type>::value,
-        void const**> = nullptr) {
+    std::enable_if_t<(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
+                      sizeof(T) == 8) &&
+                         std::is_same<typename MemoryOrder::memory_order,
+                                      std::remove_cv_t<MemoryOrder>>::value,
+                     void const**> = nullptr) {
   __atomic_store_n(ptr, val, MemoryOrder::gnu_constant);
 }
 
 template <class T, class MemoryOrder>
 KOKKOS_INTERNAL_INLINE_DEVICE_IF_CUDA_ARCH void _atomic_store(
     T* ptr, T val, MemoryOrder,
-    std::enable_if_t<
-        !(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
-          sizeof(T) == 8) &&
-            std::is_default_constructible<T>::value &&
-            std::is_same<typename MemoryOrder::memory_order,
-                         typename std::remove_cv<MemoryOrder>::type>::value,
-        void const**> = nullptr) {
+    std::enable_if_t<!(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
+                       sizeof(T) == 8) &&
+                         std::is_default_constructible<T>::value &&
+                         std::is_same<typename MemoryOrder::memory_order,
+                                      std::remove_cv_t<MemoryOrder>>::value,
+                     void const**> = nullptr) {
   __atomic_store(ptr, &val, MemoryOrder::gnu_constant);
 }
 

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -175,25 +175,25 @@ struct _construct_combined_reducer_from_args_tag {};
 template <class T>
 KOKKOS_INLINE_FUNCTION auto _get_value_from_combined_reducer_ctor_arg(
     T&& arg) noexcept
-    -> std::enable_if_t<!is_view<typename std::decay<T>::type>::value &&
-                            !is_reducer<typename std::decay<T>::type>::value,
-                        typename std::decay<T>::type> {
+    -> std::enable_if_t<!is_view<std::decay_t<T>>::value &&
+                            !is_reducer<std::decay_t<T>>::value,
+                        std::decay_t<T>> {
   return arg;
 }
 
 template <class T>
 KOKKOS_INLINE_FUNCTION auto _get_value_from_combined_reducer_ctor_arg(
     T&& arg) noexcept ->
-    typename std::enable_if_t<is_view<typename std::decay<T>::type>::value,
-                              typename std::decay<T>::type>::value_type {
+    typename std::enable_if_t<is_view<std::decay_t<T>>::value,
+                              std::decay_t<T>>::value_type {
   return arg();
 }
 
 template <class T>
 KOKKOS_INLINE_FUNCTION auto _get_value_from_combined_reducer_ctor_arg(
     T&& arg) noexcept ->
-    typename std::enable_if_t<is_reducer<typename std::decay<T>::type>::value,
-                              typename std::decay<T>::type>::value_type {
+    typename std::enable_if_t<is_reducer<std::decay_t<T>>::value,
+                              std::decay_t<T>>::value_type {
   return arg.reference();
 }
 
@@ -414,8 +414,7 @@ struct CombinedReductionFunctorWrapper
 
 template <class Space, class Reducer>
 KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    Kokkos::is_reducer<typename std::decay<Reducer>::type>::value,
-    typename std::decay<Reducer>::type>
+    Kokkos::is_reducer<std::decay_t<Reducer>>::value, std::decay_t<Reducer>>
 _make_reducer_from_arg(Reducer&& arg_reducer) noexcept {
   return arg_reducer;
 }
@@ -437,12 +436,11 @@ struct _wrap_with_kokkos_sum<Space, T,
 //      (this is needed in general, though)
 template <class Space, class T>
 KOKKOS_INLINE_FUNCTION constexpr typename std::enable_if_t<
-    !Kokkos::is_reducer<typename std::decay<T>::type>::value,
-    _wrap_with_kokkos_sum<Space, typename std::decay<T>::type>>::type
+    !Kokkos::is_reducer<std::decay_t<T>>::value,
+    _wrap_with_kokkos_sum<Space, std::decay_t<T>>>::type
 _make_reducer_from_arg(T&& arg_scalar) noexcept {
   return
-      typename _wrap_with_kokkos_sum<Space, typename std::decay<T>::type>::type{
-          arg_scalar};
+      typename _wrap_with_kokkos_sum<Space, std::decay_t<T>>::type{arg_scalar};
 }
 
 // This can't be an alias template because GCC doesn't know how to mangle

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -323,30 +323,28 @@ struct FunctorAnalysis {
   //----------------------------------------
 
  public:
-  using execution_space = typename std::conditional<
-      functor_has_space::value, typename functor_has_space::type,
-      typename std::conditional<policy_has_space::value,
-                                typename policy_has_space::type,
-                                Kokkos::DefaultExecutionSpace>::type>::type;
+  using execution_space =
+      std::conditional_t<functor_has_space::value,
+                         typename functor_has_space::type,
+                         std::conditional_t<policy_has_space::value,
+                                            typename policy_has_space::type,
+                                            Kokkos::DefaultExecutionSpace>>;
 
-  using value_type = typename std::remove_extent<candidate_type>::type;
+  using value_type = std::remove_extent_t<candidate_type>;
 
   static_assert(!std::is_const<value_type>::value,
                 "Kokkos functor operator reduce argument cannot be const");
 
  private:
   // Stub to avoid defining a type 'void &'
-  using ValueType =
-      typename std::conditional<candidate_is_void, VOID, value_type>::type;
+  using ValueType = std::conditional_t<candidate_is_void, VOID, value_type>;
 
  public:
-  using pointer_type =
-      typename std::conditional<candidate_is_void, void, ValueType*>::type;
+  using pointer_type = std::conditional_t<candidate_is_void, void, ValueType*>;
 
-  using reference_type = typename std::conditional<
+  using reference_type = std::conditional_t<
       candidate_is_array, ValueType*,
-      typename std::conditional<!candidate_is_void, ValueType&,
-                                void>::type>::type;
+      std::conditional_t<!candidate_is_void, ValueType&, void>>;
 
  private:
   template <bool IsArray, class FF>

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -692,14 +692,13 @@ TeamThreadRange(
 
 template <typename iType1, typename iType2, typename Member>
 KOKKOS_INLINE_FUNCTION Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Member>
+    std::common_type_t<iType1, iType2>, Member>
 TeamThreadRange(
     Member const& member, iType1 begin, iType2 end,
     std::enable_if_t<Impl::is_thread_team_member<Member>::value> const** =
         nullptr) {
   return Impl::TeamThreadRangeBoundariesStruct<
-      typename std::common_type<iType1, iType2>::type, Member>(member, begin,
-                                                               end);
+      std::common_type_t<iType1, iType2>, Member>(member, begin, end);
 }
 
 template <typename iType, typename Member>
@@ -713,14 +712,13 @@ TeamVectorRange(
 
 template <typename iType1, typename iType2, typename Member>
 KOKKOS_INLINE_FUNCTION Impl::TeamThreadRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Member>
+    std::common_type_t<iType1, iType2>, Member>
 TeamVectorRange(
     Member const& member, iType1 begin, iType2 end,
     std::enable_if_t<Impl::is_thread_team_member<Member>::value> const** =
         nullptr) {
   return Impl::TeamThreadRangeBoundariesStruct<
-      typename std::common_type<iType1, iType2>::type, Member>(member, begin,
-                                                               end);
+      std::common_type_t<iType1, iType2>, Member>(member, begin, end);
 }
 
 template <typename iType, typename Member>
@@ -734,12 +732,12 @@ ThreadVectorRange(
 
 template <typename iType1, typename iType2, typename Member>
 KOKKOS_INLINE_FUNCTION Impl::ThreadVectorRangeBoundariesStruct<
-    typename std::common_type<iType1, iType2>::type, Member>
+    std::common_type_t<iType1, iType2>, Member>
 ThreadVectorRange(
     Member const& member, iType1 arg_begin, iType2 arg_end,
     std::enable_if_t<Impl::is_thread_team_member<Member>::value> const** =
         nullptr) {
-  using iType = typename std::common_type<iType1, iType2>::type;
+  using iType = std::common_type_t<iType1, iType2>;
   return Impl::ThreadVectorRangeBoundariesStruct<iType, Member>(
       member, iType(arg_begin), iType(arg_end));
 }

--- a/core/src/impl/Kokkos_MemoryPoolAllocator.hpp
+++ b/core/src/impl/Kokkos_MemoryPoolAllocator.hpp
@@ -89,7 +89,7 @@ class MemoryPoolAllocator {
   using value_type      = T;
   using pointer         = T*;
   using size_type       = typename MemoryPool::memory_space::size_type;
-  using difference_type = typename std::make_signed<size_type>::type;
+  using difference_type = std::make_signed_t<size_type>;
 
   template <class U>
   struct rebind {

--- a/core/src/impl/Kokkos_MultipleTaskQueue.hpp
+++ b/core/src/impl/Kokkos_MultipleTaskQueue.hpp
@@ -101,10 +101,10 @@ struct MultipleTaskQueueTeamEntry {
   using ready_queue_type =
       typename TaskQueueTraits::template ready_queue_type<task_base_type>;
   using task_queue_traits         = TaskQueueTraits;
-  using task_scheduling_info_type = typename std::conditional<
+  using task_scheduling_info_type = std::conditional_t<
       TaskQueueTraits::ready_queue_insertion_may_fail,
       FailedQueueInsertionLinkedListSchedulingInfo<TaskQueueTraits>,
-      EmptyTaskSchedulingInfo>::type;
+      EmptyTaskSchedulingInfo>;
 
  private:
   // Number of allowed priorities
@@ -348,10 +348,10 @@ class MultipleTaskQueue final
     ~SchedulerInfo() = default;
   };
 
-  using task_scheduling_info_type = typename std::conditional<
+  using task_scheduling_info_type = std::conditional_t<
       TaskQueueTraits::ready_queue_insertion_may_fail,
       FailedQueueInsertionLinkedListSchedulingInfo<TaskQueueTraits>,
-      EmptyTaskSchedulingInfo>::type;
+      EmptyTaskSchedulingInfo>;
   using team_scheduler_info_type = SchedulerInfo;
 
   using runnable_task_base_type = RunnableTaskBase<TaskQueueTraits>;

--- a/core/src/impl/Kokkos_OptionalRef.hpp
+++ b/core/src/impl/Kokkos_OptionalRef.hpp
@@ -120,18 +120,14 @@ struct OptionalRef {
   //----------------------------------------
 
   KOKKOS_INLINE_FUNCTION
-  OptionalRef<typename std::add_volatile<T>::type>
-  as_volatile() volatile noexcept {
-    return OptionalRef<typename std::add_volatile<T>::type>(*(*this));
+  OptionalRef<std::add_volatile_t<T>> as_volatile() volatile noexcept {
+    return OptionalRef<std::add_volatile_t<T>>(*(*this));
   }
 
   KOKKOS_INLINE_FUNCTION
-  OptionalRef<
-      typename std::add_volatile<typename std::add_const<T>::type>::type>
-  as_volatile() const volatile noexcept {
-    return OptionalRef<
-        typename std::add_volatile<typename std::add_const<T>::type>::type>(
-        *(*this));
+  OptionalRef<std::add_volatile_t<std::add_const_t<T>>> as_volatile() const
+      volatile noexcept {
+    return OptionalRef<std::add_volatile_t<std::add_const_t<T>>>(*(*this));
   }
 
   //----------------------------------------

--- a/core/src/impl/Kokkos_SimpleTaskScheduler.hpp
+++ b/core/src/impl/Kokkos_SimpleTaskScheduler.hpp
@@ -153,8 +153,7 @@ class SimpleTaskScheduler
   }
 
   template <int TaskEnum, class DepTaskType, class FunctorType>
-  KOKKOS_FUNCTION future_type_for_functor<
-      typename std::decay<FunctorType>::type>
+  KOKKOS_FUNCTION future_type_for_functor<std::decay_t<FunctorType>>
   _spawn_impl(
       DepTaskType arg_predecessor_task, TaskPriority arg_priority,
       typename runnable_task_base_type::function_type apply_function_ptr,
@@ -163,7 +162,7 @@ class SimpleTaskScheduler
     KOKKOS_EXPECTS(m_queue != nullptr);
 
     using functor_future_type =
-        future_type_for_functor<typename std::decay<FunctorType>::type>;
+        future_type_for_functor<std::decay_t<FunctorType>>;
     using task_type =
         typename task_queue_type::template runnable_task_type<FunctorType,
                                                               scheduler_type>;
@@ -221,7 +220,7 @@ class SimpleTaskScheduler
     // SharedAllocationRecord pattern
     using record_type =
         Impl::SharedAllocationRecord<memory_space,
-                                     Impl::DefaultDestroy<task_queue_type> >;
+                                     Impl::DefaultDestroy<task_queue_type>>;
 
     // Allocate space for the task queue
     auto* record = record_type::allocate(memory_space(), "Kokkos::TaskQueue",

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -179,9 +179,8 @@ void generic_tune_policy(const std::string& label_in, Map& map, Policy& policy,
   if (should_tune(policy)) {
     std::string label = label_in;
     if (label_in.empty()) {
-      using policy_type =
-          typename std::remove_reference<decltype(policy)>::type;
-      using work_tag = typename policy_type::work_tag;
+      using policy_type = std::remove_reference_t<decltype(policy)>;
+      using work_tag    = typename policy_type::work_tag;
       Kokkos::Impl::ParallelConstructName<Functor, work_tag> name(label);
       label = name.get();
     }
@@ -205,9 +204,8 @@ void generic_tune_policy(const std::string& label_in, Map& map, Policy& policy,
   if (should_tune(policy)) {
     std::string label = label_in;
     if (label_in.empty()) {
-      using policy_type =
-          typename std::remove_reference<decltype(policy)>::type;
-      using work_tag = typename policy_type::work_tag;
+      using policy_type = std::remove_reference_t<decltype(policy)>;
+      using work_tag    = typename policy_type::work_tag;
       Kokkos::Impl::ParallelConstructName<Functor, work_tag> name(label);
       label = name.get();
     }
@@ -312,9 +310,8 @@ void generic_report_results(const std::string& label_in, Map& map,
   if (should_tune(policy)) {
     std::string label = label_in;
     if (label_in.empty()) {
-      using policy_type =
-          typename std::remove_reference<decltype(policy)>::type;
-      using work_tag = typename policy_type::work_tag;
+      using policy_type = std::remove_reference_t<decltype(policy)>;
+      using work_tag    = typename policy_type::work_tag;
       Kokkos::Impl::ParallelConstructName<Functor, work_tag> name(label);
       label = name.get();
     }

--- a/core/src/impl/Kokkos_Traits.hpp
+++ b/core/src/impl/Kokkos_Traits.hpp
@@ -115,8 +115,7 @@ struct has_condition<DefaultType, Condition, S, Pack...> {
  public:
   enum : bool { value = self_value || next::value };
 
-  using type =
-      typename std::conditional<self_value, S, typename next::type>::type;
+  using type = std::conditional_t<self_value, S, typename next::type>;
 };
 
 template <class... Args>
@@ -156,10 +155,9 @@ struct if_c {
 
   using type = FalseType;
 
-  using value_type = typename std::remove_const<
-      typename std::remove_reference<type>::type>::type;
+  using value_type = std::remove_const_t<std::remove_reference_t<type>>;
 
-  using const_value_type = typename std::add_const<value_type>::type;
+  using const_value_type = std::add_const_t<value_type>;
 
   static KOKKOS_INLINE_FUNCTION const_value_type& select(const_value_type& v) {
     return v;
@@ -191,10 +189,9 @@ struct if_c<true, TrueType, FalseType> {
 
   using type = TrueType;
 
-  using value_type = typename std::remove_const<
-      typename std::remove_reference<type>::type>::type;
+  using value_type = std::remove_const_t<std::remove_reference_t<type>>;
 
-  using const_value_type = typename std::add_const<value_type>::type;
+  using const_value_type = std::add_const_t<value_type>;
 
   static KOKKOS_INLINE_FUNCTION const_value_type& select(const_value_type& v) {
     return v;

--- a/core/src/impl/Kokkos_VLAEmulation.hpp
+++ b/core/src/impl/Kokkos_VLAEmulation.hpp
@@ -117,7 +117,7 @@ struct ObjectWithVLAEmulation {
   using vla_entry_count_type = EntryCountType;
 
   using iterator       = VLAValueType*;
-  using const_iterator = typename std::add_const<VLAValueType>::type*;
+  using const_iterator = std::add_const_t<VLAValueType>*;
 
   // TODO @tasking @minor DSH require that Derived be marked final? (note that
   // std::is_final is C++14)

--- a/core/src/impl/Kokkos_ViewArray.hpp
+++ b/core/src/impl/Kokkos_ViewArray.hpp
@@ -75,7 +75,7 @@ struct ViewDataAnalysis<DataType, ArrayLayout, Kokkos::Array<V, N, P>> {
 
   using array_scalar_dimension = typename dimension::template append<N>::type;
 
-  using scalar_type = typename std::conditional<is_const, const V, V>::type;
+  using scalar_type           = std::conditional_t<is_const, const V, V>;
   using non_const_scalar_type = V;
   using const_scalar_type     = const V;
 
@@ -230,8 +230,8 @@ class ViewMapping<Traits, Kokkos::Array<>> {
   }
 
   using reference_type =
-      typename std::conditional<is_contiguous_reference, contiguous_reference,
-                                strided_reference>::type;
+      std::conditional_t<is_contiguous_reference, contiguous_reference,
+                         strided_reference>;
 
   using pointer_type = handle_type;
 
@@ -565,36 +565,34 @@ class ViewMapping<
 
   // Subview's layout
   using array_layout =
-      typename std::conditional<((rank == 0) ||
-                                 (rank <= 2 && R0 &&
-                                  std::is_same<typename SrcTraits::array_layout,
-                                               Kokkos::LayoutLeft>::value) ||
-                                 (rank <= 2 && R0_rev &&
-                                  std::is_same<typename SrcTraits::array_layout,
-                                               Kokkos::LayoutRight>::value)),
-                                typename SrcTraits::array_layout,
-                                Kokkos::LayoutStride>::type;
+      std::conditional_t<((rank == 0) ||
+                          (rank <= 2 && R0 &&
+                           std::is_same<typename SrcTraits::array_layout,
+                                        Kokkos::LayoutLeft>::value) ||
+                          (rank <= 2 && R0_rev &&
+                           std::is_same<typename SrcTraits::array_layout,
+                                        Kokkos::LayoutRight>::value)),
+                         typename SrcTraits::array_layout,
+                         Kokkos::LayoutStride>;
 
   using value_type = typename SrcTraits::value_type;
 
-  using data_type = typename std::conditional<
+  using data_type = std::conditional_t<
       rank == 0, value_type,
-      typename std::conditional<
+      std::conditional_t<
           rank == 1, value_type *,
-          typename std::conditional<
+          std::conditional_t<
               rank == 2, value_type **,
-              typename std::conditional<
+              std::conditional_t<
                   rank == 3, value_type ***,
-                  typename std::conditional<
+                  std::conditional_t<
                       rank == 4, value_type ****,
-                      typename std::conditional<
+                      std::conditional_t<
                           rank == 5, value_type *****,
-                          typename std::conditional<
+                          std::conditional_t<
                               rank == 6, value_type ******,
-                              typename std::conditional<
-                                  rank == 7, value_type *******,
-                                  value_type ********>::type>::type>::type>::
-                      type>::type>::type>::type>::type;
+                              std::conditional_t<rank == 7, value_type *******,
+                                                 value_type ********>>>>>>>>;
 
  public:
   using traits_type = Kokkos::ViewTraits<data_type, array_layout,

--- a/core/src/impl/Kokkos_ViewLayoutTiled.hpp
+++ b/core/src/impl/Kokkos_ViewLayoutTiled.hpp
@@ -773,11 +773,10 @@ class ViewMapping<std::enable_if_t<(N2 == 0 && N3 == 0 && N4 == 0 && N5 == 0 &&
 
   static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
   static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
-  using array_layout =
-      typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
-                                Kokkos::LayoutRight>::type;
-  using traits = Kokkos::ViewTraits<T[N0][N1], array_layout, P...>;
-  using type   = Kokkos::View<T[N0][N1], array_layout, P...>;
+  using array_layout = std::conditional_t<is_inner_left, Kokkos::LayoutLeft,
+                                          Kokkos::LayoutRight>;
+  using traits       = Kokkos::ViewTraits<T[N0][N1], array_layout, P...>;
+  using type         = Kokkos::View<T[N0][N1], array_layout, P...>;
 
   KOKKOS_INLINE_FUNCTION static void assign(
       ViewMapping<traits, void>& dst, const ViewMapping<src_traits, void>& src,
@@ -825,11 +824,10 @@ class ViewMapping<std::enable_if_t<(N3 == 0 && N4 == 0 && N5 == 0 && N6 == 0 &&
 
   static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
   static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
-  using array_layout =
-      typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
-                                Kokkos::LayoutRight>::type;
-  using traits = Kokkos::ViewTraits<T[N0][N1][N2], array_layout, P...>;
-  using type   = Kokkos::View<T[N0][N1][N2], array_layout, P...>;
+  using array_layout = std::conditional_t<is_inner_left, Kokkos::LayoutLeft,
+                                          Kokkos::LayoutRight>;
+  using traits       = Kokkos::ViewTraits<T[N0][N1][N2], array_layout, P...>;
+  using type         = Kokkos::View<T[N0][N1][N2], array_layout, P...>;
 
   KOKKOS_INLINE_FUNCTION static void assign(
       ViewMapping<traits, void>& dst, const ViewMapping<src_traits, void>& src,
@@ -883,9 +881,8 @@ class ViewMapping<
 
   static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
   static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
-  using array_layout =
-      typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
-                                Kokkos::LayoutRight>::type;
+  using array_layout = std::conditional_t<is_inner_left, Kokkos::LayoutLeft,
+                                          Kokkos::LayoutRight>;
   using traits = Kokkos::ViewTraits<T[N0][N1][N2][N3], array_layout, P...>;
   using type   = Kokkos::View<T[N0][N1][N2][N3], array_layout, P...>;
 
@@ -945,9 +942,8 @@ class ViewMapping<std::enable_if_t<(N5 == 0 && N6 == 0 && N7 == 0)>  // void
 
   static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
   static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
-  using array_layout =
-      typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
-                                Kokkos::LayoutRight>::type;
+  using array_layout = std::conditional_t<is_inner_left, Kokkos::LayoutLeft,
+                                          Kokkos::LayoutRight>;
   using traits = Kokkos::ViewTraits<T[N0][N1][N2][N3][N4], array_layout, P...>;
   using type   = Kokkos::View<T[N0][N1][N2][N3][N4], array_layout, P...>;
 
@@ -1013,9 +1009,8 @@ class ViewMapping<std::enable_if_t<(N6 == 0 && N7 == 0)>  // void
 
   static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
   static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
-  using array_layout =
-      typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
-                                Kokkos::LayoutRight>::type;
+  using array_layout = std::conditional_t<is_inner_left, Kokkos::LayoutLeft,
+                                          Kokkos::LayoutRight>;
   using traits =
       Kokkos::ViewTraits<T[N0][N1][N2][N3][N4][N5], array_layout, P...>;
   using type = Kokkos::View<T[N0][N1][N2][N3][N4][N5], array_layout, P...>;
@@ -1087,9 +1082,8 @@ class ViewMapping<std::enable_if_t<(N7 == 0)>  // void
 
   static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
   static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
-  using array_layout =
-      typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
-                                Kokkos::LayoutRight>::type;
+  using array_layout = std::conditional_t<is_inner_left, Kokkos::LayoutLeft,
+                                          Kokkos::LayoutRight>;
   using traits =
       Kokkos::ViewTraits<T[N0][N1][N2][N3][N4][N5][N6], array_layout, P...>;
   using type = Kokkos::View<T[N0][N1][N2][N3][N4][N5][N6], array_layout, P...>;
@@ -1169,9 +1163,8 @@ class ViewMapping<
 
   static constexpr bool is_outer_left = (OuterP == Kokkos::Iterate::Left);
   static constexpr bool is_inner_left = (InnerP == Kokkos::Iterate::Left);
-  using array_layout =
-      typename std::conditional<is_inner_left, Kokkos::LayoutLeft,
-                                Kokkos::LayoutRight>::type;
+  using array_layout = std::conditional_t<is_inner_left, Kokkos::LayoutLeft,
+                                          Kokkos::LayoutRight>;
   using traits =
       Kokkos::ViewTraits<T[N0][N1][N2][N3][N4][N5][N6][N7], array_layout, P...>;
   using type =
@@ -1241,22 +1234,22 @@ namespace Kokkos {
 template <typename T, Kokkos::Iterate OuterP, Kokkos::Iterate InnerP,
           unsigned N0, unsigned N1, unsigned N2, unsigned N3, unsigned N4,
           unsigned N5, unsigned N6, unsigned N7, class... P>
-KOKKOS_INLINE_FUNCTION Kokkos::View<
-    T[N0][N1],
-    typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                              Kokkos::LayoutLeft, Kokkos::LayoutRight>::type,
-    P...>
-tile_subview(const Kokkos::View<
-                 T**,
-                 Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2,
-                                                   N3, N4, N5, N6, N7, true>,
-                 P...>& src,
-             const size_t i_tile0, const size_t i_tile1) {
+KOKKOS_INLINE_FUNCTION
+    Kokkos::View<T[N0][N1],
+                 std::conditional_t<(InnerP == Kokkos::Iterate::Left),
+                                    Kokkos::LayoutLeft, Kokkos::LayoutRight>,
+                 P...>
+    tile_subview(const Kokkos::View<
+                     T**,
+                     Kokkos::Experimental::LayoutTiled<
+                         OuterP, InnerP, N0, N1, N2, N3, N4, N5, N6, N7, true>,
+                     P...>& src,
+                 const size_t i_tile0, const size_t i_tile1) {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   using array_layout =
-      typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                                Kokkos::LayoutLeft, Kokkos::LayoutRight>::type;
+      std::conditional_t<(InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft,
+                         Kokkos::LayoutRight>;
   using SrcLayout =
       Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2, N3, N4, N5,
                                         N6, N7, true>;
@@ -1269,22 +1262,23 @@ tile_subview(const Kokkos::View<
 template <typename T, Kokkos::Iterate OuterP, Kokkos::Iterate InnerP,
           unsigned N0, unsigned N1, unsigned N2, unsigned N3, unsigned N4,
           unsigned N5, unsigned N6, unsigned N7, class... P>
-KOKKOS_INLINE_FUNCTION Kokkos::View<
-    T[N0][N1][N2],
-    typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                              Kokkos::LayoutLeft, Kokkos::LayoutRight>::type,
-    P...>
-tile_subview(const Kokkos::View<
-                 T***,
-                 Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2,
-                                                   N3, N4, N5, N6, N7, true>,
-                 P...>& src,
-             const size_t i_tile0, const size_t i_tile1, const size_t i_tile2) {
+KOKKOS_INLINE_FUNCTION
+    Kokkos::View<T[N0][N1][N2],
+                 std::conditional_t<(InnerP == Kokkos::Iterate::Left),
+                                    Kokkos::LayoutLeft, Kokkos::LayoutRight>,
+                 P...>
+    tile_subview(const Kokkos::View<
+                     T***,
+                     Kokkos::Experimental::LayoutTiled<
+                         OuterP, InnerP, N0, N1, N2, N3, N4, N5, N6, N7, true>,
+                     P...>& src,
+                 const size_t i_tile0, const size_t i_tile1,
+                 const size_t i_tile2) {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   using array_layout =
-      typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                                Kokkos::LayoutLeft, Kokkos::LayoutRight>::type;
+      std::conditional_t<(InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft,
+                         Kokkos::LayoutRight>;
   using SrcLayout =
       Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2, N3, N4, N5,
                                         N6, N7, true>;
@@ -1297,23 +1291,23 @@ tile_subview(const Kokkos::View<
 template <typename T, Kokkos::Iterate OuterP, Kokkos::Iterate InnerP,
           unsigned N0, unsigned N1, unsigned N2, unsigned N3, unsigned N4,
           unsigned N5, unsigned N6, unsigned N7, class... P>
-KOKKOS_INLINE_FUNCTION Kokkos::View<
-    T[N0][N1][N2][N3],
-    typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                              Kokkos::LayoutLeft, Kokkos::LayoutRight>::type,
-    P...>
-tile_subview(const Kokkos::View<
-                 T****,
-                 Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2,
-                                                   N3, N4, N5, N6, N7, true>,
-                 P...>& src,
-             const size_t i_tile0, const size_t i_tile1, const size_t i_tile2,
-             const size_t i_tile3) {
+KOKKOS_INLINE_FUNCTION
+    Kokkos::View<T[N0][N1][N2][N3],
+                 std::conditional_t<(InnerP == Kokkos::Iterate::Left),
+                                    Kokkos::LayoutLeft, Kokkos::LayoutRight>,
+                 P...>
+    tile_subview(const Kokkos::View<
+                     T****,
+                     Kokkos::Experimental::LayoutTiled<
+                         OuterP, InnerP, N0, N1, N2, N3, N4, N5, N6, N7, true>,
+                     P...>& src,
+                 const size_t i_tile0, const size_t i_tile1,
+                 const size_t i_tile2, const size_t i_tile3) {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   using array_layout =
-      typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                                Kokkos::LayoutLeft, Kokkos::LayoutRight>::type;
+      std::conditional_t<(InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft,
+                         Kokkos::LayoutRight>;
   using SrcLayout =
       Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2, N3, N4, N5,
                                         N6, N7, true>;
@@ -1326,23 +1320,24 @@ tile_subview(const Kokkos::View<
 template <typename T, Kokkos::Iterate OuterP, Kokkos::Iterate InnerP,
           unsigned N0, unsigned N1, unsigned N2, unsigned N3, unsigned N4,
           unsigned N5, unsigned N6, unsigned N7, class... P>
-KOKKOS_INLINE_FUNCTION Kokkos::View<
-    T[N0][N1][N2][N3][N4],
-    typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                              Kokkos::LayoutLeft, Kokkos::LayoutRight>::type,
-    P...>
-tile_subview(const Kokkos::View<
-                 T*****,
-                 Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2,
-                                                   N3, N4, N5, N6, N7, true>,
-                 P...>& src,
-             const size_t i_tile0, const size_t i_tile1, const size_t i_tile2,
-             const size_t i_tile3, const size_t i_tile4) {
+KOKKOS_INLINE_FUNCTION
+    Kokkos::View<T[N0][N1][N2][N3][N4],
+                 std::conditional_t<(InnerP == Kokkos::Iterate::Left),
+                                    Kokkos::LayoutLeft, Kokkos::LayoutRight>,
+                 P...>
+    tile_subview(const Kokkos::View<
+                     T*****,
+                     Kokkos::Experimental::LayoutTiled<
+                         OuterP, InnerP, N0, N1, N2, N3, N4, N5, N6, N7, true>,
+                     P...>& src,
+                 const size_t i_tile0, const size_t i_tile1,
+                 const size_t i_tile2, const size_t i_tile3,
+                 const size_t i_tile4) {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   using array_layout =
-      typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                                Kokkos::LayoutLeft, Kokkos::LayoutRight>::type;
+      std::conditional_t<(InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft,
+                         Kokkos::LayoutRight>;
   using SrcLayout =
       Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2, N3, N4, N5,
                                         N6, N7, true>;
@@ -1355,23 +1350,24 @@ tile_subview(const Kokkos::View<
 template <typename T, Kokkos::Iterate OuterP, Kokkos::Iterate InnerP,
           unsigned N0, unsigned N1, unsigned N2, unsigned N3, unsigned N4,
           unsigned N5, unsigned N6, unsigned N7, class... P>
-KOKKOS_INLINE_FUNCTION Kokkos::View<
-    T[N0][N1][N2][N3][N4][N5],
-    typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                              Kokkos::LayoutLeft, Kokkos::LayoutRight>::type,
-    P...>
-tile_subview(const Kokkos::View<
-                 T******,
-                 Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2,
-                                                   N3, N4, N5, N6, N7, true>,
-                 P...>& src,
-             const size_t i_tile0, const size_t i_tile1, const size_t i_tile2,
-             const size_t i_tile3, const size_t i_tile4, const size_t i_tile5) {
+KOKKOS_INLINE_FUNCTION
+    Kokkos::View<T[N0][N1][N2][N3][N4][N5],
+                 std::conditional_t<(InnerP == Kokkos::Iterate::Left),
+                                    Kokkos::LayoutLeft, Kokkos::LayoutRight>,
+                 P...>
+    tile_subview(const Kokkos::View<
+                     T******,
+                     Kokkos::Experimental::LayoutTiled<
+                         OuterP, InnerP, N0, N1, N2, N3, N4, N5, N6, N7, true>,
+                     P...>& src,
+                 const size_t i_tile0, const size_t i_tile1,
+                 const size_t i_tile2, const size_t i_tile3,
+                 const size_t i_tile4, const size_t i_tile5) {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   using array_layout =
-      typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                                Kokkos::LayoutLeft, Kokkos::LayoutRight>::type;
+      std::conditional_t<(InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft,
+                         Kokkos::LayoutRight>;
   using SrcLayout =
       Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2, N3, N4, N5,
                                         N6, N7, true>;
@@ -1384,24 +1380,25 @@ tile_subview(const Kokkos::View<
 template <typename T, Kokkos::Iterate OuterP, Kokkos::Iterate InnerP,
           unsigned N0, unsigned N1, unsigned N2, unsigned N3, unsigned N4,
           unsigned N5, unsigned N6, unsigned N7, class... P>
-KOKKOS_INLINE_FUNCTION Kokkos::View<
-    T[N0][N1][N2][N3][N4][N5][N6],
-    typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                              Kokkos::LayoutLeft, Kokkos::LayoutRight>::type,
-    P...>
-tile_subview(const Kokkos::View<
-                 T*******,
-                 Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2,
-                                                   N3, N4, N5, N6, N7, true>,
-                 P...>& src,
-             const size_t i_tile0, const size_t i_tile1, const size_t i_tile2,
-             const size_t i_tile3, const size_t i_tile4, const size_t i_tile5,
-             const size_t i_tile6) {
+KOKKOS_INLINE_FUNCTION
+    Kokkos::View<T[N0][N1][N2][N3][N4][N5][N6],
+                 std::conditional_t<(InnerP == Kokkos::Iterate::Left),
+                                    Kokkos::LayoutLeft, Kokkos::LayoutRight>,
+                 P...>
+    tile_subview(const Kokkos::View<
+                     T*******,
+                     Kokkos::Experimental::LayoutTiled<
+                         OuterP, InnerP, N0, N1, N2, N3, N4, N5, N6, N7, true>,
+                     P...>& src,
+                 const size_t i_tile0, const size_t i_tile1,
+                 const size_t i_tile2, const size_t i_tile3,
+                 const size_t i_tile4, const size_t i_tile5,
+                 const size_t i_tile6) {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   using array_layout =
-      typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                                Kokkos::LayoutLeft, Kokkos::LayoutRight>::type;
+      std::conditional_t<(InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft,
+                         Kokkos::LayoutRight>;
   using SrcLayout =
       Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2, N3, N4, N5,
                                         N6, N7, true>;
@@ -1415,24 +1412,25 @@ tile_subview(const Kokkos::View<
 template <typename T, Kokkos::Iterate OuterP, Kokkos::Iterate InnerP,
           unsigned N0, unsigned N1, unsigned N2, unsigned N3, unsigned N4,
           unsigned N5, unsigned N6, unsigned N7, class... P>
-KOKKOS_INLINE_FUNCTION Kokkos::View<
-    T[N0][N1][N2][N3][N4][N5][N6][N7],
-    typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                              Kokkos::LayoutLeft, Kokkos::LayoutRight>::type,
-    P...>
-tile_subview(const Kokkos::View<
-                 T********,
-                 Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2,
-                                                   N3, N4, N5, N6, N7, true>,
-                 P...>& src,
-             const size_t i_tile0, const size_t i_tile1, const size_t i_tile2,
-             const size_t i_tile3, const size_t i_tile4, const size_t i_tile5,
-             const size_t i_tile6, const size_t i_tile7) {
+KOKKOS_INLINE_FUNCTION
+    Kokkos::View<T[N0][N1][N2][N3][N4][N5][N6][N7],
+                 std::conditional_t<(InnerP == Kokkos::Iterate::Left),
+                                    Kokkos::LayoutLeft, Kokkos::LayoutRight>,
+                 P...>
+    tile_subview(const Kokkos::View<
+                     T********,
+                     Kokkos::Experimental::LayoutTiled<
+                         OuterP, InnerP, N0, N1, N2, N3, N4, N5, N6, N7, true>,
+                     P...>& src,
+                 const size_t i_tile0, const size_t i_tile1,
+                 const size_t i_tile2, const size_t i_tile3,
+                 const size_t i_tile4, const size_t i_tile5,
+                 const size_t i_tile6, const size_t i_tile7) {
   // Force the specialized ViewMapping for extracting a tile
   // by using the first subview argument as the layout.
   using array_layout =
-      typename std::conditional<(InnerP == Kokkos::Iterate::Left),
-                                Kokkos::LayoutLeft, Kokkos::LayoutRight>::type;
+      std::conditional_t<(InnerP == Kokkos::Iterate::Left), Kokkos::LayoutLeft,
+                         Kokkos::LayoutRight>;
   using SrcLayout =
       Kokkos::Experimental::LayoutTiled<OuterP, InnerP, N0, N1, N2, N3, N4, N5,
                                         N6, N7, true>;

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -112,7 +112,7 @@ struct rank_dynamic<Val, Args...> {
   template <unsigned RD>                                                    \
   struct ViewDimension##R<0u, RD> {                                         \
     static constexpr size_t ArgN##R = 0;                                    \
-    typename std::conditional<(RD < 3), size_t, unsigned>::type N##R;       \
+    std::conditional_t<(RD < 3), size_t, unsigned> N##R;                    \
     ViewDimension##R()                        = default;                    \
     ViewDimension##R(const ViewDimension##R&) = default;                    \
     ViewDimension##R& operator=(const ViewDimension##R&) = default;         \
@@ -347,8 +347,8 @@ struct is_integral_extent_type<std::initializer_list<iType>> {
 template <unsigned I, class... Args>
 struct is_integral_extent {
   // get_type is void when sizeof...(Args) <= I
-  using type = typename std::remove_cv<typename std::remove_reference<
-      typename Kokkos::Impl::get_type<I, Args...>::type>::type>::type;
+  using type = std::remove_cv_t<std::remove_reference_t<
+      typename Kokkos::Impl::get_type<I, Args...>::type>>;
 
   enum : bool { value = is_integral_extent_type<type>::value };
 
@@ -754,8 +754,8 @@ struct ViewDataType<T, ViewDimension<N, Args...>> {
 template <class T>
 struct ViewArrayAnalysis {
   using value_type           = T;
-  using const_value_type     = typename std::add_const<T>::type;
-  using non_const_value_type = typename std::remove_const<T>::type;
+  using const_value_type     = std::add_const_t<T>;
+  using non_const_value_type = std::remove_const_t<T>;
   using static_dimension     = ViewDimension<>;
   using dynamic_dimension    = ViewDimension<>;
   using dimension            = ViewDimension<>;
@@ -3750,8 +3750,7 @@ struct SubViewDataTypeImpl<void, ValueType, Kokkos::Experimental::Extents<>> {
 template <class ValueType, ptrdiff_t Ext, ptrdiff_t... Exts, class Integral,
           class... Args>
 struct SubViewDataTypeImpl<
-    std::enable_if_t<
-        std::is_integral<typename std::decay<Integral>::type>::value>,
+    std::enable_if_t<std::is_integral<std::decay_t<Integral>>::value>,
     ValueType, Kokkos::Experimental::Extents<Ext, Exts...>, Integral, Args...>
     : SubViewDataTypeImpl<void, ValueType,
                           Kokkos::Experimental::Extents<Exts...>, Args...> {};
@@ -3837,7 +3836,7 @@ class ViewMapping<
   };
 
   // Subview's layout
-  using array_layout = typename std::conditional<
+  using array_layout = std::conditional_t<
       (            /* Same array layout IF */
        (rank == 0) /* output rank zero */
        || SubviewLegalArgsCompileTime<typename SrcTraits::array_layout,
@@ -3855,7 +3854,7 @@ class ViewMapping<
         std::is_same<typename SrcTraits::array_layout,
                      Kokkos::LayoutRight>::value)  // replace input rank
        ),
-      typename SrcTraits::array_layout, Kokkos::LayoutStride>::type;
+      typename SrcTraits::array_layout, Kokkos::LayoutStride>;
 
   using value_type = typename SrcTraits::value_type;
 

--- a/core/src/impl/Kokkos_ViewUniformType.hpp
+++ b/core/src/impl/Kokkos_ViewUniformType.hpp
@@ -76,15 +76,13 @@ struct ViewUniformLayout<Kokkos::LayoutRight, 1> {
 
 template <class ViewType, int Traits>
 struct ViewUniformType {
-  using data_type = typename ViewType::data_type;
-  using const_data_type =
-      typename std::add_const<typename ViewType::data_type>::type;
+  using data_type       = typename ViewType::data_type;
+  using const_data_type = std::add_const_t<typename ViewType::data_type>;
   using runtime_data_type =
       typename ViewScalarToDataType<typename ViewType::value_type,
                                     ViewType::rank>::type;
   using runtime_const_data_type = typename ViewScalarToDataType<
-      typename std::add_const<typename ViewType::value_type>::type,
-      ViewType::rank>::type;
+      std::add_const_t<typename ViewType::value_type>, ViewType::rank>::type;
 
   using array_layout =
       typename ViewUniformLayout<typename ViewType::array_layout,

--- a/core/unit_test/TestAtomics.hpp
+++ b/core/unit_test/TestAtomics.hpp
@@ -405,9 +405,9 @@ T ExchLoop(int loop) {
 }
 
 template <class T>
-T ExchLoopSerial(
-    typename std::conditional<!std::is_same<T, Kokkos::complex<double> >::value,
-                              int, void>::type loop) {
+T ExchLoopSerial(std::conditional_t<
+                 !std::is_same<T, Kokkos::complex<double> >::value, int, void>
+                     loop) {
   T* data  = new T[1];
   T* data2 = new T[1];
   data[0]  = 0;
@@ -427,9 +427,9 @@ T ExchLoopSerial(
 }
 
 template <class T>
-T ExchLoopSerial(
-    typename std::conditional<std::is_same<T, Kokkos::complex<double> >::value,
-                              int, void>::type loop) {
+T ExchLoopSerial(std::conditional_t<
+                 std::is_same<T, Kokkos::complex<double> >::value, int, void>
+                     loop) {
   T* data  = new T[1];
   T* data2 = new T[1];
   data[0]  = 0;

--- a/core/unit_test/TestDeepCopyAlignment.hpp
+++ b/core/unit_test/TestDeepCopyAlignment.hpp
@@ -225,12 +225,12 @@ struct TestDeepCopyScalarConversion {
   using view_type_s1_2d = Kokkos::View<Scalar1**, Layout1, TEST_EXECSPACE>;
   using view_type_s2_2d = Kokkos::View<Scalar2**, Layout2, TEST_EXECSPACE>;
 
-  using base_layout1 = typename std::conditional<
-      std::is_same<Layout1, Kokkos::LayoutStride>::value, Kokkos::LayoutLeft,
-      Layout1>::type;
-  using base_layout2 = typename std::conditional<
-      std::is_same<Layout2, Kokkos::LayoutStride>::value, Kokkos::LayoutLeft,
-      Layout2>::type;
+  using base_layout1 =
+      std::conditional_t<std::is_same<Layout1, Kokkos::LayoutStride>::value,
+                         Kokkos::LayoutLeft, Layout1>;
+  using base_layout2 =
+      std::conditional_t<std::is_same<Layout2, Kokkos::LayoutStride>::value,
+                         Kokkos::LayoutLeft, Layout2>;
 
   using base_type_s1_1d = Kokkos::View<Scalar1*, base_layout1, TEST_EXECSPACE>;
   using base_type_s2_1d = Kokkos::View<Scalar2*, base_layout2, TEST_EXECSPACE>;

--- a/core/unit_test/TestReduceCombinatorical.hpp
+++ b/core/unit_test/TestReduceCombinatorical.hpp
@@ -523,9 +523,9 @@ struct TestReduceCombinatoricalInstantiation {
 #ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
     AddLambdaRange(
         N,
-        typename std::conditional<
+        std::conditional_t<
             std::is_same<ExecSpace, Kokkos::DefaultExecutionSpace>::value,
-            void*, Kokkos::InvalidType>::type(),
+            void*, Kokkos::InvalidType>(),
         args...);
 #endif
   }
@@ -536,9 +536,9 @@ struct TestReduceCombinatoricalInstantiation {
 #ifdef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
     AddLambdaTeam(
         N,
-        typename std::conditional<
+        std::conditional_t<
             std::is_same<ExecSpace, Kokkos::DefaultExecutionSpace>::value,
-            void*, Kokkos::InvalidType>::type(),
+            void*, Kokkos::InvalidType>(),
         args...);
 #endif
   }

--- a/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
+++ b/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
@@ -67,9 +67,9 @@ struct TestViewAPI<
       Kokkos::MemoryTraits<0>;  // maybe we want to add that later to the matrix
   using view_type =
       Kokkos::View<data_type, layout_type, space_type, traits_type>;
-  using alloc_layout_type = typename std::conditional<
-      std::is_same<layout_type, Kokkos::LayoutStride>::value,
-      Kokkos::LayoutLeft, layout_type>::type;
+  using alloc_layout_type =
+      std::conditional_t<std::is_same<layout_type, Kokkos::LayoutStride>::value,
+                         Kokkos::LayoutLeft, layout_type>;
   using d_alloc_type = Kokkos::View<data_type, alloc_layout_type, space_type>;
   using h_alloc_type = typename Kokkos::View<data_type, alloc_layout_type,
                                              space_type>::HostMirror;


### PR DESCRIPTION
Based on top of #4958, related to #4990.
Again, most of the work was done by something like
```bash
 git ls-files | xargs -n 1 perl -0777 -i -pe 's/typename std::([a-z]*_[a-z][a-z]+)(<((?>[^<>]+)|(?2))*\>)::type/std::\1_t\2/g'
```
plus some more manual changes.