### PR TITLE
Avoid `InitArguments` in interoperability unit tests

### DIFF
--- a/core/unit_test/cuda/TestCuda_InterOp_Init.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Init.cpp
@@ -61,8 +61,7 @@ __global__ void offset(int* p) {
 TEST(cuda, raw_cuda_interop) {
   int* p;
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&p, sizeof(int) * 100));
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
+  Kokkos::initialize();
 
   Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged>> v(p, 100);
   Kokkos::deep_copy(v, 5);

--- a/core/unit_test/cuda/TestCuda_InterOp_Streams.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Streams.cpp
@@ -50,8 +50,7 @@ namespace Test {
 TEST(cuda, raw_cuda_streams) {
   cudaStream_t stream;
   cudaStreamCreate(&stream);
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
+  Kokkos::initialize();
   int* p;
   cudaMalloc(&p, sizeof(int) * 100);
   using MemorySpace = typename TEST_EXECSPACE::memory_space;

--- a/core/unit_test/hip/TestHIP_InterOp_Init.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Init.cpp
@@ -61,8 +61,7 @@ __global__ void offset(int* p) {
 TEST(hip, raw_hip_interop) {
   int* p;
   KOKKOS_IMPL_HIP_SAFE_CALL(hipMalloc(&p, sizeof(int) * 100));
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
+  Kokkos::initialize();
 
   Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged>> v(p, 100);
   Kokkos::deep_copy(v, 5);

--- a/core/unit_test/hip/TestHIP_InterOp_Streams.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Streams.cpp
@@ -52,8 +52,7 @@ namespace Test {
 TEST(hip, raw_hip_streams) {
   hipStream_t stream;
   KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamCreate(&stream));
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
+  Kokkos::initialize();
   int* p;
   KOKKOS_IMPL_HIP_SAFE_CALL(hipMalloc(&p, sizeof(int) * 100));
   using MemorySpace = typename TEST_EXECSPACE::memory_space;

--- a/core/unit_test/hpx/TestHPX_InterOp.cpp
+++ b/core/unit_test/hpx/TestHPX_InterOp.cpp
@@ -48,10 +48,10 @@
 namespace Test {
 
 // Test whether allocations survive Kokkos initialize/finalize if done via Raw
-// Cuda.
+// HPX.
 TEST(hpx, raw_hpx_interop) {
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
+  // FIXME_HPX
+  Kokkos::initialize();
   Kokkos::finalize();
 }
 }  // namespace Test

--- a/core/unit_test/openmp/TestOpenMP_InterOp.cpp
+++ b/core/unit_test/openmp/TestOpenMP_InterOp.cpp
@@ -62,8 +62,7 @@ TEST(openmp, raw_openmp_interop) {
 
   ASSERT_EQ(count, num_threads);
 
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
+  Kokkos::initialize();
 
   count = 0;
 #pragma omp parallel

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
@@ -52,8 +52,7 @@ namespace Test {
 // Test whether allocations survive Kokkos initialize/finalize if done via Raw
 // SYCL.
 TEST(sycl, raw_sycl_interop) {
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
+  Kokkos::initialize();
 
   Kokkos::Experimental::SYCL default_space;
   sycl::context default_context = default_space.sycl_context();

--- a/core/unit_test/sycl/TestSYCL_InterOp_Streams.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Streams.cpp
@@ -50,8 +50,7 @@ namespace Test {
 TEST(sycl, raw_sycl_queues) {
   sycl::default_selector device_selector;
   sycl::queue queue(device_selector);
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
+  Kokkos::initialize();
   int* p            = sycl::malloc_device<int>(100, queue);
   using MemorySpace = typename TEST_EXECSPACE::memory_space;
 


### PR DESCRIPTION
Rational: A vain attempt to split up #5135 to facilitate review