### PR TITLE
Fix repeated team_reduce without barrier

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -116,6 +116,7 @@ __device__ inline void cuda_inter_warp_reduction(
   value = result[0];
   for (int i = 1; (i * step < max_active_thread) && i < STEP_WIDTH; i++)
     reducer.join(&value, &result[i]);
+  __syncthreads();
 }
 
 template <class ValueType, class ReducerType>

--- a/core/src/HIP/Kokkos_HIP_Shuffle_Reduce.hpp
+++ b/core/src/HIP/Kokkos_HIP_Shuffle_Reduce.hpp
@@ -113,6 +113,7 @@ __device__ inline void hip_inter_warp_shuffle_reduction(
   value = result[0];
   for (int i = 1; (i * step < max_active_thread) && (i < step_width); ++i)
     reducer.join(&value, &result[i]);
+  __syncthreads();
 }
 
 template <typename ValueType, typename ReducerType>

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1664,6 +1664,7 @@ struct TestRepeatedTeamReduce {
     // Choose a non-recommened (non-power of two for GPUs) team size
     int team_size = team_size_recommended > 1 ? team_size_recommended - 1 : 1;
 
+    // The failure was non-deterministic so run the test a bunch of times
     for (int it = 0; it < 100; ++it) {
       Kokkos::parallel_for(
           Kokkos::TeamPolicy<ExecutionSpace>(ncol, team_size, 1), *this);

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1629,6 +1629,8 @@ struct TestRepeatedTeamReduce {
     constexpr auto pi  = Kokkos::numbers::pi;
     double b           = 0.;
     for (int ri = 0; ri < 10; ++ri) {
+      // The contributions here must be sufficiently complex, simply adding ones
+      // wasn't enough to trigger the bug.
       const auto g1 = [&](const int k, double &acc) {
         acc += Kokkos::cos(pi * double(k) / nlev);
       };

--- a/core/unit_test/TestTeamReductionScan.hpp
+++ b/core/unit_test/TestTeamReductionScan.hpp
@@ -134,5 +134,15 @@ TEST(TEST_CATEGORY, team_parallel_dummy_with_reducer_and_scratch_space) {
   }
 }
 
+TEST(TEST_CATEGORY, repeated_team_reduce) {
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+  if (std::is_same<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget>::value)
+    GTEST_SKIP() << "skipping since team_reduce for OpenMPTarget is not "
+                    "properly implemented";
+#endif
+
+  TestRepeatedTeamReduce<TEST_EXECSPACE>();
+}
+
 }  // namespace Test
 #endif


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/5475.
`cuda_inter_warp_reduction` uses shared memory and we need to ensure that we are done using it before exiting the function. Otherwise, repeated calls to team_reduce might fail as the test demonstrates.