### PR TITLE
Add runtime function to query Kokkos initialization settings

### DIFF
--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -99,6 +99,8 @@ void declare_configuration_metadata(const std::string& category,
 [[nodiscard]] bool is_initialized() noexcept;
 [[nodiscard]] bool is_finalized() noexcept;
 
+[[nodiscard]] InitializationSettings initialization_settings() noexcept;
+
 bool show_warnings() noexcept;
 bool tune_internals() noexcept;
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -823,6 +823,7 @@ endif()
 SET(DEFAULT_DEVICE_SOURCES
   UnitTestMainInit.cpp
   TestInitializationSettings.cpp
+  TestQueryInitializationSettings.cpp
   TestParseCmdLineArgsAndEnvVars.cpp
   TestSharedSpace.cpp
   TestSharedHostPinnedSpace.cpp

--- a/core/unit_test/TestQueryInitializationSettings.cpp
+++ b/core/unit_test/TestQueryInitializationSettings.cpp
@@ -1,0 +1,27 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include "Kokkos_Core.hpp"
+
+namespace {
+TEST(defaultdevicetype, query_initialization_settings) {
+  // not doing much besides checking that the runtime function is callable
+  ASSERT_NO_THROW((void)Kokkos::initialization_settings(););
+}
+
+}  // namespace


### PR DESCRIPTION
Tentative resolution for #5843 

Adding `Kokkos::initialization_settings()` runtime function that returns the settings including the environment variable parsing.