### PR TITLE
Fix warning: calling a __host__ function from a __host__ __device__ function is not allowed in Kokkos_View.hpp(1750)

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1747,8 +1747,7 @@ KOKKOS_FUNCTION std::enable_if_t<
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
          Args...>>
 as_view_of_rank_n(View<T, Args...>) {
-  Kokkos::Impl::throw_runtime_exception(
-      "Trying to get at a View of the wrong rank");
+  Kokkos::abort("Trying to get at a View of the wrong rank");
   return {};
 }
 


### PR DESCRIPTION
Resolves #5587 

Changed from calling `Kokkos::Impl::throw_runtime_exception` to `Kokkos::abort`.
According to the comment, this `as_view_of_rank_n()` in `Kokkos_View.hpp` should never be called. So there shouldn't be any functional change from this.

https://github.com/kokkos/kokkos/blob/8bc6922dd7f9e64b22f2f87df2a789d4e2f5229a/core/src/Kokkos_View.hpp#L1741-L1749