### PR TITLE
Quit using current time as seed for random number generator in unit tests

### DIFF
--- a/core/unit_test/TestViewLayoutStrideAssignment.hpp
+++ b/core/unit_test/TestViewLayoutStrideAssignment.hpp
@@ -55,10 +55,7 @@ namespace Test {
 TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
   using exec_space = TEST_EXECSPACE;
 
-  auto t = time(nullptr);
-  srand(t);  // Use current time as seed for random generator
-  printf("view_layoutstride_left_to_layoutleft_assignment: srand(%lu)\n",
-         static_cast<unsigned long>(t));
+  srand(123456);  // arbitrary seed for random generator
 
   {  // Assignment of rank-1 LayoutLeft = LayoutStride
     int ndims   = 1;
@@ -337,10 +334,7 @@ TEST(TEST_CATEGORY, view_layoutstride_left_to_layoutleft_assignment) {
 TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
   using exec_space = TEST_EXECSPACE;
 
-  auto t = time(nullptr);
-  srand(t);  // Use current time as seed for random generator
-  printf("view_layoutstride_right_to_layoutright_assignment: srand(%lu)\n",
-         static_cast<unsigned long>(t));
+  srand(123456);  // arbitrary seed for random generator
 
   {  // Assignment of rank-1 LayoutRight = LayoutStride
     int ndims   = 1;
@@ -620,10 +614,7 @@ TEST(TEST_CATEGORY, view_layoutstride_right_to_layoutright_assignment) {
 TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
   using exec_space = TEST_EXECSPACE;
 
-  auto t = time(nullptr);
-  srand(t);  // Use current time as seed for random generator
-  printf("view_layoutstride_right_to_layoutleft_assignment: srand(%lu)\n",
-         static_cast<unsigned long>(t));
+  srand(123456);  // arbitrary seed for random generator
 
   {  // Assignment of rank-1 LayoutLeft = LayoutStride (LayoutRight compatible)
     int ndims   = 1;
@@ -775,10 +766,7 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
 TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
   using exec_space = TEST_EXECSPACE;
 
-  auto t = time(nullptr);
-  srand(t);  // Use current time as seed for random generator
-  printf("view_layoutstride_left_to_layoutright_assignment: srand(%lu)\n",
-         static_cast<unsigned long>(t));
+  srand(123456);  // arbitrary seed for random generator
 
   {  // Assignment of rank-1 LayoutRight = LayoutStride (LayoutLeft compatible)
     int ndims   = 1;


### PR DESCRIPTION
Ran into these while hunting for unwanted print statements in unit tests (#4463)
We are printing the random seed being used in the unit tests.