### PR TITLE
Raise deprecation warnings if non empty `WorkTag` class is used

### DIFF
--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -220,8 +220,10 @@ struct PolicyTraits
   using base_t =
       ExecPolicyTraitsWithDefaults<AnalyzeExecPolicy<void, Traits...>>;
   using base_t::base_t;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   KOKKOS_IMPL_STATIC_WARNING(!std::is_empty<typename base_t::work_tag>::value &&
                              !std::is_void<typename base_t::work_tag>::value);
+#endif
 };
 
 #undef KOKKOS_IMPL_STATIC_WARNING

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -205,13 +205,26 @@ struct ExecPolicyTraitsWithDefaults : AnalysisResults {
 };
 
 //------------------------------------------------------------------------------
+
+constexpr bool warn_if_deprecated(std::false_type) { return true; }
+KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Invalid WorkTag template argument in execution policy!!")
+constexpr bool warn_if_deprecated(std::true_type) { return true; }
+#define KOKKOS_IMPL_STATIC_WARNING(...) \
+  static_assert(                        \
+      warn_if_deprecated(std::integral_constant<bool, __VA_ARGS__>()), "")
+
 template <typename... Traits>
 struct PolicyTraits
     : ExecPolicyTraitsWithDefaults<AnalyzeExecPolicy<void, Traits...>> {
   using base_t =
       ExecPolicyTraitsWithDefaults<AnalyzeExecPolicy<void, Traits...>>;
   using base_t::base_t;
+  KOKKOS_IMPL_STATIC_WARNING(!std::is_empty<typename base_t::work_tag>::value &&
+                             !std::is_void<typename base_t::work_tag>::value);
 };
+
+#undef KOKKOS_IMPL_STATIC_WARNING
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/traits/Kokkos_WorkTagTrait.hpp
+++ b/core/src/traits/Kokkos_WorkTagTrait.hpp
@@ -109,7 +109,10 @@ struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
   //   we should benchmark this assumption if it becomes a problem.
   template <class T>
   using trait_matches_specification = std::integral_constant<
-      bool, !std::is_void<T>::value && /*is_empty<T>::value &&*/
+      bool, !std::is_void<T>::value &&
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_3
+                std::is_empty<T>::value &&
+#endif
                 !type_list_any<_trait_matches_spec_predicate<T>::template apply,
                                _exec_policy_traits_without_work_tag>::value>;
 };

--- a/core/src/traits/Kokkos_WorkTagTrait.hpp
+++ b/core/src/traits/Kokkos_WorkTagTrait.hpp
@@ -109,7 +109,7 @@ struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
   //   we should benchmark this assumption if it becomes a problem.
   template <class T>
   using trait_matches_specification = std::integral_constant<
-      bool, !std::is_void<T>::value &&
+      bool, !std::is_void<T>::value && /*is_empty<T>::value &&*/
                 !type_list_any<_trait_matches_spec_predicate<T>::template apply,
                                _exec_policy_traits_without_work_tag>::value>;
 };

--- a/core/src/traits/Kokkos_WorkTagTrait.hpp
+++ b/core/src/traits/Kokkos_WorkTagTrait.hpp
@@ -109,12 +109,14 @@ struct WorkTagTrait : TraitSpecificationBase<WorkTagTrait> {
   //   we should benchmark this assumption if it becomes a problem.
   template <class T>
   using trait_matches_specification = std::integral_constant<
-      bool, !std::is_void<T>::value &&
+      bool,
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE_3
-                std::is_empty<T>::value &&
+      std::is_empty<T>::value &&
+#else
+      !std::is_void<T>::value &&
 #endif
-                !type_list_any<_trait_matches_spec_predicate<T>::template apply,
-                               _exec_policy_traits_without_work_tag>::value>;
+          !type_list_any<_trait_matches_spec_predicate<T>::template apply,
+                         _exec_policy_traits_without_work_tag>::value>;
 };
 
 // </editor-fold> end trait specification }}}1


### PR DESCRIPTION
Drafted our emitting deprecation warnings when user code specifies non empty class as an execution policy `WorkTag` template argument as a tentative fix for #5223 
The intent is to use it as a base for discussion.
```
In file included from <kokkos>/core/src/Kokkos_Core.hpp:57:
In file included from <kokkos>/cmake-build-default/KokkosCore_Config_DeclareBackend.hpp:47:
In file included from <kokkos>/core/src/decl/Kokkos_Declare_THREADS.hpp:49:
In file included from <kokkos>/core/src/Kokkos_Threads.hpp:199:
In file included from <kokkos>/core/src/Kokkos_ExecPolicy.hpp:60:
<kokkos>/core/src/impl/Kokkos_AnalyzePolicy.hpp:224:3: warning: 'warn_if_deprecated' is deprecated: Invalid WorkTag template argument in execution policy!! [-Wdeprecated-declarations]
  KOKKOS_IMPL_STATIC_WARNING(!std::is_empty<typename base_t::work_tag>::value &&
  ^
<kokkos>/core/src/impl/Kokkos_AnalyzePolicy.hpp:216:7: note: expanded from macro 'KOKKOS_IMPL_STATIC_WARNING'
      warn_if_deprecated(std::integral_constant<bool, __VA_ARGS__>()), "")
      ^
<kokkos>/core/src/Kokkos_ExecPolicy.hpp:99:28: note: in instantiation of template class 'Kokkos::Impl::PolicyTraits<Kokkos::HostSpace>' requested here
class RangePolicy : public Impl::PolicyTraits<Properties...> {
                           ^
<kokkos>/core/unit_test/default/TestDefaultDeviceDevelop.cpp:59:30: note: in instantiation of template class 'Kokkos::RangePolicy<Kokkos::HostSpace>' requested here
  static_assert(std::is_same<Policy::work_tag, Kokkos::HostSpace>::value, "");
                             ^
<kokkos>/core/src/impl/Kokkos_AnalyzePolicy.hpp:211:1: note: 'warn_if_deprecated' has been explicitly marked deprecated here
KOKKOS_DEPRECATED_WITH_COMMENT(
^
<kokkos>/core/src/Kokkos_Macros.hpp:610:51: note: expanded from macro 'KOKKOS_DEPRECATED_WITH_COMMENT'
#define KOKKOS_DEPRECATED_WITH_COMMENT(comment) [[deprecated(comment)]]
                                                  ^
1 warning generated.