### PR TITLE
Add dummy source file to SIMD to allow deduction of linker language.

### DIFF
--- a/simd/src/CMakeLists.txt
+++ b/simd/src/CMakeLists.txt
@@ -17,10 +17,10 @@ INSTALL (
 
 # We have to pass the sources in here for Tribits
 # These will get ignored for standalone CMake and a true interface library made
-KOKKOS_ADD_INTERFACE_LIBRARY(
+KOKKOS_ADD_LIBRARY(
   kokkossimd
-  HEADERS ${SIMD_HEADERS}
   SOURCES ${SIMD_SOURCES}
+  HEADERS ${SIMD_HEADERS}
 )
 KOKKOS_LIB_INCLUDE_DIRECTORIES(kokkossimd
   ${KOKKOS_TOP_BUILD_DIR}

--- a/simd/src/Kokkos_SIMD_dummy.cpp
+++ b/simd/src/Kokkos_SIMD_dummy.cpp
@@ -1,4 +1,4 @@
-// This file is need in order to get the linker language
+// This file is needed in order to get the linker language
 // for the header only submodule.
 // While we set the language properties in our normal cmake
 // path it does not get set in the Trilinos environment.

--- a/simd/src/Kokkos_SIMD_dummy.cpp
+++ b/simd/src/Kokkos_SIMD_dummy.cpp
@@ -1,0 +1,7 @@
+// This file is need in order to get the linker language
+// for the header only submodule.
+// While we set the language properties in our normal cmake
+// path it does not get set in the Trilinos environment.
+// Furthermore, setting LINKER_LANGUAGE is only supported
+// in CMAKE 3.19 and up.
+void KOKKOS_SIMD_SRC_DUMMY_PREVENT_LINK_ERROR() {}


### PR DESCRIPTION
This is really only necessary for Trilinos ...

This works with CMake prior to 3.19 which the other attempt didn't.