### PR TITLE
typecast to Scalar

### DIFF
--- a/benchmarks/bytes_and_flops/bench_unroll_stride.hpp
+++ b/benchmarks/bytes_and_flops/bench_unroll_stride.hpp
@@ -38,25 +38,25 @@ struct Run<Scalar, UNROLL, STRIDE> {
                     Scalar a1      = A(n, i, 0);
                     const Scalar b = B(n, i, 0);
 #if (UNROLL > 1)
-                    Scalar a2 = a1 * 1.3;
+                    Scalar a2 = a1 * static_cast<Scalar>(1.3);
 #endif
 #if (UNROLL > 2)
-                    Scalar a3 = a2 * 1.1;
+                    Scalar a3 = a2 * static_cast<Scalar>(1.1);
 #endif
 #if (UNROLL > 3)
-                    Scalar a4 = a3 * 1.1;
+                    Scalar a4 = a3 * static_cast<Scalar>(1.1);
 #endif
 #if (UNROLL > 4)
-                    Scalar a5 = a4 * 1.3;
+                    Scalar a5 = a4 * static_cast<Scalar>(1.3);
 #endif
 #if (UNROLL > 5)
-                    Scalar a6 = a5 * 1.1;
+                    Scalar a6 = a5 * static_cast<Scalar>(1.1);
 #endif
 #if (UNROLL > 6)
-                    Scalar a7 = a6 * 1.1;
+                    Scalar a7 = a6 * static_cast<Scalar>(1.1);
 #endif
 #if (UNROLL > 7)
-                    Scalar a8 = a7 * 1.1;
+                    Scalar a8 = a7 * static_cast<Scalar>(1.1);
 #endif
 
                     for (int f = 0; f < F; f++) {


### PR DESCRIPTION
This PR explicitly typecasts some real literals to `Scalar` for the `bytes_and_flops` benchmark.  Without this, we noticed a performance regression for the FP32 benchmark from ROCm 5.1 to ROCm 5.3 (& 5.4).  Performance appears to be restored in 5.4 by adding some typecast.

These are performance data collected: 

## FP32
run command: srun -n 1 ./bytes_and_flops.exe 1 100000 1024 1 1 8 64 256 6000
* [ROCm 5.1] 
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.003323s **Bandwidth: 344.339361GiB/s GFlop/s: 31981.781092**
* [ROCm 5.3] 
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.004009s **Bandwidth: 285.490147GiB/s GFlop/s: 26515.944512**
* [ROCm 5.4] 
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.004001s **Bandwidth: 286.013238GiB/s GFlop/s: 26564.528470**
* [ROCm 5.4, typecast to Scalar]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.003191s **Bandwidth: 358.683384GiB/s GFlop/s: 33314.034876**

## FP64
run command: srun -n 1 ./bytes_and_flops.exe 2 100000 1024 1 1 8 64 256 6000
* [ROCm 5.1]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.005776s **Bandwidth: 396.229589GiB/s GFlop/s: 18400.638186**
* [ROCm 5.3]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.005798s **Bandwidth: 394.781203GiB/s GFlop/s: 18333.376080**
* [ROCm 5.4]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.005744s **Bandwidth: 398.464760GiB/s GFlop/s: 18504.438029**
* [ROCm 5.4, typecast to Scalar] 
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.005775s **Bandwidth: 396.300575GiB/s GFlop/s: 18403.934744**

## Int32
run command: srun -n 1 ./bytes_and_flops.exe 3 100000 1024 1 1 8 64 256 6000
* [ROCm 5.1]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.010551s **Bandwidth: 108.469447GiB/s GFlop/s: 10074.497743**
* [ROCm 5.3]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.005791s **Bandwidth: 197.602018GiB/s GFlop/s: 18353.012137**
* [ROCm 5.4]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.005760s **Bandwidth: 198.697503GiB/s GFlop/s: 18454.759412**
* [ROCm 5.4, typecast to Scalar]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.005587s **Bandwidth: 204.827383GiB/s GFlop/s: 19024.094480**

## Int64
run command: srun -n 1 ./bytes_and_flops.exe 4 100000 1024 1 1 8 64 256 6000
* [ROCm 5.1]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.031074s **Bandwidth: 73.656282GiB/s GFlop/s: 3420.548659**
* [ROCm 5.3]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.026461s **Bandwidth: 86.499282GiB/s GFlop/s: 4016.969021**
* [ROCm 5.4]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.026475s **Bandwidth: 86.453017GiB/s GFlop/s: 4014.820515**
* [ROCm 5.4, typecast to Scalar]
  * NKRUFTSBI: 100000 1024 1 8 64 256 6000 2 10 Time: 0.025726s **Bandwidth: 88.970518GiB/s GFlop/s: 4131.731597**
