### PR TITLE
Deprecate `CudaUVMSpace::available()`

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -122,7 +122,9 @@ void DeepCopyAsyncCuda(void *dst, const void *src, size_t n) {
 
 namespace Kokkos {
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 bool CudaUVMSpace::available() { return true; }
+#endif
 
 /*--------------------------------------------------------------------------*/
 

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -167,8 +167,10 @@ class CudaUVMSpace {
   using device_type     = Kokkos::Device<execution_space, memory_space>;
   using size_type       = unsigned int;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   /** \brief  If UVM capability is available */
-  static bool available();
+  KOKKOS_DEPRECATED static bool available();
+#endif
 
   /*--------------------------------*/
 

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -260,20 +260,18 @@ TEST(cuda, space_access) {
 }
 
 TEST(cuda, uvm) {
-  if (Kokkos::CudaUVMSpace::available()) {
-    int *uvm_ptr = static_cast<int *>(
-        Kokkos::kokkos_malloc<Kokkos::CudaUVMSpace>("uvm_ptr", sizeof(int)));
+  int *uvm_ptr = static_cast<int *>(
+      Kokkos::kokkos_malloc<Kokkos::CudaUVMSpace>("uvm_ptr", sizeof(int)));
 
-    *uvm_ptr = 42;
+  *uvm_ptr = 42;
 
-    Kokkos::fence();
-    test_cuda_spaces_int_value<<<1, 1>>>(uvm_ptr);
-    Kokkos::fence();
+  Kokkos::fence();
+  test_cuda_spaces_int_value<<<1, 1>>>(uvm_ptr);
+  Kokkos::fence();
 
-    EXPECT_EQ(*uvm_ptr, int(2 * 42));
+  EXPECT_EQ(*uvm_ptr, int(2 * 42));
 
-    Kokkos::kokkos_free<Kokkos::CudaUVMSpace>(uvm_ptr);
-  }
+  Kokkos::kokkos_free<Kokkos::CudaUVMSpace>(uvm_ptr);
 }
 
 template <class MemSpace, class ExecSpace>


### PR DESCRIPTION
`CudaUVMSpace::available` was proposed for deprecation by @dalg24 in https://github.com/kokkos/kokkos/issues/5472

Function is not available in other backends and is obsolete as it always returns `true`.