### PR TITLE
Define new type trait to identify cuda-type execution space in deep copy

### DIFF
--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -447,6 +447,20 @@ struct SpaceAccessibility {
 
 }  // namespace Kokkos
 
+namespace Kokkos {
+namespace Impl{
+
+//! Grant Kokkos Resilience permission to specialize this trait to control the behavior of deep_copy
+template <class ExecutionSpace, class Enabled = void >
+struct ExecutionSpaceAlias{
+
+  using type = ExecutionSpace;
+
+};
+
+}
+}
+
 //----------------------------------------------------------------------------
 
 #endif  // KOKKOS_CORE_CONCEPTS_HPP

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -450,11 +450,10 @@ struct SpaceAccessibility {
 namespace Kokkos {
 namespace Impl {
 
-//! Grant Kokkos Resilience permission to specialize this trait to control 
+//! Grant Kokkos Resilience permission to specialize this trait to control
 //! the behavior of deep_copy
 template <class ExecutionSpace, class Enabled = void>
 struct ExecutionSpaceAlias {
-
   using type = ExecutionSpace;
 };
 

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -448,19 +448,18 @@ struct SpaceAccessibility {
 }  // namespace Kokkos
 
 namespace Kokkos {
-namespace Impl{
+namespace Impl {
 
-//! Grant Kokkos Resilience permission to specialize this trait to control the behavior of deep_copy
-template <class ExecutionSpace, class Enabled = void >
-struct ExecutionSpaceAlias{
+//! Grant Kokkos Resilience permission to specialize this trait to control 
+//! the behavior of deep_copy
+template <class ExecutionSpace, class Enabled = void>
+struct ExecutionSpaceAlias {
 
   using type = ExecutionSpace;
-
 };
 
-}
-}
-
+}  // namespace Impl
+}  // namespace Kokkos
 //----------------------------------------------------------------------------
 
 #endif  // KOKKOS_CORE_CONCEPTS_HPP

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -81,7 +81,6 @@ struct CudaDispatchProperties {
 };
 }  // namespace Experimental
 }  // namespace Impl
-
 /// \class Cuda
 /// \brief Kokkos Execution Space that uses CUDA to run on GPUs.
 ///

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -81,6 +81,7 @@ struct CudaDispatchProperties {
 };
 }  // namespace Experimental
 }  // namespace Impl
+
 /// \class Cuda
 /// \brief Kokkos Execution Space that uses CUDA to run on GPUs.
 ///

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -50,6 +50,9 @@ namespace Kokkos {
 namespace Impl {
 
 template <typename T>
+struct is_cuda_type_ex_space : public std::false_type {};
+
+template <typename T>
 struct is_cuda_type_space : public std::false_type {};
 
 }  // namespace Impl
@@ -120,6 +123,9 @@ class CudaSpace {
 
 template <>
 struct Impl::is_cuda_type_space<CudaSpace> : public std::true_type {};
+
+template <>
+struct Impl::is_cuda_type_ex_space<Cuda> : public std::true_type {};
 
 }  // namespace Kokkos
 
@@ -443,7 +449,7 @@ template <class MemSpace1, class MemSpace2, class ExecutionSpace>
 struct DeepCopy<MemSpace1, MemSpace2, ExecutionSpace,
                 std::enable_if_t<is_cuda_type_space<MemSpace1>::value &&
                                  is_cuda_type_space<MemSpace2>::value &&
-                                 !std::is_same<ExecutionSpace, Cuda>::value>> {
+			         !Impl::is_cuda_type_ex_space<ExecutionSpace>::value>> {
   inline DeepCopy(void* dst, const void* src, size_t n) {
     DeepCopyCuda(dst, src, n);
   }
@@ -466,8 +472,8 @@ struct DeepCopy<MemSpace1, MemSpace2, ExecutionSpace,
 
 template <class MemSpace, class ExecutionSpace>
 struct DeepCopy<MemSpace, HostSpace, ExecutionSpace,
-                std::enable_if_t<is_cuda_type_space<MemSpace>::value &&
-                                 !std::is_same<ExecutionSpace, Cuda>::value>> {
+                std::enable_if_t<is_cuda_type_space<MemSpace>::value && 
+				 !Impl::is_cuda_type_ex_space<ExecutionSpace>::value>> {
   inline DeepCopy(void* dst, const void* src, size_t n) {
     DeepCopyCuda(dst, src, n);
   }
@@ -489,8 +495,8 @@ struct DeepCopy<MemSpace, HostSpace, ExecutionSpace,
 
 template <class MemSpace, class ExecutionSpace>
 struct DeepCopy<HostSpace, MemSpace, ExecutionSpace,
-                std::enable_if_t<is_cuda_type_space<MemSpace>::value &&
-                                 !std::is_same<ExecutionSpace, Cuda>::value>> {
+                std::enable_if_t<is_cuda_type_space<MemSpace>::value && 
+				 !Impl::is_cuda_type_ex_space<ExecutionSpace>::value>> {
   inline DeepCopy(void* dst, const void* src, size_t n) {
     DeepCopyCuda(dst, src, n);
   }

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -405,11 +405,11 @@ struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::CudaUVMSpace> {
 namespace Kokkos {
 namespace Impl {
 
-template <class ExecutionSpace, class Enabled >
+template <class ExecutionSpace, class Enabled>
 struct ExecutionSpaceAlias;
 
-}
-}
+}  // namespace Impl
+}  // namespace Kokkos
 
 namespace Kokkos {
 namespace Impl {
@@ -450,9 +450,11 @@ struct DeepCopy<MemSpace1, MemSpace2, Cuda,
 template <class MemSpace1, class MemSpace2, class ExecutionSpace>
 struct DeepCopy<
     MemSpace1, MemSpace2, ExecutionSpace,
-    std::enable_if_t<is_cuda_type_space<MemSpace1>::value &&
-                     is_cuda_type_space<MemSpace2>::value &&
-                     !std::is_same_v<typename ExecutionSpaceAlias<ExecutionSpace>::type, Cuda> >> {
+    std::enable_if_t<
+        is_cuda_type_space<MemSpace1>::value &&
+        is_cuda_type_space<MemSpace2>::value &&
+        !std::is_same_v<typename ExecutionSpaceAlias<ExecutionSpace>::type,
+                        Cuda>>> {
   inline DeepCopy(void* dst, const void* src, size_t n) {
     DeepCopyCuda(dst, src, n);
   }
@@ -476,8 +478,10 @@ struct DeepCopy<
 template <class MemSpace, class ExecutionSpace>
 struct DeepCopy<
     MemSpace, HostSpace, ExecutionSpace,
-    std::enable_if_t<is_cuda_type_space<MemSpace>::value &&
-	     !std::is_same_v<typename ExecutionSpaceAlias<ExecutionSpace>::type, Cuda> >> {
+    std::enable_if_t<
+        is_cuda_type_space<MemSpace>::value &&
+        !std::is_same_v<typename ExecutionSpaceAlias<ExecutionSpace>::type,
+                        Cuda>>> {
   inline DeepCopy(void* dst, const void* src, size_t n) {
     DeepCopyCuda(dst, src, n);
   }
@@ -500,8 +504,10 @@ struct DeepCopy<
 template <class MemSpace, class ExecutionSpace>
 struct DeepCopy<
     HostSpace, MemSpace, ExecutionSpace,
-    std::enable_if_t<is_cuda_type_space<MemSpace>::value &&
-                     !std::is_same_v<typename ExecutionSpaceAlias<ExecutionSpace>::type, Cuda> >> {
+    std::enable_if_t<
+        is_cuda_type_space<MemSpace>::value &&
+        !std::is_same_v<typename ExecutionSpaceAlias<ExecutionSpace>::type,
+                        Cuda>>> {
   inline DeepCopy(void* dst, const void* src, size_t n) {
     DeepCopyCuda(dst, src, n);
   }

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -33,6 +33,7 @@ static_assert(false,
 #include <memory>
 
 #include <Kokkos_HostSpace.hpp>
+#include <Kokkos_Concepts.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
 
 #include <impl/Kokkos_Profiling_Interface.hpp>
@@ -120,6 +121,7 @@ class CudaSpace {
 
 template <>
 struct Impl::is_cuda_type_space<CudaSpace> : public std::true_type {};
+
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/
@@ -401,15 +403,6 @@ struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::CudaUVMSpace> {
 
 /*--------------------------------------------------------------------------*/
 /*--------------------------------------------------------------------------*/
-
-namespace Kokkos {
-namespace Impl {
-
-template <class ExecutionSpace, class Enabled>
-struct ExecutionSpaceAlias;
-
-}  // namespace Impl
-}  // namespace Kokkos
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/Kokkos_CudaSpace.hpp
+++ b/core/src/Kokkos_CudaSpace.hpp
@@ -49,6 +49,7 @@ extern "C" void kokkos_impl_cuda_set_pin_uvm_to_host(bool);
 namespace Kokkos {
 namespace Impl {
 
+//! Allow Kokkos Resilience to specialize DeepCopy on this trait
 template <typename T>
 struct is_cuda_type_ex_space : public std::false_type {};
 
@@ -446,10 +447,11 @@ struct DeepCopy<MemSpace1, MemSpace2, Cuda,
 };
 
 template <class MemSpace1, class MemSpace2, class ExecutionSpace>
-struct DeepCopy<MemSpace1, MemSpace2, ExecutionSpace,
-                std::enable_if_t<is_cuda_type_space<MemSpace1>::value &&
-                                 is_cuda_type_space<MemSpace2>::value &&
-			         !Impl::is_cuda_type_ex_space<ExecutionSpace>::value>> {
+struct DeepCopy<
+    MemSpace1, MemSpace2, ExecutionSpace,
+    std::enable_if_t<is_cuda_type_space<MemSpace1>::value &&
+                     is_cuda_type_space<MemSpace2>::value &&
+                     !Impl::is_cuda_type_ex_space<ExecutionSpace>::value>> {
   inline DeepCopy(void* dst, const void* src, size_t n) {
     DeepCopyCuda(dst, src, n);
   }
@@ -471,9 +473,10 @@ struct DeepCopy<MemSpace1, MemSpace2, ExecutionSpace,
 };
 
 template <class MemSpace, class ExecutionSpace>
-struct DeepCopy<MemSpace, HostSpace, ExecutionSpace,
-                std::enable_if_t<is_cuda_type_space<MemSpace>::value && 
-				 !Impl::is_cuda_type_ex_space<ExecutionSpace>::value>> {
+struct DeepCopy<
+    MemSpace, HostSpace, ExecutionSpace,
+    std::enable_if_t<is_cuda_type_space<MemSpace>::value &&
+                     !Impl::is_cuda_type_ex_space<ExecutionSpace>::value>> {
   inline DeepCopy(void* dst, const void* src, size_t n) {
     DeepCopyCuda(dst, src, n);
   }
@@ -494,9 +497,10 @@ struct DeepCopy<MemSpace, HostSpace, ExecutionSpace,
 };
 
 template <class MemSpace, class ExecutionSpace>
-struct DeepCopy<HostSpace, MemSpace, ExecutionSpace,
-                std::enable_if_t<is_cuda_type_space<MemSpace>::value && 
-				 !Impl::is_cuda_type_ex_space<ExecutionSpace>::value>> {
+struct DeepCopy<
+    HostSpace, MemSpace, ExecutionSpace,
+    std::enable_if_t<is_cuda_type_space<MemSpace>::value &&
+                     !Impl::is_cuda_type_ex_space<ExecutionSpace>::value>> {
   inline DeepCopy(void* dst, const void* src, size_t n) {
     DeepCopyCuda(dst, src, n);
   }


### PR DESCRIPTION
I am creating a resilient Cuda execution space. Currently, a DeepCopy from a resilient Cuda space (ResCudaSpace) to a ResCudaSpace using a resilient Cuda execution space will get caught by the template `template <class MemSpace1, class MemSpace2, class ExecutionSpace>` that filters `ExecutionSpace` as `!Cuda`.

I need it to filter into the template that has the `ExecutionSpace ` type `Cuda`. This could be achieved by changing the filter from `std::enable_if_t<!std::is_same<ExecutionSpace, Cuda>::value>` to `std::enable_if_t<!std::derived_from<ExecutionSpace, Cuda>::value>`.

It has been mentioned that this might be a suboptimal extension point from a Trilinos perspective, so I propose this type trait to identify a Cuda type execution space. There is already a type trait to identify a Cuda type memory space and this follows a similar pattern. This would keep the modification in `Impl `and limit the impact: Only the current `Cuda` space and the `ResCuda` execution space need be defined as Cuda type execution spaces.