### PR TITLE
Give back to Core what belongs to Core (aka moving tune_internals option from Tools back to Core)

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -125,10 +125,6 @@ void combine(Kokkos::InitializationSettings& out,
 void combine(Kokkos::InitializationSettings& out,
              Kokkos::Tools::InitArguments const& in) {
   using Kokkos::Tools::InitArguments;
-  if (in.tune_internals != InitArguments::PossiblyUnsetOption::unset) {
-    out.set_tune_internals(in.tune_internals ==
-                           InitArguments::PossiblyUnsetOption::on);
-  }
   if (in.help != InitArguments::PossiblyUnsetOption::unset) {
     out.set_tool_help(in.help == InitArguments::PossiblyUnsetOption::on);
   }
@@ -143,11 +139,6 @@ void combine(Kokkos::InitializationSettings& out,
 void combine(Kokkos::Tools::InitArguments& out,
              Kokkos::InitializationSettings const& in) {
   using Kokkos::Tools::InitArguments;
-  if (in.has_tune_internals()) {
-    out.tune_internals = in.get_tune_internals()
-                             ? InitArguments::PossiblyUnsetOption::on
-                             : InitArguments::PossiblyUnsetOption::off;
-  }
   if (in.has_tool_help()) {
     out.help = in.get_tool_help() ? InitArguments::PossiblyUnsetOption::on
                                   : InitArguments::PossiblyUnsetOption::off;
@@ -964,6 +955,18 @@ void Kokkos::Impl::parse_environment_variables(
     bool const disable_warnings =
         std::regex_match(env_disable_warnings_str, regex);
     settings.set_disable_warnings(disable_warnings);
+  }
+  char* env_tune_internals_str = std::getenv("KOKKOS_TUNE_INTERNALS");
+  if (env_tune_internals_str != nullptr) {
+    std::string env_str(env_tune_internals_str);  // deep-copies string
+    for (char& c : env_str) {
+      c = toupper(c);
+    }
+    if ((env_str == "TRUE") || (env_str == "ON") || (env_str == "1")) {
+      settings.set_tune_internals(true);
+    } else {
+      settings.set_tune_internals(false);
+    }
   }
 }
 

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -114,16 +114,12 @@ void parse_command_line_arguments(int& narg, char* arg[],
   using Kokkos::Impl::check_int_arg;
   using Kokkos::Impl::check_str_arg;
 
-  auto& lib            = arguments.lib;
-  auto& args           = arguments.args;
-  auto& help           = arguments.help;
-  auto& tune_internals = arguments.tune_internals;
+  auto& lib  = arguments.lib;
+  auto& args = arguments.args;
+  auto& help = arguments.help;
   while (iarg < narg) {
     bool remove_flag = false;
-    if (check_arg(arg[iarg], "--kokkos-tune-internals")) {
-      tune_internals = InitArguments::PossiblyUnsetOption::on;
-      remove_flag    = true;
-    } else if (check_str_arg(arg[iarg], "--kokkos-tools-library", lib)) {
+    if (check_str_arg(arg[iarg], "--kokkos-tools-library", lib)) {
       warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(arg[iarg]);
       remove_flag = true;
     } else if (check_str_arg(arg[iarg], "--kokkos-tools-args", args)) {
@@ -162,24 +158,12 @@ void parse_command_line_arguments(int& narg, char* arg[],
 }
 Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
     InitArguments& arguments) {
-  auto& tool_lib       = arguments.lib;
-  auto& tune_internals = arguments.tune_internals;
-  auto env_tool_lib    = std::getenv("KOKKOS_PROFILE_LIBRARY");
+  auto& tool_lib    = arguments.lib;
+  auto env_tool_lib = std::getenv("KOKKOS_PROFILE_LIBRARY");
   if (env_tool_lib != nullptr) {
     warn_env_var_ignored_when_kokkos_tools_disabled("KOKKOS_PROFILE_LIBRARY",
                                                     env_tool_lib);
     tool_lib = env_tool_lib;
-  }
-  char* env_tuneinternals_str = std::getenv("KOKKOS_TUNE_INTERNALS");
-  if (env_tuneinternals_str != nullptr) {
-    std::string env_str(env_tuneinternals_str);  // deep-copies string
-    for (char& c : env_str) {
-      c = toupper(c);
-    }
-    if ((env_str == "TRUE") || (env_str == "ON") || (env_str == "1"))
-      tune_internals = InitArguments::PossiblyUnsetOption::on;
-    else
-      tune_internals = InitArguments::PossiblyUnsetOption::off;
   }
   return {
       Kokkos::Tools::Impl::InitializationStatus::InitializationResult::success};

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -67,10 +67,9 @@ struct InitArguments {
   // for this long-term
   static const std::string unset_string_option;
   enum PossiblyUnsetOption { unset, off, on };
-  PossiblyUnsetOption tune_internals = unset;
-  PossiblyUnsetOption help           = unset;
-  std::string lib                    = unset_string_option;
-  std::string args                   = unset_string_option;
+  PossiblyUnsetOption help = unset;
+  std::string lib          = unset_string_option;
+  std::string args         = unset_string_option;
 };
 
 namespace Impl {


### PR DESCRIPTION
Fix #5087