### PR TITLE
Prefer C++11 built-in support for threads to detect the number of processors

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -57,6 +57,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <thread>
 
 namespace Kokkos {
 namespace Impl {
@@ -340,13 +341,14 @@ void OpenMPInternal::initialize(int thread_count) {
   // Check for over-subscription
   auto const reported_ranks = mpi_ranks_per_node();
   auto const mpi_local_size = reported_ranks < 0 ? 1 : reported_ranks;
+  int const procs_per_node  = std::thread::hardware_concurrency();
   if (Kokkos::show_warnings() &&
-      (mpi_local_size * long(thread_count) > Impl::processors_per_node())) {
+      (mpi_local_size * long(thread_count) > procs_per_node)) {
     std::cerr << "Kokkos::OpenMP::initialize WARNING: You are likely "
                  "oversubscribing your CPU cores."
               << std::endl;
     std::cerr << "                                    Detected: "
-              << Impl::processors_per_node() << " cores per node." << std::endl;
+              << procs_per_node << " cores per node." << std::endl;
     std::cerr << "                                    Detected: "
               << mpi_local_size << " MPI_ranks per node." << std::endl;
     std::cerr << "                                    Requested: "

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -782,13 +782,14 @@ void ThreadsExec::initialize(int thread_count_arg) {
   // Check for over-subscription
   auto const reported_ranks = mpi_ranks_per_node();
   auto const mpi_local_size = reported_ranks < 0 ? 1 : reported_ranks;
+  int const procs_per_node  = std::thread::hardware_concurrency();
   if (Kokkos::show_warnings() &&
-      (mpi_local_size * long(thread_count) > Impl::processors_per_node())) {
+      (mpi_local_size * long(thread_count) > procs_per_node)) {
     std::cerr << "Kokkos::Threads::initialize WARNING: You are likely "
                  "oversubscribing your CPU cores."
               << std::endl;
     std::cerr << "                                    Detected: "
-              << Impl::processors_per_node() << " cores per node." << std::endl;
+              << procs_per_node << " cores per node." << std::endl;
     std::cerr << "                                    Detected: "
               << mpi_local_size << " MPI_ranks per node." << std::endl;
     std::cerr << "                                    Requested: "

--- a/core/src/impl/Kokkos_CPUDiscovery.cpp
+++ b/core/src/impl/Kokkos_CPUDiscovery.cpp
@@ -48,41 +48,8 @@
 
 #include <impl/Kokkos_CPUDiscovery.hpp>
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#elif defined(__APPLE__)
-#include <sys/types.h>
-#include <sys/sysctl.h>
-#else
-#include <unistd.h>
-#endif
-
 #include <cstdlib>  // getenv
 #include <string>
-
-int Kokkos::Impl::processors_per_node() {
-#ifdef _SC_NPROCESSORS_ONLN
-  int const num_procs     = sysconf(_SC_NPROCESSORS_ONLN);
-  int const num_procs_max = sysconf(_SC_NPROCESSORS_CONF);
-  if ((num_procs < 1) || (num_procs_max < 1)) {
-    return -1;
-  }
-  return num_procs;
-#elif defined(__APPLE__)
-  int ncpu;
-  int activecpu;
-  size_t size = sizeof(int);
-  sysctlbyname("hw.ncpu", &ncpu, &size, nullptr, 0);
-  sysctlbyname("hw.activecpu", &activecpu, &size, nullptr, 0);
-  if (ncpu < 1 || activecpu < 1)
-    return -1;
-  else
-    return activecpu;
-#else
-  return -1;
-#endif
-}
 
 int Kokkos::Impl::mpi_ranks_per_node() {
   for (char const* env_var : {

--- a/core/src/impl/Kokkos_CPUDiscovery.hpp
+++ b/core/src/impl/Kokkos_CPUDiscovery.hpp
@@ -44,7 +44,6 @@
 namespace Kokkos {
 namespace Impl {
 
-int processors_per_node();
 int mpi_ranks_per_node();
 int mpi_local_rank_on_node();
 


### PR DESCRIPTION
Proposed resolution for #5631 
Drop `Impl::processors_per_node()` and use `std::thread::hardware_concurrency` instead.

One concern we had was that GCC requires linking against pthread to use `std::thread` but it turns out it is not needed for `hardware_concurrency()` so I can't think of any good reason not to use it instead of implementing our own facility to detect the number of processors.

Note that we should consider renaming `Kokkos_CPUDiscovery.{hpp,cpp}` to something more sensible but I decided to abstain for now so I don't create conflicts with #5640 