### PR TITLE
Rename tools settings for consistency

### DIFF
--- a/core/src/impl/Kokkos_Command_Line_Parsing.cpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.cpp
@@ -134,6 +134,14 @@ void Kokkos::Impl::warn_deprecated_environment_variable(
             << " Raised by Kokkos::initialize(int argc, char* argv[])."
             << std::endl;
 }
+void Kokkos::Impl::warn_deprecated_environment_variable(
+    std::string deprecated, std::string use_instead) {
+  std::cerr << "Warning: environment variable '" << deprecated
+            << "' is deprecated."
+            << " Use '" << use_instead << "' instead."
+            << " Raised by Kokkos::initialize(int argc, char* argv[])."
+            << std::endl;
+}
 void Kokkos::Impl::warn_deprecated_command_line_argument(
     std::string deprecated) {
   std::cerr << "Warning: command line argument '" << deprecated

--- a/core/src/impl/Kokkos_Command_Line_Parsing.hpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.hpp
@@ -56,6 +56,8 @@ bool check_arg(char const* arg, char const* expected);
 bool check_int_arg(char const* arg, char const* expected, int* value);
 bool check_str_arg(char const* arg, char const* expected, std::string& value);
 void warn_deprecated_environment_variable(std::string deprecated);
+void warn_deprecated_environment_variable(std::string deprecated,
+                                          std::string use_instead);
 void warn_deprecated_command_line_argument(std::string deprecated);
 void warn_deprecated_command_line_argument(std::string deprecated,
                                            std::string use_instead);

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -637,10 +637,10 @@ Kokkos Core Options:
                                    screen output.
 
 Kokkos Tools Options:
-  --kokkos-tools-library         : Equivalent to KOKKOS_PROFILE_LIBRARY environment
-                                   variable. Must either be full path to library or
-                                   name of library if the path is present in the
-                                   runtime library search path (e.g. LD_LIBRARY_PATH)
+  --kokkos-tools-libs=STR        : Specify which of the tools to use. Must either
+                                   be full path to library or name of library if the
+                                   path is present in the runtime library search path
+                                   (e.g. LD_LIBRARY_PATH)
   --kokkos-tools-help            : Query the (loaded) kokkos-tool for its command-line
                                    option support (which should then be passed via
                                    --kokkos-tools-args="...")

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -116,9 +116,9 @@ void combine(Kokkos::InitializationSettings& out,
   KOKKOS_IMPL_COMBINE_SETTING(skip_device);
   KOKKOS_IMPL_COMBINE_SETTING(disable_warnings);
   KOKKOS_IMPL_COMBINE_SETTING(tune_internals);
-  KOKKOS_IMPL_COMBINE_SETTING(tool_help);
-  KOKKOS_IMPL_COMBINE_SETTING(tool_lib);
-  KOKKOS_IMPL_COMBINE_SETTING(tool_args);
+  KOKKOS_IMPL_COMBINE_SETTING(tools_help);
+  KOKKOS_IMPL_COMBINE_SETTING(tools_libs);
+  KOKKOS_IMPL_COMBINE_SETTING(tools_args);
 #undef KOKKOS_IMPL_COMBINE_SETTING
 }
 
@@ -126,28 +126,28 @@ void combine(Kokkos::InitializationSettings& out,
              Kokkos::Tools::InitArguments const& in) {
   using Kokkos::Tools::InitArguments;
   if (in.help != InitArguments::PossiblyUnsetOption::unset) {
-    out.set_tool_help(in.help == InitArguments::PossiblyUnsetOption::on);
+    out.set_tools_help(in.help == InitArguments::PossiblyUnsetOption::on);
   }
   if (in.lib != InitArguments::unset_string_option) {
-    out.set_tool_lib(in.lib);
+    out.set_tools_libs(in.lib);
   }
   if (in.args != InitArguments::unset_string_option) {
-    out.set_tool_args(in.args);
+    out.set_tools_args(in.args);
   }
 }
 
 void combine(Kokkos::Tools::InitArguments& out,
              Kokkos::InitializationSettings const& in) {
   using Kokkos::Tools::InitArguments;
-  if (in.has_tool_help()) {
-    out.help = in.get_tool_help() ? InitArguments::PossiblyUnsetOption::on
-                                  : InitArguments::PossiblyUnsetOption::off;
+  if (in.has_tools_help()) {
+    out.help = in.get_tools_help() ? InitArguments::PossiblyUnsetOption::on
+                                   : InitArguments::PossiblyUnsetOption::off;
   }
-  if (in.has_tool_lib()) {
-    out.lib = in.get_tool_lib();
+  if (in.has_tools_libs()) {
+    out.lib = in.get_tools_libs();
   }
-  if (in.has_tool_args()) {
-    out.args = in.get_tool_args();
+  if (in.has_tools_args()) {
+    out.args = in.get_tools_args();
   }
 }
 
@@ -828,7 +828,7 @@ void Kokkos::Impl::parse_command_line_arguments(
   if ((tools_init_arguments.args ==
        Kokkos::Tools::InitArguments::unset_string_option) &&
       argc > 0) {
-    settings.set_tool_args(argv[0]);
+    settings.set_tools_args(argv[0]);
   }
 }
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -650,6 +650,12 @@ Kokkos Tools Options:
                                    `<EXE> --kokkos-tools-args="-c input.txt"` will
                                    pass `<EXE> -c input.txt` as argc/argv to tool
 
+Except for --kokkos[-tools]-help, you can alternatively set the corresponding
+environment variable of a flag (all letters in upper-case and underscores
+instead of hyphens). For example, to disable warning messages, you can either
+specify --kokkos-disable-warnings or set the KOKKOS_DISABLE_WARNINGS
+environment variable to yes.
+
 Join us on Slack, visit https://kokkosteam.slack.com
 Report bugs to https://github.com/kokkos/kokkos/issues
 --------------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_InitializationSettings.hpp
+++ b/core/src/impl/Kokkos_InitializationSettings.hpp
@@ -144,9 +144,9 @@ class InitializationSettings {
   KOKKOS_IMPL_DECLARE(int, skip_device);
   KOKKOS_IMPL_DECLARE(bool, disable_warnings);
   KOKKOS_IMPL_DECLARE(bool, tune_internals);
-  KOKKOS_IMPL_DECLARE(bool, tool_help);
-  KOKKOS_IMPL_DECLARE(std::string, tool_lib);
-  KOKKOS_IMPL_DECLARE(std::string, tool_args);
+  KOKKOS_IMPL_DECLARE(bool, tools_help);
+  KOKKOS_IMPL_DECLARE(std::string, tools_libs);
+  KOKKOS_IMPL_DECLARE(std::string, tools_args);
 
 #undef KOKKOS_IMPL_INIT_ARGS_DATA_MEMBER_TYPE
 #undef KOKKOS_IMPL_INIT_ARGS_DATA_MEMBER
@@ -176,13 +176,13 @@ class InitializationSettings {
       set_tune_internals(true);
     }
     if (old.tool_help) {
-      set_tool_help(true);
+      set_tools_help(true);
     }
     if (!old.tool_lib.empty()) {
-      set_tool_lib(old.tool_lib);
+      set_tools_libs(old.tool_lib);
     }
     if (!old.tool_args.empty()) {
-      set_tool_args(old.tool_args);
+      set_tools_args(old.tool_args);
     }
   }
 #endif

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -114,12 +114,18 @@ void parse_command_line_arguments(int& argc, char* argv[],
   using Kokkos::Impl::check_int_arg;
   using Kokkos::Impl::check_str_arg;
 
-  auto& lib  = arguments.lib;
+  auto& libs = arguments.lib;
   auto& args = arguments.args;
   auto& help = arguments.help;
   while (iarg < argc) {
     bool remove_flag = false;
-    if (check_str_arg(argv[iarg], "--kokkos-tools-library", lib)) {
+    if (check_str_arg(argv[iarg], "--kokkos-tools-libs", libs) ||
+        check_str_arg(argv[iarg], "--kokkos-tools-library", libs)) {
+      if (check_arg(argv[iarg], "--kokkos-tools-library")) {
+        using Kokkos::Impl::warn_deprecated_command_line_argument;
+        warn_deprecated_command_line_argument("--kokkos-tools-library",
+                                              "--kokkos-tools-libs");
+      }
       warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(argv[iarg]);
       remove_flag = true;
     } else if (check_str_arg(argv[iarg], "--kokkos-tools-args", args)) {

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -107,7 +107,7 @@ const std::string InitArguments::unset_string_option = {
 InitArguments tool_arguments;
 
 namespace Impl {
-void parse_command_line_arguments(int& narg, char* arg[],
+void parse_command_line_arguments(int& argc, char* argv[],
                                   InitArguments& arguments) {
   int iarg = 0;
   using Kokkos::Impl::check_arg;
@@ -117,13 +117,13 @@ void parse_command_line_arguments(int& narg, char* arg[],
   auto& lib  = arguments.lib;
   auto& args = arguments.args;
   auto& help = arguments.help;
-  while (iarg < narg) {
+  while (iarg < argc) {
     bool remove_flag = false;
-    if (check_str_arg(arg[iarg], "--kokkos-tools-library", lib)) {
-      warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(arg[iarg]);
+    if (check_str_arg(argv[iarg], "--kokkos-tools-library", lib)) {
+      warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(argv[iarg]);
       remove_flag = true;
-    } else if (check_str_arg(arg[iarg], "--kokkos-tools-args", args)) {
-      warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(arg[iarg]);
+    } else if (check_str_arg(argv[iarg], "--kokkos-tools-args", args)) {
+      warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(argv[iarg]);
       remove_flag = true;
       // strip any leading and/or trailing quotes if they were retained in the
       // string because this will very likely cause parsing issues for tools.
@@ -138,22 +138,22 @@ void parse_command_line_arguments(int& narg, char* arg[],
         if (args.back() == '"') args = args.substr(0, args.length() - 1);
       }
       // add the name of the executable to the beginning
-      if (narg > 0) args = std::string(arg[0]) + " " + args;
-    } else if (check_arg(arg[iarg], "--kokkos-tools-help")) {
+      if (argc > 0) args = std::string(argv[0]) + " " + args;
+    } else if (check_arg(argv[iarg], "--kokkos-tools-help")) {
       help = InitArguments::PossiblyUnsetOption::on;
-      warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(arg[iarg]);
+      warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(argv[iarg]);
       remove_flag = true;
     } else {
       iarg++;
     }
     if (remove_flag) {
-      for (int k = iarg; k < narg - 1; k++) {
-        arg[k] = arg[k + 1];
+      for (int k = iarg; k < argc - 1; k++) {
+        argv[k] = argv[k + 1];
       }
-      narg--;
+      argc--;
     }
-    if ((args == Kokkos::Tools::InitArguments::unset_string_option) && narg > 0)
-      args = arg[0];
+    if ((args == Kokkos::Tools::InitArguments::unset_string_option) && argc > 0)
+      args = argv[0];
   }
 }
 Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -828,7 +828,7 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
       NAME ProfilingTestLibraryCmdLineHelp
       EXE  ProfilingAllCalls
       ARGS --kokkos-tools-help
-           --kokkos-tools-library=$<TARGET_FILE:kokkosprinter-tool>
+           --kokkos-tools-libs=$<TARGET_FILE:kokkosprinter-tool>
       PASS_REGULAR_EXPRESSION
         "kokkosp_init_library::kokkosp_print_help:KokkosCore_ProfilingAllCalls::kokkosp_finalize_library::")
 
@@ -854,7 +854,7 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
       NAME ProfilingTestLibraryCmdLine
       EXE  ProfilingAllCalls
       ARGS [=[--kokkos-tools-args=-c test delimit]=]
-            --kokkos-tools-library=$<TARGET_FILE:kokkosprinter-tool>
+            --kokkos-tools-libs=$<TARGET_FILE:kokkosprinter-tool>
       PASS_REGULAR_EXPRESSION "kokkosp_init_library::kokkosp_parse_args:4:KokkosCore_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
     )
   endif() #KOKKOS_ENABLE_LIBDL

--- a/core/unit_test/TestInitializationSettings.cpp
+++ b/core/unit_test/TestInitializationSettings.cpp
@@ -66,9 +66,9 @@ TEST(defaultdevicetype,
   EXPECT_FALSE(settings.has_disable_warnings());
   EXPECT_TRUE(settings.has_tune_internals());
   EXPECT_TRUE(settings.get_tune_internals());
-  EXPECT_FALSE(settings.has_tool_help());
-  EXPECT_FALSE(settings.has_tool_lib());
-  EXPECT_FALSE(settings.has_tool_args());
+  EXPECT_FALSE(settings.has_tools_help());
+  EXPECT_FALSE(settings.has_tools_libs());
+  EXPECT_FALSE(settings.has_tools_args());
 }
 #endif
 
@@ -76,7 +76,7 @@ TEST(defaultdevicetype, initialization_settings) {
   auto const settings = Kokkos::InitializationSettings()
                             .set_num_threads(255)
                             .set_disable_warnings(false)
-                            .set_tool_lib("my_custom_tool.so");
+                            .set_tools_libs("my_custom_tool.so");
   EXPECT_TRUE(settings.has_num_threads());
   EXPECT_EQ(settings.get_num_threads(), 255);
   EXPECT_FALSE(settings.has_device_id());
@@ -85,10 +85,10 @@ TEST(defaultdevicetype, initialization_settings) {
   EXPECT_TRUE(settings.has_disable_warnings());
   EXPECT_FALSE(settings.get_disable_warnings());
   EXPECT_FALSE(settings.has_tune_internals());
-  EXPECT_FALSE(settings.has_tool_help());
-  EXPECT_TRUE(settings.has_tool_lib());
-  EXPECT_EQ(settings.get_tool_lib(), "my_custom_tool.so");
-  EXPECT_FALSE(settings.has_tool_args());
+  EXPECT_FALSE(settings.has_tools_help());
+  EXPECT_TRUE(settings.has_tools_libs());
+  EXPECT_EQ(settings.get_tools_libs(), "my_custom_tool.so");
+  EXPECT_FALSE(settings.has_tools_args());
 }
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, "")  // FIXME C++17
@@ -109,9 +109,9 @@ constexpr bool test_initialization_settings_getter() {
   CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(skip_device, int);
   CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(disable_warnings, bool);
   CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(tune_internals, bool);
-  CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(tool_help, bool);
-  CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(tool_lib, std::string);
-  CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(tool_args, std::string);
+  CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(tools_help, bool);
+  CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(tools_libs, std::string);
+  CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE(tools_args, std::string);
 #undef CHECK_INITIALIZATION_SETTINGS_GETTER_RETURN_TYPE
   return true;
 }


### PR DESCRIPTION
As part of our effort to cleanup or initialization settings, this PR is suggesting to make the following changes to the tools options:
* `InitializationSetting::{set,has,get}_...`: renamed `tool_lib -> tools_libs`, `tool_args -> tools_args`, and `tool_help -> tools_help`
* Command line arguments: renamed `--kokkos-tools-{library -> libs}`
  `--kokkos-tools-args` and `--kokkos-tools-help` unchanged.
* Environment variables: renamed `KOKKOS_{PROFILE_LIBRARY -> TOOLS_LIBS}` and added `KOKKOS_TOOLS_ARGS`
  We still look for `KOKKOS_PROFILE_LIBRARY` and raise a warning stating it is deprecated.  If both `KOKKOS_PROFILE_LIBRARY` and `KOKKOS_TOOLS_LIBS` are set, we ensure that they match.
  Haven't added `KOKKOS_TOOLS_HELP`.  Let me know if you think I should do so.

The `Kokkos::Tools::InitArguments` struct is not updated as part of this PR.
https://github.com/kokkos/kokkos/blob/e0347a21df7639721ccd953dddb610bc9ad8f2b2/core/src/impl/Kokkos_Profiling.hpp#L64-L73
We still need to decide whether we just want to change the data member name or opt for a design similar to what we did in Core.  In any case I would prefer to handle it in a follow-up PR.