### PR TITLE
Replace outdated Cuda signing key

### DIFF
--- a/scripts/docker/Dockerfile.kokkosllvmproject
+++ b/scripts/docker/Dockerfile.kokkosllvmproject
@@ -1,5 +1,7 @@
 FROM nvidia/cuda:10.1-devel
 
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 RUN apt-get update && apt-get install -y \
         bc \
         git \

--- a/scripts/docker/Dockerfile.nvcc
+++ b/scripts/docker/Dockerfile.nvcc
@@ -3,6 +3,8 @@ FROM $BASE
 
 ARG ADDITIONAL_PACKAGES
 
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 RUN apt-get update && apt-get install -y \
         bc \
         wget \

--- a/scripts/docker/Dockerfile.openmptarget
+++ b/scripts/docker/Dockerfile.openmptarget
@@ -1,4 +1,4 @@
-ARG BASE=nvidia/cuda:11.1-devel-ubuntu20.04
+ARG BASE=nvidia/cuda:11.1.1-devel-ubuntu20.04
 FROM $BASE
 
 RUN apt-get update && apt-get install -y \

--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -1,6 +1,8 @@
 ARG BASE=nvidia/cuda:10.2-devel
 FROM $BASE
 
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 RUN apt-get update && apt-get install -y \
         bc \
         wget \


### PR DESCRIPTION
https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
NVIDIA updated a number of their images but not all the ones we are using.  I opted from retrieving the new key in most cases.  For OpenMPTarget I opted for pinning to an image that is still supported.