### PR TITLE
Fix ScratchSpace pointer comparison for SYCL

### DIFF
--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -110,7 +110,7 @@ class ScratchMemorySpace {
     // Note: for team scratch m_offset is 0, since every
     // thread will get back the same shared pointer
     void* tmp           = m_iter + m_offset * size;
-    ptrdiff_t increment = size * m_multiplier;
+    uintptr_t increment = size * m_multiplier;
 
     // Cast to uintptr_t to avoid problems with pointer arithmetic using SYCL
     const auto end_iter =


### PR DESCRIPTION
Fixes #5761. The changes to `Kokkos_ScratchSpace.hpp` in https://github.com/kokkos/kokkos/pull/5687 were breaking tests on Intel GPUs for optimization levels higher than `-O1`.

I'm not entirely sure why the current version breaks. Both sides of the comparison are of type `ptrdiff_t` but trying to display the value for the right-hand side shows a ridiculously small negative number for one of the tests (-4611686018427379892 close to  `LONG_MIN`/2; `ptrdiff_t` is `long`).

edit: Instead of rewriting the comparison, casting to `uintptr_t` seems to work as well.
