### PR TITLE
CTAD (deduction guides) for various types

### DIFF
--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -398,55 +398,58 @@ struct MDRangePolicy<P, Properties...>
 };
 
 template <typename LT, size_t N, typename UT>
-MDRangePolicy(const LT (&)[N], const UT (&)[N]) -> MDRangePolicy<Rank<N>>;
+MDRangePolicy(const LT (&)[N], const UT (&)[N])->MDRangePolicy<Rank<N>>;
 
 template <typename LT, size_t N, typename UT, typename TT, size_t TN>
 MDRangePolicy(const LT (&)[N], const UT (&)[N], const TT (&)[TN])
-    -> MDRangePolicy<Rank<N>>;
+    ->MDRangePolicy<Rank<N>>;
 
 template <typename LT, size_t N, typename UT>
 MDRangePolicy(DefaultExecutionSpace const&, const LT (&)[N], const UT (&)[N])
-    -> MDRangePolicy<Rank<N>>;
+    ->MDRangePolicy<Rank<N>>;
 
 template <typename LT, size_t N, typename UT, typename TT, size_t TN>
 MDRangePolicy(DefaultExecutionSpace const&, const LT (&)[N], const UT (&)[N],
-              const TT (&)[TN]) -> MDRangePolicy<Rank<N>>;
+              const TT (&)[TN])
+    ->MDRangePolicy<Rank<N>>;
 
 template <typename ES, typename LT, size_t N, typename UT,
           typename = std::enable_if_t<is_execution_space_v<ES>>>
 MDRangePolicy(ES const&, const LT (&)[N], const UT (&)[N])
-    -> MDRangePolicy<ES, Rank<N>>;
+    ->MDRangePolicy<ES, Rank<N>>;
 
 template <typename ES, typename LT, size_t N, typename UT, typename TT,
           size_t TN, typename = std::enable_if_t<is_execution_space_v<ES>>>
 MDRangePolicy(ES const&, const LT (&)[N], const UT (&)[N], const TT (&)[TN])
-    -> MDRangePolicy<ES, Rank<N>>;
+    ->MDRangePolicy<ES, Rank<N>>;
 
 template <typename T, size_t N>
-MDRangePolicy(Array<T, N> const&, Array<T, N> const&) -> MDRangePolicy<Rank<N>>;
+MDRangePolicy(Array<T, N> const&, Array<T, N> const&)->MDRangePolicy<Rank<N>>;
 
 template <typename T, size_t N, size_t NT>
 MDRangePolicy(Array<T, N> const&, Array<T, N> const&, Array<T, NT> const&)
-    -> MDRangePolicy<Rank<N>>;
+    ->MDRangePolicy<Rank<N>>;
 
 template <typename T, size_t N>
 MDRangePolicy(DefaultExecutionSpace const&, Array<T, N> const&,
-              Array<T, N> const&) -> MDRangePolicy<Rank<N>>;
+              Array<T, N> const&)
+    ->MDRangePolicy<Rank<N>>;
 
 template <typename T, size_t N, size_t NT>
 MDRangePolicy(DefaultExecutionSpace const&, Array<T, N> const&,
               Array<T, N> const&, Array<T, NT> const&)
-    -> MDRangePolicy<Rank<N>>;
+    ->MDRangePolicy<Rank<N>>;
 
 template <typename ES, typename T, size_t N,
           typename = std::enable_if_t<is_execution_space_v<ES>>>
 MDRangePolicy(ES const&, Array<T, N> const&, Array<T, N> const&)
-    -> MDRangePolicy<ES, Rank<N>>;
+    ->MDRangePolicy<ES, Rank<N>>;
 
 template <typename ES, typename T, size_t N, size_t NT,
           typename = std::enable_if_t<is_execution_space_v<ES>>>
 MDRangePolicy(ES const&, Array<T, N> const&, Array<T, N> const&,
-              Array<T, NT> const&) -> MDRangePolicy<ES, Rank<N>>;
+              Array<T, NT> const&)
+    ->MDRangePolicy<ES, Rank<N>>;
 
 }  // namespace Kokkos
 

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -386,6 +386,58 @@ struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   }
 };
 
+template <typename LT, size_t N, typename UT>
+MDRangePolicy(const LT (&)[N], const UT (&)[N]) -> MDRangePolicy<Rank<N>>;
+
+template <typename LT, size_t N, typename UT, typename TT, size_t TN>
+MDRangePolicy(const LT (&)[N], const UT (&)[N], const TT (&)[TN])
+    -> MDRangePolicy<Rank<N>>;
+
+template <typename LT, size_t N, typename UT>
+MDRangePolicy(DefaultExecutionSpace const&, const LT (&)[N], const UT (&)[N])
+    -> MDRangePolicy<Rank<N>>;
+
+template <typename LT, size_t N, typename UT, typename TT, size_t TN>
+MDRangePolicy(DefaultExecutionSpace const&, const LT (&)[N], const UT (&)[N],
+              const TT (&)[TN]) -> MDRangePolicy<Rank<N>>;
+
+template <typename ES, typename LT, size_t N, typename UT,
+          typename = std::enable_if_t<is_execution_space_v<ES>>>
+MDRangePolicy(ES const&, const LT (&)[N], const UT (&)[N])
+    -> MDRangePolicy<ES, Rank<N>>;
+
+template <typename ES, typename LT, size_t N, typename UT, typename TT,
+          size_t TN,
+          typename = std::enable_if_t<is_execution_space_v<ES>>>
+MDRangePolicy(ES const&, const LT (&)[N], const UT (&)[N], const TT (&)[TN])
+    -> MDRangePolicy<ES, Rank<N>>;
+
+template <typename T, size_t N>
+MDRangePolicy(Array<T, N> const&, Array<T, N> const&) -> MDRangePolicy<Rank<N>>;
+
+template <typename T, size_t N, size_t NT>
+MDRangePolicy(Array<T, N> const&, Array<T, N> const&, Array<T, NT> const&)
+    -> MDRangePolicy<Rank<N>>;
+
+template <typename T, size_t N>
+MDRangePolicy(DefaultExecutionSpace const&, Array<T, N> const&,
+              Array<T, N> const&) -> MDRangePolicy<Rank<N>>;
+
+template <typename T, size_t N, size_t NT>
+MDRangePolicy(DefaultExecutionSpace const&, Array<T, N> const&,
+              Array<T, N> const&, Array<T, NT> const&)
+    -> MDRangePolicy<Rank<N>>;
+
+template <typename ES, typename T, size_t N,
+          typename = std::enable_if_t<is_execution_space_v<ES>>>
+MDRangePolicy(ES const&, Array<T, N> const&, Array<T, N> const&)
+    -> MDRangePolicy<ES, Rank<N>>;
+
+template <typename ES, typename T, size_t N, size_t NT,
+          typename = std::enable_if_t<is_execution_space_v<ES>>>
+MDRangePolicy(ES const&, Array<T, N> const&, Array<T, N> const&,
+              Array<T, NT> const&) -> MDRangePolicy<ES, Rank<N>>;
+
 }  // namespace Kokkos
 
 #endif  // KOKKOS_CORE_EXP_MD_RANGE_POLICY_HPP

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -177,38 +177,16 @@ TileSizeProperties get_tile_size_properties(const ExecutionSpace&) {
 }  // namespace Impl
 
 // multi-dimensional iteration pattern
-//
-// Note: If MDRangePolicy has a primary template, implicit CTAD (deduction
-// guides) are generated -> MDRangePolicy<>, which is incorrect.  If we make it
-// a template specialization instead, no implicit CTAD is generated.  This works
-// because there has to be at least one property specified which is Rank<N>;
-// otherwise, we'd get the static assert "Kokkos::Error: MD iteration pattern
-// not defined".  The template specialization uses <P, Properties...>
-// for correctness.
-
 template <typename... Properties>
 struct MDRangePolicy;
 
-// TODO remove the MDRangePolicy primary template and leave only the
-// MDRangePolicy<P, Properties...> specialization
-#ifdef KOKKOS_IMPL_MDRANGEPOLICY_PRIMARY_TEMPLATE
-
-template <typename... Properties>
-struct MDRangePolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
-  using traits       = Kokkos::Impl::PolicyTraits<Properties...>;
-  using range_policy = RangePolicy<Properties...>;
-
-  typename traits::execution_space m_space;
-
-  using impl_range_policy =
-      RangePolicy<typename traits::execution_space,
-                  typename traits::schedule_type, typename traits::index_type>;
-
-  using execution_policy =
-      MDRangePolicy<Properties...>;  // needed for is_execution_space
-                                     // interrogation
-#else
-
+// Note: If MDRangePolicy has a primary template, implicit CTAD (deduction
+// guides) are generated -> MDRangePolicy<> by some compilers, which is
+// incorrect.  By making it a template specialization instead, no implicit CTAD
+// is generated.  This works because there has to be at least one property
+// specified (which is Rank<...>); otherwise, we'd get the static_assert
+// "Kokkos::Error: MD iteration pattern not defined".  This template
+// specialization uses <P, Properties...> in all places for correctness.
 template <typename P, typename... Properties>
 struct MDRangePolicy<P, Properties...>
     : public Kokkos::Impl::PolicyTraits<P, Properties...> {
@@ -224,8 +202,6 @@ struct MDRangePolicy<P, Properties...>
   using execution_policy =
       MDRangePolicy<P, Properties...>;  // needed for is_execution_space
                                         // interrogation
-
-#endif
 
   template <class... OtherProperties>
   friend struct MDRangePolicy;

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -189,6 +189,8 @@ TileSizeProperties get_tile_size_properties(const ExecutionSpace&) {
 template <typename... Properties>
 struct MDRangePolicy;
 
+// TODO remove the MDRangePolicy primary template and leave only the
+// MDRangePolicy<P, Properties...> specialization
 #ifdef KOKKOS_IMPL_MDRANGEPOLICY_PRIMARY_TEMPLATE
 
 template <typename... Properties>

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -290,8 +290,7 @@ RangePolicy(int64_t, int64_t, Args...)->RangePolicy<>;
 template <typename ES, typename... Args,
           typename = std::enable_if_t<
               std::is_convertible_v<ES, DefaultExecutionSpace>>>
-RangePolicy(ES const&, int64_t, int64_t, Args...)
-    ->RangePolicy<>;
+RangePolicy(ES const&, int64_t, int64_t, Args...)->RangePolicy<>;
 
 template <typename ES, typename... Args,
           typename = std::enable_if_t<

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -283,15 +283,15 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
 RangePolicy()->RangePolicy<>;
 
 template <typename... Args>
-RangePolicy(int64_t, int64_t, Args...) -> RangePolicy<>;
+RangePolicy(int64_t, int64_t, Args...)->RangePolicy<>;
 
 template <typename... Args>
 RangePolicy(DefaultExecutionSpace const&, int64_t, int64_t, Args...)
-    -> RangePolicy<>;
+    ->RangePolicy<>;
 
 template <typename ES, typename... Args,
           typename = std::enable_if_t<is_execution_space_v<ES>>>
-RangePolicy(ES const&, int64_t, int64_t, Args...) -> RangePolicy<ES>;
+RangePolicy(ES const&, int64_t, int64_t, Args...)->RangePolicy<ES>;
 
 }  // namespace Kokkos
 
@@ -693,28 +693,28 @@ TeamPolicy(DefaultExecutionSpace const&, int, int, Kokkos::AUTO_t const&)
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, int) -> TeamPolicy<ES>;
+TeamPolicy(ES const&, int, int)->TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, int, int) -> TeamPolicy<ES>;
+TeamPolicy(ES const&, int, int, int)->TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, Kokkos::AUTO_t const&) -> TeamPolicy<ES>;
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&)->TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, int) -> TeamPolicy<ES>;
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, int)->TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
 TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&)
-    -> TeamPolicy<ES>;
+    ->TeamPolicy<ES>;
 
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
-TeamPolicy(ES const&, int, int, Kokkos::AUTO_t const&) -> TeamPolicy<ES>;
+TeamPolicy(ES const&, int, int, Kokkos::AUTO_t const&)->TeamPolicy<ES>;
 
 namespace Impl {
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -285,12 +285,14 @@ RangePolicy()->RangePolicy<>;
 template <typename B, typename E, typename... Args,
           typename = std::enable_if_t<
               !is_execution_space<B>::value &&
+              !std::is_convertible_v<B, DefaultExecutionSpace> &&
               std::is_same_v<std::common_type_t<B, E>, int64_t>>>
 RangePolicy(B, E, Args...) -> RangePolicy<>;
 
 template <typename B, typename E, typename... Args,
           typename = std::enable_if_t<
               !is_execution_space<B>::value &&
+              !std::is_convertible_v<B, DefaultExecutionSpace> &&
               !std::is_same_v<std::common_type_t<B, E>, int64_t>>>
 RangePolicy(B, E, Args...) -> RangePolicy<IndexType<std::common_type_t<B, E>>>;
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -282,47 +282,16 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
 
 RangePolicy()->RangePolicy<>;
 
-template <typename B, typename E, typename... Args,
-          typename = std::enable_if_t<
-              !is_execution_space<B>::value &&
-              !std::is_convertible_v<B, DefaultExecutionSpace> &&
-              std::is_same_v<std::common_type_t<B, E>, int64_t>>>
-RangePolicy(B, E, Args...) -> RangePolicy<>;
+template <typename... Args>
+RangePolicy(int64_t, int64_t, Args...) -> RangePolicy<>;
 
-template <typename B, typename E, typename... Args,
-          typename = std::enable_if_t<
-              !is_execution_space<B>::value &&
-              !std::is_convertible_v<B, DefaultExecutionSpace> &&
-              !std::is_same_v<std::common_type_t<B, E>, int64_t>>>
-RangePolicy(B, E, Args...) -> RangePolicy<IndexType<std::common_type_t<B, E>>>;
+template <typename... Args>
+RangePolicy(DefaultExecutionSpace const&, int64_t, int64_t, Args...)
+    -> RangePolicy<>;
 
-template <typename ES, typename B, typename E, typename... Args,
-          typename = std::enable_if_t<
-              std::is_convertible_v<ES, DefaultExecutionSpace> &&
-              std::is_same_v<std::common_type_t<B, E>, int64_t>>>
-RangePolicy(const ES&, B, E, Args...) -> RangePolicy<>;
-
-template <typename ES, typename B, typename E, typename... Args,
-          typename = std::enable_if_t<
-              is_execution_space<ES>::value &&
-              !std::is_same_v<ES, DefaultExecutionSpace> &&
-              std::is_same_v<std::common_type_t<B, E>, int64_t>>>
-RangePolicy(const ES&, B, E, Args...) -> RangePolicy<ES>;
-
-template <typename ES, typename B, typename E, typename... Args,
-          typename = std::enable_if_t<
-              std::is_convertible_v<ES, DefaultExecutionSpace> &&
-              !std::is_same_v<std::common_type_t<B, E>, int64_t>>>
-RangePolicy(const ES&, B, E, Args...)
-    -> RangePolicy<IndexType<std::common_type_t<B, E>>>;
-
-template <typename ES, typename B, typename E, typename... Args,
-          typename = std::enable_if_t<
-              is_execution_space<ES>::value &&
-              !std::is_same_v<ES, DefaultExecutionSpace> &&
-              !std::is_same_v<std::common_type_t<B, E>, int64_t>>>
-RangePolicy(const ES&, B, E, Args...)
-    -> RangePolicy<ES, IndexType<std::common_type_t<B, E>>>;
+template <typename ES, typename... Args,
+          typename = std::enable_if_t<is_execution_space_v<ES>>>
+RangePolicy(ES const&, int64_t, int64_t, Args...) -> RangePolicy<ES>;
 
 }  // namespace Kokkos
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -280,6 +280,30 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   };
 };
 
+RangePolicy()->RangePolicy<>;
+
+template <typename... Args>
+RangePolicy(int64_t, int64_t, Args...) -> RangePolicy<>;
+
+template <typename... Args>
+RangePolicy(const DefaultExecutionSpace&, int64_t, int64_t, Args...)
+    -> RangePolicy<>;
+
+template <typename ES, typename... Args,
+          typename = std::enable_if_t<is_execution_space<ES>::value>>
+RangePolicy(const ES&, int64_t, int64_t, Args...) -> RangePolicy<ES>;
+
+template <typename IT, typename... Args>
+RangePolicy(IT, IT, Args...) -> RangePolicy<IndexType<IT>>;
+
+template <typename IT, typename... Args>
+RangePolicy(const DefaultExecutionSpace&, IT, IT, Args...)
+    -> RangePolicy<IndexType<IT>>;
+
+template <typename ES, typename IT, typename... Args,
+          typename = std::enable_if_t<is_execution_space<ES>::value>>
+RangePolicy(const ES&, IT, IT, Args...) -> RangePolicy<ES, IndexType<IT>>;
+
 }  // namespace Kokkos
 
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -285,12 +285,17 @@ RangePolicy()->RangePolicy<>;
 template <typename... Args>
 RangePolicy(int64_t, int64_t, Args...)->RangePolicy<>;
 
-template <typename... Args>
-RangePolicy(DefaultExecutionSpace const&, int64_t, int64_t, Args...)
+// enable_if is used in these deduction guides in order
+// to get around a gcc8 deduction guide overload set bug
+template <typename ES, typename... Args,
+          typename = std::enable_if_t<
+              std::is_convertible_v<ES, DefaultExecutionSpace>>>
+RangePolicy(ES const&, int64_t, int64_t, Args...)
     ->RangePolicy<>;
 
 template <typename ES, typename... Args,
-          typename = std::enable_if_t<is_execution_space_v<ES>>>
+          typename = std::enable_if_t<
+              !std::is_convertible_v<ES, DefaultExecutionSpace>>>
 RangePolicy(ES const&, int64_t, int64_t, Args...)->RangePolicy<ES>;
 
 }  // namespace Kokkos

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -664,6 +664,54 @@ class TeamPolicy
   }
 };
 
+// Execution space not provided deduces to TeamPolicy<>
+TeamPolicy()->TeamPolicy<>;
+TeamPolicy(int, int)->TeamPolicy<>;
+TeamPolicy(int, int, int)->TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&)->TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&, int)->TeamPolicy<>;
+TeamPolicy(int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&)->TeamPolicy<>;
+TeamPolicy(int, int, Kokkos::AUTO_t const&)->TeamPolicy<>;
+
+// DefaultExecutionSpace deduces to TeamPolicy<>
+TeamPolicy(DefaultExecutionSpace const&, int, int)->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, int, int)->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&)
+    ->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&, int)
+    ->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&,
+           Kokkos::AUTO_t const&)
+    ->TeamPolicy<>;
+TeamPolicy(DefaultExecutionSpace const&, int, int, Kokkos::AUTO_t const&)
+    ->TeamPolicy<>;
+
+// ES != DefaultExecutionSpace deduces to TeamPolicy<ES>
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, int) -> TeamPolicy<ES>;
+
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, int, int) -> TeamPolicy<ES>;
+
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&) -> TeamPolicy<ES>;
+
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, int) -> TeamPolicy<ES>;
+
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&)
+    -> TeamPolicy<ES>;
+
+template <typename ES,
+          typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
+TeamPolicy(ES const&, int, int, Kokkos::AUTO_t const&) -> TeamPolicy<ES>;
+
 namespace Impl {
 
 template <typename iType, class TeamMemberType>

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -282,27 +282,47 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
 
 RangePolicy()->RangePolicy<>;
 
-template <typename... Args>
-RangePolicy(int64_t, int64_t, Args...) -> RangePolicy<>;
+template <typename B, typename E, typename... Args,
+          typename = std::enable_if_t<
+              !is_execution_space<B>::value &&
+              std::is_same_v<std::common_type_t<B, E>, int64_t>>>
+RangePolicy(B, E, Args...) -> RangePolicy<>;
 
-template <typename... Args>
-RangePolicy(const DefaultExecutionSpace&, int64_t, int64_t, Args...)
-    -> RangePolicy<>;
+template <typename B, typename E, typename... Args,
+          typename = std::enable_if_t<
+              !is_execution_space<B>::value &&
+              !std::is_same_v<std::common_type_t<B, E>, int64_t>>>
+RangePolicy(B, E, Args...) -> RangePolicy<IndexType<std::common_type_t<B, E>>>;
 
-template <typename ES, typename... Args,
-          typename = std::enable_if_t<is_execution_space<ES>::value>>
-RangePolicy(const ES&, int64_t, int64_t, Args...) -> RangePolicy<ES>;
+template <typename ES, typename B, typename E, typename... Args,
+          typename = std::enable_if_t<
+              is_execution_space<ES>::value &&
+              std::is_same_v<ES, DefaultExecutionSpace> &&
+              std::is_same_v<std::common_type_t<B, E>, int64_t>>>
+RangePolicy(const ES&, B, E, Args...) -> RangePolicy<>;
 
-template <typename IT, typename... Args>
-RangePolicy(IT, IT, Args...) -> RangePolicy<IndexType<IT>>;
+template <typename ES, typename B, typename E, typename... Args,
+          typename = std::enable_if_t<
+              is_execution_space<ES>::value &&
+              !std::is_same_v<ES, DefaultExecutionSpace> &&
+              std::is_same_v<std::common_type_t<B, E>, int64_t>>>
+RangePolicy(const ES&, B, E, Args...) -> RangePolicy<ES>;
 
-template <typename IT, typename... Args>
-RangePolicy(const DefaultExecutionSpace&, IT, IT, Args...)
-    -> RangePolicy<IndexType<IT>>;
+template <typename ES, typename B, typename E, typename... Args,
+          typename = std::enable_if_t<
+              is_execution_space<ES>::value &&
+              std::is_same_v<ES, DefaultExecutionSpace> &&
+              !std::is_same_v<std::common_type_t<B, E>, int64_t>>>
+RangePolicy(const ES&, B, E, Args...)
+    -> RangePolicy<IndexType<std::common_type_t<B, E>>>;
 
-template <typename ES, typename IT, typename... Args,
-          typename = std::enable_if_t<is_execution_space<ES>::value>>
-RangePolicy(const ES&, IT, IT, Args...) -> RangePolicy<ES, IndexType<IT>>;
+template <typename ES, typename B, typename E, typename... Args,
+          typename = std::enable_if_t<
+              is_execution_space<ES>::value &&
+              !std::is_same_v<ES, DefaultExecutionSpace> &&
+              !std::is_same_v<std::common_type_t<B, E>, int64_t>>>
+RangePolicy(const ES&, B, E, Args...)
+    -> RangePolicy<ES, IndexType<std::common_type_t<B, E>>>;
 
 }  // namespace Kokkos
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -296,8 +296,7 @@ RangePolicy(B, E, Args...) -> RangePolicy<IndexType<std::common_type_t<B, E>>>;
 
 template <typename ES, typename B, typename E, typename... Args,
           typename = std::enable_if_t<
-              is_execution_space<ES>::value &&
-              std::is_same_v<ES, DefaultExecutionSpace> &&
+              std::is_convertible_v<ES, DefaultExecutionSpace> &&
               std::is_same_v<std::common_type_t<B, E>, int64_t>>>
 RangePolicy(const ES&, B, E, Args...) -> RangePolicy<>;
 
@@ -310,8 +309,7 @@ RangePolicy(const ES&, B, E, Args...) -> RangePolicy<ES>;
 
 template <typename ES, typename B, typename E, typename... Args,
           typename = std::enable_if_t<
-              is_execution_space<ES>::value &&
-              std::is_same_v<ES, DefaultExecutionSpace> &&
+              std::is_convertible_v<ES, DefaultExecutionSpace> &&
               !std::is_same_v<std::common_type_t<B, E>, int64_t>>>
 RangePolicy(const ES&, B, E, Args...)
     -> RangePolicy<IndexType<std::common_type_t<B, E>>>;

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -665,7 +665,9 @@ class TeamPolicy
 };
 
 // Execution space not provided deduces to TeamPolicy<>
+
 TeamPolicy()->TeamPolicy<>;
+
 TeamPolicy(int, int)->TeamPolicy<>;
 TeamPolicy(int, int, int)->TeamPolicy<>;
 TeamPolicy(int, Kokkos::AUTO_t const&)->TeamPolicy<>;
@@ -674,6 +676,7 @@ TeamPolicy(int, Kokkos::AUTO_t const&, Kokkos::AUTO_t const&)->TeamPolicy<>;
 TeamPolicy(int, int, Kokkos::AUTO_t const&)->TeamPolicy<>;
 
 // DefaultExecutionSpace deduces to TeamPolicy<>
+
 TeamPolicy(DefaultExecutionSpace const&, int, int)->TeamPolicy<>;
 TeamPolicy(DefaultExecutionSpace const&, int, int, int)->TeamPolicy<>;
 TeamPolicy(DefaultExecutionSpace const&, int, Kokkos::AUTO_t const&)
@@ -687,6 +690,7 @@ TeamPolicy(DefaultExecutionSpace const&, int, int, Kokkos::AUTO_t const&)
     ->TeamPolicy<>;
 
 // ES != DefaultExecutionSpace deduces to TeamPolicy<ES>
+
 template <typename ES,
           typename = std::enable_if_t<Kokkos::is_execution_space_v<ES>>>
 TeamPolicy(ES const&, int, int) -> TeamPolicy<ES>;

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -99,6 +99,11 @@ struct Sum {
   bool references_scalar() const { return references_scalar_v; }
 };
 
+template <typename ValueType, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
+Sum(View<ValueType, Space> const&) -> Sum<ValueType, Space>;
+
 template <class Scalar, class Space>
 struct Prod {
  public:
@@ -138,6 +143,11 @@ struct Prod {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <typename ValueType, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
+Prod(View<ValueType, Space> const&) -> Prod<ValueType, Space>;
 
 template <class Scalar, class Space>
 struct Min {
@@ -180,6 +190,11 @@ struct Min {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <typename ValueType, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
+Min(View<ValueType, Space> const&) -> Min<ValueType, Space>;
 
 template <class Scalar, class Space>
 struct Max {
@@ -224,6 +239,11 @@ struct Max {
   bool references_scalar() const { return references_scalar_v; }
 };
 
+template <typename ValueType, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
+Max(View<ValueType, Space> const&) -> Max<ValueType, Space>;
+
 template <class Scalar, class Space>
 struct LAnd {
  public:
@@ -264,6 +284,11 @@ struct LAnd {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <typename ValueType, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
+LAnd(View<ValueType, Space> const&) -> LAnd<ValueType, Space>;
 
 template <class Scalar, class Space>
 struct LOr {
@@ -307,6 +332,11 @@ struct LOr {
   bool references_scalar() const { return references_scalar_v; }
 };
 
+template <typename ValueType, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
+LOr(View<ValueType, Space> const&) -> LOr<ValueType, Space>;
+
 template <class Scalar, class Space>
 struct BAnd {
  public:
@@ -349,6 +379,11 @@ struct BAnd {
   bool references_scalar() const { return references_scalar_v; }
 };
 
+template <typename ValueType, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
+BAnd(View<ValueType, Space> const&) -> BAnd<ValueType, Space>;
+
 template <class Scalar, class Space>
 struct BOr {
  public:
@@ -390,6 +425,11 @@ struct BOr {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <typename ValueType, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
+BOr(View<ValueType, Space> const&) -> BOr<ValueType, Space>;
 
 template <class Scalar, class Index>
 struct ValLocScalar {
@@ -449,6 +489,13 @@ struct MinLoc {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <typename Scalar, typename Index, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
+              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+MinLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
+    -> MinLoc<Scalar, Index, Space>;
 
 template <class Scalar, class Index, class Space>
 struct MaxLoc {

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -100,7 +100,7 @@ struct Sum {
 };
 
 template <typename Scalar, typename Space>
-Sum(View<Scalar, Space> const&) -> Sum<Scalar, Space>;
+Sum(View<Scalar, Space> const&)->Sum<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct Prod {
@@ -143,7 +143,7 @@ struct Prod {
 };
 
 template <typename Scalar, typename Space>
-Prod(View<Scalar, Space> const&) -> Prod<Scalar, Space>;
+Prod(View<Scalar, Space> const&)->Prod<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct Min {
@@ -188,7 +188,7 @@ struct Min {
 };
 
 template <typename Scalar, typename Space>
-Min(View<Scalar, Space> const&) -> Min<Scalar, Space>;
+Min(View<Scalar, Space> const&)->Min<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct Max {
@@ -234,7 +234,7 @@ struct Max {
 };
 
 template <typename Scalar, typename Space>
-Max(View<Scalar, Space> const&) -> Max<Scalar, Space>;
+Max(View<Scalar, Space> const&)->Max<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct LAnd {
@@ -278,7 +278,7 @@ struct LAnd {
 };
 
 template <typename Scalar, typename Space>
-LAnd(View<Scalar, Space> const&) -> LAnd<Scalar, Space>;
+LAnd(View<Scalar, Space> const&)->LAnd<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct LOr {
@@ -323,7 +323,7 @@ struct LOr {
 };
 
 template <typename Scalar, typename Space>
-LOr(View<Scalar, Space> const&) -> LOr<Scalar, Space>;
+LOr(View<Scalar, Space> const&)->LOr<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct BAnd {
@@ -368,7 +368,7 @@ struct BAnd {
 };
 
 template <typename Scalar, typename Space>
-BAnd(View<Scalar, Space> const&) -> BAnd<Scalar, Space>;
+BAnd(View<Scalar, Space> const&)->BAnd<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct BOr {
@@ -413,7 +413,7 @@ struct BOr {
 };
 
 template <typename Scalar, typename Space>
-BOr(View<Scalar, Space> const&) -> BOr<Scalar, Space>;
+BOr(View<Scalar, Space> const&)->BOr<Scalar, Space>;
 
 template <class Scalar, class Index>
 struct ValLocScalar {
@@ -476,7 +476,7 @@ struct MinLoc {
 
 template <typename Scalar, typename Index, typename Space>
 MinLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
-    -> MinLoc<Scalar, Index, Space>;
+    ->MinLoc<Scalar, Index, Space>;
 
 template <class Scalar, class Index, class Space>
 struct MaxLoc {
@@ -527,7 +527,7 @@ struct MaxLoc {
 
 template <typename Scalar, typename Index, typename Space>
 MaxLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
-    -> MaxLoc<Scalar, Index, Space>;
+    ->MaxLoc<Scalar, Index, Space>;
 
 template <class Scalar>
 struct MinMaxScalar {
@@ -592,7 +592,7 @@ struct MinMax {
 };
 
 template <typename Scalar, typename Space>
-MinMax(View<MinMaxScalar<Scalar>, Space> const&) -> MinMax<Scalar, Space>;
+MinMax(View<MinMaxScalar<Scalar>, Space> const&)->MinMax<Scalar, Space>;
 
 template <class Scalar, class Index>
 struct MinMaxLocScalar {
@@ -666,7 +666,7 @@ struct MinMaxLoc {
 
 template <typename Scalar, typename Index, typename Space>
 MinMaxLoc(View<MinMaxLocScalar<Scalar, Index>, Space> const&)
-    -> MinMaxLoc<Scalar, Index, Space>;
+    ->MinMaxLoc<Scalar, Index, Space>;
 
 // --------------------------------------------------
 // reducers added to support std algorithms
@@ -728,7 +728,7 @@ struct MaxFirstLoc {
 
 template <typename Scalar, typename Index, typename Space>
 MaxFirstLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
-    -> MaxFirstLoc<Scalar, Index, Space>;
+    ->MaxFirstLoc<Scalar, Index, Space>;
 
 //
 // MaxFirstLocCustomComparator
@@ -793,7 +793,7 @@ template <typename Scalar, typename Index, typename ComparatorType,
           typename Space>
 MaxFirstLocCustomComparator(View<ValLocScalar<Scalar, Index>, Space> const&,
                             ComparatorType)
-    -> MaxFirstLocCustomComparator<Scalar, Index, ComparatorType, Space>;
+    ->MaxFirstLocCustomComparator<Scalar, Index, ComparatorType, Space>;
 
 //
 // MinFirstLoc
@@ -851,7 +851,7 @@ struct MinFirstLoc {
 
 template <typename Scalar, typename Index, typename Space>
 MinFirstLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
-    -> MinFirstLoc<Scalar, Index, Space>;
+    ->MinFirstLoc<Scalar, Index, Space>;
 
 //
 // MinFirstLocCustomComparator
@@ -916,7 +916,7 @@ template <typename Scalar, typename Index, typename ComparatorType,
           typename Space>
 MinFirstLocCustomComparator(View<ValLocScalar<Scalar, Index>, Space> const&,
                             ComparatorType)
-    -> MinFirstLocCustomComparator<Scalar, Index, ComparatorType, Space>;
+    ->MinFirstLocCustomComparator<Scalar, Index, ComparatorType, Space>;
 
 //
 // MinMaxFirstLastLoc
@@ -985,7 +985,7 @@ struct MinMaxFirstLastLoc {
 
 template <typename Scalar, typename Index, typename Space>
 MinMaxFirstLastLoc(View<MinMaxLocScalar<Scalar, Index>, Space> const&)
-    -> MinMaxFirstLastLoc<Scalar, Index, Space>;
+    ->MinMaxFirstLastLoc<Scalar, Index, Space>;
 
 //
 // MinMaxFirstLastLocCustomComparator
@@ -1060,7 +1060,7 @@ template <typename Scalar, typename Index, typename ComparatorType,
           typename Space>
 MinMaxFirstLastLocCustomComparator(
     View<MinMaxLocScalar<Scalar, Index>, Space> const&, ComparatorType)
-    -> MinMaxFirstLastLocCustomComparator<Scalar, Index, ComparatorType, Space>;
+    ->MinMaxFirstLastLocCustomComparator<Scalar, Index, ComparatorType, Space>;
 
 //
 // FirstLoc
@@ -1121,7 +1121,7 @@ struct FirstLoc {
 };
 
 template <typename Index, typename Space>
-FirstLoc(View<FirstLocScalar<Index>, Space> const&) -> FirstLoc<Index, Space>;
+FirstLoc(View<FirstLocScalar<Index>, Space> const&)->FirstLoc<Index, Space>;
 
 //
 // LastLoc
@@ -1182,7 +1182,7 @@ struct LastLoc {
 };
 
 template <typename Index, typename Space>
-LastLoc(View<LastLocScalar<Index>, Space> const&) -> LastLoc<Index, Space>;
+LastLoc(View<LastLocScalar<Index>, Space> const&)->LastLoc<Index, Space>;
 
 template <class Index>
 struct StdIsPartScalar {
@@ -1253,7 +1253,7 @@ struct StdIsPartitioned {
 
 template <typename Index, typename Space>
 StdIsPartitioned(View<StdIsPartScalar<Index>, Space> const&)
-    -> StdIsPartitioned<Index, Space>;
+    ->StdIsPartitioned<Index, Space>;
 
 template <class Index>
 struct StdPartPointScalar {
@@ -1318,7 +1318,7 @@ struct StdPartitionPoint {
 
 template <typename Index, typename Space>
 StdPartitionPoint(View<StdPartPointScalar<Index>, Space> const&)
-    -> StdPartitionPoint<Index, Space>;
+    ->StdPartitionPoint<Index, Space>;
 
 }  // namespace Kokkos
 namespace Kokkos {

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -99,8 +99,9 @@ struct Sum {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space>
-Sum(View<Scalar, Space> const&)->Sum<Scalar, Space>;
+template <typename Scalar, typename... Properties>
+Sum(View<Scalar, Properties...> const&)
+    ->Sum<Scalar, typename View<Scalar, Properties...>::memory_space>;
 
 template <class Scalar, class Space>
 struct Prod {
@@ -142,8 +143,9 @@ struct Prod {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space>
-Prod(View<Scalar, Space> const&)->Prod<Scalar, Space>;
+template <typename Scalar, typename... Properties>
+Prod(View<Scalar, Properties...> const&)
+    ->Prod<Scalar, typename View<Scalar, Properties...>::memory_space>;
 
 template <class Scalar, class Space>
 struct Min {
@@ -187,8 +189,9 @@ struct Min {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space>
-Min(View<Scalar, Space> const&)->Min<Scalar, Space>;
+template <typename Scalar, typename... Properties>
+Min(View<Scalar, Properties...> const&)
+    ->Min<Scalar, typename View<Scalar, Properties...>::memory_space>;
 
 template <class Scalar, class Space>
 struct Max {
@@ -233,8 +236,9 @@ struct Max {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space>
-Max(View<Scalar, Space> const&)->Max<Scalar, Space>;
+template <typename Scalar, typename... Properties>
+Max(View<Scalar, Properties...> const&)
+    ->Max<Scalar, typename View<Scalar, Properties...>::memory_space>;
 
 template <class Scalar, class Space>
 struct LAnd {
@@ -277,8 +281,9 @@ struct LAnd {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space>
-LAnd(View<Scalar, Space> const&)->LAnd<Scalar, Space>;
+template <typename Scalar, typename... Properties>
+LAnd(View<Scalar, Properties...> const&)
+    ->LAnd<Scalar, typename View<Scalar, Properties...>::memory_space>;
 
 template <class Scalar, class Space>
 struct LOr {
@@ -322,8 +327,9 @@ struct LOr {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space>
-LOr(View<Scalar, Space> const&)->LOr<Scalar, Space>;
+template <typename Scalar, typename... Properties>
+LOr(View<Scalar, Properties...> const&)
+    ->LOr<Scalar, typename View<Scalar, Properties...>::memory_space>;
 
 template <class Scalar, class Space>
 struct BAnd {
@@ -367,8 +373,9 @@ struct BAnd {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space>
-BAnd(View<Scalar, Space> const&)->BAnd<Scalar, Space>;
+template <typename Scalar, typename... Properties>
+BAnd(View<Scalar, Properties...> const&)
+    ->BAnd<Scalar, typename View<Scalar, Properties...>::memory_space>;
 
 template <class Scalar, class Space>
 struct BOr {
@@ -412,8 +419,9 @@ struct BOr {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space>
-BOr(View<Scalar, Space> const&)->BOr<Scalar, Space>;
+template <typename Scalar, typename... Properties>
+BOr(View<Scalar, Properties...> const&)
+    ->BOr<Scalar, typename View<Scalar, Properties...>::memory_space>;
 
 template <class Scalar, class Index>
 struct ValLocScalar {
@@ -474,9 +482,11 @@ struct MinLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space>
-MinLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
-    ->MinLoc<Scalar, Index, Space>;
+template <typename Scalar, typename Index, typename... Properties>
+MinLoc(View<ValLocScalar<Scalar, Index>, Properties...> const&)
+    ->MinLoc<Scalar, Index,
+             typename View<ValLocScalar<Scalar, Index>,
+                           Properties...>::memory_space>;
 
 template <class Scalar, class Index, class Space>
 struct MaxLoc {
@@ -525,9 +535,11 @@ struct MaxLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space>
-MaxLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
-    ->MaxLoc<Scalar, Index, Space>;
+template <typename Scalar, typename Index, typename... Properties>
+MaxLoc(View<ValLocScalar<Scalar, Index>, Properties...> const&)
+    ->MaxLoc<Scalar, Index,
+             typename View<ValLocScalar<Scalar, Index>,
+                           Properties...>::memory_space>;
 
 template <class Scalar>
 struct MinMaxScalar {
@@ -591,8 +603,10 @@ struct MinMax {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space>
-MinMax(View<MinMaxScalar<Scalar>, Space> const&)->MinMax<Scalar, Space>;
+template <typename Scalar, typename... Properties>
+MinMax(View<MinMaxScalar<Scalar>, Properties...> const&)
+    ->MinMax<Scalar,
+             typename View<MinMaxScalar<Scalar>, Properties...>::memory_space>;
 
 template <class Scalar, class Index>
 struct MinMaxLocScalar {
@@ -664,9 +678,11 @@ struct MinMaxLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space>
-MinMaxLoc(View<MinMaxLocScalar<Scalar, Index>, Space> const&)
-    ->MinMaxLoc<Scalar, Index, Space>;
+template <typename Scalar, typename Index, typename... Properties>
+MinMaxLoc(View<MinMaxLocScalar<Scalar, Index>, Properties...> const&)
+    ->MinMaxLoc<Scalar, Index,
+                typename View<MinMaxLocScalar<Scalar, Index>,
+                              Properties...>::memory_space>;
 
 // --------------------------------------------------
 // reducers added to support std algorithms
@@ -726,9 +742,11 @@ struct MaxFirstLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space>
-MaxFirstLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
-    ->MaxFirstLoc<Scalar, Index, Space>;
+template <typename Scalar, typename Index, typename... Properties>
+MaxFirstLoc(View<ValLocScalar<Scalar, Index>, Properties...> const&)
+    ->MaxFirstLoc<Scalar, Index,
+                  typename View<ValLocScalar<Scalar, Index>,
+                                Properties...>::memory_space>;
 
 //
 // MaxFirstLocCustomComparator
@@ -790,10 +808,12 @@ struct MaxFirstLocCustomComparator {
 };
 
 template <typename Scalar, typename Index, typename ComparatorType,
-          typename Space>
-MaxFirstLocCustomComparator(View<ValLocScalar<Scalar, Index>, Space> const&,
-                            ComparatorType)
-    ->MaxFirstLocCustomComparator<Scalar, Index, ComparatorType, Space>;
+          typename... Properties>
+MaxFirstLocCustomComparator(
+    View<ValLocScalar<Scalar, Index>, Properties...> const&, ComparatorType)
+    ->MaxFirstLocCustomComparator<Scalar, Index, ComparatorType,
+                                  typename View<ValLocScalar<Scalar, Index>,
+                                                Properties...>::memory_space>;
 
 //
 // MinFirstLoc
@@ -849,9 +869,11 @@ struct MinFirstLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space>
-MinFirstLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
-    ->MinFirstLoc<Scalar, Index, Space>;
+template <typename Scalar, typename Index, typename... Properties>
+MinFirstLoc(View<ValLocScalar<Scalar, Index>, Properties...> const&)
+    ->MinFirstLoc<Scalar, Index,
+                  typename View<ValLocScalar<Scalar, Index>,
+                                Properties...>::memory_space>;
 
 //
 // MinFirstLocCustomComparator
@@ -913,10 +935,12 @@ struct MinFirstLocCustomComparator {
 };
 
 template <typename Scalar, typename Index, typename ComparatorType,
-          typename Space>
-MinFirstLocCustomComparator(View<ValLocScalar<Scalar, Index>, Space> const&,
-                            ComparatorType)
-    ->MinFirstLocCustomComparator<Scalar, Index, ComparatorType, Space>;
+          typename... Properties>
+MinFirstLocCustomComparator(
+    View<ValLocScalar<Scalar, Index>, Properties...> const&, ComparatorType)
+    ->MinFirstLocCustomComparator<Scalar, Index, ComparatorType,
+                                  typename View<ValLocScalar<Scalar, Index>,
+                                                Properties...>::memory_space>;
 
 //
 // MinMaxFirstLastLoc
@@ -983,9 +1007,11 @@ struct MinMaxFirstLastLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space>
-MinMaxFirstLastLoc(View<MinMaxLocScalar<Scalar, Index>, Space> const&)
-    ->MinMaxFirstLastLoc<Scalar, Index, Space>;
+template <typename Scalar, typename Index, typename... Properties>
+MinMaxFirstLastLoc(View<MinMaxLocScalar<Scalar, Index>, Properties...> const&)
+    ->MinMaxFirstLastLoc<Scalar, Index,
+                         typename View<MinMaxLocScalar<Scalar, Index>,
+                                       Properties...>::memory_space>;
 
 //
 // MinMaxFirstLastLocCustomComparator
@@ -1057,10 +1083,13 @@ struct MinMaxFirstLastLocCustomComparator {
 };
 
 template <typename Scalar, typename Index, typename ComparatorType,
-          typename Space>
+          typename... Properties>
 MinMaxFirstLastLocCustomComparator(
-    View<MinMaxLocScalar<Scalar, Index>, Space> const&, ComparatorType)
-    ->MinMaxFirstLastLocCustomComparator<Scalar, Index, ComparatorType, Space>;
+    View<MinMaxLocScalar<Scalar, Index>, Properties...> const&, ComparatorType)
+    ->MinMaxFirstLastLocCustomComparator<
+        Scalar, Index, ComparatorType,
+        typename View<MinMaxLocScalar<Scalar, Index>,
+                      Properties...>::memory_space>;
 
 //
 // FirstLoc
@@ -1120,8 +1149,10 @@ struct FirstLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Index, typename Space>
-FirstLoc(View<FirstLocScalar<Index>, Space> const&)->FirstLoc<Index, Space>;
+template <typename Index, typename... Properties>
+FirstLoc(View<FirstLocScalar<Index>, Properties...> const&)
+    ->FirstLoc<Index, typename View<FirstLocScalar<Index>,
+                                    Properties...>::memory_space>;
 
 //
 // LastLoc
@@ -1181,8 +1212,10 @@ struct LastLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Index, typename Space>
-LastLoc(View<LastLocScalar<Index>, Space> const&)->LastLoc<Index, Space>;
+template <typename Index, typename... Properties>
+LastLoc(View<LastLocScalar<Index>, Properties...> const&)
+    ->LastLoc<Index,
+              typename View<LastLocScalar<Index>, Properties...>::memory_space>;
 
 template <class Index>
 struct StdIsPartScalar {
@@ -1251,9 +1284,10 @@ struct StdIsPartitioned {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Index, typename Space>
-StdIsPartitioned(View<StdIsPartScalar<Index>, Space> const&)
-    ->StdIsPartitioned<Index, Space>;
+template <typename Index, typename... Properties>
+StdIsPartitioned(View<StdIsPartScalar<Index>, Properties...> const&)
+    ->StdIsPartitioned<Index, typename View<StdIsPartScalar<Index>,
+                                            Properties...>::memory_space>;
 
 template <class Index>
 struct StdPartPointScalar {
@@ -1316,9 +1350,10 @@ struct StdPartitionPoint {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Index, typename Space>
-StdPartitionPoint(View<StdPartPointScalar<Index>, Space> const&)
-    ->StdPartitionPoint<Index, Space>;
+template <typename Index, typename... Properties>
+StdPartitionPoint(View<StdPartPointScalar<Index>, Properties...> const&)
+    ->StdPartitionPoint<Index, typename View<StdPartPointScalar<Index>,
+                                             Properties...>::memory_space>;
 
 }  // namespace Kokkos
 namespace Kokkos {

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -99,9 +99,7 @@ struct Sum {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+template <typename Scalar, typename Space>
 Sum(View<Scalar, Space> const&) -> Sum<Scalar, Space>;
 
 template <class Scalar, class Space>
@@ -144,9 +142,7 @@ struct Prod {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+template <typename Scalar, typename Space>
 Prod(View<Scalar, Space> const&) -> Prod<Scalar, Space>;
 
 template <class Scalar, class Space>
@@ -191,9 +187,7 @@ struct Min {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+template <typename Scalar, typename Space>
 Min(View<Scalar, Space> const&) -> Min<Scalar, Space>;
 
 template <class Scalar, class Space>
@@ -239,9 +233,7 @@ struct Max {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+template <typename Scalar, typename Space>
 Max(View<Scalar, Space> const&) -> Max<Scalar, Space>;
 
 template <class Scalar, class Space>
@@ -285,9 +277,7 @@ struct LAnd {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+template <typename Scalar, typename Space>
 LAnd(View<Scalar, Space> const&) -> LAnd<Scalar, Space>;
 
 template <class Scalar, class Space>
@@ -332,9 +322,7 @@ struct LOr {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+template <typename Scalar, typename Space>
 LOr(View<Scalar, Space> const&) -> LOr<Scalar, Space>;
 
 template <class Scalar, class Space>
@@ -379,9 +367,7 @@ struct BAnd {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+template <typename Scalar, typename Space>
 BAnd(View<Scalar, Space> const&) -> BAnd<Scalar, Space>;
 
 template <class Scalar, class Space>
@@ -426,9 +412,7 @@ struct BOr {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+template <typename Scalar, typename Space>
 BOr(View<Scalar, Space> const&) -> BOr<Scalar, Space>;
 
 template <class Scalar, class Index>
@@ -490,10 +474,7 @@ struct MinLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
-              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Scalar, typename Index, typename Space>
 MinLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
     -> MinLoc<Scalar, Index, Space>;
 
@@ -544,10 +525,7 @@ struct MaxLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
-              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Scalar, typename Index, typename Space>
 MaxLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
     -> MaxLoc<Scalar, Index, Space>;
 
@@ -613,9 +591,7 @@ struct MinMax {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+template <typename Scalar, typename Space>
 MinMax(View<MinMaxScalar<Scalar>, Space> const&) -> MinMax<Scalar, Space>;
 
 template <class Scalar, class Index>
@@ -688,10 +664,7 @@ struct MinMaxLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
-              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Scalar, typename Index, typename Space>
 MinMaxLoc(View<MinMaxLocScalar<Scalar, Index>, Space> const&)
     -> MinMaxLoc<Scalar, Index, Space>;
 
@@ -753,10 +726,7 @@ struct MaxFirstLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
-              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Scalar, typename Index, typename Space>
 MaxFirstLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
     -> MaxFirstLoc<Scalar, Index, Space>;
 
@@ -819,11 +789,8 @@ struct MaxFirstLocCustomComparator {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <
-    typename Scalar, typename Index, typename ComparatorType, typename Space,
-    typename =
-        std::enable_if_t<std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
-                         std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Scalar, typename Index, typename ComparatorType,
+          typename Space>
 MaxFirstLocCustomComparator(View<ValLocScalar<Scalar, Index>, Space> const&,
                             ComparatorType)
     -> MaxFirstLocCustomComparator<Scalar, Index, ComparatorType, Space>;
@@ -882,10 +849,7 @@ struct MinFirstLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
-              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Scalar, typename Index, typename Space>
 MinFirstLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
     -> MinFirstLoc<Scalar, Index, Space>;
 
@@ -948,11 +912,8 @@ struct MinFirstLocCustomComparator {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <
-    typename Scalar, typename Index, typename ComparatorType, typename Space,
-    typename =
-        std::enable_if_t<std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
-                         std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Scalar, typename Index, typename ComparatorType,
+          typename Space>
 MinFirstLocCustomComparator(View<ValLocScalar<Scalar, Index>, Space> const&,
                             ComparatorType)
     -> MinFirstLocCustomComparator<Scalar, Index, ComparatorType, Space>;
@@ -1022,10 +983,7 @@ struct MinMaxFirstLastLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename Scalar, typename Index, typename Space,
-          typename = std::enable_if_t<
-              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
-              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Scalar, typename Index, typename Space>
 MinMaxFirstLastLoc(View<MinMaxLocScalar<Scalar, Index>, Space> const&)
     -> MinMaxFirstLastLoc<Scalar, Index, Space>;
 
@@ -1098,11 +1056,8 @@ struct MinMaxFirstLastLocCustomComparator {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <
-    typename Scalar, typename Index, typename ComparatorType, typename Space,
-    typename =
-        std::enable_if_t<std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
-                         std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Scalar, typename Index, typename ComparatorType,
+          typename Space>
 MinMaxFirstLastLocCustomComparator(
     View<MinMaxLocScalar<Scalar, Index>, Space> const&, ComparatorType)
     -> MinMaxFirstLastLocCustomComparator<Scalar, Index, ComparatorType, Space>;
@@ -1165,9 +1120,7 @@ struct FirstLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <
-    typename Index, typename Space,
-    typename = std::enable_if_t<std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Index, typename Space>
 FirstLoc(View<FirstLocScalar<Index>, Space> const&) -> FirstLoc<Index, Space>;
 
 //
@@ -1228,9 +1181,7 @@ struct LastLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <
-    typename Index, typename Space,
-    typename = std::enable_if_t<std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Index, typename Space>
 LastLoc(View<LastLocScalar<Index>, Space> const&) -> LastLoc<Index, Space>;
 
 template <class Index>
@@ -1300,9 +1251,7 @@ struct StdIsPartitioned {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <
-    typename Index, typename Space,
-    typename = std::enable_if_t<std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Index, typename Space>
 StdIsPartitioned(View<StdIsPartScalar<Index>, Space> const&)
     -> StdIsPartitioned<Index, Space>;
 
@@ -1367,9 +1316,7 @@ struct StdPartitionPoint {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <
-    typename Index, typename Space,
-    typename = std::enable_if_t<std::is_same_v<Index, std::remove_cv_t<Index>>>>
+template <typename Index, typename Space>
 StdPartitionPoint(View<StdPartPointScalar<Index>, Space> const&)
     -> StdPartitionPoint<Index, Space>;
 

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -99,10 +99,10 @@ struct Sum {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename ValueType, typename Space,
+template <typename Scalar, typename Space,
           typename = std::enable_if_t<
-              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
-Sum(View<ValueType, Space> const&) -> Sum<ValueType, Space>;
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+Sum(View<Scalar, Space> const&) -> Sum<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct Prod {
@@ -144,10 +144,10 @@ struct Prod {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename ValueType, typename Space,
+template <typename Scalar, typename Space,
           typename = std::enable_if_t<
-              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
-Prod(View<ValueType, Space> const&) -> Prod<ValueType, Space>;
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+Prod(View<Scalar, Space> const&) -> Prod<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct Min {
@@ -191,10 +191,10 @@ struct Min {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename ValueType, typename Space,
+template <typename Scalar, typename Space,
           typename = std::enable_if_t<
-              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
-Min(View<ValueType, Space> const&) -> Min<ValueType, Space>;
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+Min(View<Scalar, Space> const&) -> Min<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct Max {
@@ -239,10 +239,10 @@ struct Max {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename ValueType, typename Space,
+template <typename Scalar, typename Space,
           typename = std::enable_if_t<
-              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
-Max(View<ValueType, Space> const&) -> Max<ValueType, Space>;
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+Max(View<Scalar, Space> const&) -> Max<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct LAnd {
@@ -285,10 +285,10 @@ struct LAnd {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename ValueType, typename Space,
+template <typename Scalar, typename Space,
           typename = std::enable_if_t<
-              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
-LAnd(View<ValueType, Space> const&) -> LAnd<ValueType, Space>;
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+LAnd(View<Scalar, Space> const&) -> LAnd<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct LOr {
@@ -332,10 +332,10 @@ struct LOr {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename ValueType, typename Space,
+template <typename Scalar, typename Space,
           typename = std::enable_if_t<
-              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
-LOr(View<ValueType, Space> const&) -> LOr<ValueType, Space>;
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+LOr(View<Scalar, Space> const&) -> LOr<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct BAnd {
@@ -379,10 +379,10 @@ struct BAnd {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename ValueType, typename Space,
+template <typename Scalar, typename Space,
           typename = std::enable_if_t<
-              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
-BAnd(View<ValueType, Space> const&) -> BAnd<ValueType, Space>;
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+BAnd(View<Scalar, Space> const&) -> BAnd<Scalar, Space>;
 
 template <class Scalar, class Space>
 struct BOr {
@@ -426,10 +426,10 @@ struct BOr {
   bool references_scalar() const { return references_scalar_v; }
 };
 
-template <typename ValueType, typename Space,
+template <typename Scalar, typename Space,
           typename = std::enable_if_t<
-              std::is_same_v<ValueType, std::remove_cv_t<ValueType>>>>
-BOr(View<ValueType, Space> const&) -> BOr<ValueType, Space>;
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+BOr(View<Scalar, Space> const&) -> BOr<Scalar, Space>;
 
 template <class Scalar, class Index>
 struct ValLocScalar {
@@ -544,6 +544,13 @@ struct MaxLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
+template <typename Scalar, typename Index, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
+              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+MaxLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
+    -> MaxLoc<Scalar, Index, Space>;
+
 template <class Scalar>
 struct MinMaxScalar {
   Scalar min_val, max_val;
@@ -605,6 +612,11 @@ struct MinMax {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <typename Scalar, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>>>>
+MinMax(View<MinMaxScalar<Scalar>, Space> const&) -> MinMax<Scalar, Space>;
 
 template <class Scalar, class Index>
 struct MinMaxLocScalar {
@@ -676,6 +688,13 @@ struct MinMaxLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
+template <typename Scalar, typename Index, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
+              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+MinMaxLoc(View<MinMaxLocScalar<Scalar, Index>, Space> const&)
+    -> MinMaxLoc<Scalar, Index, Space>;
+
 // --------------------------------------------------
 // reducers added to support std algorithms
 // --------------------------------------------------
@@ -733,6 +752,13 @@ struct MaxFirstLoc {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <typename Scalar, typename Index, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
+              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+MaxFirstLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
+    -> MaxFirstLoc<Scalar, Index, Space>;
 
 //
 // MaxFirstLocCustomComparator
@@ -793,6 +819,15 @@ struct MaxFirstLocCustomComparator {
   bool references_scalar() const { return references_scalar_v; }
 };
 
+template <
+    typename Scalar, typename Index, typename ComparatorType, typename Space,
+    typename =
+        std::enable_if_t<std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
+                         std::is_same_v<Index, std::remove_cv_t<Index>>>>
+MaxFirstLocCustomComparator(View<ValLocScalar<Scalar, Index>, Space> const&,
+                            ComparatorType)
+    -> MaxFirstLocCustomComparator<Scalar, Index, ComparatorType, Space>;
+
 //
 // MinFirstLoc
 //
@@ -846,6 +881,13 @@ struct MinFirstLoc {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <typename Scalar, typename Index, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
+              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+MinFirstLoc(View<ValLocScalar<Scalar, Index>, Space> const&)
+    -> MinFirstLoc<Scalar, Index, Space>;
 
 //
 // MinFirstLocCustomComparator
@@ -905,6 +947,15 @@ struct MinFirstLocCustomComparator {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <
+    typename Scalar, typename Index, typename ComparatorType, typename Space,
+    typename =
+        std::enable_if_t<std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
+                         std::is_same_v<Index, std::remove_cv_t<Index>>>>
+MinFirstLocCustomComparator(View<ValLocScalar<Scalar, Index>, Space> const&,
+                            ComparatorType)
+    -> MinFirstLocCustomComparator<Scalar, Index, ComparatorType, Space>;
 
 //
 // MinMaxFirstLastLoc
@@ -970,6 +1021,13 @@ struct MinMaxFirstLastLoc {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <typename Scalar, typename Index, typename Space,
+          typename = std::enable_if_t<
+              std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
+              std::is_same_v<Index, std::remove_cv_t<Index>>>>
+MinMaxFirstLastLoc(View<MinMaxLocScalar<Scalar, Index>, Space> const&)
+    -> MinMaxFirstLastLoc<Scalar, Index, Space>;
 
 //
 // MinMaxFirstLastLocCustomComparator
@@ -1040,6 +1098,15 @@ struct MinMaxFirstLastLocCustomComparator {
   bool references_scalar() const { return references_scalar_v; }
 };
 
+template <
+    typename Scalar, typename Index, typename ComparatorType, typename Space,
+    typename =
+        std::enable_if_t<std::is_same_v<Scalar, std::remove_cv_t<Scalar>> &&
+                         std::is_same_v<Index, std::remove_cv_t<Index>>>>
+MinMaxFirstLastLocCustomComparator(
+    View<MinMaxLocScalar<Scalar, Index>, Space> const&, ComparatorType)
+    -> MinMaxFirstLastLocCustomComparator<Scalar, Index, ComparatorType, Space>;
+
 //
 // FirstLoc
 //
@@ -1098,6 +1165,11 @@ struct FirstLoc {
   bool references_scalar() const { return references_scalar_v; }
 };
 
+template <
+    typename Index, typename Space,
+    typename = std::enable_if_t<std::is_same_v<Index, std::remove_cv_t<Index>>>>
+FirstLoc(View<FirstLocScalar<Index>, Space> const&) -> FirstLoc<Index, Space>;
+
 //
 // LastLoc
 //
@@ -1155,6 +1227,11 @@ struct LastLoc {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <
+    typename Index, typename Space,
+    typename = std::enable_if_t<std::is_same_v<Index, std::remove_cv_t<Index>>>>
+LastLoc(View<LastLocScalar<Index>, Space> const&) -> LastLoc<Index, Space>;
 
 template <class Index>
 struct StdIsPartScalar {
@@ -1223,6 +1300,12 @@ struct StdIsPartitioned {
   bool references_scalar() const { return references_scalar_v; }
 };
 
+template <
+    typename Index, typename Space,
+    typename = std::enable_if_t<std::is_same_v<Index, std::remove_cv_t<Index>>>>
+StdIsPartitioned(View<StdIsPartScalar<Index>, Space> const&)
+    -> StdIsPartitioned<Index, Space>;
+
 template <class Index>
 struct StdPartPointScalar {
   Index min_loc_false;
@@ -1283,6 +1366,12 @@ struct StdPartitionPoint {
   KOKKOS_INLINE_FUNCTION
   bool references_scalar() const { return references_scalar_v; }
 };
+
+template <
+    typename Index, typename Space,
+    typename = std::enable_if_t<std::is_same_v<Index, std::remove_cv_t<Index>>>>
+StdPartitionPoint(View<StdPartPointScalar<Index>, Space> const&)
+    -> StdPartitionPoint<Index, Space>;
 
 }  // namespace Kokkos
 namespace Kokkos {

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1708,6 +1708,7 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 };
 
+// These deduction guides result in an unmanaged View
 template <typename T>
 View(T*) -> View<T>;
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1708,6 +1708,35 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 };
 
+template <typename T>
+View(T*) -> View<T>;
+
+template <typename T>
+View(T*, size_t) -> View<T*>;
+
+template <typename T>
+View(T*, size_t, size_t) -> View<T**>;
+
+template <typename T>
+View(T*, size_t, size_t, size_t) -> View<T***>;
+
+template <typename T>
+View(T*, size_t, size_t, size_t, size_t) -> View<T****>;
+
+template <typename T>
+View(T*, size_t, size_t, size_t, size_t, size_t) -> View<T*****>;
+
+template <typename T>
+View(T*, size_t, size_t, size_t, size_t, size_t, size_t) -> View<T******>;
+
+template <typename T>
+View(T*, size_t, size_t, size_t, size_t, size_t, size_t, size_t)
+    -> View<T*******>;
+
+template <typename T>
+View(T*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t)
+    -> View<T********>;
+
 /** \brief Temporary free function rank()
  *         until rank() is implemented
  *         in the View

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1710,33 +1710,33 @@ class View : public ViewTraits<DataType, Properties...> {
 
 // These deduction guides result in an unmanaged View
 template <typename T>
-View(T*) -> View<T>;
+View(T*)->View<T>;
 
 template <typename T>
-View(T*, size_t) -> View<T*>;
+View(T*, size_t)->View<T*>;
 
 template <typename T>
-View(T*, size_t, size_t) -> View<T**>;
+View(T*, size_t, size_t)->View<T**>;
 
 template <typename T>
-View(T*, size_t, size_t, size_t) -> View<T***>;
+View(T*, size_t, size_t, size_t)->View<T***>;
 
 template <typename T>
-View(T*, size_t, size_t, size_t, size_t) -> View<T****>;
+View(T*, size_t, size_t, size_t, size_t)->View<T****>;
 
 template <typename T>
-View(T*, size_t, size_t, size_t, size_t, size_t) -> View<T*****>;
+View(T*, size_t, size_t, size_t, size_t, size_t)->View<T*****>;
 
 template <typename T>
-View(T*, size_t, size_t, size_t, size_t, size_t, size_t) -> View<T******>;
+View(T*, size_t, size_t, size_t, size_t, size_t, size_t)->View<T******>;
 
 template <typename T>
 View(T*, size_t, size_t, size_t, size_t, size_t, size_t, size_t)
-    -> View<T*******>;
+    ->View<T*******>;
 
 template <typename T>
 View(T*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t)
-    -> View<T********>;
+    ->View<T********>;
 
 /** \brief Temporary free function rank()
  *         until rank() is implemented

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1,11 +1,11 @@
 #
-# Add test-only library for gtest to be reused by all the subpackages
+#Add test - only library for gtest to be reused by all the subpackages
 #
 
 IF(NOT GTest_FOUND)  # fallback to internal gtest
   SET(GTEST_SOURCE_DIR ${${PARENT_PACKAGE_NAME}_SOURCE_DIR}/tpls/gtest)
 
-  #need here for tribits
+#need here for tribits
   KOKKOS_INCLUDE_DIRECTORIES(${GTEST_SOURCE_DIR})
   KOKKOS_ADD_TEST_LIBRARY(
     kokkos_gtest
@@ -18,7 +18,7 @@ IF(NOT GTest_FOUND)  # fallback to internal gtest
     TARGET_COMPILE_FEATURES(kokkos_gtest PUBLIC cxx_std_14)
   ENDIF()
 
-  # Suppress clang-tidy diagnostics on code that we do not have control over
+#Suppress clang - tidy diagnostics on code that we do not have control over
   IF(CMAKE_CXX_CLANG_TIDY)
     SET_TARGET_PROPERTIES(kokkos_gtest PROPERTIES CXX_CLANG_TIDY "")
   ENDIF()
@@ -31,8 +31,8 @@ IF(NOT GTest_FOUND)  # fallback to internal gtest
 ENDIF()
 
 #
-# Define Incremental Testing Feature Levels
-# Define Device name mappings (i.e. what comes after Kokkos:: for the ExecSpace)
+#Define Incremental Testing Feature Levels
+#Define Device name mappings(i.e.what comes after Kokkos::for the ExecSpace)
 #
 
 SET(KOKKOS_CUDA_FEATURE_LEVEL 999)
@@ -44,7 +44,9 @@ SET(KOKKOS_HPX_NAME Experimental::HPX)
 SET(KOKKOS_OPENMP_FEATURE_LEVEL 999)
 SET(KOKKOS_OPENMP_NAME OpenMP)
 
-# FIXME_OPENMPTARGET - The NVIDIA HPC compiler nvc++ only compiles the first 8 incremental tests for the OpenMPTarget backend.
+#FIXME_OPENMPTARGET -                               \
+    The NVIDIA HPC compiler nvc++ only compiles the \
+        first 8 incremental tests for the OpenMPTarget backend.
 IF(KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
   SET(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 10)
 ELSE()
@@ -61,9 +63,8 @@ SET(KOKKOS_THREADS_NAME Threads)
 SET(KOKKOS_OPENACC_FEATURE_LEVEL 8)
 SET(KOKKOS_OPENACC_NAME Experimental::OpenACC)
 
-
 #
-# Define the tests
+#Define the tests
 #
 
 #I will leave these alone for now because I don't need transitive dependencies on tests
@@ -79,7 +80,7 @@ SET(COMPILE_ONLY_SOURCES
   TestStringManipulation.cpp
   TestTypeList.cpp
 )
-# TestInterOp has a dependency on containers
+#TestInterOp has a dependency on containers
 IF(KOKKOS_HAS_TRILINOS)
   LIST(REMOVE_ITEM COMPILE_ONLY_SOURCES TestInterOp.cpp)
 ENDIF()
@@ -96,9 +97,11 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
   if(Kokkos_ENABLE_${DEVICE})
     set(dir ${CMAKE_CURRENT_BINARY_DIR}/${dir})
     file(MAKE_DIRECTORY ${dir})
-    # Needed to split this for Windows NVCC, since it ends up putting everything on the
-    # command line in an intermediate compilation step even if CMake generated a response
-    # file. That then exceeded the shell command line max length.
+#Needed to split this for Windows NVCC, \
+    since it ends up putting everything on the
+#command line in an intermediate compilation step even if CMake generated a \
+    response
+#file.That then exceeded the shell command line max length.
     set(${Tag}_SOURCES1A)
     foreach(Name
         AtomicOperations_int
@@ -137,8 +140,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         MathematicalSpecialFunctions
         )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-      # Write to a temporary intermediate file and call configure_file to avoid
-      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+#Write to a temporary intermediate file and call configure_file to avoid
+#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${Tag}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -170,8 +173,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         ViewMapping_a
         )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-      # Write to a temporary intermediate file and call configure_file to avoid
-      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+#Write to a temporary intermediate file and call configure_file to avoid
+#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${Tag}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -212,8 +215,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       WithoutInitializing
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-      # Write to a temporary intermediate file and call configure_file to avoid
-      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+#Write to a temporary intermediate file and call configure_file to avoid
+#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${Tag}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -242,8 +245,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       SubView_c05
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-      # Write to a temporary intermediate file and call configure_file to avoid
-      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+#Write to a temporary intermediate file and call configure_file to avoid
+#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${TagHostAccessible}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -260,8 +263,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       SubView_c09
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-      # Write to a temporary intermediate file and call configure_file to avoid
-      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+#Write to a temporary intermediate file and call configure_file to avoid
+#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${TagHostAccessible}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -279,8 +282,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       SubView_c14
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-      # Write to a temporary intermediate file and call configure_file to avoid
-      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+#Write to a temporary intermediate file and call configure_file to avoid
+#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${TagHostAccessible}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -319,8 +322,8 @@ foreach(PairDeviceSpace HIP-HostPinned;HIP-Managed;Cuda-HostPinned;Cuda-UVM;SYCL
       ViewMapping_subview
       )
       set(file ${dir}/Test${DEVICE}${SPACE}_${Name}.cpp)
-      # Write to a temporary intermediate file and call configure_file to avoid
-      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+#Write to a temporary intermediate file and call configure_file to avoid
+#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${DEVICE}${SPACE}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -389,7 +392,8 @@ IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
   )
 ENDIF()
 
-# FIXME_OPENMPTARGET - Comment non-passing tests with the NVIDIA HPC compiler nvc++
+#FIXME_OPENMPTARGET - Comment non - \
+    passing tests with the NVIDIA HPC compiler nvc++
 IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
   list(REMOVE_ITEM OpenMPTarget_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_int64_t_reduce.cpp
@@ -723,7 +727,7 @@ endif()
 
 if(Kokkos_ENABLE_SYCL)
   list(REMOVE_ITEM SYCL_SOURCES1A
-       # FIXME_SYCL atomic_fetch_oper for large types to be implemented
+#FIXME_SYCL atomic_fetch_oper for large types to be implemented
        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_AtomicOperations_complexdouble.cpp
   )
 
@@ -777,7 +781,7 @@ if(Kokkos_ENABLE_SYCL)
     UnitTest_SYCL3
     SOURCES
       UnitTestMainInit.cpp
-      # FIXME_SYCL
+#FIXME_SYCL
       sycl/TestSYCL_Task.cpp
       sycl/TestSYCL_TeamScratchStreams.cpp
       ${SYCL_SOURCES3}
@@ -850,8 +854,8 @@ KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_PushFinalizeHook.cpp
 )
 
-# This test is intended for development and debugging by putting code
-# into TestDefaultDeviceDevelop.cpp. By default its empty.
+#This test is intended for development and debugging by putting code
+#into TestDefaultDeviceDevelop.cpp.By default its empty.
 KOKKOS_ADD_EXECUTABLE_AND_TEST(
   UnitTest_Develop
   SOURCES
@@ -859,10 +863,10 @@ KOKKOS_ADD_EXECUTABLE_AND_TEST(
     default/TestDefaultDeviceDevelop.cpp
 )
 
-# This test is special, because it passes exactly when it prints the
-# message "PASSED: I am the custom std::terminate handler.", AND calls
-# std::terminate.  This means that we can't use
-# KOKKOS_ADD_EXECUTABLE_AND_TEST.  See GitHub issue #2147.
+#This test is special, because it passes exactly when it prints the
+#message "PASSED: I am the custom std::terminate handler.", AND calls
+#std::terminate.This means that we can't use
+#KOKKOS_ADD_EXECUTABLE_AND_TEST.See GitHub issue #2147.
 
 KOKKOS_ADD_TEST_EXECUTABLE( push_finalize_hook_terminate
   SOURCES UnitTest_PushFinalizeHook_terminate.cpp
@@ -947,7 +951,7 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
     set(SIZE_REGEX "[0-9]*")
     set(SKIP_SCRATCH_INITIALIZATION_REGEX ".*")
 
-    # check help works via environment variable
+#check help works via environment variable
     KOKKOS_ADD_TEST(
       SKIP_TRIBITS
       NAME ProfilingTestLibraryLoadHelp
@@ -957,7 +961,7 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
       PASS_REGULAR_EXPRESSION
         "kokkosp_init_library::kokkosp_print_help:KokkosCore_ProfilingAllCalls::kokkosp_finalize_library::")
 
-    # check help works via direct library specification
+#check help works via direct library specification
     KOKKOS_ADD_TEST(
       SKIP_TRIBITS
       NAME ProfilingTestLibraryCmdLineHelp
@@ -976,14 +980,15 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
       PASS_REGULAR_EXPRESSION "kokkosp_init_library::kokkosp_parse_args:4:KokkosCore_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
     )
 
-    # Above will test that leading/trailing quotes are stripped bc ctest cmd args is:
-    #       "--kokkos-tools-args="-c test delimit""
-    # The bracket argument syntax: [=[ and ]=] used below ensures it is treated as
-    # a single argument:
-    #       "--kokkos-tools-args=-c test delimit"
-    #
-    # https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#bracket-argument
-    #
+#Above will test that leading / \
+    trailing quotes are stripped bc ctest cmd args is:
+#"--kokkos-tools-args=" - c test delimit ""
+#The bracket argument syntax : [=[and] = ] used below ensures it is treated as
+#a single argument:
+#"--kokkos-tools-args=-c test delimit"
+#
+#https:  // cmake.org/cmake/help/latest/manual/cmake-language.7.html#bracket-argument
+#
     KOKKOS_ADD_TEST(
       SKIP_TRIBITS
       NAME ProfilingTestLibraryCmdLine
@@ -1004,8 +1009,8 @@ KOKKOS_ADD_TEST_EXECUTABLE(
     TestStackTrace_f3.cpp
     TestStackTrace_f4.cpp
 )
-# We need -rdynamic on GNU platforms for the stacktrace functionality
-# to work correctly with shared libraries
+#We need - rdynamic on GNU platforms for the stacktrace functionality
+#to work correctly with shared libraries
 KOKKOS_SET_EXE_PROPERTY(StackTraceTestExec ENABLE_EXPORTS ON)
 
 KOKKOS_ADD_TEST( NAME UnitTest_StackTraceTest
@@ -1032,10 +1037,10 @@ endif()
 
 FUNCTION (KOKKOS_ADD_INCREMENTAL_TEST DEVICE)
   KOKKOS_OPTION( ${DEVICE}_EXCLUDE_TESTS "" STRING "Incremental test exclude list" )
-  # Add unit test main
+#Add unit test main
   SET(${DEVICE}_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestMainInit.cpp)
 
-  # Iterate over incremental tests in directory
+#Iterate over incremental tests in directory
 
   APPEND_GLOB(INCREMENTAL_FILE_LIST ${CMAKE_CURRENT_SOURCE_DIR}/incremental/*.hpp)
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1,11 +1,11 @@
 #
-#Add test - only library for gtest to be reused by all the subpackages
+# Add test-only library for gtest to be reused by all the subpackages
 #
 
 IF(NOT GTest_FOUND)  # fallback to internal gtest
   SET(GTEST_SOURCE_DIR ${${PARENT_PACKAGE_NAME}_SOURCE_DIR}/tpls/gtest)
 
-#need here for tribits
+  #need here for tribits
   KOKKOS_INCLUDE_DIRECTORIES(${GTEST_SOURCE_DIR})
   KOKKOS_ADD_TEST_LIBRARY(
     kokkos_gtest
@@ -18,7 +18,7 @@ IF(NOT GTest_FOUND)  # fallback to internal gtest
     TARGET_COMPILE_FEATURES(kokkos_gtest PUBLIC cxx_std_14)
   ENDIF()
 
-#Suppress clang - tidy diagnostics on code that we do not have control over
+  # Suppress clang-tidy diagnostics on code that we do not have control over
   IF(CMAKE_CXX_CLANG_TIDY)
     SET_TARGET_PROPERTIES(kokkos_gtest PROPERTIES CXX_CLANG_TIDY "")
   ENDIF()
@@ -31,8 +31,8 @@ IF(NOT GTest_FOUND)  # fallback to internal gtest
 ENDIF()
 
 #
-#Define Incremental Testing Feature Levels
-#Define Device name mappings(i.e.what comes after Kokkos::for the ExecSpace)
+# Define Incremental Testing Feature Levels
+# Define Device name mappings (i.e. what comes after Kokkos:: for the ExecSpace)
 #
 
 SET(KOKKOS_CUDA_FEATURE_LEVEL 999)
@@ -44,9 +44,7 @@ SET(KOKKOS_HPX_NAME Experimental::HPX)
 SET(KOKKOS_OPENMP_FEATURE_LEVEL 999)
 SET(KOKKOS_OPENMP_NAME OpenMP)
 
-#FIXME_OPENMPTARGET -                               \
-    The NVIDIA HPC compiler nvc++ only compiles the \
-        first 8 incremental tests for the OpenMPTarget backend.
+# FIXME_OPENMPTARGET - The NVIDIA HPC compiler nvc++ only compiles the first 8 incremental tests for the OpenMPTarget backend.
 IF(KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
   SET(KOKKOS_OPENMPTARGET_FEATURE_LEVEL 10)
 ELSE()
@@ -63,8 +61,9 @@ SET(KOKKOS_THREADS_NAME Threads)
 SET(KOKKOS_OPENACC_FEATURE_LEVEL 8)
 SET(KOKKOS_OPENACC_NAME Experimental::OpenACC)
 
+
 #
-#Define the tests
+# Define the tests
 #
 
 #I will leave these alone for now because I don't need transitive dependencies on tests
@@ -80,7 +79,7 @@ SET(COMPILE_ONLY_SOURCES
   TestStringManipulation.cpp
   TestTypeList.cpp
 )
-#TestInterOp has a dependency on containers
+# TestInterOp has a dependency on containers
 IF(KOKKOS_HAS_TRILINOS)
   LIST(REMOVE_ITEM COMPILE_ONLY_SOURCES TestInterOp.cpp)
 ENDIF()
@@ -97,11 +96,9 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
   if(Kokkos_ENABLE_${DEVICE})
     set(dir ${CMAKE_CURRENT_BINARY_DIR}/${dir})
     file(MAKE_DIRECTORY ${dir})
-#Needed to split this for Windows NVCC, \
-    since it ends up putting everything on the
-#command line in an intermediate compilation step even if CMake generated a \
-    response
-#file.That then exceeded the shell command line max length.
+    # Needed to split this for Windows NVCC, since it ends up putting everything on the
+    # command line in an intermediate compilation step even if CMake generated a response
+    # file. That then exceeded the shell command line max length.
     set(${Tag}_SOURCES1A)
     foreach(Name
         AtomicOperations_int
@@ -140,8 +137,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         MathematicalSpecialFunctions
         )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-#Write to a temporary intermediate file and call configure_file to avoid
-#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+      # Write to a temporary intermediate file and call configure_file to avoid
+      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${Tag}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -173,8 +170,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         ViewMapping_a
         )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-#Write to a temporary intermediate file and call configure_file to avoid
-#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+      # Write to a temporary intermediate file and call configure_file to avoid
+      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${Tag}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -215,8 +212,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       WithoutInitializing
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-#Write to a temporary intermediate file and call configure_file to avoid
-#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+      # Write to a temporary intermediate file and call configure_file to avoid
+      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${Tag}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -245,8 +242,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       SubView_c05
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-#Write to a temporary intermediate file and call configure_file to avoid
-#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+      # Write to a temporary intermediate file and call configure_file to avoid
+      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${TagHostAccessible}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -263,8 +260,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       SubView_c09
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-#Write to a temporary intermediate file and call configure_file to avoid
-#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+      # Write to a temporary intermediate file and call configure_file to avoid
+      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${TagHostAccessible}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -282,8 +279,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       SubView_c14
       )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
-#Write to a temporary intermediate file and call configure_file to avoid
-#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+      # Write to a temporary intermediate file and call configure_file to avoid
+      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${TagHostAccessible}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -322,8 +319,8 @@ foreach(PairDeviceSpace HIP-HostPinned;HIP-Managed;Cuda-HostPinned;Cuda-UVM;SYCL
       ViewMapping_subview
       )
       set(file ${dir}/Test${DEVICE}${SPACE}_${Name}.cpp)
-#Write to a temporary intermediate file and call configure_file to avoid
-#updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+      # Write to a temporary intermediate file and call configure_file to avoid
+      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       file(WRITE ${dir}/dummy.cpp
           "#include <Test${DEVICE}${SPACE}_Category.hpp>\n"
           "#include <Test${Name}.hpp>\n"
@@ -392,8 +389,7 @@ IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
   )
 ENDIF()
 
-#FIXME_OPENMPTARGET - Comment non - \
-    passing tests with the NVIDIA HPC compiler nvc++
+# FIXME_OPENMPTARGET - Comment non-passing tests with the NVIDIA HPC compiler nvc++
 IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
   list(REMOVE_ITEM OpenMPTarget_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_int64_t_reduce.cpp
@@ -727,7 +723,7 @@ endif()
 
 if(Kokkos_ENABLE_SYCL)
   list(REMOVE_ITEM SYCL_SOURCES1A
-#FIXME_SYCL atomic_fetch_oper for large types to be implemented
+       # FIXME_SYCL atomic_fetch_oper for large types to be implemented
        ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_AtomicOperations_complexdouble.cpp
   )
 
@@ -781,7 +777,7 @@ if(Kokkos_ENABLE_SYCL)
     UnitTest_SYCL3
     SOURCES
       UnitTestMainInit.cpp
-#FIXME_SYCL
+      # FIXME_SYCL
       sycl/TestSYCL_Task.cpp
       sycl/TestSYCL_TeamScratchStreams.cpp
       ${SYCL_SOURCES3}
@@ -854,8 +850,8 @@ KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_PushFinalizeHook.cpp
 )
 
-#This test is intended for development and debugging by putting code
-#into TestDefaultDeviceDevelop.cpp.By default its empty.
+# This test is intended for development and debugging by putting code
+# into TestDefaultDeviceDevelop.cpp. By default its empty.
 KOKKOS_ADD_EXECUTABLE_AND_TEST(
   UnitTest_Develop
   SOURCES
@@ -863,10 +859,10 @@ KOKKOS_ADD_EXECUTABLE_AND_TEST(
     default/TestDefaultDeviceDevelop.cpp
 )
 
-#This test is special, because it passes exactly when it prints the
-#message "PASSED: I am the custom std::terminate handler.", AND calls
-#std::terminate.This means that we can't use
-#KOKKOS_ADD_EXECUTABLE_AND_TEST.See GitHub issue #2147.
+# This test is special, because it passes exactly when it prints the
+# message "PASSED: I am the custom std::terminate handler.", AND calls
+# std::terminate.  This means that we can't use
+# KOKKOS_ADD_EXECUTABLE_AND_TEST.  See GitHub issue #2147.
 
 KOKKOS_ADD_TEST_EXECUTABLE( push_finalize_hook_terminate
   SOURCES UnitTest_PushFinalizeHook_terminate.cpp
@@ -951,7 +947,7 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
     set(SIZE_REGEX "[0-9]*")
     set(SKIP_SCRATCH_INITIALIZATION_REGEX ".*")
 
-#check help works via environment variable
+    # check help works via environment variable
     KOKKOS_ADD_TEST(
       SKIP_TRIBITS
       NAME ProfilingTestLibraryLoadHelp
@@ -961,7 +957,7 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
       PASS_REGULAR_EXPRESSION
         "kokkosp_init_library::kokkosp_print_help:KokkosCore_ProfilingAllCalls::kokkosp_finalize_library::")
 
-#check help works via direct library specification
+    # check help works via direct library specification
     KOKKOS_ADD_TEST(
       SKIP_TRIBITS
       NAME ProfilingTestLibraryCmdLineHelp
@@ -980,15 +976,14 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
       PASS_REGULAR_EXPRESSION "kokkosp_init_library::kokkosp_parse_args:4:KokkosCore_ProfilingAllCalls:-c:test:delimit::.*::kokkosp_allocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]source] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_allocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_begin_parallel_for:Kokkos::View::initialization [[]destination] via memset:[0-9]+:0::kokkosp_end_parallel_for:0::kokkosp_begin_deep_copy:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::.*kokkosp_end_deep_copy::kokkosp_begin_parallel_for:parallel_for:${SIZE_REGEX}:0::kokkosp_end_parallel_for:0::kokkosp_begin_parallel_reduce:parallel_reduce:${SIZE_REGEX}:1${SKIP_SCRATCH_INITIALIZATION_REGEX}::kokkosp_end_parallel_reduce:1::kokkosp_begin_parallel_scan:parallel_scan:${SIZE_REGEX}:2::kokkosp_end_parallel_scan:2::kokkosp_push_profile_region:push_region::kokkosp_pop_profile_region::kokkosp_create_profile_section:created_section:3::kokkosp_start_profile_section:3::kokkosp_stop_profile_section:3::kokkosp_destroy_profile_section:3::kokkosp_profile_event:profiling_event::kokkosp_declare_metadata:dogs:good::kokkosp_deallocate_data:${MEMSPACE_REGEX}:destination:${ADDRESS_REGEX}:40::kokkosp_deallocate_data:${MEMSPACE_REGEX}:source:${ADDRESS_REGEX}:40::kokkosp_finalize_library::"
     )
 
-#Above will test that leading / \
-    trailing quotes are stripped bc ctest cmd args is:
-#"--kokkos-tools-args=" - c test delimit ""
-#The bracket argument syntax : [=[and] = ] used below ensures it is treated as
-#a single argument:
-#"--kokkos-tools-args=-c test delimit"
-#
-#https:  // cmake.org/cmake/help/latest/manual/cmake-language.7.html#bracket-argument
-#
+    # Above will test that leading/trailing quotes are stripped bc ctest cmd args is:
+    #       "--kokkos-tools-args="-c test delimit""
+    # The bracket argument syntax: [=[ and ]=] used below ensures it is treated as
+    # a single argument:
+    #       "--kokkos-tools-args=-c test delimit"
+    #
+    # https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#bracket-argument
+    #
     KOKKOS_ADD_TEST(
       SKIP_TRIBITS
       NAME ProfilingTestLibraryCmdLine
@@ -1009,8 +1004,8 @@ KOKKOS_ADD_TEST_EXECUTABLE(
     TestStackTrace_f3.cpp
     TestStackTrace_f4.cpp
 )
-#We need - rdynamic on GNU platforms for the stacktrace functionality
-#to work correctly with shared libraries
+# We need -rdynamic on GNU platforms for the stacktrace functionality
+# to work correctly with shared libraries
 KOKKOS_SET_EXE_PROPERTY(StackTraceTestExec ENABLE_EXPORTS ON)
 
 KOKKOS_ADD_TEST( NAME UnitTest_StackTraceTest
@@ -1037,10 +1032,10 @@ endif()
 
 FUNCTION (KOKKOS_ADD_INCREMENTAL_TEST DEVICE)
   KOKKOS_OPTION( ${DEVICE}_EXCLUDE_TESTS "" STRING "Incremental test exclude list" )
-#Add unit test main
+  # Add unit test main
   SET(${DEVICE}_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestMainInit.cpp)
 
-#Iterate over incremental tests in directory
+  # Iterate over incremental tests in directory
 
   APPEND_GLOB(INCREMENTAL_FILE_LIST ${CMAKE_CURRENT_SOURCE_DIR}/incremental/*.hpp)
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -198,6 +198,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
       ViewAPI_e
       ViewCopy_a
       ViewCopy_b
+      ViewCtorCTADs
       ViewCtorDimMatch
       ViewHooks
       ViewLayoutStrideAssignment

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -164,6 +164,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         Reducers_d
         Reducers_e
         Reductions_DeviceView
+        ReducerCTADs
         Scan
         SharedAlloc
         ViewMapping_a

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -1179,10 +1179,10 @@ TEST(TEST_CATEGORY, md_range_policy_compile_time_deduction_guides) {
   SomeExecutionSpace ses{};
   TEST_EXECSPACE es{};
 
-  constexpr int t[5]       = {};
-  constexpr int64_t tt[5]  = {};
-  Kokkos::Array<int, 3> a  = {};
-  Kokkos::Array<int, 2> aa = {};
+  constexpr int t[5]           = {};
+  constexpr int64_t tt[5]      = {};
+  Kokkos::Array<int64_t, 3> a  = {};
+  Kokkos::Array<int64_t, 2> aa = {};
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> ptc;
   Kokkos::MDRangePolicy pdc(ptc);

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -334,21 +334,20 @@ class TestRangePolicyConstruction {
       Kokkos::RangePolicy rp4(es, i64, i64, cs);
       ASSERT_TRUE((std::is_same_v<decltype(rp4), Kokkos::RangePolicy<>>));
 
-      // Deduce to RangePolicy<IndexType<int32_t>>
+      // Take a type convertible to int64_t; Deduce to RangePolicy<>
 
-      using IT32 = Kokkos::IndexType<int32_t>;
-      IT32::type i32{};
+      int32_t i32{};
       Kokkos::RangePolicy rp5(i32, i32);
-      ASSERT_TRUE((std::is_same_v<decltype(rp5), Kokkos::RangePolicy<IT32>>));
+      ASSERT_TRUE((std::is_same_v<decltype(rp5), Kokkos::RangePolicy<>>));
 
       Kokkos::RangePolicy rp6(i32, i32, cs);
-      ASSERT_TRUE((std::is_same_v<decltype(rp6), Kokkos::RangePolicy<IT32>>));
+      ASSERT_TRUE((std::is_same_v<decltype(rp6), Kokkos::RangePolicy<>>));
 
       Kokkos::RangePolicy rp7(es, i32, i32);
-      ASSERT_TRUE((std::is_same_v<decltype(rp7), Kokkos::RangePolicy<IT32>>));
+      ASSERT_TRUE((std::is_same_v<decltype(rp7), Kokkos::RangePolicy<>>));
 
       Kokkos::RangePolicy rp8(es, i32, i32, cs);
-      ASSERT_TRUE((std::is_same_v<decltype(rp8), Kokkos::RangePolicy<IT32>>));
+      ASSERT_TRUE((std::is_same_v<decltype(rp8), Kokkos::RangePolicy<>>));
 
       // Deduce to RangePolicy<SomeExecutionSpace>
 
@@ -366,12 +365,12 @@ class TestRangePolicyConstruction {
       Kokkos::RangePolicy rp11(ses, i32, i32);
       ASSERT_TRUE(
           (std::is_same_v<decltype(rp11),
-                          Kokkos::RangePolicy<SomeExecutionSpace, IT32>>));
+                          Kokkos::RangePolicy<SomeExecutionSpace>>));
 
       Kokkos::RangePolicy rp12(ses, i32, i32, cs);
       ASSERT_TRUE(
           (std::is_same_v<decltype(rp12),
-                          Kokkos::RangePolicy<SomeExecutionSpace, IT32>>));
+                          Kokkos::RangePolicy<SomeExecutionSpace>>));
 
       // Test convertible to DefaultExecutionSpace
 
@@ -386,28 +385,26 @@ class TestRangePolicyConstruction {
       ASSERT_TRUE((std::is_same_v<decltype(rp14), Kokkos::RangePolicy<>>));
 
       Kokkos::RangePolicy rp15(notES, i32, i32);
-      ASSERT_TRUE((std::is_same_v<decltype(rp15), Kokkos::RangePolicy<IT32>>));
+      ASSERT_TRUE((std::is_same_v<decltype(rp15), Kokkos::RangePolicy<>>));
 
       Kokkos::RangePolicy rp16(notES, i32, i32, cs);
-      ASSERT_TRUE((std::is_same_v<decltype(rp16), Kokkos::RangePolicy<IT32>>));
+      ASSERT_TRUE((std::is_same_v<decltype(rp16), Kokkos::RangePolicy<>>));
 
       // Test mixed index types
       signed char sc{};
       unsigned short us{};
-      using ITUI = Kokkos::IndexType<int>;  // commmon_type<signed char,
-                                            // unsigned short> == int
 
       Kokkos::RangePolicy rp17(us, sc);
-      ASSERT_TRUE((std::is_same_v<decltype(rp17), Kokkos::RangePolicy<ITUI>>));
+      ASSERT_TRUE((std::is_same_v<decltype(rp17), Kokkos::RangePolicy<>>));
 
       Kokkos::RangePolicy rp18(sc, us, cs);
-      ASSERT_TRUE((std::is_same_v<decltype(rp18), Kokkos::RangePolicy<ITUI>>));
+      ASSERT_TRUE((std::is_same_v<decltype(rp18), Kokkos::RangePolicy<>>));
 
       Kokkos::RangePolicy rp19(es, sc, us);
-      ASSERT_TRUE((std::is_same_v<decltype(rp19), Kokkos::RangePolicy<ITUI>>));
+      ASSERT_TRUE((std::is_same_v<decltype(rp19), Kokkos::RangePolicy<>>));
 
       Kokkos::RangePolicy rp20(es, sc, us, cs);
-      ASSERT_TRUE((std::is_same_v<decltype(rp20), Kokkos::RangePolicy<ITUI>>));
+      ASSERT_TRUE((std::is_same_v<decltype(rp20), Kokkos::RangePolicy<>>));
     }
   }
 

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -722,7 +722,7 @@ class TestTeamPolicyConstruction {
         std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace>,
         Kokkos::TeamPolicy<>, Kokkos::TeamPolicy<ExecutionSpace>>;
 
-    int i{};
+    int i{1};
 
     // Copy/Move
 

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -86,6 +86,7 @@ class TestRangePolicyConstruction {
  public:
   TestRangePolicyConstruction() {
     test_compile_time_parameters();
+    test_compile_time_implicit_deduction_guides();
     test_compile_time_deduction_guides();
     test_runtime_parameters();
   }
@@ -317,6 +318,24 @@ class TestRangePolicyConstruction {
     }
   }
 
+  void test_compile_time_implicit_deduction_guides() {
+    // icpc generates an ICE on implicit deduction guides for copy/move
+    //
+    // internal error: assertion failed: find_placeholder_arg_for_pack: symbol
+    // not found (scope_stk.c, line 11248 in find_placeholder_arg_for_pack)
+#if not defined(__INTEL_COMPILER)
+    // Copy
+    Kokkos::RangePolicy<SomeExecutionSpace> rptc;
+    Kokkos::RangePolicy rpdc(rptc);
+    ASSERT_TRUE((std::is_same_v<decltype(rptc), decltype(rpdc)>));
+
+    // Move
+    Kokkos::RangePolicy<SomeExecutionSpace> rptm;
+    Kokkos::RangePolicy rpdm(std::move(rptm));
+    ASSERT_TRUE((std::is_same_v<decltype(rptm), decltype(rpdm)>));
+#endif  // not defined(__INTEL_COMPILER)
+  }
+
   void test_compile_time_deduction_guides() {
     Kokkos::DefaultExecutionSpace des{};
     ImplicitlyConvertibleToDefaultExecutionSpace notEs{};
@@ -330,15 +349,6 @@ class TestRangePolicyConstruction {
     int64_t i64{};
     int32_t i32{};
     Kokkos::ChunkSize cs{0};
-
-    // Copy/move
-    Kokkos::RangePolicy<SomeExecutionSpace> rptc;
-    Kokkos::RangePolicy rpdc(rptc);
-    ASSERT_TRUE((std::is_same_v<decltype(rptc), decltype(rpdc)>));
-
-    Kokkos::RangePolicy<SomeExecutionSpace> rptm;
-    Kokkos::RangePolicy rpdm(std::move(rptm));
-    ASSERT_TRUE((std::is_same_v<decltype(rptm), decltype(rpdm)>));
 
     // RangePolicy()
 
@@ -481,6 +491,7 @@ class TestTeamPolicyConstruction {
  public:
   TestTeamPolicyConstruction() {
     test_compile_time_parameters();
+    test_compile_time_implicit_deduction_guides();
     test_compile_time_deduction_guides();
     test_run_time_parameters();
   }
@@ -712,6 +723,24 @@ class TestTeamPolicyConstruction {
     }
   }
 
+  void test_compile_time_implicit_deduction_guides() {
+    // icpc generates an ICE on implicit deduction guides for copy/move:
+    //
+    // internal error: assertion failed: find_placeholder_arg_for_pack: symbol
+    // not found (scope_stk.c, line 11248 in find_placeholder_arg_for_pack)
+#if not defined(__INTEL_COMPILER)
+    // Copy
+    Kokkos::TeamPolicy<SomeExecutionSpace> ptc;
+    Kokkos::TeamPolicy pdc(ptc);
+    ASSERT_TRUE((std::is_same_v<decltype(pdc), decltype(ptc)>));
+
+    // Move
+    Kokkos::TeamPolicy<SomeExecutionSpace> ptm;
+    Kokkos::TeamPolicy pdm(std::move(ptm));
+    ASSERT_TRUE((std::is_same_v<decltype(pdm), decltype(ptm)>));
+#endif  // not defined(__INTEL_COMPILER)
+  }
+
   void test_compile_time_deduction_guides() {
     Kokkos::DefaultExecutionSpace des{};
     ImplicitlyConvertibleToDefaultExecutionSpace notEs{};
@@ -723,16 +752,6 @@ class TestTeamPolicyConstruction {
         Kokkos::TeamPolicy<>, Kokkos::TeamPolicy<ExecutionSpace>>;
 
     int i{1};
-
-    // Copy/Move
-
-    Kokkos::TeamPolicy<SomeExecutionSpace> ptc;
-    Kokkos::TeamPolicy pdc(ptc);
-    ASSERT_TRUE((std::is_same_v<decltype(pdc), decltype(ptc)>));
-
-    Kokkos::TeamPolicy<SomeExecutionSpace> ptm;
-    Kokkos::TeamPolicy pdm(std::move(ptm));
-    ASSERT_TRUE((std::is_same_v<decltype(pdm), decltype(ptm)>));
 
     // Execution space not provided deduces to TeamPolicy<>
 

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -305,14 +305,15 @@ class TestRangePolicyConstruction {
 
   void test_compile_time_deduction_guides() {
     {
+      Kokkos::DefaultExecutionSpace des{};
+      ImplicitlyConvertibleToDefaultExecutionSpace notEs{};
+      SomeExecutionSpace ses{};
       ExecutionSpace es{};
+
       using RPES = std::conditional_t<
           std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace>,
           Kokkos::RangePolicy<>, Kokkos::RangePolicy<ExecutionSpace>>;
 
-      Kokkos::DefaultExecutionSpace des{};
-      ImplicitlyConvertibleToDefaultExecutionSpace notEs{};
-      SomeExecutionSpace ses{};
       int64_t i64{};
       int32_t i32{};
       Kokkos::ChunkSize cs{0};

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -1160,10 +1160,10 @@ TEST(TEST_CATEGORY, md_range_policy_compile_time_deduction_guides) {
   SomeExecutionSpace ses{};
   TEST_EXECSPACE es{};
 
-  constexpr int t[5]       = {};
-  constexpr int64_t tt[5]  = {};
-  Kokkos::Array<int, 3> a  = {};
-  Kokkos::Array<int, 2> aa = {};
+  constexpr int t[5]           = {};
+  constexpr int64_t tt[5]      = {};
+  Kokkos::Array<int64_t, 3> a  = {};
+  Kokkos::Array<int64_t, 2> aa = {};
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> ptc;
   Kokkos::MDRangePolicy pdc(ptc);

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -323,18 +323,13 @@ class TestRangePolicyConstruction {
     SomeExecutionSpace ses{};
     ExecutionSpace es{};
 
-    using RPES = std::conditional_t<
+    using RangePolicyExecSpace = std::conditional_t<
         std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace>,
         Kokkos::RangePolicy<>, Kokkos::RangePolicy<ExecutionSpace>>;
 
     int64_t i64{};
     int32_t i32{};
     Kokkos::ChunkSize cs{0};
-
-    // RangePolicy()
-
-    Kokkos::RangePolicy rp0;
-    ASSERT_TRUE((std::is_same_v<decltype(rp0), Kokkos::RangePolicy<>>));
 
     // Copy/move
     Kokkos::RangePolicy<SomeExecutionSpace> rptc;
@@ -345,77 +340,99 @@ class TestRangePolicyConstruction {
     Kokkos::RangePolicy rpdm(std::move(rptm));
     ASSERT_TRUE((std::is_same_v<decltype(rptm), decltype(rpdm)>));
 
+    // RangePolicy()
+
+    Kokkos::RangePolicy<> pt0;
+    Kokkos::RangePolicy pd0;
+    ASSERT_TRUE((std::is_same_v<decltype(pd0), decltype(pt0)>));
+
     // RangePolicy(execution_space, index_type, index_type)
 
-    Kokkos::RangePolicy rpa1(des, i64, i64);
-    ASSERT_TRUE((std::is_same_v<decltype(rpa1), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt1(des, i64, i64);
+    Kokkos::RangePolicy pd1(des, i64, i64);
+    ASSERT_TRUE((std::is_same_v<decltype(pd1), decltype(pt1)>));
 
-    Kokkos::RangePolicy rpa2(notEs, i64, i64);
-    ASSERT_TRUE((std::is_same_v<decltype(rpa2), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt2(notEs, i64, i64);
+    Kokkos::RangePolicy pd2(notEs, i64, i64);
+    ASSERT_TRUE((std::is_same_v<decltype(pd2), decltype(pt2)>));
 
-    Kokkos::RangePolicy rpa3(ses, i64, i64);
-    ASSERT_TRUE((std::is_same_v<decltype(rpa3),
-                                Kokkos::RangePolicy<SomeExecutionSpace>>));
+    Kokkos::RangePolicy<SomeExecutionSpace> pt3(ses, i64, i64);
+    Kokkos::RangePolicy pd3(ses, i64, i64);
+    ASSERT_TRUE((std::is_same_v<decltype(pd3), decltype(pt3)>));
 
-    Kokkos::RangePolicy rpa4(es, i64, i64);
-    ASSERT_TRUE((std::is_same_v<decltype(rpa4), RPES>));
+    RangePolicyExecSpace pt4(es, i64, i64);
+    Kokkos::RangePolicy pd4(es, i64, i64);
+    ASSERT_TRUE((std::is_same_v<decltype(pd4), decltype(pt4)>));
 
-    Kokkos::RangePolicy rpa5(des, i32, i32);
-    ASSERT_TRUE((std::is_same_v<decltype(rpa5), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt5(des, i32, i32);
+    Kokkos::RangePolicy pd5(des, i32, i32);
+    ASSERT_TRUE((std::is_same_v<decltype(pd5), decltype(pt5)>));
 
-    Kokkos::RangePolicy rpa6(notEs, i32, i32);
-    ASSERT_TRUE((std::is_same_v<decltype(rpa6), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt6(notEs, i32, i32);
+    Kokkos::RangePolicy pd6(notEs, i32, i32);
+    ASSERT_TRUE((std::is_same_v<decltype(pd6), decltype(pt6)>));
 
-    Kokkos::RangePolicy rpa7(ses, i32, i32);
-    ASSERT_TRUE((std::is_same_v<decltype(rpa7),
-                                Kokkos::RangePolicy<SomeExecutionSpace>>));
+    Kokkos::RangePolicy<SomeExecutionSpace> pt7(ses, i32, i32);
+    Kokkos::RangePolicy pd7(ses, i32, i32);
+    ASSERT_TRUE((std::is_same_v<decltype(pd7), decltype(pt7)>));
 
-    Kokkos::RangePolicy rpa8(es, i32, i32);
-    ASSERT_TRUE((std::is_same_v<decltype(rpa8), RPES>));
+    RangePolicyExecSpace pt8(es, i32, i32);
+    Kokkos::RangePolicy pd8(es, i32, i32);
+    ASSERT_TRUE((std::is_same_v<decltype(pd8), decltype(pt8)>));
 
     // RangePolicy(index_type, index_type)
 
-    Kokkos::RangePolicy rpb1(i64, i64);
-    ASSERT_TRUE((std::is_same_v<decltype(rpb1), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt9(i64, i64);
+    Kokkos::RangePolicy pd9(i64, i64);
+    ASSERT_TRUE((std::is_same_v<decltype(pd9), decltype(pt9)>));
 
-    Kokkos::RangePolicy rpb2(i32, i32);
-    ASSERT_TRUE((std::is_same_v<decltype(rpb2), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt10(i32, i32);
+    Kokkos::RangePolicy pd10(i32, i32);
+    ASSERT_TRUE((std::is_same_v<decltype(pd10), decltype(pt10)>));
 
     // RangePolicy(execution_space, index_type, index_type, Args...)
 
-    Kokkos::RangePolicy rpc1(des, i64, i64, cs);
-    ASSERT_TRUE((std::is_same_v<decltype(rpc1), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt11(des, i64, i64, cs);
+    Kokkos::RangePolicy pd11(des, i64, i64, cs);
+    ASSERT_TRUE((std::is_same_v<decltype(pd11), decltype(pt11)>));
 
-    Kokkos::RangePolicy rpc2(notEs, i64, i64, cs);
-    ASSERT_TRUE((std::is_same_v<decltype(rpc2), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt12(notEs, i64, i64, cs);
+    Kokkos::RangePolicy pd12(notEs, i64, i64, cs);
+    ASSERT_TRUE((std::is_same_v<decltype(pd12), decltype(pt12)>));
 
-    Kokkos::RangePolicy rpc3(ses, i64, i64, cs);
-    ASSERT_TRUE((std::is_same_v<decltype(rpc3),
-                                Kokkos::RangePolicy<SomeExecutionSpace>>));
+    Kokkos::RangePolicy<SomeExecutionSpace> pt13(ses, i64, i64, cs);
+    Kokkos::RangePolicy pd13(ses, i64, i64, cs);
+    ASSERT_TRUE((std::is_same_v<decltype(pd13), decltype(pt13)>));
 
-    Kokkos::RangePolicy rpc4(es, i64, i64, cs);
-    ASSERT_TRUE((std::is_same_v<decltype(rpc4), RPES>));
+    RangePolicyExecSpace pt14(es, i64, i64, cs);
+    Kokkos::RangePolicy pd14(es, i64, i64, cs);
+    ASSERT_TRUE((std::is_same_v<decltype(pd14), decltype(pt14)>));
 
-    Kokkos::RangePolicy rpc5(des, i32, i32, cs);
-    ASSERT_TRUE((std::is_same_v<decltype(rpc5), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt15(des, i32, i32, cs);
+    Kokkos::RangePolicy pd15(des, i32, i32, cs);
+    ASSERT_TRUE((std::is_same_v<decltype(pd15), decltype(pt15)>));
 
-    Kokkos::RangePolicy rpc6(notEs, i32, i32, cs);
-    ASSERT_TRUE((std::is_same_v<decltype(rpc6), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt16(notEs, i32, i32, cs);
+    Kokkos::RangePolicy pd16(notEs, i32, i32, cs);
+    ASSERT_TRUE((std::is_same_v<decltype(pd16), decltype(pt16)>));
 
-    Kokkos::RangePolicy rpc7(ses, i32, i32, cs);
-    ASSERT_TRUE((std::is_same_v<decltype(rpc7),
-                                Kokkos::RangePolicy<SomeExecutionSpace>>));
+    Kokkos::RangePolicy<SomeExecutionSpace> pt17(ses, i32, i32, cs);
+    Kokkos::RangePolicy pd17(ses, i32, i32, cs);
+    ASSERT_TRUE((std::is_same_v<decltype(pd17), decltype(pt17)>));
 
-    Kokkos::RangePolicy rpc8(es, i32, i32, cs);
-    ASSERT_TRUE((std::is_same_v<decltype(rpc8), RPES>));
+    RangePolicyExecSpace pt18(es, i32, i32, cs);
+    Kokkos::RangePolicy pd18(es, i32, i32, cs);
+    ASSERT_TRUE((std::is_same_v<decltype(pd18), decltype(pt18)>));
 
     // RangePolicy(index_type, index_type, Args...)
 
-    Kokkos::RangePolicy rpd1(i64, i64, cs);
-    ASSERT_TRUE((std::is_same_v<decltype(rpd1), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt19(i64, i64, cs);
+    Kokkos::RangePolicy pd19(i64, i64, cs);
+    ASSERT_TRUE((std::is_same_v<decltype(pt19), decltype(pd19)>));
 
-    Kokkos::RangePolicy rpd2(i32, i32, cs);
-    ASSERT_TRUE((std::is_same_v<decltype(rpd2), Kokkos::RangePolicy<>>));
+    Kokkos::RangePolicy<> pt20(i32, i32, cs);
+    Kokkos::RangePolicy pd20(i32, i32, cs);
+    ASSERT_TRUE((std::is_same_v<decltype(pd20), decltype(pt20)>));
   }
 
   void test_runtime_parameters() {
@@ -701,7 +718,7 @@ class TestTeamPolicyConstruction {
     SomeExecutionSpace ses{};
     ExecutionSpace es{};
 
-    using TPES = std::conditional_t<
+    using PolicyExecSpace = std::conditional_t<
         std::is_same_v<ExecutionSpace, Kokkos::DefaultExecutionSpace>,
         Kokkos::TeamPolicy<>, Kokkos::TeamPolicy<ExecutionSpace>>;
 
@@ -709,122 +726,148 @@ class TestTeamPolicyConstruction {
 
     // Copy/Move
 
-    Kokkos::TeamPolicy<SomeExecutionSpace> tptc;
-    Kokkos::TeamPolicy tpdc(tptc);
-    ASSERT_TRUE((std::is_same_v<decltype(tptc), decltype(tpdc)>));
+    Kokkos::TeamPolicy<SomeExecutionSpace> ptc;
+    Kokkos::TeamPolicy pdc(ptc);
+    ASSERT_TRUE((std::is_same_v<decltype(pdc), decltype(ptc)>));
 
-    Kokkos::TeamPolicy<SomeExecutionSpace> tptm;
-    Kokkos::TeamPolicy tpdm(std::move(tptm));
-    ASSERT_TRUE((std::is_same_v<decltype(tptm), decltype(tpdm)>));
+    Kokkos::TeamPolicy<SomeExecutionSpace> ptm;
+    Kokkos::TeamPolicy pdm(std::move(ptm));
+    ASSERT_TRUE((std::is_same_v<decltype(pdm), decltype(ptm)>));
 
     // Execution space not provided deduces to TeamPolicy<>
 
-    Kokkos::TeamPolicy tp;
-    ASSERT_TRUE((std::is_same_v<decltype(tp), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt0;
+    Kokkos::TeamPolicy pd0;
+    ASSERT_TRUE((std::is_same_v<decltype(pd0), decltype(pt0)>));
 
-    Kokkos::TeamPolicy tpii(i, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpii), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt1(i, i);
+    Kokkos::TeamPolicy pd1(i, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd1), decltype(pt1)>));
 
-    Kokkos::TeamPolicy tpiii(i, i, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpiii), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt2(i, i, i);
+    Kokkos::TeamPolicy pd2(i, i, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd2), decltype(pt2)>));
 
-    Kokkos::TeamPolicy tpia(i, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpia), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt3(i, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd3(i, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd3), decltype(pt3)>));
 
-    Kokkos::TeamPolicy tpiai(i, Kokkos::AUTO, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpiai), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt4(i, Kokkos::AUTO, i);
+    Kokkos::TeamPolicy pd4(i, Kokkos::AUTO, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd4), decltype(pt4)>));
 
-    Kokkos::TeamPolicy tpiaa(i, Kokkos::AUTO, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpiaa), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt5(i, Kokkos::AUTO, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd5(i, Kokkos::AUTO, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pt5), decltype(pd5)>));
 
-    Kokkos::TeamPolicy tpiia(i, i, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpiia), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt6(i, i, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd6(i, i, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd6), decltype(pt6)>));
 
     // DefaultExecutionSpace deduces to TeamPolicy<>
 
-    Kokkos::TeamPolicy tpdii(des, i, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpdii), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt7(des, i, i);
+    Kokkos::TeamPolicy pd7(des, i, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pt7), decltype(pd7)>));
 
-    Kokkos::TeamPolicy tpdiii(des, i, i, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpdiii), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt8(des, i, i, i);
+    Kokkos::TeamPolicy pd8(des, i, i, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pt8), decltype(pd8)>));
 
-    Kokkos::TeamPolicy tpdia(des, i, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpdia), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt9(des, i, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd9(des, i, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd9), decltype(pt9)>));
 
-    Kokkos::TeamPolicy tpdiai(des, i, Kokkos::AUTO, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpdiai), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt10(des, i, Kokkos::AUTO, i);
+    Kokkos::TeamPolicy pd10(des, i, Kokkos::AUTO, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd10), decltype(pt10)>));
 
-    Kokkos::TeamPolicy tpdiaa(des, i, Kokkos::AUTO, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpdiaa), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt11(des, i, Kokkos::AUTO, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd11(des, i, Kokkos::AUTO, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pt11), decltype(pd11)>));
 
-    Kokkos::TeamPolicy tpdiia(des, i, i, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpdiia), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt12(des, i, i, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd12(des, i, i, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd12), decltype(pt12)>));
 
     // Convertible to DefaultExecutionSpace deduces to TeamPolicy<>
 
-    Kokkos::TeamPolicy tpnii(notEs, i, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpnii), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt13(notEs, i, i);
+    Kokkos::TeamPolicy pd13(notEs, i, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd13), decltype(pt13)>));
 
-    Kokkos::TeamPolicy tpniii(notEs, i, i, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpniii), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt14(notEs, i, i, i);
+    Kokkos::TeamPolicy pd14(notEs, i, i, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd14), decltype(pt14)>));
 
-    Kokkos::TeamPolicy tpnia(notEs, i, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpnia), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt15(notEs, i, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd15(notEs, i, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd15), decltype(pt15)>));
 
-    Kokkos::TeamPolicy tpniai(notEs, i, Kokkos::AUTO, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpniai), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt16(notEs, i, Kokkos::AUTO, i);
+    Kokkos::TeamPolicy pd16(notEs, i, Kokkos::AUTO, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd16), decltype(pt16)>));
 
-    Kokkos::TeamPolicy tpniaa(notEs, i, Kokkos::AUTO, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpniaa), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt17(notEs, i, Kokkos::AUTO, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd17(notEs, i, Kokkos::AUTO, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd17), decltype(pt17)>));
 
-    Kokkos::TeamPolicy tpniia(notEs, i, i, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpniia), Kokkos::TeamPolicy<>>));
+    Kokkos::TeamPolicy<> pt18(notEs, i, i, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd18(notEs, i, i, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd18), decltype(pt18)>));
 
     // ES != DefaultExecutionSpacea deduces to TeamPolicy<ES>
 
-    Kokkos::TeamPolicy tpsii(ses, i, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpsii),
-                                Kokkos::TeamPolicy<SomeExecutionSpace>>));
+    Kokkos::TeamPolicy<SomeExecutionSpace> pt19(ses, i, i);
+    Kokkos::TeamPolicy pd19(ses, i, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd19), decltype(pt19)>));
 
-    Kokkos::TeamPolicy tpsiii(ses, i, i, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpsiii),
-                                Kokkos::TeamPolicy<SomeExecutionSpace>>));
+    Kokkos::TeamPolicy<SomeExecutionSpace> pt20(ses, i, i, i);
+    Kokkos::TeamPolicy pd20(ses, i, i, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd20), decltype(pt20)>));
 
-    Kokkos::TeamPolicy tpsia(ses, i, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpsia),
-                                Kokkos::TeamPolicy<SomeExecutionSpace>>));
+    Kokkos::TeamPolicy<SomeExecutionSpace> pt21(ses, i, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd21(ses, i, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd21), decltype(pt21)>));
 
-    Kokkos::TeamPolicy tpsiai(ses, i, Kokkos::AUTO, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpsiai),
-                                Kokkos::TeamPolicy<SomeExecutionSpace>>));
+    Kokkos::TeamPolicy<SomeExecutionSpace> pt22(ses, i, Kokkos::AUTO, i);
+    Kokkos::TeamPolicy pd22(ses, i, Kokkos::AUTO, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd22), decltype(pt22)>));
 
-    Kokkos::TeamPolicy tpsiaa(ses, i, Kokkos::AUTO, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpsiaa),
-                                Kokkos::TeamPolicy<SomeExecutionSpace>>));
+    Kokkos::TeamPolicy<SomeExecutionSpace> pt23(ses, i, Kokkos::AUTO,
+                                                Kokkos::AUTO);
+    Kokkos::TeamPolicy pd23(ses, i, Kokkos::AUTO, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd23), decltype(pt23)>));
 
-    Kokkos::TeamPolicy tpsiia(ses, i, i, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpsiia),
-                                Kokkos::TeamPolicy<SomeExecutionSpace>>));
+    Kokkos::TeamPolicy<SomeExecutionSpace> pt24(ses, i, i, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd24(ses, i, i, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd24), decltype(pt24)>));
 
     // Confirm it works for the ExecutionSpace template parameter passed in
 
-    Kokkos::TeamPolicy tpeii(es, i, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpeii), TPES>));
+    PolicyExecSpace pt25(es, i, i);
+    Kokkos::TeamPolicy pd25(es, i, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd25), decltype(pt25)>));
 
-    Kokkos::TeamPolicy tpeiii(es, i, i, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpeiii), TPES>));
+    PolicyExecSpace pt26(es, i, i, i);
+    Kokkos::TeamPolicy pd26(es, i, i, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd26), decltype(pt26)>));
 
-    Kokkos::TeamPolicy tpeia(es, i, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpeia), TPES>));
+    PolicyExecSpace pt27(es, i, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd27(es, i, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd27), decltype(pt27)>));
 
-    Kokkos::TeamPolicy tpeiai(es, i, Kokkos::AUTO, i);
-    ASSERT_TRUE((std::is_same_v<decltype(tpeiai), TPES>));
+    PolicyExecSpace pt28(es, i, Kokkos::AUTO, i);
+    Kokkos::TeamPolicy pd28(es, i, Kokkos::AUTO, i);
+    ASSERT_TRUE((std::is_same_v<decltype(pd28), decltype(pt28)>));
 
-    Kokkos::TeamPolicy tpeiaa(es, i, Kokkos::AUTO, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpeiaa), TPES>));
+    PolicyExecSpace pt29(es, i, Kokkos::AUTO, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd29(es, i, Kokkos::AUTO, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd29), decltype(pt29)>));
 
-    Kokkos::TeamPolicy tpeiia(es, i, i, Kokkos::AUTO);
-    ASSERT_TRUE((std::is_same_v<decltype(tpeiia), TPES>));
+    PolicyExecSpace pt30(es, i, i, Kokkos::AUTO);
+    Kokkos::TeamPolicy pd30(es, i, i, Kokkos::AUTO);
+    ASSERT_TRUE((std::is_same_v<decltype(pd30), decltype(pt30)>));
   }
 
   template <class policy_t>

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -1181,8 +1181,8 @@ TEST(TEST_CATEGORY, md_range_policy_compile_time_deduction_guides) {
 
   constexpr int t[5]           = {};
   constexpr int64_t tt[5]      = {};
-  Kokkos::Array<int64_t, 3> a  = {};
-  Kokkos::Array<int64_t, 2> aa = {};
+  Kokkos::Array<int, 3> a  = {};
+  Kokkos::Array<int, 2> aa = {};
 
   Kokkos::MDRangePolicy<Kokkos::Rank<2>> ptc;
   Kokkos::MDRangePolicy pdc(ptc);

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -874,8 +874,8 @@ class TestTeamPolicyConstruction {
   void test_run_time_parameters_type() {
     int league_size = 131;
     int team_size   = 4 < policy_t::execution_space::concurrency()
-                          ? 4
-                          : policy_t::execution_space::concurrency();
+                        ? 4
+                        : policy_t::execution_space::concurrency();
 #ifdef KOKKOS_ENABLE_HPX
     team_size = 1;
 #endif

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -1179,8 +1179,8 @@ TEST(TEST_CATEGORY, md_range_policy_compile_time_deduction_guides) {
   SomeExecutionSpace ses{};
   TEST_EXECSPACE es{};
 
-  constexpr int t[5]           = {};
-  constexpr int64_t tt[5]      = {};
+  constexpr int t[5]       = {};
+  constexpr int64_t tt[5]  = {};
   Kokkos::Array<int, 3> a  = {};
   Kokkos::Array<int, 2> aa = {};
 

--- a/core/unit_test/TestReducerCTADs.hpp
+++ b/core/unit_test/TestReducerCTADs.hpp
@@ -43,7 +43,6 @@
 */
 
 #include <Kokkos_Core.hpp>
-#include <iostream>
 
 namespace Test {
 

--- a/core/unit_test/TestReducerCTADs.hpp
+++ b/core/unit_test/TestReducerCTADs.hpp
@@ -48,9 +48,10 @@ namespace Test {
 
 template <typename ExecSpace = TEST_EXECSPACE>
 struct TestReducerCTADs {
-  using scalar        = double*;
-  using memspace      = typename ExecSpace::memory_space;
-  using view_type     = Kokkos::View<scalar, memspace>;
+  using scalar     = double;
+  using memspace   = typename ExecSpace::memory_space;
+  using view_type  = Kokkos::View<scalar, memspace>;
+  using index_type = int;
 
   static void test_sum() {
     view_type view;
@@ -79,6 +80,7 @@ struct TestReducerCTADs {
     Kokkos::Prod rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
   }
+
   static void test_min() {
     view_type view;
 
@@ -92,6 +94,7 @@ struct TestReducerCTADs {
     Kokkos::Min rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
   }
+
   static void test_max() {
     view_type view;
 
@@ -105,6 +108,7 @@ struct TestReducerCTADs {
     Kokkos::Max rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
   }
+
   static void test_land() {
     view_type view;
 
@@ -118,6 +122,7 @@ struct TestReducerCTADs {
     Kokkos::LAnd rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
   }
+
   static void test_lor() {
     view_type view;
 
@@ -131,6 +136,7 @@ struct TestReducerCTADs {
     Kokkos::LOr rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
   }
+
   static void test_band() {
     view_type view;
 
@@ -144,6 +150,7 @@ struct TestReducerCTADs {
     Kokkos::BAnd rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
   }
+
   static void test_bor() {
     view_type view;
 
@@ -157,8 +164,216 @@ struct TestReducerCTADs {
     Kokkos::BOr rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
   }
-  //TODO
+
   static void test_minloc() {
+    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+
+    Kokkos::MinLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MinLoc rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::MinLoc rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::MinLoc rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_maxloc() {
+    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+
+    Kokkos::MaxLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MaxLoc rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::MaxLoc rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::MaxLoc rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_minmax() {
+    Kokkos::View<Kokkos::MinMaxScalar<scalar>, memspace> view;
+
+    Kokkos::MinMax<scalar, memspace> rt(view);
+    Kokkos::MinMax rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::MinMax rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::MinMax rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_minmaxloc() {
+    Kokkos::View<Kokkos::MinMaxLocScalar<scalar, index_type>, memspace> view;
+
+    Kokkos::MinMaxLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MinMaxLoc rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::MinMaxLoc rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::MinMaxLoc rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_maxfirstloc() {
+    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+
+    Kokkos::MaxFirstLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MaxFirstLoc rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::MaxFirstLoc rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::MaxFirstLoc rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_maxfirstloccustomcomparator() {
+    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+
+    auto comparator       = [](scalar, scalar) { return true; };
+    using comparator_type = decltype(comparator);
+
+    Kokkos::MaxFirstLocCustomComparator<scalar, index_type, comparator_type,
+                                        memspace>
+        rt(view, comparator);
+    Kokkos::MaxFirstLocCustomComparator rd(view, comparator);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::MaxFirstLocCustomComparator rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::MaxFirstLocCustomComparator rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_minfirstloc() {
+    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+
+    Kokkos::MinFirstLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MinFirstLoc rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::MinFirstLoc rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::MinFirstLoc rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_minfirstloccustomcomparator() {
+    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+
+    auto comparator       = [](scalar, scalar) { return true; };
+    using comparator_type = decltype(comparator);
+
+    Kokkos::MinFirstLocCustomComparator<scalar, index_type, comparator_type,
+                                        memspace>
+        rt(view, comparator);
+    Kokkos::MinFirstLocCustomComparator rd(view, comparator);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::MinFirstLocCustomComparator rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::MinFirstLocCustomComparator rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_minmaxfirstlastloc() {
+    Kokkos::View<Kokkos::MinMaxLocScalar<scalar, index_type>, memspace> view;
+
+    Kokkos::MinMaxFirstLastLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MinMaxFirstLastLoc rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::MinMaxFirstLastLoc rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::MinMaxFirstLastLoc rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_minmaxfirstlastloccustomcomparator() {
+    Kokkos::View<Kokkos::MinMaxLocScalar<scalar, index_type>, memspace> view;
+
+    auto comparator       = [](scalar, scalar) { return true; };
+    using comparator_type = decltype(comparator);
+
+    Kokkos::MinMaxFirstLastLocCustomComparator<scalar, index_type,
+                                               comparator_type, memspace>
+        rt(view, comparator);
+    Kokkos::MinMaxFirstLastLocCustomComparator rd(view, comparator);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::MinMaxFirstLastLocCustomComparator rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::MinMaxFirstLastLocCustomComparator rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_firstloc() {
+    Kokkos::View<Kokkos::FirstLocScalar<index_type>, memspace> view;
+
+    Kokkos::FirstLoc<index_type, memspace> rt(view);
+    Kokkos::FirstLoc rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::FirstLoc rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::FirstLoc rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_lastloc() {
+    Kokkos::View<Kokkos::LastLocScalar<index_type>, memspace> view;
+
+    Kokkos::LastLoc<index_type, memspace> rt(view);
+    Kokkos::LastLoc rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::LastLoc rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::LastLoc rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_stdispartitioned() {
+    Kokkos::View<Kokkos::StdIsPartScalar<index_type>, memspace> view;
+
+    Kokkos::StdIsPartitioned<index_type, memspace> rt(view);
+    Kokkos::StdIsPartitioned rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::StdIsPartitioned rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::StdIsPartitioned rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_stdpartitionpoint() {
+    Kokkos::View<Kokkos::StdPartPointScalar<index_type>, memspace> view;
+
+    Kokkos::StdPartitionPoint<index_type, memspace> rt(view);
+    Kokkos::StdPartitionPoint rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::StdPartitionPoint rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::StdPartitionPoint rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
   }
 };
 
@@ -172,6 +387,19 @@ TEST(TEST_CATEGORY, reducer_ctads) {
   TestReducerCTADs<TEST_EXECSPACE>::test_band();
   TestReducerCTADs<TEST_EXECSPACE>::test_bor();
   TestReducerCTADs<TEST_EXECSPACE>::test_minloc();
+  TestReducerCTADs<TEST_EXECSPACE>::test_maxloc();
+  TestReducerCTADs<TEST_EXECSPACE>::test_minmax();
+  TestReducerCTADs<TEST_EXECSPACE>::test_minmaxloc();
+  TestReducerCTADs<TEST_EXECSPACE>::test_maxfirstloc();
+  TestReducerCTADs<TEST_EXECSPACE>::test_maxfirstloccustomcomparator();
+  TestReducerCTADs<TEST_EXECSPACE>::test_minfirstloc();
+  TestReducerCTADs<TEST_EXECSPACE>::test_minfirstloccustomcomparator();
+  TestReducerCTADs<TEST_EXECSPACE>::test_minmaxfirstlastloc();
+  TestReducerCTADs<TEST_EXECSPACE>::test_minmaxfirstlastloccustomcomparator();
+  TestReducerCTADs<TEST_EXECSPACE>::test_firstloc();
+  TestReducerCTADs<TEST_EXECSPACE>::test_lastloc();
+  TestReducerCTADs<TEST_EXECSPACE>::test_stdispartitioned();
+  TestReducerCTADs<TEST_EXECSPACE>::test_stdpartitionpoint();
 }
 
 }  // namespace Test

--- a/core/unit_test/TestReducerCTADs.hpp
+++ b/core/unit_test/TestReducerCTADs.hpp
@@ -54,6 +54,10 @@ struct TestReducerCTADs {
   using index_type  = int;
   using memspace    = typename execspace::memory_space;
 
+  template <typename Scalar, typename Space>
+  using VS = Kokkos::View<Scalar, Kokkos::LayoutStride, Space,
+                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+
   static void test_sum() {
     Kokkos::View<scalar_type, memspace> view;
 
@@ -66,6 +70,11 @@ struct TestReducerCTADs {
 
     Kokkos::Sum rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<scalar_type, memspace> vs;
+    Kokkos::Sum rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_prod() {
@@ -80,6 +89,11 @@ struct TestReducerCTADs {
 
     Kokkos::Prod rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<scalar_type, memspace> vs;
+    Kokkos::Prod rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_min() {
@@ -94,6 +108,11 @@ struct TestReducerCTADs {
 
     Kokkos::Min rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<scalar_type, memspace> vs;
+    Kokkos::Min rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_max() {
@@ -108,6 +127,11 @@ struct TestReducerCTADs {
 
     Kokkos::Max rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<scalar_type, memspace> vs;
+    Kokkos::Max rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_land() {
@@ -122,6 +146,11 @@ struct TestReducerCTADs {
 
     Kokkos::LAnd rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<scalar_type, memspace> vs;
+    Kokkos::LAnd rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_lor() {
@@ -136,6 +165,11 @@ struct TestReducerCTADs {
 
     Kokkos::LOr rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<scalar_type, memspace> vs;
+    Kokkos::LOr rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_band() {
@@ -150,6 +184,11 @@ struct TestReducerCTADs {
 
     Kokkos::BAnd rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<scalar_type, memspace> vs;
+    Kokkos::BAnd rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_bor() {
@@ -164,6 +203,11 @@ struct TestReducerCTADs {
 
     Kokkos::BOr rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<scalar_type, memspace> vs;
+    Kokkos::BOr rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_minloc() {
@@ -178,6 +222,11 @@ struct TestReducerCTADs {
 
     Kokkos::MinLoc rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> vs;
+    Kokkos::MinLoc rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_maxloc() {
@@ -192,6 +241,11 @@ struct TestReducerCTADs {
 
     Kokkos::MaxLoc rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> vs;
+    Kokkos::MaxLoc rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_minmax() {
@@ -206,6 +260,11 @@ struct TestReducerCTADs {
 
     Kokkos::MinMax rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::MinMaxScalar<scalar_type>, memspace> vs;
+    Kokkos::MinMax rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_minmaxloc() {
@@ -221,6 +280,11 @@ struct TestReducerCTADs {
 
     Kokkos::MinMaxLoc rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::MinMaxLocScalar<scalar_type, index_type>, memspace> vs;
+    Kokkos::MinMaxLoc rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_maxfirstloc() {
@@ -235,6 +299,11 @@ struct TestReducerCTADs {
 
     Kokkos::MaxFirstLoc rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> vs;
+    Kokkos::MaxFirstLoc rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_maxfirstloccustomcomparator() {
@@ -254,6 +323,11 @@ struct TestReducerCTADs {
 
     Kokkos::MaxFirstLocCustomComparator rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> vs;
+    Kokkos::MaxFirstLocCustomComparator rs(vs, comparator);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_minfirstloc() {
@@ -268,6 +342,11 @@ struct TestReducerCTADs {
 
     Kokkos::MinFirstLoc rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> vs;
+    Kokkos::MinFirstLoc rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_minfirstloccustomcomparator() {
@@ -287,6 +366,11 @@ struct TestReducerCTADs {
 
     Kokkos::MinFirstLocCustomComparator rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> vs;
+    Kokkos::MinFirstLocCustomComparator rs(vs, comparator);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_minmaxfirstlastloc() {
@@ -302,6 +386,11 @@ struct TestReducerCTADs {
 
     Kokkos::MinMaxFirstLastLoc rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::MinMaxLocScalar<scalar_type, index_type>, memspace> vs;
+    Kokkos::MinMaxFirstLastLoc rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_minmaxfirstlastloccustomcomparator() {
@@ -322,6 +411,11 @@ struct TestReducerCTADs {
 
     Kokkos::MinMaxFirstLastLocCustomComparator rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::MinMaxLocScalar<scalar_type, index_type>, memspace> vs;
+    Kokkos::MinMaxFirstLastLocCustomComparator rs(vs, comparator);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_firstloc() {
@@ -336,6 +430,11 @@ struct TestReducerCTADs {
 
     Kokkos::FirstLoc rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::FirstLocScalar<index_type>, memspace> vs;
+    Kokkos::FirstLoc rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_lastloc() {
@@ -350,6 +449,11 @@ struct TestReducerCTADs {
 
     Kokkos::LastLoc rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::LastLocScalar<index_type>, memspace> vs;
+    Kokkos::LastLoc rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_stdispartitioned() {
@@ -364,6 +468,11 @@ struct TestReducerCTADs {
 
     Kokkos::StdIsPartitioned rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::StdIsPartScalar<index_type>, memspace> vs;
+    Kokkos::StdIsPartitioned rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 
   static void test_stdpartitionpoint() {
@@ -378,6 +487,11 @@ struct TestReducerCTADs {
 
     Kokkos::StdPartitionPoint rdm(std::move(rt));
     ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+
+    VS<Kokkos::StdPartPointScalar<index_type>, memspace> vs;
+    Kokkos::StdPartitionPoint rs(vs);
+    ASSERT_FALSE((std::is_same_v<decltype(vs), decltype(view)>));
+    ASSERT_TRUE((std::is_same_v<decltype(rs), decltype(rt)>));
   }
 };
 

--- a/core/unit_test/TestReducerCTADs.hpp
+++ b/core/unit_test/TestReducerCTADs.hpp
@@ -43,20 +43,22 @@
 */
 
 #include <Kokkos_Core.hpp>
+#include <iostream>
 
 namespace Test {
 
 template <typename ExecSpace = TEST_EXECSPACE>
 struct TestReducerCTADs {
-  using scalar     = double;
-  using memspace   = typename ExecSpace::memory_space;
-  using view_type  = Kokkos::View<scalar, memspace>;
-  using index_type = int;
+  using execspace = ExecSpace;
+
+  using scalar_type = double;
+  using index_type  = int;
+  using memspace    = typename execspace::memory_space;
 
   static void test_sum() {
-    view_type view;
+    Kokkos::View<scalar_type, memspace> view;
 
-    Kokkos::Sum<scalar, memspace> rt(view);
+    Kokkos::Sum<scalar_type, memspace> rt(view);
     Kokkos::Sum rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -68,9 +70,9 @@ struct TestReducerCTADs {
   }
 
   static void test_prod() {
-    view_type view;
+    Kokkos::View<scalar_type, memspace> view;
 
-    Kokkos::Prod<scalar, memspace> rt(view);
+    Kokkos::Prod<scalar_type, memspace> rt(view);
     Kokkos::Prod rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -82,9 +84,9 @@ struct TestReducerCTADs {
   }
 
   static void test_min() {
-    view_type view;
+    Kokkos::View<scalar_type, memspace> view;
 
-    Kokkos::Min<scalar, memspace> rt(view);
+    Kokkos::Min<scalar_type, memspace> rt(view);
     Kokkos::Min rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -96,9 +98,9 @@ struct TestReducerCTADs {
   }
 
   static void test_max() {
-    view_type view;
+    Kokkos::View<scalar_type, memspace> view;
 
-    Kokkos::Max<scalar, memspace> rt(view);
+    Kokkos::Max<scalar_type, memspace> rt(view);
     Kokkos::Max rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -110,9 +112,9 @@ struct TestReducerCTADs {
   }
 
   static void test_land() {
-    view_type view;
+    Kokkos::View<scalar_type, memspace> view;
 
-    Kokkos::LAnd<scalar, memspace> rt(view);
+    Kokkos::LAnd<scalar_type, memspace> rt(view);
     Kokkos::LAnd rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -124,9 +126,9 @@ struct TestReducerCTADs {
   }
 
   static void test_lor() {
-    view_type view;
+    Kokkos::View<scalar_type, memspace> view;
 
-    Kokkos::LOr<scalar, memspace> rt(view);
+    Kokkos::LOr<scalar_type, memspace> rt(view);
     Kokkos::LOr rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -138,9 +140,9 @@ struct TestReducerCTADs {
   }
 
   static void test_band() {
-    view_type view;
+    Kokkos::View<scalar_type, memspace> view;
 
-    Kokkos::BAnd<scalar, memspace> rt(view);
+    Kokkos::BAnd<scalar_type, memspace> rt(view);
     Kokkos::BAnd rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -152,9 +154,9 @@ struct TestReducerCTADs {
   }
 
   static void test_bor() {
-    view_type view;
+    Kokkos::View<scalar_type, memspace> view;
 
-    Kokkos::BOr<scalar, memspace> rt(view);
+    Kokkos::BOr<scalar_type, memspace> rt(view);
     Kokkos::BOr rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -166,9 +168,9 @@ struct TestReducerCTADs {
   }
 
   static void test_minloc() {
-    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+    Kokkos::View<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> view;
 
-    Kokkos::MinLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MinLoc<scalar_type, index_type, memspace> rt(view);
     Kokkos::MinLoc rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -180,9 +182,9 @@ struct TestReducerCTADs {
   }
 
   static void test_maxloc() {
-    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+    Kokkos::View<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> view;
 
-    Kokkos::MaxLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MaxLoc<scalar_type, index_type, memspace> rt(view);
     Kokkos::MaxLoc rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -194,9 +196,9 @@ struct TestReducerCTADs {
   }
 
   static void test_minmax() {
-    Kokkos::View<Kokkos::MinMaxScalar<scalar>, memspace> view;
+    Kokkos::View<Kokkos::MinMaxScalar<scalar_type>, memspace> view;
 
-    Kokkos::MinMax<scalar, memspace> rt(view);
+    Kokkos::MinMax<scalar_type, memspace> rt(view);
     Kokkos::MinMax rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -208,9 +210,10 @@ struct TestReducerCTADs {
   }
 
   static void test_minmaxloc() {
-    Kokkos::View<Kokkos::MinMaxLocScalar<scalar, index_type>, memspace> view;
+    Kokkos::View<Kokkos::MinMaxLocScalar<scalar_type, index_type>, memspace>
+        view;
 
-    Kokkos::MinMaxLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MinMaxLoc<scalar_type, index_type, memspace> rt(view);
     Kokkos::MinMaxLoc rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -222,9 +225,9 @@ struct TestReducerCTADs {
   }
 
   static void test_maxfirstloc() {
-    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+    Kokkos::View<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> view;
 
-    Kokkos::MaxFirstLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MaxFirstLoc<scalar_type, index_type, memspace> rt(view);
     Kokkos::MaxFirstLoc rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -236,13 +239,13 @@ struct TestReducerCTADs {
   }
 
   static void test_maxfirstloccustomcomparator() {
-    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+    Kokkos::View<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> view;
 
-    auto comparator       = [](scalar, scalar) { return true; };
+    auto comparator       = [](scalar_type, scalar_type) { return true; };
     using comparator_type = decltype(comparator);
 
-    Kokkos::MaxFirstLocCustomComparator<scalar, index_type, comparator_type,
-                                        memspace>
+    Kokkos::MaxFirstLocCustomComparator<scalar_type, index_type,
+                                        comparator_type, memspace>
         rt(view, comparator);
     Kokkos::MaxFirstLocCustomComparator rd(view, comparator);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
@@ -255,9 +258,9 @@ struct TestReducerCTADs {
   }
 
   static void test_minfirstloc() {
-    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+    Kokkos::View<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> view;
 
-    Kokkos::MinFirstLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MinFirstLoc<scalar_type, index_type, memspace> rt(view);
     Kokkos::MinFirstLoc rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -269,13 +272,13 @@ struct TestReducerCTADs {
   }
 
   static void test_minfirstloccustomcomparator() {
-    Kokkos::View<Kokkos::ValLocScalar<scalar, index_type>, memspace> view;
+    Kokkos::View<Kokkos::ValLocScalar<scalar_type, index_type>, memspace> view;
 
-    auto comparator       = [](scalar, scalar) { return true; };
+    auto comparator       = [](scalar_type, scalar_type) { return true; };
     using comparator_type = decltype(comparator);
 
-    Kokkos::MinFirstLocCustomComparator<scalar, index_type, comparator_type,
-                                        memspace>
+    Kokkos::MinFirstLocCustomComparator<scalar_type, index_type,
+                                        comparator_type, memspace>
         rt(view, comparator);
     Kokkos::MinFirstLocCustomComparator rd(view, comparator);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
@@ -288,9 +291,10 @@ struct TestReducerCTADs {
   }
 
   static void test_minmaxfirstlastloc() {
-    Kokkos::View<Kokkos::MinMaxLocScalar<scalar, index_type>, memspace> view;
+    Kokkos::View<Kokkos::MinMaxLocScalar<scalar_type, index_type>, memspace>
+        view;
 
-    Kokkos::MinMaxFirstLastLoc<scalar, index_type, memspace> rt(view);
+    Kokkos::MinMaxFirstLastLoc<scalar_type, index_type, memspace> rt(view);
     Kokkos::MinMaxFirstLastLoc rd(view);
     ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
 
@@ -302,12 +306,13 @@ struct TestReducerCTADs {
   }
 
   static void test_minmaxfirstlastloccustomcomparator() {
-    Kokkos::View<Kokkos::MinMaxLocScalar<scalar, index_type>, memspace> view;
+    Kokkos::View<Kokkos::MinMaxLocScalar<scalar_type, index_type>, memspace>
+        view;
 
-    auto comparator       = [](scalar, scalar) { return true; };
+    auto comparator       = [](scalar_type, scalar_type) { return true; };
     using comparator_type = decltype(comparator);
 
-    Kokkos::MinMaxFirstLastLocCustomComparator<scalar, index_type,
+    Kokkos::MinMaxFirstLastLocCustomComparator<scalar_type, index_type,
                                                comparator_type, memspace>
         rt(view, comparator);
     Kokkos::MinMaxFirstLastLocCustomComparator rd(view, comparator);

--- a/core/unit_test/TestReducerCTADs.hpp
+++ b/core/unit_test/TestReducerCTADs.hpp
@@ -1,0 +1,177 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+
+template <typename ExecSpace = TEST_EXECSPACE>
+struct TestReducerCTADs {
+  using scalar        = double*;
+  using memspace      = typename ExecSpace::memory_space;
+  using view_type     = Kokkos::View<scalar, memspace>;
+
+  static void test_sum() {
+    view_type view;
+
+    Kokkos::Sum<scalar, memspace> rt(view);
+    Kokkos::Sum rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::Sum rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::Sum rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+
+  static void test_prod() {
+    view_type view;
+
+    Kokkos::Prod<scalar, memspace> rt(view);
+    Kokkos::Prod rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::Prod rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::Prod rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+  static void test_min() {
+    view_type view;
+
+    Kokkos::Min<scalar, memspace> rt(view);
+    Kokkos::Min rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::Min rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::Min rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+  static void test_max() {
+    view_type view;
+
+    Kokkos::Max<scalar, memspace> rt(view);
+    Kokkos::Max rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::Max rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::Max rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+  static void test_land() {
+    view_type view;
+
+    Kokkos::LAnd<scalar, memspace> rt(view);
+    Kokkos::LAnd rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::LAnd rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::LAnd rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+  static void test_lor() {
+    view_type view;
+
+    Kokkos::LOr<scalar, memspace> rt(view);
+    Kokkos::LOr rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::LOr rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::LOr rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+  static void test_band() {
+    view_type view;
+
+    Kokkos::BAnd<scalar, memspace> rt(view);
+    Kokkos::BAnd rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::BAnd rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::BAnd rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+  static void test_bor() {
+    view_type view;
+
+    Kokkos::BOr<scalar, memspace> rt(view);
+    Kokkos::BOr rd(view);
+    ASSERT_TRUE((std::is_same_v<decltype(rd), decltype(rt)>));
+
+    Kokkos::BOr rdc(rt);
+    ASSERT_TRUE((std::is_same_v<decltype(rdc), decltype(rt)>));
+
+    Kokkos::BOr rdm(std::move(rt));
+    ASSERT_TRUE((std::is_same_v<decltype(rdm), decltype(rt)>));
+  }
+  //TODO
+  static void test_minloc() {
+  }
+};
+
+TEST(TEST_CATEGORY, reducer_ctads) {
+  TestReducerCTADs<TEST_EXECSPACE>::test_sum();
+  TestReducerCTADs<TEST_EXECSPACE>::test_prod();
+  TestReducerCTADs<TEST_EXECSPACE>::test_min();
+  TestReducerCTADs<TEST_EXECSPACE>::test_max();
+  TestReducerCTADs<TEST_EXECSPACE>::test_land();
+  TestReducerCTADs<TEST_EXECSPACE>::test_lor();
+  TestReducerCTADs<TEST_EXECSPACE>::test_band();
+  TestReducerCTADs<TEST_EXECSPACE>::test_bor();
+  TestReducerCTADs<TEST_EXECSPACE>::test_minloc();
+}
+
+}  // namespace Test

--- a/core/unit_test/TestViewCtorCTADs.hpp
+++ b/core/unit_test/TestViewCtorCTADs.hpp
@@ -1,0 +1,167 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+
+struct TestViewCtorCTADs {
+  using DataType                     = double;
+  static constexpr DataType* m       = nullptr;
+  static constexpr const DataType* c = nullptr;
+
+  static void test_viewctorcopymove() {
+    Kokkos::View<DataType> vt;
+    Kokkos::View cd(vt);
+    ASSERT_TRUE((std::is_same_v<decltype(cd), decltype(vt)>));
+
+    Kokkos::View md(std::move(vt));
+    ASSERT_TRUE((std::is_same_v<decltype(md), decltype(vt)>));
+  }
+
+  static void test_viewctor0params() {
+    Kokkos::View<DataType> mt0(m);
+    Kokkos::View md0(m);
+    ASSERT_TRUE((std::is_same_v<decltype(md0), decltype(mt0)>));
+
+    Kokkos::View<const DataType> ct0(c);
+    Kokkos::View cd0(c);
+    ASSERT_TRUE((std::is_same_v<decltype(cd0), decltype(ct0)>));
+  }
+
+  static void test_viewctor1params() {
+    Kokkos::View<DataType*> mt1(m, 1);
+    Kokkos::View md1(m, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(md1), decltype(mt1)>));
+
+    Kokkos::View<const DataType*> ct1(c, 1);
+    Kokkos::View cd1(c, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(cd1), decltype(ct1)>));
+  }
+
+  static void test_viewctor2params() {
+    Kokkos::View<DataType**> mt2(m, 1, 1);
+    Kokkos::View md2(m, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(md2), decltype(mt2)>));
+
+    Kokkos::View<const DataType**> ct2(c, 1, 1);
+    Kokkos::View cd2(c, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(cd2), decltype(ct2)>));
+  }
+
+  static void test_viewctor3params() {
+    Kokkos::View<DataType***> mt3(m, 1, 1, 1);
+    Kokkos::View md3(m, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(md3), decltype(mt3)>));
+
+    Kokkos::View<const DataType***> ct3(c, 1, 1, 1);
+    Kokkos::View cd3(c, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(cd3), decltype(ct3)>));
+  }
+
+  static void test_viewctor4params() {
+    Kokkos::View<DataType****> mt4(m, 1, 1, 1, 1);
+    Kokkos::View md4(m, 1, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(md4), decltype(mt4)>));
+
+    Kokkos::View<const DataType****> ct4(c, 1, 1, 1, 1);
+    Kokkos::View cd4(c, 1, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(cd4), decltype(ct4)>));
+  }
+
+  static void test_viewctor5params() {
+    Kokkos::View<DataType*****> mt5(m, 1, 1, 1, 1, 1);
+    Kokkos::View md5(m, 1, 1, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(md5), decltype(mt5)>));
+
+    Kokkos::View<const DataType*****> ct5(c, 1, 1, 1, 1, 1);
+    Kokkos::View cd5(c, 1, 1, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(cd5), decltype(ct5)>));
+  }
+
+  static void test_viewctor6params() {
+    Kokkos::View<DataType******> mt6(m, 1, 1, 1, 1, 1, 1);
+    Kokkos::View md6(m, 1, 1, 1, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(md6), decltype(mt6)>));
+
+    Kokkos::View<const DataType******> ct6(c, 1, 1, 1, 1, 1, 1);
+    Kokkos::View cd6(c, 1, 1, 1, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(cd6), decltype(ct6)>));
+  }
+
+  static void test_viewctor7params() {
+    Kokkos::View<DataType*******> mt7(m, 1, 1, 1, 1, 1, 1, 1);
+    Kokkos::View md7(m, 1, 1, 1, 1, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(md7), decltype(mt7)>));
+
+    Kokkos::View<const DataType*******> ct7(c, 1, 1, 1, 1, 1, 1, 1);
+    Kokkos::View cd7(c, 1, 1, 1, 1, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(cd7), decltype(ct7)>));
+  }
+
+  static void test_viewctor8params() {
+    Kokkos::View<DataType********> mt8(m, 1, 1, 1, 1, 1, 1, 1, 1);
+    Kokkos::View md8(m, 1, 1, 1, 1, 1, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(md8), decltype(mt8)>));
+
+    Kokkos::View<const DataType********> ct8(c, 1, 1, 1, 1, 1, 1, 1, 1);
+    Kokkos::View cd8(c, 1, 1, 1, 1, 1, 1, 1, 1);
+    ASSERT_TRUE((std::is_same_v<decltype(cd8), decltype(ct8)>));
+  }
+};
+
+TEST(TEST_CATEGORY, view_ctor_ctads) {
+  TestViewCtorCTADs::test_viewctorcopymove();
+  TestViewCtorCTADs::test_viewctor0params();
+  TestViewCtorCTADs::test_viewctor1params();
+  TestViewCtorCTADs::test_viewctor2params();
+  TestViewCtorCTADs::test_viewctor3params();
+  TestViewCtorCTADs::test_viewctor4params();
+  TestViewCtorCTADs::test_viewctor5params();
+  TestViewCtorCTADs::test_viewctor6params();
+  TestViewCtorCTADs::test_viewctor7params();
+  TestViewCtorCTADs::test_viewctor8params();
+}
+
+}  // namespace Test


### PR DESCRIPTION
With @ldh4

Added deduction guides for:

```
RangePolicy
TeamPolicy
MDRangePolicy
View
standard reducers
```

This addresses issue #5257.