### PR TITLE
Remove obsolete container configuration

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -48,8 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/kokkos/ci-containers/${{ matrix.distro }}
-      # see https://github.com/actions/virtual-environments/issues/3812
-      options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout desul
         uses: actions/checkout@v3


### PR DESCRIPTION
Remove obsolete container options in CI (as https://github.com/actions/virtual-environments/issues/3812 is fixed).