### PR TITLE
Fixup OpenACC CI build must run on a machine that can handle large images

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -32,7 +32,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.nvhpc'
                             dir 'scripts/docker'
-                            label 'nvidia-docker && volta'
+                            label 'nvidia-docker && volta && large_images'
                             args '--env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/5288/files#r932787151

We regularly run out of disk space on some of the machines and #5288 removed the only thing that kept that build to making things worse.  The image is ~8GB