### PR TITLE
Remove pre C++17 workarounds and use fold expressions

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -209,11 +209,9 @@ inline void create_Cuda_instances(std::vector<Cuda>& instances) {
 
 template <class... Args>
 std::vector<Cuda> partition_space(const Cuda&, Args...) {
-#ifdef __cpp_fold_expressions
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-#endif
   std::vector<Cuda> instances(sizeof...(Args));
   Impl::create_Cuda_instances(instances);
   return instances;

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -181,11 +181,9 @@ inline void create_HIP_instances(std::vector<HIP> &instances) {
 
 template <class... Args>
 std::vector<HIP> partition_space(const HIP &, Args...) {
-#ifdef __cpp_fold_expressions
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-#endif
 
   std::vector<HIP> instances(sizeof...(Args));
   Impl::create_HIP_instances(instances);

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -288,11 +288,9 @@ std::vector<ExecSpace> partition_space(ExecSpace space, Args...) {
   static_assert(is_execution_space<ExecSpace>::value,
                 "Kokkos Error: partition_space expects an Execution Space as "
                 "first argument");
-#ifdef __cpp_fold_expressions
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-#endif
   std::vector<ExecSpace> instances(sizeof...(Args));
   for (int s = 0; s < int(sizeof...(Args)); s++) instances[s] = space;
   return instances;

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -58,8 +58,6 @@
 // GraphAccess needs to be defined, not just declared
 #include <impl/Kokkos_GraphImpl.hpp>
 
-#include <impl/Kokkos_Utilities.hpp>  // fold emulation
-
 #include <functional>
 #include <memory>
 
@@ -145,8 +143,7 @@ auto when_all(PredecessorRefs&&... arg_pred_refs) {
           .lock();
   auto node_ptr_impl = graph_ptr_impl->create_aggregate_ptr(arg_pred_refs...);
   graph_ptr_impl->add_node(node_ptr_impl);
-  KOKKOS_IMPL_FOLD_COMMA_OPERATOR(
-      graph_ptr_impl->add_predecessor(node_ptr_impl, arg_pred_refs) /* ... */);
+  (graph_ptr_impl->add_predecessor(node_ptr_impl, arg_pred_refs), ...);
   return Kokkos::Impl::GraphAccess::make_graph_node_ref(
       std::move(graph_ptr_impl), std::move(node_ptr_impl));
 }

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -176,11 +176,9 @@ struct DeviceTypeTraits<Kokkos::Experimental::SYCL> {
 namespace Experimental {
 template <class... Args>
 std::vector<SYCL> partition_space(const SYCL& sycl_space, Args...) {
-#ifdef __cpp_fold_expressions
   static_assert(
       (... && std::is_arithmetic_v<Args>),
       "Kokkos Error: partitioning arguments must be integers or floats");
-#endif
 
   sycl::context context = sycl_space.sycl_queue().get_context();
   sycl::device device =

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -103,26 +103,6 @@ struct is_specialization_of<Template<Args...>, Template> : std::true_type {};
 //==============================================================================
 
 //==============================================================================
-// <editor-fold desc="Folding emulation"> {{{1
-
-// acts like void for comma fold emulation
-struct _fold_comma_emulation_return {};
-
-template <class... Ts>
-constexpr KOKKOS_INLINE_FUNCTION _fold_comma_emulation_return
-emulate_fold_comma_operator(Ts&&...) noexcept {
-  return _fold_comma_emulation_return{};
-}
-
-#define KOKKOS_IMPL_FOLD_COMMA_OPERATOR(expr)                                \
-  ::Kokkos::Impl::emulate_fold_comma_operator(                               \
-      ::std::initializer_list<::Kokkos::Impl::_fold_comma_emulation_return>{ \
-          ((expr), ::Kokkos::Impl::_fold_comma_emulation_return{})...})
-
-// </editor-fold> end Folding emulation }}}1
-//==============================================================================
-
-//==============================================================================
 // destruct_delete is a unique_ptr deleter for objects
 // created by placement new into already allocated memory
 // by only calling the destructor on the object.

--- a/core/unit_test/TestUtilities.hpp
+++ b/core/unit_test/TestUtilities.hpp
@@ -69,22 +69,4 @@ void test_is_specialization_of() {
                 "");
 }
 
-template <std::size_t... Idxs, class... Args>
-std::size_t do_comma_emulation_test(std::integer_sequence<std::size_t, Idxs...>,
-                                    Args... args) {
-  // Count the bugs, since ASSERT_EQ is a statement and not an expression
-  std::size_t bugs = 0;
-  // Ensure in-order evaluation
-  std::size_t i = 0;
-  KOKKOS_IMPL_FOLD_COMMA_OPERATOR(bugs += std::size_t(Idxs != i++) /*, ...*/);
-  // Ensure expansion of multiple packs works
-  KOKKOS_IMPL_FOLD_COMMA_OPERATOR(bugs += std::size_t(Idxs != args) /*, ...*/);
-  return bugs;
-}
-
-TEST(utilities, comma_operator_emulation) {
-  ASSERT_EQ(0u, do_comma_emulation_test(std::make_index_sequence<5>{}, 0, 1, 2,
-                                        3, 4));
-}
-
 }  // namespace Test

--- a/core/unit_test/tools/include/ToolTestingUtilities.hpp
+++ b/core/unit_test/tools/include/ToolTestingUtilities.hpp
@@ -131,7 +131,7 @@ struct function_traits<R (*)(A...)> {
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if ((... && !std::dynamic_pointer_cast<A>(std::forward<Args>(args)))) {
+    if ((!std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
     return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);
@@ -155,7 +155,7 @@ struct function_traits<R (C::*)(A...)> {
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if ((... && !std::dynamic_pointer_cast<A>(std::forward<Args>(args)))) {
+    if ((!std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
     return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);
@@ -180,7 +180,7 @@ struct function_traits<R (C::*)(A...) const>  // const
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if ((... && !std::dynamic_pointer_cast<A>(std::forward<Args>(args)))) {
+    if ((!std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
     return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);

--- a/core/unit_test/tools/include/ToolTestingUtilities.hpp
+++ b/core/unit_test/tools/include/ToolTestingUtilities.hpp
@@ -131,7 +131,7 @@ struct function_traits<R (*)(A...)> {
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if ((!std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
+    if (!(std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
     return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);
@@ -155,7 +155,7 @@ struct function_traits<R (C::*)(A...)> {
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if ((!std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
+    if (!(std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
     return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);
@@ -180,7 +180,7 @@ struct function_traits<R (C::*)(A...) const>  // const
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if ((!std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
+    if (!(std::dynamic_pointer_cast<A>(std::forward<Args>(args)) && ...)) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
     return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);

--- a/core/unit_test/tools/include/ToolTestingUtilities.hpp
+++ b/core/unit_test/tools/include/ToolTestingUtilities.hpp
@@ -93,28 +93,6 @@ using EventBasePtr = std::shared_ptr<EventBase>;
 using event_vector = std::vector<EventBasePtr>;
 
 /**
- * @brief Base case of a recursive reduction using templates
- * Should be replaced with a fold in C++17
- */
-
-inline bool are_valid() { return true; }
-
-/**
- * @brief Recursive reduction to check whether any pointer in a set is null
- *
- * @tparam Head Type of the pointer to examine
- * @tparam Tail Types of the rest of the pointers
- * @param head The pointer to examine
- * @param tail The rest of the pointers
- * @return true if no pointer is null, false otherwise
- *
- */
-template <class Head, class... Tail>
-bool are_valid(const Head& head, const Tail&... tail) {
-  return (head != nullptr) && (are_valid(tail...));
-}
-
-/**
  * @brief In order to call some arbitrary set of lambdas representing matchers,
  * we need the ability to look at a lambda, and deduce its arguments.
  *
@@ -153,7 +131,7 @@ struct function_traits<R (*)(A...)> {
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if (!are_valid(std::dynamic_pointer_cast<A>(std::forward<Args>(args))...)) {
+    if ((... && !std::dynamic_pointer_cast<A>(std::forward<Args>(args)))) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
     return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);
@@ -177,7 +155,7 @@ struct function_traits<R (C::*)(A...)> {
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if (!are_valid(std::dynamic_pointer_cast<A>(std::forward<Args>(args))...)) {
+    if ((... && !std::dynamic_pointer_cast<A>(std::forward<Args>(args)))) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
     return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);
@@ -202,7 +180,7 @@ struct function_traits<R (C::*)(A...) const>  // const
   constexpr static int num_arguments = sizeof...(A);
   template <class Call, class... Args>
   static auto invoke_as(const Call& call, Args&&... args) {
-    if (!are_valid(std::dynamic_pointer_cast<A>(std::forward<Args>(args))...)) {
+    if ((... && !std::dynamic_pointer_cast<A>(std::forward<Args>(args)))) {
       return MatchDiagnostic{false, {"Types didn't match on arguments"}};
     }
     return call(*std::dynamic_pointer_cast<A>(std::forward<Args>(args))...);


### PR DESCRIPTION
Fold expressions are supported in C++17.  This PR is removing workarounds that are not necessary any more.
* Drop comma fold emulations facility that was introduced in the implementation of the combined reducers
* Drop unnecessary `ifdef __cpp_fold_expressions` guards in `partition_space`
* Cleanup tool testing utilities