### PR TITLE
Update numerics support for `__float128`

### DIFF
--- a/core/src/impl/Kokkos_QuadPrecisionMath.hpp
+++ b/core/src/impl/Kokkos_QuadPrecisionMath.hpp
@@ -88,7 +88,14 @@ KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(finite_max,     __float128, __float128, FLT
 KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(epsilon,        __float128, __float128, FLT128_EPSILON)
 KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(round_error,    __float128, __float128, static_cast<__float128>(0.5))
 KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(norm_min,       __float128, __float128, FLT128_MIN)
+KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(denorm_min,     __float128, __float128, FLT128_DENORM_MIN)
+KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(reciprocal_overflow_threshold, __float128, __float128, FLT128_MIN)
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU >= 710)
+KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(quiet_NaN,      __float128, __float128, __builtin_nanq(""))
+KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(signaling_NaN,  __float128, __float128, __builtin_nansq(""))
+#endif
 
+// Numeric characteristics traits
 KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(digits,         __float128,        int, FLT128_MANT_DIG)
 KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(digits10,       __float128,        int, FLT128_DIG)
 KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(max_digits10,   __float128,        int, 36)

--- a/core/src/impl/Kokkos_QuadPrecisionMath.hpp
+++ b/core/src/impl/Kokkos_QuadPrecisionMath.hpp
@@ -130,15 +130,12 @@ namespace Experimental {
 inline __float128 fabs(__float128 x) { return ::fabsq(x); }
 inline __float128 fmod(__float128 x, __float128 y) { return ::fmodq(x, y); }
 inline __float128 remainder(__float128 x, __float128 y) { return ::remainderq(x, y); }
-inline __float128 fmin(__float128 x, __float128 y) { return ::fminq(x, y); }
+// remquo
+// fma
 inline __float128 fmax(__float128 x, __float128 y) { return ::fmaxq(x, y); }
+inline __float128 fmin(__float128 x, __float128 y) { return ::fminq(x, y); }
 inline __float128 fdim(__float128 x, __float128 y) { return ::fdimq(x, y); }
 inline __float128 nanq(char const* arg) { return ::nanq(arg); }
-// Power functions
-inline __float128 pow(__float128 x, __float128 y) { return ::powq(x, y); }
-inline __float128 sqrt(__float128 x) { return ::sqrtq(x); }
-inline __float128 cbrt(__float128 x) { return ::cbrtq(x); }
-inline __float128 hypot(__float128 x, __float128 y) { return ::hypotq(x, y); }
 // Exponential functions
 inline __float128 exp(__float128 x) { return ::expq(x); }
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU >= 910)
@@ -149,6 +146,11 @@ inline __float128 log(__float128 x) { return ::logq(x); }
 inline __float128 log10(__float128 x) { return ::log10q(x); }
 inline __float128 log2(__float128 x) { return ::log2q(x); }
 inline __float128 log1p(__float128 x) { return ::log1pq(x); }
+// Power functions
+inline __float128 pow(__float128 x, __float128 y) { return ::powq(x, y); }
+inline __float128 sqrt(__float128 x) { return ::sqrtq(x); }
+inline __float128 cbrt(__float128 x) { return ::cbrtq(x); }
+inline __float128 hypot(__float128 x, __float128 y) { return ::hypotq(x, y); }
 // Trigonometric functions
 inline __float128 sin(__float128 x) { return ::sinq(x); }
 inline __float128 cos(__float128 x) { return ::cosq(x); }
@@ -173,11 +175,40 @@ inline __float128 lgamma(__float128 x) { return ::lgammaq(x); }
 inline __float128 ceil(__float128 x) { return ::ceilq(x); }
 inline __float128 floor(__float128 x) { return ::floorq(x); }
 inline __float128 trunc(__float128 x) { return ::truncq(x); }
+inline __float128 round(__float128 x) { return ::roundq(x); }
+// lround
+// llround
 inline __float128 nearbyint(__float128 x) { return ::nearbyintq(x); }
+// rint
+// lrint
+// llrint
+// Floating point manipulation functions
+// frexp
+// ldexp
+// modf
+// scalbn
+// scalbln
+// ilog
+#if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU >= 610)
+inline __float128 logb(__float128 x) { return ::logbq(x); }
+#endif
+inline __float128 nextafter(__float128 x, __float128 y) { return ::nextafterq(x, y); }
+// nexttoward
+inline __float128 copysign(__float128 x, __float128 y) { return ::copysignq(x, y); }
 // Classification and comparison
+// fpclassify
 inline bool isfinite(__float128 x) { return !::isinfq(x); }  // isfiniteq not provided
 inline bool isinf(__float128 x) { return ::isinfq(x); }
 inline bool isnan(__float128 x) { return ::isnanq(x); }
+// isnormal
+inline bool signbit(__float128 x) { return ::signbitq(x); }
+// isgreater
+// isgreaterequal
+// isless
+// islessequal
+// islessgreater
+// isunordered
+// clang-format on
 }  // namespace Experimental
 }  // namespace Kokkos
 //</editor-fold>

--- a/core/src/impl/Kokkos_QuadPrecisionMath.hpp
+++ b/core/src/impl/Kokkos_QuadPrecisionMath.hpp
@@ -124,7 +124,6 @@ struct reduction_identity<__float128> {
 
 //<editor-fold desc="Common mathematical functions __float128 overloads">
 namespace Kokkos {
-namespace Experimental {
 // clang-format off
 // Basic operations
 inline __float128 fabs(__float128 x) { return ::fabsq(x); }
@@ -209,7 +208,6 @@ inline bool signbit(__float128 x) { return ::signbitq(x); }
 // islessgreater
 // isunordered
 // clang-format on
-}  // namespace Experimental
 }  // namespace Kokkos
 //</editor-fold>
 

--- a/core/unit_test/TestQuadPrecisionMath.hpp
+++ b/core/unit_test/TestQuadPrecisionMath.hpp
@@ -98,11 +98,11 @@ TEST(TEST_CATEGORY, quad_precision_common_math_functions) {
   Kokkos::parallel_for(
       Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, 1),
       KOKKOS_LAMBDA(int) {
-        (void)Kokkos::Experimental::fabs((__float128)0);
-        (void)Kokkos::Experimental::sqrt((__float128)1);
-        (void)Kokkos::Experimental::exp((__float128)2);
-        (void)Kokkos::Experimental::sin((__float128)3);
-        (void)Kokkos::Experimental::cosh((__float128)4);
+        (void)Kokkos::fabs((__float128)0);
+        (void)Kokkos::sqrt((__float128)1);
+        (void)Kokkos::exp((__float128)2);
+        (void)Kokkos::sin((__float128)3);
+        (void)Kokkos::cosh((__float128)4);
       });
 }
 


### PR DESCRIPTION
Fix #5080 

Note that 4b758fb is technically a defect in 3.6.00
I am not sure whether we should bother with cherry-picking in 3.6.01, I think we can live without it.