### PR TITLE
Replace HIP_LOCK_ARRAYS macros by functions

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -375,14 +375,6 @@ Kokkos::HIP::size_type *hip_internal_scratch_flags(const HIP &instance,
 
 namespace Kokkos {
 namespace Impl {
-void hip_device_synchronize(const std::string &name) {
-  Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::HIP>(
-      name,
-      Kokkos::Tools::Experimental::SpecialSynchronizationCases::
-          GlobalDeviceSynchronization,
-      [&]() { KOKKOS_IMPL_HIP_SAFE_CALL(hipDeviceSynchronize()); });
-}
-
 void hip_internal_error_throw(hipError_t e, const char *name, const char *file,
                               const int line) {
   std::ostringstream out;

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -458,7 +458,7 @@ struct HIPParallelLaunch<
             "HIPParallelLaunch FAILED: shared memory request is too large");
       }
 
-      KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
+      ensure_hip_lock_arrays_on_device();
 
       // Invoke the driver function on the device
       base_t::invoke_kernel(driver, grid, block, shmem, hip_instance);

--- a/core/src/HIP/Kokkos_HIP_Locks.cpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.cpp
@@ -67,8 +67,6 @@ void initialize_host_hip_lock_arrays() {
   copy_hip_lock_arrays_to_device();
   init_lock_array_kernel_atomic<<<
       (KOKKOS_IMPL_HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256, 0, nullptr>>>();
-  HIP::impl_static_fence(
-      "Kokkos::Impl::initialize_host_hip_lock_arrays: Post Init Lock Arrays");
 }
 
 void finalize_host_hip_lock_arrays() {

--- a/core/src/HIP/Kokkos_HIP_Locks.cpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.cpp
@@ -55,8 +55,7 @@ HIPLockArrays g_host_hip_lock_arrays = {nullptr, 0};
 void initialize_host_hip_lock_arrays() {
 #ifdef KOKKOS_ENABLE_IMPL_DESUL_ATOMICS
   desul::Impl::init_lock_arrays();
-
-  DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
+  desul::ensure_hip_lock_arrays_on_device();
 #endif
 
   if (g_host_hip_lock_arrays.atomic != nullptr) return;
@@ -65,10 +64,11 @@ void initialize_host_hip_lock_arrays() {
       sizeof(std::int32_t) * (KOKKOS_IMPL_HIP_SPACE_ATOMIC_MASK + 1)));
 
   g_host_hip_lock_arrays.n = HIPInternal::concurrency();
-
-  KOKKOS_COPY_HIP_LOCK_ARRAYS_TO_DEVICE();
+  copy_hip_lock_arrays_to_device();
   init_lock_array_kernel_atomic<<<
       (KOKKOS_IMPL_HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256, 0, nullptr>>>();
+  HIP::impl_static_fence(
+      "Kokkos::Impl::initialize_host_hip_lock_arrays: Post Init Lock Arrays");
 }
 
 void finalize_host_hip_lock_arrays() {
@@ -81,7 +81,7 @@ void finalize_host_hip_lock_arrays() {
   g_host_hip_lock_arrays.atomic = nullptr;
   g_host_hip_lock_arrays.n      = 0;
 #ifdef KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE
-  KOKKOS_COPY_HIP_LOCK_ARRAYS_TO_DEVICE();
+  copy_hip_lock_arrays_to_device();
 #endif
 }
 

--- a/core/src/HIP/Kokkos_HIP_Locks.hpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.hpp
@@ -122,9 +122,9 @@ inline static
     void
     copy_hip_lock_arrays_to_device() {
   if (lock_array_copied == 0) {
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipMemcpyToSymbol(g_device_hip_lock_arrays,
-                                                &g_host_hip_lock_arrays,
-                                                sizeof(HIPLockArrays)));
+    KOKKOS_IMPL_HIP_SAFE_CALL(
+        hipMemcpyToSymbol(HIP_SYMBOL(g_device_hip_lock_arrays),
+                          &g_host_hip_lock_arrays, sizeof(HIPLockArrays)));
   }
   lock_array_copied = 1;
 }

--- a/core/src/HIP/Kokkos_HIP_Locks.hpp
+++ b/core/src/HIP/Kokkos_HIP_Locks.hpp
@@ -60,7 +60,7 @@ void finalize_host_hip_lock_arrays();
 /// instance of this global variable for the entire executable,
 /// whose definition will be in Kokkos_HIP_Locks.cpp (and whose declaration
 /// here must then be extern).
-/// This one instance will be initialized by initialize_host_HIP_lock_arrays
+/// This one instance will be initialized by initialize_host_hip_lock_arrays
 /// and need not be modified afterwards.
 ///
 /// When relocatable device code is disabled, an instance of this variable
@@ -69,7 +69,7 @@ void finalize_host_hip_lock_arrays();
 /// instances in other translation units, we must update this HIP global
 /// variable based on the Host global variable prior to running any kernels
 /// that will use it.
-/// That is the purpose of the KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE macro.
+/// That is the purpose of the ensure_hip_lock_arrays_on_device function.
 __device__
 #ifdef KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE
     __constant__ extern
@@ -94,7 +94,7 @@ __device__ inline bool lock_address_hip_space(void* ptr) {
 ///
 /// This function releases the lock for the hash value derived
 /// from the provided ptr. This function should only be called
-/// after previously successfully aquiring a lock with
+/// after previously successfully acquiring a lock with
 /// lock_address.
 __device__ inline void unlock_address_hip_space(void* ptr) {
   auto offset = reinterpret_cast<size_t>(ptr);
@@ -113,44 +113,48 @@ namespace {
 static int lock_array_copied = 0;
 inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
 }  // namespace
-}  // namespace Impl
-}  // namespace Kokkos
 
-/* Dan Ibanez: it is critical that this code be a macro, so that it will
-   capture the right address for g_device_hip_lock_arrays!
-   putting this in an inline function will NOT do the right thing! */
-#define KOKKOS_COPY_HIP_LOCK_ARRAYS_TO_DEVICE()                 \
-  {                                                             \
-    if (::Kokkos::Impl::lock_array_copied == 0) {               \
-      KOKKOS_IMPL_HIP_SAFE_CALL(hipMemcpyToSymbol(              \
-          HIP_SYMBOL(::Kokkos::Impl::g_device_hip_lock_arrays), \
-          &::Kokkos::Impl::g_host_hip_lock_arrays,              \
-          sizeof(::Kokkos::Impl::HIPLockArrays)));              \
-    }                                                           \
-    ::Kokkos::Impl::lock_array_copied = 1;                      \
+#ifdef KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE
+inline
+#else
+inline static
+#endif
+    void
+    copy_hip_lock_arrays_to_device() {
+  if (lock_array_copied == 0) {
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipMemcpyToSymbol(g_device_hip_lock_arrays,
+                                                &g_host_hip_lock_arrays,
+                                                sizeof(HIPLockArrays)));
   }
+  lock_array_copied = 1;
+}
 
 #ifndef KOKKOS_ENABLE_IMPL_DESUL_ATOMICS
 
 #ifdef KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE
-#define KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE()
+inline void ensure_hip_lock_arrays_on_device() {}
 #else
-#define KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE() \
-  KOKKOS_COPY_HIP_LOCK_ARRAYS_TO_DEVICE()
+inline static void ensure_hip_lock_arrays_on_device() {
+  copy_hip_lock_arrays_to_device();
+}
 #endif
 
 #else
 
 #ifdef KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE
-#define KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE()
+inline void ensure_hip_lock_arrays_on_device() {}
 #else
-// Still Need COPY_CUDA_LOCK_ARRAYS for team scratch etc.
-#define KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE() \
-  KOKKOS_COPY_HIP_LOCK_ARRAYS_TO_DEVICE()         \
-  DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE()
+// Still Need copy_hip_lock_arrays for team scratch etc.
+inline static void ensure_hip_lock_arrays_on_device() {
+  copy_hip_lock_arrays_to_device();
+  desul::ensure_hip_lock_arrays_on_device();
+}
 #endif
 
 #endif /* defined( KOKKOS_ENABLE_IMPL_DESUL_ATOMICS ) */
+
+}  // namespace Impl
+}  // namespace Kokkos
 
 #endif /* defined( __HIPCC__ ) */
 

--- a/tpls/desul/include/desul/atomics/Lock_Array.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array.hpp
@@ -67,7 +67,7 @@ inline void ensure_lock_arrays_on_device() {
 #endif
 
 #ifdef DESUL_HAVE_HIP_ATOMICS
-  DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE();
+  ensure_hip_lock_arrays_on_device();
 #endif
 }
 

--- a/tpls/desul/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_HIP.hpp
@@ -142,10 +142,10 @@ inline static
     void
     copy_hip_lock_arrays_to_device() {
   if (lock_array_copied == 0) {
-    (void)hipMemcpyToSymbol(HIP_SPACE_ATOMIC_LOCKS_DEVICE,
+    (void)hipMemcpyToSymbol(HIP_SYMBOL(HIP_SPACE_ATOMIC_LOCKS_DEVICE),
                        &HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,
                        sizeof(int32_t*));
-    (void)hipMemcpyToSymbol(HIP_SPACE_ATOMIC_LOCKS_NODE,
+    (void)hipMemcpyToSymbol(HIP_SYMBOL(HIP_SPACE_ATOMIC_LOCKS_NODE),
                        &HIP_SPACE_ATOMIC_LOCKS_NODE_h,
                        sizeof(int32_t*));
   }

--- a/tpls/desul/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_HIP.hpp
@@ -143,11 +143,11 @@ inline static
     copy_hip_lock_arrays_to_device() {
   if (lock_array_copied == 0) {
     (void)hipMemcpyToSymbol(HIP_SYMBOL(HIP_SPACE_ATOMIC_LOCKS_DEVICE),
-                       &HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,
-                       sizeof(int32_t*));
+                            &HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,
+                            sizeof(int32_t*));
     (void)hipMemcpyToSymbol(HIP_SYMBOL(HIP_SPACE_ATOMIC_LOCKS_NODE),
-                       &HIP_SPACE_ATOMIC_LOCKS_NODE_h,
-                       sizeof(int32_t*));
+                            &HIP_SPACE_ATOMIC_LOCKS_NODE_h,
+                            sizeof(int32_t*));
   }
   lock_array_copied = 1;
 }

--- a/tpls/desul/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_HIP.hpp
@@ -35,7 +35,7 @@ extern int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE_h;
 template <typename /*AlwaysInt*/ = int>
 void init_lock_arrays_hip();
 
-/// \brief After this call, the g_host_cuda_lock_arrays variable has
+/// \brief After this call, the g_host_hip_lock_arrays variable has
 ///        all null pointers, and all array memory has been freed.
 ///
 /// This call is idempotent.
@@ -64,10 +64,10 @@ namespace Impl {
  * be created in every translation unit that sees this header file (we make this
  * clear by marking it static, meaning no other translation unit can link to
  * it). Since the Kokkos_HIP_Locks.cpp translation unit cannot initialize the
- * instances in other translation units, we must update this CUDA global
+ * instances in other translation units, we must update this HIP global
  * variable based on the Host global variable prior to running any kernels that
  * will use it.  That is the purpose of the
- * KOKKOS_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE macro.
+ * ensure_hip_lock_arrays_on_device function.
  */
 __device__
 #ifdef DESUL_HIP_RDC
@@ -133,31 +133,34 @@ namespace {
 static int lock_array_copied = 0;
 inline int eliminate_warning_for_lock_array() { return lock_array_copied; }
 }  // namespace
-}  // namespace Impl
-}  // namespace desul
 
-/* It is critical that this code be a macro, so that it will
-   capture the right address for g_device_hip_lock_arrays!
-   putting this in an inline function will NOT do the right thing! */
-#define DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE()                                   \
-  {                                                                                   \
-    if (::desul::Impl::lock_array_copied == 0) {                                      \
-      (void)hipMemcpyToSymbol(                                                        \
-          HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE),                   \
-          &::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,                            \
-          sizeof(int32_t*));                                                          \
-      (void)hipMemcpyToSymbol(HIP_SYMBOL(::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE), \
-                              &::desul::Impl::HIP_SPACE_ATOMIC_LOCKS_NODE_h,          \
-                              sizeof(int32_t*));                                      \
-    }                                                                                 \
-    ::desul::Impl::lock_array_copied = 1;                                             \
+#ifdef DESUL_HIP_RDC
+inline
+#else
+inline static
+#endif
+    void
+    copy_hip_lock_arrays_to_device() {
+  if (lock_array_copied == 0) {
+    (void)hipMemcpyToSymbol(HIP_SPACE_ATOMIC_LOCKS_DEVICE,
+                       &HIP_SPACE_ATOMIC_LOCKS_DEVICE_h,
+                       sizeof(int32_t*));
+    (void)hipMemcpyToSymbol(HIP_SPACE_ATOMIC_LOCKS_NODE,
+                       &HIP_SPACE_ATOMIC_LOCKS_NODE_h,
+                       sizeof(int32_t*));
   }
+  lock_array_copied = 1;
+}
+}  // namespace Impl
 
 #if defined(DESUL_HIP_RDC) || (!defined(__HIPCC__))
-#define DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE()
+inline void ensure_hip_lock_arrays_on_device() {}
 #else
-#define DESUL_ENSURE_HIP_LOCK_ARRAYS_ON_DEVICE() \
-  DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE()
+static inline void ensure_hip_lock_arrays_on_device() {
+  Impl::copy_hip_lock_arrays_to_device();
+}
 #endif
+
+}  // namespace desul
 
 #endif

--- a/tpls/desul/src/Lock_Array_HIP.cpp
+++ b/tpls/desul/src/Lock_Array_HIP.cpp
@@ -70,7 +70,7 @@ void init_lock_arrays_hip() {
                             "init_lock_arrays_hip: hipMallocHost host locks");
 
   auto error_sync1 = hipDeviceSynchronize();
-  DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE();
+  copy_hip_lock_arrays_to_device();
   check_error_and_throw_hip(error_sync1, "init_lock_arrays_hip: post malloc");
 
   init_lock_arrays_hip_kernel<<<(HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>();
@@ -89,7 +89,7 @@ void finalize_lock_arrays_hip() {
   HIP_SPACE_ATOMIC_LOCKS_DEVICE_h = nullptr;
   HIP_SPACE_ATOMIC_LOCKS_NODE_h = nullptr;
 #ifdef DESUL_HIP_RDC
-  DESUL_IMPL_COPY_HIP_LOCK_ARRAYS_TO_DEVICE();
+  copy_hip_lock_arrays_to_device();
 #endif
 }
 


### PR DESCRIPTION
The corresponding pull request on the `desul`-side was merged (https://github.com/desul/desul/pull/88).
The purpose was to get rid of more obscure macros and to make the `CUDA` and `HIP` implementations more similar (again).