### PR TITLE
complex(math) : log10 support

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -785,6 +785,13 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> log(
   return Kokkos::complex<RealType>(log(abs(x)), phi);
 }
 
+//! base 10 log of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> log10(
+    const complex<RealType>& x) {
+  return log(x) / log(RealType(10));
+}
+
 //! sine of a complex number.
 template <class RealType>
 KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sin(

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -369,6 +369,10 @@ struct TestComplexSpecialFunctions {
     r = {1.380543138238714, 0.2925178131625636};
     ASSERT_FLOAT_EQ(h_results(17).real(), r.real());
     ASSERT_FLOAT_EQ(h_results(17).imag(), r.imag());
+    // log10
+    r = std::log10(a);
+    ASSERT_FLOAT_EQ(h_results(18).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(18).imag(), r.imag());
 #endif
   }
 
@@ -396,6 +400,7 @@ struct TestComplexSpecialFunctions {
     d_results(15) = Kokkos::asin(a);
     d_results(16) = Kokkos::acos(a);
     d_results(17) = Kokkos::atan(a);
+    d_results(18) = Kokkos::log10(a);
   }
 };
 


### PR DESCRIPTION
This PR adds `log10` support for `Kokkos::complex` type.

This PR targets https://github.com/kokkos/kokkos/issues/3877.

It also comes with the accompanying test in `core/unit_test/TestComplex.hpp`.