### PR TITLE
Cleanup/rework fence overloads

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -913,13 +913,7 @@ void Cuda::print_configuration(std::ostream &s, const bool) {
 void Cuda::impl_static_fence(const std::string &name) {
   Kokkos::Impl::cuda_device_synchronize(name);
 }
-void Cuda::impl_static_fence() {
-  impl_static_fence("Kokkos::Cuda::impl_static_fence(): Unnamed Static Fence");
-}
 
-void Cuda::fence() const {
-  fence("Kokkos::Cuda::fence(): Unnamed Instance Fence");
-}
 void Cuda::fence(const std::string &name) const {
   m_space_instance->fence(name);
 }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -956,13 +956,7 @@ void CudaSpaceInitializer::finalize(bool all_spaces) {
   }
 }
 
-void CudaSpaceInitializer::fence() {
-  Kokkos::Cuda::impl_static_fence(
-      "Kokkos::CudaSpaceInitializer::fence: Initializer Fence");
-}
 void CudaSpaceInitializer::fence(const std::string &name) {
-  // Kokkos::Cuda::impl_static_fence("Kokkos::CudaSpaceInitializer::fence:
-  // "+name); //TODO: or this
   Kokkos::Cuda::impl_static_fence(name);
 }
 

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -431,9 +431,6 @@ void HIPSpaceInitializer::finalize(const bool all_spaces) {
   }
 }
 
-void HIPSpaceInitializer::fence() {
-  Kokkos::Experimental::HIP::impl_static_fence();
-}
 void HIPSpaceInitializer::fence(const std::string& name) {
   Kokkos::Experimental::HIP::impl_static_fence(name);
 }

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -385,15 +385,9 @@ void HIP::impl_static_fence(const std::string& name) {
           GlobalDeviceSynchronization,
       [&]() { KOKKOS_IMPL_HIP_SAFE_CALL(hipDeviceSynchronize()); });
 }
-void HIP::impl_static_fence() {
-  impl_static_fence("Kokkos::HIP::impl_static_fence: Unnamed Static Fence");
-}
 
 void HIP::fence(const std::string& name) const {
   m_space_instance->fence(name);
-}
-void HIP::fence() const {
-  fence("Kokkos::HIP::fence(): Unnamed Instance Fence");
 }
 
 hipStream_t HIP::hip_stream() const { return m_space_instance->m_stream; }

--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -184,9 +184,6 @@ void HPXSpaceInitializer::finalize(const bool all_spaces) {
 void HPXSpaceInitializer::fence(const std::string &name) {
   Kokkos::Experimental::HPX::impl_static_fence(name);
 }
-void HPXSpaceInitializer::fence() {
-  Kokkos::Experimental::HPX::impl_static_fence();
-}
 
 void HPXSpaceInitializer::print_configuration(std::ostream &msg,
                                               const bool detail) {

--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -182,10 +182,10 @@ void HPXSpaceInitializer::finalize(const bool all_spaces) {
 }
 
 void HPXSpaceInitializer::fence(const std::string &name) {
-  Kokkos::Experimental::HPX::impl_fence_global(name);
+  Kokkos::Experimental::HPX::impl_static_fence(name);
 }
 void HPXSpaceInitializer::fence() {
-  Kokkos::Experimental::HPX::impl_fence_global();
+  Kokkos::Experimental::HPX::impl_static_fence();
 }
 
 void HPXSpaceInitializer::print_configuration(std::ostream &msg,

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -204,8 +204,7 @@ void push_finalize_hook(std::function<void()> f);
 KOKKOS_DEPRECATED void finalize_all();
 #endif
 
-void fence();
-void fence(const std::string&);
+void fence(const std::string& name /*= "Kokkos::fence: Unnamed Global Fence"*/);
 
 /** \brief Print "Bill of Materials" */
 void print_configuration(std::ostream&, const bool detail = false);

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -292,8 +292,7 @@ class LogicalMemorySpace;
 //----------------------------------------------------------------------------
 
 namespace Kokkos {
-void fence();
-void fence(const std::string &);
+void fence(const std::string &name = "Kokkos::fence: Unnamed Global Fence");
 }  // namespace Kokkos
 
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -183,11 +183,12 @@ class Cuda {
   /// return asynchronously, before the functor completes.  This
   /// method does not return until all dispatched functors on this
   /// device have completed.
-  static void impl_static_fence();
-  static void impl_static_fence(const std::string&);
+  static void impl_static_fence(
+      const std::string& name =
+          "Kokkos::Cuda::impl_static_fence(): Unnamed Static Fence");
 
-  void fence() const;
-  void fence(const std::string&) const;
+  void fence(const std::string& name =
+                 "Kokkos::Cuda::fence(): Unnamed Instance Fence") const;
 
   /** \brief  Return the maximum amount of concurrency.  */
   static int concurrency();

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -183,9 +183,7 @@ class Cuda {
   /// return asynchronously, before the functor completes.  This
   /// method does not return until all dispatched functors on this
   /// device have completed.
-  static void impl_static_fence(
-      const std::string& name =
-          "Kokkos::Cuda::impl_static_fence(): Unnamed Static Fence");
+  static void impl_static_fence(const std::string& name);
 
   void fence(const std::string& name =
                  "Kokkos::Cuda::fence(): Unnamed Instance Fence") const;

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -274,7 +274,6 @@ class CudaSpaceInitializer : public ExecSpaceInitializerBase {
   ~CudaSpaceInitializer() = default;
   void initialize(const InitArguments& args) final;
   void finalize(const bool all_spaces) final;
-  void fence() final;
   void fence(const std::string&) final;
   void print_configuration(std::ostream& msg, const bool detail) final;
 };

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -519,9 +519,7 @@ class HIP {
    * asynchronously, before the functor completes. This method does not return
    * until all dispatched functors on this device have completed.
    */
-  static void impl_static_fence(
-      const std::string& name =
-          "Kokkos::HIP::impl_static_fence: Unnamed Static Fence");
+  static void impl_static_fence(const std::string& name);
 
   void fence(const std::string& name =
                  "Kokkos::HIP::fence(): Unnamed Instance Fence") const;

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -587,7 +587,6 @@ class HIPSpaceInitializer : public Kokkos::Impl::ExecSpaceInitializerBase {
   ~HIPSpaceInitializer() = default;
   void initialize(const InitArguments& args) final;
   void finalize(const bool) final;
-  void fence() final;
   void fence(const std::string&) final;
   void print_configuration(std::ostream& msg, const bool detail) final;
 };

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -519,11 +519,12 @@ class HIP {
    * asynchronously, before the functor completes. This method does not return
    * until all dispatched functors on this device have completed.
    */
-  static void impl_static_fence();
-  static void impl_static_fence(const std::string&);
+  static void impl_static_fence(
+      const std::string& name =
+          "Kokkos::HIP::impl_static_fence: Unnamed Static Fence");
 
-  void fence() const;
-  void fence(const std::string&) const;
+  void fence(const std::string& name =
+                 "Kokkos::HIP::fence(): Unnamed Instance Fence") const;
 
   hipStream_t hip_stream() const;
 

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -308,9 +308,9 @@ class HPX {
   }
 #endif
 
-  void impl_fence_instance(const std::string &name =
-                               "Kokkos::Experimental::HPX::impl_fence_instance:"
-                               " Unnamed Instance Fence") const {
+  void fence(
+      const std::string &name =
+          "Kokkos::Experimental::HPX::fence: Unnamed Instance Fence") const {
     Kokkos::Tools::Experimental::Impl::profile_fence_event<
         Kokkos::Experimental::HPX>(
         name,
@@ -326,7 +326,9 @@ class HPX {
         });
   }
 
-  static void impl_fence_global(const std::string &name) {
+  static void impl_static_fence(const std::string &name =
+                                    "Kokkos::Experimental::HPX::impl_static_"
+                                    "fence: Unnamed Static Fence") {
     Kokkos::Tools::Experimental::Impl::profile_fence_event<
         Kokkos::Experimental::HPX>(
         name,
@@ -341,7 +343,7 @@ class HPX {
           // Reset the future to free variables that may have been captured in
           // parallel regions (however, we don't have access to futures from
           // instances other than the default instances, they will only be
-          // released by impl_fence_instance).
+          // released by fence).
           HPX().impl_get_future() = hpx::make_ready_future<void>();
 #endif
         });
@@ -349,17 +351,6 @@ class HPX {
 
   static hpx::execution::parallel_executor impl_get_executor() {
     return hpx::execution::parallel_executor();
-  }
-
-  void fence(
-      const std::string &name =
-          "Kokkos::Experimental::HPX::fence: Unnamed Instance Fence") const {
-    impl_fence_instance(name);
-  }
-  static void impl_static_fence(const std::string &name =
-                                    "Kokkos::Experimental::HPX::impl_static_"
-                                    "fence: Unnamed Static Fence") {
-    impl_fence_instance(name);
   }
 
   static bool is_asynchronous(HPX const & = HPX()) noexcept {

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -326,9 +326,7 @@ class HPX {
         });
   }
 
-  static void impl_static_fence(const std::string &name =
-                                    "Kokkos::Experimental::HPX::impl_static_"
-                                    "fence: Unnamed Static Fence") {
+  static void impl_static_fence(const std::string &name) {
     Kokkos::Tools::Experimental::Impl::profile_fence_event<
         Kokkos::Experimental::HPX>(
         name,

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -358,7 +358,7 @@ class HPX {
   }
   static void impl_static_fence(const std::string &name =
                                     "Kokkos::Experimental::HPX::impl_static_"
-                                    "fence: Unnamed Global Fence") {
+                                    "fence: Unnamed Static Fence") {
     impl_fence_instance(name);
   }
 

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -326,9 +326,7 @@ class HPX {
         });
   }
 
-  static void impl_fence_global(const std::string &name =
-                                    "Kokkos::Experimental::HPX::impl_fence_"
-                                    "global: Unnamed Global Fence") {
+  static void impl_fence_global(const std::string &name) {
     Kokkos::Tools::Experimental::Impl::profile_fence_event<
         Kokkos::Experimental::HPX>(
         name,
@@ -353,8 +351,16 @@ class HPX {
     return hpx::execution::parallel_executor();
   }
 
-  void fence() const { impl_fence_instance(); }
-  void fence(const std::string &name) const { impl_fence_instance(name); }
+  void fence(
+      const std::string &name =
+          "Kokkos::Experimental::HPX::fence: Unnamed Instance Fence") const {
+    impl_fence_instance(name);
+  }
+  static void impl_static_fence(const std::string &name =
+                                    "Kokkos::Experimental::HPX::impl_static_"
+                                    "fence: Unnamed Global Fence") {
+    impl_fence_instance(name);
+  }
 
   static bool is_asynchronous(HPX const & = HPX()) noexcept {
 #if defined(KOKKOS_ENABLE_HPX_ASYNC_DISPATCH)

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -503,7 +503,6 @@ class HPXSpaceInitializer : public ExecSpaceInitializerBase {
   ~HPXSpaceInitializer() = default;
   void initialize(const InitArguments &args) final;
   void finalize(const bool) final;
-  void fence() final;
   void fence(const std::string &) final;
   void print_configuration(std::ostream &msg, const bool detail) final;
 };

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -107,9 +107,7 @@ class OpenMP {
   /// \brief Wait until all dispatched functors complete on the given instance
   ///
   ///  This is a no-op on OpenMP
-  static void impl_static_fence(
-      std::string const& name =
-          "Kokkos::OpenMP::impl_static_fence: Unnamed Static Fence");
+  static void impl_static_fence(std::string const& name);
 
   void fence(std::string const& name =
                  "Kokkos::OpenMP::fence: Unnamed Instance Fence") const;

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -203,7 +203,6 @@ class OpenMPSpaceInitializer : public ExecSpaceInitializerBase {
   ~OpenMPSpaceInitializer() = default;
   void initialize(const InitArguments& args) final;
   void finalize(const bool) final;
-  void fence() final;
   void fence(const std::string&) final;
   void print_configuration(std::ostream& msg, const bool detail) final;
 };

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -107,11 +107,12 @@ class OpenMP {
   /// \brief Wait until all dispatched functors complete on the given instance
   ///
   ///  This is a no-op on OpenMP
-  static void impl_static_fence(OpenMP const&           = OpenMP(),
-                                const std::string& name = "") noexcept;
+  static void impl_static_fence(
+      std::string const& name =
+          "Kokkos::OpenMP::impl_static_fence: Unnamed Static Fence");
 
-  void fence() const;
-  void fence(const std::string& name) const;
+  void fence(std::string const& name =
+                 "Kokkos::OpenMP::fence: Unnamed Instance Fence") const;
 
   /// \brief Does the given instance return immediately after launching
   /// a parallel algorithm

--- a/core/src/Kokkos_OpenMPTarget.hpp
+++ b/core/src/Kokkos_OpenMPTarget.hpp
@@ -93,9 +93,7 @@ class OpenMPTarget {
   static void fence(const std::string& name =
                         "Kokkos::OpenMPTarget::fence: Unnamed Instance Fence");
 
-  static void impl_static_fence(
-      const std::string& name =
-          "Kokkos::OpenMPTarget::impl_static_fence: Unnamed Static Fence");
+  static void impl_static_fence(const std::string& name);
 
   /** \brief  Return the maximum amount of concurrency.  */
   static int concurrency();

--- a/core/src/Kokkos_OpenMPTarget.hpp
+++ b/core/src/Kokkos_OpenMPTarget.hpp
@@ -90,11 +90,13 @@ class OpenMPTarget {
 
   inline static bool in_parallel() { return omp_in_parallel(); }
 
-  static void fence();
-  static void fence(const std::string&);
+  static void fence(const std::string& name =
+                        "Kokkos::OpenMPTarget::fence: Unnamed Instance Fence");
 
-  static void impl_static_fence();
-  static void impl_static_fence(const std::string&);
+  static void impl_static_fence(
+      const std::string& name =
+          "Kokkos::OpenMPTarget::impl_static_fence: Unnamed Static Fence");
+
   /** \brief  Return the maximum amount of concurrency.  */
   static int concurrency();
 

--- a/core/src/Kokkos_OpenMPTarget.hpp
+++ b/core/src/Kokkos_OpenMPTarget.hpp
@@ -158,7 +158,6 @@ class OpenMPTargetSpaceInitializer : public ExecSpaceInitializerBase {
   ~OpenMPTargetSpaceInitializer() = default;
   void initialize(const InitArguments& args) final;
   void finalize(const bool) final;
-  void fence() final;
   void fence(const std::string&) final;
   void print_configuration(std::ostream& msg, const bool detail) final;
 };

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -111,10 +111,12 @@ class SYCL {
   static bool wake();
 
   /** \brief Wait until all dispatched functors complete. A noop for OpenMP. */
-  static void impl_static_fence();
-  static void impl_static_fence(const std::string&);
-  void fence() const;
-  void fence(const std::string&) const;
+  static void impl_static_fence(const std::string& name =
+                                    "Kokkos::Experimental::SYCL::impl_static_"
+                                    "fence: Unnamed Static Fence");
+  void fence(
+      const std::string& name =
+          "Kokkos::Experimental::SYCL::fence: Unnamed Instance Fence") const;
 
   /// \brief Print configuration information to the given output stream.
   void print_configuration(std::ostream&, const bool detail = false);

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -111,9 +111,8 @@ class SYCL {
   static bool wake();
 
   /** \brief Wait until all dispatched functors complete. A noop for OpenMP. */
-  static void impl_static_fence(const std::string& name =
-                                    "Kokkos::Experimental::SYCL::impl_static_"
-                                    "fence: Unnamed Static Fence");
+  static void impl_static_fence(const std::string& name);
+
   void fence(
       const std::string& name =
           "Kokkos::Experimental::SYCL::fence: Unnamed Instance Fence") const;

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -170,7 +170,6 @@ class SYCLSpaceInitializer : public Kokkos::Impl::ExecSpaceInitializerBase {
  public:
   void initialize(const InitArguments& args) final;
   void finalize(const bool) final;
-  void fence() final;
   void fence(const std::string&) final;
   void print_configuration(std::ostream& msg, const bool detail) final;
 };

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -150,11 +150,9 @@ class Serial {
   /// return asynchronously, before the functor completes.  This
   /// method does not return until all dispatched functors on this
   /// device have completed.
-  static void impl_static_fence() {
-    impl_static_fence(
-        "Kokkos::Serial::impl_static_fence: Unnamed Static Fence");
-  }
-  static void impl_static_fence(const std::string& name) {
+  static void impl_static_fence(
+      const std::string& name =
+          "Kokkos::Serial::impl_static_fence: Unnamed Static Fence") {
     Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Serial>(
         name,
         Kokkos::Tools::Experimental::SpecialSynchronizationCases::
@@ -163,8 +161,8 @@ class Serial {
     Kokkos::memory_fence();
   }
 
-  void fence() const { fence("Kokkos::Serial::fence: Unnamed Instance Fence"); }
-  void fence(const std::string& name) const {
+  void fence(const std::string& name =
+                 "Kokkos::Serial::fence: Unnamed Instance Fence") const {
     Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Serial>(
         name, Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{1},
         []() {});  // TODO: correct device ID

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -150,9 +150,7 @@ class Serial {
   /// return asynchronously, before the functor completes.  This
   /// method does not return until all dispatched functors on this
   /// device have completed.
-  static void impl_static_fence(
-      const std::string& name =
-          "Kokkos::Serial::impl_static_fence: Unnamed Static Fence") {
+  static void impl_static_fence(const std::string& name) {
     Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::Serial>(
         name,
         Kokkos::Tools::Experimental::SpecialSynchronizationCases::

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -236,7 +236,6 @@ class SerialSpaceInitializer : public ExecSpaceInitializerBase {
   ~SerialSpaceInitializer() = default;
   void initialize(const InitArguments& args) final;
   void finalize(const bool) final;
-  void fence() final;
   void fence(const std::string&) final;
   void print_configuration(std::ostream& msg, const bool detail) final;
 };

--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -178,7 +178,6 @@ class ThreadsSpaceInitializer : public ExecSpaceInitializerBase {
   ~ThreadsSpaceInitializer() = default;
   void initialize(const InitArguments& args) final;
   void finalize(const bool) final;
-  void fence() final;
   void fence(const std::string&) final;
   void print_configuration(std::ostream& msg, const bool detail) final;
 };

--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -107,11 +107,12 @@ class Threads {
   /// return asynchronously, before the functor completes.  This
   /// method does not return until all dispatched functors on this
   /// device have completed.
-  static void impl_static_fence();
-  static void impl_static_fence(const std::string& name);
+  static void impl_static_fence(
+      const std::string& name =
+          "Kokkos::Threads::impl_static_fence: Unnamed Static Fence");
 
-  void fence() const;
-  void fence(const std::string&) const;
+  void fence(const std::string& name =
+                 "Kokkos::Threads::fence: Unnamed Instance Fence") const;
 
   /** \brief  Return the maximum amount of concurrency.  */
   static int concurrency();

--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -107,9 +107,7 @@ class Threads {
   /// return asynchronously, before the functor completes.  This
   /// method does not return until all dispatched functors on this
   /// device have completed.
-  static void impl_static_fence(
-      const std::string& name =
-          "Kokkos::Threads::impl_static_fence: Unnamed Static Fence");
+  static void impl_static_fence(const std::string& name);
 
   void fence(const std::string& name =
                  "Kokkos::Threads::fence: Unnamed Instance Fence") const;

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -446,9 +446,6 @@ OpenMP OpenMP::create_instance(...) { return OpenMP(); }
 
 int OpenMP::concurrency() { return Impl::g_openmp_hardware_max_threads; }
 
-void OpenMP::fence() const {
-  fence("Kokkos::OpenMP::fence: Unnamed Instance Fence");
-}
 void OpenMP::fence(const std::string &name) const {
   Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::OpenMP>(
       name, Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{1}, []() {});
@@ -468,8 +465,9 @@ void OpenMPSpaceInitializer::finalize(const bool) {
 }
 
 void OpenMPSpaceInitializer::fence() { Kokkos::OpenMP::impl_static_fence(); }
+
 void OpenMPSpaceInitializer::fence(const std::string &name) {
-  Kokkos::OpenMP::impl_static_fence(OpenMP(), name);
+  Kokkos::OpenMP::impl_static_fence(name);
 }
 
 void OpenMPSpaceInitializer::print_configuration(std::ostream &msg,

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -464,8 +464,6 @@ void OpenMPSpaceInitializer::finalize(const bool) {
   if (Kokkos::OpenMP::impl_is_initialized()) Kokkos::OpenMP::impl_finalize();
 }
 
-void OpenMPSpaceInitializer::fence() { Kokkos::OpenMP::impl_static_fence(); }
-
 void OpenMPSpaceInitializer::fence(const std::string &name) {
   Kokkos::OpenMP::impl_static_fence(name);
 }

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -167,8 +167,7 @@ int OpenMP::impl_thread_pool_rank() noexcept {
   KOKKOS_IF_ON_DEVICE((return -1;))
 }
 
-inline void OpenMP::impl_static_fence(OpenMP const& /**instance*/,
-                                      const std::string& name) noexcept {
+inline void OpenMP::impl_static_fence(std::string const& name) {
   Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::OpenMP>(
       name,
       Kokkos::Tools::Experimental::SpecialSynchronizationCases::

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
@@ -145,18 +145,11 @@ uint32_t OpenMPTarget::impl_instance_id() const noexcept {
 int OpenMPTarget::concurrency() {
   return Impl::OpenMPTargetInternal::impl_singleton()->concurrency();
 }
-void OpenMPTarget::fence() {
-  Impl::OpenMPTargetInternal::impl_singleton()->fence(
-      "Kokkos::OpenMPTarget::fence: Unnamed Instance Fence");
-}
+
 void OpenMPTarget::fence(const std::string& name) {
   Impl::OpenMPTargetInternal::impl_singleton()->fence(name);
 }
-void OpenMPTarget::impl_static_fence() {
-  Impl::OpenMPTargetInternal::impl_singleton()->fence(
-      "Kokkos::OpenMPTarget::fence: Unnamed Instance Fence",
-      Kokkos::Experimental::Impl::openmp_fence_is_static::yes);
-}
+
 void OpenMPTarget::impl_static_fence(const std::string& name) {
   Impl::OpenMPTargetInternal::impl_singleton()->fence(
       name, Kokkos::Experimental::Impl::openmp_fence_is_static::yes);

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
@@ -193,9 +193,6 @@ void OpenMPTargetSpaceInitializer::finalize(const bool all_spaces) {
   }
 }
 
-void OpenMPTargetSpaceInitializer::fence() {
-  Kokkos::Experimental::OpenMPTarget::impl_static_fence();
-}
 void OpenMPTargetSpaceInitializer::fence(const std::string& name) {
   Kokkos::Experimental::OpenMPTarget::impl_static_fence(name);
 }

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -302,9 +302,6 @@ void SYCLSpaceInitializer::finalize(const bool all_spaces) {
   }
 }
 
-void SYCLSpaceInitializer::fence() {
-  Kokkos::Experimental::SYCL::impl_static_fence();
-}
 void SYCLSpaceInitializer::fence(const std::string& name) {
   Kokkos::Experimental::SYCL::impl_static_fence(name);
 }

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -111,18 +111,11 @@ void SYCL::print_configuration(std::ostream& s, const bool detailed) {
     SYCL::impl_sycl_info(s, m_space_instance->m_queue->get_device());
 }
 
-void SYCL::fence() const {
-  fence("Kokkos::Experimental::SYCL::fence: Unnamed Instance Fence");
-}
 void SYCL::fence(const std::string& name) const {
   Impl::SYCLInternal::fence(*m_space_instance->m_queue, name,
                             impl_instance_id());
 }
 
-void SYCL::impl_static_fence() {
-  impl_static_fence(
-      "Kokkos::Experimental::SYCL::fence: Unnamed Instance Fence");
-}
 void SYCL::impl_static_fence(const std::string& name) {
   Kokkos::Tools::Experimental::Impl::profile_fence_event<
       Kokkos::Experimental::SYCL>(

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -850,7 +850,6 @@ void ThreadsSpaceInitializer::finalize(const bool all_spaces) {
   }
 }
 
-void ThreadsSpaceInitializer::fence() { Kokkos::Threads::impl_static_fence(); }
 void ThreadsSpaceInitializer::fence(const std::string &name) {
   Kokkos::Threads::impl_static_fence(name);
 }

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -807,9 +807,6 @@ void ThreadsExec::finalize() {
 namespace Kokkos {
 
 int Threads::concurrency() { return impl_thread_pool_size(0); }
-void Threads::fence() const {
-  Impl::ThreadsExec::internal_fence(Impl::fence_is_static::no);
-}
 void Threads::fence(const std::string &name) const {
   Impl::ThreadsExec::internal_fence(name, Impl::fence_is_static::no);
 }

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -297,7 +297,7 @@ void ThreadsExec::fence(const std::string &name) {
 void ThreadsExec::internal_fence(Impl::fence_is_static is_static) {
   internal_fence((is_static == Impl::fence_is_static::no)
                      ? "Kokkos::ThreadsExec::fence: Unnamed Instance Fence"
-                     : "Kokkos::ThreadsExec::fence: Unnamed Global Fence",
+                     : "Kokkos::ThreadsExec::fence: Unnamed Static Fence",
                  is_static);
 }
 

--- a/core/src/Threads/Kokkos_ThreadsExec.hpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.hpp
@@ -626,9 +626,6 @@ inline void Threads::print_configuration(std::ostream &s, const bool detail) {
   Impl::ThreadsExec::print_configuration(s, detail);
 }
 
-inline void Threads::impl_static_fence() {
-  Impl::ThreadsExec::internal_fence(Impl::fence_is_static::yes);
-}
 inline void Threads::impl_static_fence(const std::string &name) {
   Impl::ThreadsExec::internal_fence(name, Impl::fence_is_static::yes);
 }

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -999,7 +999,6 @@ void finalize() { Impl::finalize_internal(); }
 KOKKOS_DEPRECATED void finalize_all() { Impl::finalize_internal(); }
 #endif
 
-void fence() { Impl::fence_internal("Kokkos::fence: Unnamed Global Fence"); }
 void fence(const std::string& name) { Impl::fence_internal(name); }
 
 void print_helper(std::ostringstream& out,

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -126,11 +126,6 @@ void ExecSpaceManager::finalize_spaces() {
   }
 }
 
-void ExecSpaceManager::static_fence() {
-  for (auto& to_fence : exec_space_factory_list) {
-    to_fence.second->fence();
-  }
-}
 void ExecSpaceManager::static_fence(const std::string& name) {
   for (auto& to_fence : exec_space_factory_list) {
     to_fence.second->fence(name);

--- a/core/src/impl/Kokkos_ExecSpaceInitializer.hpp
+++ b/core/src/impl/Kokkos_ExecSpaceInitializer.hpp
@@ -54,7 +54,6 @@ class ExecSpaceInitializerBase {
  public:
   virtual void initialize(const InitArguments &args)                     = 0;
   virtual void finalize(const bool all_spaces)                           = 0;
-  virtual void fence()                                                   = 0;
   virtual void fence(const std::string &)                                = 0;
   virtual void print_configuration(std::ostream &msg, const bool detail) = 0;
   ExecSpaceInitializerBase()          = default;

--- a/core/src/impl/Kokkos_Serial.cpp
+++ b/core/src/impl/Kokkos_Serial.cpp
@@ -209,7 +209,6 @@ void SerialSpaceInitializer::finalize(const bool) {
   if (Kokkos::Serial::impl_is_initialized()) Kokkos::Serial::impl_finalize();
 }
 
-void SerialSpaceInitializer::fence() { Kokkos::Serial::impl_static_fence(); }
 void SerialSpaceInitializer::fence(const std::string& name) {
   Kokkos::Serial::impl_static_fence(name);
 }


### PR DESCRIPTION
(Re-opening #5147 that I accidentally closed)

Yet another attempt to harmonize/simplify the interface of execution spaces.
These changes are necessary to write generic code in #5144

* Prefer default argument in `ExecutionSpace::fence` and "global" `fence`
* Remove `ExecutionSpace::impl_static_fence(void)`
* Provide (missing) `HPX::impl_static_fence`
* Drop leading execution space argument in `OpenMP::impl_static_fence`
* Remove `ExecSpaceInitializerBase::fence()` overload that takes no label argument