### PR TITLE
Replace nvidia/cuda:11.0-devel->nvidia/cuda:11.0.3-devel-ubuntu18.04

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -353,7 +353,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.nvcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.0-devel --build-arg ADDITIONAL_PACKAGES="g++-8 gfortran clang" --build-arg CMAKE_VERSION=3.17.3'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:11.0.3-devel-ubuntu18.04 --build-arg ADDITIONAL_PACKAGES="g++-8 gfortran clang" --build-arg CMAKE_VERSION=3.17.3'
                             label 'nvidia-docker'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }


### PR DESCRIPTION
Looking sat https://hub.docker.com/r/nvidia/cuda/tags?page=1&name=11.0 it seems `nvidia/cuda:11.0-devel` no longer exists and we also see
```
manifest for nvidia/cuda:11.0-devel not found: manifest unknown: manifest unknown
```
in our CI. This pull request suggests replacing it with `nvidia/cuda:11.0.3-devel-ubuntu18.04` which seems to be close enough.