### PR TITLE
Make memory allocated by hipHostMalloc coarse-grained

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -194,7 +194,7 @@ void* HIPHostPinnedSpace::impl_allocate(
   void* ptr = nullptr;
 
   auto const error_code =
-      hipHostMalloc(&ptr, arg_alloc_size, hipMemAttachGlobal);
+      hipHostMalloc(&ptr, arg_alloc_size, hipHostMallocNonCoherent);
   if (error_code != hipSuccess) {
     // This is the only way to clear the last error, which we should do here
     // since we're turning it into an exception here

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -193,7 +193,8 @@ void* HIPHostPinnedSpace::impl_allocate(
     const Kokkos::Tools::SpaceHandle arg_handle) const {
   void* ptr = nullptr;
 
-  auto const error_code = hipHostMalloc(&ptr, arg_alloc_size);
+  auto const error_code =
+      hipHostMalloc(&ptr, arg_alloc_size, hipMemAttachGlobal);
   if (error_code != hipSuccess) {
     // This is the only way to clear the last error, which we should do here
     // since we're turning it into an exception here

--- a/core/unit_test/hip/TestHIP_Memory_Requirements.cpp
+++ b/core/unit_test/hip/TestHIP_Memory_Requirements.cpp
@@ -76,8 +76,10 @@ bool checkMemoryCoarseGrainedness(HIPMemoryContainer const& container) {
 TEST(hip, memory_requirements) {
   // we want all user-facing memory in hip to be coarse grained. As of
   // today(07.01.22) the documentation is not reliable/correct, we test the
-  // memory on the device as well as the managed memory
+  // memory on the device and host
   KOKKOS_TEST_MEMORY_COARSEGRAINEDNESS(Kokkos::Experimental::HIPSpace, int, 10);
+  KOKKOS_TEST_MEMORY_COARSEGRAINEDNESS(Kokkos::Experimental::HIPHostPinnedSpace,
+                                       int, 10);
   KOKKOS_TEST_MEMORY_COARSEGRAINEDNESS(Kokkos::Experimental::HIPManagedSpace,
                                        int, 10);
 }


### PR DESCRIPTION
hipHostMalloc allocates fine grained memory per default. According to the documentation of AMD there is no way of calling MemAdvise on it to make it coarse-grained (Nevertheless, the memAdvise works on some combinations of driver and hardware).
To get coarse-grained memory on all AMD GPUs we can allocate with the MemAttachGlobal flag (I will ask someone at AMD just to make sure).

The tests that verify if we get the memory grained-ness we want in the Kokkos::Views is part of the already merged PR [5112](https://github.com/kokkos/kokkos/pull/5112) as it was important for the HIPManagedSpace.