### PR TITLE
Fix using OpenMP in code downstream from Trilinos

### DIFF
--- a/cmake/kokkos_install.cmake
+++ b/cmake/kokkos_install.cmake
@@ -29,6 +29,15 @@ IF (NOT KOKKOS_HAS_TRILINOS AND NOT Kokkos_INSTALL_TESTING)
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Kokkos)
   install(EXPORT KokkosTargets NAMESPACE Kokkos:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Kokkos)
 ELSE()
+  # FIXME We don't generate the same CMake configure files when configuring
+  # inside Trilinos so we add find_dependency for OpenMP manually here.
+  # KOKKOS_TPL_EXPORTS wouldn't be defined at this point anyway.
+  IF(KOKKOS_ENABLE_OPENMP)
+    file(APPEND
+      "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/KokkosConfig_install.cmake"
+      "\nINCLUDE(CMakeFindDependencyMacro)\n"
+      "FIND_DEPENDENCY(OpenMP REQUIRED)\n\n")
+  ENDIF()
   CONFIGURE_FILE(cmake/KokkosConfigCommon.cmake.in ${Kokkos_BINARY_DIR}/KokkosConfigCommon.cmake @ONLY)
   file(READ ${Kokkos_BINARY_DIR}/KokkosConfigCommon.cmake KOKKOS_CONFIG_COMMON)
   file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/KokkosConfig_install.cmake" "${KOKKOS_CONFIG_COMMON}")


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/5514. As the comment says, the way we create `KokkosConfig.cmake` in `Trilinos` is very different from what we are doing in a standalone build. In particular, we didn't include https://github.com/kokkos/kokkos/blob/61d7db55fceac3318c987a291f77b844fd94c165/cmake/KokkosConfig.cmake.in#L10-L15 which is required for `OpenMP` after #4105.

This pull request just adds the required lines in case `Kokkos` was configured with `OpenMP` in the most straightforward way. Unfortunately, this requires some synchronization between `cmake/kokkos_install.cmake` and `cmake/KokkosConfig.cmake` in case we change anything with the way to detect and link to `OpenMP`. I still opted for this way to avoid a major refactor of the way `KokkosConfig.cmake` is created in `Trilinos` (which I would be afraid of doing anyway) and also in anticipation that `Kokkos` would be treated as a regular dependency in `Trilinos` in the not so far future.