### PR TITLE
HIP: Pass functor by value when using LocalMemory launch mechanism

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -237,10 +237,6 @@ void HIPInternal::initialize(int hip_device_id, hipStream_t stream,
 
     m_stream        = stream;
     m_manage_stream = manage_stream;
-    for (int i = 0; i < m_n_team_scratch; ++i) {
-      m_team_scratch_current_size[i] = 0;
-      m_team_scratch_ptr[i]          = nullptr;
-    }
 
     // number of multiprocessors
     m_multiProcCount = hipProp.multiProcessorCount;

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -235,10 +235,12 @@ void HIPInternal::initialize(int hip_device_id, hipStream_t stream,
 
     KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(m_hipDev));
 
-    m_stream                    = stream;
-    m_manage_stream             = manage_stream;
-    m_team_scratch_current_size = 0;
-    m_team_scratch_ptr          = nullptr;
+    m_stream        = stream;
+    m_manage_stream = manage_stream;
+    for (int i = 0; i < m_n_team_scratch; ++i) {
+      m_team_scratch_current_size[i] = 0;
+      m_team_scratch_ptr[i]          = nullptr;
+    }
 
     // number of multiprocessors
     m_multiProcCount = hipProp.multiProcessorCount;
@@ -358,20 +360,37 @@ Kokkos::HIP::size_type *HIPInternal::scratch_flags(const std::size_t size) {
   return m_scratchFlags;
 }
 
-void *HIPInternal::resize_team_scratch_space(std::int64_t bytes,
-                                             bool force_shrink) {
-  if (m_team_scratch_current_size == 0) {
-    m_team_scratch_current_size = bytes;
-    m_team_scratch_ptr          = Kokkos::kokkos_malloc<Kokkos::HIPSpace>(
-        "Kokkos::HIPSpace::TeamScratchMemory", m_team_scratch_current_size);
+std::pair<void *, int> HIPInternal::resize_team_scratch_space(
+    std::int64_t bytes, bool force_shrink) {
+  // Multiple ParallelFor/Reduce Teams can call this function at the same time
+  // and invalidate the m_team_scratch_ptr. We use a pool to avoid any race
+  // condition.
+
+  int current_team_scratch = 0;
+  int zero                 = 0;
+  int one                  = 1;
+  while (!m_team_scratch_pool[current_team_scratch].compare_exchange_weak(
+      zero, one, std::memory_order_release, std::memory_order_relaxed)) {
+    current_team_scratch = (current_team_scratch + 1) % m_n_team_scratch;
   }
-  if ((bytes > m_team_scratch_current_size) ||
-      ((bytes < m_team_scratch_current_size) && (force_shrink))) {
-    m_team_scratch_current_size = bytes;
-    m_team_scratch_ptr          = Kokkos::kokkos_realloc<Kokkos::HIPSpace>(
-        m_team_scratch_ptr, m_team_scratch_current_size);
+  if (m_team_scratch_current_size[current_team_scratch] == 0) {
+    m_team_scratch_current_size[current_team_scratch] = bytes;
+    m_team_scratch_ptr[current_team_scratch] =
+        Kokkos::kokkos_malloc<Kokkos::HIPSpace>(
+            "Kokkos::HIPSpace::TeamScratchMemory",
+            m_team_scratch_current_size[current_team_scratch]);
   }
-  return m_team_scratch_ptr;
+  if ((bytes > m_team_scratch_current_size[current_team_scratch]) ||
+      ((bytes < m_team_scratch_current_size[current_team_scratch]) &&
+       (force_shrink))) {
+    m_team_scratch_current_size[current_team_scratch] = bytes;
+    m_team_scratch_ptr[current_team_scratch] =
+        Kokkos::kokkos_realloc<Kokkos::HIPSpace>(
+            m_team_scratch_ptr[current_team_scratch],
+            m_team_scratch_current_size[current_team_scratch]);
+  }
+  return std::make_pair(m_team_scratch_ptr[current_team_scratch],
+                        current_team_scratch);
 }
 
 //----------------------------------------------------------------------------
@@ -392,27 +411,31 @@ void HIPInternal::finalize() {
     RecordHIP::decrement(RecordHIP::get_record(m_scratchFlags));
     RecordHIP::decrement(RecordHIP::get_record(m_scratchSpace));
 
-    if (m_team_scratch_current_size > 0)
-      Kokkos::kokkos_free<Kokkos::HIPSpace>(m_team_scratch_ptr);
+    for (int i = 0; i < m_n_team_scratch; ++i) {
+      if (m_team_scratch_current_size[i] > 0)
+        Kokkos::kokkos_free<Kokkos::HIPSpace>(m_team_scratch_ptr[i]);
+    }
 
     if (m_manage_stream && m_stream != nullptr)
       KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamDestroy(m_stream));
   }
 
-  m_hipDev                    = -1;
-  m_hipArch                   = -1;
-  m_multiProcCount            = 0;
-  m_maxWarpCount              = 0;
-  m_maxBlock                  = {0, 0, 0};
-  m_maxSharedWords            = 0;
-  m_maxShmemPerBlock          = 0;
-  m_scratchSpaceCount         = 0;
-  m_scratchFlagsCount         = 0;
-  m_scratchSpace              = nullptr;
-  m_scratchFlags              = nullptr;
-  m_stream                    = nullptr;
-  m_team_scratch_current_size = 0;
-  m_team_scratch_ptr          = nullptr;
+  m_hipDev            = -1;
+  m_hipArch           = -1;
+  m_multiProcCount    = 0;
+  m_maxWarpCount      = 0;
+  m_maxBlock          = {0, 0, 0};
+  m_maxSharedWords    = 0;
+  m_maxShmemPerBlock  = 0;
+  m_scratchSpaceCount = 0;
+  m_scratchFlagsCount = 0;
+  m_scratchSpace      = nullptr;
+  m_scratchFlags      = nullptr;
+  m_stream            = nullptr;
+  for (int i = 0; i < m_n_team_scratch; ++i) {
+    m_team_scratch_current_size[i] = 0;
+    m_team_scratch_ptr[i]          = nullptr;
+  }
 
   KOKKOS_IMPL_HIP_SAFE_CALL(hipFree(m_scratch_locks));
   m_scratch_locks = nullptr;

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -364,9 +364,8 @@ std::pair<void *, int> HIPInternal::resize_team_scratch_space(
 
   int current_team_scratch = 0;
   int zero                 = 0;
-  int one                  = 1;
   while (!m_team_scratch_pool[current_team_scratch].compare_exchange_weak(
-      zero, one, std::memory_order_release, std::memory_order_relaxed)) {
+      zero, 1, std::memory_order_release, std::memory_order_relaxed)) {
     current_team_scratch = (current_team_scratch + 1) % m_n_team_scratch;
   }
   if (m_team_scratch_current_size[current_team_scratch] == 0) {
@@ -387,6 +386,10 @@ std::pair<void *, int> HIPInternal::resize_team_scratch_space(
   }
   return std::make_pair(m_team_scratch_ptr[current_team_scratch],
                         current_team_scratch);
+}
+
+void HIPInternal::release_team_scratch_pool(int scratch_pool_id) {
+  m_team_scratch_pool[scratch_pool_id] = 0;
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -100,20 +100,6 @@ class HIPInternal {
   int m_maxShmemPerBlock              = 0;
   int m_maxThreadsPerSM               = 0;
 
-  // array of DriverTypes to be allocated in host-pinned memory for async
-  // kernel launches
-  mutable char *d_driverWorkArray = nullptr;
-  // number of kernel launches that can be in-flight w/o synchronization
-  const int m_maxDriverCycles = 100;
-  // max size of a DriverType [bytes]
-  mutable size_t m_maxDriverTypeSize = 1024 * 10;
-  // the current index in the driverWorkArray
-  mutable int m_cycleId = 0;
-  // mutex to access d_driverWorkArray
-  mutable std::mutex m_mutexWorkArray;
-  // mutex to access shared memory
-  mutable std::mutex m_mutexSharedMemory;
-
   // Scratch Spaces for Reductions
   std::size_t m_scratchSpaceCount = 0;
   std::size_t m_scratchFlagsCount = 0;
@@ -156,9 +142,6 @@ class HIPInternal {
 
   void fence() const;
   void fence(const std::string &) const;
-
-  // returns the next driver type pointer in our work array
-  char *get_next_driver(size_t driverTypeSize) const;
 
   ~HIPInternal();
 

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -117,13 +117,9 @@ class HIPInternal {
 
   // Team Scratch Level 1 Space
   int m_n_team_scratch                            = 10;
-  mutable int64_t m_team_scratch_current_size[10] = {0, 0, 0, 0, 0,
-                                                     0, 0, 0, 0, 0};
-  mutable void *m_team_scratch_ptr[10] = {nullptr, nullptr, nullptr, nullptr,
-                                          nullptr, nullptr, nullptr, nullptr,
-                                          nullptr, nullptr};
-  mutable std::atomic_int m_team_scratch_pool[10] = {0, 0, 0, 0, 0,
-                                                     0, 0, 0, 0, 0};
+  mutable int64_t m_team_scratch_current_size[10] = {};
+  mutable void *m_team_scratch_ptr[10]            = {};
+  mutable std::atomic_int m_team_scratch_pool[10] = {};
   std::int32_t *m_scratch_locks;
 
   bool was_finalized = false;
@@ -159,6 +155,7 @@ class HIPInternal {
   // Resizing of team level 1 scratch
   std::pair<void *, int> resize_team_scratch_space(std::int64_t bytes,
                                                    bool force_shrink = false);
+  void release_team_scratch_pool(int scratch_pool_id);
 };
 
 }  // namespace Impl

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -116,10 +116,14 @@ class HIPInternal {
   bool m_manage_stream = false;
 
   // Team Scratch Level 1 Space
-  int m_n_team_scratch = 10;
-  mutable int64_t m_team_scratch_current_size[10];
-  mutable void *m_team_scratch_ptr[10];
-  mutable std::atomic_int m_team_scratch_pool[10];
+  int m_n_team_scratch                            = 10;
+  mutable int64_t m_team_scratch_current_size[10] = {0, 0, 0, 0, 0,
+                                                     0, 0, 0, 0, 0};
+  mutable void *m_team_scratch_ptr[10] = {nullptr, nullptr, nullptr, nullptr,
+                                          nullptr, nullptr, nullptr, nullptr,
+                                          nullptr, nullptr};
+  mutable std::atomic_int m_team_scratch_pool[10] = {0, 0, 0, 0, 0,
+                                                     0, 0, 0, 0, 0};
   std::int32_t *m_scratch_locks;
 
   bool was_finalized = false;
@@ -146,13 +150,7 @@ class HIPInternal {
 
   ~HIPInternal();
 
-  HIPInternal() {
-    for (int i = 0; i < m_n_team_scratch; ++i) {
-      m_team_scratch_current_size[i] = 0;
-      m_team_scratch_ptr[i]          = nullptr;
-      m_team_scratch_pool[i]         = 0;
-    }
-  }
+  HIPInternal() = default;
 
   // Resizing of reduction related scratch spaces
   size_type *scratch_space(const std::size_t size);

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -96,18 +96,16 @@ __global__ __launch_bounds__(
 
 template <class DriverType>
 __global__ static void hip_parallel_launch_local_memory(
-    const DriverType *driver) {
-  // FIXME_HIP driver() pass by copy
-  driver->operator()();
+    const DriverType driver) {
+  driver();
 }
 
 template <class DriverType, unsigned int maxTperB, unsigned int minBperSM>
 __global__ __launch_bounds__(
     maxTperB,
     minBperSM) static void hip_parallel_launch_local_memory(const DriverType
-                                                                *driver) {
-  // FIXME_HIP driver() pass by copy
-  driver->operator()();
+                                                                driver) {
+  driver();
 }
 
 template <typename DriverType>
@@ -387,7 +385,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
   using base_t = HIPParallelLaunchKernelFunc<DriverType, LaunchBounds,
                                              HIPLaunchMechanism::LocalMemory>;
 
-  static void invoke_kernel(DriverType const *driver, dim3 const &grid,
+  static void invoke_kernel(DriverType const &driver, dim3 const &grid,
                             dim3 const &block, int shmem,
                             HIPInternal const *hip_instance) {
     (base_t::get_kernel_func())<<<grid, block, shmem, hip_instance->m_stream>>>(
@@ -404,9 +402,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
   using base_t = HIPParallelLaunchKernelFunc<DriverType, LaunchBounds,
                                              HIPLaunchMechanism::GlobalMemory>;
 
-  // FIXME_HIP the code is different than cuda because driver cannot be passed
-  // by copy
-  static void invoke_kernel(DriverType const *driver, dim3 const &grid,
+  static void invoke_kernel(DriverType const &driver, dim3 const &grid,
                             dim3 const &block, int shmem,
                             HIPInternal const *hip_instance) {
     (base_t::get_kernel_func())<<<grid, block, shmem, hip_instance->m_stream>>>(
@@ -427,7 +423,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
                 "Kokkos Error: Requested HIPLaunchConstantMemory with a "
                 "Functor larger than 32kB.");
 
-  static void invoke_kernel(DriverType const *driver, dim3 const &grid,
+  static void invoke_kernel(DriverType const &driver, dim3 const &grid,
                             dim3 const &block, int shmem,
                             HIPInternal const *hip_instance) {
     // Wait until the previous kernel that uses the constant buffer is done
@@ -437,7 +433,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
     // Copy functor (synchronously) to staging buffer in pinned host memory
     unsigned long *staging = hip_instance->constantMemHostStaging;
-    std::memcpy((void *)staging, (void *)driver, sizeof(DriverType));
+    std::memcpy((void *)staging, (void *)&driver, sizeof(DriverType));
 
     // Copy functor asynchronously from there to constant memory on the device
     KOKKOS_IMPL_HIP_SAFE_CALL(hipMemcpyToSymbolAsync(
@@ -486,13 +482,8 @@ struct HIPParallelLaunch<
 
       KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
 
-      std::lock_guard<std::mutex> const lock(hip_instance->m_mutexWorkArray);
-
       // Invoke the driver function on the device
-      DriverType *d_driver = reinterpret_cast<DriverType *>(
-          hip_instance->get_next_driver(sizeof(DriverType)));
-      std::memcpy((void *)d_driver, (void *)&driver, sizeof(DriverType));
-      base_t::invoke_kernel(d_driver, grid, block, shmem, hip_instance);
+      base_t::invoke_kernel(driver, grid, block, shmem, hip_instance);
 
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
       KOKKOS_IMPL_HIP_SAFE_CALL(hipGetLastError());

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -433,7 +433,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
     // Copy functor (synchronously) to staging buffer in pinned host memory
     unsigned long *staging = hip_instance->constantMemHostStaging;
-    std::memcpy((void *)staging, (void *)&driver, sizeof(DriverType));
+    std::memcpy(staging, &driver, sizeof(DriverType));
 
     // Copy functor asynchronously from there to constant memory on the device
     KOKKOS_IMPL_HIP_SAFE_CALL(hipMemcpyToSymbolAsync(

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -236,9 +236,6 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   const bool m_result_ptr_device_accessible;
   size_type* m_scratch_space;
   size_type* m_scratch_flags;
-  // Only let one Parallel/Scan modify the shared memory. The
-  // constructor acquires the mutex which is released in the destructor.
-  std::lock_guard<std::mutex> m_shared_memory_lock;
 
   using DeviceIteratePattern = typename Kokkos::Impl::Reduce::DeviceIterateTile<
       Policy::rank, Policy, FunctorType, WorkTag, reference_type>;
@@ -390,10 +387,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
             MemorySpaceAccess<HIPSpace,
                               typename ViewType::memory_space>::accessible),
         m_scratch_space(nullptr),
-        m_scratch_flags(nullptr),
-        m_shared_memory_lock(m_policy.space()
-                                 .impl_internal_space_instance()
-                                 ->m_mutexSharedMemory) {}
+        m_scratch_flags(nullptr) {}
 
   ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
                  const ReducerType& reducer)
@@ -405,10 +399,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
             MemorySpaceAccess<HIPSpace, typename ReducerType::result_view_type::
                                             memory_space>::accessible),
         m_scratch_space(nullptr),
-        m_scratch_flags(nullptr),
-        m_shared_memory_lock(m_policy.space()
-                                 .impl_internal_space_instance()
-                                 ->m_mutexSharedMemory) {}
+        m_scratch_flags(nullptr) {}
 
   template <typename Policy, typename Functor>
   static int max_tile_size_product(const Policy&, const Functor&) {

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -615,7 +615,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
     if (m_scratch_pool_id >= 0) {
       m_policy.space()
           .impl_internal_space_instance()
-          ->m_team_scratch_pool[m_scratch_pool_id] = 0;
+          ->release_team_scratch_pool(m_scratch_pool_id);
     }
   }
 };
@@ -1017,8 +1017,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                       static_cast<std::int64_t>(HIP::concurrency() /
                                                 (m_team_size * m_vector_size)),
                       static_cast<std::int64_t>(m_league_size))));
-      m_scratch_ptr[1]  = scratch_ptr_id.first;
-      m_scratch_pool_id = scratch_ptr_id.second;
+      std::tie(m_scratch_ptr[1], m_scratch_pool_id) = scratch_ptr_id;
     }
 
     // The global parallel_reduce does not support vector_length other than 1 at
@@ -1060,7 +1059,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     if (m_scratch_pool_id >= 0) {
       m_policy.space()
           .impl_internal_space_instance()
-          ->m_team_scratch_pool[m_scratch_pool_id] = 0;
+          ->release_team_scratch_pool(m_scratch_pool_id);
     }
   }
 };

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -507,6 +507,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
   int m_shmem_size;
   void* m_scratch_ptr[2];
   size_t m_scratch_size[2];
+  int m_scratch_pool_id = -1;
   int32_t* m_scratch_locks;
 
   template <typename TagType>
@@ -580,17 +581,21 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
     // Functor's reduce memory, team scan memory, and team shared memory depend
     // upon team size.
     m_scratch_ptr[0] = nullptr;
-    m_scratch_ptr[1] =
-        m_team_size <= 0
-            ? nullptr
-            : m_policy.space()
-                  .impl_internal_space_instance()
-                  ->resize_team_scratch_space(
-                      static_cast<std::int64_t>(m_scratch_size[1]) *
-                      (std::min(static_cast<std::int64_t>(
-                                    HIP::concurrency() /
-                                    (m_team_size * m_vector_size)),
-                                static_cast<std::int64_t>(m_league_size))));
+    if (m_team_size <= 0) {
+      m_scratch_ptr[1] = nullptr;
+    } else {
+      auto scratch_ptr_id =
+          m_policy.space()
+              .impl_internal_space_instance()
+              ->resize_team_scratch_space(
+                  static_cast<std::int64_t>(m_scratch_size[1]) *
+                  (std::min(
+                      static_cast<std::int64_t>(HIP::concurrency() /
+                                                (m_team_size * m_vector_size)),
+                      static_cast<std::int64_t>(m_league_size))));
+      m_scratch_ptr[1]  = scratch_ptr_id.first;
+      m_scratch_pool_id = scratch_ptr_id.second;
+    }
 
     int const shmem_size_total = m_shmem_begin + m_shmem_size;
     if (m_policy.space().impl_internal_space_instance()->m_maxShmemPerBlock <
@@ -603,6 +608,14 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
     if (static_cast<int>(m_team_size) > static_cast<int>(max_size)) {
       Kokkos::Impl::throw_runtime_exception(std::string(
           "Kokkos::Impl::ParallelFor< HIP > requested too large team size."));
+    }
+  }
+
+  ~ParallelFor() {
+    if (m_scratch_pool_id >= 0) {
+      m_policy.space()
+          .impl_internal_space_instance()
+          ->m_team_scratch_pool[m_scratch_pool_id] = 0;
     }
   }
 };
@@ -667,6 +680,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   size_type m_shmem_size;
   void* m_scratch_ptr[2];
   size_t m_scratch_size[2];
+  int m_scratch_pool_id = -1;
   int32_t* m_scratch_locks;
   const size_type m_league_size;
   int m_team_size;
@@ -894,17 +908,21 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     m_scratch_size[1] = m_policy.scratch_size(1, m_team_size);
     m_scratch_locks =
         m_policy.space().impl_internal_space_instance()->m_scratch_locks;
-    m_scratch_ptr[1] =
-        m_team_size <= 0
-            ? nullptr
-            : m_policy.space()
-                  .impl_internal_space_instance()
-                  ->resize_team_scratch_space(
-                      static_cast<std::int64_t>(m_scratch_size[1]) *
-                      (std::min(static_cast<std::int64_t>(
-                                    HIP::concurrency() /
-                                    (m_team_size * m_vector_size)),
-                                static_cast<std::int64_t>(m_league_size))));
+    if (m_team_size <= 0) {
+      m_scratch_ptr[1] = nullptr;
+    } else {
+      auto scratch_ptr_id =
+          m_policy.space()
+              .impl_internal_space_instance()
+              ->resize_team_scratch_space(
+                  static_cast<std::int64_t>(m_scratch_size[1]) *
+                  (std::min(
+                      static_cast<std::int64_t>(HIP::concurrency() /
+                                                (m_team_size * m_vector_size)),
+                      static_cast<std::int64_t>(m_league_size))));
+      m_scratch_ptr[1]  = scratch_ptr_id.first;
+      m_scratch_pool_id = scratch_ptr_id.second;
+    }
 
     // The global parallel_reduce does not support vector_length other than 1 at
     // the moment
@@ -987,17 +1005,21 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     m_scratch_size[1] = m_policy.scratch_size(1, m_team_size);
     m_scratch_locks =
         m_policy.space().impl_internal_space_instance()->m_scratch_locks;
-    m_scratch_ptr[1] =
-        m_team_size <= 0
-            ? nullptr
-            : m_policy.space()
-                  .impl_internal_space_instance()
-                  ->resize_team_scratch_space(
-                      static_cast<std::int64_t>(m_scratch_size[1]) *
-                      (std::min(static_cast<std::int64_t>(
-                                    HIP::concurrency() /
-                                    (m_team_size * m_vector_size)),
-                                static_cast<std::int64_t>(m_league_size))));
+    if (m_team_size <= 0) {
+      m_scratch_ptr[1] = nullptr;
+    } else {
+      auto scratch_ptr_id =
+          m_policy.space()
+              .impl_internal_space_instance()
+              ->resize_team_scratch_space(
+                  static_cast<std::int64_t>(m_scratch_size[1]) *
+                  (std::min(
+                      static_cast<std::int64_t>(HIP::concurrency() /
+                                                (m_team_size * m_vector_size)),
+                      static_cast<std::int64_t>(m_league_size))));
+      m_scratch_ptr[1]  = scratch_ptr_id.first;
+      m_scratch_pool_id = scratch_ptr_id.second;
+    }
 
     // The global parallel_reduce does not support vector_length other than 1 at
     // the moment
@@ -1031,6 +1053,14 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       Kokkos::Impl::throw_runtime_exception(
           std::string("Kokkos::Impl::ParallelReduce< HIP > requested too "
                       "large team size."));
+    }
+  }
+
+  ~ParallelReduce() {
+    if (m_scratch_pool_id >= 0) {
+      m_policy.space()
+          .impl_internal_space_instance()
+          ->m_team_scratch_pool[m_scratch_pool_id] = 0;
     }
   }
 };

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -508,9 +508,6 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
   void* m_scratch_ptr[2];
   size_t m_scratch_size[2];
   int32_t* m_scratch_locks;
-  // Only let one ParallelFor/Reduce modify the team scratch memory. The
-  // constructor acquires the mutex which is released in the destructor.
-  std::lock_guard<std::mutex> m_scratch_lock_guard;
 
   template <typename TagType>
   __device__ inline std::enable_if_t<std::is_void<TagType>::value> exec_team(
@@ -566,10 +563,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
         m_policy(arg_policy),
         m_league_size(arg_policy.league_size()),
         m_team_size(arg_policy.team_size()),
-        m_vector_size(arg_policy.impl_vector_length()),
-        m_scratch_lock_guard(m_policy.space()
-                                 .impl_internal_space_instance()
-                                 ->m_team_scratch_mutex) {
+        m_vector_size(arg_policy.impl_vector_length()) {
     m_team_size = m_team_size >= 0 ? m_team_size
                                    : arg_policy.team_size_recommended(
                                          arg_functor, ParallelForTag());
@@ -677,9 +671,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   const size_type m_league_size;
   int m_team_size;
   const size_type m_vector_size;
-  // Only let one ParallelFor/Reduce modify the team scratch memory. The
-  // constructor acquires the mutex which is released in the destructor.
-  std::lock_guard<std::mutex> m_scratch_lock_guard;
 
   template <class TagType>
   __device__ inline std::enable_if_t<std::is_void<TagType>::value> exec_team(
@@ -884,10 +875,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         m_scratch_ptr{nullptr, nullptr},
         m_league_size(arg_policy.league_size()),
         m_team_size(arg_policy.team_size()),
-        m_vector_size(arg_policy.impl_vector_length()),
-        m_scratch_lock_guard(m_policy.space()
-                                 .impl_internal_space_instance()
-                                 ->m_team_scratch_mutex) {
+        m_vector_size(arg_policy.impl_vector_length()) {
     m_team_size = m_team_size >= 0 ? m_team_size
                                    : arg_policy.team_size_recommended(
                                          arg_functor, ParallelReduceTag());
@@ -980,10 +968,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         m_scratch_ptr{nullptr, nullptr},
         m_league_size(arg_policy.league_size()),
         m_team_size(arg_policy.team_size()),
-        m_vector_size(arg_policy.impl_vector_length()),
-        m_scratch_lock_guard(m_policy.space()
-                                 .impl_internal_space_instance()
-                                 ->m_team_scratch_mutex) {
+        m_vector_size(arg_policy.impl_vector_length()) {
     m_team_size = m_team_size >= 0
                       ? m_team_size
                       : arg_policy.team_size_recommended(arg_functor, reducer,

--- a/core/unit_test/hip/TestHIP_AsyncLauncher.cpp
+++ b/core/unit_test/hip/TestHIP_AsyncLauncher.cpp
@@ -69,10 +69,9 @@ TEST(hip, async_launcher) {
   KOKKOS_IMPL_HIP_SAFE_CALL(hipMalloc(&flag, sizeof(size_t)));
   KOKKOS_IMPL_HIP_SAFE_CALL(hipMemset(flag, 0, sizeof(size_t)));
   // launch # of cycles * 1000 kernels w/ distinct values
-  auto space        = Kokkos::HIP();
-  auto instance     = space.impl_internal_space_instance();
-  size_t max_cycles = instance->m_maxDriverCycles;
-  size_t nkernels   = max_cycles * 1000;
+  auto space      = Kokkos::HIP();
+  auto instance   = space.impl_internal_space_instance();
+  size_t nkernels = 1000;
   for (size_t i = 0; i < nkernels; ++i) {
     TestAsyncLauncher(flag, i).run();
   }


### PR DESCRIPTION
In the past, we had to pass the functor by reference because of compiler bugs. These have been fixed. To ensure that multiple teams did not use the same scratch memory, the HIP backend was using a lock. I have replaced the lock with a memory pool (this is what is done in CUDA). As noticed https://github.com/kokkos/kokkos/issues/4861#issuecomment-1228924111, the class `ParallelScanHIPBase` cannot have a pure virtual function. Using a dummy implementation fixes the problem.

Related to #4861