### PR TITLE
Thread Safety: Call cudaSetDevice before almost any CUDA API call

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -40,7 +40,7 @@
 /*--------------------------------------------------------------------------*/
 /*--------------------------------------------------------------------------*/
 
-// Don't need to call cudaSetDevice, since its called at every call site
+// Don't need to call cudaSetDevice here, since that's called at every call site
 cudaStream_t Kokkos::Impl::cuda_get_deep_copy_stream() {
   static cudaStream_t s = nullptr;
   if (s == nullptr) {

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -132,8 +132,8 @@ void cuda_device_synchronize(const std::string &name) {
       []() {  // TODO: correct device ID
         // Ensure all subsequent CUDA API calls happen on correct GPU
         // Note we call this on only the device of the default execution space
-        // instance if we ever support multiple gpus, we need to somehow loop
-        // over all devices active in Kokkos::fence(), maybe at this point this
+        // instance. If we ever support multiple GPUs, we need to somehow loop
+        // over all active devices in Kokkos::fence(), maybe at this point this
         // function should take a device id??
         KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(CudaInternal::m_cudaDev));
         KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceSynchronize());

--- a/core/src/Cuda/Kokkos_Cuda_Locks.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Locks.cpp
@@ -48,6 +48,8 @@ namespace Impl {
 
 CudaLockArrays g_host_cuda_lock_arrays = {nullptr, 0};
 
+// Only ever called from the CudaInternal::initialize
+// So don't need to call cudaSetDevice here
 void initialize_host_cuda_lock_arrays() {
 #ifdef KOKKOS_ENABLE_IMPL_DESUL_ATOMICS
   desul::Impl::init_lock_arrays();

--- a/core/src/Kokkos_Cuda.hpp
+++ b/core/src/Kokkos_Cuda.hpp
@@ -249,6 +249,9 @@ struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
   ZeroMemset(const Kokkos::Cuda& exec_space_instance,
              const View<DT, DP...>& dst,
              typename View<DT, DP...>::const_value_type&) {
+    // Ensure all subsequent CUDA API calls happen on correct GPU
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        cudaSetDevice(exec_space_instance.cuda_device()));
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemsetAsync(
         dst.data(), 0,
         dst.size() * sizeof(typename View<DT, DP...>::value_type),
@@ -257,6 +260,9 @@ struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
 
   ZeroMemset(const View<DT, DP...>& dst,
              typename View<DT, DP...>::const_value_type&) {
+    // Ensure all subsequent CUDA API calls happen on correct GPU
+    // Can't use CudaInternal::m_cudaDev here
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(Kokkos::Cuda().cuda_device()));
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         cudaMemset(dst.data(), 0,
                    dst.size() * sizeof(typename View<DT, DP...>::value_type)));


### PR DESCRIPTION
When one creates a new thread, that thread will get the default CUDA environment. I.e. any CUDA API call will initally be with respect to device zero unless `cudaSetDevice` is called on that thread.

This means we have to call `cudaSetDevice` again before practically any CUDA API call to be safe.

Currently the device ID we use is a static variable. Subsequently it could be a per-instance ID. This would require us to change some of these places, in particular the `Kokkos::fence()` impl, which would need to iterate over all active devices.

This fixes #5713 and related threading issues