### PR TITLE
Trilinos: Pass OpenMP flags instead of linking with the OpenMP target

### DIFF
--- a/cmake/kokkos_tpls.cmake
+++ b/cmake/kokkos_tpls.cmake
@@ -97,7 +97,13 @@ endif()
 
 IF (Kokkos_ENABLE_OPENMP)
   find_package(OpenMP REQUIRED)
-  KOKKOS_EXPORT_CMAKE_TPL(OpenMP REQUIRED)
+  # FIXME_TRILINOS Trilinos doesn't allow for Kokkos to use find_dependency
+  # so we just append the flags here instead of linking with the OpenMP target.
+  IF(KOKKOS_HAS_TRILINOS)
+    COMPILER_SPECIFIC_FLAGS(DEFAULT ${OpenMP_CXX_FLAGS})
+  ELSE()
+    KOKKOS_EXPORT_CMAKE_TPL(OpenMP REQUIRED)
+  ENDIF()
 ENDIF()
 
 #Convert list to newlines (which CMake doesn't always like in cache variables)

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -170,13 +170,13 @@ IF (Kokkos_ENABLE_IMPL_DESUL_ATOMICS AND KOKKOS_ENABLE_OPENMPTARGET)
   target_link_libraries(kokkoscore PUBLIC atomic)
 ENDIF()
 
-# FIXME_TRILINOS Trilinos doesn't allow for Kokkos to use find_dependency so we
-# just append the flags in cmake/kokkos_tpls.cmake instead of linking with the
-# OpenMP target.
 IF (Kokkos_ENABLE_IMPL_DESUL_ATOMICS AND desul_FOUND)
   target_link_libraries(kokkoscore PUBLIC desul_atomics)
 ENDIF()
 
+# FIXME_TRILINOS Trilinos doesn't allow for Kokkos to use find_dependency so we
+# just append the flags in cmake/kokkos_tpls.cmake instead of linking with the
+# OpenMP target.
 IF(Kokkos_ENABLE_OPENMP AND NOT KOKKOS_HAS_TRILINOS)
   target_link_libraries(kokkoscore PUBLIC OpenMP::OpenMP_CXX)
 ENDIF()

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -170,11 +170,14 @@ IF (Kokkos_ENABLE_IMPL_DESUL_ATOMICS AND KOKKOS_ENABLE_OPENMPTARGET)
   target_link_libraries(kokkoscore PUBLIC atomic)
 ENDIF()
 
+# FIXME_TRILINOS Trilinos doesn't allow for Kokkos to use find_dependency so we
+# just append the flags in cmake/kokkos_tpls.cmake instead of linking with the
+# OpenMP target.
 IF (Kokkos_ENABLE_IMPL_DESUL_ATOMICS AND desul_FOUND)
   target_link_libraries(kokkoscore PUBLIC desul_atomics)
 ENDIF()
 
-IF(Kokkos_ENABLE_OPENMP)
+IF(Kokkos_ENABLE_OPENMP AND NOT KOKKOS_HAS_TRILINOS)
   target_link_libraries(kokkoscore PUBLIC OpenMP::OpenMP_CXX)
 ENDIF()
 


### PR DESCRIPTION
Alternative to #5526 fixing #5514. We discovered that properly linking with the `OpenMP` target in `Trilinos` requires more changes in `Trilinos` itself (and it's not clear to me what the best path there is), also see https://github.com/kokkos/kokkos/issues/5514#issuecomment-1270644310. Those changes would include forcing `Trilinos_ENABLE_OpenMP` for `Kokkos_ENABLE_OPENMP` and enabling `TriBITS`' `CMake` flag detection for `Kokkos` again, see https://github.com/trilinos/Trilinos/blob/master/cmake/ProjectCompilerPostConfig.cmake and https://github.com/kokkos/kokkos/issues/5514#issuecomment-1270848852. These changes might break downstream `Trilinos` users.

Instead, this pull request just tries to extract the `OpenMP` flags similar to what we did before, see https://github.com/kokkos/kokkos/pull/4105/files, and what `TriBITS` does anyway, see https://github.com/trilinos/Trilinos/blob/fef3ccfae5e6cc865aad5025d7d8f99740aa5aa8/cmake/tribits/core/package_arch/TribitsGlobalMacros.cmake#L1685-L1700.

I couldn't restrict the changes to `core/src/CMakeLists.txt` since adding to the compiler flags there is too late to be recognized.