### PR TITLE
HIP simplify code using C++17

### DIFF
--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -62,9 +62,8 @@ template <typename DriverType, typename LaunchBounds = Kokkos::LaunchBounds<>,
           HIPLaunchMechanism LaunchMechanism =
               DeduceHIPLaunchMechanism<DriverType>::launch_mechanism>
 unsigned get_preferred_blocksize_impl() {
-  // FIXME_HIP - could be if constexpr for c++17
-  if (!HIPParallelLaunch<DriverType, LaunchBounds,
-                         LaunchMechanism>::default_launchbounds()) {
+  if constexpr (!HIPParallelLaunch<DriverType, LaunchBounds,
+                                   LaunchMechanism>::default_launchbounds()) {
     // use the user specified value
     return LaunchBounds::maxTperB;
   } else {
@@ -76,14 +75,12 @@ unsigned get_preferred_blocksize_impl() {
   }
 }
 
-// FIXME_HIP - entire function could be constexpr for c++17
 template <typename DriverType, typename LaunchBounds = Kokkos::LaunchBounds<>,
           HIPLaunchMechanism LaunchMechanism =
               DeduceHIPLaunchMechanism<DriverType>::launch_mechanism>
-unsigned get_max_blocksize_impl() {
-  // FIXME_HIP - could be if constexpr for c++17
-  if (!HIPParallelLaunch<DriverType, LaunchBounds,
-                         LaunchMechanism>::default_launchbounds()) {
+constexpr unsigned get_max_blocksize_impl() {
+  if constexpr (!HIPParallelLaunch<DriverType, LaunchBounds,
+                                   LaunchMechanism>::default_launchbounds()) {
     // use the user specified value
     return LaunchBounds::maxTperB;
   } else {
@@ -104,15 +101,13 @@ hipFuncAttributes get_hip_func_attributes_impl() {
   return HIPParallelLaunch<DriverType, LaunchBounds,
                            LaunchMechanism>::get_hip_func_attributes();
 #else
-  // FIXME_HIP - could be if constexpr for c++17
-  if (!HIPParallelLaunch<DriverType, LaunchBounds,
-                         LaunchMechanism>::default_launchbounds()) {
+  if constexpr (!HIPParallelLaunch<DriverType, LaunchBounds,
+                                   LaunchMechanism>::default_launchbounds()) {
     // for user defined, we *always* honor the request
     return HIPParallelLaunch<DriverType, LaunchBounds,
                              LaunchMechanism>::get_hip_func_attributes();
   } else {
-    // FIXME_HIP - could be if constexpr for c++17
-    if (BlockSize == BlockType::Max) {
+    if constexpr (BlockSize == BlockType::Max) {
       return HIPParallelLaunch<
           DriverType, Kokkos::LaunchBounds<HIPTraits::MaxThreadsPerBlock, 1>,
           LaunchMechanism>::get_hip_func_attributes();
@@ -153,8 +148,7 @@ unsigned hip_internal_get_block_size(const HIPInternal *hip_instance,
     // find how many threads we can fit with this blocksize based on LDS usage
     unsigned tperb_shmem = total_shmem > shmem_per_sm ? 0 : block_size;
 
-    // FIXME_HIP - could be if constexpr for c++17
-    if (BlockSize == BlockType::Max) {
+    if constexpr (BlockSize == BlockType::Max) {
       // we want the maximum blocksize possible
       // just wait until we get a case where we can fit the LDS per SM
       if (tperb_shmem) return block_size;

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -508,9 +508,8 @@ void hip_parallel_launch(const DriverType &driver, const dim3 &grid,
   HIPParallelLaunch<DriverType, LaunchBounds, LaunchMechanism>(
       driver, grid, block, shmem, hip_instance, prefer_shmem);
 #else
-  // FIXME_HIP - could be if constexpr for c++17
-  if (!HIPParallelLaunch<DriverType, LaunchBounds,
-                         LaunchMechanism>::default_launchbounds()) {
+  if constexpr (!HIPParallelLaunch<DriverType, LaunchBounds,
+                                   LaunchMechanism>::default_launchbounds()) {
     // for user defined, we *always* honor the request
     HIPParallelLaunch<DriverType, LaunchBounds, LaunchMechanism>(
         driver, grid, block, shmem, hip_instance, prefer_shmem);

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -103,7 +103,8 @@ class TeamPolicyInternal<HIP, Properties...>
     using closure_type =
         Impl::ParallelFor<FunctorType, TeamPolicy<Properties...>>;
 
-    return internal_team_size_common<BlockType::Max, closure_type>(f);
+    return internal_team_size_common<BlockType::Max, closure_type, FunctorType,
+                                     ParallelForTag>(f);
   }
 
   template <class FunctorType>
@@ -118,7 +119,8 @@ class TeamPolicyInternal<HIP, Properties...>
     using closure_type =
         Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                              reducer_type>;
-    return internal_team_size_max<closure_type>(f);
+    return internal_team_size_common<BlockType::Max, closure_type, FunctorType,
+                                     ParallelReduceTag>(f);
   }
 
   template <typename FunctorType, typename ReducerType>
@@ -127,7 +129,8 @@ class TeamPolicyInternal<HIP, Properties...>
     using closure_type =
         Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                              ReducerType>;
-    return internal_team_size_max<closure_type>(f);
+    return internal_team_size_common<BlockType::Max, closure_type, FunctorType,
+                                     ParallelReduceTag>(f);
   }
 
   template <typename FunctorType>
@@ -135,7 +138,8 @@ class TeamPolicyInternal<HIP, Properties...>
     using closure_type =
         Impl::ParallelFor<FunctorType, TeamPolicy<Properties...>>;
 
-    return internal_team_size_common<BlockType::Preferred, closure_type>(f);
+    return internal_team_size_common<BlockType::Preferred, closure_type,
+                                     FunctorType, ParallelForTag>(f);
   }
 
   template <typename FunctorType>
@@ -150,7 +154,8 @@ class TeamPolicyInternal<HIP, Properties...>
     using closure_type =
         Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                              reducer_type>;
-    return internal_team_size_recommended<closure_type>(f);
+    return internal_team_size_common<BlockType::Preferred, closure_type,
+                                     FunctorType, ParallelReduceTag>(f);
   }
 
   template <typename FunctorType, typename ReducerType>
@@ -159,7 +164,8 @@ class TeamPolicyInternal<HIP, Properties...>
     using closure_type =
         Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                              ReducerType>;
-    return internal_team_size_recommended<closure_type>(f);
+    return internal_team_size_common<BlockType::Preferred, closure_type,
+                                     FunctorType, ParallelReduceTag>(f);
   }
 
   inline bool impl_auto_vector_length() const { return m_tune_vector_length; }
@@ -345,58 +351,20 @@ class TeamPolicyInternal<HIP, Properties...>
   using member_type = Kokkos::Impl::HIPTeamMember;
 
  protected:
-  template <BlockType BlockSize, class ClosureType, class FunctorType>
-  int internal_team_size_common(const FunctorType& f) const {
-    // FIXME_HIP: this could be unified with the
-    // internal_team_size_common_reduce
-    //            once we can turn c++17 constexpr on by default.
-    //            The problem right now is that we can't turn off the evaluation
-    //            of the Analysis' valuesize / StaticValueSize
-
-    const unsigned shmem_block  = team_scratch_size(0) + 2 * sizeof(double);
-    const unsigned shmem_thread = thread_scratch_size(0) + sizeof(double);
-    const int vector_length     = impl_vector_length();
-
-    const auto functor = [&f, shmem_block, shmem_thread, vector_length](
-                             const hipFuncAttributes& attr, int block_size) {
-      int functor_shmem =
-          ::Kokkos::Impl::FunctorTeamShmemSize<FunctorType>::value(
-              f, block_size / vector_length);
-      return shmem_block + shmem_thread * (block_size / vector_length) +
-             functor_shmem + attr.sharedSizeBytes;
-    };
-    int block_size;
-    // FIXME_HIP - could be if constexpr for c++17
-    if (BlockSize == BlockType::Max) {
-      block_size = hip_get_max_team_blocksize<ClosureType,
-                                              typename traits::launch_bounds>(
-          space().impl_internal_space_instance(), functor);
-    } else {
-      block_size =
-          hip_get_preferred_team_blocksize<ClosureType,
-                                           typename traits::launch_bounds>(
-              space().impl_internal_space_instance(), functor);
-    }
-    if (block_size == 0) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelFor< HIP > could not find a valid "
-                      "team size."));
-    }
-    return block_size / impl_vector_length();
-  }
-
-  template <BlockType BlockSize, class ClosureType, class FunctorType>
-  int internal_team_size_common_reduce(const FunctorType& f) const {
-    using Interface =
-        typename Impl::DeduceFunctorPatternInterface<ClosureType>::type;
-    using Analysis =
-        Impl::FunctorAnalysis<Interface, typename ClosureType::Policy,
-                              FunctorType>;
-
+  template <BlockType BlockSize, class ClosureType, class FunctorType,
+            class Tag>
+  int internal_team_size_common(FunctorType const& f) const {
     const unsigned shmem_block = team_scratch_size(0) + 2 * sizeof(double);
-    const unsigned shmem_thread =
-        thread_scratch_size(0) + sizeof(double) +
-        ((Analysis::StaticValueSize != 0) ? 0 : Analysis::value_size(f));
+    unsigned shmem_thread      = thread_scratch_size(0) + sizeof(double);
+    if constexpr (std::is_same_v<Tag, ParallelReduceTag>) {
+      using Interface =
+          typename Impl::DeduceFunctorPatternInterface<ClosureType>::type;
+      using Analysis =
+          Impl::FunctorAnalysis<Interface, typename ClosureType::Policy,
+                                FunctorType>;
+      shmem_thread +=
+          ((Analysis::StaticValueSize != 0) ? 0 : Analysis::value_size(f));
+    }
     const int vector_length = impl_vector_length();
 
     const auto functor = [&f, shmem_block, shmem_thread, vector_length](
@@ -408,8 +376,7 @@ class TeamPolicyInternal<HIP, Properties...>
              functor_shmem + attr.sharedSizeBytes;
     };
     int block_size;
-    // FIXME_HIP - could be if constexpr for c++17
-    if (BlockSize == BlockType::Max) {
+    if constexpr (BlockSize == BlockType::Max) {
       block_size = hip_get_max_team_blocksize<ClosureType,
                                               typename traits::launch_bounds>(
           space().impl_internal_space_instance(), functor);
@@ -421,26 +388,19 @@ class TeamPolicyInternal<HIP, Properties...>
     }
 
     if (block_size == 0) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelReduce< HIP > could not find a "
-                      "valid team size."));
+      Kokkos::Impl::throw_runtime_exception(std::string(
+          "Kokkos::Impl::ParallelFor/Reduce< HIP > could not find a valid "
+          "team size."));
     }
-    // Currently we require Power-of-2 team size for reductions.
-    int p2 = 1;
-    while (p2 <= block_size) p2 *= 2;
-    p2 /= 2;
-    return p2 / impl_vector_length();
-  }
-
-  template <class ClosureType, class FunctorType>
-  int internal_team_size_max(const FunctorType& f) const {
-    return internal_team_size_common_reduce<BlockType::Max, ClosureType>(f);
-  }
-
-  template <class ClosureType, class FunctorType>
-  int internal_team_size_recommended(const FunctorType& f) const {
-    return internal_team_size_common_reduce<BlockType::Preferred, ClosureType>(
-        f);
+    if constexpr (std::is_same_v<Tag, ParallelForTag>) {
+      return block_size / impl_vector_length();
+    } else {
+      // Currently we require Power-of-2 team size for reductions.
+      int p2 = 1;
+      while (p2 <= block_size) p2 *= 2;
+      p2 /= 2;
+      return p2 / impl_vector_length();
+    }
   }
 };
 

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -103,7 +103,7 @@ class TeamPolicyInternal<HIP, Properties...>
     using closure_type =
         Impl::ParallelFor<FunctorType, TeamPolicy<Properties...>>;
 
-    return internal_team_size_common<BlockType::Max, closure_type, FunctorType,
+    return internal_team_size_common<BlockType::Max, closure_type,
                                      ParallelForTag>(f);
   }
 
@@ -119,7 +119,7 @@ class TeamPolicyInternal<HIP, Properties...>
     using closure_type =
         Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                              reducer_type>;
-    return internal_team_size_common<BlockType::Max, closure_type, FunctorType,
+    return internal_team_size_common<BlockType::Max, closure_type,
                                      ParallelReduceTag>(f);
   }
 
@@ -129,7 +129,7 @@ class TeamPolicyInternal<HIP, Properties...>
     using closure_type =
         Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                              ReducerType>;
-    return internal_team_size_common<BlockType::Max, closure_type, FunctorType,
+    return internal_team_size_common<BlockType::Max, closure_type,
                                      ParallelReduceTag>(f);
   }
 
@@ -139,7 +139,7 @@ class TeamPolicyInternal<HIP, Properties...>
         Impl::ParallelFor<FunctorType, TeamPolicy<Properties...>>;
 
     return internal_team_size_common<BlockType::Preferred, closure_type,
-                                     FunctorType, ParallelForTag>(f);
+                                     ParallelForTag>(f);
   }
 
   template <typename FunctorType>
@@ -155,7 +155,7 @@ class TeamPolicyInternal<HIP, Properties...>
         Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                              reducer_type>;
     return internal_team_size_common<BlockType::Preferred, closure_type,
-                                     FunctorType, ParallelReduceTag>(f);
+                                     ParallelReduceTag>(f);
   }
 
   template <typename FunctorType, typename ReducerType>
@@ -165,7 +165,7 @@ class TeamPolicyInternal<HIP, Properties...>
         Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
                              ReducerType>;
     return internal_team_size_common<BlockType::Preferred, closure_type,
-                                     FunctorType, ParallelReduceTag>(f);
+                                     ParallelReduceTag>(f);
   }
 
   inline bool impl_auto_vector_length() const { return m_tune_vector_length; }
@@ -351,8 +351,8 @@ class TeamPolicyInternal<HIP, Properties...>
   using member_type = Kokkos::Impl::HIPTeamMember;
 
  protected:
-  template <BlockType BlockSize, class ClosureType, class FunctorType,
-            class Tag>
+  template <BlockType BlockSize, class ClosureType, class Tag,
+            class FunctorType>
   int internal_team_size_common(FunctorType const& f) const {
     const unsigned shmem_block = team_scratch_size(0) + 2 * sizeof(double);
     unsigned shmem_thread      = thread_scratch_size(0) + sizeof(double);
@@ -547,11 +547,11 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
     } else {
       m_scratch_pool_id = internal_space_instance->acquire_team_scratch_space();
       m_scratch_ptr[1]  = internal_space_instance->resize_team_scratch_space(
-          m_scratch_pool_id,
-          static_cast<std::int64_t>(m_scratch_size[1]) *
-              (std::min(static_cast<std::int64_t>(
+           m_scratch_pool_id,
+           static_cast<std::int64_t>(m_scratch_size[1]) *
+               (std::min(static_cast<std::int64_t>(
                             HIP::concurrency() / (m_team_size * m_vector_size)),
-                        static_cast<std::int64_t>(m_league_size))));
+                         static_cast<std::int64_t>(m_league_size))));
     }
 
     int const shmem_size_total = m_shmem_begin + m_shmem_size;
@@ -870,11 +870,11 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     } else {
       m_scratch_pool_id = internal_space_instance->acquire_team_scratch_space();
       m_scratch_ptr[1]  = internal_space_instance->resize_team_scratch_space(
-          m_scratch_pool_id,
-          static_cast<std::int64_t>(m_scratch_size[1]) *
-              (std::min(static_cast<std::int64_t>(
+           m_scratch_pool_id,
+           static_cast<std::int64_t>(m_scratch_size[1]) *
+               (std::min(static_cast<std::int64_t>(
                             HIP::concurrency() / (m_team_size * m_vector_size)),
-                        static_cast<std::int64_t>(m_league_size))));
+                         static_cast<std::int64_t>(m_league_size))));
     }
 
     // The global parallel_reduce does not support vector_length other than 1 at
@@ -963,11 +963,11 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     } else {
       m_scratch_pool_id = internal_space_instance->acquire_team_scratch_space();
       m_scratch_ptr[1]  = internal_space_instance->resize_team_scratch_space(
-          m_scratch_pool_id,
-          static_cast<std::int64_t>(m_scratch_size[1]) *
-              (std::min(static_cast<std::int64_t>(
+           m_scratch_pool_id,
+           static_cast<std::int64_t>(m_scratch_size[1]) *
+               (std::min(static_cast<std::int64_t>(
                             HIP::concurrency() / (m_team_size * m_vector_size)),
-                        static_cast<std::int64_t>(m_league_size))));
+                         static_cast<std::int64_t>(m_league_size))));
     }
 
     // The global parallel_reduce does not support vector_length other than 1 at


### PR DESCRIPTION
This PR does two things:
 - we had a few `FIXME_HIP` to remind us that some functions could be `constexpr`
 - using `if constexpr` we can use a single function to compute the team size. Instead of having a function for `ParallelFor` and one for `ParallelReduce`