### PR TITLE
Rework CUDA cache config using carveout calculations

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -179,7 +179,6 @@ int cuda_get_opt_block_size(const CudaInternal* cuda_instance,
                                 LaunchBounds{});
 }
 
-// Assuming cudaFuncSetCacheConfig(MyKernel, cudaFuncCachePreferL1)
 // NOTE these number can be obtained several ways:
 // * One option is to download the CUDA Occupancy Calculator spreadsheet, select
 // "Compute Capability" first and check what is the smallest "Shared Memory
@@ -214,6 +213,7 @@ inline size_t get_shmem_per_sm_prefer_l1(cudaDeviceProp const& properties) {
     return 0;
   }() * 1024;
 }
+
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -400,8 +400,6 @@ Kokkos::Cuda::initialize WARNING: Cuda is allocating into UVMSpace by default
   }
 #endif
 
-  cudaDeviceSetCacheConfig(cudaFuncCachePreferShared);
-
   // Init the array for used for arbitrarily sized atomics
   if (this == &singleton()) Impl::initialize_host_cuda_lock_arrays();
 

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -65,10 +65,6 @@ namespace Impl {
 //   __launch_bounds__(maxThreadsPerBlock,minBlocksPerMultiprocessor)
 // function qualifier which could be used to improve performance.
 //----------------------------------------------------------------------------
-// Maximize L1 cache and minimize shared memory:
-//   cudaFuncSetCacheConfig(MyKernel, cudaFuncCachePreferL1 );
-// For 2.0 capability: 48 KB L1 and 16 KB shared
-//----------------------------------------------------------------------------
 
 template <class DriverType>
 __global__ static void cuda_parallel_launch_constant_memory() {
@@ -130,62 +126,103 @@ inline void check_shmem_request(CudaInternal const* cuda_instance, int shmem) {
   }
 }
 
-// This function needs to be template on DriverType and LaunchBounds
+// These functions needs to be template on DriverType and LaunchBounds
 // so that the static bool is unique for each type combo
 // KernelFuncPtr does not necessarily contain that type information.
+
 template <class DriverType, class LaunchBounds, class KernelFuncPtr>
-inline void configure_shmem_preference(KernelFuncPtr const& func,
-                                       bool prefer_shmem) {
-#ifndef KOKKOS_ARCH_KEPLER
-  // On Kepler the L1 has no benefit since it doesn't cache reads
-  auto set_cache_config = [&] {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncSetCacheConfig(
-        func,
-        (prefer_shmem ? cudaFuncCachePreferShared : cudaFuncCachePreferL1)));
-    return prefer_shmem;
+const cudaFuncAttributes& get_cuda_kernel_func_attributes(
+    const KernelFuncPtr& func) {
+  // Race condition inside of cudaFuncGetAttributes if the same address is
+  // given requires using a local variable as input instead of a static Rely
+  // on static variable initialization to make sure only one thread executes
+  // the code and the result is visible.
+  auto wrap_get_attributes = [func]() -> cudaFuncAttributes {
+    cudaFuncAttributes attr_tmp;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncGetAttributes(&attr_tmp, func));
+    return attr_tmp;
   };
-  static bool cache_config_preference_cached = set_cache_config();
-  if (cache_config_preference_cached != prefer_shmem) {
+  static cudaFuncAttributes func_attr = wrap_get_attributes();
+  return func_attr;
+}
+
+template <class DriverType, class LaunchBounds, class KernelFuncPtr>
+inline void configure_shmem_preference(const KernelFuncPtr& func,
+                                       const cudaDeviceProp& device_props,
+                                       const size_t block_size, int& shmem,
+                                       const size_t occupancy) {
+#ifndef KOKKOS_ARCH_KEPLER
+
+  const auto& func_attr =
+      get_cuda_kernel_func_attributes<DriverType, LaunchBounds>(func);
+
+  // Compute limits for number of blocks due do registers/SM
+  const size_t regs_per_sm     = device_props.regsPerMultiprocessor;
+  const size_t regs_per_thread = func_attr.numRegs;
+  // The granularity of register allocation is chunks of 256 registers per warp
+  // -> 8 registers per thread
+  const size_t allocated_regs_per_thread = 8 * ((regs_per_thread + 8 - 1) / 8);
+  const size_t max_blocks_regs =
+      regs_per_sm / (allocated_regs_per_thread * block_size);
+
+  // Compute how many threads per sm we actually want
+  const size_t maxthreads_per_sm = device_props.maxThreadsPerMultiProcessor;
+  // only allocate multiples of warp size
+  const size_t numthreads_desired =
+      ((maxthreads_per_sm * occupancy / 100 + 31) / 32) * 32;
+  // Get close to the desired occupancy,
+  // don't undershoot by much but also don't allocate a whole new block just
+  // because one is a few threads over otherwise.
+  size_t numblocks_desired =
+      (numthreads_desired + block_size * 0.8) / block_size;
+  numblocks_desired = ::std::min(max_blocks_regs, numblocks_desired);
+  if (numblocks_desired == 0) numblocks_desired = 1;
+
+  // Calculate how much shared memory we need per block
+  size_t shmem_per_block = shmem + func_attr.sharedSizeBytes;
+  // The minimum shared memory allocation we can have in total per SM is 8kB
+  // if we want to lower occupancy we have to make sure we at least request that
+  // much in aggregate over all blocks, so that shared memory actually becomes a
+  // limiting factor for occupancy
+  constexpr size_t min_shmem_size_per_sm = 8192;
+  if ((occupancy < 100) &&
+      (shmem_per_block * numblocks_desired < min_shmem_size_per_sm)) {
+    shmem_per_block = min_shmem_size_per_sm / numblocks_desired;
+    shmem           = shmem_per_block - func_attr.sharedSizeBytes;
+  }
+
+  // Compute the carveout fraction we need based on occupancy
+  // Use multiples of 8kB
+  const size_t maxshmem_per_sm = device_props.sharedMemPerMultiprocessor;
+  size_t carveout              = shmem_per_block == 0
+                        ? 0
+                        : 100 *
+                              (((numblocks_desired * shmem_per_block +
+                                 min_shmem_size_per_sm - 1) /
+                                min_shmem_size_per_sm) *
+                               min_shmem_size_per_sm) /
+                              maxshmem_per_sm;
+  if (carveout > 100) carveout = 100;
+
+  // Set the carveout, but only call it once per kernel or when it changes
+  auto set_cache_config = [&] {
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFuncSetAttribute(
+        func, cudaFuncAttributePreferredSharedMemoryCarveout, carveout));
+    return carveout;
+  };
+  // Store the value in a static variable so we only reset if needed
+  static int cache_config_preference_cached = set_cache_config();
+  if (cache_config_preference_cached != carveout) {
     cache_config_preference_cached = set_cache_config();
   }
 #else
   // Use the parameters so we don't get a warning
   (void)func;
-  (void)prefer_shmem;
+  (void)device_props;
+  (void)block_size;
+  (void)occupancy;
 #endif
 }
-
-template <class Policy>
-std::enable_if_t<Policy::experimental_contains_desired_occupancy>
-modify_launch_configuration_if_desired_occupancy_is_specified(
-    Policy const& policy, cudaDeviceProp const& properties,
-    cudaFuncAttributes const& attributes, dim3 const& block, int& shmem,
-    bool& prefer_shmem) {
-  int const block_size        = block.x * block.y * block.z;
-  int const desired_occupancy = policy.impl_get_desired_occupancy().value();
-
-  size_t const shmem_per_sm_prefer_l1 = get_shmem_per_sm_prefer_l1(properties);
-  size_t const static_shmem           = attributes.sharedSizeBytes;
-
-  // round to nearest integer and avoid division by zero
-  int active_blocks = std::max(
-      1, static_cast<int>(std::round(
-             static_cast<double>(properties.maxThreadsPerMultiProcessor) /
-             block_size * desired_occupancy / 100)));
-  int const dynamic_shmem =
-      shmem_per_sm_prefer_l1 / active_blocks - static_shmem;
-
-  if (dynamic_shmem > shmem) {
-    shmem        = dynamic_shmem;
-    prefer_shmem = false;
-  }
-}
-
-template <class Policy>
-std::enable_if_t<!Policy::experimental_contains_desired_occupancy>
-modify_launch_configuration_if_desired_occupancy_is_specified(
-    Policy const&, cudaDeviceProp const&, cudaFuncAttributes const&,
-    dim3 const& /*block*/, int& /*shmem*/, bool& /*prefer_shmem*/) {}
 
 // </editor-fold> end Some helper functions for launch code readability }}}1
 //==============================================================================
@@ -319,7 +356,7 @@ struct CudaParallelLaunchKernelInvoker<
 
   inline static void create_parallel_launch_graph_node(
       DriverType const& driver, dim3 const& grid, dim3 const& block, int shmem,
-      CudaInternal const* cuda_instance, bool prefer_shmem) {
+      CudaInternal const* cuda_instance) {
     //----------------------------------------
     auto const& graph = Impl::get_cuda_graph_from_kernel(driver);
     KOKKOS_EXPECTS(bool(graph));
@@ -329,8 +366,15 @@ struct CudaParallelLaunchKernelInvoker<
 
     if (!Impl::is_empty_launch(grid, block)) {
       Impl::check_shmem_request(cuda_instance, shmem);
-      Impl::configure_shmem_preference<DriverType, LaunchBounds>(
-          base_t::get_kernel_func(), prefer_shmem);
+      if constexpr (DriverType::Policy::
+                        experimental_contains_desired_occupancy) {
+        int desired_occupancy =
+            driver.get_policy().impl_get_desired_occupancy().value();
+        size_t block_size = block.x * block.y * block.z;
+        Impl::configure_shmem_preference<DriverType, LaunchBounds>(
+            base_t::get_kernel_func(), cuda_instance->m_deviceProp, block_size,
+            shmem, desired_occupancy);
+      }
 
       void const* args[] = {&driver};
 
@@ -411,7 +455,7 @@ struct CudaParallelLaunchKernelInvoker<
 
   inline static void create_parallel_launch_graph_node(
       DriverType const& driver, dim3 const& grid, dim3 const& block, int shmem,
-      CudaInternal const* cuda_instance, bool prefer_shmem) {
+      CudaInternal const* cuda_instance) {
     //----------------------------------------
     auto const& graph = Impl::get_cuda_graph_from_kernel(driver);
     KOKKOS_EXPECTS(bool(graph));
@@ -421,8 +465,15 @@ struct CudaParallelLaunchKernelInvoker<
 
     if (!Impl::is_empty_launch(grid, block)) {
       Impl::check_shmem_request(cuda_instance, shmem);
-      Impl::configure_shmem_preference<DriverType, LaunchBounds>(
-          base_t::get_kernel_func(), prefer_shmem);
+      if constexpr (DriverType::Policy::
+                        experimental_contains_desired_occupancy) {
+        int desired_occupancy =
+            driver.get_policy().impl_get_desired_occupancy().value();
+        size_t block_size = block.x * block.y * block.z;
+        Impl::configure_shmem_preference<DriverType, LaunchBounds>(
+            base_t::get_kernel_func(), cuda_instance->m_deviceProp, block_size,
+            shmem, desired_occupancy);
+      }
 
       auto* driver_ptr = Impl::allocate_driver_storage_for_kernel(driver);
 
@@ -533,7 +584,7 @@ struct CudaParallelLaunchKernelInvoker<
 
   inline static void create_parallel_launch_graph_node(
       DriverType const& driver, dim3 const& grid, dim3 const& block, int shmem,
-      CudaInternal const* cuda_instance, bool prefer_shmem) {
+      CudaInternal const* cuda_instance) {
     // Just use global memory; coordinating through events to share constant
     // memory with the non-graph interface is not really reasonable since
     // events don't work with Graphs directly, and this would anyway require
@@ -547,7 +598,7 @@ struct CudaParallelLaunchKernelInvoker<
         DriverType, LaunchBounds,
         Experimental::CudaLaunchMechanism::GlobalMemory>;
     global_launch_impl_t::create_parallel_launch_graph_node(
-        driver, grid, block, shmem, cuda_instance, prefer_shmem);
+        driver, grid, block, shmem, cuda_instance);
   }
 };
 
@@ -579,8 +630,7 @@ struct CudaParallelLaunchImpl<
 
   inline static void launch_kernel(const DriverType& driver, const dim3& grid,
                                    const dim3& block, int shmem,
-                                   const CudaInternal* cuda_instance,
-                                   bool prefer_shmem) {
+                                   const CudaInternal* cuda_instance) {
     if (!Impl::is_empty_launch(grid, block)) {
       // Prevent multiple threads to simultaneously set the cache configuration
       // preference and launch the same kernel
@@ -589,18 +639,17 @@ struct CudaParallelLaunchImpl<
 
       Impl::check_shmem_request(cuda_instance, shmem);
 
-      // If a desired occupancy is specified, we compute how much shared memory
-      // to ask for to achieve that occupancy, assuming that the cache
-      // configuration is `cudaFuncCachePreferL1`.  If the amount of dynamic
-      // shared memory computed is actually smaller than `shmem` we overwrite
-      // `shmem` and set `prefer_shmem` to `false`.
-      modify_launch_configuration_if_desired_occupancy_is_specified(
-          driver.get_policy(), cuda_instance->m_deviceProp,
-          get_cuda_func_attributes(), block, shmem, prefer_shmem);
-
-      Impl::configure_shmem_preference<
-          DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>>(
-          base_t::get_kernel_func(), prefer_shmem);
+      if constexpr (DriverType::Policy::
+                        experimental_contains_desired_occupancy) {
+        int desired_occupancy =
+            driver.get_policy().impl_get_desired_occupancy().value();
+        size_t block_size = block.x * block.y * block.z;
+        Impl::configure_shmem_preference<
+            DriverType,
+            Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>>(
+            base_t::get_kernel_func(), cuda_instance->m_deviceProp, block_size,
+            shmem, desired_occupancy);
+      }
 
       ensure_cuda_lock_arrays_on_device();
 
@@ -616,18 +665,9 @@ struct CudaParallelLaunchImpl<
   }
 
   static cudaFuncAttributes get_cuda_func_attributes() {
-    // Race condition inside of cudaFuncGetAttributes if the same address is
-    // given requires using a local variable as input instead of a static Rely
-    // on static variable initialization to make sure only one thread executes
-    // the code and the result is visible.
-    auto wrap_get_attributes = []() -> cudaFuncAttributes {
-      cudaFuncAttributes attr_tmp;
-      KOKKOS_IMPL_CUDA_SAFE_CALL(
-          cudaFuncGetAttributes(&attr_tmp, base_t::get_kernel_func()));
-      return attr_tmp;
-    };
-    static cudaFuncAttributes attr = wrap_get_attributes();
-    return attr;
+    return get_cuda_kernel_func_attributes<
+        DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>>(
+        base_t::get_kernel_func());
   }
 };
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -93,8 +93,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               maxblocks[1]),
           1);
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
-          *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          false);
+          *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else if (RP::rank == 3) {
       const dim3 block(m_rp.m_tile[0], m_rp.m_tile[1], m_rp.m_tile[2]);
       KOKKOS_ASSERT(block.x > 0);
@@ -111,8 +110,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               (m_rp.m_upper[2] - m_rp.m_lower[2] + block.z - 1) / block.z,
               maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
-          *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          false);
+          *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else if (RP::rank == 4) {
       // id0,id1 encoded within threadIdx.x; id2 to threadIdx.y; id3 to
       // threadIdx.z
@@ -130,8 +128,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               (m_rp.m_upper[3] - m_rp.m_lower[3] + block.z - 1) / block.z,
               maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
-          *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          false);
+          *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else if (RP::rank == 5) {
       // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4 to
       // threadIdx.z
@@ -147,8 +144,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
               (m_rp.m_upper[4] - m_rp.m_lower[4] + block.z - 1) / block.z,
               maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
-          *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          false);
+          *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else if (RP::rank == 6) {
       // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4,id5 to
       // threadIdx.z
@@ -163,8 +159,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
           std::min<array_index_type>(m_rp.m_tile_end[4] * m_rp.m_tile_end[5],
                                      maxblocks[2]));
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
-          *this, grid, block, 0, m_rp.space().impl_internal_space_instance(),
-          false);
+          *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
     } else {
       Kokkos::abort("Kokkos::MDRange Error: Exceeded rank bounds with Cuda\n");
     }
@@ -377,8 +372,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem,
-          m_policy.space().impl_internal_space_instance(),
-          false);  // copy to device and execute
+          m_policy.space()
+              .impl_internal_space_instance());  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
         if (m_result_ptr) {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -107,8 +107,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 #endif
 
     CudaParallelLaunch<ParallelFor, LaunchBounds>(
-        *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),
-        false);
+        *this, grid, block, 0, m_policy.space().impl_internal_space_instance());
   }
 
   ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
@@ -345,8 +344,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem,
-          m_policy.space().impl_internal_space_instance(),
-          false);  // copy to device and execute
+          m_policy.space()
+              .impl_internal_space_instance());  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
         if (m_result_ptr) {
@@ -696,16 +695,16 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
         m_final = false;
         CudaParallelLaunch<ParallelScan, LaunchBounds>(
             *this, grid, block, shmem,
-            m_policy.space().impl_internal_space_instance(),
-            false);  // copy to device and execute
+            m_policy.space()
+                .impl_internal_space_instance());  // copy to device and execute
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
       }
 #endif
       m_final = true;
       CudaParallelLaunch<ParallelScan, LaunchBounds>(
           *this, grid, block, shmem,
-          m_policy.space().impl_internal_space_instance(),
-          false);  // copy to device and execute
+          m_policy.space()
+              .impl_internal_space_instance());  // copy to device and execute
     }
   }
 
@@ -1013,14 +1012,14 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
         m_final = false;
         CudaParallelLaunch<ParallelScanWithTotal, LaunchBounds>(
             *this, grid, block, shmem,
-            m_policy.space().impl_internal_space_instance(),
-            false);  // copy to device and execute
+            m_policy.space()
+                .impl_internal_space_instance());  // copy to device and execute
       }
       m_final = true;
       CudaParallelLaunch<ParallelScanWithTotal, LaunchBounds>(
           *this, grid, block, shmem,
-          m_policy.space().impl_internal_space_instance(),
-          false);  // copy to device and execute
+          m_policy.space()
+              .impl_internal_space_instance());  // copy to device and execute
 
       const int size = Analysis::value_size(m_functor);
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -519,8 +519,8 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
     CudaParallelLaunch<ParallelFor, LaunchBounds>(
         *this, grid, block, shmem_size_total,
-        m_policy.space().impl_internal_space_instance(),
-        true);  // copy to device and execute
+        m_policy.space()
+            .impl_internal_space_instance());  // copy to device and execute
   }
 
   ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
@@ -838,8 +838,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem_size_total,
-          m_policy.space().impl_internal_space_instance(),
-          true);  // copy to device and execute
+          m_policy.space()
+              .impl_internal_space_instance());  // copy to device and execute
 
       if (!m_result_ptr_device_accessible) {
         m_policy.space().fence(

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -400,11 +400,6 @@ struct CudaReductionsFunctor<FunctorType, false, false> {
 //   __launch_bounds__(maxThreadsPerBlock,minBlocksPerMultiprocessor)
 // function qualifier which could be used to improve performance.
 //----------------------------------------------------------------------------
-// Maximize shared memory and minimize L1 cache:
-//   cudaFuncSetCacheConfig(MyKernel, cudaFuncCachePreferShared );
-// For 2.0 capability: 48 KB shared and 16 KB L1
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
 /*
  *  Algorithmic constraints:
  *   (a) blockDim.y <= 1024

--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -82,8 +82,7 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
     const int shared = 0;
 
     Kokkos::Impl::CudaParallelLaunch<Self>(
-        *this, grid, block, shared, Cuda().impl_internal_space_instance(),
-        false);
+        *this, grid, block, shared, Cuda().impl_internal_space_instance());
   }
 
   inline ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)


### PR DESCRIPTION
This will generally rely on the CUDA runtime to figure out best cache configuration, without us setting it manually anymore. We only set it manually if and when someone requests restricted occupancy. However, I did test the carveout scheme when always manually setting, and it did basically replicate the performance obtained by not setting anything for LAMMPS - and beats what we had before which was more limited. I also wrote a test code to check that the occupancy limitation works more or less as expected. Note that this is fairly iffy since there are many moving parts.

```c++
#include <Kokkos_Core.hpp>
#include <cmath>

void check_range(int N, int occupancy, int work, int size) {
  Kokkos::View<int> count("C");
  Kokkos::View<double**> workarray("A",N,size);

  auto lambda = KOKKOS_LAMBDA(int i, int& lmax) {
    int id = Kokkos::atomic_fetch_add(&count(), 1);
    for(int j=1; j<work; j++) workarray(i,j%size) += workarray(i, (j-1)%size) + j;
    Kokkos::atomic_add(&count(), -1);
    if(id > lmax) lmax = id;
  };

  Kokkos::RangePolicy<> p(0,N);
  auto occ_p = Kokkos::Experimental::prefer(p, Kokkos::Experimental::DesiredOccupancy{occupancy});
  int max_val;
  Kokkos::parallel_reduce(occ_p, lambda, Kokkos::Max<int>(max_val));
  printf("Occ: %i Max: %i\n",occupancy, max_val);
}

void check_team(int N, int occupancy, int work, int size, int team_size, int shmem) {
  Kokkos::View<int> count("C");
  Kokkos::View<double**> workarray("A",N,size);

  auto lambda = KOKKOS_LAMBDA(const typename Kokkos::TeamPolicy<>::member_type& team, int& lmax) {
    int i = team.league_rank()*team_size+team.team_rank();
    int id = Kokkos::atomic_fetch_add(&count(), 1);
    for(int j=1; j<work; j++) workarray(i,j%size) += workarray(i, (j-1)%size) + j;
    Kokkos::atomic_add(&count(), -1);
    if(id > lmax) lmax = id;
  };

  Kokkos::TeamPolicy<> p(N/team_size, team_size);
  p.set_scratch_size(0, Kokkos::PerTeam(shmem));
  auto occ_p = Kokkos::Experimental::prefer(p, Kokkos::Experimental::DesiredOccupancy{occupancy});
  int max_val;
  Kokkos::parallel_reduce(occ_p, lambda, Kokkos::Max<int>(max_val));
  printf("Occ: %i Max: %i\n",occupancy, max_val);
}
int main(int argc, char* argv[]) {
  Kokkos::initialize(argc, argv);
  {
    int N = argc > 1 ? atoi(argv[1]) : 1000000;
    int work = argc > 2 ? atoi(argv[2]) : 10000;
    int size = argc > 3 ? atoi(argv[3]) : 100;
    int occupancy = argc > 4 ? atoi(argv[4]) : 100;
    int team_size = argc > 5 ? atoi(argv[5]) : 128;
    int shmem = argc > 6 ? atoi(argv[6]) : 0;
    check_range(N,occupancy,work,size);
    check_team(N, occupancy, work, size, team_size, shmem);
  }
  Kokkos::finalize();
}
```

We may consider adding this test, however it requires that the GPU is used exclusively. 
