### PR TITLE
Do not add `--expt-extended-lambda` compile flag in GNU generated makefiles with HIP

### DIFF
--- a/Makefile.kokkos
+++ b/Makefile.kokkos
@@ -1064,9 +1064,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_CUDA_ARCH), 1)
       endif
     endif
   endif
-  ifeq ($(KOKKOS_INTERNAL_USE_HIP), 1)
-    KOKKOS_CXXFLAGS += --expt-extended-lambda
-  endif
 endif
 
 


### PR DESCRIPTION
It was copied over from CUDA in the initial commit adding the HIP backend.
The best part is that it is guarded by `ifeq ($(KOKKOS_INTERNAL_USE_CUDA_ARCH), 1)`
Maybe at the time we there thinking we may allow targeting NVIDIA GPU from the HIP backend?