### PR TITLE
#4077 Follow-on cleanup: drop volatile-qualified members from Pair and Complex

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -279,11 +279,7 @@ class
     return *this;
   }
 
-  //---------------------------------------------------------------------------
-  // TODO: refactor Kokkos reductions to remove dependency on
-  // volatile member overloads since they are being deprecated in c++20
-  //---------------------------------------------------------------------------
-
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   //! Copy constructor from volatile.
   template <
       class RType,
@@ -436,8 +432,7 @@ class
     re_ *= src;
     im_ *= src;
   }
-
-  // TODO DSH 2019-10-7 why are there no volatile /= and friends?
+#endif  // KOKKOS_ENABLE_DEPRECATED_CODE_4
 };
 
 //==============================================================================

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -284,7 +284,8 @@ class
   template <
       class RType,
       std::enable_if_t<std::is_convertible<RType, RealType>::value, int> = 0>
-  KOKKOS_INLINE_FUNCTION complex(const volatile complex<RType>& src) noexcept
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED
+  complex(const volatile complex<RType>& src) noexcept
       // Intentionally do the conversions implicitly here so that users don't
       // get any warnings about narrowing, etc., that they would expect to get
       // otherwise.
@@ -312,7 +313,8 @@ class
   //    vl = cr;
   template <class Complex,
             std::enable_if_t<std::is_same<Complex, complex>::value, int> = 0>
-  KOKKOS_INLINE_FUNCTION void operator=(const Complex& src) volatile noexcept {
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator=(
+      const Complex& src) volatile noexcept {
     re_ = src.re_;
     im_ = src.im_;
     // We deliberately do not return anything here.  See explanation
@@ -334,7 +336,7 @@ class
   //    vl = cvr;
   template <class Complex,
             std::enable_if_t<std::is_same<Complex, complex>::value, int> = 0>
-  KOKKOS_INLINE_FUNCTION volatile complex& operator=(
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED volatile complex& operator=(
       const volatile Complex& src) volatile noexcept {
     re_ = src.re_;
     im_ = src.im_;
@@ -356,7 +358,7 @@ class
   //
   template <class Complex,
             std::enable_if_t<std::is_same<Complex, complex>::value, int> = 0>
-  KOKKOS_INLINE_FUNCTION complex& operator=(
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED complex& operator=(
       const volatile Complex& src) noexcept {
     re_ = src.re_;
     im_ = src.im_;
@@ -367,7 +369,8 @@ class
   // RealType RHS versions.
 
   //! Assignment operator (from a volatile real number).
-  KOKKOS_INLINE_FUNCTION void operator=(const volatile RealType& val) noexcept {
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator=(
+      const volatile RealType& val) noexcept {
     re_ = val;
     im_ = RealType(0);
     // We deliberately do not return anything here.  See explanation
@@ -375,7 +378,7 @@ class
   }
 
   //! Assignment operator volatile LHS and non-volatile RHS
-  KOKKOS_INLINE_FUNCTION complex& operator=(
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED complex& operator=(
       const RealType& val) volatile noexcept {
     re_ = val;
     im_ = RealType(0);
@@ -384,7 +387,7 @@ class
 
   //! Assignment operator volatile LHS and volatile RHS
   // TODO Should this return void like the other volatile assignment operators?
-  KOKKOS_INLINE_FUNCTION complex& operator=(
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED complex& operator=(
       const volatile RealType& val) volatile noexcept {
     re_ = val;
     im_ = RealType(0);
@@ -392,33 +395,41 @@ class
   }
 
   //! The imaginary part of this complex number (volatile overload).
-  KOKKOS_INLINE_FUNCTION
-  volatile RealType& imag() volatile noexcept { return im_; }
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED volatile RealType&
+  imag() volatile noexcept {
+    return im_;
+  }
 
   //! The real part of this complex number (volatile overload).
-  KOKKOS_INLINE_FUNCTION
-  volatile RealType& real() volatile noexcept { return re_; }
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED volatile RealType&
+  real() volatile noexcept {
+    return re_;
+  }
 
   //! The imaginary part of this complex number (volatile overload).
-  KOKKOS_INLINE_FUNCTION
-  RealType imag() const volatile noexcept { return im_; }
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED RealType imag() const
+      volatile noexcept {
+    return im_;
+  }
 
   //! The real part of this complex number (volatile overload).
-  KOKKOS_INLINE_FUNCTION
-  RealType real() const volatile noexcept { return re_; }
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED RealType real() const
+      volatile noexcept {
+    return re_;
+  }
 
-  KOKKOS_INLINE_FUNCTION void operator+=(
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator+=(
       const volatile complex<RealType>& src) volatile noexcept {
     re_ += src.re_;
     im_ += src.im_;
   }
 
-  KOKKOS_INLINE_FUNCTION void operator+=(
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator+=(
       const volatile RealType& src) volatile noexcept {
     re_ += src;
   }
 
-  KOKKOS_INLINE_FUNCTION void operator*=(
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator*=(
       const volatile complex<RealType>& src) volatile noexcept {
     const RealType realPart = re_ * src.re_ - im_ * src.im_;
     const RealType imagPart = re_ * src.im_ + im_ * src.re_;
@@ -427,7 +438,7 @@ class
     im_ = imagPart;
   }
 
-  KOKKOS_INLINE_FUNCTION void operator*=(
+  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator*=(
       const volatile RealType& src) volatile noexcept {
     re_ *= src;
     im_ *= src;

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -603,8 +603,9 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 // Guard intel compiler version 19 and older
 // intel error #2651: attribute does not apply to any entity
 // using <deprecated_type> KOKKOS_DEPRECATED = ...
-#if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS) && !defined(__NVCC__) && \
-    (!defined(KOKKOS_COMPILER_INTEL) || KOKKOS_COMPILER_INTEL >= 2021)
+#if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS) && !defined(__NVCC__) &&  \
+    (!defined(KOKKOS_COMPILER_INTEL) || KOKKOS_COMPILER_INTEL >= 2021) && \
+    !defined(KOKKOS_ENABLE_OPENACC)
 #define KOKKOS_DEPRECATED [[deprecated]]
 #define KOKKOS_DEPRECATED_WITH_COMMENT(comment) [[deprecated(comment)]]
 #else

--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -117,7 +117,8 @@ struct pair {
   /// This calls the copy constructors of T1 and T2.  It won't compile
   /// if those copy constructors are not defined and public.
   template <class U, class V>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr pair(const volatile pair<U, V>& p)
+  KOKKOS_FORCEINLINE_FUNCTION KOKKOS_DEPRECATED constexpr pair(
+      const volatile pair<U, V>& p)
       : first(p.first), second(p.second) {}
 #endif
 
@@ -145,7 +146,7 @@ struct pair {
   /// practice, this means that you should not chain assignments with
   /// volatile lvalues.
   template <class U, class V>
-  KOKKOS_FORCEINLINE_FUNCTION void operator=(
+  KOKKOS_FORCEINLINE_FUNCTION KOKKOS_DEPRECATED void operator=(
       const volatile pair<U, V>& p) volatile {
     first  = p.first;
     second = p.second;

--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -111,6 +111,7 @@ struct pair {
       : first(p.first), second(p.second) {
   }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   /// \brief Copy constructor.
   ///
   /// This calls the copy constructors of T1 and T2.  It won't compile
@@ -118,6 +119,7 @@ struct pair {
   template <class U, class V>
   KOKKOS_FORCEINLINE_FUNCTION constexpr pair(const volatile pair<U, V>& p)
       : first(p.first), second(p.second) {}
+#endif
 
   /// \brief Assignment operator.
   ///
@@ -130,6 +132,7 @@ struct pair {
     return *this;
   }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   /// \brief Assignment operator, for volatile <tt>*this</tt>.
   ///
   /// \param p [in] Input; right-hand side of the assignment.
@@ -149,6 +152,7 @@ struct pair {
     // We deliberately do not return anything here.  See explanation
     // in public documentation above.
   }
+#endif
 
   // from std::pair<U,V>
   template <class U, class V>

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -112,9 +112,9 @@ struct TestComplexConstruction {
     d_results(2)              = c;
     Kokkos::complex<double> d(3.5);
     d_results(3) = d;
-    volatile Kokkos::complex<double> a_v(4.5, 5.5);
+    Kokkos::complex<double> a_v(4.5, 5.5);
     d_results(4) = a_v;
-    volatile Kokkos::complex<double> b_v(a);
+    Kokkos::complex<double> b_v(a);
     d_results(5) = b_v;
     Kokkos::complex<double> e(a_v);
     d_results(6) = e;


### PR DESCRIPTION
Inspired by documentation work in https://github.com/kokkos/kokkos-core-wiki/issues/151, whose corresponding PR will reflect this