### PR TITLE
Fix calling ZeroMemset in deep_copy

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1292,9 +1292,9 @@ struct ZeroMemset {
 
 template <typename ExecutionSpace, class DT, class... DP>
 inline std::enable_if_t<
-    std::is_trivial<typename ViewTraits<DT, DP...>::const_value_type>::value &&
+    std::is_trivial<typename ViewTraits<DT, DP...>::value_type>::value &&
     std::is_trivially_copy_assignable<
-        typename ViewTraits<DT, DP...>::const_value_type>::value>
+        typename ViewTraits<DT, DP...>::value_type>::value>
 contiguous_fill_or_memset(
     const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
@@ -1309,10 +1309,10 @@ contiguous_fill_or_memset(
 }
 
 template <typename ExecutionSpace, class DT, class... DP>
-inline std::enable_if_t<!(
-    std::is_trivial<typename ViewTraits<DT, DP...>::const_value_type>::value &&
-    std::is_trivially_copy_assignable<
-        typename ViewTraits<DT, DP...>::const_value_type>::value)>
+inline std::enable_if_t<
+    !(std::is_trivial<typename ViewTraits<DT, DP...>::value_type>::value &&
+      std::is_trivially_copy_assignable<
+          typename ViewTraits<DT, DP...>::value_type>::value)>
 contiguous_fill_or_memset(
     const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
@@ -1321,9 +1321,9 @@ contiguous_fill_or_memset(
 
 template <class DT, class... DP>
 inline std::enable_if_t<
-    std::is_trivial<typename ViewTraits<DT, DP...>::const_value_type>::value &&
+    std::is_trivial<typename ViewTraits<DT, DP...>::value_type>::value &&
     std::is_trivially_copy_assignable<
-        typename ViewTraits<DT, DP...>::const_value_type>::value>
+        typename ViewTraits<DT, DP...>::value_type>::value>
 contiguous_fill_or_memset(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {
@@ -1341,10 +1341,10 @@ contiguous_fill_or_memset(
 }
 
 template <class DT, class... DP>
-inline std::enable_if_t<!(
-    std::is_trivial<typename ViewTraits<DT, DP...>::const_value_type>::value &&
-    std::is_trivially_copy_assignable<
-        typename ViewTraits<DT, DP...>::const_value_type>::value)>
+inline std::enable_if_t<
+    !(std::is_trivial<typename ViewTraits<DT, DP...>::value_type>::value &&
+      std::is_trivially_copy_assignable<
+          typename ViewTraits<DT, DP...>::value_type>::value)>
 contiguous_fill_or_memset(
     const View<DT, DP...>& dst,
     typename ViewTraits<DT, DP...>::const_value_type& value) {

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -279,10 +279,13 @@ namespace Impl {
 
 template <class DT, class... DP>
 struct ZeroMemset<typename HostSpace::execution_space, DT, DP...> {
-  ZeroMemset(const typename HostSpace::execution_space&,
+  ZeroMemset(const typename HostSpace::execution_space& exec,
              const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type& value)
-      : ZeroMemset(dst, value) {}
+             typename View<DT, DP...>::const_value_type&) {
+    hostspace_fence(exec);
+    using ValueType = typename View<DT, DP...>::value_type;
+    std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
+  }
 
   ZeroMemset(const View<DT, DP...>& dst,
              typename View<DT, DP...>::const_value_type&) {

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -282,6 +282,10 @@ struct ZeroMemset<typename HostSpace::execution_space, DT, DP...> {
   ZeroMemset(const typename HostSpace::execution_space& exec,
              const View<DT, DP...>& dst,
              typename View<DT, DP...>::const_value_type&) {
+    // Host spaces, except for HPX, are synchronous and we need to fence for HPX
+    // since we can't properly enqueue a std::memset otherwise.
+    // We can't use exec.fence() directly since we don't have a full definition
+    // of HostSpace here.
     hostspace_fence(exec);
     using ValueType = typename View<DT, DP...>::value_type;
     std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.cpp
@@ -49,6 +49,8 @@ namespace Kokkos {
 
 namespace Impl {
 
+void hostspace_fence(const DefaultHostExecutionSpace& exec) { exec.fence(); }
+
 void hostspace_parallel_deepcopy(void* dst, const void* src, ptrdiff_t n) {
   Kokkos::DefaultHostExecutionSpace exec;
   hostspace_parallel_deepcopy_async(exec, dst, src, n);

--- a/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
+++ b/core/src/impl/Kokkos_HostSpace_deepcopy.hpp
@@ -51,6 +51,8 @@ namespace Kokkos {
 
 namespace Impl {
 
+void hostspace_fence(const DefaultHostExecutionSpace& exec);
+
 void hostspace_parallel_deepcopy(void* dst, const void* src, ptrdiff_t n);
 // DeepCopy called with an execution space that can't access HostSpace
 void hostspace_parallel_deepcopy_async(void* dst, const void* src, ptrdiff_t n);

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -215,3 +215,20 @@ TEST(TEST_CATEGORY, view_alloc_exec_space_int) {
   ASSERT_TRUE(success);
   listen_tool_events(Config::DisableAll());
 }
+
+TEST(TEST_CATEGORY, deep_copy_zero_memset) {
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableKernels());
+  Kokkos::View<int*, TEST_EXECSPACE> bla("bla", 8);
+
+  auto success =
+      validate_absence([&]() { Kokkos::deep_copy(bla, 0); },
+                       [&](BeginParallelForEvent) {
+                         return MatchDiagnostic{true, {"Found begin event"}};
+                       },
+                       [&](EndParallelForEvent) {
+                         return MatchDiagnostic{true, {"Found end event"}};
+                       });
+  ASSERT_TRUE(success);
+  listen_tool_events(Config::DisableAll());
+}

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -194,6 +194,12 @@ TEST(TEST_CATEGORY, view_alloc_exec_space_int) {
                    Kokkos::CudaUVMSpace>::value)
     return;
 #endif
+    // FIXME_OPENMPTARGET The OpenMPTarget backend doesn't implement ZeroMemset
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+  if (std::is_same<typename TEST_EXECSPACE,
+                   Kokkos::Experimental::OpenMPTarget>::value)
+    return;
+#endif
 
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableFences());

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -194,12 +194,6 @@ TEST(TEST_CATEGORY, view_alloc_exec_space_int) {
                    Kokkos::CudaUVMSpace>::value)
     return;
 #endif
-    // FIXME_OPENMPTARGET The OpenMPTarget backend doesn't implement ZeroMemset
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-  if (std::is_same<typename TEST_EXECSPACE,
-                   Kokkos::Experimental::OpenMPTarget>::value)
-    return;
-#endif
 
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableFences());
@@ -223,6 +217,13 @@ TEST(TEST_CATEGORY, view_alloc_exec_space_int) {
 }
 
 TEST(TEST_CATEGORY, deep_copy_zero_memset) {
+// FIXME_OPENMPTARGET The OpenMPTarget backend doesn't implement ZeroMemset
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+  if (std::is_same<typename TEST_EXECSPACE,
+                   Kokkos::Experimental::OpenMPTarget>::value)
+    return;
+#endif
+
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());
   Kokkos::View<int*, TEST_EXECSPACE> bla("bla", 8);


### PR DESCRIPTION
While working on #5035, I realized that we don't call `ZeroMemset` in `deep_copy` as intended because `std::is_trivially_copy_assignable<>::value` is `false` for `const` types.