### PR TITLE
OpenMPTarget: Adding a workaound for team scan.

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -1639,11 +1639,6 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     member.team_broadcast(accum, team_size - 1);
   }
 #endif
-
-  // for (iType i = 0; i < nchunk; ++i) {
-  // if(omp_get_thread_num() == 0)
-  // lambda(i, accum, true);
-  //}
 }
 
 }  // namespace Kokkos

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -1591,13 +1591,10 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     const Impl::TeamThreadRangeBoundariesStruct<
         iType, Impl::OpenMPTargetExecTeamMember>& loop_bounds,
     const FunctorType& lambda) {
-  using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
+  using Analysis   = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
                                          TeamPolicy<Experimental::OpenMPTarget>,
                                          FunctorType>;
-  // Extract value_type from lambda
-  using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void,
-      FunctorType>::value_type;
+  using value_type = typename Analysis::value_type;
 
   const auto start = loop_bounds.start;
   const auto end   = loop_bounds.end;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Exec.hpp
@@ -1619,8 +1619,9 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
 #else
   const auto nchunk = (end - start + team_size - 1) / team_size;
   value_type accum  = 0;
-  each team has to process one or
-      more chunks of the prefix scan for (iType i = 0; i < nchunk; ++i) {
+  // each team has to process one or
+  //      more chunks of the prefix scan
+  for (iType i = 0; i < nchunk; ++i) {
     auto ii = start + i * team_size + team_rank;
     // local accumulation for this chunk
     value_type local_accum = 0;


### PR DESCRIPTION
The PR avoids the non-working team_scan code path.
The strategy it uses is to make one thread per team do the work.  