### PR TITLE
Min max pragma push

### DIFF
--- a/core/perf_test/test_sharedSpace.cpp
+++ b/core/perf_test/test_sharedSpace.cpp
@@ -63,7 +63,7 @@ unsigned getBytesPerPage() { return sysconf(_SC_PAGESIZE); }
 namespace {
 void printTimings(std::ostream& out, std::vector<double> const& tr,
                   size_t numBytes,
-                  double threshold = std::numeric_limits<double>::max()) {
+                  double threshold = (std::numeric_limits<double>::max)()) {
   out << "TimingResult contains " << tr.size() << " results:\n";
   for (auto it = tr.begin(); it != tr.end(); ++it) {
     out << "Duration of loop " << it - tr.begin() << " is " << *it

--- a/core/perf_test/test_sharedSpace.cpp
+++ b/core/perf_test/test_sharedSpace.cpp
@@ -45,13 +45,6 @@
 #include <Kokkos_Core.hpp>
 
 #if defined _WIN32
-// FIXME_Windows : Even though Kokkos_Core does include windows.h it is not
-// visible here. Furthermore, the char max() in Kokkos_NumericTraits seems to
-// conflict with definitions in windows.h and raises a bunch of interpretation
-// errors
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 unsigned getBytesPerPage() {
   SYSTEM_INFO si;

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -50,6 +50,22 @@
 #endif
 
 //----------------------------------------------------------------------------
+// In the case windows.h is included before Kokkos_Core.hpp there might be
+// errors due to the potentially defined macros with name "min" and "max" in
+// windows.h. These collide with the use of "min" and "max" in names inside
+// Kokkos. The macros will be redefined at the end of Kokkos_Core.hpp
+#if defined(min)
+#pragma push_macro("min")
+#undef min
+#define KOKKOS_PUSH_MACRO_MIN
+#endif
+#if defined(max)
+#pragma push_macro("max")
+#undef max
+#define KOKKOS_PUSH_MACRO_MAX
+#endif
+
+//----------------------------------------------------------------------------
 // Include the execution space header files for the enabled execution spaces.
 
 #include <Kokkos_Core_fwd.hpp>
@@ -312,6 +328,16 @@ std::vector<ExecSpace> partition_space(ExecSpace space,
 
 // Specializations required after core definitions
 #include <KokkosCore_Config_PostInclude.hpp>
+
+//----------------------------------------------------------------------------
+// Redefinition of the macros min and max if we pushed them at entry of
+// Kokkos_Core.hpp
+#if defined(KOKKOS_PUSH_MACRO_MIN)
+#pragma pop_macro("min")
+#endif
+#if defined(KOKKOS_PUSH_MACRO_MAX)
+#pragma pop_macro("max")
+#endif
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -57,12 +57,12 @@
 #if defined(min)
 #pragma push_macro("min")
 #undef min
-#define KOKKOS_PUSH_MACRO_MIN
+#define KOKKOS_IMPL_PUSH_MACRO_MIN
 #endif
 #if defined(max)
 #pragma push_macro("max")
 #undef max
-#define KOKKOS_PUSH_MACRO_MAX
+#define KOKKOS_IMPL_PUSH_MACRO_MAX
 #endif
 
 //----------------------------------------------------------------------------
@@ -332,13 +332,13 @@ std::vector<ExecSpace> partition_space(ExecSpace space,
 //----------------------------------------------------------------------------
 // Redefinition of the macros min and max if we pushed them at entry of
 // Kokkos_Core.hpp
-#if defined(KOKKOS_PUSH_MACRO_MIN)
+#if defined(KOKKOS_IMPL_PUSH_MACRO_MIN)
 #pragma pop_macro("min")
-#undef KOKKOS_PUSH_MACRO_MIN
+#undef KOKKOS_IMPL_PUSH_MACRO_MIN
 #endif
-#if defined(KOKKOS_PUSH_MACRO_MAX)
+#if defined(KOKKOS_IMPL_PUSH_MACRO_MAX)
 #pragma pop_macro("max")
-#undef KOKKOS_PUSH_MACRO_MAX
+#undef KOKKOS_IMPL_PUSH_MACRO_MAX
 #endif
 
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -334,9 +334,11 @@ std::vector<ExecSpace> partition_space(ExecSpace space,
 // Kokkos_Core.hpp
 #if defined(KOKKOS_PUSH_MACRO_MIN)
 #pragma pop_macro("min")
+#undef KOKKOS_PUSH_MACRO_MIN
 #endif
 #if defined(KOKKOS_PUSH_MACRO_MAX)
 #pragma pop_macro("max")
+#undef KOKKOS_PUSH_MACRO_MAX
 #endif
 
 //----------------------------------------------------------------------------

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -90,14 +90,14 @@ KOKKOS_ADD_EXECUTABLE(
   ${COMPILE_ONLY_SOURCES}
 )
 
-if (WIN32)
+if(WIN32)
   KOKKOS_ADD_EXECUTABLE(
     TestCompileOnlyWindowsInclude
     SOURCES
     TestWindowsInclude.cpp
     TestCompileMain.cpp
     )
-endif (WIN32)
+endif()
 
 foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
   string(TOUPPER ${Tag} DEVICE)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -79,6 +79,12 @@ SET(COMPILE_ONLY_SOURCES
   TestStringManipulation.cpp
   TestTypeList.cpp
 )
+
+#testing if windows.h and Kokkos_Core.hpp can be included
+if(WIN32)
+  LIST(APPEND COMPILE_ONLY_SOURCES TestWindowsInclude.cpp)
+endif()
+
 # TestInterOp has a dependency on containers
 IF(KOKKOS_HAS_TRILINOS)
   LIST(REMOVE_ITEM COMPILE_ONLY_SOURCES TestInterOp.cpp)
@@ -89,15 +95,6 @@ KOKKOS_ADD_EXECUTABLE(
   TestCompileMain.cpp
   ${COMPILE_ONLY_SOURCES}
 )
-
-if(WIN32)
-  KOKKOS_ADD_EXECUTABLE(
-    TestCompileOnlyWindowsInclude
-    SOURCES
-    TestWindowsInclude.cpp
-    TestCompileMain.cpp
-    )
-endif()
 
 foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
   string(TOUPPER ${Tag} DEVICE)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -90,6 +90,14 @@ KOKKOS_ADD_EXECUTABLE(
   ${COMPILE_ONLY_SOURCES}
 )
 
+if (WIN32)
+  KOKKOS_ADD_EXECUTABLE(
+    TestCompileOnlyWindowsInclude
+    TestWindowsInclude.cpp
+    TestCompileMain.cpp
+    )
+endif (WIN32)
+
 foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
   string(TOUPPER ${Tag} DEVICE)
   string(TOLOWER ${Tag} dir)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -93,6 +93,7 @@ KOKKOS_ADD_EXECUTABLE(
 if (WIN32)
   KOKKOS_ADD_EXECUTABLE(
     TestCompileOnlyWindowsInclude
+    SOURCES
     TestWindowsInclude.cpp
     TestCompileMain.cpp
     )

--- a/core/unit_test/TestSharedSpace.cpp
+++ b/core/unit_test/TestSharedSpace.cpp
@@ -63,7 +63,7 @@ unsigned getBytesPerPage() { return sysconf(_SC_PAGESIZE); }
 
 namespace {
 void printTimings(std::ostream& out, std::vector<uint64_t> const& tr,
-                  uint64_t threshold = std::numeric_limits<uint64_t>::max()) {
+                  uint64_t threshold = (std::numeric_limits<uint64_t>::max)()) {
   out << "TimingResult contains " << tr.size() << " results:\n";
   for (auto it = tr.begin(); it != tr.end(); ++it) {
     out << "Duration of loop " << it - tr.begin() << " is " << *it

--- a/core/unit_test/TestSharedSpace.cpp
+++ b/core/unit_test/TestSharedSpace.cpp
@@ -45,13 +45,6 @@
 #include <Kokkos_Core.hpp>
 
 #if defined(_WIN32)
-// FIXME_Windows : Even though Kokkos_Core does include windows.h it is not
-// visible here. Furthermore, the char max() in Kokkos_NumericTraits seems to
-// conflict with definitions in windows.h and raises a bunch of interpretation
-// errors
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 unsigned getBytesPerPage() {
   SYSTEM_INFO si;

--- a/core/unit_test/TestWindowsInclude.cpp
+++ b/core/unit_test/TestWindowsInclude.cpp
@@ -1,0 +1,49 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+// as we use min and max as names in our headers and these are defined as macros
+// in windows.h, we added a pragma push to disable them at the beginning of
+// Kokkos_Core and pop them back into existence at the end.
+#include <windows.h>
+#include <Kokkos_Core.hpp>


### PR DESCRIPTION
Fix #5446 by trying to `pragma_push` the macros `min` and `max` when entering `Kokkos_Core.hpp` and redefining with `pragma_pop` at end. The macros being defined in e.g. `windows.h` lead to syntax errors otherwise. I hope this fixes the problem