### PR TITLE
Fix DynamicView::resize_serial

### DIFF
--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -219,11 +219,14 @@ struct ChunkedArrayManager {
 
   pointer_type* get_ptr() const { return m_chunks; }
 
-  template <typename Space>
-  void deep_copy_to(ChunkedArrayManager<Space, ValueType> const& other) const {
+  template <typename OtherMemorySpace, typename ExecutionSpace>
+  void deep_copy_to(
+      const ExecutionSpace& exec_space,
+      ChunkedArrayManager<OtherMemorySpace, ValueType> const& other) const {
     if (other.m_chunks != m_chunks) {
-      Kokkos::Impl::DeepCopy<Space, MemorySpace>(
-          other.m_chunks, m_chunks, sizeof(pointer_type) * (m_chunk_max + 2));
+      Kokkos::Impl::DeepCopy<OtherMemorySpace, MemorySpace, ExecutionSpace>(
+          exec_space, other.m_chunks, m_chunks,
+          sizeof(pointer_type) * (m_chunk_max + 2));
     }
   }
 
@@ -481,7 +484,10 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
     // *m_chunks_host[m_chunk_max+1] stores the 'extent' requested by resize
     *(pc + 1) = n;
 
-    m_chunks_host.deep_copy_to(m_chunks);
+    typename device_space::execution_space exec{};
+    m_chunks_host.deep_copy_to(exec, m_chunks);
+    exec.fence(
+        "DynamicView::resize_serial: Fence after copying chunks to the device");
   }
 
   KOKKOS_INLINE_FUNCTION bool is_allocated() const {
@@ -564,7 +570,23 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
       m_chunks_host.template allocate_with_destroy<device_space>(
           label, m_chunks.get_ptr());
       m_chunks_host.initialize();
-      m_chunks_host.deep_copy_to(m_chunks);
+
+      // Add some properties if not provided to avoid need for if constexpr
+      using alloc_prop_input = Kokkos::Impl::ViewCtorProp<Prop...>;
+      using alloc_prop       = Kokkos::Impl::ViewCtorProp<
+          Prop..., std::conditional_t<alloc_prop_input::has_execution_space,
+                                      std::integral_constant<unsigned int, 15>,
+                                      typename device_space::execution_space>>;
+      alloc_prop arg_prop_copy(arg_prop);
+
+      const auto& exec = static_cast<const Kokkos::Impl::ViewCtorProp<
+          void, typename alloc_prop::execution_space>&>(arg_prop_copy)
+                             .value;
+      m_chunks_host.deep_copy_to(exec, m_chunks);
+      if (!alloc_prop_input::has_execution_space)
+        exec.fence(
+            "DynamicView::DynamicView(): Fence after copying chunks to the "
+            "device");
     }
   }
 
@@ -821,12 +843,13 @@ inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
   else if (SrcExecCanAccessDst)
     Kokkos::Impl::ViewRemap<dst_type, src_type, src_execution_space>(dst, src);
   else
-    src.impl_get_chunks().deep_copy_to(dst.impl_get_chunks());
+    src.impl_get_chunks().deep_copy_to(dst_execution_space{},
+                                       dst.impl_get_chunks());
   Kokkos::fence("Kokkos::deep_copy(DynamicView)");
 }
 
 template <class ExecutionSpace, class T, class... DP, class... SP>
-inline void deep_copy(const ExecutionSpace&,
+inline void deep_copy(const ExecutionSpace& exec,
                       const Kokkos::Experimental::DynamicView<T, DP...>& dst,
                       const Kokkos::Experimental::DynamicView<T, SP...>& src) {
   using dst_type = Kokkos::Experimental::DynamicView<T, DP...>;
@@ -850,7 +873,7 @@ inline void deep_copy(const ExecutionSpace&,
   else if (SrcExecCanAccessDst)
     Kokkos::Impl::ViewRemap<dst_type, src_type, src_execution_space>(dst, src);
   else
-    src.impl_get_chunks().deep_copy_to(dst.impl_get_chunks());
+    src.impl_get_chunks().deep_copy_to(exec, dst.impl_get_chunks());
 }
 
 template <class T, class... DP, class... SP>


### PR DESCRIPTION
I was running into a case where the call operator for `DynamicView` would deadlock in https://github.com/kokkos/kokkos/blob/902a50d4486faa036bd88cb30db4c139a70c7a24/containers/src/Kokkos_DynamicView.hpp#L435-L438. As discussed on slack, the code there was only useful before the removal of `resize_parallel` in  768f657d7251b3cdbce0de48a75574f9a2cdd29d.
In particular, it's just an error if the chunk pointer we need to access is a `nullptr`. I took the freedom to remove all that logic in https://github.com/kokkos/kokkos/commit/6b7a1a0bf111e94fc0fbc46903d8806538221ab6 to only check if for out-of-bounds errors and not checking the pointer to be a `nullptr` at all.

The origin of the issue was seeing was that the deep copy in `resize_serial` hadn't finished before we were trying to access the `View`. Conceivably, this can happen if the access happens on a different execution space instance than the one used for deep copy. In this case, it was the same execution space instance but the deep copy wasn't properly enqueued (also see https://github.com/kokkos/kokkos/pull/5065). Since we are supposed to fence after calling `DeepCopy` internally anyway, I didn't bother with adding the workaround there as well.
In the end, it was enough to just fence the deep copy operation in `resize_serial`, and to do that I had to provide `ChunkManager::deep_copy_to` with an execution space instance argument. This also allowed (and enforced) using an execution space instance in a couple of other places using `deep_copy_to`.