### PR TITLE
Fix using ZeroMemset for Serial

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -458,6 +458,7 @@ pipeline {
                                 -DKokkos_ENABLE_OPENMP=ON \
                                 -DKokkos_ENABLE_LIBDL=OFF \
                                 -DKokkos_ENABLE_LIBQUADMATH=ON \
+                                -DKokkos_ENABLE_SERIAL=ON \
                                 -DCMAKE_PREFIX_PATH=/usr/lib/gcc/x86_64-linux-gnu/5.3.1 \
                               .. && \
                               make -j8 && ctest --verbose && gcc -I$PWD/../core/src/ ../core/unit_test/tools/TestCInterface.c'''


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/5076. There is a specialization for `DefaultHostExecutionSpace` that we would not use for `Serial` when there is another host parallel execution space.