### PR TITLE
Bugfix preserve view label when calling `realloc()`

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -2445,15 +2445,12 @@ inline void impl_realloc(DynRankView<T, P...>& v, const size_t n0,
                 "The view constructor arguments passed to Kokkos::realloc must "
                 "not include a memory space instance!");
 
-  const std::string label = v.label();
-
-  v = drview_type();  // Deallocate first, if the only view to allocation
-
   using alloc_prop = Impl::ViewCtorProp<ViewCtorArgs..., std::string>;
   alloc_prop arg_prop_copy(arg_prop);
   static_cast<Kokkos::Impl::ViewCtorProp<void, std::string>&>(arg_prop_copy)
       .value = v.label();
 
+  v = drview_type();  // Deallocate first, if the only view to allocation
   v = drview_type(arg_prop_copy, n0, n1, n2, n3, n4, n5, n6, n7);
 }
 

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -61,9 +61,12 @@ TEST(TEST_CATEGORY, resize_realloc_no_init_dualview) {
   auto success = validate_absence(
       [&]() {
         Kokkos::resize(Kokkos::WithoutInitializing, bla, 5, 6, 7, 9);
+        EXPECT_EQ(bla.template view<TEST_EXECSPACE>().label(), "bla");
         Kokkos::realloc(Kokkos::WithoutInitializing, bla, 8, 8, 8, 8);
+        EXPECT_EQ(bla.template view<TEST_EXECSPACE>().label(), "bla");
         Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing), bla, 5,
                         6, 7, 8);
+        EXPECT_EQ(bla.template view<TEST_EXECSPACE>().label(), "bla");
       },
       [&](BeginParallelForEvent event) {
         if (event.descriptor().find("initialization") != std::string::npos)
@@ -89,7 +92,9 @@ TEST(TEST_CATEGORY, resize_realloc_no_alloc_dualview) {
   auto success = validate_absence(
       [&]() {
         Kokkos::resize(bla, 8, 7, 6, 5);
+        EXPECT_EQ(bla.template view<TEST_EXECSPACE>().label(), "bla");
         Kokkos::realloc(Kokkos::WithoutInitializing, bla, 8, 7, 6, 5);
+        EXPECT_EQ(bla.template view<TEST_EXECSPACE>().label(), "bla");
       },
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found begin event"}};
@@ -119,6 +124,7 @@ TEST(TEST_CATEGORY, resize_exec_space_dualview) {
         Kokkos::resize(
             Kokkos::view_alloc(TEST_EXECSPACE{}, Kokkos::WithoutInitializing),
             bla, 5, 6, 7, 8);
+        EXPECT_EQ(bla.template view<TEST_EXECSPACE>().label(), "bla");
       },
       [&](BeginFenceEvent event) {
         if (event.descriptor().find("Kokkos::resize(View)") !=
@@ -159,7 +165,10 @@ TEST(TEST_CATEGORY, realloc_exec_space_dualview) {
   view_type v(Kokkos::view_alloc(TEST_EXECSPACE{}, "bla"), 8);
 
   auto success = validate_absence(
-      [&]() { Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), v, 8); },
+      [&]() {
+        Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), v, 8);
+        EXPECT_EQ(v.template view<TEST_EXECSPACE>().label(), "bla");
+      },
       [&](BeginFenceEvent event) {
         if ((event.descriptor().find("Debug Only Check for Execution Error") !=
              std::string::npos) ||
@@ -179,9 +188,12 @@ TEST(TEST_CATEGORY, resize_realloc_no_init_dynrankview) {
   auto success = validate_absence(
       [&]() {
         Kokkos::resize(Kokkos::WithoutInitializing, bla, 5, 6, 7, 9);
+        EXPECT_EQ(bla.label(), "bla");
         Kokkos::realloc(Kokkos::WithoutInitializing, bla, 8, 8, 8, 8);
+        EXPECT_EQ(bla.label(), "bla");
         Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing), bla, 5,
                         6, 7, 8);
+        EXPECT_EQ(bla.label(), "bla");
       },
       [&](BeginParallelForEvent event) {
         if (event.descriptor().find("initialization") != std::string::npos)
@@ -208,6 +220,7 @@ TEST(TEST_CATEGORY, resize_exec_space_dynrankview) {
         Kokkos::resize(
             Kokkos::view_alloc(TEST_EXECSPACE{}, Kokkos::WithoutInitializing),
             bla, 5, 6, 7, 8);
+        EXPECT_EQ(bla.label(), "bla");
       },
       [&](BeginFenceEvent event) {
         if (event.descriptor().find("Kokkos::resize(View)") !=
@@ -260,6 +273,7 @@ TEST(TEST_CATEGORY, realloc_exec_space_dynrankview) {
         Kokkos::realloc(
             Kokkos::view_alloc(Kokkos::WithoutInitializing, TEST_EXECSPACE{}),
             inner_view, 10);
+        EXPECT_EQ(inner_view.label(), "bla");
         outer_view2 = inner_view;
       },
       [&](BeginFenceEvent event) {
@@ -283,9 +297,12 @@ TEST(TEST_CATEGORY, resize_realloc_no_init_scatterview) {
   auto success = validate_absence(
       [&]() {
         Kokkos::resize(Kokkos::WithoutInitializing, bla, 4, 5, 6, 8);
+        EXPECT_EQ(bla.subview().label(), "bla");
         Kokkos::realloc(Kokkos::WithoutInitializing, bla, 8, 8, 8, 8);
+        EXPECT_EQ(bla.subview().label(), "bla");
         Kokkos::realloc(Kokkos::view_alloc(Kokkos::WithoutInitializing), bla, 5,
                         6, 7, 8);
+        EXPECT_EQ(bla.subview().label(), "bla");
       },
       [&](BeginParallelForEvent event) {
         if (event.descriptor().find("initialization") != std::string::npos)
@@ -312,7 +329,9 @@ TEST(TEST_CATEGORY, resize_realloc_no_alloc_scatterview) {
   auto success = validate_absence(
       [&]() {
         Kokkos::resize(bla, 7, 6, 5, 4);
+        EXPECT_EQ(bla.subview().label(), "bla");
         Kokkos::realloc(Kokkos::WithoutInitializing, bla, 7, 6, 5, 4);
+        EXPECT_EQ(bla.subview().label(), "bla");
       },
       [&](BeginParallelForEvent) {
         return MatchDiagnostic{true, {"Found begin event"}};
@@ -343,6 +362,7 @@ TEST(TEST_CATEGORY, resize_exec_space_scatterview) {
         Kokkos::resize(
             Kokkos::view_alloc(TEST_EXECSPACE{}, Kokkos::WithoutInitializing),
             bla, 5, 6, 7, 8);
+        EXPECT_EQ(bla.subview().label(), "bla");
       },
       [&](BeginFenceEvent event) {
         if (event.descriptor().find("Kokkos::resize(View)") !=
@@ -396,8 +416,10 @@ TEST(TEST_CATEGORY, realloc_exec_space_scatterview) {
         Kokkos::realloc(
             Kokkos::view_alloc(Kokkos::WithoutInitializing, TEST_EXECSPACE{}),
             inner_view, 10);
+        EXPECT_EQ(inner_view.subview().label(), "bla");
         outer_view2 = inner_view;
         Kokkos::realloc(Kokkos::view_alloc(TEST_EXECSPACE{}), inner_view, 10);
+        EXPECT_EQ(inner_view.subview().label(), "bla");
       },
       [&](BeginFenceEvent event) {
         if ((event.descriptor().find("Debug Only Check for Execution Error") !=

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3278,26 +3278,25 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
   const bool sizeMismatch = Impl::size_mismatch(v, v.rank_dynamic, new_extents);
 
   if (sizeMismatch) {
-    v = view_type();  // Deallocate first, if the only view to allocation
-    v = view_type(arg_prop, n0, n1, n2, n3, n4, n5, n6, n7);
+    auto const& label = v.label();  // Save the label
+    v = view_type();  // Best effort to deallocate in case no other view refers
+                      // to the shared allocation
+    using alloc_prop = Impl::ViewCtorProp<ViewCtorArgs..., std::string>;
+    alloc_prop arg_prop_copy(arg_prop);
+    static_cast<Kokkos::Impl::ViewCtorProp<void, std::string>&>(arg_prop_copy)
+        .value = label;
+    v          = view_type(arg_prop_copy, n0, n1, n2, n3, n4, n5, n6, n7);
   } else if (alloc_prop_input::initialize) {
     if (alloc_prop_input::has_execution_space) {
-      // Add execution_space if not provided to avoid need for if constexpr
       using alloc_prop = Impl::ViewCtorProp<
           ViewCtorArgs...,
           std::conditional_t<alloc_prop_input::has_execution_space,
                              std::integral_constant<unsigned int, 2>,
-                             typename view_type::execution_space>,
-          std::string>;
+                             typename view_type::execution_space>>;
       alloc_prop arg_prop_copy(arg_prop);
-      static_cast<Kokkos::Impl::ViewCtorProp<void, std::string>&>(arg_prop_copy)
-          .value                 = v.label();
-      using execution_space_type = typename alloc_prop::execution_space;
-      const execution_space_type& exec_space =
-          static_cast<
-              Kokkos::Impl::ViewCtorProp<void, execution_space_type> const&>(
-              arg_prop_copy)
-              .value;
+      auto const& exec_space = static_cast<Kokkos::Impl::ViewCtorProp<
+          void, typename alloc_prop::execution_space> const&>(arg_prop_copy)
+                                   .value;
       Kokkos::deep_copy(exec_space, v, typename view_type::value_type{});
     } else
       Kokkos::deep_copy(v, typename view_type::value_type{});

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3278,14 +3278,13 @@ impl_realloc(Kokkos::View<T, P...>& v, const size_t n0, const size_t n1,
   const bool sizeMismatch = Impl::size_mismatch(v, v.rank_dynamic, new_extents);
 
   if (sizeMismatch) {
-    auto const& label = v.label();  // Save the label
-    v = view_type();  // Best effort to deallocate in case no other view refers
-                      // to the shared allocation
     using alloc_prop = Impl::ViewCtorProp<ViewCtorArgs..., std::string>;
     alloc_prop arg_prop_copy(arg_prop);
     static_cast<Kokkos::Impl::ViewCtorProp<void, std::string>&>(arg_prop_copy)
-        .value = label;
-    v          = view_type(arg_prop_copy, n0, n1, n2, n3, n4, n5, n6, n7);
+        .value = v.label();
+    v = view_type();  // Best effort to deallocate in case no other view refers
+                      // to the shared allocation
+    v = view_type(arg_prop_copy, n0, n1, n2, n3, n4, n5, n6, n7);
   } else if (alloc_prop_input::initialize) {
     if (alloc_prop_input::has_execution_space) {
       using alloc_prop = Impl::ViewCtorProp<

--- a/core/unit_test/TestRealloc.hpp
+++ b/core/unit_test/TestRealloc.hpp
@@ -71,35 +71,47 @@ void impl_testRealloc() {
     using view_type = Kokkos::View<int*, DeviceType>;
     view_type view_1d("view_1d", sizes[0]);
     const int* oldPointer = view_1d.data();
+    auto const& oldLabel  = view_1d.label();
     EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_1d, sizes[0]);
+    auto const& newLabel = view_1d.label();
+    EXPECT_EQ(oldLabel, newLabel);
     const int* newPointer = view_1d.data();
     EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int**, DeviceType>;
     view_type view_2d("view_2d", sizes[0], sizes[1]);
+    auto const& oldLabel  = view_2d.label();
     const int* oldPointer = view_2d.data();
     EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_2d, sizes[0], sizes[1]);
+    auto const& newLabel = view_2d.label();
+    EXPECT_EQ(oldLabel, newLabel);
     const int* newPointer = view_2d.data();
     EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int***, DeviceType>;
     view_type view_3d("view_3d", sizes[0], sizes[1], sizes[2]);
+    auto const& oldLabel  = view_3d.label();
     const int* oldPointer = view_3d.data();
     EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_3d, sizes[0], sizes[1], sizes[2]);
+    auto const& newLabel = view_3d.label();
+    EXPECT_EQ(oldLabel, newLabel);
     const int* newPointer = view_3d.data();
     EXPECT_EQ(oldPointer, newPointer);
   }
   {
     using view_type = Kokkos::View<int****, DeviceType>;
     view_type view_4d("view_4d", sizes[0], sizes[1], sizes[2], sizes[3]);
+    auto const& oldLabel  = view_4d.label();
     const int* oldPointer = view_4d.data();
     EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_4d, sizes[0], sizes[1], sizes[2], sizes[3]);
+    auto const& newLabel = view_4d.label();
+    EXPECT_EQ(oldLabel, newLabel);
     const int* newPointer = view_4d.data();
     EXPECT_EQ(oldPointer, newPointer);
   }
@@ -107,10 +119,13 @@ void impl_testRealloc() {
     using view_type = Kokkos::View<int*****, DeviceType>;
     view_type view_5d("view_5d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4]);
+    auto const& oldLabel  = view_5d.label();
     const int* oldPointer = view_5d.data();
     EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_5d, sizes[0], sizes[1], sizes[2], sizes[3],
                      sizes[4]);
+    auto const& newLabel = view_5d.label();
+    EXPECT_EQ(oldLabel, newLabel);
     const int* newPointer = view_5d.data();
     EXPECT_EQ(oldPointer, newPointer);
   }
@@ -119,9 +134,12 @@ void impl_testRealloc() {
     view_type view_6d("view_6d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5]);
     const int* oldPointer = view_6d.data();
+    auto const& oldLabel  = view_6d.label();
     EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_6d, sizes[0], sizes[1], sizes[2], sizes[3],
                      sizes[4], sizes[5]);
+    auto const& newLabel = view_6d.label();
+    EXPECT_EQ(oldLabel, newLabel);
     const int* newPointer = view_6d.data();
     EXPECT_EQ(oldPointer, newPointer);
   }
@@ -129,10 +147,13 @@ void impl_testRealloc() {
     using view_type = Kokkos::View<int*******, DeviceType>;
     view_type view_7d("view_7d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5], sizes[6]);
+    auto const& oldLabel  = view_7d.label();
     const int* oldPointer = view_7d.data();
     EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_7d, sizes[0], sizes[1], sizes[2], sizes[3],
                      sizes[4], sizes[5], sizes[6]);
+    auto const& newLabel = view_7d.label();
+    EXPECT_EQ(oldLabel, newLabel);
     const int* newPointer = view_7d.data();
     EXPECT_EQ(oldPointer, newPointer);
   }
@@ -140,10 +161,13 @@ void impl_testRealloc() {
     using view_type = Kokkos::View<int********, DeviceType>;
     view_type view_8d("view_8d", sizes[0], sizes[1], sizes[2], sizes[3],
                       sizes[4], sizes[5], sizes[6], sizes[7]);
+    auto const& oldLabel  = view_8d.label();
     const int* oldPointer = view_8d.data();
     EXPECT_NE(oldPointer, nullptr);
     realloc_dispatch(Tag{}, view_8d, sizes[0], sizes[1], sizes[2], sizes[3],
                      sizes[4], sizes[5], sizes[6], sizes[7]);
+    auto const& newLabel = view_8d.label();
+    EXPECT_EQ(oldLabel, newLabel);
     const int* newPointer = view_8d.data();
     EXPECT_EQ(oldPointer, newPointer);
   }


### PR DESCRIPTION
Fix #5364 