### PR TITLE
OpenACC initial implementation of `parallel_reduce` for `MDRange`

### DIFF
--- a/core/src/OpenACC/Kokkos_OpenACC_MDRangePolicy.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_MDRangePolicy.hpp
@@ -42,4 +42,19 @@ struct ThreadAndVectorNestLevel<Rank, Kokkos::Experimental::OpenACC,
 }  // namespace Impl
 }  // namespace Kokkos
 
+namespace Kokkos::Experimental::Impl {
+
+struct OpenACCCollapse {};
+struct OpenACCTile {};
+using OpenACCIterateLeft  = std::integral_constant<Iterate, Iterate::Left>;
+using OpenACCIterateRight = std::integral_constant<Iterate, Iterate::Right>;
+template <int N>
+using OpenACCMDRangeBegin = decltype(MDRangePolicy<OpenACC, Rank<N>>::m_lower);
+template <int N>
+using OpenACCMDRangeEnd = decltype(MDRangePolicy<OpenACC, Rank<N>>::m_upper);
+template <int N>
+using OpenACCMDRangeTile = decltype(MDRangePolicy<OpenACC, Rank<N>>::m_tile);
+
+}  // namespace Kokkos::Experimental::Impl
+
 #endif

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_MDRange.hpp
@@ -24,17 +24,6 @@
 
 namespace Kokkos::Experimental::Impl {
 
-struct OpenACCCollapse {};
-struct OpenACCTile {};
-using OpenACCIterateLeft  = std::integral_constant<Iterate, Iterate::Left>;
-using OpenACCIterateRight = std::integral_constant<Iterate, Iterate::Right>;
-template <int N>
-using OpenACCMDRangeBegin = decltype(MDRangePolicy<OpenACC, Rank<N>>::m_lower);
-template <int N>
-using OpenACCMDRangeEnd = decltype(MDRangePolicy<OpenACC, Rank<N>>::m_upper);
-template <int N>
-using OpenACCMDRangeTile = decltype(MDRangePolicy<OpenACC, Rank<N>>::m_tile);
-
 template <class Functor>
 void OpenACCParallelForMDRangePolicy(OpenACCCollapse, OpenACCIterateLeft,
                                      Functor const& functor,

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
@@ -1,0 +1,458 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_OPENACC_PARALLEL_REDUCE_MDRANGE_HPP
+#define KOKKOS_OPENACC_PARALLEL_REDUCE_MDRANGE_HPP
+
+#include <OpenACC/Kokkos_OpenACC.hpp>
+#include <OpenACC/Kokkos_OpenACC_Macros.hpp>
+#include <OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp>
+#include <OpenACC/Kokkos_OpenACC_MDRangePolicy.hpp>
+#include <Kokkos_Parallel.hpp>
+
+namespace Kokkos::Experimental::Impl {
+
+// primary template: catch-all non-implemented custom reducers
+template <class Functor, class Reducer, class Policy,
+          bool = std::is_arithmetic_v<typename Reducer::value_type>>
+struct OpenACCParallelReduceMDRangeHelper {
+  OpenACCParallelReduceMDRangeHelper(Functor const&, Reducer const&,
+                                     Policy const&) {
+    static_assert(!Kokkos::Impl::always_true<Functor>::value,
+                  "not implemented");
+  }
+};
+}  // namespace Kokkos::Experimental::Impl
+
+template <class Functor, class ReducerType, class... Traits>
+class Kokkos::Impl::ParallelReduce<Functor, Kokkos::MDRangePolicy<Traits...>,
+                                   ReducerType, Kokkos::Experimental::OpenACC> {
+  using Policy = MDRangePolicy<Traits...>;
+
+  using ReducerConditional =
+      if_c<std::is_same_v<InvalidType, ReducerType>, Functor, ReducerType>;
+  using ReducerTypeFwd = typename ReducerConditional::type;
+  using Analysis =
+      FunctorAnalysis<FunctorPatternInterface::REDUCE, Policy, ReducerTypeFwd>;
+
+  using Pointer   = typename Analysis::pointer_type;
+  using ValueType = typename Analysis::value_type;
+
+  Functor m_functor;
+  Policy m_policy;
+  ReducerType m_reducer;
+  Pointer m_result_ptr;
+
+ public:
+  ParallelReduce(Functor const& functor, Policy const& policy,
+                 ReducerType const& reducer)
+      : m_functor(functor),
+        m_policy(policy),
+        m_reducer(reducer),
+        m_result_ptr(reducer.view().data()) {}
+
+  template <class ViewType>
+  ParallelReduce(
+      const Functor& functor, const Policy& policy, const ViewType& result,
+      std::enable_if_t<Kokkos::is_view<ViewType>::value, void*> = nullptr)
+      : m_functor(functor),
+        m_policy(policy),
+        m_reducer(InvalidType()),
+        m_result_ptr(result.data()) {}
+
+  void execute() const {
+    static_assert(1 < Policy::rank && Policy::rank < 7);
+    static_assert(Policy::inner_direction == Iterate::Left ||
+                  Policy::inner_direction == Iterate::Right);
+    constexpr int rank = Policy::rank;
+    for (int i = 0; i < rank; ++i) {
+      if (m_policy.m_lower[i] >= m_policy.m_upper[i]) {
+        return;
+      }
+    }
+
+    ValueType val;
+    typename Analysis::Reducer final_reducer(
+        &ReducerConditional::select(m_functor, m_reducer));
+    final_reducer.init(&val);
+
+    Kokkos::Experimental::Impl::OpenACCParallelReduceMDRangeHelper(
+        Kokkos::Experimental::Impl::FunctorAdapter<Functor, Policy>(m_functor),
+        std::conditional_t<is_reducer_v<ReducerType>, ReducerType,
+                           Sum<ValueType>>(val),
+        m_policy);
+
+    *m_result_ptr = val;
+  }
+};
+
+#define KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_DISPATCH_ITERATE(REDUCER,         \
+                                                             OPERATOR)        \
+  namespace Kokkos::Experimental::Impl {                                      \
+  template <class ValueType, class Functor>                                   \
+  void OpenACCParallelReduce##REDUCER(OpenACCIterateLeft, ValueType& aval,    \
+                                      Functor const& afunctor,                \
+                                      OpenACCMDRangeBegin<2> const& begin,    \
+                                      OpenACCMDRangeEnd<2> const& end,        \
+                                      int async_arg) {                        \
+    auto val = aval;                                                          \
+    auto const functor(afunctor);                                             \
+    int begin1 = begin[1];                                                    \
+    int end1   = end[1];                                                      \
+    int begin0 = begin[0];                                                    \
+    int end0   = end[0];                                                      \
+    /* clang-format off */ \
+    KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang vector collapse(2) reduction(OPERATOR:val) copyin(functor) async(async_arg))                                                  \
+    /* clang-format on */                                                     \
+    for (auto i1 = begin1; i1 < end1; ++i1) {                                 \
+      for (auto i0 = begin0; i0 < end0; ++i0) {                               \
+        functor(i0, i1, val);                                                 \
+      }                                                                       \
+    }                                                                         \
+    aval = val;                                                               \
+  }                                                                           \
+                                                                              \
+  template <class ValueType, class Functor>                                   \
+  void OpenACCParallelReduce##REDUCER(OpenACCIterateRight, ValueType& aval,   \
+                                      Functor const& afunctor,                \
+                                      OpenACCMDRangeBegin<2> const& begin,    \
+                                      OpenACCMDRangeEnd<2> const& end,        \
+                                      int async_arg) {                        \
+    auto val = aval;                                                          \
+    auto const functor(afunctor);                                             \
+    int begin0 = begin[0];                                                    \
+    int end0   = end[0];                                                      \
+    int begin1 = begin[1];                                                    \
+    int end1   = end[1];                                                      \
+    /* clang-format off */ \
+    KOKKOS_IMPL_ACC_PGRAMA(parallel loop gang vector collapse(2) reduction(OPERATOR:val) copyin(functor) async(async_arg))                                                  \
+    /* clang-format on */                                                     \
+    for (auto i0 = begin0; i0 < end0; ++i0) {                                 \
+      for (auto i1 = begin1; i1 < end1; ++i1) {                               \
+        functor(i0, i1, val);                                                 \
+      }                                                                       \
+    }                                                                         \
+    aval = val;                                                               \
+  }                                                                           \
+                                                                              \
+  template <class ValueType, class Functor>                                   \
+  void OpenACCParallelReduce##REDUCER(OpenACCIterateLeft, ValueType& aval,    \
+                                      Functor const& afunctor,                \
+                                      OpenACCMDRangeBegin<3> const& begin,    \
+                                      OpenACCMDRangeEnd<3> const& end,        \
+                                      int async_arg) {                        \
+    auto val = aval;                                                          \
+    auto const functor(afunctor);                                             \
+    int begin2 = begin[2];                                                    \
+    int end2   = end[2];                                                      \
+    int begin1 = begin[1];                                                    \
+    int end1   = end[1];                                                      \
+    int begin0 = begin[0];                                                    \
+    int end0   = end[0];                                                      \
+    /* clang-format off */                                                  \
+    KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang vector collapse(3) reduction( \
+        OPERATOR                                                            \
+        : val) copyin(functor) async(async_arg)) \
+    /* clang-format on */                                                     \
+    for (auto i2 = begin2; i2 < end2; ++i2) {                                 \
+      for (auto i1 = begin1; i1 < end1; ++i1) {                               \
+        for (auto i0 = begin0; i0 < end0; ++i0) {                             \
+          functor(i0, i1, i2, val);                                           \
+        }                                                                     \
+      }                                                                       \
+    }                                                                         \
+    aval = val;                                                               \
+  }                                                                           \
+                                                                              \
+  template <class ValueType, class Functor>                                   \
+  void OpenACCParallelReduce##REDUCER(OpenACCIterateRight, ValueType& aval,   \
+                                      Functor const& afunctor,                \
+                                      OpenACCMDRangeBegin<3> const& begin,    \
+                                      OpenACCMDRangeEnd<3> const& end,        \
+                                      int async_arg) {                        \
+    auto val = aval;                                                          \
+    auto const functor(afunctor);                                             \
+    int begin0 = begin[0];                                                    \
+    int end0   = end[0];                                                      \
+    int begin1 = begin[1];                                                    \
+    int end1   = end[1];                                                      \
+    int begin2 = begin[2];                                                    \
+    int end2   = end[2];                                                      \
+    /* clang-format off */                                                  \
+    KOKKOS_IMPL_ACC_PGRAMA(parallel loop gang vector collapse(3) reduction( \
+        OPERATOR                                                            \
+        : val) copyin(functor) async(async_arg)) \
+    /* clang-format on */                                                     \
+    for (auto i0 = begin0; i0 < end0; ++i0) {                                 \
+      for (auto i1 = begin1; i1 < end1; ++i1) {                               \
+        for (auto i2 = begin2; i2 < end2; ++i2) {                             \
+          functor(i0, i1, i2, val);                                           \
+        }                                                                     \
+      }                                                                       \
+    }                                                                         \
+    aval = val;                                                               \
+  }                                                                           \
+                                                                              \
+  template <class ValueType, class Functor>                                   \
+  void OpenACCParallelReduce##REDUCER(OpenACCIterateLeft, ValueType& aval,    \
+                                      Functor const& afunctor,                \
+                                      OpenACCMDRangeBegin<4> const& begin,    \
+                                      OpenACCMDRangeEnd<4> const& end,        \
+                                      int async_arg) {                        \
+    auto val = aval;                                                          \
+    auto const functor(afunctor);                                             \
+    int begin3 = begin[3];                                                    \
+    int end3   = end[3];                                                      \
+    int begin2 = begin[2];                                                    \
+    int end2   = end[2];                                                      \
+    int begin1 = begin[1];                                                    \
+    int end1   = end[1];                                                      \
+    int begin0 = begin[0];                                                    \
+    int end0   = end[0];                                                      \
+    /* clang-format off */ \
+    KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang vector collapse(4) reduction(OPERATOR:val) copyin(functor) async(async_arg))                                                  \
+    /* clang-format on */                                                     \
+    for (auto i3 = begin3; i3 < end3; ++i3) {                                 \
+      for (auto i2 = begin2; i2 < end2; ++i2) {                               \
+        for (auto i1 = begin1; i1 < end1; ++i1) {                             \
+          for (auto i0 = begin0; i0 < end0; ++i0) {                           \
+            functor(i0, i1, i2, i3, val);                                     \
+          }                                                                   \
+        }                                                                     \
+      }                                                                       \
+    }                                                                         \
+    aval = val;                                                               \
+  }                                                                           \
+                                                                              \
+  template <class ValueType, class Functor>                                   \
+  void OpenACCParallelReduce##REDUCER(OpenACCIterateRight, ValueType& aval,   \
+                                      Functor const& afunctor,                \
+                                      OpenACCMDRangeBegin<4> const& begin,    \
+                                      OpenACCMDRangeEnd<4> const& end,        \
+                                      int async_arg) {                        \
+    auto val = aval;                                                          \
+    auto const functor(afunctor);                                             \
+    int begin0 = begin[0];                                                    \
+    int end0   = end[0];                                                      \
+    int begin1 = begin[1];                                                    \
+    int end1   = end[1];                                                      \
+    int begin2 = begin[2];                                                    \
+    int end2   = end[2];                                                      \
+    int begin3 = begin[3];                                                    \
+    int end3   = end[3];                                                      \
+    /* clang-format off */ \
+    KOKKOS_IMPL_ACC_PGRAMA(parallel loop gang vector collapse(4) reduction(OPERATOR:val) copyin(functor) async(async_arg))                                                  \
+    /* clang-format on */                                                     \
+    for (auto i0 = begin0; i0 < end0; ++i0) {                                 \
+      for (auto i1 = begin1; i1 < end1; ++i1) {                               \
+        for (auto i2 = begin2; i2 < end2; ++i2) {                             \
+          for (auto i3 = begin3; i3 < end3; ++i3) {                           \
+            functor(i0, i1, i2, i3, val);                                     \
+          }                                                                   \
+        }                                                                     \
+      }                                                                       \
+    }                                                                         \
+    aval = val;                                                               \
+  }                                                                           \
+                                                                              \
+  template <class ValueType, class Functor>                                   \
+  void OpenACCParallelReduce##REDUCER(OpenACCIterateLeft, ValueType& aval,    \
+                                      Functor const& afunctor,                \
+                                      OpenACCMDRangeBegin<5> const& begin,    \
+                                      OpenACCMDRangeEnd<5> const& end,        \
+                                      int async_arg) {                        \
+    auto val = aval;                                                          \
+    auto const functor(afunctor);                                             \
+    int begin4 = begin[4];                                                    \
+    int end4   = end[4];                                                      \
+    int begin3 = begin[3];                                                    \
+    int end3   = end[3];                                                      \
+    int begin2 = begin[2];                                                    \
+    int end2   = end[2];                                                      \
+    int begin1 = begin[1];                                                    \
+    int end1   = end[1];                                                      \
+    int begin0 = begin[0];                                                    \
+    int end0   = end[0];                                                      \
+    /* clang-format off */ \
+    KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang vector collapse(5) reduction(OPERATOR:val) copyin(functor) async(async_arg))                                                  \
+    /* clang-format on */                                                     \
+    for (auto i4 = begin4; i4 < end4; ++i4) {                                 \
+      for (auto i3 = begin3; i3 < end3; ++i3) {                               \
+        for (auto i2 = begin2; i2 < end2; ++i2) {                             \
+          for (auto i1 = begin1; i1 < end1; ++i1) {                           \
+            for (auto i0 = begin0; i0 < end0; ++i0) {                         \
+              functor(i0, i1, i2, i3, i4, val);                               \
+            }                                                                 \
+          }                                                                   \
+        }                                                                     \
+      }                                                                       \
+    }                                                                         \
+    aval = val;                                                               \
+  }                                                                           \
+                                                                              \
+  template <class ValueType, class Functor>                                   \
+  void OpenACCParallelReduce##REDUCER(OpenACCIterateRight, ValueType& aval,   \
+                                      Functor const& afunctor,                \
+                                      OpenACCMDRangeBegin<5> const& begin,    \
+                                      OpenACCMDRangeEnd<5> const& end,        \
+                                      int async_arg) {                        \
+    auto val = aval;                                                          \
+    auto const functor(afunctor);                                             \
+    int begin0 = begin[0];                                                    \
+    int end0   = end[0];                                                      \
+    int begin1 = begin[1];                                                    \
+    int end1   = end[1];                                                      \
+    int begin2 = begin[2];                                                    \
+    int end2   = end[2];                                                      \
+    int begin3 = begin[3];                                                    \
+    int end3   = end[3];                                                      \
+    int begin4 = begin[4];                                                    \
+    int end4   = end[4];                                                      \
+    /* clang-format off */ \
+    KOKKOS_IMPL_ACC_PGRAMA(parallel loop gang vector collapse(5) reduction(OPERATOR:val) copyin(functor) async(async_arg))                                                  \
+    /* clang-format on */                                                     \
+    for (auto i0 = begin0; i0 < end0; ++i0) {                                 \
+      for (auto i1 = begin1; i1 < end1; ++i1) {                               \
+        for (auto i2 = begin2; i2 < end2; ++i2) {                             \
+          for (auto i3 = begin3; i3 < end3; ++i3) {                           \
+            for (auto i4 = begin4; i4 < end4; ++i4) {                         \
+              functor(i0, i1, i2, i3, i4, val);                               \
+            }                                                                 \
+          }                                                                   \
+        }                                                                     \
+      }                                                                       \
+    }                                                                         \
+    aval = val;                                                               \
+  }                                                                           \
+                                                                              \
+  template <class ValueType, class Functor>                                   \
+  void OpenACCParallelReduce##REDUCER(OpenACCIterateLeft, ValueType& aval,    \
+                                      Functor const& afunctor,                \
+                                      OpenACCMDRangeBegin<6> const& begin,    \
+                                      OpenACCMDRangeEnd<6> const& end,        \
+                                      int async_arg) {                        \
+    auto val = aval;                                                          \
+    auto const functor(afunctor);                                             \
+    int begin5 = begin[5];                                                    \
+    int end5   = end[5];                                                      \
+    int begin4 = begin[4];                                                    \
+    int end4   = end[4];                                                      \
+    int begin3 = begin[3];                                                    \
+    int end3   = end[3];                                                      \
+    int begin2 = begin[2];                                                    \
+    int end2   = end[2];                                                      \
+    int begin1 = begin[1];                                                    \
+    int end1   = end[1];                                                      \
+    int begin0 = begin[0];                                                    \
+    int end0   = end[0];                                                      \
+    /* clang-format off */ \
+    KOKKOS_IMPL_ACC_PRAGMA(parallel loop gang vector collapse(6) reduction(OPERATOR:val) copyin(functor) async(async_arg))                                                  \
+    /* clang-format on */                                                     \
+    for (auto i5 = begin5; i5 < end5; ++i5) {                                 \
+      for (auto i4 = begin4; i4 < end4; ++i4) {                               \
+        for (auto i3 = begin3; i3 < end3; ++i3) {                             \
+          for (auto i2 = begin2; i2 < end2; ++i2) {                           \
+            for (auto i1 = begin1; i1 < end1; ++i1) {                         \
+              for (auto i0 = begin0; i0 < end0; ++i0) {                       \
+                functor(i0, i1, i2, i3, i4, i5, val);                         \
+              }                                                               \
+            }                                                                 \
+          }                                                                   \
+        }                                                                     \
+      }                                                                       \
+    }                                                                         \
+    aval = val;                                                               \
+  }                                                                           \
+                                                                              \
+  template <class ValueType, class Functor>                                   \
+  void OpenACCParallelReduce##REDUCER(OpenACCIterateRight, ValueType& aval,   \
+                                      Functor const& afunctor,                \
+                                      OpenACCMDRangeBegin<6> const& begin,    \
+                                      OpenACCMDRangeEnd<6> const& end,        \
+                                      int async_arg) {                        \
+    auto val = aval;                                                          \
+    auto const functor(afunctor);                                             \
+    int begin0 = begin[0];                                                    \
+    int end0   = end[0];                                                      \
+    int begin1 = begin[1];                                                    \
+    int end1   = end[1];                                                      \
+    int begin2 = begin[2];                                                    \
+    int end2   = end[2];                                                      \
+    int begin3 = begin[3];                                                    \
+    int end3   = end[3];                                                      \
+    int begin4 = begin[4];                                                    \
+    int end4   = end[4];                                                      \
+    int begin5 = begin[5];                                                    \
+    int end5   = end[5];                                                      \
+    /* clang-format off */ \
+    KOKKOS_IMPL_ACC_PGRAMA(parallel loop gang vector collapse(6) reduction(OPERATOR:val) copyin(functor) async(async_arg))                                                  \
+    /* clang-format on */                                                     \
+    for (auto i0 = begin0; i0 < end0; ++i0) {                                 \
+      for (auto i1 = begin1; i1 < end1; ++i1) {                               \
+        for (auto i2 = begin2; i2 < end2; ++i2) {                             \
+          for (auto i3 = begin3; i3 < end3; ++i3) {                           \
+            for (auto i4 = begin4; i4 < end4; ++i4) {                         \
+              for (auto i5 = begin5; i5 < end5; ++i5) {                       \
+                functor(i0, i1, i2, i3, i4, i5, val);                         \
+              }                                                               \
+            }                                                                 \
+          }                                                                   \
+        }                                                                     \
+      }                                                                       \
+    }                                                                         \
+    aval = val;                                                               \
+  }                                                                           \
+  }  // namespace Kokkos::Experimental::Impl
+
+#define KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_MDRANGE_HELPER(REDUCER, OPERATOR) \
+  KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_DISPATCH_ITERATE(REDUCER, OPERATOR)     \
+  template <class Functor, class Scalar, class Space, class... Traits>        \
+  struct Kokkos::Experimental::Impl::OpenACCParallelReduceMDRangeHelper<      \
+      Functor, Kokkos::REDUCER<Scalar, Space>,                                \
+      Kokkos::MDRangePolicy<Traits...>, true> {                               \
+    using Policy    = MDRangePolicy<Traits...>;                               \
+    using Reducer   = REDUCER<Scalar, Space>;                                 \
+    using ValueType = typename Reducer::value_type;                           \
+                                                                              \
+    OpenACCParallelReduceMDRangeHelper(Functor const& functor,                \
+                                       Reducer const& reducer,                \
+                                       Policy const& policy) {                \
+      ValueType val;                                                          \
+      reducer.init(val);                                                      \
+                                                                              \
+      int const async_arg = policy.space().acc_async_queue();                 \
+                                                                              \
+      OpenACCParallelReduce##REDUCER(                                         \
+          std::integral_constant<Iterate, Policy::inner_direction>(), val,    \
+          functor, policy.m_lower, policy.m_upper, async_arg);                \
+                                                                              \
+      reducer.reference() = val;                                              \
+    }                                                                         \
+  }
+
+KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_MDRANGE_HELPER(Sum, +);
+KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_MDRANGE_HELPER(Prod, *);
+KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_MDRANGE_HELPER(Min, min);
+KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_MDRANGE_HELPER(Max, max);
+KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_MDRANGE_HELPER(LAnd, &&);
+KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_MDRANGE_HELPER(LOr, ||);
+KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_MDRANGE_HELPER(BAnd, &);
+KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_MDRANGE_HELPER(BOr, |);
+
+#undef KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_MDRANGE_HELPER
+#undef KOKKOS_IMPL_OPENACC_PARALLEL_REDUCE_DISPATCH_ITERATE
+
+#endif

--- a/core/src/decl/Kokkos_Declare_OPENACC.hpp
+++ b/core/src/decl/Kokkos_Declare_OPENACC.hpp
@@ -26,6 +26,7 @@
 #include <OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp>
 #include <OpenACC/Kokkos_OpenACC_MDRangePolicy.hpp>
 #include <OpenACC/Kokkos_OpenACC_ParallelFor_MDRange.hpp>
+#include <OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp>
 #include <OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp>
 #endif
 

--- a/core/unit_test/incremental/Test14_MDRangeReduce.hpp
+++ b/core/unit_test/incremental/Test14_MDRangeReduce.hpp
@@ -93,6 +93,8 @@ struct TestMDRangeReduce {
         },
         d_result);
 
+// FIXME_OPENACC: scalar reduction variable on the device is not yet supported.
+#if !defined(KOKKOS_ENABLE_OPENACC)
     // Parallel reduce on a view.
     Kokkos::parallel_reduce(
         mdPolicy_2D,
@@ -100,16 +102,23 @@ struct TestMDRangeReduce {
           update_value += d_data(i, j);
         },
         d_resultView);
+#endif
 
     // Check correctness.
     ASSERT_EQ(h_result, d_result);
 
+// FIXME_OPENACC: scalar reduction variable on the device is not yet supported.
+#if !defined(KOKKOS_ENABLE_OPENACC)
     // Copy view back to host.
     value_type view_result = 0.0;
     Kokkos::deep_copy(view_result, d_resultView);
     ASSERT_EQ(h_result, view_result);
+#endif
   }
 
+// FIXME_OPENACC: custom reductions are not yet supported in the
+// OpenACC backend.
+#if !defined(KOKKOS_ENABLE_OPENACC)
   // Custom Reduction
   void reduce_custom() {
     Complex_View_1D d_data("complex array", N);
@@ -136,6 +145,7 @@ struct TestMDRangeReduce {
     ASSERT_EQ(result._re, sum * 0.5);
     ASSERT_EQ(result._im, -sum * 0.5);
   }
+#endif
 };
 
 // Reductions tests for MDRange policy and customized reduction.
@@ -144,8 +154,12 @@ TEST(TEST_CATEGORY, incr_14_MDrangeReduce) {
   test.reduce_MDRange();
 // FIXME_OPENMPTARGET: custom reductions are not yet supported in the
 // OpenMPTarget backend.
+// FIXME_OPENACC: custom reductions are not yet supported in the
+// OpenACC backend.
 #if !defined(KOKKOS_ENABLE_OPENMPTARGET)
+#if !defined(KOKKOS_ENABLE_OPENACC)
   test.reduce_custom();
+#endif
 #endif
 }
 


### PR DESCRIPTION
Intended to supersede #5618 
It is more a refactor that anything else.  It does not address https://github.com/kokkos/kokkos/pull/5618#discussion_r1018180681 and suffers the same general issues with the implementation in #5618.  I attempted to enable the incremental test 14 and the one that is reducing into a value on the device gives a memory access violation (the other one passes).  The `parallel_reduce` for `Range` has the same bug so I suppose we could tackle that elsewhere.