### PR TITLE
Warn if a command line argument prefixed by `--kokkos*` is not recognized

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -663,7 +663,7 @@ void parse_command_line_arguments(int& narg, char* arg[],
       if (!is_unsigned_int(num1_only) || (strlen(num1_only) == 0)) {
         throw_runtime_exception(
             "Error: expecting an integer number after command line argument "
-            "'--kokkos-numdevices'. Raised by "
+            "'--kokkos-num-devices'. Raised by "
             "Kokkos::initialize(int narg, char* argc[]).");
       }
       if (check_arg(arg[iarg], "--kokkos-num-devices") ||
@@ -871,7 +871,7 @@ void parse_environment_variables(InitArguments& arguments) {
           "integer. Raised by Kokkos::initialize(int narg, char* argc[]).");
     if ((device != -1) && (env_device != device))
       Impl::throw_runtime_exception(
-          "Error: expecting a match between --kokkos-device and "
+          "Error: expecting a match between --kokkos-device-id and "
           "KOKKOS_DEVICE_ID if both are set. Raised by Kokkos::initialize(int "
           "narg, char* argc[]).");
     else
@@ -901,7 +901,7 @@ void parse_environment_variables(InitArguments& arguments) {
             "argc[]).");
       if ((ndevices != -1) && (env_ndevices != ndevices))
         Impl::throw_runtime_exception(
-            "Error: expecting a match between --kokkos-ndevices and "
+            "Error: expecting a match between --kokkos-num-devices and "
             "KOKKOS_NUM_DEVICES if both are set. Raised by "
             "Kokkos::initialize(int narg, char* argc[]).");
       else
@@ -936,7 +936,7 @@ void parse_environment_variables(InitArguments& arguments) {
             "argc[]).");
       if ((skip_device != 9999) && (env_skip_device != skip_device))
         Impl::throw_runtime_exception(
-            "Error: expecting a match between --kokkos-ndevices and "
+            "Error: expecting a match between --kokkos-num-devices and "
             "KOKKOS_SKIP_DEVICE if both are set. Raised by "
             "Kokkos::initialize(int narg, char* argc[]).");
       else

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -735,6 +735,9 @@ void parse_command_line_arguments(int& narg, char* arg[],
       if (check_arg(arg[iarg], "--kokkos-help")) {
         remove_flag = true;
       }
+    } else if (strncmp("--kokkos", arg[iarg], 8) == 0) {
+      std::cerr << "Warning: command line argument '" << arg[iarg]
+                << "' is not recognized and will be ignored" << std::endl;
     }
 
     if (remove_flag) {

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -596,42 +596,32 @@ void parse_command_line_arguments(int& narg, char* arg[],
   int iarg = 0;
 
   while (iarg < narg) {
+    bool remove_flag = false;
     if (check_int_arg(arg[iarg], "--kokkos-threads", &num_threads)) {
-      for (int k = iarg; k < narg - 1; k++) {
-        arg[k] = arg[k + 1];
-      }
+      remove_flag          = true;
       kokkos_threads_found = true;
-      narg--;
     } else if (!kokkos_threads_found &&
                check_int_arg(arg[iarg], "--threads", &num_threads)) {
-      iarg++;
+      // nothing
     } else if (check_int_arg(arg[iarg], "--kokkos-numa", &numa)) {
-      for (int k = iarg; k < narg - 1; k++) {
-        arg[k] = arg[k + 1];
-      }
+      remove_flag       = true;
       kokkos_numa_found = true;
-      narg--;
     } else if (!kokkos_numa_found &&
                check_int_arg(arg[iarg], "--numa", &numa)) {
-      iarg++;
     } else if (check_int_arg(arg[iarg], "--kokkos-device-id", &device) ||
                check_int_arg(arg[iarg], "--kokkos-device", &device)) {
       if (check_arg(arg[iarg], "--kokkos-device")) {
         warn_deprecated_command_line_argument("--kokkos-device",
                                               "--kokkos-device-id");
       }
-      for (int k = iarg; k < narg - 1; k++) {
-        arg[k] = arg[k + 1];
-      }
+      remove_flag         = true;
       kokkos_device_found = true;
-      narg--;
     } else if (!kokkos_device_found &&
                (check_int_arg(arg[iarg], "--device-id", &device) ||
                 check_int_arg(arg[iarg], "--device", &device))) {
       if (check_arg(arg[iarg], "--device")) {
         warn_deprecated_command_line_argument("--device", "--device-id");
       }
-      iarg++;
     } else if (check_arg(arg[iarg], "--kokkos-num-devices") ||
                check_arg(arg[iarg], "--num-devices") ||
                check_arg(arg[iarg], "--kokkos-ndevices") ||
@@ -687,26 +677,14 @@ void parse_command_line_arguments(int& narg, char* arg[],
       // --num-devices
       if (check_arg(arg[iarg], "--kokkos-num-devices") ||
           check_arg(arg[iarg], "--kokkos-ndevices")) {
-        for (int k = iarg; k < narg - 1; k++) {
-          arg[k] = arg[k + 1];
-        }
-        kokkos_ndevices_found = true;
-        narg--;
-      } else {
-        iarg++;
+        remove_flag = true;
       }
     } else if (check_arg(arg[iarg], "--kokkos-disable-warnings")) {
+      remove_flag      = true;
       disable_warnings = true;
-      for (int k = iarg; k < narg - 1; k++) {
-        arg[k] = arg[k + 1];
-      }
-      narg--;
     } else if (check_arg(arg[iarg], "--kokkos-tune-internals")) {
+      remove_flag    = true;
       tune_internals = true;
-      for (int k = iarg; k < narg - 1; k++) {
-        arg[k] = arg[k + 1];
-      }
-      narg--;
     } else if (check_arg(arg[iarg], "--kokkos-help") ||
                check_arg(arg[iarg], "--help")) {
       auto const help_message = R"(
@@ -755,15 +733,18 @@ void parse_command_line_arguments(int& narg, char* arg[],
 
       // Remove the --kokkos-help argument from the list but leave --help
       if (check_arg(arg[iarg], "--kokkos-help")) {
-        for (int k = iarg; k < narg - 1; k++) {
-          arg[k] = arg[k + 1];
-        }
-        narg--;
-      } else {
-        iarg++;
+        remove_flag = true;
       }
-    } else
+    }
+
+    if (remove_flag) {
+      for (int k = iarg; k < narg - 1; k++) {
+        arg[k] = arg[k + 1];
+      }
+      narg--;
+    } else {
       iarg++;
+    }
   }
   if ((tools_init_arguments.args ==
        Kokkos::Tools::InitArguments::unset_string_option) &&


### PR DESCRIPTION
Do not silently ignore a `--kokkos*` argument because it is likely a typo.

Drive-by changes:
* Fix typo in error message and replace mentions to deprecated command line arguments
* Refactor to avoid code duplication when processing args