### PR TITLE
Dispatch Kokkos::sort(Kokkos::View) to std::sort

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -630,7 +630,6 @@ std::enable_if_t<(Kokkos::is_execution_space<ExecutionSpace>::value) &&
                                     memory_space>::accessible)>
 sort(const ExecutionSpace& space,
      const Kokkos::View<DataType, Properties...>& view) {
-  space.fence("Kokkos::sort: Fence before sorting on the host");
   auto first = Experimental::begin(view);
   auto last  = Experimental::end(view);
   std::sort(first, last);

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -580,7 +580,7 @@ struct min_max_functor {
 
 template <class ExecutionSpace, class DataType, class... Properties>
 std::enable_if_t<(Kokkos::is_execution_space<ExecutionSpace>::value) &&
-                 (not SpaceAccessibility<
+                 (!SpaceAccessibility<
                      HostSpace, typename Kokkos::View<DataType, Properties...>::
                                     memory_space>::accessible)>
 sort(const ExecutionSpace& exec,

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -585,7 +585,7 @@ std::enable_if_t<(Kokkos::is_execution_space<ExecutionSpace>::value) &&
                                     memory_space>::accessible)>
 sort(const ExecutionSpace& exec,
      const Kokkos::View<DataType, Properties...>& view) {
-  using ViewType = typename Kokkos::View<DataType, Properties...>;
+  using ViewType = Kokkos::View<DataType, Properties...>;
   using CompType = BinOp1D<ViewType>;
 
   Kokkos::MinMaxScalar<typename ViewType::non_const_value_type> result;

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -53,6 +53,10 @@
 
 #include <algorithm>
 
+#if defined(KOKKOS_ENABLE_SERIAL)
+#include "std_algorithms/Kokkos_BeginEnd.hpp"
+#endif
+
 namespace Kokkos {
 
 namespace Impl {
@@ -615,6 +619,17 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
   bin_sort.create_permute_vector(exec);
   bin_sort.sort(exec, view);
 }
+
+#if defined(KOKKOS_ENABLE_SERIAL)
+template <class DataType, class... Properties>
+void sort(const Serial& space,
+          const Kokkos::View<DataType, Properties...>& view) {
+  space.fence("Kokkos::sort: Fence before sorting on the host");
+  auto first = Experimental::begin(view);
+  auto last  = Experimental::end(view);
+  std::sort(first, last);
+}
+#endif
 
 template <class ViewType>
 void sort(ViewType const& view) {

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -628,8 +628,7 @@ std::enable_if_t<(Kokkos::is_execution_space<ExecutionSpace>::value) &&
                  (SpaceAccessibility<
                      HostSpace, typename Kokkos::View<DataType, Properties...>::
                                     memory_space>::accessible)>
-sort(const ExecutionSpace& space,
-     const Kokkos::View<DataType, Properties...>& view) {
+sort(const ExecutionSpace&, const Kokkos::View<DataType, Properties...>& view) {
   auto first = Experimental::begin(view);
   auto last  = Experimental::end(view);
   std::sort(first, last);


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/issues/5071

As @dalg24 suggested (https://github.com/kokkos/kokkos/pull/5183#discussion_r950460815) I removed `always_use_kokkos_sort` argument. 

`std::sort()` is used ~~only for SERIAL~~ for any execution space that can access host_space.