### PR TITLE
Warn in ScopeGuard about illegal usage

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -204,16 +204,10 @@ inline std::string scopeguard_correct_usage() {
       "    !Kokkos::is_initialized() && !Kokkos::is_finalized()?\n"
       "    new ScopeGuard(argc,argv) : nullptr;\n");
 }
-inline std::string scopeguard_create_after_init_warning() {
-  return std::string(
-             "Kokkos Error: Creating a ScopeGuard after Kokkos was initialized "
-             "is illegal.\n")
-      .append(scopeguard_correct_usage());
-}
 
-inline std::string scopeguard_destruct_without_init_warning() {
+inline std::string scopeguard_create_while_initialized_warning() {
   return std::string(
-             "Kokkos Error: Destroying a ScopeGuard after Kokkos was finalized "
+             "Kokkos Error: Creating a ScopeGuard while Kokkos is initialized "
              "is illegal.\n")
       .append(scopeguard_correct_usage());
 }
@@ -244,7 +238,8 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
     sg_init = false;
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
     if (is_initialized()) {
-      std::cerr << Impl::scopeguard_create_after_init_warning() << std::endl;
+      std::cerr << Impl::scopeguard_create_while_initialized_warning()
+                << std::endl;
     }
     if (is_finalized()) {
       std::cerr << Impl::scopeguard_create_after_finalize_warning()
@@ -265,7 +260,8 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
     sg_init = false;
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
     if (is_initialized()) {
-      std::cerr << Impl::scopeguard_create_after_init_warning() << std::endl;
+      std::cerr << Impl::scopeguard_create_while_initialized_warning()
+                << std::endl;
     }
     if (is_finalized()) {
       std::cerr << Impl::scopeguard_create_after_finalize_warning()
@@ -280,10 +276,6 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
 
   ~ScopeGuard() {
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-    if (!is_initialized() && !is_finalized()) {
-      std::cerr << Impl::scopeguard_destruct_without_init_warning()
-                << std::endl;
-    }
     if (is_finalized()) {
       std::cerr << Impl::scopeguard_destruct_after_finalize_warning()
                 << std::endl;
@@ -311,7 +303,8 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
 
   ScopeGuard(int& argc, char* argv[]) {
     if (is_initialized()) {
-      Kokkos::abort(Impl::scopeguard_create_after_init_warning().c_str());
+      Kokkos::abort(
+          Impl::scopeguard_create_while_initialized_warning().c_str());
     }
     if (is_finalized()) {
       Kokkos::abort(Impl::scopeguard_create_after_finalize_warning().c_str());
@@ -325,7 +318,8 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
   ScopeGuard(
       const InitializationSettings& settings = InitializationSettings()) {
     if (is_initialized()) {
-      Kokkos::abort(Impl::scopeguard_create_after_init_warning().c_str());
+      Kokkos::abort(
+          Impl::scopeguard_create_while_initialized_warning().c_str());
     }
     if (is_finalized()) {
       Kokkos::abort(Impl::scopeguard_create_after_finalize_warning().c_str());
@@ -334,9 +328,6 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
   }
 
   ~ScopeGuard() {
-    if (!is_initialized() && !is_finalized()) {
-      Kokkos::abort(Impl::scopeguard_destruct_without_init_warning().c_str());
-    }
     if (is_finalized()) {
       Kokkos::abort(Impl::scopeguard_destruct_after_finalize_warning().c_str());
     }

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -255,7 +255,7 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
 #if defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) >= 201907
   KOKKOS_ATTRIBUTE_NODISCARD
 #endif
-  ScopeGuard(
+  explicit ScopeGuard(
       const InitializationSettings& settings = InitializationSettings()) {
     sg_init = false;
 #ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
@@ -286,11 +286,13 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
     }
   }
 
-  // private:
+ private:
   bool sg_init;
 
   ScopeGuard& operator=(const ScopeGuard&) = delete;
-  ScopeGuard(const ScopeGuard&)            = delete;
+  ScopeGuard& operator=(ScopeGuard&&) = delete;
+  ScopeGuard(const ScopeGuard&)       = delete;
+  ScopeGuard(ScopeGuard&&)            = delete;
 };
 
 #else  // ifndef KOKKOS_ENABLE_DEPRECATED_CODE3
@@ -300,7 +302,6 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
 #if defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) >= 201907
   KOKKOS_ATTRIBUTE_NODISCARD
 #endif
-
   ScopeGuard(int& argc, char* argv[]) {
     if (is_initialized()) {
       Kokkos::abort(
@@ -334,9 +335,11 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
     finalize();
   }
 
-  // private:
+ private:
   ScopeGuard& operator=(const ScopeGuard&) = delete;
-  ScopeGuard(const ScopeGuard&)            = delete;
+  ScopeGuard& operator=(ScopeGuard&&) = delete;
+  ScopeGuard(const ScopeGuard&)       = delete;
+  ScopeGuard(ScopeGuard&&)            = delete;
 };
 #endif
 
@@ -391,7 +394,7 @@ std::vector<ExecSpace> partition_space(ExecSpace space,
 // implementation of the RAII wrapper is using Kokkos::single.
 #include <Kokkos_AcquireUniqueTokenImpl.hpp>
 
-// Specializations requires after core definitions
+// Specializations required after core definitions
 #include <KokkosCore_Config_PostInclude.hpp>
 
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -289,6 +289,7 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
  private:
   bool sg_init;
 
+ public:
   ScopeGuard& operator=(const ScopeGuard&) = delete;
   ScopeGuard& operator=(ScopeGuard&&) = delete;
   ScopeGuard(const ScopeGuard&)       = delete;
@@ -335,7 +336,6 @@ class KOKKOS_ATTRIBUTE_NODISCARD ScopeGuard {
     finalize();
   }
 
- private:
   ScopeGuard& operator=(const ScopeGuard&) = delete;
   ScopeGuard& operator=(ScopeGuard&&) = delete;
   ScopeGuard(const ScopeGuard&)       = delete;


### PR DESCRIPTION
We (Damien and I) are considering a change of behavior and how to use it for ScopeGuard.
Specifically, we believe its current design is problematic in various ways, one of them being the silent ignoring of arguments handed to it if Kokkos was already initialized.

Besides better warnings in cases which were previously already broken (like creating a ScopeGuard after Kokkos::finalize() was called), the primary change is that you can't create a ScopeGuard after Kokkos::initialize was called. This also means that you can't create a ScopeGuard after any other ScopeGuard was created. The error message provided shows a way how to do nested scopeguards (as they might currently be in use) if really desired, but essentially its pushing more of the correctness check behavior on the user. 

Please let us know what you think.

Note: this PR is missing tests, which I am working on. 