### PR TITLE
Make `{Serial,OpenACC,Threads}::concurrency()` a non-static member function

### DIFF
--- a/core/src/Kokkos_Serial.hpp
+++ b/core/src/Kokkos_Serial.hpp
@@ -140,7 +140,11 @@ class Serial {
   }
 
   /** \brief  Return the maximum amount of concurrency.  */
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency() { return 1; }
+#else
+  int concurrency() const { return 1; }
+#endif
 
   //! Print configuration information to the given output stream.
   void print_configuration(std::ostream& os, bool verbose = false) const;

--- a/core/src/Kokkos_Threads.hpp
+++ b/core/src/Kokkos_Threads.hpp
@@ -90,7 +90,11 @@ class Threads {
                  "Kokkos::Threads::fence: Unnamed Instance Fence") const;
 
   /** \brief  Return the maximum amount of concurrency.  */
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency();
+#else
+  int concurrency() const;
+#endif
 
   /// \brief Free any resources being consumed by the device.
   ///

--- a/core/src/OpenACC/Kokkos_OpenACC.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.hpp
@@ -83,7 +83,11 @@ class OpenACC {
   static void impl_static_fence(std::string const& name);
 
   static char const* name() { return "OpenACC"; }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency() { return 256000; }  // FIXME_OPENACC
+#else
+  int concurrency() const { return 256000; }  // FIXME_OPENACC
+#endif
   static bool in_parallel() { return acc_on_device(acc_device_not_host); }
   uint32_t impl_instance_id() const noexcept;
   Impl::OpenACCInternal* impl_internal_space_instance() const {

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -832,7 +832,12 @@ void ThreadsExec::finalize() {
 
 namespace Kokkos {
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 int Threads::concurrency() { return impl_thread_pool_size(0); }
+#else
+int Threads::concurrency() const { return impl_thread_pool_size(0); }
+#endif
+
 void Threads::fence(const std::string &name) const {
   Impl::ThreadsExec::internal_fence(name, Impl::fence_is_static::no);
 }

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -754,7 +754,7 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
  private:
   /** \brief finalize chunk_size if it was set to AUTO*/
   inline void set_auto_chunk_size() {
-    int64_t concurrency = traits::execution_space::concurrency() / m_team_alloc;
+    int64_t concurrency = space().concurrency() / m_team_alloc;
     if (concurrency == 0) concurrency = 1;
 
     if (m_chunk_size > 0) {


### PR DESCRIPTION
Partial fix for #5655 
Starting with the easy stuff.
I am proposing to guard the changes with for `KOKKOS_ENABLE_DEPRECATED_CODE_4` not defined.
As said in https://github.com/kokkos/kokkos/issues/5655#issuecomment-1334446830, I cannot think of a way to emit warnings if the member function is being called from an object.