### PR TITLE
Fixup call `ExecutionSpace::concurrency()` from an actual execution space

### DIFF
--- a/core/perf_test/PerfTest_CustomReduction.cpp
+++ b/core/perf_test/PerfTest_CustomReduction.cpp
@@ -58,8 +58,8 @@ void custom_reduction_test(int N, int R, int num_trials) {
   Scalar max;
 
   int team_size = 32;
-  if (team_size > Kokkos::DefaultExecutionSpace::concurrency())
-    team_size = Kokkos::DefaultExecutionSpace::concurrency();
+  if (team_size > Kokkos::DefaultExecutionSpace().concurrency())
+    team_size = Kokkos::DefaultExecutionSpace().concurrency();
   // Warm up
   Kokkos::parallel_reduce(
       Kokkos::TeamPolicy<>(N / 1024, team_size),

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -223,8 +223,7 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
       return;
     }
 #endif
-    int64_t concurrency =
-        static_cast<int64_t>(traits::execution_space::concurrency());
+    auto concurrency = static_cast<int64_t>(m_space.concurrency());
     if (concurrency == 0) concurrency = 1;
 
     if (m_granularity > 0) {

--- a/core/src/Kokkos_UniqueToken.hpp
+++ b/core/src/Kokkos_UniqueToken.hpp
@@ -90,7 +90,7 @@ class UniqueToken {
 };
 
 /// \brief Instance scope UniqueToken allows for a max size other than
-/// execution_space::concurrency()
+/// execution_space().concurrency()
 ///
 /// This object should behave like a ref-counted object, so that when the last
 /// instance is destroyed, resources are free if needed
@@ -107,9 +107,9 @@ class UniqueToken<ExecutionSpace, UniqueTokenScope::Instance>
   /// threads that will attempt to acquire the UniqueToken. This constructor is
   /// most commonly useful when you:
   ///   1) Have a loop bound that may be smaller than
-  ///   execution_space::concurrency().
+  ///   execution_space().concurrency().
   ///   2) Want a per-team unique token in the range [0,
-  ///   execution_space::concurrency() / team_size)
+  ///   execution_space().concurrency() / team_size)
   UniqueToken(size_type max_size, execution_space const& = execution_space());
 };
 

--- a/core/src/impl/Kokkos_ExecSpaceManager.hpp
+++ b/core/src/impl/Kokkos_ExecSpaceManager.hpp
@@ -85,6 +85,10 @@ using fence_t = std::enable_if_t<
     std::is_void_v<decltype(T::impl_static_fence("name"))>>;
 
 template <class T>
+using concurrency_t = std::enable_if_t<
+    std::is_same_v<int, decltype(std::declval<T const&>().concurrency())>>;
+
+template <class T>
 constexpr bool check_is_semiregular() {
   static_assert(std::is_default_constructible_v<T>);
   static_assert(std::is_copy_constructible_v<T>);
@@ -125,6 +129,7 @@ constexpr bool check_valid_execution_space() {
   static_assert(is_detected_v<print_configuration_t, ExecutionSpace>);
   static_assert(is_detected_v<initialize_finalize_t, ExecutionSpace>);
   static_assert(is_detected_v<fence_t, ExecutionSpace>);
+  static_assert(is_detected_v<concurrency_t, ExecutionSpace>);
 #ifndef KOKKOS_ENABLE_HPX  // FIXME_HPX
   static_assert(sizeof(ExecutionSpace) <= 2 * sizeof(void*));
 #endif

--- a/core/unit_test/TestBlockSizeDeduction.hpp
+++ b/core/unit_test/TestBlockSizeDeduction.hpp
@@ -62,7 +62,7 @@ void test_bug_pr_3103() {
   using Policy =
       Kokkos::TeamPolicy<ExecutionSpace, Kokkos::LaunchBounds<32, 1>>;
   int const league_size   = 1;
-  int const team_size     = std::min(32, ExecutionSpace::concurrency());
+  int const team_size     = std::min(32, ExecutionSpace().concurrency());
   int const vector_length = 1;
 
   Kokkos::parallel_for(Policy(league_size, team_size, vector_length),

--- a/core/unit_test/TestPolicyConstruction.hpp
+++ b/core/unit_test/TestPolicyConstruction.hpp
@@ -565,9 +565,8 @@ class TestTeamPolicyConstruction {
   template <class policy_t>
   void test_run_time_parameters_type() {
     int league_size = 131;
-    int team_size   = 4 < policy_t::execution_space::concurrency()
-                        ? 4
-                        : policy_t::execution_space::concurrency();
+    int concurrency = typename policy_t::execution_space().concurrency();
+    int team_size   = 4 < concurrency ? 4 : concurrency;
 #ifdef KOKKOS_ENABLE_HPX
     team_size = 1;
 #endif

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -285,10 +285,11 @@ struct TestRange {
     auto const N_no_implicit_capture = N;
     using policy_t =
         Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >;
+    int const concurrency = ExecSpace().concurrency();
 
     {
       Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
-          count("Count", ExecSpace::concurrency());
+          count("Count", concurrency);
       Kokkos::View<int *, ExecSpace> a("A", N);
 
       Kokkos::parallel_for(
@@ -309,17 +310,16 @@ struct TestRange {
           error);
       ASSERT_EQ(error, 0);
 
-      if ((ExecSpace::concurrency() > (int)1) &&
-          (N > static_cast<int>(4 * ExecSpace::concurrency()))) {
+      if ((concurrency > 1) && (N > 4 * concurrency)) {
         size_t min = N;
         size_t max = 0;
-        for (int t = 0; t < ExecSpace::concurrency(); t++) {
+        for (int t = 0; t < concurrency; t++) {
           if (count(t) < min) min = count(t);
           if (count(t) > max) max = count(t);
         }
         ASSERT_LT(min, max);
 
-        // if ( ExecSpace::concurrency() > 2 ) {
+        // if ( concurrency > 2 ) {
         //  ASSERT_LT( 2 * min, max );
         //}
       }
@@ -327,7 +327,7 @@ struct TestRange {
 
     {
       Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
-          count("Count", ExecSpace::concurrency());
+          count("Count", concurrency);
       Kokkos::View<int *, ExecSpace> a("A", N);
 
       value_type sum = 0;
@@ -353,17 +353,16 @@ struct TestRange {
           error);
       ASSERT_EQ(error, 0);
 
-      if ((ExecSpace::concurrency() > (int)1) &&
-          (N > static_cast<int>(4 * ExecSpace::concurrency()))) {
+      if ((concurrency > 1) && (N > 4 * concurrency)) {
         size_t min = N;
         size_t max = 0;
-        for (int t = 0; t < ExecSpace::concurrency(); t++) {
+        for (int t = 0; t < concurrency; t++) {
           if (count(t) < min) min = count(t);
           if (count(t) > max) max = count(t);
         }
         ASSERT_LT(min, max);
 
-        // if ( ExecSpace::concurrency() > 2 ) {
+        // if ( concurrency > 2 ) {
         //  ASSERT_LT( 2 * min, max );
         //}
       }

--- a/core/unit_test/TestRangePolicyRequire.hpp
+++ b/core/unit_test/TestRangePolicyRequire.hpp
@@ -277,10 +277,11 @@ struct TestRangeRequire {
     auto const N_no_implicit_capture = N;
     using policy_t =
         Kokkos::RangePolicy<ExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >;
+    int const concurrency = ExecSpace().concurrency();
 
     {
       Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
-          count("Count", ExecSpace::concurrency());
+          count("Count", concurrency);
       Kokkos::View<int *, ExecSpace> a("A", N);
 
       Kokkos::parallel_for(
@@ -301,17 +302,16 @@ struct TestRangeRequire {
           error);
       ASSERT_EQ(error, 0);
 
-      if ((ExecSpace::concurrency() > (int)1) &&
-          (N > static_cast<int>(4 * ExecSpace::concurrency()))) {
+      if ((concurrency > 1) && (N > 4 * concurrency)) {
         size_t min = N;
         size_t max = 0;
-        for (int t = 0; t < ExecSpace::concurrency(); t++) {
+        for (int t = 0; t < concurrency; t++) {
           if (count(t) < min) min = count(t);
           if (count(t) > max) max = count(t);
         }
         ASSERT_LT(min, max);
 
-        // if ( ExecSpace::concurrency() > 2 ) {
+        // if ( concurrency > 2 ) {
         //  ASSERT_LT( 2 * min, max );
         //}
       }
@@ -319,7 +319,7 @@ struct TestRangeRequire {
 
     {
       Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic> >
-          count("Count", ExecSpace::concurrency());
+          count("Count", concurrency);
       Kokkos::View<int *, ExecSpace> a("A", N);
 
       int sum = 0;
@@ -345,17 +345,16 @@ struct TestRangeRequire {
           error);
       ASSERT_EQ(error, 0);
 
-      if ((ExecSpace::concurrency() > (int)1) &&
-          (N > static_cast<int>(4 * ExecSpace::concurrency()))) {
+      if ((concurrency > 1) && (N > 4 * concurrency)) {
         size_t min = N;
         size_t max = 0;
-        for (int t = 0; t < ExecSpace::concurrency(); t++) {
+        for (int t = 0; t < concurrency; t++) {
           if (count(t) < min) min = count(t);
           if (count(t) > max) max = count(t);
         }
         ASSERT_LT(min, max);
 
-        // if ( ExecSpace::concurrency() > 2 ) {
+        // if ( concurrency > 2 ) {
         //  ASSERT_LT( 2 * min, max );
         //}
       }

--- a/core/unit_test/TestReduceCombinatorical.hpp
+++ b/core/unit_test/TestReduceCombinatorical.hpp
@@ -415,11 +415,11 @@ struct TestReduceCombinatoricalInstantiation {
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
     CallParallelReduce(args...,
                        Test::ReduceCombinatorical::AddPlus<double>(value));
-    if ((Kokkos::DefaultExecutionSpace::concurrency() > 1) &&
-        (ExecSpace::concurrency() > 1) && (expected_result > 0)) {
+    if ((Kokkos::DefaultExecutionSpace().concurrency() > 1) &&
+        (ExecSpace().concurrency() > 1) && (expected_result > 0)) {
       ASSERT_LT(expected_result, value);
-    } else if (((Kokkos::DefaultExecutionSpace::concurrency() > 1) ||
-                (ExecSpace::concurrency() > 1)) &&
+    } else if (((Kokkos::DefaultExecutionSpace().concurrency() > 1) ||
+                (ExecSpace().concurrency() > 1)) &&
                (expected_result > 0)) {
       ASSERT_LE(expected_result, value);
     } else {
@@ -429,11 +429,11 @@ struct TestReduceCombinatoricalInstantiation {
     value = 99;
     Test::ReduceCombinatorical::AddPlus<double> add(value);
     CallParallelReduce(args..., add);
-    if ((Kokkos::DefaultExecutionSpace::concurrency() > 1) &&
-        (ExecSpace::concurrency() > 1) && (expected_result > 0)) {
+    if ((Kokkos::DefaultExecutionSpace().concurrency() > 1) &&
+        (ExecSpace().concurrency() > 1) && (expected_result > 0)) {
       ASSERT_LT(expected_result, value);
-    } else if (((Kokkos::DefaultExecutionSpace::concurrency() > 1) ||
-                (ExecSpace::concurrency() > 1)) &&
+    } else if (((Kokkos::DefaultExecutionSpace().concurrency() > 1) ||
+                (ExecSpace().concurrency() > 1)) &&
                (expected_result > 0)) {
       ASSERT_LE(expected_result, value);
     } else {

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1025,8 +1025,8 @@ struct ClassNoShmemSizeFunction {
 #else
     int team_size      = 8;
 #endif
-    if (team_size > ExecSpace::concurrency())
-      team_size = ExecSpace::concurrency();
+    int const concurrency = ExecSpace().concurrency();
+    if (team_size > concurrency) team_size = concurrency;
     {
       Kokkos::TeamPolicy<TagFor, ExecSpace, ScheduleType> policy(10, team_size,
                                                                  16);
@@ -1098,8 +1098,9 @@ struct ClassWithShmemSizeFunction {
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>::shmem_size(1600);
 
     int team_size = 8;
-    if (team_size > ExecSpace::concurrency())
-      team_size = ExecSpace::concurrency();
+
+    int const concurrency = ExecSpace().concurrency();
+    if (team_size > concurrency) team_size = concurrency;
 
     {
       Kokkos::TeamPolicy<TagFor, ExecSpace, ScheduleType> policy(10, team_size,
@@ -1173,8 +1174,8 @@ void test_team_mulit_level_scratch_test_lambda() {
 #else
   int team_size = 8;
 #endif
-  if (team_size > ExecSpace::concurrency())
-    team_size = ExecSpace::concurrency();
+  int const concurrency = ExecSpace().concurrency();
+  if (team_size > concurrency) team_size = concurrency;
 
   Kokkos::TeamPolicy<ExecSpace, ScheduleType> policy(10, team_size, 16);
 

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -729,8 +729,8 @@ bool Test(int test) {
 #else
   int team_size = 33;
 #endif
-  if (team_size > int(ExecutionSpace::concurrency()))
-    team_size = int(ExecutionSpace::concurrency());
+  int const concurrency = ExecutionSpace().concurrency();
+  if (team_size > concurrency) team_size = concurrency;
   passed = passed && test_scalar<int, ExecutionSpace>(317, team_size, test);
   passed = passed &&
            test_scalar<long long int, ExecutionSpace>(317, team_size, test);
@@ -770,8 +770,9 @@ class TestTripleNestedReduce {
 
   void run_test(const size_type &nrows, const size_type &ncols,
                 size_type team_size, const size_type &vector_length) {
-    if (team_size > size_type(DeviceType::execution_space::concurrency()))
-      team_size = size_type(DeviceType::execution_space::concurrency());
+    auto const concurrency =
+        static_cast<size_type>(execution_space().concurrency());
+    if (team_size > concurrency) team_size = concurrency;
 
 #ifdef KOKKOS_ENABLE_HPX
     team_size = 1;

--- a/core/unit_test/TestTeamVectorRange.hpp
+++ b/core/unit_test/TestTeamVectorRange.hpp
@@ -443,8 +443,8 @@ bool Test(int test) {
 #else
   int team_size = 33;
 #endif
-  if (team_size > int(ExecutionSpace::concurrency()))
-    team_size = int(ExecutionSpace::concurrency());
+  int const concurrency = ExecutionSpace().concurrency();
+  if (team_size > concurrency) team_size = concurrency;
   passed = passed && test_scalar<int, ExecutionSpace>(317, team_size, test);
   passed = passed &&
            test_scalar<long long int, ExecutionSpace>(317, team_size, test);

--- a/core/unit_test/TestUniqueToken.hpp
+++ b/core/unit_test/TestUniqueToken.hpp
@@ -221,7 +221,7 @@ class TestAcquireTeamUniqueToken {
   }
 
   TestAcquireTeamUniqueToken(int team_size)
-      : tokens(execution_space::concurrency() / team_size, execution_space()),
+      : tokens(execution_space().concurrency() / team_size, execution_space()),
         verify("TestAcquireTeamUniqueTokenVerify", tokens.size()),
         counts("TestAcquireTeamUniqueTokenCounts", tokens.size()),
         errors("TestAcquireTeamUniqueTokenErrors", 1) {}

--- a/core/unit_test/incremental/Test10_HierarchicalBasics.hpp
+++ b/core/unit_test/incremental/Test10_HierarchicalBasics.hpp
@@ -58,7 +58,8 @@ struct HierarchicalBasics {
   using team_t   = typename policy_t::member_type;
 
   void run(const int nP, int nT) {
-    if (nT > ExecSpace::concurrency()) nT = ExecSpace::concurrency();
+    int const concurrency = ExecSpace().concurrency();
+    if (nT > concurrency) nT = concurrency;
 
     policy_t pol(nP, nT);
 

--- a/core/unit_test/openmp/TestOpenMP_InterOp.cpp
+++ b/core/unit_test/openmp/TestOpenMP_InterOp.cpp
@@ -71,7 +71,7 @@ TEST(openmp, raw_openmp_interop) {
     count++;
   }
 
-  concurrency = Kokkos::OpenMP::concurrency();
+  concurrency = Kokkos::OpenMP().concurrency();
   ASSERT_EQ(count, concurrency);
 
   Kokkos::finalize();

--- a/example/tutorial/Hierarchical_Parallelism/04_team_scan/team_scan.cpp
+++ b/example/tutorial/Hierarchical_Parallelism/04_team_scan/team_scan.cpp
@@ -127,9 +127,9 @@ int main(int narg, char* args[]) {
 
     Kokkos::Timer timer;
     // threads/team is automatically limited to maximum supported by the device.
-    int team_size = TEAM_SIZE;
-    if (team_size > Device::execution_space::concurrency())
-      team_size = Device::execution_space::concurrency();
+    int const concurrency = Device::execution_space().concurrency();
+    int team_size         = TEAM_SIZE;
+    if (team_size > concurrency) team_size = concurrency;
     Kokkos::parallel_for(team_policy(nchunks, team_size),
                          find_2_tuples(chunk_size, data, histogram));
     Kokkos::fence();


### PR DESCRIPTION
Partially addressing #5655 by ensuring we call `ExecutionSpace::concurrency()` from an actual execution space in code that is not backend-specific.

Also adding the detection of the member function to static checks for all backends.  Note that I elected to only check that `concurrency()` is callable and that, even though that is something that we would be able to check later after we update all backends, I don't actually plan on enforcing that backends do not declare the member function to be static.