### PR TITLE
Fix max scratch size calculation for level 0 of CUDA and HIP

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -203,16 +203,16 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     // shared ID. Furthermore, they use additional scratch memory in some
     // reduction scenarios, which depend on the size of the value_type and is
     // NOT captured here.
-    constexpr size_t cuda_team_max_reserved_shared_mem =
-        (1024 + 2) * sizeof(double) + sizeof(int64_t);
+    constexpr size_t max_possible_team_size = 1024;
+    constexpr size_t max_reserved_shared_mem_per_team =
+        (max_possible_team_size + 2) * sizeof(double) + sizeof(int64_t);
+    // arbitrarily setting level 1 scratch limit to 20MB, for a
+    // Volta V100 that would give us about 3.2GB for 2 teams per SM
+    constexpr size_t max_l1_scratch_size = 20 * 1024 * 1024;
 
     size_t max_shmem = Cuda().cuda_device_prop().sharedMemPerBlock;
-    return (level == 0
-                ? max_shmem - cuda_team_max_reserved_shared_mem
-                :
-                // arbitrarily setting level 1 scratch limit to 20MB, for a
-                // Volta V100 that would give us about 3.2GB for 2 teams per SM
-                20 * 1024 * 1024);
+    return (level == 0 ? max_shmem - max_reserved_shared_mem_per_team
+                       : max_l1_scratch_size);
   }
 
   //----------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -47,14 +47,6 @@ extern bool show_warnings() noexcept;
 
 namespace Impl {
 
-// Cuda Teams use (team_size + 2)*sizeof(double) shared memory for team
-// reductions. They also use one int64_t in static shared memory for a shared
-// ID. Furthermore, they use additional scratch memory in some reduction
-// scenarios, which depend on the size of the value_type and is NOT captured
-// here.
-constexpr size_t cuda_team_max_reserved_shared_mem =
-    (1024 + 2) * sizeof(double) + sizeof(int64_t);
-
 template <class... Properties>
 class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     : public PolicyTraits<Properties...> {
@@ -206,6 +198,14 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
   }
 
   inline static int scratch_size_max(int level) {
+    // Cuda Teams use (team_size + 2)*sizeof(double) shared memory for team
+    // reductions. They also use one int64_t in static shared memory for a
+    // shared ID. Furthermore, they use additional scratch memory in some
+    // reduction scenarios, which depend on the size of the value_type and is
+    // NOT captured here.
+    constexpr size_t cuda_team_max_reserved_shared_mem =
+        (1024 + 2) * sizeof(double) + sizeof(int64_t);
+
     size_t max_shmem = Cuda().cuda_device_prop().sharedMemPerBlock;
     return (level == 0
                 ? max_shmem - cuda_team_max_reserved_shared_mem

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -48,9 +48,10 @@ extern bool show_warnings() noexcept;
 namespace Impl {
 
 // Cuda Teams use (team_size + 2)*sizeof(double) shared memory for team
-// reductions they also use one int64_t static shared memory for a shared ID
-// Furthermore, they use additional scratch memory in some reduction scenarios,
-// which depend on the size of the value_type and is NOT captured here.
+// reductions. They also use one int64_t in static shared memory for a shared
+// ID. Furthermore, they use additional scratch memory in some reduction
+// scenarios, which depend on the size of the value_type and is NOT captured
+// here.
 constexpr size_t cuda_team_max_reserved_shared_mem =
     (1024 + 2) * sizeof(double) + sizeof(int64_t);
 

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -30,14 +30,6 @@
 namespace Kokkos {
 namespace Impl {
 
-// HIP Teams use (team_size + 2)*sizeof(double) shared memory for team
-// reductions. They also use one int64_t in static shared memory for a shared
-// ID. Furthermore, they use additional scratch memory in some reduction
-// scenarios, which depend on the size of the value_type and is NOT captured
-// here.
-constexpr size_t hip_team_max_reserved_shared_mem =
-    (1024 + 2) * sizeof(double) + sizeof(int64_t);
-
 template <typename... Properties>
 class TeamPolicyInternal<HIP, Properties...>
     : public PolicyTraits<Properties...> {
@@ -167,6 +159,14 @@ class TeamPolicyInternal<HIP, Properties...>
   }
 
   inline static int scratch_size_max(int level) {
+    // HIP Teams use (team_size + 2)*sizeof(double) shared memory for team
+    // reductions. They also use one int64_t in static shared memory for a
+    // shared ID. Furthermore, they use additional scratch memory in some
+    // reduction scenarios, which depend on the size of the value_type and is
+    // NOT captured here.
+    constexpr size_t hip_team_max_reserved_shared_mem =
+        (1024 + 2) * sizeof(double) + sizeof(int64_t);
+
     size_t max_shmem = HIP().hip_device_prop().sharedMemPerBlock;
     return (
         level == 0 ? max_shmem - hip_team_max_reserved_shared_mem :


### PR DESCRIPTION
This takes a bit better into account the internal shared memory teams are using by default. It does not take into account static shared memory which teams may use for certain types of team level reductions. The amount of shared memory there depends on the `value_type` and thus can't be taken into account without handing over the functor. 

It does otherwise fix #1811 