### PR TITLE
Fix cudaErrorInvalidDeviceFunction error caused by an uninstantiated functor

### DIFF
--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2924,8 +2924,8 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
         n(arg_n),
         name(std::move(arg_name)),
         default_exec_space(false) {
-          functor_instantiate_workaround();
-        }
+    functor_instantiate_workaround();
+  }
 
   ViewValueFunctor(ValueType* const arg_ptr, size_t const arg_n,
                    std::string arg_name)
@@ -2934,8 +2934,8 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
         n(arg_n),
         name(std::move(arg_name)),
         default_exec_space(true) {
-          functor_instantiate_workaround();
-        }
+    functor_instantiate_workaround();
+  }
 
   template <typename Dummy = ValueType>
   std::enable_if_t<std::is_trivial<Dummy>::value &&

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2976,13 +2976,6 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
   std::enable_if_t<!(std::is_trivial<Dummy>::value &&
                      std::is_trivially_copy_assignable<ValueType>::value)>
   construct_dispatch() {
-    if (false) {
-      // To ensure that the functor with this tag is instantiated
-      // This is to avoid "cudaErrorInvalidDeviceFunction" error later
-      // when this function is queried with cudaFuncGetAttributes
-      parallel_for_implementation<DestroyTag>();
-    }
-
     parallel_for_implementation<ConstructTag>();
   }
 
@@ -3022,7 +3015,15 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
     }
   }
 
-  void construct_shared_allocation() { construct_dispatch(); }
+  void construct_shared_allocation() {
+    if (false) {
+      // To ensure that the functor with this tag is instantiated
+      // This is to avoid "cudaErrorInvalidDeviceFunction" error later
+      // when this function is queried with cudaFuncGetAttributes
+      parallel_for_implementation<DestroyTag>();
+    }
+    construct_dispatch();
+  }
 
   void destroy_shared_allocation() {
     parallel_for_implementation<DestroyTag>();

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2923,7 +2923,9 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
         ptr(arg_ptr),
         n(arg_n),
         name(std::move(arg_name)),
-        default_exec_space(false) {}
+        default_exec_space(false) {
+          functor_instantiate_workaround();
+        }
 
   ViewValueFunctor(ValueType* const arg_ptr, size_t const arg_n,
                    std::string arg_name)
@@ -2931,7 +2933,9 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
         ptr(arg_ptr),
         n(arg_n),
         name(std::move(arg_name)),
-        default_exec_space(true) {}
+        default_exec_space(true) {
+          functor_instantiate_workaround();
+        }
 
   template <typename Dummy = ValueType>
   std::enable_if_t<std::is_trivial<Dummy>::value &&
@@ -3015,18 +3019,22 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
     }
   }
 
-  void construct_shared_allocation() {
-    if (false) {
-      // To ensure that the functor with this tag is instantiated
-      // This is to avoid "cudaErrorInvalidDeviceFunction" error later
-      // when this function is queried with cudaFuncGetAttributes
-      parallel_for_implementation<DestroyTag>();
-    }
-    construct_dispatch();
-  }
+  void construct_shared_allocation() { construct_dispatch(); }
 
   void destroy_shared_allocation() {
     parallel_for_implementation<DestroyTag>();
+  }
+
+  // This function is to ensure that the functor with DestroyTag is instantiated
+  // This is a workaround to avoid "cudaErrorInvalidDeviceFunction" error later
+  // when the function is queried with cudaFuncGetAttributes
+  void functor_instantiate_workaround() {
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
+    defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENMPTARGET)
+    if (false) {
+      parallel_for_implementation<DestroyTag>();
+    }
+#endif
   }
 };
 
@@ -3467,15 +3475,6 @@ class ViewMapping<
                            m_impl_offset.span(), alloc_name)
             : functor_type((value_type*)m_impl_handle, m_impl_offset.span(),
                            alloc_name);
-
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENMPTARGET)
-    if (false) {
-      // Make sure the destroy functor gets instantiated.
-      // This avoids "cudaErrorInvalidDeviceFunction"-type errors.
-      functor.destroy_shared_allocation();
-    }
-#endif
 
     //  Only initialize if the allocation is non-zero.
     //  May be zero if one of the dimensions is zero.

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2976,6 +2976,13 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
   std::enable_if_t<!(std::is_trivial<Dummy>::value &&
                      std::is_trivially_copy_assignable<ValueType>::value)>
   construct_dispatch() {
+    if (false) {
+      // To ensure that the functor with this tag is instantiated
+      // This is to avoid "cudaErrorInvalidDeviceFunction" error later
+      // when this function is queried with cudaFuncGetAttributes
+      parallel_for_implementation<DestroyTag>();
+    }
+
     parallel_for_implementation<ConstructTag>();
   }
 


### PR DESCRIPTION
To resolve #5474 

The error `cudaErrorInvalidDeviceFunction` is from `cudaFuncGetAttributes` when it's called during the deallocation of a dynamic ranked view. 
https://github.com/kokkos/kokkos/blob/dc7691829b6afcb25ffb4506a3a464b94cbc5078/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp#L646-L659

The error indicates that the functor with `DestroyTag` was not instantiated at the time of `cudaFuncGetAttributes` call. This change is to instantiate that destroy functor during the construction stage, well before the destruction stage.