### PR TITLE
Change powerPC clocktic into 64 bit version and remove 32 bit version

### DIFF
--- a/core/src/impl/Kokkos_ClockTic.hpp
+++ b/core/src/impl/Kokkos_ClockTic.hpp
@@ -118,17 +118,6 @@ KOKKOS_IMPL_HOST_FUNCTION inline uint64_t clock_tic_host() noexcept {
 
   return (uint64_t)cycles;
 
-#elif defined(__powerpc) || defined(__powerpc__) || defined(__POWERPC__) || \
-    defined(__ppc__)
-
-  unsigned int lower_word = 0;
-  unsigned int upper_word = 0;
-
-  asm volatile("mftb %0" : "=r"(lower_word));
-  asm volatile("mftbu %0" : "=r"(upper_word));
-
-  return (((uint64_t)upper_word) << 32 | ((uint64_t)lower_word));
-
 #else
 
   return std::chrono::high_resolution_clock::now().time_since_epoch().count();

--- a/core/src/impl/Kokkos_ClockTic.hpp
+++ b/core/src/impl/Kokkos_ClockTic.hpp
@@ -110,14 +110,24 @@ KOKKOS_IMPL_HOST_FUNCTION inline uint64_t clock_tic_host() noexcept {
 
   return ((uint64_t)a) | (((uint64_t)d) << 32);
 
-#elif defined(__powerpc) || defined(__powerpc__) || defined(__powerpc64__) || \
-    defined(__POWERPC__) || defined(__ppc__) || defined(__ppc64__)
+#elif defined(__powerpc64__) || defined(__ppc64__)
 
-  unsigned int cycles = 0;
+  unsigned long cycles = 0;
 
   asm volatile("mftb %0" : "=r"(cycles));
 
   return (uint64_t)cycles;
+
+#elif defined(__powerpc) || defined(__powerpc__) || defined(__POWERPC__) || \
+    defined(__ppc__)
+
+  unsigned int lower_word = 0;
+  unsigned int upper_word = 0;
+
+  asm volatile("mftb %0" : "=r"(lower_word));
+  asm volatile("mftbu %0" : "=r"(upper_word));
+
+  return (((uint64_t)upper_word) << 32 | ((uint64_t)lower_word));
 
 #else
 


### PR DESCRIPTION
In https://github.com/kokkos/kokkos/issues/5502 we discovered that sometimes one of our tests fails on `PowerPC`. The failing test uses the `ClockTic` functionality to count the cycles that elapsed. The cycles counted as elapsed in the failing test is (in this case) `11'258'999'065'812`. The test `TestSharedSpace` uses a difference of `uint64_t` returned by the `ClockTic` to measure timings independent of the current frequency the core is running on. The differences is then added in a `parallel_reduce` to compute the number of cycles needed for the memory accesses.
As the difference of unsigned should not be affected by any overflow, I suspect something being wrong with how the `ClockTic` is read from the registers. I ended up looking at the documentation I found for the registers [here](https://www.ibm.com/docs/en/SSGH2K_13.1.3/com.ibm.compilers.aix.doc/compiler.pdf)

> ## Move to/from register functions
> **__mftb Purpose**
> Move from Time Base
> In 32-bit compilation mode, returns the lower word of the time base register. In 64-bit mode, returns the entire doubleword of the time base register.
> **Prototype**
> unsigned long __mftb (void);
> **Usage**
> In 32-bit mode, this function can be used in conjunction with the__mftbu built-in function to read the entire time base register. In 64-bit mode, the entire doubleword of the time base register is returned, so separate use of __mftbu is unnecessary
>It is recommended that you insert the __fence built-in function before and after the __mftb built-in function.

and 
> **__mftbu Purpose**
> Move from Time Base Upper
> Returns the upper word of the time base register. Prototype
unsigned int __mftbu (void);
> **Usage**
In 32-bit mode you can use this function in conjunction with the __mftb built-in function to read the entire time base register
It is recommended that you insert the __fence built-in function before and after the __mftbu built-in function.


So I tried to split the implementation for PowerPC into a 32 and 64 bit version, as the 64 bit version apparently can read the register as one `unsigned long` value while the 32 bit needs to read two registers and add them like on `x86`.
If we have anyone who is good with `asm` and knows this kind of stuff: any help/insight/thing here is greatly appreciated.
Also I might be looking in a completely wrong direction here ... 