### PR TITLE
Fix position of KOKKOS_DEPRECATED

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -284,7 +284,7 @@ class
   template <
       class RType,
       std::enable_if_t<std::is_convertible<RType, RealType>::value, int> = 0>
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION
   complex(const volatile complex<RType>& src) noexcept
       // Intentionally do the conversions implicitly here so that users don't
       // get any warnings about narrowing, etc., that they would expect to get
@@ -313,7 +313,7 @@ class
   //    vl = cr;
   template <class Complex,
             std::enable_if_t<std::is_same<Complex, complex>::value, int> = 0>
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator=(
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION void operator=(
       const Complex& src) volatile noexcept {
     re_ = src.re_;
     im_ = src.im_;
@@ -336,7 +336,7 @@ class
   //    vl = cvr;
   template <class Complex,
             std::enable_if_t<std::is_same<Complex, complex>::value, int> = 0>
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED volatile complex& operator=(
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION volatile complex& operator=(
       const volatile Complex& src) volatile noexcept {
     re_ = src.re_;
     im_ = src.im_;
@@ -358,7 +358,7 @@ class
   //
   template <class Complex,
             std::enable_if_t<std::is_same<Complex, complex>::value, int> = 0>
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED complex& operator=(
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION complex& operator=(
       const volatile Complex& src) noexcept {
     re_ = src.re_;
     im_ = src.im_;
@@ -369,7 +369,7 @@ class
   // RealType RHS versions.
 
   //! Assignment operator (from a volatile real number).
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator=(
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION void operator=(
       const volatile RealType& val) noexcept {
     re_ = val;
     im_ = RealType(0);
@@ -378,7 +378,7 @@ class
   }
 
   //! Assignment operator volatile LHS and non-volatile RHS
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED complex& operator=(
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION complex& operator=(
       const RealType& val) volatile noexcept {
     re_ = val;
     im_ = RealType(0);
@@ -387,7 +387,7 @@ class
 
   //! Assignment operator volatile LHS and volatile RHS
   // TODO Should this return void like the other volatile assignment operators?
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED complex& operator=(
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION complex& operator=(
       const volatile RealType& val) volatile noexcept {
     re_ = val;
     im_ = RealType(0);
@@ -395,41 +395,41 @@ class
   }
 
   //! The imaginary part of this complex number (volatile overload).
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED volatile RealType&
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION volatile RealType&
   imag() volatile noexcept {
     return im_;
   }
 
   //! The real part of this complex number (volatile overload).
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED volatile RealType&
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION volatile RealType&
   real() volatile noexcept {
     return re_;
   }
 
   //! The imaginary part of this complex number (volatile overload).
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED RealType imag() const
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION RealType imag() const
       volatile noexcept {
     return im_;
   }
 
   //! The real part of this complex number (volatile overload).
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED RealType real() const
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION RealType real() const
       volatile noexcept {
     return re_;
   }
 
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator+=(
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION void operator+=(
       const volatile complex<RealType>& src) volatile noexcept {
     re_ += src.re_;
     im_ += src.im_;
   }
 
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator+=(
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION void operator+=(
       const volatile RealType& src) volatile noexcept {
     re_ += src;
   }
 
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator*=(
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION void operator*=(
       const volatile complex<RealType>& src) volatile noexcept {
     const RealType realPart = re_ * src.re_ - im_ * src.im_;
     const RealType imagPart = re_ * src.im_ + im_ * src.re_;
@@ -438,7 +438,7 @@ class
     im_ = imagPart;
   }
 
-  KOKKOS_INLINE_FUNCTION KOKKOS_DEPRECATED void operator*=(
+  KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION void operator*=(
       const volatile RealType& src) volatile noexcept {
     re_ *= src;
     im_ *= src;

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -603,9 +603,8 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 // Guard intel compiler version 19 and older
 // intel error #2651: attribute does not apply to any entity
 // using <deprecated_type> KOKKOS_DEPRECATED = ...
-#if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS) && !defined(__NVCC__) &&  \
-    (!defined(KOKKOS_COMPILER_INTEL) || KOKKOS_COMPILER_INTEL >= 2021) && \
-    !defined(KOKKOS_ENABLE_OPENACC)
+#if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS) && !defined(__NVCC__) && \
+    (!defined(KOKKOS_COMPILER_INTEL) || KOKKOS_COMPILER_INTEL >= 2021)
 #define KOKKOS_DEPRECATED [[deprecated]]
 #define KOKKOS_DEPRECATED_WITH_COMMENT(comment) [[deprecated(comment)]]
 #else

--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -117,7 +117,7 @@ struct pair {
   /// This calls the copy constructors of T1 and T2.  It won't compile
   /// if those copy constructors are not defined and public.
   template <class U, class V>
-  KOKKOS_FORCEINLINE_FUNCTION KOKKOS_DEPRECATED constexpr pair(
+  KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr pair(
       const volatile pair<U, V>& p)
       : first(p.first), second(p.second) {}
 #endif
@@ -146,7 +146,7 @@ struct pair {
   /// practice, this means that you should not chain assignments with
   /// volatile lvalues.
   template <class U, class V>
-  KOKKOS_FORCEINLINE_FUNCTION KOKKOS_DEPRECATED void operator=(
+  KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION void operator=(
       const volatile pair<U, V>& p) volatile {
     first  = p.first;
     second = p.second;


### PR DESCRIPTION
Fixing #5412. `IntelLLVM` was complaining with
```
'deprecated' attribute cannot be applied to types
an attribute list cannot appear here
```
CI didn't catch that since deprecation warnings are always disabled (because of `Werror`).