### PR TITLE
Remove unused view ctor property `Impl::NullSpace_t`

### DIFF
--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -53,7 +53,6 @@ namespace Impl {
 
 struct WithoutInitializing_t {};
 struct AllowPadding_t {};
-struct NullSpace_t {};
 
 template <typename>
 struct is_view_ctor_property : public std::false_type {};
@@ -63,9 +62,6 @@ struct is_view_ctor_property<WithoutInitializing_t> : public std::true_type {};
 
 template <>
 struct is_view_ctor_property<AllowPadding_t> : public std::true_type {};
-
-template <>
-struct is_view_ctor_property<NullSpace_t> : public std::true_type {};
 
 //----------------------------------------------------------------------------
 /**\brief Whether a type can be used for a view label */


### PR DESCRIPTION

## pasting discussion from Slack \#nucleus for reference

[dalg24](https://app.slack.com/team/U6K791Y04)  [8:01 AM](https://kokkosteam.slack.com/archives/G5CBLMFLP/p1652961695662779)
Who knows anything about Kokkos::Impl::NullSpace_t





[8:01](https://kokkosteam.slack.com/archives/G5CBLMFLP/p1652961717301539)
Defined here https://github.com/kokkos/kokkos/blob/5ea9421e4a378ca65944f4a8eeb78ca9477bdb6f/core/src/impl/Kokkos_ViewCtor.hpp#L56

[Kokkos_ViewCtor.hpp](https://github.com/kokkos/kokkos/blob/5ea9421e4a378ca65944f4a8eeb78ca9477bdb6f/core/src/impl/Kokkos_ViewCtor.hpp)
struct NullSpace_t {};
<https://github.com/[kokkos/kokkos](https://github.com/kokkos/kokkos)|kokkos/kokkos>kokkos/kokkos | Added by [GitHub](https://kokkosteam.slack.com/services/B022NMX66H5)
[8:02](https://kokkosteam.slack.com/archives/G5CBLMFLP/p1652961728345209)
Seems to only be used in specialization
[8:02](https://kokkosteam.slack.com/archives/G5CBLMFLP/p1652961754582569)
of is_view_ctor_property class template but not used anywhere else
[8:02](https://kokkosteam.slack.com/archives/G5CBLMFLP/p1652961755840549)
https://github.com/kokkos/kokkos/blob/5ea9421e4a378ca65944f4a8eeb78ca9477bdb6f/core/src/impl/Kokkos_ViewCtor.hpp#L67-L68

[Kokkos_ViewCtor.hpp](https://github.com/kokkos/kokkos/blob/5ea9421e4a378ca65944f4a8eeb78ca9477bdb6f/core/src/impl/Kokkos_ViewCtor.hpp)
template <>
struct is_view_ctor_property<NullSpace_t> : public std::true_type {};
<https://github.com/[kokkos/kokkos](https://github.com/kokkos/kokkos)|kokkos/kokkos>kokkos/kokkos | Added by [GitHub](https://kokkosteam.slack.com/services/B022NMX66H5)


[Daniel Arndt](https://app.slack.com/team/ULFRJU1C4)  [8:05 AM](https://kokkosteam.slack.com/archives/G5CBLMFLP/p1652961941141949)
It only appears in https://github.com/kokkos/kokkos/commit/da7980d672fc348176b34702768f7d7c119a5263 (originally introduced) and https://github.com/kokkos/kokkos/commit/575e9b9a0d3e2fe2989b98e69dfde8115b1e3653 (is_view_ctor_property)