### PR TITLE
Fix null deref in SharedAllocationRecord::print_records

### DIFF
--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -338,28 +338,24 @@ void SharedAllocationRecord<void, void>::print_host_accessible_records(
                reinterpret_cast<uintptr_t>(r->m_next),
                reinterpret_cast<uintptr_t>(r->m_alloc_ptr), r->m_alloc_size,
                r->use_count(), reinterpret_cast<uintptr_t>(r->m_dealloc),
-               r->m_alloc_ptr ? r->m_alloc_ptr->m_label : " [NOT ALLOCATED]");
+               r->m_alloc_ptr->m_label);
       s << buffer;
       r = r->m_next;
     }
   } else {
     while (r != root) {
-      if (r->m_alloc_ptr) {
-        // Formatting dependent on sizeof(uintptr_t)
-        const char* format_string;
+      // Formatting dependent on sizeof(uintptr_t)
+      const char* format_string;
 
-        if (sizeof(uintptr_t) == sizeof(unsigned long)) {
-          format_string = "%s [ 0x%.12lx + %ld ] %s\n";
-        } else if (sizeof(uintptr_t) == sizeof(unsigned long long)) {
-          format_string = "%s [ 0x%.12llx + %ld ] %s\n";
-        }
-
-        snprintf(buffer, 256, format_string, space_name,
-                 reinterpret_cast<uintptr_t>(r->data()), r->size(),
-                 r->m_alloc_ptr->m_label);
-      } else {
-        snprintf(buffer, 256, "%s [ 0 + 0 ]\n", space_name);
+      if (sizeof(uintptr_t) == sizeof(unsigned long)) {
+        format_string = "%s [ 0x%.12lx + %ld ] %s\n";
+      } else if (sizeof(uintptr_t) == sizeof(unsigned long long)) {
+        format_string = "%s [ 0x%.12llx + %ld ] %s\n";
       }
+
+      snprintf(buffer, 256, format_string, space_name,
+               reinterpret_cast<uintptr_t>(r->data()), r->size(),
+               r->m_alloc_ptr->m_label);
       s << buffer;
       r = r->m_next;
     }

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -311,12 +311,14 @@ SharedAllocationRecord<void, void>* SharedAllocationRecord<
 void SharedAllocationRecord<void, void>::print_host_accessible_records(
     std::ostream& s, const char* const space_name,
     const SharedAllocationRecord* const root, const bool detail) {
-  const SharedAllocationRecord<void, void>* r = root;
+  // Print every node except the root, which does not represent an actual
+  // allocation.
+  const SharedAllocationRecord<void, void>* r = root->m_next;
 
   char buffer[256];
 
   if (detail) {
-    do {
+    while (r != root) {
       // Formatting dependent on sizeof(uintptr_t)
       const char* format_string;
 
@@ -336,12 +338,12 @@ void SharedAllocationRecord<void, void>::print_host_accessible_records(
                reinterpret_cast<uintptr_t>(r->m_next),
                reinterpret_cast<uintptr_t>(r->m_alloc_ptr), r->m_alloc_size,
                r->use_count(), reinterpret_cast<uintptr_t>(r->m_dealloc),
-               r->m_alloc_ptr->m_label);
+               r->m_alloc_ptr ? r->m_alloc_ptr->m_label : " [NOT ALLOCATED]");
       s << buffer;
       r = r->m_next;
-    } while (r != root);
+    }
   } else {
-    do {
+    while (r != root) {
       if (r->m_alloc_ptr) {
         // Formatting dependent on sizeof(uintptr_t)
         const char* format_string;
@@ -360,7 +362,7 @@ void SharedAllocationRecord<void, void>::print_host_accessible_records(
       }
       s << buffer;
       r = r->m_next;
-    } while (r != root);
+    }
   }
 }
 #else


### PR DESCRIPTION
For some memory spaces, the doubly linked list of SharedAllocationRecords starts off with a special root node that doesn't have an actual allocation associated with it (``m_alloc_ptr == nullptr``). So trying to print out ``r->m_alloc_ptr->m_label`` will segfault.

Example reproducer:
```
#include <Kokkos_Core.hpp>
int main(int argc, char* argv[]) {
  Kokkos::initialize(argc, argv);
  Kokkos::DefaultExecutionSpace{}.print_configuration(std::cout);
  {
    Kokkos::Impl::SharedAllocationRecord<Kokkos::HostSpace>::print_records( std::cout, Kokkos::HostSpace(), true );
  }
  Kokkos::finalize();
  return 0;
} 
```
Without this PR, the above segfaults. With this PR:
```
Host Serial Execution Space:
  KOKKOS_ENABLE_SERIAL: yes
Serial Atomics:
  KOKKOS_ENABLE_SERIAL_ATOMICS: no

Serial Runtime Configuration:
Host addr( 0x00000067ffa0 ) list( 0x00000067ffa0 0x00000067ffa0 ) extent[ 0x000000000000 + 00000000 ] count(0) dealloc(0x000000000000) [NOT ALLOCATED]
```
(``Kokkos_ENABLE_DEBUG`` needs to be ON for ``print_records`` to work).

Interestingly, this issue seemed to affect HostSpace and CudaUVMSpace, but not CudaSpace. In CudaSpace, this root node still has a null data pointer and 0 extent, but the m_alloc_ptr is NOT null.