### PR TITLE
Exclude `SharedSpace` test from tests if built as part of Trilinos

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -816,6 +816,12 @@ SET(DEFAULT_DEVICE_SOURCES
 if ((KOKKOS_ENABLE_OPENACC) OR (KOKKOS_ENABLE_OPENMPTARGET) OR (KOKKOS_ENABLE_SYCL))
   LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedSpace.cpp)
 endif()
+# The SharedSpace test is sensible to running tests in parallel (as done by the Trilinos nightlies).
+# Thus the test is disabled for Trilinos builds.
+if(KOKKOS_HAS_TRILINOS)
+  LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedSpace.cpp)
+endif()
+
 # FIXME_OPENMPTARGET and FIXME_OPENACC do not provide a HostPinnedMemorySpace that can be accessed from all ExecSpaces
 if ((KOKKOS_ENABLE_OPENACC) OR (KOKKOS_ENABLE_OPENMPTARGET))
   LIST(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedHostPinnedSpace.cpp)


### PR DESCRIPTION
~Fix #5502 As Trilinos and other project might run tests in parallel and we saw that `TestSharedSpace` might be sensitive to other stuff running on the same GPU, it is marked with the property `RUN_SERIAL`.~

The `TestSharedSpace` still is sensitive to other stuff running on the same GPU. But as all easy options to get the test to be run in serial even tough `ctest` is run with `-j`. This pr disables the test if Kokkos is built as part of Trilinos.