### PR TITLE
ENH: drop deprecated sprintf usage in Kokkos_Profiling.cpp

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -627,9 +627,9 @@ void initialize(const std::string& profileLibrary) {
 
   char* envProfileLibrary = const_cast<char*>(profileLibrary.c_str());
 
-  const auto envProfileCopy =
-      std::make_unique<char[]>(strlen(envProfileLibrary) + 1);
-  sprintf(envProfileCopy.get(), "%s", envProfileLibrary);
+  const size_t envProfileLen = strlen(envProfileLibrary) + 1;
+  const auto envProfileCopy  = std::make_unique<char[]>(envProfileLen);
+  snprintf(envProfileCopy.get(), envProfileLen, "%s", envProfileLibrary);
 
   char* profileLibraryName = strtok(envProfileCopy.get(), ";");
 


### PR DESCRIPTION
fixes a deprecation warning with the latest version of Xcode (14.1)

```
 warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  sprintf(envProfileCopy.get(), "%s", envProfileLibrary);
  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
```

I just fixed the one call that is hit in my application; I am not attempting to perform this migration over the whole code base, but I'm willing to do it if considered helpful.
