### PR TITLE
Also filter out `-pedantic-errors` from nvcc options

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -381,7 +381,7 @@ do
   -std=c++98|--std=c++98)
     ;;
   #strip of pedantic because it produces endless warnings about #LINE added by the preprocessor
-  -pedantic|-Wpedantic|-ansi)
+  -pedantic|-pedantic-errors|-Wpedantic|-ansi)
     ;;
   #strip of -Woverloaded-virtual to avoid "cc1: warning: command line option ‘-Woverloaded-virtual’ is valid for C++/ObjC++ but not for C"
   -Woverloaded-virtual)


### PR DESCRIPTION
See https://github.com/lammps/lammps/issues/3353 and https://github.com/jbeder/yaml-cpp/issues/831 for some context.