### PR TITLE
[3.7.01] Fix warning calling a `__host__ `function from a `__host__ __device__` from `View:: as_view_of_rank_n `

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1771,8 +1771,7 @@ KOKKOS_FUNCTION std::enable_if_t<
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
          Args...>>
 as_view_of_rank_n(View<T, Args...>) {
-  Kokkos::Impl::throw_runtime_exception(
-      "Trying to get at a View of the wrong rank");
+  Kokkos::abort("Trying to get at a View of the wrong rank");
   return {};
 }
 


### PR DESCRIPTION
Cherry-pick #5590 
Essentially a fixup for #5553 that introduced a warning about calling a `__host__ `function from a `__host__ __device__` function 