### PR TITLE
Fix UB in logical spaces unit test

### DIFF
--- a/core/unit_test/tools/TestLogicalSpaces.hpp
+++ b/core/unit_test/tools/TestLogicalSpaces.hpp
@@ -131,7 +131,7 @@ void test_malloc_free() {
   auto* temp =
       Kokkos::kokkos_malloc<fake_memory_space>("does_malloc_work", 1000);
   expect_deallocation_event("does_malloc_work", "TestSpace", "Error in free");
-  Kokkos::kokkos_free(temp);
+  Kokkos::kokkos_free<fake_memory_space>(temp);
   Kokkos::Tools::Experimental::pause_tools();
 }
 void test_chained_spaces() {


### PR DESCRIPTION
Fix issue reported by Clang's UndefinedBehaviorSanitizer
```
[ RUN      ] defaultdevicetype.logical_space_malloc
<kokkos>/core/src/impl/Kokkos_SharedAlloc_timpl.hpp:131:10: runtime error: downcast of address 0x600001250190 which does not point to an object of type 'Kokkos::Impl::SharedAllocationRecordCommon<Kokkos::HostSpace>::derived_t' (aka 'SharedAllocationRecord<Kokkos::HostSpace, void>')
0x600001250190: note: object is of type 'Kokkos::Impl::SharedAllocationRecord<Kokkos::Experimental::LogicalMemorySpace<Kokkos::HostSpace, Kokkos::Threads, Test::TestSpaceNamer, Kokkos::Experimental::LogicalSpaceSharesAccess::shared_access>, void>'
 20 7d 0a 00  98 22 d3 02 01 00 00 00  40 88 00 51 01 00 00 00  68 04 00 00 00 00 00 00  40 d0 a9 02
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'Kokkos::Impl::SharedAllocationRecord<Kokkos::Experimental::LogicalMemorySpace<Kokkos::HostSpace, Kokkos::Threads, Test::TestSpaceNamer, Kokkos::Experimental::LogicalSpaceSharesAccess::shared_access>, void>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior <kokkos>/core/src/impl/Kokkos_SharedAlloc_timpl.hpp:131:10 in
```