### PR TITLE
#5194: Warn about parallel_reduce cases that call join() with volatile-qualified arguments

### DIFF
--- a/core/unit_test/TestJoinBackwardCompatibility.hpp
+++ b/core/unit_test/TestJoinBackwardCompatibility.hpp
@@ -123,9 +123,13 @@ struct ReducerWithJoinThatTakesVolatileQualifiedArgs {
 void test_join_backward_compatibility() {
   MyJoinBackCompatValueType result;
   Kokkos::RangePolicy<> policy(0, 1);
+
+#if defined KOKKOS_ENABLE_DEPRECATED_CODE_3
   Kokkos::parallel_reduce(
       policy, ReducerWithJoinThatTakesVolatileQualifiedArgs{}, result);
   ASSERT_EQ(result.err, no_error);
+#endif
+
   Kokkos::parallel_reduce(
       policy, ReducerWithJoinThatTakesBothVolatileAndNonVolatileQualifiedArgs{},
       result);


### PR DESCRIPTION
This generates a warning on exactly the case we want:

```
In file included from /Users/pbmille/build/kokkos/2022-07-13-volatile/core/unit_test/serial/TestSerial_JoinBackwardCompatibility.cpp:2:
In file included from /Users/pbmille/repos/kokkos/core/unit_test/TestJoinBackwardCompatibility.hpp:45:
In file included from /Users/pbmille/repos/kokkos/core/src/Kokkos_Core.hpp:57:
In file included from /Users/pbmille/build/kokkos/2022-07-13-volatile/KokkosCore_Config_DeclareBackend.hpp:47:
In file included from /Users/pbmille/repos/kokkos/core/src/decl/Kokkos_Declare_SERIAL.hpp:49:
In file included from /Users/pbmille/repos/kokkos/core/src/Kokkos_Serial.hpp:68:
In file included from /Users/pbmille/repos/kokkos/core/src/Kokkos_TaskScheduler.hpp:66:
In file included from /Users/pbmille/repos/kokkos/core/src/Kokkos_MemoryPool.hpp:58:
In file included from /Users/pbmille/repos/kokkos/core/src/Kokkos_Parallel.hpp:69:
/Users/pbmille/repos/kokkos/core/src/impl/Kokkos_FunctorAnalysis.hpp:645:16: warning: 'has_volatile_join_no_tag_function<(anonymous namespace)::ReducerWithJoinThatTakesVolatileQualifiedArgs, false>' is deprecated: Reduce/scan join() taking `volatile`-qualified parameters is deprecated. Remove the `volatile` qualifier. [-Wdeprecated-declarations]
      : public has_volatile_join_no_tag_function<F> {
               ^
/Users/pbmille/repos/kokkos/core/src/impl/Kokkos_FunctorAnalysis.hpp:650:30: note: in instantiation of template class 'Kokkos::Impl::FunctorAnalysis<Kokkos::Impl::FunctorPatternInterface::REDUCE, Kokkos::RangePolicy<>, (anonymous namespace)::ReducerWithJoinThatTakesVolatileQualifiedArgs>::DeduceJoinNoTag<>' requested here
  struct DeduceJoin : public DeduceJoinNoTag<F> {};
                             ^
/Users/pbmille/repos/kokkos/core/src/impl/Kokkos_FunctorAnalysis.hpp:899:37: note: in instantiation of template class 'Kokkos::Impl::FunctorAnalysis<Kokkos::Impl::FunctorPatternInterface::REDUCE, Kokkos::RangePolicy<>, (anonymous namespace)::ReducerWithJoinThatTakesVolatileQualifiedArgs>::DeduceJoin<>' requested here
  enum { has_join_member_function = DeduceJoin<>::value };
                                    ^
/Users/pbmille/repos/kokkos/core/src/Kokkos_Parallel_Reduce.hpp:1393:13: note: in instantiation of template class 'Kokkos::Impl::FunctorAnalysis<Kokkos::Impl::FunctorPatternInterface::REDUCE, Kokkos::RangePolicy<>, (anonymous namespace)::ReducerWithJoinThatTakesVolatileQualifiedArgs>' requested here
      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
            ^
/Users/pbmille/repos/kokkos/core/src/Kokkos_Parallel_Reduce.hpp:1397:36: note: in instantiation of static data member 'Kokkos::Impl::ParallelReduceAdaptor<Kokkos::RangePolicy<>, (anonymous namespace)::ReducerWithJoinThatTakesVolatileQualifiedArgs, (anonymous namespace)::MyJoinBackCompatValueType>::is_array_reduction' requested here
  static inline std::enable_if_t<!(is_array_reduction &&
                                   ^
/Users/pbmille/repos/kokkos/core/src/Kokkos_Parallel_Reduce.hpp:1567:9: note: in instantiation of template class 'Kokkos::Impl::ParallelReduceAdaptor<Kokkos::RangePolicy<>, (anonymous namespace)::ReducerWithJoinThatTakesVolatileQualifiedArgs, (anonymous namespace)::MyJoinBackCompatValueType>' requested here
  Impl::ParallelReduceAdaptor<PolicyType, FunctorType, ReturnType>::execute(
        ^
/Users/pbmille/repos/kokkos/core/unit_test/TestJoinBackwardCompatibility.hpp:126:11: note: in instantiation of function template specialization 'Kokkos::parallel_reduce<Kokkos::RangePolicy<>, (anonymous namespace)::ReducerWithJoinThatTakesVolatileQualifiedArgs, (anonymous namespace)::MyJoinBackCompatValueType>' requested here
  Kokkos::parallel_reduce(
          ^
/Users/pbmille/repos/kokkos/core/src/impl/Kokkos_FunctorAnalysis.hpp:436:10: note: 'has_volatile_join_no_tag_function<(anonymous namespace)::ReducerWithJoinThatTakesVolatileQualifiedArgs, false>' has been explicitly marked deprecated here
  struct KOKKOS_DEPRECATED_WITH_COMMENT("Reduce/scan join() taking `volatile`-qualified parameters is deprecated. Remove the `volatile` qualifier.") has_volatile_join_no_tag_function<F, /*is_array*/ false> {
         ^
/Users/pbmille/repos/kokkos/core/src/Kokkos_Macros.hpp:610:51: note: expanded from macro 'KOKKOS_DEPRECATED_WITH_COMMENT'
#define KOKKOS_DEPRECATED_WITH_COMMENT(comment) [[deprecated(comment)]]
                                                  ^
1 warning generated.
```

I had to modify the SFINAE detection logic to split the cases into different specializations rather than using `std::conditional_t` to avoid warning on the case where the `volatile`-qualified version wasn't selected.

The logic currently makes no distinction between different possible signatures of a user-defined `operator +=`. I'll see if I can add that, but I don't think it's essential to moving ahead with the improvement offered here.