### PR TITLE
Avoid static/extern thread_local 

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -61,12 +61,6 @@
 namespace Kokkos {
 namespace Impl {
 
-int g_openmp_hardware_max_threads = 1;
-
-thread_local int t_openmp_hardware_id = 0;
-// FIXME_OPENMP we can remove this after we remove partition_master
-thread_local OpenMPInternal *t_openmp_instance = nullptr;
-
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
 void OpenMPInternal::validate_partition_impl(const int nthreads,
                                              int &num_partitions,

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -69,11 +69,11 @@ namespace Impl {
 
 class OpenMPInternal;
 
-extern int g_openmp_hardware_max_threads;
+inline int g_openmp_hardware_max_threads = 1;
 
-extern thread_local int t_openmp_hardware_id;
+inline thread_local int t_openmp_hardware_id = 0;
 // FIXME_OPENMP we can remove this after we remove partition_master
-extern thread_local OpenMPInternal* t_openmp_instance;
+inline thread_local OpenMPInternal* t_openmp_instance = nullptr;
 
 struct OpenMPTraits {
   static int constexpr MAX_THREAD_COUNT = 512;

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -51,8 +51,6 @@
 namespace Kokkos {
 namespace Impl {
 
-thread_local int SharedAllocationRecord<void, void>::t_tracking_enabled = 1;
-
 #ifdef KOKKOS_ENABLE_DEBUG
 bool SharedAllocationRecord<void, void>::is_sane(
     SharedAllocationRecord<void, void>* arg_record) {

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -141,7 +141,7 @@ class SharedAllocationRecord<void, void> {
       SharedAllocationHeader* arg_alloc_ptr, size_t arg_alloc_size,
       function_type arg_dealloc, const std::string& label);
  private:
-  static thread_local int t_tracking_enabled;
+  static inline thread_local int t_tracking_enabled = 1;
 
  public:
   virtual std::string get_label() const { return std::string("Unmanaged"); }


### PR DESCRIPTION
Partially addressing #5581. The regression was introduced in https://github.com/kokkos/kokkos/pull/5064. https://stackoverflow.com/a/13123870 might provide some explanations.

Drive-by: Change `extern int g_openmp_hardware_max_threads;` in the same way for consistency.