### PR TITLE
Deprecate parallel_* overloads taking the label as later argument

### DIFF
--- a/containers/performance_tests/TestScatterView.hpp
+++ b/containers/performance_tests/TestScatterView.hpp
@@ -82,8 +82,8 @@ void test_scatter_view(int m, int n) {
         Kokkos::Timer timer;
         timer.reset();
         for (int k = 0; k < m; ++k) {
-          Kokkos::parallel_for(policy, f2,
-                               "hand_coded_duplicate_scatter_view_test");
+          Kokkos::parallel_for("hand_coded_duplicate_scatter_view_test", policy,
+                               f2);
         }
         Kokkos::fence();
         auto t = timer.seconds();
@@ -102,7 +102,7 @@ void test_scatter_view(int m, int n) {
         Kokkos::Timer timer;
         timer.reset();
         for (int k = 0; k < m; ++k) {
-          Kokkos::parallel_for(policy, f, "scatter_view_test");
+          Kokkos::parallel_for("scatter_view_test", policy, f);
         }
         Kokkos::fence();
         auto t = timer.seconds();

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -90,7 +90,7 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
     scatterSize = n;
     auto policy =
         Kokkos::RangePolicy<typename DeviceType::execution_space, int>(0, n);
-    Kokkos::parallel_for(policy, *this, "scatter_view_test: Sum");
+    Kokkos::parallel_for("scatter_view_test: Sum", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -235,7 +235,7 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
     scatterSize = n;
     auto policy =
         Kokkos::RangePolicy<typename DeviceType::execution_space, int>(0, n);
-    Kokkos::parallel_for(policy, *this, "scatter_view_test: Prod");
+    Kokkos::parallel_for("scatter_view_test: Prod", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -336,7 +336,7 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
     scatterSize = n;
     auto policy =
         Kokkos::RangePolicy<typename DeviceType::execution_space, int>(0, n);
-    Kokkos::parallel_for(policy, *this, "scatter_view_test: Prod");
+    Kokkos::parallel_for("scatter_view_test: Prod", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -435,7 +435,7 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
   void run_parallel(int n) {
     scatterSize = n;
     Kokkos::RangePolicy<typename DeviceType::execution_space, int> policy(0, n);
-    Kokkos::parallel_for(policy, *this, "scatter_view_test: Prod");
+    Kokkos::parallel_for("scatter_view_test: Prod", policy, *this);
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -150,12 +150,11 @@ namespace Kokkos {
  * This compares to a single iteration \c iwork of a \c for loop.
  * If \c execution_space is not defined DefaultExecutionSpace will be used.
  */
-template <class ExecPolicy, class FunctorType>
-inline void parallel_for(
-    const ExecPolicy& policy, const FunctorType& functor,
-    const std::string& str = "",
-    std::enable_if_t<Kokkos::is_execution_policy<ExecPolicy>::value>* =
-        nullptr) {
+template <class ExecPolicy, class FunctorType,
+          class Enable =
+              std::enable_if_t<Kokkos::is_execution_policy<ExecPolicy>::value>>
+inline void parallel_for(const std::string& str, const ExecPolicy& policy,
+                         const FunctorType& functor) {
   uint64_t kpID = 0;
 
   ExecPolicy inner_policy = policy;
@@ -170,34 +169,53 @@ inline void parallel_for(
   Kokkos::Tools::Impl::end_parallel_for(inner_policy, functor, str, kpID);
 }
 
+template <class ExecPolicy, class FunctorType>
+inline void parallel_for(
+    const ExecPolicy& policy, const FunctorType& functor,
+    std::enable_if_t<Kokkos::is_execution_policy<ExecPolicy>::value>* =
+        nullptr) {
+  Kokkos::parallel_for("", policy, functor);
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+template <class ExecPolicy, class FunctorType>
+KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use the overload taking the label as first argument instead!")
+inline void parallel_for(
+    const ExecPolicy& policy, const FunctorType& functor,
+    const std::string& str,
+    std::enable_if_t<Kokkos::is_execution_policy<ExecPolicy>::value>* =
+        nullptr) {
+  Kokkos::parallel_for(str, policy, functor);
+}
+#endif
+
 template <class FunctorType>
-inline void parallel_for(const size_t work_count, const FunctorType& functor,
-                         const std::string& str = "") {
+inline void parallel_for(const std::string& str, const size_t work_count,
+                         const FunctorType& functor) {
   using execution_space =
       typename Impl::FunctorPolicyExecutionSpace<FunctorType,
                                                  void>::execution_space;
   using policy = RangePolicy<execution_space>;
 
-  uint64_t kpID = 0;
-
   policy execution_policy = policy(0, work_count);
-
-  Kokkos::Tools::Impl::begin_parallel_for(execution_policy, functor, str, kpID);
-
-  Kokkos::Impl::shared_allocation_tracking_disable();
-  Impl::ParallelFor<FunctorType, policy> closure(functor, execution_policy);
-  Kokkos::Impl::shared_allocation_tracking_enable();
-
-  closure.execute();
-
-  Kokkos::Tools::Impl::end_parallel_for(execution_policy, functor, str, kpID);
+  ::Kokkos::parallel_for(str, execution_policy, functor);
 }
 
-template <class ExecPolicy, class FunctorType>
-inline void parallel_for(const std::string& str, const ExecPolicy& policy,
-                         const FunctorType& functor) {
-  ::Kokkos::parallel_for(policy, functor, str);
+template <class FunctorType>
+inline void parallel_for(const size_t work_count, const FunctorType& functor) {
+  ::Kokkos::parallel_for("", work_count, functor);
 }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+template <class FunctorType>
+KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use the overload taking the label as first argument instead!")
+inline void parallel_for(const size_t work_count, const FunctorType& functor,
+                         const std::string& str) {
+  ::Kokkos::parallel_for(str, work_count, functor);
+}
+#endif
 
 }  // namespace Kokkos
 
@@ -372,12 +390,11 @@ namespace Kokkos {
 /// };
 /// \endcode
 ///
-template <class ExecutionPolicy, class FunctorType>
-inline void parallel_scan(
-    const ExecutionPolicy& policy, const FunctorType& functor,
-    const std::string& str = "",
-    std::enable_if_t<Kokkos::is_execution_policy<ExecutionPolicy>::value>* =
-        nullptr) {
+template <class ExecutionPolicy, class FunctorType,
+          class Enable = std::enable_if_t<
+              Kokkos::is_execution_policy<ExecutionPolicy>::value>>
+inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
+                          const FunctorType& functor) {
   uint64_t kpID                = 0;
   ExecutionPolicy inner_policy = policy;
   Kokkos::Tools::Impl::begin_parallel_scan(inner_policy, functor, str, kpID);
@@ -392,40 +409,61 @@ inline void parallel_scan(
   Kokkos::Tools::Impl::end_parallel_scan(inner_policy, functor, str, kpID);
 }
 
+template <class ExecutionPolicy, class FunctorType>
+inline void parallel_scan(
+    const ExecutionPolicy& policy, const FunctorType& functor,
+    std::enable_if_t<Kokkos::is_execution_policy<ExecutionPolicy>::value>* =
+        nullptr) {
+  ::Kokkos::parallel_scan("", policy, functor);
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+template <class ExecutionPolicy, class FunctorType>
+KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use the overload taking the label as first argument instead!")
+inline void parallel_scan(
+    const ExecutionPolicy& policy, const FunctorType& functor,
+    const std::string& str,
+    std::enable_if_t<Kokkos::is_execution_policy<ExecutionPolicy>::value>* =
+        nullptr) {
+  ::Kokkos::parallel_scan(str, policy, functor);
+}
+#endif
+
 template <class FunctorType>
-inline void parallel_scan(const size_t work_count, const FunctorType& functor,
-                          const std::string& str = "") {
+inline void parallel_scan(const std::string& str, const size_t work_count,
+                          const FunctorType& functor) {
   using execution_space =
       typename Kokkos::Impl::FunctorPolicyExecutionSpace<FunctorType,
                                                          void>::execution_space;
 
   using policy = Kokkos::RangePolicy<execution_space>;
 
-  uint64_t kpID = 0;
   policy execution_policy(0, work_count);
-  Kokkos::Tools::Impl::begin_parallel_scan(execution_policy, functor, str,
-                                           kpID);
-  Kokkos::Impl::shared_allocation_tracking_disable();
-  Impl::ParallelScan<FunctorType, policy> closure(functor, execution_policy);
-  Kokkos::Impl::shared_allocation_tracking_enable();
-
-  closure.execute();
-
-  Kokkos::Tools::Impl::end_parallel_scan(execution_policy, functor, str, kpID);
+  parallel_scan(str, execution_policy, functor);
 }
 
-template <class ExecutionPolicy, class FunctorType>
+template <class FunctorType>
+inline void parallel_scan(const size_t work_count, const FunctorType& functor) {
+  ::Kokkos::parallel_scan("", work_count, functor);
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+template <class FunctorType>
+KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use the overload taking the label as first argument instead!")
+inline void parallel_scan(const size_t work_count, const FunctorType& functor,
+                          const std::string& str) {
+  ::Kokkos::parallel_scan("", work_count, functor);
+}
+#endif
+
+template <class ExecutionPolicy, class FunctorType, class ReturnType,
+          class Enable = std::enable_if_t<
+              Kokkos::is_execution_policy<ExecutionPolicy>::value>>
 inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
-                          const FunctorType& functor) {
-  ::Kokkos::parallel_scan(policy, functor, str);
-}
-
-template <class ExecutionPolicy, class FunctorType, class ReturnType>
-inline void parallel_scan(
-    const ExecutionPolicy& policy, const FunctorType& functor,
-    ReturnType& return_value, const std::string& str = "",
-    std::enable_if_t<Kokkos::is_execution_policy<ExecutionPolicy>::value>* =
-        nullptr) {
+                          const FunctorType& functor,
+                          ReturnType& return_value) {
   uint64_t kpID                = 0;
   ExecutionPolicy inner_policy = policy;
   Kokkos::Tools::Impl::begin_parallel_scan(inner_policy, functor, str, kpID);
@@ -443,10 +481,30 @@ inline void parallel_scan(
       "Kokkos::parallel_scan: fence due to result being a value, not a view");
 }
 
+template <class ExecutionPolicy, class FunctorType, class ReturnType>
+inline void parallel_scan(
+    const ExecutionPolicy& policy, const FunctorType& functor,
+    ReturnType& return_value,
+    std::enable_if_t<Kokkos::is_execution_policy<ExecutionPolicy>::value>* =
+        nullptr) {
+  ::Kokkos::parallel_scan("", policy, functor, return_value);
+}
+
+#ifdef KOKKOS_ENABLE_DISABLE_DEPRECATED_CODE_3
+template <class ExecutionPolicy, class FunctorType, class ReturnType>
+inline void parallel_scan(
+    const ExecutionPolicy& policy, const FunctorType& functor,
+    ReturnType& return_value, const std::string& str,
+    std::enable_if_t<Kokkos::is_execution_policy<ExecutionPolicy>::value>* =
+        nullptr) {
+  ::Kokkos::parallel_scan(str, policy, functor, return_value);
+}
+#endif
+
 template <class FunctorType, class ReturnType>
-inline void parallel_scan(const size_t work_count, const FunctorType& functor,
-                          ReturnType& return_value,
-                          const std::string& str = "") {
+inline void parallel_scan(const std::string& str, const size_t work_count,
+                          const FunctorType& functor,
+                          ReturnType& return_value) {
   using execution_space =
       typename Kokkos::Impl::FunctorPolicyExecutionSpace<FunctorType,
                                                          void>::execution_space;
@@ -454,29 +512,24 @@ inline void parallel_scan(const size_t work_count, const FunctorType& functor,
   using policy = Kokkos::RangePolicy<execution_space>;
 
   policy execution_policy(0, work_count);
-  uint64_t kpID = 0;
-  Kokkos::Tools::Impl::begin_parallel_scan(execution_policy, functor, str,
-                                           kpID);
-
-  Kokkos::Impl::shared_allocation_tracking_disable();
-  Impl::ParallelScanWithTotal<FunctorType, policy, ReturnType> closure(
-      functor, execution_policy, return_value);
-  Kokkos::Impl::shared_allocation_tracking_enable();
-
-  closure.execute();
-
-  Kokkos::Tools::Impl::end_parallel_scan(execution_policy, functor, str, kpID);
-
-  execution_space().fence(
-      "Kokkos::parallel_scan: fence after scan with return value");
+  parallel_scan(str, execution_policy, functor, return_value);
 }
 
-template <class ExecutionPolicy, class FunctorType, class ReturnType>
-inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
-                          const FunctorType& functor,
+template <class FunctorType, class ReturnType>
+inline void parallel_scan(const size_t work_count, const FunctorType& functor,
                           ReturnType& return_value) {
-  ::Kokkos::parallel_scan(policy, functor, return_value, str);
+  ::Kokkos::parallel_scan("", work_count, functor, return_value);
 }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+template <class FunctorType, class ReturnType>
+KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use the overload taking the label as first argument instead!")
+inline void parallel_scan(const size_t work_count, const FunctorType& functor,
+                          ReturnType& return_value, const std::string& str) {
+  ::Kokkos::parallel_scan(str, work_count, functor, return_value);
+}
+#endif
 
 }  // namespace Kokkos
 

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -487,6 +487,8 @@ inline void parallel_scan(
 
 #ifdef KOKKOS_ENABLE_DISABLE_DEPRECATED_CODE_3
 template <class ExecutionPolicy, class FunctorType, class ReturnType>
+KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use the overload taking the label as first argument instead!")
 inline void parallel_scan(
     const ExecutionPolicy& policy, const FunctorType& functor,
     ReturnType& return_value, const std::string& str,

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -150,9 +150,9 @@ namespace Kokkos {
  * This compares to a single iteration \c iwork of a \c for loop.
  * If \c execution_space is not defined DefaultExecutionSpace will be used.
  */
-template <class ExecPolicy, class FunctorType,
-          class Enable =
-              std::enable_if_t<Kokkos::is_execution_policy<ExecPolicy>::value>>
+template <
+    class ExecPolicy, class FunctorType,
+    class Enable = std::enable_if_t<is_execution_policy<ExecPolicy>::value>>
 inline void parallel_for(const std::string& str, const ExecPolicy& policy,
                          const FunctorType& functor) {
   uint64_t kpID = 0;
@@ -172,8 +172,7 @@ inline void parallel_for(const std::string& str, const ExecPolicy& policy,
 template <class ExecPolicy, class FunctorType>
 inline void parallel_for(
     const ExecPolicy& policy, const FunctorType& functor,
-    std::enable_if_t<Kokkos::is_execution_policy<ExecPolicy>::value>* =
-        nullptr) {
+    std::enable_if_t<is_execution_policy<ExecPolicy>::value>* = nullptr) {
   Kokkos::parallel_for("", policy, functor);
 }
 
@@ -184,8 +183,7 @@ KOKKOS_DEPRECATED_WITH_COMMENT(
 inline void parallel_for(
     const ExecPolicy& policy, const FunctorType& functor,
     const std::string& str,
-    std::enable_if_t<Kokkos::is_execution_policy<ExecPolicy>::value>* =
-        nullptr) {
+    std::enable_if_t<is_execution_policy<ExecPolicy>::value>* = nullptr) {
   Kokkos::parallel_for(str, policy, functor);
 }
 #endif
@@ -391,8 +389,8 @@ namespace Kokkos {
 /// \endcode
 ///
 template <class ExecutionPolicy, class FunctorType,
-          class Enable = std::enable_if_t<
-              Kokkos::is_execution_policy<ExecutionPolicy>::value>>
+          class Enable =
+              std::enable_if_t<is_execution_policy<ExecutionPolicy>::value>>
 inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
                           const FunctorType& functor) {
   uint64_t kpID                = 0;
@@ -412,8 +410,7 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
 template <class ExecutionPolicy, class FunctorType>
 inline void parallel_scan(
     const ExecutionPolicy& policy, const FunctorType& functor,
-    std::enable_if_t<Kokkos::is_execution_policy<ExecutionPolicy>::value>* =
-        nullptr) {
+    std::enable_if_t<is_execution_policy<ExecutionPolicy>::value>* = nullptr) {
   ::Kokkos::parallel_scan("", policy, functor);
 }
 
@@ -424,8 +421,7 @@ KOKKOS_DEPRECATED_WITH_COMMENT(
 inline void parallel_scan(
     const ExecutionPolicy& policy, const FunctorType& functor,
     const std::string& str,
-    std::enable_if_t<Kokkos::is_execution_policy<ExecutionPolicy>::value>* =
-        nullptr) {
+    std::enable_if_t<is_execution_policy<ExecutionPolicy>::value>* = nullptr) {
   ::Kokkos::parallel_scan(str, policy, functor);
 }
 #endif
@@ -454,13 +450,13 @@ KOKKOS_DEPRECATED_WITH_COMMENT(
     "Use the overload taking the label as first argument instead!")
 inline void parallel_scan(const size_t work_count, const FunctorType& functor,
                           const std::string& str) {
-  ::Kokkos::parallel_scan("", work_count, functor);
+  ::Kokkos::parallel_scan(str, work_count, functor);
 }
 #endif
 
 template <class ExecutionPolicy, class FunctorType, class ReturnType,
-          class Enable = std::enable_if_t<
-              Kokkos::is_execution_policy<ExecutionPolicy>::value>>
+          class Enable =
+              std::enable_if_t<is_execution_policy<ExecutionPolicy>::value>>
 inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
                           const FunctorType& functor,
                           ReturnType& return_value) {
@@ -485,8 +481,7 @@ template <class ExecutionPolicy, class FunctorType, class ReturnType>
 inline void parallel_scan(
     const ExecutionPolicy& policy, const FunctorType& functor,
     ReturnType& return_value,
-    std::enable_if_t<Kokkos::is_execution_policy<ExecutionPolicy>::value>* =
-        nullptr) {
+    std::enable_if_t<is_execution_policy<ExecutionPolicy>::value>* = nullptr) {
   ::Kokkos::parallel_scan("", policy, functor, return_value);
 }
 
@@ -495,8 +490,7 @@ template <class ExecutionPolicy, class FunctorType, class ReturnType>
 inline void parallel_scan(
     const ExecutionPolicy& policy, const FunctorType& functor,
     ReturnType& return_value, const std::string& str,
-    std::enable_if_t<Kokkos::is_execution_policy<ExecutionPolicy>::value>* =
-        nullptr) {
+    std::enable_if_t<is_execution_policy<ExecutionPolicy>::value>* = nullptr) {
   ::Kokkos::parallel_scan(str, policy, functor, return_value);
 }
 #endif


### PR DESCRIPTION
This is not even documented, see https://github.com/kokkos/kokkos/wiki/Kokkos::parallel_for, https://github.com/kokkos/kokkos/wiki/Kokkos::parallel_reduce, and https://github.com/kokkos/kokkos/wiki/Kokkos::parallel_scan.