### PR TITLE
Disable global device variables in SYCL+Cuda CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -107,6 +107,7 @@ pipeline {
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=clang++ \
                                 -DCMAKE_CXX_FLAGS="-fsycl-device-code-split=per_kernel -Werror -Wno-gnu-zero-variadic-macro-arguments -Wno-linker-warnings" \
+                                -DKOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED=0 \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ARCH_VOLTA70=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \


### PR DESCRIPTION
Apparently, using `sycl::device_global` variables with the compiler versions in the `SYCL+Cuda` CI results in all kinds of problems (even though the feature detection compiles successfully). Let's just disable that feature for now in the CI manually.