### PR TITLE
Fixup make `{Cuda,HIP}::concurrency()` member function non static

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -679,7 +679,11 @@ Cuda::size_type Cuda::detect_device_count() {
   return Impl::CudaInternalDevices::singleton().m_cudaDevCount;
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 int Cuda::concurrency() {
+#else
+int Cuda::concurrency() const {
+#endif
   return Impl::CudaInternal::concurrency();
 }
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -267,6 +267,12 @@ const CudaInternalDevices &CudaInternalDevices::singleton() {
 
 //----------------------------------------------------------------------------
 
+int Impl::CudaInternal::concurrency() {
+  static int const concurrency = m_deviceProp.maxThreadsPerMultiProcessor *
+                                 m_deviceProp.multiProcessorCount;
+  return concurrency;
+}
+
 void CudaInternal::print_configuration(std::ostream &s) const {
   const CudaInternalDevices &dev_info = CudaInternalDevices::singleton();
 
@@ -417,9 +423,9 @@ Kokkos::Cuda::initialize WARNING: Cuda is allocating into UVMSpace by default
   }
 
   KOKKOS_IMPL_CUDA_SAFE_CALL(
-      cudaMalloc(&m_scratch_locks, sizeof(int32_t) * m_maxConcurrency));
+      cudaMalloc(&m_scratch_locks, sizeof(int32_t) * concurrency()));
   KOKKOS_IMPL_CUDA_SAFE_CALL(
-      cudaMemset(m_scratch_locks, 0, sizeof(int32_t) * m_maxConcurrency));
+      cudaMemset(m_scratch_locks, 0, sizeof(int32_t) * concurrency()));
 }
 
 //----------------------------------------------------------------------------
@@ -674,7 +680,7 @@ Cuda::size_type Cuda::detect_device_count() {
 }
 
 int Cuda::concurrency() {
-  return Impl::CudaInternal::singleton().m_maxConcurrency;
+  return Impl::CudaInternal::concurrency();
 }
 
 int Cuda::impl_is_initialized() {
@@ -781,8 +787,6 @@ void Cuda::impl_initialize(InitializationSettings const &settings) {
                 << " does not support unified virtual address space"
                 << std::endl;
     }
-    Impl::CudaInternal::m_maxConcurrency =
-        Impl::CudaInternal::m_maxThreadsPerSM * cudaProp.multiProcessorCount;
   } else {
     std::ostringstream msg;
     msg << "Kokkos::Cuda::initialize(" << cuda_device_id << ") FAILED: Device ";

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -109,12 +109,12 @@ class CudaInternal {
   inline static unsigned m_maxWarpCount             = 0;
   inline static std::array<size_type, 3> m_maxBlock = {0, 0, 0};
   inline static unsigned m_maxSharedWords           = 0;
-  inline static uint32_t m_maxConcurrency           = 0;
   inline static int m_shmemPerSM                    = 0;
   inline static int m_maxShmemPerBlock              = 0;
   inline static int m_maxBlocksPerSM                = 0;
   inline static int m_maxThreadsPerSM               = 0;
   inline static int m_maxThreadsPerBlock            = 0;
+  static int concurrency();
 
   inline static cudaDeviceProp m_deviceProp;
 

--- a/core/src/Cuda/Kokkos_Cuda_Locks.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.cpp
@@ -59,7 +59,7 @@ void initialize_host_cuda_lock_arrays() {
                  sizeof(int) * (CUDA_SPACE_ATOMIC_MASK + 1)));
   Impl::cuda_device_synchronize(
       "Kokkos::Impl::initialize_host_cuda_lock_arrays: Pre Init Lock Arrays");
-  g_host_cuda_lock_arrays.n = Cuda::concurrency();
+  g_host_cuda_lock_arrays.n = CudaInternal::concurrency();
   copy_cuda_lock_arrays_to_device();
   init_lock_array_kernel_atomic<<<(CUDA_SPACE_ATOMIC_MASK + 1 + 255) / 256,
                                   256>>>();

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -562,7 +562,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
           m_scratch_pool_id,
           static_cast<std::int64_t>(m_scratch_size[1]) *
               (std::min(
-                  static_cast<std::int64_t>(Cuda::concurrency() /
+                  static_cast<std::int64_t>(Cuda().concurrency() /
                                             (m_team_size * m_vector_size)),
                   static_cast<std::int64_t>(m_league_size))));
     }
@@ -928,7 +928,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
           m_scratch_pool_id,
           static_cast<std::int64_t>(m_scratch_size[1]) *
               (std::min(
-                  static_cast<std::int64_t>(Cuda::concurrency() /
+                  static_cast<std::int64_t>(Cuda().concurrency() /
                                             (m_team_size * m_vector_size)),
                   static_cast<std::int64_t>(m_league_size))));
     }
@@ -1033,7 +1033,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
           m_scratch_pool_id,
           static_cast<std::int64_t>(m_scratch_size[1]) *
               (std::min(
-                  static_cast<std::int64_t>(Cuda::concurrency() /
+                  static_cast<std::int64_t>(Cuda().concurrency() /
                                             (m_team_size * m_vector_size)),
                   static_cast<std::int64_t>(m_league_size))));
     }

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -29,7 +29,13 @@
 
 namespace Kokkos {
 
-int HIP::concurrency() { return Impl::HIPInternal::concurrency(); }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+int HIP::concurrency() {
+#else
+int HIP::concurrency() const {
+#endif
+  return Impl::HIPInternal::concurrency();
+}
 
 int HIP::impl_is_initialized() {
   return Impl::HIPInternal::singleton().is_initialized();

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -29,10 +29,8 @@
 
 namespace Kokkos {
 
-int HIP::concurrency() {
-  auto const& prop = hip_device_prop();
-  return prop.maxThreadsPerMultiProcessor * prop.multiProcessorCount;
-}
+int HIP::concurrency() { return Impl::HIPInternal::concurrency(); }
+
 int HIP::impl_is_initialized() {
   return Impl::HIPInternal::singleton().is_initialized();
 }

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -95,7 +95,11 @@ class HIP {
 
   static size_type detect_device_count();
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency();
+#else
+  int concurrency() const;
+#endif
   static const char* name();
 
   inline Impl::HIPInternal* impl_internal_space_instance() const {

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -80,6 +80,8 @@ class HIPInternal {
 
   inline static hipDeviceProp_t m_deviceProp;
 
+  static int concurrency();
+
   // Scratch Spaces for Reductions
   std::size_t m_scratchSpaceCount = 0;
   std::size_t m_scratchFlagsCount = 0;

--- a/core/src/HIP/Kokkos_HIP_Locks.cpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.cpp
@@ -23,6 +23,7 @@
 #include <HIP/Kokkos_HIP_Locks.hpp>
 #include <HIP/Kokkos_HIP_Error.hpp>
 #include <HIP/Kokkos_HIP.hpp>
+#include <HIP/Kokkos_HIP_Instance.hpp>
 
 #include <hip/hip_runtime.h>
 

--- a/core/src/HIP/Kokkos_HIP_Locks.cpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.cpp
@@ -63,7 +63,7 @@ void initialize_host_hip_lock_arrays() {
       &g_host_hip_lock_arrays.atomic,
       sizeof(std::int32_t) * (KOKKOS_IMPL_HIP_SPACE_ATOMIC_MASK + 1)));
 
-  g_host_hip_lock_arrays.n = HIP::concurrency();
+  g_host_hip_lock_arrays.n = HIPInternal::concurrency();
 
   KOKKOS_COPY_HIP_LOCK_ARRAYS_TO_DEVICE();
   init_lock_array_kernel_atomic<<<

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -515,9 +515,10 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>, HIP> {
       m_scratch_ptr[1]  = internal_space_instance->resize_team_scratch_space(
           m_scratch_pool_id,
           static_cast<std::int64_t>(m_scratch_size[1]) *
-              (std::min(static_cast<std::int64_t>(
-                            HIP::concurrency() / (m_team_size * m_vector_size)),
-                        static_cast<std::int64_t>(m_league_size))));
+              (std::min(
+                  static_cast<std::int64_t>(HIP().concurrency() /
+                                            (m_team_size * m_vector_size)),
+                  static_cast<std::int64_t>(m_league_size))));
     }
 
     int const shmem_size_total = m_shmem_begin + m_shmem_size;
@@ -838,9 +839,10 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       m_scratch_ptr[1]  = internal_space_instance->resize_team_scratch_space(
           m_scratch_pool_id,
           static_cast<std::int64_t>(m_scratch_size[1]) *
-              (std::min(static_cast<std::int64_t>(
-                            HIP::concurrency() / (m_team_size * m_vector_size)),
-                        static_cast<std::int64_t>(m_league_size))));
+              (std::min(
+                  static_cast<std::int64_t>(HIP().concurrency() /
+                                            (m_team_size * m_vector_size)),
+                  static_cast<std::int64_t>(m_league_size))));
     }
 
     // The global parallel_reduce does not support vector_length other than 1 at
@@ -931,9 +933,10 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
       m_scratch_ptr[1]  = internal_space_instance->resize_team_scratch_space(
           m_scratch_pool_id,
           static_cast<std::int64_t>(m_scratch_size[1]) *
-              (std::min(static_cast<std::int64_t>(
-                            HIP::concurrency() / (m_team_size * m_vector_size)),
-                        static_cast<std::int64_t>(m_league_size))));
+              (std::min(
+                  static_cast<std::int64_t>(HIP().concurrency() /
+                                            (m_team_size * m_vector_size)),
+                  static_cast<std::int64_t>(m_league_size))));
     }
 
     // The global parallel_reduce does not support vector_length other than 1 at

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -166,7 +166,11 @@ class Cuda {
                  "Kokkos::Cuda::fence(): Unnamed Instance Fence") const;
 
   /** \brief  Return the maximum amount of concurrency.  */
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency();
+#else
+  int concurrency() const;
+#endif
 
   //! Print configuration information to the given output stream.
   void print_configuration(std::ostream& os, bool verbose = false) const;


### PR DESCRIPTION
Partial fix for #5655 