### PR TITLE
Deprecate nested types in functional

### DIFF
--- a/containers/src/Kokkos_Functional.hpp
+++ b/containers/src/Kokkos_Functional.hpp
@@ -52,10 +52,12 @@ namespace Kokkos {
 
 template <typename T>
 struct pod_hash {
-  using argument_type        = T;
-  using first_argument_type  = T;
-  using second_argument_type = uint32_t;
-  using result_type          = uint32_t;
+#if defined KOKKOS_ENABLE_DEPRECATED_CODE_3
+  using argument_type KOKKOS_DEPRECATED        = T;
+  using first_argument_type KOKKOS_DEPRECATED  = T;
+  using second_argument_type KOKKOS_DEPRECATED = uint32_t;
+  using result_type KOKKOS_DEPRECATED          = uint32_t;
+#endif
 
   KOKKOS_FORCEINLINE_FUNCTION
   uint32_t operator()(T const& t) const {
@@ -70,9 +72,11 @@ struct pod_hash {
 
 template <typename T>
 struct pod_equal_to {
-  using first_argument_type  = T;
-  using second_argument_type = T;
-  using result_type          = bool;
+#if defined KOKKOS_ENABLE_DEPRECATED_CODE_3
+  using first_argument_type KOKKOS_DEPRECATED  = T;
+  using second_argument_type KOKKOS_DEPRECATED = T;
+  using result_type KOKKOS_DEPRECATED          = bool;
+#endif
 
   KOKKOS_FORCEINLINE_FUNCTION
   bool operator()(T const& a, T const& b) const {
@@ -82,9 +86,11 @@ struct pod_equal_to {
 
 template <typename T>
 struct pod_not_equal_to {
-  using first_argument_type  = T;
-  using second_argument_type = T;
-  using result_type          = bool;
+#if defined KOKKOS_ENABLE_DEPRECATED_CODE_3
+  using first_argument_type KOKKOS_DEPRECATED  = T;
+  using second_argument_type KOKKOS_DEPRECATED = T;
+  using result_type KOKKOS_DEPRECATED          = bool;
+#endif
 
   KOKKOS_FORCEINLINE_FUNCTION
   bool operator()(T const& a, T const& b) const {
@@ -94,9 +100,11 @@ struct pod_not_equal_to {
 
 template <typename T>
 struct equal_to {
-  using first_argument_type  = T;
-  using second_argument_type = T;
-  using result_type          = bool;
+#if defined KOKKOS_ENABLE_DEPRECATED_CODE_3
+  using first_argument_type KOKKOS_DEPRECATED  = T;
+  using second_argument_type KOKKOS_DEPRECATED = T;
+  using result_type KOKKOS_DEPRECATED          = bool;
+#endif
 
   KOKKOS_FORCEINLINE_FUNCTION
   bool operator()(T const& a, T const& b) const { return a == b; }
@@ -104,9 +112,11 @@ struct equal_to {
 
 template <typename T>
 struct not_equal_to {
-  using first_argument_type  = T;
-  using second_argument_type = T;
-  using result_type          = bool;
+#if defined KOKKOS_ENABLE_DEPRECATED_CODE_3
+  using first_argument_type KOKKOS_DEPRECATED  = T;
+  using second_argument_type KOKKOS_DEPRECATED = T;
+  using result_type KOKKOS_DEPRECATED          = bool;
+#endif
 
   KOKKOS_FORCEINLINE_FUNCTION
   bool operator()(T const& a, T const& b) const { return a != b; }
@@ -114,9 +124,11 @@ struct not_equal_to {
 
 template <typename T>
 struct greater {
-  using first_argument_type  = T;
-  using second_argument_type = T;
-  using result_type          = bool;
+#if defined KOKKOS_ENABLE_DEPRECATED_CODE_3
+  using first_argument_type KOKKOS_DEPRECATED  = T;
+  using second_argument_type KOKKOS_DEPRECATED = T;
+  using result_type KOKKOS_DEPRECATED          = bool;
+#endif
 
   KOKKOS_FORCEINLINE_FUNCTION
   bool operator()(T const& a, T const& b) const { return a > b; }
@@ -124,9 +136,11 @@ struct greater {
 
 template <typename T>
 struct less {
-  using first_argument_type  = T;
-  using second_argument_type = T;
-  using result_type          = bool;
+#if defined KOKKOS_ENABLE_DEPRECATED_CODE_3
+  using first_argument_type KOKKOS_DEPRECATED  = T;
+  using second_argument_type KOKKOS_DEPRECATED = T;
+  using result_type KOKKOS_DEPRECATED          = bool;
+#endif
 
   KOKKOS_FORCEINLINE_FUNCTION
   bool operator()(T const& a, T const& b) const { return a < b; }
@@ -134,9 +148,11 @@ struct less {
 
 template <typename T>
 struct greater_equal {
-  using first_argument_type  = T;
-  using second_argument_type = T;
-  using result_type          = bool;
+#if defined KOKKOS_ENABLE_DEPRECATED_CODE_3
+  using first_argument_type KOKKOS_DEPRECATED  = T;
+  using second_argument_type KOKKOS_DEPRECATED = T;
+  using result_type KOKKOS_DEPRECATED          = bool;
+#endif
 
   KOKKOS_FORCEINLINE_FUNCTION
   bool operator()(T const& a, T const& b) const { return a >= b; }
@@ -144,9 +160,11 @@ struct greater_equal {
 
 template <typename T>
 struct less_equal {
-  using first_argument_type  = T;
-  using second_argument_type = T;
-  using result_type          = bool;
+#if defined KOKKOS_ENABLE_DEPRECATED_CODE_3
+  using first_argument_type KOKKOS_DEPRECATED  = T;
+  using second_argument_type KOKKOS_DEPRECATED = T;
+  using result_type KOKKOS_DEPRECATED          = bool;
+#endif
 
   KOKKOS_FORCEINLINE_FUNCTION
   bool operator()(T const& a, T const& b) const { return a <= b; }


### PR DESCRIPTION
The functions in `Kokkos_Functional.hpp` mimic parts of  `<functional>` but are device portable. See [greater](https://en.cppreference.com/w/cpp/utility/functional/greater) as example. 
In the std lib the nested typenames `result_type`, `first_argument_type`, and `second_argument_type` are deprecated in c++17 and removed in 20. The respective functions in Kokkos should be marked deprecated when bumping to c++17

~Unfortunately, it looks like `using` declarations can not be attributed with `[[deprecated]]` but `typedef` can.~