### PR TITLE
Don't assume layouts are default-constructible

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1765,7 +1765,8 @@ KOKKOS_INLINE_FUNCTION constexpr auto DynRankView<D, P...>::layout() const ->
           Kokkos::abort(
               "Calling DynRankView::layout on DRV of unexpected rank");)
   }
-  return typename traits::array_layout{};
+  // control flow should never reach here
+  return m_map.layout();
 }
 
 /** \brief  Deep copy a value from Host memory into a view.  */


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/5287. Apparently, there are some layouts used in `Trilinos` that are not default-constructible.