### PR TITLE
cuda: Remove hard error check on compute compatibility

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -424,16 +424,6 @@ void CudaInternal::initialize(int cuda_device_id, cudaStream_t stream,
     int compiled_major = m_cudaArch / 100;
     int compiled_minor = (m_cudaArch % 100) / 10;
 
-    if (compiled_major != cudaProp.major || compiled_minor > cudaProp.minor) {
-      std::stringstream ss;
-      ss << "Kokkos::Cuda::initialize ERROR: running kernels compiled for "
-            "compute capability "
-         << compiled_major << "." << compiled_minor
-         << " on device with compute capability " << cudaProp.major << "."
-         << cudaProp.minor << " is not supported by CUDA!\n";
-      std::string msg = ss.str();
-      Kokkos::abort(msg.c_str());
-    }
     if (Kokkos::show_warnings() && (compiled_major != cudaProp.major ||
                                     compiled_minor != cudaProp.minor)) {
       std::cerr << "Kokkos::Cuda::initialize WARNING: running kernels compiled "


### PR DESCRIPTION
CUDA Compute compatibility is defined across architectures via PTX JIT, applications/Kokkos just needs to ensure the features are conditionally compiled for those virtual architectures that don't support them.

Allowing this allows for applications and libraries compiled with older CUDA toolkits to be forward compatible to newer hardware, allowing for more compatibility and utility in Kokkos.