### PR TITLE
Make execution spaces regular

### DIFF
--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -264,6 +264,9 @@ struct is_device_helper<Device<ExecutionSpace, MemorySpace>> : std::true_type {
 template <typename T>
 using is_device = typename Impl::is_device_helper<std::remove_cv_t<T>>::type;
 
+template <typename T>
+inline constexpr bool is_device_v = is_device<T>::value;
+
 //----------------------------------------------------------------------------
 
 template <typename T>

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -245,6 +245,13 @@ class Cuda {
   uint32_t impl_instance_id() const noexcept;
 
  private:
+  friend bool operator==(Cuda const& lhs, Cuda const& rhs) {
+    return lhs.impl_internal_space_instance() ==
+           rhs.impl_internal_space_instance();
+  }
+  friend bool operator!=(Cuda const& lhs, Cuda const& rhs) {
+    return !(lhs == rhs);
+  }
   Kokkos::Impl::HostSharedPtr<Impl::CudaInternal> m_space_instance;
 };
 

--- a/core/src/Kokkos_HIP_Space.hpp
+++ b/core/src/Kokkos_HIP_Space.hpp
@@ -740,6 +740,13 @@ class HIP {
   uint32_t impl_instance_id() const noexcept;
 
  private:
+  friend bool operator==(HIP const& lhs, HIP const& rhs) {
+    return lhs.impl_internal_space_instance() ==
+           rhs.impl_internal_space_instance();
+  }
+  friend bool operator!=(HIP const& lhs, HIP const& rhs) {
+    return !(lhs == rhs);
+  }
   Kokkos::Impl::HostSharedPtr<Impl::HIPInternal> m_space_instance;
 };
 }  // namespace Experimental

--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -479,6 +479,14 @@ class HPX {
 #endif
 
   static constexpr const char *name() noexcept { return "HPX"; }
+
+ private:
+  friend bool operator==(HPX const &lhs, HPX const &rhs) {
+    return lhs.m_instance_id == rhs.m_instance_id;
+  }
+  friend bool operator!=(HPX const &lhs, HPX const &rhs) {
+    return !(lhs == rhs);
+  }
 };
 }  // namespace Experimental
 

--- a/core/src/Kokkos_OpenMP.hpp
+++ b/core/src/Kokkos_OpenMP.hpp
@@ -172,6 +172,13 @@ class OpenMP {
   uint32_t impl_instance_id() const noexcept { return 1; }
 
  private:
+  friend bool operator==(OpenMP const& lhs, OpenMP const& rhs) {
+    return lhs.impl_internal_space_instance() ==
+           rhs.impl_internal_space_instance();
+  }
+  friend bool operator!=(OpenMP const& lhs, OpenMP const& rhs) {
+    return !(lhs == rhs);
+  }
   Kokkos::Impl::HostSharedPtr<Impl::OpenMPInternal> m_space_instance;
 };
 

--- a/core/src/Kokkos_OpenMPTarget.hpp
+++ b/core/src/Kokkos_OpenMPTarget.hpp
@@ -125,6 +125,13 @@ class OpenMPTarget {
   uint32_t impl_instance_id() const noexcept;
 
  private:
+  friend bool operator==(OpenMPTarget const& lhs, OpenMPTarget const& rhs) {
+    return lhs.impl_internal_space_instance() ==
+           rhs.impl_internal_space_instance();
+  }
+  friend bool operator!=(OpenMPTarget const& lhs, OpenMPTarget const& rhs) {
+    return !(lhs == rhs);
+  }
   Impl::OpenMPTargetInternal* m_space_instance;
 };
 }  // namespace Experimental

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -143,6 +143,13 @@ class SYCL {
   static std::ostream& impl_sycl_info(std::ostream& os,
                                       const sycl::device& device);
 
+  friend bool operator==(SYCL const& lhs, SYCL const& rhs) {
+    return lhs.impl_internal_space_instance() ==
+           rhs.impl_internal_space_instance();
+  }
+  friend bool operator!=(SYCL const& lhs, SYCL const& rhs) {
+    return !(lhs == rhs);
+  }
   Kokkos::Impl::HostSharedPtr<Impl::SYCLInternal> m_space_instance;
 };
 

--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -212,6 +212,13 @@ class Serial {
 #else
   Kokkos::Impl::HostSharedPtr<Impl::SerialInternal> m_space_instance;
 #endif
+  friend bool operator==(Serial const& lhs, Serial const& rhs) {
+    return lhs.impl_internal_space_instance() ==
+           rhs.impl_internal_space_instance();
+  }
+  friend bool operator!=(Serial const& lhs, Serial const& rhs) {
+    return !(lhs == rhs);
+  }
   //--------------------------------------------------------------------------
 };
 

--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -161,6 +161,9 @@ class Threads {
   static const char* name();
   //@}
   //----------------------------------------
+ private:
+  friend bool operator==(Threads const&, Threads const&) { return true; }
+  friend bool operator!=(Threads const&, Threads const&) { return false; }
 };
 
 namespace Tools {

--- a/core/src/OpenACC/Kokkos_OpenACC.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.hpp
@@ -74,6 +74,14 @@ namespace Kokkos::Experimental {
 class OpenACC {
   Kokkos::Impl::HostSharedPtr<Impl::OpenACCInternal> m_space_instance;
 
+  friend bool operator==(OpenACC const& lhs, OpenACC const& rhs) {
+    return lhs.impl_internal_space_instance() ==
+           rhs.impl_internal_space_instance();
+  }
+  friend bool operator!=(OpenACC const& lhs, OpenACC const& rhs) {
+    return !(lhs == rhs);
+  }
+
  public:
   using execution_space = OpenACC;
   using memory_space    = OpenACCSpace;

--- a/core/src/impl/Kokkos_ExecSpaceManager.hpp
+++ b/core/src/impl/Kokkos_ExecSpaceManager.hpp
@@ -57,40 +57,40 @@ namespace {
 
 template <class T>
 using public_member_types_t = std::enable_if_t<
-    Kokkos::is_execution_space<typename T::execution_space>::value &&
-    Kokkos::is_memory_space<typename T::memory_space>::value &&
-    Kokkos::is_device<typename T::device_type>::value &&
-    Kokkos::is_array_layout<typename T::array_layout>::value &&
-    std::is_integral<typename T::size_type>::value &&
-    Kokkos::is_memory_space<typename T::scratch_memory_space>::value>;
+    Kokkos::is_execution_space_v<typename T::execution_space> &&
+    Kokkos::is_memory_space_v<typename T::memory_space> &&
+    Kokkos::is_device_v<typename T::device_type> &&
+    Kokkos::is_array_layout_v<typename T::array_layout> &&
+    std::is_integral_v<typename T::size_type> &&
+    Kokkos::is_memory_space_v<typename T::scratch_memory_space>>;
 
 template <class T>
 using print_configuration_t = std::enable_if_t<
-    std::is_void<decltype(std::declval<T const&>().print_configuration(
-        std::declval<std::ostream&>()))>::value &&
-    std::is_void<decltype(std::declval<T const&>().print_configuration(
-        std::declval<std::ostream&>(), false))>::value>;
+    std::is_void_v<decltype(std::declval<T const&>().print_configuration(
+        std::declval<std::ostream&>()))> &&
+    std::is_void_v<decltype(std::declval<T const&>().print_configuration(
+        std::declval<std::ostream&>(), false))>>;
 
 template <class T>
 using initialize_finalize_t = std::enable_if_t<
-    std::is_void<decltype(T::impl_initialize(
-        std::declval<Kokkos::InitializationSettings const&>()))>::value &&
-    std::is_void<decltype(T::impl_finalize())>::value>;
+    std::is_void_v<decltype(T::impl_initialize(
+        std::declval<Kokkos::InitializationSettings const&>()))> &&
+    std::is_void_v<decltype(T::impl_finalize())>>;
 
 template <class T>
 using fence_t = std::enable_if_t<
-    std::is_void<decltype(std::declval<T const&>().fence())>::value &&
-    std::is_void<decltype(std::declval<T const&>().fence("name"))>::value &&
-    std::is_void<decltype(T::impl_static_fence("name"))>::value>;
+    std::is_void_v<decltype(std::declval<T const&>().fence())> &&
+    std::is_void_v<decltype(std::declval<T const&>().fence("name"))> &&
+    std::is_void_v<decltype(T::impl_static_fence("name"))>>;
 
 template <class ExecutionSpace>
 constexpr bool check_valid_execution_space() {
-  using Kokkos::is_detected;
-  static_assert(std::is_default_constructible<ExecutionSpace>::value);
-  static_assert(is_detected<public_member_types_t, ExecutionSpace>::value);
-  static_assert(is_detected<print_configuration_t, ExecutionSpace>::value);
-  static_assert(is_detected<initialize_finalize_t, ExecutionSpace>::value);
-  static_assert(is_detected<fence_t, ExecutionSpace>::value);
+  using Kokkos::is_detected_v;
+  static_assert(std::is_default_constructible_v<ExecutionSpace>);
+  static_assert(is_detected_v<public_member_types_t, ExecutionSpace>);
+  static_assert(is_detected_v<print_configuration_t, ExecutionSpace>);
+  static_assert(is_detected_v<initialize_finalize_t, ExecutionSpace>);
+  static_assert(is_detected_v<fence_t, ExecutionSpace>);
 #ifndef KOKKOS_ENABLE_HPX  // FIXME_HPX
   static_assert(sizeof(ExecutionSpace) <= 2 * sizeof(void*));
 #endif
@@ -112,7 +112,7 @@ struct ExecSpaceBase {
 
 template <class ExecutionSpace>
 struct ExecSpaceDerived : ExecSpaceBase {
-  static_assert(check_valid_execution_space<ExecutionSpace>(), "");
+  static_assert(check_valid_execution_space<ExecutionSpace>());
   void initialize(InitializationSettings const& settings) final {
     ExecutionSpace::impl_initialize(settings);
   }


### PR DESCRIPTION
Related to #5397 
* Add `operator==` and `operator!=` for all execution spaces and check that they meet the syntactic requirements of *regular* types

Drive-by changes:
* add missing `is_device_v` helper variable
* more C++17