### PR TITLE
Disable native OpenMP `parallel_for` implementation (fix `openmp.scatterview` test)

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -56,6 +56,8 @@
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
+#define KOKKOS_INTERNAL_DISABLE_NATIVE_OPENMP
+
 #define KOKKOS_PRAGMA_IVDEP_IF_ENABLED
 #if defined(KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION) && \
     defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
@@ -1211,6 +1213,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
+#undef KOKKOS_INTERNAL_DISABLE_NATIVE_OPENMP
 #undef KOKKOS_PRAGMA_IVDEP_IF_ENABLED
 #undef KOKKOS_OPENMP_OPTIONAL_CHUNK_SIZE
 


### PR DESCRIPTION
fixes #5025

___
Note: this does not fix the root cause but simply disables changes introduced in #4664 (which caused the errors to manifest more frequently).