### PR TITLE
Try removing volatile from AtomicDataElement

### DIFF
--- a/core/src/impl/Kokkos_Atomic_View.hpp
+++ b/core/src/impl/Kokkos_Atomic_View.hpp
@@ -248,19 +248,6 @@ class AtomicViewDataHandle {
   operator typename ViewTraits::value_type*() const { return ptr; }
 };
 
-template <unsigned Size>
-struct Kokkos_Atomic_is_only_allowed_with_32bit_and_64bit_scalars;
-
-template <>
-struct Kokkos_Atomic_is_only_allowed_with_32bit_and_64bit_scalars<4> {
-  using type = int;
-};
-
-template <>
-struct Kokkos_Atomic_is_only_allowed_with_32bit_and_64bit_scalars<8> {
-  using type = int64_t;
-};
-
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Atomic_View.hpp
+++ b/core/src/impl/Kokkos_Atomic_View.hpp
@@ -60,19 +60,14 @@ class AtomicDataElement {
   using value_type           = typename ViewTraits::value_type;
   using const_value_type     = typename ViewTraits::const_value_type;
   using non_const_value_type = typename ViewTraits::non_const_value_type;
-  volatile value_type* const ptr;
+  value_type* const ptr;
 
   KOKKOS_INLINE_FUNCTION
   AtomicDataElement(value_type* ptr_, AtomicViewConstTag) : ptr(ptr_) {}
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator=(const_value_type& val) const {
-    *ptr = val;
-    return val;
-  }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator=(volatile const_value_type& val) const {
-    *ptr = val;
+    Kokkos::Impl::atomic_store(ptr, val, Kokkos::Impl::memory_order_relaxed);
     return val;
   }
 
@@ -111,19 +106,9 @@ class AtomicDataElement {
     const_value_type tmp = Kokkos::atomic_fetch_add(ptr, val);
     return tmp + val;
   }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator+=(volatile const_value_type& val) const {
-    const_value_type tmp = Kokkos::atomic_fetch_add(ptr, val);
-    return tmp + val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator-=(const_value_type& val) const {
-    const_value_type tmp = Kokkos::atomic_fetch_sub(ptr, val);
-    return tmp - val;
-  }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator-=(volatile const_value_type& val) const {
     const_value_type tmp = Kokkos::atomic_fetch_sub(ptr, val);
     return tmp - val;
   }
@@ -132,17 +117,9 @@ class AtomicDataElement {
   const_value_type operator*=(const_value_type& val) const {
     return Kokkos::atomic_mul_fetch(ptr, val);
   }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator*=(volatile const_value_type& val) const {
-    return Kokkos::atomic_mul_fetch(ptr, val);
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator/=(const_value_type& val) const {
-    return Kokkos::atomic_div_fetch(ptr, val);
-  }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator/=(volatile const_value_type& val) const {
     return Kokkos::atomic_div_fetch(ptr, val);
   }
 
@@ -150,17 +127,9 @@ class AtomicDataElement {
   const_value_type operator%=(const_value_type& val) const {
     return Kokkos::atomic_mod_fetch(ptr, val);
   }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator%=(volatile const_value_type& val) const {
-    return Kokkos::atomic_mod_fetch(ptr, val);
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator&=(const_value_type& val) const {
-    return Kokkos::atomic_and_fetch(ptr, val);
-  }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator&=(volatile const_value_type& val) const {
     return Kokkos::atomic_and_fetch(ptr, val);
   }
 
@@ -168,17 +137,9 @@ class AtomicDataElement {
   const_value_type operator^=(const_value_type& val) const {
     return Kokkos::atomic_xor_fetch(ptr, val);
   }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator^=(volatile const_value_type& val) const {
-    return Kokkos::atomic_xor_fetch(ptr, val);
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator|=(const_value_type& val) const {
-    return Kokkos::atomic_or_fetch(ptr, val);
-  }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator|=(volatile const_value_type& val) const {
     return Kokkos::atomic_or_fetch(ptr, val);
   }
 
@@ -186,54 +147,26 @@ class AtomicDataElement {
   const_value_type operator<<=(const_value_type& val) const {
     return Kokkos::atomic_lshift_fetch(ptr, val);
   }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator<<=(volatile const_value_type& val) const {
-    return Kokkos::atomic_lshift_fetch(ptr, val);
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator>>=(const_value_type& val) const {
     return Kokkos::atomic_rshift_fetch(ptr, val);
   }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator>>=(volatile const_value_type& val) const {
-    return Kokkos::atomic_rshift_fetch(ptr, val);
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator+(const_value_type& val) const { return *ptr + val; }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator+(volatile const_value_type& val) const {
-    return *ptr + val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator-(const_value_type& val) const { return *ptr - val; }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator-(volatile const_value_type& val) const {
-    return *ptr - val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator*(const_value_type& val) const { return *ptr * val; }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator*(volatile const_value_type& val) const {
-    return *ptr * val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator/(const_value_type& val) const { return *ptr / val; }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator/(volatile const_value_type& val) const {
-    return *ptr / val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator%(const_value_type& val) const { return *ptr ^ val; }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator%(volatile const_value_type& val) const {
-    return *ptr ^ val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator!() const { return !*ptr; }
@@ -242,40 +175,20 @@ class AtomicDataElement {
   const_value_type operator&&(const_value_type& val) const {
     return *ptr && val;
   }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator&&(volatile const_value_type& val) const {
-    return *ptr && val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator||(const_value_type& val) const {
     return *ptr | val;
   }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator||(volatile const_value_type& val) const {
-    return *ptr | val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator&(const_value_type& val) const { return *ptr & val; }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator&(volatile const_value_type& val) const {
-    return *ptr & val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator|(const_value_type& val) const { return *ptr | val; }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator|(volatile const_value_type& val) const {
-    return *ptr | val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator^(const_value_type& val) const { return *ptr ^ val; }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator^(volatile const_value_type& val) const {
-    return *ptr ^ val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator~() const { return ~*ptr; }
@@ -284,63 +197,33 @@ class AtomicDataElement {
   const_value_type operator<<(const unsigned int& val) const {
     return *ptr << val;
   }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator<<(volatile const unsigned int& val) const {
-    return *ptr << val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   const_value_type operator>>(const unsigned int& val) const {
     return *ptr >> val;
   }
-  KOKKOS_INLINE_FUNCTION
-  const_value_type operator>>(volatile const unsigned int& val) const {
-    return *ptr >> val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   bool operator==(const AtomicDataElement& val) const { return *ptr == val; }
-  KOKKOS_INLINE_FUNCTION
-  bool operator==(volatile const AtomicDataElement& val) const {
-    return *ptr == val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   bool operator!=(const AtomicDataElement& val) const { return *ptr != val; }
-  KOKKOS_INLINE_FUNCTION
-  bool operator!=(volatile const AtomicDataElement& val) const {
-    return *ptr != val;
-  }
 
   KOKKOS_INLINE_FUNCTION
   bool operator>=(const_value_type& val) const { return *ptr >= val; }
-  KOKKOS_INLINE_FUNCTION
-  bool operator>=(volatile const_value_type& val) const { return *ptr >= val; }
 
   KOKKOS_INLINE_FUNCTION
   bool operator<=(const_value_type& val) const { return *ptr <= val; }
-  KOKKOS_INLINE_FUNCTION
-  bool operator<=(volatile const_value_type& val) const { return *ptr <= val; }
 
   KOKKOS_INLINE_FUNCTION
   bool operator<(const_value_type& val) const { return *ptr < val; }
-  KOKKOS_INLINE_FUNCTION
-  bool operator<(volatile const_value_type& val) const { return *ptr < val; }
 
   KOKKOS_INLINE_FUNCTION
   bool operator>(const_value_type& val) const { return *ptr > val; }
-  KOKKOS_INLINE_FUNCTION
-  bool operator>(volatile const_value_type& val) const { return *ptr > val; }
 
   KOKKOS_INLINE_FUNCTION
-  operator const_value_type() const {
-    // return Kokkos::atomic_load(ptr);
-    return *ptr;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  operator non_const_value_type() volatile const {
-    return Kokkos::Impl::atomic_load(ptr);
+  operator value_type() const {
+    return Kokkos::Impl::atomic_load(ptr, Kokkos::Impl::memory_order_relaxed);
   }
 };
 


### PR DESCRIPTION
In the last hackathon I was mentoring, my team wanted to use `MemorytTraits:::Atomic` with a custom type. This currently requires defining all kinds of `volatile` qualified member functions which is not very user-friendly.

It appears that none of the `volatile` overloads in `AtomicDataElement` are used anymore, though, and there doesn't seem to be a point in combing `volatile` with `atomic`.
Also, `Kokkos_Atomic_is_only_allowed_with_32bit_and_64bit_scalars` is not used at all.