### PR TITLE
Consolidate all HPX "IndependentInstances" unit tests into a single executable

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -502,25 +502,10 @@ if(Kokkos_ENABLE_HPX)
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_HPX_IndependentInstances
     SOURCES
-      UnitTestMain.cpp
+      UnitTestMainInit.cpp
       hpx/TestHPX_IndependentInstances.cpp
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    UnitTest_HPX_IndependentInstancesDelayedExecution
-    SOURCES
-      UnitTestMain.cpp
       hpx/TestHPX_IndependentInstancesDelayedExecution.cpp
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    UnitTest_HPX_IndependentInstancesInstanceIds
-    SOURCES
-      UnitTestMain.cpp
       hpx/TestHPX_IndependentInstancesInstanceIds.cpp
-  )
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    UnitTest_HPX_IndependentInstancesRefCounting
-    SOURCES
-      UnitTestMain.cpp
       hpx/TestHPX_IndependentInstancesRefCounting.cpp
   )
 endif()

--- a/core/unit_test/hpx/TestHPX_IndependentInstances.cpp
+++ b/core/unit_test/hpx/TestHPX_IndependentInstances.cpp
@@ -51,9 +51,8 @@
 #ifdef KOKKOS_ENABLE_HPX_ASYNC_DISPATCH
 #ifndef HPX_COMPUTE_DEVICE_CODE
 
-namespace Test {
-
 namespace {
+
 struct FunctorInitConstant {
   Kokkos::View<int *, Kokkos::Experimental::HPX> a;
   int c;
@@ -107,82 +106,75 @@ struct FunctorReduce {
   KOKKOS_INLINE_FUNCTION
   void operator()(const int i, int &lsum) const { lsum += a(i); }
 };
-}  // namespace
 
 TEST(hpx, independent_instances) {
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
-
   const int n = 100;
   const int c = 1;
   const int d = 3;
 
-  {
-    Kokkos::View<int *, Kokkos::Experimental::HPX> v1("v1", n);
-    Kokkos::View<int *, Kokkos::Experimental::HPX> v2("v2", n);
-    Kokkos::View<int *, Kokkos::Experimental::HPX> v3("v3", n);
-    Kokkos::View<int *, Kokkos::Experimental::HPX> v4("v4", n);
-    Kokkos::View<int, Kokkos::Experimental::HPX> sum_v("sum_v");
+  Kokkos::View<int *, Kokkos::Experimental::HPX> v1("v1", n);
+  Kokkos::View<int *, Kokkos::Experimental::HPX> v2("v2", n);
+  Kokkos::View<int *, Kokkos::Experimental::HPX> v3("v3", n);
+  Kokkos::View<int *, Kokkos::Experimental::HPX> v4("v4", n);
+  Kokkos::View<int, Kokkos::Experimental::HPX> sum_v("sum_v");
 
-    Kokkos::Experimental::HPX hpx1(
-        Kokkos::Experimental::HPX::instance_mode::independent);
-    Kokkos::parallel_for(
-        "Test::hpx::independent_instances::init",
-        Kokkos::Experimental::require(
-            Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx1, 0, n),
-            Kokkos::Experimental::WorkItemProperty::HintLightWeight),
-        FunctorInitConstant(v1, c));
+  Kokkos::Experimental::HPX hpx1(
+      Kokkos::Experimental::HPX::instance_mode::independent);
+  Kokkos::parallel_for(
+      "Test::hpx::independent_instances::init",
+      Kokkos::Experimental::require(
+          Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx1, 0, n),
+          Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+      FunctorInitConstant(v1, c));
 
-    Kokkos::Experimental::HPX hpx2(hpx1.impl_get_future());
-    Kokkos::parallel_for(
-        "Test::hpx::independent_instances::add",
-        Kokkos::Experimental::require(
-            Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx2, 0, n),
-            Kokkos::Experimental::WorkItemProperty::HintLightWeight),
-        FunctorAdd(v1, v2, d));
+  Kokkos::Experimental::HPX hpx2(hpx1.impl_get_future());
+  Kokkos::parallel_for(
+      "Test::hpx::independent_instances::add",
+      Kokkos::Experimental::require(
+          Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx2, 0, n),
+          Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+      FunctorAdd(v1, v2, d));
 
-    Kokkos::Experimental::HPX hpx3(hpx1.impl_get_future());
-    Kokkos::parallel_for(
-        "Test::hpx::independent_instances::add_index",
-        Kokkos::Experimental::require(
-            Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx3, 0, n),
-            Kokkos::Experimental::WorkItemProperty::HintLightWeight),
-        FunctorAddIndex(v1, v3));
+  Kokkos::Experimental::HPX hpx3(hpx1.impl_get_future());
+  Kokkos::parallel_for(
+      "Test::hpx::independent_instances::add_index",
+      Kokkos::Experimental::require(
+          Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx3, 0, n),
+          Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+      FunctorAddIndex(v1, v3));
 
-    // NOTE: This monstrosity is used to collapse a future<tuple<future<void>,
-    // future<void>>> (return type of when_all) into a future<void> which is
-    // ready whenever the un-collapsed future would've been ready. HPX does not
-    // currently have the functionality to collapse this automatically.
-    Kokkos::Experimental::HPX hpx4(hpx::get<0>(hpx::split_future(
-        hpx::when_all(hpx2.impl_get_future(), hpx3.impl_get_future()))));
-    Kokkos::parallel_for(
-        "Test::hpx::independent_instances::pointwise_sum",
-        Kokkos::Experimental::require(
-            Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx4, 0, n),
-            Kokkos::Experimental::WorkItemProperty::HintLightWeight),
-        FunctorPointwiseSum(v2, v3, v4));
+  // NOTE: This monstrosity is used to collapse a future<tuple<future<void>,
+  // future<void>>> (return type of when_all) into a future<void> which is
+  // ready whenever the un-collapsed future would've been ready. HPX does not
+  // currently have the functionality to collapse this automatically.
+  Kokkos::Experimental::HPX hpx4(hpx::get<0>(hpx::split_future(
+      hpx::when_all(hpx2.impl_get_future(), hpx3.impl_get_future()))));
+  Kokkos::parallel_for(
+      "Test::hpx::independent_instances::pointwise_sum",
+      Kokkos::Experimental::require(
+          Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx4, 0, n),
+          Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+      FunctorPointwiseSum(v2, v3, v4));
 
-    Kokkos::parallel_reduce(
-        "Test::hpx::independent_instances::reduce",
-        Kokkos::Experimental::require(
-            Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx4, 0, n),
-            Kokkos::Experimental::WorkItemProperty::HintLightWeight),
-        FunctorReduce(v4), Kokkos::Sum<int>(sum_v));
+  Kokkos::parallel_reduce(
+      "Test::hpx::independent_instances::reduce",
+      Kokkos::Experimental::require(
+          Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx4, 0, n),
+          Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+      FunctorReduce(v4), Kokkos::Sum<int>(sum_v));
 
-    hpx4.fence();
+  hpx4.fence();
 
-    ASSERT_EQ(true, hpx1.impl_get_future().is_ready());
-    ASSERT_EQ(true, hpx2.impl_get_future().is_ready());
-    ASSERT_EQ(true, hpx3.impl_get_future().is_ready());
-    ASSERT_EQ(true, hpx4.impl_get_future().is_ready());
+  ASSERT_EQ(true, hpx1.impl_get_future().is_ready());
+  ASSERT_EQ(true, hpx2.impl_get_future().is_ready());
+  ASSERT_EQ(true, hpx3.impl_get_future().is_ready());
+  ASSERT_EQ(true, hpx4.impl_get_future().is_ready());
 
-    const int expected_sum = n * (2 * c + d) + (n * (n - 1) / 2);
-    ASSERT_EQ(expected_sum, sum_v());
-  }
-
-  Kokkos::finalize();
+  const int expected_sum = n * (2 * c + d) + (n * (n - 1) / 2);
+  ASSERT_EQ(expected_sum, sum_v());
 }
-}  // namespace Test
+
+}  // namespace
 
 #endif
 #endif

--- a/core/unit_test/hpx/TestHPX_IndependentInstancesDelayedExecution.cpp
+++ b/core/unit_test/hpx/TestHPX_IndependentInstancesDelayedExecution.cpp
@@ -49,36 +49,30 @@
 
 #ifdef KOKKOS_ENABLE_HPX_ASYNC_DISPATCH
 
-namespace Test {
+namespace {
 
-TEST(hpx, delayed_execution) {
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
+TEST(hpx, independent_instances_delayed_execution) {
+  Kokkos::View<bool, Kokkos::Experimental::HPX> ran("ran");
+  hpx::lcos::local::promise<void> p;
+  hpx::shared_future<void> f = p.get_future();
 
-  {
-    Kokkos::View<bool, Kokkos::Experimental::HPX> ran("ran");
-    hpx::lcos::local::promise<void> p;
-    hpx::shared_future<void> f = p.get_future();
+  Kokkos::Experimental::HPX hpx(f);
+  Kokkos::parallel_for(
+      "Test::hpx::independent_instances::delay_execution",
+      Kokkos::Experimental::require(
+          Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx, 0, 1),
+          Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+      KOKKOS_LAMBDA(int) { ran() = true; });
 
-    Kokkos::Experimental::HPX hpx(f);
-    Kokkos::parallel_for(
-        "Test::hpx::independent_instances::delay_execution",
-        Kokkos::Experimental::require(
-            Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx, 0, 1),
-            Kokkos::Experimental::WorkItemProperty::HintLightWeight),
-        KOKKOS_LAMBDA(int) { ran() = true; });
+  ASSERT_FALSE(ran());
+  ASSERT_FALSE(hpx.impl_get_future().is_ready());
 
-    ASSERT_EQ(false, ran());
-    ASSERT_EQ(false, hpx.impl_get_future().is_ready());
+  p.set_value();
 
-    p.set_value();
-
-    hpx.fence();
-    ASSERT_EQ(true, hpx.impl_get_future().is_ready());
-  }
-
-  Kokkos::finalize();
+  hpx.fence();
+  ASSERT_TRUE(hpx.impl_get_future().is_ready());
 }
-}  // namespace Test
+
+}  // namespace
 
 #endif

--- a/core/unit_test/hpx/TestHPX_IndependentInstancesInstanceIds.cpp
+++ b/core/unit_test/hpx/TestHPX_IndependentInstancesInstanceIds.cpp
@@ -49,69 +49,63 @@
 
 #ifdef KOKKOS_ENABLE_HPX_ASYNC_DISPATCH
 
-namespace Test {
+namespace {
 
-TEST(hpx, instance_ids) {
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
+TEST(hpx, independent_instances_instance_ids) {
+  Kokkos::Experimental::HPX hpx_default1;
+  Kokkos::Experimental::HPX hpx_default2 = hpx_default1;
+  Kokkos::Experimental::HPX hpx_default3{hpx_default1};
+  Kokkos::Experimental::HPX hpx_default4(
+      Kokkos::Experimental::HPX::instance_mode::default_);
+  Kokkos::Experimental::HPX hpx_default5;
+  hpx_default5 = hpx_default1;
 
-  {
-    Kokkos::Experimental::HPX hpx_default1;
-    Kokkos::Experimental::HPX hpx_default2 = hpx_default1;
-    Kokkos::Experimental::HPX hpx_default3{hpx_default1};
-    Kokkos::Experimental::HPX hpx_default4(
-        Kokkos::Experimental::HPX::instance_mode::default_);
-    Kokkos::Experimental::HPX hpx_default5;
-    hpx_default5 = hpx_default1;
+  ASSERT_EQ(Kokkos::Experimental::HPX::impl_default_instance_id(),
+            hpx_default1.impl_instance_id());
+  ASSERT_EQ(Kokkos::Experimental::HPX::impl_default_instance_id(),
+            hpx_default2.impl_instance_id());
+  ASSERT_EQ(Kokkos::Experimental::HPX::impl_default_instance_id(),
+            hpx_default3.impl_instance_id());
+  ASSERT_EQ(Kokkos::Experimental::HPX::impl_default_instance_id(),
+            hpx_default4.impl_instance_id());
+  ASSERT_EQ(Kokkos::Experimental::HPX::impl_default_instance_id(),
+            hpx_default5.impl_instance_id());
 
-    ASSERT_EQ(Kokkos::Experimental::HPX::impl_default_instance_id(),
-              hpx_default1.impl_instance_id());
-    ASSERT_EQ(Kokkos::Experimental::HPX::impl_default_instance_id(),
-              hpx_default2.impl_instance_id());
-    ASSERT_EQ(Kokkos::Experimental::HPX::impl_default_instance_id(),
-              hpx_default3.impl_instance_id());
-    ASSERT_EQ(Kokkos::Experimental::HPX::impl_default_instance_id(),
-              hpx_default4.impl_instance_id());
-    ASSERT_EQ(Kokkos::Experimental::HPX::impl_default_instance_id(),
-              hpx_default5.impl_instance_id());
+  Kokkos::Experimental::HPX hpx_independent1(
+      Kokkos::Experimental::HPX::instance_mode::independent);
+  Kokkos::Experimental::HPX hpx_independent2 = hpx_independent1;
+  Kokkos::Experimental::HPX hpx_independent3{hpx_independent1};
+  Kokkos::Experimental::HPX hpx_independent4;
+  hpx_independent4 = hpx_independent1;
 
-    Kokkos::Experimental::HPX hpx_independent1(
-        Kokkos::Experimental::HPX::instance_mode::independent);
-    Kokkos::Experimental::HPX hpx_independent2 = hpx_independent1;
-    Kokkos::Experimental::HPX hpx_independent3{hpx_independent1};
-    Kokkos::Experimental::HPX hpx_independent4;
-    hpx_independent4 = hpx_independent1;
+  ASSERT_NE(hpx_default1.impl_instance_id(),
+            hpx_independent1.impl_instance_id());
+  ASSERT_EQ(hpx_independent1.impl_instance_id(),
+            hpx_independent2.impl_instance_id());
+  ASSERT_EQ(hpx_independent1.impl_instance_id(),
+            hpx_independent3.impl_instance_id());
+  ASSERT_EQ(hpx_independent1.impl_instance_id(),
+            hpx_independent4.impl_instance_id());
 
-    ASSERT_NE(hpx_default1.impl_instance_id(),
-              hpx_independent1.impl_instance_id());
-    ASSERT_EQ(hpx_independent1.impl_instance_id(),
-              hpx_independent2.impl_instance_id());
-    ASSERT_EQ(hpx_independent1.impl_instance_id(),
-              hpx_independent3.impl_instance_id());
-    ASSERT_EQ(hpx_independent1.impl_instance_id(),
-              hpx_independent4.impl_instance_id());
+  hpx::shared_future<void> f = hpx::make_ready_future<void>();
+  Kokkos::Experimental::HPX hpx_independent_future1(f);
+  Kokkos::Experimental::HPX hpx_independent_future2 = hpx_independent_future1;
+  Kokkos::Experimental::HPX hpx_independent_future3{hpx_independent_future1};
+  Kokkos::Experimental::HPX hpx_independent_future4;
+  hpx_independent_future4 = hpx_independent_future1;
 
-    hpx::shared_future<void> f = hpx::make_ready_future<void>();
-    Kokkos::Experimental::HPX hpx_independent_future1(f);
-    Kokkos::Experimental::HPX hpx_independent_future2 = hpx_independent_future1;
-    Kokkos::Experimental::HPX hpx_independent_future3{hpx_independent_future1};
-    Kokkos::Experimental::HPX hpx_independent_future4;
-    hpx_independent_future4 = hpx_independent_future1;
-
-    ASSERT_NE(hpx_default1.impl_instance_id(),
-              hpx_independent1.impl_instance_id());
-    ASSERT_NE(hpx_independent1.impl_instance_id(),
-              hpx_independent_future1.impl_instance_id());
-    ASSERT_EQ(hpx_independent_future1.impl_instance_id(),
-              hpx_independent_future2.impl_instance_id());
-    ASSERT_EQ(hpx_independent_future1.impl_instance_id(),
-              hpx_independent_future3.impl_instance_id());
-    ASSERT_EQ(hpx_independent_future1.impl_instance_id(),
-              hpx_independent_future4.impl_instance_id());
-  }
-
-  Kokkos::finalize();
+  ASSERT_NE(hpx_default1.impl_instance_id(),
+            hpx_independent1.impl_instance_id());
+  ASSERT_NE(hpx_independent1.impl_instance_id(),
+            hpx_independent_future1.impl_instance_id());
+  ASSERT_EQ(hpx_independent_future1.impl_instance_id(),
+            hpx_independent_future2.impl_instance_id());
+  ASSERT_EQ(hpx_independent_future1.impl_instance_id(),
+            hpx_independent_future3.impl_instance_id());
+  ASSERT_EQ(hpx_independent_future1.impl_instance_id(),
+            hpx_independent_future4.impl_instance_id());
 }
-}  // namespace Test
+
+}  // namespace
 
 #endif

--- a/core/unit_test/hpx/TestHPX_IndependentInstancesRefCounting.cpp
+++ b/core/unit_test/hpx/TestHPX_IndependentInstancesRefCounting.cpp
@@ -47,7 +47,6 @@
 
 #ifdef KOKKOS_ENABLE_HPX_ASYNC_DISPATCH
 
-namespace Test {
 namespace {
 std::atomic<int> dummy_count;
 
@@ -57,38 +56,32 @@ struct dummy {
   ~dummy() { --dummy_count; }
   void f() const {}
 };
-}  // namespace
+
 // This test makes sure the independent HPX instances don't hold on to captured
 // data after destruction.
-TEST(hpx, reference_counting) {
-  Kokkos::InitArguments arguments{-1, -1, -1, false};
-  Kokkos::initialize(arguments);
+TEST(hpx, independent_instances_reference_counting) {
+  dummy d;
+  Kokkos::Experimental::HPX hpx(
+      Kokkos::Experimental::HPX::instance_mode::independent);
+  Kokkos::parallel_for(
+      "Test::hpx::reference_counting::dummy",
+      Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx, 0, 1),
+      KOKKOS_LAMBDA(int) {
+        // Make sure dummy struct is captured.
+        d.f();
+      });
 
-  {
-    dummy d;
-    Kokkos::Experimental::HPX hpx(
-        Kokkos::Experimental::HPX::instance_mode::independent);
-    Kokkos::parallel_for(
-        "Test::hpx::reference_counting::dummy",
-        Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx, 0, 1),
-        KOKKOS_LAMBDA(int) {
-          // Make sure dummy struct is captured.
-          d.f();
-        });
+  hpx.fence();
 
-    hpx.fence();
+  // The fence above makes sure that copies of dummy get released. However,
+  // all copies are not guaranteed to be released as soon as fence returns.
+  // Therefore we wait for a short time to make it almost guaranteed that all
+  // copies have been released.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    // The fence above makes sure that copies of dummy get released. However,
-    // all copies are not guaranteed to be released as soon as fence returns.
-    // Therefore we wait for a short time to make it almost guaranteed that all
-    // copies have been released.
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-    ASSERT_EQ(1, dummy_count);
-  }
-
-  Kokkos::finalize();
+  ASSERT_EQ(1, dummy_count);
 }
-}  // namespace Test
+
+}  // namespace
 
 #endif


### PR DESCRIPTION
cc @msimberg 

Rational for touching these was the `InitArguments` struct is being deprecated.
Make sure you hide whitespaces when you review.