### PR TITLE
Provide ViewCtorProp overload for create_mirror_view_and_copy

### DIFF
--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -217,7 +217,7 @@ struct ChunkedArrayManager {
 
   template <typename Space>
   std::enable_if_t<!IsAccessibleFrom<Space>::value> deep_copy_to(
-      ChunkedArrayManager<Space, ValueType> const& other) {
+      ChunkedArrayManager<Space, ValueType> const& other) const {
     Kokkos::Impl::DeepCopy<Space, MemorySpace>(
         other.m_chunks, m_chunks, sizeof(pointer_type) * (m_chunk_max + 2));
   }
@@ -497,6 +497,12 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
     }
   }
 
+  KOKKOS_FUNCTION const device_accessor& impl_get_chunks() const {
+    return m_chunks;
+  }
+
+  KOKKOS_FUNCTION device_accessor& impl_get_chunks() { return m_chunks; }
+
   //----------------------------------------------------------------------
 
   ~DynamicView()                  = default;
@@ -570,6 +576,14 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
 };
 
 }  // namespace Experimental
+
+template <class>
+struct is_dynamic_view : public std::false_type {};
+
+template <class D, class... P>
+struct is_dynamic_view<Kokkos::Experimental::DynamicView<D, P...>>
+    : public std::true_type {};
+
 }  // namespace Kokkos
 
 namespace Kokkos {
@@ -786,6 +800,61 @@ inline auto create_mirror_view(
 }
 
 template <class T, class... DP, class... SP>
+inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
+                      const Kokkos::Experimental::DynamicView<T, SP...>& src) {
+  using dst_type = Kokkos::Experimental::DynamicView<T, DP...>;
+  using src_type = Kokkos::Experimental::DynamicView<T, SP...>;
+
+  using dst_execution_space = typename ViewTraits<T, DP...>::execution_space;
+  using src_execution_space = typename ViewTraits<T, SP...>::execution_space;
+  using dst_memory_space    = typename ViewTraits<T, DP...>::memory_space;
+  using src_memory_space    = typename ViewTraits<T, SP...>::memory_space;
+
+  constexpr bool DstExecCanAccessSrc =
+      Kokkos::SpaceAccessibility<dst_execution_space,
+                                 src_memory_space>::accessible;
+  constexpr bool SrcExecCanAccessDst =
+      Kokkos::SpaceAccessibility<src_execution_space,
+                                 dst_memory_space>::accessible;
+
+  if (DstExecCanAccessSrc)
+    Kokkos::Impl::ViewRemap<dst_type, src_type, dst_execution_space>(dst, src);
+  else if (SrcExecCanAccessDst)
+    Kokkos::Impl::ViewRemap<dst_type, src_type, src_execution_space>(dst, src);
+  else
+    src.impl_get_chunks().deep_copy_to(dst.impl_get_chunks());
+  Kokkos::fence("Kokkos::deep_copy(DynamicView)");
+}
+
+template <class ExecutionSpace, class T, class... DP, class... SP>
+inline void deep_copy(const ExecutionSpace&,
+                      const Kokkos::Experimental::DynamicView<T, DP...>& dst,
+                      const Kokkos::Experimental::DynamicView<T, SP...>& src) {
+  using dst_type = Kokkos::Experimental::DynamicView<T, DP...>;
+  using src_type = Kokkos::Experimental::DynamicView<T, SP...>;
+
+  using dst_execution_space = typename ViewTraits<T, DP...>::execution_space;
+  using src_execution_space = typename ViewTraits<T, SP...>::execution_space;
+  using dst_memory_space    = typename ViewTraits<T, DP...>::memory_space;
+  using src_memory_space    = typename ViewTraits<T, SP...>::memory_space;
+
+  constexpr bool DstExecCanAccessSrc =
+      Kokkos::SpaceAccessibility<dst_execution_space,
+                                 src_memory_space>::accessible;
+  constexpr bool SrcExecCanAccessDst =
+      Kokkos::SpaceAccessibility<src_execution_space,
+                                 dst_memory_space>::accessible;
+
+  // FIXME use execution space
+  if (DstExecCanAccessSrc)
+    Kokkos::Impl::ViewRemap<dst_type, src_type, dst_execution_space>(dst, src);
+  else if (SrcExecCanAccessDst)
+    Kokkos::Impl::ViewRemap<dst_type, src_type, src_execution_space>(dst, src);
+  else
+    src.impl_get_chunks().deep_copy_to(dst.impl_get_chunks());
+}
+
+template <class T, class... DP, class... SP>
 inline void deep_copy(const View<T, DP...>& dst,
                       const Kokkos::Experimental::DynamicView<T, SP...>& src) {
   using dst_type = View<T, DP...>;
@@ -804,6 +873,7 @@ inline void deep_copy(const View<T, DP...>& dst,
     // Copying data between views in accessible memory spaces and either
     // non-contiguous or incompatible shape.
     Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
+    Kokkos::fence("Kokkos::deep_copy(DynamicView)");
   } else {
     Kokkos::Impl::throw_runtime_exception(
         "deep_copy given views that would require a temporary allocation");
@@ -829,6 +899,7 @@ inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
     // Copying data between views in accessible memory spaces and either
     // non-contiguous or incompatible shape.
     Kokkos::Impl::ViewRemap<dst_type, src_type>(dst, src);
+    Kokkos::fence("Kokkos::deep_copy(DynamicView)");
   } else {
     Kokkos::Impl::throw_runtime_exception(
         "deep_copy given views that would require a temporary allocation");
@@ -915,6 +986,100 @@ struct ViewCopy<Kokkos::Experimental::DynamicView<DP...>,
 };
 
 }  // namespace Impl
+
+template <class... ViewCtorArgs, class T, class... P>
+auto create_mirror_view_and_copy(
+    const Impl::ViewCtorProp<ViewCtorArgs...>&,
+    const Kokkos::Experimental::DynamicView<T, P...>& src,
+    std::enable_if_t<
+        std::is_void<typename ViewTraits<T, P...>::specialize>::value &&
+        Impl::MirrorDynamicViewType<
+            typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
+            P...>::is_same_memspace>* = nullptr) {
+  using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
+  static_assert(
+      alloc_prop_input::has_memory_space,
+      "The view constructor arguments passed to "
+      "Kokkos::create_mirror_view_and_copy must include a memory space!");
+  static_assert(!alloc_prop_input::has_pointer,
+                "The view constructor arguments passed to "
+                "Kokkos::create_mirror_view_and_copy must "
+                "not include a pointer!");
+  static_assert(!alloc_prop_input::allow_padding,
+                "The view constructor arguments passed to "
+                "Kokkos::create_mirror_view_and_copy must "
+                "not explicitly allow padding!");
+
+  // same behavior as deep_copy(src, src)
+  if (!alloc_prop_input::has_execution_space)
+    fence(
+        "Kokkos::create_mirror_view_and_copy: fence before returning src view");
+  return src;
+}
+
+template <class... ViewCtorArgs, class T, class... P>
+auto create_mirror_view_and_copy(
+    const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
+    const Kokkos::Experimental::DynamicView<T, P...>& src,
+    std::enable_if_t<
+        std::is_void<typename ViewTraits<T, P...>::specialize>::value &&
+        !Impl::MirrorDynamicViewType<
+            typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
+            P...>::is_same_memspace>* = nullptr) {
+  using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
+  static_assert(
+      alloc_prop_input::has_memory_space,
+      "The view constructor arguments passed to "
+      "Kokkos::create_mirror_view_and_copy must include a memory space!");
+  static_assert(!alloc_prop_input::has_pointer,
+                "The view constructor arguments passed to "
+                "Kokkos::create_mirror_view_and_copy must "
+                "not include a pointer!");
+  static_assert(!alloc_prop_input::allow_padding,
+                "The view constructor arguments passed to "
+                "Kokkos::create_mirror_view_and_copy must "
+                "not explicitly allow padding!");
+  using Space = typename alloc_prop_input::memory_space;
+  using Mirror =
+      typename Impl::MirrorDynamicViewType<Space, T, P...>::view_type;
+
+  // Add some properties if not provided to avoid need for if constexpr
+  using alloc_prop = Impl::ViewCtorProp<
+      ViewCtorArgs...,
+      std::conditional_t<alloc_prop_input::has_label,
+                         std::integral_constant<unsigned int, 12>, std::string>,
+      std::conditional_t<!alloc_prop_input::initialize,
+                         std::integral_constant<unsigned int, 13>,
+                         Impl::WithoutInitializing_t>,
+      std::conditional_t<alloc_prop_input::has_execution_space,
+                         std::integral_constant<unsigned int, 14>,
+                         typename Space::execution_space>>;
+  alloc_prop arg_prop_copy(arg_prop);
+
+  std::string& label =
+      static_cast<Impl::ViewCtorProp<void, std::string>&>(arg_prop_copy).value;
+  if (label.empty()) label = src.label();
+  auto mirror = typename Mirror::non_const_type(
+      arg_prop_copy, src.chunk_size(), src.chunk_max() * src.chunk_size());
+  if (alloc_prop_input::has_execution_space) {
+    using ExecutionSpace = typename alloc_prop::execution_space;
+    deep_copy(
+        static_cast<Impl::ViewCtorProp<void, ExecutionSpace>&>(arg_prop_copy)
+            .value,
+        mirror, src);
+  } else
+    deep_copy(mirror, src);
+  return mirror;
+}
+
+template <class Space, class T, class... P>
+auto create_mirror_view_and_copy(
+    const Space&, const Kokkos::Experimental::DynamicView<T, P...>& src,
+    std::string const& name = "") {
+  return create_mirror_view_and_copy(
+      Kokkos::view_alloc(typename Space::memory_space{}, name), src);
+}
+
 }  // namespace Kokkos
 
 #endif /* #ifndef KOKKOS_DYNAMIC_VIEW_HPP */

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -216,10 +216,8 @@ struct ChunkedArrayManager {
   pointer_type* get_ptr() const { return m_chunks; }
 
   template <typename Space>
-  void deep_copy_to(
-      ChunkedArrayManager<Space, ValueType> const& other) const {
-    if (other.m_chunks != m_chunks)
-    {
+  void deep_copy_to(ChunkedArrayManager<Space, ValueType> const& other) const {
+    if (other.m_chunks != m_chunks) {
       Kokkos::Impl::DeepCopy<Space, MemorySpace>(
           other.m_chunks, m_chunks, sizeof(pointer_type) * (m_chunk_max + 2));
     }

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -216,16 +216,13 @@ struct ChunkedArrayManager {
   pointer_type* get_ptr() const { return m_chunks; }
 
   template <typename Space>
-  std::enable_if_t<!IsAccessibleFrom<Space>::value> deep_copy_to(
+  void deep_copy_to(
       ChunkedArrayManager<Space, ValueType> const& other) const {
-    Kokkos::Impl::DeepCopy<Space, MemorySpace>(
-        other.m_chunks, m_chunks, sizeof(pointer_type) * (m_chunk_max + 2));
-  }
-
-  template <typename Space>
-  std::enable_if_t<IsAccessibleFrom<Space>::value> deep_copy_to(
-      ChunkedArrayManager<Space, ValueType> const&) {
-    // no-op
+    if (other.m_chunks != m_chunks)
+    {
+      Kokkos::Impl::DeepCopy<Space, MemorySpace>(
+          other.m_chunks, m_chunks, sizeof(pointer_type) * (m_chunk_max + 2));
+    }
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -2067,6 +2067,16 @@ inline auto create_mirror_view(
 }
 
 // Create a mirror view and deep_copy in a new space
+template <class... ViewCtorArgs, class T, class... P>
+typename Kokkos::Impl::MirrorOffsetViewType<
+    typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
+    P...>::view_type
+create_mirror_view_and_copy(
+    const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
+    const Kokkos::Experimental::OffsetView<T, P...>& src) {
+  return {create_mirror_view_and_copy(arg_prop, src.view()), src.begins()};
+}
+
 template <class Space, class T, class... P>
 typename Kokkos::Impl::MirrorOffsetViewType<Space, T, P...>::view_type
 create_mirror_view_and_copy(

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -13,7 +13,20 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
     set(dir ${CMAKE_CURRENT_BINARY_DIR}/${dir})
     file(MAKE_DIRECTORY ${dir})
     foreach(Name
+        Bitset
+        DualView
+        DynamicView
+        DynViewAPI_generic
+        DynViewAPI_rank12345
+        DynViewAPI_rank67
+        ErrorReporter
+        OffsetView
+        ScatterView
+        StaticCrsGraph
         WithoutInitializing
+        UnorderedMap
+        Vector
+        ViewCtorPropEmbeddedDim
         )
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -13,20 +13,7 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
     set(dir ${CMAKE_CURRENT_BINARY_DIR}/${dir})
     file(MAKE_DIRECTORY ${dir})
     foreach(Name
-        Bitset
-        DualView
-        DynamicView
-        DynViewAPI_generic
-        DynViewAPI_rank12345
-        DynViewAPI_rank67
-        ErrorReporter
-        OffsetView
-        ScatterView
-        StaticCrsGraph
         WithoutInitializing
-        UnorderedMap
-        Vector
-        ViewCtorPropEmbeddedDim
         )
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -304,7 +304,7 @@ TEST(TEST_CATEGORY, resize_exec_space_scatterview) {
 TEST(TEST_CATEGORY, create_mirror_no_init_dynrankview) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());
-  Kokkos::DynRankView<int, Kokkos::DefaultExecutionSpace> device_view(
+  Kokkos::DynRankView<int, TEST_EXECSPACE> device_view(
       "device view", 10);
   Kokkos::DynRankView<int, Kokkos::HostSpace> host_view("host view", 10);
 
@@ -314,11 +314,11 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynrankview) {
             Kokkos::create_mirror(Kokkos::WithoutInitializing, device_view);
         auto mirror_host =
             Kokkos::create_mirror(Kokkos::WithoutInitializing,
-                                  Kokkos::DefaultExecutionSpace{}, host_view);
+                                  TEST_EXECSPACE{}, host_view);
         auto mirror_device_view = Kokkos::create_mirror_view(
             Kokkos::WithoutInitializing, device_view);
         auto mirror_host_view = Kokkos::create_mirror_view(
-            Kokkos::WithoutInitializing, Kokkos::DefaultExecutionSpace{},
+            Kokkos::WithoutInitializing, TEST_EXECSPACE{},
             host_view);
       },
       [&](BeginParallelForEvent) {
@@ -367,15 +367,15 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynrankview) {
                      Config::EnableFences());
 
   Kokkos::DynRankView<int, Kokkos::HostSpace> host_view("host view", 10);
-  decltype(Kokkos::create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace{},
+  decltype(Kokkos::create_mirror_view_and_copy(TEST_EXECSPACE{},
                                                host_view)) device_view;
 
   auto success = validate_absence(
       [&]() {
         auto mirror_device = Kokkos::create_mirror_view_and_copy(
             Kokkos::view_alloc(
-                Kokkos::DefaultExecutionSpace{},
-                typename Kokkos::DefaultExecutionSpace::memory_space{}),
+                TEST_EXECSPACE{},
+                typename TEST_EXECSPACE::memory_space{}),
             host_view);
         // Avoid fences for deallocation when mirror_device goes out of scope.
         device_view = mirror_device;
@@ -395,7 +395,7 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynrankview) {
 TEST(TEST_CATEGORY, create_mirror_no_init_offsetview) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());
-  Kokkos::Experimental::OffsetView<int*, Kokkos::DefaultExecutionSpace>
+  Kokkos::Experimental::OffsetView<int*, TEST_EXECSPACE>
       device_view("device view", {0, 10});
   Kokkos::Experimental::OffsetView<int*, Kokkos::HostSpace> host_view(
       "host view", {0, 10});
@@ -406,11 +406,11 @@ TEST(TEST_CATEGORY, create_mirror_no_init_offsetview) {
             Kokkos::create_mirror(Kokkos::WithoutInitializing, device_view);
         auto mirror_host =
             Kokkos::create_mirror(Kokkos::WithoutInitializing,
-                                  Kokkos::DefaultExecutionSpace{}, host_view);
+                                  TEST_EXECSPACE{}, host_view);
         auto mirror_device_view = Kokkos::create_mirror_view(
             Kokkos::WithoutInitializing, device_view);
         auto mirror_host_view = Kokkos::create_mirror_view(
-            Kokkos::WithoutInitializing, Kokkos::DefaultExecutionSpace{},
+            Kokkos::WithoutInitializing, TEST_EXECSPACE{},
             host_view);
       },
       [&](BeginParallelForEvent) {
@@ -461,22 +461,22 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_offsetview) {
 
   Kokkos::Experimental::OffsetView<int*, Kokkos::HostSpace> host_view(
       "host view", {0, 10});
-  decltype(Kokkos::create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace{},
+  decltype(Kokkos::create_mirror_view_and_copy(TEST_EXECSPACE{},
                                                host_view)) device_view;
 
   auto success = validate_absence(
       [&]() {
         auto mirror_device = Kokkos::create_mirror_view_and_copy(
             Kokkos::view_alloc(
-                Kokkos::DefaultExecutionSpace{},
-                typename Kokkos::DefaultExecutionSpace::memory_space{}),
+                TEST_EXECSPACE{},
+                typename TEST_EXECSPACE::memory_space{}),
             host_view);
         // Avoid fences for deallocation when mirror_device goes out of scope.
         device_view               = mirror_device;
         auto mirror_device_mirror = Kokkos::create_mirror_view_and_copy(
             Kokkos::view_alloc(
-                Kokkos::DefaultExecutionSpace{},
-                typename Kokkos::DefaultExecutionSpace::memory_space{}),
+                TEST_EXECSPACE{},
+                typename TEST_EXECSPACE::memory_space{}),
             mirror_device);
       },
       [&](BeginParallelForEvent) {
@@ -496,7 +496,7 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_offsetview) {
 TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());
-  Kokkos::Experimental::DynamicView<int*, Kokkos::DefaultExecutionSpace>
+  Kokkos::Experimental::DynamicView<int*, TEST_EXECSPACE>
       device_view("device view", 2, 10);
   Kokkos::Experimental::DynamicView<int*, Kokkos::HostSpace> host_view(
       "host view", 2, 10);
@@ -507,11 +507,11 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
             Kokkos::create_mirror(Kokkos::WithoutInitializing, device_view);
         auto mirror_host =
             Kokkos::create_mirror(Kokkos::WithoutInitializing,
-                                  Kokkos::DefaultExecutionSpace{}, host_view);
+                                  TEST_EXECSPACE{}, host_view);
         auto mirror_device_view = Kokkos::create_mirror_view(
             Kokkos::WithoutInitializing, device_view);
         auto mirror_host_view = Kokkos::create_mirror_view(
-            Kokkos::WithoutInitializing, Kokkos::DefaultExecutionSpace{},
+            Kokkos::WithoutInitializing, TEST_EXECSPACE{},
             host_view);
       },
       [&](BeginParallelForEvent) {
@@ -530,22 +530,22 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynamicview) {
 
   Kokkos::Experimental::DynamicView<int*, Kokkos::HostSpace> host_view(
       "host view", 2, 10);
-  decltype(Kokkos::create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace{},
+  decltype(Kokkos::create_mirror_view_and_copy(TEST_EXECSPACE{},
                                                host_view)) device_view;
 
   auto success = validate_absence(
       [&]() {
         auto mirror_device = Kokkos::create_mirror_view_and_copy(
             Kokkos::view_alloc(
-                Kokkos::DefaultExecutionSpace{},
-                typename Kokkos::DefaultExecutionSpace::memory_space{}),
+                TEST_EXECSPACE{},
+                typename TEST_EXECSPACE::memory_space{}),
             host_view);
         // Avoid fences for deallocation when mirror_device goes out of scope.
         device_view               = mirror_device;
         auto mirror_device_mirror = Kokkos::create_mirror_view_and_copy(
             Kokkos::view_alloc(
-                Kokkos::DefaultExecutionSpace{},
-                typename Kokkos::DefaultExecutionSpace::memory_space{}),
+                TEST_EXECSPACE{},
+                typename TEST_EXECSPACE::memory_space{}),
             mirror_device);
       },
       [&](BeginParallelForEvent) {

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -304,22 +304,19 @@ TEST(TEST_CATEGORY, resize_exec_space_scatterview) {
 TEST(TEST_CATEGORY, create_mirror_no_init_dynrankview) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());
-  Kokkos::DynRankView<int, TEST_EXECSPACE> device_view(
-      "device view", 10);
+  Kokkos::DynRankView<int, TEST_EXECSPACE> device_view("device view", 10);
   Kokkos::DynRankView<int, Kokkos::HostSpace> host_view("host view", 10);
 
   auto success = validate_absence(
       [&]() {
         auto mirror_device =
             Kokkos::create_mirror(Kokkos::WithoutInitializing, device_view);
-        auto mirror_host =
-            Kokkos::create_mirror(Kokkos::WithoutInitializing,
-                                  TEST_EXECSPACE{}, host_view);
+        auto mirror_host = Kokkos::create_mirror(Kokkos::WithoutInitializing,
+                                                 TEST_EXECSPACE{}, host_view);
         auto mirror_device_view = Kokkos::create_mirror_view(
             Kokkos::WithoutInitializing, device_view);
         auto mirror_host_view = Kokkos::create_mirror_view(
-            Kokkos::WithoutInitializing, TEST_EXECSPACE{},
-            host_view);
+            Kokkos::WithoutInitializing, TEST_EXECSPACE{}, host_view);
       },
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found begin event"}};
@@ -363,8 +360,9 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynrankview_viewctor) {
 
 TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynrankview) {
 #ifdef KOKKOS_ENABLE_CUDA
-	if (std::is_same<typename TEST_EXECSPACE::memory_space, Kokkos::CudaUVMSpace>::value)
-		return;
+  if (std::is_same<typename TEST_EXECSPACE::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
 #endif
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
@@ -377,9 +375,8 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynrankview) {
   auto success = validate_absence(
       [&]() {
         auto mirror_device = Kokkos::create_mirror_view_and_copy(
-            Kokkos::view_alloc(
-                TEST_EXECSPACE{},
-                typename TEST_EXECSPACE::memory_space{}),
+            Kokkos::view_alloc(TEST_EXECSPACE{},
+                               typename TEST_EXECSPACE::memory_space{}),
             host_view);
         // Avoid fences for deallocation when mirror_device goes out of scope.
         device_view = mirror_device;
@@ -399,8 +396,8 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynrankview) {
 TEST(TEST_CATEGORY, create_mirror_no_init_offsetview) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());
-  Kokkos::Experimental::OffsetView<int*, TEST_EXECSPACE>
-      device_view("device view", {0, 10});
+  Kokkos::Experimental::OffsetView<int*, TEST_EXECSPACE> device_view(
+      "device view", {0, 10});
   Kokkos::Experimental::OffsetView<int*, Kokkos::HostSpace> host_view(
       "host view", {0, 10});
 
@@ -408,14 +405,12 @@ TEST(TEST_CATEGORY, create_mirror_no_init_offsetview) {
       [&]() {
         auto mirror_device =
             Kokkos::create_mirror(Kokkos::WithoutInitializing, device_view);
-        auto mirror_host =
-            Kokkos::create_mirror(Kokkos::WithoutInitializing,
-                                  TEST_EXECSPACE{}, host_view);
+        auto mirror_host = Kokkos::create_mirror(Kokkos::WithoutInitializing,
+                                                 TEST_EXECSPACE{}, host_view);
         auto mirror_device_view = Kokkos::create_mirror_view(
             Kokkos::WithoutInitializing, device_view);
         auto mirror_host_view = Kokkos::create_mirror_view(
-            Kokkos::WithoutInitializing, TEST_EXECSPACE{},
-            host_view);
+            Kokkos::WithoutInitializing, TEST_EXECSPACE{}, host_view);
       },
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found begin event"}};
@@ -459,9 +454,10 @@ TEST(TEST_CATEGORY, create_mirror_no_init_offsetview_view_ctor) {
 }
 
 TEST(TEST_CATEGORY, create_mirror_view_and_copy_offsetview) {
-	#ifdef KOKKOS_ENABLE_CUDA
-        if (std::is_same<typename TEST_EXECSPACE::memory_space, Kokkos::CudaUVMSpace>::value)
-                return;
+#ifdef KOKKOS_ENABLE_CUDA
+  if (std::is_same<typename TEST_EXECSPACE::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
 #endif
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
@@ -475,16 +471,14 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_offsetview) {
   auto success = validate_absence(
       [&]() {
         auto mirror_device = Kokkos::create_mirror_view_and_copy(
-            Kokkos::view_alloc(
-                TEST_EXECSPACE{},
-                typename TEST_EXECSPACE::memory_space{}),
+            Kokkos::view_alloc(TEST_EXECSPACE{},
+                               typename TEST_EXECSPACE::memory_space{}),
             host_view);
         // Avoid fences for deallocation when mirror_device goes out of scope.
         device_view               = mirror_device;
         auto mirror_device_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::view_alloc(
-                TEST_EXECSPACE{},
-                typename TEST_EXECSPACE::memory_space{}),
+            Kokkos::view_alloc(TEST_EXECSPACE{},
+                               typename TEST_EXECSPACE::memory_space{}),
             mirror_device);
       },
       [&](BeginParallelForEvent) {
@@ -504,8 +498,8 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_offsetview) {
 TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());
-  Kokkos::Experimental::DynamicView<int*, TEST_EXECSPACE>
-      device_view("device view", 2, 10);
+  Kokkos::Experimental::DynamicView<int*, TEST_EXECSPACE> device_view(
+      "device view", 2, 10);
   Kokkos::Experimental::DynamicView<int*, Kokkos::HostSpace> host_view(
       "host view", 2, 10);
 
@@ -513,14 +507,12 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
       [&]() {
         auto mirror_device =
             Kokkos::create_mirror(Kokkos::WithoutInitializing, device_view);
-        auto mirror_host =
-            Kokkos::create_mirror(Kokkos::WithoutInitializing,
-                                  TEST_EXECSPACE{}, host_view);
+        auto mirror_host = Kokkos::create_mirror(Kokkos::WithoutInitializing,
+                                                 TEST_EXECSPACE{}, host_view);
         auto mirror_device_view = Kokkos::create_mirror_view(
             Kokkos::WithoutInitializing, device_view);
         auto mirror_host_view = Kokkos::create_mirror_view(
-            Kokkos::WithoutInitializing, TEST_EXECSPACE{},
-            host_view);
+            Kokkos::WithoutInitializing, TEST_EXECSPACE{}, host_view);
       },
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found begin event"}};
@@ -532,9 +524,10 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
 }
 
 TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynamicview) {
-	#ifdef KOKKOS_ENABLE_CUDA
-        if (std::is_same<typename TEST_EXECSPACE::memory_space, Kokkos::CudaUVMSpace>::value)
-                return;
+#ifdef KOKKOS_ENABLE_CUDA
+  if (std::is_same<typename TEST_EXECSPACE::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
 #endif
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
@@ -548,16 +541,14 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynamicview) {
   auto success = validate_absence(
       [&]() {
         auto mirror_device = Kokkos::create_mirror_view_and_copy(
-            Kokkos::view_alloc(
-                TEST_EXECSPACE{},
-                typename TEST_EXECSPACE::memory_space{}),
+            Kokkos::view_alloc(TEST_EXECSPACE{},
+                               typename TEST_EXECSPACE::memory_space{}),
             host_view);
         // Avoid fences for deallocation when mirror_device goes out of scope.
         device_view               = mirror_device;
         auto mirror_device_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::view_alloc(
-                TEST_EXECSPACE{},
-                typename TEST_EXECSPACE::memory_space{}),
+            Kokkos::view_alloc(TEST_EXECSPACE{},
+                               typename TEST_EXECSPACE::memory_space{}),
             mirror_device);
       },
       [&](BeginParallelForEvent) {

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -361,7 +361,7 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynrankview_viewctor) {
   ASSERT_TRUE(success);
 }
 
-TEST(kokkosp, create_mirror_view_and_copy_dynrankview) {
+TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynrankview) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
                      Config::EnableFences());

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -362,6 +362,10 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynrankview_viewctor) {
 }
 
 TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynrankview) {
+#ifdef KOKKOS_ENABLE_CUDA
+	if (std::is_same<typename TEST_EXECSPACE::memory_space, Kokkos::CudaUVMSpace>::value)
+		return;
+#endif
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
                      Config::EnableFences());
@@ -455,6 +459,10 @@ TEST(TEST_CATEGORY, create_mirror_no_init_offsetview_view_ctor) {
 }
 
 TEST(TEST_CATEGORY, create_mirror_view_and_copy_offsetview) {
+	#ifdef KOKKOS_ENABLE_CUDA
+        if (std::is_same<typename TEST_EXECSPACE::memory_space, Kokkos::CudaUVMSpace>::value)
+                return;
+#endif
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
                      Config::EnableFences());
@@ -524,6 +532,10 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
 }
 
 TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynamicview) {
+	#ifdef KOKKOS_ENABLE_CUDA
+        if (std::is_same<typename TEST_EXECSPACE::memory_space, Kokkos::CudaUVMSpace>::value)
+                return;
+#endif
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
                      Config::EnableFences());

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -522,6 +522,43 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
       });
   ASSERT_TRUE(success);
 }
+
+TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynamicview) {
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
+                     Config::EnableFences());
+
+  Kokkos::Experimental::DynamicView<int*, Kokkos::HostSpace> host_view(
+      "host view", 2, 10);
+  decltype(Kokkos::create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace{},
+                                               host_view)) device_view;
+
+  auto success = validate_absence(
+      [&]() {
+        auto mirror_device = Kokkos::create_mirror_view_and_copy(
+            Kokkos::view_alloc(
+                Kokkos::DefaultExecutionSpace{},
+                typename Kokkos::DefaultExecutionSpace::memory_space{}),
+            host_view);
+        // Avoid fences for deallocation when mirror_device goes out of scope.
+        device_view               = mirror_device;
+        auto mirror_device_mirror = Kokkos::create_mirror_view_and_copy(
+            Kokkos::view_alloc(
+                Kokkos::DefaultExecutionSpace{},
+                typename Kokkos::DefaultExecutionSpace::memory_space{}),
+            mirror_device);
+      },
+      [&](BeginParallelForEvent) {
+        return MatchDiagnostic{true, {"Found begin event"}};
+      },
+      [&](BeginFenceEvent event) {
+        return MatchDiagnostic{
+            event.descriptor().find(
+                "fence after copying header from HostSpace") ==
+            std::string::npos};
+      });
+  ASSERT_TRUE(success);
+}
 #endif
 
 // FIXME OPENMPTARGET

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -361,6 +361,37 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynrankview_viewctor) {
   ASSERT_TRUE(success);
 }
 
+TEST(kokkosp, create_mirror_view_and_copy_dynrankview) {
+  using namespace Kokkos::Test::Tools;
+  listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
+                     Config::EnableFences());
+
+  Kokkos::DynRankView<int, Kokkos::HostSpace> host_view("host view", 10);
+  decltype(Kokkos::create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace{},
+                                               host_view)) device_view;
+
+  auto success = validate_absence(
+      [&]() {
+        auto mirror_device = Kokkos::create_mirror_view_and_copy(
+            Kokkos::view_alloc(
+                Kokkos::DefaultExecutionSpace{},
+                typename Kokkos::DefaultExecutionSpace::memory_space{}),
+            host_view);
+        // Avoid fences for deallocation when mirror_device goes out of scope.
+        device_view = mirror_device;
+      },
+      [&](BeginParallelForEvent) {
+        return MatchDiagnostic{true, {"Found begin event"}};
+      },
+      [&](BeginFenceEvent event) {
+        return MatchDiagnostic{
+            event.descriptor().find(
+                "fence after copying header from HostSpace") ==
+            std::string::npos};
+      });
+  ASSERT_TRUE(success);
+}
+
 TEST(TEST_CATEGORY, create_mirror_no_init_offsetview) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3732,7 +3732,8 @@ auto create_mirror_view_and_copy(
   return mirror;
 }
 
-template <class Space, class T, class... P>
+template <class Space, class T, class... P,
+          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 auto create_mirror_view_and_copy(
     const Space&, const Kokkos::View<T, P...>& src,
     std::string const& name = "",

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3733,8 +3733,7 @@ auto create_mirror_view_and_copy(
 }
 
 template <class Space, class T, class... P>
-typename Impl::MirrorViewType<Space, T, P...>::view_type
-create_mirror_view_and_copy(
+auto create_mirror_view_and_copy(
     const Space&, const Kokkos::View<T, P...>& src,
     std::string const& name = "",
     std::enable_if_t<

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3651,7 +3651,7 @@ auto create_mirror_view(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
 
 template <class... ViewCtorArgs, class T, class... P>
 auto create_mirror_view_and_copy(
-    const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
+    const Impl::ViewCtorProp<ViewCtorArgs...>&,
     const Kokkos::View<T, P...>& src,
     std::enable_if_t<
         std::is_void<typename ViewTraits<T, P...>::specialize>::value &&

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3708,12 +3708,12 @@ auto create_mirror_view_and_copy(
   using alloc_prop = Impl::ViewCtorProp<
       ViewCtorArgs...,
       std::conditional_t<alloc_prop_input::has_label,
-                         std::integral_constant<unsigned int, 2>, std::string>,
+                         std::integral_constant<unsigned int, 12>, std::string>,
       std::conditional_t<!alloc_prop_input::initialize,
-                         std::integral_constant<unsigned int, 3>,
+                         std::integral_constant<unsigned int, 13>,
                          Impl::WithoutInitializing_t>,
       std::conditional_t<alloc_prop_input::has_execution_space,
-                         std::integral_constant<unsigned int, 4>,
+                         std::integral_constant<unsigned int, 14>,
                          typename Space::execution_space>>;
   alloc_prop arg_prop_copy(arg_prop);
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3649,38 +3649,99 @@ auto create_mirror_view(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
   return Impl::create_mirror_view(v, arg_prop);
 }
 
-// Create a mirror view and deep_copy in a new space (specialization for same
-// space)
-template <class Space, class T, class... P>
-typename Impl::MirrorViewType<Space, T, P...>::view_type
-create_mirror_view_and_copy(
-    const Space&, const Kokkos::View<T, P...>& src,
-    std::string const& name = "",
+template <class... ViewCtorArgs, class T, class... P>
+auto create_mirror_view_and_copy(
+    const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
+    const Kokkos::View<T, P...>& src,
     std::enable_if_t<
         std::is_void<typename ViewTraits<T, P...>::specialize>::value &&
-        Impl::MirrorViewType<Space, T, P...>::is_same_memspace>* = nullptr) {
-  (void)name;
-  fence(
-      "Kokkos::create_mirror_view_and_copy: fence before returning src view");  // same behavior as deep_copy(src, src)
+        Impl::MirrorViewType<
+            typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
+            P...>::is_same_memspace>* = nullptr) {
+  using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
+  static_assert(
+      alloc_prop_input::has_memory_space,
+      "The view constructor arguments passed to "
+      "Kokkos::create_mirror_view_and_copy must include a memory space!");
+  static_assert(!alloc_prop_input::has_pointer,
+                "The view constructor arguments passed to "
+                "Kokkos::create_mirror_view_and_copy must "
+                "not include a pointer!");
+  static_assert(!alloc_prop_input::allow_padding,
+                "The view constructor arguments passed to "
+                "Kokkos::create_mirror_view_and_copy must "
+                "not explicitly allow padding!");
+
+  // same behavior as deep_copy(src, src)
+  if (!alloc_prop_input::has_execution_space)
+    fence(
+        "Kokkos::create_mirror_view_and_copy: fence before returning src view");
   return src;
 }
 
-// Create a mirror view and deep_copy in a new space (specialization for
-// different space)
+template <class... ViewCtorArgs, class T, class... P>
+auto create_mirror_view_and_copy(
+    const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
+    const Kokkos::View<T, P...>& src,
+    std::enable_if_t<
+        std::is_void<typename ViewTraits<T, P...>::specialize>::value &&
+        !Impl::MirrorViewType<
+            typename Impl::ViewCtorProp<ViewCtorArgs...>::memory_space, T,
+            P...>::is_same_memspace>* = nullptr) {
+  using alloc_prop_input = Impl::ViewCtorProp<ViewCtorArgs...>;
+  static_assert(
+      alloc_prop_input::has_memory_space,
+      "The view constructor arguments passed to "
+      "Kokkos::create_mirror_view_and_copy must include a memory space!");
+  static_assert(!alloc_prop_input::has_pointer,
+                "The view constructor arguments passed to "
+                "Kokkos::create_mirror_view_and_copy must "
+                "not include a pointer!");
+  static_assert(!alloc_prop_input::allow_padding,
+                "The view constructor arguments passed to "
+                "Kokkos::create_mirror_view_and_copy must "
+                "not explicitly allow padding!");
+  using Space  = typename alloc_prop_input::memory_space;
+  using Mirror = typename Impl::MirrorViewType<Space, T, P...>::view_type;
+
+  // Add some properties if not provided to avoid need for if constexpr
+  using alloc_prop = Impl::ViewCtorProp<
+      ViewCtorArgs...,
+      std::conditional_t<alloc_prop_input::has_label,
+                         std::integral_constant<unsigned int, 2>, std::string>,
+      std::conditional_t<!alloc_prop_input::initialize,
+                         std::integral_constant<unsigned int, 3>,
+                         Impl::WithoutInitializing_t>,
+      std::conditional_t<alloc_prop_input::has_execution_space,
+                         std::integral_constant<unsigned int, 4>,
+                         typename Space::execution_space>>;
+  alloc_prop arg_prop_copy(arg_prop);
+
+  std::string& label =
+      static_cast<Impl::ViewCtorProp<void, std::string>&>(arg_prop_copy).value;
+  if (label.empty()) label = src.label();
+  auto mirror = typename Mirror::non_const_type{arg_prop_copy, src.layout()};
+  if (alloc_prop_input::has_execution_space) {
+    using ExecutionSpace = typename alloc_prop::execution_space;
+    deep_copy(
+        static_cast<Impl::ViewCtorProp<void, ExecutionSpace>&>(arg_prop_copy)
+            .value,
+        mirror, src);
+  } else
+    deep_copy(mirror, src);
+  return mirror;
+}
+
 template <class Space, class T, class... P>
 typename Impl::MirrorViewType<Space, T, P...>::view_type
 create_mirror_view_and_copy(
     const Space&, const Kokkos::View<T, P...>& src,
     std::string const& name = "",
     std::enable_if_t<
-        std::is_void<typename ViewTraits<T, P...>::specialize>::value &&
-        !Impl::MirrorViewType<Space, T, P...>::is_same_memspace>* = nullptr) {
-  using Mirror      = typename Impl::MirrorViewType<Space, T, P...>::view_type;
-  std::string label = name.empty() ? src.label() : name;
-  auto mirror       = typename Mirror::non_const_type{
-      view_alloc(WithoutInitializing, label), src.layout()};
-  deep_copy(mirror, src);
-  return mirror;
+        std::is_void<typename ViewTraits<T, P...>::specialize>::value>* =
+        nullptr) {
+  return create_mirror_view_and_copy(
+      Kokkos::view_alloc(typename Space::memory_space{}, name), src);
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3

--- a/core/unit_test/tools/TestWithoutInitializing.cpp
+++ b/core/unit_test/tools/TestWithoutInitializing.cpp
@@ -133,14 +133,11 @@ TEST(kokkosp, create_mirror_view_and_copy) {
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found begin event"}};
       },
-      [&](EndParallelForEvent) {
-        return MatchDiagnostic{true, {"Found end event"}};
-      },
-      [&](BeginParallelForEvent) {
-        return MatchDiagnostic{true, {"Found begin event"}};
-      },
-      [&](EndParallelForEvent) {
-        return MatchDiagnostic{true, {"Found end event"}};
+      [&](BeginFenceEvent event) {
+        return MatchDiagnostic{
+            event.descriptor().find(
+                "fence after copying header from HostSpace") ==
+            std::string::npos};
       });
   ASSERT_TRUE(success);
 }

--- a/core/unit_test/tools/TestWithoutInitializing.cpp
+++ b/core/unit_test/tools/TestWithoutInitializing.cpp
@@ -119,6 +119,12 @@ TEST(kokkosp, create_mirror_view_and_copy) {
   return;
 #endif
 
+#ifdef KOKKOS_ENABLE_CUDA
+  if (std::is_same<typename Kokkos::DefaultExecutionSpace::memory_space,
+                   Kokkos::CudaUVMSpace>::value)
+    return;
+#endif
+
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
                      Config::EnableFences());

--- a/core/unit_test/tools/TestWithoutInitializing.cpp
+++ b/core/unit_test/tools/TestWithoutInitializing.cpp
@@ -114,6 +114,11 @@ TEST(kokkosp, create_mirror_no_init_view_ctor) {
 }
 
 TEST(kokkosp, create_mirror_view_and_copy) {
+// FIXME_OPENMPTARGET
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+  return;
+#endif
+
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
                      Config::EnableFences());


### PR DESCRIPTION
Similar to #5095, #5035 and #4844. #4826 would help remove more fences here.

This pull request provides a `ViewCtorProp` overload for `create_mirror_view_and_copy` that also allows specifying an execution space to be used in the `allocation` and the `deep_copy`. The existing version is changed to always use an execution space for `allocation` (but still uses the two-argument `deep_copy`).