### PR TITLE
Fix #4942 Scratch Allocation Alignment

### DIFF
--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -41,9 +41,8 @@ class ScratchMemorySpace {
       "Instantiating ScratchMemorySpace on non-execution-space type.");
 
  public:
-  // Alignment of memory chunks returned by 'get'
-  // must be a power of two
-  enum { ALIGN = 8 };
+  // Minimal overalignment used by view scratch allocations
+  constexpr static int ALIGN = 8;
 
  private:
   mutable char* m_iter_L0 = nullptr;
@@ -55,7 +54,7 @@ class ScratchMemorySpace {
   mutable int m_offset        = 0;
   mutable int m_default_level = 0;
 
-  enum { MASK = ALIGN - 1 };  // Alignment used by View::shmem_size
+  constexpr static int DEFAULT_ALIGNMENT_MASK = ALIGN - 1;
 
  public:
   //! Tag this class as a memory space
@@ -69,10 +68,13 @@ class ScratchMemorySpace {
 
   static constexpr const char* name() { return "ScratchMemorySpace"; }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  // This function is unused
   template <typename IntType>
-  KOKKOS_INLINE_FUNCTION static IntType align(const IntType& size) {
-    return (size + MASK) & ~MASK;
+  KOKKOS_INLINE_FUNCTION static constexpr IntType align(const IntType& size) {
+    return (size + DEFAULT_ALIGNMENT_MASK) & ~DEFAULT_ALIGNMENT_MASK;
   }
+#endif
 
   template <typename IntType>
   KOKKOS_INLINE_FUNCTION void* get_shmem(const IntType& size,
@@ -93,15 +95,29 @@ class ScratchMemorySpace {
                                                 const ptrdiff_t alignment,
                                                 int level = -1) const {
     if (level == -1) level = m_default_level;
-    auto& m_iter              = (level == 0) ? m_iter_L0 : m_iter_L1;
-    auto& m_end               = (level == 0) ? m_end_L0 : m_end_L1;
-    char* previous            = m_iter;
-    const ptrdiff_t missalign = size_t(m_iter) % alignment;
-    if (missalign) m_iter += alignment - missalign;
+    auto& m_iter = (level == 0) ? m_iter_L0 : m_iter_L1;
+    auto& m_end  = (level == 0) ? m_end_L0 : m_end_L1;
+    if constexpr (aligned) {
+      const ptrdiff_t missalign = size_t(m_iter) % alignment;
+      if (missalign) m_iter += alignment - missalign;
+    }
 
-    void* tmp = m_iter + m_offset * (aligned ? size : align(size));
-    if (m_end < (m_iter += (aligned ? size : align(size)) * m_multiplier)) {
-      m_iter = previous;  // put it back like it was
+    // This is each threads start pointer for their allocation
+    // Note: for team scratch m_offset is 0, since every
+    // thread will get back the same shared pointer
+    void* tmp           = m_iter + m_offset * size;
+    ptrdiff_t increment = size * m_multiplier;
+
+    // increment m_iter first and decrement it again if not
+    // enough memory was available. In the non-failing path
+    // this will safe instructions.
+    m_iter += increment;
+
+    if (m_end < m_iter) {
+      // Request did overflow: reset the base team ptr, and
+      // return nullptr
+      m_iter -= increment;
+      tmp = nullptr;
 #ifdef KOKKOS_ENABLE_DEBUG
       // mfh 23 Jun 2015: printf call consumes 25 registers
       // in a CUDA build, so only print in debug mode.  The
@@ -111,7 +127,6 @@ class ScratchMemorySpace {
           "%ld byte(s); remaining capacity is %ld byte(s)\n",
           long(size), long(m_end - m_iter));
 #endif  // KOKKOS_ENABLE_DEBUG
-      tmp = nullptr;
     }
     return tmp;
   }

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -99,8 +99,8 @@ class ScratchMemorySpace {
                                                 const ptrdiff_t alignment,
                                                 int level = -1) const {
     if (level == -1) level = m_default_level;
-    auto& m_iter = (level == 0) ? m_iter_L0 : m_iter_L1;
-    auto& m_end  = (level == 0) ? m_end_L0 : m_end_L1;
+    auto& m_iter    = (level == 0) ? m_iter_L0 : m_iter_L1;
+    auto& m_end     = (level == 0) ? m_end_L0 : m_end_L1;
     auto m_iter_old = m_iter;
     if constexpr (alignment_requested) {
       const ptrdiff_t missalign = size_t(m_iter) % alignment;
@@ -116,7 +116,7 @@ class ScratchMemorySpace {
     if (increment > m_end - m_iter) {
       // Request did overflow: return nullptr and reset m_iter
       m_iter = m_iter_old;
-      tmp = nullptr;
+      tmp    = nullptr;
 #ifdef KOKKOS_ENABLE_DEBUG
       // mfh 23 Jun 2015: printf call consumes 25 registers
       // in a CUDA build, so only print in debug mode.  The

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -101,6 +101,7 @@ class ScratchMemorySpace {
     if (level == -1) level = m_default_level;
     auto& m_iter = (level == 0) ? m_iter_L0 : m_iter_L1;
     auto& m_end  = (level == 0) ? m_end_L0 : m_end_L1;
+    auto m_iter_old = m_iter;
     if constexpr (alignment_requested) {
       const ptrdiff_t missalign = size_t(m_iter) % alignment;
       if (missalign) m_iter += alignment - missalign;
@@ -113,7 +114,8 @@ class ScratchMemorySpace {
     ptrdiff_t increment = size * m_multiplier;
 
     if (increment > m_end - m_iter) {
-      // Request did overflow: return nullptr
+      // Request did overflow: return nullptr and reset m_iter
+      m_iter = m_iter_old;
       tmp = nullptr;
 #ifdef KOKKOS_ENABLE_DEBUG
       // mfh 23 Jun 2015: printf call consumes 25 registers

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -112,12 +112,7 @@ class ScratchMemorySpace {
     void* tmp           = m_iter + m_offset * size;
     ptrdiff_t increment = size * m_multiplier;
 
-    // increment m_iter first and decrement it again if not
-    // enough memory was available. In the non-failing path
-    // this will save instructions.
-    m_iter += increment;
-
-    if (m_end < m_iter) {
+    if (increment > m_end - m_iter) {
       // Request did overflow: reset the base team ptr, and
       // return nullptr
       m_iter -= increment;
@@ -131,6 +126,8 @@ class ScratchMemorySpace {
           "%ld byte(s); remaining capacity is %ld byte(s)\n",
           long(size), long(m_end - m_iter));
 #endif  // KOKKOS_ENABLE_DEBUG
+    } else {
+      m_iter += increment;
     }
     return tmp;
   }

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -113,9 +113,7 @@ class ScratchMemorySpace {
     ptrdiff_t increment = size * m_multiplier;
 
     if (increment > m_end - m_iter) {
-      // Request did overflow: reset the base team ptr, and
-      // return nullptr
-      m_iter -= increment;
+      // Request did overflow: return nullptr
       tmp = nullptr;
 #ifdef KOKKOS_ENABLE_DEBUG
       // mfh 23 Jun 2015: printf call consumes 25 registers

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1640,10 +1640,10 @@ class View : public ViewTraits<DataType, Properties...> {
   // Want to be able to align to minimum scratch alignment or sizeof or alignof
   // elements
   static constexpr size_t scratch_value_alignment =
-      ::Kokkos::max(::Kokkos::max(sizeof(typename traits::value_type),
-                                  alignof(typename traits::value_type)),
-                    static_cast<size_t>(
-                        traits::execution_space::scratch_memory_space::ALIGN));
+      max({sizeof(typename traits::value_type),
+           alignof(typename traits::value_type),
+           static_cast<size_t>(
+               traits::execution_space::scratch_memory_space::ALIGN)});
 
  public:
   static KOKKOS_INLINE_FUNCTION size_t

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1636,27 +1636,27 @@ class View : public ViewTraits<DataType, Properties...> {
         arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7));
   }
 
+ private:
+  // Want to be able to align to minimum scratch alignment or sizeof or alignof
+  // elements
+  static constexpr size_t scratch_value_alignment =
+      ::Kokkos::max(::Kokkos::max(sizeof(typename traits::value_type),
+                                  alignof(typename traits::value_type)),
+                    static_cast<size_t>(
+                        traits::execution_space::scratch_memory_space::ALIGN));
+
+ public:
   static KOKKOS_INLINE_FUNCTION size_t
   shmem_size(typename traits::array_layout const& arg_layout) {
-    return map_type::memory_span(arg_layout) +
-           // Want to be able to align to minmum alignment or size of elements
-           ::Kokkos::max(
-               sizeof(typename traits::value_type),
-               static_cast<size_t>(
-                   traits::execution_space::scratch_memory_space::ALIGN));
+    return map_type::memory_span(arg_layout) + scratch_value_alignment;
   }
 
   explicit KOKKOS_INLINE_FUNCTION View(
       const typename traits::execution_space::scratch_memory_space& arg_space,
       const typename traits::array_layout& arg_layout)
-      : View(Impl::ViewCtorProp<pointer_type>(
-                 reinterpret_cast<pointer_type>(arg_space.get_shmem_aligned(
-                     map_type::memory_span(arg_layout),
-                     // Want to align to minmum alignment or size of elements
-                     ::Kokkos::max(sizeof(typename traits::value_type),
-                                   static_cast<size_t>(
-                                       traits::execution_space::
-                                           scratch_memory_space::ALIGN))))),
+      : View(Impl::ViewCtorProp<pointer_type>(reinterpret_cast<pointer_type>(
+                 arg_space.get_shmem_aligned(map_type::memory_span(arg_layout),
+                                             scratch_value_alignment))),
              arg_layout) {}
 
   explicit KOKKOS_INLINE_FUNCTION View(
@@ -1674,11 +1674,7 @@ class View : public ViewTraits<DataType, Properties...> {
                      map_type::memory_span(typename traits::array_layout(
                          arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6,
                          arg_N7)),
-                     // Want to align to minmum alignment or size of elements
-                     ::Kokkos::max(sizeof(typename traits::value_type),
-                                   static_cast<size_t>(
-                                       traits::execution_space::
-                                           scratch_memory_space::ALIGN))))),
+                     scratch_value_alignment))),
              typename traits::array_layout(arg_N0, arg_N1, arg_N2, arg_N3,
                                            arg_N4, arg_N5, arg_N6, arg_N7)) {
     static_assert(traits::array_layout::is_extent_constructible,

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1536,6 +1536,7 @@ struct TestScratchAlignment {
       Kokkos::View<int *, typename ExecSpace::scratch_memory_space>;
   void test_view(bool allocate_small) {
     int shmem_size = ScratchView::shmem_size(11);
+    // FIXME_OPENMPTARGET temporary restriction for team size to be at least 32
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
     int team_size =
         std::is_same<ExecSpace, Kokkos::Experimental::OpenMPTarget>::value ? 32
@@ -1559,7 +1560,15 @@ struct TestScratchAlignment {
 
   void test_minimal() {
     using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
-    Kokkos::TeamPolicy<ExecSpace> policy(1, 1);
+    // FIXME_OPENMPTARGET temporary restriction for team size to be at least 32
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+    int team_size =
+        std::is_same<ExecSpace, Kokkos::Experimental::OpenMPTarget>::value ? 32
+                                                                           : 1;
+#else
+    int team_size      = 1;
+#endif
+    Kokkos::TeamPolicy<ExecSpace> policy(1, team_size);
     size_t scratch_size = sizeof(int);
     Kokkos::View<int, ExecSpace> flag("Flag");
 

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1524,14 +1524,16 @@ struct TestScratchAlignment {
     double x, y, z;
   };
   TestScratchAlignment() {
-    test(true);
-    test(false);
+    test_view(true);
+    test_view(false);
+    test_minimal();
+    test_raw();
   }
   using ScratchView =
       Kokkos::View<TestScalar *, typename ExecSpace::scratch_memory_space>;
   using ScratchViewInt =
       Kokkos::View<int *, typename ExecSpace::scratch_memory_space>;
-  void test(bool allocate_small) {
+  void test_view(bool allocate_small) {
     int shmem_size = ScratchView::shmem_size(11);
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
     int team_size =
@@ -1553,12 +1555,68 @@ struct TestScratchAlignment {
         });
     Kokkos::fence();
   }
+
+  void test_minimal() {
+    using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+    Kokkos::TeamPolicy<ExecSpace> policy(1, 1);
+    size_t scratch_size = sizeof(int);
+    Kokkos::View<int, ExecSpace> flag("Flag");
+
+    Kokkos::parallel_for(
+        policy.set_scratch_size(0, Kokkos::PerTeam(scratch_size)),
+        KOKKOS_LAMBDA(const member_type &team) {
+          int *scratch_ptr = (int *)team.team_shmem().get_shmem(scratch_size);
+          if (scratch_ptr == nullptr) flag() = 1;
+        });
+    Kokkos::fence();
+    int minimal_scratch_allocation_failed = 0;
+    Kokkos::deep_copy(minimal_scratch_allocation_failed, flag);
+    ASSERT_TRUE(minimal_scratch_allocation_failed == 0);
+  }
+
+  void test_raw() {
+    using member_type = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+    Kokkos::TeamPolicy<ExecSpace> policy(1, 1);
+    Kokkos::View<int, ExecSpace> flag("Flag");
+
+    Kokkos::parallel_for(
+        policy.set_scratch_size(0, Kokkos::PerTeam(1024)),
+        KOKKOS_LAMBDA(const member_type &team) {
+          int *scratch_ptr1 = (int *)team.team_shmem().get_shmem(24);
+          int *scratch_ptr2 = (int *)team.team_shmem().get_shmem(32);
+          int *scratch_ptr3 = (int *)team.team_shmem().get_shmem(12);
+
+          if ((int(scratch_ptr2 - scratch_ptr1) != 6) ||
+              (int(scratch_ptr3 - scratch_ptr2) != 8))
+            flag() = 1;
+
+          if (((scratch_ptr3 - static_cast<int *>(nullptr)) + 3) % 2 == 1)
+            scratch_ptr1 = (int *)team.team_shmem().get_shmem_aligned(24, 4);
+          else {
+            scratch_ptr1 = (int *)team.team_shmem().get_shmem_aligned(12, 4);
+          }
+          scratch_ptr2 = (int *)team.team_shmem().get_shmem_aligned(32, 8);
+          scratch_ptr3 = (int *)team.team_shmem().get_shmem_aligned(8, 4);
+
+          if ((int(scratch_ptr2 - scratch_ptr1) != 7) &&
+              (int(scratch_ptr2 - scratch_ptr1) != 4))
+            flag() = 1;
+          if (int(scratch_ptr3 - scratch_ptr2) != 8) flag() == 1;
+          if ((int(size_t(scratch_ptr1) % 4) != 0) ||
+              (int(size_t(scratch_ptr2) % 8) != 0) ||
+              (int(size_t(scratch_ptr3) % 4) != 0))
+            flag() = 1;
+        });
+    Kokkos::fence();
+    int raw_get_shmem_alignment_failed = 0;
+    Kokkos::deep_copy(raw_get_shmem_alignment_failed, flag);
+    ASSERT_TRUE(raw_get_shmem_alignment_failed == 0);
+  }
 };
 
 }  // namespace
 
 namespace {
-
 template <class ExecSpace>
 struct TestTeamPolicyHandleByValue {
   using scalar     = double;

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1582,29 +1582,28 @@ struct TestScratchAlignment {
     Kokkos::parallel_for(
         policy.set_scratch_size(0, Kokkos::PerTeam(1024)),
         KOKKOS_LAMBDA(const member_type &team) {
-          int *scratch_ptr1 = (int *)team.team_shmem().get_shmem(24);
-          int *scratch_ptr2 = (int *)team.team_shmem().get_shmem(32);
-          int *scratch_ptr3 = (int *)team.team_shmem().get_shmem(12);
+          intptr_t scratch_ptr1 = intptr_t(team.team_shmem().get_shmem(24));
+          intptr_t scratch_ptr2 = intptr_t(team.team_shmem().get_shmem(32));
+          intptr_t scratch_ptr3 = intptr_t(team.team_shmem().get_shmem(12));
 
-          if ((int(scratch_ptr2 - scratch_ptr1) != 6) ||
-              (int(scratch_ptr3 - scratch_ptr2) != 8))
+          if (((scratch_ptr2 - scratch_ptr1) != 24) ||
+              ((scratch_ptr3 - scratch_ptr2) != 32))
             flag() = 1;
 
-          if (((scratch_ptr3 - static_cast<int *>(nullptr)) + 3) % 2 == 1)
-            scratch_ptr1 = (int *)team.team_shmem().get_shmem_aligned(24, 4);
+          if ((scratch_ptr3 + 12) % 8 == 4)
+            scratch_ptr1 = intptr_t(team.team_shmem().get_shmem_aligned(24, 4));
           else {
-            scratch_ptr1 = (int *)team.team_shmem().get_shmem_aligned(12, 4);
+            scratch_ptr1 = intptr_t(team.team_shmem().get_shmem_aligned(12, 4));
           }
-          scratch_ptr2 = (int *)team.team_shmem().get_shmem_aligned(32, 8);
-          scratch_ptr3 = (int *)team.team_shmem().get_shmem_aligned(8, 4);
+          scratch_ptr2 = intptr_t(team.team_shmem().get_shmem_aligned(32, 8));
+          scratch_ptr3 = intptr_t(team.team_shmem().get_shmem_aligned(8, 4));
 
-          if ((int(scratch_ptr2 - scratch_ptr1) != 7) &&
-              (int(scratch_ptr2 - scratch_ptr1) != 4))
+          if ((int(scratch_ptr2 - scratch_ptr1) != 28) &&
+              (int(scratch_ptr2 - scratch_ptr1) != 16))
             flag() = 1;
-          if (int(scratch_ptr3 - scratch_ptr2) != 8) flag() = 1;
-          if ((int(size_t(scratch_ptr1) % 4) != 0) ||
-              (int(size_t(scratch_ptr2) % 8) != 0) ||
-              (int(size_t(scratch_ptr3) % 4) != 0))
+          if (int(scratch_ptr3 - scratch_ptr2) != 32) flag() = 1;
+          if ((int(scratch_ptr1 % 4) != 0) || (int(scratch_ptr2 % 8) != 0) ||
+              (int(scratch_ptr3 % 4) != 0))
             flag() = 1;
         });
     Kokkos::fence();

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1601,7 +1601,7 @@ struct TestScratchAlignment {
           if ((int(scratch_ptr2 - scratch_ptr1) != 7) &&
               (int(scratch_ptr2 - scratch_ptr1) != 4))
             flag() = 1;
-          if (int(scratch_ptr3 - scratch_ptr2) != 8) flag() == 1;
+          if (int(scratch_ptr3 - scratch_ptr2) != 8) flag() = 1;
           if ((int(size_t(scratch_ptr1) % 4) != 0) ||
               (int(size_t(scratch_ptr2) % 8) != 0) ||
               (int(size_t(scratch_ptr3) % 4) != 0))


### PR DESCRIPTION
This fixes the scratch space allocation alignment, #4942.
Note there is a default over alignment used by views. This makes sure that in the mode in which we run with 64bit shared memory banks that you don't have two conflicting scratch views resulting in really bad bank conflicts.

That default alignment was always there, and our scratch allocation mechanism was now doing a weird (faulty) mix of default alignment and requested alignment. I cleaned that up in a way that `get_shmem` doesn't do any alignment, `get_aligned_shmem` uses only the provided alignment in the argument, and `Kokkos::View` takes the default alignment into account for its scratch allocations.