### PR TITLE
#5382: Delete deprecated overloads of Kokkos::sort() taking parameter 'bool always_use_kokkos_sort'

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -624,38 +624,12 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
   bin_sort.sort(exec, view);
 }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
-template <class ExecutionSpace, class ViewType>
-KOKKOS_DEPRECATED_WITH_COMMENT(
-    "Use the overload not taking bool always_use_kokkos_sort")
-std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
-    const ExecutionSpace& exec, ViewType const& view,
-    bool const always_use_kokkos_sort) {
-  if (!always_use_kokkos_sort && Impl::try_std_sort(view, exec)) {
-    return;
-  } else {
-    sort(exec, view);
-  }
-}
-#endif
-
 template <class ViewType>
 void sort(ViewType const& view) {
   typename ViewType::execution_space exec;
   sort(exec, view);
   exec.fence("Kokkos::Sort: fence after sorting");
 }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
-template <class ViewType>
-KOKKOS_DEPRECATED_WITH_COMMENT(
-    "Use the overload not taking bool always_use_kokkos_sort")
-void sort(ViewType const& view, bool const always_use_kokkos_sort = false) {
-  typename ViewType::execution_space exec;
-  sort(exec, view, always_use_kokkos_sort);
-  exec.fence("Kokkos::Sort: fence after sorting");
-}
-#endif
 
 template <class ExecutionSpace, class ViewType>
 std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -586,11 +586,7 @@ struct min_max_functor {
 
 template <class ExecutionSpace, class ViewType>
 std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
-    const ExecutionSpace& exec, ViewType const& view,
-    bool const always_use_kokkos_sort = false) {
-  if (!always_use_kokkos_sort) {
-    if (Impl::try_std_sort(view, exec)) return;
-  }
+    const ExecutionSpace& exec, ViewType const& view) {
   using CompType = BinOp1D<ViewType>;
 
   Kokkos::MinMaxScalar<typename ViewType::non_const_value_type> result;
@@ -628,12 +624,38 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
   bin_sort.sort(exec, view);
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+template <class ExecutionSpace, class ViewType>
+KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use the overload not taking bool always_use_kokkos_sort")
+std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
+    const ExecutionSpace& exec, ViewType const& view,
+    bool const always_use_kokkos_sort) {
+  if (!always_use_kokkos_sort && Impl::try_std_sort(view, exec)) {
+    return;
+  } else {
+    sort(exec, view);
+  }
+}
+#endif
+
 template <class ViewType>
+void sort(ViewType const& view) {
+  typename ViewType::execution_space exec;
+  sort(exec, view);
+  exec.fence("Kokkos::Sort: fence after sorting");
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+template <class ViewType>
+KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use the overload not taking bool always_use_kokkos_sort")
 void sort(ViewType const& view, bool const always_use_kokkos_sort = false) {
   typename ViewType::execution_space exec;
   sort(exec, view, always_use_kokkos_sort);
   exec.fence("Kokkos::Sort: fence after sorting");
 }
+#endif
 
 template <class ExecutionSpace, class ViewType>
 std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -549,24 +549,6 @@ struct BinOp3D {
 
 namespace Impl {
 
-template <class ViewType, class ExecutionSpace>
-bool try_std_sort(ViewType view, const ExecutionSpace& exec) {
-  bool possible    = true;
-  size_t stride[8] = {view.stride_0(), view.stride_1(), view.stride_2(),
-                      view.stride_3(), view.stride_4(), view.stride_5(),
-                      view.stride_6(), view.stride_7()};
-  possible         = possible &&
-             SpaceAccessibility<HostSpace,
-                                typename ViewType::memory_space>::accessible;
-  possible = possible && (ViewType::Rank == 1);
-  possible = possible && (stride[0] == 1);
-  if (possible) {
-    exec.fence("Kokkos::sort: Fence before sorting on the host");
-    std::sort(view.data(), view.data() + view.extent(0));
-  }
-  return possible;
-}
-
 template <class ViewType>
 struct min_max_functor {
   using minmax_scalar =

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -396,7 +396,7 @@ void test_sort_integer_overflow() {
             Kokkos::Experimental::finite_min<T>::value};
   auto vd = Kokkos::create_mirror_view_and_copy(
       ExecutionSpace(), Kokkos::View<T[2], Kokkos::HostSpace>(a));
-  Kokkos::sort(vd, /*force using Kokkos bin sort*/ true);
+  Kokkos::sort(vd);
   auto vh = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), vd);
   EXPECT_TRUE(std::is_sorted(vh.data(), vh.data() + 2))
       << "view (" << vh[0] << ", " << vh[1] << ") is not sorted";

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -130,14 +130,14 @@ struct sum3D {
 };
 
 template <class ExecutionSpace, typename KeyType>
-void test_1D_sort_impl(unsigned int n, bool force_kokkos) {
+void test_1D_sort_impl(unsigned int n) {
   using KeyViewType = Kokkos::View<KeyType*, ExecutionSpace>;
   KeyViewType keys("Keys", n);
 
   // Test sorting array with all numbers equal
   ExecutionSpace exec;
   Kokkos::deep_copy(exec, keys, KeyType(1));
-  Kokkos::sort(exec, keys, force_kokkos);
+  Kokkos::sort(exec, keys);
 
   Kokkos::Random_XorShift64_Pool<ExecutionSpace> g(1931);
   Kokkos::fill_random(keys, g,
@@ -151,7 +151,7 @@ void test_1D_sort_impl(unsigned int n, bool force_kokkos) {
   Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace>(exec, 0, n),
                           sum<ExecutionSpace, KeyType>(keys), sum_before);
 
-  Kokkos::sort(exec, keys, force_kokkos);
+  Kokkos::sort(exec, keys);
 
   Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace>(exec, 0, n),
                           sum<ExecutionSpace, KeyType>(keys), sum_after);
@@ -406,8 +406,7 @@ void test_sort_integer_overflow() {
 
 template <class ExecutionSpace, typename KeyType>
 void test_1D_sort(unsigned int N) {
-  test_1D_sort_impl<ExecutionSpace, KeyType>(N * N * N, true);
-  test_1D_sort_impl<ExecutionSpace, KeyType>(N * N * N, false);
+  test_1D_sort_impl<ExecutionSpace, KeyType>(N * N * N);
 }
 
 template <class ExecutionSpace, typename KeyType>


### PR DESCRIPTION
A richer sorting interface will be implemented later, probably involving a handle class of some sort. This is just clearing out an obsolete design.