### PR TITLE
Disable TestViewMemoryAccessViolation for SYCL temporarily

### DIFF
--- a/core/unit_test/TestViewMemoryAccessViolation.hpp
+++ b/core/unit_test/TestViewMemoryAccessViolation.hpp
@@ -46,9 +46,6 @@
 
 #include <gtest/gtest.h>
 
-// FIXME_SYCL
-#if !(defined(KOKKOS_COMPILER_INTEL) && defined(KOKKOS_ENABLE_SYCL))
-
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC
 template <class View, class ExecutionSpace>
 struct TestViewMemoryAccessViolation {
@@ -173,6 +170,8 @@ void test_view_memory_access_violations_from_device() {
   // clang-format on
 }
 
+// FIXME_SYCL
+#if !(defined(KOKKOS_COMPILER_INTEL) && defined(KOKKOS_ENABLE_SYCL))
 TEST(TEST_CATEGORY_DEATH, view_memory_access_violations_from_host) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
@@ -186,6 +185,7 @@ TEST(TEST_CATEGORY_DEATH, view_memory_access_violations_from_host) {
 
   test_view_memory_access_violations_from_host<ExecutionSpace>();
 }
+#endif
 
 TEST(TEST_CATEGORY_DEATH, view_memory_access_violations_from_device) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
@@ -218,5 +218,4 @@ TEST(TEST_CATEGORY_DEATH, view_memory_access_violations_from_device) {
 
   test_view_memory_access_violations_from_device<ExecutionSpace>();
 }
-#endif
 #endif

--- a/core/unit_test/TestViewMemoryAccessViolation.hpp
+++ b/core/unit_test/TestViewMemoryAccessViolation.hpp
@@ -46,6 +46,9 @@
 
 #include <gtest/gtest.h>
 
+// FIXME_SYCL
+#if !(defined(KOKKOS_COMPILER_INTEL) && defined(KOKKOS_ENABLE_SYCL))
+
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC
 template <class View, class ExecutionSpace>
 struct TestViewMemoryAccessViolation {
@@ -215,4 +218,5 @@ TEST(TEST_CATEGORY_DEATH, view_memory_access_violations_from_device) {
 
   test_view_memory_access_violations_from_device<ExecutionSpace>();
 }
+#endif
 #endif


### PR DESCRIPTION
Recent Intel compiler versions run into a segmentation fault in the compiler trying to compile this test which prevents CI from running.