### PR TITLE
Drop pointless `typename` keyword in default template parameter of C-style memory management functions

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -220,7 +220,7 @@ namespace Kokkos {
  * The allocation is tracked in Kokkos memory tracking system, so
  * leaked memory can be identified.
  */
-template <class Space = typename Kokkos::DefaultExecutionSpace::memory_space>
+template <class Space = Kokkos::DefaultExecutionSpace::memory_space>
 inline void* kokkos_malloc(const std::string& arg_alloc_label,
                            const size_t arg_alloc_size) {
   using MemorySpace = typename Space::memory_space;
@@ -228,21 +228,21 @@ inline void* kokkos_malloc(const std::string& arg_alloc_label,
       MemorySpace(), arg_alloc_label, arg_alloc_size);
 }
 
-template <class Space = typename Kokkos::DefaultExecutionSpace::memory_space>
+template <class Space = Kokkos::DefaultExecutionSpace::memory_space>
 inline void* kokkos_malloc(const size_t arg_alloc_size) {
   using MemorySpace = typename Space::memory_space;
   return Impl::SharedAllocationRecord<MemorySpace>::allocate_tracked(
       MemorySpace(), "no-label", arg_alloc_size);
 }
 
-template <class Space = typename Kokkos::DefaultExecutionSpace::memory_space>
+template <class Space = Kokkos::DefaultExecutionSpace::memory_space>
 inline void kokkos_free(void* arg_alloc) {
   using MemorySpace = typename Space::memory_space;
   return Impl::SharedAllocationRecord<MemorySpace>::deallocate_tracked(
       arg_alloc);
 }
 
-template <class Space = typename Kokkos::DefaultExecutionSpace::memory_space>
+template <class Space = Kokkos::DefaultExecutionSpace::memory_space>
 inline void* kokkos_realloc(void* arg_alloc, const size_t arg_alloc_size) {
   using MemorySpace = typename Space::memory_space;
   return Impl::SharedAllocationRecord<MemorySpace>::reallocate_tracked(


### PR DESCRIPTION
Spotted while browsing our documentation.