### PR TITLE
SIMD AVX2 backend

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -49,6 +49,10 @@
 
 #include <Kokkos_SIMD_Scalar.hpp>
 
+#ifdef KOKKOS_ARCH_AVX2
+#include <Kokkos_SIMD_AVX2.hpp>
+#endif
+
 #ifdef KOKKOS_ARCH_AVX512XEON
 #include <Kokkos_SIMD_AVX512.hpp>
 #endif
@@ -62,6 +66,8 @@ namespace Impl {
 
 #if defined(KOKKOS_ARCH_AVX512XEON)
 using host_native = avx512_fixed_size<8>;
+#elif defined(KOKKOS_ARCH_AVX2)
+using host_native = avx2_fixed_size<4>;
 #else
 using host_native  = scalar;
 #endif
@@ -152,8 +158,10 @@ namespace Impl {
 template <class... Abis>
 class abi_set {};
 
-#ifdef KOKKOS_ARCH_AVX512XEON
+#if defined(KOKKOS_ARCH_AVX512XEON)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx512_fixed_size<8>>;
+#elif defined(KOKKOS_ARCH_AVX2)
+using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>>;
 #else
 using host_abi_set = abi_set<simd_abi::scalar>;
 #endif

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -67,7 +67,7 @@ namespace Impl {
 #if defined(KOKKOS_ARCH_AVX512XEON)
 using host_native = avx512_fixed_size<8>;
 #elif defined(KOKKOS_ARCH_AVX2)
-using host_native = avx2_fixed_size<4>;
+using host_native  = avx2_fixed_size<4>;
 #else
 using host_native  = scalar;
 #endif

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1,0 +1,1023 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_SIMD_AVX512_HPP
+#define KOKKOS_SIMD_AVX512_HPP
+
+#include <functional>
+#include <type_traits>
+
+#include <Kokkos_SIMD_Common.hpp>
+
+#include <immintrin.h>
+
+namespace Kokkos {
+namespace Experimental {
+
+namespace simd_abi {
+
+template <int N>
+class avx512_fixed_size {};
+
+}  // namespace simd_abi
+
+template <class T>
+class simd_mask<T, simd_abi::avx512_fixed_size<8>> {
+  __mmask8 m_value;
+
+ public:
+  class reference {
+    __mmask8& m_mask;
+    int m_lane;
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __mmask8 bit_mask() const {
+      return __mmask8(std::int16_t(1 << m_lane));
+    }
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(__mmask8& mask_arg,
+                                                    int lane_arg)
+        : m_mask(mask_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(bool value) const {
+      if (value) {
+        m_mask |= bit_mask();
+      } else {
+        m_mask &= ~bit_mask();
+      }
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
+      return (m_mask & bit_mask()) != 0;
+    }
+  };
+  using value_type                                  = bool;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+      : m_value(-std::int16_t(value)) {}
+  template <class U>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<U, simd_abi::avx512_fixed_size<8>> const& other)
+      : m_value(static_cast<__mmask8>(other)) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      __mmask8 const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask8()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return static_cast<value_type>(reference(m_value, int(i)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator||(simd_mask const& other) const {
+    return simd_mask(_kor_mask8(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator&&(simd_mask const& other) const {
+    return simd_mask(_kand_mask8(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
+    static const __mmask8 true_value(static_cast<__mmask8>(simd_mask(true)));
+    return simd_mask(_kxor_mask8(true_value, m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
+      simd_mask const& other) const {
+    return m_value == other.m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
+      simd_mask const& other) const {
+    return m_value != other.m_value;
+  }
+};
+
+template <>
+class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
+  __m256i m_value;
+
+ public:
+  using value_type = std::int32_t;
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm256_set1_epi32(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m256i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other);
+  template <class G,
+            std::enable_if_t<
+                // basically, can you do { value_type r =
+                // gen(std::integral_constant<std::size_t, i>()); }
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
+      : m_value(
+            _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
+                              gen(std::integral_constant<std::size_t, 1>()),
+                              gen(std::integral_constant<std::size_t, 2>()),
+                              gen(std::integral_constant<std::size_t, 3>()),
+                              gen(std::integral_constant<std::size_t, 4>()),
+                              gen(std::integral_constant<std::size_t, 5>()),
+                              gen(std::integral_constant<std::size_t, 6>()),
+                              gen(std::integral_constant<std::size_t, 7>()))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
+                             m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_mask_loadu_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<(simd const& other) const {
+    return mask_type(_mm256_cmplt_epi32_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>(simd const& other) const {
+    return mask_type(_mm256_cmplt_epi32_mask(other.m_value, m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<=(simd const& other) const {
+    return mask_type(_mm256_cmple_epi32_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>=(simd const& other) const {
+    return mask_type(_mm256_cmple_epi32_mask(other.m_value, m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& other) const {
+    return mask_type(_mm256_cmpeq_epi32_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& other) const {
+    return mask_type(_mm256_cmpneq_epi32_mask(m_value, other.m_value));
+  }
+};
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    operator*(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_mullo_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    operator+(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    operator-(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    operator-(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(0) - a;
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
+    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
+                              static_cast<__m256i>(b)));
+}
+
+template <>
+class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
+  __m256i m_value;
+
+ public:
+  using value_type = std::uint32_t;
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm256_set1_epi32(bit_cast<std::int32_t>(value_type(value)))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m256i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
+      : m_value(static_cast<__m256i>(other)) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<(simd const& other) const {
+    return mask_type(_mm256_cmplt_epu32_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>(simd const& other) const {
+    return mask_type(_mm256_cmplt_epu32_mask(other.m_value, m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<=(simd const& other) const {
+    return mask_type(_mm256_cmple_epu32_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>=(simd const& other) const {
+    return mask_type(_mm256_cmple_epu32_mask(other.m_value, m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& other) const {
+    return mask_type(_mm256_cmpeq_epu32_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& other) const {
+    return mask_type(_mm256_cmpneq_epu32_mask(m_value, other.m_value));
+  }
+};
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    operator*(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_mullo_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    operator+(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    operator-(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> condition(
+    simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
+                              static_cast<__m256i>(b)));
+}
+
+template <>
+class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
+  __m512i m_value;
+
+ public:
+  using value_type = std::int64_t;
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm512_set1_epi64(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
+      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm512_mask_storeu_epi64(ptr, static_cast<__mmask8>(mask_type(true)),
+                             m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(int rhs) const {
+    return _mm512_srai_epi64(m_value, rhs);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator>>(simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) const {
+    return _mm512_srav_epi64(m_value,
+                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator<<(int rhs) const {
+    return _mm512_slli_epi64(m_value, rhs);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator<<(simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) const {
+    return _mm512_sllv_epi64(m_value,
+                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<(simd const& other) const {
+    return mask_type(_mm512_cmplt_epi64_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>(simd const& other) const {
+    return mask_type(_mm512_cmplt_epi64_mask(other.m_value, m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<=(simd const& other) const {
+    return mask_type(_mm512_cmple_epi64_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>=(simd const& other) const {
+    return mask_type(_mm512_cmple_epi64_mask(other.m_value, m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& other) const {
+    return mask_type(_mm512_cmpeq_epi64_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& other) const {
+    return mask_type(_mm512_cmpneq_epi64_mask(m_value, other.m_value));
+  }
+};
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    operator*(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_mullo_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    operator+(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    operator-(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    operator-(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(0) - a;
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
+    simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
+                              static_cast<__m512i>(b)));
+}
+
+template <>
+class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
+  __m512i m_value;
+
+ public:
+  using value_type = std::uint64_t;
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm512_set1_epi64(bit_cast<std::int64_t>(value_type(value)))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, abi_type> const& other)
+      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other)
+      : m_value(static_cast<__m512i>(other)) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator>>(unsigned int rhs) const {
+    return _mm512_srli_epi64(m_value, rhs);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) const {
+    return _mm512_srlv_epi64(m_value,
+                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator<<(unsigned int rhs) const {
+    return _mm512_slli_epi64(m_value, rhs);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator<<(
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) const {
+    return _mm512_sllv_epi64(m_value,
+                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator&(simd const& other) const {
+    return _mm512_and_epi64(m_value, other.m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator|(simd const& other) const {
+    return _mm512_or_epi64(m_value, other.m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<(simd const& other) const {
+    return mask_type(_mm512_cmplt_epu64_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>(simd const& other) const {
+    return mask_type(_mm512_cmplt_epu64_mask(other.m_value, m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<=(simd const& other) const {
+    return mask_type(_mm512_cmple_epu64_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>=(simd const& other) const {
+    return mask_type(_mm512_cmple_epu64_mask(other.m_value, m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& other) const {
+    return mask_type(_mm512_cmpeq_epu64_mask(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& other) const {
+    return mask_type(_mm512_cmpneq_epu64_mask(m_value, other.m_value));
+  }
+};
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    operator*(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_mullo_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    operator+(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    operator-(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> condition(
+    simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
+                              static_cast<__m512i>(b)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
+    : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::simd(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
+    : m_value(static_cast<__m512i>(other)) {}
+
+template <>
+class simd<double, simd_abi::avx512_fixed_size<8>> {
+  __m512d m_value;
+
+ public:
+  using value_type = double;
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm512_set1_pd(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(double a, double b, double c,
+                                             double d, double e, double f,
+                                             double g, double h)
+      : m_value(_mm512_setr_pd(a, b, c, d, e, f, g, h)) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m512d const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm512_loadu_pd(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm512_storeu_pd(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512d()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<(simd const& other) const {
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_LT_OS));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>(simd const& other) const {
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_GT_OS));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<=(simd const& other) const {
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_LE_OS));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>=(simd const& other) const {
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_GE_OS));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& other) const {
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_EQ_OS));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& other) const {
+    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_NEQ_OS));
+  }
+};
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    operator*(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_mul_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    operator/(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_div_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    operator+(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_add_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    operator-(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_sub_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::avx512_fixed_size<8>>
+    operator-(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_sub_pd(_mm512_set1_pd(0.0), static_cast<__m512d>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>> copysign(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
+  static const __m512i sign_mask = reinterpret_cast<__m512i>(
+      static_cast<__m512d>(simd<double, simd_abi::avx512_fixed_size<8>>(-0.0)));
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      reinterpret_cast<__m512d>(_mm512_xor_epi64(
+          _mm512_andnot_epi64(
+              sign_mask, reinterpret_cast<__m512i>(static_cast<__m512d>(a))),
+          _mm512_and_epi64(
+              sign_mask, reinterpret_cast<__m512i>(static_cast<__m512d>(b))))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>> abs(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+  __m512d const rhs = static_cast<__m512d>(a);
+  return simd<double, simd_abi::avx512_fixed_size<8>>(reinterpret_cast<__m512d>(
+      _mm512_and_epi64(_mm512_set1_epi64(0x7FFFFFFFFFFFFFFF),
+                       reinterpret_cast<__m512i>(rhs))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>> sqrt(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_sqrt_pd(static_cast<__m512d>(a)));
+}
+
+#ifdef __INTEL_COMPILER
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>> cbrt(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_cbrt_pd(static_cast<__m512d>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>> exp(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_exp_pd(static_cast<__m512d>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>> log(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_log_pd(static_cast<__m512d>(a)));
+}
+
+#endif
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>> fma(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<double, simd_abi::avx512_fixed_size<8>> const& b,
+    simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_fmadd_pd(static_cast<__m512d>(a), static_cast<__m512d>(b),
+                      static_cast<__m512d>(c)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>> max(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_max_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>> min(
+    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_min_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx512_fixed_size<8>> condition(
+    simd_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<double, simd_abi::avx512_fixed_size<8>> const& b,
+    simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<double, simd_abi::avx512_fixed_size<8>>(
+      _mm512_mask_blend_pd(static_cast<__mmask8>(a), static_cast<__m512d>(c),
+                           static_cast<__m512d>(b)));
+}
+
+template <>
+class const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                             simd<double, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using value_type = simd<double, abi_type>;
+  using mask_type  = simd_mask<double, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
+  mask() const {
+    return m_mask;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
+  value() const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(double* mem, element_aligned_tag) const {
+    _mm512_mask_storeu_pd(mem, static_cast<__mmask8>(m_mask),
+                          static_cast<__m512d>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      double* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
+    _mm512_mask_i32scatter_pd(mem, static_cast<__mmask8>(m_mask),
+                              static_cast<__m256i>(index),
+                              static_cast<__m512d>(m_value), 8);
+  }
+};
+
+template <>
+class where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                       simd<double, simd_abi::avx512_fixed_size<8>>>
+    : public const_where_expression<
+          simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+          simd<double, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  where_expression(
+      simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      simd<double, simd_abi::avx512_fixed_size<8>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(double const* mem, element_aligned_tag) {
+    m_value = value_type(_mm512_mask_loadu_pd(
+        _mm512_set1_pd(0.0), static_cast<__mmask8>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      double const* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+    m_value = value_type(_mm512_mask_i32gather_pd(
+        _mm512_set1_pd(0.0), static_cast<__mmask8>(m_mask),
+        static_cast<__m256i>(index), mem, 8));
+  }
+  template <class U, std::enable_if_t<
+                         std::is_convertible_v<
+                             U, simd<double, simd_abi::avx512_fixed_size<8>>>,
+                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<double, simd_abi::avx512_fixed_size<8>>>(
+            std::forward<U>(x));
+    m_value = simd<double, simd_abi::avx512_fixed_size<8>>(_mm512_mask_blend_pd(
+        static_cast<__mmask8>(m_mask), static_cast<__m512d>(m_value),
+        static_cast<__m512d>(x_as_value_type)));
+  }
+};
+
+template <>
+class const_where_expression<
+    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using value_type = simd<std::int32_t, abi_type>;
+  using mask_type  = simd_mask<std::int32_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
+  mask() const {
+    return m_mask;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
+  value() const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, element_aligned_tag) const {
+    _mm256_mask_storeu_epi32(mem, static_cast<__mmask8>(m_mask),
+                             static_cast<__m256i>(m_value));
+  }
+};
+
+template <>
+class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+                       simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+    : public const_where_expression<
+          simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+          simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  where_expression(
+      simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, element_aligned_tag) {
+    m_value = value_type(_mm256_mask_loadu_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
+  }
+};
+
+template <>
+class const_where_expression<
+    simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using value_type = simd<std::int64_t, abi_type>;
+  using mask_type  = simd_mask<std::int64_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
+  mask() const {
+    return m_mask;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
+  value() const {
+    return m_value;
+  }
+};
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmax(
+    const_where_expression<
+        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+  return _mm512_mask_reduce_max_epi32(
+      static_cast<__mmask8>(x.mask()),
+      _mm512_castsi256_si512(static_cast<__m256i>(x.value())));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmin(
+    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
+        x) {
+  return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(x.mask()),
+                                   static_cast<__m512d>(x.value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
+    const_where_expression<
+        simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+        simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x,
+    std::int64_t, std::plus<>) {
+  return _mm512_mask_reduce_add_epi64(static_cast<__mmask8>(x.mask()),
+                                      static_cast<__m512i>(x.value()));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
+    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
+                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
+        x,
+    double, std::plus<>) {
+  return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(x.mask()),
+                                   static_cast<__m512d>(x.value()));
+}
+
+}  // namespace Experimental
+}  // namespace Kokkos
+
+#endif

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -106,6 +106,8 @@ class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
             -std::int64_t(value))))
   {
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(
+      simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& i32_mask);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
@@ -223,6 +225,13 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     return !operator==(other);
   }
 };
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd_mask<double, simd_abi::avx2_fixed_size<4>>::simd_mask(
+    simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& i32_mask)
+  :m_value(_mm256_castsi256_pd(_mm256_cvtepi32_epi64(static_cast<__m128i>(i32_mask))))
+{
+}
 
 template <>
 class simd<double, simd_abi::avx2_fixed_size<4>> {

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -706,6 +706,18 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
 }
 
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx2_fixed_size<4>> condition(
+    simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& b,
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+      _mm_castps_si128(_mm_blendv_ps(
+        _mm_castsi128_ps(static_cast<__m128i>(c)),
+        _mm_castsi128_ps(static_cast<__m128i>(b)),
+        _mm_castsi128_ps(static_cast<__m128i>(a)))));
+}
+
 template <>
 class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1000,14 +1000,17 @@ class where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
     m_value = value_type(_mm256_maskload_pd(mem,
           _mm256_castpd_si256(static_cast<__m256d>(m_mask))));
   }
-//KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-//void gather_from(
-//    double const* mem,
-//    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
-//  m_value = value_type(_mm256_mask_i32gather_pd(
-//      _mm256_set1_pd(0.0), static_cast<__mmask8>(m_mask),
-//      static_cast<__m256i>(index), mem, 8));
-//}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      double const* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+    m_value = value_type(_mm256_mask_i32gather_pd(
+        _mm256_set1_pd(0.0),
+        mem,
+        static_cast<__m128i>(index),
+        static_cast<__m256d>(m_mask),
+        8));
+  }
   template <class U, std::enable_if_t<
                          std::is_convertible_v<
                              U, simd<double, simd_abi::avx2_fixed_size<4>>>,

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -195,6 +195,13 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
       __m128i const& value_in)
       : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<double, abi_type> const& other)
+  {
+    for (std::size_t i = 0; i < size(); ++i) (*this)[i] = other[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<std::int64_t, abi_type> const& other);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
       const {
     return m_value;

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -94,8 +94,7 @@ class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      auto const bm = bit_mask();
-      return _mm256_testc_pd(_mm256_and_pd(bm, m_mask), bm);
+      return (_mm256_movemask_pd(m_mask) & (1 << m_lane)) != 0;
     }
   };
   using value_type                                  = bool;
@@ -140,7 +139,7 @@ class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
       simd_mask const& other) const {
-    return _mm256_testc_pd(m_value, other.m_value);
+    return _mm256_movemask_pd(m_value) == _mm256_movemask_pd(other.m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
       simd_mask const& other) const {
@@ -178,8 +177,7 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      auto const bm = bit_mask();
-      return _mm_testc_si128(_mm_and_si128(bm, m_mask), bm);
+      return (_mm_movemask_ps(_mm_castsi128_ps(m_mask)) & (1 << m_lane)) != 0;
     }
   };
   using value_type                                  = bool;
@@ -228,7 +226,8 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
       simd_mask const& other) const {
-    return _mm_testc_si128(m_value, other.m_value);
+    return _mm_movemask_ps(_mm_castsi128_ps(m_value)) ==
+           _mm_movemask_ps(_mm_castsi128_ps(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
       simd_mask const& other) const {
@@ -266,8 +265,7 @@ class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      auto const bm = bit_mask();
-      return 0 != _mm256_testc_si256(_mm256_and_si256(bm, m_mask), bm);
+      return (_mm256_movemask_pd(_mm256_castsi256_pd(m_mask)) & (1 << m_lane)) != 0;
     }
   };
   using value_type                                  = bool;
@@ -314,7 +312,8 @@ class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
       simd_mask const& other) const {
-    return 0 != _mm256_testc_si256(m_value, other.m_value);
+    return _mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
+           _mm256_movemask_pd(_mm256_castsi256_pd(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
       simd_mask const& other) const {
@@ -352,8 +351,7 @@ class simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      auto const bm = bit_mask();
-      return 0 != _mm256_testc_si256(_mm256_and_si256(bm, m_mask), bm);
+      return (_mm256_movemask_pd(_mm256_castsi256_pd(m_mask)) & (1 << m_lane)) != 0;
     }
   };
   using value_type                                  = bool;
@@ -399,7 +397,8 @@ class simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
       simd_mask const& other) const {
-    return 0 != _mm256_testc_si256(m_value, other.m_value);
+    return _mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
+           _mm256_movemask_pd(_mm256_castsi256_pd(other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
       simd_mask const& other) const {

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -640,6 +640,17 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::int32_t a, std::int32_t b, std::int32_t c,
                                              std::int32_t d)
       : m_value(_mm_setr_epi32(a, b, c, d)) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
+      : simd(gen(std::integral_constant<std::size_t, 0>()),
+             gen(std::integral_constant<std::size_t, 1>()),
+             gen(std::integral_constant<std::size_t, 2>()),
+             gen(std::integral_constant<std::size_t, 3>()))
+  {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m128i const& value_in)
       : m_value(value_in) {}
@@ -744,8 +755,6 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       : m_value(_mm256_setr_epi64x(a, b, c, d)) {}
   template <class G,
             std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -185,6 +185,8 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   using value_type                                  = bool;
   using abi_type                                    = simd_abi::avx2_fixed_size<4>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask&&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
       : m_value(_mm_set1_epi32(-std::int32_t(value)))
   {
@@ -195,13 +197,12 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
       __m128i const& value_in)
       : m_value(value_in) {}
+  template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<double, abi_type> const& other)
+      simd_mask<U, abi_type> const& other)
   {
     for (std::size_t i = 0; i < size(); ++i) (*this)[i] = other[i];
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<std::int64_t, abi_type> const& other);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
       const {
     return m_value;
@@ -272,6 +273,8 @@ class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   using value_type                                  = bool;
   using abi_type                                    = simd_abi::avx2_fixed_size<4>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask&&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
       : m_value(_mm256_set1_epi64x(-std::int64_t(value)))
   {

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -747,6 +747,11 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
       simd<std::uint64_t, abi_type> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
+      simd<std::int32_t, abi_type> const& other)
+      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
+  {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -695,6 +695,14 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       _mm_sub_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
 }
 
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    operator+(simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+              simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+      _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+}
+
 template <>
 class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1066,6 +1066,10 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
       simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask_arg,
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, element_aligned_tag) {
+    m_value = value_type(_mm_maskload_epi32(mem, static_cast<__m128i>(m_mask)));
+  }
 };
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -974,14 +974,14 @@ class const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
     _mm256_maskstore_pd(mem, _mm256_castpd_si256(static_cast<__m256d>(m_mask)),
                           static_cast<__m256d>(m_value));
   }
-//KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-//void scatter_to(
-//    double* mem,
-//    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
-//  _mm256_mask_i32scatter_pd(mem, static_cast<__mmask8>(m_mask),
-//                            static_cast<__m256i>(index),
-//                            static_cast<__m256d>(m_value), 8);
-//}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      double* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+    for (std::size_t lane = 0; lane < 4; ++lane) {
+      if (m_mask[lane]) mem[index[lane]] = m_value[lane];
+    }
+  }
 };
 
 template <>

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -275,6 +275,10 @@ class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
       __m256i const& value_in)
       : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<std::int32_t, abi_type> const& other)
+      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
+  {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
     return m_value;
@@ -771,6 +775,18 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
     operator-(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(0) - a;
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
+    simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_castpd_si256(_mm256_blendv_pd(
+        _mm256_castsi256_pd(static_cast<__m256i>(c)),
+        _mm256_castsi256_pd(static_cast<__m256i>(b)),
+        _mm256_castsi256_pd(static_cast<__m256i>(a)))));
 }
 
 template <>

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -966,6 +966,44 @@ class where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
   }
 };
 
+template <>
+class const_where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+                             simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+ public:
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
+  using value_type = simd<std::int32_t, abi_type>;
+  using mask_type  = simd_mask<std::int32_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
+  mask() const {
+    return m_mask;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
+  value() const {
+    return m_value;
+  }
+};
+
+template <>
+class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+                       simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+    : public const_where_expression<
+          simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+          simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+ public:
+  where_expression(
+      simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+};
+
 }  // namespace Experimental
 }  // namespace Kokkos
 

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -742,6 +742,19 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::int64_t a, std::int64_t b, std::int64_t c,
                                              std::int64_t d)
       : m_value(_mm256_setr_epi64x(a, b, c, d)) {}
+  template <class G,
+            std::enable_if_t<
+                // basically, can you do { value_type r =
+                // gen(std::integral_constant<std::size_t, i>()); }
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
+      : simd(gen(std::integral_constant<std::size_t, 0>()),
+             gen(std::integral_constant<std::size_t, 1>()),
+             gen(std::integral_constant<std::size_t, 2>()),
+             gen(std::integral_constant<std::size_t, 3>()))
+  {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256i const& value_in)
       : m_value(value_in) {}

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -711,6 +711,8 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256i const& value_in)
       : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
+      simd<std::uint64_t, abi_type> const& other);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -756,6 +758,20 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     return !((*this) == other);
   }
 };
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    operator-(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+              simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
+  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    operator-(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(0) - a;
+}
 
 template <>
 class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
@@ -830,6 +846,12 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return !((*this) == other);
   }
 };
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
+      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
+  :m_value(static_cast<__m256i>(other))
+{
+}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1049,6 +1049,10 @@ class const_where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4
   value() const {
     return m_value;
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, element_aligned_tag) const {
+    _mm_maskstore_epi32(mem, static_cast<__m128i>(m_mask), static_cast<__m128i>(m_value));
+  }
 };
 
 template <>

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -72,12 +72,9 @@ class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
     __m256d& m_mask;
     int m_lane;
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m256d bit_mask() const {
-      return _mm256_castsi256_pd(
-          _mm256_setr_epi64x(
-            -std::int64_t(m_lane == 0),
-            -std::int64_t(m_lane == 1),
-            -std::int64_t(m_lane == 2),
-            -std::int64_t(m_lane == 3)));
+      return _mm256_castsi256_pd(_mm256_setr_epi64x(
+          -std::int64_t(m_lane == 0), -std::int64_t(m_lane == 1),
+          -std::int64_t(m_lane == 2), -std::int64_t(m_lane == 3)));
     }
 
    public:
@@ -97,14 +94,11 @@ class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
       return (_mm256_movemask_pd(m_mask) & (1 << m_lane)) != 0;
     }
   };
-  using value_type                                  = bool;
-  using abi_type                                    = simd_abi::avx2_fixed_size<4>;
+  using value_type = bool;
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
-      : m_value(_mm256_castsi256_pd(
-          _mm256_set1_epi64x(
-            -std::int64_t(value))))
-  {
+      : m_value(_mm256_castsi256_pd(_mm256_set1_epi64x(-std::int64_t(value)))) {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
       simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& i32_mask);
@@ -123,7 +117,8 @@ class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(reference(const_cast<__m256d&>(m_value), int(i)));
+    return static_cast<value_type>(
+        reference(const_cast<__m256d&>(m_value), int(i)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
   operator||(simd_mask const& other) const {
@@ -157,10 +152,8 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     int m_lane;
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m128i bit_mask() const {
       return _mm_setr_epi32(
-            -std::int32_t(m_lane == 0),
-            -std::int32_t(m_lane == 1),
-            -std::int32_t(m_lane == 2),
-            -std::int32_t(m_lane == 3));
+          -std::int32_t(m_lane == 0), -std::int32_t(m_lane == 1),
+          -std::int32_t(m_lane == 2), -std::int32_t(m_lane == 3));
     }
 
    public:
@@ -180,15 +173,13 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       return (_mm_movemask_ps(_mm_castsi128_ps(m_mask)) & (1 << m_lane)) != 0;
     }
   };
-  using value_type                                  = bool;
-  using abi_type                                    = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  using value_type = bool;
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask()                 = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask&&)      = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
-      : m_value(_mm_set1_epi32(-std::int32_t(value)))
-  {
-  }
+      : m_value(_mm_set1_epi32(-std::int32_t(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
@@ -197,8 +188,7 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       : m_value(value_in) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, abi_type> const& other)
-  {
+      simd_mask<U, abi_type> const& other) {
     for (std::size_t i = 0; i < size(); ++i) (*this)[i] = other[i];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
@@ -210,7 +200,8 @@ class simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(reference(const_cast<__m128i&>(m_value), int(i)));
+    return static_cast<value_type>(
+        reference(const_cast<__m128i&>(m_value), int(i)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
   operator||(simd_mask const& other) const {
@@ -245,10 +236,8 @@ class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     int m_lane;
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m256i bit_mask() const {
       return _mm256_setr_epi64x(
-            -std::int64_t(m_lane == 0),
-            -std::int64_t(m_lane == 1),
-            -std::int64_t(m_lane == 2),
-            -std::int64_t(m_lane == 3));
+          -std::int64_t(m_lane == 0), -std::int64_t(m_lane == 1),
+          -std::int64_t(m_lane == 2), -std::int64_t(m_lane == 3));
     }
 
    public:
@@ -265,18 +254,17 @@ class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (_mm256_movemask_pd(_mm256_castsi256_pd(m_mask)) & (1 << m_lane)) != 0;
+      return (_mm256_movemask_pd(_mm256_castsi256_pd(m_mask)) &
+              (1 << m_lane)) != 0;
     }
   };
-  using value_type                                  = bool;
-  using abi_type                                    = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  using value_type = bool;
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask()                 = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask&&)      = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
-      : m_value(_mm256_set1_epi64x(-std::int64_t(value)))
-  {
-  }
+      : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
@@ -285,8 +273,7 @@ class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
       simd_mask<std::int32_t, abi_type> const& other)
-      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
-  {}
+      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
     return m_value;
@@ -296,7 +283,8 @@ class simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(reference(const_cast<__m256i&>(m_value), int(i)));
+    return static_cast<value_type>(
+        reference(const_cast<__m256i&>(m_value), int(i)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
   operator||(simd_mask const& other) const {
@@ -331,10 +319,8 @@ class simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     int m_lane;
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __m256i bit_mask() const {
       return _mm256_setr_epi64x(
-            -std::int64_t(m_lane == 0),
-            -std::int64_t(m_lane == 1),
-            -std::int64_t(m_lane == 2),
-            -std::int64_t(m_lane == 3));
+          -std::int64_t(m_lane == 0), -std::int64_t(m_lane == 1),
+          -std::int64_t(m_lane == 2), -std::int64_t(m_lane == 3));
     }
 
    public:
@@ -351,21 +337,18 @@ class simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (_mm256_movemask_pd(_mm256_castsi256_pd(m_mask)) & (1 << m_lane)) != 0;
+      return (_mm256_movemask_pd(_mm256_castsi256_pd(m_mask)) &
+              (1 << m_lane)) != 0;
     }
   };
-  using value_type                                  = bool;
-  using abi_type                                    = simd_abi::avx2_fixed_size<4>;
+  using value_type = bool;
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
-      : m_value(_mm256_set1_epi64x(-std::int64_t(value)))
-  {
-  }
+      : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
       simd_mask<std::int32_t, abi_type> const& other)
-      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
-  {
-  }
+      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
@@ -381,7 +364,8 @@ class simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(reference(const_cast<__m256i&>(m_value), int(i)));
+    return static_cast<value_type>(
+        reference(const_cast<__m256i&>(m_value), int(i)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
   operator||(simd_mask const& other) const {
@@ -409,9 +393,8 @@ class simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd_mask<double, simd_abi::avx2_fixed_size<4>>::simd_mask(
     simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& i32_mask)
-  :m_value(_mm256_castsi256_pd(_mm256_cvtepi32_epi64(static_cast<__m128i>(i32_mask))))
-{
-}
+    : m_value(_mm256_castsi256_pd(
+          _mm256_cvtepi32_epi64(static_cast<__m128i>(i32_mask)))) {}
 
 template <>
 class simd<double, simd_abi::avx2_fixed_size<4>> {
@@ -530,11 +513,8 @@ simd<double, simd_abi::avx2_fixed_size<4>> copysign(
     simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
   __m256d const sign_mask = _mm256_set1_pd(-0.0);
   return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_xor_pd(
-          _mm256_andnot_pd(
-              sign_mask, static_cast<__m256d>(a)),
-          _mm256_and_pd(
-              sign_mask, static_cast<__m256d>(b))));
+      _mm256_xor_pd(_mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)),
+                    _mm256_and_pd(sign_mask, static_cast<__m256d>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -609,10 +589,8 @@ simd<double, simd_abi::avx2_fixed_size<4>> condition(
     simd<double, simd_abi::avx2_fixed_size<4>> const& b,
     simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
   return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_blendv_pd(
-        static_cast<__m256d>(c),
-        static_cast<__m256d>(b),
-        static_cast<__m256d>(a)));
+      _mm256_blendv_pd(static_cast<__m256d>(c), static_cast<__m256d>(b),
+                       static_cast<__m256d>(a)));
 }
 
 template <>
@@ -636,8 +614,8 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm_set1_epi32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::int32_t a, std::int32_t b, std::int32_t c,
-                                             std::int32_t d)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::int32_t a, std::int32_t b,
+                                             std::int32_t c, std::int32_t d)
       : m_value(_mm_setr_epi32(a, b, c, d)) {}
   template <class G,
             std::enable_if_t<
@@ -648,8 +626,7 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       : simd(gen(std::integral_constant<std::size_t, 0>()),
              gen(std::integral_constant<std::size_t, 1>()),
              gen(std::integral_constant<std::size_t, 2>()),
-             gen(std::integral_constant<std::size_t, 3>()))
-  {}
+             gen(std::integral_constant<std::size_t, 3>())) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m128i const& value_in)
       : m_value(value_in) {}
@@ -717,15 +694,14 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx2_fixed_size<4>> condition(
-    simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& b,
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
-      _mm_castps_si128(_mm_blendv_ps(
-        _mm_castsi128_ps(static_cast<__m128i>(c)),
-        _mm_castsi128_ps(static_cast<__m128i>(b)),
-        _mm_castsi128_ps(static_cast<__m128i>(a)))));
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    condition(simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
+              simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& b,
+              simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(_mm_castps_si128(
+      _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(c)),
+                    _mm_castsi128_ps(static_cast<__m128i>(b)),
+                    _mm_castsi128_ps(static_cast<__m128i>(a)))));
 }
 
 template <>
@@ -749,8 +725,8 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm256_set1_epi64x(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::int64_t a, std::int64_t b, std::int64_t c,
-                                             std::int64_t d)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::int64_t a, std::int64_t b,
+                                             std::int64_t c, std::int64_t d)
       : m_value(_mm256_setr_epi64x(a, b, c, d)) {}
   template <class G,
             std::enable_if_t<
@@ -761,8 +737,7 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       : simd(gen(std::integral_constant<std::size_t, 0>()),
              gen(std::integral_constant<std::size_t, 1>()),
              gen(std::integral_constant<std::size_t, 2>()),
-             gen(std::integral_constant<std::size_t, 3>()))
-  {}
+             gen(std::integral_constant<std::size_t, 3>())) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256i const& value_in)
       : m_value(value_in) {}
@@ -770,9 +745,7 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       simd<std::uint64_t, abi_type> const& other);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
       simd<std::int32_t, abi_type> const& other)
-      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
-  {
-  }
+      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
   }
@@ -838,11 +811,10 @@ simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
     simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_castpd_si256(_mm256_blendv_pd(
-        _mm256_castsi256_pd(static_cast<__m256i>(c)),
-        _mm256_castsi256_pd(static_cast<__m256i>(b)),
-        _mm256_castsi256_pd(static_cast<__m256i>(a)))));
+  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(_mm256_castpd_si256(
+      _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
+                       _mm256_castsi256_pd(static_cast<__m256i>(b)),
+                       _mm256_castsi256_pd(static_cast<__m256i>(a)))));
 }
 
 template <>
@@ -865,7 +837,8 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm256_set1_epi64x(bit_cast<std::int64_t>(value_type(value)))) {}
+      : m_value(_mm256_set1_epi64x(bit_cast<std::int64_t>(value_type(value)))) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m256i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
@@ -887,7 +860,8 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) const {
-    return _mm256_srlv_epi64(m_value, _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs)));
+    return _mm256_srlv_epi64(m_value,
+                             _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator<<(unsigned int rhs) const {
@@ -895,7 +869,8 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator<<(
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) const {
-    return _mm256_sllv_epi64(m_value, _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs)));
+    return _mm256_sllv_epi64(m_value,
+                             _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator&(simd const& other) const {
@@ -919,27 +894,25 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
 };
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
-      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
-  :m_value(static_cast<__m256i>(other))
-{
-}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
+    : m_value(static_cast<__m256i>(other)) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(
     simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_castpd_si256(_mm256_blendv_pd(
-        _mm256_castsi256_pd(static_cast<__m256i>(c)),
-        _mm256_castsi256_pd(static_cast<__m256i>(b)),
-        _mm256_castsi256_pd(static_cast<__m256i>(a)))));
+  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(_mm256_castpd_si256(
+      _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
+                       _mm256_castsi256_pd(static_cast<__m256i>(b)),
+                       _mm256_castsi256_pd(static_cast<__m256i>(a)))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::simd(
-      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
-{
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::simd(
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other) {
   for (std::size_t i = 0; i < 4; ++i) {
     (*this)[i] = std::int32_t(other[i]);
   }
@@ -971,7 +944,7 @@ class const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(double* mem, element_aligned_tag) const {
     _mm256_maskstore_pd(mem, _mm256_castpd_si256(static_cast<__m256d>(m_mask)),
-                          static_cast<__m256d>(m_value));
+                        static_cast<__m256d>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
@@ -996,38 +969,35 @@ class where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
-    m_value = value_type(_mm256_maskload_pd(mem,
-          _mm256_castpd_si256(static_cast<__m256d>(m_mask))));
+    m_value = value_type(_mm256_maskload_pd(
+        mem, _mm256_castpd_si256(static_cast<__m256d>(m_mask))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       double const* mem,
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
     m_value = value_type(_mm256_mask_i32gather_pd(
-        _mm256_set1_pd(0.0),
-        mem,
-        static_cast<__m128i>(index),
-        static_cast<__m256d>(m_mask),
-        8));
+        _mm256_set1_pd(0.0), mem, static_cast<__m128i>(index),
+        static_cast<__m256d>(m_mask), 8));
   }
-  template <class U, std::enable_if_t<
-                         std::is_convertible_v<
-                             U, simd<double, simd_abi::avx2_fixed_size<4>>>,
-                         bool> = false>
+  template <class U,
+            std::enable_if_t<std::is_convertible_v<
+                                 U, simd<double, simd_abi::avx2_fixed_size<4>>>,
+                             bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
         static_cast<simd<double, simd_abi::avx2_fixed_size<4>>>(
             std::forward<U>(x));
     m_value = simd<double, simd_abi::avx2_fixed_size<4>>(_mm256_blendv_pd(
-        static_cast<__m256d>(m_value),
-        static_cast<__m256d>(x_as_value_type),
+        static_cast<__m256d>(m_value), static_cast<__m256d>(x_as_value_type),
         static_cast<__m256d>(m_mask)));
   }
 };
 
 template <>
-class const_where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
-                             simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+class const_where_expression<
+    simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using value_type = simd<std::int32_t, abi_type>;
@@ -1050,7 +1020,8 @@ class const_where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(std::int32_t* mem, element_aligned_tag) const {
-    _mm_maskstore_epi32(mem, static_cast<__m128i>(m_mask), static_cast<__m128i>(m_value));
+    _mm_maskstore_epi32(mem, static_cast<__m128i>(m_mask),
+                        static_cast<__m128i>(m_value));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -93,24 +93,25 @@ class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return (m_mask & bit_mask()) != 0;
+      auto const bm = bit_mask();
+      return 0 != _mm256_testc_pd(_mm256_and_pd(bm, m_mask), bm);
     }
   };
   using value_type                                  = bool;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
-      : m_value(-std::int16_t(value)) {}
-  template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, simd_abi::avx512_fixed_size<8>> const& other)
-      : m_value(static_cast<__mmask8>(other)) {}
+      : m_value(_mm256_castsi256_pd(
+          _mm256_set1_epi64x(
+            -std::int64_t(value)))
+  {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
+    return 4;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
-      __mmask8 const& value_in)
+      __m256d const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask8()
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256d()
       const {
     return m_value;
   }
@@ -123,523 +124,33 @@ class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
   operator||(simd_mask const& other) const {
-    return simd_mask(_kor_mask8(m_value, other.m_value));
+    return simd_mask(_mm256_or_pd(m_value, other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
   operator&&(simd_mask const& other) const {
-    return simd_mask(_kand_mask8(m_value, other.m_value));
+    return simd_mask(_mm256_and_pd(m_value, other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
-    static const __mmask8 true_value(static_cast<__mmask8>(simd_mask(true)));
-    return simd_mask(_kxor_mask8(true_value, m_value));
+    auto const __m256d true_value(static_cast<__m256d>(simd_mask(true)));
+    return simd_mask(_mm256_andnot(m_value, true_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
       simd_mask const& other) const {
-    return m_value == other.m_value;
+    return 0 != _mm256_testc_pd(m_value, other.m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
       simd_mask const& other) const {
-    return m_value != other.m_value;
+    return !operator==(other);
   }
 };
 
 template <>
-class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
-  __m256i m_value;
-
- public:
-  using value_type = std::int32_t;
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
-  }
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm256_set1_epi32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      __m256i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, abi_type> const& other);
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
-      : m_value(
-            _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
-                              gen(std::integral_constant<std::size_t, 1>()),
-                              gen(std::integral_constant<std::size_t, 2>()),
-                              gen(std::integral_constant<std::size_t, 3>()),
-                              gen(std::integral_constant<std::size_t, 4>()),
-                              gen(std::integral_constant<std::size_t, 5>()),
-                              gen(std::integral_constant<std::size_t, 6>()),
-                              gen(std::integral_constant<std::size_t, 7>()))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
-                             m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm256_mask_loadu_epi32(
-        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
-    return m_value;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm256_cmplt_epi32_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm256_cmplt_epi32_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm256_cmple_epi32_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm256_cmple_epi32_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm256_cmpeq_epi32_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm256_cmpneq_epi32_mask(m_value, other.m_value));
-  }
-};
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    operator*(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_mullo_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    operator+(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(0) - a;
-}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
-    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
-                              static_cast<__m256i>(b)));
-}
-
-template <>
-class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
-  __m256i m_value;
-
- public:
-  using value_type = std::uint32_t;
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
-  }
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm256_set1_epi32(bit_cast<std::int32_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      __m256i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
-      : m_value(static_cast<__m256i>(other)) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
-    return m_value;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm256_cmplt_epu32_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm256_cmplt_epu32_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm256_cmple_epu32_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm256_cmple_epu32_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm256_cmpeq_epu32_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm256_cmpneq_epu32_mask(m_value, other.m_value));
-  }
-};
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
-    operator*(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_mullo_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
-    operator+(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> condition(
-    simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
-                              static_cast<__m256i>(b)));
-}
-
-template <>
-class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
-  __m512i m_value;
-
- public:
-  using value_type = std::int64_t;
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
-  }
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm512_set1_epi64(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& other)
-      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other);
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm512_mask_storeu_epi64(ptr, static_cast<__mmask8>(mask_type(true)),
-                             m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(int rhs) const {
-    return _mm512_srai_epi64(m_value, rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator>>(simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) const {
-    return _mm512_srav_epi64(m_value,
-                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator<<(int rhs) const {
-    return _mm512_slli_epi64(m_value, rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator<<(simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) const {
-    return _mm512_sllv_epi64(m_value,
-                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
-      const {
-    return m_value;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm512_cmplt_epi64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm512_cmplt_epi64_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm512_cmple_epi64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm512_cmple_epi64_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm512_cmpeq_epi64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm512_cmpneq_epi64_mask(m_value, other.m_value));
-  }
-};
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    operator*(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_mullo_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    operator+(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(0) - a;
-}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
-    simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
-                              static_cast<__m512i>(b)));
-}
-
-template <>
-class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
-  __m512i m_value;
-
- public:
-  using value_type = std::uint64_t;
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
-  }
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm512_set1_epi64(bit_cast<std::int64_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
-      : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int32_t, abi_type> const& other)
-      : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
-      simd<std::int64_t, abi_type> const& other)
-      : m_value(static_cast<__m512i>(other)) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](std::size_t i) const {
-    return reinterpret_cast<value_type const*>(&m_value)[i];
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator>>(unsigned int rhs) const {
-    return _mm512_srli_epi64(m_value, rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) const {
-    return _mm512_srlv_epi64(m_value,
-                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator<<(unsigned int rhs) const {
-    return _mm512_slli_epi64(m_value, rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator<<(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) const {
-    return _mm512_sllv_epi64(m_value,
-                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator&(simd const& other) const {
-    return _mm512_and_epi64(m_value, other.m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator|(simd const& other) const {
-    return _mm512_or_epi64(m_value, other.m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
-      const {
-    return m_value;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm512_cmplt_epu64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm512_cmplt_epu64_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm512_cmple_epu64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm512_cmple_epu64_mask(other.m_value, m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm512_cmpeq_epu64_mask(m_value, other.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm512_cmpneq_epu64_mask(m_value, other.m_value));
-  }
-};
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
-    operator*(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_mullo_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
-    operator+(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> condition(
-    simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
-                              static_cast<__m512i>(b)));
-}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::simd(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
-    : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::simd(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& other)
-    : m_value(static_cast<__m512i>(other)) {}
-
-template <>
-class simd<double, simd_abi::avx512_fixed_size<8>> {
-  __m512d m_value;
+class simd<double, simd_abi::avx2_fixed_size<4>> {
+  __m256d m_value;
 
  public:
   using value_type = double;
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = simd_mask<value_type, abi_type>;
   using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
@@ -648,18 +159,17 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
+    return 4;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm512_set1_pd(value_type(value))) {}
+      : m_value(_mm256_set1_pd(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(double a, double b, double c,
-                                             double d, double e, double f,
-                                             double g, double h)
-      : m_value(_mm512_setr_pd(a, b, c, d, e, f, g, h)) {}
+                                             double d)
+      : m_value(_mm256_setr_pd(a, b, c, d)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      __m512d const& value_in)
+      __m256d const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reinterpret_cast<value_type*>(&m_value)[i];
@@ -670,177 +180,175 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
-    m_value = _mm512_loadu_pd(ptr);
+    m_value = _mm256_loadu_pd(ptr);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
-    _mm512_storeu_pd(ptr, m_value);
+    _mm256_storeu_pd(ptr, m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512d()
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256d()
       const {
     return m_value;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator<(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_LT_OS));
+    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_LT_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator>(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_GT_OS));
+    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_GT_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator<=(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_LE_OS));
+    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_LE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator>=(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_GE_OS));
+    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_GE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator==(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_EQ_OS));
+    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_EQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator!=(simd const& other) const {
-    return mask_type(_mm512_cmp_pd_mask(m_value, other.m_value, _CMP_NEQ_OS));
+    return mask_type(_mm256_cmp_pd(m_value, other.m_value, _CMP_NEQ_OS));
   }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    operator*(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_mul_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
+    simd<double, simd_abi::avx2_fixed_size<4>>
+    operator*(simd<double, simd_abi::avx2_fixed_size<4>> const& lhs,
+              simd<double, simd_abi::avx2_fixed_size<4>> const& rhs) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_mul_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    operator/(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_div_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
+    simd<double, simd_abi::avx2_fixed_size<4>>
+    operator/(simd<double, simd_abi::avx2_fixed_size<4>> const& lhs,
+              simd<double, simd_abi::avx2_fixed_size<4>> const& rhs) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_div_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    operator+(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_add_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
+    simd<double, simd_abi::avx2_fixed_size<4>>
+    operator+(simd<double, simd_abi::avx2_fixed_size<4>> const& lhs,
+              simd<double, simd_abi::avx2_fixed_size<4>> const& rhs) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_add_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<double, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<double, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sub_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
+    simd<double, simd_abi::avx2_fixed_size<4>>
+    operator-(simd<double, simd_abi::avx2_fixed_size<4>> const& lhs,
+              simd<double, simd_abi::avx2_fixed_size<4>> const& rhs) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_sub_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<double, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sub_pd(_mm512_set1_pd(0.0), static_cast<__m512d>(a)));
+    simd<double, simd_abi::avx2_fixed_size<4>>
+    operator-(simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_sub_pd(_mm256_set1_pd(0.0), static_cast<__m256d>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> copysign(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
-  static const __m512i sign_mask = reinterpret_cast<__m512i>(
-      static_cast<__m512d>(simd<double, simd_abi::avx512_fixed_size<8>>(-0.0)));
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      reinterpret_cast<__m512d>(_mm512_xor_epi64(
-          _mm512_andnot_epi64(
-              sign_mask, reinterpret_cast<__m512i>(static_cast<__m512d>(a))),
-          _mm512_and_epi64(
-              sign_mask, reinterpret_cast<__m512i>(static_cast<__m512d>(b))))));
+simd<double, simd_abi::avx2_fixed_size<4>> copysign(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
+  __m256d const sign_mask = _mm256_set1_pd(-0.0);
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_xor_pd(
+          _mm256_andnot_pd(
+              sign_mask, static_cast<__m256d>(a)),
+          _mm256_and_pd(
+              sign_mask, static_cast<__m256d>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> abs(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
-  __m512d const rhs = static_cast<__m512d>(a);
-  return simd<double, simd_abi::avx512_fixed_size<8>>(reinterpret_cast<__m512d>(
-      _mm512_and_epi64(_mm512_set1_epi64(0x7FFFFFFFFFFFFFFF),
-                       reinterpret_cast<__m512i>(rhs))));
+simd<double, simd_abi::avx2_fixed_size<4>> abs(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+  __m256d const sign_mask = _mm256_set1_pd(-0.0);
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> sqrt(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sqrt_pd(static_cast<__m512d>(a)));
+simd<double, simd_abi::avx2_fixed_size<4>> sqrt(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_sqrt_pd(static_cast<__m256d>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> cbrt(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_cbrt_pd(static_cast<__m512d>(a)));
+simd<double, simd_abi::avx2_fixed_size<4>> cbrt(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_cbrt_pd(static_cast<__m256d>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> exp(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_exp_pd(static_cast<__m512d>(a)));
+simd<double, simd_abi::avx2_fixed_size<4>> exp(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_exp_pd(static_cast<__m256d>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> log(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_log_pd(static_cast<__m512d>(a)));
+simd<double, simd_abi::avx2_fixed_size<4>> log(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_log_pd(static_cast<__m256d>(a)));
 }
 
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> fma(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_fmadd_pd(static_cast<__m512d>(a), static_cast<__m512d>(b),
-                      static_cast<__m512d>(c)));
+simd<double, simd_abi::avx2_fixed_size<4>> fma(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& b,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_fmadd_pd(static_cast<__m256d>(a), static_cast<__m256d>(b),
+                      static_cast<__m256d>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> max(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_max_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
+simd<double, simd_abi::avx2_fixed_size<4>> max(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_max_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> min(
-    simd<double, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& b) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_min_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
+simd<double, simd_abi::avx2_fixed_size<4>> min(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_min_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx512_fixed_size<8>> condition(
-    simd_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
-  return simd<double, simd_abi::avx512_fixed_size<8>>(
-      _mm512_mask_blend_pd(static_cast<__mmask8>(a), static_cast<__m512d>(c),
-                           static_cast<__m512d>(b)));
+simd<double, simd_abi::avx2_fixed_size<4>> condition(
+    simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& b,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_blendv_pd(static_cast<__m256d>(a), static_cast<__m256d>(c),
+                           static_cast<__m256d>(b)));
 }
 
 template <>
-class const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                             simd<double, simd_abi::avx512_fixed_size<8>>> {
+class const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
+                             simd<double, simd_abi::avx2_fixed_size<4>>> {
  public:
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
   using value_type = simd<double, abi_type>;
   using mask_type  = simd_mask<double, abi_type>;
 
@@ -861,63 +369,63 @@ class const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(double* mem, element_aligned_tag) const {
-    _mm512_mask_storeu_pd(mem, static_cast<__mmask8>(m_mask),
-                          static_cast<__m512d>(m_value));
+    _mm256_maskstore_pd(mem, _mm256_castpd_si256(static_cast<__m256d>(m_mask)),
+                          static_cast<__m256d>(m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      double* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
-    _mm512_mask_i32scatter_pd(mem, static_cast<__mmask8>(m_mask),
-                              static_cast<__m256i>(index),
-                              static_cast<__m512d>(m_value), 8);
-  }
+//KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+//void scatter_to(
+//    double* mem,
+//    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+//  _mm256_mask_i32scatter_pd(mem, static_cast<__mmask8>(m_mask),
+//                            static_cast<__m256i>(index),
+//                            static_cast<__m256d>(m_value), 8);
+//}
 };
 
 template <>
-class where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                       simd<double, simd_abi::avx512_fixed_size<8>>>
+class where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
+                       simd<double, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-          simd<double, simd_abi::avx512_fixed_size<8>>> {
+          simd_mask<double, simd_abi::avx2_fixed_size<4>>,
+          simd<double, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask_arg,
-      simd<double, simd_abi::avx512_fixed_size<8>>& value_arg)
+      simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      simd<double, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
-    m_value = value_type(_mm512_mask_loadu_pd(
-        _mm512_set1_pd(0.0), static_cast<__mmask8>(m_mask), mem));
+    m_value = value_type(_mm256_maskload_pd(mem,
+          _mm256_castpd_si256(static_cast<__m256d>(m_mask))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void gather_from(
-      double const* mem,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
-    m_value = value_type(_mm512_mask_i32gather_pd(
-        _mm512_set1_pd(0.0), static_cast<__mmask8>(m_mask),
-        static_cast<__m256i>(index), mem, 8));
-  }
+//KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+//void gather_from(
+//    double const* mem,
+//    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+//  m_value = value_type(_mm256_mask_i32gather_pd(
+//      _mm256_set1_pd(0.0), static_cast<__mmask8>(m_mask),
+//      static_cast<__m256i>(index), mem, 8));
+//}
   template <class U, std::enable_if_t<
                          std::is_convertible_v<
-                             U, simd<double, simd_abi::avx512_fixed_size<8>>>,
+                             U, simd<double, simd_abi::avx2_fixed_size<4>>>,
                          bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<simd<double, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<simd<double, simd_abi::avx2_fixed_size<4>>>(
             std::forward<U>(x));
-    m_value = simd<double, simd_abi::avx512_fixed_size<8>>(_mm512_mask_blend_pd(
-        static_cast<__mmask8>(m_mask), static_cast<__m512d>(m_value),
-        static_cast<__m512d>(x_as_value_type)));
+    m_value = simd<double, simd_abi::avx2_fixed_size<4>>(_mm256_mask_blend_pd(
+        static_cast<__mmask8>(m_mask), static_cast<__m256d>(m_value),
+        static_cast<__m256d>(x_as_value_type)));
   }
 };
 
 template <>
 class const_where_expression<
-    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
+    simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
  public:
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
   using value_type = simd<std::int32_t, abi_type>;
   using mask_type  = simd_mask<std::int32_t, abi_type>;
 
@@ -944,15 +452,15 @@ class const_where_expression<
 };
 
 template <>
-class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-                       simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+                       simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-          simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
+          simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+          simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -963,10 +471,10 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
 
 template <>
 class const_where_expression<
-    simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> {
+    simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
  public:
-  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
   using value_type = simd<std::int64_t, abi_type>;
   using mask_type  = simd_mask<std::int64_t, abi_type>;
 
@@ -989,37 +497,37 @@ class const_where_expression<
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmax(
     const_where_expression<
-        simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
-  return _mm512_mask_reduce_max_epi32(
+        simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+        simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> const& x) {
+  return _mm256_mask_reduce_max_epi32(
       static_cast<__mmask8>(x.mask()),
-      _mm512_castsi256_si512(static_cast<__m256i>(x.value())));
+      _mm256_castsi256_si512(static_cast<__m256i>(x.value())));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmin(
-    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
+    const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
+                           simd<double, simd_abi::avx2_fixed_size<4>>> const&
         x) {
-  return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(x.mask()),
-                                   static_cast<__m512d>(x.value()));
+  return _mm256_mask_reduce_min_pd(static_cast<__mmask8>(x.mask()),
+                                   static_cast<__m256d>(x.value()));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
     const_where_expression<
-        simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-        simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x,
+        simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
+        simd<std::int64_t, simd_abi::avx2_fixed_size<4>>> const& x,
     std::int64_t, std::plus<>) {
-  return _mm512_mask_reduce_add_epi64(static_cast<__mmask8>(x.mask()),
+  return _mm256_mask_reduce_add_epi64(static_cast<__mmask8>(x.mask()),
                                       static_cast<__m512i>(x.value()));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
-    const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                           simd<double, simd_abi::avx512_fixed_size<8>>> const&
+    const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
+                           simd<double, simd_abi::avx2_fixed_size<4>>> const&
         x,
     double, std::plus<>) {
-  return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(x.mask()),
-                                   static_cast<__m512d>(x.value()));
+  return _mm256_mask_reduce_add_pd(static_cast<__mmask8>(x.mask()),
+                                   static_cast<__m256d>(x.value()));
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -42,8 +42,8 @@
 //@HEADER
 */
 
-#ifndef KOKKOS_SIMD_AVX512_HPP
-#define KOKKOS_SIMD_AVX512_HPP
+#ifndef KOKKOS_SIMD_AVX2_HPP
+#define KOKKOS_SIMD_AVX2_HPP
 
 #include <functional>
 #include <type_traits>
@@ -58,17 +58,17 @@ namespace Experimental {
 namespace simd_abi {
 
 template <int N>
-class avx512_fixed_size {};
+class avx2_fixed_size {};
 
 }  // namespace simd_abi
 
-template <class T>
-class simd_mask<T, simd_abi::avx512_fixed_size<8>> {
-  __mmask8 m_value;
+template <>
+class simd_mask<double, simd_abi::avx2_fixed_size<4>> {
+  __m256d m_value;
 
  public:
   class reference {
-    __mmask8& m_mask;
+    __m256d& m_mask;
     int m_lane;
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __mmask8 bit_mask() const {
       return __mmask8(std::int16_t(1 << m_lane));

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -338,6 +338,20 @@ template <class T, class Abi>
 }
 
 template <class T, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T hmax(
+    const_where_expression<simd_mask<T, Abi>,
+                           simd<T, Abi>> const&
+        x) {
+  auto const& v = x.value();
+  auto const& m = x.mask();
+  auto result = Kokkos::reduction_identity<T>::max();
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    if (m[i]) result = Kokkos::max(result, v[i]);
+  }
+  return result;
+}
+
+template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T reduce(
     const_where_expression<simd_mask<T, Abi>,
                            simd<T, Abi>> const&

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -154,6 +154,14 @@ template <class T>
   return const_where_expression(mask, value);
 }
 
+// fallback simd multiplication using generator constructor
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<T, Abi> operator*(simd<T, Abi> const& lhs, simd<T, Abi> const& rhs) {
+  return simd<T, Abi>([&] (std::size_t i) { return lhs[i] * rhs[i]; });
+}
+
 // The code below provides:
 // operator@(simd<T, Abi>, Arithmetic)
 // operator@(Arithmetic, simd<T, Abi>)

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -323,6 +323,19 @@ template <class T, class Abi>
   return a == simd_mask<T, Abi>(false);
 }
 
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmin(
+    const_where_expression<simd_mask<T, Abi>,
+                           simd<T, Abi>> const&
+        x) {
+  auto const v = x.value();
+  auto result = v[0];
+  for (std::size_t i = 1; i < v.size(); ++i) {
+    result = Kokkos::min(result, v[1]);
+  }
+  return result;
+}
+
 }  // namespace Experimental
 
 template <class T, class Abi>

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -328,10 +328,26 @@ template <class T, class Abi>
     const_where_expression<simd_mask<T, Abi>,
                            simd<T, Abi>> const&
         x) {
-  auto const v = x.value();
-  auto result = v[0];
-  for (std::size_t i = 1; i < v.size(); ++i) {
-    result = Kokkos::min(result, v[1]);
+  auto const& v = x.value();
+  auto const& m = x.mask();
+  auto result = Kokkos::reduction_identity<T>::min();
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    if (m[i]) result = Kokkos::min(result, v[i]);
+  }
+  return result;
+}
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
+    const_where_expression<simd_mask<T, Abi>,
+                           simd<T, Abi>> const&
+        x,
+    double, std::plus<>) {
+  auto const& v = x.value();
+  auto const& m = x.mask();
+  auto result = Kokkos::reduction_identity<T>::sum();
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    if (m[i]) result += v[i];
   }
   return result;
 }

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -364,7 +364,7 @@ template <class T, class Abi>
     const_where_expression<simd_mask<T, Abi>,
                            simd<T, Abi>> const&
         x,
-    double, std::plus<>) {
+    T, std::plus<>) {
   auto const& v = x.value();
   auto const& m = x.mask();
   auto result = Kokkos::reduction_identity<T>::sum();

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -324,7 +324,7 @@ template <class T, class Abi>
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmin(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T hmin(
     const_where_expression<simd_mask<T, Abi>,
                            simd<T, Abi>> const&
         x) {
@@ -338,7 +338,7 @@ template <class T, class Abi>
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T reduce(
     const_where_expression<simd_mask<T, Abi>,
                            simd<T, Abi>> const&
         x,

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -157,9 +157,9 @@ template <class T>
 // fallback simd multiplication using generator constructor
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<T, Abi> operator*(simd<T, Abi> const& lhs, simd<T, Abi> const& rhs) {
-  return simd<T, Abi>([&] (std::size_t i) { return lhs[i] * rhs[i]; });
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator*(
+    simd<T, Abi> const& lhs, simd<T, Abi> const& rhs) {
+  return simd<T, Abi>([&](std::size_t i) { return lhs[i] * rhs[i]; });
 }
 
 // The code below provides:
@@ -332,13 +332,11 @@ template <class T, class Abi>
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T hmin(
-    const_where_expression<simd_mask<T, Abi>,
-                           simd<T, Abi>> const&
-        x) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+hmin(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   auto const& v = x.value();
   auto const& m = x.mask();
-  auto result = Kokkos::reduction_identity<T>::min();
+  auto result   = Kokkos::reduction_identity<T>::min();
   for (std::size_t i = 0; i < v.size(); ++i) {
     if (m[i]) result = Kokkos::min(result, v[i]);
   }
@@ -346,13 +344,11 @@ template <class T, class Abi>
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T hmax(
-    const_where_expression<simd_mask<T, Abi>,
-                           simd<T, Abi>> const&
-        x) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+hmax(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x) {
   auto const& v = x.value();
   auto const& m = x.mask();
-  auto result = Kokkos::reduction_identity<T>::max();
+  auto result   = Kokkos::reduction_identity<T>::max();
   for (std::size_t i = 0; i < v.size(); ++i) {
     if (m[i]) result = Kokkos::max(result, v[i]);
   }
@@ -360,14 +356,12 @@ template <class T, class Abi>
 }
 
 template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T reduce(
-    const_where_expression<simd_mask<T, Abi>,
-                           simd<T, Abi>> const&
-        x,
-    T, std::plus<>) {
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+reduce(const_where_expression<simd_mask<T, Abi>, simd<T, Abi>> const& x, T,
+       std::plus<>) {
   auto const& v = x.value();
   auto const& m = x.mask();
-  auto result = Kokkos::reduction_identity<T>::sum();
+  auto result   = Kokkos::reduction_identity<T>::sum();
   for (std::size_t i = 0; i < v.size(); ++i) {
     if (m[i]) result += v[i];
   }

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -155,6 +155,8 @@ template <class T>
 }
 
 // fallback simd multiplication using generator constructor
+// At the time of this writing, this fallback is only used
+// to multiply vectors of 64-bit signed integers for the AVX2 backend
 
 template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator*(

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -322,7 +322,7 @@ class where_expression<simd_mask<T, simd_abi::scalar>,
   }
 };
 
-template <class T, class BinaryOp>
+template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
 reduce(const_where_expression<simd_mask<T, simd_abi::scalar>,
                               simd<T, simd_abi::scalar>> const& x,

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -326,7 +326,7 @@ template <class T, class BinaryOp>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
 reduce(const_where_expression<simd_mask<T, simd_abi::scalar>,
                               simd<T, simd_abi::scalar>> const& x,
-       T identity_element, BinaryOp) {
+       T identity_element, std::plus<>) {
   return static_cast<bool>(x.mask()) ? static_cast<T>(x.value())
                                      : identity_element;
 }

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -318,6 +318,15 @@ inline void host_check_math_ops() {
 }
 
 template <class Abi>
+inline void host_check_mask_ops() {
+  using mask_type = Kokkos::Experimental::simd_mask<double, Abi>;
+  EXPECT_FALSE(none_of(mask_type(true)));
+  EXPECT_TRUE(none_of(mask_type(false)));
+  EXPECT_TRUE(all_of(mask_type(true)));
+  EXPECT_FALSE(all_of(mask_type(false)));
+}
+
+template <class Abi>
 KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
   std::size_t constexpr n     = 11;
   double const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
@@ -331,13 +340,25 @@ KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
 }
 
 template <class Abi>
+KOKKOS_INLINE_FUNCTION void device_check_mask_ops() {
+  using mask_type = Kokkos::Experimental::simd_mask<double, Abi>;
+  kokkos_checker checker;
+  checker.truth(!none_of(mask_type(true)));
+  checker.truth(none_of(mask_type(false)));
+  checker.truth(all_of(mask_type(true)));
+  checker.truth(!all_of(mask_type(false)));
+}
+
+template <class Abi>
 inline void host_check_abi() {
   host_check_math_ops<Abi>();
+  host_check_mask_ops<Abi>();
 }
 
 template <class Abi>
 KOKKOS_INLINE_FUNCTION void device_check_abi() {
   device_check_math_ops<Abi>();
+  device_check_mask_ops<Abi>();
 }
 
 inline void host_check_abis(Kokkos::Experimental::Impl::abi_set<>) {}


### PR DESCRIPTION
This work adds an AVX2 backend for SIMD types which is activated when Kokkos_ARCH_BDW is used.

It also adds additional common fallback implementations of SIMD operations such as horizontal reductions which are not supported by the AVX2 instruction set.