### PR TITLE
Reorder header self contained tests

### DIFF
--- a/algorithms/src/std_algorithms/Kokkos_ValueWrapperForNoNeutralElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ValueWrapperForNoNeutralElement.hpp
@@ -45,6 +45,8 @@
 #ifndef KOKKOS_STD_VALUE_WRAPPER_FOR_NO_NEUTRAL_ELEMENT_HPP
 #define KOKKOS_STD_VALUE_WRAPPER_FOR_NO_NEUTRAL_ELEMENT_HPP
 
+#include <Kokkos_Macros.hpp>
+
 namespace Kokkos {
 namespace Experimental {
 namespace Impl {

--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -156,3 +156,7 @@ KOKKOS_ADD_EXECUTABLE(
   UnitTest_StdAlgoCompileOnly
   SOURCES TestStdAlgorithmsCompileOnly.cpp
 )
+
+if (KOKKOS_ENABLE_HEADER_SELF_CONTAINMENT_TESTS AND NOT KOKKOS_HAS_TRILINOS AND NOT WIN32)
+  add_subdirectory(headers_self_contained)
+endif()

--- a/algorithms/unit_tests/headers_self_contained/CMakeLists.txt
+++ b/algorithms/unit_tests/headers_self_contained/CMakeLists.txt
@@ -3,8 +3,8 @@
 
 # Globbing all the header filenames to test for self-containment and presence of header guards
 SET(BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../")
-file(GLOB KOKKOS_CORE_HEADERS RELATIVE ${BASE_DIR}/core/src
-     ${BASE_DIR}/core/src/*.hpp ${BASE_DIR}/core/src/*.h)
+file(GLOB KOKKOS_ALGORITHMS_HEADERS RELATIVE  ${BASE_DIR}/algorithms/src
+     ${BASE_DIR}/algorithms/src/*.hpp ${BASE_DIR}/algorithms/src/std_algorithms/*.hpp)
 
 foreach (_header ${KOKKOS_CORE_HEADERS} ${KOKKOS_CONTAINERS_HEADERS} ${KOKKOS_ALGORITHMS_HEADERS})
   string(REGEX REPLACE "[\./]" "_" header_test_name ${_header})

--- a/algorithms/unit_tests/headers_self_contained/CMakeLists.txt
+++ b/algorithms/unit_tests/headers_self_contained/CMakeLists.txt
@@ -6,7 +6,7 @@ SET(BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../")
 file(GLOB KOKKOS_ALGORITHMS_HEADERS RELATIVE  ${BASE_DIR}/algorithms/src
      ${BASE_DIR}/algorithms/src/*.hpp ${BASE_DIR}/algorithms/src/std_algorithms/*.hpp)
 
-foreach (_header ${KOKKOS_CORE_HEADERS} ${KOKKOS_CONTAINERS_HEADERS} ${KOKKOS_ALGORITHMS_HEADERS})
+foreach (_header ${KOKKOS_ALGORITHMS_HEADERS})
   string(REGEX REPLACE "[\./]" "_" header_test_name ${_header})
   set(header_test_name Kokkos_HeaderSelfContained_${header_test_name})
   set_source_files_properties(tstHeader.cpp PROPERTIES LANGUAGE ${KOKKOS_COMPILE_LANGUAGE})

--- a/algorithms/unit_tests/headers_self_contained/tstHeader.cpp
+++ b/algorithms/unit_tests/headers_self_contained/tstHeader.cpp
@@ -1,0 +1,15 @@
+#define KOKKOS_HEADER_TEST_STRINGIZE_IMPL(x) #x
+#define KOKKOS_HEADER_TEST_STRINGIZE(x) KOKKOS_HEADER_TEST_STRINGIZE_IMPL(x)
+
+#define KOKKOS_HEADER_TO_TEST \
+  KOKKOS_HEADER_TEST_STRINGIZE(KOKKOS_HEADER_TEST_NAME)
+
+// include header twice to see if the include guards are set correctly
+#include KOKKOS_HEADER_TO_TEST
+#include KOKKOS_HEADER_TO_TEST
+
+#if !defined(KOKKOS_MACROS_HPP)
+#error "This header does not include Kokkos_Macros.hpp"
+#endif
+
+int main() { return 0; }

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -46,3 +46,8 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
     KOKKOS_ADD_EXECUTABLE_AND_TEST(UnitTest_${Tag} SOURCES ${UnitTestSources})
   endif()
 endforeach()
+
+
+if (KOKKOS_ENABLE_HEADER_SELF_CONTAINMENT_TESTS AND NOT KOKKOS_HAS_TRILINOS AND NOT WIN32)
+  add_subdirectory(headers_self_contained)
+endif()

--- a/containers/unit_tests/headers_self_contained/CMakeLists.txt
+++ b/containers/unit_tests/headers_self_contained/CMakeLists.txt
@@ -6,7 +6,7 @@ SET(BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../")
 file(GLOB KOKKOS_CONTAINERS_HEADERS RELATIVE ${BASE_DIR}/containers/src
      ${BASE_DIR}/containers/src/*.hpp)
 
-foreach (_header ${KOKKOS_CORE_HEADERS} ${KOKKOS_CONTAINERS_HEADERS} ${KOKKOS_ALGORITHMS_HEADERS})
+foreach (_header ${KOKKOS_CONTAINERS_HEADERS})
   string(REGEX REPLACE "[\./]" "_" header_test_name ${_header})
   set(header_test_name Kokkos_HeaderSelfContained_${header_test_name})
   set_source_files_properties(tstHeader.cpp PROPERTIES LANGUAGE ${KOKKOS_COMPILE_LANGUAGE})

--- a/containers/unit_tests/headers_self_contained/CMakeLists.txt
+++ b/containers/unit_tests/headers_self_contained/CMakeLists.txt
@@ -3,8 +3,8 @@
 
 # Globbing all the header filenames to test for self-containment and presence of header guards
 SET(BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../")
-file(GLOB KOKKOS_CORE_HEADERS RELATIVE ${BASE_DIR}/core/src
-     ${BASE_DIR}/core/src/*.hpp ${BASE_DIR}/core/src/*.h)
+file(GLOB KOKKOS_CONTAINERS_HEADERS RELATIVE ${BASE_DIR}/containers/src
+     ${BASE_DIR}/containers/src/*.hpp)
 
 foreach (_header ${KOKKOS_CORE_HEADERS} ${KOKKOS_CONTAINERS_HEADERS} ${KOKKOS_ALGORITHMS_HEADERS})
   string(REGEX REPLACE "[\./]" "_" header_test_name ${_header})

--- a/containers/unit_tests/headers_self_contained/tstHeader.cpp
+++ b/containers/unit_tests/headers_self_contained/tstHeader.cpp
@@ -1,0 +1,15 @@
+#define KOKKOS_HEADER_TEST_STRINGIZE_IMPL(x) #x
+#define KOKKOS_HEADER_TEST_STRINGIZE(x) KOKKOS_HEADER_TEST_STRINGIZE_IMPL(x)
+
+#define KOKKOS_HEADER_TO_TEST \
+  KOKKOS_HEADER_TEST_STRINGIZE(KOKKOS_HEADER_TEST_NAME)
+
+// include header twice to see if the include guards are set correctly
+#include KOKKOS_HEADER_TO_TEST
+#include KOKKOS_HEADER_TO_TEST
+
+#if !defined(KOKKOS_MACROS_HPP)
+#error "This header does not include Kokkos_Macros.hpp"
+#endif
+
+int main() { return 0; }

--- a/core/unit_test/headers_self_contained/CMakeLists.txt
+++ b/core/unit_test/headers_self_contained/CMakeLists.txt
@@ -6,7 +6,7 @@ SET(BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../")
 file(GLOB KOKKOS_CORE_HEADERS RELATIVE ${BASE_DIR}/core/src
      ${BASE_DIR}/core/src/*.hpp ${BASE_DIR}/core/src/*.h)
 
-foreach (_header ${KOKKOS_CORE_HEADERS} ${KOKKOS_CONTAINERS_HEADERS} ${KOKKOS_ALGORITHMS_HEADERS})
+foreach (_header ${KOKKOS_CORE_HEADERS})
   string(REGEX REPLACE "[\./]" "_" header_test_name ${_header})
   set(header_test_name Kokkos_HeaderSelfContained_${header_test_name})
   set_source_files_properties(tstHeader.cpp PROPERTIES LANGUAGE ${KOKKOS_COMPILE_LANGUAGE})


### PR DESCRIPTION
BEFORE this PR: `core/unit_tests/headers_self_contained` was testing headers from core, algorithms and containers. 

IMO, the core unit tests should only test core things. and similarly the other components. 
So this PR "fixes" that ensuring that each component has it own self-containment test of headers. 
Doing so, I found one algo header that failed the test so I fixed it by including the Kokkos_Macros. 
