### PR TITLE
sycl_queue member function

### DIFF
--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -96,13 +96,9 @@ class SYCL {
     return m_space_instance->impl_get_instance_id();
   }
 
-  sycl::context sycl_context() const noexcept {
-    return m_space_instance->m_queue->get_context();
-  };
-
   sycl::queue& sycl_queue() const noexcept {
     return *m_space_instance->m_queue;
-  };
+  }
 
   //@}
   //------------------------------------
@@ -200,7 +196,7 @@ std::vector<SYCL> partition_space(const SYCL& sycl_space, Args...) {
       "Kokkos Error: partitioning arguments must be integers or floats");
 #endif
 
-  sycl::context context = sycl_space.sycl_context();
+  sycl::context context = sycl_space.sycl_queue().get_context();
   sycl::device device =
       sycl_space.impl_internal_space_instance()->m_queue->get_device();
   std::vector<SYCL> instances;
@@ -217,7 +213,7 @@ std::vector<SYCL> partition_space(const SYCL& sycl_space,
       std::is_arithmetic<T>::value,
       "Kokkos Error: partitioning arguments must be integers or floats");
 
-  sycl::context context = sycl_space.sycl_context();
+  sycl::context context = sycl_space.sycl_queue().get_context();
   sycl::device device =
       sycl_space.impl_internal_space_instance()->m_queue->get_device();
   std::vector<SYCL> instances;

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -100,6 +100,10 @@ class SYCL {
     return m_space_instance->m_queue->get_context();
   };
 
+  sycl::queue& sycl_queue() const noexcept {
+    return *m_space_instance->m_queue;
+  };
+
   //@}
   //------------------------------------
   //! \name Functions that all Kokkos devices must implement.

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Range.hpp
@@ -87,9 +87,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
                                         const sycl::event& memcpy_event) {
     // Convenience references
     const Kokkos::Experimental::SYCL& space = policy.space();
-    Kokkos::Experimental::Impl::SYCLInternal& instance =
-        *space.impl_internal_space_instance();
-    sycl::queue& q = *instance.m_queue;
+    sycl::queue& q                          = space.sycl_queue();
 
     auto parallel_for_event = q.submit([&](sycl::handler& cgh) {
       FunctorWrapperRangePolicyParallelFor<Functor, Policy> f{policy.begin(),
@@ -223,9 +221,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   sycl::event sycl_direct_launch(const FunctorWrapper& functor_wrapper,
                                  const sycl::event& memcpy_event) const {
     // Convenience references
-    Kokkos::Experimental::Impl::SYCLInternal& instance =
-        *m_space.impl_internal_space_instance();
-    sycl::queue& q = *instance.m_queue;
+    sycl::queue& q = m_space.sycl_queue();
 
     if (m_policy.m_num_tiles == 0) return {};
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -265,7 +265,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     const Kokkos::Experimental::SYCL& space = policy.space();
     Kokkos::Experimental::Impl::SYCLInternal& instance =
         *space.impl_internal_space_instance();
-    sycl::queue& q = *instance.m_queue;
+    sycl::queue& q = space.sycl_queue();
 
     // FIXME_SYCL optimize
     constexpr size_t wgroup_size       = 128;
@@ -575,7 +575,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     // Convenience references
     Kokkos::Experimental::Impl::SYCLInternal& instance =
         *m_space.impl_internal_space_instance();
-    sycl::queue& q = *instance.m_queue;
+    sycl::queue& q = m_space.sycl_queue();
 
     const typename Policy::index_type nwork = m_policy.m_num_tiles;
     const typename Policy::index_type block_size =

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -221,9 +221,7 @@ class ParallelScanSYCLBase {
                                  sycl::event memcpy_event) const {
     // Convenience references
     const Kokkos::Experimental::SYCL& space = m_policy.space();
-    Kokkos::Experimental::Impl::SYCLInternal& instance =
-        *space.impl_internal_space_instance();
-    sycl::queue& q = *instance.m_queue;
+    sycl::queue& q                          = space.sycl_queue();
 
     const std::size_t len = m_policy.end() - m_policy.begin();
 

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -422,9 +422,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                  const sycl::event& memcpy_events) const {
     // Convenience references
     const Kokkos::Experimental::SYCL& space = policy.space();
-    Kokkos::Experimental::Impl::SYCLInternal& instance =
-        *space.impl_internal_space_instance();
-    sycl::queue& q = *instance.m_queue;
+    sycl::queue& q                          = space.sycl_queue();
 
     auto parallel_for_event = q.submit([&](sycl::handler& cgh) {
       // FIXME_SYCL accessors seem to need a size greater than zero at least for
@@ -601,7 +599,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     const Kokkos::Experimental::SYCL& space = policy.space();
     Kokkos::Experimental::Impl::SYCLInternal& instance =
         *space.impl_internal_space_instance();
-    sycl::queue& q = *instance.m_queue;
+    sycl::queue& q = space.sycl_queue();
 
     const unsigned int value_count =
         Analysis::value_count(ReducerConditional::select(m_functor, m_reducer));

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
@@ -55,7 +55,7 @@ TEST(sycl, raw_sycl_interop) {
   Kokkos::initialize();
 
   Kokkos::Experimental::SYCL default_space;
-  sycl::context default_context = default_space.sycl_context();
+  sycl::context default_context = default_space.sycl_queue().get_context();
 
   sycl::default_selector device_selector;
   sycl::queue queue(default_context, device_selector);

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
@@ -52,7 +52,7 @@ namespace Test {
 // Test whether external allocations can be accessed by the default queue.
 TEST(sycl, raw_sycl_interop_context_1) {
   Kokkos::Experimental::SYCL default_space;
-  sycl::context default_context = default_space.sycl_context();
+  sycl::context default_context = default_space.sycl_queue().get_context();
 
   sycl::default_selector device_selector;
   sycl::queue queue(default_context, device_selector);
@@ -86,7 +86,7 @@ TEST(sycl, raw_sycl_interop_context_1) {
 // Test whether regular View allocations can be accessed by non-default queues.
 TEST(sycl, raw_sycl_interop_context_2) {
   Kokkos::Experimental::SYCL default_space;
-  sycl::context default_context = default_space.sycl_context();
+  sycl::context default_context = default_space.sycl_queue().get_context();
 
   sycl::default_selector device_selector;
   sycl::queue queue(default_context, device_selector);

--- a/core/unit_test/sycl/TestSYCL_TeamScratchStreams.cpp
+++ b/core/unit_test/sycl/TestSYCL_TeamScratchStreams.cpp
@@ -102,7 +102,7 @@ void sycl_queue_scratch_test(
     Kokkos::View<int64_t, Kokkos::Experimental::SYCLDeviceUSMSpace> counter) {
   constexpr int K = 4;
   Kokkos::Experimental::SYCL default_space;
-  sycl::context default_context = default_space.sycl_context();
+  sycl::context default_context = default_space.sycl_queue().get_context();
 
   sycl::default_selector device_selector;
   sycl::queue queue(default_context, device_selector);


### PR DESCRIPTION
Talking with @lucbv, it seems useful to have access to the `sycl::queue` of an `SYCL` execution space instance that doesn't rely on calling functions with `impl` in their name to support interoperability with, say, external libraries like `DPL` or`MKL` better.