### PR TITLE
Allow specifying label in realloc

### DIFF
--- a/core/unit_test/TestRealloc.hpp
+++ b/core/unit_test/TestRealloc.hpp
@@ -161,14 +161,14 @@ void testRealloc() {
   Kokkos::View<int*, DeviceType> v;
   Kokkos::realloc(Kokkos::view_alloc("v"), v, 1);
   EXPECT_EQ(v.label(), "v");
-  EXPECT_EQ(v.size(), 1);
+  EXPECT_EQ(v.extent_int(0), 1);
   Kokkos::View<int*, DeviceType> w = v;
   EXPECT_EQ(w.label(), "v");
   Kokkos::realloc(Kokkos::view_alloc("v_realloc"), v, 2);
   EXPECT_EQ(w.label(), "v");
-  EXPECT_EQ(w.size(), 1);
+  EXPECT_EQ(w.extent_int(0), 1);
   EXPECT_EQ(v.label(), "v_realloc");
-  EXPECT_EQ(v.size(), 2);
+  EXPECT_EQ(v.extent_int(0), 2);
 }
 
 }  // namespace TestViewRealloc

--- a/core/unit_test/TestRealloc.hpp
+++ b/core/unit_test/TestRealloc.hpp
@@ -158,6 +158,17 @@ void testRealloc() {
     impl_testRealloc<DeviceType,
                      WithoutInitializing>();  // without data initialization
   }
+  Kokkos::View<int*, DeviceType> v;
+  Kokkos::realloc(Kokkos::view_alloc("v"), v, 1);
+  EXPECT_EQ(v.label(), "v");
+  EXPECT_EQ(v.size(), 1);
+  Kokkos::View<int*, DeviceType> w = v;
+  EXPECT_EQ(w.label(), "v");
+  Kokkos::realloc(Kokkos::view_alloc("v_realloc"), v, 2);
+  EXPECT_EQ(w.label(), "v");
+  EXPECT_EQ(w.size(), 1);
+  EXPECT_EQ(v.label(), "v_realloc");
+  EXPECT_EQ(v.size(), 2);
 }
 
 }  // namespace TestViewRealloc


### PR DESCRIPTION
Somewhat related to #4844. 
We discussed on slack (with @stanmoore1) that we might want to allow specifying a label for `Kokokos::realloc` which this pull request allows. More specifically, this pull request introduces an overload that allows providing the return type of `Kokkos::view_alloc` as an input argument when calling `Kokkos::realloc` for `Kokkos::Views`.
Of course, this then can also be used for `WithoutInitializing` and specifying an execution space.

I decided to only take the new label if one is provided but we can, of course, discuss other options.
