### PR TITLE
[3.7.02] Fix static init order issue in InitalizationSettings

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -1165,6 +1165,5 @@ void _kokkos_pgi_compiler_bug_workaround() {}
 #endif
 }  // namespace Kokkos
 
-Kokkos::Impl::InitializationSettingsHelper<std::string>::storage_type const
-    Kokkos::Impl::InitializationSettingsHelper<std::string>::unspecified =
-        "some string we don't expect user would ever provide";
+constexpr char
+    Kokkos::Impl::InitializationSettingsHelper<std::string>::unspecified[];

--- a/core/src/impl/Kokkos_InitializationSettings.hpp
+++ b/core/src/impl/Kokkos_InitializationSettings.hpp
@@ -104,7 +104,9 @@ struct InitializationSettingsHelper<std::string> {
   using value_type   = std::string;
   using storage_type = std::string;
 
-  static storage_type const unspecified;
+  // prefer c-string to avoid static initialization order nightmare
+  static constexpr char unspecified[] =
+      "some string we don't expect user would ever provide";
 };
 }  // namespace Impl
 


### PR DESCRIPTION
Reproducer on Power9 with GCC 8.3.1 and CUDA 11.2

```c++
#include <Kokkos_Core.hpp>
#include <cstdio>
#include <typeinfo>

static Kokkos::InitializationSettings args;

int main(int argc, char* argv[]) {
  Kokkos::initialize(argc, argv);
  Kokkos::finalize();
}
```

Crashed when initializing the string members.