### PR TITLE
Deprecate Kokkos::common_view_alloc_prop

### DIFF
--- a/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
+++ b/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
@@ -52,6 +52,7 @@
 #include <type_traits>
 #include <typeinfo>
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 namespace Test {
 
 namespace {
@@ -211,3 +212,4 @@ TEST(TEST_CATEGORY, viewctorprop_embedded_dim) {
   TestViewCtorProp_EmbeddedDim<TEST_EXECSPACE>::test_vcpt(2, 3);
 }
 }  // namespace Test
+#endif

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1881,6 +1881,7 @@ inline void shared_allocation_tracking_enable() {
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
+#if KOKKOS_ENABLE_DEPRECATED_CODE_3
 namespace Kokkos {
 namespace Impl {
 
@@ -1968,14 +1969,13 @@ using DeducedCommonPropsType =
 
 // User function
 template <class... Views>
-KOKKOS_INLINE_FUNCTION DeducedCommonPropsType<Views...> common_view_alloc_prop(
-    Views const&... views) {
+KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION DeducedCommonPropsType<Views...>
+common_view_alloc_prop(Views const&... views) {
   return DeducedCommonPropsType<Views...>(views...);
 }
 
 }  // namespace Kokkos
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1881,7 +1881,7 @@ inline void shared_allocation_tracking_enable() {
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#if KOKKOS_ENABLE_DEPRECATED_CODE_3
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -83,6 +83,7 @@ struct is_view_label<const char[N]> : public std::true_type {};
 template <typename... P>
 struct ViewCtorProp;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 // Forward declare
 template <typename Specialize, typename T>
 struct CommonViewAllocProp;
@@ -104,6 +105,7 @@ struct ViewCtorProp<void, CommonViewAllocProp<Specialize, T> > {
 
   type value;
 };
+#endif
 
 /*  std::integral_constant<unsigned,I> are dummy arguments
  *  that avoid duplicate base class errors

--- a/core/unit_test/TestOther.hpp
+++ b/core/unit_test/TestOther.hpp
@@ -48,7 +48,9 @@
 #include <TestMemoryPool.hpp>
 #include <TestCXX11.hpp>
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 #include <TestViewCtorPropEmbeddedDim.hpp>
+#endif
 // with VS 16.11.3 and CUDA 11.4.2 getting cudafe stackoverflow crash
 #if !(defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA))
 #include <TestViewLayoutTiled.hpp>


### PR DESCRIPTION
We talked about deprecating `Kokkos::comon_view_alloc_prop`. It was introduced in https://github.com/kokkos/kokkos/pull/923 and is used in some Trilinos packages, see https://github.com/trilinos/Trilinos/search?q=common_view_alloc_prop, but only in one `Sacado` unit test with more than one `Kokkos::View`.