### PR TITLE
Allow CUDA PTX forward compatibility

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -737,7 +737,9 @@ void Cuda::impl_initialize(InitializationSettings const &settings) {
     int compiled_major = Impl::CudaInternal::m_cudaArch / 100;
     int compiled_minor = (Impl::CudaInternal::m_cudaArch % 100) / 10;
 
-    if (compiled_major != cudaProp.major || compiled_minor > cudaProp.minor) {
+    if ((compiled_major > cudaProp.major) ||
+        ((compiled_major == cudaProp.major) &&
+         (compiled_minor > cudaProp.minor))) {
       std::stringstream ss;
       ss << "Kokkos::Cuda::initialize ERROR: running kernels compiled for "
             "compute capability "


### PR DESCRIPTION
Fixed the logic for building Kokkos for an older architecture. With the current logic one must use the same major architecture version in all circumstances, which is just not practical. As it can result in the following kind of nonsensical errors:

```
Kokkos::Cuda::initialize ERROR: running kernels compiled for compute capability 5.2 on device with compute capability 7.5 is not supported by CUDA!
```

Pinging @Yhatoh and @stephenswat.