### PR TITLE
Use inline static member variables for CudaInternal

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -291,24 +291,6 @@ const CudaInternalDevices &CudaInternalDevices::singleton() {
 
 }  // namespace
 
-int CudaInternal::m_cudaDev;
-int CudaInternal::m_cudaArch;
-unsigned CudaInternal::m_multiProcCount;
-unsigned CudaInternal::m_maxWarpCount;
-std::array<CudaInternal::size_type, 3> CudaInternal::m_maxBlock;
-unsigned CudaInternal::m_maxSharedWords;
-uint32_t CudaInternal::m_maxConcurrency;
-int CudaInternal::m_shmemPerSM;
-int CudaInternal::m_maxShmemPerBlock;
-int CudaInternal::m_maxBlocksPerSM;
-int CudaInternal::m_maxThreadsPerSM;
-int CudaInternal::m_maxThreadsPerBlock;
-cudaDeviceProp CudaInternal::m_deviceProp;
-CudaInternal::size_type CudaInternal::m_scratchUnifiedSupported;
-unsigned long *CudaInternal::constantMemHostStaging = nullptr;
-cudaEvent_t CudaInternal::constantMemReusable       = nullptr;
-std::mutex CudaInternal::constantMemMutex;
-
 //----------------------------------------------------------------------------
 
 void CudaInternal::print_configuration(std::ostream &s) const {

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -108,7 +108,7 @@ class CudaInternal {
   mutable std::size_t m_scratchUnifiedCount;
   mutable std::size_t m_scratchFunctorSize;
 
-  static size_type m_scratchUnifiedSupported;
+  inline static size_type m_scratchUnifiedSupported = 0;
   mutable size_type* m_scratchSpace;
   mutable size_type* m_scratchFlags;
   mutable size_type* m_scratchUnified;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -85,22 +85,22 @@ class CudaInternal {
  public:
   using size_type = Cuda::size_type;
 
-  static int m_cudaDev;
+  inline static int m_cudaDev = -1;
 
   // Device Properties
-  static int m_cudaArch;
-  static unsigned m_multiProcCount;
-  static unsigned m_maxWarpCount;
-  static std::array<size_type, 3> m_maxBlock;
-  static unsigned m_maxSharedWords;
-  static uint32_t m_maxConcurrency;
-  static int m_shmemPerSM;
-  static int m_maxShmemPerBlock;
-  static int m_maxBlocksPerSM;
-  static int m_maxThreadsPerSM;
-  static int m_maxThreadsPerBlock;
+  inline static int m_cudaArch                      = -1;
+  inline static unsigned m_multiProcCount           = 0;
+  inline static unsigned m_maxWarpCount             = 0;
+  inline static std::array<size_type, 3> m_maxBlock = {0, 0, 0};
+  inline static unsigned m_maxSharedWords           = 0;
+  inline static uint32_t m_maxConcurrency           = 0;
+  inline static int m_shmemPerSM                    = 0;
+  inline static int m_maxShmemPerBlock              = 0;
+  inline static int m_maxBlocksPerSM                = 0;
+  inline static int m_maxThreadsPerSM               = 0;
+  inline static int m_maxThreadsPerBlock            = 0;
 
-  static cudaDeviceProp m_deviceProp;
+  inline static cudaDeviceProp m_deviceProp;
 
   // Scratch Spaces for Reductions
   mutable std::size_t m_scratchSpaceCount;
@@ -129,9 +129,9 @@ class CudaInternal {
 
   // FIXME_CUDA: these want to be per-device, not per-stream...  use of 'static'
   //  here will break once there are multiple devices though
-  static unsigned long* constantMemHostStaging;
-  static cudaEvent_t constantMemReusable;
-  static std::mutex constantMemMutex;
+  inline static unsigned long* constantMemHostStaging = nullptr;
+  inline static cudaEvent_t constantMemReusable       = nullptr;
+  inline static std::mutex constantMemMutex;
 
   static CudaInternal& singleton();
 


### PR DESCRIPTION
Addressing https://github.com/kokkos/kokkos/pull/5442#discussion_r974176530 in correspondence of doing the same changes to the `HIP` backend in [`891fe55` (#5444)](https://github.com/kokkos/kokkos/pull/5444/commits/891fe55638db9f4c59d661b24728af5a1a6fb331).