### PR TITLE
Add static_assert(false) for join(volatile) if deprecated code is disabled

### DIFF
--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -656,7 +656,8 @@ struct FunctorAnalysis {
       : public has_volatile_join_no_tag_function<F> {
     enum : bool { value = true };
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE_3
-    static_assert(Impl::dependent_false_v<F>, "Reducer with a join() operator taking "
+    static_assert(Impl::dependent_false_v<F>,
+                  "Reducer with a join() operator taking "
                   "volatile-qualified parameters is no longer supported");
 #endif
   };
@@ -678,7 +679,8 @@ struct FunctorAnalysis {
       : public has_volatile_join_tag_function<F> {
     enum : bool { value = true };
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE_3
-    static_assert(Impl::dependent_false_v<F>, "Reducer with a join() operator taking "
+    static_assert(Impl::dependent_false_v<F>,
+                  "Reducer with a join() operator taking "
                   "volatile-qualified parameters is no longer supported");
 #endif
   };

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -655,6 +655,10 @@ struct FunctorAnalysis {
                         detected_volatile_join_no_tag<F>::value)>>
       : public has_volatile_join_no_tag_function<F> {
     enum : bool { value = true };
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_3
+    static_assert(Impl::dependent_false_v<F>, "Reducer with a join() operator taking "
+                  "volatile-qualified parameters is no longer supported");
+#endif
   };
 
   template <class F = Functor, typename = void>
@@ -673,6 +677,10 @@ struct FunctorAnalysis {
                                          detected_volatile_join_tag<F>::value)>>
       : public has_volatile_join_tag_function<F> {
     enum : bool { value = true };
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_3
+    static_assert(Impl::dependent_false_v<F>, "Reducer with a join() operator taking "
+                  "volatile-qualified parameters is no longer supported");
+#endif
   };
 
   //----------------------------------------

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -243,6 +243,15 @@ using filter_type_list_t =
 // </editor-fold> end type_list }}}1
 //==============================================================================
 
+//==============================================================================
+// The weird !sizeof(F*) to express false is to make the
+// expression dependent on the type of F, and thus only applicable
+// at instantiation and not first-pass semantic analysis of the
+// template definition.
+template <typename T>
+constexpr bool dependent_false_v = !sizeof(T*);
+//==============================================================================
+
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/unit_test/TestJoinBackwardCompatibility.hpp
+++ b/core/unit_test/TestJoinBackwardCompatibility.hpp
@@ -54,7 +54,7 @@ enum MyErrorCode {
   error_operator_plus_equal          = 0b001,
   error_operator_plus_equal_volatile = 0b010,
   error_join_volatile                = 0b100,
-  expected_join_volatile =            0b1000
+  expected_join_volatile             = 0b1000
 
 };
 
@@ -151,7 +151,8 @@ void test_join_backward_compatibility() {
 
 #if defined(KOKKOS_ENABLE_DEPRECATED_CODE_3)
   MyJoinBackCompatValueType result3;
-  Kokkos::parallel_reduce(policy, ReducerWithJoinThatTakesVolatileQualifiedArgs{}, result3);
+  Kokkos::parallel_reduce(
+      policy, ReducerWithJoinThatTakesVolatileQualifiedArgs{}, result3);
   ASSERT_EQ(result3.err, expected_join_volatile);
 #endif
 }


### PR DESCRIPTION
Fixes #5194 