### PR TITLE
Remove KOKKOS_THREAD_LOCAL

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -652,13 +652,6 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 #undef __CUDA_ARCH__
 #endif
 
-#if (defined(KOKKOS_COMPILER_MSVC) && !defined(KOKKOS_COMPILER_CLANG)) || \
-    (defined(KOKKOS_COMPILER_INTEL) && defined(_WIN32))
-#define KOKKOS_THREAD_LOCAL __declspec(thread)
-#else
-#define KOKKOS_THREAD_LOCAL __thread
-#endif
-
 #if (defined(KOKKOS_IMPL_WINDOWS_CUDA) || defined(KOKKOS_COMPILER_MSVC)) && \
     !defined(KOKKOS_COMPILER_CLANG)
 // MSVC (as of 16.5.5 at least) does not do empty base class optimization by

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -652,6 +652,17 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 #undef __CUDA_ARCH__
 #endif
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+#if (defined(KOKKOS_COMPILER_MSVC) && !defined(KOKKOS_COMPILER_CLANG)) || \
+    (defined(KOKKOS_COMPILER_INTEL) && defined(_WIN32))
+#define KOKKOS_THREAD_LOCAL \
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use thread_local instead!") __declspec(thread)
+#else
+#define KOKKOS_THREAD_LOCAL \
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use thread_local instead!") __thread
+#endif
+#endif
+
 #if (defined(KOKKOS_IMPL_WINDOWS_CUDA) || defined(KOKKOS_COMPILER_MSVC)) && \
     !defined(KOKKOS_COMPILER_CLANG)
 // MSVC (as of 16.5.5 at least) does not do empty base class optimization by

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -653,14 +653,8 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 #endif
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
-#if (defined(KOKKOS_COMPILER_MSVC) && !defined(KOKKOS_COMPILER_CLANG)) || \
-    (defined(KOKKOS_COMPILER_INTEL) && defined(_WIN32))
 #define KOKKOS_THREAD_LOCAL \
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use thread_local instead!") __declspec(thread)
-#else
-#define KOKKOS_THREAD_LOCAL \
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use thread_local instead!") __thread
-#endif
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use thread_local instead!") thread_local
 #endif
 
 #if (defined(KOKKOS_IMPL_WINDOWS_CUDA) || defined(KOKKOS_COMPILER_MSVC)) && \

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -61,8 +61,8 @@ namespace Impl {
 
 int g_openmp_hardware_max_threads = 1;
 
-__thread int t_openmp_hardware_id                = 0;
-__thread Impl::OpenMPInternal *t_openmp_instance = nullptr;
+thread_local int t_openmp_hardware_id                = 0;
+thread_local Impl::OpenMPInternal *t_openmp_instance = nullptr;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 void OpenMPInternal::validate_partition_impl(const int nthreads,

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -71,8 +71,8 @@ class OpenMPInternal;
 
 extern int g_openmp_hardware_max_threads;
 
-extern __thread int t_openmp_hardware_id;
-extern __thread OpenMPInternal* t_openmp_instance;
+extern thread_local int t_openmp_hardware_id;
+extern thread_local OpenMPInternal* t_openmp_instance;
 
 struct OpenMPTraits {
   static int constexpr MAX_THREAD_COUNT = 512;

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -47,8 +47,7 @@
 namespace Kokkos {
 namespace Impl {
 
-KOKKOS_THREAD_LOCAL int SharedAllocationRecord<void, void>::t_tracking_enabled =
-    1;
+thread_local int SharedAllocationRecord<void, void>::t_tracking_enabled = 1;
 
 #ifdef KOKKOS_ENABLE_DEBUG
 bool SharedAllocationRecord<void, void>::is_sane(

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -141,7 +141,7 @@ class SharedAllocationRecord<void, void> {
       SharedAllocationHeader* arg_alloc_ptr, size_t arg_alloc_size,
       function_type arg_dealloc, const std::string& label);
  private:
-  static KOKKOS_THREAD_LOCAL int t_tracking_enabled;
+  static thread_local int t_tracking_enabled;
 
  public:
   virtual std::string get_label() const { return std::string("Unmanaged"); }


### PR DESCRIPTION
There doesn't really seem any need to define this macro when we can use `thread_local` instead.