### PR TITLE
Clean up CUDA <= 10.0 checks

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -651,11 +651,7 @@ void cuda_prefetch_pointer(const Cuda &space, const void *ptr, size_t bytes,
   // DualView syncs down. Probably because the latency is not too bad in the
   // first place for the pull down. If we want to change that provde
   // cudaCpuDeviceId as the device if to_device is false
-#if CUDA_VERSION < 10000
-  bool is_managed = attr.isManaged;
-#else
   bool is_managed = attr.type == cudaMemoryTypeManaged;
-#endif
   if (to_device && is_managed &&
       space.cuda_device_prop().concurrentManagedAccess) {
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemPrefetchAsync(

--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -47,7 +47,7 @@
 
 #include <Kokkos_Macros.hpp>
 
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_CUDA_ENABLE_GRAPHS)
+#if defined(KOKKOS_ENABLE_CUDA)
 
 #include <Kokkos_Graph_fwd.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_GraphNode_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNode_Impl.hpp
@@ -47,7 +47,7 @@
 
 #include <Kokkos_Macros.hpp>
 
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_CUDA_ENABLE_GRAPHS)
+#if defined(KOKKOS_ENABLE_CUDA)
 
 #include <Kokkos_Graph_fwd.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -47,7 +47,7 @@
 
 #include <Kokkos_Macros.hpp>
 
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_CUDA_ENABLE_GRAPHS)
+#if defined(KOKKOS_ENABLE_CUDA)
 
 #include <Kokkos_Graph_fwd.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -549,11 +549,7 @@ Kokkos::Cuda::initialize WARNING: Cuda is allocating into UVMSpace by default
   }
 #endif
 
-#ifdef KOKKOS_ENABLE_PRE_CUDA_10_DEPRECATION_API
-  cudaThreadSetCacheConfig(cudaFuncCachePreferShared);
-#else
   cudaDeviceSetCacheConfig(cudaFuncCachePreferShared);
-#endif
 
   // Init the array for used for arbitrarily sized atomics
   if (stream == nullptr) Impl::initialize_host_cuda_lock_arrays();

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -345,7 +345,6 @@ struct CudaParallelLaunchKernelInvoker<
         driver);
   }
 
-#ifdef KOKKOS_CUDA_ENABLE_GRAPHS
   inline static void create_parallel_launch_graph_node(
       DriverType const& driver, dim3 const& grid, dim3 const& block, int shmem,
       CudaInternal const* cuda_instance, bool prefer_shmem) {
@@ -384,7 +383,6 @@ struct CudaParallelLaunchKernelInvoker<
     }
     KOKKOS_ENSURES(bool(graph_node))
   }
-#endif
 };
 
 // </editor-fold> end local memory }}}2
@@ -439,7 +437,6 @@ struct CudaParallelLaunchKernelInvoker<
         driver_ptr);
   }
 
-#ifdef KOKKOS_CUDA_ENABLE_GRAPHS
   inline static void create_parallel_launch_graph_node(
       DriverType const& driver, dim3 const& grid, dim3 const& block, int shmem,
       CudaInternal const* cuda_instance, bool prefer_shmem) {
@@ -488,7 +485,6 @@ struct CudaParallelLaunchKernelInvoker<
     }
     KOKKOS_ENSURES(bool(graph_node))
   }
-#endif
 };
 
 // </editor-fold> end Global Memory }}}2
@@ -563,7 +559,6 @@ struct CudaParallelLaunchKernelInvoker<
                         cudaStream_t(cuda_instance->m_stream)));
   }
 
-#ifdef KOKKOS_CUDA_ENABLE_GRAPHS
   inline static void create_parallel_launch_graph_node(
       DriverType const& driver, dim3 const& grid, dim3 const& block, int shmem,
       CudaInternal const* cuda_instance, bool prefer_shmem) {
@@ -582,7 +577,6 @@ struct CudaParallelLaunchKernelInvoker<
     global_launch_impl_t::create_parallel_launch_graph_node(
         driver, grid, block, shmem, cuda_instance, prefer_shmem);
   }
-#endif
 };
 
 // </editor-fold> end Constant Memory }}}2
@@ -674,11 +668,7 @@ struct CudaParallelLaunchImpl<
 template <class DriverType, class LaunchBounds = Kokkos::LaunchBounds<>,
           Experimental::CudaLaunchMechanism LaunchMechanism =
               DeduceCudaLaunchMechanism<DriverType>::launch_mechanism,
-          bool DoGraph = DriverType::Policy::is_graph_kernel::value
-#ifndef KOKKOS_CUDA_ENABLE_GRAPHS
-                         && false
-#endif
-          >
+          bool DoGraph = DriverType::Policy::is_graph_kernel::value>
 struct CudaParallelLaunch;
 
 // General launch mechanism
@@ -695,7 +685,6 @@ struct CudaParallelLaunch<DriverType, LaunchBounds, LaunchMechanism,
   }
 };
 
-#ifdef KOKKOS_CUDA_ENABLE_GRAPHS
 // Launch mechanism for creating graph nodes
 template <class DriverType, class LaunchBounds,
           Experimental::CudaLaunchMechanism LaunchMechanism>
@@ -709,7 +698,6 @@ struct CudaParallelLaunch<DriverType, LaunchBounds, LaunchMechanism,
     base_t::create_parallel_launch_graph_node((Args &&) args...);
   }
 };
-#endif
 
 // </editor-fold> end CudaParallelLaunch }}}1
 //==============================================================================

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -326,9 +326,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     const bool need_device_set = Analysis::has_init_member_function ||
                                  Analysis::has_final_member_function ||
                                  !m_result_ptr_host_accessible ||
-#ifdef KOKKOS_CUDA_ENABLE_GRAPHS
                                  Policy::is_graph_kernel::value ||
-#endif
                                  !std::is_same<ReducerType, InvalidType>::value;
     if ((nwork > 0) || need_device_set) {
       const int block_size = local_block_size(m_functor);

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -839,9 +839,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     const bool need_device_set = Analysis::has_init_member_function ||
                                  Analysis::has_final_member_function ||
                                  !m_result_ptr_host_accessible ||
-#ifdef KOKKOS_CUDA_ENABLE_GRAPHS
                                  Policy::is_graph_kernel::value ||
-#endif
                                  !std::is_same<ReducerType, InvalidType>::value;
     if (!is_empty_range || need_device_set) {
       const int block_count = std::max(

--- a/core/src/setup/Kokkos_Setup_Cuda.hpp
+++ b/core/src/setup/Kokkos_Setup_Cuda.hpp
@@ -90,10 +90,6 @@
 #undef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
 #endif  // !defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
-#if (10000 > CUDA_VERSION)
-#define KOKKOS_ENABLE_PRE_CUDA_10_DEPRECATION_API
-#endif
-
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700)
 // PTX atomics with memory order semantics are only available on volta and later
 #if !defined(KOKKOS_DISABLE_CUDA_ASM)
@@ -118,14 +114,6 @@
 #else
 #define KOKKOS_INLINE_FUNCTION_DELETED __device__ __host__ inline
 #endif
-#if (CUDA_VERSION < 10000)
-#define KOKKOS_DEFAULTED_FUNCTION __host__ __device__ inline
-#else
 #define KOKKOS_DEFAULTED_FUNCTION inline
-#endif
-
-#if (CUDA_VERSION >= 10000)
-#define KOKKOS_CUDA_ENABLE_GRAPHS
-#endif
 
 #endif /* KOKKOS_CUDA_SETUP_HPP_ */


### PR DESCRIPTION
`Cuda 10.0` is still the minimum version for `Clang+Cuda` so this only removes checks related to that version.