### PR TITLE
Avoid clashing with downstream usage of LIBDL_LIBRARY

### DIFF
--- a/cmake/Modules/FindTPLLIBDL.cmake
+++ b/cmake/Modules/FindTPLLIBDL.cmake
@@ -1,1 +1,8 @@
+# kokkos_create_imported_tpl errors out if a library location is specified
+# for an interface library
+SET(KOKKOS_LIBDL_LIBRARY ${LIBDL_LIBRARY})
+UNSET(LIBDL_LIBRARY CACHE)
 KOKKOS_FIND_IMPORTED(LIBDL HEADER dlfcn.h INTERFACE LIBRARIES ${CMAKE_DL_LIBS})
+IF(KOKKOS_LIBDL_LIBRARY)
+  SET(LIBDL_LIBRARY ${KOKKOS_LIBDL_LIBRARY} CACHE FILEPATH "Path to a library.")
+ENDIF()


### PR DESCRIPTION
We noticed in `Slack` that
```
cmake_minimum_required(VERSION 3.16)

include(FetchContent)

project( "test" CXX )

set(Kokkos_DIR "../../external/kokkos")
FetchContent_Declare( kokkos_external
    SOURCE_DIR ${Kokkos_DIR}
  )
# Import kokkos targets
FetchContent_MakeAvailable(kokkos_external)

find_library(LIBDL_LIBRARY dl)
```
would fail with 
```
CMake Error at /<...>/kokkos/cmake/kokkos_functions.cmake:370 (MESSAGE):
  TPL Interface library LIBDL should not have an IMPORTED_LOCATION
```
past https://github.com/kokkos/kokkos/pull/5179. This pull request tries to save, delete and restore the content of `LIBDL_LIBRARY` as a workaround. 