### PR TITLE
CMakeLists.txt: Making it possible for downstream code to see the Kokkos_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,9 @@ ELSEIF (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
   MESSAGE(FATAL_ERROR "Kokkos assumes a 64-bit build; i.e., 8-byte pointers, but found ${CMAKE_SIZEOF_VOID_P}-byte pointers instead")
 ENDIF()
 
+# Load either the real TriBITS or a TriBITS wrapper
+# for certain utility functions that are universal (like GLOBAL_SET)
+INCLUDE(${KOKKOS_SRC_PATH}/cmake/fake_tribits.cmake)
 
 set(Kokkos_VERSION_MAJOR 3)
 set(Kokkos_VERSION_MINOR 7)
@@ -139,9 +142,6 @@ math(EXPR KOKKOS_VERSION_MAJOR "${KOKKOS_VERSION} / 10000")
 math(EXPR KOKKOS_VERSION_MINOR "${KOKKOS_VERSION} / 100 % 100")
 math(EXPR KOKKOS_VERSION_PATCH "${KOKKOS_VERSION} % 100")
 
-# Load either the real TriBITS or a TriBITS wrapper
-# for certain utility functions that are universal (like GLOBAL_SET)
-INCLUDE(${KOKKOS_SRC_PATH}/cmake/fake_tribits.cmake)
 
 IF (Kokkos_ENABLE_CUDA)
   # If we are building CUDA, we have tricked CMake because we declare a CXX project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ ENDIF()
 set(Kokkos_VERSION_MAJOR 3)
 set(Kokkos_VERSION_MINOR 7)
 set(Kokkos_VERSION_PATCH 99)
-set(Kokkos_VERSION "${Kokkos_VERSION_MAJOR}.${Kokkos_VERSION_MINOR}.${Kokkos_VERSION_PATCH}")
+global_set(Kokkos_VERSION "${Kokkos_VERSION_MAJOR}.${Kokkos_VERSION_MINOR}.${Kokkos_VERSION_PATCH}")
 math(EXPR KOKKOS_VERSION "${Kokkos_VERSION_MAJOR} * 10000 + ${Kokkos_VERSION_MINOR} * 100 + ${Kokkos_VERSION_PATCH}")
 # mathematical expressions below are not stricly necessary but they eliminate
 # the rather aggravating leading 0 in the releases patch version number, and,


### PR DESCRIPTION
Change Kokkos_VERSION to global_set from SET, so it can be accessed by downstream code.