### PR TITLE
Remove HIP-only parameter for a test

### DIFF
--- a/core/unit_test/TestWorkGraph.hpp
+++ b/core/unit_test/TestWorkGraph.hpp
@@ -159,12 +159,7 @@ struct TestWorkGraph {
 }  // anonymous namespace
 
 TEST(TEST_CATEGORY, workgraph_fib) {
-  // FIXME_HIP The test is very slow with HIP and it causes the CI to timeout
-#ifdef KOKKOS_ENABLE_HIP
-  int limit = 7;
-#else
   int limit = 27;
-#endif
   for (int i = 0; i < limit; ++i) {
     TestWorkGraph<TEST_EXECSPACE> f(i);
     f.test_for();


### PR DESCRIPTION
With HIP we had a test that was much slower than the CUDA version and we had to use a different parameter for the test to run in a reasonable time. On Crusher, the test takes the same time than on V100. Let's see if the CI is still slow.