### PR TITLE
Fix default memory order for sycl::atomic_ref

### DIFF
--- a/tpls/desul/include/desul/atomics/Adapt_SYCL.hpp
+++ b/tpls/desul/include/desul/atomics/Adapt_SYCL.hpp
@@ -38,6 +38,11 @@ using sycl_memory_scope = std::conditional_t<extended_namespace,
                                              sycl::memory_scope>;
 
 //<editor-fold desc="SYCL memory order">
+// The default memory order for sycl::atomic_ref
+// can be seq_cst, acq_rel, or relaxed according to the
+// "SYCL 2020 Specification (revision 6)", see
+// https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:atomic-references.
+// Thus, we map MemoryOrderAcquire and MemoryOrderRelease to acq_rel.
 template <class MemoryOrder, bool extended_namespace = true>
 struct SYCLMemoryOrder;
 
@@ -49,12 +54,12 @@ struct SYCLMemoryOrder<MemoryOrderSeqCst, extended_namespace> {
 template <bool extended_namespace>
 struct SYCLMemoryOrder<MemoryOrderAcquire, extended_namespace> {
   static constexpr sycl_memory_order<extended_namespace> value =
-      sycl_memory_order<extended_namespace>::acquire;
+      sycl_memory_order<extended_namespace>::acq_rel;
 };
 template <bool extended_namespace>
 struct SYCLMemoryOrder<MemoryOrderRelease, extended_namespace> {
   static constexpr sycl_memory_order<extended_namespace> value =
-      sycl_memory_order<extended_namespace>::release;
+      sycl_memory_order<extended_namespace>::acq_rel;
 };
 template <bool extended_namespace>
 struct SYCLMemoryOrder<MemoryOrderAcqRel, extended_namespace> {


### PR DESCRIPTION
#5105 broke my SYCL builds uncovering invalid defaults for `sycl::atomic_ref`, see https://github.com/intel/llvm/blob/894ce25635c5ead4d1c42e70f66d1970c86a7bf5/sycl/include/sycl/atomic_ref.hpp#L125-L128=:
```
static_assert(
      detail::IsValidDefaultOrder<DefaultOrder>::value,
      "Invalid default memory_order for atomics.  Valid defaults are: "
      "relaxed, acq_rel, seq_cst");
```