### PR TITLE
SYCL: Store device_id passed from initialization

### DIFF
--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -134,8 +134,6 @@ class SYCL {
 
   static void impl_initialize(InitializationSettings const&);
 
-  int sycl_device() const;
-
   static bool impl_is_initialized();
 
   static int concurrency();
@@ -161,7 +159,7 @@ struct DeviceTypeTraits<Kokkos::Experimental::SYCL> {
   /// \brief An ID to differentiate (for example) Serial from OpenMP in Tooling
   static constexpr DeviceType id = DeviceType::SYCL;
   static int device_id(const Kokkos::Experimental::SYCL& exec) {
-    return exec.sycl_device();
+    return exec.impl_internal_space_instance()->m_syclDev;
   }
 };
 }  // namespace Experimental

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -142,10 +142,6 @@ void SYCL::impl_static_fence(const std::string& name) {
       });
 }
 
-int SYCL::sycl_device() const {
-  return impl_internal_space_instance()->m_syclDev;
-}
-
 void SYCL::impl_initialize(InitializationSettings const& settings) {
   std::vector<sycl::device> gpu_devices =
       sycl::device::get_devices(sycl::info::device_type::gpu);
@@ -158,11 +154,13 @@ void SYCL::impl_initialize(InitializationSettings const& settings) {
     !defined(KOKKOS_ARCH_AMPERE)
   if (!settings.has_device_id() && gpu_devices.empty()) {
     Impl::SYCLInternal::singleton().initialize(sycl::device());
+    Impl::SYCLInternal::m_syclDev = 0;
     return;
   }
 #endif
-  using Kokkos::Impl::get_gpu;
-  Impl::SYCLInternal::singleton().initialize(gpu_devices[get_gpu(settings)]);
+  const auto id = ::Kokkos::Impl::get_gpu(settings);
+  Impl::SYCLInternal::singleton().initialize(gpu_devices[id]);
+  Impl::SYCLInternal::m_syclDev = id;
 }
 
 std::ostream& SYCL::impl_sycl_info(std::ostream& os,

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -356,6 +356,8 @@ void SYCLInternal::USMObjectMem<Kind>::reset() {
   m_q.reset();
 }
 
+int SYCLInternal::m_syclDev;
+
 template class SYCLInternal::USMObjectMem<sycl::usm::alloc::shared>;
 template class SYCLInternal::USMObjectMem<sycl::usm::alloc::device>;
 template class SYCLInternal::USMObjectMem<sycl::usm::alloc::host>;

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -72,7 +72,7 @@ class SYCLInternal {
                                                    bool force_shrink = false);
 
   uint32_t impl_get_instance_id() const;
-  int m_syclDev = 0;
+  static int m_syclDev;
 
   size_t m_maxWorkgroupSize   = 0;
   uint32_t m_maxConcurrency   = 0;


### PR DESCRIPTION
To the best of my knowledge, there is no other way to obtain unique information about the `sycl::device` used, thus just storing what was given as `device_id` during initialization seems the best we can do. It's debatable what to do if the user passes just a `sycl::queue` add the moment we just use ~~0 by default but we could also use~~ the `device_id` the singleton was initialized with.