### PR TITLE
Drop `reciprocal_overflow_threshold` from the numeric traits

### DIFF
--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -139,32 +139,6 @@ template <> struct denorm_min_helper<float> { static constexpr float value = __F
 template <> struct denorm_min_helper<double> { static constexpr double value = __DBL_DENORM_MIN__; };
 template <> struct denorm_min_helper<long double> { static constexpr long double value = __LDBL_DENORM_MIN__; };
 #endif
-// GCC <10.3 is not able to evaluate T(1) / finite_max_v<T> at compile time when passing -frounding-math
-// https://godbolt.org/z/zj9svb1T7
-// Similar issue was reported on IBM Power without the compiler option
-#define KOKKOS_IMPL_WORKAROUND_CONSTANT_EXPRESSION_COMPILER_BUG
-#ifndef KOKKOS_IMPL_WORKAROUND_CONSTANT_EXPRESSION_COMPILER_BUG
-// NOTE see ?lamch routine from LAPACK that determines machine parameters for floating-point arithmetic
-template <class T>
-constexpr T safe_minimum(T /*ignored*/) {
-  constexpr auto one  = static_cast<T>(1);
-  constexpr auto eps  = epsilon_helper<T>::value;
-  constexpr auto tiny = norm_min_helper<T>::value;
-  constexpr auto huge = finite_max_helper<T>::value;
-  constexpr auto small = one / huge;  // error: is not a constant expression
-  return small >= tiny ? small * (one + eps) : tiny;
-}
-template <class> struct reciprocal_overflow_threshold_helper {};
-template <> struct reciprocal_overflow_threshold_helper<float> { static constexpr float value = safe_minimum(0.f); };
-template <> struct reciprocal_overflow_threshold_helper<double> { static constexpr double value = safe_minimum(0.); };
-template <> struct reciprocal_overflow_threshold_helper<long double> { static constexpr long double value = safe_minimum(0.l); };
-#else
-template <class> struct reciprocal_overflow_threshold_helper {};
-template <> struct reciprocal_overflow_threshold_helper<float> { static constexpr float value = norm_min_helper<float>::value; };  // OK for IEEE-754 floating-point numbers
-template <> struct reciprocal_overflow_threshold_helper<double> { static constexpr double value = norm_min_helper<double>::value; };
-template <> struct reciprocal_overflow_threshold_helper<long double> { static constexpr long double value = norm_min_helper<long double>::value; };
-#endif
-#undef KOKKOS_IMPL_WORKAROUND_CONSTANT_EXPRESSION_COMPILER_BUG
 template <class> struct quiet_NaN_helper {};
 template <> struct quiet_NaN_helper<float> { static constexpr float value = __builtin_nanf(""); };
 template <> struct quiet_NaN_helper<double> { static constexpr double value = __builtin_nan(""); };
@@ -290,7 +264,6 @@ KOKKOS_IMPL_DEFINE_TRAIT(epsilon)
 KOKKOS_IMPL_DEFINE_TRAIT(round_error)
 KOKKOS_IMPL_DEFINE_TRAIT(norm_min)
 KOKKOS_IMPL_DEFINE_TRAIT(denorm_min)
-KOKKOS_IMPL_DEFINE_TRAIT(reciprocal_overflow_threshold)
 KOKKOS_IMPL_DEFINE_TRAIT(quiet_NaN)
 KOKKOS_IMPL_DEFINE_TRAIT(signaling_NaN)
 

--- a/core/src/impl/Kokkos_QuadPrecisionMath.hpp
+++ b/core/src/impl/Kokkos_QuadPrecisionMath.hpp
@@ -83,7 +83,6 @@ KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(epsilon,        __float128, __float128, FLT
 KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(round_error,    __float128, __float128, static_cast<__float128>(0.5))
 KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(norm_min,       __float128, __float128, FLT128_MIN)
 KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(denorm_min,     __float128, __float128, FLT128_DENORM_MIN)
-KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(reciprocal_overflow_threshold, __float128, __float128, FLT128_MIN)
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU >= 710)
 KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(quiet_NaN,      __float128, __float128, __builtin_nanq(""))
 KOKKOS_IMPL_SPECIALIZE_NUMERIC_TRAIT(signaling_NaN,  __float128, __float128, __builtin_nansq(""))

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -81,7 +81,6 @@ struct FiniteMax { template <class T> using trait = Kokkos::Experimental::finite
 struct RoundError { template <class T> using trait = Kokkos::Experimental::round_error<T>; };
 struct NormMin { template <class T> using trait = Kokkos::Experimental::norm_min<T>; };
 struct DenormMin { template <class T> using trait = Kokkos::Experimental::denorm_min<T>; };
-struct ReciprocalOverflowThreshold { template <class T> using trait = Kokkos::Experimental::reciprocal_overflow_threshold<T>; };
 struct Digits { template <class T> using trait = Kokkos::Experimental::digits<T>; };
 struct Digits10 { template <class T> using trait = Kokkos::Experimental::digits10<T>; };
 struct MaxDigits10 { template <class T> using trait = Kokkos::Experimental::max_digits10<T>; };
@@ -149,18 +148,6 @@ struct TestNumericTraits {
     auto const max = finite_max<T>::value;
     e += (int)!(min == extrema::min(T{}));
     e += (int)!(max == extrema::max(T{}));
-    use_on_device();
-  }
-
-  KOKKOS_FUNCTION void operator()(ReciprocalOverflowThreshold, int,
-                                  int& e) const {
-    using Kokkos::Experimental::reciprocal_overflow_threshold;
-    auto const inv = 1 / reciprocal_overflow_threshold<T>::value;
-    if (inv + inv == inv && inv != 0) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-          "inverse of reciprocal overflow threshold is inf\n");
-      ++e;
-    }
     use_on_device();
   }
 
@@ -283,16 +270,6 @@ TEST(TEST_CATEGORY, numeric_traits_denorm_min) {
   // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
   // TERMINATED by signal 11
   TestNumericTraits<TEST_EXECSPACE, long double, DenormMin>();
-#endif
-}
-
-TEST(TEST_CATEGORY, numeric_traits_reciprocal_overflow_threshold) {
-  TestNumericTraits<TEST_EXECSPACE, float, ReciprocalOverflowThreshold>();
-  TestNumericTraits<TEST_EXECSPACE, double, ReciprocalOverflowThreshold>();
-#ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC:
-  // nvc++-Fatal-/home/projects/x86-64/nvidia/hpc_sdk/Linux_x86_64/22.3/compilers/bin/tools/cpp2
-  // TERMINATED by signal 11
-  TestNumericTraits<TEST_EXECSPACE, long double, ReciprocalOverflowThreshold>();
 #endif
 }
 
@@ -537,8 +514,6 @@ CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, round_error);
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(float, denorm_min);
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, denorm_min);
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, denorm_min);
-// NOTE reciprocal_overflow_threshold purposefully omitted since it does not
-// exist in std::numeric_limits
 // clang-format off
 static_assert(Kokkos::Experimental::norm_min<float      >::value == std::numeric_limits<      float>::min(), "");
 static_assert(Kokkos::Experimental::norm_min<double     >::value == std::numeric_limits<     double>::min(), "");
@@ -703,8 +678,6 @@ CHECK_INSTANTIATED_ON_CV_QUALIFIED_TYPES_INTEGRAL(finite_max);
 CHECK_INSTANTIATED_ON_CV_QUALIFIED_TYPES_FLOATING_POINT(epsilon);
 CHECK_INSTANTIATED_ON_CV_QUALIFIED_TYPES_FLOATING_POINT(round_error);
 CHECK_INSTANTIATED_ON_CV_QUALIFIED_TYPES_FLOATING_POINT(norm_min);
-CHECK_INSTANTIATED_ON_CV_QUALIFIED_TYPES_FLOATING_POINT(
-    reciprocal_overflow_threshold);
 
 CHECK_INSTANTIATED_ON_CV_QUALIFIED_TYPES_FLOATING_POINT(digits);
 CHECK_INSTANTIATED_ON_CV_QUALIFIED_TYPES_INTEGRAL(digits);


### PR DESCRIPTION
LEWG voted its removal when reviewing P2551R0 on 2022/03/29

I propose simple removal (not going through deprecation).