### PR TITLE
(Develop Only) Fixes issue 5426: spurious warning for NVCC < 11.5 about missing return statement

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -116,7 +116,11 @@
 // Code is parsed and separated into host and device code.
 // Host code is compiled again with another compiler.
 // Device code is compile to 'ptx'.
-#define KOKKOS_COMPILER_NVCC __NVCC__
+// NOTE: There is no __CUDACC_VER_PATCH__ officially, its __CUDACC_VER_BUILD__
+// which does have more than one digit (potentially undefined number of them).
+// This macro definition is in line with our other compiler defs
+#define KOKKOS_COMPILER_NVCC \
+  __CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__ * 10
 #endif  // #if defined( __NVCC__ )
 
 #if !defined(KOKKOS_LAMBDA)

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -335,7 +335,7 @@ KOKKOS_FUNCTION const auto &get_property(
 #if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)
 // pragma pop is getting a warning from the underlying GCC
 // for unknown pragma if -pedantic is used
-#ifdef __CUDAR_ARCH__
+#ifdef __CUDA_ARCH__
 #pragma pop
 #endif
 #endif

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -267,6 +267,16 @@ auto with_properties_if_unset(const ViewCtorProp<P...> &view_ctor_prop) {
   return view_ctor_prop;
 }
 
+// Suppress faulty warning from NVCC see:
+// https://github.com/kokkos/kokkos/issues/5426
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)
+// pragma pop is getting a warning from the underlying GCC
+// for unknown pragma if -pedantic is used
+#ifdef __CUDA_ARCH__
+#pragma push
+#pragma diag_suppress implicit_return_from_non_void_function
+#endif
+#endif
 template <typename... P, typename Property, typename... Properties>
 auto with_properties_if_unset(const ViewCtorProp<P...> &view_ctor_prop,
                               const Property &property,
@@ -322,6 +332,13 @@ KOKKOS_FUNCTION const auto &get_property(
     return view_ctor_prop;
   }
 }
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)
+// pragma pop is getting a warning from the underlying GCC
+// for unknown pragma if -pedantic is used
+#ifdef __CUDAR_ARCH__
+#pragma pop
+#endif
+#endif
 
 template <typename Tag, typename... P>
 KOKKOS_FUNCTION auto &get_property(ViewCtorProp<P...> &view_ctor_prop) {


### PR DESCRIPTION
See #5426 