### PR TITLE
sprintf -> snprintf

### DIFF
--- a/core/perf_test/test_atomic.cpp
+++ b/core/perf_test/test_atomic.cpp
@@ -45,7 +45,7 @@ void textcolor(int attr, int fg, int bg) {
   char command[40];
 
   /* Command is the control command to the terminal */
-  sprintf(command, "%c[%d;%d;%dm", 0x1B, attr, fg + 30, bg + 40);
+  snprintf(command, 40, "%c[%d;%d;%dm", 0x1B, attr, fg + 30, bg + 40);
   printf("%s", command);
 }
 void textcolor_standard() { textcolor(RESET, BLACK, WHITE); }

--- a/core/unit_test/TestDefaultDeviceTypeInit.hpp
+++ b/core/unit_test/TestDefaultDeviceTypeInit.hpp
@@ -41,9 +41,10 @@ char** init_kokkos_args(bool do_threads, bool do_numa, bool do_device,
   nargs = (do_threads ? 1 : 0) + (do_numa ? 1 : 0) + (do_device ? 1 : 0) +
           (do_other ? 4 : 0) + (do_tune ? 1 : 0);
 
-  char** args_kokkos = new char*[nargs];
+  char** args_kokkos      = new char*[nargs];
+  const int max_args_size = 45;
   for (int i = 0; i < nargs; i++) {
-    args_kokkos[i] = new char[45];
+    args_kokkos[i] = new char[max_args_size];
     delete_these.insert(args_kokkos[i]);
   }
 
@@ -84,7 +85,7 @@ char** init_kokkos_args(bool do_threads, bool do_numa, bool do_device,
 #endif
 
     init_args.num_threads = nthreads;
-    sprintf(args_kokkos[threads_idx], "--threads=%i", nthreads);
+    snprintf(args_kokkos[threads_idx], max_args_size, "--threads=%i", nthreads);
   }
 
   if (do_numa) {
@@ -102,24 +103,27 @@ char** init_kokkos_args(bool do_threads, bool do_numa, bool do_device,
 #endif
 
     init_args.num_numa = numa;
-    sprintf(args_kokkos[numa_idx], "--numa=%i", numa);
+    snprintf(args_kokkos[numa_idx], max_args_size, "--numa=%i", numa);
   }
 
   if (do_device) {
     init_args.device_id = 0;
-    sprintf(args_kokkos[device_idx], "--device-id=%i", 0);
+    snprintf(args_kokkos[device_idx], max_args_size, "--device-id=%i", 0);
   }
 
   if (do_other) {
-    sprintf(args_kokkos[0], "--dummyarg=1");
-    sprintf(args_kokkos[threads_idx + (do_threads ? 1 : 0)], "--dummy2arg");
-    sprintf(args_kokkos[threads_idx + (do_threads ? 1 : 0) + 1], "dummy3arg");
-    sprintf(args_kokkos[device_idx + (do_device ? 1 : 0)], "dummy4arg=1");
+    snprintf(args_kokkos[0], max_args_size, "--dummyarg=1");
+    snprintf(args_kokkos[threads_idx + (do_threads ? 1 : 0)], max_args_size,
+             "--dummy2arg");
+    snprintf(args_kokkos[threads_idx + (do_threads ? 1 : 0) + 1], max_args_size,
+             "dummy3arg");
+    snprintf(args_kokkos[device_idx + (do_device ? 1 : 0)], max_args_size,
+             "dummy4arg=1");
   }
 
   if (do_tune) {
     init_args.tune_internals = true;
-    sprintf(args_kokkos[tune_idx], "--kokkos-tune-internals");
+    snprintf(args_kokkos[tune_idx], max_args_size, "--kokkos-tune-internals");
   }
 
   return args_kokkos;

--- a/core/unit_test/TestSharedAlloc.hpp
+++ b/core/unit_test/TestSharedAlloc.hpp
@@ -63,7 +63,7 @@ void test_shared_alloc() {
     // Since always executed on host space, leave [=]
     Kokkos::parallel_for(range, [=](int i) {
       char name[64];
-      sprintf(name, "test_%.2d", i);
+      snprintf(name, 64, "test_%.2d", i);
 
       r[i] = RecordMemS::allocate(s, name, size * (i + 1));
       h[i] = Header::get_header(r[i]->data());
@@ -107,7 +107,7 @@ void test_shared_alloc() {
 
     Kokkos::parallel_for(range, [=](size_t i) {
       char name[64];
-      sprintf(name, "test_%.2d", int(i));
+      snprintf(name, 64, "test_%.2d", int(i));
 
       RecordFull* rec = RecordFull::allocate(s, name, size * (i + 1));
 


### PR DESCRIPTION
Part of #5780. A lot of compilers about any usage of `sprintf` and recommend replacing it with `snprintf`. That is what this pull request does. 