### PR TITLE
Promote math constants `Kokkos::{Experimental -> numbers}` and add missing variables without the `_v` suffix

### DIFF
--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -170,8 +170,7 @@ struct ErrorReporterDriver : public ErrorReporterDriverBase<DeviceType> {
   KOKKOS_INLINE_FUNCTION
   void operator()(const int work_idx) const {
     if (driver_base::error_condition(work_idx)) {
-      double val =
-          Kokkos::Experimental::pi_v<double> * static_cast<double>(work_idx);
+      double val = Kokkos::numbers::pi * static_cast<double>(work_idx);
       typename driver_base::report_type report = {work_idx, -2 * work_idx, val};
       driver_base::m_errorReporter.add_report(work_idx, report);
     }
@@ -197,8 +196,7 @@ struct ErrorReporterDriverUseLambda
         // NOLINTNEXTLINE(kokkos-implicit-this-capture)
         KOKKOS_CLASS_LAMBDA(const int work_idx) {
           if (driver_base::error_condition(work_idx)) {
-            double val = Kokkos::Experimental::pi_v<double> *
-                         static_cast<double>(work_idx);
+            double val = Kokkos::numbers::pi * static_cast<double>(work_idx);
             typename driver_base::report_type report = {work_idx, -2 * work_idx,
                                                         val};
             driver_base::m_errorReporter.add_report(work_idx, report);
@@ -222,8 +220,7 @@ struct ErrorReporterDriverNativeOpenMP
 #pragma omp parallel for
     for (int work_idx = 0; work_idx < test_size; ++work_idx) {
       if (driver_base::error_condition(work_idx)) {
-        double val =
-            Kokkos::Experimental::pi_v<double> * static_cast<double>(work_idx);
+        double val = Kokkos::numbers::pi * static_cast<double>(work_idx);
         typename driver_base::report_type report = {work_idx, -2 * work_idx,
                                                     val};
         driver_base::m_errorReporter.add_report(work_idx, report);

--- a/core/src/Kokkos_MathematicalConstants.hpp
+++ b/core/src/Kokkos_MathematicalConstants.hpp
@@ -51,8 +51,7 @@
 #include <Kokkos_Macros.hpp>
 #include <type_traits>
 
-namespace Kokkos {
-namespace Experimental {
+namespace Kokkos::numbers {
 
 #define KOKKOS_IMPL_MATH_CONSTANT(TRAIT, VALUE)                \
   template <class T>                                           \
@@ -78,8 +77,26 @@ KOKKOS_IMPL_MATH_CONSTANT(phi,        1.618033988749894848204586834365638118L);
 
 #undef KOKKOS_IMPL_MATH_CONSTANT
 
-}  // namespace Experimental
-}  // namespace Kokkos
+}  // namespace Kokkos::numbers
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
+namespace Kokkos::Experimental {
+using Kokkos::numbers::e_v;
+using Kokkos::numbers::egamma_v;
+using Kokkos::numbers::inv_pi_v;
+using Kokkos::numbers::inv_sqrt3_v;
+using Kokkos::numbers::inv_sqrtpi_v;
+using Kokkos::numbers::ln10_v;
+using Kokkos::numbers::ln2_v;
+using Kokkos::numbers::log10e_v;
+using Kokkos::numbers::log2e_v;
+using Kokkos::numbers::phi_v;
+using Kokkos::numbers::pi_v;
+using Kokkos::numbers::sqrt2_v;
+using Kokkos::numbers::sqrt3_v;
+}  // namespace Kokkos::Experimental
+#endif
+
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_MATHCONSTANTS
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_MATHCONSTANTS

--- a/core/src/Kokkos_MathematicalConstants.hpp
+++ b/core/src/Kokkos_MathematicalConstants.hpp
@@ -54,10 +54,11 @@
 namespace Kokkos {
 namespace Experimental {
 
-#define KOKKOS_IMPL_MATH_CONSTANT(TRAIT, VALUE) \
-  template <class T>                            \
-  inline constexpr auto TRAIT##_v =             \
-      std::enable_if_t<std::is_floating_point_v<T>, T>(VALUE)
+#define KOKKOS_IMPL_MATH_CONSTANT(TRAIT, VALUE)                \
+  template <class T>                                           \
+  inline constexpr auto TRAIT##_v =                            \
+      std::enable_if_t<std::is_floating_point_v<T>, T>(VALUE); \
+  inline constexpr auto TRAIT = TRAIT##_v<double>
 
 // clang-format off
 KOKKOS_IMPL_MATH_CONSTANT(e,          2.718281828459045235360287471352662498L);

--- a/core/src/Kokkos_MathematicalSpecialFunctions.hpp
+++ b/core/src/Kokkos_MathematicalSpecialFunctions.hpp
@@ -124,20 +124,21 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erf(
   using Kokkos::exp;
   using Kokkos::fabs;
   using Kokkos::sin;
-  using Kokkos::Experimental::epsilon;
-  using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::epsilon_v;
+  using Kokkos::Experimental::infinity_v;
+  using Kokkos::numbers::pi_v;
 
   using CmplxType = Kokkos::complex<RealType>;
 
-  constexpr auto inf = infinity<RealType>::value;
-  constexpr auto tol = epsilon<RealType>::value;
+  constexpr auto inf = infinity_v<RealType>;
+  constexpr auto tol = epsilon_v<RealType>;
 
   const RealType fnorm = 1.12837916709551;
   const RealType gnorm = 0.564189583547756;
   const RealType eh    = 0.606530659712633;
   const RealType ef    = 0.778800783071405;
   // const RealType tol   = 1.0e-13;
-  constexpr auto pi = Kokkos::Experimental::pi_v<RealType>;
+  constexpr auto pi = pi_v<RealType>;
 
   CmplxType cans;
 
@@ -302,20 +303,22 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> erfcx(
   using Kokkos::fabs;
   using Kokkos::isinf;
   using Kokkos::sin;
-  using Kokkos::Experimental::epsilon;
-  using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::epsilon_v;
+  using Kokkos::Experimental::infinity_v;
+  using Kokkos::numbers::inv_sqrtpi_v;
+  using Kokkos::numbers::pi_v;
 
   using CmplxType = Kokkos::complex<RealType>;
 
-  constexpr auto inf = infinity<RealType>::value;
-  constexpr auto tol = epsilon<RealType>::value;
+  constexpr auto inf = infinity_v<RealType>;
+  constexpr auto tol = epsilon_v<RealType>;
 
   const RealType fnorm = 1.12837916709551;
-  constexpr auto gnorm = Kokkos::Experimental::inv_sqrtpi_v<RealType>;
+  constexpr auto gnorm = inv_sqrtpi_v<RealType>;
   const RealType eh    = 0.606530659712633;
   const RealType ef    = 0.778800783071405;
   // const RealType tol   = 1.0e-13;
-  constexpr auto pi = Kokkos::Experimental::pi_v<RealType>;
+  constexpr auto pi = pi_v<RealType>;
 
   CmplxType cans;
 
@@ -492,9 +495,10 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_j0(const CmplxType& z,
   // Output:  cbj0      --- J0(z)
   using Kokkos::fabs;
   using Kokkos::pow;
+  using Kokkos::numbers::pi_v;
 
   CmplxType cbj0;
-  constexpr auto pi    = Kokkos::Experimental::pi_v<RealType>;
+  constexpr auto pi    = pi_v<RealType>;
   const RealType a[12] = {
       -0.703125e-01,           0.112152099609375e+00,   -0.5725014209747314e+00,
       0.6074042001273483e+01,  -0.1100171402692467e+03, 0.3038090510922384e+04,
@@ -580,13 +584,15 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y0(const CmplxType& z,
   //    Output:  cby0      --- Y0(z)
   using Kokkos::fabs;
   using Kokkos::pow;
-  using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::infinity_v;
+  using Kokkos::numbers::egamma_v;
+  using Kokkos::numbers::pi_v;
 
-  constexpr auto inf = infinity<RealType>::value;
+  constexpr auto inf = infinity_v<RealType>;
 
   CmplxType cby0, cbj0;
-  constexpr auto pi    = Kokkos::Experimental::pi_v<RealType>;
-  constexpr auto el    = Kokkos::Experimental::egamma_v<RealType>;
+  constexpr auto pi    = pi_v<RealType>;
+  constexpr auto el    = egamma_v<RealType>;
   const RealType a[12] = {
       -0.703125e-01,           0.112152099609375e+00,   -0.5725014209747314e+00,
       0.6074042001273483e+01,  -0.1100171402692467e+03, 0.3038090510922384e+04,
@@ -681,9 +687,10 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_j1(const CmplxType& z,
   //    Output:  cbj1      --- J1(z)
   using Kokkos::fabs;
   using Kokkos::pow;
+  using Kokkos::numbers::pi_v;
 
   CmplxType cbj1;
-  constexpr auto pi     = Kokkos::Experimental::pi_v<RealType>;
+  constexpr auto pi     = pi_v<RealType>;
   const RealType a1[12] = {0.1171875e+00,          -0.144195556640625e+00,
                            0.6765925884246826e+00, -0.6883914268109947e+01,
                            0.1215978918765359e+03, -0.3302272294480852e+04,
@@ -773,13 +780,15 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_y1(const CmplxType& z,
   //    Output:  cby1      --- Y1(z)
   using Kokkos::fabs;
   using Kokkos::pow;
-  using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::infinity_v;
+  using Kokkos::numbers::egamma_v;
+  using Kokkos::numbers::pi_v;
 
-  constexpr auto inf = infinity<RealType>::value;
+  constexpr auto inf = infinity_v<RealType>;
 
   CmplxType cby1, cbj0, cbj1, cby0;
-  constexpr auto pi     = Kokkos::Experimental::pi_v<RealType>;
-  constexpr auto el     = Kokkos::Experimental::egamma_v<RealType>;
+  constexpr auto pi     = pi_v<RealType>;
+  constexpr auto el     = egamma_v<RealType>;
   const RealType a1[12] = {0.1171875e+00,          -0.144195556640625e+00,
                            0.6765925884246826e+00, -0.6883914268109947e+01,
                            0.1215978918765359e+03, -0.3302272294480852e+04,
@@ -875,8 +884,10 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_i0(const CmplxType& z,
   //                           argument regions
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbi0      --- I0(z)
+  using Kokkos::numbers::pi_v;
+
   CmplxType cbi0;
-  constexpr auto pi    = Kokkos::Experimental::pi_v<RealType>;
+  constexpr auto pi    = pi_v<RealType>;
   const RealType a[12] = {0.125,
                           7.03125e-2,
                           7.32421875e-2,
@@ -948,13 +959,15 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k0(const CmplxType& z,
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbk0      --- K0(z)
   using Kokkos::pow;
-  using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::infinity_v;
+  using Kokkos::numbers::egamma_v;
+  using Kokkos::numbers::pi_v;
 
-  constexpr auto inf = infinity<RealType>::value;
+  constexpr auto inf = infinity_v<RealType>;
 
   CmplxType cbk0, cbi0;
-  constexpr auto pi = Kokkos::Experimental::pi_v<RealType>;
-  constexpr auto el = Kokkos::Experimental::egamma_v<RealType>;
+  constexpr auto pi = pi_v<RealType>;
+  constexpr auto el = egamma_v<RealType>;
 
   RealType a0  = Kokkos::abs(z);
   CmplxType ci = CmplxType(0.0, 1.0);
@@ -1020,8 +1033,10 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_i1(const CmplxType& z,
   //                           argument regions
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbi1      --- I1(z)
+  using Kokkos::numbers::pi_v;
+
   CmplxType cbi1;
-  constexpr auto pi    = Kokkos::Experimental::pi_v<RealType>;
+  constexpr auto pi    = pi_v<RealType>;
   const RealType b[12] = {-0.375,
                           -1.171875e-1,
                           -1.025390625e-1,
@@ -1094,13 +1109,15 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_k1(const CmplxType& z,
   //             bw_start  --- Starting point for backward recurrence
   //    Output:  cbk1      --- K1(z)
   using Kokkos::pow;
-  using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::infinity_v;
+  using Kokkos::numbers::egamma_v;
+  using Kokkos::numbers::pi_v;
 
-  constexpr auto inf = infinity<RealType>::value;
+  constexpr auto inf = infinity_v<RealType>;
 
   CmplxType cbk0, cbi0, cbk1, cbi1;
-  constexpr auto pi = Kokkos::Experimental::pi_v<RealType>;
-  constexpr auto el = Kokkos::Experimental::egamma_v<RealType>;
+  constexpr auto pi = pi_v<RealType>;
+  constexpr auto el = egamma_v<RealType>;
 
   RealType a0  = Kokkos::abs(z);
   CmplxType ci = CmplxType(0.0, 1.0);
@@ -1163,12 +1180,13 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h10(const CmplxType& z) {
   // programs CH12N in S. Zhang & J. Jin "Computation of Special Functions"
   //(Wiley, 1996).
   using RealType = typename CmplxType::value_type;
-  using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::infinity_v;
+  using Kokkos::numbers::pi_v;
 
-  constexpr auto inf = infinity<RealType>::value;
+  constexpr auto inf = infinity_v<RealType>;
 
   CmplxType ch10, cbk0, cbj0, cby0;
-  constexpr auto pi = Kokkos::Experimental::pi_v<RealType>;
+  constexpr auto pi = pi_v<RealType>;
   CmplxType ci      = CmplxType(0.0, 1.0);
 
   if ((z.real() == 0.0) && (z.imag() == 0.0)) {
@@ -1193,12 +1211,13 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h11(const CmplxType& z) {
   // programs CH12N in S. Zhang & J. Jin "Computation of Special Functions"
   //(Wiley, 1996).
   using RealType = typename CmplxType::value_type;
-  using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::infinity_v;
+  using Kokkos::numbers::pi_v;
 
-  constexpr auto inf = infinity<RealType>::value;
+  constexpr auto inf = infinity_v<RealType>;
 
   CmplxType ch11, cbk1, cbj1, cby1;
-  constexpr auto pi = Kokkos::Experimental::pi_v<RealType>;
+  constexpr auto pi = pi_v<RealType>;
   CmplxType ci      = CmplxType(0.0, 1.0);
 
   if ((z.real() == 0.0) && (z.imag() == 0.0)) {
@@ -1223,12 +1242,13 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h20(const CmplxType& z) {
   // programs CH12N in S. Zhang & J. Jin "Computation of Special Functions"
   //(Wiley, 1996).
   using RealType = typename CmplxType::value_type;
-  using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::infinity_v;
+  using Kokkos::numbers::pi_v;
 
-  constexpr auto inf = infinity<RealType>::value;
+  constexpr auto inf = infinity_v<RealType>;
 
   CmplxType ch20, cbk0, cbj0, cby0;
-  constexpr auto pi = Kokkos::Experimental::pi_v<RealType>;
+  constexpr auto pi = pi_v<RealType>;
   CmplxType ci      = CmplxType(0.0, 1.0);
 
   if ((z.real() == 0.0) && (z.imag() == 0.0)) {
@@ -1253,12 +1273,13 @@ KOKKOS_INLINE_FUNCTION CmplxType cyl_bessel_h21(const CmplxType& z) {
   // programs CH12N in S. Zhang & J. Jin "Computation of Special Functions"
   //(Wiley, 1996).
   using RealType = typename CmplxType::value_type;
-  using Kokkos::Experimental::infinity;
+  using Kokkos::Experimental::infinity_v;
+  using Kokkos::numbers::pi_v;
 
-  constexpr auto inf = infinity<RealType>::value;
+  constexpr auto inf = infinity_v<RealType>;
 
   CmplxType ch21, cbk1, cbj1, cby1;
-  constexpr auto pi = Kokkos::Experimental::pi_v<RealType>;
+  constexpr auto pi = pi_v<RealType>;
   CmplxType ci      = CmplxType(0.0, 1.0);
 
   if ((z.real() == 0.0) && (z.imag() == 0.0)) {

--- a/core/src/impl/Kokkos_QuadPrecisionMath.hpp
+++ b/core/src/impl/Kokkos_QuadPrecisionMath.hpp
@@ -208,8 +208,7 @@ inline bool signbit(__float128 x) { return ::signbitq(x); }
 //</editor-fold>
 
 //<editor-fold desc="Mathematical constants __float128 specializations">
-namespace Kokkos {
-namespace Experimental {
+namespace Kokkos::numbers {
 // clang-format off
 template <> constexpr __float128 e_v         <__float128> = 2.718281828459045235360287471352662498Q;
 template <> constexpr __float128 log2e_v     <__float128> = 1.442695040888963407359924681001892137Q;
@@ -225,8 +224,7 @@ template <> constexpr __float128 inv_sqrt3_v <__float128> = 0.577350269189625764
 template <> constexpr __float128 egamma_v    <__float128> = 0.577215664901532860606512090082402431Q;
 template <> constexpr __float128 phi_v       <__float128> = 1.618033988749894848204586834365638118Q;
 // clang-format on
-}  // namespace Experimental
-}  // namespace Kokkos
+}  // namespace Kokkos::numbers
 //</editor-fold>
 
 #endif

--- a/core/unit_test/TestMathematicalConstants.hpp
+++ b/core/unit_test/TestMathematicalConstants.hpp
@@ -53,10 +53,10 @@ KOKKOS_FUNCTION T *take_address_of(T &arg) {
 template <class T>
 KOKKOS_FUNCTION void take_by_value(T) {}
 
-#define DEFINE_MATH_CONSTANT_TRAIT(TRAIT)                          \
-  template <class T>                                               \
-  struct TRAIT {                                                   \
-    static constexpr T value = Kokkos::Experimental::TRAIT##_v<T>; \
+#define DEFINE_MATH_CONSTANT_TRAIT(TRAIT)                     \
+  template <class T>                                          \
+  struct TRAIT {                                              \
+    static constexpr T value = Kokkos::numbers::TRAIT##_v<T>; \
   }
 
 DEFINE_MATH_CONSTANT_TRAIT(e);

--- a/core/unit_test/TestQuadPrecisionMath.hpp
+++ b/core/unit_test/TestQuadPrecisionMath.hpp
@@ -121,18 +121,18 @@ static_assert(test_quad_precision_promotion_traits());
 constexpr bool test_quad_precision_math_constants() {
   // compare to mathematical constants defined in libquadmath when available
   // clang-format off
-  static_assert(Kokkos::Experimental::e_v     <__float128> == M_Eq);
-  static_assert(Kokkos::Experimental::log2e_v <__float128> == M_LOG2Eq);
-  static_assert(Kokkos::Experimental::log10e_v<__float128> == M_LOG10Eq);
-  static_assert(Kokkos::Experimental::pi_v    <__float128> == M_PIq);
+  static_assert(Kokkos::numbers::e_v     <__float128> == M_Eq);
+  static_assert(Kokkos::numbers::log2e_v <__float128> == M_LOG2Eq);
+  static_assert(Kokkos::numbers::log10e_v<__float128> == M_LOG10Eq);
+  static_assert(Kokkos::numbers::pi_v    <__float128> == M_PIq);
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU >= 930)
-  static_assert(Kokkos::Experimental::inv_pi_v<__float128> == M_1_PIq);
+  static_assert(Kokkos::::inv_pi_v<__float128> == M_1_PIq);
 #endif
   // inv_sqrtpi_v
-  static_assert(Kokkos::Experimental::ln2_v   <__float128> == M_LN2q);
-  static_assert(Kokkos::Experimental::ln10_v  <__float128> == M_LN10q);
+  static_assert(Kokkos::numbers::ln2_v   <__float128> == M_LN2q);
+  static_assert(Kokkos::numbers::ln10_v  <__float128> == M_LN10q);
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU >= 930)
-  static_assert(Kokkos::Experimental::sqrt2_v <__float128> == M_SQRT2q);
+  static_assert(Kokkos::numbers::sqrt2_v <__float128> == M_SQRT2q);
 #endif
   // sqrt3_v
   // inv_sqrt3_v


### PR DESCRIPTION
Rational: There is no good reason to keep them in `Kokkos::Experimental::` since it is just a backport of the C++20 facility.  I opted for the `Kokkos::numbers` namespace for consistency with the C++ standard.  Let me know if you want to capitalize the "N".

Drive-by changes:
* add missing math constant variables without the `_v` suffix