### PR TITLE
Finalize deep_copy_space early avoiding printing to std::cerr for Cuda

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -346,8 +346,9 @@ CudaInternal::~CudaInternal() {
 
 int CudaInternal::verify_is_initialized(const char *const label) const {
   if (m_cudaDev < 0) {
-    std::cerr << "Kokkos::Cuda::" << label << " : ERROR device not initialized"
-              << std::endl;
+    Kokkos::Impl::throw_runtime_exception(std::string("Kokkos::Cuda::") +
+                                          label +
+                                          " : ERROR device not initialized\n");
   }
   return 0 <= m_cudaDev;
 }

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -732,13 +732,22 @@ void CudaInternal::finalize() {
   if (was_finalized) return;
 
   was_finalized = true;
-  if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
-    // Only finalize this if we're the singleton
-    if (this == &singleton()) {
-      (void)Impl::cuda_global_unique_token_locks(true);
-      Impl::finalize_host_cuda_lock_arrays();
-    }
 
+  // Only finalize this if we're the singleton
+  if (this == &singleton()) {
+    (void)Impl::cuda_global_unique_token_locks(true);
+    Impl::finalize_host_cuda_lock_arrays();
+
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeHost(constantMemHostStaging));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventDestroy(constantMemReusable));
+    auto &deep_copy_space =
+        Kokkos::Impl::cuda_get_deep_copy_space(/*initialize*/ false);
+    if (deep_copy_space)
+      deep_copy_space->impl_internal_space_instance()->finalize();
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(cuda_get_deep_copy_stream()));
+  }
+
+  if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
     using RecordCuda = Kokkos::Impl::SharedAllocationRecord<CudaSpace>;
     using RecordHost =
         Kokkos::Impl::SharedAllocationRecord<CudaHostPinnedSpace>;
@@ -748,47 +757,36 @@ void CudaInternal::finalize() {
     RecordHost::decrement(RecordHost::get_record(m_scratchUnified));
     if (m_scratchFunctorSize > 0)
       RecordCuda::decrement(RecordCuda::get_record(m_scratchFunctor));
-
-    for (int i = 0; i < m_n_team_scratch; ++i) {
-      if (m_team_scratch_current_size[i] > 0)
-        Kokkos::kokkos_free<Kokkos::CudaSpace>(m_team_scratch_ptr[i]);
-    }
-
-    if (m_manage_stream && m_stream != nullptr)
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(m_stream));
-
-    m_cudaDev             = -1;
-    m_multiProcCount      = 0;
-    m_maxWarpCount        = 0;
-    m_maxBlock            = {0, 0, 0};
-    m_maxSharedWords      = 0;
-    m_scratchSpaceCount   = 0;
-    m_scratchFlagsCount   = 0;
-    m_scratchUnifiedCount = 0;
-    m_streamCount         = 0;
-    m_scratchSpace        = nullptr;
-    m_scratchFlags        = nullptr;
-    m_scratchUnified      = nullptr;
-    m_stream              = nullptr;
-    for (int i = 0; i < m_n_team_scratch; ++i) {
-      m_team_scratch_current_size[i] = 0;
-      m_team_scratch_ptr[i]          = nullptr;
-    }
-
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(m_scratch_locks));
-    m_scratch_locks = nullptr;
   }
 
-  // only destroy these if we're finalizing the singleton
-  if (this == &singleton()) {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeHost(constantMemHostStaging));
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventDestroy(constantMemReusable));
-    auto &deep_copy_space =
-        Kokkos::Impl::cuda_get_deep_copy_space(/*initialize*/ false);
-    if (deep_copy_space)
-      deep_copy_space->impl_internal_space_instance()->finalize();
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(cuda_get_deep_copy_stream()));
+  for (int i = 0; i < m_n_team_scratch; ++i) {
+    if (m_team_scratch_current_size[i] > 0)
+      Kokkos::kokkos_free<Kokkos::CudaSpace>(m_team_scratch_ptr[i]);
   }
+
+  if (m_manage_stream && m_stream != nullptr)
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(m_stream));
+
+  m_cudaDev             = -1;
+  m_multiProcCount      = 0;
+  m_maxWarpCount        = 0;
+  m_maxBlock            = {0, 0, 0};
+  m_maxSharedWords      = 0;
+  m_scratchSpaceCount   = 0;
+  m_scratchFlagsCount   = 0;
+  m_scratchUnifiedCount = 0;
+  m_streamCount         = 0;
+  m_scratchSpace        = nullptr;
+  m_scratchFlags        = nullptr;
+  m_scratchUnified      = nullptr;
+  m_stream              = nullptr;
+  for (int i = 0; i < m_n_team_scratch; ++i) {
+    m_team_scratch_current_size[i] = 0;
+    m_team_scratch_ptr[i]          = nullptr;
+  }
+
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(m_scratch_locks));
+  m_scratch_locks = nullptr;
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -346,9 +346,9 @@ CudaInternal::~CudaInternal() {
 
 int CudaInternal::verify_is_initialized(const char *const label) const {
   if (m_cudaDev < 0) {
-    Kokkos::Impl::throw_runtime_exception(std::string("Kokkos::Cuda::") +
-                                          label +
-                                          " : ERROR device not initialized\n");
+    Kokkos::abort((std::string("Kokkos::Cuda::") + label +
+                   " : ERROR device not initialized\n")
+                      .c_str());
   }
   return 0 <= m_cudaDev;
 }

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -175,9 +175,9 @@ HIPInternal::~HIPInternal() {
 
 int HIPInternal::verify_is_initialized(const char *const label) const {
   if (m_hipDev < 0) {
-    Kokkos::Impl::throw_runtime_exception(
-        std::string("Kokkos::Experimental::HIP::") + label +
-        " : ERROR device not initialized\n");
+    Kokkos::abort((std::string("Kokkos::Experimental::HIP::") + label +
+                   " : ERROR device not initialized\n")
+                      .c_str());
   }
   return 0 <= m_hipDev;
 }

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -175,8 +175,9 @@ HIPInternal::~HIPInternal() {
 
 int HIPInternal::verify_is_initialized(const char *const label) const {
   if (m_hipDev < 0) {
-    std::cerr << "Kokkos::Experimental::HIP::" << label
-              << " : ERROR device not initialized" << std::endl;
+    Kokkos::Impl::throw_runtime_exception(
+        std::string("Kokkos::Experimental::HIP::") + label +
+        " : ERROR device not initialized\n");
   }
   return 0 <= m_hipDev;
 }

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -422,10 +422,13 @@ void HIPInternal::finalize() {
   this->fence("Kokkos::HIPInternal::finalize: fence on finalization");
   was_finalized = true;
 
-  if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
-    if (this == &singleton())
-      (void)Kokkos::Impl::hip_global_unique_token_locks(true);
+  if (this == &singleton()) {
+    (void)Kokkos::Impl::hip_global_unique_token_locks(true);
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipHostFree(constantMemHostStaging));
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipEventDestroy(constantMemReusable));
+  }
 
+  if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
     using RecordHIP =
         Kokkos::Impl::SharedAllocationRecord<Kokkos::Experimental::HIPSpace>;
 
@@ -437,34 +440,29 @@ void HIPInternal::finalize() {
 
     if (m_manage_stream && m_stream != nullptr)
       KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamDestroy(m_stream));
-
-    m_hipDev                    = -1;
-    m_hipArch                   = -1;
-    m_multiProcCount            = 0;
-    m_maxWarpCount              = 0;
-    m_maxBlock                  = {0, 0, 0};
-    m_maxSharedWords            = 0;
-    m_maxShmemPerBlock          = 0;
-    m_scratchSpaceCount         = 0;
-    m_scratchFlagsCount         = 0;
-    m_scratchSpace              = nullptr;
-    m_scratchFlags              = nullptr;
-    m_stream                    = nullptr;
-    m_team_scratch_current_size = 0;
-    m_team_scratch_ptr          = nullptr;
-
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipFree(m_scratch_locks));
-    m_scratch_locks = nullptr;
   }
+
+  m_hipDev                    = -1;
+  m_hipArch                   = -1;
+  m_multiProcCount            = 0;
+  m_maxWarpCount              = 0;
+  m_maxBlock                  = {0, 0, 0};
+  m_maxSharedWords            = 0;
+  m_maxShmemPerBlock          = 0;
+  m_scratchSpaceCount         = 0;
+  m_scratchFlagsCount         = 0;
+  m_scratchSpace              = nullptr;
+  m_scratchFlags              = nullptr;
+  m_stream                    = nullptr;
+  m_team_scratch_current_size = 0;
+  m_team_scratch_ptr          = nullptr;
+
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipFree(m_scratch_locks));
+  m_scratch_locks = nullptr;
+
   if (nullptr != d_driverWorkArray) {
     KOKKOS_IMPL_HIP_SAFE_CALL(hipHostFree(d_driverWorkArray));
     d_driverWorkArray = nullptr;
-  }
-
-  // only destroy these if we're finalizing the singleton
-  if (this == &singleton()) {
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipHostFree(constantMemHostStaging));
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipEventDestroy(constantMemReusable));
   }
 }
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -73,8 +73,9 @@ SYCLInternal::~SYCLInternal() {
 
 int SYCLInternal::verify_is_initialized(const char* const label) const {
   if (!is_initialized()) {
-    std::cerr << "Kokkos::Experimental::SYCL::" << label
-              << " : ERROR device not initialized" << std::endl;
+    Kokkos::Impl::throw_runtime_exception(
+        std::string("Kokkos::Experimental::SYCL::") + label +
+        " : ERROR device not initialized\n");
   }
   return is_initialized();
 }

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -73,9 +73,9 @@ SYCLInternal::~SYCLInternal() {
 
 int SYCLInternal::verify_is_initialized(const char* const label) const {
   if (!is_initialized()) {
-    Kokkos::Impl::throw_runtime_exception(
-        std::string("Kokkos::Experimental::SYCL::") + label +
-        " : ERROR device not initialized\n");
+    Kokkos::abort((std::string("Kokkos::Experimental::SYCL::") + label +
+                   " : ERROR device not initialized\n")
+                      .c_str());
   }
   return is_initialized();
 }


### PR DESCRIPTION
We are currently printing an error message to `std::cerr` when finalizing `Cuda` execution spaces as the first commit shows.

The problem is that we are finalizing `deep_copy_space` since that needs to deallocate data which calls a fence on the default execution space and we check if the execution space has already unset `m_dev` at this point. Wd didn't see this so far, since we are only printing to `std::cerr` but not throwing an exception or aborting.
The proposed fix is to finalize `deep_copy_space` before unsettling `m_dev`.

While looking at this, I also found that some of the code in `finalize` is guarded by a check for scratch space which didn't make sense to me.

Throwing in `finalize` is debatable, of course, but makes the problem obvious (in the CI).
