### PR TITLE
Don't use <filesystem> functionality

### DIFF
--- a/core/unit_test/UnitTest_DeviceAndThreads.cpp
+++ b/core/unit_test/UnitTest_DeviceAndThreads.cpp
@@ -43,7 +43,6 @@
 */
 
 #include <Kokkos_Core.hpp>
-#include <filesystem>
 #include <iostream>
 #include <string>
 #include <thread>
@@ -131,8 +130,7 @@ int print_flag(std::string const& flag) {
 int main(int argc, char* argv[]) {
   Kokkos::ScopeGuard guard(argc, argv);
   if (argc != 2) {
-    auto const filename = std::filesystem::path(argv[0]).filename().string();
-    std::cerr << "Usage: " << filename << " NAME_OF_FLAG\n";
+    std::cerr << "Usage: <executable> NAME_OF_FLAG\n";
     return EXIT_FAILURE;
   }
   int exit_code = print_flag(argv[1]);


### PR DESCRIPTION
Alternative to https://github.com/kokkos/kokkos/pull/5401 fixing #5392.
It turns out that using `<filesystem>` functionality just creates too many problems, see https://github.com/kokkos/kokkos/pull/5401#issuecomment-1230770045 and https://github.com/kokkos/kokkos/issues/5392#issuecomment-1227582307.