### PR TITLE
Use correct policy in Threads MDRange parallel_reduce

### DIFF
--- a/core/src/Threads/Kokkos_Threads_Parallel.hpp
+++ b/core/src/Threads/Kokkos_Threads_Parallel.hpp
@@ -546,7 +546,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                                   WorkTag, void>::type;
 
   using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                                         Policy, ReducerTypeFwd>;
+                                         MDRangePolicy, ReducerTypeFwd>;
   using pointer_type   = typename Analysis::pointer_type;
   using value_type     = typename Analysis::value_type;
   using reference_type = typename Analysis::reference_type;


### PR DESCRIPTION
Fixes https://github.com/ECP-copa/Cabana/pull/537 which shows an error failing to deduce the value type. Using the `MDRange` policy rather than the underlying `RangePolicy` clearly makes more sense here.