### PR TITLE
Fix error message if mismatch between command line arg and env var

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -596,49 +596,38 @@ void parse_command_line_arguments(int& narg, char* arg[],
   int iarg = 0;
 
   while (iarg < narg) {
+    bool remove_flag = false;
     if (check_int_arg(arg[iarg], "--kokkos-num-threads", &num_threads) ||
         check_int_arg(arg[iarg], "--kokkos-threads", &num_threads)) {
       if (check_arg(arg[iarg], "--kokkos-threads")) {
         warn_deprecated_command_line_argument("--kokkos-threads",
                                               "--kokkos-num-threads");
       }
-      for (int k = iarg; k < narg - 1; k++) {
-        arg[k] = arg[k + 1];
-      }
+      remove_flag          = true;
       kokkos_threads_found = true;
-      narg--;
     } else if (!kokkos_threads_found &&
                (check_int_arg(arg[iarg], "--num-threads", &num_threads) ||
                 check_int_arg(arg[iarg], "--threads", &num_threads))) {
       warn_deprecated_command_line_argument("--threads", "--num-threads");
-      iarg++;
     } else if (check_int_arg(arg[iarg], "--kokkos-numa", &numa)) {
-      for (int k = iarg; k < narg - 1; k++) {
-        arg[k] = arg[k + 1];
-      }
+      remove_flag       = true;
       kokkos_numa_found = true;
-      narg--;
     } else if (!kokkos_numa_found &&
                check_int_arg(arg[iarg], "--numa", &numa)) {
-      iarg++;
     } else if (check_int_arg(arg[iarg], "--kokkos-device-id", &device) ||
                check_int_arg(arg[iarg], "--kokkos-device", &device)) {
       if (check_arg(arg[iarg], "--kokkos-device")) {
         warn_deprecated_command_line_argument("--kokkos-device",
                                               "--kokkos-device-id");
       }
-      for (int k = iarg; k < narg - 1; k++) {
-        arg[k] = arg[k + 1];
-      }
+      remove_flag         = true;
       kokkos_device_found = true;
-      narg--;
     } else if (!kokkos_device_found &&
                (check_int_arg(arg[iarg], "--device-id", &device) ||
                 check_int_arg(arg[iarg], "--device", &device))) {
       if (check_arg(arg[iarg], "--device")) {
         warn_deprecated_command_line_argument("--device", "--device-id");
       }
-      iarg++;
     } else if (check_arg(arg[iarg], "--kokkos-num-devices") ||
                check_arg(arg[iarg], "--num-devices") ||
                check_arg(arg[iarg], "--kokkos-ndevices") ||
@@ -694,26 +683,14 @@ void parse_command_line_arguments(int& narg, char* arg[],
       // --num-devices
       if (check_arg(arg[iarg], "--kokkos-num-devices") ||
           check_arg(arg[iarg], "--kokkos-ndevices")) {
-        for (int k = iarg; k < narg - 1; k++) {
-          arg[k] = arg[k + 1];
-        }
-        kokkos_ndevices_found = true;
-        narg--;
-      } else {
-        iarg++;
+        remove_flag = true;
       }
     } else if (check_arg(arg[iarg], "--kokkos-disable-warnings")) {
+      remove_flag      = true;
       disable_warnings = true;
-      for (int k = iarg; k < narg - 1; k++) {
-        arg[k] = arg[k + 1];
-      }
-      narg--;
     } else if (check_arg(arg[iarg], "--kokkos-tune-internals")) {
+      remove_flag    = true;
       tune_internals = true;
-      for (int k = iarg; k < narg - 1; k++) {
-        arg[k] = arg[k + 1];
-      }
-      narg--;
     } else if (check_arg(arg[iarg], "--kokkos-help") ||
                check_arg(arg[iarg], "--help")) {
       auto const help_message = R"(
@@ -762,15 +739,18 @@ void parse_command_line_arguments(int& narg, char* arg[],
 
       // Remove the --kokkos-help argument from the list but leave --help
       if (check_arg(arg[iarg], "--kokkos-help")) {
-        for (int k = iarg; k < narg - 1; k++) {
-          arg[k] = arg[k + 1];
-        }
-        narg--;
-      } else {
-        iarg++;
+        remove_flag = true;
       }
-    } else
+    }
+
+    if (remove_flag) {
+      for (int k = iarg; k < narg - 1; k++) {
+        arg[k] = arg[k + 1];
+      }
+      narg--;
+    } else {
       iarg++;
+    }
   }
   if ((tools_init_arguments.args ==
        Kokkos::Tools::InitArguments::unset_string_option) &&

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -670,7 +670,7 @@ void parse_command_line_arguments(int& narg, char* arg[],
       if (!is_unsigned_int(num1_only) || (strlen(num1_only) == 0)) {
         throw_runtime_exception(
             "Error: expecting an integer number after command line argument "
-            "'--kokkos-numdevices'. Raised by "
+            "'--kokkos-num-devices'. Raised by "
             "Kokkos::initialize(int narg, char* argc[]).");
       }
       if (check_arg(arg[iarg], "--kokkos-num-devices") ||
@@ -878,7 +878,7 @@ void parse_environment_variables(InitArguments& arguments) {
           "integer. Raised by Kokkos::initialize(int narg, char* argc[]).");
     if ((device != -1) && (env_device != device))
       Impl::throw_runtime_exception(
-          "Error: expecting a match between --kokkos-device and "
+          "Error: expecting a match between --kokkos-device-id and "
           "KOKKOS_DEVICE_ID if both are set. Raised by Kokkos::initialize(int "
           "narg, char* argc[]).");
     else
@@ -908,7 +908,7 @@ void parse_environment_variables(InitArguments& arguments) {
             "argc[]).");
       if ((ndevices != -1) && (env_ndevices != ndevices))
         Impl::throw_runtime_exception(
-            "Error: expecting a match between --kokkos-ndevices and "
+            "Error: expecting a match between --kokkos-num-devices and "
             "KOKKOS_NUM_DEVICES if both are set. Raised by "
             "Kokkos::initialize(int narg, char* argc[]).");
       else
@@ -943,7 +943,7 @@ void parse_environment_variables(InitArguments& arguments) {
             "argc[]).");
       if ((skip_device != 9999) && (env_skip_device != skip_device))
         Impl::throw_runtime_exception(
-            "Error: expecting a match between --kokkos-ndevices and "
+            "Error: expecting a match between --kokkos-num-devices and "
             "KOKKOS_SKIP_DEVICE if both are set. Raised by "
             "Kokkos::initialize(int narg, char* argc[]).");
       else


### PR DESCRIPTION
Cherry-picking non-controversial part of #5110 

* Fix typo in error message and replace mentions to deprecated command line arguments
* Refactor to avoid code duplication when processing args