### PR TITLE
Fix a bug in AVX512 simd_mask::operator[]

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -114,7 +114,7 @@ class simd_mask<T, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return static_cast<value_type>(reference(m_value, int(i)));
+    return reference(const_cast<simd_mask*>(this)->m_value, int(i));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
   operator||(simd_mask const& other) const {

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -114,7 +114,8 @@ class simd_mask<T, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
-    return reference(const_cast<simd_mask*>(this)->m_value, int(i));
+    auto const bit_mask = __mmask8(std::int16_t(1 << i));
+    return (m_value & bit_mask) != 0;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask
   operator||(simd_mask const& other) const {


### PR DESCRIPTION
this would cause a compiler error when
instantiated because of const-correctness