### PR TITLE
use snprintf to silence Apple Clang

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -627,9 +627,9 @@ void initialize(const std::string& profileLibrary) {
 
   char* envProfileLibrary = const_cast<char*>(profileLibrary.c_str());
 
-  const auto envProfileCopy =
-      std::make_unique<char[]>(strlen(envProfileLibrary) + 1);
-  sprintf(envProfileCopy.get(), "%s", envProfileLibrary);
+  auto envProfileCopySize = strlen(envProfileLibrary) + 1;
+  const auto envProfileCopy = std::make_unique<char[]>(envProfileCopySize);
+  snprintf(envProfileCopy.get(), envProfileCopySize, "%s", envProfileLibrary);
 
   char* profileLibraryName = strtok(envProfileCopy.get(), ";");
 

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -627,7 +627,7 @@ void initialize(const std::string& profileLibrary) {
 
   char* envProfileLibrary = const_cast<char*>(profileLibrary.c_str());
 
-  auto envProfileCopySize = strlen(envProfileLibrary) + 1;
+  auto envProfileCopySize   = strlen(envProfileLibrary) + 1;
   const auto envProfileCopy = std::make_unique<char[]>(envProfileCopySize);
   snprintf(envProfileCopy.get(), envProfileCopySize, "%s", envProfileLibrary);
 


### PR DESCRIPTION
the version of Apple Clang that I'm
using by default warns that sprintf
is deprecated for security reasons,
so this change switches to snprintf
to silence the warning.