### PR TITLE
Fix initialization for array reductions 

### DIFF
--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -745,8 +745,9 @@ struct FunctorAnalysis {
   struct DeduceInitNoTag {
     enum : bool { value = false };
 
-    KOKKOS_INLINE_FUNCTION static void init(F const* const, ValueType* dst) {
-      new (dst) ValueType();
+    KOKKOS_INLINE_FUNCTION static void init(F const* const f, ValueType* dst) {
+      const int n = FunctorAnalysis::value_count(*f);
+      for (int i = 0; i < n; ++i) new (&dst[i]) ValueType();
     }
   };
 

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -71,20 +71,6 @@ struct TestMDRange_ReduceArray_2D {
       : input_view("input_view", N0, N1), value_count(array_size) {}
 
   KOKKOS_INLINE_FUNCTION
-  void init(scalar_type dst[]) const {
-    for (unsigned i = 0; i < value_count; ++i) {
-      dst[i] = 0.0;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(scalar_type dst[], const scalar_type src[]) const {
-    for (unsigned i = 0; i < value_count; ++i) {
-      dst[i] += src[i];
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
   void operator()(const int i, const int j) const { input_view(i, j) = 1; }
 
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
Fixes #5379. The default `init()` function would only initialize the first element before.