### PR TITLE
Avoid allocating memory for UniqueToken

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -502,27 +502,7 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream,
       (void)scratch_flags(reduce_block_count * 2 * sizeof(size_type));
       (void)scratch_space(reduce_block_count * 16 * sizeof(size_type));
     }
-    //----------------------------------
-    // Concurrent bitset for obtaining unique tokens from within
-    // an executing kernel.
-    {
-      m_maxConcurrency = m_maxThreadsPerSM * cudaProp.multiProcessorCount;
-
-      const int32_t buffer_bound =
-          Kokkos::Impl::concurrent_bitset::buffer_bound(m_maxConcurrency);
-
-      // Allocate and initialize uint32_t[ buffer_bound ]
-
-      using Record =
-          Kokkos::Impl::SharedAllocationRecord<Kokkos::CudaSpace, void>;
-
-      Record *const r =
-          Record::allocate(Kokkos::CudaSpace(), "Kokkos::InternalScratchBitset",
-                           sizeof(uint32_t) * buffer_bound);
-
-      Record::increment(r);
-    }
-    //----------------------------------
+    m_maxConcurrency = m_maxThreadsPerSM * cudaProp.multiProcessorCount;
 
   } else {
     std::ostringstream msg;

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -293,27 +293,6 @@ void HIPInternal::initialize(int hip_device_id, hipStream_t stream,
       (void)scratch_flags(reduce_block_count * 2 * sizeof(size_type));
       (void)scratch_space(reduce_block_count * 16 * sizeof(size_type));
     }
-    //----------------------------------
-    // Concurrent bitset for obtaining unique tokens from within
-    // an executing kernel.
-    {
-      const int32_t buffer_bound =
-          Kokkos::Impl::concurrent_bitset::buffer_bound(HIP::concurrency());
-
-      // Allocate and initialize uint32_t[ buffer_bound ]
-
-      using Record =
-          Kokkos::Impl::SharedAllocationRecord<Kokkos::Experimental::HIPSpace,
-                                               void>;
-
-      Record *const r = Record::allocate(Kokkos::Experimental::HIPSpace(),
-                                         "Kokkos::InternalScratchBitset",
-                                         sizeof(uint32_t) * buffer_bound);
-
-      Record::increment(r);
-    }
-    //----------------------------------
-
   } else {
     std::ostringstream msg;
     msg << "Kokkos::Experimental::HIP::initialize(" << hip_device_id

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -138,20 +138,6 @@ void SYCLInternal::initialize(const sycl::queue& q) {
         m_maxWorkgroupSize * 2 *
         d.template get_info<sycl::info::device::max_compute_units>();
 
-    // Setup concurent bitset for obtaining unique tokens from within an
-    // executing kernel.
-    {
-      const int32_t buffer_bound =
-          Kokkos::Impl::concurrent_bitset::buffer_bound(m_maxConcurrency);
-      using Record = Kokkos::Impl::SharedAllocationRecord<
-          Kokkos::Experimental::SYCLDeviceUSMSpace, void>;
-      Record* const r =
-          Record::allocate(Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
-                           "Kokkos::Experimental::SYCL::InternalScratchBitset",
-                           sizeof(uint32_t) * buffer_bound);
-      Record::increment(r);
-    }
-
     m_maxShmemPerBlock =
         d.template get_info<sycl::info::device::local_mem_size>();
 


### PR DESCRIPTION
After https://github.com/kokkos/kokkos/pull/4741 and https://github.com/kokkos/kokkos/pull/4748 this memory isn't used anymore. Found while looking at #5269.