### PR TITLE
[4.0.0] Deprecate `KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_*` macros

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -451,7 +451,7 @@
 
 //----------------------------------------------------------------------------
 // Determine for what space the code is being compiled:
-#if defined(KOKKOS_ENABLE_DEPRECARED_CODE_4)
+#if defined(KOKKOS_ENABLE_DEPRECARED_CODE_3)
 
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__) && defined(KOKKOS_ENABLE_CUDA)
 #define KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -451,6 +451,7 @@
 
 //----------------------------------------------------------------------------
 // Determine for what space the code is being compiled:
+#if defined(KOKKOS_ENABLE_DEPRECARED_CODE_4)
 
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__) && defined(KOKKOS_ENABLE_CUDA)
 #define KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA
@@ -463,6 +464,7 @@
 #define KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
 #endif
 
+#endif
 //----------------------------------------------------------------------------
 
 // Remove surrounding parentheses if present


### PR DESCRIPTION
Cherry-pick of #5819 into RC 4.0 branch