### PR TITLE
Harmonize device selection and allow SYCL to circumvent it when no GPU is available

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -860,9 +860,7 @@ int Cuda::impl_is_initialized() {
 }
 
 void Cuda::impl_initialize(InitializationSettings const &settings) {
-  int const use_gpu = Impl::get_gpu(settings);
-  Impl::CudaInternal::singleton().initialize(use_gpu > -1 ? use_gpu : 0,
-                                             nullptr);
+  Impl::CudaInternal::singleton().initialize(Impl::get_gpu(settings));
 }
 
 std::vector<unsigned> Cuda::detect_device_arch() {

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -523,8 +523,7 @@ int HIP::impl_is_initialized() {
 }
 
 void HIP::impl_initialize(InitializationSettings const& settings) {
-  int const use_gpu = ::Kokkos::Impl::get_gpu(settings);
-  Impl::HIPInternal::singleton().initialize(use_gpu > -1 ? use_gpu : 0);
+  Impl::HIPInternal::singleton().initialize(::Kokkos::Impl::get_gpu(settings));
 }
 
 void HIP::impl_finalize() { Impl::HIPInternal::singleton().finalize(); }

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -166,9 +166,10 @@ SYCL::SYCLDevice::SYCLDevice(size_t id) {
 sycl::device SYCL::SYCLDevice::get_device() const { return m_device; }
 
 void SYCL::impl_initialize(InitializationSettings const& settings) {
-  // If there are no GPUs, sidestep Kokkos device selection and use whatever is
-  // available.
-  if (sycl::device::get_devices(sycl::info::device_type::gpu).empty()) {
+  // If the device id is not specified and there are no GPUs, sidestep Kokkos
+  // device selection and use whatever is available.
+  if (!settings.has_device_id() &&
+      sycl::device::get_devices(sycl::info::device_type::gpu).empty()) {
     Impl::SYCLInternal::singleton().initialize(
         Kokkos::Experimental::SYCL::SYCLDevice(sycl::default_selector())
             .get_device());


### PR DESCRIPTION
#5211 may have broken SYCL running on CPUs
This PR make sure backends do not try to interpret on their own the settings and use directly the GPU that is selected by Core.  It allows SYCL to not call `Impl::get_gpu` when it detects there are none.