### PR TITLE
Update nvcc_wrapper default arch to work with CUDA 12

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -10,10 +10,12 @@
 # Default settings: change those according to your machine.  For
 # example, you may have have two different wrappers with either icpc
 # or g++ as their back-end compiler.  The defaults can be overwritten
-# by using the usual arguments (e.g., -arch=sm_30 -ccbin icpc).
+# by using the usual arguments (e.g., -arch=sm_80 -ccbin icpc).
+# sm_70 is supported by every CUDA version from 9-12 and is thus
+# chosen as default
 
-default_arch="sm_35"
-#default_arch="sm_50"
+default_arch="sm_70"
+#default_arch="sm_80"
 
 #
 # The default C++ compiler.


### PR DESCRIPTION
Our cmake config uses nvcc_wrapper at some point without architecture flag, and thus the default architecture is used. CUDA 12 dropped support for Kepler so 3.5 will not be accepted. arch_70 is supported by CUDA 9 onward, and is unlikely to be dropped anytime soon from CUDA. 