### PR TITLE
[4.0.0] Changes to resolve ICE with intel/19

### DIFF
--- a/core/src/Kokkos_HPX.hpp
+++ b/core/src/Kokkos_HPX.hpp
@@ -1065,17 +1065,16 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       typename Kokkos::Impl::HostIterateTile<MDRangePolicy, FunctorType,
                                              WorkTag, void>;
 
-  const FunctorType m_functor;
-  const MDRangePolicy m_mdr_policy;
+  const iterate_type m_iter;
   const Policy m_policy;
 
  public:
-  void execute() const { dispatch_execute_task(this, m_mdr_policy.space()); }
+  void execute() const { dispatch_execute_task(this, m_iter.m_rp.space()); }
 
   inline void execute_task() const {
     // See [note 1] for an explanation.
     Kokkos::Experimental::HPX::reset_on_exit_parallel reset_on_exit(
-        m_mdr_policy.space());
+        m_iter.m_rp.space());
 
     auto exec = Kokkos::Experimental::HPX::impl_get_executor();
 
@@ -1087,9 +1086,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
     for_loop(par.on(exec).with(
                  static_chunk_size(get_hpx_adjusted_chunk_size(m_policy))),
-             m_policy.begin(), m_policy.end(), [this](const Member i) {
-               iterate_type(m_mdr_policy, m_functor)(i);
-             });
+             m_policy.begin(), m_policy.end(),
+             [this](const Member i) { iterate_type(i); });
 
 #elif KOKKOS_HPX_IMPLEMENTATION == 1
     using hpx::for_loop_strided;
@@ -1101,15 +1099,14 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
                        const Member i_end =
                            (std::min)(i_begin + chunk_size, m_policy.end());
                        for (Member i = i_begin; i < i_end; ++i) {
-                         iterate_type(m_mdr_policy, m_functor)(i);
+                         m_iter(i);
                        }
                      });
 #endif
   }
 
   inline ParallelFor(const FunctorType &arg_functor, MDRangePolicy arg_policy)
-      : m_functor(arg_functor),
-        m_mdr_policy(arg_policy),
+      : m_iter(arg_policy, arg_functor),
         m_policy(Policy(0, arg_policy.m_num_tiles).set_chunk_size(1)) {}
   template <typename Policy, typename Functor>
   static int max_tile_size_product(const Policy &, const Functor &) {
@@ -1406,8 +1403,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       typename Kokkos::Impl::HostIterateTile<MDRangePolicy, FunctorType,
                                              WorkTag, reference_type>;
 
-  const FunctorType m_functor;
-  const MDRangePolicy m_mdr_policy;
+  const iterate_type m_iter;
   const Policy m_policy;
   const ReducerType m_reducer;
   const pointer_type m_result_ptr;
@@ -1416,19 +1412,19 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
  public:
   void execute() const {
-    dispatch_execute_task(this, m_mdr_policy.space(), m_force_synchronous);
+    dispatch_execute_task(this, m_iter.m_rp.space(), m_force_synchronous);
   }
 
   inline void execute_task() const {
     // See [note 1] for an explanation.
     Kokkos::Experimental::HPX::reset_on_exit_parallel reset_on_exit(
-        m_mdr_policy.space());
+        m_iter.m_rp.space());
 
     const int num_worker_threads = Kokkos::Experimental::HPX::concurrency();
-    const std::size_t value_size =
-        Analysis::value_size(ReducerConditional::select(m_functor, m_reducer));
+    const std::size_t value_size = Analysis::value_size(
+        ReducerConditional::select(m_iter.m_func, m_reducer));
 
-    thread_buffer &buffer = m_mdr_policy.space().impl_get_buffer();
+    thread_buffer &buffer = m_iter.m_rp.space().impl_get_buffer();
     buffer.resize(num_worker_threads, value_size);
 
     using hpx::for_loop;
@@ -1438,7 +1434,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     auto exec = Kokkos::Experimental::HPX::impl_get_executor();
 
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        &ReducerConditional::select(m_iter.m_func, m_reducer));
 
 #if KOKKOS_HPX_IMPLEMENTATION == 0
 
@@ -1454,7 +1450,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                reference_type update = Analysis::Reducer::reference(
                    reinterpret_cast<pointer_type>(buffer.get(
                        Kokkos::Experimental::HPX::impl_hardware_thread_id())));
-               iterate_type(m_mdr_policy, m_functor, update)(i);
+               m_iter(i, update);
              });
 
 #elif KOKKOS_HPX_IMPLEMENTATION == 1
@@ -1477,7 +1473,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           const Member i_end = (std::min)(i_begin + chunk_size, m_policy.end());
 
           for (Member i = i_begin; i < i_end; ++i) {
-            iterate_type(m_mdr_policy, m_functor, update)(i);
+            m_iter(i, update);
           }
         });
 #endif
@@ -1491,7 +1487,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
     if (m_result_ptr != nullptr) {
       const int n = Analysis::value_count(
-          ReducerConditional::select(m_functor, m_reducer));
+          ReducerConditional::select(m_iter.m_func, m_reducer));
 
       for (int j = 0; j < n; ++j) {
         m_result_ptr[j] = reinterpret_cast<pointer_type>(buffer.get(0))[j];
@@ -1506,8 +1502,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       std::enable_if_t<Kokkos::is_view<ViewType>::value &&
                            !Kokkos::is_reducer<ReducerType>::value,
                        void *> = nullptr)
-      : m_functor(arg_functor),
-        m_mdr_policy(arg_policy),
+      : m_iter(arg_policy, arg_functor),
         m_policy(Policy(0, arg_policy.m_num_tiles).set_chunk_size(1)),
         m_reducer(InvalidType()),
         m_result_ptr(arg_view.data()),
@@ -1515,9 +1510,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
   inline ParallelReduce(const FunctorType &arg_functor,
                         MDRangePolicy arg_policy, const ReducerType &reducer)
-      : m_functor(arg_functor),
-        m_mdr_policy(arg_policy),
-        m_policy(Policy(0, m_mdr_policy.m_num_tiles).set_chunk_size(1)),
+      : m_iter(arg_policy, arg_functor),
+        m_policy(Policy(0, arg_policy.m_num_tiles).set_chunk_size(1)),
         m_reducer(reducer),
         m_result_ptr(reducer.view().data()),
         m_force_synchronous(!reducer.view().impl_track().has_record()) {}

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -44,8 +44,8 @@
 namespace Kokkos {
 namespace Impl {
 
-inline bool execute_in_serial() {
-  return (OpenMP::in_parallel() &&
+inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
+  return (OpenMP::in_parallel(space) &&
           !(omp_get_nested() && (omp_get_level() == 1)));
 }
 
@@ -111,7 +111,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::OpenMP> {
 
  public:
   inline void execute() const {
-    if (execute_in_serial()) {
+    if (execute_in_serial(m_policy.space())) {
       exec_range(m_functor, m_policy.begin(), m_policy.end());
       return;
     }
@@ -179,15 +179,12 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void>;
 
   OpenMPInternal* m_instance;
-  const FunctorType m_functor;
-  const MDRangePolicy m_mdr_policy;
+  const iterate_type m_iter;
 
-  inline static void exec_range(const MDRangePolicy& mdr_policy,
-                                const FunctorType& functor, const Member ibeg,
-                                const Member iend) {
+  inline void exec_range(const Member ibeg, const Member iend) const {
     KOKKOS_PRAGMA_IVDEP_IF_ENABLED
     for (Member iwork = ibeg; iwork < iend; ++iwork) {
-      iterate_type(mdr_policy, functor)(iwork);
+      m_iter(iwork);
     }
   }
 
@@ -198,8 +195,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 #pragma omp parallel for schedule(dynamic, 1) \
     num_threads(m_instance->thread_pool_size())
     KOKKOS_PRAGMA_IVDEP_IF_ENABLED
-    for (index_type iwork = 0; iwork < m_mdr_policy.m_num_tiles; ++iwork) {
-      iterate_type(m_mdr_policy, m_functor)(iwork);
+    for (index_type iwork = 0; iwork < m_iter.m_rp.m_num_tiles; ++iwork) {
+      m_iter(iwork);
     }
   }
 
@@ -210,16 +207,15 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 #pragma omp parallel for schedule(static, 1) \
     num_threads(m_instance->thread_pool_size())
     KOKKOS_PRAGMA_IVDEP_IF_ENABLED
-    for (index_type iwork = 0; iwork < m_mdr_policy.m_num_tiles; ++iwork) {
-      iterate_type(m_mdr_policy, m_functor)(iwork);
+    for (index_type iwork = 0; iwork < m_iter.m_rp.m_num_tiles; ++iwork) {
+      m_iter(iwork);
     }
   }
 
  public:
   inline void execute() const {
-    if (execute_in_serial()) {
-      ParallelFor::exec_range(m_mdr_policy, m_functor, 0,
-                              m_mdr_policy.m_num_tiles);
+    if (execute_in_serial(m_iter.m_rp.space())) {
+      exec_range(0, m_iter.m_rp.m_num_tiles);
       return;
     }
 
@@ -234,7 +230,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     {
       HostThreadTeamData& data = *(m_instance->get_thread_data());
 
-      data.set_work_partition(m_mdr_policy.m_num_tiles, 1);
+      data.set_work_partition(m_iter.m_rp.m_num_tiles, 1);
 
       if (is_dynamic) {
         // Make sure work partition is set before stealing
@@ -247,8 +243,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         range = is_dynamic ? data.get_work_stealing_chunk()
                            : data.get_work_partition();
 
-        ParallelFor::exec_range(m_mdr_policy, m_functor, range.first,
-                                range.second);
+        exec_range(range.first, range.second);
 
       } while (is_dynamic && 0 <= range.first);
     }
@@ -257,7 +252,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   }
 
   inline ParallelFor(const FunctorType& arg_functor, MDRangePolicy arg_policy)
-      : m_instance(nullptr), m_functor(arg_functor), m_mdr_policy(arg_policy) {
+      : m_instance(nullptr), m_iter(arg_policy, arg_functor) {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
     if (t_openmp_instance) {
       m_instance = t_openmp_instance;
@@ -367,7 +362,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                                    0  // thread_local_bytes
     );
 
-    if (execute_in_serial()) {
+    if (execute_in_serial(m_policy.space())) {
       const pointer_type ptr =
           m_result_ptr
               ? m_result_ptr
@@ -520,23 +515,21 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                                              WorkTag, reference_type>;
 
   OpenMPInternal* m_instance;
-  const FunctorType m_functor;
-  const MDRangePolicy m_mdr_policy;
+  const iterate_type m_iter;
   const ReducerType m_reducer;
   const pointer_type m_result_ptr;
 
-  inline static void exec_range(const MDRangePolicy& mdr_policy,
-                                const FunctorType& functor, const Member ibeg,
-                                const Member iend, reference_type update) {
+  inline void exec_range(const Member ibeg, const Member iend,
+                         reference_type update) const {
     for (Member iwork = ibeg; iwork < iend; ++iwork) {
-      iterate_type(mdr_policy, functor, update)(iwork);
+      m_iter(iwork, update);
     }
   }
 
  public:
   inline void execute() const {
-    const size_t pool_reduce_bytes =
-        Analysis::value_size(ReducerConditional::select(m_functor, m_reducer));
+    const size_t pool_reduce_bytes = Analysis::value_size(
+        ReducerConditional::select(m_iter.m_func, m_reducer));
 
     m_instance->acquire_lock();
 
@@ -548,9 +541,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     );
 
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        &ReducerConditional::select(m_iter.m_func, m_reducer));
 
-    if (execute_in_serial()) {
+    if (execute_in_serial(m_iter.m_rp.space())) {
       const pointer_type ptr =
           m_result_ptr
               ? m_result_ptr
@@ -559,8 +552,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
       reference_type update = final_reducer.init(ptr);
 
-      ParallelReduce::exec_range(m_mdr_policy, m_functor, 0,
-                                 m_mdr_policy.m_num_tiles, update);
+      ParallelReduce::exec_range(0, m_iter.m_rp.m_num_tiles, update);
 
       final_reducer.final(ptr);
 
@@ -579,7 +571,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     {
       HostThreadTeamData& data = *(m_instance->get_thread_data());
 
-      data.set_work_partition(m_mdr_policy.m_num_tiles, 1);
+      data.set_work_partition(m_iter.m_rp.m_num_tiles, 1);
 
       if (is_dynamic) {
         // Make sure work partition is set before stealing
@@ -595,8 +587,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
         range = is_dynamic ? data.get_work_stealing_chunk()
                            : data.get_work_partition();
 
-        ParallelReduce::exec_range(m_mdr_policy, m_functor, range.first,
-                                   range.second, update);
+        ParallelReduce::exec_range(range.first, range.second, update);
 
       } while (is_dynamic && 0 <= range.first);
     }
@@ -617,7 +608,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
     if (m_result_ptr) {
       const int n = Analysis::value_count(
-          ReducerConditional::select(m_functor, m_reducer));
+          ReducerConditional::select(m_iter.m_func, m_reducer));
 
       for (int j = 0; j < n; ++j) {
         m_result_ptr[j] = ptr[j];
@@ -637,8 +628,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                            !Kokkos::is_reducer<ReducerType>::value,
                        void*> = nullptr)
       : m_instance(nullptr),
-        m_functor(arg_functor),
-        m_mdr_policy(arg_policy),
+        m_iter(arg_policy, arg_functor),
         m_reducer(InvalidType()),
         m_result_ptr(arg_view.data()) {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
@@ -659,8 +649,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   inline ParallelReduce(const FunctorType& arg_functor,
                         MDRangePolicy arg_policy, const ReducerType& reducer)
       : m_instance(nullptr),
-        m_functor(arg_functor),
-        m_mdr_policy(arg_policy),
+        m_iter(arg_policy, arg_functor),
         m_reducer(reducer),
         m_result_ptr(reducer.view().data()) {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
@@ -748,7 +737,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
                                    0  // thread_local_bytes
     );
 
-    if (execute_in_serial()) {
+    if (execute_in_serial(m_policy.space())) {
       typename Analysis::Reducer final_reducer(&m_functor);
 
       reference_type update = final_reducer.init(
@@ -880,7 +869,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
                                    0  // thread_local_bytes
     );
 
-    if (execute_in_serial()) {
+    if (execute_in_serial(m_policy.space())) {
       typename Analysis::Reducer final_reducer(&m_functor);
 
       reference_type update = final_reducer.init(
@@ -1054,7 +1043,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     m_instance->resize_thread_data(pool_reduce_size, team_reduce_size,
                                    team_shared_size, thread_local_size);
 
-    if (execute_in_serial()) {
+    if (execute_in_serial(m_policy.space())) {
       ParallelFor::template exec_team<WorkTag>(
           m_functor, *(m_instance->get_thread_data()), 0,
           m_policy.league_size(), m_policy.league_size());
@@ -1224,7 +1213,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     m_instance->resize_thread_data(pool_reduce_size, team_reduce_size,
                                    team_shared_size, thread_local_size);
 
-    if (execute_in_serial()) {
+    if (execute_in_serial(m_policy.space())) {
       HostThreadTeamData& data = *(m_instance->get_thread_data());
       pointer_type ptr =
           m_result_ptr ? m_result_ptr : pointer_type(data.pool_reduce_local());

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -214,10 +214,12 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
  public:
   inline void execute() const {
+#ifndef KOKKOS_COMPILER_INTEL
     if (execute_in_serial(m_iter.m_rp.space())) {
       exec_range(0, m_iter.m_rp.m_num_tiles);
       return;
     }
+#endif
 
 #ifndef KOKKOS_INTERNAL_DISABLE_NATIVE_OPENMP
     execute_parallel<Policy>();
@@ -543,6 +545,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     typename Analysis::Reducer final_reducer(
         &ReducerConditional::select(m_iter.m_func, m_reducer));
 
+#ifndef KOKKOS_COMPILER_INTEL
     if (execute_in_serial(m_iter.m_rp.space())) {
       const pointer_type ptr =
           m_result_ptr
@@ -560,6 +563,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
       return;
     }
+#endif
 
     enum {
       is_dynamic = std::is_same<typename Policy::schedule_type::type,

--- a/core/src/Threads/Kokkos_Threads_Parallel_MDRange.hpp
+++ b/core/src/Threads/Kokkos_Threads_Parallel_MDRange.hpp
@@ -39,20 +39,11 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   using iterate_type = typename Kokkos::Impl::HostIterateTile<
       MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void>;
 
-  const FunctorType m_functor;
-  const MDRangePolicy m_mdr_policy;
-  const Policy m_policy;  // construct as RangePolicy( 0, num_tiles
-                          // ).set_chunk_size(1) in ctor
+  const iterate_type m_iter;
 
-  inline static void exec_range(const MDRangePolicy &mdr_policy,
-                                const FunctorType &functor, const Member ibeg,
-                                const Member iend) {
-#if defined(KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION) && \
-    defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
-#pragma ivdep
-#endif
+  inline void exec_range(const Member ibeg, const Member iend) const {
     for (Member i = ibeg; i < iend; ++i) {
-      iterate_type(mdr_policy, functor)(i);
+      m_iter(i);
     }
   }
 
@@ -65,10 +56,11 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   exec_schedule(ThreadsExec &exec, const void *arg) {
     const ParallelFor &self = *((const ParallelFor *)arg);
 
-    WorkRange range(self.m_policy, exec.pool_rank(), exec.pool_size());
+    auto const num_tiles = self.m_iter.m_rp.m_num_tiles;
+    WorkRange range(Policy(0, num_tiles).set_chunk_size(1), exec.pool_rank(),
+                    exec.pool_size());
 
-    ParallelFor::exec_range(self.m_mdr_policy, self.m_functor, range.begin(),
-                            range.end());
+    self.exec_range(range.begin(), range.end());
 
     exec.fan_in();
   }
@@ -78,23 +70,21 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   exec_schedule(ThreadsExec &exec, const void *arg) {
     const ParallelFor &self = *((const ParallelFor *)arg);
 
-    WorkRange range(self.m_policy, exec.pool_rank(), exec.pool_size());
+    auto const num_tiles = self.m_iter.m_rp.m_num_tiles;
+    WorkRange range(Policy(0, num_tiles).set_chunk_size(1), exec.pool_rank(),
+                    exec.pool_size());
 
-    exec.set_work_range(range.begin(), range.end(), self.m_policy.chunk_size());
+    exec.set_work_range(range.begin(), range.end(), 1);
     exec.reset_steal_target();
     exec.barrier();
 
     long work_index = exec.get_work_index();
 
     while (work_index != -1) {
-      const Member begin =
-          static_cast<Member>(work_index) * self.m_policy.chunk_size();
-      const Member end =
-          begin + self.m_policy.chunk_size() < self.m_policy.end()
-              ? begin + self.m_policy.chunk_size()
-              : self.m_policy.end();
+      const Member begin = static_cast<Member>(work_index);
+      const Member end   = begin + 1 < num_tiles ? begin + 1 : num_tiles;
 
-      ParallelFor::exec_range(self.m_mdr_policy, self.m_functor, begin, end);
+      self.exec_range(begin, end);
       work_index = exec.get_work_index();
     }
 
@@ -108,9 +98,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   }
 
   ParallelFor(const FunctorType &arg_functor, const MDRangePolicy &arg_policy)
-      : m_functor(arg_functor),
-        m_mdr_policy(arg_policy),
-        m_policy(Policy(0, m_mdr_policy.m_num_tiles).set_chunk_size(1)) {}
+      : m_iter(arg_policy, arg_functor) {}
 
   template <typename Policy, typename Functor>
   static int max_tile_size_product(const Policy &, const Functor &) {
@@ -152,22 +140,14 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
       typename Kokkos::Impl::HostIterateTile<MDRangePolicy, FunctorType,
                                              WorkTag, reference_type>;
 
-  const FunctorType m_functor;
-  const MDRangePolicy m_mdr_policy;
-  const Policy m_policy;  // construct as RangePolicy( 0, num_tiles
-                          // ).set_chunk_size(1) in ctor
+  const iterate_type m_iter;
   const ReducerType m_reducer;
   const pointer_type m_result_ptr;
 
-  inline static void exec_range(const MDRangePolicy &mdr_policy,
-                                const FunctorType &functor, const Member &ibeg,
-                                const Member &iend, reference_type update) {
-#if defined(KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION) && \
-    defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
-#pragma ivdep
-#endif
+  inline void exec_range(const Member &ibeg, const Member &iend,
+                         reference_type update) const {
     for (Member i = ibeg; i < iend; ++i) {
-      iterate_type(mdr_policy, functor, update)(i);
+      m_iter(i, update);
     }
   }
 
@@ -179,13 +159,16 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   static std::enable_if_t<std::is_same<Schedule, Kokkos::Static>::value>
   exec_schedule(ThreadsExec &exec, const void *arg) {
     const ParallelReduce &self = *((const ParallelReduce *)arg);
-    const WorkRange range(self.m_policy, exec.pool_rank(), exec.pool_size());
+
+    const auto num_tiles = self.m_iter.m_rp.m_num_tiles;
+    const WorkRange range(Policy(0, num_tiles).set_chunk_size(1),
+                          exec.pool_rank(), exec.pool_size());
 
     typename Analysis::Reducer reducer(
-        &ReducerConditional::select(self.m_functor, self.m_reducer));
+        &ReducerConditional::select(self.m_iter.m_func, self.m_reducer));
 
-    ParallelReduce::exec_range(
-        self.m_mdr_policy, self.m_functor, range.begin(), range.end(),
+    self.exec_range(
+        range.begin(), range.end(),
         reducer.init(static_cast<pointer_type>(exec.reduce_memory())));
 
     exec.fan_in_reduce(reducer);
@@ -195,27 +178,25 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   static std::enable_if_t<std::is_same<Schedule, Kokkos::Dynamic>::value>
   exec_schedule(ThreadsExec &exec, const void *arg) {
     const ParallelReduce &self = *((const ParallelReduce *)arg);
-    const WorkRange range(self.m_policy, exec.pool_rank(), exec.pool_size());
 
-    exec.set_work_range(range.begin(), range.end(), self.m_policy.chunk_size());
+    const auto num_tiles = self.m_iter.m_rp.m_num_tiles;
+    const WorkRange range(Policy(0, num_tiles).set_chunk_size(1),
+                          exec.pool_rank(), exec.pool_size());
+
+    exec.set_work_range(range.begin(), range.end(), 1);
     exec.reset_steal_target();
     exec.barrier();
 
     long work_index = exec.get_work_index();
     typename Analysis::Reducer reducer(
-        &ReducerConditional::select(self.m_functor, self.m_reducer));
+        &ReducerConditional::select(self.m_iter.m_func, self.m_reducer));
 
     reference_type update =
         reducer.init(static_cast<pointer_type>(exec.reduce_memory()));
     while (work_index != -1) {
-      const Member begin =
-          static_cast<Member>(work_index) * self.m_policy.chunk_size();
-      const Member end =
-          begin + self.m_policy.chunk_size() < self.m_policy.end()
-              ? begin + self.m_policy.chunk_size()
-              : self.m_policy.end();
-      ParallelReduce::exec_range(self.m_mdr_policy, self.m_functor, begin, end,
-                                 update);
+      const Member begin = static_cast<Member>(work_index);
+      const Member end   = begin + 1 < num_tiles ? begin + 1 : num_tiles;
+      self.exec_range(begin, end, update);
       work_index = exec.get_work_index();
     }
 
@@ -224,9 +205,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
  public:
   inline void execute() const {
-    ThreadsExec::resize_scratch(
-        Analysis::value_size(ReducerConditional::select(m_functor, m_reducer)),
-        0);
+    ThreadsExec::resize_scratch(Analysis::value_size(ReducerConditional::select(
+                                    m_iter.m_func, m_reducer)),
+                                0);
 
     ThreadsExec::start(&ParallelReduce::exec, this);
 
@@ -237,7 +218,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           (pointer_type)ThreadsExec::root_reduce_scratch();
 
       const unsigned n = Analysis::value_count(
-          ReducerConditional::select(m_functor, m_reducer));
+          ReducerConditional::select(m_iter.m_func, m_reducer));
       for (unsigned i = 0; i < n; ++i) {
         m_result_ptr[i] = data[i];
       }
@@ -251,9 +232,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                  std::enable_if_t<Kokkos::is_view<HostViewType>::value &&
                                       !Kokkos::is_reducer<ReducerType>::value,
                                   void *> = nullptr)
-      : m_functor(arg_functor),
-        m_mdr_policy(arg_policy),
-        m_policy(Policy(0, m_mdr_policy.m_num_tiles).set_chunk_size(1)),
+      : m_iter(arg_policy, arg_functor),
         m_reducer(InvalidType()),
         m_result_ptr(arg_result_view.data()) {
     static_assert(Kokkos::is_view<HostViewType>::value,
@@ -266,9 +245,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
   inline ParallelReduce(const FunctorType &arg_functor,
                         MDRangePolicy arg_policy, const ReducerType &reducer)
-      : m_functor(arg_functor),
-        m_mdr_policy(arg_policy),
-        m_policy(Policy(0, m_mdr_policy.m_num_tiles).set_chunk_size(1)),
+      : m_iter(arg_policy, arg_functor),
         m_reducer(reducer),
         m_result_ptr(reducer.view().data()) {
     /*static_assert( std::is_same< typename ViewType::memory_space

--- a/core/src/impl/KokkosExp_Host_IterateTile.hpp
+++ b/core/src/impl/KokkosExp_Host_IterateTile.hpp
@@ -1886,8 +1886,8 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
     m_func(m_tag, args...);
   }
 
-  RP const& m_rp;
-  Functor const& m_func;
+  RP const m_rp;
+  Functor const m_func;
   std::conditional_t<std::is_void<Tag>::value, int, Tag> m_tag;
 };
 
@@ -1902,12 +1902,10 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
 
   using value_type = ValueType;
 
-  inline HostIterateTile(RP const& rp, Functor const& func, value_type& v)
+  inline HostIterateTile(RP const& rp, Functor const& func)
       : m_rp(rp)  // Cuda 7.0 does not like braces...
         ,
-        m_func(func),
-        m_v(v)  // use with non-void ValueType struct
-  {
+        m_func(func) {
     // Errors due to braces rather than parenthesis for init (with cuda 7.0)
     //      /home/ndellin/kokkos/core/src/impl/KokkosExp_Host_IterateTile.hpp:1216:98:
     //      error: too many braces around initializer for ‘int’ [-fpermissive]
@@ -1945,7 +1943,7 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
 
 #if KOKKOS_ENABLE_NEW_LOOP_MACROS
   template <typename IType>
-  inline void operator()(IType tile_idx) const {
+  inline void operator()(IType tile_idx, value_type& val) const {
     point_type m_offset;
     point_type m_tiledims;
 
@@ -1968,7 +1966,7 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
     Tile_Loop_Type<RP::rank, (RP::inner_direction == Iterate::Left), index_type,
-                   Tag>::apply(m_v, m_func, full_tile, m_offset, m_rp.m_tile,
+                   Tag>::apply(val, m_func, full_tile, m_offset, m_rp.m_tile,
                                m_tiledims);
   }
 
@@ -2287,7 +2285,6 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
     }  // end Iterate::Right
 
   }  // end op() rank == 8
-#endif
 
   template <typename... Args>
   std::enable_if_t<(sizeof...(Args) == RP::rank && std::is_void<Tag>::value),
@@ -2302,10 +2299,10 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
   apply(Args&&... args) const {
     m_func(m_tag, args..., m_v);
   }
+#endif
 
-  RP const& m_rp;
-  Functor const& m_func;
-  value_type& m_v;
+  RP const m_rp;
+  Functor const m_func;
   std::conditional_t<std::is_void<Tag>::value, int, Tag> m_tag;
 };
 
@@ -2324,15 +2321,10 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
                                         // 'array-ness' [], only
                                         // underlying type remains
 
-  inline HostIterateTile(
-      RP const& rp, Functor const& func,
-      value_type* v)  // v should be an array; treat as pointer for
-                      // compatibility since size is not known nor needed here
-      : m_rp(rp)      // Cuda 7.0 does not like braces...
+  inline HostIterateTile(RP const& rp, Functor const& func)
+      : m_rp(rp)  // Cuda 7.0 does not like braces...
         ,
-        m_func(func),
-        m_v(v)  // use with non-void ValueType struct
-  {}
+        m_func(func) {}
 
   inline bool check_iteration_bounds(point_type& partial_tile,
                                      point_type& offset) const {
@@ -2364,7 +2356,7 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
 
 #if KOKKOS_ENABLE_NEW_LOOP_MACROS
   template <typename IType>
-  inline void operator()(IType tile_idx) const {
+  inline void operator()(IType tile_idx, value_type* val) const {
     point_type m_offset;
     point_type m_tiledims;
 
@@ -2387,7 +2379,7 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
     Tile_Loop_Type<RP::rank, (RP::inner_direction == Iterate::Left), index_type,
-                   Tag>::apply(m_v, m_func, full_tile, m_offset, m_rp.m_tile,
+                   Tag>::apply(val, m_func, full_tile, m_offset, m_rp.m_tile,
                                m_tiledims);
   }
 
@@ -2706,8 +2698,6 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
     }  // end Iterate::Right
 
   }  // end op() rank == 8
-#endif
-
   template <typename... Args>
   std::enable_if_t<(sizeof...(Args) == RP::rank && std::is_void<Tag>::value),
                    void>
@@ -2721,10 +2711,10 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
   apply(Args&&... args) const {
     m_func(m_tag, args..., m_v);
   }
+#endif
 
-  RP const& m_rp;
-  Functor const& m_func;
-  value_type* m_v;
+  RP const m_rp;
+  Functor const m_func;
   std::conditional_t<std::is_void<Tag>::value, int, Tag> m_tag;
 };
 


### PR DESCRIPTION
Changes to remove duplicate copies of policy and functor in ParallelFor specialization of MDRangePolicy Resolves internal compiler errors occurring with intel/19.0.5 OpenMP builds

Fixes #5290

Co-authored-by: Christian Trott <crtrott@sandia.gov>