### PR TITLE
Set the correct device/context in InterOp tests

### DIFF
--- a/core/unit_test/cuda/TestCuda_InterOp_Init.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Init.cpp
@@ -59,9 +59,11 @@ __global__ void offset(int* p) {
 // Test whether allocations survive Kokkos initialize/finalize if done via Raw
 // Cuda.
 TEST(cuda, raw_cuda_interop) {
+  // Make sure that we use the same device for all allocations
+  Kokkos::initialize();
+
   int* p;
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&p, sizeof(int) * 100));
-  Kokkos::initialize();
 
   Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged>> v(p, 100);
   Kokkos::deep_copy(v, 5);

--- a/core/unit_test/cuda/TestCuda_InterOp_Streams.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Streams.cpp
@@ -48,9 +48,11 @@
 namespace Test {
 // Test Interoperability with Cuda Streams
 TEST(cuda, raw_cuda_streams) {
+  // Make sure that we use the same device for all allocations
+  Kokkos::initialize();
+
   cudaStream_t stream;
   cudaStreamCreate(&stream);
-  Kokkos::initialize();
   int* p;
   cudaMalloc(&p, sizeof(int) * 100);
   using MemorySpace = typename TEST_EXECSPACE::memory_space;

--- a/core/unit_test/hip/TestHIP_InterOp_Init.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Init.cpp
@@ -59,9 +59,11 @@ __global__ void offset(int* p) {
 // Test whether allocations survive Kokkos initialize/finalize if done via Raw
 // HIP.
 TEST(hip, raw_hip_interop) {
+  // Make sure that we use the same device for all allocations
+  Kokkos::initialize();
+
   int* p;
   KOKKOS_IMPL_HIP_SAFE_CALL(hipMalloc(&p, sizeof(int) * 100));
-  Kokkos::initialize();
 
   Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged>> v(p, 100);
   Kokkos::deep_copy(v, 5);

--- a/core/unit_test/hip/TestHIP_InterOp_Streams.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Streams.cpp
@@ -50,9 +50,11 @@ namespace Test {
 // The difference with the CUDA tests are: raw HIP vs raw CUDA and no launch
 // bound in HIP due to an error when computing the block size.
 TEST(hip, raw_hip_streams) {
+  // Make sure that we use the same device for all allocations
+  Kokkos::initialize();
+
   hipStream_t stream;
   KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamCreate(&stream));
-  Kokkos::initialize();
   int* p;
   KOKKOS_IMPL_HIP_SAFE_CALL(hipMalloc(&p, sizeof(int) * 100));
   using MemorySpace = typename TEST_EXECSPACE::memory_space;

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
@@ -52,8 +52,8 @@ namespace Test {
 // Test whether allocations survive Kokkos initialize/finalize if done via Raw
 // SYCL.
 TEST(sycl, raw_sycl_interop) {
+  // Make sure all queues use the same context
   Kokkos::initialize();
-
   Kokkos::Experimental::SYCL default_space;
   sycl::context default_context = default_space.sycl_queue().get_context();
 

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
@@ -51,6 +51,7 @@ namespace Test {
 
 // Test whether external allocations can be accessed by the default queue.
 TEST(sycl, raw_sycl_interop_context_1) {
+  // Make sure all queues use the same context
   Kokkos::Experimental::SYCL default_space;
   sycl::context default_context = default_space.sycl_queue().get_context();
 

--- a/core/unit_test/sycl/TestSYCL_InterOp_Streams.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Streams.cpp
@@ -48,9 +48,13 @@
 namespace Test {
 // Test Interoperability with SYCL Streams
 TEST(sycl, raw_sycl_queues) {
-  sycl::default_selector device_selector;
-  sycl::queue queue(device_selector);
+  // Make sure all queues use the same context
   Kokkos::initialize();
+  Kokkos::Experimental::SYCL default_space;
+  sycl::context default_context = default_space.sycl_queue().get_context();
+
+  sycl::default_selector device_selector;
+  sycl::queue queue(default_context, device_selector);
   int* p            = sycl::malloc_device<int>(100, queue);
   using MemorySpace = typename TEST_EXECSPACE::memory_space;
 


### PR DESCRIPTION
Fixes #5632. This pull request proposes to set the correct device in the respective tests for non-Kokkos allocations/streams by running `Kokkos::initialize` first. 
This is sufficient for `CUDA` and `HIP` but in `SYCL` there is no runtime call to select a device. Instead, the device is associated with the respective `sycl:queue`. We ensure that allocations can be accessed by making sure the same `sycl::context` is used.

An alternative would be to only run the tests on the default device but it seems easy enough to fix this in a way that doesn't impact the purpose of the tests in a significant way. Also, note that most `SYCL` tests already took the correct `sycl::context` into consideration.