### PR TITLE
Force SYCL fallback assert

### DIFF
--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -45,6 +45,15 @@
 #ifndef KOKKOS_SETUP_SYCL_HPP_
 #define KOKKOS_SETUP_SYCL_HPP_
 
+// FIXME_SYCL the fallback assert is temporarily disabled by default in the
+// compiler so we need to force it
+#ifndef SYCL_ENABLE_FALLBACK_ASSERT
+#define SYCL_ENABLE_FALLBACK_ASSERT
+#endif
+#ifndef SYCL_FALLBACK_ASSERT
+#define SYCL_FALLBACK_ASSERT 1
+#endif
+
 #include <CL/sycl.hpp>
 
 #ifdef __SYCL_DEVICE_ONLY__


### PR DESCRIPTION
https://github.com/intel/llvm/pull/4694 disables the fallback assert, also see https://github.com/intel/llvm/blob/sycl/sycl/doc/PreprocessorMacros.md, meaning that asserts (and thus also `__assert_fail()` that we use for Kokkos::abort()) don't have any effect in SYCL kernels.

Depending on the compiler version, different preprocessor macros as necessary to force the fallback assert to work (with some overhead), see https://github.com/intel/llvm/pull/4694/commits/05a3bc8cb54530e4a7fe87ca1805c28e3bd26527 (for SYCL_ENABLE_FALLBACK_ASSERT) and https://github.com/intel/llvm/pull/4694/files.