### PR TITLE
Provide Kokkos::realloc overload taking Kokkos::view_alloc() return type

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -921,6 +921,10 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
         !alloc_prop_input::has_memory_space,
         "The view constructor arguments passed to Kokkos::realloc must "
         "not include a memory space instance!");
+    static_assert(
+        !alloc_prop_input::allow_padding,
+        "The view constructor arguments passed to Kokkos::realloc must "
+        "not explicitly allow padding!");
 
     const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
     const bool sizeMismatch =

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -917,6 +917,10 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
         !alloc_prop_input::has_pointer,
         "The view constructor arguments passed to Kokkos::realloc must "
         "not include a pointer!");
+    static_assert(
+        !alloc_prop_input::has_memory_space,
+        "The view constructor arguments passed to Kokkos::realloc must "
+        "not include a memory space instance!");
 
     const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
     const bool sizeMismatch =

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -144,7 +144,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   using t_dev_const_randomread =
       View<typename traits::const_data_type, typename traits::array_layout,
            typename traits::device_type,
-           Kokkos::MemoryTraits<Kokkos::RandomAccess> >;
+           Kokkos::MemoryTraits<Kokkos::RandomAccess>>;
 
   /// \typedef t_host_const_randomread
   /// \brief The type of a const, random-access View host mirror of
@@ -175,7 +175,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
   using t_dev_const_randomread_um =
       View<typename t_host::const_data_type, typename t_host::array_layout,
            typename t_host::device_type,
-           Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+           Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   /// \typedef t_host_const_randomread
   /// \brief The type of a const, random-access View host mirror of
@@ -232,7 +232,9 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
            const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
            const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
            const size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
-      : modified_flags(Kokkos::view_alloc(typename t_modified_flags::execution_space{}, "DualView::modified_flags")),
+      : modified_flags(
+            Kokkos::view_alloc(typename t_modified_flags::execution_space{},
+                               "DualView::modified_flags")),
         d_view(label, n0, n1, n2, n3, n4, n5, n6, n7),
         h_view(create_mirror_view(d_view))  // without UVM, host View mirrors
   {}
@@ -402,7 +404,7 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                   impl_device_matches_tdev_exec<Device>::value, t_dev,
                   typename std::conditional_t<
                       impl_device_matches_tdev_memory_space<Device>::value,
-                      t_dev, t_host> > > > >
+                      t_dev, t_host>>>>>
   view() const {
     constexpr bool device_is_memspace =
         std::is_same<Device, typename Device::memory_space>::value;

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -931,23 +931,23 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                                     typename t_host::memory_space(), d_view);
       }
     } else if (alloc_prop_input::initialize) {
-    if (alloc_prop_input::has_execution_space) {
-    // Add execution_space if not provided to avoid need for if constexpr
-      using alloc_prop = Impl::ViewCtorProp<
-        ViewCtorArgs...,
-        std::conditional_t<alloc_prop_input::has_execution_space,
-                           std::integral_constant<unsigned int, 2>,
-                           typename t_dev::execution_space>>;
-      alloc_prop arg_prop_copy(arg_prop);
-      using execution_space_type = typename alloc_prop::execution_space;
-      const execution_space_type& exec_space =  static_cast<
+      if (alloc_prop_input::has_execution_space) {
+        // Add execution_space if not provided to avoid need for if constexpr
+        using alloc_prop = Impl::ViewCtorProp<
+            ViewCtorArgs...,
+            std::conditional_t<alloc_prop_input::has_execution_space,
+                               std::integral_constant<unsigned int, 2>,
+                               typename t_dev::execution_space>>;
+        alloc_prop arg_prop_copy(arg_prop);
+        using execution_space_type = typename alloc_prop::execution_space;
+        const execution_space_type& exec_space =
+            static_cast<
                 Kokkos::Impl::ViewCtorProp<void, execution_space_type> const&>(
                 arg_prop_copy)
                 .value;
-      ::Kokkos::deep_copy(exec_space, d_view, typename t_dev::value_type{});
-    }
-    else
-      ::Kokkos::deep_copy(d_view, typename t_dev::value_type{});
+        ::Kokkos::deep_copy(exec_space, d_view, typename t_dev::value_type{});
+      } else
+        ::Kokkos::deep_copy(d_view, typename t_dev::value_type{});
     }
 
     /* Reset dirty flags */

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -921,10 +921,6 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
         !alloc_prop_input::has_memory_space,
         "The view constructor arguments passed to Kokkos::realloc must "
         "not include a memory space instance!");
-    static_assert(
-        !alloc_prop_input::allow_padding,
-        "The view constructor arguments passed to Kokkos::realloc must "
-        "not explicitly allow padding!");
 
     const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
     const bool sizeMismatch =

--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -911,6 +911,10 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
     static_assert(!alloc_prop_input::has_label,
                   "The view constructor arguments passed to Kokkos::realloc "
                   "must not include a label!");
+    static_assert(
+        !alloc_prop_input::has_pointer,
+        "The view constructor arguments passed to Kokkos::realloc must "
+        "not include a pointer!");
 
     const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
     const bool sizeMismatch =

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2369,6 +2369,9 @@ inline void impl_realloc(DynRankView<T, P...>& v, const size_t n0,
   static_assert(!alloc_prop_input::has_memory_space,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a memory space instance!");
+  static_assert(!alloc_prop_input::allow_padding,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not explicitly allow padding!");
 
   const std::string label = v.label();
 

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2363,6 +2363,9 @@ inline void impl_realloc(DynRankView<T, P...>& v, const size_t n0,
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a label!");
+  static_assert(!alloc_prop_input::has_pointer,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not include a pointer!");
 
   const std::string label = v.label();
 

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2369,9 +2369,6 @@ inline void impl_realloc(DynRankView<T, P...>& v, const size_t n0,
   static_assert(!alloc_prop_input::has_memory_space,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a memory space instance!");
-  static_assert(!alloc_prop_input::allow_padding,
-                "The view constructor arguments passed to Kokkos::realloc must "
-                "not explicitly allow padding!");
 
   const std::string label = v.label();
 

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2376,7 +2376,13 @@ inline void impl_realloc(DynRankView<T, P...>& v, const size_t n0,
   const std::string label = v.label();
 
   v = drview_type();  // Deallocate first, if the only view to allocation
-  v = drview_type(arg_prop, n0, n1, n2, n3, n4, n5, n6, n7);
+
+  using alloc_prop = Impl::ViewCtorProp<ViewCtorArgs..., std::string>;
+  alloc_prop arg_prop_copy(arg_prop);
+  static_cast<Kokkos::Impl::ViewCtorProp<void, std::string>&>(arg_prop_copy)
+      .value = v.label();
+
+  v = drview_type(arg_prop_copy, n0, n1, n2, n3, n4, n5, n6, n7);
 }
 
 template <class T, class... P, class... ViewCtorArgs>

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2366,6 +2366,9 @@ inline void impl_realloc(DynRankView<T, P...>& v, const size_t n0,
   static_assert(!alloc_prop_input::has_pointer,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a pointer!");
+  static_assert(!alloc_prop_input::has_memory_space,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not include a memory space instance!");
 
   const std::string label = v.label();
 

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -842,6 +842,19 @@ class ScatterView<DataType, Layout, DeviceType, Op, ScatterNonDuplicated,
     ::Kokkos::resize(arg_prop, internal_view, n0, n1, n2, n3, n4, n5, n6, n7);
   }
 
+  template <class... ViewCtorArgs>
+  void realloc(const Kokkos::Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
+               const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG) {
+    ::Kokkos::realloc(arg_prop, internal_view, n0, n1, n2, n3, n4, n5, n6, n7);
+  }
+
   void realloc(const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
@@ -1555,6 +1568,15 @@ void contribute(
 }  // namespace Kokkos
 
 namespace Kokkos {
+
+template <typename DT, typename LY, typename ES, typename OP, typename CT,
+          typename DP, typename... IS, class... ViewCtorArgs>
+void realloc(
+    const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
+    Kokkos::Experimental::ScatterView<DT, LY, ES, OP, CT, DP>& scatter_view,
+    IS... is) {
+  scatter_view.realloc(arg_prop, is...);
+}
 
 template <typename DT, typename LY, typename ES, typename OP, typename CT,
           typename DP, typename... IS>

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -1139,6 +1139,19 @@ class ScatterView<DataType, Kokkos::LayoutRight, DeviceType, Op,
                      n3, n4, n5, n6);
   }
 
+  template <class... ViewCtorArgs>
+  void realloc(const ::Kokkos::Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
+               const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+               const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG) {
+    ::Kokkos::realloc(arg_prop, internal_view, unique_token.size(), n0, n1, n2,
+                      n3, n4, n5, n6);
+  }
+
   void realloc(const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
                const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -493,7 +493,7 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynrankview) {
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found parallel_for event"}};
       },
-      [&](BeginFenceEvent event) {
+      [&](BeginFenceEvent) {
         return MatchDiagnostic{true, {"Found fence event"}};
       });
   ASSERT_TRUE(success);
@@ -590,7 +590,7 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_offsetview) {
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found parallel_for event"}};
       },
-      [&](BeginFenceEvent event) {
+      [&](BeginFenceEvent) {
         return MatchDiagnostic{true, {"Found fence event"}};
       });
   ASSERT_TRUE(success);
@@ -657,7 +657,7 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynamicview) {
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found parallel_for event"}};
       },
-      [&](BeginFenceEvent event) {
+      [&](BeginFenceEvent) {
         return MatchDiagnostic{true, {"Found fence event"}};
       });
   ASSERT_TRUE(success);

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -161,10 +161,6 @@ TEST(TEST_CATEGORY, realloc_exec_space_dualview) {
   auto success = validate_absence(
       [&]() { Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), v, 8); },
       [&](BeginFenceEvent event) {
-        if ((event.descriptor().find("Debug Only Check for Execution Error") !=
-             std::string::npos) ||
-            (event.descriptor().find("HostSpace fence") != std::string::npos))
-          return MatchDiagnostic{false};
         return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);
@@ -263,8 +259,6 @@ TEST(TEST_CATEGORY, realloc_exec_space_dynrankview) {
         outer_view2 = inner_view;
       },
       [&](BeginFenceEvent event) {
-        if (event.descriptor().find("HostSpace fence") != std::string::npos)
-          return MatchDiagnostic{false};
         return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);
@@ -398,10 +392,6 @@ TEST(TEST_CATEGORY, realloc_exec_space_scatterview) {
         Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), inner_view, 10);
       },
       [&](BeginFenceEvent event) {
-        if ((event.descriptor().find("Debug Only Check for Execution Error") !=
-             std::string::npos) ||
-            (event.descriptor().find("HostSpace fence") != std::string::npos))
-          return MatchDiagnostic{false};
         return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -263,11 +263,7 @@ TEST(TEST_CATEGORY, realloc_exec_space_dynrankview) {
         outer_view2 = inner_view;
       },
       [&](BeginFenceEvent event) {
-        // FIXME_CUDA FIXME_HIP FIXME_SYCL FIXME_OPENMPTARGET
-        if ((event.descriptor().find(
-                 "fence after copying header from HostSpace") !=
-             std::string::npos) ||
-            (event.descriptor().find("HostSpace fence") != std::string::npos))
+        if (event.descriptor().find("HostSpace fence") != std::string::npos)
           return MatchDiagnostic{false};
         return MatchDiagnostic{true, {"Found fence event!"}};
       });
@@ -402,11 +398,7 @@ TEST(TEST_CATEGORY, realloc_exec_space_scatterview) {
         Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), inner_view, 10);
       },
       [&](BeginFenceEvent event) {
-        // FIXME_CUDA FIXME_HIP FIXME_SYCL FIXME_OPENMPTARGET
-        if ((event.descriptor().find(
-                 "fence after copying header from HostSpace") !=
-             std::string::npos) ||
-            (event.descriptor().find("Debug Only Check for Execution Error") !=
+        if ((event.descriptor().find("Debug Only Check for Execution Error") !=
              std::string::npos) ||
             (event.descriptor().find("HostSpace fence") != std::string::npos))
           return MatchDiagnostic{false};
@@ -497,13 +489,10 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynrankview) {
         device_view = mirror_device;
       },
       [&](BeginParallelForEvent) {
-        return MatchDiagnostic{true, {"Found begin event"}};
+        return MatchDiagnostic{true, {"Found parallel_for event"}};
       },
       [&](BeginFenceEvent event) {
-        return MatchDiagnostic{
-            event.descriptor().find(
-                "fence after copying header from HostSpace") ==
-            std::string::npos};
+        return MatchDiagnostic{true, {"Found fence event"}};
       });
   ASSERT_TRUE(success);
 }
@@ -597,13 +586,10 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_offsetview) {
             mirror_device);
       },
       [&](BeginParallelForEvent) {
-        return MatchDiagnostic{true, {"Found begin event"}};
+        return MatchDiagnostic{true, {"Found parallel_for event"}};
       },
       [&](BeginFenceEvent event) {
-        return MatchDiagnostic{
-            event.descriptor().find(
-                "fence after copying header from HostSpace") ==
-            std::string::npos};
+        return MatchDiagnostic{true, {"Found fence event"}};
       });
   ASSERT_TRUE(success);
 }
@@ -667,13 +653,10 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynamicview) {
             mirror_device);
       },
       [&](BeginParallelForEvent) {
-        return MatchDiagnostic{true, {"Found begin event"}};
+        return MatchDiagnostic{true, {"Found parallel_for event"}};
       },
       [&](BeginFenceEvent event) {
-        return MatchDiagnostic{
-            event.descriptor().find(
-                "fence after copying header from HostSpace") ==
-            std::string::npos};
+        return MatchDiagnostic{true, {"Found fence event"}};
       });
   ASSERT_TRUE(success);
 }

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -150,7 +150,7 @@ TEST(TEST_CATEGORY, realloc_exec_space_dualview) {
 #ifdef KOKKOS_ENABLE_CUDA
   if (std::is_same<typename TEST_EXECSPACE::memory_space,
                    Kokkos::CudaUVMSpace>::value)
-    return;
+    GTEST_SKIP() << "skipping since CudaUVMSpace requires additional fences";
 #endif
 
   using namespace Kokkos::Test::Tools;
@@ -239,11 +239,12 @@ TEST(TEST_CATEGORY, realloc_exec_space_dynrankview) {
 #ifdef KOKKOS_ENABLE_CUDA
   if (std::is_same<typename TEST_EXECSPACE::memory_space,
                    Kokkos::CudaUVMSpace>::value)
-    return;
+    GTEST_SKIP() << "skipping since CudaUVMSpace requires additional fences";
 #endif
 // FIXME_THREADS The Threads backend fences every parallel_for
 #ifdef KOKKOS_ENABLE_THREADS
-  if (std::is_same<typename TEST_EXECSPACE, Kokkos::Threads>::value) return;
+  if (std::is_same<TEST_EXECSPACE, Kokkos::Threads>::value)
+    GTEST_SKIP() << "skipping since the Threads backend isn't asynchronous";
 #endif
 
   using namespace Kokkos::Test::Tools;
@@ -375,7 +376,12 @@ TEST(TEST_CATEGORY, realloc_exec_space_scatterview) {
 #ifdef KOKKOS_ENABLE_CUDA
   if (std::is_same<typename TEST_EXECSPACE::memory_space,
                    Kokkos::CudaUVMSpace>::value)
-    return;
+    GTEST_SKIP() << "skipping since CudaUVMSpace requires additional fences";
+#endif
+// FIXME_THREADS The Threads backend fences every parallel_for
+#ifdef KOKKOS_ENABLE_THREADS
+  if (std::is_same<typename TEST_EXECSPACE, Kokkos::Threads>::value)
+    GTEST_SKIP() << "skipping since the Threads backend isn't asynchronous";
 #endif
 
   using namespace Kokkos::Test::Tools;

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -62,6 +62,8 @@ TEST(TEST_CATEGORY, resize_realloc_no_init_dualview) {
       [&]() {
         Kokkos::resize(Kokkos::WithoutInitializing, bla, 5, 6, 7, 9);
         Kokkos::realloc(Kokkos::WithoutInitializing, bla, 8, 8, 8, 8);
+        Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing), bla, 5,
+                        6, 7, 8);
       },
       [&](BeginParallelForEvent event) {
         if (event.descriptor().find("initialization") != std::string::npos)
@@ -153,6 +155,8 @@ TEST(TEST_CATEGORY, resize_realloc_no_init_dynrankview) {
       [&]() {
         Kokkos::resize(Kokkos::WithoutInitializing, bla, 5, 6, 7, 9);
         Kokkos::realloc(Kokkos::WithoutInitializing, bla, 8, 8, 8, 8);
+        Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing), bla, 5,
+                        6, 7, 8);
       },
       [&](BeginParallelForEvent event) {
         if (event.descriptor().find("initialization") != std::string::npos)
@@ -217,6 +221,8 @@ TEST(TEST_CATEGORY, resize_realloc_no_init_scatterview) {
       [&]() {
         Kokkos::resize(Kokkos::WithoutInitializing, bla, 4, 5, 6, 8);
         Kokkos::realloc(Kokkos::WithoutInitializing, bla, 8, 8, 8, 8);
+        Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing), bla, 5,
+                        6, 7, 8);
       },
       [&](BeginParallelForEvent event) {
         if (event.descriptor().find("initialization") != std::string::npos)

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -161,10 +161,11 @@ TEST(TEST_CATEGORY, realloc_exec_space_dualview) {
   auto success = validate_absence(
       [&]() { Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), v, 8); },
       [&](BeginFenceEvent event) {
-        if (!(event.descriptor().find("Debug Only Check for Execution Error") !=
-              std::string::npos))
-          return MatchDiagnostic{true, {"Found fence event!"}};
-        return MatchDiagnostic{false};
+        if ((event.descriptor().find("Debug Only Check for Execution Error") !=
+             std::string::npos) ||
+            (event.descriptor().find("HostSpace fence") != std::string::npos))
+          return MatchDiagnostic{false};
+        return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);
   listen_tool_events(Config::DisableAll());
@@ -262,11 +263,12 @@ TEST(TEST_CATEGORY, realloc_exec_space_dynrankview) {
       },
       [&](BeginFenceEvent event) {
         // FIXME_CUDA FIXME_HIP FIXME_SYCL FIXME_OPENMPTARGET
-        if (!(event.descriptor().find(
-                  "fence after copying header from HostSpace") !=
-              std::string::npos))
-          return MatchDiagnostic{true, {"Found fence event!"}};
-        return MatchDiagnostic{false};
+        if ((event.descriptor().find(
+                 "fence after copying header from HostSpace") !=
+             std::string::npos) ||
+            (event.descriptor().find("HostSpace fence") != std::string::npos))
+          return MatchDiagnostic{false};
+        return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);
   listen_tool_events(Config::DisableAll());
@@ -399,7 +401,8 @@ TEST(TEST_CATEGORY, realloc_exec_space_scatterview) {
                  "fence after copying header from HostSpace") !=
              std::string::npos) ||
             (event.descriptor().find("Debug Only Check for Execution Error") !=
-             std::string::npos))
+             std::string::npos) ||
+            (event.descriptor().find("HostSpace fence") != std::string::npos))
           return MatchDiagnostic{false};
         return MatchDiagnostic{true, {"Found fence event!"}};
       });

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -237,6 +237,10 @@ TEST(TEST_CATEGORY, realloc_exec_space_dynrankview) {
                    Kokkos::CudaUVMSpace>::value)
     return;
 #endif
+// FIXME_THREADS The Threads backend fences every parallel_for
+#ifdef KOKKOS_ENABLE_THREADS
+  if (std::is_same<typename TEST_EXECSPACE, Kokkos::Threads>::value) return;
+#endif
 
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableFences());

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -161,6 +161,10 @@ TEST(TEST_CATEGORY, realloc_exec_space_dualview) {
   auto success = validate_absence(
       [&]() { Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), v, 8); },
       [&](BeginFenceEvent event) {
+        if ((event.descriptor().find("Debug Only Check for Execution Error") !=
+             std::string::npos) ||
+            (event.descriptor().find("HostSpace fence") != std::string::npos))
+          return MatchDiagnostic{false};
         return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);
@@ -259,6 +263,10 @@ TEST(TEST_CATEGORY, realloc_exec_space_dynrankview) {
         outer_view2 = inner_view;
       },
       [&](BeginFenceEvent event) {
+        if ((event.descriptor().find("Debug Only Check for Execution Error") !=
+             std::string::npos) ||
+            (event.descriptor().find("HostSpace fence") != std::string::npos))
+          return MatchDiagnostic{false};
         return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);
@@ -392,6 +400,10 @@ TEST(TEST_CATEGORY, realloc_exec_space_scatterview) {
         Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), inner_view, 10);
       },
       [&](BeginFenceEvent event) {
+        if ((event.descriptor().find("Debug Only Check for Execution Error") !=
+             std::string::npos) ||
+            (event.descriptor().find("HostSpace fence") != std::string::npos))
+          return MatchDiagnostic{false};
         return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -159,19 +159,13 @@ TEST(TEST_CATEGORY, realloc_exec_space_dualview) {
   view_type v(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
 
   auto success = validate_absence(
-      [&]() {
-        Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), v, 8);
-      },
-      [&](BeginFenceEvent event) {
-        return MatchDiagnostic{
-            event.descriptor().find(
-                "Kokkos::Impl::ViewValueFunctor: View init/destroy fence") !=
-            std::string::npos};
+      [&]() { Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), v, 8); },
+      [&](BeginFenceEvent) {
+        return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);
   listen_tool_events(Config::DisableAll());
 }
-
 
 TEST(TEST_CATEGORY, resize_realloc_no_init_dynrankview) {
   using namespace Kokkos::Test::Tools;
@@ -254,16 +248,13 @@ TEST(TEST_CATEGORY, realloc_exec_space_dynrankview) {
         view_type inner_view(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
         // Avoid testing the destructor
         outer_view = inner_view;
-        Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing, TEST_EXECSPACE{}),
-                        inner_view, 10);
+        Kokkos::realloc(
+            Kokkos::view_alloc(Kokkos::WithoutInitializing, TEST_EXECSPACE{}),
+            inner_view, 10);
         outer_view2 = inner_view;
-        Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), inner_view, 10);
       },
-      [&](BeginFenceEvent event) {
-        return MatchDiagnostic{
-            event.descriptor().find(
-                "Kokkos::Impl::ViewValueFunctor: View init/destroy fence") !=
-            std::string::npos};
+      [&](BeginFenceEvent) {
+        return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);
   listen_tool_events(Config::DisableAll());
@@ -375,7 +366,8 @@ TEST(TEST_CATEGORY, realloc_exec_space_scatterview) {
 
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableFences());
-  using view_type = Kokkos::Experimental::ScatterView<int*, typename TEST_EXECSPACE::array_layout, TEST_EXECSPACE>;
+  using view_type = Kokkos::Experimental::ScatterView<
+      int*, typename TEST_EXECSPACE::array_layout, TEST_EXECSPACE>;
   view_type outer_view, outer_view2;
 
   auto success = validate_absence(
@@ -383,16 +375,14 @@ TEST(TEST_CATEGORY, realloc_exec_space_scatterview) {
         view_type inner_view(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
         // Avoid testing the destructor
         outer_view = inner_view;
-        Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing, TEST_EXECSPACE{}),
-                        inner_view, 10);
+        Kokkos::realloc(
+            Kokkos::view_alloc(Kokkos::WithoutInitializing, TEST_EXECSPACE{}),
+            inner_view, 10);
         outer_view2 = inner_view;
         Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), inner_view, 10);
       },
-      [&](BeginFenceEvent event) {
-        return MatchDiagnostic{
-            event.descriptor().find(
-                "Kokkos::Impl::ViewValueFunctor: View init/destroy fence") !=
-            std::string::npos};
+      [&](BeginFenceEvent) {
+        return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);
   listen_tool_events(Config::DisableAll());

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2614,7 +2614,7 @@ inline void deep_copy(
         std::conditional_t<ViewType::Rank == 0,
                            typename ViewType::uniform_runtime_type,
                            typename ViewType::uniform_runtime_nomemspace_type>;
-    if (dst.span() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    if (dst.span() > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutRight, ExecSpace,
                                ViewType::Rank, int64_t>(dst, value, space);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3265,6 +3265,9 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
   static_assert(!alloc_prop_input::has_pointer,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a pointer!");
+  static_assert(!alloc_prop_input::has_memory_space,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not include a memory space instance!");
 
   const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
   const bool sizeMismatch = Impl::size_mismatch(v, v.rank_dynamic, new_extents);
@@ -3372,6 +3375,9 @@ impl_realloc(Kokkos::View<T, P...>& v,
   static_assert(!alloc_prop_input::has_pointer,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a pointer!");
+  static_assert(!alloc_prop_input::has_memory_space,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not include a memory space instance!");
 
   if (v.layout() != layout) {
     v = view_type();  // Deallocate first, if the only view to allocation
@@ -3423,6 +3429,9 @@ impl_realloc(Kokkos::View<T, P...>& v,
   static_assert(!alloc_prop_input::has_pointer,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a pointer!");
+  static_assert(!alloc_prop_input::has_memory_space,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not include a memory space instance!");
 
   v = view_type();  // Deallocate first, if the only view to allocation
   v = view_type(arg_prop, layout);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3219,10 +3219,12 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
 
   static_assert(Kokkos::ViewTraits<T, P...>::is_managed,
                 "Can only realloc managed views");
-
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a label!");
+  static_assert(!alloc_prop_input::has_pointer,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not include a pointer!");
 
   const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
   const bool sizeMismatch = Impl::size_mismatch(v, v.rank_dynamic, new_extents);
@@ -3310,6 +3312,9 @@ impl_realloc(Kokkos::View<T, P...>& v,
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a label!");
+  static_assert(!alloc_prop_input::has_pointer,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not include a pointer!");
 
   if (v.layout() != layout) {
     v = view_type();  // Deallocate first, if the only view to allocation
@@ -3340,6 +3345,9 @@ impl_realloc(Kokkos::View<T, P...>& v,
   static_assert(!alloc_prop_input::has_label,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a label!");
+  static_assert(!alloc_prop_input::has_pointer,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not include a pointer!");
 
   v = view_type();  // Deallocate first, if the only view to allocation
   v = view_type(arg_prop, layout);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3285,8 +3285,11 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
           ViewCtorArgs...,
           std::conditional_t<alloc_prop_input::has_execution_space,
                              std::integral_constant<unsigned int, 2>,
-                             typename view_type::execution_space>>;
+                             typename view_type::execution_space>,
+          std::string>;
       alloc_prop arg_prop_copy(arg_prop);
+      static_cast<Kokkos::Impl::ViewCtorProp<void, std::string>&>(arg_prop_copy)
+          .value                 = v.label();
       using execution_space_type = typename alloc_prop::execution_space;
       const execution_space_type& exec_space =
           static_cast<
@@ -3395,8 +3398,11 @@ impl_realloc(Kokkos::View<T, P...>& v,
           ViewCtorArgs...,
           std::conditional_t<alloc_prop_input::has_execution_space,
                              std::integral_constant<unsigned int, 2>,
-                             typename view_type::execution_space>>;
+                             typename view_type::execution_space>,
+          std::string>;
       alloc_prop arg_prop_copy(arg_prop);
+      static_cast<Kokkos::Impl::ViewCtorProp<void, std::string>&>(arg_prop_copy)
+          .value                 = v.label();
       using execution_space_type = typename alloc_prop::execution_space;
       const execution_space_type& exec_space =
           static_cast<
@@ -3443,7 +3449,12 @@ impl_realloc(Kokkos::View<T, P...>& v,
                 "not explicitly allow padding!");
 
   v = view_type();  // Deallocate first, if the only view to allocation
-  v = view_type(arg_prop, layout);
+
+  using alloc_prop = Impl::ViewCtorProp<ViewCtorArgs..., std::string>;
+  alloc_prop arg_prop_copy(arg_prop);
+  static_cast<Kokkos::Impl::ViewCtorProp<void, std::string>&>(arg_prop_copy)
+      .value = v.label();
+  v          = view_type(arg_prop_copy, layout);
 }
 
 template <class T, class... P, class... ViewCtorArgs>

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3205,11 +3205,11 @@ inline void resize(Kokkos::View<T, P...>& v,
 
 /** \brief  Resize a view with discarding old data. */
 template <class T, class... P, class... ViewCtorArgs>
-inline typename std::enable_if<
+inline std::enable_if_t<
     std::is_same<typename Kokkos::View<T, P...>::array_layout,
                  Kokkos::LayoutLeft>::value ||
     std::is_same<typename Kokkos::View<T, P...>::array_layout,
-                 Kokkos::LayoutRight>::value>::type
+                 Kokkos::LayoutRight>::value>
 impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
              const size_t n2, const size_t n3, const size_t n4, const size_t n5,
              const size_t n6, const size_t n7,

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3268,6 +3268,9 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
   static_assert(!alloc_prop_input::has_memory_space,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a memory space instance!");
+  static_assert(!alloc_prop_input::allow_padding,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not explicitly allow padding!");
 
   const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
   const bool sizeMismatch = Impl::size_mismatch(v, v.rank_dynamic, new_extents);
@@ -3378,6 +3381,9 @@ impl_realloc(Kokkos::View<T, P...>& v,
   static_assert(!alloc_prop_input::has_memory_space,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a memory space instance!");
+  static_assert(!alloc_prop_input::allow_padding,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not explicitly allow padding!");
 
   if (v.layout() != layout) {
     v = view_type();  // Deallocate first, if the only view to allocation
@@ -3432,6 +3438,9 @@ impl_realloc(Kokkos::View<T, P...>& v,
   static_assert(!alloc_prop_input::has_memory_space,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a memory space instance!");
+  static_assert(!alloc_prop_input::allow_padding,
+                "The view constructor arguments passed to Kokkos::realloc must "
+                "not explicitly allow padding!");
 
   v = view_type();  // Deallocate first, if the only view to allocation
   v = view_type(arg_prop, layout);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3268,9 +3268,6 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
   static_assert(!alloc_prop_input::has_memory_space,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a memory space instance!");
-  static_assert(!alloc_prop_input::allow_padding,
-                "The view constructor arguments passed to Kokkos::realloc must "
-                "not explicitly allow padding!");
 
   const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
   const bool sizeMismatch = Impl::size_mismatch(v, v.rank_dynamic, new_extents);
@@ -3384,9 +3381,6 @@ impl_realloc(Kokkos::View<T, P...>& v,
   static_assert(!alloc_prop_input::has_memory_space,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a memory space instance!");
-  static_assert(!alloc_prop_input::allow_padding,
-                "The view constructor arguments passed to Kokkos::realloc must "
-                "not explicitly allow padding!");
 
   if (v.layout() != layout) {
     v = view_type();  // Deallocate first, if the only view to allocation
@@ -3444,9 +3438,6 @@ impl_realloc(Kokkos::View<T, P...>& v,
   static_assert(!alloc_prop_input::has_memory_space,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a memory space instance!");
-  static_assert(!alloc_prop_input::allow_padding,
-                "The view constructor arguments passed to Kokkos::realloc must "
-                "not explicitly allow padding!");
 
   v = view_type();  // Deallocate first, if the only view to allocation
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2624,10 +2624,10 @@ inline void deep_copy(
     } else {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutRight, ExecSpace,
-                               ViewType::Rank, int>(dst, value, space);
+                               ViewType::Rank, int32_t>(dst, value, space);
       else
         Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutLeft, ExecSpace,
-                               ViewType::Rank, int>(dst, value, space);
+                               ViewType::Rank, int32_t>(dst, value, space);
     }
   }
   if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3234,21 +3234,21 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
     v = view_type(arg_prop, n0, n1, n2, n3, n4, n5, n6, n7);
   } else if (alloc_prop_input::initialize) {
     if (alloc_prop_input::has_execution_space) {
-    // Add execution_space if not provided to avoid need for if constexpr
+      // Add execution_space if not provided to avoid need for if constexpr
       using alloc_prop = Impl::ViewCtorProp<
-        ViewCtorArgs...,
-        std::conditional_t<alloc_prop_input::has_execution_space,
-                           std::integral_constant<unsigned int, 2>,
-                           typename view_type::execution_space>>;
+          ViewCtorArgs...,
+          std::conditional_t<alloc_prop_input::has_execution_space,
+                             std::integral_constant<unsigned int, 2>,
+                             typename view_type::execution_space>>;
       alloc_prop arg_prop_copy(arg_prop);
       using execution_space_type = typename alloc_prop::execution_space;
-      const execution_space_type& exec_space =  static_cast<
-                Kokkos::Impl::ViewCtorProp<void, execution_space_type> const&>(
-                arg_prop_copy)
-                .value;
+      const execution_space_type& exec_space =
+          static_cast<
+              Kokkos::Impl::ViewCtorProp<void, execution_space_type> const&>(
+              arg_prop_copy)
+              .value;
       Kokkos::deep_copy(exec_space, v, typename view_type::value_type{});
-    }
-    else
+    } else
       Kokkos::deep_copy(v, typename view_type::value_type{});
   }
 }
@@ -3338,21 +3338,21 @@ impl_realloc(Kokkos::View<T, P...>& v,
     v = view_type(arg_prop, layout);
   } else if (alloc_prop_input::initialize) {
     if (alloc_prop_input::has_execution_space) {
-    // Add execution_space if not provided to avoid need for if constexpr
+      // Add execution_space if not provided to avoid need for if constexpr
       using alloc_prop = Impl::ViewCtorProp<
-        ViewCtorArgs...,
-        std::conditional_t<alloc_prop_input::has_execution_space,
-                           std::integral_constant<unsigned int, 2>,
-                           typename view_type::execution_space>>;
+          ViewCtorArgs...,
+          std::conditional_t<alloc_prop_input::has_execution_space,
+                             std::integral_constant<unsigned int, 2>,
+                             typename view_type::execution_space>>;
       alloc_prop arg_prop_copy(arg_prop);
       using execution_space_type = typename alloc_prop::execution_space;
-      const execution_space_type& exec_space =  static_cast<
-                Kokkos::Impl::ViewCtorProp<void, execution_space_type> const&>(
-                arg_prop_copy)
-                .value;
+      const execution_space_type& exec_space =
+          static_cast<
+              Kokkos::Impl::ViewCtorProp<void, execution_space_type> const&>(
+              arg_prop_copy)
+              .value;
       Kokkos::deep_copy(exec_space, v, typename view_type::value_type{});
-    }
-    else
+    } else
       Kokkos::deep_copy(v, typename view_type::value_type{});
   }
 }

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
@@ -49,7 +49,9 @@ namespace Kokkos {
 
 namespace Impl {
 
-void hostspace_fence(const DefaultHostExecutionSpace& exec) { exec.fence(); }
+void hostspace_fence(const DefaultHostExecutionSpace& exec) {
+  exec.fence("HostSpace fence");
+}
 
 void hostspace_parallel_deepcopy(void* dst, const void* src, ptrdiff_t n) {
   Kokkos::DefaultHostExecutionSpace exec;

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -128,7 +128,8 @@ TEST(TEST_CATEGORY, realloc_exec_space) {
                  "fence after copying header from HostSpace") !=
              std::string::npos) ||
             (event.descriptor().find("Debug Only Check for Execution Error") !=
-             std::string::npos))
+             std::string::npos) ||
+            (event.descriptor().find("HostSpace fence") != std::string::npos))
           return MatchDiagnostic{false};
         return MatchDiagnostic{true, {"Found fence event!"}};
       });

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -122,7 +122,14 @@ TEST(TEST_CATEGORY, realloc_exec_space) {
         outer_view2 = inner_view;
         Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), inner_view, 10);
       },
-      [&](BeginFenceEvent) {
+      [&](BeginFenceEvent event) {
+        // FIXME_CUDA FIXME_HIP FIXME_SYCL FIXME_OPENMPTARGET
+        if ((event.descriptor().find(
+                 "fence after copying header from HostSpace") !=
+             std::string::npos) ||
+            (event.descriptor().find("Debug Only Check for Execution Error") !=
+             std::string::npos))
+          return MatchDiagnostic{false};
         return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -103,7 +103,7 @@ TEST(TEST_CATEGORY, realloc_exec_space) {
 #ifdef KOKKOS_ENABLE_CUDA
   if (std::is_same<typename TEST_EXECSPACE::memory_space,
                    Kokkos::CudaUVMSpace>::value)
-    return;
+    GTEST_SKIP() << "skipping since CudaUVMSpace requires additional fences";
 #endif
 
   using namespace Kokkos::Test::Tools;

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -116,16 +116,14 @@ TEST(TEST_CATEGORY, realloc_exec_space) {
         view_type inner_view(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
         // Avoid testing the destructor
         outer_view = inner_view;
-	Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing, TEST_EXECSPACE{}),
-			inner_view, 10);
-	outer_view2 = inner_view;
-	Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), inner_view, 10);
+        Kokkos::realloc(
+            Kokkos::view_alloc(Kokkos::WithoutInitializing, TEST_EXECSPACE{}),
+            inner_view, 10);
+        outer_view2 = inner_view;
+        Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), inner_view, 10);
       },
-      [&](BeginFenceEvent event) {
-        return MatchDiagnostic{
-            event.descriptor().find(
-                "Kokkos::Impl::ViewValueFunctor: View init/destroy fence") !=
-            std::string::npos};
+      [&](BeginFenceEvent) {
+        return MatchDiagnostic{true, {"Found fence event!"}};
       });
   ASSERT_TRUE(success);
   listen_tool_events(Config::DisableAll());

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -55,6 +55,8 @@ TEST(TEST_CATEGORY, resize_realloc_no_init) {
       [&]() {
         Kokkos::resize(Kokkos::WithoutInitializing, bla, 5, 6, 7, 9);
         Kokkos::realloc(Kokkos::WithoutInitializing, bla, 8, 8, 8, 8);
+        Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing), bla, 5,
+                        6, 7, 8);
       },
       [&](BeginParallelForEvent event) {
         if (event.descriptor().find("initialization") != std::string::npos)

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -123,11 +123,7 @@ TEST(TEST_CATEGORY, realloc_exec_space) {
         Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), inner_view, 10);
       },
       [&](BeginFenceEvent event) {
-        // FIXME_CUDA FIXME_HIP FIXME_SYCL FIXME_OPENMPTARGET
-        if ((event.descriptor().find(
-                 "fence after copying header from HostSpace") !=
-             std::string::npos) ||
-            (event.descriptor().find("Debug Only Check for Execution Error") !=
+        if ((event.descriptor().find("Debug Only Check for Execution Error") !=
              std::string::npos) ||
             (event.descriptor().find("HostSpace fence") != std::string::npos))
           return MatchDiagnostic{false};

--- a/core/unit_test/tools/TestWithoutInitializing.cpp
+++ b/core/unit_test/tools/TestWithoutInitializing.cpp
@@ -142,13 +142,10 @@ TEST(kokkosp, create_mirror_view_and_copy) {
         device_view = mirror_device;
       },
       [&](BeginParallelForEvent) {
-        return MatchDiagnostic{true, {"Found begin event"}};
+        return MatchDiagnostic{true, {"Found parallel_for event"}};
       },
       [&](BeginFenceEvent event) {
-        return MatchDiagnostic{
-            event.descriptor().find(
-                "fence after copying header from HostSpace") ==
-            std::string::npos};
+        return MatchDiagnostic{true, {"Found fence event"}};
       });
   ASSERT_TRUE(success);
 }

--- a/core/unit_test/tools/TestWithoutInitializing.cpp
+++ b/core/unit_test/tools/TestWithoutInitializing.cpp
@@ -114,15 +114,15 @@ TEST(kokkosp, create_mirror_no_init_view_ctor) {
 }
 
 TEST(kokkosp, create_mirror_view_and_copy) {
-// FIXME_OPENMPTARGET
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-  return;
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET
+  if (std::is_same<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>::value)
+    GTEST_SKIP() << "skipping since the OpenMPTarget has unexpected fences";
 #endif
 
 #ifdef KOKKOS_ENABLE_CUDA
-  if (std::is_same<typename Kokkos::DefaultExecutionSpace::memory_space,
-                   Kokkos::CudaUVMSpace>::value)
-    return;
+  if (std::is_same<TEST_EXECSPACE::memory_space, Kokkos::CudaUVMSpace>::value)
+    GTEST_SKIP()
+        << "skipping since the CudaUVMSpace requires additional fences";
 #endif
 
   using namespace Kokkos::Test::Tools;

--- a/core/unit_test/tools/TestWithoutInitializing.cpp
+++ b/core/unit_test/tools/TestWithoutInitializing.cpp
@@ -115,12 +115,14 @@ TEST(kokkosp, create_mirror_no_init_view_ctor) {
 
 TEST(kokkosp, create_mirror_view_and_copy) {
 #ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET
-  if (std::is_same<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>::value)
+  if (std::is_same<Kokkos::DefaultExecutionSpace,
+                   Kokkos::Experimental::OpenMPTarget>::value)
     GTEST_SKIP() << "skipping since the OpenMPTarget has unexpected fences";
 #endif
 
 #ifdef KOKKOS_ENABLE_CUDA
-  if (std::is_same<TEST_EXECSPACE::memory_space, Kokkos::CudaUVMSpace>::value)
+  if (std::is_same<Kokkos::DefaultExecutionSpace::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
     GTEST_SKIP()
         << "skipping since the CudaUVMSpace requires additional fences";
 #endif
@@ -144,7 +146,7 @@ TEST(kokkosp, create_mirror_view_and_copy) {
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found parallel_for event"}};
       },
-      [&](BeginFenceEvent event) {
+      [&](BeginFenceEvent) {
         return MatchDiagnostic{true, {"Found fence event"}};
       });
   ASSERT_TRUE(success);


### PR DESCRIPTION
Supersedes https://github.com/kokkos/kokkos/pull/5027. This would allow passing a label or an execution space or other (possibly multiple) View constructor properties to `Kokkos::realloc`.
We decided in #5027 to not allow passing a label at all which is implemented here.