### PR TITLE
Remove useless memcpy

### DIFF
--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -1003,7 +1003,6 @@ void __test_half_operators(half_type h_lhs, half_type h_rhs) {
   std::memcpy(c_arr, h_arr, n_bytes);
   for (i = 0; i < n_bytes; i++) ASSERT_EQ(c_arr[i], h_arr_ptr[i]);
 
-  std::memcpy(h_arr, c_arr, n_bytes);
   ASSERT_EQ(h_arr[0], h_arr0);
   ASSERT_EQ(h_arr[1], h_arr1);
 }


### PR DESCRIPTION
I get 
```
/home/kokkos/core/unit_test/TestHalfOperators.hpp: In instantiation of 'void Test::__test_half_operators(half_type, half_type) [with half_type = Kokkos::Experimental::Impl::floating_point_wrapper<__half>]':                               
/home/kokkos/core/unit_test/TestHalfOperators.hpp:1016:86:   required from here                                                                                                                                                              
/home/kokkos/core/unit_test/TestHalfOperators.hpp:1006:12: error: 'void* memcpy(void*, const void*, size_t)' writing to an object of non-trivially copyable type 'class Kokkos::Experimental::Impl::floating_point_wrapper<__half>'; use copy
-assignment or copy-initialization instead [-Werror=class-memaccess]                                                                                                                                                                         
 1006 |   std::memcpy(h_arr, c_arr, n_bytes);
```
with nvcc 11.7 and g++ 11.2.0. As far as I can tell, this memcpy is useless so removing it.