### PR TITLE
Split Random/Sort/NestedSort test into multiple cpps

### DIFF
--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -31,7 +31,11 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;HIP;SYCL;OpenMPTarget)
     # Each of these inputs is an .hpp file.
     # Generate a .cpp file for each one that runs it on the current backend (Tag),
     # and add this .cpp file to the sources for UnitTest_RandomAndSort.
-    foreach(SOURCES_A_Input TestRandomCommon;TestSortCommon;TestNestedSort)
+    foreach(SOURCES_A_Input
+        TestRandomCommon
+        TestSortCommon
+        TestNestedSort
+    )
       set(file ${dir}/${SOURCES_A_Input}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.

--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -28,17 +28,20 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;HIP;SYCL;OpenMPTarget)
 	)
     endif()
 
-    set(file ${dir}/TestRandomAndSort.cpp)
-    # Write to a temporary intermediate file and call configure_file to avoid
-    # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
-    file(WRITE ${dir}/dummy.cpp
-      "#include <Test${Tag}_Category.hpp>\n"
-      "#include <TestRandomCommon.hpp>\n"
-      "#include <TestSortCommon.hpp>\n"
-      "#include <TestNestedSort.hpp>\n"
-      )
-    configure_file(${dir}/dummy.cpp ${file})
-    list(APPEND SOURCES_A ${file})
+    # Each of these inputs is an .hpp file.
+    # Generate a .cpp file for each one that runs it on the current backend (Tag),
+    # and add this .cpp file to the sources for UnitTest_RandomAndSort.
+    foreach(SOURCES_A_Input TestRandomCommon;TestSortCommon;TestNestedSort)
+      set(file ${dir}/${SOURCES_A_Input}.cpp)
+      # Write to a temporary intermediate file and call configure_file to avoid
+      # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
+      file(WRITE ${dir}/dummy.cpp
+        "#include <Test${Tag}_Category.hpp>\n"
+        "#include <${SOURCES_A_Input}.hpp>\n"
+        )
+      configure_file(${dir}/dummy.cpp ${file})
+      list(APPEND SOURCES_A ${file})
+    endforeach()
 
     # ------------------------------------------
     # std set A

--- a/algorithms/unit_tests/TestNestedSort.hpp
+++ b/algorithms/unit_tests/TestNestedSort.hpp
@@ -47,6 +47,8 @@
 
 #include <unordered_set>
 #include <random>
+#include <Kokkos_Random.hpp>
+#include <Kokkos_NestedSort.hpp>
 
 namespace Test {
 


### PR DESCRIPTION
(Address #5414 )

Instead of including the Sort, NestedSort and Random tests into a single .cpp and compiling that into UnitTest_RandomAndSort, create one cpp file for each test header. Compile these into the same single test executable.

Note: I'm assuming that it's intentional that the final test only runs on one backend (whichever enabled backend is last in the list ``Threads;Serial;OpenMP;Cuda;HPX;HIP;SYCL;OpenMPTarget``). If not, the line ``set(SOURCES_A)`` should be moved outside this loop over backends, so that it doesn't get reset to empty for each one.