### PR TITLE
#5274 DynamicView: Properly resize mirror instances after construction

### DIFF
--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -654,11 +654,16 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynamicview) {
                                typename TEST_EXECSPACE::memory_space{}),
             mirror_device);
       },
+      [&](BeginFenceEvent event) {
+        if (event.descriptor().find("DynamicView::resize_serial: Fence after "
+                                    "copying chunks to the device") !=
+            std::string::npos)
+          return MatchDiagnostic{false};
+        return MatchDiagnostic{true, {"Found fence event"}};
+      },
+      [&](EndFenceEvent) { return MatchDiagnostic{false}; },
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found parallel_for event"}};
-      },
-      [&](BeginFenceEvent) {
-        return MatchDiagnostic{true, {"Found fence event"}};
       });
   ASSERT_TRUE(success);
 }
@@ -689,6 +694,14 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview_view_ctor) {
                                Kokkos::DefaultExecutionSpace{}),
             host_view);
       },
+      [&](BeginFenceEvent event) {
+        if (event.descriptor().find("DynamicView::resize_serial: Fence after "
+                                    "copying chunks to the device") !=
+            std::string::npos)
+          return MatchDiagnostic{false};
+        return MatchDiagnostic{true, {"Found fence event"}};
+      },
+      [&](EndFenceEvent) { return MatchDiagnostic{false}; },
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found begin event"}};
       },


### PR DESCRIPTION
The constructor arguments set the new instance's capacity, but its size is initially small/0