### PR TITLE
Fixed an incorrect struct initialization

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Locks.cpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.cpp
@@ -56,8 +56,7 @@ namespace Kokkos {
 
 #ifdef KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE
 namespace Impl {
-__device__ __constant__ HIPLockArrays g_device_hip_lock_arrays = {nullptr,
-                                                                  nullptr, 0};
+__device__ __constant__ HIPLockArrays g_device_hip_lock_arrays = {nullptr, 0};
 }
 #endif
 


### PR DESCRIPTION
Building Kokkos for a HIP build with `-DKokkos_ENABLE_HIP_RELOCATABLE_DEVICE_CODE=ON` produced an error:

```
[  4%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/desul/src/Lock_Array_HIP.cpp.o
/ascldap/users/donlee/kokkos/kokkos/core/src/HIP/Kokkos_HIP_Locks.cpp:60:67: error: cannot initialize a member subobject of type 'std::int32_t' (aka 'int') with an rvalue of type 'nullptr_t'
                                                                  nullptr, 0};
                                                                  ^~~~~~~
1 error generated when compiling for gfx908.
```

It turned out that there was a HIPLockArrays struct variable that was being initialized incorrectly.