### PR TITLE
Disable defaultdevicetype_DeathTest::access_forbidden for SYCL temporarily

### DIFF
--- a/core/unit_test/tools/TestLogicalSpaces.hpp
+++ b/core/unit_test/tools/TestLogicalSpaces.hpp
@@ -189,11 +189,14 @@ TEST(defaultdevicetype, chained_logical_spaces) { test_chained_spaces(); }
 TEST(defaultdevicetype, access_allowed) {
   test_allowed_access<fake_memory_space>();
 }
+// FIXME_SYCL
+#if !(defined(KOKKOS_COMPILER_INTEL) && defined(KOKKOS_ENABLE_SYCL))
 TEST(defaultdevicetype_DeathTest, access_forbidden) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH(
       { test_allowed_access<semantically_independent_logical_space>(); },
       "Kokkos::View ERROR: attempt to access inaccessible memory space");
 }
+#endif
 
 }  // namespace Test


### PR DESCRIPTION
Similar to https://github.com/kokkos/kokkos/pull/5158, this test also causes a segmentation fault in the compiler at the moment preventing CI to run