### PR TITLE
Remove NUMA related arguments in Threads backend initialization

### DIFF
--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -127,18 +127,7 @@ class Threads {
   //! \name Space-specific functions
   //@{
 
-  /**
-   *  Teams of threads are distributed as evenly as possible across
-   *  the requested number of numa regions and cores per numa region.
-   *  A team will not be split across a numa region.
-   *
-   *  If the 'use_' arguments are not supplied, the hwloc is queried
-   *  to use all available cores.
-   */
-  static void impl_initialize(unsigned threads_count             = 0,
-                              unsigned use_numa_count            = 0,
-                              unsigned use_cores_per_numa        = 0,
-                              bool allow_asynchronous_threadpool = false);
+  static void impl_initialize(int thread_count = -1);
 
   static int impl_is_initialized();
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -460,15 +460,7 @@ int g_openmp_space_factory_initialized =
     initialize_space_factory<OpenMPSpaceInitializer>("050_OpenMP");
 
 void OpenMPSpaceInitializer::initialize(const InitArguments &args) {
-  // Prevent "unused variable" warning for 'args' input struct.  If
-  // Serial::initialize() ever needs to take arguments from the input
-  // struct, you may remove this line of code.
-  const int num_threads = args.num_threads;
-
-  if (std::is_same<Kokkos::OpenMP, Kokkos::DefaultExecutionSpace>::value ||
-      std::is_same<Kokkos::OpenMP, Kokkos::HostSpace::execution_space>::value) {
-    Kokkos::OpenMP::impl_initialize(num_threads);
-  }
+  Kokkos::OpenMP::impl_initialize(args.num_threads);
 }
 
 void OpenMPSpaceInitializer::finalize(const bool) {

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -541,9 +541,12 @@ void ThreadsExec::print_configuration(std::ostream &s, const bool detail) {
 
 int ThreadsExec::is_initialized() { return nullptr != s_threads_exec[0]; }
 
-void ThreadsExec::initialize(unsigned thread_count, unsigned use_numa_count,
-                             unsigned use_cores_per_numa,
-                             bool allow_asynchronous_threadpool) {
+void ThreadsExec::initialize(int thread_count_arg) {
+  // legacy arguments
+  unsigned thread_count       = thread_count_arg == -1 ? 0 : thread_count_arg;
+  unsigned use_numa_count     = 0;
+  unsigned use_cores_per_numa = 0;
+  bool allow_asynchronous_threadpool = false;
   // need to provide an initializer for Intel compilers
   static const Sentinel sentinel = {};
 

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -799,22 +799,7 @@ int g_threads_space_factory_initialized =
     initialize_space_factory<ThreadsSpaceInitializer>("050_Threads");
 
 void ThreadsSpaceInitializer::initialize(const InitArguments &args) {
-  const int num_threads = args.num_threads;
-  if (std::is_same<Kokkos::Threads, Kokkos::DefaultExecutionSpace>::value ||
-      std::is_same<Kokkos::Threads,
-                   Kokkos::HostSpace::execution_space>::value) {
-    if (num_threads > 0) {
-      Kokkos::Threads::impl_initialize(num_threads);
-    } else {
-      Kokkos::Threads::impl_initialize();
-    }
-    // std::cout << "Kokkos::initialize() fyi: CppThread enabled and
-    // initialized"
-    // << std::endl ;
-  } else {
-    // std::cout << "Kokkos::initialize() fyi: CppThread enabled but not
-    // initialized" << std::endl ;
-  }
+  Kokkos::Threads::impl_initialize(args.num_threads);
 }
 
 void ThreadsSpaceInitializer::finalize(const bool all_spaces) {

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -163,9 +163,7 @@ class ThreadsExec {
 
   static int is_initialized();
 
-  static void initialize(unsigned thread_count, unsigned use_numa_count,
-                         unsigned use_cores_per_numa,
-                         bool allow_asynchronous_threadpool);
+  static void initialize(int thread_count);
 
   static void finalize();
 
@@ -615,13 +613,8 @@ inline int Threads::impl_is_initialized() {
   return Impl::ThreadsExec::is_initialized();
 }
 
-inline void Threads::impl_initialize(unsigned threads_count,
-                                     unsigned use_numa_count,
-                                     unsigned use_cores_per_numa,
-                                     bool allow_asynchronous_threadpool) {
-  Impl::ThreadsExec::initialize(threads_count, use_numa_count,
-                                use_cores_per_numa,
-                                allow_asynchronous_threadpool);
+inline void Threads::impl_initialize(int thread_count) {
+  Impl::ThreadsExec::initialize(thread_count);
 }
 
 inline void Threads::impl_finalize() { Impl::ThreadsExec::finalize(); }


### PR DESCRIPTION
Following up on #5117 
This PR does not do much besides pushing all legacy initialization code into `Impl::ThreadsExec::initialize` and make the code more consistent with the OpenMP backend interface
https://github.com/kokkos/kokkos/blob/98b6ba9cf59f79c05af5d2ebd2e637d482a54f1b/core/src/Kokkos_OpenMP.hpp#L150
https://github.com/kokkos/kokkos/blob/98b6ba9cf59f79c05af5d2ebd2e637d482a54f1b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp#L103


Drive-by cleanup of `Impl::{Threads,OpenMP}SpaceInitializer::initialize`