### PR TITLE
Restrict KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED feature macro detection to static libraries

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -526,7 +526,7 @@ ENDIF()
 # Check support for device_global variables
 # FIXME_SYCL Once the feature test macro SYCL_EXT_ONEAPI_DEVICE_GLOBAL is
 #            available, use that instead.
-IF(KOKKOS_ENABLE_SYCL)
+IF(KOKKOS_ENABLE_SYCL AND NOT BUILD_SHARED_LIBS)
   INCLUDE(CheckCXXSourceCompiles)
   STRING(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${KOKKOS_COMPILE_OPTIONS}")
   CHECK_CXX_SOURCE_COMPILES("


### PR DESCRIPTION
We are seeing test failures on the testbeds if that feature was enabled together with building shared libraries.