### PR TITLE
Restore old behavior in device selection when user specifies nothing

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -375,7 +375,7 @@ int Kokkos::Impl::get_gpu(const InitializationSettings& settings) {
   }
 
   // either map_device_id_by is not specified or it is mpi_rank
-  if (!settings.has_map_device_id_by() ||
+  if (settings.has_map_device_id_by() &&
       settings.get_map_device_id_by() != "mpi_rank") {
     Kokkos::abort("implementation bug");
   }


### PR DESCRIPTION
As reported in #5252, #5211 accidentally changed the default behavior.
The new behavior was "when the user specifies nothing fallback to using the first GPU available".  This PR revert it to the old behavior that is "always attempt to detect local MPI rank and do round-robin assignment".