### PR TITLE
Fixup bug in boolean options in `InitializationSettings`

### DIFF
--- a/core/src/impl/Kokkos_InitializationSettings.hpp
+++ b/core/src/impl/Kokkos_InitializationSettings.hpp
@@ -94,7 +94,10 @@ struct InitializationSettingsHelper<bool> {
   using value_type   = bool;
   using storage_type = char;
 
-  static constexpr storage_type unspecified = CHAR_MIN;
+  static constexpr storage_type unspecified = CHAR_MAX;
+  static_assert(static_cast<storage_type>(true) != unspecified &&
+                    static_cast<storage_type>(false) != unspecified,
+                "");
 };
 template <>
 struct InitializationSettingsHelper<std::string> {


### PR DESCRIPTION
Value is stored as `char` and I overlooked that some platform/compiler combination would use an unsigned character type which makes the sentinel value denoting "unspecified" option ambiguous.
Fix #5186