### PR TITLE
Deprecate `--[kokkos-]numa` cmdline arg and `KOKKOS_NUMA` env var

### DIFF
--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -797,7 +797,8 @@ int g_threads_space_factory_initialized =
 
 void ThreadsSpaceInitializer::initialize(const InitArguments &args) {
   const int num_threads = args.num_threads;
-  const int use_numa    = args.num_numa;
+  const int use_numa    = -1;  // args.num_numa is deprecated.
+                               // setting to legacy default value.
   if (std::is_same<Kokkos::Threads, Kokkos::DefaultExecutionSpace>::value ||
       std::is_same<Kokkos::Threads,
                    Kokkos::HostSpace::execution_space>::value) {

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -797,17 +797,11 @@ int g_threads_space_factory_initialized =
 
 void ThreadsSpaceInitializer::initialize(const InitArguments &args) {
   const int num_threads = args.num_threads;
-  const int use_numa    = -1;  // args.num_numa is deprecated.
-                               // setting to legacy default value.
   if (std::is_same<Kokkos::Threads, Kokkos::DefaultExecutionSpace>::value ||
       std::is_same<Kokkos::Threads,
                    Kokkos::HostSpace::execution_space>::value) {
     if (num_threads > 0) {
-      if (use_numa > 0) {
-        Kokkos::Threads::impl_initialize(num_threads, use_numa);
-      } else {
-        Kokkos::Threads::impl_initialize(num_threads);
-      }
+      Kokkos::Threads::impl_initialize(num_threads);
     } else {
       Kokkos::Threads::impl_initialize();
     }

--- a/core/src/impl/Kokkos_Command_Line_Parsing.cpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.cpp
@@ -123,11 +123,25 @@ bool Kokkos::Impl::check_str_arg(char const* arg, char const* expected,
   }
   return true;
 }
-void Kokkos::Impl::warn_deprecated_command_line_argument(std::string deprecated,
-                                                         std::string valid) {
-  std::cerr
-      << "Warning: command line argument '" << deprecated
-      << "' is deprecated. Use '" << valid
-      << "' instead. Raised by Kokkos::initialize(int narg, char* argc[])."
-      << std::endl;
+void Kokkos::Impl::warn_deprecated_environment_variable(
+    std::string deprecated) {
+  std::cerr << "Warning: environment variable '" << deprecated
+            << "' is deprecated."
+            << " Raised by Kokkos::initialize(int narg, char* argc[])."
+            << std::endl;
+}
+void Kokkos::Impl::warn_deprecated_command_line_argument(
+    std::string deprecated) {
+  std::cerr << "Warning: command line argument '" << deprecated
+            << "' is deprecated."
+            << " Raised by Kokkos::initialize(int narg, char* argc[])."
+            << std::endl;
+}
+void Kokkos::Impl::warn_deprecated_command_line_argument(
+    std::string deprecated, std::string use_instead) {
+  std::cerr << "Warning: command line argument '" << deprecated
+            << "' is deprecated."
+            << " Use '" << use_instead << "' instead."
+            << " Raised by Kokkos::initialize(int narg, char* argc[])."
+            << std::endl;
 }

--- a/core/src/impl/Kokkos_Command_Line_Parsing.hpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.hpp
@@ -55,8 +55,10 @@ bool check_arg(char const* arg, char const* expected);
 // void throw_runtime_exception(const std::string& msg);
 bool check_int_arg(char const* arg, char const* expected, int* value);
 bool check_str_arg(char const* arg, char const* expected, std::string& value);
+void warn_deprecated_environment_variable(std::string deprecated);
+void warn_deprecated_command_line_argument(std::string deprecated);
 void warn_deprecated_command_line_argument(std::string deprecated,
-                                           std::string valid);
+                                           std::string use_instead);
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -710,10 +710,8 @@ void parse_command_line_arguments(int& narg, char* arg[],
       --kokkos-tune-internals        : allow Kokkos to autotune policies and declare
                                        tuning features through the tuning system. If
                                        left off, Kokkos uses heuristics
-      --kokkos-num-threads=INT       : specify total number of threads or
-                                       number of threads per NUMA region if
-                                       used in conjunction with '--numa' option.
-      --kokkos-numa=INT              : specify number of NUMA regions used by process.
+      --kokkos-num-threads=INT       : specify total number of threads to use for
+                                       parallel regions on the host.
       --kokkos-device-id=INT         : specify device id to be used by Kokkos.
       --kokkos-num-devices=INT[,INT] : used when running MPI jobs. Specify number of
                                        devices per node to be used. Process to device


### PR DESCRIPTION
* Warn if they are used and ignore the value.
* Remove from the help message

It seems to be only used in the Threads backend.  This patch hard codes it to be the legacy default value.
I suggest we refactor the backend initialization later.

NOTE: I tried adding the `[[deprecated]]` attribute to `InitArguments::num_numa` but it yields bogus warnings with Clang (reproducer [here](https://godbolt.org/z/5d7xnTE17)) so I abstained for now.