### PR TITLE
Fixup temporary file in script to check copyright

### DIFF
--- a/scripts/check-copyright
+++ b/scripts/check-copyright
@@ -11,6 +11,6 @@ for file in $files; do
     echo $file >> scripts/diff_files
   fi
 done
-tmpfile=$(mktemp -t kokkos_diff_files)
+tmpfile=$(mktemp -t kokkos_diff_files.XXXX)
 cat scripts/diff_files | sort &> $tmpfile
 mv $tmpfile scripts/diff_files

--- a/scripts/check-copyright
+++ b/scripts/check-copyright
@@ -11,5 +11,6 @@ for file in $files; do
     echo $file >> scripts/diff_files
   fi
 done
-cat scripts/diff_files | sort &> tmp
-cp tmp scripts/diff_files
+tmpfile=$(mktemp -t kokkos_diff_files)
+cat scripts/diff_files | sort &> $tmpfile
+mv $tmpfile scripts/diff_files


### PR DESCRIPTION
Use `mktemp` for the temporary file.  This will avoid failure like the one below (seen in recent CI builds)
```
./scripts/check-copyright: line 14: tmp: Is a directory
cp: -r not specified; omitting directory 'tmp'
script returned exit code 1