### PR TITLE
Remove KOKKOS_ENABLE_POSIX_MEMALIGN

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -579,15 +579,6 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 #endif
 
 //----------------------------------------------------------------------------
-
-#if (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) || \
-    (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600)
-#if defined(KOKKOS_ENABLE_PERFORMANCE_POSIX_MEMALIGN)
-#define KOKKOS_ENABLE_POSIX_MEMALIGN 1
-#endif
-#endif
-
-//----------------------------------------------------------------------------
 // If compiling with CUDA, we must use relocatable device code to enable the
 // task policy.
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -448,13 +448,6 @@ void pre_initialize_internal(const InitArguments& args) {
   declare_configuration_metadata("memory", "KOKKOS_ENABLE_INTEL_MM_ALLOC",
                                  "no");
 #endif
-#ifdef KOKKOS_ENABLE_POSIX_MEMALIGN
-  declare_configuration_metadata("memory", "KOKKOS_ENABLE_POSIX_MEMALIGN",
-                                 "yes");
-#else
-  declare_configuration_metadata("memory", "KOKKOS_ENABLE_POSIX_MEMALIGN",
-                                 "no");
-#endif
 
 #ifdef KOKKOS_ENABLE_ASM
   declare_configuration_metadata("options", "KOKKOS_ENABLE_ASM", "yes");


### PR DESCRIPTION
`KOKKOS_ENABLE_POSIX_MEMALIGN` is only mentioned in
```
commit 8802c19fdfd492b70288daa8849d0d48f96441eb
Author: crtrott <crtrott@sandia.gov>
Date:   Wed Dec 2 12:27:33 2015 -0700

    Core: Add option KOKKOS_ENABLE_PERFORMANCE_POSIX_MEMALIGN
    This option is off by default, if defined we will use posix
    memalign for HostSpace, but it fails to allocate often.
    This only effects the new view implementation.  
```
in the whole `git` history. Hence, it seems to be untested and unused. We should consider removing it (or actually using and testing it).