### PR TITLE
Added multiple reducers support for team-level parallel reduce

### DIFF
--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -515,13 +515,11 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce_combined_reducers_impl(
       combined_value, returnType1, returnType2, returnTypes...);
 
   parallel_reduce(boundaries, combined_functor, combined_reducer);
-  memory_fence();
 
   combined_reducer.write_value_back_to_original_references_on_device(
       combined_value, Impl::_make_reducer_from_arg<mem_space_type>(returnType1),
       Impl::_make_reducer_from_arg<mem_space_type>(returnType2),
       Impl::_make_reducer_from_arg<mem_space_type>(returnTypes)...);
-  memory_fence();
 }
 
 }  // end namespace Impl

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -210,6 +210,8 @@ struct CombinedReducerImpl<std::integer_sequence<size_t, Idxs...>, Space,
      ...);
   }
 
+  KOKKOS_FUNCTION auto& reference() const { return *m_value_view.data(); }
+
   // TODO figure out if we also need to call through to final
 
   KOKKOS_FUNCTION
@@ -245,6 +247,22 @@ struct CombinedReducerImpl<std::integer_sequence<size_t, Idxs...>, Space,
          exec_space, reducers_that_reference_original_values.view(),
          value.template get<Idxs, typename Reducers::value_type>()),
 
+     ...);
+  }
+
+  template <int Idx, class View>
+  KOKKOS_FUNCTION void write_one_value_back_on_device(
+      View const& inputView, typename View::const_value_type& value) noexcept {
+    *inputView.data() = value;
+  }
+
+  template <typename... CombinedReducers>
+  KOKKOS_FUNCTION void write_value_back_to_original_references_on_device(
+      value_type const& value,
+      CombinedReducers const&... reducers_that_reference_original_values) noexcept {
+    (write_one_value_back_on_device<Idxs>(
+         reducers_that_reference_original_values.view(),
+         value.template get<Idxs, typename CombinedReducers::value_type>()),
      ...);
   }
 };
@@ -463,12 +481,12 @@ KOKKOS_INLINE_FUNCTION constexpr auto make_combined_reducer(
   return reducer_type(value,
                       _reducer_from_arg_t<Space, ReferencesOrViewsOrReducers>{
                           (ReferencesOrViewsOrReducers &&) args}...);
-  //----------------------------------------
+  //---------------------------------------
 }
 
-template <class Functor, class Space, class... ReferencesOrViewsOrReducers>
+template <class Space, class Functor, class... ReferencesOrViewsOrReducers>
 KOKKOS_INLINE_FUNCTION constexpr auto make_wrapped_combined_functor(
-    Functor const& functor, Space, ReferencesOrViewsOrReducers&&...) {
+    Functor const& functor, ReferencesOrViewsOrReducers&&...) {
   //----------------------------------------
   return CombinedReductionFunctorWrapper<
       Functor, Space,
@@ -478,6 +496,34 @@ KOKKOS_INLINE_FUNCTION constexpr auto make_wrapped_combined_functor(
 
 template <typename FunctorType>
 using functor_has_value_t = typename FunctorType::value_type;
+
+template <typename MemberType, typename BoundaryStructType, typename Functor,
+          typename ReturnType1, typename ReturnType2, typename... ReturnTypes>
+KOKKOS_INLINE_FUNCTION void parallel_reduce_combined_reducers_impl(
+    BoundaryStructType const& boundaries, Functor const& functor,
+    ReturnType1&& returnType1, ReturnType2&& returnType2,
+    ReturnTypes&&... returnTypes) noexcept {
+  using mem_space_type = typename MemberType::scratch_memory_space;
+
+  auto combined_value = Impl::make_combined_reducer_value<mem_space_type>(
+      returnType1, returnType2, returnTypes...);
+
+  auto combined_functor = Impl::make_wrapped_combined_functor<mem_space_type>(
+      functor, returnType1, returnType2, returnTypes...);
+
+  auto combined_reducer = Impl::make_combined_reducer<mem_space_type>(
+      combined_value, returnType1, returnType2, returnTypes...);
+
+  parallel_reduce(boundaries, combined_functor, combined_reducer);
+  memory_fence();
+
+  combined_reducer.write_value_back_to_original_references_on_device(
+      combined_value, Impl::_make_reducer_from_arg<mem_space_type>(returnType1),
+      Impl::_make_reducer_from_arg<mem_space_type>(returnType2),
+      Impl::_make_reducer_from_arg<mem_space_type>(returnTypes)...);
+  memory_fence();
+}
+
 }  // end namespace Impl
 
 //==============================================================================
@@ -509,8 +555,8 @@ auto parallel_reduce(std::string const& label, PolicyType const& policy,
   auto combined_reducer = Impl::make_combined_reducer<space_type>(
       value, returnType1, returnType2, returnTypes...);
 
-  auto combined_functor = Impl::make_wrapped_combined_functor(
-      functor, space_type{}, returnType1, returnType2, returnTypes...);
+  auto combined_functor = Impl::make_wrapped_combined_functor<space_type>(
+      functor, returnType1, returnType2, returnTypes...);
 
   using combined_functor_type = decltype(combined_functor);
   static_assert(
@@ -577,66 +623,36 @@ void parallel_reduce(size_t n, Functor const& functor,
 //------------------------------------------------------------------------------
 // <editor-fold desc="Team overloads"> {{{2
 
-// Copied three times because that's the best way we have right now to match
-// Impl::TeamThreadRangeBoundariesStruct,
-// Impl::ThreadVectorRangeBoundariesStruct, and
-// Impl::TeamVectorRangeBoundariesStruct.
-// TODO make these work after restructuring
+template <class iType, class MemberType, class Functor, class ReturnType1,
+          class ReturnType2, class... ReturnTypes>
+KOKKOS_INLINE_FUNCTION void parallel_reduce(
+    Impl::TeamThreadRangeBoundariesStruct<iType, MemberType> const& boundaries,
+    Functor const& functor, ReturnType1&& returnType1,
+    ReturnType2&& returnType2, ReturnTypes&&... returnTypes) noexcept {
+  Impl::parallel_reduce_combined_reducers_impl<MemberType>(
+      boundaries, functor, returnType1, returnType2, returnTypes...);
+}
 
-// template <class iType, class MemberType, class Functor, class ReturnType1,
-//          class ReturnType2, class... ReturnTypes>
-// KOKKOS_INLINE_FUNCTION void parallel_reduce(
-//    std::string const& label,
-//    Impl::TeamThreadRangeBoundariesStruct<iType, MemberType> const&
-//    boundaries, Functor const& functor, ReturnType1&& returnType1,
-//    ReturnType2&& returnType2, ReturnTypes&&... returnTypes) noexcept {
-//  const auto combined_reducer =
-//      Impl::make_combined_reducer<Kokkos::AnonymousSpace>(
-//          returnType1, returnType2, returnTypes...);
-//
-//  auto combined_functor = Impl::make_wrapped_combined_functor(
-//      functor, Kokkos::AnonymousSpace{}, returnType1, returnType2,
-//      returnTypes...);
-//
-//  parallel_reduce(label, boundaries, combined_functor, combined_reducer);
-//}
-//
-// template <class iType, class MemberType, class Functor, class ReturnType1,
-//          class ReturnType2, class... ReturnTypes>
-// KOKKOS_INLINE_FUNCTION void parallel_reduce(
-//    std::string const& label,
-//    Impl::ThreadVectorRangeBoundariesStruct<iType, MemberType> const&
-//        boundaries,
-//    Functor const& functor, ReturnType1&& returnType1,
-//    ReturnType2&& returnType2, ReturnTypes&&... returnTypes) noexcept {
-//  const auto combined_reducer =
-//      Impl::make_combined_reducer<Kokkos::AnonymousSpace>(
-//          returnType1, returnType2, returnTypes...);
-//
-//  auto combined_functor = Impl::make_wrapped_combined_functor(
-//      functor, Kokkos::AnonymousSpace{}, returnType1, returnType2,
-//      returnTypes...);
-//
-//  parallel_reduce(label, boundaries, combined_functor, combined_reducer);
-//}
+template <class iType, class MemberType, class Functor, class ReturnType1,
+          class ReturnType2, class... ReturnTypes>
+KOKKOS_INLINE_FUNCTION void parallel_reduce(
+    Impl::ThreadVectorRangeBoundariesStruct<iType, MemberType> const&
+        boundaries,
+    Functor const& functor, ReturnType1&& returnType1,
+    ReturnType2&& returnType2, ReturnTypes&&... returnTypes) noexcept {
+  Impl::parallel_reduce_combined_reducers_impl<MemberType>(
+      boundaries, functor, returnType1, returnType2, returnTypes...);
+}
 
-// template <class iType, class MemberType, class Functor, class ReturnType1,
-//          class ReturnType2, class... ReturnTypes>
-// KOKKOS_INLINE_FUNCTION void parallel_reduce(
-//    std::string const& label,
-//    Impl::TeamVectorRangeBoundariesStruct<iType, MemberType> const&
-//    boundaries, Functor const& functor, ReturnType1&& returnType1,
-//    ReturnType2&& returnType2, ReturnTypes&&... returnTypes) noexcept {
-//  const auto combined_reducer =
-//      Impl::make_combined_reducer<Kokkos::AnonymousSpace>(
-//          returnType1, returnType2, returnTypes...);
-//
-//  auto combined_functor = Impl::make_wrapped_combined_functor(
-//      functor, Kokkos::AnonymousSpace{}, returnType1, returnType2,
-//      returnTypes...);
-//
-//  parallel_reduce(label, boundaries, combined_functor, combined_reducer);
-//}
+template <class iType, class MemberType, class Functor, class ReturnType1,
+          class ReturnType2, class... ReturnTypes>
+KOKKOS_INLINE_FUNCTION void parallel_reduce(
+    Impl::TeamVectorRangeBoundariesStruct<iType, MemberType> const& boundaries,
+    Functor const& functor, ReturnType1&& returnType1,
+    ReturnType2&& returnType2, ReturnTypes&&... returnTypes) noexcept {
+  Impl::parallel_reduce_combined_reducers_impl<MemberType>(
+      boundaries, functor, returnType1, returnType2, returnTypes...);
+}
 
 // </editor-fold> end Team overloads }}}2
 //------------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -251,7 +251,7 @@ struct CombinedReducerImpl<std::integer_sequence<size_t, Idxs...>, Space,
   }
 
   template <int Idx, class View>
-  KOKKOS_FUNCTION void write_one_value_back_on_device(
+  KOKKOS_FUNCTION static void write_one_value_back_on_device(
       View const& inputView, typename View::const_value_type& value) noexcept {
     *inputView.data() = value;
   }

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -503,7 +503,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce_combined_reducers_impl(
     BoundaryStructType const& boundaries, Functor const& functor,
     ReturnType1&& returnType1, ReturnType2&& returnType2,
     ReturnTypes&&... returnTypes) noexcept {
-  using mem_space_type = DefaultExecutionSpace::memory_space;
+  using mem_space_type = typename MemberType::execution_space::memory_space;
 
   auto combined_value = Impl::make_combined_reducer_value<mem_space_type>(
       returnType1, returnType2, returnTypes...);

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -481,7 +481,7 @@ KOKKOS_INLINE_FUNCTION constexpr auto make_combined_reducer(
   return reducer_type(value,
                       _reducer_from_arg_t<Space, ReferencesOrViewsOrReducers>{
                           (ReferencesOrViewsOrReducers &&) args}...);
-  //---------------------------------------
+  //----------------------------------------
 }
 
 template <class Space, class Functor, class... ReferencesOrViewsOrReducers>
@@ -503,7 +503,7 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce_combined_reducers_impl(
     BoundaryStructType const& boundaries, Functor const& functor,
     ReturnType1&& returnType1, ReturnType2&& returnType2,
     ReturnTypes&&... returnTypes) noexcept {
-  using mem_space_type = typename MemberType::scratch_memory_space;
+  using mem_space_type = DefaultExecutionSpace::memory_space;
 
   auto combined_value = Impl::make_combined_reducer_value<mem_space_type>(
       returnType1, returnType2, returnTypes...);

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -357,6 +357,7 @@ endforeach()
 if(Kokkos_ENABLE_OPENMPTARGET)
   list(REMOVE_ITEM OpenMPTarget_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Other.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamCombinedReducers.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamReductionScan.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_WorkGraph.cpp
     )
@@ -374,6 +375,7 @@ if(Kokkos_ENABLE_OPENACC)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_MDRangePolicyConstructors.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_Other.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_RangePolicyConstructors.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_TeamCombinedReducers.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_TeamMDRange.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_TeamPolicyConstructors.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_TeamReductionScan.cpp

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -203,6 +203,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     SET(${Tag}_SOURCES2A)
     foreach(Name
       TeamBasic
+      TeamCombinedReducers
       TeamMDRange
       TeamPolicyConstructors
       TeamReductionScan

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -434,7 +434,7 @@ TEST(TEST_CATEGORY, team_thread_range_combined_reducers) {
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget> ||
       std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
     GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
-                 << TEST_EXECSPACE.name()
+                 << TEST_EXECSPACE::name()
   }
 #endif
   TeamTeamCombinedReducer tester;
@@ -452,7 +452,7 @@ TEST(TEST_CATEGORY, thread_vector_range_combined_reducers) {
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget> ||
       std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
     GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
-                 << TEST_EXECSPACE.name()
+                 << TEST_EXECSPACE::name()
   }
 #endif
   TeamTeamCombinedReducer tester;
@@ -470,7 +470,7 @@ TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget> ||
       std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
     GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
-                 << TEST_EXECSPACE.name()
+                 << TEST_EXECSPACE::name()
   }
 #endif
   TeamTeamCombinedReducer tester;

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -15,11 +15,9 @@
 //@HEADER
 
 #include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
 
-#include <iostream>
-#include <limits>
-
-namespace Test {
+namespace {
 
 // Extended lambdas in parallel_for and parallel_reduce will not compile if
 // KOKKOS_ENABLE_CUDA_LAMBDA is off
@@ -60,10 +58,17 @@ struct TeamTeamCombinedReducer {
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
-    EXPECT_EQ(n, hostView(0));
-    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
-    EXPECT_EQ(n * n * (n + 1) / 2, hostView(2));
-    EXPECT_EQ(n * n, hostView(3));
+    if (n == 0) {
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(0));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(1));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(2));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(3));
+    } else {
+      EXPECT_EQ(n, hostView(0));
+      EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+      EXPECT_EQ(n * n * (n + 1) / 2, hostView(2));
+      EXPECT_EQ(n * n, hostView(3));
+    }
   }
 
   void test_team_thread_range_only_builtin(const int n) {
@@ -100,10 +105,17 @@ struct TeamTeamCombinedReducer {
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
-    EXPECT_EQ((n * (n + 1) / 2), hostView(0));
-    EXPECT_EQ((n == 0) ? 0 : std::pow(n, n), hostView(1));
-    EXPECT_EQ((n == 0) ? 0 : 1, hostView(2));
-    EXPECT_EQ(n, hostView(3));
+    if (n == 0) {
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(0));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::prod(), hostView(1));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::min(), hostView(2));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::max(), hostView(3));
+    } else {
+      EXPECT_EQ((n * (n + 1) / 2), hostView(0));
+      EXPECT_EQ((n == 0) ? 0 : std::pow(n, n), hostView(1));
+      EXPECT_EQ((n == 0) ? 0 : 1, hostView(2));
+      EXPECT_EQ(n, hostView(3));
+    }
   }
 
   void test_team_thread_range_combined_reducers(const int n) {
@@ -140,11 +152,17 @@ struct TeamTeamCombinedReducer {
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
-    EXPECT_EQ((n * (n + 1) / 2), hostView(0));
-    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
-    EXPECT_EQ((n == 0) ? Kokkos::reduction_identity<int>::max() : n,
-              hostView(2));
-    EXPECT_EQ(n * n, hostView(3));
+    if (n == 0) {
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(0));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(1));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::max(), hostView(2));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(3));
+    } else {
+      EXPECT_EQ((n * (n + 1) / 2), hostView(0));
+      EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+      EXPECT_EQ(n, hostView(2));
+      EXPECT_EQ(n * n, hostView(3));
+    }
   }
 
   void test_thread_vector_range_only_scalars(const int n) {
@@ -181,10 +199,17 @@ struct TeamTeamCombinedReducer {
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
-    EXPECT_EQ(n, hostView(0));
-    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
-    EXPECT_EQ(n * n * (n + 1) / 2, hostView(2));
-    EXPECT_EQ(n * n, hostView(3));
+    if (n == 0) {
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(0));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(1));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(2));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(3));
+    } else {
+      EXPECT_EQ(n, hostView(0));
+      EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+      EXPECT_EQ(n * n * (n + 1) / 2, hostView(2));
+      EXPECT_EQ(n * n, hostView(3));
+    }
   }
 
   void test_thread_vector_range_only_builtin(const int n) {
@@ -222,10 +247,17 @@ struct TeamTeamCombinedReducer {
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
-    EXPECT_EQ((n * (n + 1) / 2), hostView(0));
-    EXPECT_EQ((n == 0) ? 0 : std::pow(n, n), hostView(1));
-    EXPECT_EQ((n == 0) ? 0 : 1, hostView(2));
-    EXPECT_EQ(n, hostView(3));
+    if (n == 0) {
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(0));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::prod(), hostView(1));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::min(), hostView(2));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::max(), hostView(3));
+    } else {
+      EXPECT_EQ((n * (n + 1) / 2), hostView(0));
+      EXPECT_EQ(std::pow(n, n), hostView(1));
+      EXPECT_EQ(1, hostView(2));
+      EXPECT_EQ(n, hostView(3));
+    }
   }
 
   void test_thread_vector_range_combined_reducers(const int n) {
@@ -263,13 +295,17 @@ struct TeamTeamCombinedReducer {
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
-    EXPECT_EQ(
-        (n == 0) ? Kokkos::reduction_identity<int>::prod() : std::pow(n, n),
-        hostView(0));
-    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
-    EXPECT_EQ((n == 0) ? Kokkos::reduction_identity<int>::min() : 1,
-              hostView(2));
-    EXPECT_EQ(n * n, hostView(3));
+    if (n == 0) {
+      EXPECT_EQ(Kokkos::reduction_identity<int>::prod(), hostView(0));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(1));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::min(), hostView(2));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(3));
+    } else {
+      EXPECT_EQ(std::pow(n, n), hostView(0));
+      EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+      EXPECT_EQ(1, hostView(2));
+      EXPECT_EQ(n * n, hostView(3));
+    }
   }
 
   void test_team_vector_range_only_scalars(const int n) {
@@ -305,10 +341,17 @@ struct TeamTeamCombinedReducer {
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
-    EXPECT_EQ(n, hostView(0));
-    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
-    EXPECT_EQ(n * n * (n + 1) / 2, hostView(2));
-    EXPECT_EQ(n * n, hostView(3));
+    if (n == 0) {
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(0));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(1));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(2));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(3));
+    } else {
+      EXPECT_EQ(n, hostView(0));
+      EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+      EXPECT_EQ(n * n * (n + 1) / 2, hostView(2));
+      EXPECT_EQ(n * n, hostView(3));
+    }
   }
 
   void test_team_vector_range_only_builtin(const int n) {
@@ -345,10 +388,17 @@ struct TeamTeamCombinedReducer {
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
-    EXPECT_EQ((n * (n + 1) / 2), hostView(0));
-    EXPECT_EQ((n == 0) ? 0 : std::pow(n, n), hostView(1));
-    EXPECT_EQ((n == 0) ? 0 : 1, hostView(2));
-    EXPECT_EQ(n, hostView(3));
+    if (n == 0) {
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(0));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::prod(), hostView(1));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::min(), hostView(2));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::max(), hostView(3));
+    } else {
+      EXPECT_EQ((n * (n + 1) / 2), hostView(0));
+      EXPECT_EQ(std::pow(n, n), hostView(1));
+      EXPECT_EQ(1, hostView(2));
+      EXPECT_EQ(n, hostView(3));
+    }
   }
 
   void test_team_vector_range_combined_reducers(const int n) {
@@ -385,11 +435,17 @@ struct TeamTeamCombinedReducer {
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
-    EXPECT_EQ((n * (n + 1) / 2), hostView(0));
-    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
-    EXPECT_EQ((n == 0) ? Kokkos::reduction_identity<int>::max() : n,
-              hostView(2));
-    EXPECT_EQ(n * n, hostView(3));
+    if (n == 0) {
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(0));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(1));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::max(), hostView(2));
+      EXPECT_EQ(Kokkos::reduction_identity<int>::sum(), hostView(3));
+    } else {
+      EXPECT_EQ((n * (n + 1) / 2), hostView(0));
+      EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+      EXPECT_EQ(n, hostView(2));
+      EXPECT_EQ(n * n, hostView(3));
+    }
   }
 };
 
@@ -456,4 +512,4 @@ TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
 
 #endif
 
-}  // namespace Test
+}  // namespace

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -433,7 +433,10 @@ TEST(TEST_CATEGORY, team_thread_range_combined_reducers) {
   TeamTeamCombinedReducer tester;
   tester.test_team_thread_range_only_scalars(5);
   tester.test_team_thread_range_only_builtin(7);
+<<<<<<< HEAD
   tester.test_team_thread_range_combined_reducers(0);
+=======
+>>>>>>> e25327412 (fixed warnings from unit tests)
   tester.test_team_thread_range_combined_reducers(9);
 }
 
@@ -441,7 +444,10 @@ TEST(TEST_CATEGORY, thread_vector_range_combined_reducers) {
   TeamTeamCombinedReducer tester;
   tester.test_thread_vector_range_only_scalars(5);
   tester.test_thread_vector_range_only_builtin(7);
+<<<<<<< HEAD
   tester.test_thread_vector_range_combined_reducers(0);
+=======
+>>>>>>> e25327412 (fixed warnings from unit tests)
   tester.test_thread_vector_range_combined_reducers(9);
 }
 
@@ -449,7 +455,10 @@ TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
   TeamTeamCombinedReducer tester;
   tester.test_team_vector_range_only_scalars(5);
   tester.test_team_vector_range_only_builtin(7);
+<<<<<<< HEAD
   tester.test_team_vector_range_combined_reducers(0);
+=======
+>>>>>>> e25327412 (fixed warnings from unit tests)
   tester.test_team_vector_range_combined_reducers(9);
 }
 

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -430,13 +430,18 @@ struct TeamTeamCombinedReducer {
 };
 
 TEST(TEST_CATEGORY, team_thread_range_combined_reducers) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_OPENACC)
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget> ||
-      std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)
+  if constexpr (std::is_same_v<TEST_EXECSPACE,
+                               Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
-                 << TEST_EXECSPACE::name()
-  }
+                 << TEST_EXECSPACE::name();
+
+#elif defined(KOKKOS_ENABLE_OPENACC)
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
+                 << TEST_EXECSPACE::name();
 #endif
+
   TeamTeamCombinedReducer tester;
   tester.test_team_thread_range_only_scalars(5);
   tester.test_team_thread_range_only_builtin(7);
@@ -448,13 +453,18 @@ TEST(TEST_CATEGORY, team_thread_range_combined_reducers) {
 }
 
 TEST(TEST_CATEGORY, thread_vector_range_combined_reducers) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_OPENACC)
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget> ||
-      std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)
+  if constexpr (std::is_same_v<TEST_EXECSPACE,
+                               Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
-                 << TEST_EXECSPACE::name()
-  }
+                 << TEST_EXECSPACE::name();
+
+#elif defined(KOKKOS_ENABLE_OPENACC)
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
+                 << TEST_EXECSPACE::name();
 #endif
+
   TeamTeamCombinedReducer tester;
   tester.test_thread_vector_range_only_scalars(5);
   tester.test_thread_vector_range_only_builtin(7);
@@ -466,13 +476,18 @@ TEST(TEST_CATEGORY, thread_vector_range_combined_reducers) {
 }
 
 TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_OPENACC)
-  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget> ||
-      std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)
+  if constexpr (std::is_same_v<TEST_EXECSPACE,
+                               Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
-                 << TEST_EXECSPACE::name()
-  }
+                 << TEST_EXECSPACE::name();
+
+#elif defined(KOKKOS_ENABLE_OPENACC)
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+    GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
+                 << TEST_EXECSPACE::name();
 #endif
+
   TeamTeamCombinedReducer tester;
   tester.test_team_vector_range_only_scalars(5);
   tester.test_team_vector_range_only_builtin(7);

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -112,8 +112,8 @@ struct TeamTeamCombinedReducer {
       EXPECT_EQ(Kokkos::reduction_identity<int>::max(), hostView(3));
     } else {
       EXPECT_EQ((n * (n + 1) / 2), hostView(0));
-      EXPECT_EQ((n == 0) ? 0 : std::pow(n, n), hostView(1));
-      EXPECT_EQ((n == 0) ? 0 : 1, hostView(2));
+      EXPECT_EQ(std::pow(n, n), hostView(1));
+      EXPECT_EQ(1, hostView(2));
       EXPECT_EQ(n, hostView(3));
     }
   }

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -449,10 +449,7 @@ TEST(TEST_CATEGORY, team_thread_range_combined_reducers) {
   TeamTeamCombinedReducer tester;
   tester.test_team_thread_range_only_scalars(5);
   tester.test_team_thread_range_only_builtin(7);
-<<<<<<< HEAD
   tester.test_team_thread_range_combined_reducers(0);
-=======
->>>>>>> e25327412 (fixed warnings from unit tests)
   tester.test_team_thread_range_combined_reducers(9);
 }
 
@@ -472,10 +469,7 @@ TEST(TEST_CATEGORY, thread_vector_range_combined_reducers) {
   TeamTeamCombinedReducer tester;
   tester.test_thread_vector_range_only_scalars(5);
   tester.test_thread_vector_range_only_builtin(7);
-<<<<<<< HEAD
   tester.test_thread_vector_range_combined_reducers(0);
-=======
->>>>>>> e25327412 (fixed warnings from unit tests)
   tester.test_thread_vector_range_combined_reducers(9);
 }
 
@@ -496,10 +490,7 @@ TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
   TeamTeamCombinedReducer tester;
   tester.test_team_vector_range_only_scalars(5);
   tester.test_team_vector_range_only_builtin(7);
-<<<<<<< HEAD
   tester.test_team_vector_range_combined_reducers(0);
-=======
->>>>>>> e25327412 (fixed warnings from unit tests)
   tester.test_team_vector_range_combined_reducers(9);
 }
 

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -430,6 +430,13 @@ struct TeamTeamCombinedReducer {
 };
 
 TEST(TEST_CATEGORY, team_thread_range_combined_reducers) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_OPENACC)
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget> ||
+      std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+    GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
+                 << TEST_EXECSPACE.name()
+  }
+#endif
   TeamTeamCombinedReducer tester;
   tester.test_team_thread_range_only_scalars(5);
   tester.test_team_thread_range_only_builtin(7);
@@ -441,6 +448,13 @@ TEST(TEST_CATEGORY, team_thread_range_combined_reducers) {
 }
 
 TEST(TEST_CATEGORY, thread_vector_range_combined_reducers) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_OPENACC)
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget> ||
+      std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+    GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
+                 << TEST_EXECSPACE.name()
+  }
+#endif
   TeamTeamCombinedReducer tester;
   tester.test_thread_vector_range_only_scalars(5);
   tester.test_thread_vector_range_only_builtin(7);
@@ -452,6 +466,13 @@ TEST(TEST_CATEGORY, thread_vector_range_combined_reducers) {
 }
 
 TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_OPENACC)
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenMPTarget> ||
+      std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+    GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
+                 << TEST_EXECSPACE.name()
+  }
+#endif
   TeamTeamCombinedReducer tester;
   tester.test_team_vector_range_only_scalars(5);
   tester.test_team_vector_range_only_builtin(7);

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -487,7 +487,7 @@ TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
                  << TEST_EXECSPACE::name();
 #endif
 
-#ifdef KOKKOS_ENABLE_OPENACC // FIXME_OPENACC
+#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
     GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
                  << TEST_EXECSPACE::name();

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -21,9 +21,9 @@
 
 namespace Test {
 
-struct TEST_CATEGORY_FIXTURE(team_combined_reducer) : public ::testing::Test {
+struct TeamTeamCombinedReducer {
  public:
-  void test_team_thread_range_only_scalars(const unsigned n) {
+  void test_team_thread_range_only_scalars(const int n) {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
@@ -66,7 +66,7 @@ struct TEST_CATEGORY_FIXTURE(team_combined_reducer) : public ::testing::Test {
     EXPECT_EQ(n * n, hostView(3));
   }
 
-  void test_team_thread_range_only_builtin(const unsigned n) {
+  void test_team_thread_range_only_builtin(const int n) {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
@@ -110,7 +110,7 @@ struct TEST_CATEGORY_FIXTURE(team_combined_reducer) : public ::testing::Test {
     EXPECT_EQ(n, hostView(3));
   }
 
-  void test_team_thread_range_combined_reducers(const unsigned n) {
+  void test_team_thread_range_combined_reducers(const int n) {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
@@ -154,7 +154,7 @@ struct TEST_CATEGORY_FIXTURE(team_combined_reducer) : public ::testing::Test {
     EXPECT_EQ(n * n, hostView(3));
   }
 
-  void test_thread_vector_range_only_scalars(const unsigned n) {
+  void test_thread_vector_range_only_scalars(const int n) {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
@@ -198,7 +198,7 @@ struct TEST_CATEGORY_FIXTURE(team_combined_reducer) : public ::testing::Test {
     EXPECT_EQ(n * n, hostView(3));
   }
 
-  void test_thread_vector_range_only_builtin(const unsigned n) {
+  void test_thread_vector_range_only_builtin(const int n) {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
@@ -243,7 +243,7 @@ struct TEST_CATEGORY_FIXTURE(team_combined_reducer) : public ::testing::Test {
     EXPECT_EQ(n, hostView(3));
   }
 
-  void test_thread_vector_range_combined_reducers(const unsigned n) {
+  void test_thread_vector_range_combined_reducers(const int n) {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
@@ -288,7 +288,7 @@ struct TEST_CATEGORY_FIXTURE(team_combined_reducer) : public ::testing::Test {
     EXPECT_EQ(n * n, hostView(3));
   }
 
-  void test_team_vector_range_only_scalars(const unsigned n) {
+  void test_team_vector_range_only_scalars(const int n) {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
@@ -331,7 +331,7 @@ struct TEST_CATEGORY_FIXTURE(team_combined_reducer) : public ::testing::Test {
     EXPECT_EQ(n * n, hostView(3));
   }
 
-  void test_team_vector_range_only_builtin(const unsigned n) {
+  void test_team_vector_range_only_builtin(const int n) {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
@@ -375,7 +375,7 @@ struct TEST_CATEGORY_FIXTURE(team_combined_reducer) : public ::testing::Test {
     EXPECT_EQ(n, hostView(3));
   }
 
-  void test_team_vector_range_combined_reducers(const unsigned n) {
+  void test_team_vector_range_combined_reducers(const int n) {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
@@ -420,25 +420,25 @@ struct TEST_CATEGORY_FIXTURE(team_combined_reducer) : public ::testing::Test {
   }
 };
 
-TEST_F(TEST_CATEGORY_FIXTURE(team_combined_reducer),
-       team_thread_range_combined_reducers) {
-  test_team_thread_range_only_scalars(5);
-  test_team_thread_range_only_builtin(7);
-  test_team_thread_range_combined_reducers(9);
+TEST(TEST_CATEGORY, team_thread_range_combined_reducers) {
+  TeamTeamCombinedReducer tester;
+  tester.test_team_thread_range_only_scalars(5);
+  tester.test_team_thread_range_only_builtin(7);
+  tester.test_team_thread_range_combined_reducers(9);
 }
 
-TEST_F(TEST_CATEGORY_FIXTURE(team_combined_reducer),
-       thread_vector_range_combined_reducers) {
-  test_thread_vector_range_only_scalars(5);
-  test_thread_vector_range_only_builtin(7);
-  test_thread_vector_range_combined_reducers(9);
+TEST(TEST_CATEGORY, thread_vector_range_combined_reducers) {
+  TeamTeamCombinedReducer tester;
+  tester.test_thread_vector_range_only_scalars(5);
+  tester.test_thread_vector_range_only_builtin(7);
+  tester.test_thread_vector_range_combined_reducers(9);
 }
 
-TEST_F(TEST_CATEGORY_FIXTURE(team_combined_reducer),
-       team_vector_range_combined_reducers) {
-  test_team_vector_range_only_scalars(5);
-  test_team_vector_range_only_builtin(7);
-  test_team_vector_range_combined_reducers(9);
+TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
+  TeamTeamCombinedReducer tester;
+  tester.test_team_vector_range_only_scalars(5);
+  tester.test_team_vector_range_only_builtin(7);
+  tester.test_team_vector_range_combined_reducers(9);
 }
 
 }  // namespace Test

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -1,0 +1,444 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+#include <iostream>
+#include <limits>
+
+namespace Test {
+
+struct TEST_CATEGORY_FIXTURE(team_combined_reducer) : public ::testing::Test {
+ public:
+  void test_team_thread_range_only_scalars(const unsigned n) {
+    auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
+    using team_member_type = decltype(policy)::member_type;
+
+    Kokkos::View<int*> teamView =
+        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+
+    Kokkos::parallel_for(
+        policy, KOKKOS_LAMBDA(team_member_type const& team) {
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n);
+          int teamResult0      = 0;
+          int teamResult1      = 0;
+          int teamResult2      = 0;
+          int teamResult3      = 0;
+
+          Kokkos::parallel_reduce(
+              teamThreadRange,
+              [=](int const& i, int& localVal0, int& localVal1, int& localVal2,
+                  int& localVal3) {
+                localVal0 += 1;
+                localVal1 += i + 1;
+                localVal2 += (i + 1) * n;
+                localVal3 += n;
+              },
+              teamResult0, teamResult1, teamResult2, teamResult3);
+
+          Kokkos::single(Kokkos::PerTeam(team), [=]() {
+            teamView(0) += teamResult0;
+            teamView(1) += teamResult1;
+            teamView(2) += teamResult2;
+            teamView(3) += teamResult3;
+          });
+        });
+
+    auto hostView = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), teamView);
+
+    EXPECT_EQ(n, hostView(0));
+    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+    EXPECT_EQ(n * n * (n + 1) / 2, hostView(2));
+    EXPECT_EQ(n * n, hostView(3));
+  }
+
+  void test_team_thread_range_only_builtin(const unsigned n) {
+    auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
+    using team_member_type = decltype(policy)::member_type;
+
+    Kokkos::View<int*> teamView =
+        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+
+    Kokkos::parallel_for(
+        policy, KOKKOS_LAMBDA(team_member_type const& team) {
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n);
+          int teamResult0      = 0;
+          int teamResult1      = 0;
+          int teamResult2      = 0;
+          int teamResult3      = 0;
+
+          Kokkos::parallel_reduce(
+              teamThreadRange,
+              [=](int const& i, int& localVal0, int& localVal1, int& localVal2,
+                  int& localVal3) {
+                localVal0 += i + 1;
+                localVal1 *= n;
+                localVal2 = (localVal2 > (i + 1)) ? (i + 1) : localVal2;
+                localVal3 = (localVal3 < (i + 1)) ? (i + 1) : localVal3;
+              },
+              Kokkos::Sum<int>(teamResult0), Kokkos::Prod<int>(teamResult1),
+              Kokkos::Min<int>(teamResult2), Kokkos::Max<int>(teamResult3));
+
+          Kokkos::single(Kokkos::PerTeam(team), [=]() {
+            teamView(0) += teamResult0;
+            teamView(1) += teamResult1;
+            teamView(2) += teamResult2;
+            teamView(3) += teamResult3;
+          });
+        });
+
+    auto hostView = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), teamView);
+
+    EXPECT_EQ((n * (n + 1) / 2), hostView(0));
+    EXPECT_EQ(std::pow(n, n), hostView(1));
+    EXPECT_EQ(1, hostView(2));
+    EXPECT_EQ(n, hostView(3));
+  }
+
+  void test_team_thread_range_combined_reducers(const unsigned n) {
+    auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
+    using team_member_type = decltype(policy)::member_type;
+
+    Kokkos::View<int*> teamView =
+        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+
+    Kokkos::parallel_for(
+        policy, KOKKOS_LAMBDA(team_member_type const& team) {
+          auto teamThreadRange = Kokkos::TeamThreadRange(team, n);
+          int teamResult0      = 0;
+          int teamResult1      = 0;
+          int teamResult2      = 0;
+          int teamResult3      = 0;
+
+          Kokkos::parallel_reduce(
+              teamThreadRange,
+              [=](int const& i, int& localVal0, int& localVal1, int& localVal2,
+                  int& localVal3) {
+                localVal0 += i + 1;
+                localVal1 += i + 1;
+                localVal2 = (localVal2 < (i + 1)) ? (i + 1) : localVal2;
+                localVal3 += n;
+              },
+              teamResult0, Kokkos::Sum<int>(teamResult1),
+              Kokkos::Max<int>(teamResult2), teamResult3);
+
+          Kokkos::single(Kokkos::PerTeam(team), [=]() {
+            teamView(0) += teamResult0;
+            teamView(1) += teamResult1;
+            teamView(2) += teamResult2;
+            teamView(3) += teamResult3;
+          });
+        });
+
+    auto hostView = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), teamView);
+
+    EXPECT_EQ((n * (n + 1) / 2), hostView(0));
+    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+    EXPECT_EQ(n, hostView(2));
+    EXPECT_EQ(n * n, hostView(3));
+  }
+
+  void test_thread_vector_range_only_scalars(const unsigned n) {
+    auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
+    using team_member_type = decltype(policy)::member_type;
+
+    Kokkos::View<int*> teamView =
+        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+
+    Kokkos::parallel_for(
+        policy, KOKKOS_LAMBDA(team_member_type const& team) {
+          auto teamThreadRange   = Kokkos::TeamThreadRange(team, 1);
+          auto threadVectorRange = Kokkos::ThreadVectorRange(team, n);
+          int teamResult0        = 0;
+          int teamResult1        = 0;
+          int teamResult2        = 0;
+          int teamResult3        = 0;
+
+          Kokkos::parallel_for(teamThreadRange, [&](int const&) {
+            Kokkos::parallel_reduce(
+                threadVectorRange,
+                [=](int const& i, int& localVal0, int& localVal1,
+                    int& localVal2, int& localVal3) {
+                  localVal0 += 1;
+                  localVal1 += i + 1;
+                  localVal2 += (i + 1) * n;
+                  localVal3 += n;
+                },
+                teamResult0, teamResult1, teamResult2, teamResult3);
+
+            teamView(0) += teamResult0;
+            teamView(1) += teamResult1;
+            teamView(2) += teamResult2;
+            teamView(3) += teamResult3;
+          });
+        });
+
+    auto hostView = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), teamView);
+
+    EXPECT_EQ(n, hostView(0));
+    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+    EXPECT_EQ(n * n * (n + 1) / 2, hostView(2));
+    EXPECT_EQ(n * n, hostView(3));
+  }
+
+  void test_thread_vector_range_only_builtin(const unsigned n) {
+    auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
+    using team_member_type = decltype(policy)::member_type;
+
+    Kokkos::View<int*> teamView =
+        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+
+    Kokkos::parallel_for(
+        policy, KOKKOS_LAMBDA(team_member_type const& team) {
+          auto teamThreadRange   = Kokkos::TeamThreadRange(team, 1);
+          auto threadVectorRange = Kokkos::ThreadVectorRange(team, n);
+          int teamResult0        = 0;
+          int teamResult1        = 0;
+          int teamResult2        = 0;
+          int teamResult3        = 0;
+
+          Kokkos::parallel_for(teamThreadRange, [&](int const&) {
+            Kokkos::parallel_reduce(
+                threadVectorRange,
+                [=](int const& i, int& localVal0, int& localVal1,
+                    int& localVal2, int& localVal3) {
+                  localVal0 += i + 1;
+                  localVal1 *= n;
+                  localVal2 = (localVal2 > (i + 1)) ? (i + 1) : localVal2;
+                  localVal3 = (localVal3 < (i + 1)) ? (i + 1) : localVal3;
+                },
+                Kokkos::Sum<int>(teamResult0), Kokkos::Prod<int>(teamResult1),
+                Kokkos::Min<int>(teamResult2), Kokkos::Max<int>(teamResult3));
+
+            teamView(0) += teamResult0;
+            teamView(1) += teamResult1;
+            teamView(2) += teamResult2;
+            teamView(3) += teamResult3;
+          });
+        });
+
+    auto hostView = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), teamView);
+
+    EXPECT_EQ((n * (n + 1) / 2), hostView(0));
+    EXPECT_EQ(std::pow(n, n), hostView(1));
+    EXPECT_EQ(1, hostView(2));
+    EXPECT_EQ(n, hostView(3));
+  }
+
+  void test_thread_vector_range_combined_reducers(const unsigned n) {
+    auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
+    using team_member_type = decltype(policy)::member_type;
+
+    Kokkos::View<int*> teamView =
+        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+
+    Kokkos::parallel_for(
+        policy, KOKKOS_LAMBDA(team_member_type const& team) {
+          auto teamThreadRange   = Kokkos::TeamThreadRange(team, 1);
+          auto threadVectorRange = Kokkos::ThreadVectorRange(team, n);
+          int teamResult0        = 0;
+          int teamResult1        = 0;
+          int teamResult2        = 0;
+          int teamResult3        = 0;
+
+          Kokkos::parallel_for(teamThreadRange, [&](int const&) {
+            Kokkos::parallel_reduce(
+                threadVectorRange,
+                [=](int const& i, int& localVal0, int& localVal1,
+                    int& localVal2, int& localVal3) {
+                  localVal0 *= n;
+                  localVal1 += i + 1;
+                  localVal2 = (localVal2 > (i + 1)) ? (i + 1) : localVal2;
+                  localVal3 += n;
+                },
+                Kokkos::Prod<int>(teamResult0), teamResult1,
+                Kokkos::Min<int>(teamResult2), teamResult3);
+
+            teamView(0) += teamResult0;
+            teamView(1) += teamResult1;
+            teamView(2) += teamResult2;
+            teamView(3) += teamResult3;
+          });
+        });
+
+    auto hostView = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), teamView);
+
+    EXPECT_EQ(std::pow(n, n), hostView(0));
+    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+    EXPECT_EQ(1, hostView(2));
+    EXPECT_EQ(n * n, hostView(3));
+  }
+
+  void test_team_vector_range_only_scalars(const unsigned n) {
+    auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
+    using team_member_type = decltype(policy)::member_type;
+
+    Kokkos::View<int*> teamView =
+        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+
+    Kokkos::parallel_for(
+        policy, KOKKOS_LAMBDA(team_member_type const& team) {
+          auto teamVectorRange = Kokkos::TeamVectorRange(team, n);
+          int teamResult0      = 0;
+          int teamResult1      = 0;
+          int teamResult2      = 0;
+          int teamResult3      = 0;
+
+          Kokkos::parallel_reduce(
+              teamVectorRange,
+              [=](int const& i, int& localVal0, int& localVal1, int& localVal2,
+                  int& localVal3) {
+                localVal0 += 1;
+                localVal1 += i + 1;
+                localVal2 += (i + 1) * n;
+                localVal3 += n;
+              },
+              teamResult0, teamResult1, teamResult2, teamResult3);
+
+          Kokkos::single(Kokkos::PerTeam(team), [=]() {
+            teamView(0) += teamResult0;
+            teamView(1) += teamResult1;
+            teamView(2) += teamResult2;
+            teamView(3) += teamResult3;
+          });
+        });
+
+    auto hostView = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), teamView);
+
+    EXPECT_EQ(n, hostView(0));
+    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+    EXPECT_EQ(n * n * (n + 1) / 2, hostView(2));
+    EXPECT_EQ(n * n, hostView(3));
+  }
+
+  void test_team_vector_range_only_builtin(const unsigned n) {
+    auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
+    using team_member_type = decltype(policy)::member_type;
+
+    Kokkos::View<int*> teamView =
+        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+
+    Kokkos::parallel_for(
+        policy, KOKKOS_LAMBDA(team_member_type const& team) {
+          auto teamVectorRange = Kokkos::TeamVectorRange(team, n);
+          int teamResult0      = 0;
+          int teamResult1      = 0;
+          int teamResult2      = 0;
+          int teamResult3      = 0;
+
+          Kokkos::parallel_reduce(
+              teamVectorRange,
+              [=](int const& i, int& localVal0, int& localVal1, int& localVal2,
+                  int& localVal3) {
+                localVal0 += i + 1;
+                localVal1 *= n;
+                localVal2 = (localVal2 > (i + 1)) ? (i + 1) : localVal2;
+                localVal3 = (localVal3 < (i + 1)) ? (i + 1) : localVal3;
+              },
+              Kokkos::Sum<int>(teamResult0), Kokkos::Prod<int>(teamResult1),
+              Kokkos::Min<int>(teamResult2), Kokkos::Max<int>(teamResult3));
+
+          Kokkos::single(Kokkos::PerTeam(team), [=]() {
+            teamView(0) += teamResult0;
+            teamView(1) += teamResult1;
+            teamView(2) += teamResult2;
+            teamView(3) += teamResult3;
+          });
+        });
+
+    auto hostView = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), teamView);
+
+    EXPECT_EQ((n * (n + 1) / 2), hostView(0));
+    EXPECT_EQ(std::pow(n, n), hostView(1));
+    EXPECT_EQ(1, hostView(2));
+    EXPECT_EQ(n, hostView(3));
+  }
+
+  void test_team_vector_range_combined_reducers(const unsigned n) {
+    auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
+    using team_member_type = decltype(policy)::member_type;
+
+    Kokkos::View<int*> teamView =
+        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+
+    Kokkos::parallel_for(
+        policy, KOKKOS_LAMBDA(team_member_type const& team) {
+          auto teamVectorRange = Kokkos::TeamVectorRange(team, n);
+          int teamResult0      = 0;
+          int teamResult1      = 0;
+          int teamResult2      = 0;
+          int teamResult3      = 0;
+
+          Kokkos::parallel_reduce(
+              teamVectorRange,
+              [=](int const& i, int& localVal0, int& localVal1, int& localVal2,
+                  int& localVal3) {
+                localVal0 += i + 1;
+                localVal1 += i + 1;
+                localVal2 = (localVal2 < (i + 1)) ? (i + 1) : localVal2;
+                localVal3 += n;
+              },
+              teamResult0, Kokkos::Sum<int>(teamResult1),
+              Kokkos::Max<int>(teamResult2), teamResult3);
+
+          Kokkos::single(Kokkos::PerTeam(team), [=]() {
+            teamView(0) += teamResult0;
+            teamView(1) += teamResult1;
+            teamView(2) += teamResult2;
+            teamView(3) += teamResult3;
+          });
+        });
+
+    auto hostView = Kokkos::create_mirror_view_and_copy(
+        Kokkos::DefaultHostExecutionSpace(), teamView);
+
+    EXPECT_EQ((n * (n + 1) / 2), hostView(0));
+    EXPECT_EQ((n * (n + 1) / 2), hostView(1));
+    EXPECT_EQ(n, hostView(2));
+    EXPECT_EQ(n * n, hostView(3));
+  }
+};
+
+TEST_F(TEST_CATEGORY_FIXTURE(team_combined_reducer),
+       team_thread_range_combined_reducers) {
+  test_team_thread_range_only_scalars(5);
+  test_team_thread_range_only_builtin(7);
+  test_team_thread_range_combined_reducers(9);
+}
+
+TEST_F(TEST_CATEGORY_FIXTURE(team_combined_reducer),
+       thread_vector_range_combined_reducers) {
+  test_thread_vector_range_only_scalars(5);
+  test_thread_vector_range_only_builtin(7);
+  test_thread_vector_range_combined_reducers(9);
+}
+
+TEST_F(TEST_CATEGORY_FIXTURE(team_combined_reducer),
+       team_vector_range_combined_reducers) {
+  test_team_vector_range_only_scalars(5);
+  test_team_vector_range_only_builtin(7);
+  test_team_vector_range_combined_reducers(9);
+}
+
+}  // namespace Test

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -21,6 +21,10 @@
 
 namespace Test {
 
+// Extended lambdas in parallel_for and parallel_reduce will not compile if
+// KOKKOS_ENABLE_CUDA_LAMBDA is off
+#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
+
 struct TeamTeamCombinedReducer {
  public:
   void test_team_thread_range_only_scalars(const int n) {
@@ -497,5 +501,7 @@ TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
 >>>>>>> e25327412 (fixed warnings from unit tests)
   tester.test_team_vector_range_combined_reducers(9);
 }
+
+#endif
 
 }  // namespace Test

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -48,12 +48,14 @@ struct TeamTeamCombinedReducer {
               },
               teamResult0, teamResult1, teamResult2, teamResult3);
 
-          Kokkos::single(Kokkos::PerTeam(team), [=]() {
-            teamView(0) += teamResult0;
-            teamView(1) += teamResult1;
-            teamView(2) += teamResult2;
-            teamView(3) += teamResult3;
-          });
+          if (n > 0) {
+            Kokkos::single(Kokkos::PerTeam(team), [=]() {
+              teamView(0) += teamResult0;
+              teamView(1) += teamResult1;
+              teamView(2) += teamResult2;
+              teamView(3) += teamResult3;
+            });
+          }
         });
 
     auto hostView = Kokkos::create_mirror_view_and_copy(
@@ -91,20 +93,22 @@ struct TeamTeamCombinedReducer {
               Kokkos::Sum<int>(teamResult0), Kokkos::Prod<int>(teamResult1),
               Kokkos::Min<int>(teamResult2), Kokkos::Max<int>(teamResult3));
 
-          Kokkos::single(Kokkos::PerTeam(team), [=]() {
-            teamView(0) += teamResult0;
-            teamView(1) += teamResult1;
-            teamView(2) += teamResult2;
-            teamView(3) += teamResult3;
-          });
+          if (n > 0) {
+            Kokkos::single(Kokkos::PerTeam(team), [=]() {
+              teamView(0) += teamResult0;
+              teamView(1) += teamResult1;
+              teamView(2) += teamResult2;
+              teamView(3) += teamResult3;
+            });
+          }
         });
 
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
     EXPECT_EQ((n * (n + 1) / 2), hostView(0));
-    EXPECT_EQ(std::pow(n, n), hostView(1));
-    EXPECT_EQ(1, hostView(2));
+    EXPECT_EQ((n == 0) ? 0 : std::pow(n, n), hostView(1));
+    EXPECT_EQ((n == 0) ? 0 : 1, hostView(2));
     EXPECT_EQ(n, hostView(3));
   }
 
@@ -134,12 +138,14 @@ struct TeamTeamCombinedReducer {
               teamResult0, Kokkos::Sum<int>(teamResult1),
               Kokkos::Max<int>(teamResult2), teamResult3);
 
-          Kokkos::single(Kokkos::PerTeam(team), [=]() {
-            teamView(0) += teamResult0;
-            teamView(1) += teamResult1;
-            teamView(2) += teamResult2;
-            teamView(3) += teamResult3;
-          });
+          if (n > 0) {
+            Kokkos::single(Kokkos::PerTeam(team), [=]() {
+              teamView(0) += teamResult0;
+              teamView(1) += teamResult1;
+              teamView(2) += teamResult2;
+              teamView(3) += teamResult3;
+            });
+          }
         });
 
     auto hostView = Kokkos::create_mirror_view_and_copy(
@@ -178,10 +184,12 @@ struct TeamTeamCombinedReducer {
                 },
                 teamResult0, teamResult1, teamResult2, teamResult3);
 
-            teamView(0) += teamResult0;
-            teamView(1) += teamResult1;
-            teamView(2) += teamResult2;
-            teamView(3) += teamResult3;
+            if (n > 0) {
+              teamView(0) += teamResult0;
+              teamView(1) += teamResult1;
+              teamView(2) += teamResult2;
+              teamView(3) += teamResult3;
+            }
           });
         });
 
@@ -222,10 +230,12 @@ struct TeamTeamCombinedReducer {
                 Kokkos::Sum<int>(teamResult0), Kokkos::Prod<int>(teamResult1),
                 Kokkos::Min<int>(teamResult2), Kokkos::Max<int>(teamResult3));
 
-            teamView(0) += teamResult0;
-            teamView(1) += teamResult1;
-            teamView(2) += teamResult2;
-            teamView(3) += teamResult3;
+            if (n > 0) {
+              teamView(0) += teamResult0;
+              teamView(1) += teamResult1;
+              teamView(2) += teamResult2;
+              teamView(3) += teamResult3;
+            }
           });
         });
 
@@ -233,8 +243,8 @@ struct TeamTeamCombinedReducer {
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
     EXPECT_EQ((n * (n + 1) / 2), hostView(0));
-    EXPECT_EQ(std::pow(n, n), hostView(1));
-    EXPECT_EQ(1, hostView(2));
+    EXPECT_EQ((n == 0) ? 0 : std::pow(n, n), hostView(1));
+    EXPECT_EQ((n == 0) ? 0 : 1, hostView(2));
     EXPECT_EQ(n, hostView(3));
   }
 
@@ -266,19 +276,21 @@ struct TeamTeamCombinedReducer {
                 Kokkos::Prod<int>(teamResult0), teamResult1,
                 Kokkos::Min<int>(teamResult2), teamResult3);
 
-            teamView(0) += teamResult0;
-            teamView(1) += teamResult1;
-            teamView(2) += teamResult2;
-            teamView(3) += teamResult3;
+            if (n > 0) {
+              teamView(0) += teamResult0;
+              teamView(1) += teamResult1;
+              teamView(2) += teamResult2;
+              teamView(3) += teamResult3;
+            }
           });
         });
 
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
-    EXPECT_EQ(std::pow(n, n), hostView(0));
+    EXPECT_EQ((n == 0) ? 0 : std::pow(n, n), hostView(0));
     EXPECT_EQ((n * (n + 1) / 2), hostView(1));
-    EXPECT_EQ(1, hostView(2));
+    EXPECT_EQ((n == 0) ? 0 : 1, hostView(2));
     EXPECT_EQ(n * n, hostView(3));
   }
 
@@ -307,12 +319,14 @@ struct TeamTeamCombinedReducer {
               },
               teamResult0, teamResult1, teamResult2, teamResult3);
 
-          Kokkos::single(Kokkos::PerTeam(team), [=]() {
-            teamView(0) += teamResult0;
-            teamView(1) += teamResult1;
-            teamView(2) += teamResult2;
-            teamView(3) += teamResult3;
-          });
+          if (n > 0) {
+            Kokkos::single(Kokkos::PerTeam(team), [=]() {
+              teamView(0) += teamResult0;
+              teamView(1) += teamResult1;
+              teamView(2) += teamResult2;
+              teamView(3) += teamResult3;
+            });
+          }
         });
 
     auto hostView = Kokkos::create_mirror_view_and_copy(
@@ -350,20 +364,22 @@ struct TeamTeamCombinedReducer {
               Kokkos::Sum<int>(teamResult0), Kokkos::Prod<int>(teamResult1),
               Kokkos::Min<int>(teamResult2), Kokkos::Max<int>(teamResult3));
 
-          Kokkos::single(Kokkos::PerTeam(team), [=]() {
-            teamView(0) += teamResult0;
-            teamView(1) += teamResult1;
-            teamView(2) += teamResult2;
-            teamView(3) += teamResult3;
-          });
+          if (n > 0) {
+            Kokkos::single(Kokkos::PerTeam(team), [=]() {
+              teamView(0) += teamResult0;
+              teamView(1) += teamResult1;
+              teamView(2) += teamResult2;
+              teamView(3) += teamResult3;
+            });
+          }
         });
 
     auto hostView = Kokkos::create_mirror_view_and_copy(
         Kokkos::DefaultHostExecutionSpace(), teamView);
 
     EXPECT_EQ((n * (n + 1) / 2), hostView(0));
-    EXPECT_EQ(std::pow(n, n), hostView(1));
-    EXPECT_EQ(1, hostView(2));
+    EXPECT_EQ((n == 0) ? 0 : std::pow(n, n), hostView(1));
+    EXPECT_EQ((n == 0) ? 0 : 1, hostView(2));
     EXPECT_EQ(n, hostView(3));
   }
 
@@ -393,12 +409,14 @@ struct TeamTeamCombinedReducer {
               teamResult0, Kokkos::Sum<int>(teamResult1),
               Kokkos::Max<int>(teamResult2), teamResult3);
 
-          Kokkos::single(Kokkos::PerTeam(team), [=]() {
-            teamView(0) += teamResult0;
-            teamView(1) += teamResult1;
-            teamView(2) += teamResult2;
-            teamView(3) += teamResult3;
-          });
+          if (n > 0) {
+            Kokkos::single(Kokkos::PerTeam(team), [=]() {
+              teamView(0) += teamResult0;
+              teamView(1) += teamResult1;
+              teamView(2) += teamResult2;
+              teamView(3) += teamResult3;
+            });
+          }
         });
 
     auto hostView = Kokkos::create_mirror_view_and_copy(
@@ -415,6 +433,7 @@ TEST(TEST_CATEGORY, team_thread_range_combined_reducers) {
   TeamTeamCombinedReducer tester;
   tester.test_team_thread_range_only_scalars(5);
   tester.test_team_thread_range_only_builtin(7);
+  tester.test_team_thread_range_combined_reducers(0);
   tester.test_team_thread_range_combined_reducers(9);
 }
 
@@ -422,6 +441,7 @@ TEST(TEST_CATEGORY, thread_vector_range_combined_reducers) {
   TeamTeamCombinedReducer tester;
   tester.test_thread_vector_range_only_scalars(5);
   tester.test_thread_vector_range_only_builtin(7);
+  tester.test_thread_vector_range_combined_reducers(0);
   tester.test_thread_vector_range_combined_reducers(9);
 }
 
@@ -429,6 +449,7 @@ TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
   TeamTeamCombinedReducer tester;
   tester.test_team_vector_range_only_scalars(5);
   tester.test_team_vector_range_only_builtin(7);
+  tester.test_team_vector_range_combined_reducers(0);
   tester.test_team_vector_range_combined_reducers(9);
 }
 

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -480,13 +480,14 @@ TEST(TEST_CATEGORY, thread_vector_range_combined_reducers) {
 }
 
 TEST(TEST_CATEGORY, team_vector_range_combined_reducers) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET)
+#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET
   if constexpr (std::is_same_v<TEST_EXECSPACE,
                                Kokkos::Experimental::OpenMPTarget>)
     GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
                  << TEST_EXECSPACE::name();
+#endif
 
-#elif defined(KOKKOS_ENABLE_OPENACC)
+#ifdef KOKKOS_ENABLE_OPENACC // FIXME_OPENACC
   if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
     GTEST_SKIP() << "team_reduce with a generic reducer is not implemented for "
                  << TEST_EXECSPACE::name();

--- a/core/unit_test/TestTeamCombinedReducers.hpp
+++ b/core/unit_test/TestTeamCombinedReducers.hpp
@@ -27,8 +27,7 @@ struct TeamTeamCombinedReducer {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
-    Kokkos::View<int*> teamView =
-        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+    auto teamView = Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
 
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(team_member_type const& team) {
@@ -70,8 +69,7 @@ struct TeamTeamCombinedReducer {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
-    Kokkos::View<int*> teamView =
-        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+    auto teamView = Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
 
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(team_member_type const& team) {
@@ -114,8 +112,7 @@ struct TeamTeamCombinedReducer {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
-    Kokkos::View<int*> teamView =
-        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+    auto teamView = Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
 
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(team_member_type const& team) {
@@ -158,8 +155,7 @@ struct TeamTeamCombinedReducer {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
-    Kokkos::View<int*> teamView =
-        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+    auto teamView = Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
 
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(team_member_type const& team) {
@@ -202,8 +198,7 @@ struct TeamTeamCombinedReducer {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
-    Kokkos::View<int*> teamView =
-        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+    auto teamView = Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
 
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(team_member_type const& team) {
@@ -247,8 +242,7 @@ struct TeamTeamCombinedReducer {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
-    Kokkos::View<int*> teamView =
-        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+    auto teamView = Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
 
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(team_member_type const& team) {
@@ -292,8 +286,7 @@ struct TeamTeamCombinedReducer {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
-    Kokkos::View<int*> teamView =
-        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+    auto teamView = Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
 
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(team_member_type const& team) {
@@ -335,8 +328,7 @@ struct TeamTeamCombinedReducer {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
-    Kokkos::View<int*> teamView =
-        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+    auto teamView = Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
 
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(team_member_type const& team) {
@@ -379,8 +371,7 @@ struct TeamTeamCombinedReducer {
     auto policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO);
     using team_member_type = decltype(policy)::member_type;
 
-    Kokkos::View<int*> teamView =
-        Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
+    auto teamView = Kokkos::View<int*, TEST_EXECSPACE::memory_space>("view", 4);
 
     Kokkos::parallel_for(
         policy, KOKKOS_LAMBDA(team_member_type const& team) {


### PR DESCRIPTION
Resolves #4510 

Added an interface to allow parallel_reduce with TeamThreadRange, ThreadVectorRange or TeamVectorRange policy to be called with more than one reducer.