### PR TITLE
SYCL: Fence memcpy instead of using in-order queues

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -98,11 +98,7 @@ void SYCLInternal::initialize(const sycl::device& d) {
       Kokkos::Impl::throw_runtime_exception(
           "There was an asynchronous SYCL error!\n");
   };
-  // FIXME_SYCL using an in-order queue here should not be necessary since we
-  // are using submit_barrier for managing kernel dependencies but this seems to
-  // be required as a hot fix for now.
-  initialize(
-      sycl::queue{d, exception_handler, sycl::property::queue::in_order()});
+  initialize(sycl::queue{d, exception_handler});
 }
 
 // FIXME_SYCL

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -63,10 +63,13 @@ void DeepCopySYCL(void* dst, const void* src, size_t n) {
 
 void DeepCopyAsyncSYCL(const Kokkos::Experimental::SYCL& instance, void* dst,
                        const void* src, size_t n) {
-  auto event =
-      instance.impl_internal_space_instance()->m_queue->memcpy(dst, src, n);
-  instance.impl_internal_space_instance()->m_queue->ext_oneapi_submit_barrier(
-      std::vector<sycl::event>{event});
+  // FIXME_SYCL using an in-order queue here should not be necessary since we
+  // are using submit_barrier for managing kernel dependencies but this seems to
+  // be required as a hot fix for now.
+  sycl::queue& q = *instance.impl_internal_space_instance()->m_queue;
+  q.wait_and_throw();
+  auto event = q.memcpy(dst, src, n);
+  q.ext_oneapi_submit_barrier(std::vector<sycl::event>{event});
 }
 
 void DeepCopyAsyncSYCL(void* dst, const void* src, size_t n) {

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
@@ -93,10 +93,8 @@ TEST(sycl, raw_sycl_interop_context_2) {
   constexpr int n = 100;
 
   Kokkos::Experimental::SYCL space(queue);
-  // FIXME_SYCL WithoutInitialing should not be necessary but works around a
-  // compiler regression
-  Kokkos::View<int*, Kokkos::Experimental::SYCLDeviceUSMSpace> v(
-      Kokkos::view_alloc(Kokkos::WithoutInitializing, "default_view"), n);
+  Kokkos::View<int*, Kokkos::Experimental::SYCLDeviceUSMSpace> v("default_view",
+                                                                 n);
   Kokkos::deep_copy(space, v, 5);
 
   auto* v_ptr = v.data();

--- a/core/unit_test/sycl/TestSYCL_InterOp_Streams.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Streams.cpp
@@ -49,10 +49,7 @@ namespace Test {
 // Test Interoperability with SYCL Streams
 TEST(sycl, raw_sycl_queues) {
   sycl::default_selector device_selector;
-  // FIXME_SYCL using an in-order queue here should not be necessary since we
-  // are using submit_barrier for managing kernel dependencies but this seems to
-  // be required as a hot fix for now.
-  sycl::queue queue(device_selector, sycl::property::queue::in_order());
+  sycl::queue queue(device_selector);
   Kokkos::InitArguments arguments{-1, -1, -1, false};
   Kokkos::initialize(arguments);
   int* p            = sycl::malloc_device<int>(100, queue);


### PR DESCRIPTION
This fixes some issues with recent versions of the compiler. Essentially, we can get rid of in-order queues if we only make sure that we fence before `memcpy` which seems the better workaround.