### PR TITLE
Add overloads of `hypot` math function that take 3 arguments

### DIFF
--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -295,7 +295,7 @@ using promote_3_t = typename promote_3<T, U, V>::type;
                                std::is_same_v<T3, long double>),            \
                           long double>                                      \
   FUNC(T1 x, T2 y, T3 z) {                                                  \
-    using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                     \
+    using Promoted = Kokkos::Impl::promote_3_t<T1, T2, T3>;                 \
     static_assert(std::is_same_v<Promoted, long double>);                   \
     using std::FUNC;                                                        \
     return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y),         \

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -399,7 +399,49 @@ KOKKOS_IMPL_MATH_BINARY_FUNCTION(pow)
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(sqrt)
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(cbrt)
 KOKKOS_IMPL_MATH_BINARY_FUNCTION(hypot)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL)
+KOKKOS_INLINE_FUNCTION float hypot(float x, float y, float z) {
+  return sqrt(x * x + y * y + z * z);
+}
+KOKKOS_INLINE_FUNCTION double hypot(double x, double y, double z) {
+  return sqrt(x * x + y * y + z * z);
+}
+inline long double hypot(long double x, long double y, long double z) {
+  return sqrt(x * x + y * y + z * z);
+}
+KOKKOS_INLINE_FUNCTION float hypotf(float x, float y, float z) {
+  return sqrt(x * x + y * y + z * z);
+}
+inline long double hypotl(long double x, long double y, long double z) {
+  return sqrt(x * x + y * y + z * z);
+}
+template <
+    class T1, class T2, class T3,
+    class Promoted = std::enable_if_t<
+        std::is_arithmetic_v<T1> && std::is_arithmetic_v<T2> &&
+            std::is_arithmetic_v<T3> && !std::is_same_v<T1, long double> &&
+            !std::is_same_v<T2, long double> &&
+            !std::is_same_v<T3, long double>,
+        Impl::promote_3_t<T1, T2, T3>>>
+KOKKOS_INLINE_FUNCTION Promoted hypot(T1 x, T2 y, T3 z) {
+  return hypot(static_cast<Promoted>(x), static_cast<Promoted>(y),
+               static_cast<Promoted>(z));
+}
+template <
+    class T1, class T2, class T3,
+    class = std::enable_if_t<
+        std::is_arithmetic_v<T1> && std::is_arithmetic_v<T2> &&
+        std::is_arithmetic_v<T3> &&
+        (std::is_same_v<T1, long double> || std::is_same_v<T2, long double> ||
+         std::is_same_v<T3, long double>)>>
+inline long double hypot(T1 x, T2 y, T3 z) {
+  return hypot(static_cast<long double>(x), static_cast<long double>(y),
+               static_cast<long double>(z));
+}
+#else
 KOKKOS_IMPL_MATH_TERNARY_FUNCTION(hypot)
+#endif
 // Trigonometric functions
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(sin)
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(cos)

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -61,7 +61,7 @@
 namespace Kokkos {
 
 namespace Impl {
-template <class T, bool = std::is_integral<T>::value>
+template <class T, bool = std::is_integral_v<T>>
 struct promote {
   using type = double;
 };
@@ -82,7 +82,7 @@ struct promote<float> {
 template <class T>
 using promote_t = typename promote<T>::type;
 template <class T, class U,
-          bool = std::is_arithmetic<T>::value&& std::is_arithmetic<U>::value>
+          bool = std::is_arithmetic_v<T>&& std::is_arithmetic_v<U>>
 struct promote_2 {
   using type = decltype(promote_t<T>() + promote_t<U>());
 };
@@ -90,6 +90,16 @@ template <class T, class U>
 struct promote_2<T, U, false> {};
 template <class T, class U>
 using promote_2_t = typename promote_2<T, U>::type;
+template <class T, class U, class V,
+          bool = std::is_arithmetic_v<T>&& std::is_arithmetic_v<U>&&
+              std::is_arithmetic_v<V>>
+struct promote_3 {
+  using type = decltype(promote_t<T>() + promote_t<U>() + promote_t<V>());
+};
+template <class T, class U, class V>
+struct promote_3<T, U, V, false> {};
+template <class T, class U, class V>
+using promote_3_t = typename promote_3<T, U, V>::type;
 }  // namespace Impl
 
 // NOTE long double overloads are not available on the device
@@ -115,132 +125,183 @@ using promote_2_t = typename promote_2<T, U>::type;
   /* nothing */
 #endif
 
-#define KOKKOS_IMPL_MATH_UNARY_FUNCTION(FUNC)                                 \
-  KOKKOS_INLINE_FUNCTION float FUNC(float x) {                                \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                         \
-    return FUNC(x);                                                           \
-  }                                                                           \
-  KOKKOS_INLINE_FUNCTION double FUNC(double x) {                              \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                         \
-    return FUNC(x);                                                           \
-  }                                                                           \
-  inline long double FUNC(long double x) {                                    \
-    using std::FUNC;                                                          \
-    return FUNC(x);                                                           \
-  }                                                                           \
-  KOKKOS_INLINE_FUNCTION float FUNC##f(float x) {                             \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                         \
-    return FUNC(x);                                                           \
-  }                                                                           \
-  inline long double FUNC##l(long double x) {                                 \
-    using std::FUNC;                                                          \
-    return FUNC(x);                                                           \
-  }                                                                           \
-  template <class T>                                                          \
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral<T>::value, double> \
-  FUNC(T x) {                                                                 \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                         \
-    return FUNC(static_cast<double>(x));                                      \
-  }                                                                           \
-  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(              \
-      namespace Experimental {                                                \
-        using ::Kokkos::FUNC;                                                 \
-        using ::Kokkos::FUNC##f;                                              \
-        using ::Kokkos::FUNC##l;                                              \
+#define KOKKOS_IMPL_MATH_UNARY_FUNCTION(FUNC)                                  \
+  KOKKOS_INLINE_FUNCTION float FUNC(float x) {                                 \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    return FUNC(x);                                                            \
+  }                                                                            \
+  KOKKOS_INLINE_FUNCTION double FUNC(double x) {                               \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    return FUNC(x);                                                            \
+  }                                                                            \
+  inline long double FUNC(long double x) {                                     \
+    using std::FUNC;                                                           \
+    return FUNC(x);                                                            \
+  }                                                                            \
+  KOKKOS_INLINE_FUNCTION float FUNC##f(float x) {                              \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    return FUNC(x);                                                            \
+  }                                                                            \
+  inline long double FUNC##l(long double x) {                                  \
+    using std::FUNC;                                                           \
+    return FUNC(x);                                                            \
+  }                                                                            \
+  template <class T>                                                           \
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, double> FUNC( \
+      T x) {                                                                   \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    return FUNC(static_cast<double>(x));                                       \
+  }                                                                            \
+  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(               \
+      namespace Experimental {                                                 \
+        using ::Kokkos::FUNC;                                                  \
+        using ::Kokkos::FUNC##f;                                               \
+        using ::Kokkos::FUNC##l;                                               \
       })
 
 // isinf, isnan, and isinfinite do not work on Windows with CUDA with std::
 // getting warnings about calling host function in device function then
 // runtime test fails
 #if defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA)
-#define KOKKOS_IMPL_MATH_UNARY_PREDICATE(FUNC)                              \
-  KOKKOS_INLINE_FUNCTION bool FUNC(float x) { return ::FUNC(x); }           \
-  KOKKOS_INLINE_FUNCTION bool FUNC(double x) { return ::FUNC(x); }          \
-  inline bool FUNC(long double x) {                                         \
-    using std::FUNC;                                                        \
-    return FUNC(x);                                                         \
-  }                                                                         \
-  template <class T>                                                        \
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral<T>::value, bool> \
-  FUNC(T x) {                                                               \
-    return ::FUNC(static_cast<double>(x));                                  \
-  }                                                                         \
-  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(            \
+#define KOKKOS_IMPL_MATH_UNARY_PREDICATE(FUNC)                               \
+  KOKKOS_INLINE_FUNCTION bool FUNC(float x) { return ::FUNC(x); }            \
+  KOKKOS_INLINE_FUNCTION bool FUNC(double x) { return ::FUNC(x); }           \
+  inline bool FUNC(long double x) {                                          \
+    using std::FUNC;                                                         \
+    return FUNC(x);                                                          \
+  }                                                                          \
+  template <class T>                                                         \
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, bool> FUNC( \
+      T x) {                                                                 \
+    return ::FUNC(static_cast<double>(x));                                   \
+  }                                                                          \
+  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(             \
       namespace Experimental { using ::Kokkos::FUNC; })
 #else
-#define KOKKOS_IMPL_MATH_UNARY_PREDICATE(FUNC)                              \
-  KOKKOS_INLINE_FUNCTION bool FUNC(float x) {                               \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                       \
-    return FUNC(x);                                                         \
-  }                                                                         \
-  KOKKOS_INLINE_FUNCTION bool FUNC(double x) {                              \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                       \
-    return FUNC(x);                                                         \
-  }                                                                         \
-  inline bool FUNC(long double x) {                                         \
-    using std::FUNC;                                                        \
-    return FUNC(x);                                                         \
-  }                                                                         \
-  template <class T>                                                        \
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral<T>::value, bool> \
-  FUNC(T x) {                                                               \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                       \
-    return FUNC(static_cast<double>(x));                                    \
-  }                                                                         \
-  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(            \
+#define KOKKOS_IMPL_MATH_UNARY_PREDICATE(FUNC)                               \
+  KOKKOS_INLINE_FUNCTION bool FUNC(float x) {                                \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                        \
+    return FUNC(x);                                                          \
+  }                                                                          \
+  KOKKOS_INLINE_FUNCTION bool FUNC(double x) {                               \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                        \
+    return FUNC(x);                                                          \
+  }                                                                          \
+  inline bool FUNC(long double x) {                                          \
+    using std::FUNC;                                                         \
+    return FUNC(x);                                                          \
+  }                                                                          \
+  template <class T>                                                         \
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, bool> FUNC( \
+      T x) {                                                                 \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                        \
+    return FUNC(static_cast<double>(x));                                     \
+  }                                                                          \
+  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(             \
       namespace Experimental { using ::Kokkos::FUNC; })
 #endif
 
-#define KOKKOS_IMPL_MATH_BINARY_FUNCTION(FUNC)                          \
-  KOKKOS_INLINE_FUNCTION float FUNC(float x, float y) {                 \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                   \
-    return FUNC(x, y);                                                  \
-  }                                                                     \
-  KOKKOS_INLINE_FUNCTION double FUNC(double x, double y) {              \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                   \
-    return FUNC(x, y);                                                  \
-  }                                                                     \
-  inline long double FUNC(long double x, long double y) {               \
-    using std::FUNC;                                                    \
-    return FUNC(x, y);                                                  \
-  }                                                                     \
-  KOKKOS_INLINE_FUNCTION float FUNC##f(float x, float y) {              \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                   \
-    return FUNC(x, y);                                                  \
-  }                                                                     \
-  inline long double FUNC##l(long double x, long double y) {            \
-    using std::FUNC;                                                    \
-    return FUNC(x, y);                                                  \
-  }                                                                     \
-  template <class T1, class T2>                                         \
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<                              \
-      std::is_arithmetic<T1>::value && std::is_arithmetic<T2>::value && \
-          !std::is_same<T1, long double>::value &&                      \
-          !std::is_same<T2, long double>::value,                        \
-      Kokkos::Impl::promote_2_t<T1, T2>>                                \
-  FUNC(T1 x, T2 y) {                                                    \
-    using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                 \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                   \
-    return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));    \
-  }                                                                     \
-  template <class T1, class T2>                                         \
-  inline std::enable_if_t<std::is_arithmetic<T1>::value &&              \
-                              std::is_arithmetic<T2>::value &&          \
-                              (std::is_same<T1, long double>::value ||  \
-                               std::is_same<T2, long double>::value),   \
-                          long double>                                  \
-  FUNC(T1 x, T2 y) {                                                    \
-    using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                 \
-    static_assert(std::is_same<Promoted, long double>::value, "");      \
-    using std::FUNC;                                                    \
-    return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));    \
-  }                                                                     \
-  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(        \
-      namespace Experimental {                                          \
-        using ::Kokkos::FUNC;                                           \
-        using ::Kokkos::FUNC##f;                                        \
-        using ::Kokkos::FUNC##l;                                        \
+#define KOKKOS_IMPL_MATH_BINARY_FUNCTION(FUNC)                                 \
+  KOKKOS_INLINE_FUNCTION float FUNC(float x, float y) {                        \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    return FUNC(x, y);                                                         \
+  }                                                                            \
+  KOKKOS_INLINE_FUNCTION double FUNC(double x, double y) {                     \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    return FUNC(x, y);                                                         \
+  }                                                                            \
+  inline long double FUNC(long double x, long double y) {                      \
+    using std::FUNC;                                                           \
+    return FUNC(x, y);                                                         \
+  }                                                                            \
+  KOKKOS_INLINE_FUNCTION float FUNC##f(float x, float y) {                     \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    return FUNC(x, y);                                                         \
+  }                                                                            \
+  inline long double FUNC##l(long double x, long double y) {                   \
+    using std::FUNC;                                                           \
+    return FUNC(x, y);                                                         \
+  }                                                                            \
+  template <class T1, class T2>                                                \
+  KOKKOS_INLINE_FUNCTION                                                       \
+      std::enable_if_t<std::is_arithmetic_v<T1> && std::is_arithmetic_v<T2> && \
+                           !std::is_same_v<T1, long double> &&                 \
+                           !std::is_same_v<T2, long double>,                   \
+                       Kokkos::Impl::promote_2_t<T1, T2>>                      \
+      FUNC(T1 x, T2 y) {                                                       \
+    using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                        \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));           \
+  }                                                                            \
+  template <class T1, class T2>                                                \
+  inline std::enable_if_t<std::is_arithmetic_v<T1> &&                          \
+                              std::is_arithmetic_v<T2> &&                      \
+                              (std::is_same_v<T1, long double> ||              \
+                               std::is_same_v<T2, long double>),               \
+                          long double>                                         \
+  FUNC(T1 x, T2 y) {                                                           \
+    using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                        \
+    static_assert(std::is_same_v<Promoted, long double>, "");                  \
+    using std::FUNC;                                                           \
+    return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));           \
+  }                                                                            \
+  KOKKOS_IMPL_MATH_FUNCTIONS_DEFINED_IF_DEPRECATED_CODE_ENABLED(               \
+      namespace Experimental {                                                 \
+        using ::Kokkos::FUNC;                                                  \
+        using ::Kokkos::FUNC##f;                                               \
+        using ::Kokkos::FUNC##l;                                               \
       })
+
+#define KOKKOS_IMPL_MATH_TERNARY_FUNCTION(FUNC)                             \
+  KOKKOS_INLINE_FUNCTION float FUNC(float x, float y, float z) {            \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                       \
+    return FUNC(x, y, z);                                                   \
+  }                                                                         \
+  KOKKOS_INLINE_FUNCTION double FUNC(double x, double y, double z) {        \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                       \
+    return FUNC(x, y, z);                                                   \
+  }                                                                         \
+  inline long double FUNC(long double x, long double y, long double z) {    \
+    using std::FUNC;                                                        \
+    return FUNC(x, y, z);                                                   \
+  }                                                                         \
+  KOKKOS_INLINE_FUNCTION float FUNC##f(float x, float y, float z) {         \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                       \
+    return FUNC(x, y, z);                                                   \
+  }                                                                         \
+  inline long double FUNC##l(long double x, long double y, long double z) { \
+    using std::FUNC;                                                        \
+    return FUNC(x, y, z);                                                   \
+  }                                                                         \
+  template <class T1, class T2, class T3>                                   \
+  KOKKOS_INLINE_FUNCTION std::enable_if_t<                                  \
+      std::is_arithmetic_v<T1> && std::is_arithmetic_v<T2> &&               \
+          std::is_arithmetic_v<T3> && !std::is_same_v<T1, long double> &&   \
+          !std::is_same_v<T2, long double> &&                               \
+          !std::is_same_v<T3, long double>,                                 \
+      Kokkos::Impl::promote_3_t<T1, T2, T3>>                                \
+  FUNC(T1 x, T2 y, T3 z) {                                                  \
+    using Promoted = Kokkos::Impl::promote_3_t<T1, T2, T3>;                 \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                       \
+    return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y),         \
+                static_cast<Promoted>(z));                                  \
+  }                                                                         \
+  template <class T1, class T2, class T3>                                   \
+  inline std::enable_if_t<std::is_arithmetic_v<T1> &&                       \
+                              std::is_arithmetic_v<T2> &&                   \
+                              std::is_arithmetic_v<T3> &&                   \
+                              (std::is_same_v<T1, long double> ||           \
+                               std::is_same_v<T2, long double> ||           \
+                               std::is_same_v<T3, long double>),            \
+                          long double>                                      \
+  FUNC(T1 x, T2 y, T3 z) {                                                  \
+    using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                     \
+    static_assert(std::is_same_v<Promoted, long double>);                   \
+    using std::FUNC;                                                        \
+    return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y),         \
+                static_cast<Promoted>(z));                                  \
+  }
+
 // Basic operations
 KOKKOS_INLINE_FUNCTION int abs(int n) {
   using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::abs;
@@ -338,6 +399,7 @@ KOKKOS_IMPL_MATH_BINARY_FUNCTION(pow)
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(sqrt)
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(cbrt)
 KOKKOS_IMPL_MATH_BINARY_FUNCTION(hypot)
+KOKKOS_IMPL_MATH_TERNARY_FUNCTION(hypot)
 // Trigonometric functions
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(sin)
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(cos)
@@ -402,6 +464,7 @@ KOKKOS_IMPL_MATH_UNARY_PREDICATE(signbit)
 #undef KOKKOS_IMPL_MATH_UNARY_FUNCTION
 #undef KOKKOS_IMPL_MATH_UNARY_PREDICATE
 #undef KOKKOS_IMPL_MATH_BINARY_FUNCTION
+#undef KOKKOS_IMPL_MATH_TERNARY_FUNCTION
 
 }  // namespace Kokkos
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -224,6 +224,9 @@ template <> struct math_binary_function_return_type<unsigned long long,        l
 template <class T, class U>
 using math_binary_function_return_type_t = typename math_binary_function_return_type<T, U>::type;
 // clang-format on
+template <class T, class U, class V>
+using math_ternary_function_return_type_t = math_binary_function_return_type_t<
+    T, math_binary_function_return_type_t<U, V>>;
 
 struct FloatingPointComparison {
  private:
@@ -292,29 +295,29 @@ struct FloatingPointComparison {
 template <class>
 struct math_function_name;
 
-#define DEFINE_UNARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                           \
-  struct MathUnaryFunction_##FUNC {                                            \
-    template <typename T>                                                      \
-    static KOKKOS_FUNCTION auto eval(T x) {                                    \
-      static_assert(std::is_same<decltype(Kokkos::FUNC((T)0)),                 \
-                                 math_unary_function_return_type_t<T>>::value, \
-                    "");                                                       \
-      return Kokkos::FUNC(x);                                                  \
-    }                                                                          \
-    template <typename T>                                                      \
-    static auto eval_std(T x) {                                                \
-      static_assert(std::is_same<decltype(std::FUNC((T)0)),                    \
-                                 math_unary_function_return_type_t<T>>::value, \
-                    "");                                                       \
-      return std::FUNC(x);                                                     \
-    }                                                                          \
-    static KOKKOS_FUNCTION double ulp_factor() { return ULP_FACTOR; }          \
-  };                                                                           \
-  using kk_##FUNC = MathUnaryFunction_##FUNC;                                  \
-  template <>                                                                  \
-  struct math_function_name<MathUnaryFunction_##FUNC> {                        \
-    static constexpr char name[] = #FUNC;                                      \
-  };                                                                           \
+#define DEFINE_UNARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                  \
+  struct MathUnaryFunction_##FUNC {                                   \
+    template <typename T>                                             \
+    static KOKKOS_FUNCTION auto eval(T x) {                           \
+      static_assert(                                                  \
+          std::is_same<decltype(Kokkos::FUNC((T)0)),                  \
+                       math_unary_function_return_type_t<T>>::value); \
+      return Kokkos::FUNC(x);                                         \
+    }                                                                 \
+    template <typename T>                                             \
+    static auto eval_std(T x) {                                       \
+      static_assert(                                                  \
+          std::is_same<decltype(std::FUNC((T)0)),                     \
+                       math_unary_function_return_type_t<T>>::value); \
+      return std::FUNC(x);                                            \
+    }                                                                 \
+    static KOKKOS_FUNCTION double ulp_factor() { return ULP_FACTOR; } \
+  };                                                                  \
+  using kk_##FUNC = MathUnaryFunction_##FUNC;                         \
+  template <>                                                         \
+  struct math_function_name<MathUnaryFunction_##FUNC> {               \
+    static constexpr char name[] = #FUNC;                             \
+  };                                                                  \
   constexpr char math_function_name<MathUnaryFunction_##FUNC>::name[]
 
 #ifndef KOKKOS_MATHEMATICAL_FUNCTIONS_SKIP_1
@@ -380,31 +383,29 @@ DEFINE_UNARY_FUNCTION_EVAL(logb, 2);
 
 #undef DEFINE_UNARY_FUNCTION_EVAL
 
-#define DEFINE_BINARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                    \
-  struct MathBinaryFunction_##FUNC {                                     \
-    template <typename T, typename U>                                    \
-    static KOKKOS_FUNCTION auto eval(T x, U y) {                         \
-      static_assert(                                                     \
-          std::is_same<decltype(Kokkos::FUNC((T)0, (U)0)),               \
-                       math_binary_function_return_type_t<T, U>>::value, \
-          "");                                                           \
-      return Kokkos::FUNC(x, y);                                         \
-    }                                                                    \
-    template <typename T, typename U>                                    \
-    static auto eval_std(T x, U y) {                                     \
-      static_assert(                                                     \
-          std::is_same<decltype(std::FUNC((T)0, (U)0)),                  \
-                       math_binary_function_return_type_t<T, U>>::value, \
-          "");                                                           \
-      return std::FUNC(x, y);                                            \
-    }                                                                    \
-    static KOKKOS_FUNCTION double ulp_factor() { return ULP_FACTOR; }    \
-  };                                                                     \
-  using kk_##FUNC = MathBinaryFunction_##FUNC;                           \
-  template <>                                                            \
-  struct math_function_name<MathBinaryFunction_##FUNC> {                 \
-    static constexpr char name[] = #FUNC;                                \
-  };                                                                     \
+#define DEFINE_BINARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                     \
+  struct MathBinaryFunction_##FUNC {                                      \
+    template <typename T, typename U>                                     \
+    static KOKKOS_FUNCTION auto eval(T x, U y) {                          \
+      static_assert(                                                      \
+          std::is_same<decltype(Kokkos::FUNC((T)0, (U)0)),                \
+                       math_binary_function_return_type_t<T, U>>::value); \
+      return Kokkos::FUNC(x, y);                                          \
+    }                                                                     \
+    template <typename T, typename U>                                     \
+    static auto eval_std(T x, U y) {                                      \
+      static_assert(                                                      \
+          std::is_same<decltype(std::FUNC((T)0, (U)0)),                   \
+                       math_binary_function_return_type_t<T, U>>::value); \
+      return std::FUNC(x, y);                                             \
+    }                                                                     \
+    static KOKKOS_FUNCTION double ulp_factor() { return ULP_FACTOR; }     \
+  };                                                                      \
+  using kk_##FUNC = MathBinaryFunction_##FUNC;                            \
+  template <>                                                             \
+  struct math_function_name<MathBinaryFunction_##FUNC> {                  \
+    static constexpr char name[] = #FUNC;                                 \
+  };                                                                      \
   constexpr char math_function_name<MathBinaryFunction_##FUNC>::name[]
 
 #ifndef KOKKOS_MATHEMATICAL_FUNCTIONS_SKIP_1
@@ -417,6 +418,37 @@ DEFINE_BINARY_FUNCTION_EVAL(copysign, 1);
 #endif
 
 #undef DEFINE_BINARY_FUNCTION_EVAL
+
+#define DEFINE_TERNARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                        \
+  struct MathTernaryFunction_##FUNC {                                         \
+    template <typename T, typename U, typename V>                             \
+    static KOKKOS_FUNCTION auto eval(T x, U y, V z) {                         \
+      static_assert(                                                          \
+          std::is_same<decltype(Kokkos::FUNC((T)0, (U)0), (V)0),              \
+                       math_ternary_function_return_type_t<T, U, V>>::value); \
+      return Kokkos::FUNC(x, y, z);                                           \
+    }                                                                         \
+    template <typename T, typename U, typename V>                             \
+    static auto eval_std(T x, U y, V z) {                                     \
+      static_assert(                                                          \
+          std::is_same<decltype(std::FUNC((T)0, (U)0, (V)0)),                 \
+                       math_ternary_function_return_type_t<T, U, V>>::value); \
+      return std::FUNC(x, y, z);                                              \
+    }                                                                         \
+    static KOKKOS_FUNCTION double ulp_factor() { return ULP_FACTOR; }         \
+  };                                                                          \
+  using kk3_##FUNC = MathTernaryFunction_##FUNC;                              \
+  template <>                                                                 \
+  struct math_function_name<MathTernaryFunction_##FUNC> {                     \
+    static constexpr char name[] = #FUNC;                                     \
+  };                                                                          \
+  constexpr char math_function_name<MathTernaryFunction_##FUNC>::name[]
+
+#ifndef KOKKOS_MATHEMATICAL_FUNCTIONS_SKIP_1
+DEFINE_TERNARY_FUNCTION_EVAL(hypot, 2);
+#endif
+
+#undef DEFINE_TERNARY_FUNCTION_EVAL
 
 // clang-format off
 template <class>
@@ -507,6 +539,49 @@ template <class Space, class... Func, class Arg1, class Arg2>
 void do_test_math_binary_function(Arg1 arg1, Arg2 arg2) {
   (void)std::initializer_list<int>{
       (TestMathBinaryFunction<Space, Func, Arg1, Arg2>(arg1, arg2), 0)...};
+}
+
+template <class Space, class Func, class Arg1, class Arg2, class Arg3,
+          class Ret = math_ternary_function_return_type_t<Arg1, Arg2, Arg3>>
+struct TestMathTernaryFunction : FloatingPointComparison {
+  Arg1 val1_;
+  Arg2 val2_;
+  Arg3 val3_;
+  Ret res_;
+  TestMathTernaryFunction(Arg1 val1, Arg2 val2, Arg3 val3)
+      : val1_(val1),
+        val2_(val2),
+        val3_(val3),
+        res_(Func::eval_std(val1, val2, val3)) {
+    run();
+  }
+  void run() {
+    int errors = 0;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    ASSERT_EQ(errors, 0) << "Failed check no error for "
+                         << math_function_name<Func>::name << "("
+                         << type_helper<Arg1>::name() << ", "
+                         << type_helper<Arg1>::name() << ", "
+                         << type_helper<Arg3>::name() << ")";
+  }
+  KOKKOS_FUNCTION void operator()(int, int& e) const {
+    bool ar =
+        compare(Func::eval(val1_, val2_, val3_), res_, Func::ulp_factor());
+    if (!ar) {
+      ++e;
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "value at %f, %f, %f which is %f was expected to be %f\n",
+          (double)val1_, (double)val2_, (double)val3_,
+          (double)Func::eval(val1_, val2_, val3_), (double)res_);
+    }
+  }
+};
+
+template <class Space, class... Func, class Arg1, class Arg2, class Arg3>
+void do_test_math_ternary_function(Arg1 arg1, Arg2 arg2, Arg3 arg3) {
+  (void)std::initializer_list<int>{
+      (TestMathTernaryFunction<Space, Func, Arg1, Arg2, Arg3>(arg1, arg2, arg3),
+       0)...};
 }
 
 #ifndef KOKKOS_MATHEMATICAL_FUNCTIONS_SKIP_1
@@ -632,6 +707,11 @@ TEST(TEST_CATEGORY, mathematical_functions_power_functions) {
   do_test_math_binary_function<TEST_EXECSPACE, kk_hypot>(2.l, 3.l);
 #endif
 #endif
+
+  do_test_math_ternary_function<TEST_EXECSPACE, kk3_hypot>(2.f, 3.f, 4.f);
+  do_test_math_ternary_function<TEST_EXECSPACE, kk3_hypot>(2., 3., 4.);
+  do_test_math_ternary_function<TEST_EXECSPACE, kk3_hypot>(2, 3.f, 4.);
+  do_test_math_ternary_function<TEST_EXECSPACE, kk3_hypot>(2.l, 3.l, 4.l);
 }
 
 TEST(TEST_CATEGORY, mathematical_functions_exponential_functions) {

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -711,7 +711,9 @@ TEST(TEST_CATEGORY, mathematical_functions_power_functions) {
   do_test_math_ternary_function<TEST_EXECSPACE, kk3_hypot>(2.f, 3.f, 4.f);
   do_test_math_ternary_function<TEST_EXECSPACE, kk3_hypot>(2., 3., 4.);
   do_test_math_ternary_function<TEST_EXECSPACE, kk3_hypot>(2, 3.f, 4.);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
   do_test_math_ternary_function<TEST_EXECSPACE, kk3_hypot>(2.l, 3.l, 4.l);
+#endif
 }
 
 TEST(TEST_CATEGORY, mathematical_functions_exponential_functions) {


### PR DESCRIPTION
Requested on Slack
See #4767

Drive by changes more C++17