### PR TITLE
Remove unused KOKKOS_ABORT_MESSAGE_BUFFER_SIZE

### DIFF
--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -58,10 +58,6 @@
 #include <SYCL/Kokkos_SYCL_Abort.hpp>
 #endif
 
-#ifndef KOKKOS_ABORT_MESSAGE_BUFFER_SIZE
-#define KOKKOS_ABORT_MESSAGE_BUFFER_SIZE 2048
-#endif  // ifndef KOKKOS_ABORT_MESSAGE_BUFFER_SIZE
-
 namespace Kokkos {
 namespace Impl {
 


### PR DESCRIPTION
This appears to be entirely unused, even in https://github.com/kokkos/kokkos/commit/095aa87fcdc12691e7c9cbfc0fc3e1268f81a071 that introduced it.