### PR TITLE
#4913: Make View self-assignment not produce double-free

### DIFF
--- a/core/src/impl/Kokkos_ViewTracker.hpp
+++ b/core/src/impl/Kokkos_ViewTracker.hpp
@@ -102,6 +102,7 @@ struct ViewTracker {
 
   KOKKOS_INLINE_FUNCTION ViewTracker& operator=(
       const ViewTracker& rhs) noexcept {
+    if (this == &rhs) return *this;
     KOKKOS_IF_ON_HOST((
         if (view_traits::is_managed && Kokkos::Impl::SharedAllocationRecord<
                                            void, void>::tracking_enabled()) {

--- a/core/src/impl/Kokkos_ViewTracker.hpp
+++ b/core/src/impl/Kokkos_ViewTracker.hpp
@@ -91,6 +91,9 @@ struct ViewTracker {
 
   template <class RT, class... RP>
   KOKKOS_INLINE_FUNCTION void assign(const View<RT, RP...>& vt) noexcept {
+    if (reinterpret_cast<void*>(this) ==
+        reinterpret_cast<const void*>(&vt.m_track))
+      return;
     KOKKOS_IF_ON_HOST((
         if (view_traits::is_managed && Kokkos::Impl::SharedAllocationRecord<
                                            void, void>::tracking_enabled()) {

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1087,6 +1087,12 @@ class TestViewAPI {
     dView4_unmanaged unmanaged_dx = dx;
     ASSERT_EQ(dx.use_count(), 1);
 
+    // Test self assignment
+    dx = dx;
+    ASSERT_EQ(dx.use_count(), 1);
+    dx = reinterpret_cast<typename dView4::uniform_type &>(dx);
+    ASSERT_EQ(dx.use_count(), 1);
+
     dView4_unmanaged unmanaged_from_ptr_dx = dView4_unmanaged(
         dx.data(), dx.extent(0), dx.extent(1), dx.extent(2), dx.extent(3));
 


### PR DESCRIPTION
Replacing #4914 because I can neither push to NexGenAnalytics organization nor, do a PR against that fork??

Fixes #4913 