### PR TITLE
Don't rely on synchronization behavior of default stream in CUDA and HIP

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -142,8 +142,7 @@ class CudaInternal {
     return nullptr != m_scratchSpace && nullptr != m_scratchFlags;
   }
 
-  void initialize(int cuda_device_id, cudaStream_t stream = nullptr,
-                  bool manage_stream = false);
+  void initialize(int cuda_device_id, cudaStream_t stream, bool manage_stream);
   void finalize();
 
   void print_configuration(std::ostream&) const;

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -65,7 +65,10 @@ int HIP::impl_is_initialized() {
 }
 
 void HIP::impl_initialize(InitializationSettings const& settings) {
-  Impl::HIPInternal::singleton().initialize(::Kokkos::Impl::get_gpu(settings));
+  hipStream_t singleton_stream;
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamCreate(&singleton_stream));
+  Impl::HIPInternal::singleton().initialize(::Kokkos::Impl::get_gpu(settings),
+                                            singleton_stream, /*manage*/ true);
 }
 
 void HIP::impl_finalize() { Impl::HIPInternal::singleton().finalize(); }

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -296,11 +296,11 @@ void HIPInternal::initialize(int hip_device_id, hipStream_t stream,
   }
 
   // Init the array for used for arbitrarily sized atomics
-  if (m_stream == nullptr) ::Kokkos::Impl::initialize_host_hip_lock_arrays();
+  if (this == &singleton()) ::Kokkos::Impl::initialize_host_hip_lock_arrays();
 
   // Allocate a staging buffer for constant mem in pinned host memory
   // and an event to avoid overwriting driver for previous kernel launches
-  if (m_stream == nullptr) {
+  if (this == &singleton()) {
     KOKKOS_IMPL_HIP_SAFE_CALL(hipHostMalloc((void **)&constantMemHostStaging,
                                             HIPTraits::ConstantMemoryUsage));
 

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -149,8 +149,7 @@ class HIPInternal {
 
   int is_initialized() const { return m_hipDev >= 0; }
 
-  void initialize(int hip_device_id, hipStream_t stream = nullptr,
-                  bool manage_stream = false);
+  void initialize(int hip_device_id, hipStream_t stream, bool manage_stream);
   void finalize();
 
   void print_configuration(std::ostream &) const;

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -266,9 +266,9 @@ TEST(cuda, uvm) {
 
     *uvm_ptr = 42;
 
-    Kokkos::Cuda().fence();
+    Kokkos::fence();
     test_cuda_spaces_int_value<<<1, 1>>>(uvm_ptr);
-    Kokkos::Cuda().fence();
+    Kokkos::fence();
 
     EXPECT_EQ(*uvm_ptr, int(2 * 42));
 


### PR DESCRIPTION
https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html:
> The legacy default stream is an implicit stream which synchronizes with all other streams in the same CUcontext except for non-blocking streams, described below. (For applications using the runtime APIs only, there will be one context per device.) When an action is taken in the legacy stream such as a kernel launch or cudaStreamWaitEvent(), the legacy stream first waits on all blocking streams, the action is queued in the legacy stream, and then all blocking streams wait on the legacy stream. 

and HIP behaves similarly, see https://github.com/ROCm-Developer-Tools/HIP/issues/129#issuecomment-318667584. 
As discussed on Slack, the default execution space instance shouldn't have any special synchronization behavior with respect to other execution space instances. Hence, this pull request also creates a stream for the singleton that is used for the default execution space instance.