### PR TITLE
Drop KOKKOS_IMPL_WORKAROUND_INTEL_LLVM_DEFAULT_FLOATING_POINT_MODEL

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         distro: ['fedora:latest', 'fedora:rawhide', 'ubuntu:latest']
         cxx: ['g++', 'clang++']
+        cxx_extra_flags: ['']
         cmake_build_type: ['Release', 'Debug']
         backend: ['OPENMP']
         clang-tidy: ['']
@@ -28,11 +29,13 @@ jobs:
             clang-tidy: ''
           - distro: 'fedora:intel'
             cxx: 'icpx'
+            cxx_extra_flags: '-fp-model=precise'
             cmake_build_type: 'Release'
             backend: 'OPENMP'
             clang-tidy: ''
           - distro: 'fedora:intel'
             cxx: 'icpx'
+            cxx_extra_flags: '-fp-model=precise'
             cmake_build_type: 'Debug'
             backend: 'OPENMP'
             clang-tidy: ''
@@ -100,6 +103,7 @@ jobs:
             -DKokkos_ENABLE_EXAMPLES=ON \
             -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
             -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+            -DCMAKE_CXX_FLAGS="${{ matrix.cxx_extra_flags }}" \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -30,12 +30,6 @@
 #define MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
 #endif
 
-// WORKAROUND icpx changing default FP model when optimization level is >= 1
-// using -fp-model=precise works too
-#if defined(__INTEL_LLVM_COMPILER)
-#define KOKKOS_IMPL_WORKAROUND_INTEL_LLVM_DEFAULT_FLOATING_POINT_MODEL
-#endif
-
 // clang-format off
 template <class>
 struct math_unary_function_return_type;
@@ -1060,11 +1054,7 @@ struct TestAbsoluteValueFunction {
     // special values
     using Kokkos::isinf;
     using Kokkos::isnan;
-    if (abs(-0.) != 0.
-#ifndef KOKKOS_IMPL_WORKAROUND_INTEL_LLVM_DEFAULT_FLOATING_POINT_MODEL
-        || !isinf(abs(-INFINITY)) || !isnan(abs(-NAN))
-#endif
-    ) {
+    if (abs(-0.) != 0. || !isinf(abs(-INFINITY)) || !isnan(abs(-NAN))) {
       ++e;
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "failed abs(floating_point) special values\n");
@@ -1101,44 +1091,31 @@ struct TestIsNaN {
       ++e;
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed isnan(integral)\n");
     }
-    if (isnan(2.f)
-#ifndef KOKKOS_IMPL_WORKAROUND_INTEL_LLVM_DEFAULT_FLOATING_POINT_MODEL
-        || !isnan(quiet_NaN<float>::value) ||
+    if (isnan(2.f) || !isnan(quiet_NaN<float>::value) ||
         !isnan(signaling_NaN<float>::value)
-#endif
 
     ) {
       ++e;
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed isnan(float)\n");
     }
     if (isnan(3.)
-#ifndef KOKKOS_IMPL_WORKAROUND_INTEL_LLVM_DEFAULT_FLOATING_POINT_MODEL
 #ifndef KOKKOS_COMPILER_NVHPC  // FIXME_NVHPC
         || !isnan(quiet_NaN<double>::value) ||
         !isnan(signaling_NaN<double>::value)
-#endif
 #endif
     ) {
       ++e;
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed isnan(double)\n");
     }
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    if (isnan(4.l)
-#ifndef KOKKOS_IMPL_WORKAROUND_INTEL_LLVM_DEFAULT_FLOATING_POINT_MODEL
-        || !isnan(quiet_NaN<long double>::value) ||
-        !isnan(signaling_NaN<long double>::value)
-#endif
-    ) {
+    if (isnan(4.l) || !isnan(quiet_NaN<long double>::value) ||
+        !isnan(signaling_NaN<long double>::value)) {
       ++e;
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("failed isnan(long double)\n");
     }
 #endif
     // special values
-    if (isnan(INFINITY)
-#ifndef KOKKOS_IMPL_WORKAROUND_INTEL_LLVM_DEFAULT_FLOATING_POINT_MODEL
-        || !isnan(NAN)
-#endif
-    ) {
+    if (isnan(INFINITY) || !isnan(NAN)) {
       ++e;
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "failed isnan(floating_point) special values\n");


### PR DESCRIPTION
Part of #5780. There are more warnings than the ones covered by the guard in question and in my experience unit testing only really gives sensible results with `-fp-model=precise` anyway. 