### PR TITLE
Fix UnorderedMapRehash::operator()

### DIFF
--- a/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
+++ b/containers/src/impl/Kokkos_UnorderedMap_impl.hpp
@@ -78,7 +78,11 @@ struct UnorderedMapRehash {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(size_type i) const {
-    if (m_src.valid_at(i)) m_dst.insert(m_src.key_at(i), m_src.value_at(i));
+    if constexpr (std::is_void_v<typename map_type::value_type>) {
+      if (m_src.valid_at(i)) m_dst.insert(m_src.key_at(i));
+    } else {
+      if (m_src.valid_at(i)) m_dst.insert(m_src.key_at(i), m_src.value_at(i));
+    }
   }
 };
 

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -334,6 +334,9 @@ TEST(TEST_CATEGORY, UnorderedMap_clear_zero_size) {
   m.insert(5);
   m.insert(7);
   ASSERT_EQ(4u, m.size());
+  m.rehash(0);
+  ASSERT_EQ(128u, m.capacity());
+  ASSERT_EQ(4u, m.size());
 
   m.clear();
   ASSERT_EQ(0u, m.size());


### PR DESCRIPTION
https://kokkos.github.io/kokkos-core-wiki/API/containers/Unordered-Map.html?highlight=unorderedmap
> An UnorderedMap behaves like an unordered set if the template parameter Value is void.

In particular, https://github.com/kokkos/kokkos/pull/5297 removed the deprecated `value_at` if the value type is `void`. https://github.com/kokkos/kokkos/pull/4639 should have touched this code as well (but we apparently don't have a test using it).