### PR TITLE
Deprecate `KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_*` macros

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -451,7 +451,7 @@
 
 //----------------------------------------------------------------------------
 // Determine for what space the code is being compiled:
-#if defined(KOKKOS_ENABLE_DEPRECARED_CODE_4)
+#if defined(KOKKOS_ENABLE_DEPRECARED_CODE_3)
 
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__) && defined(KOKKOS_ENABLE_CUDA)
 #define KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -451,6 +451,7 @@
 
 //----------------------------------------------------------------------------
 // Determine for what space the code is being compiled:
+#if defined(KOKKOS_ENABLE_DEPRECARED_CODE_4)
 
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__) && defined(KOKKOS_ENABLE_CUDA)
 #define KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA
@@ -463,6 +464,7 @@
 #define KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
 #endif
 
+#endif
 //----------------------------------------------------------------------------
 
 // Remove surrounding parentheses if present


### PR DESCRIPTION
Oversight in release 3.6
We still define these macros and code downstream are still using them.
See trilinos/Trilinos#11511 trilinos/Trilinos#11508,
trilinos/Trilinos#11511 trilinos/Trilinos#11509,
trilinos/Trilinos#11511 trilinos/Trilinos#11510, and
trilinos/Trilinos#11511 trilinos/Trilinos#11511

Sacado is also using it.  Haven't reported it yet because I am trying to figure out how to get them out of using `Kokkos::Impl::lock_address_*_space` and the two issues are intertwined.

(**edit**: Forgot to mention KokkosKernels still somehow using it in the infamous `<Kokkos_ArithTraits.hpp>` header.)
(**edit2**: Adding reference to #4668 that clearly stated our intent to get rid of these macros)

Our CHANGELOG clearly list these `KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_*` macros in the list of deprecation for release 3.6.
I opted for the cautious approach and guarded with `#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4` but I am tempted to retro deprecate and use `KOKKOS_ENABLE_DEPRECATED_CODE_3`.  Any thought on this?