### PR TITLE
Make SYCL::concurrency non-static

### DIFF
--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -109,7 +109,12 @@ class SYCL {
 
   static bool impl_is_initialized();
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency();
+#else
+  int concurrency() const;
+#endif
+
   static const char* name();
 
   inline Impl::SYCLInternal* impl_internal_space_instance() const {

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -65,9 +65,15 @@ SYCL::SYCL(const sycl::queue& stream)
   m_space_instance->initialize(stream);
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 int SYCL::concurrency() {
   return Impl::SYCLInternal::singleton().m_maxConcurrency;
 }
+#else
+int SYCL::concurrency() const {
+  return Impl::SYCLInternal::singleton().m_maxConcurrency;
+}
+#endif
 
 const char* SYCL::name() { return "SYCL"; }
 

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -70,9 +70,7 @@ int SYCL::concurrency() {
   return Impl::SYCLInternal::singleton().m_maxConcurrency;
 }
 #else
-int SYCL::concurrency() const {
-  return Impl::SYCLInternal::singleton().m_maxConcurrency;
-}
+int SYCL::concurrency() const { return m_space_instance->m_maxConcurrency; }
 #endif
 
 const char* SYCL::name() { return "SYCL"; }


### PR DESCRIPTION
Corresponding to #5669. It seems that we don't need `g_host_cuda_lock_arrays` (probably even after merging the generic atomics pull request). Hence, I haven't included a static `SYCLInternal::concurrency` function.