### PR TITLE
bug_report.md: new PR branching from `develop`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,16 +6,17 @@ labels: ''
 assignees: ''
 ---
 **Describe the bug**
-Please provide a concise, clear description of the bug, as well as any available error logs.
 
-**Please also include the following items to support reproducing the bug**
-1. compilers (with versions)
+Please provide a concise, clear description of the bug, as well as any available error logs.  Feel free to contact the Kokkos Slack `# build` channel for further discussion of your issue. 
+
+**Please include the following for a minimal reproducer**
+
+1. Compilers (with versions)
 2. Kokkos release or commit used (i.e., the sha1 number)
-3. platform and backend
-4. cmake configure command
-5. output from cmake command
-6. code needed to reproduce the bug
-7. command line needed to reproduce the bug
-7. please also attach the `KokkosCore_config.h` header file (generated during the build);
-**Any additional info**
-Please provide any additional context about the issue here.
+3. Platform, architecture and backend
+4. CMake configure command
+5. Output from CMake configure command
+6. Minimum, complete code needed to reproduce the bug
+7. Command line needed to reproduce the bug
+8. `KokkosCore_config.h` header file (generated during the build)
+9. Please provide any additional relevant error logs

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to correct failures and improve our code
+about: Create a report (for github issue tracker) to correct failures
 title: ''
 labels: ''
 assignees: ''


### PR DESCRIPTION
Reducing verbosity of bug report issue template for clarity and ease of use.  This PR is a "do over" for the previous, taking care to rebase on `develop`.