### PR TITLE
Make TestStdAlgorithmsCompileOnly runnable

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsCompileOnly.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCompileOnly.cpp
@@ -123,18 +123,20 @@ struct TrivialTransformReduceBinaryTransformer {
   }
 };
 
-// put all code here and don't call from main
-// so that even if one runs the executable,
-// nothing is run anyway
+namespace KE = Kokkos::Experimental;
 
-namespace KE     = Kokkos::Experimental;
-using count_type = std::size_t;
-using T          = double;
-Kokkos::View<T *> in1("in1", 10);
-Kokkos::View<T *> in2("in2", 10);
-Kokkos::View<T *> in3("in3", 10);
-Kokkos::DefaultExecutionSpace exe_space;
-std::string const label = "trivial";
+struct TestStruct {
+  // put all code here and don't call from main
+  // so that even if one runs the executable,
+  // nothing is run anyway
+
+  using count_type      = std::size_t;
+  using T               = double;
+  Kokkos::View<T *> in1 = Kokkos::View<T *>("in1", 10);
+  Kokkos::View<T *> in2 = Kokkos::View<T *>("in2", 10);
+  Kokkos::View<T *> in3 = Kokkos::View<T *>("in3", 10);
+  Kokkos::DefaultExecutionSpace exe_space;
+  std::string const label = "trivial";
 
 //
 // just iterators
@@ -239,293 +241,299 @@ std::string const label = "trivial";
   (void)KE::ALGO(exe_space, /*--*/ in1, ARG, in2); \
   (void)KE::ALGO(label, exe_space, in1, ARG, in2);
 
-void non_modifying_seq_ops() {
-  TEST_ALGO_MACRO_B1E1_VARIAD(find, T{});
-  TEST_ALGO_MACRO_V1_VARIAD(find, T{});
+  void non_modifying_seq_ops() {
+    TEST_ALGO_MACRO_B1E1_VARIAD(find, T{});
+    TEST_ALGO_MACRO_V1_VARIAD(find, T{});
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(find_if, TrivialUnaryPredicate<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(find_if, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(find_if, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(find_if, TrivialUnaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(find_if_not, TrivialUnaryPredicate<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(find_if_not, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(find_if_not, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(find_if_not, TrivialUnaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(for_each, TimesTwoFunctor<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(for_each, TimesTwoFunctor<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(for_each, TimesTwoFunctor<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(for_each, TimesTwoFunctor<T>());
 
-  TEST_ALGO_MACRO_B1_VARIAD(for_each_n, count_type{}, TimesTwoFunctor<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(for_each_n, count_type{}, TimesTwoFunctor<T>());
+    TEST_ALGO_MACRO_B1_VARIAD(for_each_n, count_type{}, TimesTwoFunctor<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(for_each_n, count_type{}, TimesTwoFunctor<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(count_if, TrivialUnaryPredicate<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(count_if, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(count_if, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(count_if, TrivialUnaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(count, T{});
-  TEST_ALGO_MACRO_V1_VARIAD(count, T{});
+    TEST_ALGO_MACRO_B1E1_VARIAD(count, T{});
+    TEST_ALGO_MACRO_V1_VARIAD(count, T{});
 
-  TEST_ALGO_MACRO_B1E1B2E2(mismatch);
-  TEST_ALGO_MACRO_B1E1B2E2_VARIAD(mismatch, TrivialBinaryPredicate<T>());
-  TEST_ALGO_MACRO_V1V2(mismatch);
-  TEST_ALGO_MACRO_V1V2_VARIAD(mismatch, TrivialBinaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1B2E2(mismatch);
+    TEST_ALGO_MACRO_B1E1B2E2_VARIAD(mismatch, TrivialBinaryPredicate<T>());
+    TEST_ALGO_MACRO_V1V2(mismatch);
+    TEST_ALGO_MACRO_V1V2_VARIAD(mismatch, TrivialBinaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(all_of, TrivialUnaryPredicate<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(all_of, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(all_of, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(all_of, TrivialUnaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(any_of, TrivialUnaryPredicate<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(any_of, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(any_of, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(any_of, TrivialUnaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(none_of, TrivialUnaryPredicate<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(none_of, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(none_of, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(none_of, TrivialUnaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1B2(equal);
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(equal, TrivialBinaryPredicate<T>());
-  TEST_ALGO_MACRO_V1V2(equal);
-  TEST_ALGO_MACRO_V1V2_VARIAD(equal, TrivialBinaryPredicate<T>());
-  TEST_ALGO_MACRO_B1E1B2E2(equal);
-  TEST_ALGO_MACRO_B1E1B2E2_VARIAD(equal, TrivialBinaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1B2(equal);
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(equal, TrivialBinaryPredicate<T>());
+    TEST_ALGO_MACRO_V1V2(equal);
+    TEST_ALGO_MACRO_V1V2_VARIAD(equal, TrivialBinaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1B2E2(equal);
+    TEST_ALGO_MACRO_B1E1B2E2_VARIAD(equal, TrivialBinaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1B2E2(lexicographical_compare);
-  TEST_ALGO_MACRO_B1E1B2E2_VARIAD(lexicographical_compare,
-                                  TrivialComparator<T>());
-  TEST_ALGO_MACRO_V1V2(lexicographical_compare);
-  TEST_ALGO_MACRO_V1V2_VARIAD(lexicographical_compare, TrivialComparator<T>());
+    TEST_ALGO_MACRO_B1E1B2E2(lexicographical_compare);
+    TEST_ALGO_MACRO_B1E1B2E2_VARIAD(lexicographical_compare,
+                                    TrivialComparator<T>());
+    TEST_ALGO_MACRO_V1V2(lexicographical_compare);
+    TEST_ALGO_MACRO_V1V2_VARIAD(lexicographical_compare,
+                                TrivialComparator<T>());
 
-  TEST_ALGO_MACRO_B1E1(adjacent_find);
-  TEST_ALGO_MACRO_V1(adjacent_find);
-  TEST_ALGO_MACRO_B1E1_VARIAD(adjacent_find, TrivialBinaryFunctor<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(adjacent_find, TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_B1E1(adjacent_find);
+    TEST_ALGO_MACRO_V1(adjacent_find);
+    TEST_ALGO_MACRO_B1E1_VARIAD(adjacent_find, TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(adjacent_find, TrivialBinaryFunctor<T>());
 
-  TEST_ALGO_MACRO_B1E1B2E2(search);
-  TEST_ALGO_MACRO_V1V2(search);
-  TEST_ALGO_MACRO_B1E1B2E2_VARIAD(search, TrivialBinaryFunctor<T>());
-  TEST_ALGO_MACRO_V1V2_VARIAD(search, TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_B1E1B2E2(search);
+    TEST_ALGO_MACRO_V1V2(search);
+    TEST_ALGO_MACRO_B1E1B2E2_VARIAD(search, TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_V1V2_VARIAD(search, TrivialBinaryFunctor<T>());
 
-  TEST_ALGO_MACRO_B1E1B2E2(find_first_of);
-  TEST_ALGO_MACRO_V1V2(find_first_of);
-  TEST_ALGO_MACRO_B1E1B2E2_VARIAD(find_first_of, TrivialBinaryFunctor<T>());
-  TEST_ALGO_MACRO_V1V2_VARIAD(find_first_of, TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_B1E1B2E2(find_first_of);
+    TEST_ALGO_MACRO_V1V2(find_first_of);
+    TEST_ALGO_MACRO_B1E1B2E2_VARIAD(find_first_of, TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_V1V2_VARIAD(find_first_of, TrivialBinaryFunctor<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(search_n, count_type{}, T{});
-  TEST_ALGO_MACRO_V1_VARIAD(search_n, count_type{}, T{});
-  TEST_ALGO_MACRO_B1E1_VARIAD(search_n, count_type{}, T{},
+    TEST_ALGO_MACRO_B1E1_VARIAD(search_n, count_type{}, T{});
+    TEST_ALGO_MACRO_V1_VARIAD(search_n, count_type{}, T{});
+    TEST_ALGO_MACRO_B1E1_VARIAD(search_n, count_type{}, T{},
+                                TrivialBinaryPredicate<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(search_n, count_type{}, T{},
                               TrivialBinaryPredicate<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(search_n, count_type{}, T{},
-                            TrivialBinaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1B2E2(find_end);
-  TEST_ALGO_MACRO_V1V2(find_end);
-  TEST_ALGO_MACRO_B1E1B2E2_VARIAD(find_end, TrivialBinaryFunctor<T>());
-  TEST_ALGO_MACRO_V1V2_VARIAD(find_end, TrivialBinaryFunctor<T>());
-}
+    TEST_ALGO_MACRO_B1E1B2E2(find_end);
+    TEST_ALGO_MACRO_V1V2(find_end);
+    TEST_ALGO_MACRO_B1E1B2E2_VARIAD(find_end, TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_V1V2_VARIAD(find_end, TrivialBinaryFunctor<T>());
+  }
 
-void modifying_seq_ops() {
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(replace_copy, T{}, T{});
-  TEST_ALGO_MACRO_V1V2_VARIAD(replace_copy, T{}, T{});
+  void modifying_seq_ops() {
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(replace_copy, T{}, T{});
+    TEST_ALGO_MACRO_V1V2_VARIAD(replace_copy, T{}, T{});
 
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(replace_copy_if, TrivialUnaryPredicate<T>(),
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(replace_copy_if, TrivialUnaryPredicate<T>(),
+                                  T{});
+    TEST_ALGO_MACRO_V1V2_VARIAD(replace_copy_if, TrivialUnaryPredicate<T>(),
                                 T{});
-  TEST_ALGO_MACRO_V1V2_VARIAD(replace_copy_if, TrivialUnaryPredicate<T>(), T{});
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(replace, T{}, T{});
-  TEST_ALGO_MACRO_V1_VARIAD(replace, T{}, T{});
+    TEST_ALGO_MACRO_B1E1_VARIAD(replace, T{}, T{});
+    TEST_ALGO_MACRO_V1_VARIAD(replace, T{}, T{});
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(replace_if, TrivialUnaryPredicate<T>(), T{});
-  TEST_ALGO_MACRO_V1_VARIAD(replace_if, TrivialUnaryPredicate<T>(), T{});
+    TEST_ALGO_MACRO_B1E1_VARIAD(replace_if, TrivialUnaryPredicate<T>(), T{});
+    TEST_ALGO_MACRO_V1_VARIAD(replace_if, TrivialUnaryPredicate<T>(), T{});
 
-  TEST_ALGO_MACRO_B1E1B2(copy);
-  TEST_ALGO_MACRO_V1V2(copy);
+    TEST_ALGO_MACRO_B1E1B2(copy);
+    TEST_ALGO_MACRO_V1V2(copy);
 
-  TEST_ALGO_MACRO_B1_ARG_B2(copy_n, count_type{});
-  TEST_ALGO_MACRO_V1_ARG_V2(copy_n, count_type{});
+    TEST_ALGO_MACRO_B1_ARG_B2(copy_n, count_type{});
+    TEST_ALGO_MACRO_V1_ARG_V2(copy_n, count_type{});
 
-  TEST_ALGO_MACRO_B1E1B2(copy_backward);
-  TEST_ALGO_MACRO_V1V2(copy_backward);
+    TEST_ALGO_MACRO_B1E1B2(copy_backward);
+    TEST_ALGO_MACRO_V1V2(copy_backward);
 
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(copy_if, TrivialUnaryPredicate<T>());
-  TEST_ALGO_MACRO_V1V2_VARIAD(copy_if, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(copy_if, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_V1V2_VARIAD(copy_if, TrivialUnaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(fill, T{});
-  TEST_ALGO_MACRO_V1_VARIAD(fill, T{});
+    TEST_ALGO_MACRO_B1E1_VARIAD(fill, T{});
+    TEST_ALGO_MACRO_V1_VARIAD(fill, T{});
 
-  TEST_ALGO_MACRO_B1_VARIAD(fill_n, count_type{}, T{});
-  TEST_ALGO_MACRO_V1_VARIAD(fill_n, count_type{}, T{});
+    TEST_ALGO_MACRO_B1_VARIAD(fill_n, count_type{}, T{});
+    TEST_ALGO_MACRO_V1_VARIAD(fill_n, count_type{}, T{});
 
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(transform, TrivialUnaryFunctor<T>{});
-  TEST_ALGO_MACRO_V1V2_VARIAD(transform, TrivialUnaryFunctor<T>{});
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(transform, TrivialUnaryFunctor<T>{});
+    TEST_ALGO_MACRO_V1V2_VARIAD(transform, TrivialUnaryFunctor<T>{});
 
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(transform, TrivialUnaryFunctor<T>{});
-  TEST_ALGO_MACRO_B1E1B2B3_VARIAD(transform, TrivialBinaryFunctor<T>{});
-  TEST_ALGO_MACRO_V1V2_VARIAD(transform, TrivialUnaryFunctor<T>{});
-  TEST_ALGO_MACRO_V1V2V3_VARIAD(transform, TrivialBinaryFunctor<T>{});
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(transform, TrivialUnaryFunctor<T>{});
+    TEST_ALGO_MACRO_B1E1B2B3_VARIAD(transform, TrivialBinaryFunctor<T>{});
+    TEST_ALGO_MACRO_V1V2_VARIAD(transform, TrivialUnaryFunctor<T>{});
+    TEST_ALGO_MACRO_V1V2V3_VARIAD(transform, TrivialBinaryFunctor<T>{});
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(generate, TrivialGenerator<T>{});
-  TEST_ALGO_MACRO_V1_VARIAD(generate, TrivialGenerator<T>{});
+    TEST_ALGO_MACRO_B1E1_VARIAD(generate, TrivialGenerator<T>{});
+    TEST_ALGO_MACRO_V1_VARIAD(generate, TrivialGenerator<T>{});
 
-  TEST_ALGO_MACRO_B1_VARIAD(generate_n, count_type{}, TrivialGenerator<T>{});
-  TEST_ALGO_MACRO_V1_VARIAD(generate_n, count_type{}, TrivialGenerator<T>{});
+    TEST_ALGO_MACRO_B1_VARIAD(generate_n, count_type{}, TrivialGenerator<T>{});
+    TEST_ALGO_MACRO_V1_VARIAD(generate_n, count_type{}, TrivialGenerator<T>{});
 
-  TEST_ALGO_MACRO_B1E1B2(reverse_copy);
-  TEST_ALGO_MACRO_V1V2(reverse_copy);
+    TEST_ALGO_MACRO_B1E1B2(reverse_copy);
+    TEST_ALGO_MACRO_V1V2(reverse_copy);
 
-  TEST_ALGO_MACRO_B1E1(reverse);
-  TEST_ALGO_MACRO_V1(reverse);
+    TEST_ALGO_MACRO_B1E1(reverse);
+    TEST_ALGO_MACRO_V1(reverse);
 
-  TEST_ALGO_MACRO_B1E1B2(move);
-  TEST_ALGO_MACRO_V1V2(move);
+    TEST_ALGO_MACRO_B1E1B2(move);
+    TEST_ALGO_MACRO_V1V2(move);
 
-  TEST_ALGO_MACRO_B1E1E2(move_backward);
-  TEST_ALGO_MACRO_V1V2(move_backward);
+    TEST_ALGO_MACRO_B1E1E2(move_backward);
+    TEST_ALGO_MACRO_V1V2(move_backward);
 
-  TEST_ALGO_MACRO_B1E1B2(swap_ranges);
-  TEST_ALGO_MACRO_V1V2(swap_ranges);
+    TEST_ALGO_MACRO_B1E1B2(swap_ranges);
+    TEST_ALGO_MACRO_V1V2(swap_ranges);
 
-  TEST_ALGO_MACRO_B1E1(unique);
-  TEST_ALGO_MACRO_V1(unique);
-  TEST_ALGO_MACRO_B1E1_VARIAD(unique, TrivialBinaryPredicate<T>{});
-  TEST_ALGO_MACRO_V1_VARIAD(unique, TrivialBinaryPredicate<T>{});
+    TEST_ALGO_MACRO_B1E1(unique);
+    TEST_ALGO_MACRO_V1(unique);
+    TEST_ALGO_MACRO_B1E1_VARIAD(unique, TrivialBinaryPredicate<T>{});
+    TEST_ALGO_MACRO_V1_VARIAD(unique, TrivialBinaryPredicate<T>{});
 
-  TEST_ALGO_MACRO_B1E1B2(unique_copy);
-  TEST_ALGO_MACRO_V1V2(unique_copy);
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(unique_copy, TrivialBinaryPredicate<T>{});
-  TEST_ALGO_MACRO_V1V2_VARIAD(unique_copy, TrivialBinaryPredicate<T>{});
+    TEST_ALGO_MACRO_B1E1B2(unique_copy);
+    TEST_ALGO_MACRO_V1V2(unique_copy);
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(unique_copy, TrivialBinaryPredicate<T>{});
+    TEST_ALGO_MACRO_V1V2_VARIAD(unique_copy, TrivialBinaryPredicate<T>{});
 
-  TEST_ALGO_MACRO_B1E1E2(rotate);
-  TEST_ALGO_MACRO_V1_VARIAD(rotate, count_type{});
+    TEST_ALGO_MACRO_B1E1E2(rotate);
+    TEST_ALGO_MACRO_V1_VARIAD(rotate, count_type{});
 
-  TEST_ALGO_MACRO_B1E1E1B2(rotate_copy);
-  TEST_ALGO_MACRO_V1_ARG_V2(rotate_copy, count_type{});
+    TEST_ALGO_MACRO_B1E1E1B2(rotate_copy);
+    TEST_ALGO_MACRO_V1_ARG_V2(rotate_copy, count_type{});
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(remove_if, TrivialUnaryPredicate<T>{});
-  TEST_ALGO_MACRO_V1_VARIAD(remove_if, TrivialUnaryPredicate<T>{});
+    TEST_ALGO_MACRO_B1E1_VARIAD(remove_if, TrivialUnaryPredicate<T>{});
+    TEST_ALGO_MACRO_V1_VARIAD(remove_if, TrivialUnaryPredicate<T>{});
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(remove, T{});
-  TEST_ALGO_MACRO_V1_VARIAD(remove, T{});
+    TEST_ALGO_MACRO_B1E1_VARIAD(remove, T{});
+    TEST_ALGO_MACRO_V1_VARIAD(remove, T{});
 
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(remove_copy, T{});
-  TEST_ALGO_MACRO_V1V2_VARIAD(remove_copy, T{});
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(remove_copy, T{});
+    TEST_ALGO_MACRO_V1V2_VARIAD(remove_copy, T{});
 
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(remove_copy_if, TrivialUnaryPredicate<T>());
-  TEST_ALGO_MACRO_V1V2_VARIAD(remove_copy_if, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(remove_copy_if, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_V1V2_VARIAD(remove_copy_if, TrivialUnaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(shift_left, count_type{});
-  TEST_ALGO_MACRO_V1_VARIAD(shift_left, count_type{});
+    TEST_ALGO_MACRO_B1E1_VARIAD(shift_left, count_type{});
+    TEST_ALGO_MACRO_V1_VARIAD(shift_left, count_type{});
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(shift_right, count_type{});
-  TEST_ALGO_MACRO_V1_VARIAD(shift_right, count_type{});
-}
+    TEST_ALGO_MACRO_B1E1_VARIAD(shift_right, count_type{});
+    TEST_ALGO_MACRO_V1_VARIAD(shift_right, count_type{});
+  }
 
-void sorting_ops() {
-  TEST_ALGO_MACRO_B1E1(is_sorted_until);
-  TEST_ALGO_MACRO_V1(is_sorted_until);
+  void sorting_ops() {
+    TEST_ALGO_MACRO_B1E1(is_sorted_until);
+    TEST_ALGO_MACRO_V1(is_sorted_until);
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
-  TEST_ALGO_MACRO_B1E1_VARIAD(is_sorted_until, TrivialComparator<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(is_sorted_until, TrivialComparator<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(is_sorted_until, TrivialComparator<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(is_sorted_until, TrivialComparator<T>());
 #endif
 
-  TEST_ALGO_MACRO_B1E1(is_sorted);
-  TEST_ALGO_MACRO_V1(is_sorted);
+    TEST_ALGO_MACRO_B1E1(is_sorted);
+    TEST_ALGO_MACRO_V1(is_sorted);
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
-  TEST_ALGO_MACRO_B1E1_VARIAD(is_sorted, TrivialComparator<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(is_sorted, TrivialComparator<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(is_sorted, TrivialComparator<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(is_sorted, TrivialComparator<T>());
 #endif
-}
+  }
 
-void minmax_ops() {
-  TEST_ALGO_MACRO_B1E1(min_element);
-  TEST_ALGO_MACRO_V1(min_element);
-  TEST_ALGO_MACRO_B1E1(max_element);
-  TEST_ALGO_MACRO_V1(max_element);
-  TEST_ALGO_MACRO_B1E1(minmax_element);
-  TEST_ALGO_MACRO_V1(minmax_element);
+  void minmax_ops() {
+    TEST_ALGO_MACRO_B1E1(min_element);
+    TEST_ALGO_MACRO_V1(min_element);
+    TEST_ALGO_MACRO_B1E1(max_element);
+    TEST_ALGO_MACRO_V1(max_element);
+    TEST_ALGO_MACRO_B1E1(minmax_element);
+    TEST_ALGO_MACRO_V1(minmax_element);
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
-  TEST_ALGO_MACRO_B1E1_VARIAD(min_element, TrivialComparator<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(min_element, TrivialComparator<T>());
-  TEST_ALGO_MACRO_B1E1_VARIAD(max_element, TrivialComparator<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(max_element, TrivialComparator<T>());
-  TEST_ALGO_MACRO_B1E1_VARIAD(minmax_element, TrivialComparator<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(minmax_element, TrivialComparator<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(min_element, TrivialComparator<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(min_element, TrivialComparator<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(max_element, TrivialComparator<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(max_element, TrivialComparator<T>());
+    TEST_ALGO_MACRO_B1E1_VARIAD(minmax_element, TrivialComparator<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(minmax_element, TrivialComparator<T>());
 #endif
-}
+  }
 
-void partitionig_ops() {
-  TEST_ALGO_MACRO_B1E1_VARIAD(is_partitioned, TrivialUnaryPredicate<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(is_partitioned, TrivialUnaryPredicate<T>());
+  void partitionig_ops() {
+    TEST_ALGO_MACRO_B1E1_VARIAD(is_partitioned, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(is_partitioned, TrivialUnaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1B2B3_VARIAD(partition_copy, TrivialUnaryPredicate<T>());
-  TEST_ALGO_MACRO_V1V2V3_VARIAD(partition_copy, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_B1E1B2B3_VARIAD(partition_copy, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_V1V2V3_VARIAD(partition_copy, TrivialUnaryPredicate<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(partition_point, TrivialUnaryPredicate<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(partition_point, TrivialUnaryPredicate<T>());
-}
+    TEST_ALGO_MACRO_B1E1_VARIAD(partition_point, TrivialUnaryPredicate<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(partition_point, TrivialUnaryPredicate<T>());
+  }
 
-void numeric() {
-  TEST_ALGO_MACRO_B1E1B2(adjacent_difference);
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(adjacent_difference, TrivialBinaryFunctor<T>());
-  TEST_ALGO_MACRO_V1V2(adjacent_difference);
-  TEST_ALGO_MACRO_V1V2_VARIAD(adjacent_difference, TrivialBinaryFunctor<T>());
+  void numeric() {
+    TEST_ALGO_MACRO_B1E1B2(adjacent_difference);
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(adjacent_difference,
+                                  TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_V1V2(adjacent_difference);
+    TEST_ALGO_MACRO_V1V2_VARIAD(adjacent_difference, TrivialBinaryFunctor<T>());
 
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(exclusive_scan, T{});
-  TEST_ALGO_MACRO_V1V2_VARIAD(exclusive_scan, T{});
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(exclusive_scan, T{});
+    TEST_ALGO_MACRO_V1V2_VARIAD(exclusive_scan, T{});
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(exclusive_scan, T{}, TrivialBinaryFunctor<T>());
-  TEST_ALGO_MACRO_V1V2_VARIAD(exclusive_scan, T{}, TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(exclusive_scan, T{},
+                                  TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_V1V2_VARIAD(exclusive_scan, T{}, TrivialBinaryFunctor<T>());
 
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(transform_exclusive_scan, T{},
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(transform_exclusive_scan, T{},
+                                  TrivialBinaryFunctor<T>(),
+                                  TrivialUnaryFunctor<T>());
+    TEST_ALGO_MACRO_V1V2_VARIAD(transform_exclusive_scan, T{},
                                 TrivialBinaryFunctor<T>(),
                                 TrivialUnaryFunctor<T>());
-  TEST_ALGO_MACRO_V1V2_VARIAD(transform_exclusive_scan, T{},
-                              TrivialBinaryFunctor<T>(),
-                              TrivialUnaryFunctor<T>());
 #endif
 
-  TEST_ALGO_MACRO_B1E1B2(inclusive_scan);
-  TEST_ALGO_MACRO_V1V2(inclusive_scan);
+    TEST_ALGO_MACRO_B1E1B2(inclusive_scan);
+    TEST_ALGO_MACRO_V1V2(inclusive_scan);
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(inclusive_scan, TrivialBinaryFunctor<T>());
-  TEST_ALGO_MACRO_V1V2_VARIAD(inclusive_scan, TrivialBinaryFunctor<T>());
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(inclusive_scan, TrivialBinaryFunctor<T>(), T{});
-  TEST_ALGO_MACRO_V1V2_VARIAD(inclusive_scan, TrivialBinaryFunctor<T>(), T{});
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(inclusive_scan, TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_V1V2_VARIAD(inclusive_scan, TrivialBinaryFunctor<T>());
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(inclusive_scan, TrivialBinaryFunctor<T>(),
+                                  T{});
+    TEST_ALGO_MACRO_V1V2_VARIAD(inclusive_scan, TrivialBinaryFunctor<T>(), T{});
 
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(transform_inclusive_scan,
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(transform_inclusive_scan,
+                                  TrivialBinaryFunctor<T>(),
+                                  TrivialUnaryFunctor<T>());
+    TEST_ALGO_MACRO_V1V2_VARIAD(transform_inclusive_scan,
                                 TrivialBinaryFunctor<T>(),
                                 TrivialUnaryFunctor<T>());
-  TEST_ALGO_MACRO_V1V2_VARIAD(transform_inclusive_scan,
-                              TrivialBinaryFunctor<T>(),
-                              TrivialUnaryFunctor<T>());
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(transform_inclusive_scan,
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(transform_inclusive_scan,
+                                  TrivialBinaryFunctor<T>(),
+                                  TrivialUnaryFunctor<T>(), T{});
+    TEST_ALGO_MACRO_V1V2_VARIAD(transform_inclusive_scan,
                                 TrivialBinaryFunctor<T>(),
                                 TrivialUnaryFunctor<T>(), T{});
-  TEST_ALGO_MACRO_V1V2_VARIAD(transform_inclusive_scan,
-                              TrivialBinaryFunctor<T>(),
-                              TrivialUnaryFunctor<T>(), T{});
 #endif
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
-  TEST_ALGO_MACRO_B1E1(reduce);
-  TEST_ALGO_MACRO_V1(reduce);
-  TEST_ALGO_MACRO_B1E1_VARIAD(reduce, T{});
-  TEST_ALGO_MACRO_V1_VARIAD(reduce, T{});
-  TEST_ALGO_MACRO_B1E1_VARIAD(reduce, T{}, TrivialReduceJoinFunctor<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(reduce, T{}, TrivialReduceJoinFunctor<T>());
+    TEST_ALGO_MACRO_B1E1(reduce);
+    TEST_ALGO_MACRO_V1(reduce);
+    TEST_ALGO_MACRO_B1E1_VARIAD(reduce, T{});
+    TEST_ALGO_MACRO_V1_VARIAD(reduce, T{});
+    TEST_ALGO_MACRO_B1E1_VARIAD(reduce, T{}, TrivialReduceJoinFunctor<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(reduce, T{}, TrivialReduceJoinFunctor<T>());
 
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(transform_reduce, T{});
-  TEST_ALGO_MACRO_V1V2_VARIAD(transform_reduce, T{});
-  TEST_ALGO_MACRO_B1E1B2_VARIAD(transform_reduce, T{},
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(transform_reduce, T{});
+    TEST_ALGO_MACRO_V1V2_VARIAD(transform_reduce, T{});
+    TEST_ALGO_MACRO_B1E1B2_VARIAD(transform_reduce, T{},
+                                  TrivialReduceJoinFunctor<T>(),
+                                  TrivialTransformReduceBinaryTransformer<T>());
+    TEST_ALGO_MACRO_V1V2_VARIAD(transform_reduce, T{},
                                 TrivialReduceJoinFunctor<T>(),
                                 TrivialTransformReduceBinaryTransformer<T>());
-  TEST_ALGO_MACRO_V1V2_VARIAD(transform_reduce, T{},
-                              TrivialReduceJoinFunctor<T>(),
-                              TrivialTransformReduceBinaryTransformer<T>());
 
-  TEST_ALGO_MACRO_B1E1_VARIAD(transform_reduce, T{},
+    TEST_ALGO_MACRO_B1E1_VARIAD(transform_reduce, T{},
+                                TrivialReduceJoinFunctor<T>(),
+                                TrivialTransformReduceUnaryTransformer<T>());
+    TEST_ALGO_MACRO_V1_VARIAD(transform_reduce, T{},
                               TrivialReduceJoinFunctor<T>(),
                               TrivialTransformReduceUnaryTransformer<T>());
-  TEST_ALGO_MACRO_V1_VARIAD(transform_reduce, T{},
-                            TrivialReduceJoinFunctor<T>(),
-                            TrivialTransformReduceUnaryTransformer<T>());
 #endif
-}
+  }
+};
 
 }  // namespace compileonly
 }  // namespace stdalgos


### PR DESCRIPTION
One of my collaborators complained that TestStdAlgorithmsCompileOnly fails as runtime since it uses global `View` objects. Although we intend this test to be a compile-time test, making it runnable seems sensible to avoid confusion.