### PR TITLE
Fix static extents assignment for LayoutLeft/LayoutRight assignment

### DIFF
--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -1128,9 +1128,8 @@ struct ViewOffset<
   KOKKOS_INLINE_FUNCTION constexpr ViewOffset(
       const ViewOffset<DimRHS, Kokkos::LayoutRight, void>& rhs)
       : m_dim(rhs.m_dim.N0, 0, 0, 0, 0, 0, 0, 0) {
-    static_assert((DimRHS::rank == 0 && dimension_type::rank == 0) ||
-                      (DimRHS::rank == 1 && dimension_type::rank == 1 &&
-                       dimension_type::rank_dynamic == 1),
+    static_assert(((DimRHS::rank == 0 && dimension_type::rank == 0) ||
+                   (DimRHS::rank == 1 && dimension_type::rank == 1)),
                   "ViewOffset LayoutLeft and LayoutRight are only compatible "
                   "when rank <= 1");
   }
@@ -1778,8 +1777,7 @@ struct ViewOffset<
       const ViewOffset<DimRHS, Kokkos::LayoutLeft, void>& rhs)
       : m_dim(rhs.m_dim.N0, 0, 0, 0, 0, 0, 0, 0) {
     static_assert((DimRHS::rank == 0 && dimension_type::rank == 0) ||
-                      (DimRHS::rank == 1 && dimension_type::rank == 1 &&
-                       dimension_type::rank_dynamic == 1),
+                      (DimRHS::rank == 1 && dimension_type::rank == 1),
                   "ViewOffset LayoutRight and LayoutLeft are only compatible "
                   "when rank <= 1");
   }
@@ -3546,9 +3544,7 @@ class ViewMapping<
                      typename SrcTraits::array_layout>::value ||
         std::is_same<typename DstTraits::array_layout,
                      Kokkos::LayoutStride>::value ||
-        (DstTraits::dimension::rank == 0) ||
-        (DstTraits::dimension::rank == 1 &&
-         DstTraits::dimension::rank_dynamic == 1)
+        (DstTraits::dimension::rank == 0) || (DstTraits::dimension::rank == 1)
   };
 
  public:

--- a/core/unit_test/TestViewIsAssignable.hpp
+++ b/core/unit_test/TestViewIsAssignable.hpp
@@ -92,8 +92,18 @@ TEST(TEST_CATEGORY, view_is_assignable) {
                           View<double*, left, d_exec>>::test(false, false, 10);
 
   // Layout assignment
+  Impl::TestAssignability<View<int, left, d_exec>,
+                          View<int, right, d_exec>>::test(true, true);
   Impl::TestAssignability<View<int*, left, d_exec>,
                           View<int*, right, d_exec>>::test(true, true, 10);
+  Impl::TestAssignability<View<int[5], left, d_exec>,
+                          View<int*, right, d_exec>>::test(false, false, 10);
+  Impl::TestAssignability<View<int[10], left, d_exec>,
+                          View<int*, right, d_exec>>::test(false, true, 10);
+  Impl::TestAssignability<View<int*, left, d_exec>,
+                          View<int[5], right, d_exec>>::test(true, true);
+  Impl::TestAssignability<View<int[5], left, d_exec>,
+                          View<int[10], right, d_exec>>::test(false, false);
 
   // This could be made possible (due to the degenerate nature of the views) but
   // we do not allow this yet


### PR DESCRIPTION
We always supported the following:
```c++
Kokkos::View<int[5]> a("A");
Kokkos::View<int[5]> b("A");
Kokkos::View<int*> c("C",5);
a = b;
b = a;
b = c;
```

We also supported for always:
```c++
Kokkos::View<int*,Kokkos::LayoutLeft> a("A",5);
Kokkos::View<int*,Kokkos::LayoutRight> b("B",5);
a = b;
b = a;
```

What apparently doesn't work is:
```c++
Kokkos::View<int[5],Kokkos::LayoutLeft> a("A");
Kokkos::View<int[5],Kokkos::LayoutRight> b("B");
a = b;
b = a;
```

Turns out we do some extra checks for dynamic rank match, when accounting for LayoutLeft/LayoutRight convertibility of Rank 0 and Rank 1 Views.
That check is unnecessary, since it will get checked via the dimension assignability check already.
I.e. we hadn't properly orthogonalized the extents assignability from the Layout assignability for mixing LayoutLeft/LayoutRight.

This fixes this by getting rid of the erroneous condition. 