### PR TITLE
Fix Kokkos::Vector::push_back for default execution space

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -785,7 +785,10 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
             std::enable_if_t<!Dummy::impl_dualview_is_single_device::value>* =
                 nullptr>
   void modify() {
-    if (modified_flags.data() == nullptr) return;
+    if (modified_flags.data() == nullptr) {
+      modified_flags = t_modified_flags("DualView::modified_flags");
+    }
+
     int dev = get_device_side<Device>();
 
     if (dev == 1) {  // if Device is the same as DualView's device type
@@ -969,17 +972,17 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
                                     typename t_host::memory_space(), d_view);
 
         /* Mark Device copy as modified */
-        modified_flags(1) = modified_flags(1) + 1;
+        ++modified_flags(1);
       }
     } else {
-      /* Realloc on Device */
+      /* Resize on Host */
       if (sizeMismatch) {
         ::Kokkos::resize(arg_prop..., h_view, n0, n1, n2, n3, n4, n5, n6, n7);
         d_view = create_mirror_view(arg_prop..., typename t_dev::memory_space(),
                                     h_view);
 
         /* Mark Host copy as modified */
-        modified_flags(0) = modified_flags(0) + 1;
+        ++modified_flags(0);
       }
     }
   }

--- a/containers/unit_tests/TestVector.hpp
+++ b/containers/unit_tests/TestVector.hpp
@@ -302,9 +302,9 @@ TEST(TEST_CATEGORY, vector_push_back_default_exec) {
   using TestVectorDeviceType =
       Kokkos::Device<Kokkos::DefaultExecutionSpace,
                      typename Kokkos::DefaultExecutionSpace::memory_space>;
-  typedef unsigned long long int UInt64;
-  typedef Kokkos::pair<int, UInt64> Pair;
-  typedef Kokkos::vector<Pair, TestVectorDeviceType> PairVec;
+  using UInt64  = unsigned long long int;
+  using Pair    = Kokkos::pair<int, UInt64>;
+  using PairVec = Kokkos::vector<Pair, TestVectorDeviceType>;
   PairVec V;
   V.clear();
   {

--- a/containers/unit_tests/TestVector.hpp
+++ b/containers/unit_tests/TestVector.hpp
@@ -298,6 +298,36 @@ TEST(TEST_CATEGORY, vector_insert) {
   Impl::test_vector_insert<int, TEST_EXECSPACE>(3057);
 }
 
+TEST(TEST_CATEGORY, vector_push_back_default_exec) {
+  using TestVectorDeviceType =
+      Kokkos::Device<Kokkos::DefaultExecutionSpace,
+                     typename Kokkos::DefaultExecutionSpace::memory_space>;
+  typedef unsigned long long int UInt64;
+  typedef Kokkos::pair<int, UInt64> Pair;
+  typedef Kokkos::vector<Pair, TestVectorDeviceType> PairVec;
+  PairVec V;
+  V.clear();
+  {
+    const int first     = 4;
+    const UInt64 second = 1;
+    const Pair p(first, second);
+    V.push_back(p);
+  }
+  ASSERT_EQ(V[0].first, 4);
+  ASSERT_EQ(V[0].second, 1u);
+
+  {
+    const int first     = 3;
+    const UInt64 second = 2;
+    const Pair p(first, second);
+    V.push_back(p);
+  }
+  ASSERT_EQ(V[1].first, 3);
+  ASSERT_EQ(V[1].second, 2u);
+  ASSERT_EQ(V[0].first, 4);
+  ASSERT_EQ(V[0].second, 1u);
+}
+
 }  // namespace Test
 
 #endif  // KOKKOS_TEST_UNORDERED_MAP_HPP

--- a/containers/unit_tests/TestVector.hpp
+++ b/containers/unit_tests/TestVector.hpp
@@ -298,34 +298,17 @@ TEST(TEST_CATEGORY, vector_insert) {
   Impl::test_vector_insert<int, TEST_EXECSPACE>(3057);
 }
 
+// The particular scenario below triggered a bug where empty modified_flags
+// would cause resize in push_back to be executed on the device overwriting the
+// values that were stored on the host previously.
 TEST(TEST_CATEGORY, vector_push_back_default_exec) {
-  using TestVectorDeviceType =
-      Kokkos::Device<Kokkos::DefaultExecutionSpace,
-                     typename Kokkos::DefaultExecutionSpace::memory_space>;
-  using UInt64  = unsigned long long int;
-  using Pair    = Kokkos::pair<int, UInt64>;
-  using PairVec = Kokkos::vector<Pair, TestVectorDeviceType>;
-  PairVec V;
+  Kokkos::vector<int, TEST_EXECSPACE> V;
   V.clear();
-  {
-    const int first     = 4;
-    const UInt64 second = 1;
-    const Pair p(first, second);
-    V.push_back(p);
-  }
-  ASSERT_EQ(V[0].first, 4);
-  ASSERT_EQ(V[0].second, 1u);
-
-  {
-    const int first     = 3;
-    const UInt64 second = 2;
-    const Pair p(first, second);
-    V.push_back(p);
-  }
-  ASSERT_EQ(V[1].first, 3);
-  ASSERT_EQ(V[1].second, 2u);
-  ASSERT_EQ(V[0].first, 4);
-  ASSERT_EQ(V[0].second, 1u);
+  V.push_back(4);
+  ASSERT_EQ(V[0], 4);
+  V.push_back(3);
+  ASSERT_EQ(V[1], 3);
+  ASSERT_EQ(V[0], 4);
 }
 
 }  // namespace Test


### PR DESCRIPTION
Fixes #5042. The main change is to allocate (and initialize) `create modified_flags` if it's not yet allocated in `modify`.
Without this, `resize` is copying the device data which has not been modified.