### PR TITLE
Fixup warning in Jenkins CI build with GNU generated makefile

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -343,7 +343,7 @@ pipeline {
                                 --with-cuda \
                                 --with-cuda-options=enable_lambda \
                                 --arch=Volta70 \
-                              .. && \
+                              && \
                               make test -j8'''
                     }
                     post {


### PR DESCRIPTION
Noticed 
```
warning: ignoring unknown option ..
```
in the build logs