### PR TITLE
Cleanup CUDA block size deduction

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -162,41 +162,6 @@ int cuda_get_opt_block_size(const CudaInternal* cuda_instance,
                                 LaunchBounds{});
 }
 
-// NOTE these number can be obtained several ways:
-// * One option is to download the CUDA Occupancy Calculator spreadsheet, select
-// "Compute Capability" first and check what is the smallest "Shared Memory
-// Size Config" that is available.  The "Shared Memory Per Multiprocessor" in
-// bytes is then to be found below in the summary.
-// * Another option would be to look for the information in the "Tuning
-// Guide(s)" of the CUDA Toolkit Documentation for each GPU architecture, in
-// the "Shared Memory" section (more tedious)
-inline size_t get_shmem_per_sm_prefer_l1(cudaDeviceProp const& properties) {
-  int const compute_capability = properties.major * 10 + properties.minor;
-  return [compute_capability]() {
-    switch (compute_capability) {
-      case 30:
-      case 32:
-      case 35: return 16;
-      case 37: return 80;
-      case 50:
-      case 53:
-      case 60:
-      case 62: return 64;
-      case 52:
-      case 61: return 96;
-      case 70:
-      case 80:
-      case 86:
-      case 90: return 8;
-      case 75: return 32;
-      default:
-        Kokkos::Impl::throw_runtime_exception(
-            "Unknown device in cuda block size deduction");
-    }
-    return 0;
-  }() * 1024;
-}
-
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -51,24 +51,7 @@ inline int cuda_max_active_blocks_per_sm(cudaDeviceProp const& properties,
                              : max_blocks_regs);
 
   // Limits due to blocks/SM
-#if CUDA_VERSION >= 11000
   int const max_blocks_per_sm = properties.maxBlocksPerMultiProcessor;
-#else
-  int const max_blocks_per_sm = [&properties]() {
-    switch (properties.major) {
-      case 3: return 16;
-      case 5:
-      case 6: return 32;
-      case 7: {
-        int isTuring = properties.minor == 5;
-        return (isTuring) ? 16 : 32;
-      }
-      default:
-        throw_runtime_exception("Unknown device in cuda block size deduction");
-        return 0;
-    }
-  }();
-#endif
 
   // Overall occupancy in blocks
   return std::min({max_blocks_regs, max_blocks_shmem, max_blocks_per_sm});

--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -51,7 +51,24 @@ inline int cuda_max_active_blocks_per_sm(cudaDeviceProp const& properties,
                              : max_blocks_regs);
 
   // Limits due to blocks/SM
+#if CUDA_VERSION >= 11000
   int const max_blocks_per_sm = properties.maxBlocksPerMultiProcessor;
+#else
+  int const max_blocks_per_sm = [&properties]() {
+    switch (properties.major) {
+      case 3: return 16;
+      case 5:
+      case 6: return 32;
+      case 7: {
+        int isTuring = properties.minor == 5;
+        return (isTuring) ? 16 : 32;
+      }
+      default:
+        throw_runtime_exception("Unknown device in cuda block size deduction");
+        return 0;
+    }
+  }();
+#endif
 
   // Overall occupancy in blocks
   return std::min({max_blocks_regs, max_blocks_shmem, max_blocks_per_sm});


### PR DESCRIPTION
* ~~Minimum CUDA required version is 11 so the `#if CUDA_VERSION >= 11000` to get `max_blocks_per_sm` can be removed.~~  **edit** I was reminded that we support CUDA 10 with Clang as the CUDA compiler
* `get_shmem_per_sm_prefer_l1` was only used in code removed in #5706