### PR TITLE
Update precedence rule in initialization

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -971,6 +971,26 @@ void parse_environment_variables(InitArguments& arguments) {
   }
 }
 
+void combine(InitArguments& out, InitArguments const& in) {
+  InitArguments default_;
+#define KOKKOS_IMPL_OVERWRITE_IF_DEFAULT(DATA_MEMBER) \
+  if (out.DATA_MEMBER == default_.DATA_MEMBER) {      \
+    out.DATA_MEMBER = in.DATA_MEMBER;                 \
+  }                                                   \
+  static_assert(true, "no-op to require trailing semicolon")
+  KOKKOS_IMPL_OVERWRITE_IF_DEFAULT(num_threads);
+  KOKKOS_IMPL_OVERWRITE_IF_DEFAULT(num_numa);
+  KOKKOS_IMPL_OVERWRITE_IF_DEFAULT(device_id);
+  KOKKOS_IMPL_OVERWRITE_IF_DEFAULT(ndevices);
+  KOKKOS_IMPL_OVERWRITE_IF_DEFAULT(skip_device);
+  KOKKOS_IMPL_OVERWRITE_IF_DEFAULT(disable_warnings);
+  KOKKOS_IMPL_OVERWRITE_IF_DEFAULT(tune_internals);
+  KOKKOS_IMPL_OVERWRITE_IF_DEFAULT(tool_help);
+  KOKKOS_IMPL_OVERWRITE_IF_DEFAULT(tool_lib);
+  KOKKOS_IMPL_OVERWRITE_IF_DEFAULT(tool_args);
+#undef KOKKOS_IMPL_OVERWRITE_IF_DEFAULT
+}
+
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -1000,13 +1000,15 @@ namespace Kokkos {
 
 void initialize(int& narg, char* arg[]) {
   InitArguments arguments;
-  Impl::parse_command_line_arguments(narg, arg, arguments);
   Impl::parse_environment_variables(arguments);
+  Impl::parse_command_line_arguments(narg, arg, arguments);
   Impl::initialize_internal(arguments);
 }
 
 void initialize(InitArguments arguments) {
-  Impl::parse_environment_variables(arguments);
+  InitArguments tmp;
+  Impl::parse_environment_variables(tmp);
+  Impl::combine(arguments, tmp);
   Impl::initialize_internal(arguments);
 }
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -843,13 +843,7 @@ void parse_environment_variables(InitArguments& arguments) {
       Impl::throw_runtime_exception(
           "Error: KOKKOS_NUM_THREADS out of range of representable values by "
           "an integer. Raised by Kokkos::initialize(int narg, char* argc[]).");
-    if ((num_threads != -1) && (env_num_threads != num_threads))
-      Impl::throw_runtime_exception(
-          "Error: expecting a match between --kokkos-num-threads and "
-          "KOKKOS_NUM_THREADS if both are set. Raised by "
-          "Kokkos::initialize(int narg, char* argc[]).");
-    else
-      num_threads = env_num_threads;
+    num_threads = env_num_threads;
   }
   auto env_numa_str = std::getenv("KOKKOS_NUMA");
   if (env_numa_str != nullptr) {
@@ -867,13 +861,7 @@ void parse_environment_variables(InitArguments& arguments) {
       Impl::throw_runtime_exception(
           "Error: KOKKOS_DEVICE_ID out of range of representable values by an "
           "integer. Raised by Kokkos::initialize(int narg, char* argc[]).");
-    if ((device != -1) && (env_device != device))
-      Impl::throw_runtime_exception(
-          "Error: expecting a match between --kokkos-device-id and "
-          "KOKKOS_DEVICE_ID if both are set. Raised by Kokkos::initialize(int "
-          "narg, char* argc[]).");
-    else
-      device = env_device;
+    device = env_device;
   }
   auto env_rdevices_str = std::getenv("KOKKOS_RAND_DEVICES");
   auto env_ndevices_str = std::getenv("KOKKOS_NUM_DEVICES");
@@ -897,13 +885,7 @@ void parse_environment_variables(InitArguments& arguments) {
             "Error: KOKKOS_NUM_DEVICES out of range of representable values by "
             "an integer. Raised by Kokkos::initialize(int narg, char* "
             "argc[]).");
-      if ((ndevices != -1) && (env_ndevices != ndevices))
-        Impl::throw_runtime_exception(
-            "Error: expecting a match between --kokkos-num-devices and "
-            "KOKKOS_NUM_DEVICES if both are set. Raised by "
-            "Kokkos::initialize(int narg, char* argc[]).");
-      else
-        ndevices = env_ndevices;
+      ndevices = env_ndevices;
     } else {  // you set KOKKOS_RAND_DEVICES
       auto env_rdevices = std::strtol(env_rdevices_str, &endptr, 10);
       if (endptr == env_ndevices_str)
@@ -932,13 +914,7 @@ void parse_environment_variables(InitArguments& arguments) {
             "Error: KOKKOS_SKIP_DEVICE out of range of representable values by "
             "an integer. Raised by Kokkos::initialize(int narg, char* "
             "argc[]).");
-      if ((skip_device != 9999) && (env_skip_device != skip_device))
-        Impl::throw_runtime_exception(
-            "Error: expecting a match between --kokkos-num-devices and "
-            "KOKKOS_SKIP_DEVICE if both are set. Raised by "
-            "Kokkos::initialize(int narg, char* argc[]).");
-      else
-        skip_device = env_skip_device;
+      skip_device = env_skip_device;
     }
     if (rdevices > 0) {
       if (skip_device > 0 && rdevices == 1)
@@ -955,19 +931,10 @@ void parse_environment_variables(InitArguments& arguments) {
   }
   char* env_disablewarnings_str = std::getenv("KOKKOS_DISABLE_WARNINGS");
   if (env_disablewarnings_str != nullptr) {
-    std::string env_str(env_disablewarnings_str);  // deep-copies string
-    for (char& c : env_str) {
-      c = toupper(c);
-    }
-    const auto _rc = std::regex_constants::icase | std::regex_constants::egrep;
-    const auto _re = std::regex("^(true|on|yes|[1-9])$", _rc);
-    if (std::regex_match(env_str, _re))
-      disable_warnings = true;
-    else if (disable_warnings)
-      Impl::throw_runtime_exception(
-          "Error: expecting a match between --kokkos-disable-warnings and "
-          "KOKKOS_DISABLE_WARNINGS if both are set. Raised by "
-          "Kokkos::initialize(int narg, char* argc[]).");
+    auto const regex =
+        std::regex("^(true|on|yes|[1-9])$",
+                   std::regex_constants::icase | std::regex_constants::egrep);
+    disable_warnings = std::regex_match(env_disablewarnings_str, regex);
   }
 }
 

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -164,15 +164,7 @@ Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
   if (env_tool_lib != nullptr) {
     warn_env_var_ignored_when_kokkos_tools_disabled("KOKKOS_PROFILE_LIBRARY",
                                                     env_tool_lib);
-    if ((tool_lib != Kokkos::Tools::InitArguments::unset_string_option) &&
-        std::string(env_tool_lib) != tool_lib)
-      return {Kokkos::Tools::Impl::InitializationStatus::InitializationResult::
-                  environment_argument_mismatch,
-              "Error: expecting a match between --kokkos-tools-library and "
-              "KOKKOS_PROFILE_LIBRARY if both are set. Raised by "
-              "Kokkos::initialize(int narg, char* argc[])."};
-    else
-      tool_lib = env_tool_lib;
+    tool_lib = env_tool_lib;
   }
   char* env_tuneinternals_str = std::getenv("KOKKOS_TUNE_INTERNALS");
   if (env_tuneinternals_str != nullptr) {
@@ -182,12 +174,8 @@ Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
     }
     if ((env_str == "TRUE") || (env_str == "ON") || (env_str == "1"))
       tune_internals = InitArguments::PossiblyUnsetOption::on;
-    else if (tune_internals)
-      return {Kokkos::Tools::Impl::InitializationStatus::InitializationResult::
-                  environment_argument_mismatch,
-              "Error: expecting a match between --kokkos-tune-internals and "
-              "KOKKOS_TUNE_INTERNALS if both are set. Raised by "
-              "Kokkos::initialize(int narg, char* argc[])."};
+    else
+      tune_internals = InitArguments::PossiblyUnsetOption::off;
   }
   return {
       Kokkos::Tools::Impl::InitializationStatus::InitializationResult::success};
@@ -220,8 +208,8 @@ void initialize(const InitArguments& arguments) {
 }
 void initialize(int argc, char* argv[]) {
   InitArguments arguments;
-  Impl::parse_command_line_arguments(argc, argv, arguments);
   Impl::parse_environment_variables(arguments);
+  Impl::parse_command_line_arguments(argc, argv, arguments);
   initialize(arguments);
 }
 

--- a/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
+++ b/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
@@ -299,31 +299,48 @@ TEST(defaultdevicetype, env_vars_num_devices) {
 }
 
 TEST(defaultdevicetype, env_vars_disable_warnings) {
-  EnvVarsHelper ev = {{
-      {"KOKKOS_DISABLE_WARNINGS", "1"},
-  }};
-  SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
-  Kokkos::InitArguments ia;
-  Kokkos::Impl::parse_environment_variables(ia);
-  EXPECT_TRUE(ia.disable_warnings);
-
-  ev = {{
-      {"KOKKOS_DISABLE_WARNINGS", "0"},
-  }};
-  SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
-  ia = {};
-  Kokkos::Impl::parse_environment_variables(ia);
-  EXPECT_FALSE(ia.disable_warnings);
+  for (auto const& value_true : {"1", "true", "TRUE", "3", "yEs", "ON"}) {
+    EnvVarsHelper ev = {{
+        {"KOKKOS_DISABLE_WARNINGS", value_true},
+    }};
+    SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
+    Kokkos::InitArguments ia;
+    Kokkos::Impl::parse_environment_variables(ia);
+    EXPECT_TRUE(ia.disable_warnings)
+        << "KOKKOS_DISABLE_WARNINGS=" << value_true;
+  }
+  for (auto const& value_false : {"0", "false", "whatever", "123"}) {
+    EnvVarsHelper ev = {{
+        {"KOKKOS_DISABLE_WARNINGS", value_false},
+    }};
+    SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
+    Kokkos::InitArguments ia;
+    Kokkos::Impl::parse_environment_variables(ia);
+    EXPECT_FALSE(ia.disable_warnings)
+        << "KOKKOS_DISABLE_WARNINGS=" << value_false;
+  }
 }
 
 TEST(defaultdevicetype, env_vars_tune_internals) {
-  EnvVarsHelper ev = {{
-      {"KOKKOS_TUNE_INTERNALS", "1"},
-  }};
-  SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
-  Kokkos::InitArguments ia;
-  Kokkos::Impl::parse_environment_variables(ia);
-  EXPECT_TRUE(ia.tune_internals);
+  for (auto const& value_true : {"1", "true", "TRUE", "on", "tRuE"}) {
+    EnvVarsHelper ev = {{
+        {"KOKKOS_TUNE_INTERNALS", value_true},
+    }};
+    SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
+    Kokkos::InitArguments ia;
+    Kokkos::Impl::parse_environment_variables(ia);
+    EXPECT_TRUE(ia.tune_internals) << "KOKKOS_TUNE_INTERNALS=" << value_true;
+  }
+  for (auto const& value_false :
+       {"0", "false", "whatever", "123", "3", "YES"}) {
+    EnvVarsHelper ev = {{
+        {"KOKKOS_TUNE_INTERNALS", value_false},
+    }};
+    SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
+    Kokkos::InitArguments ia;
+    Kokkos::Impl::parse_environment_variables(ia);
+    EXPECT_FALSE(ia.tune_internals) << "KOKKOS_TUNE_INTERNALS=" << value_false;
+  }
 }
 
 }  // namespace

--- a/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
+++ b/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
@@ -130,6 +130,12 @@ class EnvVarsHelper {
   EnvVarsHelper& operator=(EnvVarsHelper&) = delete;
 };
 std::mutex EnvVarsHelper::mutex_;
+#define SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev)       \
+  if (ev.skip()) {                                         \
+    GTEST_SKIP() << "environment variable '" << *ev.skip() \
+                 << "' is already set";                    \
+  }                                                        \
+  static_assert(true, "no-op to require trailing semicolon")
 
 class CmdLineArgsHelper {
   int argc_;
@@ -263,10 +269,7 @@ TEST(defaultdevicetype, env_vars_num_threads) {
       {"KOKKOS_NUM_THREADS", "24"},
       {"KOKKOS_DISABLE_WARNINGS", "1"},
   }};
-  if (ev.skip()) {
-    GTEST_SKIP() << "environment variable '" << *ev.skip()
-                 << "' is already set";
-  }
+  SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
   Kokkos::InitArguments ia;
   Kokkos::Impl::parse_environment_variables(ia);
   EXPECT_EQ(ia.num_threads, 24);
@@ -277,10 +280,7 @@ TEST(defaultdevicetype, env_vars_device_id) {
   EnvVarsHelper ev = {{
       {"KOKKOS_DEVICE_ID", "33"},
   }};
-  if (ev.skip()) {
-    GTEST_SKIP() << "environment variable '" << *ev.skip()
-                 << "' is already set";
-  }
+  SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
   Kokkos::InitArguments ia;
   Kokkos::Impl::parse_environment_variables(ia);
   EXPECT_EQ(ia.device_id, 33);
@@ -291,10 +291,7 @@ TEST(defaultdevicetype, env_vars_num_devices) {
       {"KOKKOS_NUM_DEVICES", "4"},
       {"KOKKOS_SKIP_DEVICE", "1"},
   }};
-  if (ev.skip()) {
-    GTEST_SKIP() << "environment variable '" << *ev.skip()
-                 << "' is already set";
-  }
+  SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
   Kokkos::InitArguments ia;
   Kokkos::Impl::parse_environment_variables(ia);
   EXPECT_EQ(ia.ndevices, 4);
@@ -305,10 +302,7 @@ TEST(defaultdevicetype, env_vars_disable_warnings) {
   EnvVarsHelper ev = {{
       {"KOKKOS_DISABLE_WARNINGS", "1"},
   }};
-  if (ev.skip()) {
-    GTEST_SKIP() << "environment variable '" << *ev.skip()
-                 << "' is already set";
-  }
+  SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
   Kokkos::InitArguments ia;
   Kokkos::Impl::parse_environment_variables(ia);
   EXPECT_TRUE(ia.disable_warnings);
@@ -316,10 +310,7 @@ TEST(defaultdevicetype, env_vars_disable_warnings) {
   ev = {{
       {"KOKKOS_DISABLE_WARNINGS", "0"},
   }};
-  if (ev.skip()) {
-    GTEST_SKIP() << "environment variable '" << *ev.skip()
-                 << "' is already set";
-  }
+  SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
   ia = {};
   Kokkos::Impl::parse_environment_variables(ia);
   EXPECT_FALSE(ia.disable_warnings);
@@ -329,10 +320,7 @@ TEST(defaultdevicetype, env_vars_tune_internals) {
   EnvVarsHelper ev = {{
       {"KOKKOS_TUNE_INTERNALS", "1"},
   }};
-  if (ev.skip()) {
-    GTEST_SKIP() << "environment variable '" << *ev.skip()
-                 << "' is already set";
-  }
+  SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
   Kokkos::InitArguments ia;
   Kokkos::Impl::parse_environment_variables(ia);
   EXPECT_TRUE(ia.tune_internals);


### PR DESCRIPTION
Implement what was decided at the last developer meeting, that is command-line arguments or non-defaulted data members of `InitArguments` take precedence over the environment variable (without checking whether they match or not)

You will note some oddities in the parsing of boolean environment variables.  I was planning on resolving these in the next PR.