### PR TITLE
Fix bug with CUDA's team reduction for empty ranges

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -436,10 +436,11 @@ __device__ inline int64_t cuda_get_scratch_index(Cuda::size_type league_size,
   int64_t threadid = 0;
   __shared__ int64_t base_thread_id;
   if (threadIdx.x == 0 && threadIdx.y == 0) {
-    int64_t const wraparound_len = Kokkos::Experimental::min(
-        int64_t(league_size),
-        (int64_t(Kokkos::Impl::g_device_cuda_lock_arrays.n)) /
-            (blockDim.x * blockDim.y));
+    int64_t const wraparound_len = Kokkos::Experimental::max(
+        int64_t(1), Kokkos::Experimental::min(
+                        int64_t(league_size),
+                        (int64_t(Kokkos::Impl::g_device_cuda_lock_arrays.n)) /
+                            (blockDim.x * blockDim.y)));
     threadid = (blockIdx.x * blockDim.z + threadIdx.z) % wraparound_len;
     threadid *= blockDim.x * blockDim.y;
     int done = 0;
@@ -872,9 +873,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 #endif
                                  !std::is_same<ReducerType, InvalidType>::value;
     if (!is_empty_range || need_device_set) {
-      const int block_count =
-          UseShflReduction ? std::min(m_league_size, size_type(1024 * 32))
-                           : std::min(int(m_league_size), m_team_size);
+      const int block_count = std::max(
+          1u, UseShflReduction ? std::min(m_league_size, size_type(1024 * 32))
+                               : std::min(int(m_league_size), m_team_size));
 
       m_scratch_space = cuda_internal_scratch_space(
           m_policy.space(), Analysis::value_size(ReducerConditional::select(

--- a/core/unit_test/TestTeamReductionScan.hpp
+++ b/core/unit_test/TestTeamReductionScan.hpp
@@ -58,8 +58,7 @@ TEST(TEST_CATEGORY, team_reduction_scan) {
 }
 
 TEST(TEST_CATEGORY, team_long_reduce) {
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-  // WORKAROUND OPENMPTARGET: Not implemented
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET: Not implemented
   if constexpr (!std::is_same<TEST_EXECSPACE,
                               Kokkos::Experimental::OpenMPTarget>::value)
 #endif
@@ -76,8 +75,7 @@ TEST(TEST_CATEGORY, team_long_reduce) {
 }
 
 TEST(TEST_CATEGORY, team_double_reduce) {
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-  // WORKAROUND OPENMPTARGET: Not implemented
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET: Not implemented
   if constexpr (!std::is_same<TEST_EXECSPACE,
                               Kokkos::Experimental::OpenMPTarget>::value)
 #endif

--- a/core/unit_test/TestTeamReductionScan.hpp
+++ b/core/unit_test/TestTeamReductionScan.hpp
@@ -95,5 +95,44 @@ TEST(TEST_CATEGORY, team_double_reduce) {
   }
 }
 
+template <typename ExecutionSpace>
+struct DummyTeamReductionFunctor {
+  using TeamPolicy     = Kokkos::TeamPolicy<ExecutionSpace>;
+  using TeamHandleType = typename TeamPolicy::member_type;
+
+  KOKKOS_FUNCTION void operator()(const TeamHandleType&, double&) const {}
+};
+
+template <typename ExecutionSpace>
+void test_team_parallel_reduce(const int num_loop_size) {
+  using TeamPolicy = Kokkos::TeamPolicy<ExecutionSpace>;
+
+  using ReducerType = Kokkos::Sum<double>;
+  double result     = 10.;
+  ReducerType reducer(result);
+
+  const int bytes_per_team   = 0;
+  const int bytes_per_thread = 117;
+
+  TeamPolicy team_exec(num_loop_size, Kokkos::AUTO);
+  team_exec.set_scratch_size(1, Kokkos::PerTeam(bytes_per_team),
+                             Kokkos::PerThread(bytes_per_thread));
+
+  Kokkos::parallel_reduce(team_exec,
+                          DummyTeamReductionFunctor<ExecutionSpace>{}, reducer);
+  ASSERT_EQ(result, 0.);
+}
+
+TEST(TEST_CATEGORY, team_parallel_dummy_with_reducer_and_scratch_space) {
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET: Not implemented
+  if constexpr (!std::is_same<TEST_EXECSPACE,
+                              Kokkos::Experimental::OpenMPTarget>::value)
+#endif
+  {
+    test_team_parallel_reduce<TEST_EXECSPACE>(0);
+    test_team_parallel_reduce<TEST_EXECSPACE>(1);
+  }
+}
+
 }  // namespace Test
 #endif


### PR DESCRIPTION
Fixes #5075. This was only triggered when scratch memory was requested.