### PR TITLE
CMake: update package COMPATIBILITY mode

### DIFF
--- a/cmake/kokkos_install.cmake
+++ b/cmake/kokkos_install.cmake
@@ -19,7 +19,7 @@ IF (NOT KOKKOS_HAS_TRILINOS AND NOT Kokkos_INSTALL_TESTING)
 
   WRITE_BASIC_PACKAGE_VERSION_FILE("${Kokkos_BINARY_DIR}/KokkosConfigVersion.cmake"
       VERSION "${Kokkos_VERSION}"
-      COMPATIBILITY SameMajorVersion)
+      COMPATIBILITY AnyNewerVersion)
 
   # Install the KokkosConfig*.cmake files
   install(FILES


### PR DESCRIPTION
In #5751 we did not anticipate that `find_package(Kokkos 3.7)` would not accept the newer Kokkos version
```
CMake Error at CMakeLists.txt:4 (find_package):
  Could not find a configuration file for package "Kokkos" that is compatible
  with requested version "3.7".

  The following configuration files were considered but not accepted:

    <prefix>/lib/cmake/Kokkos/KokkosConfig.cmake, version: 4.0.99
```
One way to resolve this would be to change the COMPATIBILITY mode when we generate our package version file