### PR TITLE
Fix HIP Global Launch with HSA_XNACK=1

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -260,17 +260,19 @@ Kokkos::HIP::size_type *HIPInternal::scratch_functor(
 
 Kokkos::HIP::size_type *HIPInternal::scratch_functor_host(
     const std::size_t size) const {
-  if (verify_is_initialized("scratch_functor_host") && m_scratchFunctorSize < size) {
+  if (verify_is_initialized("scratch_functor_host") &&
+      m_scratchFunctorSize < size) {
     m_scratchFunctorSize = size;
 
-    using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPHostPinnedSpace, void>;
+    using Record =
+        Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPHostPinnedSpace, void>;
 
     if (m_scratchFunctorHost)
       Record::decrement(Record::get_record(m_scratchFunctorHost));
 
-    Record *const r =
-        Record::allocate(Kokkos::HIPHostPinnedSpace(), "Kokkos::InternalScratchFunctorHost",
-                         m_scratchFunctorSize);
+    Record *const r = Record::allocate(Kokkos::HIPHostPinnedSpace(),
+                                       "Kokkos::InternalScratchFunctorHost",
+                                       m_scratchFunctorSize);
 
     Record::increment(r);
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -279,7 +279,7 @@ Kokkos::HIP::size_type *HIPInternal::scratch_functor_host(
     m_scratchFunctorHost = reinterpret_cast<size_type *>(r->data());
   }
 
-  return m_scratchFunctor;
+  return m_scratchFunctorHost;
 }
 
 int HIPInternal::acquire_team_scratch_space() {

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -236,6 +236,48 @@ Kokkos::HIP::size_type *HIPInternal::scratch_flags(const std::size_t size) {
   return m_scratchFlags;
 }
 
+Kokkos::HIP::size_type *HIPInternal::stage_functor_for_execution(
+    void const *driver, std::size_t const size) const {
+  if (verify_is_initialized("scratch_functor") && m_scratchFunctorSize < size) {
+    m_scratchFunctorSize = size;
+
+    using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPSpace, void>;
+    using RecordHost =
+        Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPHostPinnedSpace, void>;
+
+    if (m_scratchFunctor) {
+      Record::decrement(Record::get_record(m_scratchFunctor));
+      RecordHost::decrement(RecordHost::get_record(m_scratchFunctorHost));
+    }
+
+    Record *const r =
+        Record::allocate(Kokkos::HIPSpace(), "Kokkos::InternalScratchFunctor",
+                         m_scratchFunctorSize);
+    RecordHost *const r_host = RecordHost::allocate(
+        Kokkos::HIPHostPinnedSpace(), "Kokkos::InternalScratchFunctorHost",
+        m_scratchFunctorSize);
+
+    Record::increment(r);
+    RecordHost::increment(r_host);
+
+    m_scratchFunctor     = reinterpret_cast<size_type *>(r->data());
+    m_scratchFunctorHost = reinterpret_cast<size_type *>(r_host->data());
+  }
+
+  // When using HSA_XNACK=1, it is necessary to copy the driver to the host to
+  // ensure that the driver is not destroyed before the computation is done.
+  // Without this fix, all the atomic tests fail. It is not obvious that this
+  // problem is limited to HSA_XNACK=1 even if all the tests pass when
+  // HSA_XNACK=0. That's why we always copy the driver.
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamSynchronize(m_stream));
+  std::memcpy(m_scratchFunctorHost, driver, size);
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipMemcpyAsync(m_scratchFunctor,
+                                           m_scratchFunctorHost, size,
+                                           hipMemcpyDefault, m_stream));
+
+  return m_scratchFunctor;
+}
+
 int HIPInternal::acquire_team_scratch_space() {
   int current_team_scratch = 0;
   int zero                 = 0;

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -90,6 +90,7 @@ class HIPInternal {
   size_type *m_scratchSpace           = nullptr;
   size_type *m_scratchFlags           = nullptr;
   mutable size_type *m_scratchFunctor = nullptr;
+  mutable size_type *m_scratchFunctorHost = nullptr;
 
   hipStream_t m_stream = nullptr;
   uint32_t m_instance_id =
@@ -136,6 +137,7 @@ class HIPInternal {
   size_type *scratch_space(const std::size_t size);
   size_type *scratch_flags(const std::size_t size);
   size_type *scratch_functor(const std::size_t size) const;
+  size_type *scratch_functor_host(const std::size_t size) const;
   uint32_t impl_get_instance_id() const noexcept;
   int acquire_team_scratch_space();
   // Resizing of team level 1 scratch

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -19,6 +19,7 @@
 #ifndef KOKKOS_HIP_INSTANCE_HPP
 #define KOKKOS_HIP_INSTANCE_HPP
 
+#include <HIP/Kokkos_HIP_SharedAllocationRecord.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
 #include <HIP/Kokkos_HIP_Error.hpp>
 
@@ -136,8 +137,8 @@ class HIPInternal {
   // Resizing of reduction related scratch spaces
   size_type *scratch_space(const std::size_t size);
   size_type *scratch_flags(const std::size_t size);
-  size_type *scratch_functor(const std::size_t size) const;
-  size_type *scratch_functor_host(const std::size_t size) const;
+  template <typename DriverType>
+  size_type *scratch_functor(DriverType const &driver) const;
   uint32_t impl_get_instance_id() const noexcept;
   int acquire_team_scratch_space();
   // Resizing of team level 1 scratch
@@ -145,6 +146,50 @@ class HIPInternal {
                                   bool force_shrink = false);
   void release_team_scratch_space(int scratch_pool_id);
 };
+
+template <typename DriverType>
+Kokkos::HIP::size_type *HIPInternal::scratch_functor(
+    DriverType const &driver) const {
+  std::size_t size = sizeof(DriverType);
+  if (verify_is_initialized("scratch_functor") && m_scratchFunctorSize < size) {
+    m_scratchFunctorSize = size;
+
+    using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPSpace, void>;
+    using RecordHost =
+        Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPHostPinnedSpace, void>;
+
+    if (m_scratchFunctor) {
+      Record::decrement(Record::get_record(m_scratchFunctor));
+      RecordHost::decrement(RecordHost::get_record(m_scratchFunctorHost));
+    }
+
+    Record *const r =
+        Record::allocate(Kokkos::HIPSpace(), "Kokkos::InternalScratchFunctor",
+                         m_scratchFunctorSize);
+    RecordHost *const r_host = RecordHost::allocate(
+        Kokkos::HIPHostPinnedSpace(), "Kokkos::InternalScratchFunctorHost",
+        m_scratchFunctorSize);
+
+    Record::increment(r);
+    RecordHost::increment(r_host);
+
+    m_scratchFunctor     = reinterpret_cast<size_type *>(r->data());
+    m_scratchFunctorHost = reinterpret_cast<size_type *>(r_host->data());
+  }
+
+  // When using HSA_XNACK=1, it is necessary to copy the driver to the host to
+  // ensure that the driver is not destroyed before the computation is done.
+  // Without this fix, all the atomic tests fail. It is not obvious that this
+  // problem is limited to HSA_XNACK=1 even if all the tests pass when
+  // HSA_XNACK=0. That's why we always copy the driver.
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamSynchronize(m_stream));
+  std::memcpy(m_scratchFunctorHost, &driver, size);
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipMemcpyAsync(m_scratchFunctor,
+                                           m_scratchFunctorHost, size,
+                                           hipMemcpyDefault, m_stream));
+
+  return m_scratchFunctor;
+}
 
 }  // namespace Impl
 

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -87,9 +87,9 @@ class HIPInternal {
   std::size_t m_scratchFlagsCount          = 0;
   mutable std::size_t m_scratchFunctorSize = 0;
 
-  size_type *m_scratchSpace           = nullptr;
-  size_type *m_scratchFlags           = nullptr;
-  mutable size_type *m_scratchFunctor = nullptr;
+  size_type *m_scratchSpace               = nullptr;
+  size_type *m_scratchFlags               = nullptr;
+  mutable size_type *m_scratchFunctor     = nullptr;
   mutable size_type *m_scratchFunctorHost = nullptr;
 
   hipStream_t m_stream = nullptr;

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -135,10 +135,10 @@ class HIPInternal {
   HIPInternal() = default;
 
   // Resizing of reduction related scratch spaces
-  size_type *scratch_space(const std::size_t size);
-  size_type *scratch_flags(const std::size_t size);
-  template <typename DriverType>
-  size_type *scratch_functor(DriverType const &driver) const;
+  size_type *scratch_space(std::size_t const size);
+  size_type *scratch_flags(std::size_t const size);
+  size_type *stage_functor_for_execution(void const *driver,
+                                         std::size_t const size) const;
   uint32_t impl_get_instance_id() const noexcept;
   int acquire_team_scratch_space();
   // Resizing of team level 1 scratch
@@ -146,50 +146,6 @@ class HIPInternal {
                                   bool force_shrink = false);
   void release_team_scratch_space(int scratch_pool_id);
 };
-
-template <typename DriverType>
-Kokkos::HIP::size_type *HIPInternal::scratch_functor(
-    DriverType const &driver) const {
-  std::size_t size = sizeof(DriverType);
-  if (verify_is_initialized("scratch_functor") && m_scratchFunctorSize < size) {
-    m_scratchFunctorSize = size;
-
-    using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPSpace, void>;
-    using RecordHost =
-        Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPHostPinnedSpace, void>;
-
-    if (m_scratchFunctor) {
-      Record::decrement(Record::get_record(m_scratchFunctor));
-      RecordHost::decrement(RecordHost::get_record(m_scratchFunctorHost));
-    }
-
-    Record *const r =
-        Record::allocate(Kokkos::HIPSpace(), "Kokkos::InternalScratchFunctor",
-                         m_scratchFunctorSize);
-    RecordHost *const r_host = RecordHost::allocate(
-        Kokkos::HIPHostPinnedSpace(), "Kokkos::InternalScratchFunctorHost",
-        m_scratchFunctorSize);
-
-    Record::increment(r);
-    RecordHost::increment(r_host);
-
-    m_scratchFunctor     = reinterpret_cast<size_type *>(r->data());
-    m_scratchFunctorHost = reinterpret_cast<size_type *>(r_host->data());
-  }
-
-  // When using HSA_XNACK=1, it is necessary to copy the driver to the host to
-  // ensure that the driver is not destroyed before the computation is done.
-  // Without this fix, all the atomic tests fail. It is not obvious that this
-  // problem is limited to HSA_XNACK=1 even if all the tests pass when
-  // HSA_XNACK=0. That's why we always copy the driver.
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamSynchronize(m_stream));
-  std::memcpy(m_scratchFunctorHost, &driver, size);
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipMemcpyAsync(m_scratchFunctor,
-                                           m_scratchFunctorHost, size,
-                                           hipMemcpyDefault, m_stream));
-
-  return m_scratchFunctor;
-}
 
 }  // namespace Impl
 

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -19,7 +19,6 @@
 #ifndef KOKKOS_HIP_INSTANCE_HPP
 #define KOKKOS_HIP_INSTANCE_HPP
 
-#include <HIP/Kokkos_HIP_SharedAllocationRecord.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
 #include <HIP/Kokkos_HIP_Error.hpp>
 

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -91,6 +91,7 @@ class HIPInternal {
   size_type *m_scratchFlags               = nullptr;
   mutable size_type *m_scratchFunctor     = nullptr;
   mutable size_type *m_scratchFunctorHost = nullptr;
+  inline static std::mutex scratchFunctorMutex;
 
   hipStream_t m_stream = nullptr;
   uint32_t m_instance_id =

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -377,20 +377,8 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
   static void invoke_kernel(DriverType const &driver, dim3 const &grid,
                             dim3 const &block, int shmem,
                             HIPInternal const *hip_instance) {
-    // When using HSA_XNACK=1, it is necessary to copy the driver to the host to
-    // ensure that the driver is not destroyed before the computation is done.
-    // Without this fix, all the atomic tests fail. It is not obvious that this
-    // problem is limited to HSA_XNACK=1 even if all the tests pass when
-    // HSA_XNACK=0. That's why we always copy the driver.
-    DriverType *driver_ptr = reinterpret_cast<DriverType *>(
-        hip_instance->scratch_functor(sizeof(DriverType)));
-    DriverType *driver_ptr_host = reinterpret_cast<DriverType *>(
-        hip_instance->scratch_functor_host(sizeof(DriverType)));
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamSynchronize(hip_instance->m_stream));
-    std::memcpy(driver_ptr_host, &driver, sizeof(DriverType));
-    KOKKOS_IMPL_HIP_SAFE_CALL(
-        hipMemcpyAsync(driver_ptr, driver_ptr_host, sizeof(DriverType),
-                       hipMemcpyDefault, hip_instance->m_stream));
+    DriverType *driver_ptr =
+        reinterpret_cast<DriverType *>(hip_instance->scratch_functor(driver));
     (base_t::get_kernel_func())<<<grid, block, shmem, hip_instance->m_stream>>>(
         driver_ptr);
   }

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -377,8 +377,9 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
   static void invoke_kernel(DriverType const &driver, dim3 const &grid,
                             dim3 const &block, int shmem,
                             HIPInternal const *hip_instance) {
-    DriverType *driver_ptr =
-        reinterpret_cast<DriverType *>(hip_instance->scratch_functor(driver));
+    DriverType *driver_ptr = reinterpret_cast<DriverType *>(
+        hip_instance->stage_functor_for_execution(
+            reinterpret_cast<void const *>(&driver), sizeof(DriverType)));
     (base_t::get_kernel_func())<<<grid, block, shmem, hip_instance->m_stream>>>(
         driver_ptr);
   }

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -377,6 +377,8 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
   static void invoke_kernel(DriverType const &driver, dim3 const &grid,
                             dim3 const &block, int shmem,
                             HIPInternal const *hip_instance) {
+    // Wait until the previous kernel that uses m_scratchFuntor is dne
+    std::lock_guard<std::mutex> lock(HIPInternal::scratchFunctorMutex);
     DriverType *driver_ptr = reinterpret_cast<DriverType *>(
         hip_instance->stage_functor_for_execution(
             reinterpret_cast<void const *>(&driver), sizeof(DriverType)));

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -377,7 +377,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
   static void invoke_kernel(DriverType const &driver, dim3 const &grid,
                             dim3 const &block, int shmem,
                             HIPInternal const *hip_instance) {
-    // Wait until the previous kernel that uses m_scratchFuntor is dne
+    // Wait until the previous kernel that uses m_scratchFuntor is done
     std::lock_guard<std::mutex> lock(HIPInternal::scratchFunctorMutex);
     DriverType *driver_ptr = reinterpret_cast<DriverType *>(
         hip_instance->stage_functor_for_execution(


### PR DESCRIPTION
This problem is found with all the versions of ROCm we support.

cc: @arghdos 