### PR TITLE
Enable `flang` for `fedora:latest` builds

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -76,12 +76,8 @@ jobs:
       - name: maybe_disable_death_tests
         if: ${{ matrix.distro == 'fedora:rawhide' }}
         run: echo "GTEST_FILTER=-*DeathTest*" >> $GITHUB_ENV
-# Re-enable when latest is F37+
-#      - name: maybe_use_flang
-#        if: ${{ matrix.cxx == 'clang++' && startsWith(matrix.distro,'fedora:') }}
-#        run: echo "FC=flang" >> $GITHUB_ENV
       - name: maybe_use_flang_new
-        if: ${{ matrix.cxx == 'clang++' && startsWith(matrix.distro,'fedora:rawhide') }}
+        if: ${{ matrix.cxx == 'clang++' && startsWith(matrix.distro,'fedora:') }}
         run: echo "FC=flang-new" >> $GITHUB_ENV
       - name: maybe_use_external_gtest
         if: ${{ matrix.distro == 'ubuntu:latest' }}


### PR DESCRIPTION
Try to re-enable `flang` in CI (F37 is already available).