### PR TITLE
Prefer ASSERT_EQ over ASSERT_TRUE with ==

### DIFF
--- a/core/unit_test/TestStackTrace.hpp
+++ b/core/unit_test/TestStackTrace.hpp
@@ -60,8 +60,7 @@ void test_stacktrace(bool bTerminate, bool bCustom = true) {
     if (bDynamic) {
       std::string foutput = sstream.str();
       printf("demangled test_f1: %s \n", foutput.c_str());
-      ASSERT_TRUE(std::string::npos !=
-                  foutput.find("Test::stacktrace_test_f1"));
+      ASSERT_NE(std::string::npos, foutput.find("Test::stacktrace_test_f1"));
       for (auto x : {"stacktrace_test_f0", "stacktrace_test_f2",
                      "stacktrace_test_f3", "stacktrace_test_f4"}) {
         ASSERT_EQ(std::string::npos, foutput.find(x));

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -1582,7 +1582,7 @@ struct TestScratchAlignment {
     Kokkos::fence();
     int minimal_scratch_allocation_failed = 0;
     Kokkos::deep_copy(minimal_scratch_allocation_failed, flag);
-    ASSERT_TRUE(minimal_scratch_allocation_failed == 0);
+    ASSERT_EQ(minimal_scratch_allocation_failed, 0);
   }
 
   // test alignment of successive allocations
@@ -1650,7 +1650,7 @@ struct TestScratchAlignment {
     Kokkos::fence();
     int raw_get_shmem_alignment_failed = 0;
     Kokkos::deep_copy(raw_get_shmem_alignment_failed, flag);
-    ASSERT_TRUE(raw_get_shmem_alignment_failed == 0);
+    ASSERT_EQ(raw_get_shmem_alignment_failed, 0);
   }
 };
 

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -474,8 +474,8 @@ void test_left_1(bool use_constr) {
       for (int i1 = 0; i1 < (int)sx4.extent(1); ++i1)
         for (int i2 = 0; i2 < (int)sx4.extent(2); ++i2)
           for (int i3 = 0; i3 < (int)sx4.extent(3); ++i3) {
-            ASSERT_TRUE(&sx4(i0, i1, i2, i3) ==
-                        &x8(0, 0 + i0, 1, 1 + i1, 1, 0 + i2, 2, 2 + i3));
+            ASSERT_EQ(&sx4(i0, i1, i2, i3),
+                      &x8(0, 0 + i0, 1, 1 + i1, 1, 0 + i2, 2, 2 + i3));
           }
   }
 }
@@ -546,8 +546,8 @@ void test_left_2() {
       for (int i1 = 0; i1 < (int)sx4.extent(1); ++i1)
         for (int i2 = 0; i2 < (int)sx4.extent(2); ++i2)
           for (int i3 = 0; i3 < (int)sx4.extent(3); ++i3) {
-            ASSERT_TRUE(&sx4(i0, i1, i2, i3) ==
-                        &x4(1 + i0, 1 + i1, 0 + i2, 2 + i3));
+            ASSERT_EQ(&sx4(i0, i1, i2, i3),
+                      &x4(1 + i0, 1 + i1, 0 + i2, 2 + i3));
           }
   }
 }
@@ -756,8 +756,8 @@ void test_right_1(bool use_constr) {
       for (int i1 = 0; i1 < (int)sx4.extent(1); ++i1)
         for (int i2 = 0; i2 < (int)sx4.extent(2); ++i2)
           for (int i3 = 0; i3 < (int)sx4.extent(3); ++i3) {
-            ASSERT_TRUE(&sx4(i0, i1, i2, i3) ==
-                        &x8(0, 0 + i0, 1, 1 + i1, 1, 0 + i2, 2, 2 + i3));
+            ASSERT_EQ(&sx4(i0, i1, i2, i3),
+                      &x8(0, 0 + i0, 1, 1 + i1, 1, 0 + i2, 2, 2 + i3));
           }
   }
 }

--- a/core/unit_test/tools/TestEventCorrectness.hpp
+++ b/core/unit_test/tools/TestEventCorrectness.hpp
@@ -197,7 +197,7 @@ TEST(kokkosp, test_multiple_default_instances) {
       ex1.fence("named_instance_fence_one");
       ex2.fence("named_instance_fence_two");
     });
-    ASSERT_TRUE(found_payloads[0].dev_id == found_payloads[1].dev_id);
+    ASSERT_EQ(found_payloads[0].dev_id, found_payloads[1].dev_id);
   });
 }
 
@@ -716,7 +716,7 @@ TEST(kokkosp, get_events) {
   });
   for (const auto& ptr : event_vector) {
     auto ptr_as_begin = std::dynamic_pointer_cast<BeginParallelForEvent>(ptr);
-    ASSERT_TRUE(ptr_as_begin == nullptr);
+    ASSERT_EQ(ptr_as_begin, nullptr);
   }
 }
 }  // namespace Test


### PR DESCRIPTION
We get better error messages when we replace `ASSERT_TRUE`.