### PR TITLE
fixup for intel 19 (most-vexing parse)

### DIFF
--- a/core/unit_test/TestSharedHostPinnedSpace.cpp
+++ b/core/unit_test/TestSharedHostPinnedSpace.cpp
@@ -107,7 +107,7 @@ TEST(defaultdevicetype, shared_host_pinned_space) {
 
   for (unsigned i = 0; i < numDeviceHostCycles; ++i) {
     // INCREMENT DEVICE
-    Increment(DeviceExecutionSpace{}, sharedData);
+    Increment incrementOnDevice(DeviceExecutionSpace{}, sharedData);
     ++incrementCount;
     Kokkos::fence();
     // CHECK RESULTS HOST
@@ -119,7 +119,7 @@ TEST(defaultdevicetype, shared_host_pinned_space) {
         << i << " of " << numDeviceHostCycles;
 
     // INCREMENT HOST
-    Increment(HostExecutionSpace{}, sharedData);
+    Increment incrementOnHost(HostExecutionSpace{}, sharedData);
     ++incrementCount;
     Kokkos::fence();
     // CHECK RESULTS Device


### PR DESCRIPTION
Fix #5523 the used Intel 19 seems to interpret an unnamed functor instance with `()` as function declaration and not a constructor call to a class. Naming the instance does the trick and has no impact on the use in the Test. 
All other compilers we used did interpret it right in the first place.

Does neither need documentation nor mentioning in the changelog