### PR TITLE
Add parameter to force using GlobalMemory launch mechanism using HIP

### DIFF
--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -127,8 +127,9 @@ struct DeduceHIPLaunchMechanism {
       light_weight = Kokkos::Experimental::WorkItemProperty::HintLightWeight;
   static constexpr Kokkos::Experimental::WorkItemProperty::HintHeavyWeight_t
       heavy_weight = Kokkos::Experimental::WorkItemProperty::HintHeavyWeight;
-  static constexpr Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t
-      force_global = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal;
+  static constexpr Kokkos::Experimental::WorkItemProperty::
+      ImplForceGlobalLaunch_t force_global_launch =
+          Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunch;
   static constexpr typename DriverType::Policy::work_item_property property =
       typename DriverType::Policy::work_item_property();
 
@@ -162,7 +163,7 @@ struct DeduceHIPLaunchMechanism {
   // Kal<F<CMU     CG  LCG C  C        CG  LG C  G    CG  CG C  C
   // CMU<F          G  LCG G  G         G  LG G  G     G  CG G  G
   static constexpr HIPLaunchMechanism launch_mechanism =
-      ((property & force_global) == force_global)
+      ((property & force_global_launch) == force_global_launch)
           ? HIPLaunchMechanism::GlobalMemory
           : ((property & light_weight) == light_weight)
                 ? (sizeof(DriverType) < HIPTraits::KernelArgumentLimit

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -74,14 +74,14 @@ struct WorkItemProperty {
       ImplWorkItemProperty<4>();
   constexpr static const ImplWorkItemProperty<8> HintIrregular =
       ImplWorkItemProperty<8>();
-  constexpr static const ImplWorkItemProperty<16> ImplForceGlobal =
+  constexpr static const ImplWorkItemProperty<16> ImplForceGlobalLaunch =
       ImplWorkItemProperty<16>();
-  using None_t            = ImplWorkItemProperty<0>;
-  using HintLightWeight_t = ImplWorkItemProperty<1>;
-  using HintHeavyWeight_t = ImplWorkItemProperty<2>;
-  using HintRegular_t     = ImplWorkItemProperty<4>;
-  using HintIrregular_t   = ImplWorkItemProperty<8>;
-  using ImplForceGlobal_t = ImplWorkItemProperty<16>;
+  using None_t                  = ImplWorkItemProperty<0>;
+  using HintLightWeight_t       = ImplWorkItemProperty<1>;
+  using HintHeavyWeight_t       = ImplWorkItemProperty<2>;
+  using HintRegular_t           = ImplWorkItemProperty<4>;
+  using HintIrregular_t         = ImplWorkItemProperty<8>;
+  using ImplForceGlobalLaunch_t = ImplWorkItemProperty<16>;
 };
 
 template <unsigned long pv1, unsigned long pv2>

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -74,11 +74,14 @@ struct WorkItemProperty {
       ImplWorkItemProperty<4>();
   constexpr static const ImplWorkItemProperty<8> HintIrregular =
       ImplWorkItemProperty<8>();
+  constexpr static const ImplWorkItemProperty<16> ImplForceGlobal =
+      ImplWorkItemProperty<16>();
   using None_t            = ImplWorkItemProperty<0>;
   using HintLightWeight_t = ImplWorkItemProperty<1>;
   using HintHeavyWeight_t = ImplWorkItemProperty<2>;
   using HintRegular_t     = ImplWorkItemProperty<4>;
   using HintIrregular_t   = ImplWorkItemProperty<8>;
+  using ImplForceGlobal_t = ImplWorkItemProperty<16>;
 };
 
 template <unsigned long pv1, unsigned long pv2>

--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -505,7 +505,12 @@ struct TestComplexBesselJ0Y0Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Bessel functions
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, N), *this);
+#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
+    using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+#else
+    using Property = Kokkos::Experimental::WorkItemProperty::None_t;
+#endif
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
     Kokkos::fence();
 
     Kokkos::deep_copy(h_cbj0, d_cbj0);
@@ -634,8 +639,8 @@ struct TestComplexBesselJ0Y0Function {
 
     Kokkos::deep_copy(d_z_large, h_z_large);
 
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, TestLargeArgTag>(0, 1),
-                         *this);
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<ExecSpace, Property, TestLargeArgTag>(0, 1), *this);
     Kokkos::fence();
 
     Kokkos::deep_copy(h_cbj0_large, d_cbj0_large);
@@ -795,7 +800,12 @@ struct TestComplexBesselJ1Y1Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Bessel functions
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, N), *this);
+#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
+    using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+#else
+    using Property = Kokkos::Experimental::WorkItemProperty::None_t;
+#endif
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
     Kokkos::fence();
 
     Kokkos::deep_copy(h_cbj1, d_cbj1);
@@ -924,8 +934,8 @@ struct TestComplexBesselJ1Y1Function {
 
     Kokkos::deep_copy(d_z_large, h_z_large);
 
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, TestLargeArgTag>(0, 1),
-                         *this);
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<ExecSpace, Property, TestLargeArgTag>(0, 1), *this);
     Kokkos::fence();
 
     Kokkos::deep_copy(h_cbj1_large, d_cbj1_large);
@@ -1083,7 +1093,12 @@ struct TestComplexBesselI0K0Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Bessel functions
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, N), *this);
+#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
+    using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+#else
+    using Property = Kokkos::Experimental::WorkItemProperty::None_t;
+#endif
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
     Kokkos::fence();
 
     Kokkos::deep_copy(h_cbi0, d_cbi0);
@@ -1205,8 +1220,8 @@ struct TestComplexBesselI0K0Function {
 
     Kokkos::deep_copy(d_z_large, h_z_large);
 
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, TestLargeArgTag>(0, 1),
-                         *this);
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<ExecSpace, Property, TestLargeArgTag>(0, 1), *this);
     Kokkos::fence();
 
     Kokkos::deep_copy(h_cbi0_large, d_cbi0_large);
@@ -1318,7 +1333,12 @@ struct TestComplexBesselI1K1Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Bessel functions
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, N), *this);
+#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
+    using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+#else
+    using Property = Kokkos::Experimental::WorkItemProperty::None_t;
+#endif
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
     Kokkos::fence();
 
     Kokkos::deep_copy(h_cbi1, d_cbi1);
@@ -1440,8 +1460,8 @@ struct TestComplexBesselI1K1Function {
 
     Kokkos::deep_copy(d_z_large, h_z_large);
 
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, TestLargeArgTag>(0, 1),
-                         *this);
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<ExecSpace, Property, TestLargeArgTag>(0, 1), *this);
     Kokkos::fence();
 
     Kokkos::deep_copy(h_cbi1_large, d_cbi1_large);
@@ -1549,7 +1569,12 @@ struct TestComplexBesselH1Function {
     Kokkos::deep_copy(d_z, h_z);
 
     // Call Hankel functions
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, N), *this);
+#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
+    using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+#else
+    using Property = Kokkos::Experimental::WorkItemProperty::None_t;
+#endif
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace, Property>(0, N), *this);
     Kokkos::fence();
 
     Kokkos::deep_copy(h_ch10, d_ch10);

--- a/core/unit_test/TestMathematicalSpecialFunctions.hpp
+++ b/core/unit_test/TestMathematicalSpecialFunctions.hpp
@@ -506,7 +506,8 @@ struct TestComplexBesselJ0Y0Function {
 
     // Call Bessel functions
 #if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
-    using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+    using Property =
+        Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunchLaunch_t;
 #else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
 #endif
@@ -801,7 +802,8 @@ struct TestComplexBesselJ1Y1Function {
 
     // Call Bessel functions
 #if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
-    using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+    using Property =
+        Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunch_t;
 #else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
 #endif
@@ -1094,7 +1096,8 @@ struct TestComplexBesselI0K0Function {
 
     // Call Bessel functions
 #if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
-    using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+    using Property =
+        Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunch_t;
 #else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
 #endif
@@ -1334,7 +1337,8 @@ struct TestComplexBesselI1K1Function {
 
     // Call Bessel functions
 #if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
-    using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+    using Property =
+        Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunch_t;
 #else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
 #endif
@@ -1570,7 +1574,8 @@ struct TestComplexBesselH1Function {
 
     // Call Hankel functions
 #if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 4)
-    using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+    using Property =
+        Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunch_t;
 #else
     using Property = Kokkos::Experimental::WorkItemProperty::None_t;
 #endif

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1542,6 +1542,7 @@ class TestViewAPI {
   }
 
   static void run_test_error() {
+#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
     if (std::is_same<typename dView1::memory_space,
                      Kokkos::Experimental::OpenMPTargetSpace>::value)
@@ -1586,6 +1587,7 @@ class TestViewAPI {
       }
 #endif
     }
+#endif
   }
 };
 

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1542,7 +1542,6 @@ class TestViewAPI {
   }
 
   static void run_test_error() {
-#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
     if (std::is_same<typename dView1::memory_space,
                      Kokkos::Experimental::OpenMPTargetSpace>::value)
@@ -1587,7 +1586,6 @@ class TestViewAPI {
       }
 #endif
     }
-#endif
   }
 };
 

--- a/core/unit_test/TestViewAPI_d.hpp
+++ b/core/unit_test/TestViewAPI_d.hpp
@@ -28,7 +28,7 @@ TEST(TEST_CATEGORY, view_api_d) {
 
 TEST(TEST_CATEGORY, view_allocation_error) {
 #if ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
-  GTEST_SKIP() << "ROCm 5.3 segfaults when trying to allocate too much memor";
+  GTEST_SKIP() << "ROCm 5.3 segfaults when trying to allocate too much memory";
 #endif
   TestViewAPI<double, TEST_EXECSPACE>::run_test_error();
 }

--- a/core/unit_test/TestViewAPI_d.hpp
+++ b/core/unit_test/TestViewAPI_d.hpp
@@ -26,8 +26,11 @@ TEST(TEST_CATEGORY, view_api_d) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_view_operator_c();
 }
 
+// ROCm 5.3 segfaults when trying to allocate too much memory
+#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
 TEST(TEST_CATEGORY, view_allocation_error) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_error();
 }
+#endif
 
 }  // namespace Test

--- a/core/unit_test/TestViewAPI_d.hpp
+++ b/core/unit_test/TestViewAPI_d.hpp
@@ -26,11 +26,11 @@ TEST(TEST_CATEGORY, view_api_d) {
   TestViewAPI<double, TEST_EXECSPACE>::run_test_view_operator_c();
 }
 
-// ROCm 5.3 segfaults when trying to allocate too much memory
-#if !((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
 TEST(TEST_CATEGORY, view_allocation_error) {
+#if ((HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3))
+  GTEST_SKIP() << "ROCm 5.3 segfaults when trying to allocate too much memor";
+#endif
   TestViewAPI<double, TEST_EXECSPACE>::run_test_error();
 }
-#endif
 
 }  // namespace Test

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -136,8 +136,9 @@ struct fill_2D {
 
 template <class Layout, class Space>
 void test_auto_1d() {
-  using mv_type   = Kokkos::View<double**, Layout, Space>;
-  using size_type = typename mv_type::size_type;
+  using mv_type         = Kokkos::View<double**, Layout, Space>;
+  using execution_space = typename Space::execution_space;
+  using size_type       = typename mv_type::size_type;
 
   const double ZERO = 0.0;
   const double ONE  = 1.0;
@@ -150,7 +151,13 @@ void test_auto_1d() {
   typename mv_type::HostMirror X_h = Kokkos::create_mirror_view(X);
 
   fill_2D<mv_type, Space> f1(X, ONE);
-  Kokkos::parallel_for(X.extent(0), f1);
+#if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3)
+  using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+#else
+  using Property = Kokkos::Experimental::WorkItemProperty::None_t;
+#endif
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<execution_space, Property>(0, X.extent(0)), f1);
   Kokkos::fence();
   Kokkos::deep_copy(X_h, X);
   for (size_type j = 0; j < numCols; ++j) {
@@ -160,7 +167,8 @@ void test_auto_1d() {
   }
 
   fill_2D<mv_type, Space> f2(X, 0.0);
-  Kokkos::parallel_for(X.extent(0), f2);
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<execution_space, Property>(0, X.extent(0)), f2);
   Kokkos::fence();
   Kokkos::deep_copy(X_h, X);
   for (size_type j = 0; j < numCols; ++j) {
@@ -170,7 +178,8 @@ void test_auto_1d() {
   }
 
   fill_2D<mv_type, Space> f3(X, TWO);
-  Kokkos::parallel_for(X.extent(0), f3);
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<execution_space, Property>(0, X.extent(0)), f3);
   Kokkos::fence();
   Kokkos::deep_copy(X_h, X);
   for (size_type j = 0; j < numCols; ++j) {
@@ -183,7 +192,8 @@ void test_auto_1d() {
     auto X_j = Kokkos::subview(X, Kokkos::ALL, j);
 
     fill_1D<decltype(X_j), Space> f4(X_j, ZERO);
-    Kokkos::parallel_for(X_j.extent(0), f4);
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<execution_space, Property>(0, X_j.extent(0)), f4);
     Kokkos::fence();
     Kokkos::deep_copy(X_h, X);
     for (size_type i = 0; i < numRows; ++i) {
@@ -193,7 +203,9 @@ void test_auto_1d() {
     for (size_type jj = 0; jj < numCols; ++jj) {
       auto X_jj = Kokkos::subview(X, Kokkos::ALL, jj);
       fill_1D<decltype(X_jj), Space> f5(X_jj, ONE);
-      Kokkos::parallel_for(X_jj.extent(0), f5);
+      Kokkos::parallel_for(
+          Kokkos::RangePolicy<execution_space, Property>(0, X_jj.extent(0)),
+          f5);
       Kokkos::fence();
       Kokkos::deep_copy(X_h, X);
       for (size_type i = 0; i < numRows; ++i) {

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -152,7 +152,8 @@ void test_auto_1d() {
 
   fill_2D<mv_type, Space> f1(X, ONE);
 #if (HIP_VERSION_MAJOR == 5) && (HIP_VERSION_MINOR == 3)
-  using Property = Kokkos::Experimental::WorkItemProperty::ImplForceGlobal_t;
+  using Property =
+      Kokkos::Experimental::WorkItemProperty::ImplForceGlobalLaunch_t;
 #else
   using Property = Kokkos::Experimental::WorkItemProperty::None_t;
 #endif


### PR DESCRIPTION
Add a parameter that users can use to force a kernel to be launched using `GlobalMemory`. This is sometimes necessary due to compiler bugs in ROCm 5.3 and ROCm 5.4 see https://github.com/kokkos/kokkos/issues/5606 and https://github.com/kokkos/kokkos/issues/5690

cc: @arghdos 