### PR TITLE
Fix SIMD for GCC less than 8

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -677,27 +677,27 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator<(simd const& other) const {
-    return mask_type(_mm512_cmplt_pd_mask(m_value, other.m_value));
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_LT_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator>(simd const& other) const {
-    return mask_type(_mm512_cmplt_pd_mask(other.m_value, m_value));
+    return mask_type(_mm512_cmp_pd_mask(other.m_value, m_value, _CMP_LT_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator<=(simd const& other) const {
-    return mask_type(_mm512_cmple_pd_mask(m_value, other.m_value));
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_LE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator>=(simd const& other) const {
-    return mask_type(_mm512_cmple_pd_mask(other.m_value, m_value));
+    return mask_type(_mm512_cmp_pd_mask(other.m_value, m_value, _CMP_LE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator==(simd const& other) const {
-    return mask_type(_mm512_cmpeq_pd_mask(m_value, other.m_value));
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_EQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator!=(simd const& other) const {
-    return mask_type(_mm512_cmpneq_pd_mask(m_value, other.m_value));
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_NEQ_OS));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -681,7 +681,7 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator>(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(other.m_value, m_value, _CMP_LT_OS));
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_GT_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator<=(simd const& other) const {
@@ -689,7 +689,7 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator>=(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(other.m_value, m_value, _CMP_LE_OS));
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_GE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator==(simd const& other) const {


### PR DESCRIPTION
GCC 7.2.0 and older don't provide the special
case _mm512_cmplt_pd_mask and friends, but all
the way down to GCC 5.5.0 do support the
three-argument _mm512_cmp_pd_mask intrinsic.
Instead of cluttering with #ifdef __GNUC__ < 8
everywhere, just use the three-argument instrinsic
always.
The Intel documentation suggests performance will
not suffer...