### PR TITLE
Cuda_InterOp test: Resolve test failures for device id != 0

### DIFF
--- a/core/unit_test/cuda/TestCuda_InterOp_Init.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Init.cpp
@@ -59,9 +59,9 @@ __global__ void offset(int* p) {
 // Test whether allocations survive Kokkos initialize/finalize if done via Raw
 // Cuda.
 TEST(cuda, raw_cuda_interop) {
+  Kokkos::initialize();
   int* p;
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&p, sizeof(int) * 100));
-  Kokkos::initialize();
 
   Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged>> v(p, 100);
   Kokkos::deep_copy(v, 5);

--- a/core/unit_test/cuda/TestCuda_InterOp_Streams.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Streams.cpp
@@ -48,9 +48,9 @@
 namespace Test {
 // Test Interoperability with Cuda Streams
 TEST(cuda, raw_cuda_streams) {
+  Kokkos::initialize();
   cudaStream_t stream;
   cudaStreamCreate(&stream);
-  Kokkos::initialize();
   int* p;
   cudaMalloc(&p, sizeof(int) * 100);
   using MemorySpace = typename TEST_EXECSPACE::memory_space;


### PR DESCRIPTION
Initialize Kokkos before creating streams so that desired device for testing is set Addresses issue #5632, thanks @masterleinad for suggested fix

Co-authored-by: Daniel Arndt <arndtd@ornl.gov>