### PR TITLE
Allow as_view_of_rank_n() to be overloaded for "special" scalar types

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1691,7 +1691,8 @@ template <unsigned N, typename T, typename... Args>
 KOKKOS_FUNCTION auto as_view_of_rank_n(
     DynRankView<T, Args...> v,
     typename std::enable_if<std::is_same<
-        typename ViewTraits<T, Args...>::specialize, void>::value>::type* = 0) {
+        typename ViewTraits<T, Args...>::specialize, void>::value>::type* =
+        nullptr) {
   if (v.rank() != N) {
     KOKKOS_IF_ON_HOST(
         const std::string message =

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1688,7 +1688,11 @@ namespace Impl {
    underlying memory, to facilitate implementation of deep_copy() and
    other routines that are defined on View */
 template <unsigned N, typename T, typename... Args>
-KOKKOS_FUNCTION auto as_view_of_rank_n(DynRankView<T, Args...> v) {
+KOKKOS_FUNCTION auto as_view_of_rank_n(
+  DynRankView<T, Args...> v,
+  typename std::enable_if<
+    std::is_same< typename ViewTraits<T,Args...>::specialize, void >::value
+  >::type * = 0) {
   if (v.rank() != N) {
     KOKKOS_IF_ON_HOST(
         const std::string message =

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1689,10 +1689,9 @@ namespace Impl {
    other routines that are defined on View */
 template <unsigned N, typename T, typename... Args>
 KOKKOS_FUNCTION auto as_view_of_rank_n(
-  DynRankView<T, Args...> v,
-  typename std::enable_if<
-    std::is_same< typename ViewTraits<T,Args...>::specialize, void >::value
-  >::type * = 0) {
+    DynRankView<T, Args...> v,
+    typename std::enable_if<std::is_same<
+        typename ViewTraits<T, Args...>::specialize, void>::value>::type* = 0) {
   if (v.rank() != N) {
     KOKKOS_IF_ON_HOST(
         const std::string message =

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1730,7 +1730,10 @@ struct RankDataType<ValueType, 0> {
 };
 
 template <unsigned N, typename... Args>
-KOKKOS_FUNCTION std::enable_if_t<N == View<Args...>::Rank, View<Args...>>
+KOKKOS_FUNCTION std::enable_if_t<
+    N == View<Args...>::Rank &&
+        std::is_same<typename ViewTraits<Args...>::specialize, void>::value,
+    View<Args...>>
 as_view_of_rank_n(View<Args...> v) {
   return v;
 }
@@ -1738,8 +1741,9 @@ as_view_of_rank_n(View<Args...> v) {
 // Placeholder implementation to compile generic code for DynRankView; should
 // never be called
 template <unsigned N, typename T, typename... Args>
-std::enable_if_t<
-    N != View<T, Args...>::Rank,
+KOKKOS_FUNCTION std::enable_if_t<
+    N != View<T, Args...>::Rank &&
+        std::is_same<typename ViewTraits<T, Args...>::specialize, void>::value,
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
          Args...>>
 as_view_of_rank_n(View<T, Args...>) {


### PR DESCRIPTION
as_view_of_rank_n() needs to be overloaded for special scalar types like Sacado that need to pass a hidden dimension.  This change adds the necessary SFINAE stuff to allow that to happen.  This will require adding the new overload in Trilinos/Sacado.

For Trilinos issue [#11018](https://github.com/trilinos/Trilinos/issues/11018) causing runtime failures in Albany.

@PhilMiller, @ndellingwood 