### PR TITLE
Fix incorrect namespace

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -67,9 +67,8 @@
 #include <vector>
 
 #ifdef KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE
-__device__ __constant__ unsigned long
-    kokkos_impl_hip_constant_memory_buffer[HIPTraits::ConstantMemoryUsage /
-                                           sizeof(unsigned long)];
+__device__ __constant__ unsigned long kokkos_impl_hip_constant_memory_buffer
+    [Kokkos::Impl::HIPTraits::ConstantMemoryUsage / sizeof(unsigned long)];
 #endif
 
 namespace Kokkos {


### PR DESCRIPTION
Fixed an incorrect namespace usage.

Reference to `HIPTraits`:
https://github.com/kokkos/kokkos/blob/3be4cef23d41b91353e045af2f28fe498097d4ce/core/src/HIP/Kokkos_HIP_Instance.hpp#L55-L59