### PR TITLE
[3.7.02] Fix nvhpc CI after host upgrade to CUDA 12

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -36,6 +36,9 @@ pipeline {
                             args '--env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }
+                    environment {
+                        CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/22.3/cuda/11.6'
+                    }
                     steps {
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
@@ -67,6 +70,7 @@ pipeline {
                         OMP_PLACES = 'threads'
                         OMP_PROC_BIND = 'spread'
                         NVCC_WRAPPER_DEFAULT_COMPILER = 'nvc++'
+                        CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/22.3/cuda/11.6'
                     }
                     steps {
                         sh '''rm -rf build && mkdir -p build && cd build && \


### PR DESCRIPTION
* Fix nvhpc-docker container to work with CUDA 12 driver

* Fixup NVHPC CI build CUDA_HOME environment variable

* Fixup use single-quote with environment variables

Co-authored-by: Damien L-G <dalg24@gmail.com>