### PR TITLE
Deprecate useless functions that exists only for the HPX and the OpenMP backend

### DIFF
--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -364,6 +364,7 @@ class HPX {
 #endif
   }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   static std::vector<HPX> partition(...) {
     Kokkos::abort(
         "Kokkos::Experimental::HPX::partition_master: can't partition an HPX "
@@ -371,7 +372,6 @@ class HPX {
     return std::vector<HPX>();
   }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   template <typename F>
   KOKKOS_DEPRECATED static void partition_master(
       F const &, int requested_num_partitions = 0, int = 0) {

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -116,6 +116,7 @@ class OpenMP {
   /// This always returns false on OpenMP
   inline static bool is_asynchronous(OpenMP const& = OpenMP()) noexcept;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   /// \brief Partition the default instance into new instances without creating
   ///  new masters
   ///
@@ -129,7 +130,6 @@ class OpenMP {
   /// This is a no-op on OpenMP since a non default instance cannot be created
   static OpenMP create_instance(...);
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   /// \brief Partition the default instance and call 'f' on each new 'master'
   /// thread
   ///

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -443,9 +443,11 @@ void OpenMP::print_configuration(std::ostream &s, const bool /*verbose*/) {
   }
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 std::vector<OpenMP> OpenMP::partition(...) { return std::vector<OpenMP>(1); }
 
 OpenMP OpenMP::create_instance(...) { return OpenMP(); }
+#endif
 
 int OpenMP::concurrency() { return Impl::g_openmp_hardware_max_threads; }
 


### PR DESCRIPTION
I want to deprecate `partition` in the HPX and OpenMP backends and `create_instance` in the OpenMP backend. Both functions are no-op and they only exist in these backends (`create_instance` is unique to `OpenMP`). The idea behind the `partition` function is similar to the new `partition_space` function but it was never implemented.