### PR TITLE
Add support for `View::rank[_dynamic]()`

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
@@ -29,7 +29,7 @@ struct is_admissible_to_kokkos_std_algorithms : std::false_type {};
 
 template <typename T>
 struct is_admissible_to_kokkos_std_algorithms<
-    T, std::enable_if_t< ::Kokkos::is_view<T>::value && T::rank == 1 &&
+    T, std::enable_if_t< ::Kokkos::is_view<T>::value && T::rank() == 1 &&
                          (std::is_same<typename T::traits::array_layout,
                                        Kokkos::LayoutLeft>::value ||
                           std::is_same<typename T::traits::array_layout,

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -827,7 +827,7 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
                   "Incompatible OffsetView copy construction");
     Mapping::assign(m_map, aview.impl_map(), m_track);
 
-    for (int i = 0; i < aview.rank; ++i) {
+    for (size_t i = 0; i < aview.rank; ++i) {
       m_begins[i] = 0;
     }
   }

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1636,19 +1636,19 @@ inline void deep_copy(
           "match: ");
       message += dst.label();
       message += "(";
-      for (int r = 0; r < dst_type::rank - 1; r++) {
-        message += std::to_string(dst.extent(r));
+      message += std::to_string(dst.extent(0));
+      for (size_t r = 1; r < dst_type::rank; r++) {
         message += ",";
+        message += std::to_string(dst.extent(r));
       }
-      message += std::to_string(dst.extent(dst_type::rank - 1));
       message += ") ";
       message += src.label();
       message += "(";
-      for (int r = 0; r < src_type::rank - 1; r++) {
-        message += std::to_string(src.extent(r));
+      message += std::to_string(src.extent(0));
+      for (size_t r = 1; r < src_type::rank; r++) {
         message += ",";
+        message += std::to_string(src.extent(r));
       }
-      message += std::to_string(src.extent(src_type::rank - 1));
       message += ") ";
 
       Kokkos::Impl::throw_runtime_exception(message);
@@ -1719,19 +1719,19 @@ inline void deep_copy(
         "Deprecation Error: Kokkos::deep_copy extents of views don't match: ");
     message += dst.label();
     message += "(";
-    for (int r = 0; r < dst_type::rank - 1; r++) {
-      message += std::to_string(dst.extent(r));
+    message += std::to_string(dst.extent(0));
+    for (size_t r = 1; r < dst_type::rank; r++) {
       message += ",";
+      message += std::to_string(dst.extent(r));
     }
-    message += std::to_string(dst.extent(dst_type::rank - 1));
     message += ") ";
     message += src.label();
     message += "(";
-    for (int r = 0; r < src_type::rank - 1; r++) {
-      message += std::to_string(src.extent(r));
+    message += std::to_string(src.extent(0));
+    for (size_t r = 1; r < src_type::rank; r++) {
       message += ",";
+      message += std::to_string(src.extent(r));
     }
-    message += std::to_string(src.extent(src_type::rank - 1));
     message += ") ";
 
     Kokkos::Impl::throw_runtime_exception(message);
@@ -2800,19 +2800,19 @@ inline void deep_copy(
           "match: ");
       message += dst.label();
       message += "(";
-      for (int r = 0; r < dst_type::rank - 1; r++) {
-        message += std::to_string(dst.extent(r));
+      message += std::to_string(dst.extent(0));
+      for (size_t r = 1; r < dst_type::rank; r++) {
         message += ",";
+        message += std::to_string(dst.extent(r));
       }
-      message += std::to_string(dst.extent(dst_type::rank - 1));
       message += ") ";
       message += src.label();
       message += "(";
-      for (int r = 0; r < src_type::rank - 1; r++) {
-        message += std::to_string(src.extent(r));
+      message += std::to_string(src.extent(0));
+      for (size_t r = 1; r < src_type::rank; r++) {
         message += ",";
+        message += std::to_string(src.extent(r));
       }
-      message += std::to_string(src.extent(src_type::rank - 1));
       message += ") ";
 
       Kokkos::Impl::throw_runtime_exception(message);
@@ -2869,19 +2869,19 @@ inline void deep_copy(
         "Deprecation Error: Kokkos::deep_copy extents of views don't match: ");
     message += dst.label();
     message += "(";
-    for (int r = 0; r < dst_type::rank - 1; r++) {
-      message += std::to_string(dst.extent(r));
+    message += std::to_string(dst.extent(0));
+    for (size_t r = 1; r < dst_type::rank; r++) {
       message += ",";
+      message += std::to_string(dst.extent(r));
     }
-    message += std::to_string(dst.extent(dst_type::rank - 1));
     message += ") ";
     message += src.label();
     message += "(";
-    for (int r = 0; r < src_type::rank - 1; r++) {
-      message += std::to_string(src.extent(r));
+    message += std::to_string(src.extent(0));
+    for (size_t r = 1; r < src_type::rank; r++) {
       message += ",";
+      message += std::to_string(src.extent(r));
     }
-    message += std::to_string(src.extent(src_type::rank - 1));
     message += ") ";
 
     Kokkos::Impl::throw_runtime_exception(message);

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1705,7 +1705,7 @@ struct RankDataType<ValueType, 0> {
 
 template <unsigned N, typename... Args>
 KOKKOS_FUNCTION std::enable_if_t<
-    N == View<Args...>::rank &&
+    N == View<Args...>::rank() &&
         std::is_same<typename ViewTraits<Args...>::specialize, void>::value,
     View<Args...>>
 as_view_of_rank_n(View<Args...> v) {
@@ -1716,7 +1716,7 @@ as_view_of_rank_n(View<Args...> v) {
 // never be called
 template <unsigned N, typename T, typename... Args>
 KOKKOS_FUNCTION std::enable_if_t<
-    N != View<T, Args...>::rank &&
+    N != View<T, Args...>::rank() &&
         std::is_same<typename ViewTraits<T, Args...>::specialize, void>::value,
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
          Args...>>

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -655,12 +655,6 @@ class View : public ViewTraits<DataType, Properties...> {
             map_type::Rank};
 #endif
 
-  /** \brief rank() to be implemented
-   */
-  // KOKKOS_INLINE_FUNCTION
-  // static
-  // constexpr unsigned rank() { return map_type::rank; }
-
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
       std::is_integral<iType>::value, size_t>
@@ -1699,14 +1693,10 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 };
 
-/** \brief Temporary free function rank()
- *         until rank() is implemented
- *         in the View
- */
 template <typename D, class... P>
 KOKKOS_INLINE_FUNCTION constexpr unsigned rank(const View<D, P...>& V) {
-  return V.rank;
-}  // Temporary until added to view
+  return V.rank();
+}
 
 namespace Impl {
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -34,6 +34,7 @@ static_assert(false,
 #include <View/Hooks/Kokkos_ViewHooks.hpp>
 
 #include <impl/Kokkos_Tools.hpp>
+#include <impl/Kokkos_Utilities.hpp>  // Impl::integral_constant
 
 #ifdef KOKKOS_ENABLE_IMPL_MDSPAN
 #include <View/MDSpan/Kokkos_MDSpan_Extents.hpp>
@@ -644,6 +645,11 @@ class View : public ViewTraits<DataType, Properties...> {
   //----------------------------------------
   // Domain rank and extents
 
+  static constexpr Impl::integral_constant<size_t, traits::dimension::rank>
+      rank = {};
+  static constexpr Impl::integral_constant<size_t,
+                                           traits::dimension::rank_dynamic>
+      rank_dynamic = {};
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   enum {Rank KOKKOS_DEPRECATED_WITH_COMMENT("Use rank instead.") =
             map_type::Rank};

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -814,14 +814,14 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename... Is>
   static KOKKOS_FUNCTION void check_access_member_function_valid_args(Is...) {
-    static_assert(traits::rank <= sizeof...(Is), "");
+    static_assert(rank <= sizeof...(Is), "");
     static_assert(sizeof...(Is) <= 8, "");
     static_assert(Kokkos::Impl::are_integral<Is...>::value, "");
   }
 
   template <typename... Is>
   static KOKKOS_FUNCTION void check_operator_parens_valid_args(Is...) {
-    static_assert(traits::rank == sizeof...(Is), "");
+    static_assert(rank == sizeof...(Is), "");
     static_assert(Kokkos::Impl::are_integral<Is...>::value, "");
   }
 
@@ -830,22 +830,22 @@ class View : public ViewTraits<DataType, Properties...> {
   // Rank 1 default map operator()
 
   template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0>::value &&  //
-       (1 == traits::rank) && is_default_map && !is_layout_stride),
-      reference_type>
-  operator()(I0 i0) const {
+  KOKKOS_FORCEINLINE_FUNCTION
+      std::enable_if_t<(Kokkos::Impl::always_true<I0>::value &&  //
+                        (1 == rank) && is_default_map && !is_layout_stride),
+                       reference_type>
+      operator()(I0 i0) const {
     check_operator_parens_valid_args(i0);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0)
     return m_map.m_impl_handle[i0];
   }
 
   template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0>::value &&  //
-       (1 == traits::rank) && is_default_map && is_layout_stride),
-      reference_type>
-  operator()(I0 i0) const {
+  KOKKOS_FORCEINLINE_FUNCTION
+      std::enable_if_t<(Kokkos::Impl::always_true<I0>::value &&  //
+                        (1 == rank) && is_default_map && is_layout_stride),
+                       reference_type>
+      operator()(I0 i0) const {
     check_operator_parens_valid_args(i0);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0)
     return m_map.m_impl_handle[m_map.m_impl_offset.m_stride.S0 * i0];
@@ -856,8 +856,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      ((1 == traits::rank) && Kokkos::Impl::are_integral<I0>::value &&
-       !is_default_map),
+      ((1 == rank) && Kokkos::Impl::are_integral<I0>::value && !is_default_map),
       reference_type>
   operator[](I0 i0) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0)
@@ -865,21 +864,21 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 
   template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      ((1 == traits::rank) && Kokkos::Impl::are_integral<I0>::value &&
-       is_default_map && !is_layout_stride),
-      reference_type>
-  operator[](I0 i0) const {
+  KOKKOS_FORCEINLINE_FUNCTION
+      std::enable_if_t<((1 == rank) && Kokkos::Impl::are_integral<I0>::value &&
+                        is_default_map && !is_layout_stride),
+                       reference_type>
+      operator[](I0 i0) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0)
     return m_map.m_impl_handle[i0];
   }
 
   template <typename I0>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      ((1 == traits::rank) && Kokkos::Impl::are_integral<I0>::value &&
-       is_default_map && is_layout_stride),
-      reference_type>
-  operator[](I0 i0) const {
+  KOKKOS_FORCEINLINE_FUNCTION
+      std::enable_if_t<((1 == rank) && Kokkos::Impl::are_integral<I0>::value &&
+                        is_default_map && is_layout_stride),
+                       reference_type>
+      operator[](I0 i0) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0)
     return m_map.m_impl_handle[m_map.m_impl_offset.m_stride.S0 * i0];
   }
@@ -888,59 +887,55 @@ class View : public ViewTraits<DataType, Properties...> {
   // Rank 2 default map operator()
 
   template <typename I0, typename I1>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::always_true<I0, I1>::value &&  //
-                        (2 == traits::rank) && is_default_map &&
-                        is_layout_left && (traits::rank_dynamic == 0)),
-                       reference_type>
-      operator()(I0 i0, I1 i1) const {
+  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
+      (Kokkos::Impl::always_true<I0, I1>::value &&  //
+       (2 == rank) && is_default_map && is_layout_left && (rank_dynamic == 0)),
+      reference_type>
+  operator()(I0 i0, I1 i1) const {
     check_operator_parens_valid_args(i0, i1);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0, i1)
     return m_map.m_impl_handle[i0 + m_map.m_impl_offset.m_dim.N0 * i1];
   }
 
   template <typename I0, typename I1>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::always_true<I0, I1>::value &&  //
-                        (2 == traits::rank) && is_default_map &&
-                        is_layout_left && (traits::rank_dynamic != 0)),
-                       reference_type>
-      operator()(I0 i0, I1 i1) const {
+  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
+      (Kokkos::Impl::always_true<I0, I1>::value &&  //
+       (2 == rank) && is_default_map && is_layout_left && (rank_dynamic != 0)),
+      reference_type>
+  operator()(I0 i0, I1 i1) const {
     check_operator_parens_valid_args(i0, i1);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0, i1)
     return m_map.m_impl_handle[i0 + m_map.m_impl_offset.m_stride * i1];
   }
 
   template <typename I0, typename I1>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::always_true<I0, I1>::value &&  //
-                        (2 == traits::rank) && is_default_map &&
-                        is_layout_right && (traits::rank_dynamic == 0)),
-                       reference_type>
-      operator()(I0 i0, I1 i1) const {
+  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
+      (Kokkos::Impl::always_true<I0, I1>::value &&  //
+       (2 == rank) && is_default_map && is_layout_right && (rank_dynamic == 0)),
+      reference_type>
+  operator()(I0 i0, I1 i1) const {
     check_operator_parens_valid_args(i0, i1);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0, i1)
     return m_map.m_impl_handle[i1 + m_map.m_impl_offset.m_dim.N1 * i0];
   }
 
   template <typename I0, typename I1>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::always_true<I0, I1>::value &&  //
-                        (2 == traits::rank) && is_default_map &&
-                        is_layout_right && (traits::rank_dynamic != 0)),
-                       reference_type>
-      operator()(I0 i0, I1 i1) const {
+  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
+      (Kokkos::Impl::always_true<I0, I1>::value &&  //
+       (2 == rank) && is_default_map && is_layout_right && (rank_dynamic != 0)),
+      reference_type>
+  operator()(I0 i0, I1 i1) const {
     check_operator_parens_valid_args(i0, i1);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0, i1)
     return m_map.m_impl_handle[i1 + m_map.m_impl_offset.m_stride * i0];
   }
 
   template <typename I0, typename I1>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1>::value &&  //
-       (2 == traits::rank) && is_default_map && is_layout_stride),
-      reference_type>
-  operator()(I0 i0, I1 i1) const {
+  KOKKOS_FORCEINLINE_FUNCTION
+      std::enable_if_t<(Kokkos::Impl::always_true<I0, I1>::value &&  //
+                        (2 == rank) && is_default_map && is_layout_stride),
+                       reference_type>
+      operator()(I0 i0, I1 i1) const {
     check_operator_parens_valid_args(i0, i1);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0, i1)
     return m_map.m_impl_handle[i0 * m_map.m_impl_offset.m_stride.S0 +
@@ -951,12 +946,11 @@ class View : public ViewTraits<DataType, Properties...> {
   // have "inlined" versions above
 
   template <typename... Is>
-  KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<(Kokkos::Impl::always_true<Is...>::value &&  //
-                        (2 != traits::rank) && (1 != traits::rank) &&
-                        (0 != traits::rank) && is_default_map),
-                       reference_type>
-      operator()(Is... indices) const {
+  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
+      (Kokkos::Impl::always_true<Is...>::value &&  //
+       (2 != rank) && (1 != rank) && (0 != rank) && is_default_map),
+      reference_type>
+  operator()(Is... indices) const {
     check_operator_parens_valid_args(indices...);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, indices...)
     return m_map.m_impl_handle[m_map.m_impl_offset(indices...)];
@@ -965,7 +959,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<Is...>::value &&  //
-                        ((0 == traits::rank) || !is_default_map)),
+                        ((0 == rank) || !is_default_map)),
                        reference_type>
       operator()(Is... indices) const {
     check_operator_parens_valid_args(indices...);
@@ -978,8 +972,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<Is...>::value && (0 == traits::rank)),
-      reference_type>
+      (Kokkos::Impl::always_true<Is...>::value && (0 == rank)), reference_type>
   access(Is... extra) const {
     check_access_member_function_valid_args(extra...);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, extra...)
@@ -992,7 +985,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, Is...>::value &&
-                        (1 == traits::rank) && !is_default_map),
+                        (1 == rank) && !is_default_map),
                        reference_type>
       access(I0 i0, Is... extra) const {
     check_access_member_function_valid_args(i0, extra...);
@@ -1001,22 +994,22 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 
   template <typename I0, typename... Is>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, Is...>::value && (1 == traits::rank) &&
-       is_default_map && !is_layout_stride),
-      reference_type>
-  access(I0 i0, Is... extra) const {
+  KOKKOS_FORCEINLINE_FUNCTION
+      std::enable_if_t<(Kokkos::Impl::always_true<I0, Is...>::value &&
+                        (1 == rank) && is_default_map && !is_layout_stride),
+                       reference_type>
+      access(I0 i0, Is... extra) const {
     check_access_member_function_valid_args(i0, extra...);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0, extra...)
     return m_map.m_impl_handle[i0];
   }
 
   template <typename I0, typename... Is>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, Is...>::value && (1 == traits::rank) &&
-       is_default_map && is_layout_stride),
-      reference_type>
-  access(I0 i0, Is... extra) const {
+  KOKKOS_FORCEINLINE_FUNCTION
+      std::enable_if_t<(Kokkos::Impl::always_true<I0, Is...>::value &&
+                        (1 == rank) && is_default_map && is_layout_stride),
+                       reference_type>
+      access(I0 i0, Is... extra) const {
     check_access_member_function_valid_args(i0, extra...);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0, extra...)
     return m_map.m_impl_handle[m_map.m_impl_offset.m_stride.S0 * i0];
@@ -1028,7 +1021,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, Is...>::value &&
-                        (2 == traits::rank) && !is_default_map),
+                        (2 == rank) && !is_default_map),
                        reference_type>
       access(I0 i0, I1 i1, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, extra...);
@@ -1038,8 +1031,8 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == traits::rank) &&
-       is_default_map && is_layout_left && (traits::rank_dynamic == 0)),
+      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == rank) &&
+       is_default_map && is_layout_left && (rank_dynamic == 0)),
       reference_type>
   access(I0 i0, I1 i1, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, extra...);
@@ -1049,8 +1042,8 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == traits::rank) &&
-       is_default_map && is_layout_left && (traits::rank_dynamic != 0)),
+      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == rank) &&
+       is_default_map && is_layout_left && (rank_dynamic != 0)),
       reference_type>
   access(I0 i0, I1 i1, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, extra...);
@@ -1060,8 +1053,8 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == traits::rank) &&
-       is_default_map && is_layout_right && (traits::rank_dynamic == 0)),
+      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == rank) &&
+       is_default_map && is_layout_right && (rank_dynamic == 0)),
       reference_type>
   access(I0 i0, I1 i1, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, extra...);
@@ -1071,8 +1064,8 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == traits::rank) &&
-       is_default_map && is_layout_right && (traits::rank_dynamic != 0)),
+      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == rank) &&
+       is_default_map && is_layout_right && (rank_dynamic != 0)),
       reference_type>
   access(I0 i0, I1 i1, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, extra...);
@@ -1081,11 +1074,11 @@ class View : public ViewTraits<DataType, Properties...> {
   }
 
   template <typename I0, typename I1, typename... Is>
-  KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == traits::rank) &&
-       is_default_map && is_layout_stride),
-      reference_type>
-  access(I0 i0, I1 i1, Is... extra) const {
+  KOKKOS_FORCEINLINE_FUNCTION
+      std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, Is...>::value &&
+                        (2 == rank) && is_default_map && is_layout_stride),
+                       reference_type>
+      access(I0 i0, I1 i1, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, extra...);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0, i1, extra...)
     return m_map.m_impl_handle[i0 * m_map.m_impl_offset.m_stride.S0 +
@@ -1098,7 +1091,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1, typename I2, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, I2, Is...>::value &&
-                        (3 == traits::rank) && is_default_map),
+                        (3 == rank) && is_default_map),
                        reference_type>
       access(I0 i0, I1 i1, I2 i2, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, extra...);
@@ -1109,7 +1102,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1, typename I2, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, I2, Is...>::value &&
-                        (3 == traits::rank) && !is_default_map),
+                        (3 == rank) && !is_default_map),
                        reference_type>
       access(I0 i0, I1 i1, I2 i2, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, extra...);
@@ -1122,8 +1115,8 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename I2, typename I3, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, I2, I3, Is...>::value &&
-       (4 == traits::rank) && is_default_map),
+      (Kokkos::Impl::always_true<I0, I1, I2, I3, Is...>::value && (4 == rank) &&
+       is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, extra...);
@@ -1133,8 +1126,8 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename I2, typename I3, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, I2, I3, Is...>::value &&
-       (4 == traits::rank) && !is_default_map),
+      (Kokkos::Impl::always_true<I0, I1, I2, I3, Is...>::value && (4 == rank) &&
+       !is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, extra...);
@@ -1149,7 +1142,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, Is...>::value &&
-       (5 == traits::rank) && is_default_map),
+       (5 == rank) && is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, extra...);
@@ -1162,7 +1155,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, Is...>::value &&
-       (5 == traits::rank) && !is_default_map),
+       (5 == rank) && !is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, extra...);
@@ -1178,7 +1171,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename I5, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, Is...>::value &&
-       (6 == traits::rank) && is_default_map),
+       (6 == rank) && is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, i5, extra...);
@@ -1191,7 +1184,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename I5, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, Is...>::value &&
-       (6 == traits::rank) && !is_default_map),
+       (6 == rank) && !is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, i5, extra...);
@@ -1207,7 +1200,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename I5, typename I6, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, I6, Is...>::value &&
-       (7 == traits::rank) && is_default_map),
+       (7 == rank) && is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, I6 i6, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, i5, i6,
@@ -1221,7 +1214,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename I5, typename I6, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, I6, Is...>::value &&
-       (7 == traits::rank) && !is_default_map),
+       (7 == rank) && !is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, I6 i6, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, i5, i6,
@@ -1239,7 +1232,7 @@ class View : public ViewTraits<DataType, Properties...> {
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, I6,
                                                   I7, Is...>::value &&
-                        (8 == traits::rank) && is_default_map),
+                        (8 == rank) && is_default_map),
                        reference_type>
       access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, I6 i6, I7 i7,
              Is... extra) const {
@@ -1256,7 +1249,7 @@ class View : public ViewTraits<DataType, Properties...> {
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, I6,
                                                   I7, Is...>::value &&
-                        (8 == traits::rank) && !is_default_map),
+                        (8 == rank) && !is_default_map),
                        reference_type>
       access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, I6 i6, I7 i7,
              Is... extra) const {
@@ -1421,7 +1414,7 @@ class View : public ViewTraits<DataType, Properties...> {
     const std::string& alloc_name =
         Impl::get_property<Impl::LabelTag>(prop_copy);
     Impl::runtime_check_rank(
-        traits::rank, traits::rank_dynamic,
+        rank, rank_dynamic,
         std::is_same<typename traits::specialize, void>::value, i0, i1, i2, i3,
         i4, i5, i6, i7, alloc_name);
 
@@ -1637,7 +1630,7 @@ class View : public ViewTraits<DataType, Properties...> {
         arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7);
 
     if (std::is_void<typename traits::specialize>::value &&
-        num_passed_args != traits::rank_dynamic) {
+        num_passed_args != rank_dynamic) {
       Kokkos::abort(
           "Kokkos::View::shmem_size() rank_dynamic != number of arguments.\n");
     }

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -29,6 +29,23 @@
 namespace Kokkos {
 namespace Impl {
 
+// same as std::integral_constant but with __host__ __device__ annotations on
+// the implicit conversion function and the call operator
+template <class T, T v>
+struct integral_constant {
+  using value_type         = T;
+  using type               = integral_constant<T, v>;
+  static constexpr T value = v;
+  KOKKOS_FUNCTION constexpr operator value_type() const noexcept {
+    return value;
+  }
+  KOKKOS_FUNCTION constexpr value_type operator()() const noexcept {
+    return value;
+  }
+};
+
+//==============================================================================
+
 template <typename... Is>
 struct always_true : std::true_type {};
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -78,6 +78,7 @@ SET(COMPILE_ONLY_SOURCES
   TestInterOp.cpp
   TestStringManipulation.cpp
   TestVersionMacros.cpp
+  TestViewRank.cpp
   TestViewTypeTraits.cpp
   TestTypeList.cpp
   view/TestExtentsDatatypeConversion.cpp

--- a/core/unit_test/TestViewAPI_e.hpp
+++ b/core/unit_test/TestViewAPI_e.hpp
@@ -100,7 +100,7 @@ void test_left_stride(Extents... extents) {
   size_t expected_stride = 1;
   size_t all_strides[view_type::rank + 1];
   view.stride(all_strides);
-  for (int i = 0; i < view_type::rank; ++i) {
+  for (size_t i = 0; i < view_type::rank; ++i) {
     ASSERT_EQ(view.stride(i), expected_stride);
     ASSERT_EQ(all_strides[i], expected_stride);
     expected_stride *= view.extent(i);
@@ -115,7 +115,7 @@ void test_right_stride(Extents... extents) {
   size_t expected_stride = 1;
   size_t all_strides[view_type::rank + 1];
   view.stride(all_strides);
-  for (int ri = 0; ri < view_type::rank; ++ri) {
+  for (size_t ri = 0; ri < view_type::rank; ++ri) {
     auto i = view_type::rank - 1 - ri;
     ASSERT_EQ(view.stride(i), expected_stride);
     ASSERT_EQ(all_strides[i], expected_stride);

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -713,7 +713,7 @@ void test_view_mapping() {
                               typename Space::memory_space>::value));
     ASSERT_TRUE((std::is_same<typename T::reference_type, int&>::value));
 
-    ASSERT_EQ(T::rank, 1);
+    ASSERT_EQ(T::rank, size_t(1));
 
     ASSERT_TRUE((std::is_same<typename C::data_type, const int*>::value));
     ASSERT_TRUE((std::is_same<typename C::const_data_type, const int*>::value));
@@ -734,7 +734,7 @@ void test_view_mapping() {
                               typename Space::memory_space>::value));
     ASSERT_TRUE((std::is_same<typename C::reference_type, const int&>::value));
 
-    ASSERT_EQ(C::rank, 1);
+    ASSERT_EQ(C::rank, size_t(1));
 
     ASSERT_EQ(vr1.extent(0), size_t(N));
 
@@ -781,7 +781,7 @@ void test_view_mapping() {
     ASSERT_TRUE((std::is_same<typename T::memory_space,
                               typename Space::memory_space>::value));
     ASSERT_TRUE((std::is_same<typename T::reference_type, int&>::value));
-    ASSERT_EQ(T::rank, 1);
+    ASSERT_EQ(T::rank, size_t(1));
 
     ASSERT_EQ(vr1.extent(0), size_t(N));
 

--- a/core/unit_test/TestViewRank.cpp
+++ b/core/unit_test/TestViewRank.cpp
@@ -1,0 +1,63 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+
+template <class View, size_t Rank, size_t RankDynamic>
+constexpr bool test_view_rank_and_dynamic_rank() {
+  static_assert(View::rank == Rank);
+  static_assert(View::rank() == Rank);
+  static_assert(View::rank_dynamic == RankDynamic);
+  static_assert(View::rank_dynamic() == RankDynamic);
+  static_assert(std::is_convertible_v<decltype(View::rank), size_t>);
+  static_assert(std::is_same_v<decltype(View::rank()), size_t>);
+  static_assert(std::is_convertible_v<decltype(View::rank_dynamic), size_t>);
+  static_assert(std::is_same_v<decltype(View::rank_dynamic()), size_t>);
+  auto rank = View::rank;  // not an integral type in contrast to Kokkos version
+  // less than 4.0.01
+  static_assert(!std::is_integral_v<decltype(rank)>);
+  auto rank_preferred = View::rank();  // since 4.0.01
+  static_assert(std::is_same_v<decltype(rank_preferred), size_t>);
+  (void)rank;
+  (void)rank_preferred;
+  return true;
+}
+
+// clang-format off
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<long long>, 0, 0>());
+
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<unsigned[1]>, 1, 0>());
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<unsigned * >, 1, 1>());
+
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<double[1][2]>, 2, 0>());
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<double * [2]>, 2, 1>());
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<double *  * >, 2, 2>());
+
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<float[1][2][3]>, 3, 0>());
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<float * [2][3]>, 3, 1>());
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<float *  * [3]>, 3, 2>());
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<float *  *  * >, 3, 3>());
+
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<int[1][2][3][4]>, 4, 0>());
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<int * [2][3][4]>, 4, 1>());
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<int *  * [3][4]>, 4, 2>());
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<int *  *  * [4]>, 4, 3>());
+static_assert(test_view_rank_and_dynamic_rank<Kokkos::View<int *  *  *  * >, 4, 4>());
+//clang-format on
+
+}  // namespace

--- a/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
+++ b/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
@@ -113,11 +113,17 @@ TYPED_TEST(TestViewAPI, sizes) {
   static_assert(view_t::rank == TestFixture::expected_rank,
                 "TestViewAPI: Error: rank mismatch");
   size_t expected_span = 1;
-  for (size_t r = 0; r < view_t::rank; r++) expected_span *= this->all_sizes[r];
+  // avoid pointless comparison of unsigned integer with zero warning
+  if constexpr (view_t::rank > 0) {
+    for (size_t r = 0; r < view_t::rank; r++)
+      expected_span *= this->all_sizes[r];
+  }
 
   EXPECT_EQ(expected_span, a.span());
-  for (size_t r = 0; r < view_t::rank; r++) {
-    EXPECT_EQ(this->all_sizes[r], a.extent(r));
-    EXPECT_EQ(this->all_sizes[r], size_t(a.extent_int(r)));
+  if constexpr (view_t::rank > 0) {
+    for (size_t r = 0; r < view_t::rank; r++) {
+      EXPECT_EQ(this->all_sizes[r], a.extent(r));
+      EXPECT_EQ(this->all_sizes[r], size_t(a.extent_int(r)));
+    }
   }
 }

--- a/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
+++ b/core/unit_test/default/TestDefaultDeviceTypeViewAPI.cpp
@@ -113,10 +113,10 @@ TYPED_TEST(TestViewAPI, sizes) {
   static_assert(view_t::rank == TestFixture::expected_rank,
                 "TestViewAPI: Error: rank mismatch");
   size_t expected_span = 1;
-  for (int r = 0; r < view_t::rank; r++) expected_span *= this->all_sizes[r];
+  for (size_t r = 0; r < view_t::rank; r++) expected_span *= this->all_sizes[r];
 
   EXPECT_EQ(expected_span, a.span());
-  for (int r = 0; r < view_t::rank; r++) {
+  for (size_t r = 0; r < view_t::rank; r++) {
     EXPECT_EQ(this->all_sizes[r], a.extent(r));
     EXPECT_EQ(this->all_sizes[r], size_t(a.extent_int(r)));
   }


### PR DESCRIPTION
Related to #5717
* Make `View::rank[_dynamic]` implicitly convertible to ~~`int`~~ `size_t` and callable
* ~~Deprecate `View::Rank` (never mentioned in the API reference for View)~~ done in #5882

~~Not sure it is worth the trouble.  Opening so we can discuss.~~ We agreed to move forward at the dev meeting.

`View` member | Before this PR | After this PR
--- | --- | ---
`View::Rank` | implementation-defined integral type | deprecated
`View::rank`  | implementation-defined integral type | unspecified type that is convertible to `size_t`
`View::rank()` | not provided | returns `size_t`
`View::rank_dynamic` | implementation-defined integral type | unspecified type that is convertible to `size_t`
`View::rank_dynamic()` | not provided | returns `size_t`

Two things worth noting:
* One advantage of the `View::rank()` member over the `rank(View)` free function is that it can be used in constant expressions.
* The actual type of `View::rank` as it was defined before was left up to the implementation (up to the compiler not to Kokkos) but in practice it was often `int` which means this change may yield warnings about comparing signed and unsigned integral types.  It may also break code that was using the type of `View::rank`.  The rational for choosing `size_t` was to align with `std::mdspan`.

