### PR TITLE
SYCL:  Remove workaround for submit_barrier not being enqueued properly

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -39,12 +39,8 @@ void DeepCopySYCL(void* dst, const void* src, size_t n) {
 
 void DeepCopyAsyncSYCL(const Kokkos::Experimental::SYCL& instance, void* dst,
                        const void* src, size_t n) {
-  // FIXME_SYCL memcpy doesn't respect submit_barrier which means that we need
-  // to actually fence the execution space to make sure the memcpy is properly
-  // enqueued when using out-of-order queues.
   sycl::queue& q = *instance.impl_internal_space_instance()->m_queue;
-  q.wait_and_throw();
-  auto event = q.memcpy(dst, src, n);
+  auto event     = q.memcpy(dst, src, n);
   q.ext_oneapi_submit_barrier(std::vector<sycl::event>{event});
 }
 


### PR DESCRIPTION
Needs https://github.com/intel/llvm/pull/6359 and https://github.com/intel/llvm/pull/6888 (or manually setting `SYCL_PI_LEVEL_ZERO_USE_MULTIPLE_COMMANDLIST_BARRIERS=1` as environment variable).
Also updates the AOT architectures.
I would consider merging it already if it passes CI (which I expect).