### PR TITLE
Disable perf tests in Trilinos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,9 +196,13 @@ INCLUDE(${KOKKOS_SRC_PATH}/cmake/kokkos_tribits.cmake)
 # to allow platform-specific checks
 INCLUDE(${KOKKOS_SRC_PATH}/cmake/kokkos_check_env.cmake)
 
-# Gather information about the runtime environment
-INCLUDE(${KOKKOS_SRC_PATH}/cmake/build_env_info.cmake)
-check_git_setup()
+IF(NOT KOKKOS_HAS_TRILINOS)
+  # This does not work in Trilinos and we simply don't care
+  # to fix it for Trilinos
+  # Gather information about the runtime environment
+  INCLUDE(${KOKKOS_SRC_PATH}/cmake/build_env_info.cmake)
+  check_git_setup()
+ENDIF()
 
 # The build environment setup goes in the following steps
 # 1) Check all the enable options. This includes checking Kokkos_DEVICES

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -7,6 +7,9 @@ IF (NOT Kokkos_INSTALL_TESTING)
 ENDIF()
 
 KOKKOS_ADD_TEST_DIRECTORIES(unit_test)
-KOKKOS_ADD_TEST_DIRECTORIES(perf_test)
+IF (NOT KOKKOS_HAS_TRILINOS)
+  # We are using the githash etc in here, which does not work correct in Trilinos
+  KOKKOS_ADD_TEST_DIRECTORIES(perf_test)
+ENDIF()
 
 KOKKOS_SUBPACKAGE_POSTPROCESS()


### PR DESCRIPTION
the git env generation doesn't work in Trilinos correct, and we don't care to figure out how to fix that.