### PR TITLE
Don't require user-defined volatile operator= in Kokkos::single for aggregates

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -163,6 +163,11 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
     // Round team size up to a multiple of 'team_gain'
     const int team_size_grain =
         team_grain * ((m_team_size + team_grain - 1) / team_grain);
+
+    // more helpful than "floating point exception occured"
+    if (0 == team_size_grain) {
+      Kokkos::abort("Kokkos::abort: Requested Team Size rounded up to 0!");
+    }
     const int team_count = pool_size / team_size_grain;
 
     // Constraint : pool_size = m_team_alloc * team_count

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -181,7 +181,8 @@ struct TestTeamForAggregate {
         Kokkos::parallel_for(team_policy_t(leagueSize, teamSize), test);
         int numErrs = 0;
         Kokkos::parallel_reduce(range_policy_t(0, problemSize), test, numErrs);
-        EXPECT_EQ(numErrs, 0);
+        EXPECT_EQ(numErrs, 0)
+            << " teamSize=" << teamSize << " problemSize=" << problemSize;
       }
     }
   }

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -114,6 +114,83 @@ TEST(TEST_CATEGORY, team_reduce_large) {
   }
 }
 
+/*! \brief Test passing an aggregate to Kokkos::single in a parallel_for with
+           team policy
+*/
+template <typename ExecutionSpace>
+struct TestTeamForAggregate {
+  using range_policy_t = Kokkos::RangePolicy<ExecutionSpace>;
+  using team_policy_t  = Kokkos::TeamPolicy<ExecutionSpace>;
+  using member_t       = typename team_policy_t::member_type;
+  using memory_space   = typename ExecutionSpace::memory_space;
+  using results_type   = Kokkos::View<double*, memory_space>;
+
+  static constexpr double INIT_VALUE   = -1.0;
+  static constexpr double EXPECT_VALUE = 1.0;
+
+  struct Agg {
+    double d;
+  };
+  results_type results_;
+
+  TestTeamForAggregate(const size_t size) : results_("results", size) {}
+  TestTeamForAggregate() : TestTeamForAggregate(0) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const member_t& t) const {
+    Agg lagg;
+    lagg.d = INIT_VALUE;
+    Kokkos::single(
+        Kokkos::PerTeam(t), [&](Agg& myAgg) { myAgg.d = EXPECT_VALUE; }, lagg);
+    size_t i = t.league_rank() * t.team_size() + t.team_rank();
+    if (i < results_.size()) {
+      results_(i) = lagg.d;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i, int& lNumErrs) const {
+    if (EXPECT_VALUE != results_(i)) {
+      ++lNumErrs;
+    }
+  }
+
+  static void run() {
+    int minTeamSize = 1;
+    /* OpenMPTarget hard-codes 32 as the minimum size
+       FIXME OPENMPTARGET
+    */
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+    if constexpr (std::is_same<ExecutionSpace,
+                               Kokkos::Experimental::OpenMPTarget>::value) {
+      minTeamSize = 32;
+    }
+#endif
+
+    int maxTeamSize;
+    {
+      TestTeamForAggregate test;
+      maxTeamSize = team_policy_t(1, minTeamSize)
+                        .team_size_max(test, Kokkos::ParallelForTag());
+    }
+
+    for (int teamSize = minTeamSize; teamSize <= maxTeamSize; teamSize *= 2) {
+      for (int problemSize : {1, 100, 10'000, 1'000'000}) {
+        const int leagueSize = (problemSize + teamSize - 1) / teamSize;
+        TestTeamForAggregate test(problemSize);
+        Kokkos::parallel_for(team_policy_t(leagueSize, teamSize), test);
+        int numErrs = 0;
+        Kokkos::parallel_reduce(range_policy_t(0, problemSize), test, numErrs);
+        EXPECT_EQ(numErrs, 0);
+      }
+    }
+  }
+};
+
+TEST(TEST_CATEGORY, team_parallel_single) {
+  TestTeamForAggregate<TEST_EXECSPACE>::run();
+}
+
 template <typename ExecutionSpace>
 struct LargeTeamScratchFunctor {
   using team_member = typename Kokkos::TeamPolicy<ExecutionSpace>::member_type;


### PR DESCRIPTION
Prior to this commit, users would have to define the following overload to pass an aggregate T to `Kokkos::single`.
* `KOKKOS_INLINE_FUNCTION void operator=(const volatile T &rhs) volatile {...}`

This was annoying because it has to have a void return type to prevent g++ from issuing a warning with the following usage:

```c++
T a, b;
a = b; // here
```

g++ will issue a warning if the return type was the expected `T&` because `a=b` will have a type of `T&`, which results in a spurious memory access if T is volatile (in g++).

it is also annoying because if the user wants to use T in any usual value-type ways, they will have to follow the rule of 7 now that they have defined one operator.