### PR TITLE
Update deprecated GitHub actions

### DIFF
--- a/.github/workflows/continuous-integration-workflow-hpx.yml
+++ b/.github/workflows/continuous-integration-workflow-hpx.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v2.2.0
+        uses: actions/checkout@v3
         with:
           path: kokkos
       - name: setup hpx dependencies
@@ -26,12 +26,12 @@ jobs:
             libboost-all-dev \
             ninja-build
       - name: checkout hpx
-        uses: actions/checkout@v2.2.0
+        uses: actions/checkout@v3
         with:
           repository: STELLAR-GROUP/hpx
           ref: 1.7.1
           path: hpx
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id:   cache-hpx
         with:
           path:         ./hpx/install

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -52,7 +52,7 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout desul
-        uses: actions/checkout@v2.2.0
+        uses: actions/checkout@v3
         with:
           repository: desul/desul
           ref: 477da9c8f40f8db369c28dd3f93a67e376d8511b
@@ -67,8 +67,8 @@ jobs:
           cmake -DDESUL_ENABLE_TESTS=OFF -DCMAKE_INSTALL_PREFIX=/usr/desul-install ..
           sudo cmake --build . --target install --parallel 2
       - name: Checkout code
-        uses: actions/checkout@v2.2.0
-      - uses: actions/cache@v2
+        uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: ~/.ccache
           key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${github.ref}-${{ github.sha }}

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -24,7 +24,7 @@ jobs:
             cmake_build_type: "Release"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: configure
         run:
           cmake -B build .


### PR DESCRIPTION
Addressing https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.