### PR TITLE
Fix Sacado create_mirror_view

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2131,9 +2131,11 @@ create_mirror_view(
 // Create a mirror view in host space
 template <class T, class... P>
 inline std::enable_if_t<
-    std::is_same<
-        typename DynRankView<T, P...>::memory_space,
-        typename DynRankView<T, P...>::HostMirror::memory_space>::value,
+    (std::is_same<
+         typename DynRankView<T, P...>::memory_space,
+         typename DynRankView<T, P...>::HostMirror::memory_space>::value &&
+     std::is_same<typename DynRankView<T, P...>::data_type,
+                  typename DynRankView<T, P...>::HostMirror::data_type>::value),
     typename DynRankView<T, P...>::HostMirror>
 create_mirror_view(const Kokkos::DynRankView<T, P...>& src) {
   return src;
@@ -2141,9 +2143,12 @@ create_mirror_view(const Kokkos::DynRankView<T, P...>& src) {
 
 template <class T, class... P>
 inline std::enable_if_t<
-    !std::is_same<
-        typename DynRankView<T, P...>::memory_space,
-        typename DynRankView<T, P...>::HostMirror::memory_space>::value,
+    !(std::is_same<
+          typename DynRankView<T, P...>::memory_space,
+          typename DynRankView<T, P...>::HostMirror::memory_space>::value &&
+      std::is_same<
+          typename DynRankView<T, P...>::data_type,
+          typename DynRankView<T, P...>::HostMirror::data_type>::value),
     typename DynRankView<T, P...>::HostMirror>
 create_mirror_view(const Kokkos::DynRankView<T, P...>& src) {
   return Kokkos::create_mirror(src);

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2130,8 +2130,23 @@ create_mirror_view(
 
 // Create a mirror view in host space
 template <class T, class... P>
-inline auto create_mirror_view(const DynRankView<T, P...>& src) {
-  return Impl::create_mirror_view(src, Impl::ViewCtorProp<>{});
+inline std::enable_if_t<
+    std::is_same<
+        typename DynRankView<T, P...>::memory_space,
+        typename DynRankView<T, P...>::HostMirror::memory_space>::value,
+    typename DynRankView<T, P...>::HostMirror>
+create_mirror_view(const Kokkos::DynRankView<T, P...>& src) {
+  return src;
+}
+
+template <class T, class... P>
+inline std::enable_if_t<
+    !std::is_same<
+        typename DynRankView<T, P...>::memory_space,
+        typename DynRankView<T, P...>::HostMirror::memory_space>::value,
+    typename DynRankView<T, P...>::HostMirror>
+create_mirror_view(const Kokkos::DynRankView<T, P...>& src) {
+  return Kokkos::create_mirror(src);
 }
 
 template <class T, class... P>
@@ -2141,10 +2156,26 @@ inline auto create_mirror_view(Kokkos::Impl::WithoutInitializing_t wi,
 }
 
 // Create a mirror view in a new space
-template <class Space, class T, class... P>
-inline auto create_mirror_view(const Space& space,
-                               const Kokkos::DynRankView<T, P...>& src) {
-  return Impl::create_mirror_view(space, src, Impl::ViewCtorProp<>{});
+// FIXME_C++17 Improve SFINAE here.
+template <class Space, class T, class... P,
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+inline typename Impl::MirrorDRViewType<Space, T, P...>::view_type
+create_mirror_view(
+    const Space&, const Kokkos::DynRankView<T, P...>& src,
+    std::enable_if_t<
+        Impl::MirrorDRViewType<Space, T, P...>::is_same_memspace>* = nullptr) {
+  return src;
+}
+
+// FIXME_C++17 Improve SFINAE here.
+template <class Space, class T, class... P,
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+inline typename Impl::MirrorDRViewType<Space, T, P...>::view_type
+create_mirror_view(
+    const Space& space, const Kokkos::DynRankView<T, P...>& src,
+    std::enable_if_t<
+        !Impl::MirrorDRViewType<Space, T, P...>::is_same_memspace>* = nullptr) {
+  return Kokkos::create_mirror(space, src);
 }
 
 template <class Space, class T, class... P>

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3754,19 +3754,27 @@ create_mirror_view(const Space&, const Kokkos::View<T, P...>& src,
 }  // namespace Impl
 
 template <class T, class... P>
-std::enable_if_t<std::is_same<typename Kokkos::View<T, P...>::memory_space,
-                              typename Kokkos::View<
-                                  T, P...>::HostMirror::memory_space>::value,
-                 typename Kokkos::View<T, P...>::HostMirror>
+std::enable_if_t<
+    std::is_same<
+        typename Kokkos::View<T, P...>::memory_space,
+        typename Kokkos::View<T, P...>::HostMirror::memory_space>::value &&
+        std::is_same<
+            typename Kokkos::View<T, P...>::data_type,
+            typename Kokkos::View<T, P...>::HostMirror::data_type>::value,
+    typename Kokkos::View<T, P...>::HostMirror>
 create_mirror_view(const Kokkos::View<T, P...>& src) {
   return src;
 }
 
 template <class T, class... P>
-std::enable_if_t<!std::is_same<typename Kokkos::View<T, P...>::memory_space,
-                               typename Kokkos::View<
-                                   T, P...>::HostMirror::memory_space>::value,
-                 typename Kokkos::View<T, P...>::HostMirror>
+std::enable_if_t<
+    !(std::is_same<
+          typename Kokkos::View<T, P...>::memory_space,
+          typename Kokkos::View<T, P...>::HostMirror::memory_space>::value &&
+      std::is_same<
+          typename Kokkos::View<T, P...>::data_type,
+          typename Kokkos::View<T, P...>::HostMirror::data_type>::value),
+    typename Kokkos::View<T, P...>::HostMirror>
 create_mirror_view(const Kokkos::View<T, P...>& src) {
   return Kokkos::create_mirror(src);
 }

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3754,9 +3754,21 @@ create_mirror_view(const Space&, const Kokkos::View<T, P...>& src,
 }  // namespace Impl
 
 template <class T, class... P>
-typename Kokkos::View<T, P...>::HostMirror create_mirror_view(
-    Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror_view(v, Impl::ViewCtorProp<>{});
+std::enable_if_t<std::is_same<typename Kokkos::View<T, P...>::memory_space,
+                              typename Kokkos::View<
+                                  T, P...>::HostMirror::memory_space>::value,
+                 typename Kokkos::View<T, P...>::HostMirror>
+create_mirror_view(const Kokkos::View<T, P...>& src) {
+  return src;
+}
+
+template <class T, class... P>
+std::enable_if_t<!std::is_same<typename Kokkos::View<T, P...>::memory_space,
+                               typename Kokkos::View<
+                                   T, P...>::HostMirror::memory_space>::value,
+                 typename Kokkos::View<T, P...>::HostMirror>
+create_mirror_view(const Kokkos::View<T, P...>& src) {
+  return Kokkos::create_mirror(src);
 }
 
 template <class T, class... P>
@@ -3765,11 +3777,24 @@ typename Kokkos::View<T, P...>::HostMirror create_mirror_view(
   return Impl::create_mirror_view(v, view_alloc(wi));
 }
 
+// FIXME_C++17 Improve SFINAE here.
 template <class Space, class T, class... P,
-          typename Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
 typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
-    Space const& space, Kokkos::View<T, P...> const& v) {
-  return Impl::create_mirror_view(space, v, Impl::ViewCtorProp<>{});
+    const Space&, const Kokkos::View<T, P...>& src,
+    std::enable_if_t<Impl::MirrorViewType<Space, T, P...>::is_same_memspace>* =
+        nullptr) {
+  return src;
+}
+
+// FIXME_C++17 Improve SFINAE here.
+template <class Space, class T, class... P,
+          class Enable = std::enable_if_t<Kokkos::is_space<Space>::value>>
+typename Impl::MirrorViewType<Space, T, P...>::view_type create_mirror_view(
+    const Space& space, const Kokkos::View<T, P...>& src,
+    std::enable_if_t<!Impl::MirrorViewType<Space, T, P...>::is_same_memspace>* =
+        nullptr) {
+  return Kokkos::create_mirror(space, src);
 }
 
 template <class Space, class T, class... P,


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/5189. It's important to call `Kokkod::create_mirror` from `Kokkos::create_mirror_view` since only the latter one is specialized in `Sacado`.