### PR TITLE
Suppress warning: function declared with "noreturn" does return for CUDA and Debug mode

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -122,14 +122,7 @@ void DeepCopyAsyncCuda(void *dst, const void *src, size_t n) {
 
 namespace Kokkos {
 
-bool CudaUVMSpace::available() {
-#if defined(CUDA_VERSION) && !defined(__APPLE__)
-  enum : bool { UVM_available = true };
-#else
-  enum : bool { UVM_available = false };
-#endif
-  return UVM_available;
-}
+bool CudaUVMSpace::available() { return true; }
 
 /*--------------------------------------------------------------------------*/
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -202,8 +202,8 @@ void cuda_internal_error_abort(cudaError e, const char *name, const char *file,
   if (file) {
     out << " " << file << ":" << line;
   }
-  // Call Kokkos::Impl::host_abort instead of Kokkos::abort to avoid a warning
-  // about Kokkos::abort returning in some cases.
+  // FIXME Call Kokkos::Impl::host_abort instead of Kokkos::abort to avoid a
+  // warning about Kokkos::abort returning in some cases.
   host_abort(out.str().c_str());
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -202,9 +202,7 @@ void cuda_internal_error_abort(cudaError e, const char *name, const char *file,
   if (file) {
     out << " " << file << ":" << line;
   }
-  // Call Kokkos::Impl::host_abort instead of Kokkos::abort to avoid a warning
-  // about Kokkos::abort returning in some cases.
-  host_abort(out.str().c_str());
+  abort(out.str().c_str());
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -202,7 +202,9 @@ void cuda_internal_error_abort(cudaError e, const char *name, const char *file,
   if (file) {
     out << " " << file << ":" << line;
   }
-  abort(out.str().c_str());
+  // Call Kokkos::Impl::host_abort instead of Kokkos::abort to avoid a warning
+  // about Kokkos::abort returning in some cases.
+  host_abort(out.str().c_str());
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda_abort.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_abort.hpp
@@ -64,13 +64,7 @@ extern __device__ void __assertfail(const void *message, const void *file,
 namespace Kokkos {
 namespace Impl {
 
-// required to workaround failures in random number generator unit tests with
-// pre-volta architectures
-#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-__device__ inline void cuda_abort(const char *const message) {
-#else
 [[noreturn]] __device__ inline void cuda_abort(const char *const message) {
-#endif
   const char empty[] = "";
 
   __assertfail((const void *)message, (const void *)empty, (unsigned int)0,
@@ -79,12 +73,8 @@ __device__ inline void cuda_abort(const char *const message) {
   // This loop is never executed. It's intended to suppress warnings that the
   // function returns, even though it does not. This is necessary because
   // __assertfail is not marked as [[noreturn]], even though it does not return.
-  //  Disable with KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK to workaround failures
-  //  in random number generator unit tests with pre-volta architectures
-#if !defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
   while (true)
     ;
-#endif
 }
 
 }  // namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda_abort.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_abort.hpp
@@ -64,7 +64,6 @@ extern __device__ void __assertfail(const void *message, const void *file,
 namespace Kokkos {
 namespace Impl {
 
-#if !defined(__APPLE__)
 // required to workaround failures in random number generator unit tests with
 // pre-volta architectures
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
@@ -87,11 +86,6 @@ __device__ inline void cuda_abort(const char *const message) {
     ;
 #endif
 }
-#else
-__device__ inline void cuda_abort(const char *const message) {
-  // __assertfail is not supported on MAC
-}
-#endif
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Cuda/Kokkos_Cuda_abort.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_abort.hpp
@@ -64,7 +64,13 @@ extern __device__ void __assertfail(const void *message, const void *file,
 namespace Kokkos {
 namespace Impl {
 
+// required to workaround failures in random number generator unit tests with
+// pre-volta architectures
+#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+__device__ inline void cuda_abort(const char *const message) {
+#else
 [[noreturn]] __device__ inline void cuda_abort(const char *const message) {
+#endif
   const char empty[] = "";
 
   __assertfail((const void *)message, (const void *)empty, (unsigned int)0,
@@ -73,8 +79,12 @@ namespace Impl {
   // This loop is never executed. It's intended to suppress warnings that the
   // function returns, even though it does not. This is necessary because
   // __assertfail is not marked as [[noreturn]], even though it does not return.
+  //  Disable with KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK to workaround failures
+  //  in random number generator unit tests with pre-volta architectures
+#if !defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
   while (true)
     ;
+#endif
 }
 
 }  // namespace Impl

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -69,7 +69,14 @@ namespace Impl {
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
 
+#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+// required to workaround failures in random number generator unit tests with
+// pre-volta architectures
+#define KOKKOS_IMPL_ABORT_NORETURN
+#else
+// cuda_abort aborts when building for other platforms than macOS
 #define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
+#endif
 
 #elif defined(KOKKOS_COMPILER_NVHPC)
 
@@ -89,7 +96,10 @@ namespace Impl {
 #define KOKKOS_IMPL_ABORT_NORETURN
 #endif
 
-#ifdef KOKKOS_ENABLE_SYCL  // FIXME_SYCL
+// FIXME_SYCL
+// Accomodate host pass for device functions that are not [[noreturn]]
+#if defined(KOKKOS_ENABLE_SYCL) || \
+    (defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK))
 #define KOKKOS_IMPL_ABORT_NORETURN_DEVICE
 #else
 #define KOKKOS_IMPL_ABORT_NORETURN_DEVICE KOKKOS_IMPL_ABORT_NORETURN

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -69,8 +69,7 @@ namespace Impl {
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
 
-#if defined(__APPLE__) || defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-// cuda_abort does not abort when building for macOS.
+#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
 // required to workaround failures in random number generator unit tests with
 // pre-volta architectures
 #define KOKKOS_IMPL_ABORT_NORETURN
@@ -99,9 +98,8 @@ namespace Impl {
 
 // FIXME_SYCL
 // Accomodate host pass for device functions that are not [[noreturn]]
-#if defined(KOKKOS_ENABLE_SYCL) ||  \
-    (defined(KOKKOS_ENABLE_CUDA) && \
-     (defined(__APPLE__) || defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)))
+#if defined(KOKKOS_ENABLE_SYCL) || \
+    (defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK))
 #define KOKKOS_IMPL_ABORT_NORETURN_DEVICE
 #else
 #define KOKKOS_IMPL_ABORT_NORETURN_DEVICE KOKKOS_IMPL_ABORT_NORETURN

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -69,14 +69,7 @@ namespace Impl {
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)
 
-#if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-// required to workaround failures in random number generator unit tests with
-// pre-volta architectures
-#define KOKKOS_IMPL_ABORT_NORETURN
-#else
-// cuda_abort aborts when building for other platforms than macOS
 #define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
-#endif
 
 #elif defined(KOKKOS_COMPILER_NVHPC)
 
@@ -96,10 +89,7 @@ namespace Impl {
 #define KOKKOS_IMPL_ABORT_NORETURN
 #endif
 
-// FIXME_SYCL
-// Accomodate host pass for device functions that are not [[noreturn]]
-#if defined(KOKKOS_ENABLE_SYCL) || \
-    (defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK))
+#ifdef KOKKOS_ENABLE_SYCL  // FIXME_SYCL
 #define KOKKOS_IMPL_ABORT_NORETURN_DEVICE
 #else
 #define KOKKOS_IMPL_ABORT_NORETURN_DEVICE KOKKOS_IMPL_ABORT_NORETURN

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -97,7 +97,11 @@ namespace Impl {
 #define KOKKOS_IMPL_ABORT_NORETURN
 #endif
 
-#ifdef KOKKOS_ENABLE_SYCL  // FIXME_SYCL
+// FIXME_SYCL
+// Accomodate host pass for device functions that are not [[noreturn]]
+#if defined(KOKKOS_ENABLE_SYCL) ||  \
+    (defined(KOKKOS_ENABLE_CUDA) && \
+     (defined(__APPLE__) || defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)))
 #define KOKKOS_IMPL_ABORT_NORETURN_DEVICE
 #else
 #define KOKKOS_IMPL_ABORT_NORETURN_DEVICE KOKKOS_IMPL_ABORT_NORETURN


### PR DESCRIPTION
Fixes #5440.
For compilers that do two passes for device functions, we need to make sure that also the host pass for the device function gets the correct attribute. Notably, that is `SYCL` and `CUDA` for `macOS` or if `KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK` is enabled.