### PR TITLE
Add is_finalized

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -204,11 +204,6 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
   ScopeGuard(int& argc, char* argv[]) {
     sg_init = false;
     if (!is_initialized()) {
-      if (is_finalized()) {
-        Kokkos::abort(
-            "Attempt to create a Kokkos::ScopeGuard after Kokkos::finalize was "
-            "called.");
-      }
       initialize(argc, argv);
       sg_init = true;
     }
@@ -221,18 +216,13 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
       const InitializationSettings& settings = InitializationSettings()) {
     sg_init = false;
     if (!is_initialized()) {
-      if (is_finalized()) {
-        Kokkos::abort(
-            "Attempt to create a Kokkos::ScopeGuard after Kokkos::finalize was "
-            "called.");
-      }
       initialize(settings);
       sg_init = true;
     }
   }
 
   ~ScopeGuard() {
-    if (!is_finalized() && sg_init) {
+    if (is_initialized() && sg_init) {
       finalize();
     }
   }

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -74,6 +74,7 @@
 //----------------------------------------------------------------------------
 namespace {
 bool g_is_initialized = false;
+bool g_is_finalized   = false;
 bool g_show_warnings  = true;
 bool g_tune_internals = false;
 // When compiling with clang/LLVM and using the GNU (GCC) C++ Standard Library
@@ -667,6 +668,7 @@ void finalize_internal() {
   Kokkos::Impl::ExecSpaceManager::get_instance().finalize_spaces();
 
   g_is_initialized = false;
+  g_is_finalized   = true;
   g_show_warnings  = true;
   g_tune_internals = false;
 }
@@ -1062,7 +1064,13 @@ void Kokkos::print_configuration(std::ostream& os, bool verbose) {
   Impl::ExecSpaceManager::get_instance().print_configuration(os, verbose);
 }
 
-bool Kokkos::is_initialized() noexcept { return g_is_initialized; }
+KOKKOS_ATTRIBUTE_NODISCARD bool Kokkos::is_initialized() noexcept {
+  return g_is_initialized;
+}
+
+KOKKOS_ATTRIBUTE_NODISCARD bool Kokkos::is_finalized() noexcept {
+  return g_is_finalized;
+}
 
 bool Kokkos::show_warnings() noexcept { return g_show_warnings; }
 

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -241,7 +241,7 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<
   const int old_count = Kokkos::atomic_fetch_sub(&arg_record->m_count, 1);
 
   if (old_count == 1) {
-    if (!Kokkos::is_initialized()) {
+    if (is_finalized()) {
       std::stringstream ss;
       ss << "Kokkos allocation \"";
       ss << arg_record->get_label();


### PR DESCRIPTION
Fixes #5208.

is_finalized is also checked in the ScopeGuard constructor

Co-Authored-By: Damien L-G <dalg24@gmail.com>