### PR TITLE
wip

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -50,6 +50,7 @@
 
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_MemorySpace.hpp>
+#include <impl/Kokkos_ExecSpaceManager.hpp>
 
 #include <stdlib.h>
 #include <iostream>
@@ -346,8 +347,9 @@ int HIP::impl_is_initialized() {
   return Impl::HIPInternal::singleton().is_initialized();
 }
 
-void HIP::impl_initialize(const HIP::SelectDevice config) {
-  Impl::HIPInternal::singleton().initialize(config.hip_device_id);
+void HIP::impl_initialize(InitArguments const& b args) {
+  int use_gpu = Impl::get_gpu(args);
+  Impl::HIPInternal::singleton().initialize(use_gpu > -1 ? use_gpu : 0);
 }
 
 void HIP::impl_finalize() { Impl::HIPInternal::singleton().finalize(); }
@@ -370,8 +372,21 @@ HIP::HIP(hipStream_t const stream, bool manage_stream)
                                manage_stream);
 }
 
-void HIP::print_configuration(std::ostream& s, const bool) {
-  Impl::HIPInternal::singleton().print_configuration(s);
+void HIP::print_configuration(std::ostream& os, const bool) {
+  os << "Devices: \n";
+  os << "  KOKKOS_ENABLE_HIP: yes\n";
+
+  os << "HIP Options:\n";
+  os << "  KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE: ";
+#ifdef KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE
+  os << "yes\n";
+#else
+  os << "no\n";
+#endif
+
+  os << "\nRuntime Configuration:\n";
+
+  Impl::HIPInternal::singleton().print_configuration(os);
 }
 
 uint32_t HIP::impl_instance_id() const noexcept {
@@ -410,57 +425,7 @@ const char* HIP::name() { return "HIP"; }
 
 namespace Impl {
 
-int g_hip_space_factory_initialized =
-    initialize_space_factory<HIPSpaceInitializer>("150_HIP");
-
-void HIPSpaceInitializer::initialize(const InitArguments& args) {
-  int use_gpu = Impl::get_gpu(args);
-
-  if (std::is_same<Kokkos::Experimental::HIP,
-                   Kokkos::DefaultExecutionSpace>::value ||
-      0 < use_gpu) {
-    if (use_gpu > -1) {
-      Kokkos::Experimental::HIP::impl_initialize(
-          Kokkos::Experimental::HIP::SelectDevice(use_gpu));
-    } else {
-      Kokkos::Experimental::HIP::impl_initialize();
-    }
-  }
-}
-
-void HIPSpaceInitializer::finalize(const bool all_spaces) {
-  if (std::is_same<Kokkos::Experimental::HIP,
-                   Kokkos::DefaultExecutionSpace>::value ||
-      all_spaces) {
-    if (Kokkos::Experimental::HIP::impl_is_initialized())
-      Kokkos::Experimental::HIP::impl_finalize();
-  }
-}
-
-void HIPSpaceInitializer::fence() {
-  Kokkos::Experimental::HIP::impl_static_fence();
-}
-void HIPSpaceInitializer::fence(const std::string& name) {
-  Kokkos::Experimental::HIP::impl_static_fence(name);
-}
-
-void HIPSpaceInitializer::print_configuration(std::ostream& msg,
-                                              const bool detail) {
-  msg << "Devices:" << std::endl;
-  msg << "  KOKKOS_ENABLE_HIP: ";
-  msg << "yes" << std::endl;
-
-  msg << "HIP Options:" << std::endl;
-  msg << "  KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE: ";
-#ifdef KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE
-  msg << "yes" << std::endl;
-#else
-  msg << "no" << std::endl;
-#endif
-
-  msg << "\nRuntime Configuration:" << std::endl;
-  Experimental::HIP::print_configuration(msg, detail);
-}
+int g_hip_space_factory_initialized = initialize_space_factory<HIP>("150_HIP");
 
 }  // namespace Impl
 

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -73,86 +73,12 @@
 #include <Kokkos_CopyViews.hpp>
 #include <functional>
 #include <iosfwd>
-#include <map>
 #include <memory>
 #include <vector>
 
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-
-struct InitArguments {
-  int num_threads;
-  int num_numa;
-  int device_id;
-  int ndevices;
-  int skip_device;
-  bool disable_warnings;
-  bool tune_internals;
-  bool tool_help        = false;
-  std::string tool_lib  = {};
-  std::string tool_args = {};
-
-  InitArguments(int nt = -1, int nn = -1, int dv = -1, bool dw = false,
-                bool ti = false)
-      : num_threads{nt},
-        num_numa{nn},
-        device_id{dv},
-        ndevices{-1},
-        skip_device{9999},
-        disable_warnings{dw},
-        tune_internals{ti} {}
-  Tools::InitArguments impl_get_tools_init_arguments() const {
-    Tools::InitArguments init_tools;
-    init_tools.tune_internals =
-        tune_internals ? Tools::InitArguments::PossiblyUnsetOption::on
-                       : Tools::InitArguments::PossiblyUnsetOption::unset;
-    init_tools.help = tool_help
-                          ? Tools::InitArguments::PossiblyUnsetOption::on
-                          : Tools::InitArguments::PossiblyUnsetOption::unset;
-    init_tools.lib = tool_lib.empty()
-                         ? Kokkos::Tools::InitArguments::unset_string_option
-                         : tool_lib;
-    init_tools.args = tool_args.empty()
-                          ? Kokkos::Tools::InitArguments::unset_string_option
-                          : tool_args;
-    return init_tools;
-  }
-};
-
-namespace Impl {
-
-/* ExecSpaceManager - Responsible for initializing all of the registered
- * backends. Backends are registered using the register_space_initializer()
- * function which should be called from a global context so that it is called
- * prior to initialize_spaces() which is called from Kokkos::initialize()
- */
-class ExecSpaceManager {
-  std::map<std::string, std::unique_ptr<ExecSpaceInitializerBase>>
-      exec_space_factory_list;
-
- public:
-  ExecSpaceManager() = default;
-
-  void register_space_factory(std::string name,
-                              std::unique_ptr<ExecSpaceInitializerBase> ptr);
-  void initialize_spaces(const Kokkos::InitArguments& args);
-  void finalize_spaces();
-  void static_fence();
-  void static_fence(const std::string&);
-  void print_configuration(std::ostream& msg, const bool detail);
-  static ExecSpaceManager& get_instance();
-};
-
-template <class SpaceInitializerType>
-int initialize_space_factory(std::string name) {
-  auto space_ptr = std::make_unique<SpaceInitializerType>();
-  ExecSpaceManager::get_instance().register_space_factory(name,
-                                                          std::move(space_ptr));
-  return 1;
-}
-
-}  // namespace Impl
 void initialize(int& narg, char* arg[]);
 
 void initialize(InitArguments args = InitArguments());

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -267,9 +267,6 @@ struct verify_space<DstMemorySpace, SrcMemorySpace, false> {
 };
 #endif
 
-// Base class for exec space initializer factories
-class ExecSpaceInitializerBase;
-
 }  // namespace Impl
 
 namespace Experimental {

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -62,8 +62,8 @@
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_MemoryTraits.hpp>
-#include <impl/Kokkos_ExecSpaceInitializer.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
+#include <impl/Kokkos_InitArguments.hpp>
 
 /*--------------------------------------------------------------------------*/
 
@@ -204,15 +204,6 @@ class Cuda {
   Cuda(cudaStream_t stream, bool manage_stream = false);
 
   //--------------------------------------------------------------------------
-  //! \name Device-specific functions
-  //@{
-
-  struct SelectDevice {
-    int cuda_device_id;
-    SelectDevice() : cuda_device_id(0) {}
-    explicit SelectDevice(int id) : cuda_device_id(id) {}
-  };
-
   //! Free any resources being consumed by the device.
   static void impl_finalize();
 
@@ -220,8 +211,7 @@ class Cuda {
   static int impl_is_initialized();
 
   //! Initialize, telling the CUDA run-time library which device to use.
-  static void impl_initialize(const SelectDevice         = SelectDevice(),
-                              const size_t num_instances = 1);
+  static void impl_initialize(InitArguments const&);
 
   /// \brief Cuda device architecture of the selected device.
   ///
@@ -266,17 +256,6 @@ struct DeviceTypeTraits<Cuda> {
 }  // namespace Tools
 
 namespace Impl {
-
-class CudaSpaceInitializer : public ExecSpaceInitializerBase {
- public:
-  CudaSpaceInitializer()  = default;
-  ~CudaSpaceInitializer() = default;
-  void initialize(const InitArguments& args) final;
-  void finalize(const bool all_spaces) final;
-  void fence() final;
-  void fence(const std::string&) final;
-  void print_configuration(std::ostream& msg, const bool detail) final;
-};
 
 template <class DT, class... DP>
 struct ZeroMemset<Kokkos::Cuda, DT, DP...> {

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -61,8 +61,8 @@
 #include <HIP/Kokkos_HIP_Error.hpp>  // HIP_SAFE_CALL
 
 #include <impl/Kokkos_Profiling_Interface.hpp>
-#include <impl/Kokkos_ExecSpaceInitializer.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
+#include <impl/Kokkos_InitArguments.hpp>
 
 #include <hip/hip_runtime_api.h>
 /*--------------------------------------------------------------------------*/
@@ -536,16 +536,10 @@ class HIP {
   /** \brief  Initialize the device.
    *
    */
-  struct SelectDevice {
-    int hip_device_id;
-    SelectDevice() : hip_device_id(0) {}
-    explicit SelectDevice(int id) : hip_device_id(id) {}
-  };
-
   int hip_device() const;
   static hipDeviceProp_t const& hip_device_prop();
 
-  static void impl_initialize(const SelectDevice = SelectDevice());
+  static void impl_initialize(InitArguments const&);
 
   static int impl_is_initialized();
 
@@ -579,18 +573,6 @@ struct DeviceTypeTraits<Kokkos::Experimental::HIP> {
 }  // namespace Tools
 
 namespace Impl {
-
-class HIPSpaceInitializer : public Kokkos::Impl::ExecSpaceInitializerBase {
- public:
-  HIPSpaceInitializer()  = default;
-  ~HIPSpaceInitializer() = default;
-  void initialize(const InitArguments& args) final;
-  void finalize(const bool) final;
-  void fence() final;
-  void fence(const std::string&) final;
-  void print_configuration(std::ostream& msg, const bool detail) final;
-};
-
 template <class DT, class... DP>
 struct ZeroMemset<Kokkos::Experimental::HIP, DT, DP...> {
   ZeroMemset(const Kokkos::Experimental::HIP& exec_space,

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -68,7 +68,7 @@
 #include <impl/Kokkos_FunctorAnalysis.hpp>
 #include <impl/Kokkos_Tools.hpp>
 #include <impl/Kokkos_TaskQueue.hpp>
-#include <impl/Kokkos_ExecSpaceInitializer.hpp>
+#include <impl/Kokkos_InitArguments.hpp>
 
 #include <KokkosExp_MDRangePolicy.hpp>
 
@@ -279,9 +279,12 @@ class HPX {
   HPX() noexcept {}
 #endif
 
-  static void print_configuration(std::ostream &,
+  static void print_configuration(std::ostream &os,
                                   const bool /* verbose */ = false) {
-    std::cout << "HPX backend" << std::endl;
+    os << "HPX backend\n";
+    os << "HPX Execution Space:\n";
+    os << "  KOKKOS_ENABLE_HPX: yes\n";
+    os << "\nHPX Runtime Configuration:\n";
   }
   uint32_t impl_instance_id() const noexcept { return m_instance_id; }
 
@@ -384,7 +387,7 @@ class HPX {
 #endif
 
   static int concurrency();
-  static void impl_initialize(int thread_count);
+  static void impl_initialize(InitArguments const &args);
   static void impl_initialize();
   static bool impl_is_initialized() noexcept;
   static void impl_finalize();
@@ -499,17 +502,6 @@ struct DeviceTypeTraits<Kokkos::Experimental::HPX> {
 }  // namespace Tools
 
 namespace Impl {
-
-class HPXSpaceInitializer : public ExecSpaceInitializerBase {
- public:
-  HPXSpaceInitializer()  = default;
-  ~HPXSpaceInitializer() = default;
-  void initialize(const InitArguments &args) final;
-  void finalize(const bool) final;
-  void fence() final;
-  void fence(const std::string &) final;
-  void print_configuration(std::ostream &msg, const bool detail) final;
-};
 
 #if defined(KOKKOS_ENABLE_HPX_ASYNC_DISPATCH)
 template <typename Closure>

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -64,7 +64,7 @@
 #include <Kokkos_Layout.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
-#include <impl/Kokkos_ExecSpaceInitializer.hpp>
+#include <impl/Kokkos_InitArguments.hpp>
 
 #include <vector>
 
@@ -193,21 +193,6 @@ struct DeviceTypeTraits<OpenMP> {
 };
 }  // namespace Experimental
 }  // namespace Tools
-
-namespace Impl {
-
-class OpenMPSpaceInitializer : public ExecSpaceInitializerBase {
- public:
-  OpenMPSpaceInitializer()  = default;
-  ~OpenMPSpaceInitializer() = default;
-  void initialize(const InitArguments& args) final;
-  void finalize(const bool) final;
-  void fence() final;
-  void fence(const std::string&) final;
-  void print_configuration(std::ostream& msg, const bool detail) final;
-};
-
-}  // namespace Impl
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/Kokkos_OpenMPTarget.hpp
+++ b/core/src/Kokkos_OpenMPTarget.hpp
@@ -59,8 +59,8 @@
 #include <Kokkos_TaskScheduler.hpp>
 #include <Kokkos_Layout.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
+#include <impl/Kokkos_InitArguments.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>
-#include <impl/Kokkos_ExecSpaceInitializer.hpp>
 /*--------------------------------------------------------------------------*/
 
 namespace Kokkos {
@@ -104,13 +104,13 @@ class OpenMPTarget {
   static const char* name();
 
   //! Free any resources being consumed by the device.
-  void impl_finalize();
+  static void impl_finalize();
 
   //! Has been initialized
   static int impl_is_initialized();
 
   //! Initialize, telling the CUDA run-time library which device to use.
-  void impl_initialize();
+  static void impl_initialize(InitArguments const&);
 
   inline Impl::OpenMPTargetInternal* impl_internal_space_instance() const {
     return m_space_instance;
@@ -147,21 +147,6 @@ struct DeviceTypeTraits<::Kokkos::Experimental::OpenMPTarget> {
 };
 }  // namespace Experimental
 }  // namespace Tools
-
-namespace Impl {
-
-class OpenMPTargetSpaceInitializer : public ExecSpaceInitializerBase {
- public:
-  OpenMPTargetSpaceInitializer()  = default;
-  ~OpenMPTargetSpaceInitializer() = default;
-  void initialize(const InitArguments& args) final;
-  void finalize(const bool) final;
-  void fence() final;
-  void fence(const std::string&) final;
-  void print_configuration(std::ostream& msg, const bool detail) final;
-};
-
-}  // namespace Impl
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -52,9 +52,9 @@
 #include <Kokkos_SYCL_Space.hpp>
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_ScratchSpace.hpp>
-#include <impl/Kokkos_ExecSpaceInitializer.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
+#include <impl/Kokkos_InitArguments.hpp>
 
 namespace Kokkos {
 namespace Experimental {
@@ -142,7 +142,7 @@ class SYCL {
     sycl::device m_device;
   };
 
-  static void impl_initialize(SYCLDevice = SYCLDevice());
+  static void impl_initialize(InitArguments const&);
 
   int sycl_device() const;
 
@@ -162,18 +162,6 @@ class SYCL {
   Kokkos::Impl::HostSharedPtr<Impl::SYCLInternal> m_space_instance;
 };
 
-namespace Impl {
-
-class SYCLSpaceInitializer : public Kokkos::Impl::ExecSpaceInitializerBase {
- public:
-  void initialize(const InitArguments& args) final;
-  void finalize(const bool) final;
-  void fence() final;
-  void fence(const std::string&) final;
-  void print_configuration(std::ostream& msg, const bool detail) final;
-};
-
-}  // namespace Impl
 }  // namespace Experimental
 
 namespace Tools {

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -65,8 +65,8 @@
 #include <impl/Kokkos_HostThreadTeam.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
 #include <impl/Kokkos_Tools.hpp>
-#include <impl/Kokkos_ExecSpaceInitializer.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
+#include <impl/Kokkos_InitArguments.hpp>
 
 #include <KokkosExp_MDRangePolicy.hpp>
 
@@ -175,10 +175,23 @@ class Serial {
   static int concurrency() { return 1; }
 
   //! Print configuration information to the given output stream.
-  static void print_configuration(std::ostream&,
-                                  const bool /* detail */ = false) {}
+  static void print_configuration(std::ostream& os,
+                                  const bool /* detail */ = false) {
+    os << "Host Serial Execution Space:\n";
+    os << "  KOKKOS_ENABLE_SERIAL: yes\n";
 
-  static void impl_initialize();
+    os << "Serial Atomics:\n";
+    os << "  KOKKOS_ENABLE_SERIAL_ATOMICS: ";
+#ifdef KOKKOS_ENABLE_SERIAL_ATOMICS
+    os << "yes\n";
+#else
+    os << "no\n";
+#endif
+
+    os << "\nSerial Runtime Configuration:\n";
+  }
+
+  static void impl_initialize(InitArguments const&);
 
   static bool impl_is_initialized();
 
@@ -229,21 +242,6 @@ struct DeviceTypeTraits<Serial> {
 };
 }  // namespace Experimental
 }  // namespace Tools
-
-namespace Impl {
-
-class SerialSpaceInitializer : public ExecSpaceInitializerBase {
- public:
-  SerialSpaceInitializer()  = default;
-  ~SerialSpaceInitializer() = default;
-  void initialize(const InitArguments& args) final;
-  void finalize(const bool) final;
-  void fence() final;
-  void fence(const std::string&) final;
-  void print_configuration(std::ostream& msg, const bool detail) final;
-};
-
-}  // namespace Impl
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -57,7 +57,7 @@
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_MemoryTraits.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
-#include <impl/Kokkos_ExecSpaceInitializer.hpp>
+#include <impl/Kokkos_InitArguments.hpp>
 
 /*--------------------------------------------------------------------------*/
 
@@ -127,7 +127,7 @@ class Threads {
   //! \name Space-specific functions
   //@{
 
-  static void impl_initialize(int thread_count = -1);
+  static void impl_initialize(InitArguments const&);
 
   static int impl_is_initialized();
 
@@ -168,21 +168,6 @@ struct DeviceTypeTraits<Threads> {
 };
 }  // namespace Experimental
 }  // namespace Tools
-
-namespace Impl {
-
-class ThreadsSpaceInitializer : public ExecSpaceInitializerBase {
- public:
-  ThreadsSpaceInitializer()  = default;
-  ~ThreadsSpaceInitializer() = default;
-  void initialize(const InitArguments& args) final;
-  void finalize(const bool) final;
-  void fence() final;
-  void fence(const std::string&) final;
-  void print_configuration(std::ostream& msg, const bool detail) final;
-};
-
-}  // namespace Impl
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
@@ -53,6 +53,7 @@
 #include <Kokkos_OpenMPTarget.hpp>
 #include <OpenMPTarget/Kokkos_OpenMPTarget_UniqueToken.hpp>
 #include <OpenMPTarget/Kokkos_OpenMPTarget_Instance.hpp>
+#include <impl/Kokkos_ExecSpaceManager.hpp>
 
 #include <sstream>
 
@@ -133,9 +134,13 @@ OpenMPTarget::OpenMPTarget()
 const char* OpenMPTarget::name() {
   return Impl::OpenMPTargetInternal::impl_singleton()->name();
 }
-void OpenMPTarget::print_configuration(std::ostream& stream,
-                                       const bool detail) {
-  m_space_instance->print_configuration(stream, detail);
+void OpenMPTarget::print_configuration(std::ostream& os, const bool detail) {
+  msg << "OpenMPTarget Execution Space:\n";
+  msg << "  KOKKOS_ENABLE_OPENMPTARGET: yes\n";
+
+  msg << "\nOpenMPTarget Runtime Configuration:\n";
+
+  m_space_instance->print_configuration(os, detail);
 }
 
 uint32_t OpenMPTarget::impl_instance_id() const noexcept {
@@ -162,8 +167,12 @@ void OpenMPTarget::impl_static_fence(const std::string& name) {
       name, Kokkos::Experimental::Impl::openmp_fence_is_static::yes);
 }
 
-void OpenMPTarget::impl_initialize() { m_space_instance->impl_initialize(); }
-void OpenMPTarget::impl_finalize() { m_space_instance->impl_finalize(); }
+void OpenMPTarget::impl_initialize(InitArguments const&) {
+  Impl::OpenMPTargetInternal::impl_singleton()->impl_initialize();
+}
+void OpenMPTarget::impl_finalize() {
+  Impl::OpenMPTargetInternal::impl_singleton()->impl_finalize();
+}
 int OpenMPTarget::impl_is_initialized() {
   return Impl::OpenMPTargetInternal::impl_singleton()->impl_is_initialized();
 }
@@ -171,51 +180,7 @@ int OpenMPTarget::impl_is_initialized() {
 
 namespace Impl {
 int g_openmptarget_space_factory_initialized =
-    Kokkos::Impl::initialize_space_factory<OpenMPTargetSpaceInitializer>(
-        "160_OpenMPTarget");
-
-void OpenMPTargetSpaceInitializer::initialize(const InitArguments& args) {
-  // Prevent "unused variable" warning for 'args' input struct.  If
-  // Serial::initialize() ever needs to take arguments from the input
-  // struct, you may remove this line of code.
-  (void)args;
-
-  if (std::is_same<Kokkos::Experimental::OpenMPTarget,
-                   Kokkos::DefaultExecutionSpace>::value) {
-    Kokkos::Experimental::OpenMPTarget().impl_initialize();
-    // std::cout << "Kokkos::initialize() fyi: OpenMP enabled and initialized"
-    // << std::endl ;
-  } else {
-    // std::cout << "Kokkos::initialize() fyi: OpenMP enabled but not
-    // initialized" << std::endl ;
-  }
-}
-
-void OpenMPTargetSpaceInitializer::finalize(const bool all_spaces) {
-  if (std::is_same<Kokkos::Experimental::OpenMPTarget,
-                   Kokkos::DefaultExecutionSpace>::value ||
-      all_spaces) {
-    if (Kokkos::Experimental::OpenMPTarget().impl_is_initialized())
-      Kokkos::Experimental::OpenMPTarget().impl_finalize();
-  }
-}
-
-void OpenMPTargetSpaceInitializer::fence() {
-  Kokkos::Experimental::OpenMPTarget::impl_static_fence();
-}
-void OpenMPTargetSpaceInitializer::fence(const std::string& name) {
-  Kokkos::Experimental::OpenMPTarget::impl_static_fence(name);
-}
-
-void OpenMPTargetSpaceInitializer::print_configuration(std::ostream& msg,
-                                                       const bool detail) {
-  msg << "OpenMPTarget Execution Space:" << std::endl;
-  msg << "  KOKKOS_ENABLE_OPENMPTARGET: ";
-  msg << "yes" << std::endl;
-
-  msg << "\nOpenMPTarget Runtime Configuration:" << std::endl;
-  Kokkos::Experimental::OpenMPTarget().print_configuration(msg, detail);
-}
+    Kokkos::Impl::initialize_space_factory<OpenMPTarget>("160_OpenMPTarget");
 
 }  // namespace Impl
 }  // Namespace Kokkos

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -57,6 +57,7 @@
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_CPUDiscovery.hpp>
 #include <impl/Kokkos_Tools.hpp>
+#include <impl/Kokkos_ExecSpaceManager.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -659,7 +660,7 @@ void ThreadsExec::initialize(int thread_count_arg) {
 
     for (unsigned ith = thread_spawn_begin; ith < thread_count; ++ith) {
       // Try to protect against cache coherency failure by casting to volatile.
-      ThreadsExec *const th = ((ThreadsExec * volatile *)s_threads_exec)[ith];
+      ThreadsExec *const th = ((ThreadsExec *volatile *)s_threads_exec)[ith];
       if (th) {
         wait_yield(th->m_pool_state, ThreadsExec::Active);
       } else {
@@ -837,36 +838,7 @@ const char *Threads::name() { return "Threads"; }
 namespace Impl {
 
 int g_threads_space_factory_initialized =
-    initialize_space_factory<ThreadsSpaceInitializer>("050_Threads");
-
-void ThreadsSpaceInitializer::initialize(const InitArguments &args) {
-  Kokkos::Threads::impl_initialize(args.num_threads);
-}
-
-void ThreadsSpaceInitializer::finalize(const bool all_spaces) {
-  if (std::is_same<Kokkos::Threads, Kokkos::DefaultExecutionSpace>::value ||
-      std::is_same<Kokkos::Threads,
-                   Kokkos::HostSpace::execution_space>::value ||
-      all_spaces) {
-    if (Kokkos::Threads::impl_is_initialized())
-      Kokkos::Threads::impl_finalize();
-  }
-}
-
-void ThreadsSpaceInitializer::fence() { Kokkos::Threads::impl_static_fence(); }
-void ThreadsSpaceInitializer::fence(const std::string &name) {
-  Kokkos::Threads::impl_static_fence(name);
-}
-
-void ThreadsSpaceInitializer::print_configuration(std::ostream &msg,
-                                                  const bool detail) {
-  msg << "Host Parallel Execution Space:" << std::endl;
-  msg << "  KOKKOS_ENABLE_THREADS: ";
-  msg << "yes" << std::endl;
-
-  msg << "\nThreads Runtime Configuration:" << std::endl;
-  Kokkos::Threads::print_configuration(msg, detail);
-}
+    initialize_space_factory<Threads>("050_Threads");
 
 }  // namespace Impl
 

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -616,13 +616,18 @@ inline int Threads::impl_is_initialized() {
   return Impl::ThreadsExec::is_initialized();
 }
 
-inline void Threads::impl_initialize(int thread_count) {
-  Impl::ThreadsExec::initialize(thread_count);
+inline void Threads::impl_initialize(InitArguments const &args) {
+  Impl::ThreadsExec::initialize(args.num_threads);
 }
 
 inline void Threads::impl_finalize() { Impl::ThreadsExec::finalize(); }
 
 inline void Threads::print_configuration(std::ostream &s, const bool detail) {
+  s << "Host Parallel Execution Space:" << std::endl;
+  s << "  KOKKOS_ENABLE_THREADS: ";
+  s << "yes" << std::endl;
+
+  s << "\nThreads Runtime Configuration:" << std::endl;
   Impl::ThreadsExec::print_configuration(s, detail);
 }
 

--- a/core/src/impl/Kokkos_ExecSpaceManager.hpp
+++ b/core/src/impl/Kokkos_ExecSpaceManager.hpp
@@ -1,0 +1,114 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_EXEC_SPACE_MANAGER_HPP
+#define KOKKOS_EXEC_SPACE_MANAGER_HPP
+
+#include <impl/Kokkos_InitArguments.hpp>
+
+#include <iosfwd>
+#include <map>
+#include <string>
+
+namespace Kokkos {
+namespace Impl {
+
+struct ExecSpaceFooBase {
+  virtual void initialize(InitArguments const&)                    = 0;
+  virtual void finalize()                                          = 0;
+  virtual void fence()                                             = 0;
+  virtual void fence(std::string)                                  = 0;
+  virtual void print_configuration(std::ostream& msg, bool detail) = 0;
+  virtual ~ExecSpaceFooBase()                                      = default;
+};
+
+template <class ExecutionSpace>
+struct ExecSpaceFooDerived : ExecSpaceFooBase {
+  void initialize(InitArguments const& args) final {
+    ExecutionSpace::impl_initialize(args);
+  }
+  void finalize() final { ExecutionSpace::impl_finalize(); }
+  void fence() final { ExecutionSpace().fence(); }
+  void fence(std::string label) final {
+    ExecutionSpace().fence(std::move(label));
+  }
+  void print_configuration(std::ostream& msg, bool detail) final {
+    ExecutionSpace::print_configuration(msg, detail);
+  }
+};
+
+/* ExecSpaceManager - Responsible for initializing all the registered
+ * backends. Backends are registered using the register_space_initializer()
+ * function which should be called from a global context so that it is called
+ * prior to initialize_spaces() which is called from Kokkos::initialize()
+ */
+class ExecSpaceManager {
+  std::map<std::string, std::unique_ptr<ExecSpaceFooBase>>
+      exec_space_factory_list;
+
+ public:
+  ExecSpaceManager() = default;
+
+  void register_space_factory(std::string name,
+                              std::unique_ptr<ExecSpaceFooBase> ptr);
+  void initialize_spaces(const Kokkos::InitArguments& args);
+  void finalize_spaces();
+  void static_fence();
+  void static_fence(const std::string&);
+  void print_configuration(std::ostream& msg, const bool detail);
+  static ExecSpaceManager& get_instance();
+};
+
+template <class ExecutionSpace>
+int initialize_space_factory(std::string name) {
+  auto space_ptr = std::make_unique<ExecSpaceFooDerived<ExecutionSpace>>();
+  ExecSpaceManager::get_instance().register_space_factory(name,
+                                                          std::move(space_ptr));
+  return 1;
+}
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif

--- a/core/src/impl/Kokkos_InitArguments.hpp
+++ b/core/src/impl/Kokkos_InitArguments.hpp
@@ -41,27 +41,41 @@
 // ************************************************************************
 //@HEADER
 */
+#ifndef KOKKOS_INIT_ARGUMENTS_HPP
+#define KOKKOS_INIT_ARGUMENTS_HPP
 
-#ifndef KOKKOS_EXEC_SPACE_INITIALIZER_HPP
-#define KOKKOS_EXEC_SPACE_INITIALIZER_HPP
-
-#include <iosfwd>
+#include <string>
 
 namespace Kokkos {
-namespace Impl {
 
-class ExecSpaceInitializerBase {
- public:
-  virtual void initialize(const InitArguments &args)                     = 0;
-  virtual void finalize(const bool all_spaces)                           = 0;
-  virtual void fence()                                                   = 0;
-  virtual void fence(const std::string &)                                = 0;
-  virtual void print_configuration(std::ostream &msg, const bool detail) = 0;
-  ExecSpaceInitializerBase()          = default;
-  virtual ~ExecSpaceInitializerBase() = default;
+namespace Tools {
+struct InitArguments;
+}
+
+struct InitArguments {
+  int num_threads;
+  int num_numa;
+  int device_id;
+  int ndevices;
+  int skip_device;
+  bool disable_warnings;
+  bool tune_internals;
+  bool tool_help        = false;
+  std::string tool_lib  = {};
+  std::string tool_args = {};
+
+  InitArguments(int nt = -1, int nn = -1, int dv = -1, bool dw = false,
+                bool ti = false)
+      : num_threads{nt},
+        num_numa{nn},
+        device_id{dv},
+        ndevices{-1},
+        skip_device{9999},
+        disable_warnings{dw},
+        tune_internals{ti} {}
+
+  Tools::InitArguments impl_get_tools_init_arguments() const;
 };
 
-}  // namespace Impl
-}  // namespace Kokkos
-
-#endif  // KOKKOS_EXEC_SPACE_INITIALIZER_HPP
+}
+#endif

--- a/core/src/impl/Kokkos_Serial.cpp
+++ b/core/src/impl/Kokkos_Serial.cpp
@@ -50,6 +50,7 @@
 #include <Kokkos_Serial.hpp>
 #include <impl/Kokkos_Traits.hpp>
 #include <impl/Kokkos_Error.hpp>
+#include <impl/Kokkos_ExecSpaceManager.hpp>
 
 #include <impl/Kokkos_SharedAlloc.hpp>
 #include <sstream>
@@ -182,7 +183,7 @@ bool Serial::impl_is_initialized() {
   return Impl::SerialInternal::singleton().is_initialized();
 }
 
-void Serial::impl_initialize() {
+void Serial::impl_initialize(InitArguments const&) {
   Impl::SerialInternal::singleton().initialize();
 }
 
@@ -193,44 +194,7 @@ const char* Serial::name() { return "Serial"; }
 namespace Impl {
 
 int g_serial_space_factory_initialized =
-    initialize_space_factory<SerialSpaceInitializer>("100_Serial");
-
-void SerialSpaceInitializer::initialize(const InitArguments& args) {
-  // Prevent "unused variable" warning for 'args' input struct.  If
-  // Serial::initialize() ever needs to take arguments from the input
-  // struct, you may remove this line of code.
-  (void)args;
-
-  // Always initialize Serial if it is configure time enabled
-  Kokkos::Serial::impl_initialize();
-}
-
-void SerialSpaceInitializer::finalize(const bool) {
-  if (Kokkos::Serial::impl_is_initialized()) Kokkos::Serial::impl_finalize();
-}
-
-void SerialSpaceInitializer::fence() { Kokkos::Serial::impl_static_fence(); }
-void SerialSpaceInitializer::fence(const std::string& name) {
-  Kokkos::Serial::impl_static_fence(name);
-}
-
-void SerialSpaceInitializer::print_configuration(std::ostream& msg,
-                                                 const bool detail) {
-  msg << "Host Serial Execution Space:" << std::endl;
-  msg << "  KOKKOS_ENABLE_SERIAL: ";
-  msg << "yes" << std::endl;
-
-  msg << "Serial Atomics:" << std::endl;
-  msg << "  KOKKOS_ENABLE_SERIAL_ATOMICS: ";
-#ifdef KOKKOS_ENABLE_SERIAL_ATOMICS
-  msg << "yes" << std::endl;
-#else
-  msg << "no" << std::endl;
-#endif
-
-  msg << "\nSerial Runtime Configuration:" << std::endl;
-  Serial::print_configuration(msg, detail);
-}
+    initialize_space_factory<Serial>("100_Serial");
 
 }  // namespace Impl
 


### PR DESCRIPTION
* Remove `ExecSpaceInitializerBase` and derived classes in each backend.
* Move `InitArguments` to its own header to resolve some nonsense circular dependency issues.
* `ExecutionSpace::impl_initialize(InitArguments const&)`

This is not ready for review.  I am opening mainly to get help on individual backends.