### PR TITLE
Avoid some unnecessary fences in parallel_reduce/scan

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -409,12 +409,12 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           false);  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
-        m_policy.space().fence(
-            "Kokkos::Impl::ParallelReduce<Cuda, MDRangePolicy>::execute: "
-            "Result Not Device Accessible");
-
         if (m_result_ptr) {
           if (m_unified_space) {
+            m_policy.space().fence(
+                "Kokkos::Impl::ParallelReduce<Cuda, MDRangePolicy>::execute: "
+                "Result Not Device Accessible");
+
             const int count = Analysis::value_count(
                 ReducerConditional::select(m_functor, m_reducer));
             for (int i = 0; i < count; ++i) {
@@ -423,7 +423,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           } else {
             const int size = Analysis::value_size(
                 ReducerConditional::select(m_functor, m_reducer));
-            DeepCopy<HostSpace, CudaSpace>(m_result_ptr, m_scratch_space, size);
+            DeepCopy<HostSpace, CudaSpace>(m_policy.space(), m_result_ptr,
+                                           m_scratch_space, size);
           }
         }
       }

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -423,8 +423,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           } else {
             const int size = Analysis::value_size(
                 ReducerConditional::select(m_functor, m_reducer));
-            DeepCopy<HostSpace, CudaSpace>(m_policy.space(), m_result_ptr,
-                                           m_scratch_space, size);
+            DeepCopy<HostSpace, CudaSpace, Cuda>(m_policy.space(), m_result_ptr,
+                                                 m_scratch_space, size);
           }
         }
       }

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -406,12 +406,12 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
           false);  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
-        m_policy.space().fence(
-            "Kokkos::Impl::ParallelReduce<Cuda, RangePolicy>::execute: Result "
-            "Not Device Accessible");
-
         if (m_result_ptr) {
           if (m_unified_space) {
+            m_policy.space().fence(
+                "Kokkos::Impl::ParallelReduce<Cuda, RangePolicy>::execute: "
+                "Result "
+                "Not Device Accessible");
             const int count = Analysis::value_count(
                 ReducerConditional::select(m_functor, m_reducer));
             for (int i = 0; i < count; ++i) {
@@ -420,7 +420,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
           } else {
             const int size = Analysis::value_size(
                 ReducerConditional::select(m_functor, m_reducer));
-            DeepCopy<HostSpace, CudaSpace>(m_result_ptr, m_scratch_space, size);
+            DeepCopy<HostSpace, CudaSpace>(m_policy.space(), m_result_ptr,
+                                           m_scratch_space, size);
           }
         }
       }
@@ -1042,12 +1043,13 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
       const int size = Analysis::value_size(m_functor);
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
       if (m_run_serial)
-        DeepCopy<HostSpace, CudaSpace>(&m_returnvalue, m_scratch_space, size);
+        DeepCopy<HostSpace, CudaSpace>(m_policy.space(), &m_returnvalue,
+                                       m_scratch_space, size);
       else
 #endif
         DeepCopy<HostSpace, CudaSpace>(
-            &m_returnvalue, m_scratch_space + (grid_x - 1) * size / sizeof(int),
-            size);
+            m_policy.space(), &m_returnvalue,
+            m_scratch_space + (grid_x - 1) * size / sizeof(int), size);
     }
   }
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -420,8 +420,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
           } else {
             const int size = Analysis::value_size(
                 ReducerConditional::select(m_functor, m_reducer));
-            DeepCopy<HostSpace, CudaSpace>(m_policy.space(), m_result_ptr,
-                                           m_scratch_space, size);
+            DeepCopy<HostSpace, CudaSpace, Cuda>(m_policy.space(), m_result_ptr,
+                                                 m_scratch_space, size);
           }
         }
       }
@@ -1043,11 +1043,11 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
       const int size = Analysis::value_size(m_functor);
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
       if (m_run_serial)
-        DeepCopy<HostSpace, CudaSpace>(m_policy.space(), &m_returnvalue,
-                                       m_scratch_space, size);
+        DeepCopy<HostSpace, CudaSpace, Cuda>(m_policy.space(), &m_returnvalue,
+                                             m_scratch_space, size);
       else
 #endif
-        DeepCopy<HostSpace, CudaSpace>(
+        DeepCopy<HostSpace, CudaSpace, Cuda>(
             m_policy.space(), &m_returnvalue,
             m_scratch_space + (grid_x - 1) * size / sizeof(int), size);
     }

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -382,17 +382,11 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           m_policy.space().impl_internal_space_instance(),
           false);  // copy to device and execute
 
-      if (!m_result_ptr_device_accessible) {
-        m_policy.space().fence(
-            "Kokkos::Impl::ParallelReduce<MDRangePolicy,HIP>: fence because "
-            "reduction can't access result storage location");
-
-        if (m_result_ptr) {
-          const int size = Analysis::value_size(
-              ReducerConditional::select(m_functor, m_reducer));
-          DeepCopy<HostSpace, Experimental::HIPSpace>(m_result_ptr,
-                                                      m_scratch_space, size);
-        }
+      if (!m_result_ptr_device_accessible && m_result_ptr) {
+        const int size = Analysis::value_size(
+            ReducerConditional::select(m_functor, m_reducer));
+        DeepCopy<HostSpace, Experimental::HIPSpace>(
+            m_policy.space(), m_result_ptr, m_scratch_space, size);
       }
     } else {
       if (m_result_ptr) {

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -385,7 +385,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       if (!m_result_ptr_device_accessible && m_result_ptr) {
         const int size = Analysis::value_size(
             ReducerConditional::select(m_functor, m_reducer));
-        DeepCopy<HostSpace, Experimental::HIPSpace>(
+        DeepCopy<HostSpace, Experimental::HIPSpace, Experimental::HIP>(
             m_policy.space(), m_result_ptr, m_scratch_space, size);
       }
     } else {

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -381,17 +381,11 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
           m_policy.space().impl_internal_space_instance(),
           false);  // copy to device and execute
 
-      if (!m_result_ptr_device_accessible) {
-        m_policy.space().impl_internal_space_instance()->fence(
-            "Kokkos::Impl::ParallelReduce<RangePolicy,HIP>: fence because "
-            "reduction can't access result storage location");
-
-        if (m_result_ptr) {
-          const int size = Analysis::value_size(
-              ReducerConditional::select(m_functor, m_reducer));
-          DeepCopy<HostSpace, ::Kokkos::Experimental::HIPSpace>(
-              m_result_ptr, m_scratch_space, size);
-        }
+      if (!m_result_ptr_device_accessible && m_result_ptr) {
+        const int size = Analysis::value_size(
+            ReducerConditional::select(m_functor, m_reducer));
+        DeepCopy<HostSpace, ::Kokkos::Experimental::HIPSpace>(
+            m_policy.space(), m_result_ptr, m_scratch_space, size);
       }
     } else {
       if (m_result_ptr) {
@@ -737,7 +731,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
     if (nwork) {
       const int size = Base::Analysis::value_size(Base::m_functor);
       DeepCopy<HostSpace, Kokkos::Experimental::HIPSpace>(
-          &m_returnvalue,
+          Base::m_policy.space(), &m_returnvalue,
           Base::m_scratch_space + (Base::m_grid_x - 1) * size / sizeof(int),
           size);
     }

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -384,8 +384,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
       if (!m_result_ptr_device_accessible && m_result_ptr) {
         const int size = Analysis::value_size(
             ReducerConditional::select(m_functor, m_reducer));
-        DeepCopy<HostSpace, ::Kokkos::Experimental::HIPSpace>(
-            m_policy.space(), m_result_ptr, m_scratch_space, size);
+        DeepCopy<HostSpace, ::Kokkos::Experimental::HIPSpace,
+                 ::Kokkos::Experimental::HIP>(m_policy.space(), m_result_ptr,
+                                              m_scratch_space, size);
       }
     } else {
       if (m_result_ptr) {
@@ -730,7 +731,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
     const auto nwork = Base::m_policy.end() - Base::m_policy.begin();
     if (nwork) {
       const int size = Base::Analysis::value_size(Base::m_functor);
-      DeepCopy<HostSpace, Kokkos::Experimental::HIPSpace>(
+      DeepCopy<HostSpace, Kokkos::Experimental::HIPSpace,
+               Kokkos::Experimental::HIP>(
           Base::m_policy.space(), &m_returnvalue,
           Base::m_scratch_space + (Base::m_grid_x - 1) * size / sizeof(int),
           size);

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -715,10 +715,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
       base_t::impl_execute(element_values, chunk_values, count);
 
       const int size = base_t::Analysis::value_size(base_t::m_functor);
-      DeepCopy<HostSpace, Kokkos::Experimental::OpenMPTargetSpace,
-               Kokkos::Experimental::OpenMPTarget>(
-          base_t::m_policy.space(), &m_returnvalue,
-          chunk_values.data() + (n_chunks - 1), size);
+      DeepCopy<HostSpace, Kokkos::Experimental::OpenMPTargetSpace>(
+          &m_returnvalue, chunk_values.data() + (n_chunks - 1), size);
     } else {
       m_returnvalue = 0;
     }

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -716,7 +716,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
       const int size = base_t::Analysis::value_size(base_t::m_functor);
       DeepCopy<HostSpace, Kokkos::Experimental::OpenMPTargetSpace>(
-          &m_returnvalue, chunk_values.data() + (n_chunks - 1), size);
+          base_t::m_policy.space(), &m_returnvalue,
+          chunk_values.data() + (n_chunks - 1), size);
     } else {
       m_returnvalue = 0;
     }

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp
@@ -715,7 +715,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
       base_t::impl_execute(element_values, chunk_values, count);
 
       const int size = base_t::Analysis::value_size(base_t::m_functor);
-      DeepCopy<HostSpace, Kokkos::Experimental::OpenMPTargetSpace>(
+      DeepCopy<HostSpace, Kokkos::Experimental::OpenMPTargetSpace,
+               Kokkos::Experimental::OpenMPTarget>(
           base_t::m_policy.space(), &m_returnvalue,
           chunk_values.data() + (n_chunks - 1), size);
     } else {

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -455,9 +455,6 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                              Kokkos::Experimental::SYCLDeviceUSMSpace>(
           space, m_result_ptr, results_ptr,
           sizeof(*m_result_ptr) * value_count);
-      space.fence(
-          "Kokkos::Impl::ParallelReduce::sycl_direct_launch: fence due to "
-          "inaccessible reducer result location");
     }
 
     return last_reduction_event;
@@ -781,9 +778,6 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                              Kokkos::Experimental::SYCLDeviceUSMSpace>(
           m_space, m_result_ptr, results_ptr,
           sizeof(*m_result_ptr) * value_count);
-      m_space.fence(
-          "Kokkos::Impl::ParallelReduce::sycl_direct_launch: fence after deep "
-          "copying results back");
     }
 
     return last_reduction_event;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -868,9 +868,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                              Kokkos::Experimental::SYCLDeviceUSMSpace>(
           space, m_result_ptr, results_ptr,
           sizeof(*m_result_ptr) * value_count);
-      space.fence(
-          "Kokkos::Impl::ParallelReduce<TeamPolicy,SYCL>: fence because "
-          "reduction can't access result storage location");
     }
 
     return last_reduction_event;


### PR DESCRIPTION
Noticed while working on #5146. 

The final fences for `parallel_reduce` and `parallel_scan` are in the interface calling the backend-specific implementations.
Also, make sure to enqueue the final copy events instead of fencing and using the default execution space.