### PR TITLE
Allow CUDA PTX forward compatibility if using Clang

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -418,7 +418,13 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream,
     int compiled_major = m_cudaArch / 100;
     int compiled_minor = (m_cudaArch % 100) / 10;
 
+#if defined(__clang__) && defined(__CUDA__)
+    // clang compiling CUDA code, allows forwards compatibility
+    if ((compiled_major > cudaProp.major) ||
+        (compiled_major == cudaProp.major && compiled_minor > cudaProp.minor)) {
+#else
     if (compiled_major != cudaProp.major || compiled_minor > cudaProp.minor) {
+#endif
       std::stringstream ss;
       ss << "Kokkos::Cuda::initialize ERROR: running kernels compiled for "
             "compute capability "


### PR DESCRIPTION
This is a fix for #3612 because Clang always includes PTX