### PR TITLE
Use raw literal string to avoid having to escape characters in git commit message

### DIFF
--- a/cmake/Kokkos_Version_Info.cpp.in
+++ b/cmake/Kokkos_Version_Info.cpp.in
@@ -19,11 +19,12 @@
 namespace Kokkos {
 namespace Impl {
 
-std::string GIT_BRANCH             = "@GIT_BRANCH@";
-std::string GIT_COMMIT_HASH        = "@GIT_COMMIT_HASH@";
-std::string GIT_CLEAN_STATUS       = "@GIT_CLEAN_STATUS@";
-std::string GIT_COMMIT_DESCRIPTION = "@GIT_COMMIT_DESCRIPTION@";
-std::string GIT_COMMIT_DATE        = "@GIT_COMMIT_DATE@";
+std::string GIT_BRANCH       = "@GIT_BRANCH@";
+std::string GIT_COMMIT_HASH  = "@GIT_COMMIT_HASH@";
+std::string GIT_CLEAN_STATUS = "@GIT_CLEAN_STATUS@";
+std::string GIT_COMMIT_DESCRIPTION =
+    R"message(@GIT_COMMIT_DESCRIPTION@)message";
+std::string GIT_COMMIT_DATE = "@GIT_COMMIT_DATE@";
 
 }  // namespace Impl
 

--- a/cmake/Kokkos_Version_Info.cpp.in
+++ b/cmake/Kokkos_Version_Info.cpp.in
@@ -19,7 +19,7 @@
 namespace Kokkos {
 namespace Impl {
 
-std::string GIT_BRANCH       = "@GIT_BRANCH@";
+std::string GIT_BRANCH       = R"branch(@GIT_BRANCH@)branch";
 std::string GIT_COMMIT_HASH  = "@GIT_COMMIT_HASH@";
 std::string GIT_CLEAN_STATUS = "@GIT_CLEAN_STATUS@";
 std::string GIT_COMMIT_DESCRIPTION =

--- a/cmake/build_env_info.cmake
+++ b/cmake/build_env_info.cmake
@@ -108,12 +108,9 @@ FUNCTION(check_git_setup)
     -P ${CURRENT_LIST_DIR}/build_env_info.cmake
     BYPRODUCTS ${post_configure_file})
 
-  if(NOT DEFINED CMAKE_CXX_STANDARD)
-    # FIXME Kokkos CXX version somehow being set later and C++11 is the minimum required for raw literal strings
-    set(CMAKE_CXX_STANDARD 17)
-  endif()
   add_library(impl_git_version ${CMAKE_BINARY_DIR}/generated/Kokkos_Version_Info.cpp)
   target_include_directories(impl_git_version PUBLIC ${CMAKE_BINARY_DIR}/generated)
+  target_compile_features(impl_git_version PRIVATE cxx_raw_string_literals)
   add_dependencies(impl_git_version AlwaysCheckGit)
 
   check_git_version()

--- a/cmake/build_env_info.cmake
+++ b/cmake/build_env_info.cmake
@@ -108,6 +108,10 @@ FUNCTION(check_git_setup)
     -P ${CURRENT_LIST_DIR}/build_env_info.cmake
     BYPRODUCTS ${post_configure_file})
 
+  if(NOT DEFINED CMAKE_CXX_STANDARD)
+    # FIXME Kokkos CXX version somehow being set later and C++11 is the minimum required for raw literal strings
+    set(CMAKE_CXX_STANDARD 17)
+  endif()
   add_library(impl_git_version ${CMAKE_BINARY_DIR}/generated/Kokkos_Version_Info.cpp)
   target_include_directories(impl_git_version PUBLIC ${CMAKE_BINARY_DIR}/generated)
   add_dependencies(impl_git_version AlwaysCheckGit)


### PR DESCRIPTION
See https://github.com/kokkos/kokkos/pull/5822#pullrequestreview-1275296494

Currently, a double quote character in the latest git commit message will yield an error at compile-time.
In contrast to #5822 that attempts to handle the issue on the CMake side by escaping double quote characters, here proposing to support it on the C++ side by using a raw literal string.
Note that initially I had not used the `message` char sequence and I realize that would fall apart if `")` is in the commit message...

Also discovered that somehow the `check_git_setup` thing happens before we setup the CXX standard for the project.  I suggest we just fallback to C++17 if CMAKE_CXX_STANDARD is not set.