### PR TITLE
OpenMPTarget: Adding declare target for constexpr variables on Intel GPUs.

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -496,13 +496,13 @@ namespace Kokkos {
 
 // FIXME_OPENMPTARGET - The `declare target` is needed for the Intel GPUs with
 // the OpenMPTarget backend
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_INTEL)
 #pragma omp declare target
 #endif
 
 inline constexpr Kokkos::ALL_t ALL{};
 
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_INTEL)
 #pragma omp end declare target
 #endif
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -496,13 +496,13 @@ namespace Kokkos {
 
 // FIXME_OPENMPTARGET - The `declare target` is needed for the Intel GPUs with
 // the OpenMPTarget backend
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_PVC)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL)
 #pragma omp declare target
 #endif
 
 inline constexpr Kokkos::ALL_t ALL{};
 
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_PVC)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL)
 #pragma omp end declare target
 #endif
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -494,7 +494,17 @@ constexpr bool is_assignable(const Kokkos::View<ViewTDst...>& dst,
 
 namespace Kokkos {
 
+// FIXME_OPENMPTARGET - The `declare target` is needed for the Intel GPUs with
+// the OpenMPTarget backend
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_PVC)
+#pragma omp declare target
+#endif
+
 inline constexpr Kokkos::ALL_t ALL{};
+
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_PVC)
+#pragma omp end declare target
+#endif
 
 inline constexpr Kokkos::Impl::WithoutInitializing_t WithoutInitializing{};
 

--- a/core/src/impl/Kokkos_Atomic_Memory_Order.hpp
+++ b/core/src/impl/Kokkos_Atomic_Memory_Order.hpp
@@ -51,7 +51,18 @@ struct memory_order_relaxed_t {
 #endif
   static constexpr auto std_constant = std::memory_order_relaxed;
 };
+
+// FIXME_OPENMPTARGET - The `declare target` is needed for the Intel GPUs with
+// the OpenMPTarget backend
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_PVC)
+#pragma omp declare target
+#endif
+
 constexpr memory_order_relaxed_t memory_order_relaxed = {};
+
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_PVC)
+#pragma omp end declare target
+#endif
 
 struct memory_order_acquire_t {
   using memory_order = memory_order_acquire_t;

--- a/core/src/impl/Kokkos_Atomic_Memory_Order.hpp
+++ b/core/src/impl/Kokkos_Atomic_Memory_Order.hpp
@@ -54,13 +54,13 @@ struct memory_order_relaxed_t {
 
 // FIXME_OPENMPTARGET - The `declare target` is needed for the Intel GPUs with
 // the OpenMPTarget backend
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_PVC)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL)
 #pragma omp declare target
 #endif
 
 constexpr memory_order_relaxed_t memory_order_relaxed = {};
 
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL_PVC)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL)
 #pragma omp end declare target
 #endif
 

--- a/core/src/impl/Kokkos_Atomic_Memory_Order.hpp
+++ b/core/src/impl/Kokkos_Atomic_Memory_Order.hpp
@@ -54,13 +54,13 @@ struct memory_order_relaxed_t {
 
 // FIXME_OPENMPTARGET - The `declare target` is needed for the Intel GPUs with
 // the OpenMPTarget backend
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_INTEL)
 #pragma omp declare target
 #endif
 
 constexpr memory_order_relaxed_t memory_order_relaxed = {};
 
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_ARCH_INTEL)
+#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_INTEL)
 #pragma omp end declare target
 #endif
 

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -481,7 +481,13 @@ CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, round_error);
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, round_error);
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(float, denorm_min);
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, denorm_min);
+
+// FIXME_OPENMPTARGET - The static_assert causes issues on Intel GPUs with the
+// OpenMPTarget backend.
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ARCH_INTEL_PVC)
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, denorm_min);
+#endif
+
 // clang-format off
 static_assert(Kokkos::Experimental::norm_min<float      >::value == std::numeric_limits<      float>::min(), "");
 static_assert(Kokkos::Experimental::norm_min<double     >::value == std::numeric_limits<     double>::min(), "");

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -484,7 +484,7 @@ CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, denorm_min);
 
 // FIXME_OPENMPTARGET - The static_assert causes issues on Intel GPUs with the
 // OpenMPTarget backend.
-#if !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ARCH_INTEL_PVC)
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ARCH_INTEL)
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, denorm_min);
 #endif
 

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -484,7 +484,7 @@ CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, denorm_min);
 
 // FIXME_OPENMPTARGET - The static_assert causes issues on Intel GPUs with the
 // OpenMPTarget backend.
-#if !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ARCH_INTEL)
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_COMPILER_INTEL)
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, denorm_min);
 #endif
 

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -484,7 +484,7 @@ CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(double, denorm_min);
 
 // FIXME_OPENMPTARGET - The static_assert causes issues on Intel GPUs with the
 // OpenMPTarget backend.
-#if !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_COMPILER_INTEL)
+#if !(defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_INTEL))
 CHECK_SAME_AS_NUMERIC_LIMITS_MEMBER_FUNCTION(long double, denorm_min);
 #endif
 


### PR DESCRIPTION
Co-authored-by: Daniel Arndt <arndtd@ornl.gov>