### PR TITLE
Fix racing condition in HIPParallelLaunch

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -468,7 +468,6 @@ void HIPInternal::finalize() {
 }
 
 char *HIPInternal::get_next_driver(size_t driverTypeSize) const {
-  std::lock_guard<std::mutex> const lock(m_mutexWorkArray);
   if (d_driverWorkArray == nullptr) {
     KOKKOS_IMPL_HIP_SAFE_CALL(
         hipHostMalloc(&d_driverWorkArray,

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -490,6 +490,8 @@ struct HIPParallelLaunch<
 
       KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
 
+      std::lock_guard<std::mutex> const lock(hip_instance->m_mutexWorkArray);
+
       // Invoke the driver function on the device
       DriverType *d_driver = reinterpret_cast<DriverType *>(
           hip_instance->get_next_driver(sizeof(DriverType)));


### PR DESCRIPTION
I encountered a racing condition within the Kokkos HIP execution space whilst doing some performance measurements in another [application](https://github.com/STEllAR-GROUP/octotiger) on a MI100.

While the method
```cpp
char *HIPInternal::get_next_driver(size_t driverTypeSize) const {
```
has a mutex and a lockguard for concurrent access, the same concurrency protections do not seem to hold for its return value ```d_driver``` in HIPParallelLaunch. Hence, it is possible that one thread gets its ```d_driver```, but before it can use it in the kernel invocation, another thread hits the ```m_maxDriverCycles``` limit in ```get_next_driver``` and calls fence (and the first thread only does its kernel invocation after this). At this point, it becomes a race: If enough kernels are scheduled on this HIP instance, we might overwrite the ```d_driver``` of the first thread while it's still in use.

Note, I think it is also possible for something similar to happen with the second branch ( ``` driverTypeSize > m_maxDriverTypeSize ``` ) in ```get_next_driver``` and another thread's return value in HIPParallelLaunch.

In my own use-case, I was seeing occasional crashes/hanging starting when 16 threads shared one HIP Executions Space (each thread launching multiple asynchronous kernels in rapid succession). At 64 threads and one exeuction space it was happening consistently enough to debug. Admittedly, the entire scenario is a bit of an edge case: We usually use more execution space instances and only tested it with a single one for some benchmark tests. Still, it should be fixed, hence this PR!

This PR fixes the issue by moving the lock guard from ```get_next_driver``` into ```HIPParallelLaunch```, thus also protecting the return value until the kernel is launched! At least for me it seems to resolve the issue entirely!

