### PR TITLE
[3.7] Force creation of the cuda_deep_space instance during init

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -861,6 +861,14 @@ int Cuda::impl_is_initialized() {
 
 void Cuda::impl_initialize(InitializationSettings const &settings) {
   Impl::CudaInternal::singleton().initialize(Impl::get_gpu(settings));
+
+  // In order to support setting an atexit hook for Kokkos::finalize
+  // We need to ensure that the Cuda deep_copy instance is not destroyed
+  // before that atexit hook is getting called.
+  // Thus we create the static instance here, so that it will be deallocated
+  // after the potential atexit call.
+  // This is neccessary since we will access that instance in Kokkos::finalize
+  (void)::Kokkos::Impl::cuda_get_deep_copy_space(true);
 }
 
 std::vector<unsigned> Cuda::detect_device_arch() {


### PR DESCRIPTION
Can't do it inside of the Cuda initialize since that ends up being
recursive.
We may want to find a better solution however.

The test I have passes if run without valgrind, so I didn't add it here
yet.

```c++
int main(int argc, char* argv[]) {
  Kokkos::initialize(argc, argv);
  std::atexit(Kokkos::finalize);
  (void) Kokkos::Impl::cuda_get_deep_copy_space(true);
}
```

Also we would need to create a separate executable for this test. 