### PR TITLE
Fix cache configuration in CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -70,8 +70,8 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.ccache
-          key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${github.ref}-${{ github.sha }}
-          restore-keys: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${{github.ref}}
+          key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${{ github.ref }}
       - name: maybe_disable_death_tests
         if: ${{ matrix.distro == 'fedora:rawhide' }}
         run: echo "GTEST_FILTER=-*DeathTest*" >> $GITHUB_ENV

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
-          path: ~/.ccache
+          path: ~/.cache/ccache
           key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.cmake_build_type }}-${{ matrix.openmp }}-${{ github.ref }}
       - name: maybe_disable_death_tests

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -24,8 +24,8 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.ccache
-          key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.openmp }}-${github.ref}-${{ github.sha }}
-          restore-keys: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.openmp }}-${{github.ref}}
+          key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.backend }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.backend }}-${{ github.ref }}
       - name: Configure Kokkos
         run: |
           cmake -B builddir \

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
-          path: ~/.ccache
+          path: ~/.cache/ccache
           key: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.backend }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: kokkos-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.backend }}-${{ github.ref }}
       - name: Configure Kokkos


### PR DESCRIPTION
fixes #5723

---
During `Run actions/cache@v3` step we currently get:
```
Cache not found for input keys: kokkos-ubuntu:latest-g++-Debug--${github.ref}-2272d3b7f6e1027da5d0fd37c67f4063f87daf4e, kokkos-ubuntu:latest-g++-Debug--refs/heads/develop
```
Change `${github.ref}` to `${{ github.ref }}` to access the variable correctly.