### PR TITLE
Tracking performance results: Collect performance results

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -93,6 +93,7 @@ jobs:
         run: |
           cmake -B builddir \
             -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ${{ matrix.clang-tidy }} \
             -Ddesul_ROOT=/usr/desul-install/ \
             -DKokkos_ARCH_NATIVE=ON \

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -93,7 +93,6 @@ jobs:
         run: |
           cmake -B builddir \
             -DCMAKE_INSTALL_PREFIX=/usr \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ${{ matrix.clang-tidy }} \
             -Ddesul_ROOT=/usr/desul-install/ \
             -DKokkos_ARCH_NATIVE=ON \
@@ -106,6 +105,7 @@ jobs:
             -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
             -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
       - name: Build
         run: |

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/kokkos/ci-containers/${{ matrix.distro }}
-      # see https://github.com/actions/virtual-environments/issues/3812
-      options: --security-opt seccomp=unconfined
     env:
       BUILD_ID: ${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.backend }}
     steps:

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -1,0 +1,66 @@
+name: github-benchmarks
+on:
+  push:
+    branches:
+      - develop
+      - performance-results-visualization
+
+jobs:
+  CI:
+    continue-on-error: true
+    strategy:
+      matrix:
+        distro: ['ubuntu:latest']
+        cxx: ['g++', 'clang++']
+        backend: ['OPENMP']
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/kokkos/ci-containers/${{ matrix.distro }}
+      # see https://github.com/actions/virtual-environments/issues/3812
+      options: --security-opt seccomp=unconfined
+    env:
+      BUILD_ID: ${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.backend }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.ccache
+          key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.openmp }}-${github.ref}-${{ github.sha }}
+          restore-keys: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.openmp }}-${{github.ref}}
+      - name: Configure Kokkos
+        run: |
+          cmake -B builddir \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DKokkos_ARCH_NATIVE=ON \
+            -DKokkos_ENABLE_HWLOC=ON \
+            -DKokkos_ENABLE_${{ matrix.backend }}=ON \
+            -DKokkos_ENABLE_TESTS=ON \
+            -DKokkos_ENABLE_BENCHMARKS=ON \
+            -DKokkos_ENABLE_EXAMPLES=ON \
+            -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
+            -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+            -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          ccache -z
+          cmake --build builddir --parallel 2
+          ccache -s
+      - name: Tests
+        working-directory: builddir
+        run: ctest --output-on-failure
+      - name: Gather benchmark results
+        run: |
+          mkdir ${{ env.BUILD_ID }}
+          find builddir/core/perf_test/ -name "*.json" -exec mv {} ${{ env.BUILD_ID }}/  \;
+      - name: Push benchmark results
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source_file: ${{ env.BUILD_ID }}
+          destination_repo: 'kokkos/kokkos-benchmark-results'
+          destination_branch: 'master'
+          user_email: 'kokkos@users.noreply.github.com'
+          user_name: 'Kokkos Developers'

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Configure Kokkos
         run: |
           cmake -B builddir \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DKokkos_ARCH_NATIVE=ON \
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_${{ matrix.backend }}=ON \

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -33,9 +33,7 @@ jobs:
             -DKokkos_ARCH_NATIVE=ON \
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_${{ matrix.backend }}=ON \
-            -DKokkos_ENABLE_TESTS=ON \
             -DKokkos_ENABLE_BENCHMARKS=ON \
-            -DKokkos_ENABLE_EXAMPLES=ON \
             -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
             -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/develop' }}
         uses: dmnemec/copy_file_to_another_repo_action@main
         env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+          API_TOKEN_GITHUB: ${{ secrets.DALG24_PUSH_BENCHMARK_RESULTS }}
         with:
           source_file: ${{ env.BUILD_ID }}
           destination_repo: 'kokkos/kokkos-benchmark-results'

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Build
         run: |
           ccache -z
-          cmake --build builddir --parallel 2
+          NUM_CPU=$(grep -c processor /proc/cpuinfo)
+          cmake --build builddir --parallel ${NUM_CPU}
           ccache -s
       - name: Tests
         working-directory: builddir

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - develop
-      - performance-results-visualization
+  pull_request:
 
 jobs:
   CI:
@@ -51,6 +51,7 @@ jobs:
           mkdir ${{ env.BUILD_ID }}
           find builddir/core/perf_test/ -name "*.json" -exec mv {} ${{ env.BUILD_ID }}/  \;
       - name: Push benchmark results
+        if: ${{ github.ref == 'refs/heads/develop' }}
         uses: dmnemec/copy_file_to_another_repo_action@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -29,13 +29,10 @@ jobs:
       - name: Configure Kokkos
         run: |
           cmake -B builddir \
-            -DCMAKE_INSTALL_PREFIX=/usr \
             -DKokkos_ARCH_NATIVE=ON \
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_${{ matrix.backend }}=ON \
             -DKokkos_ENABLE_BENCHMARKS=ON \
-            -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
-            -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_BUILD_TYPE=Release
       - name: Build

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Configure Kokkos
         run: |
           cmake -B builddir \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DKokkos_ARCH_NATIVE=ON \
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_${{ matrix.backend }}=ON \
             -DKokkos_ENABLE_BENCHMARKS=ON \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=Release
       - name: Build
         run: |

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -58,6 +58,6 @@ jobs:
         with:
           source_file: ${{ env.BUILD_ID }}
           destination_repo: 'kokkos/kokkos-benchmark-results'
-          destination_branch: 'master'
+          destination_branch: 'main'
           user_email: 'kokkos@users.noreply.github.com'
           user_name: 'Kokkos Developers'

--- a/cmake/Kokkos_Version_Info.hpp
+++ b/cmake/Kokkos_Version_Info.hpp
@@ -14,8 +14,8 @@
 //
 //@HEADER
 
-#ifndef GIT_VERSION_H
-#define GIT_VERSION_H
+#ifndef KOKKOS_GIT_VERSION_INFO_H
+#define KOKKOS_GIT_VERSION_INFO_H
 
 #include <string>
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,10 +6,23 @@ IF (NOT Kokkos_INSTALL_TESTING)
   ADD_SUBDIRECTORY(src)
 ENDIF()
 
+FUNCTION(KOKKOS_ADD_BENCHMARK_DIRECTORY DIR_NAME)
+  IF(NOT Kokkos_ENABLE_BENCHMARKS)
+    RETURN()
+  ENDIF()
+
+  IF(KOKKOS_HAS_TRILINOS)
+    message(
+      STATUS
+      "Benchmarks are not supported when building as part of Trilinos"
+    )
+    RETURN()
+  ENDIF()
+
+  ADD_SUBDIRECTORY(${DIR_NAME})
+ENDFUNCTION()
+
 KOKKOS_ADD_TEST_DIRECTORIES(unit_test)
-IF (NOT KOKKOS_HAS_TRILINOS)
-  # We are using the githash etc in here, which does not work correct in Trilinos
-  KOKKOS_ADD_TEST_DIRECTORIES(perf_test)
-ENDIF()
+KOKKOS_ADD_BENCHMARK_DIRECTORY(perf_test)
 
 KOKKOS_SUBPACKAGE_POSTPROCESS()

--- a/core/perf_test/BenchmarkMain.cpp
+++ b/core/perf_test/BenchmarkMain.cpp
@@ -16,7 +16,7 @@
 
 #include <benchmark/benchmark.h>
 
-#include <Benchmark_Context.hpp>
+#include "Benchmark_Context.hpp"
 #include <Kokkos_Core.hpp>
 
 int main(int argc, char** argv) {

--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -1,14 +1,3 @@
-
-#INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
-#INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
-
-
-# warning: PerfTest_CustomReduction.cpp uses
-# ../../algorithms/src/Kokkos_Random.hpp
-# we'll just allow it to be included, but note
-# that in TriBITS KokkosAlgorithms can be disabled...
-#INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}/../../algorithms/src")
-
 # FIXME_OPENMPTARGET - the NVIDIA HPC compiler nvc++ in the OpenMPTarget backend does not pass the perf_tests.
 # FIXME_OPENACC - temporarily disabled due to unimplemented features
 IF ((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
@@ -60,6 +49,10 @@ IF(KOKKOS_ENABLE_TESTS)
 
   #leave these as basic includes for now
   #I don't need anything transitive
+  # warning: PerfTest_CustomReduction.cpp uses
+  # ../../algorithms/src/Kokkos_Random.hpp
+  # we'll just allow it to be included, but note
+  # that in TriBITS KokkosAlgorithms can be disabled...
   KOKKOS_INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}/../../algorithms/src")
   KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
   KOKKOS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})

--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -15,102 +15,97 @@ IF ((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILE
   RETURN()
 ENDIF()
 
+IF(KOKKOS_ENABLE_TESTS)
 
-SET(SOURCES
-  PerfTestMain.cpp
-  PerfTestGramSchmidt.cpp
-  PerfTestHexGrad.cpp
-  PerfTest_CustomReduction.cpp
-  PerfTest_ExecSpacePartitioning.cpp
-  PerfTest_ViewAllocate.cpp
-  PerfTest_ViewFill_123.cpp
-  PerfTest_ViewFill_45.cpp
-  PerfTest_ViewFill_6.cpp
-  PerfTest_ViewFill_7.cpp
-  PerfTest_ViewFill_8.cpp
-  PerfTest_ViewResize_123.cpp
-  PerfTest_ViewResize_45.cpp
-  PerfTest_ViewResize_6.cpp
-  PerfTest_ViewResize_7.cpp
-  PerfTest_ViewResize_8.cpp
-  )
-
-IF(Kokkos_ENABLE_OPENMPTARGET)
-# FIXME OPENMPTARGET requires TeamPolicy Reductions and Custom Reduction
-  LIST(REMOVE_ITEM SOURCES
+  SET(SOURCES
+    PerfTestMain.cpp
     PerfTestGramSchmidt.cpp
+    PerfTestHexGrad.cpp
     PerfTest_CustomReduction.cpp
     PerfTest_ExecSpacePartitioning.cpp
-  )
-ENDIF()
+    PerfTest_ViewAllocate.cpp
+    PerfTest_ViewFill_123.cpp
+    PerfTest_ViewFill_45.cpp
+    PerfTest_ViewFill_6.cpp
+    PerfTest_ViewFill_7.cpp
+    PerfTest_ViewFill_8.cpp
+    PerfTest_ViewResize_123.cpp
+    PerfTest_ViewResize_45.cpp
+    PerfTest_ViewResize_6.cpp
+    PerfTest_ViewResize_7.cpp
+    PerfTest_ViewResize_8.cpp
+    )
 
-IF(KOKKOS_ENABLE_CUDA OR KOKKOS_ENABLE_HIP OR KOKKOS_ENABLE_SYCL)
-  KOKKOS_ADD_EXECUTABLE (
-    PerformanceTest_SharedSpace
-    SOURCES test_sharedSpace.cpp
-  )
-ENDIF()
+  IF(Kokkos_ENABLE_OPENMPTARGET)
+  # FIXME OPENMPTARGET requires TeamPolicy Reductions and Custom Reduction
+    LIST(REMOVE_ITEM SOURCES
+      PerfTestGramSchmidt.cpp
+      PerfTest_CustomReduction.cpp
+      PerfTest_ExecSpacePartitioning.cpp
+    )
+  ENDIF()
 
-# Per #374, we always want to build this test, but we only want to run
-# it as a PERFORMANCE test.  That's why we separate building the test
-# from running the test.
+  IF(KOKKOS_ENABLE_CUDA OR KOKKOS_ENABLE_HIP OR KOKKOS_ENABLE_SYCL)
+    KOKKOS_ADD_EXECUTABLE (
+      PerformanceTest_SharedSpace
+      SOURCES test_sharedSpace.cpp
+    )
+  ENDIF()
 
-#leave these as basic includes for now
-#I don't need anything transitive
-KOKKOS_INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}/../../algorithms/src")
-KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
-KOKKOS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
+  # Per #374, we always want to build this test, but we only want to run
+  # it as a PERFORMANCE test.  That's why we separate building the test
+  # from running the test.
 
-# This test currently times out for MSVC
-IF(NOT KOKKOS_CXX_COMPILER_ID STREQUAL "MSVC")
+  #leave these as basic includes for now
+  #I don't need anything transitive
+  KOKKOS_INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}/../../algorithms/src")
+  KOKKOS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
+  KOKKOS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR})
+
+  # This test currently times out for MSVC
+  IF(NOT KOKKOS_CXX_COMPILER_ID STREQUAL "MSVC")
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+      PerfTestExec
+      SOURCES ${SOURCES}
+      CATEGORIES PERFORMANCE
+    )
+  ENDIF()
+
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    PerfTestExec
-    SOURCES ${SOURCES}
+    PerformanceTest_Atomic
+    SOURCES test_atomic.cpp
     CATEGORIES PERFORMANCE
   )
-ENDIF()
 
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  PerformanceTest_Atomic
-  SOURCES test_atomic.cpp
-  CATEGORIES PERFORMANCE
-)
+  IF(NOT KOKKOS_ENABLE_CUDA OR KOKKOS_ENABLE_CUDA_LAMBDA)
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+      PerformanceTest_Atomic_MinMax
+      SOURCES test_atomic_minmax_simple.cpp
+      CATEGORIES PERFORMANCE
+    )
+  ENDIF()
 
-IF(NOT KOKKOS_ENABLE_CUDA OR KOKKOS_ENABLE_CUDA_LAMBDA)
+  # FIXME_NVHPC
+  IF(NOT KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
   KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    PerformanceTest_Atomic_MinMax
-    SOURCES test_atomic_minmax_simple.cpp
+    PerformanceTest_Mempool
+    SOURCES test_mempool.cpp
     CATEGORIES PERFORMANCE
   )
+  ENDIF()
+
+  IF(NOT Kokkos_ENABLE_OPENMPTARGET)
+  # FIXME OPENMPTARGET needs tasking
+    KOKKOS_ADD_EXECUTABLE_AND_TEST(
+      PerformanceTest_TaskDag
+      SOURCES test_taskdag.cpp
+      CATEGORIES PERFORMANCE
+    )
+  ENDIF()
+
 ENDIF()
 
-# FIXME_NVHPC
-IF(NOT KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
-KOKKOS_ADD_EXECUTABLE_AND_TEST(
-  PerformanceTest_Mempool
-  SOURCES test_mempool.cpp
-  CATEGORIES PERFORMANCE
-)
-ENDIF()
-
-IF(NOT Kokkos_ENABLE_OPENMPTARGET)
-# FIXME OPENMPTARGET needs tasking
-  KOKKOS_ADD_EXECUTABLE_AND_TEST(
-    PerformanceTest_TaskDag
-    SOURCES test_taskdag.cpp
-    CATEGORIES PERFORMANCE
-  )
-ENDIF()
-
-
-IF(NOT Kokkos_ENABLE_BENCHMARKS)
-  RETURN()
-ENDIF()
-
-IF (KOKKOS_HAS_TRILINOS)
-  message(FATAL_ERROR "Benchmarks are not supported when building as part of Trilinos")
-ENDIF()
-
+# Find or download google/benchmark library
 find_package(benchmark QUIET)
 IF(benchmark_FOUND)
   MESSAGE(STATUS "Using google benchmark found in ${benchmark_DIR}")

--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -15,6 +15,8 @@ IF ((KOKKOS_ENABLE_OPENMPTARGET OR KOKKOS_ENABLE_OPENACC) AND KOKKOS_CXX_COMPILE
   RETURN()
 ENDIF()
 
+# all PerformanceTest_* executables are part of regular tests
+# TODO: finish converting these into benchmarks (in progress)
 IF(KOKKOS_ENABLE_TESTS)
 
   SET(SOURCES

--- a/core/perf_test/PerfTest_ViewCopy_Raw.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_Raw.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_a123.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_a123.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_a45.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_a45.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_a6.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_a6.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_a7.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_a7.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_a8.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_a8.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_b123.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_b123.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_b45.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_b45.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_b6.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_b6.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_b7.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_b7.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_b8.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_b8.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_c123.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_c123.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_c45.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_c45.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_c6.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_c6.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_c7.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_c7.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_c8.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_c8.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_d123.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_d123.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_d45.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_d45.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_d6.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_d6.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_d7.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_d7.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 

--- a/core/perf_test/PerfTest_ViewCopy_d8.cpp
+++ b/core/perf_test/PerfTest_ViewCopy_d8.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <PerfTest_ViewCopy.hpp>
+#include "PerfTest_ViewCopy.hpp"
 
 namespace Test {
 


### PR DESCRIPTION
fixes #5464

Add new GitHub Actions workflow to:
- run all existing benchmarks
  - this is trigerred on PRs as well
- collect benchmark results (JSON files)
- and push them to a separate (storage) repository
  - this step will only happen after a push to `develop` -> i.e. when a PR gets merged to `develop`

---
Some snippets for re-implementing this in Jenkins:
[Adding GitHub token to Jenkins](https://stackoverflow.com/questions/61105368/how-to-use-github-personal-access-token-in-jenkins)
[Jenkins Pipeline Git push](url)