### PR TITLE
Workaround for "missing return statement at end of non-void function" warning in Kokkos_ViewCtor.hpp

### DIFF
--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -267,21 +267,6 @@ auto with_properties_if_unset(const ViewCtorProp<P...> &view_ctor_prop) {
   return view_ctor_prop;
 }
 
-// Suppress faulty warning from NVCC see:
-// https://github.com/kokkos/kokkos/issues/5426
-#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)
-// pragma pop is getting a warning from the underlying GCC
-// for unknown pragma if -pedantic is used
-#ifdef __CUDA_ARCH__
-#pragma push
-#pragma diag_suppress implicit_return_from_non_void_function
-#endif
-#endif
-#if defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL <= 2100)
-#define KOKKOS_IMPL_INTEL_BOGUS_MISSING_RETURN_STATEMENT_AT_END_OF_NON_VOID_FUNCTION
-#pragma warning(push)
-#pragma warning(disable : 1011)
-#endif
 template <typename... P, typename Property, typename... Properties>
 auto with_properties_if_unset(const ViewCtorProp<P...> &view_ctor_prop,
                               const Property &property,
@@ -301,6 +286,9 @@ auto with_properties_if_unset(const ViewCtorProp<P...> &view_ctor_prop,
     return with_properties_if_unset(new_view_ctor_prop, properties...);
   } else
     return with_properties_if_unset(view_ctor_prop, properties...);
+  Kokkos::abort(
+      "Prevents an incorrect warning: missing return statement at end of "
+      "non-void function");
 }
 
 struct ExecutionSpaceTag {};
@@ -336,6 +324,9 @@ KOKKOS_FUNCTION const auto &get_property(
     static_assert(std::is_same_v<Tag, void>, "Invalid property tag!");
     return view_ctor_prop;
   }
+  Kokkos::abort(
+      "Prevents an incorrect warning: missing return statement at end of "
+      "non-void function");
 }
 #if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)
 // pragma pop is getting a warning from the underlying GCC

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -287,16 +287,18 @@ auto with_properties_if_unset(const ViewCtorProp<P...> &view_ctor_prop,
   } else
     return with_properties_if_unset(view_ctor_prop, properties...);
 
-  // A workaround placed to prevent spurious "missing return statement at the
-  // end of non-void function" warnings from CUDA builds (issue #5470). Because
-  // KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK removes [[noreturn]] attribute from
-  // cuda_abort(), an unreachable while(true); is placed as a fallback method
+// A workaround placed to prevent spurious "missing return statement at the
+// end of non-void function" warnings from CUDA builds (issue #5470). Because
+// KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK removes [[noreturn]] attribute from
+// cuda_abort(), an unreachable while(true); is placed as a fallback method
+#if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDACC__)
   Kokkos::abort(
       "Prevents an incorrect warning: missing return statement at end of "
       "non-void function");
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   while (true)
     ;
+#endif
 #endif
 }
 
@@ -334,16 +336,18 @@ KOKKOS_FUNCTION const auto &get_property(
     return view_ctor_prop;
   }
 
-  // A workaround placed to prevent spurious "missing return statement at the
-  // end of non-void function" warnings from CUDA builds (issue #5470). Because
-  // KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK removes [[noreturn]] attribute from
-  // cuda_abort(), an unreachable while(true); is placed as a fallback method
+// A workaround placed to prevent spurious "missing return statement at the
+// end of non-void function" warnings from CUDA builds (issue #5470). Because
+// KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK removes [[noreturn]] attribute from
+// cuda_abort(), an unreachable while(true); is placed as a fallback method
+#if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDACC__)
   Kokkos::abort(
       "Prevents an incorrect warning: missing return statement at end of "
       "non-void function");
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   while (true)
     ;
+#endif
 #endif
 }
 #if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -291,7 +291,7 @@ auto with_properties_if_unset(const ViewCtorProp<P...> &view_ctor_prop,
 // end of non-void function" warnings from CUDA builds (issue #5470). Because
 // KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK removes [[noreturn]] attribute from
 // cuda_abort(), an unreachable while(true); is placed as a fallback method
-#if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDACC__)
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)
   Kokkos::abort(
       "Prevents an incorrect warning: missing return statement at end of "
       "non-void function");
@@ -340,7 +340,7 @@ KOKKOS_FUNCTION const auto &get_property(
 // end of non-void function" warnings from CUDA builds (issue #5470). Because
 // KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK removes [[noreturn]] attribute from
 // cuda_abort(), an unreachable while(true); is placed as a fallback method
-#if defined(KOKKOS_ENABLE_CUDA) && defined(__CUDACC__)
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)
   Kokkos::abort(
       "Prevents an incorrect warning: missing return statement at end of "
       "non-void function");

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -287,11 +287,17 @@ auto with_properties_if_unset(const ViewCtorProp<P...> &view_ctor_prop,
   } else
     return with_properties_if_unset(view_ctor_prop, properties...);
 
+  // A workaround placed to prevent spurious "missing return statement at the
+  // end of non-void function" warnings from CUDA builds (issue #5470). Because
+  // KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK removes [[noreturn]] attribute from
+  // cuda_abort(), an unreachable while(true); is placed as a fallback method
   Kokkos::abort(
       "Prevents an incorrect warning: missing return statement at end of "
       "non-void function");
+#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   while (true)
     ;
+#endif
 }
 
 struct ExecutionSpaceTag {};
@@ -328,11 +334,17 @@ KOKKOS_FUNCTION const auto &get_property(
     return view_ctor_prop;
   }
 
+  // A workaround placed to prevent spurious "missing return statement at the
+  // end of non-void function" warnings from CUDA builds (issue #5470). Because
+  // KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK removes [[noreturn]] attribute from
+  // cuda_abort(), an unreachable while(true); is placed as a fallback method
   Kokkos::abort(
       "Prevents an incorrect warning: missing return statement at end of "
       "non-void function");
+#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   while (true)
     ;
+#endif
 }
 #if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)
 // pragma pop is getting a warning from the underlying GCC

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -291,7 +291,8 @@ auto with_properties_if_unset(const ViewCtorProp<P...> &view_ctor_prop,
 // end of non-void function" warnings from CUDA builds (issue #5470). Because
 // KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK removes [[noreturn]] attribute from
 // cuda_abort(), an unreachable while(true); is placed as a fallback method
-#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)
+#if (defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)) || \
+    (defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL <= 2100))
   Kokkos::abort(
       "Prevents an incorrect warning: missing return statement at end of "
       "non-void function");
@@ -340,7 +341,8 @@ KOKKOS_FUNCTION const auto &get_property(
 // end of non-void function" warnings from CUDA builds (issue #5470). Because
 // KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK removes [[noreturn]] attribute from
 // cuda_abort(), an unreachable while(true); is placed as a fallback method
-#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)
+#if (defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)) || \
+    (defined(KOKKOS_COMPILER_INTEL) && (KOKKOS_COMPILER_INTEL <= 2100))
   Kokkos::abort(
       "Prevents an incorrect warning: missing return statement at end of "
       "non-void function");

--- a/core/src/impl/Kokkos_ViewCtor.hpp
+++ b/core/src/impl/Kokkos_ViewCtor.hpp
@@ -286,9 +286,12 @@ auto with_properties_if_unset(const ViewCtorProp<P...> &view_ctor_prop,
     return with_properties_if_unset(new_view_ctor_prop, properties...);
   } else
     return with_properties_if_unset(view_ctor_prop, properties...);
+
   Kokkos::abort(
       "Prevents an incorrect warning: missing return statement at end of "
       "non-void function");
+  while (true)
+    ;
 }
 
 struct ExecutionSpaceTag {};
@@ -324,9 +327,12 @@ KOKKOS_FUNCTION const auto &get_property(
     static_assert(std::is_same_v<Tag, void>, "Invalid property tag!");
     return view_ctor_prop;
   }
+
   Kokkos::abort(
       "Prevents an incorrect warning: missing return statement at end of "
       "non-void function");
+  while (true)
+    ;
 }
 #if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC < 1150)
 // pragma pop is getting a warning from the underlying GCC


### PR DESCRIPTION
To resolve #5470 

Warnings are produced from two functions: `with_properties_if_unset` and `get_property`.

Following @masterleinad's comment https://github.com/kokkos/kokkos/issues/5470#issuecomment-1252602637, using variants of `__builtin_unreachable` seemed promising to suppress this warning, but `std::unreachable` is [available starting C++23](https://en.cppreference.com/w/cpp/utility/unreachable) and can't be called from a device function.
For CUDA, its `__builtin_unreachable` is introduced in 11.3, but [Kokkos minimum compiler version for CUDA is going to be 11.0](https://github.com/kokkos/kokkos/issues/5285).

Tried to call an unreachable inline `[[noreturn]` function at the end of each warning site, but then it produced another warning `noreturn function does return`. Ironically, calling an unreachable function with `KOKKOS_IMPL_ABORT_NORETURN` attribute does not produce this warning. So, this PR is using `Kokkos::abort`, which is decorated with `KOKKOS_IMPL_ABORT_NORETURN KOKKOS_INLINE_FUNCTION`.

Additionally, defining `KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK` removes `[[noreturn]]` attribute from `cuda_abort`, which makes the warning to be back.
https://github.com/kokkos/kokkos/blob/d5fcc323490d8eb7dc931ddec45ffbf5c6c21a61/core/src/Cuda/Kokkos_Cuda_abort.hpp#L70-L74
As an additional workaround for this case, an unreachable `while(true);` is inserted at the end of `with_properties_if_unset` and `get_property`.

with @nliber