### PR TITLE
fix src/dst Properties in deep_copy(DynamicView,View)

### DIFF
--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -878,8 +878,8 @@ inline void deep_copy(const View<T, DP...>& dst,
 template <class T, class... DP, class... SP>
 inline void deep_copy(const Kokkos::Experimental::DynamicView<T, DP...>& dst,
                       const View<T, SP...>& src) {
-  using dst_type = Kokkos::Experimental::DynamicView<T, SP...>;
-  using src_type = View<T, DP...>;
+  using dst_type = Kokkos::Experimental::DynamicView<T, DP...>;
+  using src_type = View<T, SP...>;
 
   using dst_execution_space = typename ViewTraits<T, DP...>::execution_space;
   using src_memory_space    = typename ViewTraits<T, SP...>::memory_space;

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -220,9 +220,10 @@ struct TestDynamicView {
       using device_view_type = Kokkos::View<Scalar*, Space>;
       using host_view_type = typename Kokkos::View<Scalar*, Space>::HostMirror;
 
-      view_type        device_dynamic_view("on-device DynamicView", 1024, arg_total_size);
+      view_type device_dynamic_view("on-device DynamicView", 1024,
+                                    arg_total_size);
       device_view_type device_view("on-device View", arg_total_size);
-      host_view_type   host_view("on-host View", arg_total_size);
+      host_view_type host_view("on-host View", arg_total_size);
 
       unsigned da_size = arg_total_size / 8;
       device_dynamic_view.resize_serial(da_size);
@@ -275,15 +276,17 @@ struct TestDynamicView {
       // destination execution space cannot access the source memory space.
       try {
         Kokkos::deep_copy(host_view, device_dynamic_view);
-      } catch (std::runtime_error const &error) {
+      } catch (std::runtime_error const& error) {
         std::string msg = error.what();
-        std::cerr << "Copy from on-device DynamicView to on-host View failed:\n" << msg << std::endl;
+        std::cerr << "Copy from on-device DynamicView to on-host View failed:\n"
+                  << msg << std::endl;
       }
       try {
         Kokkos::deep_copy(device_dynamic_view, host_view);
-      } catch (std::runtime_error const &error) {
+      } catch (std::runtime_error const& error) {
         std::string msg = error.what();
-        std::cerr << "Copy from on-host View to on-device DynamicView failed:\n" << msg << std::endl;
+        std::cerr << "Copy from on-host View to on-device DynamicView failed:\n"
+                  << msg << std::endl;
       }
     }
   }

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -212,6 +212,77 @@ struct TestDynamicView {
       ASSERT_EQ(new_result_sum, (value_type)(da_resize * (da_resize - 1) / 2));
 #endif
     }  // end scope
+
+    // Test: Reproducer to demonstrate compile-time error of deep_copy
+    // of DynamicView to/from on-host View.
+    //   Case 4:
+    {
+      using device_view_type = Kokkos::View<Scalar*, Space>;
+      using host_view_type = typename Kokkos::View<Scalar*, Space>::HostMirror;
+
+      view_type        device_dynamic_view("on-device DynamicView", 1024, arg_total_size);
+      device_view_type device_view("on-device View", arg_total_size);
+      host_view_type   host_view("on-host View", arg_total_size);
+
+      // Use parallel_for to populate device_dynamic_view and verify values
+#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+      Kokkos::parallel_for(
+          Kokkos::RangePolicy<execution_space>(0, arg_total_size),
+          KOKKOS_LAMBDA(const int i) { device_dynamic_view(i) = Scalar(i); });
+
+      value_type result_sum = 0.0;
+      Kokkos::parallel_reduce(
+          Kokkos::RangePolicy<execution_space>(0, arg_total_size),
+          KOKKOS_LAMBDA(const int i, value_type& partial_sum) {
+            partial_sum += (value_type)device_dynamic_view(i);
+          },
+          result_sum);
+
+      ASSERT_EQ(result_sum, (value_type)(arg_total_size * (arg_total_size - 1) / 2));
+#endif
+
+      // Use an on-device View as intermediate to deep_copy the
+      // device_dynamic_view to host, zero out the device_dynamic_view,
+      // deep_copy from host back to the device_dynamic_view and verify
+      Kokkos::deep_copy(device_view, device_dynamic_view);
+      Kokkos::deep_copy(host_view, device_view);
+      Kokkos::deep_copy(device_view, host_view);
+#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+      Kokkos::parallel_for(
+          Kokkos::RangePolicy<execution_space>(0, arg_total_size),
+          KOKKOS_LAMBDA(const int i) { device_dynamic_view(i) = Scalar(0); });
+#endif
+      Kokkos::deep_copy(device_dynamic_view, device_view);
+#if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+      value_type new_result_sum = 0.0;
+      Kokkos::parallel_reduce(
+          Kokkos::RangePolicy<execution_space>(0, arg_total_size),
+          KOKKOS_LAMBDA(const int i, value_type& partial_sum) {
+            partial_sum += (value_type)device_dynamic_view(i);
+          },
+          new_result_sum);
+
+      ASSERT_EQ(new_result_sum, (value_type)(arg_total_size * (arg_total_size - 1) / 2));
+#endif
+
+      // Try to deep_copy device_dynamic_view directly to/from host.
+      // host-to-device currently fails to compile because DP and SP are
+      // swapped in the deep_copy implementation.
+      // Once that's fixed, both deep_copy's will fail at runtime because the
+      // destination execution space cannot access the source memory space.
+      try {
+        Kokkos::deep_copy(host_view, device_dynamic_view);
+      } catch (std::runtime_error const &error) {
+        std::string msg = error.what();
+        std::cerr << "Copy from on-device DynamicView to on-host View failed:\n" << msg << std::endl;
+      }
+      try {
+        Kokkos::deep_copy(device_dynamic_view, host_view);
+      } catch (std::runtime_error const &error) {
+        std::string msg = error.what();
+        std::cerr << "Copy from on-host View to on-device DynamicView failed:\n" << msg << std::endl;
+      }
+    }
   }
 };
 


### PR DESCRIPTION
In deep_copy(DynamicView, View), fix the dst Properties (DP) and the src Properties (SP) that were swapped in the using statements defining dst_type and src_type.

Add a reproducer unit test.