### PR TITLE
Remove Kokkos::Rank limit of 6 ranks

### DIFF
--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -208,6 +208,7 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   using member_type       = typename range_policy::member_type;
 
   static constexpr int rank = iteration_pattern::rank;
+  static_assert(rank < 7, "Kokkos MDRangePolicy Error: Unsupported rank...");
 
   using index_type       = typename traits::index_type;
   using array_index_type = std::int64_t;

--- a/core/src/Kokkos_Rank.hpp
+++ b/core/src/Kokkos_Rank.hpp
@@ -66,7 +66,7 @@ struct Rank {
   static_assert(N != 0u, "Kokkos Error: rank 0 undefined");
   static_assert(N != 1u,
                 "Kokkos Error: rank 1 is not a multi-dimensional range");
-  static_assert(N < 7u, "Kokkos Error: Unsupported rank...");
+  static_assert(N < 9u, "Kokkos Error: Unsupported rank...");
 
   using iteration_pattern = Rank<N, OuterDir, InnerDir>;
 


### PR DESCRIPTION
Now limited to 8 ranks to match the rest of Kokkos.
To preserve the previous behavior in MDRangePolicy, `static_assert` that limits the rank to 6 has been moved to MDRangePolicy struct.

This is to support Kokkos::Rank usage in #5238, which is not currently limited to any ranks.

If another component of Kokkos should have a rank limit less than 8, we can place that limitation in that component.