### PR TITLE
Refactor OpenMP instances and introduce singleton instances

### DIFF
--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -62,6 +62,7 @@
 #include <Kokkos_Parallel.hpp>
 #include <Kokkos_TaskScheduler.hpp>
 #include <Kokkos_Layout.hpp>
+#include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
 #include <impl/Kokkos_ExecSpaceInitializer.hpp>
 
@@ -94,6 +95,8 @@ class OpenMP {
   using array_layout         = LayoutRight;
   using size_type            = memory_space::size_type;
   using scratch_memory_space = ScratchMemorySpace<OpenMP>;
+
+  OpenMP();
 
   /// \brief Print configuration information to the given output stream.
   static void print_configuration(std::ostream&, const bool verbose = false);
@@ -170,8 +173,15 @@ class OpenMP {
 
   static int impl_get_current_max_threads() noexcept;
 
+  Impl::OpenMPInternal* impl_internal_space_instance() const {
+    return m_space_instance.get();
+  }
+
   static constexpr const char* name() noexcept { return "OpenMP"; }
   uint32_t impl_instance_id() const noexcept { return 1; }
+
+ private:
+  Kokkos::Impl::HostSharedPtr<Impl::OpenMPInternal> m_space_instance;
 };
 
 namespace Tools {

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -72,6 +72,7 @@ class OpenMPInternal;
 extern int g_openmp_hardware_max_threads;
 
 extern thread_local int t_openmp_hardware_id;
+// FIXME_OPENMP we can remove this after we remove partition_master
 extern thread_local OpenMPInternal* t_openmp_instance;
 
 struct OpenMPTraits {
@@ -85,6 +86,10 @@ class OpenMPInternal {
 
   ~OpenMPInternal() { clear_thread_data(); }
 
+  static int get_current_max_threads() noexcept;
+
+  bool m_initialized = false;
+
   int m_pool_size;
   int m_level;
 
@@ -92,6 +97,12 @@ class OpenMPInternal {
 
  public:
   friend class Kokkos::OpenMP;
+
+  static OpenMPInternal& singleton();
+
+  void initialize(int thread_cound);
+
+  void finalize();
 
   void clear_thread_data();
 
@@ -105,38 +116,51 @@ class OpenMPInternal {
                                       int& partition_size);
 #endif
 
-  static void verify_is_master(const char* const);
-
   void resize_thread_data(size_t pool_reduce_bytes, size_t team_reduce_bytes,
                           size_t team_shared_bytes, size_t thread_local_bytes);
 
-  inline HostThreadTeamData* get_thread_data() const noexcept {
+  HostThreadTeamData* get_thread_data() const noexcept {
     return m_pool[m_level == omp_get_level() ? 0 : omp_get_thread_num()];
   }
 
-  inline HostThreadTeamData* get_thread_data(int i) const noexcept {
+  HostThreadTeamData* get_thread_data(int i) const noexcept {
     return m_pool[i];
   }
+
+  bool is_initialized() const { return m_initialized; }
+
+  bool verify_is_initialized(const char* const label) const;
+
+  void print_configuration(std::ostream& s) const;
 };
 
 }  // namespace Impl
 inline bool OpenMP::impl_is_initialized() noexcept {
-  return Impl::t_openmp_instance != nullptr;
+  return Impl::OpenMPInternal::singleton().is_initialized();
 }
 
 inline bool OpenMP::in_parallel(OpenMP const&) noexcept {
-  // t_openmp_instance is only non-null on a master thread
-  return !Impl::t_openmp_instance ||
-         Impl::t_openmp_instance->m_level < omp_get_level();
+  // FIXME_OPENMP We are forced to use t_openmp_instance because the function is
+  // static and does not use the OpenMP object
+  return ((Impl::OpenMPInternal::singleton().m_level < omp_get_level()) &&
+          (!Impl::t_openmp_instance ||
+           Impl::t_openmp_instance->m_level < omp_get_level()));
 }
 
 inline int OpenMP::impl_thread_pool_size() noexcept {
-  return OpenMP::in_parallel() ? omp_get_num_threads()
-                               : Impl::t_openmp_instance->m_pool_size;
+  // FIXME_OPENMP We are forced to use t_openmp_instance because the function is
+  // static
+  return OpenMP::in_parallel()
+             ? omp_get_num_threads()
+             : (Impl::t_openmp_instance
+                    ? Impl::t_openmp_instance->m_pool_size
+                    : Impl::OpenMPInternal::singleton().m_pool_size);
 }
 
 KOKKOS_INLINE_FUNCTION
 int OpenMP::impl_thread_pool_rank() noexcept {
+  // FIXME_OPENMP We are forced to use t_openmp_instance because the function is
+  // static
   KOKKOS_IF_ON_HOST(
       (return Impl::t_openmp_instance ? 0 : omp_get_thread_num();))
 
@@ -167,7 +191,7 @@ KOKKOS_DEPRECATED void OpenMP::partition_master(F const& f, int num_partitions,
 #endif
     using Exec = Impl::OpenMPInternal;
 
-    Exec* prev_instance = Impl::t_openmp_instance;
+    Exec* prev_instance = &Impl::OpenMPInternal::singleton();
 
     Exec::validate_partition_impl(prev_instance->m_pool_size, num_partitions,
                                   partition_size);
@@ -176,35 +200,22 @@ KOKKOS_DEPRECATED void OpenMP::partition_master(F const& f, int num_partitions,
 
 #pragma omp parallel num_threads(num_partitions)
     {
-      void* ptr = nullptr;
-      try {
-        ptr = space.allocate(sizeof(Exec));
-      } catch (
-          Kokkos::Experimental::RawMemoryAllocationFailure const& failure) {
-        // For now, just rethrow the error message the existing way
-        Kokkos::Impl::throw_runtime_exception(failure.get_error_message());
-      }
-
-      Impl::t_openmp_instance = new (ptr) Exec(partition_size);
+      Exec thread_local_instance(partition_size);
+      Impl::t_openmp_instance = &thread_local_instance;
 
       size_t pool_reduce_bytes  = 32 * partition_size;
       size_t team_reduce_bytes  = 32 * partition_size;
       size_t team_shared_bytes  = 1024 * partition_size;
       size_t thread_local_bytes = 1024;
 
-      Impl::t_openmp_instance->resize_thread_data(
+      thread_local_instance.resize_thread_data(
           pool_reduce_bytes, team_reduce_bytes, team_shared_bytes,
           thread_local_bytes);
 
       omp_set_num_threads(partition_size);
       f(omp_get_thread_num(), omp_get_num_threads());
-
-      Impl::t_openmp_instance->~Exec();
-      space.deallocate(Impl::t_openmp_instance, sizeof(Exec));
       Impl::t_openmp_instance = nullptr;
     }
-
-    Impl::t_openmp_instance = prev_instance;
   } else {
     // nested openmp not enabled
     f(0, 1);

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -139,7 +139,6 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::OpenMP> {
       return;
     }
 
-    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_for");
 #ifndef KOKKOS_INTERNAL_DISABLE_NATIVE_OPENMP
     execute_parallel<Policy>();
 #else
@@ -173,7 +172,9 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::OpenMP> {
   }
 
   inline ParallelFor(const FunctorType& arg_functor, Policy arg_policy)
-      : m_instance(t_openmp_instance),
+      : m_instance(t_openmp_instance
+                       ? t_openmp_instance
+                       : arg_policy.space().impl_internal_space_instance()),
         m_functor(arg_functor),
         m_policy(arg_policy) {}
 };
@@ -240,7 +241,6 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       return;
     }
 
-    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_for");
 #ifndef KOKKOS_INTERNAL_DISABLE_NATIVE_OPENMP
     execute_parallel<Policy>();
 #else
@@ -277,7 +277,9 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   }
 
   inline ParallelFor(const FunctorType& arg_functor, MDRangePolicy arg_policy)
-      : m_instance(t_openmp_instance),
+      : m_instance(t_openmp_instance
+                       ? t_openmp_instance
+                       : arg_policy.space().impl_internal_space_instance()),
         m_functor(arg_functor),
         m_mdr_policy(arg_policy),
         m_policy(Policy(0, m_mdr_policy.m_num_tiles).set_chunk_size(1)) {}
@@ -368,8 +370,6 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                                 Kokkos::Dynamic>::value
     };
 
-    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_reduce");
-
     const size_t pool_reduce_bytes =
         Analysis::value_size(ReducerConditional::select(m_functor, m_reducer));
 
@@ -441,7 +441,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       std::enable_if_t<Kokkos::is_view<ViewType>::value &&
                            !Kokkos::is_reducer<ReducerType>::value,
                        void*> = nullptr)
-      : m_instance(t_openmp_instance),
+      : m_instance(t_openmp_instance
+                       ? t_openmp_instance
+                       : arg_policy.space().impl_internal_space_instance()),
         m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),
@@ -454,7 +456,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
   inline ParallelReduce(const FunctorType& arg_functor, Policy arg_policy,
                         const ReducerType& reducer)
-      : m_instance(t_openmp_instance),
+      : m_instance(t_openmp_instance
+                       ? t_openmp_instance
+                       : arg_policy.space().impl_internal_space_instance()),
         m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(reducer),
@@ -519,8 +523,6 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       is_dynamic = std::is_same<typename Policy::schedule_type::type,
                                 Kokkos::Dynamic>::value
     };
-
-    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_reduce");
 
     const size_t pool_reduce_bytes =
         Analysis::value_size(ReducerConditional::select(m_functor, m_reducer));
@@ -597,7 +599,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       std::enable_if_t<Kokkos::is_view<ViewType>::value &&
                            !Kokkos::is_reducer<ReducerType>::value,
                        void*> = nullptr)
-      : m_instance(t_openmp_instance),
+      : m_instance(t_openmp_instance
+                       ? t_openmp_instance
+                       : arg_policy.space().impl_internal_space_instance()),
         m_functor(arg_functor),
         m_mdr_policy(arg_policy),
         m_policy(Policy(0, m_mdr_policy.m_num_tiles).set_chunk_size(1)),
@@ -611,7 +615,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
   inline ParallelReduce(const FunctorType& arg_functor,
                         MDRangePolicy arg_policy, const ReducerType& reducer)
-      : m_instance(t_openmp_instance),
+      : m_instance(t_openmp_instance
+                       ? t_openmp_instance
+                       : arg_policy.space().impl_internal_space_instance()),
         m_functor(arg_functor),
         m_mdr_policy(arg_policy),
         m_policy(Policy(0, m_mdr_policy.m_num_tiles).set_chunk_size(1)),
@@ -683,8 +689,6 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
 
  public:
   inline void execute() const {
-    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_scan");
-
     const int value_count          = Analysis::value_count(m_functor);
     const size_t pool_reduce_bytes = 2 * Analysis::value_size(m_functor);
 
@@ -745,7 +749,9 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   //----------------------------------------
 
   inline ParallelScan(const FunctorType& arg_functor, const Policy& arg_policy)
-      : m_instance(t_openmp_instance),
+      : m_instance(t_openmp_instance
+                       ? t_openmp_instance
+                       : arg_policy.space().impl_internal_space_instance()),
         m_functor(arg_functor),
         m_policy(arg_policy) {}
 
@@ -794,8 +800,6 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
  public:
   inline void execute() const {
-    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_scan");
-
     const int value_count          = Analysis::value_count(m_functor);
     const size_t pool_reduce_bytes = 2 * Analysis::value_size(m_functor);
 
@@ -861,7 +865,9 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   inline ParallelScanWithTotal(const FunctorType& arg_functor,
                                const Policy& arg_policy,
                                ReturnType& arg_returnvalue)
-      : m_instance(t_openmp_instance),
+      : m_instance(t_openmp_instance
+                       ? t_openmp_instance
+                       : arg_policy.space().impl_internal_space_instance()),
         m_functor(arg_functor),
         m_policy(arg_policy),
         m_returnvalue(arg_returnvalue) {}
@@ -937,8 +943,6 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   inline void execute() const {
     enum { is_dynamic = std::is_same<SchedTag, Kokkos::Dynamic>::value };
 
-    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_for");
-
     const size_t pool_reduce_size  = 0;  // Never shrinks
     const size_t team_reduce_size  = TEAM_REDUCE_SIZE * m_policy.team_size();
     const size_t team_shared_size  = m_shmem_size;
@@ -985,7 +989,9 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   inline ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
-      : m_instance(t_openmp_instance),
+      : m_instance(t_openmp_instance
+                       ? t_openmp_instance
+                       : arg_policy.space().impl_internal_space_instance()),
         m_functor(arg_functor),
         m_policy(arg_policy),
         m_shmem_size(arg_policy.scratch_size(0) + arg_policy.scratch_size(1) +
@@ -1082,7 +1088,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       }
       return;
     }
-    OpenMPInternal::verify_is_master("Kokkos::OpenMP parallel_reduce");
 
     const size_t pool_reduce_size =
         Analysis::value_size(ReducerConditional::select(m_functor, m_reducer));
@@ -1179,7 +1184,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       std::enable_if_t<Kokkos::is_view<ViewType>::value &&
                            !Kokkos::is_reducer<ReducerType>::value,
                        void*> = nullptr)
-      : m_instance(t_openmp_instance),
+      : m_instance(t_openmp_instance
+                       ? t_openmp_instance
+                       : arg_policy.space().impl_internal_space_instance()),
         m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(InvalidType()),
@@ -1190,7 +1197,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
   inline ParallelReduce(const FunctorType& arg_functor, Policy arg_policy,
                         const ReducerType& reducer)
-      : m_instance(t_openmp_instance),
+      : m_instance(t_openmp_instance
+                       ? t_openmp_instance
+                       : arg_policy.space().impl_internal_space_instance()),
         m_functor(arg_functor),
         m_policy(arg_policy),
         m_reducer(reducer),

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -96,10 +96,8 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::OpenMP, QueueType>> {
     // HostThreadTeamData& team_data_single =
     // HostThreadTeamDataSingleton::singleton();
 
-    // TODO @tasking @generalization DSH use
-    // scheduler.get_execution_space().impl() (or something like that) instead
-    // of the thread-local variable
-    Impl::OpenMPInternal* instance = t_openmp_instance;
+    Impl::OpenMPInternal* instance =
+        execution_space().impl_internal_space_instance();
     const int pool_size = get_max_team_count(scheduler.get_execution_space());
 
     // TODO @tasking @new_feature DSH allow team sizes other than 1
@@ -258,8 +256,9 @@ class TaskQueueSpecializationConstrained<
     HostThreadTeamData& team_data_single =
         HostThreadTeamDataSingleton::singleton();
 
-    Impl::OpenMPInternal* instance = t_openmp_instance;
-    const int pool_size            = OpenMP::impl_thread_pool_size();
+    Impl::OpenMPInternal* instance =
+        execution_space().impl_internal_space_instance();
+    const int pool_size = OpenMP::impl_thread_pool_size();
 
     const int team_size = 1;       // Threads per core
     instance->resize_thread_data(0 /* global reduce buffer */


### PR DESCRIPTION
This PR refactors the OpenMP instance. It introduces a singleton instance similar to the other backends. There is some ugly code that we will be able to remove once we remove `partition_master`.

Part of #4935