### PR TITLE
Link with stdc++fs if necessary

### DIFF
--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -144,19 +144,4 @@ IF(Kokkos_ENABLE_OPENMP)
   target_link_libraries(kokkoscore PUBLIC OpenMP::OpenMP_CXX)
 ENDIF()
 
-INCLUDE(CheckCXXSourceCompiles)
-CHECK_CXX_SOURCE_COMPILES("
-  #include <ciso646>
-
-  #if !defined (__GLIBCXX__) || __GLIBCXX__ >= 20210601 // godbolt gcc 9.4
-    static_assert(false, \"don't need lstdc++fs\");
-  #endif
-
-  int main() {}"
-  KOKKOS_NEED_STDCPPFS)
-
-IF(KOKKOS_NEED_STDCPPFS)
-  target_link_libraries(kokkoscore PUBLIC stdc++fs)
-ENDIF()
-
 KOKKOS_LINK_TPL(kokkoscore PUBLIC LIBQUADMATH)

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -144,4 +144,19 @@ IF(Kokkos_ENABLE_OPENMP)
   target_link_libraries(kokkoscore PUBLIC OpenMP::OpenMP_CXX)
 ENDIF()
 
+INCLUDE(CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES("
+  #include <ciso646>
+
+  #if !defined (__GLIBCXX__) || __GLIBCXX__ >= 20210601 // godbolt gcc 9.4
+    static_assert(false, \"don't need lstdc++fs\");
+  #endif
+
+  int main() {}"
+  KOKKOS_NEED_STDCPPFS)
+
+IF(KOKKOS_NEED_STDCPPFS)
+  target_link_libraries(kokkoscore PUBLIC stdc++fs)
+ENDIF()
+
 KOKKOS_LINK_TPL(kokkoscore PUBLIC LIBQUADMATH)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1065,8 +1065,24 @@ KOKKOS_ADD_EXECUTABLE_AND_TEST(
 
 # This test is not properly set up to run within Trilinos
 if (NOT KOKKOS_HAS_TRILINOS)
+  include(CheckCXXSourceCompiles)
+  # older versions of the GNU Standard C++ Library need to link with stdc++fs
+  # for functionality in the <filesystem> header.
+  check_cxx_source_compiles("
+    #include <ciso646>
+
+    #if !defined (__GLIBCXX__) || __GLIBCXX__ >= 20210601 // godbolt gcc 9.4
+      static_assert(false, \"don't need lstdc++fs\");
+    #endif
+
+    int main() {}"
+    KOKKOS_NEED_STDCPPFS)
+
   add_executable(KokkosCore_UnitTest_DeviceAndThreads UnitTest_DeviceAndThreads.cpp)
   target_link_libraries(KokkosCore_UnitTest_DeviceAndThreads Kokkos::kokkoscore)
+  if(KOKKOS_NEED_STDCPPFS)
+    target_link_libraries(KokkosCore_UnitTest_DeviceAndThreads stdc++fs)
+  endif()
   find_package(Python3 COMPONENTS Interpreter)
   if(Python3_Interpreter_FOUND AND Python3_VERSION VERSION_GREATER_EQUAL 3.7)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1063,23 +1063,26 @@ KOKKOS_ADD_EXECUTABLE_AND_TEST(
   ARGS "one 2 THREE"
 )
 
-add_executable(KokkosCore_UnitTest_DeviceAndThreads UnitTest_DeviceAndThreads.cpp)
-target_link_libraries(KokkosCore_UnitTest_DeviceAndThreads Kokkos::kokkoscore)
-find_package(Python3 COMPONENTS Interpreter)
-if(Python3_Interpreter_FOUND AND Python3_VERSION VERSION_GREATER_EQUAL 3.7)
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
-    set(USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED USE_SOURCE_PERMISSIONS)
-  endif()
-  file(GENERATE
-    OUTPUT $<TARGET_FILE_DIR:KokkosCore_UnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
-    INPUT TestDeviceAndThreads.py
-    ${USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED}
-  )
-  if(NOT Kokkos_ENABLE_OPENMPTARGET)  # FIXME_OPENMPTARGET does not select the right device
-    add_test(
-      NAME KokkosCore_UnitTest_DeviceAndThreads
-      COMMAND ${Python3_EXECUTABLE} -m unittest -v $<TARGET_FILE_DIR:KokkosCore_UnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
+# This test is not properly set up to run within Trilinos
+if (NOT KOKKOS_HAS_TRILINOS)
+  add_executable(KokkosCore_UnitTest_DeviceAndThreads UnitTest_DeviceAndThreads.cpp)
+  target_link_libraries(KokkosCore_UnitTest_DeviceAndThreads Kokkos::kokkoscore)
+  find_package(Python3 COMPONENTS Interpreter)
+  if(Python3_Interpreter_FOUND AND Python3_VERSION VERSION_GREATER_EQUAL 3.7)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
+      set(USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED USE_SOURCE_PERMISSIONS)
+    endif()
+    file(GENERATE
+      OUTPUT $<TARGET_FILE_DIR:KokkosCore_UnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
+      INPUT TestDeviceAndThreads.py
+      ${USE_SOURCE_PERMISSIONS_WHEN_SUPPORTED}
     )
+    if(NOT Kokkos_ENABLE_OPENMPTARGET)  # FIXME_OPENMPTARGET does not select the right device
+      add_test(
+        NAME KokkosCore_UnitTest_DeviceAndThreads
+        COMMAND ${Python3_EXECUTABLE} -m unittest -v $<TARGET_FILE_DIR:KokkosCore_UnitTest_DeviceAndThreads>/TestDeviceAndThreads.py
+      )
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/5392. Trying multiple gcc versions on https://godbolt.org/z/4hrq3vz9G the value here seems to be recent enough not to require linking with `stdc++fs`.