### PR TITLE
SYCL: Set RangePolicy default chunk_size to 1

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -213,11 +213,11 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
  private:
   /** \brief finalize chunk_size if it was set to AUTO*/
   inline void set_auto_chunk_size() {
-    // chunk_size <=1 lets the compiler choose the workgroup size when launching
-    // kernels
 #ifdef KOKKOS_ENABLE_SYCL
     if (std::is_same_v<typename traits::execution_space,
                        Kokkos::Experimental::SYCL>) {
+      // chunk_size <=1 lets the compiler choose the workgroup size when
+      // launching kernels
       m_granularity      = 1;
       m_granularity_mask = 0;
       return;

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -213,6 +213,16 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
  private:
   /** \brief finalize chunk_size if it was set to AUTO*/
   inline void set_auto_chunk_size() {
+    // chunk_size <=1 lets the compiler choose the workgroup size when launching
+    // kernels
+#ifdef KOKKOS_ENABLE_SYCL
+    if (std::is_same_v<typename traits::execution_space,
+                       Kokkos::Experimental::SYCL>) {
+      m_granularity      = 1;
+      m_granularity_mask = 0;
+      return;
+    }
+#endif
     int64_t concurrency =
         static_cast<int64_t>(traits::execution_space::concurrency());
     if (concurrency == 0) concurrency = 1;


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/4875 allowed using `chunk_size` to force a workgroup size.
It turns out that for very large ranges, the default `chunk_size` is greater than 1 (see for the full logic below) resulting in performance regressions for some apps.
This pull request just forces the default chunk size for `SYCL` to be 1 so that the workgroup size is determined by the compiler.   