### PR TITLE
Fixup host device annotation on defaulted random pool default constructors

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -888,8 +888,7 @@ class Random_XorShift64_Pool {
   using generator_type = Random_XorShift64<DeviceType>;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_FUNCTION
-  Random_XorShift64_Pool() = default;
+  KOKKOS_DEFAULTED_FUNCTION Random_XorShift64_Pool() = default;
 
   KOKKOS_DEFAULTED_FUNCTION Random_XorShift64_Pool(
       Random_XorShift64_Pool const&) = default;
@@ -1135,8 +1134,7 @@ class Random_XorShift1024_Pool {
   using generator_type = Random_XorShift1024<DeviceType>;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_FUNCTION
-  Random_XorShift1024_Pool() = default;
+  KOKKOS_DEFAULTED_FUNCTION Random_XorShift1024_Pool() = default;
 
   KOKKOS_DEFAULTED_FUNCTION Random_XorShift1024_Pool(
       Random_XorShift1024_Pool const&) = default;


### PR DESCRIPTION
Franceso reported on Slack warnings in CI logs
```
/var/jenkins/workspace/Kokkos/install/include/Kokkos_Random.hpp(891): warning: __device__ annotation is ignored on a function("Random_XorShift64_Pool") that is explicitly defaulted on its first declaration
```
following the merge of #5716 

I had annotated the default constructor with `KOKKOS_FUNCTION` instead of `KOKKOS_DEFAULTED_FUNCTION` by mistake.