### PR TITLE
Remove two-argument constructor for `CudaLDGFetch`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -97,11 +97,8 @@ struct CudaLDGFetch {
     return *this;
   }
 
-  template <class CudaMemorySpace>
-  inline explicit CudaLDGFetch(
-      const ValueType* const arg_ptr,
-      Kokkos::Impl::SharedAllocationRecord<CudaMemorySpace, void>*)
-      : m_ptr(arg_ptr) {}
+  KOKKOS_INLINE_FUNCTION
+  explicit CudaLDGFetch(const ValueType* const arg_ptr) : m_ptr(arg_ptr) {}
 
   KOKKOS_INLINE_FUNCTION
   CudaLDGFetch(CudaLDGFetch const rhs, size_t offset)
@@ -117,7 +114,7 @@ struct CudaLDGFetch {
 namespace Kokkos {
 namespace Impl {
 
-/** \brief  Replace Default ViewDataHandle with Cuda texture fetch
+/** \brief  Replace Default ViewDataHandle with CudaLDGFetch
  * specialization if 'const' value type, CudaSpace and random access.
  */
 template <class Traits>
@@ -165,26 +162,9 @@ class ViewDataHandle<
 
   KOKKOS_INLINE_FUNCTION
   static handle_type assign(value_type* arg_data_ptr,
-                            track_type const& arg_tracker) {
+                            track_type const& /*arg_tracker*/) {
     if (arg_data_ptr == nullptr) return handle_type();
-
-    KOKKOS_IF_ON_HOST((
-        // Assignment of texture = non-texture requires creation of a texture
-        // object which can only occur on the host.  In addition, 'get_record'
-        // is only valid if called in a host execution space
-
-        using memory_space = typename Traits::memory_space;
-        using record =
-            typename Impl::SharedAllocationRecord<memory_space, void>;
-
-        record* const r = arg_tracker.template get_record<memory_space>();
-
-        return handle_type(arg_data_ptr, r);))
-
-    KOKKOS_IF_ON_DEVICE(
-        ((void)arg_tracker; Kokkos::Impl::cuda_abort(
-             "Cannot create Cuda texture object from within a Cuda kernel");
-         return handle_type();))
+    return handle_type(arg_data_ptr);
   }
 };
 

--- a/core/unit_test/cuda/TestCuda_Spaces.cpp
+++ b/core/unit_test/cuda/TestCuda_Spaces.cpp
@@ -375,4 +375,74 @@ TEST(cuda, impl_view_texture) {
   TestViewCudaTexture<Kokkos::CudaUVMSpace>::run();
 }
 
+// couldn't create a random-access subview of a view of const T in Kokkos::Cuda
+namespace issue_5594 {
+
+template <typename View>
+struct InitFunctor {
+  InitFunctor(const View &view) : view_(view) {}
+  KOKKOS_INLINE_FUNCTION
+  void operator()(int i) const { view_(i) = i; }
+  View view_;
+};
+
+template <typename V1, typename V2>
+struct Issue5594Functor {
+  Issue5594Functor(const V1 &v1) : v1_(v1) {}
+  KOKKOS_INLINE_FUNCTION
+  void operator()(int i, int &lerr) const {
+    V2 v2(&v1_(0),
+          v1_.size());  // failure here -- create subview in execution space
+    lerr += v1_(i) != v2(i);  // check that subview is correct
+  }
+  V1 v1_;
+};
+
+template <typename View>
+View create_view() {
+  using execution_space = typename View::execution_space;
+  View view("", 10);
+  InitFunctor iota(view);
+  Kokkos::parallel_for("test_view_subview_const_randomaccess",
+                       Kokkos::RangePolicy<execution_space>(0, view.extent(0)),
+                       iota);
+  return view;
+}
+
+// creating a RandomAccess subview of a view of const T in Kokkos::Cuda
+template <typename Exec, typename Mem>
+void test_view_subview_const_randomaccess() {
+  using view_t         = Kokkos::View<int *, Mem>;
+  using view_const_t   = Kokkos::View<const int *, Mem>;
+  using u_view_const_t = Kokkos::View<
+      const int *, Mem,
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
+
+  // create non-const view with known values
+  view_t nonConst = create_view<view_t>();
+  // get a const version of the values
+  view_const_t view(nonConst);
+
+  // create a subview in the execution space and check that it worked
+  Issue5594Functor<view_const_t, u_view_const_t> checker(view);
+  int errCount;
+  Kokkos::parallel_reduce("test_view_subview_const_randomaccess",
+                          Kokkos::RangePolicy<Exec>(0, view.extent(0)), checker,
+                          errCount);
+  EXPECT_TRUE(0 == errCount);
+}
+}  // namespace issue_5594
+
+TEST(cuda, view_subview_const_randomaccess) {
+#if defined(KOKKOS_ENABLE_CUDA) && \
+    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC (similar failure to
+                                    // TestViewCudaTexture?)
+  GTEST_SKIP() << "RandomAccess view not working on NVHPC?";
+#endif
+  issue_5594::test_view_subview_const_randomaccess<Kokkos::Cuda,
+                                                   Kokkos::CudaSpace>();
+  issue_5594::test_view_subview_const_randomaccess<Kokkos::Cuda,
+                                                   Kokkos::CudaUVMSpace>();
+}
+
 }  // namespace Test


### PR DESCRIPTION
Kokkos_Cuda_View.hpp:232 uses `CudaLDGFetch` as the `handle_type` for `ViewDataHandle`.

Kokkos_ViewMapping.hpp:3398 tried to construct `handle_type m_impl_handle` with a single `Impl::get_property<Impl::PointerTag>(arg_prop)` argument

There is no such single-argument `CudaLDGFetch` constructor, though there is one that takes two arguments and ignores the second:
```c++
  template <class CudaMemorySpace>
  inline explicit CudaLDGFetch(
      const ValueType* const arg_ptr,
      Kokkos::Impl::SharedAllocationRecord<CudaMemorySpace, void>*)
      : m_ptr(arg_ptr) {}
```

I propose to add a new `CudaLDGFetch` constructor that only has the first argument:
```c++
  inline explicit CudaLDGFetch(
      const ValueType* const arg_ptr)
      : m_ptr(arg_ptr) {}
```