### PR TITLE
Deprecate Subview type from public interface

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1770,12 +1770,14 @@ void apply_to_view_of_static_rank(Function&& f, View<Args...> a) {
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
+#if defined KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class V, class... Args>
-using Subview =
+using Subview KOKKOS_DEPRECATED =
     typename Kokkos::Impl::ViewMapping<void /* deduce subview type from source
                                                view traits */
                                        ,
                                        typename V::traits, Args...>::type;
+#endif
 
 template <class D, class... P, class... Args>
 KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
During documentation @nmm0 and me wrote documentation for this public using declaration.
The doc started a discussion about whether we wanted to have this type in our public interface, as `decltype(Kokkos::subview(...))` would serve the same purpose.

As the discussion stalled, I propose to deprecate it from the public interface. This would also finalize the discussion on [#75](https://github.com/kokkos/kokkos-core-wiki/pull/75) and [#72](https://github.com/kokkos/kokkos-core-wiki/pull/72)