### PR TITLE
Check execution spaces interface as they are registered to core

### DIFF
--- a/core/src/impl/Kokkos_ExecSpaceManager.hpp
+++ b/core/src/impl/Kokkos_ExecSpaceManager.hpp
@@ -93,7 +93,9 @@ constexpr bool check_valid_execution_space() {
   STATIC_ASSERT(is_detected<print_configuration_t, ExecutionSpace>::value);
   STATIC_ASSERT(is_detected<initialize_finalize_t, ExecutionSpace>::value);
   STATIC_ASSERT(is_detected<fence_t, ExecutionSpace>::value);
+#ifndef KOKKOS_ENABLE_HPX  // FIXME_HPX
   STATIC_ASSERT(sizeof(ExecutionSpace) <= 2 * sizeof(void*));
+#endif
   return true;
 }
 

--- a/core/src/impl/Kokkos_ExecSpaceManager.hpp
+++ b/core/src/impl/Kokkos_ExecSpaceManager.hpp
@@ -46,10 +46,60 @@
 #define KOKKOS_EXEC_SPACE_MANAGER_HPP
 
 #include <impl/Kokkos_InitializationSettings.hpp>
+#include <Kokkos_DetectionIdiom.hpp>
+#include <Kokkos_Concepts.hpp>
 
 #include <iosfwd>
 #include <map>
 #include <string>
+
+namespace {
+
+template <class T>
+using public_member_types_t = std::enable_if_t<
+    Kokkos::is_execution_space<typename T::execution_space>::value &&
+    Kokkos::is_memory_space<typename T::memory_space>::value &&
+    Kokkos::is_device<typename T::device_type>::value &&
+    Kokkos::is_array_layout<typename T::array_layout>::value &&
+    std::is_integral<typename T::size_type>::value &&
+    Kokkos::is_memory_space<typename T::scratch_memory_space>::value>;
+
+template <class T>
+using print_configuration_t = std::enable_if_t<
+    std::is_void<decltype(std::declval<T const&>().print_configuration(
+        std::declval<std::ostream&>()))>::value &&
+    std::is_void<decltype(std::declval<T const&>().print_configuration(
+        std::declval<std::ostream&>(), false))>::value>;
+
+template <class T>
+using initialize_finalize_t = std::enable_if_t<
+    std::is_void<decltype(T::impl_initialize(
+        std::declval<Kokkos::InitializationSettings const&>()))>::value &&
+    std::is_void<decltype(T::impl_finalize())>::value>;
+
+template <class T>
+using fence_t = std::enable_if_t<
+    std::is_void<decltype(std::declval<T const&>().fence())>::value &&
+    std::is_void<decltype(std::declval<T const&>().fence("name"))>::value &&
+    std::is_void<decltype(T::impl_static_fence("name"))>::value>;
+
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, "")  // FIXME C++17
+
+template <class ExecutionSpace>
+constexpr bool check_valid_execution_space() {
+  using Kokkos::is_detected;
+  STATIC_ASSERT(std::is_default_constructible<ExecutionSpace>::value);
+  STATIC_ASSERT(is_detected<public_member_types_t, ExecutionSpace>::value);
+  STATIC_ASSERT(is_detected<print_configuration_t, ExecutionSpace>::value);
+  STATIC_ASSERT(is_detected<initialize_finalize_t, ExecutionSpace>::value);
+  STATIC_ASSERT(is_detected<fence_t, ExecutionSpace>::value);
+  STATIC_ASSERT(sizeof(ExecutionSpace) <= 2 * sizeof(void*));
+  return true;
+}
+
+#undef STATIC_ASSERT
+
+}  // namespace
 
 namespace Kokkos {
 namespace Impl {
@@ -64,6 +114,7 @@ struct ExecSpaceBase {
 
 template <class ExecutionSpace>
 struct ExecSpaceDerived : ExecSpaceBase {
+  static_assert(check_valid_execution_space<ExecutionSpace>(), "");
   void initialize(InitializationSettings const& settings) final {
     ExecutionSpace::impl_initialize(settings);
   }


### PR DESCRIPTION
Compile-time introspection of the execution spaces to enforce a common API.
The check is only done at compile-time in our own source file and does not impact user code.