### PR TITLE
Fix warning and undefined behavior in tools unit tests

### DIFF
--- a/cmake/fake_tribits.cmake
+++ b/cmake/fake_tribits.cmake
@@ -117,7 +117,7 @@ FUNCTION(KOKKOS_ADD_TEST)
       if(TEST_TOOL)
         add_dependencies(${EXE} ${TEST_TOOL}) #make sure the exe has to build the tool
         foreach(TEST_ADDED ${ALL_TESTS_ADDED})
-          set_property(TEST ${TEST_ADDED} APPEND PROPERTY ENVIRONMENT "KOKKOS_PROFILE_LIBRARY=$<TARGET_FILE:${TEST_TOOL}>")
+          set_property(TEST ${TEST_ADDED} APPEND PROPERTY ENVIRONMENT "KOKKOS_TOOLS_LIBS=$<TARGET_FILE:${TEST_TOOL}>")
         endforeach()
       endif()
     endif()

--- a/core/unit_test/tools/printing-tool.cpp
+++ b/core/unit_test/tools/printing-tool.cpp
@@ -78,7 +78,7 @@ extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
   std::cout << "kokkosp_end_parallel_reduce:" << kID << "::";
 }
 
-extern "C" void kokkosp_push_profile_region(char* regionName) {
+extern "C" void kokkosp_push_profile_region(const char* regionName) {
   std::cout << "kokkosp_push_profile_region:" << regionName << "::";
 }
 
@@ -87,13 +87,13 @@ extern "C" void kokkosp_pop_profile_region() {
 }
 
 extern "C" void kokkosp_allocate_data(SpaceHandle handle, const char* name,
-                                      void* ptr, uint64_t size) {
+                                      const void* ptr, uint64_t size) {
   std::cout << "kokkosp_allocate_data:" << handle.name << ":" << name << ":"
             << ptr << ":" << size << "::";
 }
 
 extern "C" void kokkosp_deallocate_data(SpaceHandle handle, const char* name,
-                                        void* ptr, uint64_t size) {
+                                        const void* ptr, uint64_t size) {
   std::cout << "kokkosp_deallocate_data:" << handle.name << ":" << name << ":"
             << ptr << ":" << size << "::";
 }


### PR DESCRIPTION
* Update cmake test registering helper function to avoid runtime warnings about using the deprecated `KOKKOS_PROFILE_LIBRARY` environment variable
```
Warning: environment variable 'KOKKOS_PROFILE_LIBRARY' is deprecated. Use 'KOKKOS_TOOLS_LIBS' instead. Raised by Kokkos::initialize().
```
* Partial fix for issues raised by Clang's UndefinedBehaviorSanitizer
```
13: /kokkos/core/src/impl/Kokkos_Profiling.cpp:322:5: runtime error: call to function kokkosp_allocate_data through pointer to incorrect function type 'void (*)(Kokkos_Profiling_SpaceHandle, const char *, const void *, unsigned long)'
13: /kokkos/core/unit_test/tools/printing-tool.cpp:90: note: kokkosp_allocate_data defined here
13: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /kokkos/core/src/impl/Kokkos_Profiling.cpp:322:5 in
13: /kokkos/core/src/impl/Kokkos_Profiling.cpp:322:5: runtime error: call to function kokkosp_begin_deep_copy through pointer to incorrect function type 'void (*)(Kokkos_Profiling_SpaceHandle, const char *, const void *, Kokkos_Profiling_SpaceHandle, const char *, const void *, unsigned long)'
13: /kokkos/core/unit_test/tools/printing-tool.cpp:106: note: kokkosp_begin_deep_copy defined here
13: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /kokkos/core/src/impl/Kokkos_Profiling.cpp:322:5 in
13: /kokkos/core/src/impl/Kokkos_Profiling.cpp:322:5: runtime error: call to function kokkosp_push_profile_region through pointer to incorrect function type 'void (*)(const char *)'
13: /kokkos/core/unit_test/tools/printing-tool.cpp:81: note: kokkosp_push_profile_region defined here
13: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /kokkos/core/src/impl/Kokkos_Profiling.cpp:322:5 in
```
The changes proposed resolve the `kokkosp_push_profile_region` issue but `kokkosp_allocate_data ` and `kokkosp_begin_deep_copy` error reporting are still there because of the `SpaceHandle` argument and our relying on type punning.  Fixing these is would be much more involved (because of backward compatibility considerations) and beyond the scope of this PR.