### PR TITLE
core/unit_test: Only use even numbers in bhalf reductions

### DIFF
--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -298,10 +298,10 @@ struct TestReducers {
       int denom = sizeof(Scalar) <= 2 ? 10 : 100;
       // clang-format off
       // For bhalf, we start overflowing integer values at 2^8.
-      //            after 2^8,  we loose representation of odd numbers;
-      //            after 2^9,  we loose representation of odd and even numbers in position 1.
-      //            after 2^10, we loose representation of odd and even numbers in position 1-3.
-      //            after 2^11, we loose representation of odd and even numbers in position 1-7.
+      //            after 2^8,  we lose representation of odd numbers;
+      //            after 2^9,  we lose representation of odd and even numbers in position 1.
+      //            after 2^10, we lose representation of odd and even numbers in position 1-3.
+      //            after 2^11, we lose representation of odd and even numbers in position 1-7.
       //            ...
       // Generally, for IEEE 754 floating point numbers, we start this overflow pattern at: 2^(num_fraction_bits+1).
       // brain float has num_fraction_bits = 7.

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -295,8 +295,24 @@ struct TestReducers {
     Scalar reference_sum = 0;
 
     for (int i = 0; i < N; i++) {
-      int denom   = sizeof(Scalar) <= 2 ? 10 : 100;
-      h_values(i) = (Scalar)(rand() % denom);
+      int denom = sizeof(Scalar) <= 2 ? 10 : 100;
+      // clang-format off
+      // For bhalf, we start overflowing integer values at 2^8.
+      //            after 2^8,  we loose representation of odd numbers;
+      //            after 2^9,  we loose representation of odd and even numbers in position 1.
+      //            after 2^10, we loose representation of odd and even numbers in position 1-3.
+      //            after 2^11, we loose representation of odd and even numbers in position 1-7.
+      //            ...
+      // Generally, for IEEE 754 floating point numbers, we start this overflow pattern at: 2^(num_fraction_bits+1).
+      // brain float has num_fraction_bits = 7.
+      // This mask addresses #4719 for N <= 51.
+      // The mask is not needed for N <= 25.
+      // clang-format on
+      int mask =
+          std::is_same<Scalar, Kokkos::Experimental::bhalf_t>::value && N > 25
+              ? 0xfffffffe
+              : 0xffffffff;
+      h_values(i) = (Scalar)((rand() % denom) & mask);
       reference_sum += h_values(i);
     }
     Kokkos::deep_copy(values, h_values);
@@ -313,19 +329,19 @@ struct TestReducers {
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
                               reducer_scalar);
-      ASSERT_EQ(sum_scalar, init);
+      ASSERT_EQ(sum_scalar, init) << "N: " << N;
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
                               reducer_scalar);
-      ASSERT_EQ(sum_scalar, reference_sum);
+      ASSERT_EQ(sum_scalar, reference_sum) << "N: " << N;
 
       sum_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
                               f_tag, reducer_scalar);
-      ASSERT_EQ(sum_scalar, reference_sum);
+      ASSERT_EQ(sum_scalar, reference_sum) << "N: " << N;
 
       Scalar sum_scalar_view = reducer_scalar.reference();
-      ASSERT_EQ(sum_scalar_view, reference_sum);
+      ASSERT_EQ(sum_scalar_view, reference_sum) << "N: " << N;
     }
 
     {
@@ -336,16 +352,16 @@ struct TestReducers {
                               reducer_view);
       Kokkos::fence();
       Scalar sum_view_scalar = sum_view();
-      ASSERT_EQ(sum_view_scalar, init);
+      ASSERT_EQ(sum_view_scalar, init) << "N: " << N;
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
                               reducer_view);
       Kokkos::fence();
       sum_view_scalar = sum_view();
-      ASSERT_EQ(sum_view_scalar, reference_sum);
+      ASSERT_EQ(sum_view_scalar, reference_sum) << "N: " << N;
 
       Scalar sum_view_view = reducer_view.reference();
-      ASSERT_EQ(sum_view_view, reference_sum);
+      ASSERT_EQ(sum_view_view, reference_sum) << "N: " << N;
     }
 
     {
@@ -358,13 +374,13 @@ struct TestReducers {
       Kokkos::fence();
       Scalar sum_view_scalar;
       Kokkos::deep_copy(sum_view_scalar, sum_view);
-      ASSERT_EQ(sum_view_scalar, init);
+      ASSERT_EQ(sum_view_scalar, init) << "N: " << N;
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
                               reducer_view);
       Kokkos::fence();
       Kokkos::deep_copy(sum_view_scalar, sum_view);
-      ASSERT_EQ(sum_view_scalar, reference_sum);
+      ASSERT_EQ(sum_view_scalar, reference_sum) << "N: " << N;
     }
   }
 

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -310,8 +310,8 @@ struct TestReducers {
       // clang-format on
       int mask =
           std::is_same<Scalar, Kokkos::Experimental::bhalf_t>::value && N > 25
-              ? 0xfffffffe
-              : 0xffffffff;
+              ? (int)0xfffffffe
+              : (int)0xffffffff;
       h_values(i) = (Scalar)((rand() % denom) & mask);
       reference_sum += h_values(i);
     }

--- a/core/unit_test/TestReducers_d.hpp
+++ b/core/unit_test/TestReducers_d.hpp
@@ -79,50 +79,19 @@ TEST(TEST_CATEGORY, reducers_half_t) {
   TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(25);
 }
 
-// TODO: File a bug report for this?
-// This fails on the CUDA-11.0-NVCC-C++17-RDC CI check.
-// TEST(TEST_CATEGORY, openmp_cuda11_reduction_bug_with_bhalf_t) {
-//  using ThisTestType = Kokkos::Experimental::bhalf_t;
-//  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(50);
-//  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(51);
-//  // For some reason commenting out reductions of 52,53,54,55 causes
-//  // the reduction of 56 to fail on OpenMP with Cuda/11.0
-//  //TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(52);
-//  //TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(53);
-//  //TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(54);
-//  //TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(55);
-//  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(56);
-//}
-
 TEST(TEST_CATEGORY, reducers_bhalf_t) {
-#if defined(KOKKOS_ENABLE_OPENMP)
-  if (!std::is_same<TEST_EXECSPACE, Kokkos::OpenMP>::value)
-#else
-  if (true)
-#endif  // ENABLE_OPENMP
-  {
-    using ThisTestType = Kokkos::Experimental::bhalf_t;
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(2);
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(50);
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(51);
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(52);
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(53);
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(54);
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(55);
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(56);
-    // TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(57);
-    // This could be 57 on device but there seems to be a loss of precision when
-    // running on OpenMP with Cuda/11.0
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(5);
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(10);
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(15);
-#if (CUDA_VERSION < 11000)
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(20);
-    TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(21);
-#endif
-  } else {
-    GTEST_SKIP();
-  }
+  using ThisTestType = Kokkos::Experimental::bhalf_t;
+
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(2);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(25);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(50);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(51);
+
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(5);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(10);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(15);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(20);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(25);
 }
 
 TEST(TEST_CATEGORY, reducers_int8_t) {


### PR DESCRIPTION
Fixes #4719.