### PR TITLE
#5312: Revert #3580 and try a different workaround

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -759,9 +759,15 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     }
 
     // Reduce with final value at blockDim.y - 1 location.
-    // Doing code duplication here to fix issue #3428
-    // Suspect optimizer bug??
-    if (m_league_size == 0) {
+    bool zero_length        = m_league_size == 0;
+    bool do_final_reduction = true;
+    if (!zero_length)
+      do_final_reduction = cuda_single_inter_block_reduce_scan<false>(
+          final_reducer, blockIdx.x, gridDim.x,
+          kokkos_impl_cuda_shared_memory<size_type>(), m_scratch_space,
+          m_scratch_flags);
+
+    if (do_final_reduction) {
       // This is the final block with the final result at the final threads'
       // location
 
@@ -782,35 +788,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
       for (unsigned i = threadIdx.y; i < word_count.value; i += blockDim.y) {
         global[i] = shared[i];
-      }
-    }
-
-    if (m_league_size != 0) {
-      if (cuda_single_inter_block_reduce_scan<false>(
-              final_reducer, blockIdx.x, gridDim.x,
-              kokkos_impl_cuda_shared_memory<size_type>(), m_scratch_space,
-              m_scratch_flags)) {
-        // This is the final block with the final result at the final threads'
-        // location
-
-        size_type* const shared = kokkos_impl_cuda_shared_memory<size_type>() +
-                                  (blockDim.y - 1) * word_count.value;
-        size_type* const global =
-            m_result_ptr_device_accessible
-                ? reinterpret_cast<size_type*>(m_result_ptr)
-                : (m_unified_space ? m_unified_space : m_scratch_space);
-
-        if (threadIdx.y == 0) {
-          final_reducer.final(reinterpret_cast<value_type*>(shared));
-        }
-
-        if (CudaTraits::WarpSize < word_count.value) {
-          __syncthreads();
-        }
-
-        for (unsigned i = threadIdx.y; i < word_count.value; i += blockDim.y) {
-          global[i] = shared[i];
-        }
       }
     }
   }


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/3580 was an overwrought attempt at working around a bug in NVCC 9.x. On the hypothesis that the original compiler bug was related to re-use/re-assignment of the predicate variable do_final_reduction, I tried reverting the workaround and introducing separate variables for the initial and subsequent condition. It seems to have worked for both Clang 10 and NVCC 9.2 and 10.1

Fixes: https://github.com/kokkos/kokkos/issues/5312