### PR TITLE
Move min, max, clamp, minmax routines out of Experimental namespace

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
@@ -131,7 +131,7 @@ bool lexicographical_compare_impl(const std::string& label,
   // run
   const auto d1    = Kokkos::Experimental::distance(first1, last1);
   const auto d2    = Kokkos::Experimental::distance(first2, last2);
-  const auto range = Kokkos::Experimental::min(d1, d2);
+  const auto range = Kokkos::min(d1, d2);
   reduction_value_type red_result;
   reducer_type reducer(red_result);
   using func1_t =

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -437,10 +437,9 @@ __device__ inline int64_t cuda_get_scratch_index(Cuda::size_type league_size,
   __shared__ int64_t base_thread_id;
   if (threadIdx.x == 0 && threadIdx.y == 0) {
     int64_t const wraparound_len = Kokkos::max(
-        int64_t(1),
-        Kokkos::min(int64_t(league_size),
-                                  (int64_t(g_device_cuda_lock_arrays.n)) /
-                                      (blockDim.x * blockDim.y)));
+        int64_t(1), Kokkos::min(int64_t(league_size),
+                                (int64_t(g_device_cuda_lock_arrays.n)) /
+                                    (blockDim.x * blockDim.y)));
     threadid = (blockIdx.x * blockDim.z + threadIdx.z) % wraparound_len;
     threadid *= blockDim.x * blockDim.y;
     int done = 0;

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -436,9 +436,9 @@ __device__ inline int64_t cuda_get_scratch_index(Cuda::size_type league_size,
   int64_t threadid = 0;
   __shared__ int64_t base_thread_id;
   if (threadIdx.x == 0 && threadIdx.y == 0) {
-    int64_t const wraparound_len = Kokkos::Experimental::max(
+    int64_t const wraparound_len = Kokkos::max(
         int64_t(1),
-        Kokkos::Experimental::min(int64_t(league_size),
+        Kokkos::min(int64_t(league_size),
                                   (int64_t(g_device_cuda_lock_arrays.n)) /
                                       (blockDim.x * blockDim.y)));
     threadid = (blockIdx.x * blockDim.z + threadIdx.z) % wraparound_len;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -459,10 +459,10 @@ __device__ inline int64_t hip_get_scratch_index(
   int64_t threadid = 0;
   __shared__ int64_t base_thread_id;
   if (threadIdx.x == 0 && threadIdx.y == 0) {
-    int64_t const wraparound_len = Kokkos::min(
-        int64_t(league_size),
-        (int64_t(Kokkos::Impl::g_device_hip_lock_arrays.n)) /
-            (blockDim.x * blockDim.y));
+    int64_t const wraparound_len =
+        Kokkos::min(int64_t(league_size),
+                    (int64_t(Kokkos::Impl::g_device_hip_lock_arrays.n)) /
+                        (blockDim.x * blockDim.y));
     threadid = (blockIdx.x * blockDim.z + threadIdx.z) % wraparound_len;
     threadid *= blockDim.x * blockDim.y;
     int done = 0;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -459,7 +459,7 @@ __device__ inline int64_t hip_get_scratch_index(
   int64_t threadid = 0;
   __shared__ int64_t base_thread_id;
   if (threadIdx.x == 0 && threadIdx.y == 0) {
-    int64_t const wraparound_len = Kokkos::Experimental::min(
+    int64_t const wraparound_len = Kokkos::min(
         int64_t(league_size),
         (int64_t(Kokkos::Impl::g_device_hip_lock_arrays.n)) /
             (blockDim.x * blockDim.y));

--- a/core/src/Kokkos_MinMaxClamp.hpp
+++ b/core/src/Kokkos_MinMaxClamp.hpp
@@ -51,7 +51,6 @@
 #include <initializer_list>
 
 namespace Kokkos {
-namespace Experimental {
 
 // clamp
 template <class T>
@@ -223,7 +222,6 @@ KOKKOS_INLINE_FUNCTION constexpr Kokkos::pair<T, T> minmax(
   return result;
 }
 
-}  // namespace Experimental
 }  // namespace Kokkos
 
 #endif

--- a/core/src/Kokkos_MinMaxClamp.hpp
+++ b/core/src/Kokkos_MinMaxClamp.hpp
@@ -222,6 +222,15 @@ KOKKOS_INLINE_FUNCTION constexpr Kokkos::pair<T, T> minmax(
   return result;
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+namespace Experimental {
+using ::Kokkos::clamp;
+using ::Kokkos::max;
+using ::Kokkos::min;
+using ::Kokkos::minmax;
+}  // namespace Experimental
+#endif
+
 }  // namespace Kokkos
 
 #endif

--- a/core/unit_test/TestMinMaxClamp.hpp
+++ b/core/unit_test/TestMinMaxClamp.hpp
@@ -72,32 +72,30 @@ struct PairIntCompareFirst {
 // test max()
 // ----------------------------------------------------------
 TEST(TEST_CATEGORY, max) {
-  namespace KE = Kokkos::Experimental;
-
   int a = 1;
   int b = 2;
-  EXPECT_EQ(KE::max(a, b), 2);
+  EXPECT_EQ(Kokkos::max(a, b), 2);
 
   a = 3;
   b = 1;
-  EXPECT_EQ(KE::max(a, b), 3);
+  EXPECT_EQ(Kokkos::max(a, b), 3);
 
-  STATIC_ASSERT(KE::max(1, 2) == 2);
-  STATIC_ASSERT(KE::max(1, 2, ::Test::Greater<int>{}) == 1);
+  STATIC_ASSERT(Kokkos::max(1, 2) == 2);
+  STATIC_ASSERT(Kokkos::max(1, 2, ::Test::Greater<int>{}) == 1);
 
-  EXPECT_EQ(KE::max({3.f, -1.f, 0.f}), 3.f);
+  EXPECT_EQ(Kokkos::max({3.f, -1.f, 0.f}), 3.f);
 
-  STATIC_ASSERT(KE::max({3, -1, 0}) == 3);
-  STATIC_ASSERT(KE::max({3, -1, 0}, ::Test::Greater<int>{}) == -1);
+  STATIC_ASSERT(Kokkos::max({3, -1, 0}) == 3);
+  STATIC_ASSERT(Kokkos::max({3, -1, 0}, ::Test::Greater<int>{}) == -1);
 
-  STATIC_ASSERT(KE::max({
-                            ::Test::PairIntCompareFirst{255, 0},
-                            ::Test::PairIntCompareFirst{255, 1},
-                            ::Test::PairIntCompareFirst{0, 2},
-                            ::Test::PairIntCompareFirst{0, 3},
-                            ::Test::PairIntCompareFirst{255, 4},
-                            ::Test::PairIntCompareFirst{0, 5},
-                        })
+  STATIC_ASSERT(Kokkos::max({
+                                ::Test::PairIntCompareFirst{255, 0},
+                                ::Test::PairIntCompareFirst{255, 1},
+                                ::Test::PairIntCompareFirst{0, 2},
+                                ::Test::PairIntCompareFirst{0, 3},
+                                ::Test::PairIntCompareFirst{255, 4},
+                                ::Test::PairIntCompareFirst{0, 5},
+                            })
                     .second == 0);  // leftmost element
 }
 
@@ -107,9 +105,8 @@ struct StdAlgoMinMaxOpsTestMax {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int& ind) const {
-    namespace KE = Kokkos::Experimental;
-    auto v1      = 10.;
-    if (KE::max(v1, m_view(ind)) == 10.) {
+    auto v1 = 10.;
+    if (Kokkos::max(v1, m_view(ind)) == 10.) {
       m_view(ind) = 6.;
     }
   }
@@ -136,32 +133,30 @@ TEST(TEST_CATEGORY, max_within_parfor) {
 // test min()
 // ----------------------------------------------------------
 TEST(TEST_CATEGORY, min) {
-  namespace KE = Kokkos::Experimental;
-
   int a = 1;
   int b = 2;
-  EXPECT_EQ(KE::min(a, b), 1);
+  EXPECT_EQ(Kokkos::min(a, b), 1);
 
   a = 3;
   b = 2;
-  EXPECT_EQ(KE::min(a, b), 2);
+  EXPECT_EQ(Kokkos::min(a, b), 2);
 
-  STATIC_ASSERT(KE::min(3.f, 2.f) == 2.f);
-  STATIC_ASSERT(KE::min(3.f, 2.f, ::Test::Greater<int>{}) == 3.f);
+  STATIC_ASSERT(Kokkos::min(3.f, 2.f) == 2.f);
+  STATIC_ASSERT(Kokkos::min(3.f, 2.f, ::Test::Greater<int>{}) == 3.f);
 
-  EXPECT_EQ(KE::min({3.f, -1.f, 0.f}), -1.f);
+  EXPECT_EQ(Kokkos::min({3.f, -1.f, 0.f}), -1.f);
 
-  STATIC_ASSERT(KE::min({3, -1, 0}) == -1);
-  STATIC_ASSERT(KE::min({3, -1, 0}, ::Test::Greater<int>{}) == 3);
+  STATIC_ASSERT(Kokkos::min({3, -1, 0}) == -1);
+  STATIC_ASSERT(Kokkos::min({3, -1, 0}, ::Test::Greater<int>{}) == 3);
 
-  STATIC_ASSERT(KE::min({
-                            ::Test::PairIntCompareFirst{255, 0},
-                            ::Test::PairIntCompareFirst{255, 1},
-                            ::Test::PairIntCompareFirst{0, 2},
-                            ::Test::PairIntCompareFirst{0, 3},
-                            ::Test::PairIntCompareFirst{255, 4},
-                            ::Test::PairIntCompareFirst{0, 5},
-                        })
+  STATIC_ASSERT(Kokkos::min({
+                                ::Test::PairIntCompareFirst{255, 0},
+                                ::Test::PairIntCompareFirst{255, 1},
+                                ::Test::PairIntCompareFirst{0, 2},
+                                ::Test::PairIntCompareFirst{0, 3},
+                                ::Test::PairIntCompareFirst{255, 4},
+                                ::Test::PairIntCompareFirst{0, 5},
+                            })
                     .second == 2);  // leftmost element
 }
 
@@ -171,9 +166,8 @@ struct StdAlgoMinMaxOpsTestMin {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int& ind) const {
-    namespace KE = Kokkos::Experimental;
-    auto v1      = 10.;
-    if (KE::min(v1, m_view(ind)) == 0.) {
+    auto v1 = 10.;
+    if (Kokkos::min(v1, m_view(ind)) == 0.) {
       m_view(ind) = 8.;
     }
   }
@@ -199,16 +193,15 @@ TEST(TEST_CATEGORY, min_within_parfor) {
 // test minmax()
 // ----------------------------------------------------------
 TEST(TEST_CATEGORY, minmax) {
-  namespace KE  = Kokkos::Experimental;
   int a         = 1;
   int b         = 2;
-  const auto& r = KE::minmax(a, b);
+  const auto& r = Kokkos::minmax(a, b);
   EXPECT_EQ(r.first, 1);
   EXPECT_EQ(r.second, 2);
 
   a              = 3;
   b              = 2;
-  const auto& r2 = KE::minmax(a, b);
+  const auto& r2 = Kokkos::minmax(a, b);
   EXPECT_EQ(r2.first, 2);
   EXPECT_EQ(r2.second, 3);
 
@@ -216,35 +209,35 @@ TEST(TEST_CATEGORY, minmax) {
                                // constexpr constructors so I removed the
                                // constexpr in pair, which makes STATIC_ASSERT
                                // here fail
-  STATIC_ASSERT((Kokkos::pair<float, float>(KE::minmax(3.f, 2.f)) ==
+  STATIC_ASSERT((Kokkos::pair<float, float>(Kokkos::minmax(3.f, 2.f)) ==
                  Kokkos::make_pair(2.f, 3.f)));
   STATIC_ASSERT(
-      (Kokkos::pair<float, float>(KE::minmax(
+      (Kokkos::pair<float, float>(Kokkos::minmax(
            3.f, 2.f, ::Test::Greater<int>{})) == Kokkos::make_pair(3.f, 2.f)));
 
-  EXPECT_EQ(KE::minmax({3.f, -1.f, 0.f}), Kokkos::make_pair(-1.f, 3.f));
+  EXPECT_EQ(Kokkos::minmax({3.f, -1.f, 0.f}), Kokkos::make_pair(-1.f, 3.f));
 
-  STATIC_ASSERT(KE::minmax({3, -1, 0}) == Kokkos::make_pair(-1, 3));
-  STATIC_ASSERT(KE::minmax({3, -1, 0}, ::Test::Greater<int>{}) ==
+  STATIC_ASSERT(Kokkos::minmax({3, -1, 0}) == Kokkos::make_pair(-1, 3));
+  STATIC_ASSERT(Kokkos::minmax({3, -1, 0}, ::Test::Greater<int>{}) ==
                 Kokkos::make_pair(3, -1));
 
-  STATIC_ASSERT(KE::minmax({
-                               ::Test::PairIntCompareFirst{255, 0},
-                               ::Test::PairIntCompareFirst{255, 1},
-                               ::Test::PairIntCompareFirst{0, 2},
-                               ::Test::PairIntCompareFirst{0, 3},
-                               ::Test::PairIntCompareFirst{255, 4},
-                               ::Test::PairIntCompareFirst{0, 5},
-                           })
+  STATIC_ASSERT(Kokkos::minmax({
+                                   ::Test::PairIntCompareFirst{255, 0},
+                                   ::Test::PairIntCompareFirst{255, 1},
+                                   ::Test::PairIntCompareFirst{0, 2},
+                                   ::Test::PairIntCompareFirst{0, 3},
+                                   ::Test::PairIntCompareFirst{255, 4},
+                                   ::Test::PairIntCompareFirst{0, 5},
+                               })
                     .first.second == 2);  // leftmost
-  STATIC_ASSERT(KE::minmax({
-                               ::Test::PairIntCompareFirst{255, 0},
-                               ::Test::PairIntCompareFirst{255, 1},
-                               ::Test::PairIntCompareFirst{0, 2},
-                               ::Test::PairIntCompareFirst{0, 3},
-                               ::Test::PairIntCompareFirst{255, 4},
-                               ::Test::PairIntCompareFirst{0, 5},
-                           })
+  STATIC_ASSERT(Kokkos::minmax({
+                                   ::Test::PairIntCompareFirst{255, 0},
+                                   ::Test::PairIntCompareFirst{255, 1},
+                                   ::Test::PairIntCompareFirst{0, 2},
+                                   ::Test::PairIntCompareFirst{0, 3},
+                                   ::Test::PairIntCompareFirst{255, 4},
+                                   ::Test::PairIntCompareFirst{0, 5},
+                               })
                     .second.second == 4);  // rightmost
 #endif
 }
@@ -255,9 +248,8 @@ struct StdAlgoMinMaxOpsTestMinMax {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int& ind) const {
-    namespace KE  = Kokkos::Experimental;
     auto v1       = 7.;
-    const auto& r = KE::minmax(v1, m_view(ind));
+    const auto& r = Kokkos::minmax(v1, m_view(ind));
     m_view(ind)   = (double)(r.first - r.second);
   }
 
@@ -266,7 +258,6 @@ struct StdAlgoMinMaxOpsTestMinMax {
 };
 
 TEST(TEST_CATEGORY, minmax_within_parfor) {
-  namespace KE = Kokkos::Experimental;
   using view_t = Kokkos::View<double*>;
   view_t a("a", 10);
 
@@ -282,26 +273,24 @@ TEST(TEST_CATEGORY, minmax_within_parfor) {
 // test clamp()
 // ----------------------------------------------------------
 TEST(TEST_CATEGORY, clamp) {
-  namespace KE = Kokkos::Experimental;
-
   int a         = 1;
   int b         = 2;
   int c         = 19;
-  const auto& r = KE::clamp(a, b, c);
+  const auto& r = Kokkos::clamp(a, b, c);
   EXPECT_EQ(&r, &b);
   EXPECT_EQ(r, b);
 
   a              = 5;
   b              = -2;
   c              = 3;
-  const auto& r2 = KE::clamp(a, b, c);
+  const auto& r2 = Kokkos::clamp(a, b, c);
   EXPECT_EQ(&r2, &c);
   EXPECT_EQ(r2, c);
 
   a              = 5;
   b              = -2;
   c              = 7;
-  const auto& r3 = KE::clamp(a, b, c);
+  const auto& r3 = Kokkos::clamp(a, b, c);
   EXPECT_EQ(&r3, &a);
   EXPECT_EQ(r3, a);
 }
@@ -312,11 +301,10 @@ struct StdAlgoMinMaxOpsTestClamp {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int& ind) const {
-    namespace KE  = Kokkos::Experimental;
     m_view(ind)   = 10.;
     const auto b  = -2.;
     const auto c  = 3.;
-    const auto& r = KE::clamp(m_view(ind), b, c);
+    const auto& r = Kokkos::clamp(m_view(ind), b, c);
     m_view(ind)   = (double)(r);
   }
 
@@ -325,7 +313,6 @@ struct StdAlgoMinMaxOpsTestClamp {
 };
 
 TEST(TEST_CATEGORY, clamp_within_parfor) {
-  namespace KE = Kokkos::Experimental;
   using view_t = Kokkos::View<double*>;
   view_t a("a", 10);
 


### PR DESCRIPTION
Fixes #5168.

I propose moving the min, max, clamp and minmax routines out of the `Experimental` namespace, and into the `Kokkos` namespace.

I developed these changes using this build: 

```
cmake \
-DKokkos_ENABLE_TESTS=ON \
-DKokkos_ENABLE_CUDA=ON \
-DKokkos_ENABLE_CUDA_LAMBDA=ON \
-DKokkos_ARCH_VOLTA70=ON \
-DKokkos_ENABLE_SERIAL=ON \
-DCMAKE_CXX_STANDARD=14 \
-DCMAKE_BUILD_TYPE=Release ..\

```

I ran all unit tests thusly:

`ctest --output-on-failure`

All tests passed.

