### PR TITLE
Finalize HIP lock arrays

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -284,6 +284,8 @@ void HIPInternal::finalize() {
 
   if (this == &singleton()) {
     (void)Kokkos::Impl::hip_global_unique_token_locks(true);
+    Impl::finalize_host_hip_lock_arrays();
+
     KOKKOS_IMPL_HIP_SAFE_CALL(hipHostFree(constantMemHostStaging));
     KOKKOS_IMPL_HIP_SAFE_CALL(hipEventDestroy(constantMemReusable));
   }


### PR DESCRIPTION
Apparently, we were never cleaning up the lock arrays:
```
$ git grep -n "finalize_host_hip_lock_arrays" .
core/src/HIP/Kokkos_HIP_Locks.cpp:74:void finalize_host_hip_lock_arrays() {
core/src/HIP/Kokkos_HIP_Locks.hpp:52:void finalize_host_hip_lock_arrays();
```
vs
```
$ git grep -n "finalize_host_cuda_lock_arrays" .
core/src/Cuda/Kokkos_Cuda_Instance.cpp:579:    Impl::finalize_host_cuda_lock_arrays();
core/src/Cuda/Kokkos_Cuda_Locks.cpp:70:void finalize_host_cuda_lock_arrays() {
core/src/Cuda/Kokkos_Cuda_Locks.hpp:54:void finalize_host_cuda_lock_arrays();
```