### PR TITLE
Increase support to detect local MPI ranks

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -434,6 +434,7 @@ int Kokkos::Impl::get_gpu(const InitializationSettings& settings) {
            "MV2_COMM_WORLD_LOCAL_RANK",   // MVAPICH2
            "MPI_LOCALRANKID",             // MPICH
            "SLURM_LOCALID",               // SLURM
+           "PMI_LOCAL_RANK"               // PMI
        }) {
     local_rank_str = std::getenv(env_var);
     if (local_rank_str) break;


### PR DESCRIPTION
Following up on https://github.com/kokkos/kokkos/pull/5570#issuecomment-1282893923

For now only proposing support for the Process Management Interface (PMI) since I could find multiple sources mentioning it.  I am not sure yet whether to also add `MPT_LRANK`.  Anyone knows more about this one?