### PR TITLE
Cleanup `CudaLDGFetch` class template

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -45,8 +45,8 @@ struct CudaLDGFetch {
   KOKKOS_INLINE_FUNCTION
   operator const ValueType*() const { return m_ptr; }
 
-  KOKKOS_INLINE_FUNCTION
-  CudaLDGFetch() : m_ptr() {}
+  KOKKOS_DEFAULTED_FUNCTION
+  CudaLDGFetch() = default;
 
   KOKKOS_INLINE_FUNCTION
   explicit CudaLDGFetch(const ValueType* const arg_ptr) : m_ptr(arg_ptr) {}

--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -31,7 +31,7 @@ struct CudaLDGFetch {
   const ValueType* m_ptr;
 
   template <typename iType>
-  KOKKOS_INLINE_FUNCTION ValueType operator[](const iType& i) const {
+  KOKKOS_FUNCTION ValueType operator[](const iType& i) const {
 #if defined(KOKKOS_ARCH_KEPLER30) || defined(KOKKOS_ARCH_KEPLER32)
     return m_ptr[i];
 #else
@@ -42,16 +42,16 @@ struct CudaLDGFetch {
 #endif
   }
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   operator const ValueType*() const { return m_ptr; }
 
   KOKKOS_DEFAULTED_FUNCTION
   CudaLDGFetch() = default;
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   explicit CudaLDGFetch(const ValueType* const arg_ptr) : m_ptr(arg_ptr) {}
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   CudaLDGFetch(CudaLDGFetch const rhs, size_t offset)
       : m_ptr(rhs.m_ptr + offset) {}
 };

--- a/core/src/Cuda/Kokkos_Cuda_View.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_View.hpp
@@ -48,27 +48,6 @@ struct CudaLDGFetch {
   KOKKOS_INLINE_FUNCTION
   CudaLDGFetch() : m_ptr() {}
 
-  KOKKOS_DEFAULTED_FUNCTION
-  ~CudaLDGFetch() = default;
-
-  KOKKOS_INLINE_FUNCTION
-  CudaLDGFetch(const CudaLDGFetch& rhs) : m_ptr(rhs.m_ptr) {}
-
-  KOKKOS_INLINE_FUNCTION
-  CudaLDGFetch(CudaLDGFetch&& rhs) : m_ptr(rhs.m_ptr) {}
-
-  KOKKOS_INLINE_FUNCTION
-  CudaLDGFetch& operator=(const CudaLDGFetch& rhs) {
-    m_ptr = rhs.m_ptr;
-    return *this;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  CudaLDGFetch& operator=(CudaLDGFetch&& rhs) {
-    m_ptr = rhs.m_ptr;
-    return *this;
-  }
-
   KOKKOS_INLINE_FUNCTION
   explicit CudaLDGFetch(const ValueType* const arg_ptr) : m_ptr(arg_ptr) {}
 


### PR DESCRIPTION
Follow-up for #5621
Let the compiler generate special member functions and drop unnecessary inline specifiers