### PR TITLE
Call `Kokkos::abort` for invalid uses of `initialize` or `finalize`

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -1050,8 +1050,19 @@ void Kokkos::Impl::parse_environment_variables(
 }
 
 //----------------------------------------------------------------------------
+namespace {
+bool kokkos_initialize_was_called() {
+  return Kokkos::is_initialized() || Kokkos::is_finalized();
+}
+bool kokkos_finalize_was_called() { return Kokkos::is_finalized(); }
+}  // namespace
 
 void Kokkos::initialize(int& argc, char* argv[]) {
+  if (kokkos_initialize_was_called()) {
+    Kokkos::abort(
+        "Error: Kokkos::initialize() has already been called."
+        " Kokkos can be initialized at most once.\n");
+  }
   InitializationSettings settings;
   Impl::parse_environment_variables(settings);
   Impl::parse_command_line_arguments(argc, argv, settings);
@@ -1059,6 +1070,11 @@ void Kokkos::initialize(int& argc, char* argv[]) {
 }
 
 void Kokkos::initialize(InitializationSettings const& settings) {
+  if (kokkos_initialize_was_called()) {
+    Kokkos::abort(
+        "Error: Kokkos::initialize() has already been called."
+        " Kokkos can be initialized at most once.\n");
+  }
   InitializationSettings tmp;
   Impl::parse_environment_variables(tmp);
   combine(tmp, settings);
@@ -1077,7 +1093,17 @@ void Kokkos::push_finalize_hook(std::function<void()> f) {
   finalize_hooks.push(f);
 }
 
-void Kokkos::finalize() { finalize_internal(); }
+void Kokkos::finalize() {
+  if (!kokkos_initialize_was_called()) {
+    Kokkos::abort(
+        "Error: Kokkos::finalize() may only be called after Kokkos has been "
+        "initialized.\n");
+  }
+  if (kokkos_finalize_was_called()) {
+    Kokkos::abort("Error: Kokkos::finalize() has already been called.\n");
+  }
+  finalize_internal();
+}
 
 #ifdef KOKKOS_COMPILER_INTEL
 void Kokkos::fence() { fence("Kokkos::fence: Unnamed Global Fence"); }


### PR DESCRIPTION
Wasted time again in the RC 3.7 tests in Trilinos figuring out some CUDA runtime error which essentially was `Kokkos::finalize()` being called even though Kokkos had never been initialized.

Calling `Kokkos::abort`
* in `Kokkos::initialize` if it is been called more than once
* in `Kokkos::finalize` if it is called before `Kokkos::initialize`
* in `Kokkos::finalize` if it is called twice