### PR TITLE
Refactor `BitOps` to not rely on `__CUDA_ARCH__` macro

### DIFF
--- a/core/src/impl/Kokkos_BitOps.hpp
+++ b/core/src/impl/Kokkos_BitOps.hpp
@@ -70,8 +70,8 @@ int int_log2_fallback(unsigned i) {
 
 KOKKOS_IMPL_DEVICE_FUNCTION
 inline int int_log2_device(unsigned i) {
-  constexpr int shift = sizeof(unsigned) * CHAR_BIT - 1;
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+  constexpr int shift = sizeof(unsigned) * CHAR_BIT - 1;
   return shift - __clz(i);
 #elif defined(KOKKOS_COMPILER_INTEL)
   return _bit_scan_reverse(i);
@@ -84,6 +84,7 @@ KOKKOS_IMPL_HOST_FUNCTION
 inline int int_log2_host(unsigned i) {
   constexpr int shift = sizeof(unsigned) * CHAR_BIT - 1;
 #if defined(KOKKOS_COMPILER_INTEL)
+  (void)shift;
   return _bit_scan_reverse(i);
 #elif defined(KOKKOS_COMPILER_CRAYC)
   return i ? shift - _leadz32(i) : 0;
@@ -131,6 +132,7 @@ inline int bit_first_zero_device(unsigned i) noexcept {
 #elif defined(KOKKOS_COMPILER_INTEL)
   return full != i ? _bit_scan_forward(~i) : -1;
 #else
+  (void)full;
   return bit_first_zero_fallback(i);
 #endif
 }
@@ -145,6 +147,7 @@ inline int bit_first_zero_host(unsigned i) noexcept {
 #elif defined(KOKKOS_COMPILER_GNU) || defined(__GNUC__) || defined(__GNUG__)
   return full != i ? __builtin_ffs(~i) - 1 : -1;
 #else
+  (void)full;
   return bit_first_zero_fallback(i);
 #endif
 }

--- a/core/src/impl/Kokkos_BitOps.hpp
+++ b/core/src/impl/Kokkos_BitOps.hpp
@@ -58,7 +58,8 @@ namespace Impl {
 
 KOKKOS_FORCEINLINE_FUNCTION
 int int_log2_fallback(unsigned i) {
-  enum : int { shift = sizeof(unsigned) * CHAR_BIT - 1 };
+  constexpr int shift = sizeof(unsigned) * CHAR_BIT - 1;
+
   int offset = 0;
   if (i) {
     for (offset = shift; (i & (1 << offset)) == 0; --offset)
@@ -69,7 +70,7 @@ int int_log2_fallback(unsigned i) {
 
 KOKKOS_IMPL_DEVICE_FUNCTION
 inline int int_log2_device(unsigned i) {
-  enum : int { shift = sizeof(unsigned) * CHAR_BIT - 1 };
+  constexpr int shift = sizeof(unsigned) * CHAR_BIT - 1;
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   return shift - __clz(i);
 #else
@@ -79,7 +80,7 @@ inline int int_log2_device(unsigned i) {
 
 KOKKOS_IMPL_HOST_FUNCTION
 inline int int_log2_host(unsigned i) {
-  enum : int { shift = sizeof(unsigned) * CHAR_BIT - 1 };
+  constexpr int shift = sizeof(unsigned) * CHAR_BIT - 1;
 #if defined(KOKKOS_COMPILER_INTEL)
   return _bit_scan_reverse(i);
 #elif defined(KOKKOS_COMPILER_CRAYC)
@@ -110,7 +111,8 @@ int int_log2(unsigned i) {
  */
 KOKKOS_FORCEINLINE_FUNCTION
 int bit_first_zero_fallback(unsigned i) noexcept {
-  enum : unsigned { full = ~0u };
+  constexpr unsigned full = ~0u;
+
   int offset = -1;
   if (full != i) {
     for (offset = 0; i & (1 << offset); ++offset)
@@ -121,7 +123,7 @@ int bit_first_zero_fallback(unsigned i) noexcept {
 
 KOKKOS_IMPL_DEVICE_FUNCTION
 inline int bit_first_zero_device(unsigned i) noexcept {
-  enum : unsigned { full = ~0u };
+  constexpr unsigned full = ~0u;
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   return full != i ? __ffs(~i) - 1 : -1;
 #else
@@ -131,8 +133,7 @@ inline int bit_first_zero_device(unsigned i) noexcept {
 
 KOKKOS_IMPL_HOST_FUNCTION
 inline int bit_first_zero_host(unsigned i) noexcept {
-  enum : unsigned { full = ~0u };
-
+  constexpr unsigned full = ~0u;
 #if defined(KOKKOS_COMPILER_INTEL)
   return full != i ? _bit_scan_forward(~i) : -1;
 #elif defined(KOKKOS_COMPILER_CRAYC)

--- a/core/src/impl/Kokkos_BitOps.hpp
+++ b/core/src/impl/Kokkos_BitOps.hpp
@@ -73,6 +73,8 @@ inline int int_log2_device(unsigned i) {
   constexpr int shift = sizeof(unsigned) * CHAR_BIT - 1;
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   return shift - __clz(i);
+#elif defined(KOKKOS_COMPILER_INTEL)
+  return _bit_scan_reverse(i);
 #else
   return int_log2_fallback(i);
 #endif
@@ -126,6 +128,8 @@ inline int bit_first_zero_device(unsigned i) noexcept {
   constexpr unsigned full = ~0u;
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   return full != i ? __ffs(~i) - 1 : -1;
+#elif defined(KOKKOS_COMPILER_INTEL)
+  return full != i ? _bit_scan_forward(~i) : -1;
 #else
   return bit_first_zero_fallback(i);
 #endif
@@ -171,6 +175,8 @@ int bit_scan_forward_fallback(unsigned i) {
 KOKKOS_IMPL_DEVICE_FUNCTION inline int bit_scan_forward_device(unsigned i) {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   return __ffs(i) - 1;
+#elif defined(KOKKOS_COMPILER_INTEL)
+  return _bit_scan_forward(i);
 #else
   return bit_scan_forward_fallback(i);
 #endif
@@ -216,6 +222,8 @@ int bit_count_fallback(unsigned i) {
 KOKKOS_IMPL_DEVICE_FUNCTION inline int bit_count_device(unsigned i) {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   return __popc(i);
+#elif defined(__INTEL_COMPILER)
+  return _popcnt32(i);
 #else
   return bit_count_fallback(i);
 #endif

--- a/core/src/impl/Kokkos_BitOps.hpp
+++ b/core/src/impl/Kokkos_BitOps.hpp
@@ -169,7 +169,7 @@ int bit_scan_forward_fallback(unsigned i) {
 
 KOKKOS_IMPL_DEVICE_FUNCTION inline int bit_scan_forward_device(unsigned i) {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
-  return __popc(i);
+  return __ffs(i) - 1;
 #else
   return bit_scan_forward_fallback(i);
 #endif

--- a/core/src/impl/Kokkos_BitOps.hpp
+++ b/core/src/impl/Kokkos_BitOps.hpp
@@ -225,7 +225,7 @@ int bit_count_fallback(unsigned i) {
 KOKKOS_IMPL_DEVICE_FUNCTION inline int bit_count_device(unsigned i) {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   return __popc(i);
-#elif defined(__INTEL_COMPILER)
+#elif defined(KOKKOS_COMPILER_INTEL)
   return _popcnt32(i);
 #else
   return bit_count_fallback(i);
@@ -233,7 +233,7 @@ KOKKOS_IMPL_DEVICE_FUNCTION inline int bit_count_device(unsigned i) {
 }
 
 KOKKOS_IMPL_HOST_FUNCTION inline int bit_count_host(unsigned i) {
-#if defined(__INTEL_COMPILER)
+#if defined(KOKKOS_COMPILER_INTEL)
   return _popcnt32(i);
 #elif defined(KOKKOS_COMPILER_CRAYC)
   return _popcnt(i);

--- a/core/src/impl/Kokkos_BitOps.hpp
+++ b/core/src/impl/Kokkos_BitOps.hpp
@@ -57,84 +57,152 @@ namespace Kokkos {
 namespace Impl {
 
 KOKKOS_FORCEINLINE_FUNCTION
-int int_log2(unsigned i) {
+int int_log2_fallback(unsigned i) {
   enum : int { shift = sizeof(unsigned) * CHAR_BIT - 1 };
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  return shift - __clz(i);
-#elif defined(KOKKOS_COMPILER_INTEL)
-  return _bit_scan_reverse(i);
-#elif defined(KOKKOS_COMPILER_CRAYC)
-  return i ? shift - _leadz32(i) : 0;
-#elif defined(__GNUC__) || defined(__GNUG__)
-  return shift - __builtin_clz(i);
-#else
   int offset = 0;
   if (i) {
     for (offset = shift; (i & (1 << offset)) == 0; --offset)
       ;
   }
   return offset;
+}
+
+KOKKOS_IMPL_DEVICE_FUNCTION
+inline int int_log2_device(unsigned i) {
+  enum : int { shift = sizeof(unsigned) * CHAR_BIT - 1 };
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+  return shift - __clz(i);
+#else
+  return int_log2_fallback(i);
 #endif
 }
+
+KOKKOS_IMPL_HOST_FUNCTION
+inline int int_log2_host(unsigned i) {
+  enum : int { shift = sizeof(unsigned) * CHAR_BIT - 1 };
+#if defined(KOKKOS_COMPILER_INTEL)
+  return _bit_scan_reverse(i);
+#elif defined(KOKKOS_COMPILER_CRAYC)
+  return i ? shift - _leadz32(i) : 0;
+#elif defined(__GNUC__) || defined(__GNUG__)
+  return shift - __builtin_clz(i);
+#else
+  return int_log2_fallback(i);
+#endif
+}
+
+#if defined(__EDG__)
+#pragma push
+#pragma diag_suppress implicit_return_from_non_void_function
+#endif
+KOKKOS_FORCEINLINE_FUNCTION
+int int_log2(unsigned i) {
+  KOKKOS_IF_ON_DEVICE((return int_log2_device(i);))
+  KOKKOS_IF_ON_HOST((return int_log2_host(i);))
+}
+#if defined(__EDG__)
+#pragma pop
+#endif
 
 /**\brief  Find first zero bit.
  *
  *  If none then return -1 ;
  */
 KOKKOS_FORCEINLINE_FUNCTION
-int bit_first_zero(unsigned i) noexcept {
+int bit_first_zero_fallback(unsigned i) noexcept {
   enum : unsigned { full = ~0u };
-
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  return full != i ? __ffs(~i) - 1 : -1;
-#elif defined(KOKKOS_COMPILER_INTEL)
-  return full != i ? _bit_scan_forward(~i) : -1;
-#elif defined(KOKKOS_COMPILER_CRAYC)
-  return full != i ? _popcnt(i ^ (i + 1)) - 1 : -1;
-#elif defined(KOKKOS_COMPILER_GNU) || defined(__GNUC__) || defined(__GNUG__)
-  return full != i ? __builtin_ffs(~i) - 1 : -1;
-#else
   int offset = -1;
   if (full != i) {
     for (offset = 0; i & (1 << offset); ++offset)
       ;
   }
   return offset;
+}
+
+KOKKOS_IMPL_DEVICE_FUNCTION
+inline int bit_first_zero_device(unsigned i) noexcept {
+  enum : unsigned { full = ~0u };
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+  return full != i ? __ffs(~i) - 1 : -1;
+#else
+  return bit_first_zero_fallback(i);
 #endif
 }
 
-KOKKOS_FORCEINLINE_FUNCTION
-int bit_scan_forward(unsigned i) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  return __ffs(i) - 1;
-#elif defined(KOKKOS_COMPILER_INTEL)
-  return _bit_scan_forward(i);
+KOKKOS_IMPL_HOST_FUNCTION
+inline int bit_first_zero_host(unsigned i) noexcept {
+  enum : unsigned { full = ~0u };
+
+#if defined(KOKKOS_COMPILER_INTEL)
+  return full != i ? _bit_scan_forward(~i) : -1;
 #elif defined(KOKKOS_COMPILER_CRAYC)
-  return i ? _popcnt(~i & (i - 1)) : -1;
+  return full != i ? _popcnt(i ^ (i + 1)) - 1 : -1;
 #elif defined(KOKKOS_COMPILER_GNU) || defined(__GNUC__) || defined(__GNUG__)
-  return __builtin_ffs(i) - 1;
+  return full != i ? __builtin_ffs(~i) - 1 : -1;
 #else
+  return bit_first_zero_fallback(i);
+#endif
+}
+
+#if defined(__EDG__)
+#pragma push
+#pragma diag_suppress implicit_return_from_non_void_function
+#endif
+KOKKOS_FORCEINLINE_FUNCTION
+int bit_first_zero(unsigned i) noexcept {
+  KOKKOS_IF_ON_DEVICE((return bit_first_zero_device(i);))
+  KOKKOS_IF_ON_HOST((return bit_first_zero_host(i);))
+}
+#if defined(__EDG__)
+#pragma pop
+#endif
+
+KOKKOS_FORCEINLINE_FUNCTION
+int bit_scan_forward_fallback(unsigned i) {
   int offset = -1;
   if (i) {
     for (offset = 0; (i & (1 << offset)) == 0; ++offset)
       ;
   }
   return offset;
+}
+
+KOKKOS_IMPL_DEVICE_FUNCTION inline int bit_scan_forward_device(unsigned i) {
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+  return __popc(i);
+#else
+  return bit_scan_forward_fallback(i);
 #endif
 }
 
+KOKKOS_IMPL_HOST_FUNCTION inline int bit_scan_forward_host(unsigned i) {
+#if defined(KOKKOS_COMPILER_INTEL)
+  return _bit_scan_forward(i);
+#elif defined(KOKKOS_COMPILER_CRAYC)
+  return i ? _popcnt(~i & (i - 1)) : -1;
+#elif defined(KOKKOS_COMPILER_GNU) || defined(__GNUC__) || defined(__GNUG__)
+  return __builtin_ffs(i) - 1;
+#else
+  return bit_scan_forward_fallback(i);
+#endif
+}
+
+#if defined(__EDG__)
+#pragma push
+#pragma diag_suppress implicit_return_from_non_void_function
+#endif
+KOKKOS_FORCEINLINE_FUNCTION
+int bit_scan_forward(unsigned i) {
+  KOKKOS_IF_ON_DEVICE((return bit_scan_forward_device(i);))
+  KOKKOS_IF_ON_HOST((return bit_scan_forward_host(i);))
+}
+#if defined(__EDG__)
+#pragma pop
+#endif
+
 /// Count the number of bits set.
 KOKKOS_FORCEINLINE_FUNCTION
-int bit_count(unsigned i) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  return __popc(i);
-#elif defined(__INTEL_COMPILER)
-  return _popcnt32(i);
-#elif defined(KOKKOS_COMPILER_CRAYC)
-  return _popcnt(i);
-#elif defined(__GNUC__) || defined(__GNUG__)
-  return __builtin_popcount(i);
-#else
+int bit_count_fallback(unsigned i) {
   // http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetNaive
   i = i - ((i >> 1) & ~0u / 3u);                           // temp
   i = (i & ~0u / 15u * 3u) + ((i >> 2) & ~0u / 15u * 3u);  // temp
@@ -142,8 +210,40 @@ int bit_count(unsigned i) {
 
   // count
   return (int)((i * (~0u / 255u)) >> (sizeof(unsigned) - 1) * CHAR_BIT);
+}
+
+KOKKOS_IMPL_DEVICE_FUNCTION inline int bit_count_device(unsigned i) {
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+  return __popc(i);
+#else
+  return bit_count_fallback(i);
 #endif
 }
+
+KOKKOS_IMPL_HOST_FUNCTION inline int bit_count_host(unsigned i) {
+#if defined(__INTEL_COMPILER)
+  return _popcnt32(i);
+#elif defined(KOKKOS_COMPILER_CRAYC)
+  return _popcnt(i);
+#elif defined(__GNUC__) || defined(__GNUG__)
+  return __builtin_popcount(i);
+#else
+  return bit_count_fallback(i);
+#endif
+}
+
+#if defined(__EDG__)
+#pragma push
+#pragma diag_suppress implicit_return_from_non_void_function
+#endif
+KOKKOS_FORCEINLINE_FUNCTION
+int bit_count(unsigned i) {
+  KOKKOS_IF_ON_DEVICE((return bit_count_device(i);))
+  KOKKOS_IF_ON_HOST((return bit_count_host(i);))
+}
+#if defined(__EDG__)
+#pragma pop
+#endif
 
 KOKKOS_INLINE_FUNCTION
 unsigned integral_power_of_two_that_contains(const unsigned N) {


### PR DESCRIPTION
Following up on #4660