### PR TITLE
Also use _mm_malloc for icpx

### DIFF
--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -50,7 +50,7 @@
 
 /*--------------------------------------------------------------------------*/
 
-#if defined(__INTEL_COMPILER) && !defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_COMPILER_INTEL) && !defined(KOKKOS_ENABLE_CUDA)
 
 // Intel specialized allocator does not interoperate with CUDA memory allocation
 


### PR DESCRIPTION
There doesn't seem to be a good reason to differentiate between `icpc` and `icpx`. I checked that it also works for the latter.