### PR TITLE
SIMD backend of ARM NEON

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -140,7 +140,7 @@ class abi_set {};
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx512_fixed_size<8>>;
 #elif defined(KOKKOS_ARCH_AVX2)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>>;
-#elif defined(KOKKOS_ARCH_NEON)
+#elif defined(__ARM_NEON)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
 #else
 using host_abi_set = abi_set<simd_abi::scalar>;

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -29,6 +29,10 @@
 #include <Kokkos_SIMD_AVX512.hpp>
 #endif
 
+#ifdef __ARM_NEON
+#include <Kokkos_SIMD_NEON.hpp>
+#endif
+
 namespace Kokkos {
 namespace Experimental {
 
@@ -40,6 +44,8 @@ namespace Impl {
 using host_native = avx512_fixed_size<8>;
 #elif defined(KOKKOS_ARCH_AVX2)
 using host_native  = avx2_fixed_size<4>;
+#elif defined(__ARM_NEON)
+using host_native  = neon_fixed_size<2>;
 #else
 using host_native  = scalar;
 #endif
@@ -134,6 +140,8 @@ class abi_set {};
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx512_fixed_size<8>>;
 #elif defined(KOKKOS_ARCH_AVX2)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>>;
+#elif defined(KOKKOS_ARCH_NEON)
+using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
 #else
 using host_abi_set = abi_set<simd_abi::scalar>;
 #endif

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -136,6 +136,22 @@ template <class T, class Abi>
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] * rhs[i]; });
 }
 
+// fallback simd shift using generator constructor
+// At the time of this writing, these fallbacks are only used
+// to shift vectors of 64-bit unsigned integers for the NEON backend
+
+template <class T, class U, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator>>(
+    simd<T, Abi> const& lhs, simd<U, Abi> const& rhs) {
+  return simd<T, Abi>([&](std::size_t i) { return lhs[i] >> rhs[i]; });
+}
+
+template <class T, class U, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator<<(
+    simd<T, Abi> const& lhs, simd<U, Abi> const& rhs) {
+  return simd<T, Abi>([&](std::size_t i) { return lhs[i] << rhs[i]; });
+}
+
 // The code below provides:
 // operator@(simd<T, Abi>, Arithmetic)
 // operator@(Arithmetic, simd<T, Abi>)

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -142,6 +142,18 @@ template <class T, class Abi>
 
 template <class T, class U, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator>>(
+    simd<T, Abi> const& lhs, unsigned int rhs) {
+  return simd<T, Abi>([&](std::size_t i) { return lhs[i] >> rhs; });
+}
+
+template <class T, class U, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator<<(
+    simd<T, Abi> const& lhs, unsigned int rhs) {
+  return simd<T, Abi>([&](std::size_t i) { return lhs[i] << rhs; });
+}
+
+template <class T, class U, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator>>(
     simd<T, Abi> const& lhs, simd<U, Abi> const& rhs) {
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] >> rhs[i]; });
 }

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -983,8 +983,8 @@ class const_where_expression<
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(std::int32_t* mem, element_aligned_tag) const {
-    _mm_maskstore_epi32(mem, static_cast<__m128i>(m_mask),
-                        static_cast<__m128i>(m_value));
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
   }
 };
 
@@ -1001,7 +1001,8 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
-    m_value = value_type(_mm_maskload_epi32(mem, static_cast<__m128i>(m_mask)));
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
   }
 };
 

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -444,10 +444,10 @@ simd<double, simd_abi::neon_fixed_size<2>> min(
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::neon_fixed_size<2>> condition(
-    simd_mask<double, simd_abi::neon_fixed_size<2>> const& a,
-    simd<double, simd_abi::neon_fixed_size<2>> const& b,
-    simd<double, simd_abi::neon_fixed_size<2>> const& c) {
+    simd<double, simd_abi::neon_fixed_size<2>>
+    condition(simd_mask<double, simd_abi::neon_fixed_size<2>> const& a,
+              simd<double, simd_abi::neon_fixed_size<2>> const& b,
+              simd<double, simd_abi::neon_fixed_size<2>> const& c) {
   return simd<double, simd_abi::neon_fixed_size<2>>(
       vbslq_f64(static_cast<uint64x2_t>(a), static_cast<float64x2_t>(b),
                 static_cast<float64x2_t>(c)));
@@ -720,10 +720,10 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::neon_fixed_size<2>> condition(
-    simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& a,
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& b,
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& c) {
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>>
+    condition(simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& a,
+              simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& b,
+              simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& c) {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
       vbslq_s64(static_cast<uint64x2_t>(a), static_cast<int64x2_t>(b),
                 static_cast<int64x2_t>(c)));
@@ -856,10 +856,10 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
     : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::neon_fixed_size<2>> condition(
-    simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a,
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& b,
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& c) {
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
+    condition(simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a,
+              simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& b,
+              simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& c) {
   return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
       vbslq_u64(static_cast<uint64x2_t>(a), static_cast<uint64x2_t>(b),
                 static_cast<uint64x2_t>(c)));

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -50,7 +50,8 @@ class simd_mask<double, simd_abi::neon_fixed_size<2>> {
         : m_mask(mask_arg), m_lane(lane_arg) {}
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
     operator=(bool value) const {
-      // this switch statement is needed because the lane argument has to be a constant
+      // this switch statement is needed because the lane argument has to be a
+      // constant
       switch (m_lane) {
         case 0:
           m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, 0);
@@ -63,10 +64,8 @@ class simd_mask<double, simd_abi::neon_fixed_size<2>> {
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
       switch (m_lane) {
-        case 0:
-          return vgetq_lane_u64(m_mask, 0) != 0;
-        case 1:
-          return vgetq_lane_u64(m_mask, 1) != 0;
+        case 0: return vgetq_lane_u64(m_mask, 0) != 0;
+        case 1: return vgetq_lane_u64(m_mask, 1) != 0;
       }
       return false;
     }
@@ -75,9 +74,7 @@ class simd_mask<double, simd_abi::neon_fixed_size<2>> {
   using abi_type   = simd_abi::neon_fixed_size<2>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
-      : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0))
-  {
-  }
+      : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
       simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
@@ -113,8 +110,10 @@ class simd_mask<double, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
       simd_mask const& other) const {
     uint64x2_t const elementwise_equality = vceqq_u64(m_value, other.m_value);
-    uint32x2_t const narrow_elementwise_equality = vqmovn_u64(elementwise_equality);
-    uint64x1_t const overall_equality_neon = vreinterpret_u64_u32(narrow_elementwise_equality);
+    uint32x2_t const narrow_elementwise_equality =
+        vqmovn_u64(elementwise_equality);
+    uint64x1_t const overall_equality_neon =
+        vreinterpret_u64_u32(narrow_elementwise_equality);
     uint64_t const overall_equality = vget_lane_u64(overall_equality_neon, 0);
     return overall_equality == 0xFFFFFFFFFFFFFFFFULL;
   }
@@ -151,10 +150,8 @@ class simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> {
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
       switch (m_lane) {
-        case 0:
-          return vget_lane_u32(m_mask, 0) != 0;
-        case 1:
-          return vget_lane_u32(m_mask, 1) != 0;
+        case 0: return vget_lane_u32(m_mask, 0) != 0;
+        case 1: return vget_lane_u32(m_mask, 1) != 0;
       }
       return false;
     }
@@ -163,9 +160,7 @@ class simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> {
   using abi_type   = simd_abi::neon_fixed_size<2>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
-      : m_value(vdup_n_u32(value ? 0xFFFFFFFFU : 0))
-  {
-  }
+      : m_value(vdup_n_u32(value ? 0xFFFFFFFFU : 0)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
       simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
@@ -201,7 +196,8 @@ class simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
       simd_mask const& other) const {
     uint32x2_t const elementwise_equality = vceq_u32(m_value, other.m_value);
-    uint64x1_t const overall_equality_neon = vreinterpret_u64_u32(elementwise_equality);
+    uint64x1_t const overall_equality_neon =
+        vreinterpret_u64_u32(elementwise_equality);
     uint64_t const overall_equality = vget_lane_u64(overall_equality_neon, 0);
     return overall_equality == 0xFFFFFFFFFFFFFFFFULL;
   }
@@ -238,10 +234,8 @@ class simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> {
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
       switch (m_lane) {
-        case 0:
-          return vgetq_lane_u64(m_mask, 0) != 0;
-        case 1:
-          return vgetq_lane_u64(m_mask, 1) != 0;
+        case 0: return vgetq_lane_u64(m_mask, 0) != 0;
+        case 1: return vgetq_lane_u64(m_mask, 1) != 0;
       }
       return false;
     }
@@ -250,9 +244,7 @@ class simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> {
   using abi_type   = simd_abi::neon_fixed_size<2>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
-      : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0))
-  {
-  }
+      : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
       simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
@@ -288,8 +280,10 @@ class simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
       simd_mask const& other) const {
     uint64x2_t const elementwise_equality = vceqq_u64(m_value, other.m_value);
-    uint32x2_t const narrow_elementwise_equality = vqmovn_u64(elementwise_equality);
-    uint64x1_t const overall_equality_neon = vreinterpret_u64_u32(narrow_elementwise_equality);
+    uint32x2_t const narrow_elementwise_equality =
+        vqmovn_u64(elementwise_equality);
+    uint64x1_t const overall_equality_neon =
+        vreinterpret_u64_u32(narrow_elementwise_equality);
     uint64_t const overall_equality = vget_lane_u64(overall_equality_neon, 0);
     return overall_equality == 0xFFFFFFFFFFFFFFFFULL;
   }
@@ -326,10 +320,8 @@ class simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
       switch (m_lane) {
-        case 0:
-          return vgetq_lane_u64(m_mask, 0) != 0;
-        case 1:
-          return vgetq_lane_u64(m_mask, 1) != 0;
+        case 0: return vgetq_lane_u64(m_mask, 0) != 0;
+        case 1: return vgetq_lane_u64(m_mask, 1) != 0;
       }
       return false;
     }
@@ -338,9 +330,7 @@ class simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   using abi_type   = simd_abi::neon_fixed_size<2>;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
-      : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0))
-  {
-  }
+      : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
       simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
@@ -376,8 +366,10 @@ class simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
       simd_mask const& other) const {
     uint64x2_t const elementwise_equality = vceqq_u64(m_value, other.m_value);
-    uint32x2_t const narrow_elementwise_equality = vqmovn_u64(elementwise_equality);
-    uint64x1_t const overall_equality_neon = vreinterpret_u64_u32(narrow_elementwise_equality);
+    uint32x2_t const narrow_elementwise_equality =
+        vqmovn_u64(elementwise_equality);
+    uint64x1_t const overall_equality_neon =
+        vreinterpret_u64_u32(narrow_elementwise_equality);
     uint64_t const overall_equality = vget_lane_u64(overall_equality_neon, 0);
     return overall_equality == 0xFFFFFFFFFFFFFFFFULL;
   }
@@ -406,21 +398,15 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
     operator=(double value) const {
       switch (m_lane) {
-        case 0:
-          m_value = vsetq_lane_f64(value, m_value, 0);
-          break;
-        case 1:
-          m_value = vsetq_lane_f64(value, m_value, 1);
-          break;
+        case 0: m_value = vsetq_lane_f64(value, m_value, 0); break;
+        case 1: m_value = vsetq_lane_f64(value, m_value, 1); break;
       }
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator double() const {
       switch (m_lane) {
-        case 0:
-          return vgetq_lane_f64(m_value, 0);
-        case 1:
-          return vgetq_lane_f64(m_value, 1);
+        case 0: return vgetq_lane_f64(m_value, 0);
+        case 1: return vgetq_lane_f64(m_value, 1);
       }
       return 0;
     }
@@ -444,8 +430,7 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
-  {
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
     vsetq_lane_f64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
     vsetq_lane_f64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
   }
@@ -467,8 +452,8 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
       value_type* ptr, element_aligned_tag) const {
     vst1q_f64(ptr, m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator float64x2_t()
-      const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit
+  operator float64x2_t() const {
     return m_value;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
@@ -548,12 +533,10 @@ simd<double, simd_abi::neon_fixed_size<2>> copysign(
     simd<double, simd_abi::neon_fixed_size<2>> const& a,
     simd<double, simd_abi::neon_fixed_size<2>> const& b) {
   uint64x2_t const sign_mask = vreinterpretq_u64_f64(vdupq_n_f64(-0.0));
-  return simd<double, simd_abi::neon_fixed_size<2>>(
-      vreinterpretq_f64_u64(
-      vorrq_u64(
-        vreinterpretq_u64_f64(static_cast<float64x2_t>(abs(a))),
-        vandq_u64(sign_mask,
-          vreinterpretq_u64_f64(static_cast<float64x2_t>(b))))));
+  return simd<double, simd_abi::neon_fixed_size<2>>(vreinterpretq_f64_u64(
+      vorrq_u64(vreinterpretq_u64_f64(static_cast<float64x2_t>(abs(a))),
+                vandq_u64(sign_mask, vreinterpretq_u64_f64(
+                                         static_cast<float64x2_t>(b))))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -569,10 +552,8 @@ simd<double, simd_abi::neon_fixed_size<2>> fma(
     simd<double, simd_abi::neon_fixed_size<2>> const& b,
     simd<double, simd_abi::neon_fixed_size<2>> const& c) {
   return simd<double, simd_abi::neon_fixed_size<2>>(
-      vfmaq_f64(
-        static_cast<float64x2_t>(c),
-        static_cast<float64x2_t>(b),
-        static_cast<float64x2_t>(a)));
+      vfmaq_f64(static_cast<float64x2_t>(c), static_cast<float64x2_t>(b),
+                static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -597,10 +578,8 @@ simd<double, simd_abi::neon_fixed_size<2>> condition(
     simd<double, simd_abi::neon_fixed_size<2>> const& b,
     simd<double, simd_abi::neon_fixed_size<2>> const& c) {
   return simd<double, simd_abi::neon_fixed_size<2>>(
-      vbslq_f64(
-        static_cast<uint64x2_t>(a),
-        static_cast<float64x2_t>(b),
-        static_cast<float64x2_t>(c)));
+      vbslq_f64(static_cast<uint64x2_t>(a), static_cast<float64x2_t>(b),
+                static_cast<float64x2_t>(c)));
 }
 
 template <>
@@ -622,21 +601,15 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
     operator=(std::int32_t value) const {
       switch (m_lane) {
-        case 0:
-          m_value = vset_lane_s32(value, m_value, 0);
-          break;
-        case 1:
-          m_value = vset_lane_s32(value, m_value, 1);
-          break;
+        case 0: m_value = vset_lane_s32(value, m_value, 0); break;
+        case 1: m_value = vset_lane_s32(value, m_value, 1); break;
       }
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator std::int32_t() const {
       switch (m_lane) {
-        case 0:
-          return vget_lane_s32(m_value, 0);
-        case 1:
-          return vget_lane_s32(m_value, 1);
+        case 0: return vget_lane_s32(m_value, 0);
+        case 1: return vget_lane_s32(m_value, 1);
       }
       return 0;
     }
@@ -658,8 +631,7 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
-  {
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
     vset_lane_s32(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
     vset_lane_s32(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
   }
@@ -735,8 +707,7 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
               simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& b,
               simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& c) {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
-      vbsl_s32(static_cast<uint32x2_t>(a),
-               static_cast<int32x2_t>(b),
+      vbsl_s32(static_cast<uint32x2_t>(a), static_cast<int32x2_t>(b),
                static_cast<int32x2_t>(c)));
 }
 
@@ -759,21 +730,15 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
     operator=(std::int64_t value) const {
       switch (m_lane) {
-        case 0:
-          m_value = vsetq_lane_s64(value, m_value, 0);
-          break;
-        case 1:
-          m_value = vsetq_lane_s64(value, m_value, 1);
-          break;
+        case 0: m_value = vsetq_lane_s64(value, m_value, 0); break;
+        case 1: m_value = vsetq_lane_s64(value, m_value, 1); break;
       }
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator std::int64_t() const {
       switch (m_lane) {
-        case 0:
-          return vgetq_lane_s64(m_value, 0);
-        case 1:
-          return vgetq_lane_s64(m_value, 1);
+        case 0: return vgetq_lane_s64(m_value, 0);
+        case 1: return vgetq_lane_s64(m_value, 1);
       }
       return 0;
     }
@@ -788,8 +753,7 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-  {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value) {
     vsetq_lane_s64(value_type(value), m_value, 0);
     vsetq_lane_s64(value_type(value), m_value, 1);
   }
@@ -798,8 +762,7 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
-  {
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
     vsetq_lane_s64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
     vsetq_lane_s64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
   }
@@ -872,8 +835,7 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>> condition(
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& b,
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& c) {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
-      vbslq_s64(static_cast<uint64x2_t>(a),
-                static_cast<int64x2_t>(b),
+      vbslq_s64(static_cast<uint64x2_t>(a), static_cast<int64x2_t>(b),
                 static_cast<int64x2_t>(c)));
 }
 
@@ -896,21 +858,15 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
     operator=(std::uint64_t value) const {
       switch (m_lane) {
-        case 0:
-          m_value = vsetq_lane_u64(value, m_value, 0);
-          break;
-        case 1:
-          m_value = vsetq_lane_u64(value, m_value, 1);
-          break;
+        case 0: m_value = vsetq_lane_u64(value, m_value, 0); break;
+        case 1: m_value = vsetq_lane_u64(value, m_value, 1); break;
       }
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator std::uint64_t() const {
       switch (m_lane) {
-        case 0:
-          return vgetq_lane_u64(m_value, 0);
-        case 1:
-          return vgetq_lane_u64(m_value, 1);
+        case 0: return vgetq_lane_u64(m_value, 0);
+        case 1: return vgetq_lane_u64(m_value, 1);
       }
       return 0;
     }
@@ -925,8 +881,7 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-  {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value) {
     vsetq_lane_u64(value_type(value), m_value, 0);
     vsetq_lane_u64(value_type(value), m_value, 1);
   }
@@ -935,12 +890,12 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
-  {
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
     vsetq_lane_u64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
     vsetq_lane_u64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(uint64x2_t const& value_in)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(
+      uint64x2_t const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reference(m_value, int(i));
@@ -977,8 +932,7 @@ simd<std::uint64_t, simd_abi::neon_fixed_size<2>> condition(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& b,
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& c) {
   return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
-      vbslq_u64(static_cast<uint64x2_t>(a),
-                static_cast<uint64x2_t>(b),
+      vbslq_u64(static_cast<uint64x2_t>(a), static_cast<uint64x2_t>(b),
                 static_cast<uint64x2_t>(c)));
 }
 
@@ -1051,10 +1005,9 @@ class where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
         static_cast<simd<double, simd_abi::neon_fixed_size<2>>>(
             std::forward<U>(x));
     m_value = static_cast<simd<double, simd_abi::neon_fixed_size<2>>>(
-        vbslq_f64(
-        static_cast<uint64x2_t>(m_mask),
-        static_cast<float64x2_t>(x_as_value_type),
-        static_cast<float64x2_t>(m_value)));
+        vbslq_f64(static_cast<uint64x2_t>(m_mask),
+                  static_cast<float64x2_t>(x_as_value_type),
+                  static_cast<float64x2_t>(m_value)));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -704,7 +704,7 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
       vnegq_s64(static_cast<int64x2_t>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> condition(
     simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& a,
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& b,

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -226,11 +226,24 @@ class simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> {
         : m_mask(mask_arg), m_lane(lane_arg) {}
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
     operator=(bool value) const {
-      m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, m_lane);
+      switch (m_lane) {
+        case 0:
+          m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, 0);
+          break;
+        case 1:
+          m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, 1);
+          break;
+      }
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return vgetq_lane_u64(m_mask, m_lane) != 0;
+      switch (m_lane) {
+        case 0:
+          return vgetq_lane_u64(m_mask, 0) != 0;
+        case 1:
+          return vgetq_lane_u64(m_mask, 1) != 0;
+      }
+      return false;
     }
   };
   using value_type = bool;
@@ -301,11 +314,24 @@ class simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> {
         : m_mask(mask_arg), m_lane(lane_arg) {}
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
     operator=(bool value) const {
-      m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, m_lane);
+      switch (m_lane) {
+        case 0:
+          m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, 0);
+          break;
+        case 1:
+          m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, 1);
+          break;
+      }
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
-      return vgetq_lane_u64(m_mask, m_lane) != 0;
+      switch (m_lane) {
+        case 0:
+          return vgetq_lane_u64(m_mask, 0) != 0;
+        case 1:
+          return vgetq_lane_u64(m_mask, 1) != 0;
+      }
+      return false;
     }
   };
   using value_type = bool;
@@ -379,11 +405,24 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
         : m_value(mask_arg), m_lane(lane_arg) {}
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
     operator=(double value) const {
-      m_value = vsetq_lane_f64(value, m_mask, m_lane);
+      switch (m_lane) {
+        case 0:
+          m_value = vsetq_lane_f64(value, m_value, 0);
+          break;
+        case 1:
+          m_value = vsetq_lane_f64(value, m_value, 1);
+          break;
+      }
       return *this;
     }
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator double() const {
-      return vgetq_lane_f64(m_mask, m_lane);
+      switch (m_lane) {
+        case 0:
+          return vgetq_lane_f64(m_value, 0);
+        case 1:
+          return vgetq_lane_f64(m_value, 1);
+      }
+      return 0;
     }
   };
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
@@ -418,7 +457,7 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return vgetq_lane(m_value, int(i));
+    return reference(const_cast<simd*>(this)->m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -75,8 +75,8 @@ class neon_mask<Derived, 64> {
       return false;
     }
   };
-  using value_type = bool;
-  using abi_type   = simd_abi::neon_fixed_size<2>;
+  using value_type          = bool;
+  using abi_type            = simd_abi::neon_fixed_size<2>;
   using implementation_type = uint64x2_t;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit neon_mask(value_type value)
@@ -88,11 +88,8 @@ class neon_mask<Derived, 64> {
     operator[](1) = bool(other[1]);
   }
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
-      neon_mask<U, 64> const& other)
-    :neon_mask(static_cast<uint64x2_t>(other))
-  {
-  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 64> const& other)
+      : neon_mask(static_cast<uint64x2_t>(other)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
@@ -172,8 +169,8 @@ class neon_mask<Derived, 32> {
       return false;
     }
   };
-  using value_type = bool;
-  using abi_type   = simd_abi::neon_fixed_size<2>;
+  using value_type          = bool;
+  using abi_type            = simd_abi::neon_fixed_size<2>;
   using implementation_type = uint32x2_t;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit neon_mask(value_type value)
@@ -185,15 +182,11 @@ class neon_mask<Derived, 32> {
       uint32x2_t const& value_in)
       : m_value(value_in) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
-      neon_mask<U, 64> const& other)
-    : m_value(vqmovn_u64(static_cast<uint64x2_t>(other)))
-  {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 64> const& other)
+      : m_value(vqmovn_u64(static_cast<uint64x2_t>(other))) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
-      neon_mask<U, 32> const& other)
-    : m_value(static_cast<uint32x2_t>(other))
-  {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 32> const& other)
+      : m_value(static_cast<uint32x2_t>(other)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint32x2_t()
       const {
     return m_value;
@@ -232,30 +225,27 @@ class neon_mask<Derived, 32> {
   }
 };
 
-}
+}  // namespace Impl
 
 template <class T>
 class simd_mask<T, simd_abi::neon_fixed_size<2>>
-  : public Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<2>>, sizeof(T) * 8>
-{
-  using base_type = Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<2>>, sizeof(T) * 8>;
+    : public Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<2>>,
+                             sizeof(T) * 8> {
+  using base_type = Impl::neon_mask<simd_mask<T, simd_abi::neon_fixed_size<2>>,
+                                    sizeof(T) * 8>;
+
  public:
   using implementation_type = typename base_type::implementation_type;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(bool value)
-    :base_type(value)
-  {}
+      : base_type(value) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
       simd_mask<U, simd_abi::neon_fixed_size<2>> const& other)
-    :base_type(other)
-  {
-  }
+      : base_type(other) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
       implementation_type const& value)
-    :base_type(value)
-  {
-  }
+      : base_type(value) {}
 };
 
 template <>

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -828,6 +828,22 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   }
 };
 
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
+    operator-(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+              simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) {
+  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
+      vsubq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
+    operator+(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+              simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) {
+  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
+      vaddq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::neon_fixed_size<2>>::simd(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -443,7 +443,7 @@ simd<double, simd_abi::neon_fixed_size<2>> min(
       vminq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<double, simd_abi::neon_fixed_size<2>> condition(
     simd_mask<double, simd_abi::neon_fixed_size<2>> const& a,
     simd<double, simd_abi::neon_fixed_size<2>> const& b,
@@ -839,7 +839,7 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
     : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> condition(
     simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a,
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& b,

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -77,8 +77,7 @@ class simd_mask<double, simd_abi::neon_fixed_size<2>> {
       : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0)) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, simd_abi::neon_fixed_size<2>> const& other)
-  {
+      simd_mask<U, simd_abi::neon_fixed_size<2>> const& other) {
     operator[](0) = bool(other[0]);
     operator[](1) = bool(other[1]);
   }
@@ -174,9 +173,7 @@ class simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> {
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
       simd_mask<double, simd_abi::neon_fixed_size<2>> const& other)
-    : m_value(vqmovn_u64(static_cast<uint64x2_t>(other)))
-  {
-  }
+      : m_value(vqmovn_u64(static_cast<uint64x2_t>(other))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint32x2_t()
       const {
     return m_value;
@@ -255,8 +252,7 @@ class simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> {
       : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0)) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, simd_abi::neon_fixed_size<2>> const& other)
-  {
+      simd_mask<U, simd_abi::neon_fixed_size<2>> const& other) {
     operator[](0) = bool(other[0]);
     operator[](1) = bool(other[1]);
   }
@@ -346,8 +342,7 @@ class simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0)) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, simd_abi::neon_fixed_size<2>> const& other)
-  {
+      simd_mask<U, simd_abi::neon_fixed_size<2>> const& other) {
     operator[](0) = bool(other[0]);
     operator[](1) = bool(other[1]);
   }
@@ -449,8 +444,10 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
-    m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
-    m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
+    m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 0>()),
+                             m_value, 0);
+    m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 1>()),
+                             m_value, 1);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       float64x2_t const& value_in)
@@ -650,8 +647,10 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
-    m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
-    m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
+    m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 0>()),
+                            m_value, 0);
+    m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 1>()),
+                            m_value, 1);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int32x2_t const& value_in)
@@ -772,22 +771,23 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-  : m_value(vmovq_n_s64(value_type(value)))
-  {
-  }
+      : m_value(vmovq_n_s64(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
-    m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
-    m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
+    m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 0>()),
+                             m_value, 0);
+    m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 1>()),
+                             m_value, 1);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int64x2_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(simd<std::uint64_t, abi_type> const&);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const&);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reference(m_value, int(i));
   }
@@ -901,25 +901,25 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-  : m_value(vmovq_n_u64(value_type(value)))
-  {
-  }
+      : m_value(vmovq_n_u64(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
-    m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
-    m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
+    m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 0>()),
+                             m_value, 0);
+    m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 1>()),
+                             m_value, 1);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       uint64x2_t const& value_in)
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(simd<std::int32_t, abi_type> const& other)
-    :m_value(vreinterpretq_u64_s64(vmovl_s32(static_cast<int32x2_t>(other))))
-  {
-  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, abi_type> const& other)
+      : m_value(
+            vreinterpretq_u64_s64(vmovl_s32(static_cast<int32x2_t>(other)))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reference(m_value, int(i));
   }
@@ -939,12 +939,12 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator<<(unsigned int rhs) const
-  {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator<<(unsigned int rhs) const {
     return simd(vshlq_u64(m_value, vdupq_n_s64(std::int64_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(unsigned int rhs) const
-  {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator>>(unsigned int rhs) const {
     return simd(vshlq_u64(m_value, vdupq_n_s64(-std::int64_t(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
@@ -960,16 +960,13 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::neon_fixed_size<2>>::simd(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
-  :m_value(vmovn_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))))
-{
-}
+    : m_value(
+          vmovn_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other)))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
-  :m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other)))
-{
-}
+    : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> condition(

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -917,6 +917,14 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       const {
     return m_value;
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator<<(unsigned int rhs) const
+  {
+    return simd(vshlq_u64(m_value, vdupq_n_s64(std::int64_t(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(unsigned int rhs) const
+  {
+    return simd(vshlq_u64(m_value, vdupq_n_s64(-std::int64_t(rhs))));
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator==(simd const& other) const {
     return mask_type(vceqq_u64(m_value, other.m_value));

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -431,8 +431,8 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
-    vsetq_lane_f64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
-    vsetq_lane_f64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
+    m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
+    m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       float64x2_t const& value_in)
@@ -632,8 +632,8 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
-    vset_lane_s32(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
-    vset_lane_s32(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
+    m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
+    m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int32x2_t const& value_in)
@@ -754,8 +754,8 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value) {
-    vsetq_lane_s64(value_type(value), m_value, 0);
-    vsetq_lane_s64(value_type(value), m_value, 1);
+    m_value = vsetq_lane_s64(value_type(value), m_value, 0);
+    m_value = vsetq_lane_s64(value_type(value), m_value, 1);
   }
   template <class G,
             std::enable_if_t<
@@ -763,12 +763,13 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
-    vsetq_lane_s64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
-    vsetq_lane_s64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
+    m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
+    m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       int64x2_t const& value_in)
       : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(simd<std::uint64_t, abi_type> const&);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reference(m_value, int(i));
   }
@@ -882,8 +883,8 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value) {
-    vsetq_lane_u64(value_type(value), m_value, 0);
-    vsetq_lane_u64(value_type(value), m_value, 1);
+    m_value = vsetq_lane_u64(value_type(value), m_value, 0);
+    m_value = vsetq_lane_u64(value_type(value), m_value, 1);
   }
   template <class G,
             std::enable_if_t<
@@ -891,8 +892,8 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
-    vsetq_lane_u64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
-    vsetq_lane_u64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
+    m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
+    m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(
       uint64x2_t const& value_in)
@@ -925,6 +926,13 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     return !((*this) == other);
   }
 };
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
+  :m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other)))
+{
+}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> condition(

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -560,6 +560,13 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int32_t, simd_abi::neon_fixed_size<2>>
+    operator-(simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& a) {
+  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
+      vneg_s32(static_cast<int32x2_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>>
     operator-(simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
               simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -175,18 +175,18 @@ class neon_mask<Derived, 32> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit neon_mask(value_type value)
       : m_value(vdup_n_u32(value ? 0xFFFFFFFFU : 0)) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 2;
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit neon_mask(
-      uint32x2_t const& value_in)
-      : m_value(value_in) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 64> const& other)
       : m_value(vqmovn_u64(static_cast<uint64x2_t>(other))) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 32> const& other)
       : m_value(static_cast<uint32x2_t>(other)) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 2;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit neon_mask(
+      uint32x2_t const& value_in)
+      : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint32x2_t()
       const {
     return m_value;

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -80,7 +80,7 @@ class neon_mask<Derived, 64> {
   using implementation_type = uint64x2_t;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit neon_mask(value_type value)
-      : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0)) {}
+      : m_value(vmovq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0)) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(
       neon_mask<U, 32> const& other) {
@@ -174,7 +174,7 @@ class neon_mask<Derived, 32> {
   using implementation_type = uint32x2_t;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit neon_mask(value_type value)
-      : m_value(vdup_n_u32(value ? 0xFFFFFFFFU : 0)) {}
+      : m_value(vmov_n_u32(value ? 0xFFFFFFFFU : 0)) {}
   template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION neon_mask(neon_mask<U, 64> const& other)
       : m_value(vqmovn_u64(static_cast<uint64x2_t>(other))) {}
@@ -291,7 +291,7 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(vdupq_n_f64(value_type(value))) {}
+      : m_value(vmovq_n_f64(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -403,7 +403,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<double, simd_abi::neon_fixed_size<2>> copysign(
     simd<double, simd_abi::neon_fixed_size<2>> const& a,
     simd<double, simd_abi::neon_fixed_size<2>> const& b) {
-  uint64x2_t const sign_mask = vreinterpretq_u64_f64(vdupq_n_f64(-0.0));
+  uint64x2_t const sign_mask = vreinterpretq_u64_f64(vmovq_n_f64(-0.0));
   return simd<double, simd_abi::neon_fixed_size<2>>(vreinterpretq_f64_u64(
       vorrq_u64(vreinterpretq_u64_f64(static_cast<float64x2_t>(abs(a))),
                 vandq_u64(sign_mask, vreinterpretq_u64_f64(
@@ -496,7 +496,7 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(vdup_n_s32(value_type(value))) {}
+      : m_value(vmov_n_s32(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
@@ -812,11 +812,11 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator<<(unsigned int rhs) const {
-    return simd(vshlq_u64(m_value, vdupq_n_s64(std::int64_t(rhs))));
+    return simd(vshlq_u64(m_value, vmovq_n_s64(std::int64_t(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator>>(unsigned int rhs) const {
-    return simd(vshlq_u64(m_value, vdupq_n_s64(-std::int64_t(rhs))));
+    return simd(vshlq_u64(m_value, vmovq_n_s64(-std::int64_t(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator==(simd const& other) const {

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -1,0 +1,1011 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_SIMD_NEON_HPP
+#define KOKKOS_SIMD_NEON_HPP
+
+#include <functional>
+#include <type_traits>
+
+#include <Kokkos_SIMD_Common.hpp>
+
+#include <arm_neon.h>
+
+namespace Kokkos {
+
+namespace Experimental {
+
+namespace simd_abi {
+
+template <int N>
+class neon_fixed_size {};
+
+}  // namespace simd_abi
+
+template <>
+class simd_mask<double, simd_abi::neon_fixed_size<2>> {
+  uint64x2_t m_value;
+
+ public:
+  class reference {
+    uint64x2_t& m_mask;
+    int m_lane;
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(uint64x2_t& mask_arg,
+                                                    int lane_arg)
+        : m_mask(mask_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(bool value) const {
+      m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, m_lane);
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
+      return vgetq_lane_u64(m_mask, m_lane) != 0;
+    }
+  };
+  using value_type = bool;
+  using abi_type   = simd_abi::neon_fixed_size<2>;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+      : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0))
+  {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 2;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      uint64x2_t const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint64x2_t()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return static_cast<value_type>(
+        reference(const_cast<uint64x2_t&>(m_value), int(i)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator||(simd_mask const& other) const {
+    return simd_mask(vorrq_u64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator&&(simd_mask const& other) const {
+    return simd_mask(vandq_u64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
+    auto const true_value = static_cast<uint64x2_t>(simd_mask(true));
+    return simd_mask(veorq_u64(m_value, true_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
+      simd_mask const& other) const {
+    uint64x2_t const elementwise_equality = vceqq_u64(m_value, other.m_value);
+    uint32x2_t const narrow_elementwise_equality = vqmovn_u64(elementwise_equality);
+    uint64x1_t const overall_equality_neon = vreinterpret_u64_u32(narrow_elementwise_equality);
+    uint64_t const overall_equality = vget_lane_u64(overall_equality_neon, 0);
+    return overall_equality == 0xFFFFFFFFFFFFFFFFULL;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
+      simd_mask const& other) const {
+    return !operator==(other);
+  }
+};
+
+template <>
+class simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> {
+  uint32x2_t m_value;
+
+ public:
+  class reference {
+    uint32x2_t& m_mask;
+    int m_lane;
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(uint32x2_t& mask_arg,
+                                                    int lane_arg)
+        : m_mask(mask_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(bool value) const {
+      m_mask = vset_lane_u32(value ? 0xFFFFFFFFU : 0, m_mask, m_lane);
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
+      return vget_lane_u32(m_mask, m_lane) != 0;
+    }
+  };
+  using value_type = bool;
+  using abi_type   = simd_abi::neon_fixed_size<2>;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+      : m_value(vdup_n_u32(value ? 0xFFFFFFFFU : 0))
+  {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 2;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      uint32x2_t const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint32x2_t()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return static_cast<value_type>(
+        reference(const_cast<uint32x2_t&>(m_value), int(i)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator||(simd_mask const& other) const {
+    return simd_mask(vorr_u32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator&&(simd_mask const& other) const {
+    return simd_mask(vand_u32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
+    auto const true_value = static_cast<uint32x2_t>(simd_mask(true));
+    return simd_mask(veor_u32(m_value, true_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
+      simd_mask const& other) const {
+    uint32x2_t const elementwise_equality = vceq_u32(m_value, other.m_value);
+    uint64x1_t const overall_equality_neon = vreinterpret_u64_u32(elementwise_equality);
+    uint64_t const overall_equality = vget_lane_u64(overall_equality_neon, 0);
+    return overall_equality == 0xFFFFFFFFFFFFFFFFULL;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
+      simd_mask const& other) const {
+    return !operator==(other);
+  }
+};
+
+template <>
+class simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> {
+  uint64x2_t m_value;
+
+ public:
+  class reference {
+    uint64x2_t& m_mask;
+    int m_lane;
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(uint64x2_t& mask_arg,
+                                                    int lane_arg)
+        : m_mask(mask_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(bool value) const {
+      m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, m_lane);
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
+      return vgetq_lane_u64(m_mask, m_lane) != 0;
+    }
+  };
+  using value_type = bool;
+  using abi_type   = simd_abi::neon_fixed_size<2>;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+      : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0))
+  {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 2;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      uint64x2_t const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint64x2_t()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return static_cast<value_type>(
+        reference(const_cast<uint64x2_t&>(m_value), int(i)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator||(simd_mask const& other) const {
+    return simd_mask(vorrq_u64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator&&(simd_mask const& other) const {
+    return simd_mask(vandq_u64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
+    auto const true_value = static_cast<uint64x2_t>(simd_mask(true));
+    return simd_mask(veorq_u64(m_value, true_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
+      simd_mask const& other) const {
+    uint64x2_t const elementwise_equality = vceqq_u64(m_value, other.m_value);
+    uint32x2_t const narrow_elementwise_equality = vqmovn_u64(elementwise_equality);
+    uint64x1_t const overall_equality_neon = vreinterpret_u64_u32(narrow_elementwise_equality);
+    uint64_t const overall_equality = vget_lane_u64(overall_equality_neon, 0);
+    return overall_equality == 0xFFFFFFFFFFFFFFFFULL;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
+      simd_mask const& other) const {
+    return !operator==(other);
+  }
+};
+
+template <>
+class simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> {
+  uint64x2_t m_value;
+
+ public:
+  class reference {
+    uint64x2_t& m_mask;
+    int m_lane;
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(uint64x2_t& mask_arg,
+                                                    int lane_arg)
+        : m_mask(mask_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(bool value) const {
+      m_mask = vsetq_lane_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0, m_mask, m_lane);
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator bool() const {
+      return vgetq_lane_u64(m_mask, m_lane) != 0;
+    }
+  };
+  using value_type = bool;
+  using abi_type   = simd_abi::neon_fixed_size<2>;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
+      : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0))
+  {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 2;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
+      uint64x2_t const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint64x2_t()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return static_cast<value_type>(
+        reference(const_cast<uint64x2_t&>(m_value), int(i)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator||(simd_mask const& other) const {
+    return simd_mask(vorrq_u64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
+  operator&&(simd_mask const& other) const {
+    return simd_mask(vandq_u64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask operator!() const {
+    auto const true_value = static_cast<uint64x2_t>(simd_mask(true));
+    return simd_mask(veorq_u64(m_value, true_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator==(
+      simd_mask const& other) const {
+    uint64x2_t const elementwise_equality = vceqq_u64(m_value, other.m_value);
+    uint32x2_t const narrow_elementwise_equality = vqmovn_u64(elementwise_equality);
+    uint64x1_t const overall_equality_neon = vreinterpret_u64_u32(narrow_elementwise_equality);
+    uint64_t const overall_equality = vget_lane_u64(overall_equality_neon, 0);
+    return overall_equality == 0xFFFFFFFFFFFFFFFFULL;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool operator!=(
+      simd_mask const& other) const {
+    return !operator==(other);
+  }
+};
+
+template <>
+class simd<double, simd_abi::neon_fixed_size<2>> {
+  float64x2_t m_value;
+
+ public:
+  using value_type = double;
+  using abi_type   = simd_abi::neon_fixed_size<2>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  class reference {
+    float64x2_t& m_value;
+    int m_lane;
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(float64x2_t& mask_arg,
+                                                    int lane_arg)
+        : m_value(mask_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(double value) const {
+      m_value = vsetq_lane_f64(value, m_mask, m_lane);
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator double() const {
+      return vgetq_lane_f64(m_mask, m_lane);
+    }
+  };
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 2;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(vdupq_n_f64(value_type(value))) {}
+  template <class G,
+            std::enable_if_t<
+                // basically, can you do { value_type r =
+                // gen(std::integral_constant<std::size_t, i>()); }
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
+  {
+    vsetq_lane_f64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
+    vsetq_lane_f64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      float64x2_t const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return vgetq_lane(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = vld1q_f64(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    vst1q_f64(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator float64x2_t()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<(simd const& other) const {
+    return mask_type(vcltq_f64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>(simd const& other) const {
+    return mask_type(vcgtq_f64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<=(simd const& other) const {
+    return mask_type(vcleq_f64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>=(simd const& other) const {
+    return mask_type(vcgeq_f64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& other) const {
+    return mask_type(vceqq_f64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& other) const {
+    return !(operator==(other));
+  }
+};
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::neon_fixed_size<2>>
+    operator*(simd<double, simd_abi::neon_fixed_size<2>> const& lhs,
+              simd<double, simd_abi::neon_fixed_size<2>> const& rhs) {
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vmulq_f64(static_cast<float64x2_t>(lhs), static_cast<float64x2_t>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::neon_fixed_size<2>>
+    operator/(simd<double, simd_abi::neon_fixed_size<2>> const& lhs,
+              simd<double, simd_abi::neon_fixed_size<2>> const& rhs) {
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vdivq_f64(static_cast<float64x2_t>(lhs), static_cast<float64x2_t>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::neon_fixed_size<2>>
+    operator+(simd<double, simd_abi::neon_fixed_size<2>> const& lhs,
+              simd<double, simd_abi::neon_fixed_size<2>> const& rhs) {
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vaddq_f64(static_cast<float64x2_t>(lhs), static_cast<float64x2_t>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::neon_fixed_size<2>>
+    operator-(simd<double, simd_abi::neon_fixed_size<2>> const& lhs,
+              simd<double, simd_abi::neon_fixed_size<2>> const& rhs) {
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vsubq_f64(static_cast<float64x2_t>(lhs), static_cast<float64x2_t>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<double, simd_abi::neon_fixed_size<2>>
+    operator-(simd<double, simd_abi::neon_fixed_size<2>> const& a) {
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vnegq_f64(static_cast<float64x2_t>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx2_fixed_size<4>> copysign(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
+  __m256d const sign_mask = _mm256_set1_pd(-0.0);
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_xor_pd(_mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)),
+                    _mm256_and_pd(sign_mask, static_cast<__m256d>(b))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx2_fixed_size<4>> abs(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+  __m256d const sign_mask = _mm256_set1_pd(-0.0);
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx2_fixed_size<4>> sqrt(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_sqrt_pd(static_cast<__m256d>(a)));
+}
+
+#ifdef __INTEL_COMPILER
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx2_fixed_size<4>> cbrt(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_cbrt_pd(static_cast<__m256d>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx2_fixed_size<4>> exp(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_exp_pd(static_cast<__m256d>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx2_fixed_size<4>> log(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_log_pd(static_cast<__m256d>(a)));
+}
+
+#endif
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx2_fixed_size<4>> fma(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& b,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_fmadd_pd(static_cast<__m256d>(a), static_cast<__m256d>(b),
+                      static_cast<__m256d>(c)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx2_fixed_size<4>> max(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_max_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx2_fixed_size<4>> min(
+    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_min_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<double, simd_abi::avx2_fixed_size<4>> condition(
+    simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& b,
+    simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
+  return simd<double, simd_abi::avx2_fixed_size<4>>(
+      _mm256_blendv_pd(static_cast<__m256d>(c), static_cast<__m256d>(b),
+                       static_cast<__m256d>(a)));
+}
+
+template <>
+class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
+  __m128i m_value;
+
+ public:
+  using value_type = std::int32_t;
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 4;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm_set1_epi32(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::int32_t a, std::int32_t b,
+                                             std::int32_t c, std::int32_t d)
+      : m_value(_mm_setr_epi32(a, b, c, d)) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
+      : simd(gen(std::integral_constant<std::size_t, 0>()),
+             gen(std::integral_constant<std::size_t, 1>()),
+             gen(std::integral_constant<std::size_t, 2>()),
+             gen(std::integral_constant<std::size_t, 3>())) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m128i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::uint64_t, abi_type> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask_type(true)), m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& other) const {
+    return mask_type(_mm_cmpeq_epi32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>(simd const& other) const {
+    return mask_type(_mm_cmpgt_epi32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<(simd const& other) const {
+    return mask_type(_mm_cmplt_epi32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<=(simd const& other) const {
+    return ((*this) < other) || ((*this) == other);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>=(simd const& other) const {
+    return ((*this) > other) || ((*this) == other);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& other) const {
+    return !((*this) == other);
+  }
+};
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    operator-(simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+              simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+      _mm_sub_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    operator+(simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+              simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+      _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    condition(simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
+              simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& b,
+              simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(_mm_castps_si128(
+      _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(c)),
+                    _mm_castsi128_ps(static_cast<__m128i>(b)),
+                    _mm_castsi128_ps(static_cast<__m128i>(a)))));
+}
+
+template <>
+class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
+  __m256i m_value;
+
+ public:
+  using value_type = std::int64_t;
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 4;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm256_set1_epi64x(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::int64_t a, std::int64_t b,
+                                             std::int64_t c, std::int64_t d)
+      : m_value(_mm256_setr_epi64x(a, b, c, d)) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
+      : simd(gen(std::integral_constant<std::size_t, 0>()),
+             gen(std::integral_constant<std::size_t, 1>()),
+             gen(std::integral_constant<std::size_t, 2>()),
+             gen(std::integral_constant<std::size_t, 3>())) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m256i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
+      simd<std::uint64_t, abi_type> const& other);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(
+      simd<std::int32_t, abi_type> const& other)
+      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_maskload_epi64(ptr, static_cast<__m256i>(mask_type(true)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_maskstore_epi64(ptr, static_cast<__m256i>(mask_type(true)), m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+      const {
+    return m_value;
+  }
+  // AVX2 only has eq and gt comparisons for int64
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& other) const {
+    return mask_type(_mm256_cmpeq_epi64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>(simd const& other) const {
+    return mask_type(_mm256_cmpgt_epi64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<(simd const& other) const {
+    return other > (*this);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<=(simd const& other) const {
+    return ((*this) < other) || ((*this) == other);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>=(simd const& other) const {
+    return ((*this) > other) || ((*this) == other);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& other) const {
+    return !((*this) == other);
+  }
+};
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    operator-(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+              simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
+  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    operator-(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(0) - a;
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
+    simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(_mm256_castpd_si256(
+      _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
+                       _mm256_castsi256_pd(static_cast<__m256i>(b)),
+                       _mm256_castsi256_pd(static_cast<__m256i>(a)))));
+}
+
+template <>
+class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
+  __m256i m_value;
+
+ public:
+  using value_type = std::uint64_t;
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm256_set1_epi64x(bit_cast<std::int64_t>(value_type(value)))) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m256i const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int32_t, abi_type> const& other)
+      : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
+      simd<std::int64_t, abi_type> const& other)
+      : m_value(static_cast<__m256i>(other)) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator>>(unsigned int rhs) const {
+    return _mm256_srli_epi64(m_value, rhs);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) const {
+    return _mm256_srlv_epi64(m_value,
+                             _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator<<(unsigned int rhs) const {
+    return _mm256_slli_epi64(m_value, rhs);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator<<(
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) const {
+    return _mm256_sllv_epi64(m_value,
+                             _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator&(simd const& other) const {
+    return _mm256_and_si256(m_value, other.m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator|(simd const& other) const {
+    return _mm256_or_si256(m_value, other.m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& other) const {
+    return mask_type(_mm256_cmpeq_epi64(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& other) const {
+    return !((*this) == other);
+  }
+};
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
+    : m_value(static_cast<__m256i>(other)) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(
+    simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(_mm256_castpd_si256(
+      _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
+                       _mm256_castsi256_pd(static_cast<__m256i>(b)),
+                       _mm256_castsi256_pd(static_cast<__m256i>(a)))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::simd(
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other) {
+  for (std::size_t i = 0; i < 4; ++i) {
+    (*this)[i] = std::int32_t(other[i]);
+  }
+}
+
+template <>
+class const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
+                             simd<double, simd_abi::avx2_fixed_size<4>>> {
+ public:
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
+  using value_type = simd<double, abi_type>;
+  using mask_type  = simd_mask<double, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
+  mask() const {
+    return m_mask;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
+  value() const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(double* mem, element_aligned_tag) const {
+    _mm256_maskstore_pd(mem, _mm256_castpd_si256(static_cast<__m256d>(m_mask)),
+                        static_cast<__m256d>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      double* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+    for (std::size_t lane = 0; lane < 4; ++lane) {
+      if (m_mask[lane]) mem[index[lane]] = m_value[lane];
+    }
+  }
+};
+
+template <>
+class where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
+                       simd<double, simd_abi::avx2_fixed_size<4>>>
+    : public const_where_expression<
+          simd_mask<double, simd_abi::avx2_fixed_size<4>>,
+          simd<double, simd_abi::avx2_fixed_size<4>>> {
+ public:
+  where_expression(
+      simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      simd<double, simd_abi::avx2_fixed_size<4>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(double const* mem, element_aligned_tag) {
+    m_value = value_type(_mm256_maskload_pd(
+        mem, _mm256_castpd_si256(static_cast<__m256d>(m_mask))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      double const* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+    m_value = value_type(_mm256_mask_i32gather_pd(
+        _mm256_set1_pd(0.0), mem, static_cast<__m128i>(index),
+        static_cast<__m256d>(m_mask), 8));
+  }
+  template <class U,
+            std::enable_if_t<std::is_convertible_v<
+                                 U, simd<double, simd_abi::avx2_fixed_size<4>>>,
+                             bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<double, simd_abi::avx2_fixed_size<4>>>(
+            std::forward<U>(x));
+    m_value = simd<double, simd_abi::avx2_fixed_size<4>>(_mm256_blendv_pd(
+        static_cast<__m256d>(m_value), static_cast<__m256d>(x_as_value_type),
+        static_cast<__m256d>(m_mask)));
+  }
+};
+
+template <>
+class const_where_expression<
+    simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+ public:
+  using abi_type   = simd_abi::avx2_fixed_size<4>;
+  using value_type = simd<std::int32_t, abi_type>;
+  using mask_type  = simd_mask<std::int32_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
+  mask() const {
+    return m_mask;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
+  value() const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, element_aligned_tag) const {
+    _mm_maskstore_epi32(mem, static_cast<__m128i>(m_mask),
+                        static_cast<__m128i>(m_value));
+  }
+};
+
+template <>
+class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+                       simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+    : public const_where_expression<
+          simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+          simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+ public:
+  where_expression(
+      simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, element_aligned_tag) {
+    m_value = value_type(_mm_maskload_epi32(mem, static_cast<__m128i>(m_mask)));
+  }
+};
+
+}  // namespace Experimental
+}  // namespace Kokkos
+
+#endif

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -161,14 +161,17 @@ class simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
       : m_value(vdup_n_u32(value ? 0xFFFFFFFFU : 0)) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
       uint32x2_t const& value_in)
       : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
+      simd_mask<double, simd_abi::neon_fixed_size<2>> const& other)
+    : m_value(vqmovn_u64(static_cast<uint64x2_t>(other)))
+  {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint32x2_t()
       const {
     return m_value;

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -698,6 +698,13 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int64_t, simd_abi::neon_fixed_size<2>>
+    operator-(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& a) {
+  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+      vnegq_s64(static_cast<int64x2_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>>
     operator-(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
               simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
@@ -706,9 +713,10 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int64_t, simd_abi::neon_fixed_size<2>>
-    operator-(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& a) {
+    operator+(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+              simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
-      vnegq_s64(static_cast<int64x2_t>(a)));
+      vaddq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -756,9 +756,9 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value) {
-    m_value = vsetq_lane_s64(value_type(value), m_value, 0);
-    m_value = vsetq_lane_s64(value_type(value), m_value, 1);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  : m_value(vmovq_n_s64(value_type(value)))
+  {
   }
   template <class G,
             std::enable_if_t<
@@ -885,9 +885,9 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value) {
-    m_value = vsetq_lane_u64(value_type(value), m_value, 0);
-    m_value = vsetq_lane_u64(value_type(value), m_value, 1);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+  : m_value(vmovq_n_u64(value_type(value)))
+  {
   }
   template <class G,
             std::enable_if_t<
@@ -898,9 +898,13 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
     m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       uint64x2_t const& value_in)
       : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(simd<std::int32_t, abi_type> const& other)
+    :m_value(vreinterpretq_u64_s64(vmovl_s32(static_cast<int32x2_t>(other))))
+  {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
     return reference(m_value, int(i));
   }
@@ -910,11 +914,11 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator&(simd const& other) const {
-    return vandq_u64(m_value, other.m_value);
+    return simd(vandq_u64(m_value, other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator|(simd const& other) const {
-    return vorrq_u64(m_value, other.m_value);
+    return simd(vorrq_u64(m_value, other.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint64x2_t()
       const {

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -943,6 +943,13 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
 };
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::neon_fixed_size<2>>::simd(
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
+  :m_value(vmovn_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))))
+{
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
   :m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other)))

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -471,132 +471,123 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> copysign(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
-  __m256d const sign_mask = _mm256_set1_pd(-0.0);
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_xor_pd(_mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)),
-                    _mm256_and_pd(sign_mask, static_cast<__m256d>(b))));
+simd<double, simd_abi::neon_fixed_size<2>> abs(
+    simd<double, simd_abi::neon_fixed_size<2>> const& a) {
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vabsq_f64(static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> abs(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
-  __m256d const sign_mask = _mm256_set1_pd(-0.0);
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)));
+simd<double, simd_abi::neon_fixed_size<2>> copysign(
+    simd<double, simd_abi::neon_fixed_size<2>> const& a,
+    simd<double, simd_abi::neon_fixed_size<2>> const& b) {
+  float64x2_t const sign_mask = vdupq_n_f64(-0.0);
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vorrq_f64(static_cast<float64x2_t>(abs(a)),
+        vandq_f64(sign_mask, static_cast<float64x2_t>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> sqrt(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_sqrt_pd(static_cast<__m256d>(a)));
-}
-
-#ifdef __INTEL_COMPILER
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> cbrt(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_cbrt_pd(static_cast<__m256d>(a)));
+simd<double, simd_abi::neon_fixed_size<2>> sqrt(
+    simd<double, simd_abi::neon_fixed_size<2>> const& a) {
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vsqrtq_f64(static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> exp(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_exp_pd(static_cast<__m256d>(a)));
+simd<double, simd_abi::neon_fixed_size<2>> fma(
+    simd<double, simd_abi::neon_fixed_size<2>> const& a,
+    simd<double, simd_abi::neon_fixed_size<2>> const& b,
+    simd<double, simd_abi::neon_fixed_size<2>> const& c) {
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vfmaq_f64(
+        static_cast<float64x2_t>(c),
+        static_cast<float64x2_t>(b),
+        static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> log(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_log_pd(static_cast<__m256d>(a)));
-}
-
-#endif
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> fma(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& b,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_fmadd_pd(static_cast<__m256d>(a), static_cast<__m256d>(b),
-                      static_cast<__m256d>(c)));
+simd<double, simd_abi::neon_fixed_size<2>> max(
+    simd<double, simd_abi::neon_fixed_size<2>> const& a,
+    simd<double, simd_abi::neon_fixed_size<2>> const& b) {
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vmaxq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> max(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_max_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
+simd<double, simd_abi::neon_fixed_size<2>> min(
+    simd<double, simd_abi::neon_fixed_size<2>> const& a,
+    simd<double, simd_abi::neon_fixed_size<2>> const& b) {
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vminq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> min(
-    simd<double, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& b) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_min_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
-}
-
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<double, simd_abi::avx2_fixed_size<4>> condition(
-    simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& b,
-    simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
-  return simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_blendv_pd(static_cast<__m256d>(c), static_cast<__m256d>(b),
-                       static_cast<__m256d>(a)));
+simd<double, simd_abi::neon_fixed_size<2>> condition(
+    simd_mask<double, simd_abi::neon_fixed_size<2>> const& a,
+    simd<double, simd_abi::neon_fixed_size<2>> const& b,
+    simd<double, simd_abi::neon_fixed_size<2>> const& c) {
+  return simd<double, simd_abi::neon_fixed_size<2>>(
+      vbslq_f64(
+        static_cast<uint64x2_t>(a),
+        static_cast<float64x2_t>(b),
+        static_cast<float64x2_t>(c)));
 }
 
 template <>
-class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
-  __m128i m_value;
+class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
+  int32x2_t m_value;
 
  public:
   using value_type = std::int32_t;
-  using abi_type   = simd_abi::avx2_fixed_size<4>;
+  using abi_type   = simd_abi::neon_fixed_size<2>;
   using mask_type  = simd_mask<value_type, abi_type>;
-  using reference  = value_type&;
+  class reference {
+    int32x2_t& m_value;
+    int m_lane;
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(int32x2_t& value_arg,
+                                                    int lane_arg)
+        : m_value(value_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(std::int32_t value) const {
+      m_value = vset_lane_s32(value, m_value, m_lane);
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator double() const {
+      return vget_lane_s32(m_value, m_lane);
+    }
+  };
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 4;
+    return 2;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm_set1_epi32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::int32_t a, std::int32_t b,
-                                             std::int32_t c, std::int32_t d)
-      : m_value(_mm_setr_epi32(a, b, c, d)) {}
+      : m_value(vdup_n_s32(value_type(value))) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
-      : simd(gen(std::integral_constant<std::size_t, 0>()),
-             gen(std::integral_constant<std::size_t, 1>()),
-             gen(std::integral_constant<std::size_t, 2>()),
-             gen(std::integral_constant<std::size_t, 3>())) {}
+  {
+    vset_lane_s32(gen(std::integral_constant<std::size_t, 0>()), m_value, 0);
+    vset_lane_s32(gen(std::integral_constant<std::size_t, 1>()), m_value, 1);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
-      __m128i const& value_in)
+      int32x2_t const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
       simd<std::uint64_t, abi_type> const& other);
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
-    return reinterpret_cast<value_type*>(&m_value)[i];
+    return reference(m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -75,8 +75,13 @@ class simd_mask<double, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
       : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0)) {}
+  template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
+      simd_mask<U, simd_abi::neon_fixed_size<2>> const& other)
+  {
+    operator[](0) = bool(other[0]);
+    operator[](1) = bool(other[1]);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
@@ -248,8 +253,13 @@ class simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
       : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0)) {}
+  template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
+      simd_mask<U, simd_abi::neon_fixed_size<2>> const& other)
+  {
+    operator[](0) = bool(other[0]);
+    operator[](1) = bool(other[1]);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
@@ -334,8 +344,13 @@ class simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
       : m_value(vdupq_n_u64(value ? 0xFFFFFFFFFFFFFFFFULL : 0)) {}
+  template <class U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& i32_mask);
+      simd_mask<U, simd_abi::neon_fixed_size<2>> const& other)
+  {
+    operator[](0) = bool(other[0]);
+    operator[](1) = bool(other[1]);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -311,6 +311,11 @@ inline void host_check_conversions() {
   EXPECT_TRUE(all_of(b == decltype(b)(1)));
   }
   {
+  auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+  auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
+  EXPECT_TRUE(all_of(b == decltype(b)(1)));
+  }
+  {
   auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
   auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
   EXPECT_TRUE(b == decltype(b)(true));
@@ -358,6 +363,11 @@ KOKKOS_INLINE_FUNCTION void device_check_conversions() {
   {
   auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
   auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
+  checker.truth(all_of(b == decltype(b)(1)));
+  }
+  {
+  auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+  auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
   checker.truth(all_of(b == decltype(b)(1)));
   }
   {

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -320,6 +320,21 @@ inline void host_check_conversions() {
   auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
   EXPECT_TRUE(b == decltype(b)(true));
   }
+  {
+  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+  auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
+  EXPECT_TRUE(b == decltype(b)(true));
+  }
+  {
+  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+  auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
+  EXPECT_TRUE(b == decltype(b)(true));
+  }
+  {
+  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+  auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
+  EXPECT_TRUE(b == decltype(b)(true));
+  }
 }
 
 template <class Abi>
@@ -327,6 +342,15 @@ inline void host_check_shifts() {
   auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(8);
   auto b = a >> 1;
   EXPECT_TRUE(all_of(b == decltype(b)(4)));
+}
+
+template <class Abi>
+inline void host_check_condition() {
+  auto a = Kokkos::Experimental::condition(
+      Kokkos::Experimental::simd<std::int32_t, Abi>(1) > 0,
+      Kokkos::Experimental::simd<std::uint64_t, Abi>(16),
+      Kokkos::Experimental::simd<std::uint64_t, Abi>(20));
+  EXPECT_TRUE(all_of(a == decltype(a)(16)));
 }
 
 template <class Abi>
@@ -375,6 +399,21 @@ KOKKOS_INLINE_FUNCTION void device_check_conversions() {
   auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
   checker.truth(b == decltype(b)(true));
   }
+  {
+  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+  auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
+  checker.truth(b == decltype(b)(true));
+  }
+  {
+  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+  auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
+  checker.truth(b == decltype(b)(true));
+  }
+  {
+  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+  auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
+  checker.truth(b == decltype(b)(true));
+  }
 }
 
 template <class Abi>
@@ -386,11 +425,22 @@ KOKKOS_INLINE_FUNCTION void device_check_shifts() {
 }
 
 template <class Abi>
+KOKKOS_INLINE_FUNCTION void device_check_condition() {
+  kokkos_checker checker;
+  auto a = Kokkos::Experimental::condition(
+      Kokkos::Experimental::simd<std::int32_t, Abi>(1) > 0,
+      Kokkos::Experimental::simd<std::uint64_t, Abi>(16),
+      Kokkos::Experimental::simd<std::uint64_t, Abi>(20));
+  checker.truth(all_of(a == decltype(a)(16)));
+}
+
+template <class Abi>
 inline void host_check_abi() {
   host_check_math_ops<Abi>();
   host_check_mask_ops<Abi>();
   host_check_conversions<Abi>();
   host_check_shifts<Abi>();
+  host_check_condition<Abi>();
 }
 
 template <class Abi>
@@ -399,6 +449,7 @@ KOKKOS_INLINE_FUNCTION void device_check_abi() {
   device_check_mask_ops<Abi>();
   device_check_conversions<Abi>();
   device_check_shifts<Abi>();
+  device_check_condition<Abi>();
 }
 
 inline void host_check_abis(Kokkos::Experimental::Impl::abi_set<>) {}

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -306,6 +306,11 @@ inline void host_check_conversions() {
   EXPECT_TRUE(all_of(b == decltype(b)(1)));
   }
   {
+  auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
+  auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
+  EXPECT_TRUE(all_of(b == decltype(b)(1)));
+  }
+  {
   auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
   auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
   EXPECT_TRUE(b == decltype(b)(true));
@@ -348,6 +353,11 @@ KOKKOS_INLINE_FUNCTION void device_check_conversions() {
   {
   auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
   auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
+  checker.truth(all_of(b == decltype(b)(1)));
+  }
+  {
+  auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
+  auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
   checker.truth(all_of(b == decltype(b)(1)));
   }
   {

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -300,9 +300,16 @@ inline void host_check_mask_ops() {
 
 template <class Abi>
 inline void host_check_conversions() {
+  {
   auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
   auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
   EXPECT_TRUE(all_of(b == decltype(b)(1)));
+  }
+  {
+  auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
+  auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
+  EXPECT_TRUE(b == decltype(b)(true));
+  }
 }
 
 template <class Abi>
@@ -338,9 +345,16 @@ KOKKOS_INLINE_FUNCTION void device_check_mask_ops() {
 template <class Abi>
 KOKKOS_INLINE_FUNCTION void device_check_conversions() {
   kokkos_checker checker;
+  {
   auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
   auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
   checker.truth(all_of(b == decltype(b)(1)));
+  }
+  {
+  auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
+  auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
+  checker.truth(b == decltype(b)(true));
+  }
 }
 
 template <class Abi>

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -301,39 +301,39 @@ inline void host_check_mask_ops() {
 template <class Abi>
 inline void host_check_conversions() {
   {
-  auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-  auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
-  EXPECT_TRUE(all_of(b == decltype(b)(1)));
+    auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+    auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
+    EXPECT_TRUE(all_of(b == decltype(b)(1)));
   }
   {
-  auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
-  auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
-  EXPECT_TRUE(all_of(b == decltype(b)(1)));
+    auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
+    auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
+    EXPECT_TRUE(all_of(b == decltype(b)(1)));
   }
   {
-  auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-  auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
-  EXPECT_TRUE(all_of(b == decltype(b)(1)));
+    auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+    auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
+    EXPECT_TRUE(all_of(b == decltype(b)(1)));
   }
   {
-  auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
-  auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
-  EXPECT_TRUE(b == decltype(b)(true));
+    auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
+    auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
+    EXPECT_TRUE(b == decltype(b)(true));
   }
   {
-  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-  auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
-  EXPECT_TRUE(b == decltype(b)(true));
+    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+    auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
+    EXPECT_TRUE(b == decltype(b)(true));
   }
   {
-  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-  auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
-  EXPECT_TRUE(b == decltype(b)(true));
+    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+    auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
+    EXPECT_TRUE(b == decltype(b)(true));
   }
   {
-  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-  auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
-  EXPECT_TRUE(b == decltype(b)(true));
+    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+    auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
+    EXPECT_TRUE(b == decltype(b)(true));
   }
 }
 
@@ -380,39 +380,39 @@ template <class Abi>
 KOKKOS_INLINE_FUNCTION void device_check_conversions() {
   kokkos_checker checker;
   {
-  auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-  auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
-  checker.truth(all_of(b == decltype(b)(1)));
+    auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+    auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
+    checker.truth(all_of(b == decltype(b)(1)));
   }
   {
-  auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
-  auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
-  checker.truth(all_of(b == decltype(b)(1)));
+    auto a = Kokkos::Experimental::simd<std::int32_t, Abi>(1);
+    auto b = Kokkos::Experimental::simd<std::uint64_t, Abi>(a);
+    checker.truth(all_of(b == decltype(b)(1)));
   }
   {
-  auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
-  auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
-  checker.truth(all_of(b == decltype(b)(1)));
+    auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+    auto b = Kokkos::Experimental::simd<std::int32_t, Abi>(a);
+    checker.truth(all_of(b == decltype(b)(1)));
   }
   {
-  auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
-  auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
-  checker.truth(b == decltype(b)(true));
+    auto a = Kokkos::Experimental::simd_mask<double, Abi>(true);
+    auto b = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(a);
+    checker.truth(b == decltype(b)(true));
   }
   {
-  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-  auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
-  checker.truth(b == decltype(b)(true));
+    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+    auto b = Kokkos::Experimental::simd_mask<std::uint64_t, Abi>(a);
+    checker.truth(b == decltype(b)(true));
   }
   {
-  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-  auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
-  checker.truth(b == decltype(b)(true));
+    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+    auto b = Kokkos::Experimental::simd_mask<std::int64_t, Abi>(a);
+    checker.truth(b == decltype(b)(true));
   }
   {
-  auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
-  auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
-  checker.truth(b == decltype(b)(true));
+    auto a = Kokkos::Experimental::simd_mask<std::int32_t, Abi>(true);
+    auto b = Kokkos::Experimental::simd_mask<double, Abi>(a);
+    checker.truth(b == decltype(b)(true));
   }
 }
 

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -306,6 +306,13 @@ inline void host_check_conversions() {
 }
 
 template <class Abi>
+inline void host_check_shifts() {
+  auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(8);
+  auto b = a >> 1;
+  EXPECT_TRUE(all_of(b == decltype(b)(4)));
+}
+
+template <class Abi>
 KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
   std::size_t constexpr n     = 11;
   double const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
@@ -337,10 +344,19 @@ KOKKOS_INLINE_FUNCTION void device_check_conversions() {
 }
 
 template <class Abi>
+KOKKOS_INLINE_FUNCTION void device_check_shifts() {
+  kokkos_checker checker;
+  auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(8);
+  auto b = a >> 1;
+  checker.truth(all_of(b == decltype(b)(4)));
+}
+
+template <class Abi>
 inline void host_check_abi() {
   host_check_math_ops<Abi>();
   host_check_mask_ops<Abi>();
   host_check_conversions<Abi>();
+  host_check_shifts<Abi>();
 }
 
 template <class Abi>
@@ -348,6 +364,7 @@ KOKKOS_INLINE_FUNCTION void device_check_abi() {
   device_check_math_ops<Abi>();
   device_check_mask_ops<Abi>();
   device_check_conversions<Abi>();
+  device_check_shifts<Abi>();
 }
 
 inline void host_check_abis(Kokkos::Experimental::Impl::abi_set<>) {}

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -170,7 +170,7 @@ void host_check_binary_op_one_loader(BinaryOp binary_op, std::size_t n,
     simd_type expected_result;
     for (std::size_t lane = 0; lane < nlanes; ++lane) {
       expected_result[lane] =
-          binary_op.on_host(first_arg[lane], second_arg[lane]);
+          binary_op.on_host(T(first_arg[lane]), T(second_arg[lane]));
     }
     simd_type const computed_result = binary_op.on_host(first_arg, second_arg);
     host_check_equality(expected_result, computed_result, nlanes);
@@ -299,6 +299,13 @@ inline void host_check_mask_ops() {
 }
 
 template <class Abi>
+inline void host_check_conversions() {
+  auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+  auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
+  EXPECT_TRUE(all_of(b == decltype(b)(1)));
+}
+
+template <class Abi>
 KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
   std::size_t constexpr n     = 11;
   double const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
@@ -322,15 +329,25 @@ KOKKOS_INLINE_FUNCTION void device_check_mask_ops() {
 }
 
 template <class Abi>
+KOKKOS_INLINE_FUNCTION void device_check_conversions() {
+  kokkos_checker checker;
+  auto a = Kokkos::Experimental::simd<std::uint64_t, Abi>(1);
+  auto b = Kokkos::Experimental::simd<std::int64_t, Abi>(a);
+  checker.truth(all_of(b == decltype(b)(1)));
+}
+
+template <class Abi>
 inline void host_check_abi() {
   host_check_math_ops<Abi>();
   host_check_mask_ops<Abi>();
+  host_check_conversions<Abi>();
 }
 
 template <class Abi>
 KOKKOS_INLINE_FUNCTION void device_check_abi() {
   device_check_math_ops<Abi>();
   device_check_mask_ops<Abi>();
+  device_check_conversions<Abi>();
 }
 
 inline void host_check_abis(Kokkos::Experimental::Impl::abi_set<>) {}


### PR DESCRIPTION
This adds a backend to the SIMD tools for the ARM NEON intrinsics. It compiles and passes unit tests using the ARM 21.0 `armclang` compilers.
Setting CMake configuration `-DKokkos_ARCH_ARMV8_THUNDERX2=ON`, and possibly other ARM ARCH settings, should enable this NEON backend and make it the "native" SIMD ABI.