### PR TITLE
Rename trait `Impl::{identity -> type_identity}`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -154,14 +154,15 @@ template <class KernelType,
           class Tag =
               typename PatternTagFromImplSpecialization<KernelType>::type>
 struct get_graph_node_kernel_type
-    : identity<GraphNodeKernelImpl<Kokkos::Cuda, typename KernelType::Policy,
-                                   typename KernelType::functor_type, Tag>> {};
+    : type_identity<
+          GraphNodeKernelImpl<Kokkos::Cuda, typename KernelType::Policy,
+                              typename KernelType::functor_type, Tag>> {};
 template <class KernelType>
 struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
-    : identity<GraphNodeKernelImpl<Kokkos::Cuda, typename KernelType::Policy,
-                                   typename KernelType::functor_type,
-                                   Kokkos::ParallelReduceTag,
-                                   typename KernelType::reducer_type>> {};
+    : type_identity<GraphNodeKernelImpl<
+          Kokkos::Cuda, typename KernelType::Policy,
+          typename KernelType::functor_type, Kokkos::ParallelReduceTag,
+          typename KernelType::reducer_type>> {};
 
 //==============================================================================
 // <editor-fold desc="get_cuda_graph_*() helper functions"> {{{1

--- a/core/src/Kokkos_Atomic.hpp
+++ b/core/src/Kokkos_Atomic.hpp
@@ -103,7 +103,7 @@ KOKKOS_INLINE_FUNCTION void desul_atomic_inc(T* dest, MemoryOrderSeqCst,
 
 template <class T>
 KOKKOS_INLINE_FUNCTION T
-desul_atomic_exchange(T* dest, const Kokkos::Impl::identity_t<T> val,
+desul_atomic_exchange(T* dest, const Kokkos::Impl::type_identity_t<T> val,
                       MemoryOrderSeqCst, MemoryScopeDevice) {
   return desul::atomic_exchange(const_cast<T*>(dest), val,
                                 desul::MemoryOrderSeqCst(),
@@ -112,8 +112,8 @@ desul_atomic_exchange(T* dest, const Kokkos::Impl::identity_t<T> val,
 
 template <class T>
 KOKKOS_INLINE_FUNCTION T desul_atomic_compare_exchange(
-    T* dest, Kokkos::Impl::identity_t<const T> compare,
-    Kokkos::Impl::identity_t<const T> val, MemoryOrderSeqCst,
+    T* dest, Kokkos::Impl::type_identity_t<const T> compare,
+    Kokkos::Impl::type_identity_t<const T> val, MemoryOrderSeqCst,
     MemoryScopeDevice) {
   return desul::atomic_compare_exchange(dest, compare, val,
                                         desul::MemoryOrderSeqCst(),
@@ -401,15 +401,15 @@ KOKKOS_INLINE_FUNCTION void desul_atomic_inc(T* dest, MemoryOrderSeqCst,
 
 template <class T>
 KOKKOS_INLINE_FUNCTION T
-desul_atomic_exchange(T* dest, Kokkos::Impl::identity_t<const T> val,
+desul_atomic_exchange(T* dest, Kokkos::Impl::type_identity_t<const T> val,
                       MemoryOrderSeqCst, MemoryScopeDevice) {
   return Kokkos::atomic_exchange(dest, val);
 }
 
 template <class T>
 KOKKOS_INLINE_FUNCTION T desul_atomic_compare_exchange(
-    T* dest, Kokkos::Impl::identity_t<const T> compare,
-    Kokkos::Impl::identity_t<const T> val, MemoryOrderSeqCst,
+    T* dest, Kokkos::Impl::type_identity_t<const T> compare,
+    Kokkos::Impl::type_identity_t<const T> val, MemoryOrderSeqCst,
     MemoryScopeDevice) {
   return Kokkos::atomic_compare_exchange(dest, compare, val);
 }

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -910,30 +910,30 @@ struct PatternImplSpecializationFromTag;
 
 template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelForTag, Args...>
-    : identity<ParallelFor<Args...>> {};
+    : type_identity<ParallelFor<Args...>> {};
 
 template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelReduceTag, Args...>
-    : identity<ParallelReduce<Args...>> {};
+    : type_identity<ParallelReduce<Args...>> {};
 
 template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelScanTag, Args...>
-    : identity<ParallelScan<Args...>> {};
+    : type_identity<ParallelScan<Args...>> {};
 
 template <class PatternImpl>
 struct PatternTagFromImplSpecialization;
 
 template <class... Args>
 struct PatternTagFromImplSpecialization<ParallelFor<Args...>>
-    : identity<ParallelForTag> {};
+    : type_identity<ParallelForTag> {};
 
 template <class... Args>
 struct PatternTagFromImplSpecialization<ParallelReduce<Args...>>
-    : identity<ParallelReduceTag> {};
+    : type_identity<ParallelReduceTag> {};
 
 template <class... Args>
 struct PatternTagFromImplSpecialization<ParallelScan<Args...>>
-    : identity<ParallelScanTag> {};
+    : type_identity<ParallelScanTag> {};
 
 }  // end namespace Impl
 

--- a/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
+++ b/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
@@ -315,9 +315,9 @@ KOKKOS_INLINE_FUNCTION T atomic_compare_exchange(volatile T* const dest_v,
 // dummy for non-CUDA Kokkos headers being processed by NVCC
 #if defined(__CUDA_ARCH__) && !defined(KOKKOS_ENABLE_CUDA)
 template <typename T>
-__inline__ __device__ T
-atomic_compare_exchange(volatile T* const, const Kokkos::Impl::identity_t<T>,
-                        const Kokkos::Impl::identity_t<T>) {
+__inline__ __device__ T atomic_compare_exchange(
+    volatile T* const, const Kokkos::Impl::type_identity_t<T>,
+    const Kokkos::Impl::type_identity_t<T>) {
   return T();
 }
 #endif

--- a/core/src/impl/Kokkos_Atomic_Exchange.hpp
+++ b/core/src/impl/Kokkos_Atomic_Exchange.hpp
@@ -389,14 +389,14 @@ inline void atomic_assign(volatile T* const dest_v, const T val) {
 // dummy for non-CUDA Kokkos headers being processed by NVCC
 #if defined(__CUDA_ARCH__) && !defined(KOKKOS_ENABLE_CUDA)
 template <typename T>
-__inline__ __device__ T atomic_exchange(volatile T* const,
-                                        const Kokkos::Impl::identity_t<T>) {
+__inline__ __device__ T
+atomic_exchange(volatile T* const, const Kokkos::Impl::type_identity_t<T>) {
   return T();
 }
 
 template <typename T>
-__inline__ __device__ void atomic_assign(volatile T* const,
-                                         const Kokkos::Impl::identity_t<T>) {}
+__inline__ __device__ void atomic_assign(
+    volatile T* const, const Kokkos::Impl::type_identity_t<T>) {}
 #endif
 
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
@@ -379,7 +379,7 @@ T atomic_fetch_add(volatile T* const dest_v, std::add_const_t<T> val) {
 #if defined(__CUDA_ARCH__) && !defined(KOKKOS_ENABLE_CUDA)
 template <typename T>
 __inline__ __device__ T atomic_fetch_add(volatile T* const,
-                                         Kokkos::Impl::identity_t<T>) {
+                                         Kokkos::Impl::type_identity_t<T>) {
   return T();
 }
 #endif

--- a/core/src/impl/Kokkos_Atomic_Fetch_And.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_And.hpp
@@ -176,7 +176,7 @@ T atomic_fetch_and(volatile T* const dest_v, const T val) {
 #if defined(__CUDA_ARCH__) && !defined(KOKKOS_ENABLE_CUDA)
 template <typename T>
 __inline__ __device__ T atomic_fetch_and(volatile T* const,
-                                         Kokkos::Impl::identity_t<T>) {
+                                         Kokkos::Impl::type_identity_t<T>) {
   return T();
 }
 #endif

--- a/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Or.hpp
@@ -177,7 +177,7 @@ T atomic_fetch_or(volatile T* const dest_v, const T val) {
 #if defined(__CUDA_ARCH__) && !defined(KOKKOS_ENABLE_CUDA)
 template <typename T>
 __inline__ __device__ T atomic_fetch_or(volatile T* const,
-                                        Kokkos::Impl::identity_t<T>) {
+                                        Kokkos::Impl::type_identity_t<T>) {
   return T();
 }
 #endif

--- a/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
@@ -312,7 +312,7 @@ T atomic_fetch_sub(volatile T* const dest_v, const T val) {
 #if defined(__CUDA_ARCH__) && !defined(KOKKOS_ENABLE_CUDA)
 template <typename T>
 __inline__ __device__ T atomic_fetch_sub(volatile T* const,
-                                         Kokkos::Impl::identity_t<T>) {
+                                         Kokkos::Impl::type_identity_t<T>) {
   return T();
 }
 #endif

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -57,19 +57,24 @@
 namespace Kokkos {
 namespace Impl {
 
-template <typename T>
-struct identity {
-  using type = T;
-};
-
-template <typename T>
-using identity_t = typename identity<T>::type;
-
 template <typename... Is>
 struct always_true : std::true_type {};
 
 //==============================================================================
-// <editor-fold desc="remove_cvref_t"> {{{1
+
+#if defined(__cpp_lib_type_identity)
+// since C++20
+using std::type_identity;
+using std::type_identity_t;
+#else
+template <typename T>
+struct type_identity {
+  using type = T;
+};
+
+template <typename T>
+using type_identity_t = typename type_identity<T>::type;
+#endif
 
 #if defined(__cpp_lib_remove_cvref)
 // since C++20
@@ -84,9 +89,6 @@ struct remove_cvref {
 template <class T>
 using remove_cvref_t = typename remove_cvref<T>::type;
 #endif
-
-// </editor-fold> end remove_cvref_t }}}1
-//==============================================================================
 
 //==============================================================================
 // <editor-fold desc="is_specialization_of"> {{{1
@@ -168,7 +170,7 @@ struct _type_list_remove_first_impl<Entry, type_list<Entry, Ts...>,
 
 template <class Entry, class... OutTs>
 struct _type_list_remove_first_impl<Entry, type_list<>, type_list<OutTs...>>
-    : identity<type_list<OutTs...>> {};
+    : type_identity<type_list<OutTs...>> {};
 
 template <class Entry, class List>
 struct type_list_remove_first


### PR DESCRIPTION
Rational: do not roll our own, prefer standard facility

Rename `Impl::{identity -> type_identity}` and import it from `std::` when C++20 is available