### PR TITLE
Update CUDA occupancy calculation to reflect register allocation granularity of 256 registers per warp

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -57,9 +57,11 @@ inline int cuda_max_active_blocks_per_sm(cudaDeviceProp const& properties,
                                          cudaFuncAttributes const& attributes,
                                          int block_size, size_t dynamic_shmem) {
   // Limits due do registers/SM
-  int const regs_per_sm     = properties.regsPerMultiprocessor;
-  int const regs_per_thread = attributes.numRegs;
-  int const max_blocks_regs = regs_per_sm / (regs_per_thread * block_size);
+  // The granularity of register allocation is chunks of 256 registers per warp -> 8 registers per thread
+  int const regs_per_sm               = properties.regsPerMultiprocessor;
+  int const regs_per_thread           = attributes.numRegs;
+  int const allocated_regs_per_thread = 8 * ((regs_per_thread + 8 - 1) / 8);
+  int const max_blocks_regs           = regs_per_sm / (allocated_regs_per_thread * block_size);
 
   // Limits due to shared memory/SM
   size_t const shmem_per_sm            = properties.sharedMemPerMultiprocessor;

--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -57,11 +57,13 @@ inline int cuda_max_active_blocks_per_sm(cudaDeviceProp const& properties,
                                          cudaFuncAttributes const& attributes,
                                          int block_size, size_t dynamic_shmem) {
   // Limits due do registers/SM
-  // The granularity of register allocation is chunks of 256 registers per warp -> 8 registers per thread
-  int const regs_per_sm               = properties.regsPerMultiprocessor;
-  int const regs_per_thread           = attributes.numRegs;
+  int const regs_per_sm     = properties.regsPerMultiprocessor;
+  int const regs_per_thread = attributes.numRegs;
+  // The granularity of register allocation is chunks of 256 registers per warp
+  // -> 8 registers per thread
   int const allocated_regs_per_thread = 8 * ((regs_per_thread + 8 - 1) / 8);
-  int const max_blocks_regs           = regs_per_sm / (allocated_regs_per_thread * block_size);
+  int const max_blocks_regs =
+      regs_per_sm / (allocated_regs_per_thread * block_size);
 
   // Limits due to shared memory/SM
   size_t const shmem_per_sm            = properties.sharedMemPerMultiprocessor;


### PR DESCRIPTION
This PR was motivated by noticing large end-to-end performance variations in LAMMPS due to trivial changes in register allocations from CUDA version to CUDA version. In particular, the Lennard-Jones benchmark in LAMMPS saw a ~15% regression on A100-80GB going from CUDA 11.5 to CUDA 11.7, where the only change of substance was the register allocation going from `41` to `43`. In this case, Kokkos's current calculation triggered a blocksize change which reduced the performance, when in reality the blocksize that maximizes occupancy had not changed.

This PR updates Kokkos' occupancy calculation for the CUDA backend to reflect how the register granularity (for Kepler+) is 256 registers per warp, or equivalently 8 registers per thread, addressing the issue above. This is in contrast to earlier architectures which had finer allocation granularities. The overall premise of this PR was discussed with @crtrott offline.

This register granularity is publicly documented via the occupancy calculator in recent versions of Nsight Compute (Register Allocation Unit Size == 256, Register Allocation Granularity == warp). It can also be backed out programmatically from the public header `cuda_occupancy.h` that comes with the CUDA toolkit via the function `cudaOccRegAllocationGranularity` (which returns 256 for compute versions 3.*, 5.*, 6.*, 7.*, 8.*, and as of CUDA 11.8 9.*) plus a subset of the logic within the function `cudaOccMaxBlocksPerSMRegsLimit` which explicitly calculates the allocated registers per warp via:

```
regsPerWarp          = attributes->numRegs * properties->warpSize;
regsAllocatedPerWarp = __occRoundUp(regsPerWarp, allocationGranularity);
```

(Note: the granularity is also technically noted in the CUDA programming guide, but there is a known typo stating the granularity is per-block as opposed to the correct per-warp.)

This PR has been confirmed to make the maximum number of blocks per register at fixed register count agree with Nsight Systems/Compute for functions whose occupancy is bound by register count (as opposed to shared memory, max blocks per SM, etc.)

Of course, this PR is not without consequence, because occupancy ~= performance, as opposed to occupancy == performance. Applications that are sensitive to cache reuse, such as molecular dynamics, may indeed see performance regressions because "incorrectly" sub-optimal occupancy happened to lead to better behavior due to reduced cache thrashing. That said, since more occupancy _generally_ leads to better performance, this should in general be a win.

Final thoughts:
 * This change makes the maximum number of blocks (for register-count-bound occupancies) functionally correct.
 * By extension, this change would make the maximum occupancy match what's reported in various NVIDIA profiling tools, etc.
 * The change is justifiable based on public information, and can be derived directly from included APIs (i.e., "no magic numbers")
 * More often than not, higher occupancy does translate to better performance
 * If need be, mechanisms to override the occupancy heuristics (tiling for `MDRangePolicy`, explicit team sizes for `TeamPolicy`) already exist and should (already) be used by developers who desire every ounce of performance.