### PR TITLE
Workaround intel/19 OMP internal compiler errors in Trilinos

### DIFF
--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -182,14 +182,22 @@ class OpenMP {
   static int impl_get_current_max_threads() noexcept;
 
   Impl::OpenMPInternal* impl_internal_space_instance() const {
+#ifdef KOKKOS_IMPL_WORKAROUND_ICE_IN_TRILINOS_WITH_OLD_INTEL_COMPILERS
+    return m_space_instance;
+#else
     return m_space_instance.get();
+#endif
   }
 
   static constexpr const char* name() noexcept { return "OpenMP"; }
   uint32_t impl_instance_id() const noexcept { return 1; }
 
  private:
+#ifdef KOKKOS_IMPL_WORKAROUND_ICE_IN_TRILINOS_WITH_OLD_INTEL_COMPILERS
+  Impl::OpenMPInternal* m_space_instance;
+#else
   Kokkos::Impl::HostSharedPtr<Impl::OpenMPInternal> m_space_instance;
+#endif
 };
 
 namespace Tools {

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -422,11 +422,16 @@ bool OpenMPInternal::verify_is_initialized(const char *const label) const {
 //----------------------------------------------------------------------------
 
 OpenMP::OpenMP()
+#ifdef KOKKOS_IMPL_WORKAROUND_ICE_IN_TRILINOS_WITH_OLD_INTEL_COMPILERS
+    : m_space_instance(&Impl::OpenMPInternal::singleton()) {
+}
+#else
     : m_space_instance(&Impl::OpenMPInternal::singleton(),
                        [](Impl::OpenMPInternal *) {}) {
   Impl::OpenMPInternal::singleton().verify_is_initialized(
       "OpenMP instance constructor");
 }
+#endif
 
 int OpenMP::impl_get_current_max_threads() noexcept {
   return Impl::OpenMPInternal::get_current_max_threads();


### PR DESCRIPTION
by making m_space_instance a OpenMPInternal* pointer type for intel
compilers of major version <= 19