### PR TITLE
Desul atomics: let pointer to the device lock arrays always be in constant memory

### DIFF
--- a/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -69,17 +69,15 @@ namespace Impl {
 /// variable based on the Host global variable prior to running any kernels
 /// that will use it.
 /// That is the purpose of the ensure_cuda_lock_arrays_on_device function.
-__device__
 #ifdef __CUDACC_RDC__
-    __constant__ extern
+extern
 #endif
-    int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE;
+    __device__ __constant__ int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE;
 
-__device__
 #ifdef __CUDACC_RDC__
-    __constant__ extern
+extern
 #endif
-    int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE;
+    __device__ __constant__ int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE;
 
 #define CUDA_SPACE_ATOMIC_MASK 0x1FFFF
 

--- a/tpls/desul/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_HIP.hpp
@@ -69,17 +69,15 @@ namespace Impl {
  * will use it.  That is the purpose of the
  * ensure_hip_lock_arrays_on_device function.
  */
-__device__
 #ifdef DESUL_HIP_RDC
-    __constant__ extern
+extern
 #endif
-    int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE;
+    __device__ __constant__ int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE;
 
-__device__
 #ifdef DESUL_HIP_RDC
-    __constant__ extern
+extern
 #endif
-    int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE;
+    __device__ __constant__ int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE;
 
 #define HIP_SPACE_ATOMIC_MASK 0x1FFFF
 


### PR DESCRIPTION
Was in constant memory only when relocatable device code is enabled.

Making sure it actually works before I open a PR on the desul side.