### PR TITLE
Cleanup: drop `desul_*` helper functions in tasking

### DIFF
--- a/core/src/Kokkos_Atomic.hpp
+++ b/core/src/Kokkos_Atomic.hpp
@@ -48,51 +48,6 @@
 
 #include <Kokkos_Atomics_Desul_Wrapper.hpp>
 #include <Kokkos_Atomics_Desul_Volatile_Wrapper.hpp>
-#include <impl/Kokkos_Utilities.hpp>
-
-// Helper functions for places where we really should have called SeqCst atomics
-// anyway These can go away when we call desul unconditionally Non-Desul
-// versions are below
-namespace Kokkos {
-namespace Impl {
-using desul::MemoryOrderSeqCst;
-using desul::MemoryScopeDevice;
-
-template <class T>
-KOKKOS_INLINE_FUNCTION void desul_atomic_dec(T* dest, MemoryOrderSeqCst,
-                                             MemoryScopeDevice) {
-  return desul::atomic_dec(const_cast<T*>(dest), desul::MemoryOrderSeqCst(),
-                           desul::MemoryScopeDevice());
-}
-
-template <class T>
-KOKKOS_INLINE_FUNCTION void desul_atomic_inc(T* dest, MemoryOrderSeqCst,
-                                             MemoryScopeDevice) {
-  return desul::atomic_inc(const_cast<T*>(dest), desul::MemoryOrderSeqCst(),
-                           desul::MemoryScopeDevice());
-}
-
-template <class T>
-KOKKOS_INLINE_FUNCTION T
-desul_atomic_exchange(T* dest, const Kokkos::Impl::type_identity_t<T> val,
-                      MemoryOrderSeqCst, MemoryScopeDevice) {
-  return desul::atomic_exchange(const_cast<T*>(dest), val,
-                                desul::MemoryOrderSeqCst(),
-                                desul::MemoryScopeDevice());
-}
-
-template <class T>
-KOKKOS_INLINE_FUNCTION T desul_atomic_compare_exchange(
-    T* dest, Kokkos::Impl::type_identity_t<const T> compare,
-    Kokkos::Impl::type_identity_t<const T> val, MemoryOrderSeqCst,
-    MemoryScopeDevice) {
-  return desul::atomic_compare_exchange(dest, compare, val,
-                                        desul::MemoryOrderSeqCst(),
-                                        desul::MemoryScopeDevice());
-}
-
-}  // namespace Impl
-}  // namespace Kokkos
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_ATOMIC
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE

--- a/core/src/Kokkos_TaskScheduler.hpp
+++ b/core/src/Kokkos_TaskScheduler.hpp
@@ -347,9 +347,8 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
         if (nullptr != t) {
           // Increment reference count to track subsequent assignment.
           // This likely has to be SeqCst
-          Kokkos::Impl::desul_atomic_inc(&(t->m_ref_count),
-                                         Kokkos::Impl::MemoryOrderSeqCst(),
-                                         Kokkos::Impl::MemoryScopeDevice());
+          desul::atomic_inc(&(t->m_ref_count), desul::MemoryOrderSeqCst(),
+                            desul::MemoryScopeDevice());
           if (q != static_cast<queue_type const*>(t->m_queue)) {
             Kokkos::abort(
                 "Kokkos when_all Futures must be in the same scheduler");
@@ -445,9 +444,9 @@ class BasicTaskScheduler : public Impl::TaskSchedulerBase {
           //}
           // Increment reference count to track subsequent assignment.
           // This increment likely has to be SeqCst
-          Kokkos::Impl::desul_atomic_inc(&(arg_f.m_task->m_ref_count),
-                                         Kokkos::Impl::MemoryOrderSeqCst(),
-                                         Kokkos::Impl::MemoryScopeDevice());
+          desul::atomic_inc(&(arg_f.m_task->m_ref_count),
+                            desul::MemoryOrderSeqCst(),
+                            desul::MemoryScopeDevice());
           dep[i] = arg_f.m_task;
         }
       }

--- a/core/src/impl/Kokkos_TaskBase.hpp
+++ b/core/src/impl/Kokkos_TaskBase.hpp
@@ -174,17 +174,15 @@ class TaskBase {
 
     // Assign dependence to m_next.  It will be processed in the subsequent
     // call to schedule.  Error if the dependence is reset.
-    if (lock != Kokkos::Impl::desul_atomic_exchange(
-                    &m_next, dep, Kokkos::Impl::MemoryOrderSeqCst(),
-                    Kokkos::Impl::MemoryScopeDevice())) {
+    if (lock != desul::atomic_exchange(&m_next, dep, desul::MemoryOrderSeqCst(),
+                                       desul::MemoryScopeDevice())) {
       Kokkos::abort("TaskScheduler ERROR: resetting task dependence");
     }
     if (nullptr != dep) {
       // The future may be destroyed upon returning from this call
       // so increment reference count to track this assignment.
-      Kokkos::Impl::desul_atomic_inc(&(dep->m_ref_count),
-                                     Kokkos::Impl::MemoryOrderSeqCst(),
-                                     Kokkos::Impl::MemoryScopeDevice());
+      desul::atomic_inc(&(dep->m_ref_count), desul::MemoryOrderSeqCst(),
+                        desul::MemoryScopeDevice());
     }
   }
 

--- a/core/src/impl/Kokkos_TaskNode.hpp
+++ b/core/src/impl/Kokkos_TaskNode.hpp
@@ -131,9 +131,8 @@ class ReferenceCountedBase {
 
   KOKKOS_INLINE_FUNCTION
   void increment_reference_count() {
-    Kokkos::Impl::desul_atomic_inc(&m_ref_count,
-                                   Kokkos::Impl::MemoryOrderSeqCst(),
-                                   Kokkos::Impl::MemoryScopeDevice());
+    desul::atomic_inc(&m_ref_count, desul::MemoryOrderSeqCst(),
+                      desul::MemoryScopeDevice());
   }
 };
 

--- a/core/src/impl/Kokkos_TaskQueue.hpp
+++ b/core/src/impl/Kokkos_TaskQueue.hpp
@@ -160,9 +160,8 @@ class TaskQueue : public TaskQueueBase {
                                      task_root_type* const rhs) {
     if (*lhs) decrement(*lhs);
     if (rhs) {
-      Kokkos::Impl::desul_atomic_inc(&rhs->m_ref_count,
-                                     Kokkos::Impl::MemoryOrderSeqCst(),
-                                     Kokkos::Impl::MemoryScopeDevice());
+      desul::atomic_inc(&rhs->m_ref_count, desul::MemoryOrderSeqCst(),
+                        desul::MemoryScopeDevice());
     }
 
     // Force write of *lhs

--- a/core/src/impl/Kokkos_TaskQueueCommon.hpp
+++ b/core/src/impl/Kokkos_TaskQueueCommon.hpp
@@ -129,17 +129,15 @@ class TaskQueueCommonMixin {
   KOKKOS_INLINE_FUNCTION
   void _increment_ready_count() {
     // TODO @tasking @memory_order DSH memory order
-    Kokkos::Impl::desul_atomic_inc(&this->m_ready_count,
-                                   Kokkos::Impl::MemoryOrderSeqCst(),
-                                   Kokkos::Impl::MemoryScopeDevice());
+    desul::atomic_inc(&this->m_ready_count, desul::MemoryOrderSeqCst(),
+                      desul::MemoryScopeDevice());
   }
 
   KOKKOS_INLINE_FUNCTION
   void _decrement_ready_count() {
     // TODO @tasking @memory_order DSH memory order
-    Kokkos::Impl::desul_atomic_dec(&this->m_ready_count,
-                                   Kokkos::Impl::MemoryOrderSeqCst(),
-                                   Kokkos::Impl::MemoryScopeDevice());
+    desul::atomic_dec(&this->m_ready_count, desul::MemoryOrderSeqCst(),
+                      desul::MemoryScopeDevice());
   }
 
  public:

--- a/core/src/impl/Kokkos_TaskQueueMemoryManager.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMemoryManager.hpp
@@ -73,9 +73,9 @@ class TaskQueueMemoryManager : public TaskQueueBase {
     } else {
       void* data = m_pool.allocate(static_cast<size_t>(requested_size));
 
-      Kokkos::Impl::desul_atomic_inc(
-          &m_count_alloc, Kokkos::Impl::MemoryOrderSeqCst(),
-          Kokkos::Impl::MemoryScopeDevice());  // TODO? memory_order_relaxed
+      desul::atomic_inc(
+          &m_count_alloc, desul::MemoryOrderSeqCst(),
+          desul::MemoryScopeDevice());  // TODO? memory_order_relaxed
       // TODO @tasking @minor DSH make this thread safe? (otherwise, it's just
       // an approximation, which is probably fine...)
       if (m_max_alloc < m_count_alloc) m_max_alloc = m_count_alloc;
@@ -171,9 +171,9 @@ class TaskQueueMemoryManager : public TaskQueueBase {
   KOKKOS_INLINE_FUNCTION void deallocate(
       PoolAllocatedObjectBase<CountType>&& obj) {
     m_pool.deallocate((void*)&obj, 1);
-    Kokkos::Impl::desul_atomic_dec(
-        &m_count_alloc, Kokkos::Impl::MemoryOrderSeqCst(),
-        Kokkos::Impl::MemoryScopeDevice());  // TODO? memory_order_relaxed
+    desul::atomic_dec(
+        &m_count_alloc, desul::MemoryOrderSeqCst(),
+        desul::MemoryScopeDevice());  // TODO? memory_order_relaxed
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/core/src/impl/Kokkos_TaskQueueMultiple.hpp
+++ b/core/src/impl/Kokkos_TaskQueueMultiple.hpp
@@ -128,14 +128,12 @@ class TaskQueueMultiple : public TaskQueue<ExecSpace, MemorySpace> {
               // task stolen.
               // first increment our ready count, then decrement the ready count
               // on the other queue:
-              Kokkos::Impl::desul_atomic_inc(
-                  &this->m_ready_count, Kokkos::Impl::MemoryOrderSeqCst(),
-                  Kokkos::Impl::MemoryScopeDevice());  // TODO?
-                                                       // memory_order_relaxed
-              Kokkos::Impl::desul_atomic_dec(
-                  &steal_from.m_ready_count, Kokkos::Impl::MemoryOrderSeqCst(),
-                  Kokkos::Impl::MemoryScopeDevice());  // TODO?
-                                                       // memory_order_relaxed
+              desul::atomic_inc(
+                  &this->m_ready_count, desul::MemoryOrderSeqCst(),
+                  desul::MemoryScopeDevice());  // TODO? memory_order_relaxed
+              desul::atomic_dec(
+                  &steal_from.m_ready_count, desul::MemoryOrderSeqCst(),
+                  desul::MemoryScopeDevice());  // TODO? memory_order_relaxed
               return rv;
             }
           }


### PR DESCRIPTION
Partial step 3 in #5789
Use desul atomics directly instead