### PR TITLE
Make unique token unit tests print max reuse on failure only

### DIFF
--- a/core/unit_test/TestUniqueToken.hpp
+++ b/core/unit_test/TestUniqueToken.hpp
@@ -275,10 +275,15 @@ class TestAcquireTeamUniqueToken {
   }
 };
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET - Not yet implemented
 TEST(TEST_CATEGORY, unique_token_team_acquire) {
-  TestAcquireTeamUniqueToken<TEST_EXECSPACE>::run();
-}
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET
+  if constexpr (std::is_same<TEST_EXECSPACE,
+                             Kokkos::Experimental::OpenMPTarget>::value) {
+    GTEST_SKIP() << "skipping because OpenMPTarget does not implement yet a "
+                    "specialization of AcquireTeamUniqueToken";
+  } else
 #endif
+    TestAcquireTeamUniqueToken<TEST_EXECSPACE>::run();
+}
 
 }  // namespace

--- a/core/unit_test/TestUniqueToken.hpp
+++ b/core/unit_test/TestUniqueToken.hpp
@@ -42,11 +42,11 @@
 //@HEADER
 */
 
-#include <iostream>
+#include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
 
-namespace Test {
+namespace {
 
 template <class Space, Kokkos::Experimental::UniqueTokenScope Scope>
 class TestUniqueToken {
@@ -152,14 +152,12 @@ class TestUniqueToken {
     }
 #endif
 
-    std::cout << "TestUniqueToken max reuse = " << max << std::endl;
-
     typename view_type::HostMirror host_errors =
         Kokkos::create_mirror_view(self.errors);
 
     Kokkos::deep_copy(host_errors, self.errors);
 
-    ASSERT_EQ(host_errors(0), 0);
+    ASSERT_EQ(host_errors(0), 0) << "max reuse was " << max;
   }
 };
 
@@ -268,22 +266,19 @@ class TestAcquireTeamUniqueToken {
       }
     }
 
-    std::cout << "TestAcquireTeamUniqueToken max reuse = " << max << std::endl;
-
     typename view_type::HostMirror host_errors =
         Kokkos::create_mirror_view(self.errors);
 
     Kokkos::deep_copy(host_errors, self.errors);
 
-    ASSERT_EQ(host_errors(0), 0);
+    ASSERT_EQ(host_errors(0), 0) << "max reuse was " << max;
   }
 };
 
-TEST(TEST_CATEGORY, acquire_team_unique_token) {
-  // FIXME_OPENMPTARGET - Not yet implemented.
-#if !defined(KOKKOS_ENABLE_OPENMPTARGET)
+#ifndef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET - Not yet implemented
+TEST(TEST_CATEGORY, unique_token_team_acquire) {
   TestAcquireTeamUniqueToken<TEST_EXECSPACE>::run();
-#endif
 }
+#endif
 
-}  // namespace Test
+}  // namespace


### PR DESCRIPTION
* Rename {acquire_team_unique_token -> unique_token_team_acquire} for
  consistency

* Move OpenMPTarget macro guards to avoid giving false sense that the
  test ran


Yet another partial fix for #4463 