### PR TITLE
Only test product for bhalf_t for N<=5

### DIFF
--- a/core/unit_test/TestReducers_d.hpp
+++ b/core/unit_test/TestReducers_d.hpp
@@ -87,11 +87,11 @@ TEST(TEST_CATEGORY, reducers_bhalf_t) {
   TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(50);
   TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(51);
 
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(1);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(2);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(3);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(4);
   TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(5);
-  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(10);
-  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(15);
-  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(20);
-  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(25);
 }
 
 TEST(TEST_CATEGORY, reducers_int8_t) {


### PR DESCRIPTION
Following https://github.com/kokkos/kokkos/blob/39c677e0113998d433dacbd06da8915dfa8b6afb/core/unit_test/TestReducers.hpp#L299-L310,
we can only represent numbers up to 2^8=256. Given that we multiply numbers from 1 to 4 in the product test, it seems that we can only multiply five numbers reliably with the worst case being only 3s, i.e., 3^5=243. The more even numbers we have the more we can represent, of course.