### PR TITLE
Make OpenMP::concurrency and impl_thread_pool_size non-static

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.cpp
@@ -72,10 +72,10 @@ void OpenMP::print_configuration(std::ostream &os, bool /*verbose*/) const {
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 int OpenMP::concurrency(OpenMP const &instance) {
-  return impl_thread_pool_size(instance);
+  return instance.impl_thread_pool_size();
 }
 #else
-int OpenMP::concurrency() const { return impl_thread_pool_size(*this); }
+int OpenMP::concurrency() const { return impl_thread_pool_size(); }
 #endif
 
 void OpenMP::fence(const std::string &name) const {
@@ -98,17 +98,16 @@ bool OpenMP::in_parallel(OpenMP const &exec_space) noexcept {
 #endif
 }
 
-int OpenMP::impl_thread_pool_size(OpenMP const &exec_space) noexcept {
+int OpenMP::impl_thread_pool_size() const noexcept {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_3
   return OpenMP::in_parallel(exec_space)
              ? omp_get_num_threads()
              : (Impl::t_openmp_instance
                     ? Impl::t_openmp_instance->m_pool_size
-                    : exec_space.impl_internal_space_instance()->m_pool_size);
+                    : impl_internal_space_instance()->m_pool_size);
 #else
-  return OpenMP::in_parallel(exec_space)
-             ? omp_get_num_threads()
-             : exec_space.impl_internal_space_instance()->m_pool_size;
+  return OpenMP::in_parallel() ? omp_get_num_threads()
+                               : impl_internal_space_instance()->m_pool_size;
 #endif
 }
 

--- a/core/src/OpenMP/Kokkos_OpenMP.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.cpp
@@ -70,9 +70,13 @@ void OpenMP::print_configuration(std::ostream &os, bool /*verbose*/) const {
   m_space_instance->print_configuration(os);
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 int OpenMP::concurrency(OpenMP const &instance) {
   return impl_thread_pool_size(instance);
 }
+#else
+int OpenMP::concurrency() const { return impl_thread_pool_size(*this); }
+#endif
 
 void OpenMP::fence(const std::string &name) const {
   Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::OpenMP>(

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -131,12 +131,12 @@ class OpenMP {
   /// \brief Free any resources being consumed by the default execution space
   static void impl_finalize();
 
-  static int impl_thread_pool_size(OpenMP const& = OpenMP()) noexcept;
+  int impl_thread_pool_size() const noexcept;
+
+  inline int impl_thread_pool_size(int depth) const;
 
   /** \brief  The rank of the executing thread in this thread pool */
   inline static int impl_thread_pool_rank() noexcept;
-
-  inline static int impl_thread_pool_size(int depth, OpenMP const& = OpenMP());
 
   // use UniqueToken
   static int impl_max_hardware_threads() noexcept;
@@ -190,8 +190,8 @@ inline bool OpenMP::is_asynchronous(OpenMP const& /*instance*/) noexcept {
   return false;
 }
 
-inline int OpenMP::impl_thread_pool_size(int depth, OpenMP const& exec_space) {
-  return depth < 2 ? impl_thread_pool_size(exec_space) : 1;
+inline int OpenMP::impl_thread_pool_size(int depth) const {
+  return depth < 2 ? impl_thread_pool_size() : 1;
 }
 
 KOKKOS_INLINE_FUNCTION

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -116,7 +116,11 @@ class OpenMP {
       int requested_partition_size = 0);
 #endif
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency(OpenMP const& = OpenMP());
+#else
+  int concurrency() const;
+#endif
 
   static void impl_initialize(InitializationSettings const&);
 

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -133,7 +133,7 @@ class OpenMP {
 
   int impl_thread_pool_size() const noexcept;
 
-  inline int impl_thread_pool_size(int depth) const;
+  int impl_thread_pool_size(int depth) const;
 
   /** \brief  The rank of the executing thread in this thread pool */
   inline static int impl_thread_pool_rank() noexcept;

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -156,7 +156,7 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::OpenMP, QueueType>> {
   }
 
   static uint32_t get_max_team_count(execution_space const& espace) {
-    return static_cast<uint32_t>(OpenMP::impl_thread_pool_size(espace));
+    return static_cast<uint32_t>(espace.impl_thread_pool_size());
   }
 
   // TODO @tasking @optimization DSH specialize this for trivially destructible
@@ -189,7 +189,8 @@ class TaskQueueSpecializationConstrained<
     using task_base_type = typename scheduler_type::task_base;
     using queue_type     = typename scheduler_type::queue_type;
 
-    if (1 == OpenMP::impl_thread_pool_size()) {
+    execution_space exec;
+    if (1 == exec.impl_thread_pool_size()) {
       task_base_type* const end = (task_base_type*)task_base_type::EndTag;
 
       HostThreadTeamData& team_data_single =

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -59,7 +59,7 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
 
   template <class FunctorType>
   int team_size_max(const FunctorType&, const ParallelForTag&) const {
-    int pool_size = traits::execution_space::impl_thread_pool_size(1, m_space);
+    int pool_size          = m_space.impl_thread_pool_size(1);
     int max_host_team_size = Impl::HostThreadTeamData::max_team_members;
     return pool_size < max_host_team_size ? pool_size : max_host_team_size;
   }
@@ -68,7 +68,7 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
 
   template <class FunctorType>
   int team_size_max(const FunctorType&, const ParallelReduceTag&) const {
-    int pool_size = traits::execution_space::impl_thread_pool_size(1, m_space);
+    int pool_size          = m_space.impl_thread_pool_size(1);
     int max_host_team_size = Impl::HostThreadTeamData::max_team_members;
     return pool_size < max_host_team_size ? pool_size : max_host_team_size;
   }
@@ -79,12 +79,12 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
   }
   template <class FunctorType>
   int team_size_recommended(const FunctorType&, const ParallelForTag&) const {
-    return traits::execution_space::impl_thread_pool_size(2, m_space);
+    return m_space.impl_thread_pool_size(2);
   }
   template <class FunctorType>
   int team_size_recommended(const FunctorType&,
                             const ParallelReduceTag&) const {
-    return traits::execution_space::impl_thread_pool_size(2, m_space);
+    return m_space.impl_thread_pool_size(2);
   }
   template <class FunctorType, class ReducerType>
   inline int team_size_recommended(const FunctorType& f, const ReducerType&,
@@ -120,10 +120,8 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
   typename traits::execution_space m_space;
 
   inline void init(const int league_size_request, const int team_size_request) {
-    const int pool_size =
-        traits::execution_space::impl_thread_pool_size(0, m_space);
-    const int team_grain =
-        traits::execution_space::impl_thread_pool_size(2, m_space);
+    const int pool_size          = m_space.impl_thread_pool_size(0);
+    const int team_grain         = m_space.impl_thread_pool_size(2);
     const int max_host_team_size = Impl::HostThreadTeamData::max_team_members;
     const int team_max =
         ((pool_size < max_host_team_size) ? pool_size : max_host_team_size);
@@ -192,8 +190,7 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
         m_tune_team(true),
         m_tune_vector(false),
         m_space(space) {
-    init(league_size_request,
-         traits::execution_space::impl_thread_pool_size(2, m_space));
+    init(league_size_request, m_space.impl_thread_pool_size(2));
   }
 
   TeamPolicyInternal(const typename traits::execution_space& space,
@@ -207,8 +204,7 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
         m_tune_team(true),
         m_tune_vector(true),
         m_space(space) {
-    init(league_size_request,
-         traits::execution_space::impl_thread_pool_size(2, m_space));
+    init(league_size_request, m_space.impl_thread_pool_size(2));
   }
 
   TeamPolicyInternal(const typename traits::execution_space& space,
@@ -242,8 +238,7 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
         m_chunk_size(0),
         m_tune_team(true),
         m_tune_vector(false) {
-    init(league_size_request,
-         traits::execution_space::impl_thread_pool_size(2, m_space));
+    init(league_size_request, m_space.impl_thread_pool_size(2));
   }
 
   TeamPolicyInternal(int league_size_request,
@@ -255,8 +250,7 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
         m_chunk_size(0),
         m_tune_team(true),
         m_tune_vector(true) {
-    init(league_size_request,
-         traits::execution_space::impl_thread_pool_size(2, m_space));
+    init(league_size_request, m_space.impl_thread_pool_size(2));
   }
 
   TeamPolicyInternal(int league_size_request, int team_size_request,
@@ -310,9 +304,7 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
  private:
   /** \brief finalize chunk_size if it was set to AUTO*/
   inline void set_auto_chunk_size() {
-    int concurrency =
-        traits::execution_space::impl_thread_pool_size(0, m_space) /
-        m_team_alloc;
+    int concurrency = m_space.impl_thread_pool_size(0) / m_team_alloc;
     if (concurrency == 0) concurrency = 1;
 
     if (m_chunk_size > 0) {

--- a/core/src/OpenMP/Kokkos_OpenMP_UniqueToken.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_UniqueToken.hpp
@@ -28,7 +28,7 @@ class UniqueToken<OpenMP, UniqueTokenScope::Instance> {
 
  private:
   using buffer_type = Kokkos::View<uint32_t*, Kokkos::HostSpace>;
-  execution_space const& m_exec;
+  execution_space m_exec;
   size_type m_count;
   buffer_type m_buffer_view;
   uint32_t volatile* m_buffer;

--- a/core/src/OpenMP/Kokkos_OpenMP_UniqueToken.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_UniqueToken.hpp
@@ -22,26 +22,31 @@
 namespace Kokkos::Experimental {
 template <>
 class UniqueToken<OpenMP, UniqueTokenScope::Instance> {
- private:
-  using buffer_type = Kokkos::View<uint32_t*, Kokkos::HostSpace>;
-  int m_count;
-  buffer_type m_buffer_view;
-  uint32_t volatile* m_buffer;
-
  public:
   using execution_space = OpenMP;
   using size_type       = int;
 
+ private:
+  using buffer_type = Kokkos::View<uint32_t*, Kokkos::HostSpace>;
+  execution_space const& m_exec;
+  size_type m_count;
+  buffer_type m_buffer_view;
+  uint32_t volatile* m_buffer;
+
+ public:
   /// \brief create object size for concurrency on the given instance
   ///
   /// This object should not be shared between instances
-  UniqueToken(execution_space const& = execution_space()) noexcept
-      : m_count(::Kokkos::OpenMP::impl_thread_pool_size()),
+  UniqueToken(execution_space const& exec = execution_space()) noexcept
+      : m_exec(exec),
+        m_count(m_exec.impl_thread_pool_size()),
         m_buffer_view(buffer_type()),
         m_buffer(nullptr) {}
 
-  UniqueToken(size_type max_size, execution_space const& = execution_space())
-      : m_count(max_size),
+  UniqueToken(size_type max_size,
+              execution_space const& exec = execution_space())
+      : m_exec(exec),
+        m_count(max_size),
         m_buffer_view("UniqueToken::m_buffer_view",
                       ::Kokkos::Impl::concurrent_bitset::buffer_bound(m_count)),
         m_buffer(m_buffer_view.data()) {}
@@ -58,8 +63,8 @@ class UniqueToken<OpenMP, UniqueTokenScope::Instance> {
   KOKKOS_INLINE_FUNCTION
   int acquire() const noexcept {
     KOKKOS_IF_ON_HOST(
-        (if (m_count >= ::Kokkos::OpenMP::impl_thread_pool_size()) return ::
-             Kokkos::OpenMP::impl_thread_pool_rank();
+        (if (m_count >= m_exec.impl_thread_pool_size()) return m_exec
+             .impl_thread_pool_rank();
          const ::Kokkos::pair<int, int> result =
              ::Kokkos::Impl::concurrent_bitset::acquire_bounded(
                  m_buffer, m_count, ::Kokkos::Impl::clock_tic() % m_count);
@@ -78,10 +83,9 @@ class UniqueToken<OpenMP, UniqueTokenScope::Instance> {
   /// \brief release a value acquired by generate
   KOKKOS_INLINE_FUNCTION
   void release(int i) const noexcept {
-    KOKKOS_IF_ON_HOST(
-        (if (m_count < ::Kokkos::OpenMP::impl_thread_pool_size()) {
-          ::Kokkos::Impl::concurrent_bitset::release(m_buffer, i);
-        }))
+    KOKKOS_IF_ON_HOST((if (m_count < m_exec.impl_thread_pool_size()) {
+      ::Kokkos::Impl::concurrent_bitset::release(m_buffer, i);
+    }))
 
     KOKKOS_IF_ON_DEVICE(((void)i;))
   }

--- a/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
@@ -49,7 +49,8 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
     // We need to introduce pool_size to work around NVHPC 22.5 ICE
     // We need to use [[maybe_unused]] to work around an unused-variable warning
     // from HIP
-    [[maybe_unused]] int pool_size = OpenMP::impl_thread_pool_size();
+    OpenMP exec;
+    [[maybe_unused]] int pool_size = exec.impl_thread_pool_size();
 #pragma omp parallel num_threads(pool_size)
     {
       // Spin until COMPLETED_TOKEN.


### PR DESCRIPTION
When we merged `partition_space`  (#5105) we decided to make non-static in a following PR. Here it is.