### PR TITLE
Threads: Fix serial resizing scratch space 

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -14,44 +14,37 @@ jobs:
         cxx: ['g++', 'clang++']
         cmake_build_type: ['Release', 'Debug']
         backend: ['OPENMP']
-        hwloc: ['ON']
         clang-tidy: ['']
         include:
           - distro: 'fedora:intel'
             cxx: 'icpc'
             cmake_build_type: 'Release'
             backend: 'OPENMP'
-            hwloc: 'ON'
             clang-tidy: ''
           - distro: 'fedora:intel'
             cxx: 'icpc'
             cmake_build_type: 'Debug'
             backend: 'OPENMP'
-            hwloc: 'ON'
             clang-tidy: ''
           - distro: 'fedora:intel'
             cxx: 'icpx'
             cmake_build_type: 'Release'
             backend: 'OPENMP'
-            hwloc: 'ON'
             clang-tidy: ''
           - distro: 'fedora:intel'
             cxx: 'icpx'
             cmake_build_type: 'Debug'
             backend: 'OPENMP'
-            hwloc: 'ON'
             clang-tidy: ''
           - distro: 'ubuntu:latest'
             cxx: 'clang++'
             cmake_build_type: 'RelWithDebInfo'
             backend: 'THREADS'
-            hwloc: 'OFF'
             clang-tidy: '-DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"'
           - distro: 'ubuntu:latest'
             cxx: 'g++'
             cmake_build_type: 'RelWithDebInfo'
             backend: 'THREADS'
-            hwloc: 'OFF'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/kokkos/ci-containers/${{ matrix.distro }}
@@ -80,7 +73,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr \
             ${{ matrix.clang-tidy }} \
             -DKokkos_ARCH_NATIVE=ON \
-            -DKokkos_ENABLE_HWLOC=${{ matrix.hwloc }} \
+            -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_${{ matrix.backend }}=ON \
             -DKokkos_ENABLE_TESTS=ON \
             -DKokkos_ENABLE_EXAMPLES=ON \

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -443,14 +443,14 @@ void *ThreadsExec::root_reduce_scratch() {
 }
 
 void ThreadsExec::execute_resize_scratch(ThreadsExec &exec, const void *) {
-  using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HostSpace, void>;
-
   exec.m_scratch_reduce_end = s_threads_process.m_scratch_reduce_end;
   exec.m_scratch_thread_end = s_threads_process.m_scratch_thread_end;
 
   if (s_threads_process.m_scratch_thread_end) {
     // Allocate tracked memory:
     {
+      using Record =
+          Kokkos::Impl::SharedAllocationRecord<Kokkos::HostSpace, void>;
       Record *const r =
           Record::allocate(Kokkos::HostSpace(), "Kokkos::thread_scratch",
                            s_threads_process.m_scratch_thread_end);

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -399,7 +399,7 @@ bool ThreadsExec::wake() {
 
 //----------------------------------------------------------------------------
 
-void ThreadsExec::execute_resize_scratch_in_serial() {
+void ThreadsExec::first_touch_allocate_thread_private_scratch_in_serial() {
   const unsigned begin = s_threads_process.m_pool_base ? 1 : 0;
 
   auto deallocate_scratch_memory = [](ThreadsExec &exec) {
@@ -417,7 +417,7 @@ void ThreadsExec::execute_resize_scratch_in_serial() {
     }
   }
 
-  s_current_function     = &execute_resize_scratch;
+  s_current_function     = &first_touch_allocate_thread_private_scratch;
   s_current_function_arg = &s_threads_process;
 
   // Make sure function and arguments are written before activating threads.
@@ -434,7 +434,7 @@ void ThreadsExec::execute_resize_scratch_in_serial() {
   if (s_threads_process.m_pool_base) {
     deallocate_scratch_memory(s_threads_process);
     s_threads_process.m_pool_state = ThreadsExec::Active;
-    execute_resize_scratch(s_threads_process, nullptr);
+    first_touch_allocate_thread_private_scratch(s_threads_process, nullptr);
     s_threads_process.m_pool_state = ThreadsExec::Inactive;
   }
 
@@ -451,7 +451,8 @@ void *ThreadsExec::root_reduce_scratch() {
   return s_threads_process.reduce_memory();
 }
 
-void ThreadsExec::execute_resize_scratch(ThreadsExec &exec, const void *) {
+void ThreadsExec::first_touch_allocate_thread_private_scratch(ThreadsExec &exec,
+                                                              const void *) {
   exec.m_scratch_reduce_end = s_threads_process.m_scratch_reduce_end;
   exec.m_scratch_thread_end = s_threads_process.m_scratch_thread_end;
 
@@ -501,7 +502,7 @@ void *ThreadsExec::resize_scratch(size_t reduce_size, size_t thread_size) {
     s_threads_process.m_scratch_reduce_end = reduce_size;
     s_threads_process.m_scratch_thread_end = reduce_size + thread_size;
 
-    execute_resize_scratch_in_serial();
+    first_touch_allocate_thread_private_scratch_in_serial();
 
     s_threads_process.m_scratch = s_threads_exec[0]->m_scratch;
   }

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -399,6 +399,38 @@ bool ThreadsExec::wake() {
 
 //----------------------------------------------------------------------------
 
+void ThreadsExec::execute_serial(void (*func)(ThreadsExec &, const void *)) {
+  s_current_function     = func;
+  s_current_function_arg = &s_threads_process;
+
+  // Make sure function and arguments are written before activating threads.
+  memory_fence();
+
+  const unsigned begin = s_threads_process.m_pool_base ? 1 : 0;
+
+  for (unsigned i = s_thread_pool_size[0]; begin < i;) {
+    ThreadsExec &th = *s_threads_exec[--i];
+
+    th.m_pool_state = ThreadsExec::Active;
+
+    wait_yield(th.m_pool_state, ThreadsExec::Active);
+  }
+
+  if (s_threads_process.m_pool_base) {
+    s_threads_process.m_pool_state = ThreadsExec::Active;
+    (*func)(s_threads_process, nullptr);
+    s_threads_process.m_pool_state = ThreadsExec::Inactive;
+  }
+
+  s_current_function_arg = nullptr;
+  s_current_function     = nullptr;
+
+  // Make sure function and arguments are cleared before proceeding.
+  memory_fence();
+}
+
+//----------------------------------------------------------------------------
+
 void *ThreadsExec::root_reduce_scratch() {
   return s_threads_process.reduce_memory();
 }
@@ -461,7 +493,7 @@ void *ThreadsExec::resize_scratch(size_t reduce_size, size_t thread_size) {
     s_threads_process.m_scratch_reduce_end = reduce_size;
     s_threads_process.m_scratch_thread_end = reduce_size + thread_size;
 
-    execute_resize_scratch(s_threads_process, nullptr);
+    execute_serial(&execute_resize_scratch);
 
     s_threads_process.m_scratch = s_threads_exec[0]->m_scratch;
   }

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -399,7 +399,7 @@ bool ThreadsExec::wake() {
 
 //----------------------------------------------------------------------------
 
-void ThreadsExec::first_touch_allocate_thread_private_scratch_in_serial() {
+void ThreadsExec::execute_resize_scratch_in_serial() {
   const unsigned begin = s_threads_process.m_pool_base ? 1 : 0;
 
   auto deallocate_scratch_memory = [](ThreadsExec &exec) {
@@ -502,7 +502,7 @@ void *ThreadsExec::resize_scratch(size_t reduce_size, size_t thread_size) {
     s_threads_process.m_scratch_reduce_end = reduce_size;
     s_threads_process.m_scratch_thread_end = reduce_size + thread_size;
 
-    first_touch_allocate_thread_private_scratch_in_serial();
+    execute_resize_scratch_in_serial();
 
     s_threads_process.m_scratch = s_threads_exec[0]->m_scratch;
   }

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -129,7 +129,7 @@ class ThreadsExec {
   ThreadsExec(const ThreadsExec &);
   ThreadsExec &operator=(const ThreadsExec &);
 
-  static void first_touch_allocate_thread_private_scratch_in_serial();
+  static void execute_resize_scratch_in_serial();
 
  public:
   KOKKOS_INLINE_FUNCTION int pool_size() const { return m_pool_size; }

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -128,6 +128,8 @@ class ThreadsExec {
   ThreadsExec(const ThreadsExec &);
   ThreadsExec &operator=(const ThreadsExec &);
 
+  static void execute_serial(void (*)(ThreadsExec &, const void *));
+
  public:
   KOKKOS_INLINE_FUNCTION int pool_size() const { return m_pool_size; }
   KOKKOS_INLINE_FUNCTION int pool_rank() const { return m_pool_rank; }

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -122,13 +122,14 @@ class ThreadsExec {
   static void global_unlock();
   static void spawn();
 
-  static void execute_resize_scratch(ThreadsExec &, const void *);
+  static void first_touch_allocate_thread_private_scratch(ThreadsExec &,
+                                                          const void *);
   static void execute_sleep(ThreadsExec &, const void *);
 
   ThreadsExec(const ThreadsExec &);
   ThreadsExec &operator=(const ThreadsExec &);
 
-  static void execute_resize_scratch_in_serial();
+  static void first_touch_allocate_thread_private_scratch_in_serial();
 
  public:
   KOKKOS_INLINE_FUNCTION int pool_size() const { return m_pool_size; }

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -128,7 +128,7 @@ class ThreadsExec {
   ThreadsExec(const ThreadsExec &);
   ThreadsExec &operator=(const ThreadsExec &);
 
-  static void execute_serial(void (*)(ThreadsExec &, const void *));
+  static void execute_resize_scratch_in_serial();
 
  public:
   KOKKOS_INLINE_FUNCTION int pool_size() const { return m_pool_size; }


### PR DESCRIPTION
Fixes #5107. Fixes #4878. This pull request reverts parts of #4499 and makes sure that we call 
```
s_threads_process.m_pool_state = ThreadsExec::Active;
```
after deallocating scratch space (if necessary) to avoid deadlocking.