### PR TITLE
Cleanup random pool special member functions and precondition check in `get_state()`

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -897,19 +897,6 @@ class Random_XorShift64_Pool {
     init(seed, execution_space().concurrency());
   }
 
-  KOKKOS_INLINE_FUNCTION
-  Random_XorShift64_Pool(const Random_XorShift64_Pool& src)
-      : locks_(src.locks_), state_(src.state_), num_states_(src.num_states_) {}
-
-  KOKKOS_INLINE_FUNCTION
-  Random_XorShift64_Pool operator=(const Random_XorShift64_Pool& src) {
-    locks_      = src.locks_;
-    state_      = src.state_;
-    num_states_ = src.num_states_;
-    padding_    = src.padding_;
-    return *this;
-  }
-
   void init(uint64_t seed, int num_states) {
     if (seed == 0) seed = uint64_t(1318319);
     // I only want to pad on CPU like archs (less than 1000 threads). 64 is a
@@ -1146,23 +1133,6 @@ class Random_XorShift1024_Pool {
     num_states_ = 0;
 
     init(seed, execution_space().concurrency());
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  Random_XorShift1024_Pool(const Random_XorShift1024_Pool& src)
-      : locks_(src.locks_),
-        state_(src.state_),
-        p_(src.p_),
-        num_states_(src.num_states_) {}
-
-  KOKKOS_INLINE_FUNCTION
-  Random_XorShift1024_Pool operator=(const Random_XorShift1024_Pool& src) {
-    locks_      = src.locks_;
-    state_      = src.state_;
-    p_          = src.p_;
-    num_states_ = src.num_states_;
-    padding_    = src.padding_;
-    return *this;
   }
 
   inline void init(uint64_t seed, int num_states) {

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -895,6 +895,12 @@ class Random_XorShift64_Pool {
     KOKKOS_IF_ON_HOST(init(0, execution_space().concurrency());)
   }
 
+  KOKKOS_DEFAULTED_FUNCTION Random_XorShift64_Pool(
+      Random_XorShift64_Pool const&) = default;
+
+  KOKKOS_DEFAULTED_FUNCTION Random_XorShift64_Pool& operator=(
+      Random_XorShift64_Pool const&) = default;
+
   Random_XorShift64_Pool(uint64_t seed) {
     num_states_ = 0;
 
@@ -1144,6 +1150,12 @@ class Random_XorShift1024_Pool {
         num_states_ = 0;)
     KOKKOS_IF_ON_HOST(init(0, execution_space().concurrency());)
   }
+
+  KOKKOS_DEFAULTED_FUNCTION Random_XorShift1024_Pool(
+      Random_XorShift1024_Pool const&) = default;
+
+  KOKKOS_DEFAULTED_FUNCTION Random_XorShift1024_Pool& operator=(
+      Random_XorShift1024_Pool const&) = default;
 
   Random_XorShift1024_Pool(uint64_t seed) {
     num_states_ = 0;

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -878,41 +878,32 @@ class Random_XorShift64_Pool {
   using execution_space = typename device_type::execution_space;
   using locks_type      = View<int**, device_type>;
   using state_data_type = View<uint64_t**, device_type>;
-  locks_type locks_;
-  state_data_type state_;
-  int num_states_;
-  int padding_;
+
+  locks_type locks_      = {};
+  state_data_type state_ = {};
+  int num_states_        = {};
+  int padding_           = {};
 
  public:
   using generator_type = Random_XorShift64<DeviceType>;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_FUNCTION
-  Random_XorShift64_Pool() {
-    KOKKOS_IF_ON_DEVICE((
-        /* nonsensical initialization in the name of backward compatibility */
-        num_states_ = 0; padding_ = 0;))
-    KOKKOS_IF_ON_HOST(init(0, execution_space().concurrency());)
-  }
+  Random_XorShift64_Pool() = default;
 
   KOKKOS_DEFAULTED_FUNCTION Random_XorShift64_Pool(
       Random_XorShift64_Pool const&) = default;
 
   KOKKOS_DEFAULTED_FUNCTION Random_XorShift64_Pool& operator=(
       Random_XorShift64_Pool const&) = default;
-
+#else
+  Random_XorShift64_Pool()   = default;
+#endif
   Random_XorShift64_Pool(uint64_t seed) {
     num_states_ = 0;
 
     init(seed, execution_space().concurrency());
   }
-#else
-  Random_XorShift64_Pool(uint64_t seed = 0) {
-    num_states_ = 0;
-
-    init(seed, execution_space().concurrency());
-  }
-#endif
 
   void init(uint64_t seed, int num_states) {
     if (seed == 0) seed = uint64_t(1318319);
@@ -1132,11 +1123,11 @@ class Random_XorShift1024_Pool {
   using int_view_type   = View<int**, device_type>;
   using state_data_type = View<uint64_t * [16], device_type>;
 
-  locks_type locks_;
-  state_data_type state_;
-  int_view_type p_;
-  int num_states_;
-  int padding_;
+  locks_type locks_      = {};
+  state_data_type state_ = {};
+  int_view_type p_       = {};
+  int num_states_        = {};
+  int padding_           = {};
   friend class Random_XorShift1024<DeviceType>;
 
  public:
@@ -1144,31 +1135,22 @@ class Random_XorShift1024_Pool {
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_FUNCTION
-  Random_XorShift1024_Pool() {
-    KOKKOS_IF_ON_DEVICE(
-        /* nonsensical initialization in the name of backward compatibility */
-        num_states_ = 0;)
-    KOKKOS_IF_ON_HOST(init(0, execution_space().concurrency());)
-  }
+  Random_XorShift1024_Pool() = default;
 
   KOKKOS_DEFAULTED_FUNCTION Random_XorShift1024_Pool(
       Random_XorShift1024_Pool const&) = default;
 
   KOKKOS_DEFAULTED_FUNCTION Random_XorShift1024_Pool& operator=(
       Random_XorShift1024_Pool const&) = default;
+#else
+  Random_XorShift1024_Pool() = default;
+#endif
 
   Random_XorShift1024_Pool(uint64_t seed) {
     num_states_ = 0;
 
     init(seed, execution_space().concurrency());
   }
-#else
-  Random_XorShift1024_Pool(uint64_t seed = 0) {
-    num_states_ = 0;
-
-    init(seed, execution_space().concurrency());
-  }
-#endif
 
   void init(uint64_t seed, int num_states) {
     if (seed == 0) seed = uint64_t(1318319);

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -886,16 +886,27 @@ class Random_XorShift64_Pool {
  public:
   using generator_type = Random_XorShift64<DeviceType>;
 
-  KOKKOS_INLINE_FUNCTION
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_FUNCTION
   Random_XorShift64_Pool() {
-    num_states_ = 0;
-    padding_    = 0;
+    KOKKOS_IF_ON_DEVICE((
+        /* nonsensical initialization in the name of backward compatibility */
+        num_states_ = 0; padding_ = 0;))
+    KOKKOS_IF_ON_HOST(init(0, execution_space().concurrency());)
   }
+
   Random_XorShift64_Pool(uint64_t seed) {
     num_states_ = 0;
 
     init(seed, execution_space().concurrency());
   }
+#else
+  Random_XorShift64_Pool(uint64_t seed = 0) {
+    num_states_ = 0;
+
+    init(seed, execution_space().concurrency());
+  }
+#endif
 
   void init(uint64_t seed, int num_states) {
     if (seed == 0) seed = uint64_t(1318319);
@@ -1126,14 +1137,27 @@ class Random_XorShift1024_Pool {
  public:
   using generator_type = Random_XorShift1024<DeviceType>;
 
-  KOKKOS_INLINE_FUNCTION
-  Random_XorShift1024_Pool() { num_states_ = 0; }
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_FUNCTION
+  Random_XorShift1024_Pool() {
+    KOKKOS_IF_ON_DEVICE(
+        /* nonsensical initialization in the name of backward compatibility */
+        num_states_ = 0;)
+    KOKKOS_IF_ON_HOST(init(0, execution_space().concurrency());)
+  }
 
   Random_XorShift1024_Pool(uint64_t seed) {
     num_states_ = 0;
 
     init(seed, execution_space().concurrency());
   }
+#else
+  Random_XorShift1024_Pool(uint64_t seed = 0) {
+    num_states_ = 0;
+
+    init(seed, execution_space().concurrency());
+  }
+#endif
 
   void init(uint64_t seed, int num_states) {
     if (seed == 0) seed = uint64_t(1318319);

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -945,8 +945,7 @@ class Random_XorShift64_Pool {
     deep_copy(locks_, h_lock);
   }
 
-  KOKKOS_INLINE_FUNCTION
-  Random_XorShift64<DeviceType> get_state() const {
+  KOKKOS_INLINE_FUNCTION Random_XorShift64<DeviceType> get_state() const {
     const int i = Impl::Random_UniqueIndex<device_type>::get_state_idx(locks_);
     return Random_XorShift64<DeviceType>(state_(i, 0), i);
   }

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -943,6 +943,7 @@ class Random_XorShift64_Pool {
   }
 
   KOKKOS_INLINE_FUNCTION Random_XorShift64<DeviceType> get_state() const {
+    KOKKOS_EXPECTS(num_states_ > 0);
     const int i = Impl::Random_UniqueIndex<device_type>::get_state_idx(locks_);
     return Random_XorShift64<DeviceType>(state_(i, 0), i);
   }
@@ -1195,6 +1196,7 @@ class Random_XorShift1024_Pool {
 
   KOKKOS_INLINE_FUNCTION
   Random_XorShift1024<DeviceType> get_state() const {
+    KOKKOS_EXPECTS(num_states_ > 0);
     const int i = Impl::Random_UniqueIndex<device_type>::get_state_idx(locks_);
     return Random_XorShift1024<DeviceType>(state_, p_(i, 0), i);
   };

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -1129,13 +1129,13 @@ class Random_XorShift1024_Pool {
   KOKKOS_INLINE_FUNCTION
   Random_XorShift1024_Pool() { num_states_ = 0; }
 
-  inline Random_XorShift1024_Pool(uint64_t seed) {
+  Random_XorShift1024_Pool(uint64_t seed) {
     num_states_ = 0;
 
     init(seed, execution_space().concurrency());
   }
 
-  inline void init(uint64_t seed, int num_states) {
+  void init(uint64_t seed, int num_states) {
     if (seed == 0) seed = uint64_t(1318319);
     // I only want to pad on CPU like archs (less than 1000 threads). 64 is a
     // magic number, or random number I just wanted something not too large and


### PR DESCRIPTION
Tentative fix for #5714
Default-constructed random pool are toxic because they don't properly initialize their "state".
~~I propose to remove the default constructor on the device side and to properly initialize with a default seed on the host.~~
**EDIT** Default-constructed pool have no state by design.  This PR is adding is a precondition check in `Random_XorShift{64,1024}_Pool::get_state()` that they are indeed states.
The device markups are removed from the default constructor and we prefer in-class initializer and defaulted special members.

I dropped the copy constructors and copy assignment operators as the compiler is able to generate them.  Note that the copy constructors were buggy and that we had forgotten to update them in #4218

I haven't actually investigated whether random pools actually get constructed on the device, neither in our codebase nor in Trilinos.