### PR TITLE
Disable OpenMPTarget unit tests that cause ICEs with icpx

### DIFF
--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -137,7 +137,8 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;HIP;SYCL;OpenMPTarget)
   endif()
 endforeach()
 
-# FIXME_OPENMPTARGET
+# FIXME_OPENMPTARGET These tests cause internal compiler errors as of 09/01/22
+# when compiling for Intel's Xe-HP GPUs.
 if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
   list(REMOVE_ITEM STDALGO_SOURCES_D
     TestStdAlgorithmsCopyIf.cpp
@@ -151,7 +152,8 @@ if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
   )
 endif()
 
-# FIXME_OPENMPTARGET
+# FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
+# when compiling for Intel's Xe-HP GPUs.
 if(NOT (KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM))
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
     UnitTest_RandomAndSort
@@ -170,7 +172,8 @@ foreach(ID A;B;C;D;E)
     )
 endforeach()
 
-# FIXME_OPENMPTARGET
+# FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
+# when compiling for Intel's Xe-HP GPUs.
 if(NOT (KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM))
   KOKKOS_ADD_EXECUTABLE(
     UnitTest_StdAlgoCompileOnly

--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -137,12 +137,29 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;HIP;SYCL;OpenMPTarget)
   endif()
 endforeach()
 
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  UnitTest_RandomAndSort
-  SOURCES
-    UnitTestMain.cpp
-    ${SOURCES_A}
-)
+# FIXME_OPENMPTARGET
+if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
+  list(REMOVE_ITEM STDALGO_SOURCES_D
+    TestStdAlgorithmsCopyIf.cpp
+    TestStdAlgorithmsRemoveCopy.cpp
+    TestStdAlgorithmsUnique.cpp
+    TestStdAlgorithmsUniqueCopy.cpp
+  )
+  list(REMOVE_ITEM STDALGO_SOURCES_E
+    TestStdAlgorithmsExclusiveScan.cpp
+    TestStdAlgorithmsInclusiveScan.cpp
+  )
+endif()
+
+# FIXME_OPENMPTARGET
+if(NOT (KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM))
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    UnitTest_RandomAndSort
+    SOURCES
+      UnitTestMain.cpp
+      ${SOURCES_A}
+  )
+endif()
 
 foreach(ID A;B;C;D;E)
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
@@ -153,7 +170,10 @@ foreach(ID A;B;C;D;E)
     )
 endforeach()
 
-KOKKOS_ADD_EXECUTABLE(
-  UnitTest_StdAlgoCompileOnly
-  SOURCES TestStdAlgorithmsCompileOnly.cpp
-)
+# FIXME_OPENMPTARGET
+if(NOT (KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM))
+  KOKKOS_ADD_EXECUTABLE(
+    UnitTest_StdAlgoCompileOnly
+    SOURCES TestStdAlgorithmsCompileOnly.cpp
+  )
+endif()

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -377,6 +377,8 @@ IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang AND KOKK
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_e.cpp
   )
 ENDIF()
+# FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
+# when compiling for Intel's Xe-HP GPUs.
 IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
   LIST(REMOVE_ITEM OpenMPTarget_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp
@@ -894,6 +896,8 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
     tools/TestProfilingSection.cpp
     )
 
+  # FIXME_OPENMPTARGET This test causes internal compiler errors as of 09/01/22
+  # when compiling for Intel's Xe-HP GPUs.
   if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
     list(REMOVE_ITEM KOKKOSP_SOURCES tools/TestEventCorrectness.cpp)
   endif()

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -377,6 +377,11 @@ IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang AND KOKK
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_e.cpp
   )
 ENDIF()
+IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
+  LIST(REMOVE_ITEM OpenMPTarget_SOURCES
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamVectorRange.cpp
+  )
+ENDIF()
 
 # FIXME_OPENMPTARGET - Comment non-passing tests with the NVIDIA HPC compiler nvc++
 IF(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
@@ -882,13 +887,21 @@ KOKKOS_ADD_ADVANCED_TEST( UnitTest_PushFinalizeHook_terminate
       tools/TestLogicalSpaces.cpp
   )
   endif()
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    UnitTest_KokkosP
-    SOURCES
+  SET(KOKKOSP_SOURCES
     UnitTestMainInit.cpp
     tools/TestEventCorrectness.cpp
     tools/TestWithoutInitializing.cpp
     tools/TestProfilingSection.cpp
+    )
+
+  if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM)
+    list(REMOVE_ITEM KOKKOSP_SOURCES tools/TestEventCorrectness.cpp)
+  endif()
+
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    UnitTest_KokkosP
+    SOURCES
+    ${KOKKOSP_SOURCES}
   )
   if(KOKKOS_ENABLE_LIBDL)
     KOKKOS_ADD_EXECUTABLE_AND_TEST(


### PR DESCRIPTION
Trying to compile those unit tests with `icpx` for `OpenMPTarget` (and Intel GPUs) causes internal compiler errors.