### PR TITLE
Rename OpenMPExec to OpenMPInternal in line with the other backends

### DIFF
--- a/Makefile.targets
+++ b/Makefile.targets
@@ -82,8 +82,8 @@ Kokkos_ThreadsExec.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/Threads/Kokk
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)
-Kokkos_OpenMP_Exec.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
-	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/OpenMP/Kokkos_OpenMP_Exec.cpp
+Kokkos_OpenMP_Instance.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
 Kokkos_OpenMP_Task.o: $(KOKKOS_CPP_DEPENDS) $(KOKKOS_PATH)/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
 	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) -c $(KOKKOS_PATH)/core/src/OpenMP/Kokkos_OpenMP_Task.cpp
 endif

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -72,7 +72,7 @@
 namespace Kokkos {
 
 namespace Impl {
-class OpenMPExec;
+class OpenMPInternal;
 }
 
 /// \class OpenMP
@@ -220,7 +220,7 @@ struct MemorySpaceAccess<Kokkos::OpenMP::memory_space,
 /*--------------------------------------------------------------------------*/
 /*--------------------------------------------------------------------------*/
 
-#include <OpenMP/Kokkos_OpenMP_Exec.hpp>
+#include <OpenMP/Kokkos_OpenMP_Instance.hpp>
 #include <OpenMP/Kokkos_OpenMP_Team.hpp>
 #include <OpenMP/Kokkos_OpenMP_Parallel.hpp>
 #include <OpenMP/Kokkos_OpenMP_Task.hpp>

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -42,9 +42,6 @@
 //@HEADER
 */
 
-#include <Kokkos_Macros.hpp>
-#if defined(KOKKOS_ENABLE_OPENMP)
-
 #include <cstdio>
 #include <cstdlib>
 
@@ -57,19 +54,20 @@
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_CPUDiscovery.hpp>
 #include <impl/Kokkos_Tools.hpp>
+#include "Kokkos_OpenMP_Instance.hpp"
 
 namespace Kokkos {
 namespace Impl {
 
 int g_openmp_hardware_max_threads = 1;
 
-__thread int t_openmp_hardware_id            = 0;
-__thread Impl::OpenMPExec *t_openmp_instance = nullptr;
+__thread int t_openmp_hardware_id                = 0;
+__thread Impl::OpenMPInternal *t_openmp_instance = nullptr;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
-void OpenMPExec::validate_partition_impl(const int nthreads,
-                                         int &num_partitions,
-                                         int &partition_size) {
+void OpenMPInternal::validate_partition_impl(const int nthreads,
+                                             int &num_partitions,
+                                             int &partition_size) {
   if (nthreads == 1) {
     num_partitions = 1;
     partition_size = 1;
@@ -121,7 +119,7 @@ void OpenMPExec::validate_partition_impl(const int nthreads,
 }
 #endif
 
-void OpenMPExec::verify_is_master(const char *const label) {
+void OpenMPInternal::verify_is_master(const char *const label) {
   if (!t_openmp_instance) {
     std::string msg(label);
     msg.append(" ERROR: in parallel or not initialized");
@@ -138,7 +136,7 @@ void OpenMPExec::verify_is_master(const char *const label) {
 namespace Kokkos {
 namespace Impl {
 
-void OpenMPExec::clear_thread_data() {
+void OpenMPInternal::clear_thread_data() {
   const size_t member_bytes =
       sizeof(int64_t) *
       HostThreadTeamData::align_to_int64(sizeof(HostThreadTeamData));
@@ -163,10 +161,10 @@ void OpenMPExec::clear_thread_data() {
   /* END #pragma omp parallel */
 }
 
-void OpenMPExec::resize_thread_data(size_t pool_reduce_bytes,
-                                    size_t team_reduce_bytes,
-                                    size_t team_shared_bytes,
-                                    size_t thread_local_bytes) {
+void OpenMPInternal::resize_thread_data(size_t pool_reduce_bytes,
+                                        size_t team_reduce_bytes,
+                                        size_t team_shared_bytes,
+                                        size_t thread_local_bytes) {
   const size_t member_bytes =
       sizeof(int64_t) *
       HostThreadTeamData::align_to_int64(sizeof(HostThreadTeamData));
@@ -342,14 +340,14 @@ void OpenMP::impl_initialize(int thread_count) {
 
     void *ptr = nullptr;
     try {
-      ptr = space.allocate(sizeof(Impl::OpenMPExec));
+      ptr = space.allocate(sizeof(Impl::OpenMPInternal));
     } catch (Kokkos::Experimental::RawMemoryAllocationFailure const &f) {
       // For now, just rethrow the error message the existing way
       Kokkos::Impl::throw_runtime_exception(f.get_error_message());
     }
 
     Impl::t_openmp_instance =
-        new (ptr) Impl::OpenMPExec(Impl::g_openmp_hardware_max_threads);
+        new (ptr) Impl::OpenMPInternal(Impl::g_openmp_hardware_max_threads);
 
     // New, unified host thread team data:
     {
@@ -401,7 +399,7 @@ void OpenMP::impl_finalize() {
                              : Impl::t_openmp_instance->m_pool_size;
     (void)nthreads;
 
-    using Exec     = Impl::OpenMPExec;
+    using Exec     = Impl::OpenMPInternal;
     Exec *instance = Impl::t_openmp_instance;
     instance->~Exec();
 
@@ -432,7 +430,7 @@ void OpenMP::print_configuration(std::ostream &s, const bool /*verbose*/) {
   const bool is_initialized = Impl::t_openmp_instance != nullptr;
 
   if (is_initialized) {
-    Impl::OpenMPExec::verify_is_master("OpenMP::print_configuration");
+    Impl::OpenMPInternal::verify_is_master("OpenMP::print_configuration");
 
     const int numa_count      = 1;
     const int core_per_numa   = Impl::g_openmp_hardware_max_threads;
@@ -517,7 +515,3 @@ constexpr DeviceType DeviceTypeTraits<OpenMP>::id;
 #endif
 
 }  // namespace Kokkos
-
-#else
-void KOKKOS_CORE_SRC_OPENMP_EXEC_PREVENT_LINK_ERROR() {}
-#endif  // KOKKOS_ENABLE_OPENMP

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -49,7 +49,7 @@
 #if defined(KOKKOS_ENABLE_OPENMP)
 
 #include <omp.h>
-#include <OpenMP/Kokkos_OpenMP_Exec.hpp>
+#include <OpenMP/Kokkos_OpenMP_Instance.hpp>
 
 #include <KokkosExp_MDRangePolicy.hpp>
 
@@ -80,7 +80,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::OpenMP> {
   using WorkRange = typename Policy::WorkRange;
   using Member    = typename Policy::member_type;
 
-  OpenMPExec* m_instance;
+  OpenMPInternal* m_instance;
   const FunctorType m_functor;
   const Policy m_policy;
 
@@ -139,7 +139,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::OpenMP> {
       return;
     }
 
-    OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_for");
+    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_for");
 #ifndef KOKKOS_INTERNAL_DISABLE_NATIVE_OPENMP
     execute_parallel<Policy>();
 #else
@@ -193,7 +193,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   using iterate_type = typename Kokkos::Impl::HostIterateTile<
       MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void>;
 
-  OpenMPExec* m_instance;
+  OpenMPInternal* m_instance;
   const FunctorType m_functor;
   const MDRangePolicy m_mdr_policy;
   const Policy m_policy;  // construct as RangePolicy( 0, num_tiles
@@ -240,7 +240,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       return;
     }
 
-    OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_for");
+    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_for");
 #ifndef KOKKOS_INTERNAL_DISABLE_NATIVE_OPENMP
     execute_parallel<Policy>();
 #else
@@ -326,7 +326,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
 
-  OpenMPExec* m_instance;
+  OpenMPInternal* m_instance;
   const FunctorType m_functor;
   const Policy m_policy;
   const ReducerType m_reducer;
@@ -368,7 +368,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                                 Kokkos::Dynamic>::value
     };
 
-    OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_reduce");
+    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_reduce");
 
     const size_t pool_reduce_bytes =
         Analysis::value_size(ReducerConditional::select(m_functor, m_reducer));
@@ -497,7 +497,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       typename Kokkos::Impl::HostIterateTile<MDRangePolicy, FunctorType,
                                              WorkTag, reference_type>;
 
-  OpenMPExec* m_instance;
+  OpenMPInternal* m_instance;
   const FunctorType m_functor;
   const MDRangePolicy m_mdr_policy;
   const Policy m_policy;  // construct as RangePolicy( 0, num_tiles
@@ -520,7 +520,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                                 Kokkos::Dynamic>::value
     };
 
-    OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_reduce");
+    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_reduce");
 
     const size_t pool_reduce_bytes =
         Analysis::value_size(ReducerConditional::select(m_functor, m_reducer));
@@ -658,7 +658,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
 
-  OpenMPExec* m_instance;
+  OpenMPInternal* m_instance;
   const FunctorType m_functor;
   const Policy m_policy;
 
@@ -683,7 +683,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
 
  public:
   inline void execute() const {
-    OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_scan");
+    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_scan");
 
     const int value_count          = Analysis::value_count(m_functor);
     const size_t pool_reduce_bytes = 2 * Analysis::value_size(m_functor);
@@ -768,7 +768,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
 
-  OpenMPExec* m_instance;
+  OpenMPInternal* m_instance;
   const FunctorType m_functor;
   const Policy m_policy;
   ReturnType& m_returnvalue;
@@ -794,7 +794,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
  public:
   inline void execute() const {
-    OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_scan");
+    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_scan");
 
     const int value_count          = Analysis::value_count(m_functor);
     const size_t pool_reduce_bytes = 2 * Analysis::value_size(m_functor);
@@ -890,7 +890,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   using SchedTag = typename Policy::schedule_type::type;
   using Member   = typename Policy::member_type;
 
-  OpenMPExec* m_instance;
+  OpenMPInternal* m_instance;
   const FunctorType m_functor;
   const Policy m_policy;
   const size_t m_shmem_size;
@@ -937,7 +937,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   inline void execute() const {
     enum { is_dynamic = std::is_same<SchedTag, Kokkos::Dynamic>::value };
 
-    OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_for");
+    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_for");
 
     const size_t pool_reduce_size  = 0;  // Never shrinks
     const size_t team_reduce_size  = TEAM_REDUCE_SIZE * m_policy.team_size();
@@ -1023,7 +1023,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
 
-  OpenMPExec* m_instance;
+  OpenMPInternal* m_instance;
   const FunctorType m_functor;
   const Policy m_policy;
   const ReducerType m_reducer;
@@ -1082,7 +1082,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       }
       return;
     }
-    OpenMPExec::verify_is_master("Kokkos::OpenMP parallel_reduce");
+    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_reduce");
 
     const size_t pool_reduce_size =
         Analysis::value_size(ReducerConditional::select(m_functor, m_reducer));

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -99,7 +99,7 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::OpenMP, QueueType>> {
     // TODO @tasking @generalization DSH use
     // scheduler.get_execution_space().impl() (or something like that) instead
     // of the thread-local variable
-    Impl::OpenMPExec* instance = t_openmp_instance;
+    Impl::OpenMPInternal* instance = t_openmp_instance;
     const int pool_size = get_max_team_count(scheduler.get_execution_space());
 
     // TODO @tasking @new_feature DSH allow team sizes other than 1
@@ -258,8 +258,8 @@ class TaskQueueSpecializationConstrained<
     HostThreadTeamData& team_data_single =
         HostThreadTeamDataSingleton::singleton();
 
-    Impl::OpenMPExec* instance = t_openmp_instance;
-    const int pool_size        = OpenMP::impl_thread_pool_size();
+    Impl::OpenMPInternal* instance = t_openmp_instance;
+    const int pool_size            = OpenMP::impl_thread_pool_size();
 
     const int team_size = 1;       // Threads per core
     instance->resize_thread_data(0 /* global reduce buffer */

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -48,7 +48,7 @@
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_OPENMP)
 
-#include <OpenMP/Kokkos_OpenMP_Exec.hpp>
+#include <OpenMP/Kokkos_OpenMP_Instance.hpp>
 
 namespace Kokkos {
 namespace Impl {


### PR DESCRIPTION
This PR renames `OpenMPExec` to `OpenMPInternal`.

Part of https://github.com/kokkos/kokkos/issues/4935