### PR TITLE
Deprecate `finalize_all()`

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -199,8 +199,10 @@ void finalize();
  */
 void push_finalize_hook(std::function<void()> f);
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 /** \brief  Finalize all known execution spaces */
-void finalize_all();
+KOKKOS_DEPRECATED void finalize_all();
+#endif
 
 void fence();
 void fence(const std::string&);

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -137,7 +137,7 @@ class ExecSpaceManager {
   void register_space_factory(std::string name,
                               std::unique_ptr<ExecSpaceInitializerBase> ptr);
   void initialize_spaces(const Kokkos::InitArguments& args);
-  void finalize_spaces(const bool all_spaces);
+  void finalize_spaces();
   void static_fence();
   void static_fence(const std::string&);
   void print_configuration(std::ostream& msg, const bool detail);

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -506,7 +506,7 @@ void initialize_internal(const InitArguments& args) {
   post_initialize_internal(args);
 }
 
-void finalize_internal(const bool all_spaces = false) {
+void finalize_internal() {
   typename decltype(finalize_hooks)::size_type numSuccessfulCalls = 0;
   while (!finalize_hooks.empty()) {
     auto f = finalize_hooks.top();
@@ -536,7 +536,7 @@ void finalize_internal(const bool all_spaces = false) {
 
   Kokkos::Profiling::finalize();
 
-  Impl::ExecSpaceManager::get_instance().finalize_spaces(all_spaces);
+  Impl::ExecSpaceManager::get_instance().finalize_spaces(/*all_spaces=*/true);
 
   g_is_initialized = false;
   g_show_warnings  = true;
@@ -996,10 +996,7 @@ void push_finalize_hook(std::function<void()> f) { finalize_hooks.push(f); }
 void finalize() { Impl::finalize_internal(); }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
-KOKKOS_DEPRECATED void finalize_all() {
-  enum : bool { all_spaces = true };
-  Impl::finalize_internal(all_spaces);
-}
+KOKKOS_DEPRECATED void finalize_all() { Impl::finalize_internal(); }
 #endif
 
 void fence() { Impl::fence_internal("Kokkos::fence: Unnamed Global Fence"); }

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -120,9 +120,9 @@ void ExecSpaceManager::initialize_spaces(const Kokkos::InitArguments& args) {
   }
 }
 
-void ExecSpaceManager::finalize_spaces(const bool all_spaces) {
+void ExecSpaceManager::finalize_spaces() {
   for (auto& to_finalize : exec_space_factory_list) {
-    to_finalize.second->finalize(all_spaces);
+    to_finalize.second->finalize(/*all_spaces=*/true);
   }
 }
 
@@ -536,7 +536,7 @@ void finalize_internal() {
 
   Kokkos::Profiling::finalize();
 
-  Impl::ExecSpaceManager::get_instance().finalize_spaces(/*all_spaces=*/true);
+  Impl::ExecSpaceManager::get_instance().finalize_spaces();
 
   g_is_initialized = false;
   g_show_warnings  = true;

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -995,10 +995,12 @@ void push_finalize_hook(std::function<void()> f) { finalize_hooks.push(f); }
 
 void finalize() { Impl::finalize_internal(); }
 
-void finalize_all() {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+KOKKOS_DEPRECATED void finalize_all() {
   enum : bool { all_spaces = true };
   Impl::finalize_internal(all_spaces);
 }
+#endif
 
 void fence() { Impl::fence_internal("Kokkos::fence: Unnamed Global Fence"); }
 void fence(const std::string& name) { Impl::fence_internal(name); }


### PR DESCRIPTION
Oversight on our part, not used and not tested