### PR TITLE
Fix werror: pointless comparison of unsigned integer with zero

### DIFF
--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -56,7 +56,7 @@ struct CheckClassWithExecutionSpaceAsDataMemberIsCopyable {
   KOKKOS_FUNCTION void operator()(int, int& e) const {
     auto copy = *this;
     // not actually doing anything useful, mostly checking that
-    // ExecutionSpace::in_parallel() is callalable
+    // ExecutionSpace::in_parallel() is callable
     if (static_cast<int>(copy.device.in_parallel()) < 0) {
       ++e;
     }

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -57,7 +57,7 @@ struct CheckClassWithExecutionSpaceAsDataMemberIsCopyable {
     auto copy = *this;
     // not actually doing anything useful, mostly checking that
     // ExecutionSpace::in_parallel() is callalable
-    if (copy.device.in_parallel() < 0) {
+    if (static_cast<int>(copy.device.in_parallel()) < 0) {
       ++e;
     }
   }


### PR DESCRIPTION
Attempt to address -Werror `kokkos/core/unit_test/TestExecutionSpace.hpp(60): error #186: pointless comparison of unsigned integer with zero` in nightly builds by static_cast of unsigned value to int for comparison