### PR TITLE
Refactor parsing of command line arguments and environment variables

### DIFF
--- a/core/src/impl/Kokkos_Command_Line_Parsing.cpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.cpp
@@ -102,11 +102,11 @@ bool Kokkos::Impl::check_env_bool(char const* name, bool& val) {
   }
 
   if (!std::regex_match(var, regex_false)) {
-    std::cerr
-        << "Warning: unrecognized boolean value for environment variable '"
-        << name << "=" << var << "' interpreted as 'false'."
-        << " Raised by Kokkos::initialize(int argc, char* argv[])."
-        << std::endl;
+    std::stringstream ss;
+    ss << "Error: cannot convert environment variable '" << name << "=" << var
+       << "' to a boolean."
+       << " Raised by Kokkos::initialize(int argc, char* argv[]).\n";
+    Kokkos::abort(ss.str().c_str());
   }
 
   val = false;
@@ -167,11 +167,11 @@ bool Kokkos::Impl::check_arg_bool(char const* arg, char const* name,
     return true;
   }
   if (!std::regex_match(arg, regex_false)) {
-    std::cerr
-        << "Warning: unrecognized boolean value for command line argument '"
-        << name << '=' << arg << "'interpreted as 'false'."
-        << " Raised by Kokkos::initialize(int argc, char* argv[])."
-        << std::endl;
+    std::stringstream ss;
+    ss << "Error: cannot convert command line argument '" << name << "=" << arg
+       << "' to a boolean."
+       << " Raised by Kokkos::initialize(int argc, char* argv[]).\n";
+    Kokkos::abort(ss.str().c_str());
   }
   val = false;
   return true;

--- a/core/src/impl/Kokkos_Command_Line_Parsing.cpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.cpp
@@ -46,24 +46,23 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE
 #endif
 
+#include <impl/Kokkos_Command_Line_Parsing.hpp>
+#include <impl/Kokkos_Error.hpp>
+
+#include <cstring>
 #include <iostream>
+#include <regex>
 #include <string>
 #include <sstream>
-#include <cstring>
-#include <impl/Kokkos_Command_Line_Parsing.hpp>
-/** Duplicates of Kokkos_Error.cpp/hpp, reproduced here
- * for use in non-Kokkos applications
- */
+
 namespace {
-void traceback_callstack(std::ostream& msg) {
-  msg << std::endl << "Traceback functionality not available" << std::endl;
-}
-void throw_runtime_exception(const std::string& msg) {
-  std::ostringstream o;
-  o << msg;
-  traceback_callstack(o);
-  throw std::runtime_error(o.str());
-}
+
+auto const regex_true = std::regex(
+    "(yes|true|1)", std::regex_constants::icase | std::regex_constants::egrep);
+
+auto const regex_false = std::regex(
+    "(no|false|0)", std::regex_constants::icase | std::regex_constants::egrep);
+
 }  // namespace
 
 bool Kokkos::Impl::is_unsigned_int(const char* str) {
@@ -90,43 +89,152 @@ bool Kokkos::Impl::check_arg(char const* arg, char const* expected) {
   return true;
 }
 
-bool Kokkos::Impl::check_int_arg(char const* arg, char const* expected,
-                                 int* value) {
-  if (!check_arg(arg, expected)) return false;
-  std::size_t arg_len = std::strlen(arg);
-  std::size_t exp_len = std::strlen(expected);
-  bool okay           = true;
-  if (arg_len == exp_len || arg[exp_len] != '=') okay = false;
-  char const* number = arg + exp_len + 1;
-  if (!Kokkos::Impl::is_unsigned_int(number) || strlen(number) == 0)
-    okay = false;
-  *value = std::stoi(number);
-  if (!okay) {
-    std::ostringstream ss;
-    ss << "Error: expecting an '=INT' after command line argument '" << expected
-       << "'. Raised by Kokkos::initialize(int argc, char* argv[]).";
-    throw_runtime_exception(ss.str());
+bool Kokkos::Impl::check_env_bool(char const* name, bool& val) {
+  char const* var = std::getenv(name);
+
+  if (!var) {
+    return false;
   }
+
+  if (std::regex_match(var, regex_true)) {
+    val = true;
+    return true;
+  }
+
+  if (!std::regex_match(var, regex_false)) {
+    std::cerr
+        << "Warning: unrecognized boolean value for environment variable '"
+        << name << "=" << var << "' interpreted as 'false'."
+        << " Raised by Kokkos::initialize(int argc, char* argv[])."
+        << std::endl;
+  }
+
+  val = false;
   return true;
 }
-bool Kokkos::Impl::check_str_arg(char const* arg, char const* expected,
-                                 std::string& value) {
-  if (!check_arg(arg, expected)) return false;
-  std::size_t arg_len = std::strlen(arg);
-  std::size_t exp_len = std::strlen(expected);
-  bool okay           = true;
-  if (arg_len == exp_len || arg[exp_len] != '=') okay = false;
-  char const* remain = arg + exp_len + 1;
-  value              = remain;
-  if (!okay) {
-    std::ostringstream ss;
-    ss << "Error: expecting an '=STRING' after command line argument '"
-       << expected
-       << "'. Raised by Kokkos::initialize(int argc, char* argv[]).";
-    throw_runtime_exception(ss.str());
+
+bool Kokkos::Impl::check_env_int(char const* name, int& val) {
+  char const* var = std::getenv(name);
+
+  if (!var) {
+    return false;
   }
+
+  errno = 0;
+  char* var_end;
+  val = std::strtol(var, &var_end, 10);
+
+  if (var == var_end) {
+    std::stringstream ss;
+    ss << "Error: cannot convert environment variable '" << name << '=' << var
+       << "' to an integer."
+       << " Raised by Kokkos::initialize(int argc, char* argv[]).\n";
+    Kokkos::abort(ss.str().c_str());
+  }
+
+  if (errno == ERANGE) {
+    std::stringstream ss;
+    ss << "Error: converted value for environment variable '" << name << '='
+       << var << "' falls out of range."
+       << " Raised by Kokkos::initialize(int argc, char* argv[]).\n";
+    Kokkos::abort(ss.str().c_str());
+  }
+
   return true;
 }
+
+bool Kokkos::Impl::check_arg_bool(char const* arg, char const* name,
+                                  bool& val) {
+  auto const len = std::strlen(name);
+  if (std::strncmp(arg, name, len) != 0) {
+    return false;
+  }
+  auto const arg_len = strlen(arg);
+  if (arg_len == len) {
+    val = true;  // --kokkos-foo without =BOOL interpreted as fool=true
+    return true;
+  }
+  if (arg_len <= len + 1 || arg[len] != '=') {
+    std::stringstream ss;
+    ss << "Error: command line argument '" << arg
+       << "' is not recognized as a valid boolean.\n";
+    Kokkos::abort(ss.str().c_str());
+  }
+
+  std::advance(arg, len + 1);
+  if (std::regex_match(arg, regex_true)) {
+    val = true;
+    return true;
+  }
+  if (!std::regex_match(arg, regex_false)) {
+    std::cerr
+        << "Warning: unrecognized boolean value for command line argument '"
+        << name << '=' << arg << "'interpreted as 'false'."
+        << " Raised by Kokkos::initialize(int argc, char* argv[])."
+        << std::endl;
+  }
+  val = false;
+  return true;
+}
+
+bool Kokkos::Impl::check_arg_int(char const* arg, char const* name, int& val) {
+  auto const len = std::strlen(name);
+  if (std::strncmp(arg, name, len) != 0) {
+    return false;
+  }
+  auto const arg_len = strlen(arg);
+  if (arg_len <= len + 1 || arg[len] != '=') {
+    std::stringstream ss;
+    ss << "Error: command line argument '" << arg
+       << "' is not recognized as a valid integer.\n";
+    Kokkos::abort(ss.str().c_str());
+  }
+
+  std::advance(arg, len + 1);
+
+  errno = 0;
+  char* arg_end;
+  val = std::strtol(arg, &arg_end, 10);
+
+  if (arg == arg_end) {
+    std::stringstream ss;
+    ss << "Error: cannot convert command line argument '" << name << '=' << arg
+       << "' to an integer."
+       << " Raised by Kokkos::initialize(int argc, char* argv[]).";
+    Kokkos::abort(ss.str().c_str());
+  }
+
+  if (errno == ERANGE) {
+    std::stringstream ss;
+    ss << "Error: converted value for command line argument '" << name << '='
+       << arg << "' falls out of range."
+       << " Raised by Kokkos::initialize(int argc, char* argv[]).\n";
+    Kokkos::abort(ss.str().c_str());
+  }
+
+  return true;
+}
+
+bool Kokkos::Impl::check_arg_str(char const* arg, char const* name,
+                                 std::string& val) {
+  auto const len = std::strlen(name);
+  if (std::strncmp(arg, name, len) != 0) {
+    return false;
+  }
+  auto const arg_len = strlen(arg);
+  if (arg_len <= len + 1 || arg[len] != '=') {
+    std::stringstream ss;
+    ss << "Error: command line argument '" << arg
+       << "' is not recognized as a valid string.\n";
+    Kokkos::abort(ss.str().c_str());
+  }
+
+  std::advance(arg, len + 1);
+
+  val = arg;
+  return true;
+}
+
 void Kokkos::Impl::warn_deprecated_environment_variable(
     std::string deprecated) {
   std::cerr << "Warning: environment variable '" << deprecated
@@ -134,6 +242,7 @@ void Kokkos::Impl::warn_deprecated_environment_variable(
             << " Raised by Kokkos::initialize(int argc, char* argv[])."
             << std::endl;
 }
+
 void Kokkos::Impl::warn_deprecated_environment_variable(
     std::string deprecated, std::string use_instead) {
   std::cerr << "Warning: environment variable '" << deprecated
@@ -142,6 +251,7 @@ void Kokkos::Impl::warn_deprecated_environment_variable(
             << " Raised by Kokkos::initialize(int argc, char* argv[])."
             << std::endl;
 }
+
 void Kokkos::Impl::warn_deprecated_command_line_argument(
     std::string deprecated) {
   std::cerr << "Warning: command line argument '" << deprecated
@@ -149,6 +259,7 @@ void Kokkos::Impl::warn_deprecated_command_line_argument(
             << " Raised by Kokkos::initialize(int argc, char* argv[])."
             << std::endl;
 }
+
 void Kokkos::Impl::warn_deprecated_command_line_argument(
     std::string deprecated, std::string use_instead) {
   std::cerr << "Warning: command line argument '" << deprecated

--- a/core/src/impl/Kokkos_Command_Line_Parsing.hpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.hpp
@@ -46,15 +46,16 @@
 #define KOKKOS_COMMAND_LINE_PARSING_HPP
 
 #include <string>
-#include <iosfwd>
 
 namespace Kokkos {
 namespace Impl {
 bool is_unsigned_int(const char* str);
 bool check_arg(char const* arg, char const* expected);
-// void throw_runtime_exception(const std::string& msg);
-bool check_int_arg(char const* arg, char const* expected, int* value);
-bool check_str_arg(char const* arg, char const* expected, std::string& value);
+bool check_arg_bool(char const* arg, char const* name, bool& val);
+bool check_arg_int(char const* arg, char const* name, int& val);
+bool check_arg_str(char const* arg, char const* name, std::string& val);
+bool check_env_bool(char const* name, bool& val);
+bool check_env_int(char const* name, int& val);
 void warn_deprecated_environment_variable(std::string deprecated);
 void warn_deprecated_environment_variable(std::string deprecated,
                                           std::string use_instead);

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -487,7 +487,7 @@ int Kokkos::Impl::get_gpu(const InitializationSettings& settings) {
     return visible_devices[0];
   }
   // map_device_id provided
-  // either random or round-robin assignement based on local MPI rank
+  // either random or round-robin assignment based on local MPI rank
   if (!is_valid_map_device_id_by(settings.get_map_device_id_by())) {
     std::stringstream ss;
     ss << "Warning: map_device_id_by setting '"
@@ -521,7 +521,7 @@ int Kokkos::Impl::get_gpu(const InitializationSettings& settings) {
     return visible_devices[0];
   }
 
-  // use device assigned by CTest when ressource allocation is activated
+  // use device assigned by CTest when resource allocation is activated
   if (std::getenv("CTEST_KOKKOS_DEVICE_TYPE") &&
       std::getenv("CTEST_RESOURCE_GROUP_COUNT")) {
     return get_ctest_gpu(local_rank_str);

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -910,7 +910,7 @@ void Kokkos::Impl::parse_environment_variables(
       std::stringstream ss;
       ss << "Error: environment variable 'KOKKOS_NUM_THREADS=" << num_threads
          << "' is invalid."
-         << " The number of threads must be greater equal to one."
+         << " The number of threads must be greater than or equal to one."
          << " Raised by Kokkos::initialize(int argc, char* argv[]).\n";
       Kokkos::abort(ss.str().c_str());
     }
@@ -922,7 +922,7 @@ void Kokkos::Impl::parse_environment_variables(
       std::stringstream ss;
       ss << "Error: environment variable 'KOKKOS_DEVICE_ID" << device_id
          << "' is invalid."
-         << " The device id must be greater equal to zero.\n";
+         << " The device id must be greater than or equal to zero.\n";
       Kokkos::abort(ss.str().c_str());
     }
     settings.set_device_id(device_id);

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -176,8 +176,70 @@ unsigned get_process_id() {
 #endif
 }
 
+bool is_valid_num_threads(int x) { return x > 0; }
+
+bool is_valid_device_id(int x) { return x >= 0; }
+
 bool is_valid_map_device_id_by(std::string const& x) {
   return x == "mpi_rank" || x == "random";
+}
+
+auto const regex_true = std::regex(
+    "(yes|true|1)", std::regex_constants::icase | std::regex_constants::egrep);
+
+auto const regex_false = std::regex(
+    "(no|false|0)", std::regex_constants::icase | std::regex_constants::egrep);
+
+bool check_env_bool(char const* name, bool& val) {
+  char const* var = std::getenv(name);
+
+  if (!var) {
+    return false;
+  }
+
+  if (std::regex_match(var, regex_true)) {
+    val = true;
+    return true;
+  }
+
+  if (!std::regex_match(var, regex_false)) {
+    std::cerr
+        << "Warning: unrecognized boolean value for environment variable '"
+        << name << "=" << var << "' interpreted as 'false'."
+        << " Raised by Kokkos::initialize(int argc, char* argv[])."
+        << std::endl;
+  }
+
+  val = false;
+  return true;
+}
+
+bool check_env_int(char const* name, int& val) {
+  char const* var = std::getenv(name);
+
+  if (!var) {
+    return false;
+  }
+
+  errno = 0;
+  char* var_end;
+  val = std::strtol(var, &var_end, 10);
+
+  if (var == var_end) {
+    Kokkos::Impl::throw_runtime_exception(
+        std::string("Error: cannot convert ") + name +
+        " to an integer. "
+        "Raised by Kokkos::initialize(int argc, char* argv[]).");
+  }
+
+  if (errno == ERANGE) {
+    Kokkos::Impl::throw_runtime_exception(
+        std::string("Error: ") + name +
+        " out of range of representable values by an integer."
+        " Raised by Kokkos::initialize(int argc, char* argv[]).");
+  }
+
+  return true;
 }
 
 }  // namespace
@@ -912,8 +974,6 @@ void Kokkos::Impl::parse_command_line_arguments(
 
 void Kokkos::Impl::parse_environment_variables(
     InitializationSettings& settings) {
-  char* endptr;
-
   Tools::InitArguments tools_init_arguments;
   combine(tools_init_arguments, settings);
   auto init_result =
@@ -924,133 +984,82 @@ void Kokkos::Impl::parse_environment_variables(
   }
   combine(settings, tools_init_arguments);
 
-  auto env_num_threads_str = std::getenv("KOKKOS_NUM_THREADS");
-  if (env_num_threads_str != nullptr) {
-    errno                = 0;
-    auto env_num_threads = std::strtol(env_num_threads_str, &endptr, 10);
-    if (endptr == env_num_threads_str)
-      Impl::throw_runtime_exception(
-          "Error: cannot convert KOKKOS_NUM_THREADS to an integer. Raised by "
-          "Kokkos::initialize(int argc, char* argv[]).");
-    if (errno == ERANGE)
-      Impl::throw_runtime_exception(
-          "Error: KOKKOS_NUM_THREADS out of range of representable values by "
-          "an integer. Raised by Kokkos::initialize(int argc, char* argv[]).");
-    settings.set_num_threads(env_num_threads);
-  }
-  auto env_numa_str = std::getenv("KOKKOS_NUMA");
-  if (env_numa_str != nullptr) {
+  if (std::getenv("KOKKOS_NUMA")) {
     warn_deprecated_environment_variable("KOKKOS_NUMA");
   }
-  auto env_device_id_str = std::getenv("KOKKOS_DEVICE_ID");
-  if (env_device_id_str != nullptr) {
-    errno              = 0;
-    auto env_device_id = std::strtol(env_device_id_str, &endptr, 10);
-    if (endptr == env_device_id_str)
-      Impl::throw_runtime_exception(
-          "Error: cannot convert KOKKOS_DEVICE_ID to an integer. Raised by "
-          "Kokkos::initialize(int argc, char* argv[]).");
-    if (errno == ERANGE)
-      Impl::throw_runtime_exception(
-          "Error: KOKKOS_DEVICE_ID out of range of representable values by an "
-          "integer. Raised by Kokkos::initialize(int argc, char* argv[]).");
-    settings.set_device_id(env_device_id);
-  }
-  auto env_rand_devices_str = std::getenv("KOKKOS_RAND_DEVICES");
-  auto env_num_devices_str  = std::getenv("KOKKOS_NUM_DEVICES");
-  if (env_num_devices_str != nullptr || env_rand_devices_str != nullptr) {
-    errno = 0;
-    if (env_num_devices_str != nullptr && env_rand_devices_str != nullptr) {
-      Impl::throw_runtime_exception(
-          "Error: cannot specify both KOKKOS_NUM_DEVICES and "
-          "KOKKOS_RAND_DEVICES. "
-          "Raised by Kokkos::initialize(int argc, char* argv[]).");
-    }
-    if (env_num_devices_str != nullptr) {
-      warn_deprecated_environment_variable("KOKKOS_NUM_DEVICES",
-                                           "KOKKOS_MAP_DEVICE_ID_BY=mpi_rank");
-      settings.set_map_device_id_by("mpi_rank");
-      auto env_num_devices = std::strtol(env_num_devices_str, &endptr, 10);
-      if (endptr == env_num_devices_str)
-        Impl::throw_runtime_exception(
-            "Error: cannot convert KOKKOS_NUM_DEVICES to an integer. Raised by "
-            "Kokkos::initialize(int argc, char* argv[]).");
-      if (errno == ERANGE)
-        Impl::throw_runtime_exception(
-            "Error: KOKKOS_NUM_DEVICES out of range of representable values by "
-            "an integer. Raised by Kokkos::initialize(int argc, char* "
-            "argv[]).");
-      settings.set_num_devices(env_num_devices);
-    } else {  // you set KOKKOS_RAND_DEVICES
-      warn_deprecated_environment_variable("KOKKOS_RAND_DEVICES",
-                                           "KOKKOS_MAP_DEVICE_ID_BY=random");
-      settings.set_map_device_id_by("random");
-      auto env_rand_devices = std::strtol(env_rand_devices_str, &endptr, 10);
-      if (endptr == env_rand_devices_str)
-        Impl::throw_runtime_exception(
-            "Error: cannot convert KOKKOS_RAND_DEVICES to an integer. Raised "
-            "by Kokkos::initialize(int argc, char* argv[]).");
-      if (errno == ERANGE)
-        Impl::throw_runtime_exception(
-            "Error: KOKKOS_RAND_DEVICES out of range of representable values "
-            "by an integer. Raised by Kokkos::initialize(int argc, char* "
-            "argv[]).");
-      settings.set_num_devices(env_rand_devices);
-    }
-    // Skip device
-    auto env_skip_device_str = std::getenv("KOKKOS_SKIP_DEVICE");
-    if (env_skip_device_str != nullptr) {
-      warn_deprecated_environment_variable("KOKKOS_SKIP_DEVICE");
-      errno                = 0;
-      auto env_skip_device = std::strtol(env_skip_device_str, &endptr, 10);
-      if (endptr == env_skip_device_str)
-        Impl::throw_runtime_exception(
-            "Error: cannot convert KOKKOS_SKIP_DEVICE to an integer. Raised by "
-            "Kokkos::initialize(int argc, char* argv[]).");
-      if (errno == ERANGE)
-        Impl::throw_runtime_exception(
-            "Error: KOKKOS_SKIP_DEVICE out of range of representable values by "
-            "an integer. Raised by Kokkos::initialize(int argc, char* "
-            "argv[]).");
-      settings.set_skip_device(env_skip_device);
-    }
-  }
-  char* env_disable_warnings_str = std::getenv("KOKKOS_DISABLE_WARNINGS");
-  if (env_disable_warnings_str != nullptr) {
-    auto const regex =
-        std::regex("^(true|on|yes|[1-9])$",
-                   std::regex_constants::icase | std::regex_constants::egrep);
-    bool const disable_warnings =
-        std::regex_match(env_disable_warnings_str, regex);
-    settings.set_disable_warnings(disable_warnings);
-  }
-  char* env_tune_internals_str = std::getenv("KOKKOS_TUNE_INTERNALS");
-  if (env_tune_internals_str != nullptr) {
-    std::string env_str(env_tune_internals_str);  // deep-copies string
-    for (char& c : env_str) {
-      c = toupper(c);
-    }
-    if ((env_str == "TRUE") || (env_str == "ON") || (env_str == "1")) {
-      settings.set_tune_internals(true);
-    } else {
-      settings.set_tune_internals(false);
-    }
-  }
-  char* env_map_device_id_by_str = std::getenv("KOKKOS_MAP_DEVICE_ID_BY");
-  if (env_map_device_id_by_str != nullptr) {
-    if (env_device_id_str != nullptr) {
-      std::cerr << "Warning: environment vaiable KOKKOS_MAP_DEVICE_ID_BY"
-                << "ignored since KOKKOS_DEVICE_ID is specified." << std::endl;
-    }
-    if (is_valid_map_device_id_by(env_map_device_id_by_str)) {
-      settings.set_map_device_id_by(env_map_device_id_by_str);
-    } else {
+  int num_threads;
+  if (check_env_int("KOKKOS_NUM_THREADS", num_threads)) {
+    if (!is_valid_num_threads(num_threads)) {
       std::stringstream ss;
-      ss << "Warning: environment variable 'KOKKOS_MAP_DEVICE_ID_BY="
-         << env_map_device_id_by_str << "' is not recognized."
+      ss << "Error: environment variable 'KOKKOS_NUM_THREADS=" << num_threads
+         << "' is invalid."
+         << " The number of threads must be greater equal to one."
          << " Raised by Kokkos::initialize(int argc, char* argv[]).\n";
       Kokkos::abort(ss.str().c_str());
     }
+    settings.set_num_threads(num_threads);
+  }
+  int device_id;
+  if (check_env_int("KOKKOS_DEVICE_ID", device_id)) {
+    if (!is_valid_device_id(device_id)) {
+      std::stringstream ss;
+      ss << "Error: environment variable 'KOKKOS_DEVICE_ID" << device_id
+         << "' is invalid."
+         << " The device id must be greater equal to zero.\n";
+      Kokkos::abort(ss.str().c_str());
+    }
+    settings.set_device_id(device_id);
+  }
+  int num_devices;
+  int rand_devices;
+  bool has_num_devices  = check_env_int("KOKKOS_NUM_DEVICES", num_devices);
+  bool has_rand_devices = check_env_int("KOKKOS_RAND_DEVICES", rand_devices);
+  if (has_rand_devices && has_num_devices) {
+    Impl::throw_runtime_exception(
+        "Error: cannot specify both KOKKOS_NUM_DEVICES and "
+        "KOKKOS_RAND_DEVICES."
+        " Raised by Kokkos::initialize(int argc, char* argv[]).");
+  }
+  if (has_num_devices) {
+    warn_deprecated_environment_variable("KOKKOS_NUM_DEVICES",
+                                         "KOKKOS_MAP_DEVICE_ID_BY=mpi_rank");
+    settings.set_map_device_id_by("mpi_rank");
+    settings.set_num_devices(num_devices);
+  }
+  if (has_rand_devices) {
+    warn_deprecated_environment_variable("KOKKOS_RAND_DEVICES",
+                                         "KOKKOS_MAP_DEVICE_ID_BY=random");
+    settings.set_map_device_id_by("random");
+    settings.set_num_devices(rand_devices);
+  }
+  if (has_num_devices || has_rand_devices) {
+    int skip_device;
+    if (check_env_int("KOKKOS_SKIP_DEVICE", skip_device)) {
+      settings.set_skip_device(skip_device);
+    }
+  }
+  bool disable_warnings;
+  if (check_env_bool("KOKKOS_DISABLE_WARNINGS", disable_warnings)) {
+    settings.set_disable_warnings(disable_warnings);
+  }
+  bool tune_internals;
+  if (check_env_bool("KOKKOS_TUNE_INTERNALS", tune_internals)) {
+    settings.set_tune_internals(tune_internals);
+  }
+  char const* map_device_id_by = std::getenv("KOKKOS_MAP_DEVICE_ID_BY");
+  if (map_device_id_by != nullptr) {
+    if (std::getenv("KOKKOS_DEVICE_ID")) {
+      std::cerr << "Warning: environment variable KOKKOS_MAP_DEVICE_ID_BY"
+                << "ignored since KOKKOS_DEVICE_ID is specified." << std::endl;
+    }
+    if (!is_valid_map_device_id_by(map_device_id_by)) {
+      std::stringstream ss;
+      ss << "Warning: environment variable 'KOKKOS_MAP_DEVICE_ID_BY="
+         << map_device_id_by << "' is not recognized."
+         << " Raised by Kokkos::initialize(int argc, char* argv[]).\n";
+      Kokkos::abort(ss.str().c_str());
+    }
+    settings.set_map_device_id_by(map_device_id_by);
   }
 }
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -763,7 +763,7 @@ void Kokkos::Impl::parse_command_line_arguments(
       if (!is_valid_num_threads(num_threads)) {
         std::stringstream ss;
         ss << "Error: command line argument '" << argv[iarg] << "' is invalid."
-           << " The number of threads must be greater equal to one."
+           << " The number of threads must be greater than or equal to one."
            << " Raised by Kokkos::initialize(int argc, char* argv[]).\n";
         Kokkos::abort(ss.str().c_str());
       }
@@ -779,7 +779,7 @@ void Kokkos::Impl::parse_command_line_arguments(
       if (!is_valid_device_id(device_id)) {
         std::stringstream ss;
         ss << "Error: command line argument '" << argv[iarg] << "' is invalid."
-           << " The device id must be greater equal to zero.\n";
+           << " The device id must be greater than or equal to zero.\n";
         Kokkos::abort(ss.str().c_str());
       }
       settings.set_device_id(device_id);

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -111,16 +111,15 @@ void parse_command_line_arguments(int& argc, char* argv[],
                                   InitArguments& arguments) {
   int iarg = 0;
   using Kokkos::Impl::check_arg;
-  using Kokkos::Impl::check_int_arg;
-  using Kokkos::Impl::check_str_arg;
+  using Kokkos::Impl::check_arg_str;
 
   auto& libs = arguments.lib;
   auto& args = arguments.args;
   auto& help = arguments.help;
   while (iarg < argc) {
     bool remove_flag = false;
-    if (check_str_arg(argv[iarg], "--kokkos-tools-libs", libs) ||
-        check_str_arg(argv[iarg], "--kokkos-tools-library", libs)) {
+    if (check_arg_str(argv[iarg], "--kokkos-tools-libs", libs) ||
+        check_arg_str(argv[iarg], "--kokkos-tools-library", libs)) {
       if (check_arg(argv[iarg], "--kokkos-tools-library")) {
         using Kokkos::Impl::warn_deprecated_command_line_argument;
         warn_deprecated_command_line_argument("--kokkos-tools-library",
@@ -128,7 +127,7 @@ void parse_command_line_arguments(int& argc, char* argv[],
       }
       warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(argv[iarg]);
       remove_flag = true;
-    } else if (check_str_arg(argv[iarg], "--kokkos-tools-args", args)) {
+    } else if (check_arg_str(argv[iarg], "--kokkos-tools-args", args)) {
       warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(argv[iarg]);
       remove_flag = true;
       // strip any leading and/or trailing quotes if they were retained in the

--- a/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
+++ b/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
@@ -340,26 +340,6 @@ TEST(defaultdevicetype, env_vars_disable_warnings) {
     EXPECT_TRUE(captured.empty()) << "KOKKOS_DISABLE_WARNINGS=" << value_false
                                   << "\ncaptured: " << captured;
   }
-  for (auto const& value_false : {"3", "yess", "Nooooo"}) {
-    ::testing::internal::CaptureStderr();
-    EnvVarsHelper ev = {{
-        {"KOKKOS_DISABLE_WARNINGS", value_false},
-    }};
-    SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
-    Kokkos::InitializationSettings settings;
-    Kokkos::Impl::parse_environment_variables(settings);
-    EXPECT_TRUE(settings.has_disable_warnings())
-        << "KOKKOS_DISABLE_WARNINGS=" << value_false;
-    EXPECT_FALSE(settings.get_disable_warnings())
-        << "KOKKOS_DISABLE_WARNINGS=" << value_false;
-    auto const captured = ::testing::internal::GetCapturedStderr();
-    EXPECT_TRUE(std::regex_match(
-        captured, std::regex(std::string("Warning.*KOKKOS_DISABLE_WARNINGS=") +
-                                 value_false + ".*",
-                             std::regex_constants::egrep)))
-        << "KOKKOS_DISABLE_WARNINGS=" << value_false
-        << "\ncaptured: " << captured;
-  }
 }
 
 TEST(defaultdevicetype, env_vars_tune_internals) {
@@ -394,26 +374,6 @@ TEST(defaultdevicetype, env_vars_tune_internals) {
     auto const captured = ::testing::internal::GetCapturedStderr();
     EXPECT_TRUE(captured.empty()) << "KOKKOS_DISABLE_WARNINGS=" << value_false
                                   << "\ncaptured: " << captured;
-  }
-  for (auto const& value_false : {"true1", "3", "ON"}) {
-    ::testing::internal::CaptureStderr();
-    EnvVarsHelper ev = {{
-        {"KOKKOS_TUNE_INTERNALS", value_false},
-    }};
-    SKIP_IF_ENVIRONMENT_VARIABLE_ALREADY_SET(ev);
-    Kokkos::InitializationSettings settings;
-    Kokkos::Impl::parse_environment_variables(settings);
-    EXPECT_TRUE(settings.has_tune_internals())
-        << "KOKKOS_TUNE_INTERNALS=" << value_false;
-    EXPECT_FALSE(settings.get_tune_internals())
-        << "KOKKOS_TUNE_INTERNALS=" << value_false;
-    auto const captured = ::testing::internal::GetCapturedStderr();
-    EXPECT_TRUE(std::regex_match(
-        captured, std::regex(std::string("Warning.*KOKKOS_TUNE_INTERNALS=") +
-                                 value_false + ".*",
-                             std::regex_constants::egrep)))
-        << "KOKKOS_TUNE_INTERNALS=" << value_false
-        << "\ncaptured: " << captured;
   }
 }
 

--- a/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
+++ b/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
@@ -166,17 +166,6 @@ TEST(defaultdevicetype, cmd_line_args_num_threads) {
   EXPECT_EQ(settings.get_num_threads(), 2);
   EXPECT_EQ(cla.argc(), 1);
   EXPECT_STREQ(*cla.argv(), "--foo=bar");
-
-  settings = {};
-  cla      = {{
-      {"--kokkos-num-threads=-1"},
-  }};
-  EXPECT_THROW(  // consider calling abort instead
-      Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(),
-                                                 settings),
-      std::runtime_error
-      // expecting an '=INT' after command line argument '--kokkos-num-threads'
-  );
 }
 
 TEST(defaultdevicetype, cmd_line_args_device_id) {
@@ -212,15 +201,13 @@ TEST(defaultdevicetype, cmd_line_args_num_devices) {
 
 TEST(defaultdevicetype, cmd_line_args_disable_warning) {
   CmdLineArgsHelper cla = {{
-      "--kokkos-disable-warnings=0",
+      "--kokkos-disable-warnings=1",
+      "--kokkos-disable-warnings=false",
   }};
   Kokkos::InitializationSettings settings;
   Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
-  // this is the current behavior, not suggesting this cannot be revisited
-  // essentially here the =BOOL is ignored
   EXPECT_TRUE(settings.has_disable_warnings());
-  EXPECT_TRUE(settings.get_disable_warnings())
-      << "behavior changed see comment";
+  EXPECT_FALSE(settings.get_disable_warnings());
 }
 
 TEST(defaultdevicetype, cmd_line_args_tune_internals) {


### PR DESCRIPTION
* Enforce same rule everywhere to parse booleans
  case insensitive `(1,yes,true)` -> `true`
  case insensitive `(0,no,false)` -> `false`
  otherwise call `Kokkos::abort()`
* Changes in behavior
  `--kokkos-disable-warnings=false` would yield `disable_warnings=true` and now actually means `false`
  `KOKKOS_DISABLE_WARNINGS=ON` would yield `disable_warnings=true` but now is not recognized and causes abnormal termination of the program
  `--kokkos-num-devices=3 --num-devices=4` would yield `num_devices=3` and now give `num_devices=4`
