### PR TITLE
fix typo in HSA_XNACK warning message

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -206,7 +206,7 @@ Kokkos::HIP::runtime WARNING: Kokkos did not find an environment variable 'HSA_X
           std::cerr
               << "Kokkos::HIP::runtime WARNING: Kokkos detected the "
                  "environement variable "
-              << "'HSA_XNACK=" << hsa_xnack << "\n"
+              << "'HSA_XNACK'=" << hsa_xnack << "\n"
               << "Kokkos advises to set it to '1' to enable it per process."
               << std::endl;
       } while (false);


### PR DESCRIPTION
Added a missing quote to match the usage above:

https://github.com/kokkos/kokkos/blob/61d7db55fceac3318c987a291f77b844fd94c165/core/src/HIP/Kokkos_HIP_Space.cpp#L251