### PR TITLE
Work around CUDA+Clang Thrust issue

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -82,6 +82,7 @@
 // restore it at the end
 #ifdef _CubLog
 #define KOKKKOS_CubLog_save _CubLog
+#undef _CubLog
 #endif
 #define _CubLog
 #include <thrust/device_ptr.h>

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -75,11 +75,8 @@
 // failure was not investigated, however even very recent version combination
 // (Clang 10.0.0 and Cuda 10.0) demonstrated failure.
 //
-// Defining _CubLog here allows us to avoid that code path, however disabling
-// some debugging diagnostics
-//
-// If _CubLog is already defined, we save it into KOKKKOS_CubLog_save, and
-// restore it at the end
+// Defining _CubLog here locally allows us to avoid that code path, however
+// disabling some debugging diagnostics
 #pragma push_macro("_CubLog")
 #ifdef _CubLog
 #undef _CubLog

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -66,8 +66,35 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
 
+#if defined(KOKKOS_COMPILER_CLANG)
+// Some versions of Clang fail to compile Thrust, failing with errors like
+// this:
+//    <snip>/thrust/system/cuda/detail/core/agent_launcher.h:557:11:
+//    error: use of undeclared identifier 'va_printf'
+// The exact combination of versions for Clang and Thrust (or CUDA) for this
+// failure was not investigated, however even very recent version combination
+// (Clang 10.0.0 and Cuda 10.0) demonstrated failure.
+//
+// Defining _CubLog here allows us to avoid that code path, however disabling
+// some debugging diagnostics
+//
+// If _CubLog is already defined, we save it into KOKKKOS_CubLog_save, and
+// restore it at the end
+#ifdef _CubLog
+#define KOKKKOS_CubLog_save _CubLog
+#endif
+#define _CubLog
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>
+#undef _CubLog
+#ifdef KOKKKOS_CubLog_save
+#define _CubLog KOKKKOS_CubLog_save
+#undef KOKKKOS_CubLog_save
+#endif
+#else
+#include <thrust/device_ptr.h>
+#include <thrust/sort.h>
+#endif
 
 #pragma GCC diagnostic pop
 

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -80,18 +80,14 @@
 //
 // If _CubLog is already defined, we save it into KOKKKOS_CubLog_save, and
 // restore it at the end
+#pragma push_macro("_CubLog")
 #ifdef _CubLog
-#define KOKKKOS_CubLog_save _CubLog
 #undef _CubLog
 #endif
 #define _CubLog
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>
-#undef _CubLog
-#ifdef KOKKKOS_CubLog_save
-#define _CubLog KOKKKOS_CubLog_save
-#undef KOKKKOS_CubLog_save
-#endif
+#pragma pop_macro("_CubLog")
 #else
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>


### PR DESCRIPTION
We are hitting https://github.com/NVIDIA/thrust/issues/1032
```
use of undeclared identifier 'va_printf'
          _CubLog("Invoking %s<<<%u, %d, %d, %lld>>>(), %llu items total, %d items per thread, %d SM occupancy, %d vshmem size, %d ptx_version \n",
          ^
/usr/local/cuda/include/cub/util_debug.cuh:151:42: note: expanded from macro '_CubLog'
            #define _CubLog(format, ...) va_printf("[block (%d,%d,%d), thread (%d,%d,%d)]: " format, __VA_ARGS__);
```
 in https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/ArborX/detail/PR-782/5/pipeline.
The build uses `Clang 14.0.0` with `CUDA 11.0.3` on `Ubuntu 18.04`. Apparently, this is doesn't given us a recent enough `thrust` that includes https://github.com/thrust/cub/commit/a568ffa1fe061c20689934f119afd09beae820fd.

The workaround proposed here, is the same one we use in `ArborX`, see https://github.com/arborx/ArborX/blob/77e055395c9550cb42e5b90156ba659f060bd852/src/details/ArborX_DetailsSortUtils.hpp#L26-L65. 
