### PR TITLE
Do not forget to set last element to `nullptr` when removing a flag in `Kokkos::initialize`

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -941,7 +941,10 @@ void Kokkos::Impl::parse_command_line_arguments(
     }
 
     if (remove_flag) {
-      for (int k = iarg; k < argc - 1; k++) {
+      // Shift the remainder of the argv list by one.  Note that argv has
+      // (argc + 1) arguments, the last one always being nullptr.  The following
+      // loop moves the trailing nullptr element as well
+      for (int k = iarg; k < argc; ++k) {
         argv[k] = argv[k + 1];
       }
       argc--;

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -150,14 +150,22 @@ void parse_command_line_arguments(int& argc, char* argv[],
       help = InitArguments::PossiblyUnsetOption::on;
       warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(argv[iarg]);
       remove_flag = true;
-    } else {
-      iarg++;
+    } else if (std::regex_match(argv[iarg], std::regex("-?-kokkos-tool.*",
+                                                       std::regex::egrep))) {
+      std::cerr << "Warning: command line argument '" << argv[iarg]
+                << "' is not recognized."
+                << " Raised by Kokkos::initialize()." << std::endl;
     }
     if (remove_flag) {
-      for (int k = iarg; k < argc - 1; k++) {
+      // Shift the remainder of the argv list by one.  Note that argv has
+      // (argc + 1) arguments, the last one always being nullptr.  The following
+      // loop moves the trailing nullptr element as well
+      for (int k = iarg; k < argc; ++k) {
         argv[k] = argv[k + 1];
       }
       argc--;
+    } else {
+      iarg++;
     }
     if ((args == Kokkos::Tools::InitArguments::unset_string_option) && argc > 0)
       args = argv[0];

--- a/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
+++ b/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
@@ -270,6 +270,32 @@ TEST(defaultdevicetype, cmd_line_args_help) {
   EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {"--help"});
 }
 
+TEST(defaultdevicetype, cmd_line_args_tools_arguments) {
+  CmdLineArgsHelper cla = {{
+      "--kokkos-tool-libs=ich_tue_nur.so",
+  }};
+  Kokkos::InitializationSettings settings;
+  ::testing::internal::CaptureStderr();
+  Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
+  auto captured = ::testing::internal::GetCapturedStderr();
+  EXPECT_TRUE(captured.find("not recognized") != std::string::npos &&
+              captured.find("--kokkos-tool-libs=ich_tue_nur.so") !=
+                  std::string::npos &&
+              !settings.has_tools_libs())
+      << captured;
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(
+      cla, {"--kokkos-tool-libs=ich_tue_nur.so"});
+
+  cla      = {{
+      "--kokkos-tools-libs=ich_tue_nur.so",
+  }};
+  settings = {};
+  Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
+  EXPECT_TRUE(settings.has_tools_libs());
+  EXPECT_EQ(settings.get_tools_libs(), "ich_tue_nur.so");
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {});
+}
+
 TEST(defaultdevicetype, cmd_line_args_unrecognized_flag) {
   CmdLineArgsHelper cla = {{
       "--kokkos_num_threads=4",  // underscores instead of dashes

--- a/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
+++ b/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
@@ -150,10 +150,23 @@ class CmdLineArgsHelper {
       strcpy(ptr, x.c_str());
       argv_.push_back(ptr);
     }
+    argv_.push_back(nullptr);
   }
   int& argc() { return argc_; }
   char** argv() { return argv_.data(); }
 };
+#define EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, ...) \
+  do {                                                    \
+    std::vector<std::string> expected_argv = __VA_ARGS__; \
+                                                          \
+    int expected_argc = expected_argv.size();             \
+    EXPECT_EQ(cla.argc(), expected_argc);                 \
+    for (int i = 0; i < expected_argc; ++i) {             \
+      EXPECT_EQ(cla.argv()[i], expected_argv[i])          \
+          << "arguments differ at index " << i;           \
+    }                                                     \
+    EXPECT_EQ(cla.argv()[cla.argc()], nullptr);           \
+  } while (false)
 
 TEST(defaultdevicetype, cmd_line_args_num_threads) {
   CmdLineArgsHelper cla = {{
@@ -165,8 +178,7 @@ TEST(defaultdevicetype, cmd_line_args_num_threads) {
   Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
   EXPECT_TRUE(settings.has_num_threads());
   EXPECT_EQ(settings.get_num_threads(), 2);
-  EXPECT_EQ(cla.argc(), 1);
-  EXPECT_STREQ(*cla.argv(), "--foo=bar");
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {"--foo=bar"});
 }
 
 TEST(defaultdevicetype, cmd_line_args_device_id) {
@@ -179,8 +191,7 @@ TEST(defaultdevicetype, cmd_line_args_device_id) {
   Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
   EXPECT_TRUE(settings.has_device_id());
   EXPECT_EQ(settings.get_device_id(), 4);
-  EXPECT_EQ(cla.argc(), 1);
-  EXPECT_STREQ(*cla.argv(), "--dummy");
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {"--dummy"});
 }
 
 TEST(defaultdevicetype, cmd_line_args_num_devices) {
@@ -196,8 +207,7 @@ TEST(defaultdevicetype, cmd_line_args_num_devices) {
   // this is the current behavior, not suggesting this cannot be revisited
   EXPECT_TRUE(settings.has_skip_device()) << "behavior changed see comment";
   EXPECT_EQ(settings.get_skip_device(), 6) << "behavior changed see comment";
-  EXPECT_EQ(cla.argc(), 1);
-  EXPECT_STREQ(*cla.argv(), "-v");
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {"-v"});
 }
 
 TEST(defaultdevicetype, cmd_line_args_disable_warning) {
@@ -209,7 +219,7 @@ TEST(defaultdevicetype, cmd_line_args_disable_warning) {
   Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
   EXPECT_TRUE(settings.has_disable_warnings());
   EXPECT_FALSE(settings.get_disable_warnings());
-  EXPECT_EQ(cla.argc(), 0);
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {});
 }
 
 TEST(defaultdevicetype, cmd_line_args_tune_internals) {
@@ -223,7 +233,7 @@ TEST(defaultdevicetype, cmd_line_args_tune_internals) {
   EXPECT_TRUE(settings.get_tune_internals());
   EXPECT_TRUE(settings.has_num_threads());
   EXPECT_EQ(settings.get_num_threads(), 3);
-  EXPECT_EQ(cla.argc(), 0);
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {});
 }
 
 TEST(defaultdevicetype, cmd_line_args_help) {
@@ -236,8 +246,7 @@ TEST(defaultdevicetype, cmd_line_args_help) {
   auto captured = ::testing::internal::GetCapturedStdout();
   // check that error message was only printed once
   EXPECT_EQ(captured.find("--kokkos-help"), captured.rfind("--kokkos-help"));
-  EXPECT_EQ(cla.argc(), 1);
-  EXPECT_STREQ(*cla.argv(), "--help");
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {"--help"});
   auto const help_message_length = captured.length();
 
   cla = {{
@@ -247,7 +256,7 @@ TEST(defaultdevicetype, cmd_line_args_help) {
   Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
   captured = ::testing::internal::GetCapturedStdout();
   EXPECT_EQ(captured.length(), help_message_length);
-  EXPECT_EQ(cla.argc(), 0);
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {});
 
   cla = {{
       {"--kokkos-help"},
@@ -258,8 +267,7 @@ TEST(defaultdevicetype, cmd_line_args_help) {
   Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
   captured = ::testing::internal::GetCapturedStdout();
   EXPECT_EQ(captured.length(), help_message_length);
-  EXPECT_EQ(cla.argc(), 1);
-  EXPECT_STREQ(*cla.argv(), "--help");
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {"--help"});
 }
 
 TEST(defaultdevicetype, cmd_line_args_unrecognized_flag) {
@@ -274,11 +282,10 @@ TEST(defaultdevicetype, cmd_line_args_unrecognized_flag) {
               captured.find("--kokkos_num_threads=4") != std::string::npos &&
               !settings.has_num_threads())
       << captured;
-  EXPECT_EQ(cla.argc(), 1);
-  EXPECT_STREQ(cla.argv()[0], "--kokkos_num_threads=4");
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {"--kokkos_num_threads=4"});
 
   cla = {{
-      "-kokkos-num-threads=4",  // missing a one leading dash
+      "-kokkos-num-threads=4",  // missing one leading dash
   }};
   ::testing::internal::CaptureStderr();
   Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
@@ -287,8 +294,7 @@ TEST(defaultdevicetype, cmd_line_args_unrecognized_flag) {
               captured.find("-kokkos-num-threads=4") != std::string::npos &&
               !settings.has_num_threads())
       << captured;
-  EXPECT_EQ(cla.argc(), 1);
-  EXPECT_STREQ(cla.argv()[0], "-kokkos-num-threads=4");
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {"-kokkos-num-threads=4"});
 
   cla = {{
       "--kokko-num-threads=4",  // no warning when prefix misspelled
@@ -297,8 +303,7 @@ TEST(defaultdevicetype, cmd_line_args_unrecognized_flag) {
   Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
   captured = ::testing::internal::GetCapturedStderr();
   EXPECT_TRUE(captured.empty() && !settings.has_num_threads()) << captured;
-  EXPECT_EQ(cla.argc(), 1);
-  EXPECT_STREQ(cla.argv()[0], "--kokko-num-threads=4");
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla, {"--kokko-num-threads=4"});
 
   Kokkos::Impl::do_not_warn_not_recognized_command_line_argument(
       std::regex{"^--kokkos-extension.*"});
@@ -310,8 +315,8 @@ TEST(defaultdevicetype, cmd_line_args_unrecognized_flag) {
   Kokkos::Impl::parse_command_line_arguments(cla.argc(), cla.argv(), settings);
   captured = ::testing::internal::GetCapturedStderr();
   EXPECT_TRUE(captured.empty()) << captured;
-  EXPECT_EQ(cla.argc(), 1);
-  EXPECT_STREQ(cla.argv()[0], "--kokkos-extension-option=value");
+  EXPECT_REMAINING_COMMAND_LINE_ARGUMENTS(cla,
+                                          {"--kokkos-extension-option=value"});
 }
 
 TEST(defaultdevicetype, env_vars_num_threads) {


### PR DESCRIPTION
Spotted when working on the documentation for `Kokkos::initialize`
Also now raising warning in kokkos-tools when flags are not recognized