### PR TITLE
OpenMPTarget: Enable tiling for MDRange policies.

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_MDRange.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_MDRange.hpp
@@ -49,11 +49,6 @@
 #include <Kokkos_Parallel.hpp>
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp>
 
-// WORKAROUND OPENMPTARGET: sometimes tile sizes don't make it correctly,
-// this was tracked down to a bug in clang with regards of mapping structs
-// with arrays of long in it. Arrays of int might be fine though ...
-#define KOKKOS_IMPL_MDRANGE_USE_NO_TILES  // undef EOF
-
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
@@ -81,18 +76,12 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     FunctorType functor(m_functor);
     Policy policy = m_policy;
 
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    typename Policy::point_type unused;
-
-    execute_tile<Policy::rank>(unused, functor, policy);
-#else
     const int64_t begin = 0;
     const int64_t end   = m_policy.m_num_tiles;
 
 #pragma omp target teams distribute map(to : functor) num_teams(end - begin)
     {
       for (ptrdiff_t tile_idx = begin; tile_idx < end; ++tile_idx) {
-
 #pragma omp parallel
         {
           typename Policy::point_type offset;
@@ -113,182 +102,118 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         }
       }
     }
-#endif
   }
 
   template <int Rank>
   inline std::enable_if_t<Rank == 2> execute_tile(
       typename Policy::point_type offset, const FunctorType& functor,
       const Policy& policy) const {
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    (void)offset;
-    const Index begin_0 = policy.m_lower[0];
-    const Index begin_1 = policy.m_lower[1];
+    const Index begin_0 = offset[0];
+    Index end_0         = begin_0 + policy.m_tile[0];
+    end_0               = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
 
-    const Index end_0 = policy.m_upper[0];
-    const Index end_1 = policy.m_upper[1];
+    const Index begin_1 = offset[1];
+    Index end_1         = begin_1 + policy.m_tile[1];
+    end_1               = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
 
-#pragma omp target teams distribute parallel for collapse(2) map(to : functor)
-    for (auto i0 = begin_0; i0 < end_0; ++i0) {
+#pragma omp for collapse(2)
+    for (auto i0 = begin_0; i0 < end_0; ++i0)
       for (auto i1 = begin_1; i1 < end_1; ++i1) {
         if constexpr (std::is_void<typename Policy::work_tag>::value)
           functor(i0, i1);
         else
           functor(typename Policy::work_tag(), i0, i1);
       }
-    }
-#else
-    const ptrdiff_t begin_0 = offset[0];
-    ptrdiff_t end_0         = begin_0 + policy.m_tile[0];
-    end_0 = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
-
-    const ptrdiff_t begin_1 = offset[1];
-    ptrdiff_t end_1         = begin_1 + policy.m_tile[1];
-    end_1 = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
-
-#pragma omp for collapse(2)
-    for (ptrdiff_t i0 = begin_0; i0 < end_0; ++i0)
-      for (ptrdiff_t i1 = begin_1; i1 < end_1; ++i1) {
-        if constexpr (std::is_void<typename Policy::work_tag>::value)
-          functor(i0, i1);
-        else
-          functor(typename Policy::work_tag(), i0, i1);
-      }
-#endif
   }
 
   template <int Rank>
   inline std::enable_if_t<Rank == 3> execute_tile(
       typename Policy::point_type offset, const FunctorType& functor,
       const Policy& policy) const {
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    (void)offset;
-    const Index begin_0 = policy.m_lower[0];
-    const Index begin_1 = policy.m_lower[1];
-    const Index begin_2 = policy.m_lower[2];
+    const Index begin_0 = offset[0];
+    Index end_0         = begin_0 + policy.m_tile[0];
+    end_0               = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
 
-    const Index end_0 = policy.m_upper[0];
-    const Index end_1 = policy.m_upper[1];
-    const Index end_2 = policy.m_upper[2];
+    const Index begin_1 = offset[1];
+    Index end_1         = begin_1 + policy.m_tile[1];
+    end_1               = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
 
-#pragma omp target teams distribute parallel for collapse(3) map(to : functor)
-    for (auto i0 = begin_0; i0 < end_0; ++i0) {
-      for (auto i1 = begin_1; i1 < end_1; ++i1) {
+    const Index begin_2 = offset[2];
+    Index end_2         = begin_2 + policy.m_tile[2];
+    end_2               = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
+
+#pragma omp for collapse(3)
+    for (auto i0 = begin_0; i0 < end_0; ++i0)
+      for (auto i1 = begin_1; i1 < end_1; ++i1)
         for (auto i2 = begin_2; i2 < end_2; ++i2) {
           if constexpr (std::is_void<typename Policy::work_tag>::value)
             functor(i0, i1, i2);
           else
             functor(typename Policy::work_tag(), i0, i1, i2);
         }
-      }
-    }
-#else
-    const ptrdiff_t begin_0 = offset[0];
-    ptrdiff_t end_0         = begin_0 + policy.m_tile[0];
-    end_0 = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
-
-    const ptrdiff_t begin_1 = offset[1];
-    ptrdiff_t end_1         = begin_1 + policy.m_tile[1];
-    end_1 = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
-
-    const ptrdiff_t begin_2 = offset[2];
-    ptrdiff_t end_2         = begin_2 + policy.m_tile[2];
-    end_2 = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
-
-#pragma omp for collapse(3)
-    for (ptrdiff_t i0 = begin_0; i0 < end_0; ++i0)
-      for (ptrdiff_t i1 = begin_1; i1 < end_1; ++i1)
-        for (ptrdiff_t i2 = begin_2; i2 < end_2; ++i2) {
-          if constexpr (std::is_void<typename Policy::work_tag>::value)
-            functor(i0, i1, i2);
-          else
-            functor(typename Policy::work_tag(), i0, i1, i2);
-        }
-#endif
   }
 
   template <int Rank>
   inline std::enable_if_t<Rank == 4> execute_tile(
       typename Policy::point_type offset, const FunctorType& functor,
       const Policy& policy) const {
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    (void)offset;
-    const Index begin_0 = policy.m_lower[0];
-    const Index begin_1 = policy.m_lower[1];
-    const Index begin_2 = policy.m_lower[2];
-    const Index begin_3 = policy.m_lower[3];
+    const Index begin_0 = offset[0];
+    Index end_0         = begin_0 + policy.m_tile[0];
+    end_0               = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
 
-    const Index end_0 = policy.m_upper[0];
-    const Index end_1 = policy.m_upper[1];
-    const Index end_2 = policy.m_upper[2];
-    const Index end_3 = policy.m_upper[3];
+    const Index begin_1 = offset[1];
+    Index end_1         = begin_1 + policy.m_tile[1];
+    end_1               = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
 
-#pragma omp target teams distribute parallel for collapse(4) map(to : functor)
-    for (auto i0 = begin_0; i0 < end_0; ++i0) {
-      for (auto i1 = begin_1; i1 < end_1; ++i1) {
-        for (auto i2 = begin_2; i2 < end_2; ++i2) {
+    const Index begin_2 = offset[2];
+    Index end_2         = begin_2 + policy.m_tile[2];
+    end_2               = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
+
+    const Index begin_3 = offset[3];
+    Index end_3         = begin_3 + policy.m_tile[3];
+    end_3               = end_3 < policy.m_upper[3] ? end_3 : policy.m_upper[3];
+
+#pragma omp for collapse(4)
+    for (auto i0 = begin_0; i0 < end_0; ++i0)
+      for (auto i1 = begin_1; i1 < end_1; ++i1)
+        for (auto i2 = begin_2; i2 < end_2; ++i2)
           for (auto i3 = begin_3; i3 < end_3; ++i3) {
             if constexpr (std::is_void<typename Policy::work_tag>::value)
               functor(i0, i1, i2, i3);
             else
               functor(typename Policy::work_tag(), i0, i1, i2, i3);
           }
-        }
-      }
-    }
-#else
-    const ptrdiff_t begin_0 = offset[0];
-    ptrdiff_t end_0         = begin_0 + policy.m_tile[0];
-    end_0 = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
-
-    const ptrdiff_t begin_1 = offset[1];
-    ptrdiff_t end_1         = begin_1 + policy.m_tile[1];
-    end_1 = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
-
-    const ptrdiff_t begin_2 = offset[2];
-    ptrdiff_t end_2         = begin_2 + policy.m_tile[2];
-    end_2 = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
-
-    const ptrdiff_t begin_3 = offset[3];
-    ptrdiff_t end_3         = begin_3 + policy.m_tile[3];
-    end_3 = end_3 < policy.m_upper[3] ? end_3 : policy.m_upper[3];
-
-#pragma omp for collapse(4)
-    for (ptrdiff_t i0 = begin_0; i0 < end_0; ++i0)
-      for (ptrdiff_t i1 = begin_1; i1 < end_1; ++i1)
-        for (ptrdiff_t i2 = begin_2; i2 < end_2; ++i2)
-          for (ptrdiff_t i3 = begin_3; i3 < end_3; ++i3) {
-            if constexpr (std::is_void<typename Policy::work_tag>::value)
-              functor(i0, i1, i2, i3);
-            else
-              functor(typename Policy::work_tag(), i0, i1, i2, i3);
-          }
-#endif
   }
 
   template <int Rank>
   inline std::enable_if_t<Rank == 5> execute_tile(
       typename Policy::point_type offset, const FunctorType& functor,
       const Policy& policy) const {
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    (void)offset;
-    const Index begin_0 = policy.m_lower[0];
-    const Index begin_1 = policy.m_lower[1];
-    const Index begin_2 = policy.m_lower[2];
-    const Index begin_3 = policy.m_lower[3];
-    const Index begin_4 = policy.m_lower[4];
+    const Index begin_0 = offset[0];
+    Index end_0         = begin_0 + policy.m_tile[0];
+    end_0               = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
 
-    const Index end_0 = policy.m_upper[0];
-    const Index end_1 = policy.m_upper[1];
-    const Index end_2 = policy.m_upper[2];
-    const Index end_3 = policy.m_upper[3];
-    const Index end_4 = policy.m_upper[4];
+    const Index begin_1 = offset[1];
+    Index end_1         = begin_1 + policy.m_tile[1];
+    end_1               = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
 
-#pragma omp target teams distribute parallel for collapse(5) map(to : functor)
-    for (auto i0 = begin_0; i0 < end_0; ++i0) {
-      for (auto i1 = begin_1; i1 < end_1; ++i1) {
-        for (auto i2 = begin_2; i2 < end_2; ++i2) {
-          for (auto i3 = begin_3; i3 < end_3; ++i3) {
+    const Index begin_2 = offset[2];
+    Index end_2         = begin_2 + policy.m_tile[2];
+    end_2               = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
+
+    const Index begin_3 = offset[3];
+    Index end_3         = begin_3 + policy.m_tile[3];
+    end_3               = end_3 < policy.m_upper[3] ? end_3 : policy.m_upper[3];
+
+    const Index begin_4 = offset[4];
+    Index end_4         = begin_4 + policy.m_tile[4];
+    end_4               = end_4 < policy.m_upper[4] ? end_4 : policy.m_upper[4];
+
+#pragma omp for collapse(5)
+    for (auto i0 = begin_0; i0 < end_0; ++i0)
+      for (auto i1 = begin_1; i1 < end_1; ++i1)
+        for (auto i2 = begin_2; i2 < end_2; ++i2)
+          for (auto i3 = begin_3; i3 < end_3; ++i3)
             for (auto i4 = begin_4; i4 < end_4; ++i4) {
               if constexpr (std::is_same<typename Policy::work_tag,
                                          void>::value)
@@ -296,126 +221,49 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
               else
                 functor(typename Policy::work_tag(), i0, i1, i2, i3, i4);
             }
-          }
-        }
-      }
-    }
-#else
-    const ptrdiff_t begin_0 = offset[0];
-    ptrdiff_t end_0         = begin_0 + policy.m_tile[0];
-    end_0 = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
-
-    const ptrdiff_t begin_1 = offset[1];
-    ptrdiff_t end_1         = begin_1 + policy.m_tile[1];
-    end_1 = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
-
-    const ptrdiff_t begin_2 = offset[2];
-    ptrdiff_t end_2         = begin_2 + policy.m_tile[2];
-    end_2 = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
-
-    const ptrdiff_t begin_3 = offset[3];
-    ptrdiff_t end_3         = begin_3 + policy.m_tile[3];
-    end_3 = end_3 < policy.m_upper[3] ? end_3 : policy.m_upper[3];
-
-    const ptrdiff_t begin_4 = offset[4];
-    ptrdiff_t end_4         = begin_4 + policy.m_tile[4];
-    end_4 = end_4 < policy.m_upper[4] ? end_4 : policy.m_upper[4];
-
-#pragma omp for collapse(5)
-    for (ptrdiff_t i0 = begin_0; i0 < end_0; ++i0)
-      for (ptrdiff_t i1 = begin_1; i1 < end_1; ++i1)
-        for (ptrdiff_t i2 = begin_2; i2 < end_2; ++i2)
-          for (ptrdiff_t i3 = begin_3; i3 < end_3; ++i3)
-            for (ptrdiff_t i4 = begin_4; i4 < end_4; ++i4) {
-              if constexpr (std::is_same<typename Policy::work_tag,
-                                         void>::value)
-                functor(i0, i1, i2, i3, i4);
-              else
-                functor(typename Policy::work_tag(), i0, i1, i2, i3, i4);
-            }
-#endif
   }
 
   template <int Rank>
   inline std::enable_if_t<Rank == 6> execute_tile(
       typename Policy::point_type offset, const FunctorType& functor,
       const Policy& policy) const {
-#ifdef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
-    (void)offset;
-    const Index begin_0 = policy.m_lower[0];
-    const Index begin_1 = policy.m_lower[1];
-    const Index begin_2 = policy.m_lower[2];
-    const Index begin_3 = policy.m_lower[3];
-    const Index begin_4 = policy.m_lower[4];
-    const Index begin_5 = policy.m_lower[5];
+    const Index begin_0 = offset[0];
+    Index end_0         = begin_0 + policy.m_tile[0];
+    end_0               = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
 
-    const Index end_0 = policy.m_upper[0];
-    const Index end_1 = policy.m_upper[1];
-    const Index end_2 = policy.m_upper[2];
-    const Index end_3 = policy.m_upper[3];
-    const Index end_4 = policy.m_upper[4];
-    const Index end_5 = policy.m_upper[5];
+    const Index begin_1 = offset[1];
+    Index end_1         = begin_1 + policy.m_tile[1];
+    end_1               = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
 
-#pragma omp target teams distribute parallel for collapse(6) map(to : functor)
-    for (auto i0 = begin_0; i0 < end_0; ++i0) {
-      for (auto i1 = begin_1; i1 < end_1; ++i1) {
-        for (auto i2 = begin_2; i2 < end_2; ++i2) {
-          for (auto i3 = begin_3; i3 < end_3; ++i3) {
-            for (auto i4 = begin_4; i4 < end_4; ++i4) {
-              for (auto i5 = begin_5; i5 < end_5; ++i5) {
-                {
-                  if constexpr (std::is_same<typename Policy::work_tag,
-                                             void>::value)
-                    functor(i0, i1, i2, i3, i4, i5);
-                  else
-                    functor(typename Policy::work_tag(), i0, i1, i2, i3, i4,
-                            i5);
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-#else
-    const ptrdiff_t begin_0 = offset[0];
-    ptrdiff_t end_0         = begin_0 + policy.m_tile[0];
-    end_0 = end_0 < policy.m_upper[0] ? end_0 : policy.m_upper[0];
+    const Index begin_2 = offset[2];
+    Index end_2         = begin_2 + policy.m_tile[2];
+    end_2               = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
 
-    const ptrdiff_t begin_1 = offset[1];
-    ptrdiff_t end_1         = begin_1 + policy.m_tile[1];
-    end_1 = end_1 < policy.m_upper[1] ? end_1 : policy.m_upper[1];
+    const Index begin_3 = offset[3];
+    Index end_3         = begin_3 + policy.m_tile[3];
+    end_3               = end_3 < policy.m_upper[3] ? end_3 : policy.m_upper[3];
 
-    const ptrdiff_t begin_2 = offset[2];
-    ptrdiff_t end_2         = begin_2 + policy.m_tile[2];
-    end_2 = end_2 < policy.m_upper[2] ? end_2 : policy.m_upper[2];
+    const Index begin_4 = offset[4];
+    Index end_4         = begin_4 + policy.m_tile[4];
+    end_4               = end_4 < policy.m_upper[4] ? end_4 : policy.m_upper[4];
 
-    const ptrdiff_t begin_3 = offset[3];
-    ptrdiff_t end_3         = begin_3 + policy.m_tile[3];
-    end_3 = end_3 < policy.m_upper[3] ? end_3 : policy.m_upper[3];
-
-    const ptrdiff_t begin_4 = offset[4];
-    ptrdiff_t end_4         = begin_4 + policy.m_tile[4];
-    end_4 = end_4 < policy.m_upper[4] ? end_4 : policy.m_upper[4];
-
-    const ptrdiff_t begin_5 = offset[5];
-    ptrdiff_t end_5         = begin_5 + policy.m_tile[5];
-    end_5 = end_5 < policy.m_upper[5] ? end_5 : policy.m_upper[5];
+    const Index begin_5 = offset[5];
+    Index end_5         = begin_5 + policy.m_tile[5];
+    end_5               = end_5 < policy.m_upper[5] ? end_5 : policy.m_upper[5];
 
 #pragma omp for collapse(6)
-    for (ptrdiff_t i0 = begin_0; i0 < end_0; ++i0)
-      for (ptrdiff_t i1 = begin_1; i1 < end_1; ++i1)
-        for (ptrdiff_t i2 = begin_2; i2 < end_2; ++i2)
-          for (ptrdiff_t i3 = begin_3; i3 < end_3; ++i3)
-            for (ptrdiff_t i4 = begin_4; i4 < end_4; ++i4)
-              for (ptrdiff_t i5 = begin_5; i5 < end_5; ++i5) {
+    for (auto i0 = begin_0; i0 < end_0; ++i0)
+      for (auto i1 = begin_1; i1 < end_1; ++i1)
+        for (auto i2 = begin_2; i2 < end_2; ++i2)
+          for (auto i3 = begin_3; i3 < end_3; ++i3)
+            for (auto i4 = begin_4; i4 < end_4; ++i4)
+              for (auto i5 = begin_5; i5 < end_5; ++i5) {
                 if constexpr (std::is_same<typename Policy::work_tag,
                                            void>::value)
                   functor(i0, i1, i2, i3, i4, i5);
                 else
                   functor(typename Policy::work_tag(), i0, i1, i2, i3, i4, i5);
               }
-#endif
   }
 
   inline ParallelFor(const FunctorType& arg_functor, Policy arg_policy)
@@ -832,5 +680,4 @@ reduction(+:result)
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
-#undef KOKKOS_IMPL_MDRANGE_USE_NO_TILES
 #endif /* KOKKOS_OPENMPTARGET_PARALLEL_HPP */


### PR DESCRIPTION
The PR enables tiling for MDRange policies in the OpenMPTarget backend. Previously tiling for MDRange policy was disabled due to a bug in the older llvm compilers. 