### PR TITLE
#5438: Add kokkos configuration to benchmark metadata

### DIFF
--- a/core/perf_test/BenchmarkMain.cpp
+++ b/core/perf_test/BenchmarkMain.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
   Kokkos::initialize(argc, argv);
   benchmark::Initialize(&argc, argv);
   benchmark::SetDefaultTimeUnit(benchmark::kSecond);
-  Test::add_benchmark_context(true);
+  KokkosBenchmark::add_benchmark_context(true);
 
   benchmark::RunSpecifiedBenchmarks();
 

--- a/core/perf_test/Benchmark_Context.hpp
+++ b/core/perf_test/Benchmark_Context.hpp
@@ -51,7 +51,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace Test {
+namespace KokkosBenchmark {
 
 /// \brief Remove unwanted spaces and colon signs from input string. In case of
 /// invalid input it will return an empty string.
@@ -94,6 +94,6 @@ void add_benchmark_context(bool verbose = false) {
   add_kokkos_configuration(verbose);
 }
 
-}  // namespace Test
+}  // namespace KokkosBenchmark
 
 #endif

--- a/core/perf_test/Benchmark_Context.hpp
+++ b/core/perf_test/Benchmark_Context.hpp
@@ -55,7 +55,7 @@ namespace Test {
 
 std::string remove_unwanted_prefix(std::string str) {
   auto found = str.find_first_not_of(" :,");
-  if(found != std::string::npos) {
+  if (found != std::string::npos) {
     return str.substr(found);
   }
   return str;
@@ -66,12 +66,13 @@ void add_kokkos_configuration(bool verbose = false) {
   Kokkos::print_configuration(msg, verbose);
 
   std::stringstream ss{msg.str()};
-  for(std::string line; std::getline(ss, line, '\n');) {
+  for (std::string line; std::getline(ss, line, '\n');) {
     auto found = line.find_first_of(':');
-    if(found != std::string::npos){
+    if (found != std::string::npos) {
       auto val = remove_unwanted_prefix(line.substr(found + 1));
-      if(val.length()) {
-        benchmark::AddCustomContext(remove_unwanted_prefix(line.substr(0, found)), val);
+      if (val.length()) {
+        benchmark::AddCustomContext(
+            remove_unwanted_prefix(line.substr(0, found)), val);
       }
     }
   }

--- a/core/perf_test/Benchmark_Context.hpp
+++ b/core/perf_test/Benchmark_Context.hpp
@@ -70,7 +70,7 @@ void add_kokkos_configuration(bool verbose = false) {
     auto found = line.find_first_of(':');
     if (found != std::string::npos) {
       auto val = remove_unwanted_prefix(line.substr(found + 1));
-      if (val.length()) {
+      if (!val.empty()) {
         benchmark::AddCustomContext(
             remove_unwanted_prefix(line.substr(0, found)), val);
       }


### PR DESCRIPTION
Related to #5348 

This PR is adding the possibility to add kokkos configuration data to benchmark context. This way it can be included in json output file after running benchmarks.

<details>
  <summary>Example JSON</summary>

```json
{
  "context": {
    "date": "2022-08-24T12:05:55+02:00",
    "host_name": "macbook-pro.home",
    "executable": "/Users/arus/NGA/Kokkos/build/kokkos/core/perf_test/KokkosCore_PerformanceTest_Benchmark",
    "num_cpus": 8,
    "mhz_per_cpu": 24,
    "cpu_scaling_enabled": false,
    "caches": [
      {
        "type": "Data",
        "level": 1,
        "size": 65536,
        "num_sharing": 0
      },
      {
        "type": "Instruction",
        "level": 1,
        "size": 131072,
        "num_sharing": 0
      },
      {
        "type": "Unified",
        "level": 2,
        "size": 4194304,
        "num_sharing": 1
      }
    ],
    "load_avg": [2.00293,1.97412,1.46094],
    "library_build_type": "release",
    "Default Device": "N6Kokkos6OpenMPE",
    "KOKKOS_COMPILER_APPLECC": "1",
    "KOKKOS_COMPILER_GNU": "1210",
    "KOKKOS_ENABLE_ASM": "no",
    "KOKKOS_ENABLE_CXX17": "yes",
    "KOKKOS_ENABLE_CXX20": "no",
    "KOKKOS_ENABLE_CXX23": "no",
    "KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK": "yes",
    "KOKKOS_ENABLE_GNU_ATOMICS": "no",
    "KOKKOS_ENABLE_HBWSPACE": "no",
    "KOKKOS_ENABLE_HWLOC": "no",
    "KOKKOS_ENABLE_INTEL_ATOMICS": "no",
    "KOKKOS_ENABLE_INTEL_MM_ALLOC": "no",
    "KOKKOS_ENABLE_LIBDL": "yes",
    "KOKKOS_ENABLE_LIBRT": "no",
    "KOKKOS_ENABLE_OPENMP": "yes",
    "KOKKOS_ENABLE_OPENMP_ATOMICS": "no",
    "KOKKOS_ENABLE_PRAGMA_IVDEP": "no",
    "KOKKOS_ENABLE_PRAGMA_LOOPCOUNT": "no",
    "KOKKOS_ENABLE_PRAGMA_UNROLL": "no",
    "KOKKOS_ENABLE_PRAGMA_VECTOR": "no",
    "KOKKOS_ENABLE_WINDOWS_ATOMICS": "no",
    "Kokkos": "OpenMP thread_pool_topology[ 1 x 8 x 1 ]",
    "Kokkos Version": "3.7.99"
  },
  "benchmarks": [
    {
      "name": "ViewDeepCopy_Rank8<Kokkos::LayoutLeft, Kokkos::LayoutLeft>/N:10/R:1/manual_time",
      "family_index": 0,
      "per_family_instance_index": 0,
      "run_name": "ViewDeepCopy_Rank8<Kokkos::LayoutLeft, Kokkos::LayoutLeft>/N:10/R:1/manual_time",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 9,
      "real_time": 5.6612000000000010e-02,
      "cpu_time": 5.0412777777777779e-02,
      "time_unit": "s",
      "GB/s": 2.7338068860600760e+01,
      "MB": 7.6293945312500000e+02
    },
    (...)
  ]
}
```

</details>
