### PR TITLE
Desul atomics fixup detect use of SYCL

### DIFF
--- a/tpls/desul/include/desul/atomics/Macros.hpp
+++ b/tpls/desul/include/desul/atomics/Macros.hpp
@@ -39,7 +39,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_HAVE_HIP_ATOMICS
 #endif
 
-#ifdef __SYCL_DEVICE_ONLY__
+#ifdef SYCL_LANGUAGE_VERSION
 #define DESUL_HAVE_SYCL_ATOMICS
 #endif
 


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/5613/files#r1067648253

I remember we only want to use SYCL atomics only on the device side but it is not obvious to me that the macro guard is right.