### PR TITLE
Revert common view alloc prop

### DIFF
--- a/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
+++ b/containers/unit_tests/TestViewCtorPropEmbeddedDim.hpp
@@ -52,7 +52,6 @@
 #include <type_traits>
 #include <typeinfo>
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 namespace Test {
 
 namespace {
@@ -212,4 +211,3 @@ TEST(TEST_CATEGORY, viewctorprop_embedded_dim) {
   TestViewCtorProp_EmbeddedDim<TEST_EXECSPACE>::test_vcpt(2, 3);
 }
 }  // namespace Test
-#endif

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1961,7 +1961,17 @@ template <class... Views>
 using DeducedCommonPropsType =
     typename Impl::DeduceCommonViewAllocProp<Views...>::prop_type;
 
-// User function
+// This function is required in certain scenarios where users customize
+// Kokkos View internals. One example are dynamic length embedded ensemble
+// types. The function is used to propagate necessary information
+// (like the ensemble size) when creating new views.
+// However, most of the time it is called with a single view.
+// Furthermore, the propagated information is not just for view allocations.
+// From what I can tell, the type of functionality provided by
+// common_view_alloc_prop is the equivalent of propagating accessors in mdspan,
+// a mechanism we will eventually use to replace this clunky approach here, when
+// we are finally mdspan based.
+// TODO: get rid of this when we have mdspan
 template <class... Views>
 KOKKOS_INLINE_FUNCTION DeducedCommonPropsType<Views...> common_view_alloc_prop(
     Views const&... views) {

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1876,7 +1876,6 @@ inline void shared_allocation_tracking_enable() {
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 namespace Kokkos {
 namespace Impl {
 
@@ -1964,13 +1963,14 @@ using DeducedCommonPropsType =
 
 // User function
 template <class... Views>
-KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION DeducedCommonPropsType<Views...>
-common_view_alloc_prop(Views const&... views) {
+KOKKOS_INLINE_FUNCTION DeducedCommonPropsType<Views...> common_view_alloc_prop(
+    Views const&... views) {
   return DeducedCommonPropsType<Views...>(views...);
 }
 
 }  // namespace Kokkos
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -83,7 +83,6 @@ struct is_view_label<const char[N]> : public std::true_type {};
 template <typename... P>
 struct ViewCtorProp;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 // Forward declare
 template <typename Specialize, typename T>
 struct CommonViewAllocProp;
@@ -110,7 +109,6 @@ struct ViewCtorProp<void, CommonViewAllocProp<Specialize, T>> {
 
   type value;
 };
-#endif
 
 /*  std::integral_constant<unsigned,I> are dummy arguments
  *  that avoid duplicate base class errors

--- a/core/unit_test/TestOther.hpp
+++ b/core/unit_test/TestOther.hpp
@@ -53,9 +53,7 @@
 #endif
 #include <TestCXX11.hpp>
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 #include <TestViewCtorPropEmbeddedDim.hpp>
-#endif
 // with VS 16.11.3 and CUDA 11.4.2 getting cudafe stackoverflow crash
 #if !(defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA))
 #include <TestViewLayoutTiled.hpp>


### PR DESCRIPTION
Comment in code to explain this:
```
// This function is required for example for dynamic length embedded ensemble
// types It is used to propagate necessary information (like the ensemble size)
// Most of the time it is called with a single view however.
// Furthermore, the propagated information is not just for view allocations.
// From what I can tell this type of functionality is the equivalent to
// propagating accessors in mdspan, a mechanism we will use to replace this
// clunky approach here when we are finally mdspan based.
// TODO: get rid of this when we have mdspan
```