### PR TITLE
inline constexpr bool is_CONCEPT_v variables added to match C++17 traits

### DIFF
--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -171,7 +171,9 @@ namespace Kokkos {
         std::is_base_of<detected_t<have_t, T>, T>::value ||    \
         std::is_base_of<detected_t<have_type_t, T>, T>::value; \
     constexpr operator bool() const noexcept { return value; } \
-  };
+  };                                                           \
+  template <typename T>                                        \
+  inline constexpr bool is_##CONCEPT##_v = is_##CONCEPT<T>::value;
 
 // Public concept:
 

--- a/core/unit_test/TestConcepts.hpp
+++ b/core/unit_test/TestConcepts.hpp
@@ -78,6 +78,9 @@ static_assert(!Kokkos::is_space<ExecutionSpace &>{}, "");
 static_assert(!Kokkos::is_space<MemorySpace &>{}, "");
 static_assert(!Kokkos::is_space<DeviceType &>{}, "");
 
+static_assert(Kokkos::is_execution_space_v<ExecutionSpace>, "");
+static_assert(!Kokkos::is_execution_space_v<ExecutionSpace &>, "");
+
 static_assert(
     std::is_same<float, Kokkos::Impl::remove_cvref_t<float const &>>{}, "");
 static_assert(std::is_same<int, Kokkos::Impl::remove_cvref_t<int &>>{}, "");


### PR DESCRIPTION
The is_CONCEPT marco has been updated to add the is_CONCEPT_v inline variables so that all of the Kokkos concept traits get them.