### PR TITLE
#5333: CUDA: Use scratch space appropriate to small reduction elements in Team reductions

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -804,7 +804,8 @@ class ParallelReduce<CombinedFunctorReducerType,
       *result = value;
     } else if (Impl::cuda_inter_block_reduction(
                    value, init, m_functor_reducer.get_reducer(),
-                   m_scratch_space, result, m_scratch_flags, blockDim.y)) {
+                   reinterpret_cast<pointer_type>(m_scratch_space), result,
+                   m_scratch_flags, blockDim.y)) {
       const unsigned id = threadIdx.y * blockDim.x + threadIdx.x;
       if (id == 0) {
         m_functor_reducer.get_reducer().final(&value);

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -103,7 +103,7 @@ template <class FunctorType>
 __device__ bool cuda_inter_block_reduction(
     typename FunctorType::reference_type value,
     typename FunctorType::reference_type neutral, const FunctorType& reducer,
-    Cuda::size_type* const m_scratch_space,
+    void* const m_scratch_space,
     typename FunctorType::pointer_type const /*result*/,
     Cuda::size_type* const m_scratch_flags,
     const int max_active_thread = blockDim.y) {

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -103,7 +103,7 @@ template <class FunctorType>
 __device__ bool cuda_inter_block_reduction(
     typename FunctorType::reference_type value,
     typename FunctorType::reference_type neutral, const FunctorType& reducer,
-    void* const m_scratch_space,
+    typename FunctorType::pointer_type const m_scratch_space,
     typename FunctorType::pointer_type const /*result*/,
     Cuda::size_type* const m_scratch_flags,
     const int max_active_thread = blockDim.y) {
@@ -117,7 +117,7 @@ __device__ bool cuda_inter_block_reduction(
 
   // One thread in the block writes block result to global scratch_memory
   if (id == 0) {
-    pointer_type global = ((pointer_type)m_scratch_space) + blockIdx.x;
+    pointer_type global = m_scratch_space + blockIdx.x;
     *global             = value;
   }
 
@@ -140,7 +140,7 @@ __device__ bool cuda_inter_block_reduction(
       last_block = true;
       value      = neutral;
 
-      pointer_type const volatile global = (pointer_type)m_scratch_space;
+      pointer_type const volatile global = m_scratch_space;
 
       // Reduce all global values with splitting work over threads in one warp
       const int step_size =

--- a/core/src/HIP/Kokkos_HIP_Shuffle_Reduce.hpp
+++ b/core/src/HIP/Kokkos_HIP_Shuffle_Reduce.hpp
@@ -100,7 +100,7 @@ template <class FunctorType>
 __device__ inline bool hip_inter_block_shuffle_reduction(
     typename FunctorType::reference_type value,
     typename FunctorType::reference_type neutral, FunctorType const& reducer,
-    HIP::size_type* const m_scratch_space,
+    void* const m_scratch_space,
     typename FunctorType::pointer_type const /*result*/,
     HIP::size_type* const m_scratch_flags,
     int const max_active_thread = blockDim.y) {

--- a/core/src/HIP/Kokkos_HIP_Shuffle_Reduce.hpp
+++ b/core/src/HIP/Kokkos_HIP_Shuffle_Reduce.hpp
@@ -100,7 +100,7 @@ template <class FunctorType>
 __device__ inline bool hip_inter_block_shuffle_reduction(
     typename FunctorType::reference_type value,
     typename FunctorType::reference_type neutral, FunctorType const& reducer,
-    void* const m_scratch_space,
+    HIP::size_type* const m_scratch_space,
     typename FunctorType::pointer_type const /*result*/,
     HIP::size_type* const m_scratch_flags,
     int const max_active_thread = blockDim.y) {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -170,6 +170,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         const auto league_size       = m_league_size;
         const size_t scratch_size[2] = {m_scratch_size[0], m_scratch_size[1]};
         sycl::device_ptr<char> const global_scratch_ptr = m_global_scratch_ptr;
+        sycl::local_accessor<unsigned int> num_teams_done(1, cgh);
 
         auto team_reduction_factory =
             [&](sycl::local_accessor<value_type, 1> local_mem,
@@ -186,8 +187,6 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                 auto group_id = item.get_group_linear_id();
                 auto size     = n_wgroups * wgroup_size;
 
-                auto& num_teams_done = reinterpret_cast<unsigned int&>(
-                    local_mem[wgroup_size * std::max(value_count, 1u)]);
                 const auto local_id = item.get_local_linear_id();
                 const CombinedFunctorReducerType& functor_reducer =
                     functor_reducer_wrapper.get_functor();
@@ -225,10 +224,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                                      sycl::memory_scope::device,
                                      sycl::access::address_space::global_space>
                         scratch_flags_ref(*scratch_flags);
-                    num_teams_done = ++scratch_flags_ref;
+                    num_teams_done[0] = ++scratch_flags_ref;
                   }
                   sycl::group_barrier(item.get_group());
-                  if (num_teams_done == n_wgroups) {
+                  if (num_teams_done[0] == n_wgroups) {
                     if (local_id >= n_wgroups)
                       reducer.init(&local_mem[local_id * value_count]);
                     else {
@@ -277,10 +276,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                                      sycl::memory_scope::device,
                                      sycl::access::address_space::global_space>
                         scratch_flags_ref(*scratch_flags);
-                    num_teams_done = ++scratch_flags_ref;
+                    num_teams_done[0] = ++scratch_flags_ref;
                   }
                   item.barrier(sycl::access::fence_space::local_space);
-                  if (num_teams_done == n_wgroups) {
+                  if (num_teams_done[0] == n_wgroups) {
                     if (local_id >= n_wgroups)
                       reducer.init(&local_value);
                     else {
@@ -324,10 +323,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         auto wgroup_size = m_team_size * final_vector_size;
         std::size_t size = std::size_t(m_league_size) * wgroup_size;
         sycl::local_accessor<value_type, 1> local_mem(
-            sycl::range<1>(wgroup_size) * std::max(value_count, 1u) +
-                (sizeof(unsigned int) + sizeof(value_type) - 1) /
-                    sizeof(value_type),
-            cgh);
+            sycl::range<1>(wgroup_size) * std::max(value_count, 1u), cgh);
 
         const auto init_size =
             std::max<std::size_t>((size + wgroup_size - 1) / wgroup_size, 1);

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -140,9 +140,14 @@ class SYCLTeamMember {
     }
     value = sg.shuffle(value, 0);
 
+    const auto n_subgroups = sg.get_group_range()[0];
+    if (n_subgroups == 1) {
+      reducer.reference() = value;
+      return;
+    }
+
     // We need to chunk up the whole reduction because we might not have
     // allocated enough memory.
-    const auto n_subgroups = sg.get_group_range()[0];
     const unsigned int maximum_work_range =
         std::min<int>(m_team_reduce_size / sizeof(value_type), n_subgroups);
 

--- a/core/unit_test/TestNonTrivialScalarTypes.hpp
+++ b/core/unit_test/TestNonTrivialScalarTypes.hpp
@@ -214,7 +214,7 @@ struct point_t {
   uint8_t x, y, z;
 
   KOKKOS_FUNCTION
-  point_t() : x(1), y(1), z(1){};
+  point_t() : x(0), y(0), z(0){};
 
   KOKKOS_FUNCTION
   point_t(const point_t &val) : x(val.x), y(val.y), z(val.z){};

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -399,7 +399,7 @@ struct TestReducers {
         Kokkos::parallel_reduce(team_pol, tf, sum_view);
         Kokkos::deep_copy(sum_scalar, sum_view);
         std::cout << "Sum: " << sum_scalar << std::endl;
-        ASSERT_EQ(sum_scalar, 1024);
+        ASSERT_EQ(sum_scalar, Scalar{1024});
       }
 
 #if 0

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -350,12 +350,6 @@ struct TestReducers {
       return;  // FIXME_OPENACC
     }
 #endif
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-    if constexpr (std::is_same_v<ExecSpace,
-                                 Kokkos::Experimental::OpenMPTarget>) {
-      return;  // FIXME_OPENMPTARGET
-    }
-#endif
 #ifdef KOKKOS_ENABLE_SYCL
     if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::SYCL> &&
                   (std::is_same_v<Scalar, array_reduce<float, 7>> ||
@@ -375,13 +369,21 @@ struct TestReducers {
 
     constexpr int num_teams = get_num_teams();
     TeamSumFunctor tf;
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+    auto team_pol = Kokkos::TeamPolicy<ExecSpace>(num_teams, Kokkos::AUTO);
+#else
     auto team_pol = Kokkos::TeamPolicy<ExecSpace>(num_teams, 1);
+#endif
     Kokkos::parallel_reduce(team_pol, tf, sum_view);
     Kokkos::deep_copy(sum_scalar, sum_view);
     ASSERT_EQ(sum_scalar, Scalar{num_teams});
 
     Kokkos::parallel_for(
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+        Kokkos::TeamPolicy<ExecSpace>(1, Kokkos::AUTO),
+#else
         Kokkos::TeamPolicy<ExecSpace>(1, 1),
+#endif
         KOKKOS_LAMBDA(member_type team_member) {
           Scalar local_scalar;
           Kokkos::Sum<Scalar, typename ExecSpace::memory_space> reducer_scalar(

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -405,7 +405,7 @@ struct TestReducers {
         Kokkos::deep_copy(sum_scalar, sum_view);
         ASSERT_EQ(sum_scalar, Scalar{126});
       }
-      
+
       Kokkos::parallel_for(
           Kokkos::TeamPolicy<ExecSpace>(1, 1),
           KOKKOS_LAMBDA(member_type team_member) {

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -384,25 +384,20 @@ struct TestReducers {
     }
 
     {
-#if 0
       using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
-#endif
 
       Scalar sum_scalar;
       Kokkos::View<Scalar, ExecSpace> sum_view("result");
       Kokkos::deep_copy(sum_view, Scalar(1));
 
-      TeamSumFunctor tf;
-
-      if constexpr (sizeof(Scalar) > 1) {
-        auto team_pol = Kokkos::TeamPolicy<ExecSpace>(1024, 128);
-        Kokkos::parallel_reduce(team_pol, tf, sum_view);
-        Kokkos::deep_copy(sum_scalar, sum_view);
-        std::cout << "Sum: " << sum_scalar << std::endl;
-        ASSERT_EQ(sum_scalar, Scalar{1024});
-      }
-
-#if 0
+      // if constexpr (sizeof(Scalar) > 1) {
+      //   TeamSumFunctor tf;
+      //   auto team_pol = Kokkos::TeamPolicy<ExecSpace>(1024, 1);
+      //   Kokkos::parallel_reduce(team_pol, tf, sum_view);
+      //   Kokkos::deep_copy(sum_scalar, sum_view);
+      //   ASSERT_EQ(sum_scalar, Scalar{1024});
+      // }
+      
       Kokkos::parallel_for(
           Kokkos::TeamPolicy<ExecSpace>(1, 1),
           KOKKOS_LAMBDA(member_type team_member) {
@@ -416,6 +411,7 @@ struct TestReducers {
       Kokkos::deep_copy(sum_scalar, sum_view);
       ASSERT_EQ(sum_scalar, init) << "N: " << N;
 
+#if 0
       Kokkos::parallel_for(
           Kokkos::TeamPolicy<ExecSpace>(10, 128),
           KOKKOS_LAMBDA(member_type team_member) {
@@ -424,20 +420,6 @@ struct TestReducers {
                 reducer_scalar(local_scalar);
             Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team_member, N), f,
                                     reducer_scalar);
-            sum_view() = local_scalar;
-          });
-      Kokkos::deep_copy(sum_scalar, sum_view);
-      ASSERT_EQ(sum_scalar, reference_sum) << "N: " << N;
-
-      sum_scalar = init;
-      Kokkos::parallel_for(
-          Kokkos::TeamPolicy<ExecSpace>(1, 1),
-          KOKKOS_LAMBDA(member_type team_member) {
-            Scalar local_scalar;
-            Kokkos::Sum<Scalar, typename ExecSpace::memory_space>
-                reducer_scalar(local_scalar);
-            Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team_member, N),
-                                    f_tag, reducer_scalar);
             sum_view() = local_scalar;
           });
       Kokkos::deep_copy(sum_scalar, sum_view);

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -19,6 +19,7 @@
 #include <limits>
 
 #include <Kokkos_Core.hpp>
+#include <TestNonTrivialScalarTypes.hpp>
 
 //--------------------------------------------------------------------------
 
@@ -330,6 +331,34 @@ struct TestReducers {
   };
 
   static void test_sum_team_policy(int N, SumFunctor f, Scalar reference_sum) {
+#ifdef KOKKOS_ENABLE_SERIAL
+    if constexpr (std::is_same_v<ExecSpace, Kokkos::Serial> &&
+                  std::is_same_v<Scalar, Kokkos::Experimental::bhalf_t>) {
+      return;  // FIXME_SERIAL
+    }
+#endif
+#ifdef KOKKOS_ENABLE_OPENACC
+    if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::OpenACC> &&
+                  (std::is_same_v<Scalar, size_t> ||
+                   std::is_same_v<Scalar, double>)) {
+      return;  // FIXME_OPENACC
+    }
+#endif
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+    if constexpr (std::is_same_v<ExecSpace,
+                                 Kokkos::Experimental::OpenMPTarget>) {
+      return;  // FIXME_OPENMPTARGET
+    }
+#endif
+#ifdef KOKKOS_ENABLE_SYCL
+    if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::SYCL>) {
+      return;  // FIXME_SYCL
+    }
+#endif
+    if constexpr (std::is_same_v<Scalar, point_t>) {
+      return;  // FIXME_POINT_T
+    }
+
     using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
     Scalar sum_scalar;

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -357,7 +357,9 @@ struct TestReducers {
     }
 #endif
 #ifdef KOKKOS_ENABLE_SYCL
-    if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::SYCL>) {
+    if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::SYCL> &&
+                  (std::is_same_v<Scalar, array_reduce<float, 7>> ||
+                   std::is_same_v<Scalar, int8_t>)) {
       return;  // FIXME_SYCL
     }
 #endif

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -350,13 +350,6 @@ struct TestReducers {
       return;  // FIXME_OPENACC
     }
 #endif
-#ifdef KOKKOS_ENABLE_SYCL
-    if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::SYCL> &&
-                  (std::is_same_v<Scalar, array_reduce<float, 7>> ||
-                   std::is_same_v<Scalar, int8_t>)) {
-      return;  // FIXME_SYCL
-    }
-#endif
     if constexpr (std::is_same_v<Scalar, point_t>) {
       return;  // FIXME_POINT_T
     }

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -350,6 +350,12 @@ struct TestReducers {
       return;  // FIXME_OPENACC
     }
 #endif
+#ifdef KOKKOS_ENABLE_SYCL
+    if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::SYCL> &&
+                  std::is_same_v<Scalar, array_reduce<float, 7>>) {
+      return;  // FIXME_SYCL
+    }
+#endif
     if constexpr (std::is_same_v<Scalar, point_t>) {
       return;  // FIXME_POINT_T
     }

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -350,9 +350,6 @@ struct TestReducers {
       return;  // FIXME_OPENACC
     }
 #endif
-    if constexpr (std::is_same_v<Scalar, point_t>) {
-      return;  // FIXME_POINT_T
-    }
 
     using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
@@ -369,7 +366,7 @@ struct TestReducers {
 #endif
     Kokkos::parallel_reduce(team_pol, tf, sum_view);
     Kokkos::deep_copy(sum_scalar, sum_view);
-    ASSERT_EQ(sum_scalar, Scalar{num_teams});
+    ASSERT_EQ(sum_scalar, Scalar{num_teams}) << "num_teams: " << num_teams;
 
     Kokkos::parallel_for(
 #ifdef KOKKOS_ENABLE_OPENMPTARGET

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -350,12 +350,6 @@ struct TestReducers {
       return;  // FIXME_OPENACC
     }
 #endif
-#ifdef KOKKOS_ENABLE_SYCL
-    if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::SYCL> &&
-                  std::is_same_v<Scalar, array_reduce<float, 7>>) {
-      return;  // FIXME_SYCL
-    }
-#endif
     if constexpr (std::is_same_v<Scalar, point_t>) {
       return;  // FIXME_POINT_T
     }

--- a/core/unit_test/TestReducers_d.hpp
+++ b/core/unit_test/TestReducers_d.hpp
@@ -23,6 +23,7 @@ TEST(TEST_CATEGORY, reducers_complex_double) {
   TestReducers<Kokkos::complex<double>, TEST_EXECSPACE>::execute_basic();
 }
 
+#if 0
 TEST(TEST_CATEGORY, reducers_struct) {
   TestReducers<array_reduce<float, 1>, TEST_EXECSPACE>::test_sum(1031);
   TestReducers<array_reduce<float, 2>, TEST_EXECSPACE>::test_sum(1031);
@@ -36,6 +37,7 @@ TEST(TEST_CATEGORY, reducers_struct) {
   TestReducers<array_reduce<float, 7>, TEST_EXECSPACE>::test_sum(1031);
 #endif
 }
+#endif
 
 TEST(TEST_CATEGORY, reducers_half_t) {
   using ThisTestType = Kokkos::Experimental::half_t;
@@ -80,7 +82,21 @@ TEST(TEST_CATEGORY, reducers_int8_t) {
   TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(4);
 }
 
-#if !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_OPENMPTARGET)
+TEST(TEST_CATEGORY, reducers_int16_t) {
+  using ThisTestType = int16_t;
+
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(1);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(2);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(3);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_sum(4);
+
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(1);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(2);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(3);
+  TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(4);
+}
+
+#if 0 && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_OPENMPTARGET)
 // TODO - resolve: "Kokkos_HIP_Vectorization.hpp:80:15: error: call to
 //                 implicitly-deleted default constructor of 'conv_type'
 //                   conv_type tmp_in;"

--- a/core/unit_test/TestReducers_d.hpp
+++ b/core/unit_test/TestReducers_d.hpp
@@ -23,7 +23,6 @@ TEST(TEST_CATEGORY, reducers_complex_double) {
   TestReducers<Kokkos::complex<double>, TEST_EXECSPACE>::execute_basic();
 }
 
-#if 0
 TEST(TEST_CATEGORY, reducers_struct) {
   TestReducers<array_reduce<float, 1>, TEST_EXECSPACE>::test_sum(1031);
   TestReducers<array_reduce<float, 2>, TEST_EXECSPACE>::test_sum(1031);
@@ -37,7 +36,6 @@ TEST(TEST_CATEGORY, reducers_struct) {
   TestReducers<array_reduce<float, 7>, TEST_EXECSPACE>::test_sum(1031);
 #endif
 }
-#endif
 
 TEST(TEST_CATEGORY, reducers_half_t) {
   using ThisTestType = Kokkos::Experimental::half_t;

--- a/core/unit_test/TestReducers_d.hpp
+++ b/core/unit_test/TestReducers_d.hpp
@@ -94,7 +94,7 @@ TEST(TEST_CATEGORY, reducers_int16_t) {
   TestReducers<ThisTestType, TEST_EXECSPACE>::test_prod(4);
 }
 
-#if 0 && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_OPENMPTARGET)
+#if !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_OPENMPTARGET)
 // TODO - resolve: "Kokkos_HIP_Vectorization.hpp:80:15: error: call to
 //                 implicitly-deleted default constructor of 'conv_type'
 //                   conv_type tmp_in;"


### PR DESCRIPTION
Follow-on for #4156

Fixes #5333 