### PR TITLE
Preserve KOKKOS_INVALID_INDEX in ViewDimension and ArrayLayout construction

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -80,7 +80,7 @@ class ViewMapping {
 };
 
 template <typename IntType>
-KOKKOS_INLINE_FUNCTION std::size_t count_valid_integers(
+constexpr KOKKOS_INLINE_FUNCTION std::size_t count_valid_integers(
     const IntType i0, const IntType i1, const IntType i2, const IntType i3,
     const IntType i4, const IntType i5, const IntType i6, const IntType i7) {
   static_assert(std::is_integral<IntType>::value,
@@ -93,18 +93,18 @@ KOKKOS_INLINE_FUNCTION std::size_t count_valid_integers(
 }
 
 KOKKOS_INLINE_FUNCTION
-void runtime_check_rank(const size_t dyn_rank, const bool is_void_spec,
-                        const size_t i0, const size_t i1, const size_t i2,
-                        const size_t i3, const size_t i4, const size_t i5,
-                        const size_t i6, const size_t i7,
-                        const std::string& label) {
+void runtime_check_rank(const size_t rank, const size_t dyn_rank,
+                        const bool is_void_spec, const size_t i0,
+                        const size_t i1, const size_t i2, const size_t i3,
+                        const size_t i4, const size_t i5, const size_t i6,
+                        const size_t i7, const std::string& label) {
   (void)(label);
 
   if (is_void_spec) {
     const size_t num_passed_args =
         count_valid_integers(i0, i1, i2, i3, i4, i5, i6, i7);
 
-    if (num_passed_args != dyn_rank) {
+    if (num_passed_args != dyn_rank && num_passed_args != rank) {
       KOKKOS_IF_ON_HOST(
           const std::string message =
               "Constructor for Kokkos View '" + label +
@@ -1451,7 +1451,7 @@ class View : public ViewTraits<DataType, Properties...> {
               prop_copy)
               .value;
       Impl::runtime_check_rank(
-          traits::rank_dynamic,
+          traits::rank, traits::rank_dynamic,
           std::is_same<typename traits::specialize, void>::value, i0, i1, i2,
           i3, i4, i5, i6, i7, alloc_name);
     }

--- a/core/src/impl/Kokkos_ViewLayoutTiled.hpp
+++ b/core/src/impl/Kokkos_ViewLayoutTiled.hpp
@@ -493,8 +493,14 @@ struct ViewOffset<
   //----------------------------------------
 
   KOKKOS_INLINE_FUNCTION constexpr array_layout layout() const {
-    return array_layout(m_dim.N0, m_dim.N1, m_dim.N2, m_dim.N2, m_dim.N3,
-                        m_dim.N4, m_dim.N5, m_dim.N6, m_dim.N7);
+    return array_layout((VORank > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
+                        (VORank > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
+                        (VORank > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
+                        (VORank > 3 ? m_dim.N3 : KOKKOS_INVALID_INDEX),
+                        (VORank > 4 ? m_dim.N4 : KOKKOS_INVALID_INDEX),
+                        (VORank > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX),
+                        (VORank > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX),
+                        (VORank > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX));
   }
 
   KOKKOS_INLINE_FUNCTION constexpr size_type dimension_0() const {

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -197,7 +197,14 @@ struct KOKKOS_IMPL_ENFORCE_EMPTY_BASE_OPTIMIZATION ViewDimension
   KOKKOS_INLINE_FUNCTION
   constexpr ViewDimension(size_t n0, size_t n1, size_t n2, size_t n3, size_t n4,
                           size_t n5, size_t n6, size_t n7)
-      : D0(n0), D1(n1), D2(n2), D3(n3), D4(n4), D5(n5), D6(n6), D7(n7) {}
+      : D0(n0 == KOKKOS_INVALID_INDEX ? 1 : n0),
+        D1(n1 == KOKKOS_INVALID_INDEX ? 1 : n1),
+        D2(n2 == KOKKOS_INVALID_INDEX ? 1 : n2),
+        D3(n3 == KOKKOS_INVALID_INDEX ? 1 : n3),
+        D4(n4 == KOKKOS_INVALID_INDEX ? 1 : n4),
+        D5(n5 == KOKKOS_INVALID_INDEX ? 1 : n5),
+        D6(n6 == KOKKOS_INVALID_INDEX ? 1 : n6),
+        D7(n7 == KOKKOS_INVALID_INDEX ? 1 : n7) {}
 
   KOKKOS_INLINE_FUNCTION
   constexpr size_t extent(const unsigned r) const noexcept {
@@ -973,8 +980,15 @@ struct ViewOffset<
 
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
-    return array_layout(m_dim.N0, m_dim.N1, m_dim.N2, m_dim.N3, m_dim.N4,
-                        m_dim.N5, m_dim.N6, m_dim.N7);
+    constexpr auto r = dimension_type::rank_dynamic;
+    return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
+                        (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
+                        (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
+                        (r > 3 ? m_dim.N3 : KOKKOS_INVALID_INDEX),
+                        (r > 4 ? m_dim.N4 : KOKKOS_INVALID_INDEX),
+                        (r > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX),
+                        (r > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX),
+                        (r > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX));
   }
 
   KOKKOS_INLINE_FUNCTION constexpr size_type dimension_0() const {
@@ -1256,8 +1270,15 @@ struct ViewOffset<
 
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
-    return array_layout(m_dim.N0, m_dim.N1, m_dim.N2, m_dim.N3, m_dim.N4,
-                        m_dim.N5, m_dim.N6, m_dim.N7);
+    constexpr auto r = dimension_type::rank_dynamic;
+    return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
+                        (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
+                        (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
+                        (r > 3 ? m_dim.N3 : KOKKOS_INVALID_INDEX),
+                        (r > 4 ? m_dim.N4 : KOKKOS_INVALID_INDEX),
+                        (r > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX),
+                        (r > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX),
+                        (r > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX));
   }
 
   KOKKOS_INLINE_FUNCTION constexpr size_type dimension_0() const {
@@ -1600,8 +1621,15 @@ struct ViewOffset<
 
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
-    return array_layout(m_dim.N0, m_dim.N1, m_dim.N2, m_dim.N3, m_dim.N4,
-                        m_dim.N5, m_dim.N6, m_dim.N7);
+    constexpr auto r = dimension_type::rank_dynamic;
+    return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
+                        (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
+                        (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
+                        (r > 3 ? m_dim.N3 : KOKKOS_INVALID_INDEX),
+                        (r > 4 ? m_dim.N4 : KOKKOS_INVALID_INDEX),
+                        (r > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX),
+                        (r > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX),
+                        (r > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX));
   }
 
   KOKKOS_INLINE_FUNCTION constexpr size_type dimension_0() const {
@@ -1882,8 +1910,15 @@ struct ViewOffset<
 
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
-    return array_layout(m_dim.N0, m_dim.N1, m_dim.N2, m_dim.N3, m_dim.N4,
-                        m_dim.N5, m_dim.N6, m_dim.N7);
+    constexpr auto r = dimension_type::rank_dynamic;
+    return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
+                        (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
+                        (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
+                        (r > 3 ? m_dim.N3 : KOKKOS_INVALID_INDEX),
+                        (r > 4 ? m_dim.N4 : KOKKOS_INVALID_INDEX),
+                        (r > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX),
+                        (r > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX),
+                        (r > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX));
   }
 
   KOKKOS_INLINE_FUNCTION constexpr size_type dimension_0() const {
@@ -2411,10 +2446,15 @@ struct ViewOffset<Dimension, Kokkos::LayoutStride, void> {
 
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
-    return array_layout(m_dim.N0, m_stride.S0, m_dim.N1, m_stride.S1, m_dim.N2,
-                        m_stride.S2, m_dim.N3, m_stride.S3, m_dim.N4,
-                        m_stride.S4, m_dim.N5, m_stride.S5, m_dim.N6,
-                        m_stride.S6, m_dim.N7, m_stride.S7);
+    constexpr auto r = dimension_type::rank_dynamic;
+    return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX), m_stride.S0,
+                        (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX), m_stride.S1,
+                        (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX), m_stride.S2,
+                        (r > 3 ? m_dim.N3 : KOKKOS_INVALID_INDEX), m_stride.S3,
+                        (r > 4 ? m_dim.N4 : KOKKOS_INVALID_INDEX), m_stride.S4,
+                        (r > 5 ? m_dim.N5 : KOKKOS_INVALID_INDEX), m_stride.S5,
+                        (r > 6 ? m_dim.N6 : KOKKOS_INVALID_INDEX), m_stride.S6,
+                        (r > 7 ? m_dim.N7 : KOKKOS_INVALID_INDEX), m_stride.S7);
   }
 
   KOKKOS_INLINE_FUNCTION constexpr size_type dimension_0() const {

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -980,7 +980,7 @@ struct ViewOffset<
 
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
-    constexpr auto r = dimension_type::rank_dynamic;
+    constexpr auto r = dimension_type::rank;
     return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
                         (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
                         (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
@@ -1270,7 +1270,7 @@ struct ViewOffset<
 
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
-    constexpr auto r = dimension_type::rank_dynamic;
+    constexpr auto r = dimension_type::rank;
     return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
                         (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
                         (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
@@ -1621,7 +1621,7 @@ struct ViewOffset<
 
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
-    constexpr auto r = dimension_type::rank_dynamic;
+    constexpr auto r = dimension_type::rank;
     return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
                         (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
                         (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
@@ -1910,7 +1910,7 @@ struct ViewOffset<
 
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
-    constexpr auto r = dimension_type::rank_dynamic;
+    constexpr auto r = dimension_type::rank;
     return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX),
                         (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX),
                         (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX),
@@ -2446,7 +2446,7 @@ struct ViewOffset<Dimension, Kokkos::LayoutStride, void> {
 
   KOKKOS_INLINE_FUNCTION
   constexpr array_layout layout() const {
-    constexpr auto r = dimension_type::rank_dynamic;
+    constexpr auto r = dimension_type::rank;
     return array_layout((r > 0 ? m_dim.N0 : KOKKOS_INVALID_INDEX), m_stride.S0,
                         (r > 1 ? m_dim.N1 : KOKKOS_INVALID_INDEX), m_stride.S1,
                         (r > 2 ? m_dim.N2 : KOKKOS_INVALID_INDEX), m_stride.S2,

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1014,6 +1014,35 @@ class TestViewAPI {
 #endif
   }
 
+  static void run_test_contruction_from_layout() {
+    using hView0 = typename dView0::HostMirror;
+    using hView1 = typename dView1::HostMirror;
+    using hView2 = typename dView2::HostMirror;
+    using hView3 = typename dView3::HostMirror;
+    using hView4 = typename dView4::HostMirror;
+
+    hView0 hv_0("dView0::HostMirror");
+    hView1 hv_1("dView1::HostMirror", N0);
+    hView2 hv_2("dView2::HostMirror", N0);
+    hView3 hv_3("dView3::HostMirror", N0);
+    hView4 hv_4("dView4::HostMirror", N0);
+
+    dView0 dv_0_1(nullptr, 0);
+    dView0 dv_0_2(hv_0.label(), hv_0.layout());
+
+    dView1 dv_1_1(nullptr, 0);
+    dView1 dv_1_2(hv_1.label(), hv_1.layout());
+
+    dView2 dv_2_1(nullptr, 0);
+    dView2 dv_2_2(hv_2.label(), hv_2.layout());
+
+    dView3 dv_3_1(nullptr, 0);
+    dView3 dv_3_2(hv_3.label(), hv_3.layout());
+
+    dView4 dv_4_1(nullptr, 0);
+    dView4 dv_4_2(hv_4.label(), hv_4.layout());
+  }
+
   static void run_test() {
     // mfh 14 Feb 2014: This test doesn't actually create instances of
     // these types.  In order to avoid "unused type alias"

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1043,6 +1043,62 @@ class TestViewAPI {
     dView4 dv_4_2(hv_4.label(), hv_4.layout());
   }
 
+  static void run_test_contruction_from_layout_2() {
+    using dView3_0 = Kokkos::View<T ***, device>;
+    using dView3_1 = Kokkos::View<T * * [N1], device>;
+    using dView3_2 = Kokkos::View<T * [N1][N2], device>;
+    using dView3_3 = Kokkos::View<T[N0][N1][N2], device>;
+
+    dView3_0 v_0("v_0", N0, N1, N2);
+    dView3_1 v_1("v_1", N0, N1);
+    dView3_2 v_2("v_2", N0);
+    dView3_3 v_3("v_2");
+
+    dView3_1 v_1_a("v_1", N0, N1, N2);
+    dView3_2 v_2_a("v_2", N0, N1, N2);
+    dView3_3 v_3_a("v_2", N0, N1, N2);
+
+    {
+      dView3_0 dv_1(v_0.label(), v_0.layout());
+      dView3_0 dv_2(v_1.label(), v_1.layout());
+      dView3_0 dv_3(v_2.label(), v_2.layout());
+      dView3_0 dv_4(v_3.label(), v_3.layout());
+      dView3_0 dv_5(v_1_a.label(), v_1_a.layout());
+      dView3_0 dv_6(v_2_a.label(), v_2_a.layout());
+      dView3_0 dv_7(v_3_a.label(), v_3_a.layout());
+    }
+
+    {
+      dView3_1 dv_1(v_0.label(), v_0.layout());
+      dView3_1 dv_2(v_1.label(), v_1.layout());
+      dView3_1 dv_3(v_2.label(), v_2.layout());
+      dView3_1 dv_4(v_3.label(), v_3.layout());
+      dView3_1 dv_5(v_1_a.label(), v_1_a.layout());
+      dView3_1 dv_6(v_2_a.label(), v_2_a.layout());
+      dView3_1 dv_7(v_3_a.label(), v_3_a.layout());
+    }
+
+    {
+      dView3_2 dv_1(v_0.label(), v_0.layout());
+      dView3_2 dv_2(v_1.label(), v_1.layout());
+      dView3_2 dv_3(v_2.label(), v_2.layout());
+      dView3_2 dv_4(v_3.label(), v_3.layout());
+      dView3_2 dv_5(v_1_a.label(), v_1_a.layout());
+      dView3_2 dv_6(v_2_a.label(), v_2_a.layout());
+      dView3_2 dv_7(v_3_a.label(), v_3_a.layout());
+    }
+
+    {
+      dView3_3 dv_1(v_0.label(), v_0.layout());
+      dView3_3 dv_2(v_1.label(), v_1.layout());
+      dView3_3 dv_3(v_2.label(), v_2.layout());
+      dView3_3 dv_4(v_3.label(), v_3.layout());
+      dView3_3 dv_5(v_1_a.label(), v_1_a.layout());
+      dView3_3 dv_6(v_2_a.label(), v_2_a.layout());
+      dView3_3 dv_7(v_3_a.label(), v_3_a.layout());
+    }
+  }
+
   static void run_test() {
     // mfh 14 Feb 2014: This test doesn't actually create instances of
     // these types.  In order to avoid "unused type alias"

--- a/core/unit_test/TestViewAPI_b.hpp
+++ b/core/unit_test/TestViewAPI_b.hpp
@@ -51,6 +51,7 @@ TEST(TEST_CATEGORY, view_api_b) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_mirror();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_scalar();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_contruction_from_layout();
+  TestViewAPI<double, TEST_EXECSPACE>::run_test_contruction_from_layout_2();
 }
 
 }  // namespace Test

--- a/core/unit_test/TestViewAPI_b.hpp
+++ b/core/unit_test/TestViewAPI_b.hpp
@@ -50,6 +50,7 @@ TEST(TEST_CATEGORY, view_api_b) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_view_operator_a();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_mirror();
   TestViewAPI<double, TEST_EXECSPACE>::run_test_scalar();
+  TestViewAPI<double, TEST_EXECSPACE>::run_test_contruction_from_layout();
 }
 
 }  // namespace Test

--- a/core/unit_test/TestViewCtorDimMatch.hpp
+++ b/core/unit_test/TestViewCtorDimMatch.hpp
@@ -214,7 +214,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
   {
     // test View parameters for View dim = 1, dynamic = 0
     LIVE({ Kokkos::View<DType_1> v_0("v_0" PARAM_0); }, 0, 0);
-    DIE({ Kokkos::View<DType_1> v_1("v_1", PARAM_1); }, 1, 0);
+    LIVE({ Kokkos::View<DType_1> v_1("v_1", PARAM_1); }, 1, 0);
     DIE({ Kokkos::View<DType_1> v_2("v_2", PARAM_2); }, 2, 0);
     DIE({ Kokkos::View<DType_1> v_3("v_3", PARAM_3); }, 3, 0);
     DIE({ Kokkos::View<DType_1> v_4("v_4", PARAM_4); }, 4, 0);
@@ -227,7 +227,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
     // test View parameters for View dim = 2, dynamic = 0
     LIVE({ Kokkos::View<DType_2> v_0("v_0" PARAM_0); }, 0, 0);
     DIE({ Kokkos::View<DType_2> v_1("v_1", PARAM_1); }, 1, 0);
-    DIE({ Kokkos::View<DType_2> v_2("v_2", PARAM_2); }, 2, 0);
+    LIVE({ Kokkos::View<DType_2> v_2("v_2", PARAM_2); }, 2, 0);
     DIE({ Kokkos::View<DType_2> v_3("v_3", PARAM_3); }, 3, 0);
     DIE({ Kokkos::View<DType_2> v_4("v_4", PARAM_4); }, 4, 0);
     DIE({ Kokkos::View<DType_2> v_5("v_5", PARAM_5); }, 5, 0);
@@ -240,7 +240,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
     LIVE({ Kokkos::View<DType_3> v_0("v_0" PARAM_0); }, 0, 0);
     DIE({ Kokkos::View<DType_3> v_1("v_1", PARAM_1); }, 1, 0);
     DIE({ Kokkos::View<DType_3> v_2("v_2", PARAM_2); }, 2, 0);
-    DIE({ Kokkos::View<DType_3> v_3("v_3", PARAM_3); }, 3, 0);
+    LIVE({ Kokkos::View<DType_3> v_3("v_3", PARAM_3); }, 3, 0);
     DIE({ Kokkos::View<DType_3> v_4("v_4", PARAM_4); }, 4, 0);
     DIE({ Kokkos::View<DType_3> v_5("v_5", PARAM_5); }, 5, 0);
     DIE({ Kokkos::View<DType_3> v_6("v_6", PARAM_6); }, 6, 0);
@@ -253,7 +253,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
     DIE({ Kokkos::View<DType_4> v_1("v_1", PARAM_1); }, 1, 0);
     DIE({ Kokkos::View<DType_4> v_2("v_2", PARAM_2); }, 2, 0);
     DIE({ Kokkos::View<DType_4> v_3("v_3", PARAM_3); }, 3, 0);
-    DIE({ Kokkos::View<DType_4> v_4("v_4", PARAM_4); }, 4, 0);
+    LIVE({ Kokkos::View<DType_4> v_4("v_4", PARAM_4); }, 4, 0);
     DIE({ Kokkos::View<DType_4> v_5("v_5", PARAM_5); }, 5, 0);
     DIE({ Kokkos::View<DType_4> v_6("v_6", PARAM_6); }, 6, 0);
     DIE({ Kokkos::View<DType_4> v_7("v_7", PARAM_7); }, 7, 0);
@@ -266,7 +266,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
     DIE({ Kokkos::View<DType_5> v_2("v_2", PARAM_2); }, 2, 0);
     DIE({ Kokkos::View<DType_5> v_3("v_3", PARAM_3); }, 3, 0);
     DIE({ Kokkos::View<DType_5> v_4("v_4", PARAM_4); }, 4, 0);
-    DIE({ Kokkos::View<DType_5> v_5("v_5", PARAM_5); }, 5, 0);
+    LIVE({ Kokkos::View<DType_5> v_5("v_5", PARAM_5); }, 5, 0);
     DIE({ Kokkos::View<DType_5> v_6("v_6", PARAM_6); }, 6, 0);
     DIE({ Kokkos::View<DType_5> v_7("v_7", PARAM_7); }, 7, 0);
   }
@@ -279,7 +279,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
     DIE({ Kokkos::View<DType_6> v_3("v_3", PARAM_3); }, 3, 0);
     DIE({ Kokkos::View<DType_6> v_4("v_4", PARAM_4); }, 4, 0);
     DIE({ Kokkos::View<DType_6> v_5("v_5", PARAM_5); }, 5, 0);
-    DIE({ Kokkos::View<DType_6> v_6("v_6", PARAM_6); }, 6, 0);
+    LIVE({ Kokkos::View<DType_6> v_6("v_6", PARAM_6); }, 6, 0);
     DIE({ Kokkos::View<DType_6> v_7("v_7", PARAM_7); }, 7, 0);
   }
 
@@ -292,7 +292,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
     DIE({ Kokkos::View<DType_7> v_4("v_4", PARAM_4); }, 4, 0);
     DIE({ Kokkos::View<DType_7> v_5("v_5", PARAM_5); }, 5, 0);
     DIE({ Kokkos::View<DType_7> v_6("v_6", PARAM_6); }, 6, 0);
-    DIE({ Kokkos::View<DType_7> v_7("v_7", PARAM_7); }, 7, 0);
+    LIVE({ Kokkos::View<DType_7> v_7("v_7", PARAM_7); }, 7, 0);
   }
 }
 
@@ -322,7 +322,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
   {
     // test View parameters for View dim = 1, dynamic = 0
     LIVE({ Kokkos::View<DType_1> v_0("v_0" PARAM_0); }, 0, 0);
-    DIE({ Kokkos::View<DType_1> v_1("v_1", PARAM_1); }, 1, 0);
+    LIVE({ Kokkos::View<DType_1> v_1("v_1", PARAM_1); }, 1, 0);
     DIE({ Kokkos::View<DType_1> v_2("v_2", PARAM_2); }, 2, 0);
     DIE({ Kokkos::View<DType_1> v_3("v_3", PARAM_3); }, 3, 0);
     DIE({ Kokkos::View<DType_1> v_4("v_4", PARAM_4); }, 4, 0);
@@ -335,7 +335,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
     // test View parameters for View dim = 2, dynamic = 1
     DIE({ Kokkos::View<DType_2> v_0("v_0" PARAM_0); }, 0, 1);
     LIVE({ Kokkos::View<DType_2> v_1("v_1", PARAM_1); }, 1, 1);
-    DIE({ Kokkos::View<DType_2> v_2("v_2", PARAM_2); }, 2, 1);
+    LIVE({ Kokkos::View<DType_2> v_2("v_2", PARAM_2); }, 2, 1);
     DIE({ Kokkos::View<DType_2> v_3("v_3", PARAM_3); }, 3, 1);
     DIE({ Kokkos::View<DType_2> v_4("v_4", PARAM_4); }, 4, 1);
     DIE({ Kokkos::View<DType_2> v_5("v_5", PARAM_5); }, 5, 1);
@@ -348,7 +348,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
     DIE({ Kokkos::View<DType_3> v_0("v_0" PARAM_0); }, 0, 2);
     DIE({ Kokkos::View<DType_3> v_1("v_1", PARAM_1); }, 1, 2);
     LIVE({ Kokkos::View<DType_3> v_2("v_2", PARAM_2); }, 2, 2);
-    DIE({ Kokkos::View<DType_3> v_3("v_3", PARAM_3); }, 3, 2);
+    LIVE({ Kokkos::View<DType_3> v_3("v_3", PARAM_3); }, 3, 2);
     DIE({ Kokkos::View<DType_3> v_4("v_4", PARAM_4); }, 4, 2);
     DIE({ Kokkos::View<DType_3> v_5("v_5", PARAM_5); }, 5, 2);
     DIE({ Kokkos::View<DType_3> v_6("v_6", PARAM_6); }, 6, 2);
@@ -361,7 +361,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
     DIE({ Kokkos::View<DType_4> v_1("v_1", PARAM_1); }, 1, 3);
     DIE({ Kokkos::View<DType_4> v_2("v_2", PARAM_2); }, 2, 3);
     LIVE({ Kokkos::View<DType_4> v_3("v_3", PARAM_3); }, 3, 3);
-    DIE({ Kokkos::View<DType_4> v_4("v_4", PARAM_4); }, 4, 3);
+    LIVE({ Kokkos::View<DType_4> v_4("v_4", PARAM_4); }, 4, 3);
     DIE({ Kokkos::View<DType_4> v_5("v_5", PARAM_5); }, 5, 3);
     DIE({ Kokkos::View<DType_4> v_6("v_6", PARAM_6); }, 6, 3);
     DIE({ Kokkos::View<DType_4> v_7("v_7", PARAM_7); }, 7, 3);
@@ -374,7 +374,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
     DIE({ Kokkos::View<DType_5> v_2("v_2", PARAM_2); }, 2, 4);
     DIE({ Kokkos::View<DType_5> v_3("v_3", PARAM_3); }, 3, 4);
     LIVE({ Kokkos::View<DType_5> v_4("v_4", PARAM_4); }, 4, 4);
-    DIE({ Kokkos::View<DType_5> v_5("v_5", PARAM_5); }, 5, 4);
+    LIVE({ Kokkos::View<DType_5> v_5("v_5", PARAM_5); }, 5, 4);
     DIE({ Kokkos::View<DType_5> v_6("v_6", PARAM_6); }, 6, 4);
     DIE({ Kokkos::View<DType_5> v_7("v_7", PARAM_7); }, 7, 4);
   }
@@ -387,7 +387,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
     DIE({ Kokkos::View<DType_6> v_3("v_3", PARAM_3); }, 3, 5);
     DIE({ Kokkos::View<DType_6> v_4("v_4", PARAM_4); }, 4, 5);
     LIVE({ Kokkos::View<DType_6> v_5("v_5", PARAM_5); }, 5, 5);
-    DIE({ Kokkos::View<DType_6> v_6("v_6", PARAM_6); }, 6, 5);
+    LIVE({ Kokkos::View<DType_6> v_6("v_6", PARAM_6); }, 6, 5);
     DIE({ Kokkos::View<DType_6> v_7("v_7", PARAM_7); }, 7, 5);
   }
 
@@ -400,7 +400,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
     DIE({ Kokkos::View<DType_7> v_4("v_4", PARAM_4); }, 4, 6);
     DIE({ Kokkos::View<DType_7> v_5("v_5", PARAM_5); }, 5, 6);
     LIVE({ Kokkos::View<DType_7> v_6("v_6", PARAM_6); }, 6, 6);
-    DIE({ Kokkos::View<DType_7> v_7("v_7", PARAM_7); }, 7, 6);
+    LIVE({ Kokkos::View<DType_7> v_7("v_7", PARAM_7); }, 7, 6);
   }
 }
 #endif  // KOKKOS_ENABLE_OPENMPTARGET

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -248,11 +248,11 @@ void test_view_mapping() {
     ASSERT_EQ(layout.dimension[0], 2u);
     ASSERT_EQ(layout.dimension[1], 3u);
     ASSERT_EQ(layout.dimension[2], 4u);
-    ASSERT_EQ(layout.dimension[3], 1u);
-    ASSERT_EQ(layout.dimension[4], 1u);
-    ASSERT_EQ(layout.dimension[5], 1u);
-    ASSERT_EQ(layout.dimension[6], 1u);
-    ASSERT_EQ(layout.dimension[7], 1u);
+    ASSERT_EQ(layout.dimension[3], KOKKOS_INVALID_INDEX);
+    ASSERT_EQ(layout.dimension[4], KOKKOS_INVALID_INDEX);
+    ASSERT_EQ(layout.dimension[5], KOKKOS_INVALID_INDEX);
+    ASSERT_EQ(layout.dimension[6], KOKKOS_INVALID_INDEX);
+    ASSERT_EQ(layout.dimension[7], KOKKOS_INVALID_INDEX);
 
     ASSERT_EQ(stride3.m_dim.rank, 3u);
     ASSERT_EQ(stride3.m_dim.N0, 2u);


### PR DESCRIPTION
- Preserves KOKKOS_INVALID_INDEX in ViewDimension and ArrayLayout construction.
- Fixes #5175
- Adds unit test for View construction from Layout. This would have failed previously (as found in the issue).