### PR TITLE
Warn users when a flag prefixed with `-[-]kokkos` is not recognized and do not remove it

### DIFF
--- a/core/src/impl/Kokkos_Command_Line_Parsing.cpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.cpp
@@ -275,6 +275,11 @@ std::vector<std::regex> do_not_warn_regular_expressions{
 };
 }
 
+void Kokkos::Impl::do_not_warn_not_recognized_command_line_argument(
+    std::regex ignore) {
+  do_not_warn_regular_expressions.push_back(std::move(ignore));
+}
+
 void Kokkos::Impl::warn_not_recognized_command_line_argument(
     std::string not_recognized) {
   for (auto const& ignore : do_not_warn_regular_expressions) {

--- a/core/src/impl/Kokkos_Command_Line_Parsing.cpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.cpp
@@ -268,3 +268,22 @@ void Kokkos::Impl::warn_deprecated_command_line_argument(
             << " Raised by Kokkos::initialize(int argc, char* argv[])."
             << std::endl;
 }
+
+namespace {
+std::vector<std::regex> do_not_warn_regular_expressions{
+    std::regex{"--kokkos-tool.*", std::regex::egrep},
+};
+}
+
+void Kokkos::Impl::warn_not_recognized_command_line_argument(
+    std::string not_recognized) {
+  for (auto const& ignore : do_not_warn_regular_expressions) {
+    if (std::regex_match(not_recognized, ignore)) {
+      return;
+    }
+  }
+  std::cerr << "Warning: command line argument '" << not_recognized
+            << "' is not recognized."
+            << " Raised by Kokkos::initialize(int argc, char* argv[])."
+            << std::endl;
+}

--- a/core/src/impl/Kokkos_Command_Line_Parsing.hpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.hpp
@@ -62,6 +62,7 @@ void warn_deprecated_environment_variable(std::string deprecated,
 void warn_deprecated_command_line_argument(std::string deprecated);
 void warn_deprecated_command_line_argument(std::string deprecated,
                                            std::string use_instead);
+void warn_not_recognized_command_line_argument(std::string not_recognized);
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Command_Line_Parsing.hpp
+++ b/core/src/impl/Kokkos_Command_Line_Parsing.hpp
@@ -46,6 +46,7 @@
 #define KOKKOS_COMMAND_LINE_PARSING_HPP
 
 #include <string>
+#include <regex>
 
 namespace Kokkos {
 namespace Impl {
@@ -63,6 +64,7 @@ void warn_deprecated_command_line_argument(std::string deprecated);
 void warn_deprecated_command_line_argument(std::string deprecated,
                                            std::string use_instead);
 void warn_not_recognized_command_line_argument(std::string not_recognized);
+void do_not_warn_not_recognized_command_line_argument(std::regex ignore);
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -874,6 +874,9 @@ void Kokkos::Impl::parse_command_line_arguments(
         Kokkos::abort(ss.str().c_str());
       }
       settings.set_map_device_id_by(map_device_id_by);
+    } else if (std::regex_match(argv[iarg],
+                                std::regex("-?-kokkos.*", std::regex::egrep))) {
+      warn_not_recognized_command_line_argument(argv[iarg]);
     }
 
     // remove flag if prefixed with '--kokkos-'

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -756,9 +756,13 @@ void Kokkos::Impl::parse_command_line_arguments(
 
   int iarg = 0;
   while (iarg < argc) {
+    bool remove_flag = false;
+
     if (check_arg(argv[iarg], "--kokkos-numa") ||
         check_arg(argv[iarg], "--numa")) {
       warn_deprecated_command_line_argument(get_flag(argv[iarg]));
+      // remove flag if prefixed with '--kokkos-'
+      remove_flag = std::string(argv[iarg]).find("--kokkos-") == 0;
     } else if (check_arg_int(argv[iarg], "--kokkos-num-threads", num_threads) ||
                check_arg_int(argv[iarg], "--num-threads", num_threads) ||
                check_arg_int(argv[iarg], "--kokkos-threads", num_threads) ||
@@ -775,6 +779,7 @@ void Kokkos::Impl::parse_command_line_arguments(
         Kokkos::abort(ss.str().c_str());
       }
       settings.set_num_threads(num_threads);
+      remove_flag = std::string(argv[iarg]).find("--kokkos-") == 0;
     } else if (check_arg_int(argv[iarg], "--kokkos-device-id", device_id) ||
                check_arg_int(argv[iarg], "--device-id", device_id) ||
                check_arg_int(argv[iarg], "--kokkos-device", device_id) ||
@@ -790,6 +795,7 @@ void Kokkos::Impl::parse_command_line_arguments(
         Kokkos::abort(ss.str().c_str());
       }
       settings.set_device_id(device_id);
+      remove_flag = std::string(argv[iarg]).find("--kokkos-") == 0;
     } else if (check_arg(argv[iarg], "--kokkos-num-devices") ||
                check_arg(argv[iarg], "--num-devices") ||
                check_arg(argv[iarg], "--kokkos-ndevices") ||
@@ -852,18 +858,23 @@ void Kokkos::Impl::parse_command_line_arguments(
           settings.set_skip_device(skip_device);
         }
       }
+      remove_flag = std::string(argv[iarg]).find("--kokkos-") == 0;
     } else if (check_arg_bool(argv[iarg], "--kokkos-disable-warnings",
                               disable_warnings)) {
       settings.set_disable_warnings(disable_warnings);
+      remove_flag = true;
     } else if (check_arg_bool(argv[iarg], "--kokkos-print-configuration",
                               print_configuration)) {
       settings.set_print_configuration(print_configuration);
+      remove_flag = true;
     } else if (check_arg_bool(argv[iarg], "--kokkos-tune-internals",
                               tune_internals)) {
       settings.set_tune_internals(tune_internals);
+      remove_flag = true;
     } else if (check_arg(argv[iarg], "--kokkos-help") ||
                check_arg(argv[iarg], "--help")) {
-      help_flag = true;
+      help_flag   = true;
+      remove_flag = std::string(argv[iarg]).find("--kokkos-") == 0;
     } else if (check_arg_str(argv[iarg], "--kokkos-map-device-id-by",
                              map_device_id_by)) {
       if (!is_valid_map_device_id_by(map_device_id_by)) {
@@ -874,13 +885,12 @@ void Kokkos::Impl::parse_command_line_arguments(
         Kokkos::abort(ss.str().c_str());
       }
       settings.set_map_device_id_by(map_device_id_by);
+      remove_flag = true;
     } else if (std::regex_match(argv[iarg],
                                 std::regex("-?-kokkos.*", std::regex::egrep))) {
       warn_not_recognized_command_line_argument(argv[iarg]);
     }
 
-    // remove flag if prefixed with '--kokkos-'
-    bool remove_flag = std::string(argv[iarg]).find("--kokkos-") == 0;
     if (remove_flag) {
       for (int k = iarg; k < argc - 1; k++) {
         argv[k] = argv[k + 1];

--- a/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
+++ b/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
@@ -47,6 +47,7 @@
 #include <impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp>
 #include <impl/Kokkos_InitializationSettings.hpp>
 #include <impl/Kokkos_DeviceManagement.hpp>
+#include <impl/Kokkos_Command_Line_Parsing.hpp>
 
 #include <cstdlib>
 #include <memory>
@@ -298,6 +299,19 @@ TEST(defaultdevicetype, cmd_line_args_unrecognized_flag) {
   EXPECT_TRUE(captured.empty() && !settings.has_num_threads()) << captured;
   EXPECT_EQ(cla.argc(), 1);
   EXPECT_STREQ(cla.argv()[0], "--kokko-num-threads=4");
+
+  Kokkos::Impl::do_not_warn_not_recognized_command_line_argument(
+      std::regex{"^--kokkos-extension.*"});
+  cla = {{
+      "--kokkos-extension-option=value",  // user explicitly asked not to warn
+                                          // about that prefix
+  }};
+  ::testing::internal::CaptureStderr();
+  Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
+  captured = ::testing::internal::GetCapturedStderr();
+  EXPECT_TRUE(captured.empty()) << captured;
+  EXPECT_EQ(cla.argc(), 1);
+  EXPECT_STREQ(cla.argv()[0], "--kokkos-extension-option=value");
 }
 
 TEST(defaultdevicetype, env_vars_num_threads) {

--- a/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
+++ b/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
@@ -208,6 +208,7 @@ TEST(defaultdevicetype, cmd_line_args_disable_warning) {
   Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
   EXPECT_TRUE(settings.has_disable_warnings());
   EXPECT_FALSE(settings.get_disable_warnings());
+  EXPECT_EQ(cla.argc(), 0);
 }
 
 TEST(defaultdevicetype, cmd_line_args_tune_internals) {
@@ -221,6 +222,7 @@ TEST(defaultdevicetype, cmd_line_args_tune_internals) {
   EXPECT_TRUE(settings.get_tune_internals());
   EXPECT_TRUE(settings.has_num_threads());
   EXPECT_EQ(settings.get_num_threads(), 3);
+  EXPECT_EQ(cla.argc(), 0);
 }
 
 TEST(defaultdevicetype, cmd_line_args_help) {
@@ -271,6 +273,8 @@ TEST(defaultdevicetype, cmd_line_args_unrecognized_flag) {
               captured.find("--kokkos_num_threads=4") != std::string::npos &&
               !settings.has_num_threads())
       << captured;
+  EXPECT_EQ(cla.argc(), 1);
+  EXPECT_STREQ(cla.argv()[0], "--kokkos_num_threads=4");
 
   cla = {{
       "-kokkos-num-threads=4",  // missing a one leading dash
@@ -282,6 +286,8 @@ TEST(defaultdevicetype, cmd_line_args_unrecognized_flag) {
               captured.find("-kokkos-num-threads=4") != std::string::npos &&
               !settings.has_num_threads())
       << captured;
+  EXPECT_EQ(cla.argc(), 1);
+  EXPECT_STREQ(cla.argv()[0], "-kokkos-num-threads=4");
 
   cla = {{
       "--kokko-num-threads=4",  // no warning when prefix misspelled
@@ -290,6 +296,8 @@ TEST(defaultdevicetype, cmd_line_args_unrecognized_flag) {
   Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
   captured = ::testing::internal::GetCapturedStderr();
   EXPECT_TRUE(captured.empty() && !settings.has_num_threads()) << captured;
+  EXPECT_EQ(cla.argc(), 1);
+  EXPECT_STREQ(cla.argv()[0], "--kokko-num-threads=4");
 }
 
 TEST(defaultdevicetype, env_vars_num_threads) {


### PR DESCRIPTION
* Do not silently ignore flags we do not recognize when parsing command line arguments if they start with `--kokkos` or `-kokkos`
* Provide a function to tell Kokkos Core not to emit a warning for flags that match some user provided regular expression `Impl::do_not_warn_not_recognized_command_line_argument`.  By default, we only exclude those starting with `--kokkos-tool` but we could expand later as needed.
* Fix bug: do not remove flags prefixed with `--kokkos` that were not actually handled