### PR TITLE
Fix incorrect default inner direction in MD team policy

### DIFF
--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -785,7 +785,7 @@ KOKKOS_INLINE_FUNCTION auto MDThreadVectorRange(Member const& member,
   static constexpr Kokkos::Iterate inner_direction =
       InnerDirection == Kokkos::Iterate::Default
           ? Kokkos::layout_iterate_type_selector<
-                array_layout>::outer_iteration_pattern
+                array_layout>::inner_iteration_pattern
           : InnerDirection;
   using iType = std::common_type_t<Ns...>;
 
@@ -820,7 +820,7 @@ KOKKOS_INLINE_FUNCTION auto MDTeamVectorRange(Member const& member,
   static constexpr Kokkos::Iterate inner_direction =
       InnerDirection == Kokkos::Iterate::Default
           ? Kokkos::layout_iterate_type_selector<
-                array_layout>::outer_iteration_pattern
+                array_layout>::inner_iteration_pattern
           : InnerDirection;
   using iType = std::common_type_t<Ns...>;
 


### PR DESCRIPTION
Quick fix for MDTeamPolicy for serial backend that used outer iteration pattern in place of the default inner iteration.

@nliber 