### PR TITLE
Disable kk3_hypot in Power9 testing

### DIFF
--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -713,7 +713,9 @@ TEST(TEST_CATEGORY, mathematical_functions_power_functions) {
   do_test_math_ternary_function<TEST_EXECSPACE, kk3_hypot>(2., 3., 4.);
   do_test_math_ternary_function<TEST_EXECSPACE, kk3_hypot>(2, 3.f, 4.);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+#if !(defined(KOKKOS_ARCH_POWER8) || defined(KOKKOS_ARCH_POWER9))
   do_test_math_ternary_function<TEST_EXECSPACE, kk3_hypot>(2.l, 3.l, 4.l);
+#endif
 #endif
 }
 


### PR DESCRIPTION
Disable test on Power9 (and Power8) arches
Similar treatment for kk3_hypot as kk_hypot in #3962