### PR TITLE
Add `is_view_v` helper variable template

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -585,6 +585,9 @@ struct is_view<View<D, P...>> : public std::true_type {};
 template <class D, class... P>
 struct is_view<const View<D, P...>> : public std::true_type {};
 
+template <class T>
+inline constexpr bool is_view_v = is_view<T>::value;
+
 template <class DataType, class... Properties>
 class View : public ViewTraits<DataType, Properties...> {
  private:

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -77,6 +77,7 @@ SET(COMPILE_ONLY_SOURCES
   TestDetectionIdiom.cpp
   TestInterOp.cpp
   TestStringManipulation.cpp
+  TestViewTypeTraits.cpp
   TestTypeList.cpp
 )
 

--- a/core/unit_test/TestViewTypeTraits.cpp
+++ b/core/unit_test/TestViewTypeTraits.cpp
@@ -48,6 +48,23 @@
 
 namespace {
 
+constexpr bool test_view_rank() {
+  // clang-format off
+  static_assert(Kokkos::View<int         >::rank == 0);
+  static_assert(Kokkos::View<int[1]      >::rank == 1);
+  static_assert(Kokkos::View<int *       >::rank == 1);
+  static_assert(Kokkos::View<int[1][2]   >::rank == 2);
+  static_assert(Kokkos::View<int * [1]   >::rank == 2);
+  static_assert(Kokkos::View<int *  *    >::rank == 2);
+  static_assert(Kokkos::View<int[1][2][3]>::rank == 3);
+  static_assert(Kokkos::View<int * [1][2]>::rank == 3);
+  static_assert(Kokkos::View<int *  * [1]>::rank == 3);
+  static_assert(Kokkos::View<int *  *  * >::rank == 3);
+  // clang-format on
+  return true;
+}
+static_assert(test_view_rank());
+
 constexpr bool test_is_view_type_trait() {
   struct NotView {};
   static_assert(Kokkos::is_view<Kokkos::View<int>>::value);

--- a/core/unit_test/TestViewTypeTraits.cpp
+++ b/core/unit_test/TestViewTypeTraits.cpp
@@ -1,0 +1,61 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+
+#include <type_traits>
+
+namespace {
+
+constexpr bool test_is_view_type_trait() {
+  struct NotView {};
+  static_assert(Kokkos::is_view<Kokkos::View<int>>::value);
+  static_assert(Kokkos::is_view_v<Kokkos::View<int>>);
+  static_assert(!Kokkos::is_view_v<NotView>);
+  static_assert(!Kokkos::is_view<NotView>::value);
+  return true;
+}
+static_assert(test_is_view_type_trait());
+
+}  // namespace


### PR DESCRIPTION
As noted in https://github.com/kokkos/kokkos/pull/5610#discussion_r1013572336 we somehow did not have a `Kokkos::is_view_v` helper variable template.
For the record we have `is_{execution, memory}_space_v`, `is_execution_policy_v`, `is_reducer_v`, etc.