### PR TITLE
Replace CL/sycl.hpp

### DIFF
--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -55,7 +55,12 @@
 #include <type_traits>
 
 #ifdef KOKKOS_ENABLE_SYCL
+// FIXME_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #endif
 
 namespace Kokkos {

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -53,7 +53,12 @@ static_assert(false,
 #include <Kokkos_Macros.hpp>
 
 #ifdef KOKKOS_ENABLE_SYCL
+// FIXME_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <Kokkos_SYCL_Space.hpp>
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_ScratchSpace.hpp>

--- a/core/src/SYCL/Kokkos_SYCL_Abort.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Abort.hpp
@@ -47,7 +47,12 @@
 
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_SYCL)
+// FIXME_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
@@ -48,7 +48,12 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_SYCL
 
+// FIXME_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
 // Make sure no one else tries to define half_t

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -46,7 +46,12 @@
 #define KOKKOS_SYCL_INSTANCE_HPP_
 
 #include <optional>
+// FIXME_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Profiling.hpp>

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -54,7 +54,12 @@
 #define SYCL_FALLBACK_ASSERT 1
 #endif
 
+// FIXME_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define KOKKOS_IMPL_DO_NOT_USE_PRINTF(format, ...)                \

--- a/tpls/desul/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/tpls/desul/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -13,7 +13,12 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include "desul/atomics/SYCLConversions.hpp"
 #include "desul/atomics/Common.hpp"
 
+// FIXME_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 // clang-format on
 
 #ifdef DESUL_HAVE_SYCL_ATOMICS

--- a/tpls/desul/include/desul/atomics/Compare_Exchange_SYCL.hpp
+++ b/tpls/desul/include/desul/atomics/Compare_Exchange_SYCL.hpp
@@ -13,7 +13,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #include "desul/atomics/SYCLConversions.hpp"
 #include "desul/atomics/Common.hpp"
 
-// FIXME_SYCL
+// FIXME_SYCL SYCL2020 dictates that <sycl/sycl.hpp> is the header to include
+// but icpx 2022.1.0 and earlier versions only provide <CL/sycl.hpp>
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
 #else

--- a/tpls/desul/include/desul/atomics/SYCLConversions.hpp
+++ b/tpls/desul/include/desul/atomics/SYCLConversions.hpp
@@ -13,7 +13,12 @@ SPDX-License-Identifier: (BSD-3-Clause)
 // clang-format off
 #include "desul/atomics/Common.hpp"
 
+// FIXME_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 // clang-format on
 
 namespace desul {

--- a/tpls/desul/include/desul/atomics/SYCLConversions.hpp
+++ b/tpls/desul/include/desul/atomics/SYCLConversions.hpp
@@ -13,7 +13,8 @@ SPDX-License-Identifier: (BSD-3-Clause)
 // clang-format off
 #include "desul/atomics/Common.hpp"
 
-// FIXME_SYCL
+// FIXME_SYCL SYCL2020 dictates that <sycl/sycl.hpp> is the header to include
+// but icpx 2022.1.0 and earlier versions only provide <CL/sycl.hpp>
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
 #else


### PR DESCRIPTION
`CL/sycl.hpp` is deprecated in favor of `sycl/sycl.hpp`.
