### PR TITLE
Use CombinedFunctorReducerType in ParallelReduce

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -36,6 +36,13 @@
 namespace Kokkos {
 namespace Impl {
 
+// FIXME Remove once all backends implement the new reduce interface
+template <class CombinedFunctorReducer, class PolicyType>
+struct PatternImplSpecializationFromTag<
+    Kokkos::ParallelReduceTag, CombinedFunctorReducer, PolicyType, Kokkos::Cuda>
+    : type_identity<
+          ParallelReduce<CombinedFunctorReducer, PolicyType, Kokkos::Cuda>> {};
+
 template <class PolicyType, class Functor, class PatternTag, class... Args>
 class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
                           Args...>
@@ -133,8 +140,9 @@ template <class KernelType>
 struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
     : type_identity<GraphNodeKernelImpl<
           Kokkos::Cuda, typename KernelType::Policy,
-          typename KernelType::functor_type, Kokkos::ParallelReduceTag,
-          typename KernelType::reducer_type>> {};
+          CombinedFunctorReducer<typename KernelType::functor_type,
+                                 typename KernelType::reducer_type>,
+          Kokkos::ParallelReduceTag>> {};
 
 //==============================================================================
 // <editor-fold desc="get_cuda_graph_*() helper functions"> {{{1

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -260,7 +260,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
   inline __device__ void operator()() const {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
     const integral_nonzero_constant<size_type, Analysis::StaticValueSize /
                                                    sizeof(size_type)>
         word_count(Analysis::value_size(
@@ -338,7 +338,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
   inline void execute() {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     const auto nwork = m_policy.m_num_tiles;
     if (nwork) {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -188,11 +188,13 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       : m_functor(arg_functor), m_rp(arg_policy) {}
 };
 
-template <class FunctorType, class ReducerType, class... Traits>
-class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
-                     Kokkos::Cuda> {
+template <class CombinedFunctorReducerType, class... Traits>
+class ParallelReduce<CombinedFunctorReducerType,
+                     Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
  public:
-  using Policy = Kokkos::MDRangePolicy<Traits...>;
+  using Policy      = Kokkos::MDRangePolicy<Traits...>;
+  using FunctorType = typename CombinedFunctorReducerType::functor_type;
+  using ReducerType = typename CombinedFunctorReducerType::reducer_type;
 
  private:
   using array_index_type = typename Policy::array_index_type;
@@ -202,22 +204,10 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   using Member       = typename Policy::member_type;
   using LaunchBounds = typename Policy::launch_bounds;
 
-  using ReducerConditional =
-      Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                         FunctorType, ReducerType>;
-  using ReducerTypeFwd = typename ReducerConditional::type;
-  using WorkTagFwd =
-      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type;
-
-  using Analysis =
-      Kokkos::Impl::FunctorAnalysis<FunctorPatternInterface::REDUCE, Policy,
-                                    ReducerTypeFwd>;
-
  public:
-  using pointer_type   = typename Analysis::pointer_type;
-  using value_type     = typename Analysis::value_type;
-  using reference_type = typename Analysis::reference_type;
+  using pointer_type   = typename ReducerType::pointer_type;
+  using value_type     = typename ReducerType::value_type;
+  using reference_type = typename ReducerType::reference_type;
   using functor_type   = FunctorType;
   using size_type      = Cuda::size_type;
   using reducer_type   = ReducerType;
@@ -225,9 +215,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   // Algorithmic constraints: blockSize is a power of two AND blockDim.y ==
   // blockDim.z == 1
 
-  const FunctorType m_functor;
+  const CombinedFunctorReducerType m_functor_reducer;
   const Policy m_policy;  // used for workrange and nwork
-  const ReducerType m_reducer;
   const pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
   size_type* m_scratch_space;
@@ -241,7 +230,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   // Shall we use the shfl based reduction or not (only use it for static sized
   // types of more than 128bit
   static constexpr bool UseShflReduction = false;
-  //((sizeof(value_type)>2*sizeof(double)) && Analysis::StaticValueSize)
+  //((sizeof(value_type)>2*sizeof(double)) && ReducerType::static_value_size())
   // Some crutch to do function overloading
 
  public:
@@ -253,24 +242,22 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   inline __device__ void exec_range(reference_type update) const {
     Kokkos::Impl::Reduce::DeviceIterateTile<Policy::rank, Policy, FunctorType,
                                             typename Policy::work_tag,
-                                            reference_type>(m_policy, m_functor,
-                                                            update)
+                                            reference_type>(
+        m_policy, m_functor_reducer.get_functor(), update)
         .exec_range();
   }
 
   inline __device__ void operator()() const {
-    typename Analysis::Reducer final_reducer(
-        ReducerConditional::select(m_functor, m_reducer));
-    const integral_nonzero_constant<size_type, Analysis::StaticValueSize /
-                                                   sizeof(size_type)>
-        word_count(Analysis::value_size(
-                       ReducerConditional::select(m_functor, m_reducer)) /
+    const integral_nonzero_constant<
+        size_type, ReducerType::static_value_size() / sizeof(size_type)>
+        word_count(m_functor_reducer.get_reducer().value_size() /
                    sizeof(size_type));
 
     {
-      reference_type value = final_reducer.init(reinterpret_cast<pointer_type>(
-          kokkos_impl_cuda_shared_memory<size_type>() +
-          threadIdx.y * word_count.value));
+      reference_type value =
+          m_functor_reducer.get_reducer().init(reinterpret_cast<pointer_type>(
+              kokkos_impl_cuda_shared_memory<size_type>() +
+              threadIdx.y * word_count.value));
 
       // Number of blocks is bounded so that the reduction can be limited to two
       // passes. Each thread block is given an approximately equal amount of
@@ -284,7 +271,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     // Reduce with final value at blockDim.y - 1 location.
     // Problem: non power-of-two blockDim
     if (cuda_single_inter_block_reduce_scan<false>(
-            final_reducer, blockIdx.x, gridDim.x,
+            m_functor_reducer.get_reducer(), blockIdx.x, gridDim.x,
             kokkos_impl_cuda_shared_memory<size_type>(), m_scratch_space,
             m_scratch_flags)) {
       // This is the final block with the final result at the final threads'
@@ -297,7 +284,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
               : (m_unified_space ? m_unified_space : m_scratch_space);
 
       if (threadIdx.y == 0) {
-        final_reducer.final(reinterpret_cast<value_type*>(shared));
+        m_functor_reducer.get_reducer().final(
+            reinterpret_cast<value_type*>(shared));
       }
 
       if (CudaTraits::WarpSize < word_count.value) {
@@ -316,7 +304,9 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     int shmem_size =
         cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag>(
             f, n);
-    using closure_type = Impl::ParallelReduce<FunctorType, Policy, ReducerType>;
+    using closure_type =
+        Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
+                             Policy, Kokkos::Cuda>;
     cudaFuncAttributes attr =
         CudaParallelLaunch<closure_type,
                            LaunchBounds>::get_cuda_func_attributes();
@@ -337,17 +327,15 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   }
 
   inline void execute() {
-    typename Analysis::Reducer final_reducer(
-        ReducerConditional::select(m_functor, m_reducer));
-
     const auto nwork = m_policy.m_num_tiles;
     if (nwork) {
       int block_size = m_policy.m_prod_tile_dims;
       // CONSTRAINT: Algorithm requires block_size >= product of tile dimensions
       // Nearest power of two
-      int exponent_pow_two    = std::ceil(std::log2(block_size));
-      block_size              = std::pow(2, exponent_pow_two);
-      int suggested_blocksize = local_block_size(m_functor);
+      int exponent_pow_two = std::ceil(std::log2(block_size));
+      block_size           = std::pow(2, exponent_pow_two);
+      int suggested_blocksize =
+          local_block_size(m_functor_reducer.get_functor());
 
       block_size = (block_size > suggested_blocksize)
                        ? block_size
@@ -355,14 +343,12 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                                                // than or equal to 512
 
       m_scratch_space = cuda_internal_scratch_space(
-          m_policy.space(), Analysis::value_size(ReducerConditional::select(
-                                m_functor, m_reducer)) *
+          m_policy.space(), m_functor_reducer.get_reducer().value_size() *
                                 block_size /* block_size == max block_count */);
       m_scratch_flags =
           cuda_internal_scratch_flags(m_policy.space(), sizeof(size_type));
       m_unified_space = cuda_internal_scratch_unified(
-          m_policy.space(), Analysis::value_size(ReducerConditional::select(
-                                m_functor, m_reducer)));
+          m_policy.space(), m_functor_reducer.get_reducer().value_size());
 
       // REQUIRED ( 1 , N , 1 )
       const dim3 block(1, block_size, 1);
@@ -374,8 +360,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           UseShflReduction
               ? 0
               : cuda_single_inter_block_reduce_scan_shmem<false, FunctorType,
-                                                          WorkTag>(m_functor,
-                                                                   block.y);
+                                                          WorkTag>(
+                    m_functor_reducer.get_functor(), block.y);
 
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem,
@@ -389,14 +375,12 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                 "Kokkos::Impl::ParallelReduce<Cuda, MDRangePolicy>::execute: "
                 "Result Not Device Accessible");
 
-            const int count = Analysis::value_count(
-                ReducerConditional::select(m_functor, m_reducer));
+            const int count = m_functor_reducer.get_reducer().value_count();
             for (int i = 0; i < count; ++i) {
               m_result_ptr[i] = pointer_type(m_unified_space)[i];
             }
           } else {
-            const int size = Analysis::value_size(
-                ReducerConditional::select(m_functor, m_reducer));
+            const int size = m_functor_reducer.get_reducer().value_size();
             DeepCopy<HostSpace, CudaSpace, Cuda>(m_policy.space(), m_result_ptr,
                                                  m_scratch_space, size);
           }
@@ -405,19 +389,16 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     } else {
       if (m_result_ptr) {
         // TODO @graph We need to effectively insert this in to the graph
-        final_reducer.init(m_result_ptr);
+        m_functor_reducer.get_reducer().init(m_result_ptr);
       }
     }
   }
 
   template <class ViewType>
-  ParallelReduce(
-      const FunctorType& arg_functor, const Policy& arg_policy,
-      const ViewType& arg_result,
-      std::enable_if_t<Kokkos::is_view<ViewType>::value, void*> = nullptr)
-      : m_functor(arg_functor),
+  ParallelReduce(const CombinedFunctorReducerType& arg_functor_reducer,
+                 const Policy& arg_policy, const ViewType& arg_result)
+      : m_functor_reducer(arg_functor_reducer),
         m_policy(arg_policy),
-        m_reducer(InvalidType()),
         m_result_ptr(arg_result.data()),
         m_result_ptr_device_accessible(
             MemorySpaceAccess<Kokkos::CudaSpace,
@@ -425,23 +406,8 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
         m_scratch_space(nullptr),
         m_scratch_flags(nullptr),
         m_unified_space(nullptr) {
-    check_reduced_view_shmem_size<WorkTag>(m_policy, m_functor);
-  }
-
-  ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
-                 const ReducerType& reducer)
-      : m_functor(arg_functor),
-        m_policy(arg_policy),
-        m_reducer(reducer),
-        m_result_ptr(reducer.view().data()),
-        m_result_ptr_device_accessible(
-            MemorySpaceAccess<Kokkos::CudaSpace,
-                              typename ReducerType::result_view_type::
-                                  memory_space>::accessible),
-        m_scratch_space(nullptr),
-        m_scratch_flags(nullptr),
-        m_unified_space(nullptr) {
-    check_reduced_view_shmem_size<WorkTag>(m_policy, m_functor);
+    check_reduced_view_shmem_size<WorkTag>(m_policy,
+                                           m_functor_reducer.get_functor());
   }
 };
 }  // namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -114,11 +114,13 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
       : m_functor(arg_functor), m_policy(arg_policy) {}
 };
 
-template <class FunctorType, class ReducerType, class... Traits>
-class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
+template <class CombinedFunctorReducerType, class... Traits>
+class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
                      Kokkos::Cuda> {
  public:
-  using Policy = Kokkos::RangePolicy<Traits...>;
+  using Policy      = Kokkos::RangePolicy<Traits...>;
+  using FunctorType = typename CombinedFunctorReducerType::functor_type;
+  using ReducerType = typename CombinedFunctorReducerType::reducer_type;
 
  private:
   using WorkRange    = typename Policy::WorkRange;
@@ -126,22 +128,10 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   using Member       = typename Policy::member_type;
   using LaunchBounds = typename Policy::launch_bounds;
 
-  using ReducerConditional =
-      Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                         FunctorType, ReducerType>;
-  using ReducerTypeFwd = typename ReducerConditional::type;
-  using WorkTagFwd =
-      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type;
-
-  using Analysis =
-      Kokkos::Impl::FunctorAnalysis<FunctorPatternInterface::REDUCE, Policy,
-                                    ReducerTypeFwd>;
-
  public:
-  using pointer_type   = typename Analysis::pointer_type;
-  using value_type     = typename Analysis::value_type;
-  using reference_type = typename Analysis::reference_type;
+  using pointer_type   = typename ReducerType::pointer_type;
+  using value_type     = typename ReducerType::value_type;
+  using reference_type = typename ReducerType::reference_type;
   using functor_type   = FunctorType;
   // Conditionally set word_size_type to int16_t or int8_t if value_type is
   // smaller than int32_t (Kokkos::Cuda::size_type)
@@ -165,9 +155,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   // Algorithmic constraints: blockSize is a power of two AND blockDim.y ==
   // blockDim.z == 1
 
-  const FunctorType m_functor;
+  const CombinedFunctorReducerType m_functor_reducer;
   const Policy m_policy;
-  const ReducerType m_reducer;
   const pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
   const bool m_result_ptr_host_accessible;
@@ -179,7 +168,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
   // FIXME_CUDA Shall we use the shfl based reduction or not (only use it for
   // static sized types of more than 128bit:
-  // sizeof(value_type)>2*sizeof(double)) && Analysis::StaticValueSize)
+  // sizeof(value_type)>2*sizeof(double)) && ReducerType::static_value_size())
   static constexpr bool UseShflReduction = false;
 
  public:
@@ -189,29 +178,27 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   template <class TagType>
   __device__ inline std::enable_if_t<std::is_void<TagType>::value> exec_range(
       const Member& i, reference_type update) const {
-    m_functor(i, update);
+    m_functor_reducer.get_functor()(i, update);
   }
 
   template <class TagType>
   __device__ inline std::enable_if_t<!std::is_void<TagType>::value> exec_range(
       const Member& i, reference_type update) const {
-    m_functor(TagType(), i, update);
+    m_functor_reducer.get_functor()(TagType(), i, update);
   }
 
   __device__ inline void operator()() const {
-    typename Analysis::Reducer final_reducer(
-        ReducerConditional::select(m_functor, m_reducer));
-
-    const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
-                                                        sizeof(word_size_type)>
-        word_count(Analysis::value_size(
-                       ReducerConditional::select(m_functor, m_reducer)) /
+    const integral_nonzero_constant<word_size_type,
+                                    ReducerType::static_value_size() /
+                                        sizeof(word_size_type)>
+        word_count(m_functor_reducer.get_reducer().value_size() /
                    sizeof(word_size_type));
 
     {
-      reference_type value = final_reducer.init(reinterpret_cast<pointer_type>(
-          kokkos_impl_cuda_shared_memory<word_size_type>() +
-          threadIdx.y * word_count.value));
+      reference_type value =
+          m_functor_reducer.get_reducer().init(reinterpret_cast<pointer_type>(
+              kokkos_impl_cuda_shared_memory<word_size_type>() +
+              threadIdx.y * word_count.value));
 
       // Number of blocks is bounded so that the reduction can be limited to two
       // passes. Each thread block is given an approximately equal amount of
@@ -233,7 +220,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     bool do_final_reduction = true;
     if (!zero_length)
       do_final_reduction = cuda_single_inter_block_reduce_scan<false>(
-          final_reducer, blockIdx.x, gridDim.x,
+          m_functor_reducer.get_reducer(), blockIdx.x, gridDim.x,
           kokkos_impl_cuda_shared_memory<word_size_type>(), m_scratch_space,
           m_scratch_flags);
 
@@ -250,7 +237,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
               : (m_unified_space ? m_unified_space : m_scratch_space);
 
       if (threadIdx.y == 0) {
-        final_reducer.final(reinterpret_cast<value_type*>(shared));
+        m_functor_reducer.get_reducer().final(
+            reinterpret_cast<value_type*>(shared));
       }
 
       if (CudaTraits::WarpSize < word_count.value) {
@@ -269,7 +257,9 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     int shmem_size =
         cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag>(
             f, n);
-    using closure_type = Impl::ParallelReduce<FunctorType, Policy, ReducerType>;
+    using closure_type =
+        Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
+                             Policy, Kokkos::Cuda>;
     cudaFuncAttributes attr =
         CudaParallelLaunch<closure_type,
                            LaunchBounds>::get_cuda_func_attributes();
@@ -290,24 +280,20 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   }
 
   inline void execute() {
-    typename Analysis::Reducer final_reducer(
-        ReducerConditional::select(m_functor, m_reducer));
-
     const index_type nwork     = m_policy.end() - m_policy.begin();
-    const bool need_device_set = Analysis::has_init_member_function ||
-                                 Analysis::has_final_member_function ||
+    const bool need_device_set = ReducerType::has_init_member_function() ||
+                                 ReducerType::has_final_member_function() ||
                                  !m_result_ptr_host_accessible ||
                                  Policy::is_graph_kernel::value ||
                                  !std::is_same<ReducerType, InvalidType>::value;
     if ((nwork > 0) || need_device_set) {
-      const int block_size = local_block_size(m_functor);
+      const int block_size = local_block_size(m_functor_reducer.get_functor());
 
       KOKKOS_ASSERT(block_size > 0);
 
       // TODO: down casting these uses more space than required?
       m_scratch_space = (word_size_type*)cuda_internal_scratch_space(
-          m_policy.space(), Analysis::value_size(ReducerConditional::select(
-                                m_functor, m_reducer)) *
+          m_policy.space(), m_functor_reducer.get_reducer().value_size() *
                                 block_size /* block_size == max block_count */);
 
       // Intentionally do not downcast to word_size_type since we use Cuda
@@ -316,8 +302,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                                                     sizeof(Cuda::size_type));
       m_unified_space =
           reinterpret_cast<word_size_type*>(cuda_internal_scratch_unified(
-              m_policy.space(), Analysis::value_size(ReducerConditional::select(
-                                    m_functor, m_reducer))));
+              m_policy.space(), m_functor_reducer.get_reducer().value_size()));
 
       // REQUIRED ( 1 , N , 1 )
       dim3 block(1, block_size, 1);
@@ -330,8 +315,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
           UseShflReduction
               ? 0
               : cuda_single_inter_block_reduce_scan_shmem<false, FunctorType,
-                                                          WorkTag>(m_functor,
-                                                                   block.y);
+                                                          WorkTag>(
+                    m_functor_reducer.get_functor(), block.y);
 
       if ((nwork == 0)
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
@@ -354,14 +339,12 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                 "Kokkos::Impl::ParallelReduce<Cuda, RangePolicy>::execute: "
                 "Result "
                 "Not Device Accessible");
-            const int count = Analysis::value_count(
-                ReducerConditional::select(m_functor, m_reducer));
+            const int count = m_functor_reducer.get_reducer().value_count();
             for (int i = 0; i < count; ++i) {
               m_result_ptr[i] = pointer_type(m_unified_space)[i];
             }
           } else {
-            const int size = Analysis::value_size(
-                ReducerConditional::select(m_functor, m_reducer));
+            const int size = m_functor_reducer.get_reducer().value_size();
             DeepCopy<HostSpace, CudaSpace, Cuda>(m_policy.space(), m_result_ptr,
                                                  m_scratch_space, size);
           }
@@ -370,19 +353,16 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     } else {
       if (m_result_ptr) {
         // TODO @graph We need to effectively insert this in to the graph
-        final_reducer.init(m_result_ptr);
+        m_functor_reducer.get_reducer().init(m_result_ptr);
       }
     }
   }
 
   template <class ViewType>
-  ParallelReduce(
-      const FunctorType& arg_functor, const Policy& arg_policy,
-      const ViewType& arg_result,
-      std::enable_if_t<Kokkos::is_view<ViewType>::value, void*> = nullptr)
-      : m_functor(arg_functor),
+  ParallelReduce(const CombinedFunctorReducerType& arg_functor_reducer,
+                 const Policy& arg_policy, const ViewType& arg_result)
+      : m_functor_reducer(arg_functor_reducer),
         m_policy(arg_policy),
-        m_reducer(InvalidType()),
         m_result_ptr(arg_result.data()),
         m_result_ptr_device_accessible(
             MemorySpaceAccess<Kokkos::CudaSpace,
@@ -393,27 +373,8 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
         m_scratch_space(nullptr),
         m_scratch_flags(nullptr),
         m_unified_space(nullptr) {
-    check_reduced_view_shmem_size<WorkTag>(m_policy, m_functor);
-  }
-
-  ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
-                 const ReducerType& reducer)
-      : m_functor(arg_functor),
-        m_policy(arg_policy),
-        m_reducer(reducer),
-        m_result_ptr(reducer.view().data()),
-        m_result_ptr_device_accessible(
-            MemorySpaceAccess<Kokkos::CudaSpace,
-                              typename ReducerType::result_view_type::
-                                  memory_space>::accessible),
-        m_result_ptr_host_accessible(
-            MemorySpaceAccess<Kokkos::HostSpace,
-                              typename ReducerType::result_view_type::
-                                  memory_space>::accessible),
-        m_scratch_space(nullptr),
-        m_scratch_flags(nullptr),
-        m_unified_space(nullptr) {
-    check_reduced_view_shmem_size<WorkTag>(m_policy, m_functor);
+    check_reduced_view_shmem_size<WorkTag>(m_policy,
+                                           m_functor_reducer.get_functor());
   }
 };
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -200,7 +200,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
   __device__ inline void operator()() const {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
                                                         sizeof(word_size_type)>
@@ -291,7 +291,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
   inline void execute() {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     const index_type nwork     = m_policy.end() - m_policy.begin();
     const bool need_device_set = Analysis::has_init_member_function ||
@@ -484,7 +484,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
   //----------------------------------------
 
   __device__ inline void initial() const {
-    typename Analysis::Reducer final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(m_functor);
 
     const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
                                                         sizeof(word_size_type)>
@@ -524,7 +524,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
   //----------------------------------------
 
   __device__ inline void final() const {
-    typename Analysis::Reducer final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(m_functor);
 
     const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
                                                         sizeof(word_size_type)>
@@ -794,7 +794,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   //----------------------------------------
 
   __device__ inline void initial() const {
-    typename Analysis::Reducer final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(m_functor);
 
     const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
                                                         sizeof(word_size_type)>
@@ -834,7 +834,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   //----------------------------------------
 
   __device__ inline void final() const {
-    typename Analysis::Reducer final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(m_functor);
 
     const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
                                                         sizeof(word_size_type)>

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -115,12 +115,10 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
                               TeamPolicyInternal, FunctorType>;
-    using reducer_type = typename Impl::ParallelReduceReturnValue<
-        void, typename functor_analysis_type::value_type,
-        FunctorType>::reducer_type;
-    using closure_type =
-        Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
-                             reducer_type>;
+    using closure_type = Impl::ParallelReduce<
+        CombinedFunctorReducer<FunctorType,
+                               typename functor_analysis_type::Reducer>,
+        TeamPolicy<Properties...>, Kokkos::Cuda>;
     return internal_team_size_max<closure_type>(f);
   }
 
@@ -128,8 +126,8 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
   inline int team_size_max(const FunctorType& f, const ReducerType& /*r*/,
                            const ParallelReduceTag&) const {
     using closure_type =
-        Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
-                             ReducerType>;
+        Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
+                             TeamPolicy<Properties...>, Kokkos::Cuda>;
     return internal_team_size_max<closure_type>(f);
   }
 
@@ -156,12 +154,10 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
                               TeamPolicyInternal, FunctorType>;
-    using reducer_type = typename Impl::ParallelReduceReturnValue<
-        void, typename functor_analysis_type::value_type,
-        FunctorType>::reducer_type;
-    using closure_type =
-        Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
-                             reducer_type>;
+    using closure_type = Impl::ParallelReduce<
+        CombinedFunctorReducer<FunctorType,
+                               typename functor_analysis_type::Reducer>,
+        TeamPolicy<Properties...>, Kokkos::Cuda>;
     return internal_team_size_recommended<closure_type>(f);
   }
 
@@ -169,8 +165,8 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
   int team_size_recommended(const FunctorType& f, const ReducerType&,
                             const ParallelReduceTag&) const {
     using closure_type =
-        Impl::ParallelReduce<FunctorType, TeamPolicy<Properties...>,
-                             ReducerType>;
+        Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
+                             TeamPolicy<Properties...>, Kokkos::Cuda>;
     return internal_team_size_recommended<closure_type>(f);
   }
 
@@ -607,32 +603,22 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 };
 
-template <class FunctorType, class ReducerType, class... Properties>
-class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
-                     ReducerType, Kokkos::Cuda> {
+template <class CombinedFunctorReducerType, class... Properties>
+class ParallelReduce<CombinedFunctorReducerType,
+                     Kokkos::TeamPolicy<Properties...>, Kokkos::Cuda> {
  public:
-  using Policy = TeamPolicy<Properties...>;
+  using Policy      = TeamPolicy<Properties...>;
+  using FunctorType = typename CombinedFunctorReducerType::functor_type;
+  using ReducerType = typename CombinedFunctorReducerType::reducer_type;
 
  private:
   using Member       = typename Policy::member_type;
   using WorkTag      = typename Policy::work_tag;
   using LaunchBounds = typename Policy::launch_bounds;
 
-  using ReducerConditional =
-      Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                         FunctorType, ReducerType>;
-  using ReducerTypeFwd = typename ReducerConditional::type;
-  using WorkTagFwd =
-      typename Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                                  WorkTag, void>::type;
-
-  using Analysis =
-      Kokkos::Impl::FunctorAnalysis<FunctorPatternInterface::REDUCE, Policy,
-                                    ReducerTypeFwd>;
-
-  using pointer_type   = typename Analysis::pointer_type;
-  using reference_type = typename Analysis::reference_type;
-  using value_type     = typename Analysis::value_type;
+  using pointer_type   = typename ReducerType::pointer_type;
+  using reference_type = typename ReducerType::reference_type;
+  using value_type     = typename ReducerType::value_type;
 
  public:
   using functor_type = FunctorType;
@@ -640,7 +626,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   using reducer_type = ReducerType;
 
   static constexpr bool UseShflReduction =
-      (true && (Analysis::StaticValueSize != 0));
+      (true && (ReducerType::static_value_size() != 0));
 
  private:
   struct ShflReductionTag {};
@@ -654,9 +640,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   //  [ team   shared space ]
   //
 
-  const FunctorType m_functor;
+  const CombinedFunctorReducerType m_functor_reducer;
   const Policy m_policy;
-  const ReducerType m_reducer;
   const pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
   const bool m_result_ptr_host_accessible;
@@ -678,13 +663,13 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   template <class TagType>
   __device__ inline std::enable_if_t<std::is_void<TagType>::value> exec_team(
       const Member& member, reference_type update) const {
-    m_functor(member, update);
+    m_functor_reducer.get_functor()(member, update);
   }
 
   template <class TagType>
   __device__ inline std::enable_if_t<!std::is_void<TagType>::value> exec_team(
       const Member& member, reference_type update) const {
-    m_functor(TagType(), member, update);
+    m_functor_reducer.get_functor()(TagType(), member, update);
   }
 
  public:
@@ -706,18 +691,14 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   __device__ inline void run(SHMEMReductionTag&, const int& threadid) const {
-    typename Analysis::Reducer final_reducer(
-        ReducerConditional::select(m_functor, m_reducer));
-
-    const integral_nonzero_constant<size_type, Analysis::StaticValueSize /
-                                                   sizeof(size_type)>
-        word_count(Analysis::value_size(
-                       ReducerConditional::select(m_functor, m_reducer)) /
+    const integral_nonzero_constant<
+        size_type, ReducerType::static_value_size() / sizeof(size_type)>
+        word_count(m_functor_reducer.get_reducer().value_size() /
                    sizeof(size_type));
 
-    reference_type value =
-        final_reducer.init(kokkos_impl_cuda_shared_memory<size_type>() +
-                           threadIdx.y * word_count.value);
+    reference_type value = m_functor_reducer.get_reducer().init(
+        kokkos_impl_cuda_shared_memory<size_type>() +
+        threadIdx.y * word_count.value);
 
     // Iterate this block through the league
     const int int_league_size = (int)m_league_size;
@@ -738,7 +719,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     bool do_final_reduction = true;
     if (!zero_length)
       do_final_reduction = cuda_single_inter_block_reduce_scan<false>(
-          final_reducer, blockIdx.x, gridDim.x,
+          m_functor_reducer.get_reducer(), blockIdx.x, gridDim.x,
           kokkos_impl_cuda_shared_memory<size_type>(), m_scratch_space,
           m_scratch_flags);
 
@@ -754,7 +735,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
               : (m_unified_space ? m_unified_space : m_scratch_space);
 
       if (threadIdx.y == 0) {
-        final_reducer.final(reinterpret_cast<value_type*>(shared));
+        m_functor_reducer.get_reducer().final(
+            reinterpret_cast<value_type*>(shared));
       }
 
       if (CudaTraits::WarpSize < word_count.value) {
@@ -768,11 +750,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   }
 
   __device__ inline void run(ShflReductionTag, const int& threadid) const {
-    typename Analysis::Reducer final_reducer(
-        ReducerConditional::select(m_functor, m_reducer));
-
     value_type value;
-    final_reducer.init(&value);
+    m_functor_reducer.get_reducer().init(&value);
 
     // Iterate this block through the league
     const int int_league_size = (int)m_league_size;
@@ -795,29 +774,26 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                              : m_scratch_space);
 
     value_type init;
-    final_reducer.init(&init);
+    m_functor_reducer.get_reducer().init(&init);
 
     if (int_league_size == 0) {
-      final_reducer.final(&value);
+      m_functor_reducer.get_reducer().final(&value);
       *result = value;
-    } else if (Impl::cuda_inter_block_reduction(value, init, final_reducer,
-                                                m_scratch_space, result,
-                                                m_scratch_flags, blockDim.y)) {
+    } else if (Impl::cuda_inter_block_reduction(
+                   value, init, m_functor_reducer.get_reducer(),
+                   m_scratch_space, result, m_scratch_flags, blockDim.y)) {
       const unsigned id = threadIdx.y * blockDim.x + threadIdx.x;
       if (id == 0) {
-        final_reducer.final(&value);
+        m_functor_reducer.get_reducer().final(&value);
         *result = value;
       }
     }
   }
 
   inline void execute() {
-    typename Analysis::Reducer final_reducer(
-        ReducerConditional::select(m_functor, m_reducer));
-
     const bool is_empty_range  = m_league_size == 0 || m_team_size == 0;
-    const bool need_device_set = Analysis::has_init_member_function ||
-                                 Analysis::has_final_member_function ||
+    const bool need_device_set = ReducerType::has_init_member_function() ||
+                                 ReducerType::has_final_member_function() ||
                                  !m_result_ptr_host_accessible ||
                                  Policy::is_graph_kernel::value ||
                                  !std::is_same<ReducerType, InvalidType>::value;
@@ -827,14 +803,12 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                : std::min(int(m_league_size), m_team_size));
 
       m_scratch_space = cuda_internal_scratch_space(
-          m_policy.space(), Analysis::value_size(ReducerConditional::select(
-                                m_functor, m_reducer)) *
-                                block_count);
+          m_policy.space(),
+          m_functor_reducer.get_reducer().value_size() * block_count);
       m_scratch_flags =
           cuda_internal_scratch_flags(m_policy.space(), sizeof(size_type));
       m_unified_space = cuda_internal_scratch_unified(
-          m_policy.space(), Analysis::value_size(ReducerConditional::select(
-                                m_functor, m_reducer)));
+          m_policy.space(), m_functor_reducer.get_reducer().value_size());
 
       dim3 block(m_vector_size, m_team_size, 1);
       dim3 grid(block_count, 1, 1);
@@ -861,14 +835,12 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
         if (m_result_ptr) {
           if (m_unified_space) {
-            const int count = Analysis::value_count(
-                ReducerConditional::select(m_functor, m_reducer));
+            const int count = m_functor_reducer.get_reducer().value_count();
             for (int i = 0; i < count; ++i) {
               m_result_ptr[i] = pointer_type(m_unified_space)[i];
             }
           } else {
-            const int size = Analysis::value_size(
-                ReducerConditional::select(m_functor, m_reducer));
+            const int size = m_functor_reducer.get_reducer().value_size();
             DeepCopy<HostSpace, CudaSpace>(m_result_ptr, m_scratch_space, size);
           }
         }
@@ -876,19 +848,16 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     } else {
       if (m_result_ptr) {
         // TODO @graph We need to effectively insert this in to the graph
-        final_reducer.init(m_result_ptr);
+        m_functor_reducer.get_reducer().init(m_result_ptr);
       }
     }
   }
 
   template <class ViewType>
-  ParallelReduce(
-      const FunctorType& arg_functor, const Policy& arg_policy,
-      const ViewType& arg_result,
-      std::enable_if_t<Kokkos::is_view<ViewType>::value, void*> = nullptr)
-      : m_functor(arg_functor),
+  ParallelReduce(const CombinedFunctorReducerType& arg_functor_reducer,
+                 const Policy& arg_policy, const ViewType& arg_result)
+      : m_functor_reducer(arg_functor_reducer),
         m_policy(arg_policy),
-        m_reducer(InvalidType()),
         m_result_ptr(arg_result.data()),
         m_result_ptr_device_accessible(
             MemorySpaceAccess<Kokkos::CudaSpace,
@@ -915,7 +884,8 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         m_team_size >= 0
             ? m_team_size
             : Kokkos::Impl::cuda_get_opt_block_size<FunctorType, LaunchBounds>(
-                  internal_space_instance, attr, m_functor, m_vector_size,
+                  internal_space_instance, attr,
+                  m_functor_reducer.get_functor(), m_vector_size,
                   m_policy.team_scratch_size(0),
                   m_policy.thread_scratch_size(0)) /
                   m_vector_size;
@@ -924,12 +894,12 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
         UseShflReduction
             ? 0
             : cuda_single_inter_block_reduce_scan_shmem<false, FunctorType,
-                                                        WorkTag>(arg_functor,
-                                                                 m_team_size);
+                                                        WorkTag>(
+                  arg_functor_reducer.get_functor(), m_team_size);
     m_shmem_begin = sizeof(double) * (m_team_size + 2);
-    m_shmem_size =
-        m_policy.scratch_size(0, m_team_size) +
-        FunctorTeamShmemSize<FunctorType>::value(arg_functor, m_team_size);
+    m_shmem_size  = m_policy.scratch_size(0, m_team_size) +
+                   FunctorTeamShmemSize<FunctorType>::value(
+                       arg_functor_reducer.get_functor(), m_team_size);
     m_scratch_size[0]   = m_shmem_size;
     m_scratch_size[1]   = m_policy.scratch_size(1, m_team_size);
     m_scratch_locks     = internal_space_instance->m_scratch_locks;
@@ -979,113 +949,9 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     }
 
     if (int(m_team_size) >
-        arg_policy.team_size_max(m_functor, m_reducer, ParallelReduceTag())) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelReduce< Cuda > requested too "
-                      "large team size."));
-    }
-  }
-
-  ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
-                 const ReducerType& reducer)
-      : m_functor(arg_functor),
-        m_policy(arg_policy),
-        m_reducer(reducer),
-        m_result_ptr(reducer.view().data()),
-        m_result_ptr_device_accessible(
-            MemorySpaceAccess<Kokkos::CudaSpace,
-                              typename ReducerType::result_view_type::
-                                  memory_space>::accessible),
-        m_result_ptr_host_accessible(
-            MemorySpaceAccess<Kokkos::HostSpace,
-                              typename ReducerType::result_view_type::
-                                  memory_space>::accessible),
-        m_scratch_space(nullptr),
-        m_scratch_flags(nullptr),
-        m_unified_space(nullptr),
-        m_team_begin(0),
-        m_shmem_begin(0),
-        m_shmem_size(0),
-        m_scratch_ptr{nullptr, nullptr},
-        m_league_size(arg_policy.league_size()),
-        m_team_size(arg_policy.team_size()),
-        m_vector_size(arg_policy.impl_vector_length()) {
-    auto internal_space_instance =
-        m_policy.space().impl_internal_space_instance();
-    cudaFuncAttributes attr =
-        CudaParallelLaunch<ParallelReduce,
-                           LaunchBounds>::get_cuda_func_attributes();
-
-    // Valid team size not provided, deduce team size
-    m_team_size =
-        m_team_size >= 0
-            ? m_team_size
-            : Kokkos::Impl::cuda_get_opt_block_size<FunctorType, LaunchBounds>(
-                  internal_space_instance, attr, m_functor, m_vector_size,
-                  m_policy.team_scratch_size(0),
-                  m_policy.thread_scratch_size(0)) /
-                  m_vector_size;
-
-    m_team_begin =
-        UseShflReduction
-            ? 0
-            : cuda_single_inter_block_reduce_scan_shmem<false, FunctorType,
-                                                        WorkTag>(arg_functor,
-                                                                 m_team_size);
-    m_shmem_begin = sizeof(double) * (m_team_size + 2);
-    m_shmem_size =
-        m_policy.scratch_size(0, m_team_size) +
-        FunctorTeamShmemSize<FunctorType>::value(arg_functor, m_team_size);
-    m_scratch_size[0]   = m_shmem_size;
-    m_scratch_size[1]   = m_policy.scratch_size(1, m_team_size);
-    m_scratch_locks     = internal_space_instance->m_scratch_locks;
-    m_num_scratch_locks = internal_space_instance->m_num_scratch_locks;
-    if (m_team_size <= 0) {
-      m_scratch_ptr[1] = nullptr;
-    } else {
-      m_scratch_pool_id = internal_space_instance->acquire_team_scratch_space();
-      m_scratch_ptr[1]  = internal_space_instance->resize_team_scratch_space(
-          m_scratch_pool_id,
-          static_cast<std::int64_t>(m_scratch_size[1]) *
-              (std::min(
-                  static_cast<std::int64_t>(Cuda().concurrency() /
-                                            (m_team_size * m_vector_size)),
-                  static_cast<std::int64_t>(m_league_size))));
-    }
-
-    // The global parallel_reduce does not support vector_length other than 1 at
-    // the moment
-    if ((arg_policy.impl_vector_length() > 1) && !UseShflReduction)
-      Impl::throw_runtime_exception(
-          "Kokkos::parallel_reduce with a TeamPolicy using a vector length of "
-          "greater than 1 is not currently supported for CUDA for dynamic "
-          "sized reduction types.");
-
-    if ((m_team_size < 32) && !UseShflReduction)
-      Impl::throw_runtime_exception(
-          "Kokkos::parallel_reduce with a TeamPolicy using a team_size smaller "
-          "than 32 is not currently supported with CUDA for dynamic sized "
-          "reduction types.");
-
-    // Functor's reduce memory, team scan memory, and team shared memory depend
-    // upon team size.
-
-    const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
-
-    if ((!Kokkos::Impl::is_integral_power_of_two(m_team_size) &&
-         !UseShflReduction) ||
-        internal_space_instance->m_maxShmemPerBlock < shmem_size_total) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelReduce< Cuda > bad team size"));
-    }
-
-    size_type team_size_max =
-        Kokkos::Impl::cuda_get_max_block_size<FunctorType, LaunchBounds>(
-            internal_space_instance, attr, m_functor, m_vector_size,
-            m_policy.team_scratch_size(0), m_policy.thread_scratch_size(0)) /
-        m_vector_size;
-
-    if ((int)m_team_size > (int)team_size_max) {
+        arg_policy.team_size_max(m_functor_reducer.get_functor(),
+                                 m_functor_reducer.get_reducer(),
+                                 ParallelReduceTag())) {
       Kokkos::Impl::throw_runtime_exception(
           std::string("Kokkos::Impl::ParallelReduce< Cuda > requested too "
                       "large team size."));

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -707,7 +707,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
   __device__ inline void run(SHMEMReductionTag&, const int& threadid) const {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     const integral_nonzero_constant<size_type, Analysis::StaticValueSize /
                                                    sizeof(size_type)>
@@ -769,7 +769,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
   __device__ inline void run(ShflReductionTag, const int& threadid) const {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     value_type value;
     final_reducer.init(&value);
@@ -813,7 +813,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
   inline void execute() {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     const bool is_empty_range  = m_league_size == 0 || m_team_size == 0;
     const bool need_device_set = Analysis::has_init_member_function ||

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -228,7 +228,7 @@ class CudaTeamMember {
         Impl::CudaJoinFunctor<Type> cuda_join_functor;
         typename Impl::FunctorAnalysis<
             Impl::FunctorPatternInterface::SCAN, TeamPolicy<Cuda>,
-            Impl::CudaJoinFunctor<Type>>::Reducer reducer(&cuda_join_functor);
+            Impl::CudaJoinFunctor<Type>>::Reducer reducer(cuda_join_functor);
         Impl::cuda_intra_block_reduce_scan<true>(reducer, base_data + 1);
 
         if (global_accum) {

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -198,7 +198,7 @@ class CudaTeamMember {
     KOKKOS_IF_ON_DEVICE(
         (typename Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
                                         TeamPolicy<Cuda>, ReducerType>::Reducer
-             wrapped_reducer(&reducer);
+             wrapped_reducer(reducer);
          cuda_intra_block_reduction(value, wrapped_reducer, blockDim.y);
          reducer.reference() = value;))
   }

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -219,7 +219,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
   inline __device__ void operator()() const {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     const integral_nonzero_constant<size_type, Analysis::StaticValueSize /
                                                    sizeof(size_type)>
@@ -292,7 +292,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
   inline void execute() {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     using ClosureType =
         ParallelReduce<FunctorType, Policy, ReducerType, Kokkos::HIP>;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -180,7 +180,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                    sizeof(size_type));
 
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
     {
       reference_type value = final_reducer.init(reinterpret_cast<pointer_type>(
           ::Kokkos::kokkos_impl_hip_shared_memory<size_type>() +
@@ -235,7 +235,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
   __device__ inline void run(ShflReductionTag) const {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     value_type value;
     final_reducer.init(&value);
@@ -296,7 +296,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
   inline void execute() {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     const index_type nwork     = m_policy.end() - m_policy.begin();
     const bool need_device_set = Analysis::has_init_member_function ||
@@ -456,7 +456,7 @@ class ParallelScanHIPBase {
   //----------------------------------------
 
   __device__ inline void initial() const {
-    typename Analysis::Reducer final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(m_functor);
 
     const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
                                                         sizeof(word_size_type)>
@@ -494,7 +494,7 @@ class ParallelScanHIPBase {
   //----------------------------------------
 
   __device__ inline void final() const {
-    typename Analysis::Reducer final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(m_functor);
 
     const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
                                                         sizeof(word_size_type)>

--- a/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Team.hpp
@@ -674,7 +674,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
   __device__ inline void run(SHMEMReductionTag, int const threadid) const {
     typename analysis::Reducer final_reducer(
-        &reducer_conditional::select(m_functor, m_reducer));
+        reducer_conditional::select(m_functor, m_reducer));
 
     integral_nonzero_constant<size_type, analysis::StaticValueSize /
                                              sizeof(size_type)> const
@@ -723,7 +723,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
   __device__ inline void run(ShflReductionTag, int const threadid) const {
     typename analysis::Reducer final_reducer(
-        &reducer_conditional::select(m_functor, m_reducer));
+        reducer_conditional::select(m_functor, m_reducer));
 
     value_type value;
     final_reducer.init(&value);
@@ -754,7 +754,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
   inline void execute() {
     typename analysis::Reducer final_reducer(
-        &reducer_conditional::select(m_functor, m_reducer));
+        reducer_conditional::select(m_functor, m_reducer));
 
     const bool is_empty_range  = m_league_size == 0 || m_team_size == 0;
     const bool need_device_set = analysis::has_init_member_function ||

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -182,7 +182,7 @@ class HIPTeamMember {
 #ifdef __HIP_DEVICE_COMPILE__
     typename Kokkos::Impl::FunctorAnalysis<
         FunctorPatternInterface::REDUCE, TeamPolicy<HIP>, ReducerType>::Reducer
-        wrapped_reducer(&reducer);
+        wrapped_reducer(reducer);
     hip_intra_block_shuffle_reduction(value, wrapped_reducer, blockDim.y);
     reducer.reference() = value;
 #else

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -219,7 +219,7 @@ class HIPTeamMember {
     Impl::HIPJoinFunctor<Type> hip_join_functor;
     typename Kokkos::Impl::FunctorAnalysis<
         FunctorPatternInterface::REDUCE, TeamPolicy<HIP>,
-        Impl::HIPJoinFunctor<Type>>::Reducer reducer(&hip_join_functor);
+        Impl::HIPJoinFunctor<Type>>::Reducer reducer(hip_join_functor);
     Impl::hip_intra_block_reduce_scan<true>(reducer, base_data + 1);
 
     if (global_accum) {

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -1026,7 +1026,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     buffer.resize(num_worker_threads, value_size);
 
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     for (int t = 0; t < num_worker_threads; ++t) {
       final_reducer.init(reinterpret_cast<pointer_type>(buffer.get(t)));
@@ -1052,7 +1052,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   void finalize() const {
     hpx_thread_buffer &buffer = m_policy.space().impl_get_buffer();
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
     const int num_worker_threads = m_policy.space().concurrency();
     for (int i = 1; i < num_worker_threads; ++i) {
       final_reducer.join(reinterpret_cast<pointer_type>(buffer.get(0)),
@@ -1078,7 +1078,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     if (m_policy.end() <= m_policy.begin()) {
       if (m_result_ptr) {
         typename Analysis::Reducer final_reducer(
-            &ReducerConditional::select(m_functor, m_reducer));
+            ReducerConditional::select(m_functor, m_reducer));
 
         final_reducer.init(m_result_ptr);
         final_reducer.final(m_result_ptr);
@@ -1151,7 +1151,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     const int num_worker_threads = m_policy.space().concurrency();
 
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_iter.m_func, m_reducer));
+        ReducerConditional::select(m_iter.m_func, m_reducer));
     hpx_thread_buffer &buffer = m_iter.m_rp.space().impl_get_buffer();
     buffer.resize(num_worker_threads, value_size);
 
@@ -1175,7 +1175,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
   void finalize() const {
     hpx_thread_buffer &buffer = m_iter.m_rp.space().impl_get_buffer();
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_iter.m_func, m_reducer));
+        ReducerConditional::select(m_iter.m_func, m_reducer));
     const int num_worker_threads = m_policy.space().concurrency();
     for (int i = 1; i < num_worker_threads; ++i) {
       final_reducer.join(reinterpret_cast<pointer_type>(buffer.get(0)),
@@ -1287,7 +1287,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
     const std::size_t value_size = Analysis::value_size(m_functor);
 
     hpx_thread_buffer &buffer = m_policy.space().impl_get_buffer();
-    typename Analysis::Reducer final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(m_functor);
     barrier_type &barrier =
         *static_cast<barrier_type *>(buffer.get_extra_space());
     reference_type update_sum =
@@ -1390,7 +1390,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
     const std::size_t value_size = Analysis::value_size(m_functor);
 
     hpx_thread_buffer &buffer = m_policy.space().impl_get_buffer();
-    typename Analysis::Reducer final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(m_functor);
     barrier_type &barrier =
         *static_cast<barrier_type *>(buffer.get_extra_space());
     reference_type update_sum =
@@ -1554,7 +1554,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     hpx_thread_buffer &buffer = m_policy.space().impl_get_buffer();
     buffer.resize(num_worker_threads, value_size + m_shared);
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     for (int t = 0; t < num_worker_threads; ++t) {
       final_reducer.init(reinterpret_cast<pointer_type>(buffer.get(t)));
@@ -1586,7 +1586,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   void finalize() const {
     hpx_thread_buffer &buffer = m_policy.space().impl_get_buffer();
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
     const int num_worker_threads = m_policy.space().concurrency();
     const pointer_type ptr = reinterpret_cast<pointer_type>(buffer.get(0));
     for (int t = 1; t < num_worker_threads; ++t) {
@@ -1609,7 +1609,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     if (m_policy.league_size() * m_policy.team_size() == 0) {
       if (m_result_ptr) {
         typename Analysis::Reducer final_reducer(
-            &ReducerConditional::select(m_functor, m_reducer));
+            ReducerConditional::select(m_functor, m_reducer));
         final_reducer.init(m_result_ptr);
         final_reducer.final(m_result_ptr);
       }

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -331,6 +331,11 @@ template <class FunctorType, class ExecPolicy, class ReducerType = InvalidType,
 class ParallelReduce;
 
 // FIXME Remove once all backends implement the new interface
+template <typename FunctorType, typename FunctorAnalysisReducerType,
+          typename Enable = void>
+class CombinedFunctorReducer;
+
+// FIXME Remove once all backends implement the new interface
 template <typename CombinedFunctorReducerType, typename PolicyType,
           typename ExecutionSpaceType, typename Enable = void>
 class ParallelReduceWrapper;

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -330,6 +330,11 @@ template <class FunctorType, class ExecPolicy, class ReducerType = InvalidType,
               FunctorType, ExecPolicy>::execution_space>
 class ParallelReduce;
 
+// FIXME Remove once all backends implement the new interface
+template <typename CombinedFunctorReducerType, typename PolicyType,
+          typename ExecutionSpaceType, typename Enable = void>
+class ParallelReduceWrapper;
+
 /// \class ParallelScan
 /// \brief Implementation detail of parallel_scan.
 ///

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -1079,9 +1079,10 @@ template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelForTag, Args...>
     : type_identity<ParallelFor<Args...>> {};
 
+// FIXME Drop "Wrapper" when all backends implement the new reduce interface
 template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelReduceTag, Args...>
-    : type_identity<ParallelReduce<Args...>> {};
+    : type_identity<ParallelReduceWrapper<Args...>> {};
 
 template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelScanTag, Args...>

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -376,15 +376,38 @@ class GraphNodeRef {
     auto policy = Experimental::require((Policy &&) arg_policy,
                                         Kokkos::Impl::KernelInGraphProperty{});
 
-    using next_policy_t = decltype(policy);
-    using next_kernel_t = Kokkos::Impl::GraphNodeKernelImpl<
-        ExecutionSpace, next_policy_t, functor_type, Kokkos::ParallelReduceTag,
-        typename return_value_adapter::reducer_type>;
+    using passed_reducer_type = typename return_value_adapter::reducer_type;
+    using reducer_type =
+        std::conditional_t<std::is_same_v<InvalidType, passed_reducer_type>,
+                           functor_type, passed_reducer_type>;
+    using analysis = Kokkos::Impl::FunctorAnalysis<
+        Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, reducer_type>;
 
-    return this->_then_kernel(next_kernel_t{
-        std::move(arg_name), graph_impl_ptr->get_execution_space(),
-        (Functor &&) functor, (Policy &&) policy,
-        return_value_adapter::return_value(return_value, functor)});
+    using combined_functor_reducer_type =
+        Kokkos::Impl::CombinedFunctorReducer<functor_type,
+                                             typename analysis::Reducer>;
+
+    using next_policy_t = decltype(policy);
+    using next_kernel_t =
+        Kokkos::Impl::GraphNodeKernelImpl<ExecutionSpace, next_policy_t,
+                                          combined_functor_reducer_type,
+                                          Kokkos::ParallelReduceTag>;
+
+    if constexpr (std::is_same_v<InvalidType, passed_reducer_type>) {
+      combined_functor_reducer_type functor_reducer(functor);
+      return this->_then_kernel(next_kernel_t{
+          std::move(arg_name), graph_impl_ptr->get_execution_space(),
+          functor_reducer, (Policy &&) policy,
+          return_value_adapter::return_value(return_value, functor)});
+    } else {
+      auto reducer = return_value_adapter::return_value(return_value, functor);
+      combined_functor_reducer_type functor_reducer(
+          functor, typename analysis::Reducer(reducer));
+
+      return this->_then_kernel(next_kernel_t{
+          std::move(arg_name), graph_impl_ptr->get_execution_space(),
+          functor_reducer, (Policy &&) policy, reducer.view()});
+    }
   }
 
   template <

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -384,9 +384,11 @@ class GraphNodeRef {
     using analysis = Kokkos::Impl::FunctorAnalysis<
         Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy,
         typename reducer_selector::type>;
-    Kokkos::Impl::CombinedFunctorReducer functor_reducer(
-        functor, typename analysis::Reducer(
-                     reducer_selector::select(functor, return_value)));
+    typename analysis::Reducer final_reducer(
+        reducer_selector::select(functor, return_value));
+    Kokkos::Impl::CombinedFunctorReducer<functor_type,
+                                         typename analysis::Reducer>
+        functor_reducer(functor, final_reducer);
 
     using next_policy_t = decltype(policy);
     using next_kernel_t =

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1447,7 +1447,7 @@ class ParallelReduceWrapper {
                 select(combined_functor_reducer.get_reducer().get_functor(),
                        return_value)) {}
 
-  void execute() const { m_parallel_reduce.execute(); }
+  void execute() { m_parallel_reduce.execute(); }
 };
 
 template <typename CombinedFunctorReducerType, typename PolicyType,
@@ -1467,7 +1467,7 @@ class ParallelReduceWrapper<
       const PolicyType& policy, const ReturnValue& return_value)
       : m_parallel_reduce(combined_functor_reducer, policy, return_value) {}
 
-  void execute() const { m_parallel_reduce.execute(); }
+  void execute() { m_parallel_reduce.execute(); }
 };
 
 template <class T, class ReturnType, class ValueTraits>

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1414,6 +1414,11 @@ class CombinedFunctorReducer<
 template <typename ExecutionSpace>
 struct implements_new_reduce_interface : std::false_type {};
 
+#ifdef KOKKOS_ENABLE_SERIAL
+template <>
+struct implements_new_reduce_interface<Kokkos::Serial> : std::true_type {};
+#endif
+
 template <typename CombinedFunctorReducerType, typename PolicyType,
           typename ExecutionSpaceType, typename Enable>
 class ParallelReduceWrapper {

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1373,7 +1373,7 @@ namespace Kokkos {
 namespace Impl {
 
 template <typename FunctorType, typename FunctorAnalysisReducerType,
-          typename Enable = void>
+          typename Enable>
 class CombinedFunctorReducer {
  public:
   using functor_type = FunctorType;
@@ -1432,9 +1432,12 @@ class ParallelReduceWrapper {
   using reducer_type =
       std::conditional_t<has_reducer, helper_reducer_type, InvalidType>;
 
-  Impl::ParallelReduce<functor_type, PolicyType, reducer_type,
-                       ExecutionSpaceType>
-      m_parallel_reduce;
+ public:
+  using wrapped_type = Impl::ParallelReduce<functor_type, PolicyType,
+                                            reducer_type, ExecutionSpaceType>;
+
+ private:
+  wrapped_type m_parallel_reduce;
 
  public:
   template <typename ReturnValue>
@@ -1456,9 +1459,12 @@ class ParallelReduceWrapper<
     CombinedFunctorReducerType, PolicyType, ExecutionSpaceType,
     std::enable_if_t<
         implements_new_reduce_interface<ExecutionSpaceType>::value>> {
-  Impl::ParallelReduce<CombinedFunctorReducerType, PolicyType,
-                       ExecutionSpaceType>
-      m_parallel_reduce;
+ public:
+  using wrapped_type = Impl::ParallelReduce<CombinedFunctorReducerType,
+                                            PolicyType, ExecutionSpaceType>;
+
+ private:
+  wrapped_type m_parallel_reduce;
 
  public:
   template <typename ReturnValue>

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1419,6 +1419,11 @@ template <>
 struct implements_new_reduce_interface<Kokkos::Serial> : std::true_type {};
 #endif
 
+#ifdef KOKKOS_ENABLE_CUDA
+template <>
+struct implements_new_reduce_interface<Kokkos::Cuda> : std::true_type {};
+#endif
+
 template <typename CombinedFunctorReducerType, typename PolicyType,
           typename ExecutionSpaceType, typename Enable>
 class ParallelReduceWrapper {

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
@@ -86,7 +86,7 @@ class Kokkos::Impl::ParallelReduce<Functor, Kokkos::MDRangePolicy<Traits...>,
 
     ValueType val;
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
     final_reducer.init(&val);
 
     Kokkos::Experimental::Impl::OpenACCParallelReduceMDRangeHelper(

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
@@ -84,7 +84,7 @@ class Kokkos::Impl::ParallelReduce<Functor, Kokkos::RangePolicy<Traits...>,
 
     ValueType val;
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
     final_reducer.init(&val);
 
     Kokkos::Experimental::Impl::OpenACCParallelReduceHelper(

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -69,7 +69,7 @@ class Kokkos::Impl::ParallelReduce<FunctorType,
 
     value_type tmp;
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
     final_reducer.init(&tmp);
 
     Kokkos::Experimental::Impl::OpenACCParallelReduceTeamHelper(

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -345,7 +345,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
  public:
   inline void execute() const {
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     if (m_policy.end() <= m_policy.begin()) {
       if (m_result_ptr) {
@@ -550,7 +550,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     );
 
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_iter.m_func, m_reducer));
+        ReducerConditional::select(m_iter.m_func, m_reducer));
 
 #ifndef KOKKOS_COMPILER_INTEL
     if (execute_in_serial(m_iter.m_rp.space())) {
@@ -749,7 +749,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
     );
 
     if (execute_in_serial(m_policy.space())) {
-      typename Analysis::Reducer final_reducer(&m_functor);
+      typename Analysis::Reducer final_reducer(m_functor);
 
       reference_type update = final_reducer.init(
           pointer_type(m_instance->get_thread_data(0)->pool_reduce_local()));
@@ -763,7 +763,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
 #pragma omp parallel num_threads(m_instance->thread_pool_size())
     {
       HostThreadTeamData& data = *(m_instance->get_thread_data());
-      typename Analysis::Reducer final_reducer(&m_functor);
+      typename Analysis::Reducer final_reducer(m_functor);
 
       const WorkRange range(m_policy, omp_get_thread_num(),
                             omp_get_num_threads());
@@ -881,7 +881,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
     );
 
     if (execute_in_serial(m_policy.space())) {
-      typename Analysis::Reducer final_reducer(&m_functor);
+      typename Analysis::Reducer final_reducer(m_functor);
 
       reference_type update = final_reducer.init(
           pointer_type(m_instance->get_thread_data(0)->pool_reduce_local()));
@@ -899,7 +899,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 #pragma omp parallel num_threads(m_instance->thread_pool_size())
     {
       HostThreadTeamData& data = *(m_instance->get_thread_data());
-      typename Analysis::Reducer final_reducer(&m_functor);
+      typename Analysis::Reducer final_reducer(m_functor);
 
       const WorkRange range(m_policy, omp_get_thread_num(),
                             omp_get_num_threads());
@@ -1202,7 +1202,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     enum { is_dynamic = std::is_same<SchedTag, Kokkos::Dynamic>::value };
 
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     if (m_policy.league_size() == 0 || m_policy.team_size() == 0) {
       if (m_result_ptr) {

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Range.hpp
@@ -100,7 +100,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
   }
 
   template <class ViewType>
-  ParallelReduce(const FunctorType& arg_functor, Policy& arg_policy,
+  ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
                  const ViewType& arg_result_view,
                  std::enable_if_t<Kokkos::is_view<ViewType>::value &&
                                       !Kokkos::is_reducer<ReducerType>::value,
@@ -114,7 +114,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                               typename ViewType::memory_space>::accessible),
         m_result_ptr_num_elems(arg_result_view.size()) {}
 
-  ParallelReduce(const FunctorType& arg_functor, Policy& arg_policy,
+  ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
                  const ReducerType& reducer)
       : m_functor(arg_functor),
         m_policy(arg_policy),

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
@@ -525,7 +525,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                      FunctorTeamShmemSize<FunctorType>::value(
                          arg_functor, arg_policy.team_size())) {}
 
-  ParallelReduce(const FunctorType& arg_functor, Policy& arg_policy,
+  ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
                  const ReducerType& reducer)
       : m_result_ptr_on_device(
             MemorySpaceAccess<Kokkos::Experimental::OpenMPTargetSpace,

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
@@ -79,7 +79,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
     FunctorType a_functor(m_functor);
 #pragma omp target teams distribute map(to : a_functor) num_teams(nteams)
     for (idx_type team_id = 0; team_id < n_chunks; ++team_id) {
-      typename Analysis::Reducer final_reducer(&a_functor);
+      typename Analysis::Reducer final_reducer(a_functor);
 #pragma omp parallel num_threads(team_size)
       {
         const idx_type local_offset = team_id * chunk_size;
@@ -120,7 +120,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
                                         : a_functor) num_teams(nteams) \
     thread_limit(team_size)
     for (idx_type team_id = 0; team_id < n_chunks; ++team_id) {
-      typename Analysis::Reducer final_reducer(&a_functor);
+      typename Analysis::Reducer final_reducer(a_functor);
 #pragma omp parallel num_threads(team_size)
       {
         const idx_type local_offset = team_id * chunk_size;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
@@ -222,7 +222,7 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
 
 #pragma omp target map(to : f) is_device_ptr(scratch_ptr)
     {
-      typename FunctorAnalysis::Reducer final_reducer(&f);
+      typename FunctorAnalysis::Reducer final_reducer(f);
       // Enter this loop if the functor has an `init`
       if constexpr (HasInit) {
         // The `init` routine needs to be called on the device since it might
@@ -257,7 +257,7 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
     map(to                                                                   \
         : f) is_device_ptr(scratch_ptr)
     {
-      typename FunctorAnalysis::Reducer final_reducer(&f);
+      typename FunctorAnalysis::Reducer final_reducer(f);
 #pragma omp parallel
       {
         const int team_num    = omp_get_team_num();
@@ -304,7 +304,7 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
     is_device_ptr(scratch_ptr)
       for (int i = 0; i < max_teams - tree_neighbor_offset;
            i += 2 * tree_neighbor_offset) {
-        typename FunctorAnalysis::Reducer final_reducer(&f);
+        typename FunctorAnalysis::Reducer final_reducer(f);
         ValueType* team_scratch = scratch_ptr;
         const int team_offset   = max_team_threads * value_count;
         final_reducer.join(
@@ -575,7 +575,7 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
       // device members.
 #pragma omp target map(to : f) is_device_ptr(scratch_ptr)
       {
-        typename FunctorAnalysis::Reducer final_reducer(&f);
+        typename FunctorAnalysis::Reducer final_reducer(f);
         final_reducer.init(scratch_ptr);
         final_reducer.final(scratch_ptr);
       }
@@ -586,7 +586,7 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
           static_cast<ValueType*>(scratch_ptr)[i] = ValueType();
         }
 
-        typename FunctorAnalysis::Reducer final_reducer(&f);
+        typename FunctorAnalysis::Reducer final_reducer(f);
         final_reducer.final(static_cast<ValueType*>(scratch_ptr));
       }
     }
@@ -616,7 +616,7 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
         const int num_teams     = omp_get_num_teams();
         ValueType* team_scratch = static_cast<ValueType*>(scratch_ptr) +
                                   team_num * team_size * value_count;
-        typename FunctorAnalysis::Reducer final_reducer(&f);
+        typename FunctorAnalysis::Reducer final_reducer(f);
         ReferenceType result = final_reducer.init(&team_scratch[0]);
 
         for (int league_id = team_num; league_id < league_size;
@@ -642,7 +642,7 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
            i += 2 * tree_neighbor_offset) {
         ValueType* team_scratch = static_cast<ValueType*>(scratch_ptr);
         const int team_offset   = team_size * value_count;
-        typename FunctorAnalysis::Reducer final_reducer(&f);
+        typename FunctorAnalysis::Reducer final_reducer(f);
         final_reducer.join(
             &team_scratch[i * team_offset],
             &team_scratch[(i + tree_neighbor_offset) * team_offset]);

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Reduce.hpp
@@ -265,7 +265,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
           const auto& selected_reducer = ReducerConditional::select(
               static_cast<const FunctorType&>(functor),
               static_cast<const ReducerType&>(reducer_wrapper.get_functor()));
-          typename Analysis::Reducer final_reducer(&selected_reducer);
+          typename Analysis::Reducer final_reducer(selected_reducer);
           reference_type update = final_reducer.init(results_ptr);
           if (size == 1) {
             if constexpr (std::is_void<WorkTag>::value)
@@ -311,7 +311,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                   static_cast<const FunctorType&>(functor),
                   static_cast<const ReducerType&>(
                       reducer_wrapper.get_functor()));
-              typename Analysis::Reducer final_reducer(&selected_reducer);
+              typename Analysis::Reducer final_reducer(selected_reducer);
 
               using index_type       = typename Policy::index_type;
               const auto upper_bound = std::min<index_type>(
@@ -629,7 +629,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           const auto& selected_reducer = ReducerConditional::select(
               static_cast<const FunctorType&>(functor),
               static_cast<const ReducerType&>(reducer_wrapper.get_functor()));
-          typename Analysis::Reducer final_reducer(&selected_reducer);
+          typename Analysis::Reducer final_reducer(selected_reducer);
 
           reference_type update = final_reducer.init(results_ptr);
           if (size == 1) {
@@ -671,7 +671,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
           const auto& selected_reducer = ReducerConditional::select(
               static_cast<const FunctorType&>(functor),
               static_cast<const ReducerType&>(reducer_wrapper.get_functor()));
-          typename Analysis::Reducer final_reducer(&selected_reducer);
+          typename Analysis::Reducer final_reducer(selected_reducer);
 
           // In the first iteration, we call functor to initialize the local
           // memory. Otherwise, the local memory is initialized with the

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -145,7 +145,7 @@ class ParallelScanSYCLBase {
           sycl::nd_range<1>(n_wgroups * wgroup_size, wgroup_size),
           [=](sycl::nd_item<1> item) {
             const FunctorType& functor = functor_wrapper.get_functor();
-            typename Analysis::Reducer final_reducer(&functor);
+            typename Analysis::Reducer final_reducer(functor);
 
             const auto local_id  = item.get_local_linear_id();
             const auto global_id = item.get_global_linear_id();
@@ -178,7 +178,7 @@ class ParallelScanSYCLBase {
             [=](sycl::nd_item<1> item) {
               const auto global_id       = item.get_global_linear_id();
               const FunctorType& functor = functor_wrapper.get_functor();
-              typename Analysis::Reducer final_reducer(&functor);
+              typename Analysis::Reducer final_reducer(functor);
               if (global_id < size)
                 final_reducer.join(&global_mem[global_id],
                                    &group_results[item.get_group_linear_id()]);
@@ -208,7 +208,7 @@ class ParallelScanSYCLBase {
         const typename Policy::index_type id =
             static_cast<typename Policy::index_type>(item.get_id()) + begin;
         const FunctorType& functor = functor_wrapper.get_functor();
-        typename Analysis::Reducer final_reducer(&functor);
+        typename Analysis::Reducer final_reducer(functor);
 
         value_type update{};
         final_reducer.init(&update);

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Team.hpp
@@ -608,7 +608,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   static_cast<const FunctorType&>(functor),
                   static_cast<const ReducerType&>(
                       reducer_wrapper.get_functor()));
-              typename Analysis::Reducer final_reducer(&selected_reducer);
+              typename Analysis::Reducer final_reducer(selected_reducer);
 
               reference_type update = final_reducer.init(results_ptr);
               if (size == 1) {
@@ -670,7 +670,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                     static_cast<const FunctorType&>(functor),
                     static_cast<const ReducerType&>(
                         reducer_wrapper.get_functor()));
-                typename Analysis::Reducer final_reducer(&selected_reducer);
+                typename Analysis::Reducer final_reducer(selected_reducer);
 
                 if constexpr (Analysis::StaticValueSize == 0) {
                   reference_type update =

--- a/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
@@ -129,7 +129,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_iter.m_func, m_reducer));
+        ReducerConditional::select(m_iter.m_func, m_reducer));
 
     reference_type update = final_reducer.init(ptr);
 

--- a/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
@@ -58,29 +58,20 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       : m_iter(arg_policy, arg_functor) {}
 };
 
-template <class FunctorType, class ReducerType, class... Traits>
-class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
-                     Kokkos::Serial> {
+template <class CombinedFunctorReducerType, class... Traits>
+class ParallelReduce<CombinedFunctorReducerType,
+                     Kokkos::MDRangePolicy<Traits...>, Kokkos::Serial> {
  private:
   using MDRangePolicy = Kokkos::MDRangePolicy<Traits...>;
   using Policy        = typename MDRangePolicy::impl_range_policy;
+  using FunctorType   = typename CombinedFunctorReducerType::functor_type;
+  using ReducerType   = typename CombinedFunctorReducerType::reducer_type;
 
   using WorkTag = typename MDRangePolicy::work_tag;
 
-  using ReducerConditional =
-      Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                         FunctorType, ReducerType>;
-  using ReducerTypeFwd = typename ReducerConditional::type;
-  using WorkTagFwd =
-      std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
-                         void>;
-
-  using Analysis = FunctorAnalysis<FunctorPatternInterface::REDUCE,
-                                   MDRangePolicy, ReducerTypeFwd>;
-
-  using pointer_type   = typename Analysis::pointer_type;
-  using value_type     = typename Analysis::value_type;
-  using reference_type = typename Analysis::reference_type;
+  using pointer_type   = typename ReducerType::pointer_type;
+  using value_type     = typename ReducerType::value_type;
+  using reference_type = typename ReducerType::reference_type;
 
   using iterate_type =
       typename Kokkos::Impl::HostIterateTile<MDRangePolicy, FunctorType,
@@ -107,8 +98,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
     return 1024;
   }
   inline void execute() const {
-    const size_t pool_reduce_size = Analysis::value_size(
-        ReducerConditional::select(m_iter.m_func, m_reducer));
+    const size_t pool_reduce_size  = m_reducer.value_size();
     const size_t team_reduce_size  = 0;  // Never shrinks
     const size_t team_shared_size  = 0;  // Never shrinks
     const size_t thread_local_size = 0;  // Never shrinks
@@ -128,44 +118,27 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
             : pointer_type(
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
-    typename Analysis::Reducer final_reducer(
-        ReducerConditional::select(m_iter.m_func, m_reducer));
-
-    reference_type update = final_reducer.init(ptr);
+    reference_type update = m_reducer.init(ptr);
 
     this->exec(update);
 
-    final_reducer.final(ptr);
+    m_reducer.final(ptr);
   }
 
-  template <class HostViewType>
-  ParallelReduce(const FunctorType& arg_functor,
+  template <class ViewType>
+  ParallelReduce(const CombinedFunctorReducerType& arg_functor_reducer,
                  const MDRangePolicy& arg_policy,
-                 const HostViewType& arg_result_view,
-                 std::enable_if_t<Kokkos::is_view<HostViewType>::value &&
-                                      !Kokkos::is_reducer<ReducerType>::value,
-                                  void*> = nullptr)
-      : m_iter(arg_policy, arg_functor),
-        m_reducer(InvalidType()),
+                 const ViewType& arg_result_view)
+      : m_iter(arg_policy, arg_functor_reducer.get_functor()),
+        m_reducer(arg_functor_reducer.get_reducer()),
         m_result_ptr(arg_result_view.data()) {
-    static_assert(Kokkos::is_view<HostViewType>::value,
+    static_assert(Kokkos::is_view<ViewType>::value,
                   "Kokkos::Serial reduce result must be a View");
 
     static_assert(
-        Kokkos::Impl::MemorySpaceAccess<typename HostViewType::memory_space,
+        Kokkos::Impl::MemorySpaceAccess<typename ViewType::memory_space,
                                         Kokkos::HostSpace>::accessible,
         "Kokkos::Serial reduce result must be a View in HostSpace");
-  }
-
-  inline ParallelReduce(const FunctorType& arg_functor,
-                        MDRangePolicy arg_policy, const ReducerType& reducer)
-      : m_iter(arg_policy, arg_functor),
-        m_reducer(reducer),
-        m_result_ptr(reducer.view().data()) {
-    /*static_assert( std::is_same< typename ViewType::memory_space
-                                    , Kokkos::HostSpace >::value
-      , "Reduction result on Kokkos::OpenMP must be a Kokkos::View in HostSpace"
-      );*/
   }
 };
 

--- a/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
@@ -128,7 +128,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     reference_type update = final_reducer.init(ptr);
 
@@ -221,7 +221,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
         pool_reduce_size, team_reduce_size, team_shared_size,
         thread_local_size);
 
-    typename Analysis::Reducer final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(m_functor);
 
     reference_type update = final_reducer.init(pointer_type(
         internal_instance->m_thread_team_data.pool_reduce_local()));
@@ -286,7 +286,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
         pool_reduce_size, team_reduce_size, team_shared_size,
         thread_local_size);
 
-    typename Analysis::Reducer final_reducer(&m_functor);
+    typename Analysis::Reducer final_reducer(m_functor);
 
     reference_type update = final_reducer.init(pointer_type(
         internal_instance->m_thread_team_data.pool_reduce_local()));

--- a/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
@@ -268,35 +268,25 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
 /*--------------------------------------------------------------------------*/
 
-template <class FunctorType, class ReducerType, class... Properties>
-class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
-                     ReducerType, Kokkos::Serial> {
+template <class CombinedFunctorReducerType, class... Properties>
+class ParallelReduce<CombinedFunctorReducerType,
+                     Kokkos::TeamPolicy<Properties...>, Kokkos::Serial> {
  private:
-  enum { TEAM_REDUCE_SIZE = 512 };
+  static constexpr int TEAM_REDUCE_SIZE = 512;
 
-  using Policy = TeamPolicyInternal<Kokkos::Serial, Properties...>;
+  using Policy      = TeamPolicyInternal<Kokkos::Serial, Properties...>;
+  using FunctorType = typename CombinedFunctorReducerType::functor_type;
+  using ReducerType = typename CombinedFunctorReducerType::reducer_type;
 
   using Member  = typename Policy::member_type;
   using WorkTag = typename Policy::work_tag;
 
-  using ReducerConditional =
-      Kokkos::Impl::if_c<std::is_same<InvalidType, ReducerType>::value,
-                         FunctorType, ReducerType>;
-  using ReducerTypeFwd = typename ReducerConditional::type;
-  using WorkTagFwd =
-      std::conditional_t<std::is_same<InvalidType, ReducerType>::value, WorkTag,
-                         void>;
+  using pointer_type   = typename ReducerType::pointer_type;
+  using reference_type = typename ReducerType::reference_type;
 
-  using Analysis =
-      FunctorAnalysis<FunctorPatternInterface::REDUCE, Policy, ReducerTypeFwd>;
-
-  using pointer_type   = typename Analysis::pointer_type;
-  using reference_type = typename Analysis::reference_type;
-
-  const FunctorType m_functor;
+  const CombinedFunctorReducerType m_functor_reducer;
   const Policy m_policy;
   const int m_league;
-  const ReducerType m_reducer;
   pointer_type m_result_ptr;
   size_t m_shared;
 
@@ -304,7 +294,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
   inline std::enable_if_t<std::is_void<TagType>::value> exec(
       HostThreadTeamData& data, reference_type update) const {
     for (int ileague = 0; ileague < m_league; ++ileague) {
-      m_functor(Member(data, ileague, m_league), update);
+      m_functor_reducer.get_functor()(Member(data, ileague, m_league), update);
     }
   }
 
@@ -314,14 +304,15 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     const TagType t{};
 
     for (int ileague = 0; ileague < m_league; ++ileague) {
-      m_functor(t, Member(data, ileague, m_league), update);
+      m_functor_reducer.get_functor()(t, Member(data, ileague, m_league),
+                                      update);
     }
   }
 
  public:
   inline void execute() const {
     const size_t pool_reduce_size =
-        Analysis::value_size(ReducerConditional::select(m_functor, m_reducer));
+        m_functor_reducer.get_reducer().value_size();
 
     const size_t team_reduce_size  = TEAM_REDUCE_SIZE;
     const size_t team_shared_size  = m_shared;
@@ -341,29 +332,23 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
             : pointer_type(
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
-    typename Analysis::Reducer final_reducer(
-        ReducerConditional::select(m_functor, m_reducer));
-
-    reference_type update = final_reducer.init(ptr);
+    reference_type update = m_functor_reducer.get_reducer().init(ptr);
 
     this->template exec<WorkTag>(internal_instance->m_thread_team_data, update);
 
-    final_reducer.final(ptr);
+    m_functor_reducer.get_reducer().final(ptr);
   }
 
   template <class ViewType>
-  ParallelReduce(const FunctorType& arg_functor, const Policy& arg_policy,
-                 const ViewType& arg_result,
-                 std::enable_if_t<Kokkos::is_view<ViewType>::value &&
-                                      !Kokkos::is_reducer<ReducerType>::value,
-                                  void*> = nullptr)
-      : m_functor(arg_functor),
+  ParallelReduce(const CombinedFunctorReducerType& arg_functor_reducer,
+                 const Policy& arg_policy, const ViewType& arg_result)
+      : m_functor_reducer(arg_functor_reducer),
         m_policy(arg_policy),
         m_league(arg_policy.league_size()),
-        m_reducer(InvalidType()),
         m_result_ptr(arg_result.data()),
         m_shared(arg_policy.scratch_size(0) + arg_policy.scratch_size(1) +
-                 FunctorTeamShmemSize<FunctorType>::value(m_functor, 1)) {
+                 FunctorTeamShmemSize<FunctorType>::value(
+                     m_functor_reducer.get_functor(), 1)) {
     static_assert(Kokkos::is_view<ViewType>::value,
                   "Reduction result on Kokkos::Serial must be a Kokkos::View");
 
@@ -372,21 +357,6 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                                         Kokkos::HostSpace>::accessible,
         "Reduction result on Kokkos::Serial must be a Kokkos::View in "
         "HostSpace");
-  }
-
-  inline ParallelReduce(const FunctorType& arg_functor, Policy arg_policy,
-                        const ReducerType& reducer)
-      : m_functor(arg_functor),
-        m_policy(arg_policy),
-        m_league(arg_policy.league_size()),
-        m_reducer(reducer),
-        m_result_ptr(reducer.view().data()),
-        m_shared(arg_policy.scratch_size(0) + arg_policy.scratch_size(1) +
-                 FunctorTeamShmemSize<FunctorType>::value(arg_functor, 1)) {
-    /*static_assert( std::is_same< typename ViewType::memory_space
-                            , Kokkos::HostSpace >::value
-    , "Reduction result on Kokkos::OpenMP must be a Kokkos::View in HostSpace"
-    );*/
   }
 };
 

--- a/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
@@ -342,7 +342,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
     typename Analysis::Reducer final_reducer(
-        &ReducerConditional::select(m_functor, m_reducer));
+        ReducerConditional::select(m_functor, m_reducer));
 
     reference_type update = final_reducer.init(ptr);
 

--- a/core/src/Threads/Kokkos_Threads_Parallel_MDRange.hpp
+++ b/core/src/Threads/Kokkos_Threads_Parallel_MDRange.hpp
@@ -165,7 +165,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
                           exec.pool_rank(), exec.pool_size());
 
     typename Analysis::Reducer reducer(
-        &ReducerConditional::select(self.m_iter.m_func, self.m_reducer));
+        ReducerConditional::select(self.m_iter.m_func, self.m_reducer));
 
     self.exec_range(
         range.begin(), range.end(),
@@ -189,7 +189,7 @@ class ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>, ReducerType,
 
     long work_index = exec.get_work_index();
     typename Analysis::Reducer reducer(
-        &ReducerConditional::select(self.m_iter.m_func, self.m_reducer));
+        ReducerConditional::select(self.m_iter.m_func, self.m_reducer));
 
     reference_type update =
         reducer.init(static_cast<pointer_type>(exec.reduce_memory()));

--- a/core/src/Threads/Kokkos_Threads_Parallel_Range.hpp
+++ b/core/src/Threads/Kokkos_Threads_Parallel_Range.hpp
@@ -183,7 +183,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     const WorkRange range(self.m_policy, exec.pool_rank(), exec.pool_size());
 
     typename Analysis::Reducer reducer(
-        &ReducerConditional::select(self.m_functor, self.m_reducer));
+        ReducerConditional::select(self.m_functor, self.m_reducer));
 
     ParallelReduce::template exec_range<WorkTag>(
         self.m_functor, range.begin(), range.end(),
@@ -206,7 +206,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
 
     long work_index = exec.get_work_index();
     typename Analysis::Reducer reducer(
-        &ReducerConditional::select(self.m_functor, self.m_reducer));
+        ReducerConditional::select(self.m_functor, self.m_reducer));
 
     reference_type update =
         reducer.init(static_cast<pointer_type>(exec.reduce_memory()));
@@ -231,7 +231,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
     if (m_policy.end() <= m_policy.begin()) {
       if (m_result_ptr) {
         typename Analysis::Reducer final_reducer(
-            &ReducerConditional::select(m_functor, m_reducer));
+            ReducerConditional::select(m_functor, m_reducer));
         final_reducer.init(m_result_ptr);
         final_reducer.final(m_result_ptr);
       }
@@ -337,7 +337,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
 
     const WorkRange range(self.m_policy, exec.pool_rank(), exec.pool_size());
 
-    typename Analysis::Reducer final_reducer(&self.m_functor);
+    typename Analysis::Reducer final_reducer(self.m_functor);
 
     reference_type update =
         final_reducer.init(static_cast<pointer_type>(exec.reduce_memory()));
@@ -417,7 +417,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
     const WorkRange range(self.m_policy, exec.pool_rank(), exec.pool_size());
 
-    typename Analysis::Reducer final_reducer(&self.m_functor);
+    typename Analysis::Reducer final_reducer(self.m_functor);
 
     reference_type update =
         final_reducer.init(static_cast<pointer_type>(exec.reduce_memory()));

--- a/core/src/Threads/Kokkos_Threads_Parallel_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Parallel_Team.hpp
@@ -161,7 +161,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     const ParallelReduce &self = *((const ParallelReduce *)arg);
 
     typename Analysis::Reducer reducer(
-        &ReducerConditional::select(self.m_functor, self.m_reducer));
+        ReducerConditional::select(self.m_functor, self.m_reducer));
 
     ParallelReduce::template exec_team<WorkTag>(
         self.m_functor, Member(&exec, self.m_policy, self.m_shared),
@@ -175,7 +175,7 @@ class ParallelReduce<FunctorType, Kokkos::TeamPolicy<Properties...>,
     if (m_policy.league_size() * m_policy.team_size() == 0) {
       if (m_result_ptr) {
         typename Analysis::Reducer final_reducer(
-            &ReducerConditional::select(m_functor, m_reducer));
+            ReducerConditional::select(m_functor, m_reducer));
         final_reducer.init(m_result_ptr);
         final_reducer.final(m_result_ptr);
       }

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -908,7 +908,7 @@ struct FunctorAnalysis {
     template <bool IsArray>
     KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<IsArray, int> len() const
         noexcept {
-      return m_functor->value_count;
+      return m_functor.value_count;
     }
 
     template <bool IsArray>

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -320,13 +320,15 @@ struct FunctorAnalysis {
 
  private:
   template <bool IsArray, class FF>
-  KOKKOS_INLINE_FUNCTION static constexpr std::enable_if_t<IsArray, unsigned>
+  KOKKOS_INLINE_FUNCTION static constexpr std::enable_if_t<IsArray,
+                                                           unsigned int>
   get_length(FF const& f) {
     return f.value_count;
   }
 
   template <bool IsArray, class FF>
-  KOKKOS_INLINE_FUNCTION static constexpr std::enable_if_t<!IsArray, unsigned>
+  KOKKOS_INLINE_FUNCTION static constexpr std::enable_if_t<!IsArray,
+                                                           unsigned int>
   get_length(FF const&) {
     return candidate_is_void ? 0 : 1;
   }
@@ -337,12 +339,12 @@ struct FunctorAnalysis {
         !candidate_is_void && !candidate_is_array ? sizeof(ValueType) : 0
   };
 
-  KOKKOS_FORCEINLINE_FUNCTION static constexpr unsigned value_count(
+  KOKKOS_FORCEINLINE_FUNCTION static constexpr unsigned int value_count(
       const Functor& f) {
     return FunctorAnalysis::template get_length<candidate_is_array>(f);
   }
 
-  KOKKOS_FORCEINLINE_FUNCTION static constexpr unsigned value_size(
+  KOKKOS_FORCEINLINE_FUNCTION static constexpr unsigned int value_size(
       const Functor& f) {
     return FunctorAnalysis::template get_length<candidate_is_array>(f) *
            sizeof(ValueType);
@@ -351,13 +353,13 @@ struct FunctorAnalysis {
   //----------------------------------------
 
   template <class Unknown>
-  KOKKOS_FORCEINLINE_FUNCTION static constexpr unsigned value_count(
+  KOKKOS_FORCEINLINE_FUNCTION static constexpr unsigned int value_count(
       const Unknown&) {
     return candidate_is_void ? 0 : 1;
   }
 
   template <class Unknown>
-  KOKKOS_FORCEINLINE_FUNCTION static constexpr unsigned value_size(
+  KOKKOS_FORCEINLINE_FUNCTION static constexpr unsigned int value_size(
       const Unknown&) {
     return candidate_is_void ? 0 : sizeof(ValueType);
   }
@@ -903,7 +905,7 @@ struct FunctorAnalysis {
 
   struct Reducer {
    private:
-    Functor const m_functor;
+    Functor m_functor;
 
     template <bool IsArray>
     KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<IsArray, int> len() const
@@ -934,11 +936,11 @@ struct FunctorAnalysis {
       return DeduceFinal<>::value;
     }
 
-    KOKKOS_FUNCTION unsigned value_size() const {
+    KOKKOS_FUNCTION unsigned int value_size() const {
       return FunctorAnalysis::value_size(m_functor);
     }
 
-    KOKKOS_FUNCTION unsigned value_count() const {
+    KOKKOS_FUNCTION unsigned int value_count() const {
       return FunctorAnalysis::value_count(m_functor);
     }
 

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -924,8 +924,26 @@ struct FunctorAnalysis {
     using reference_type = FunctorAnalysis::reference_type;
     using functor_type   = Functor;  // Adapts a functor
 
+    static constexpr bool has_join_member_function() {
+      return DeduceJoin<>::value;
+    }
+    static constexpr bool has_init_member_function() {
+      return DeduceInit<>::value;
+    }
+    static constexpr bool has_final_member_function() {
+      return DeduceFinal<>::value;
+    }
+
     KOKKOS_FUNCTION unsigned value_size() const {
       return FunctorAnalysis::value_size(m_functor);
+    }
+
+    KOKKOS_FUNCTION unsigned value_count() const {
+      return FunctorAnalysis::value_count(m_functor);
+    }
+
+    KOKKOS_FUNCTION static constexpr unsigned int static_value_size() {
+      return StaticValueSize;
     }
 
     template <bool is_array = candidate_is_array>

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_IMPL_KOKKOS_TOOLS_GENERIC_HPP
 
 #include <impl/Kokkos_Profiling.hpp>
+#include <impl/Kokkos_FunctorAnalysis.hpp>
 
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_ExecPolicy.hpp>
@@ -99,9 +100,12 @@ struct SimpleTeamSizeCalculator {
                                         const Functor& functor,
                                         const Kokkos::ParallelReduceTag&) {
     using exec_space = typename Policy::execution_space;
-    using driver =
-        Kokkos::Impl::ParallelReduce<Functor, Policy, Kokkos::InvalidType,
-                                     exec_space>;
+    using analysis   = Kokkos::Impl::FunctorAnalysis<
+        Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, Functor>;
+    using driver = typename Kokkos::Impl::ParallelReduceWrapper<
+        Kokkos::Impl::CombinedFunctorReducer<Functor,
+                                             typename analysis::Reducer>,
+        Policy, exec_space>::wrapped_type;
     return driver::max_tile_size_product(policy, functor);
   }
 };
@@ -135,8 +139,12 @@ struct ComplexReducerSizeCalculator {
                                         const Functor& functor,
                                         const Kokkos::ParallelReduceTag&) {
     using exec_space = typename Policy::execution_space;
-    using driver =
-        Kokkos::Impl::ParallelReduce<Functor, Policy, ReducerType, exec_space>;
+    using analysis   = Kokkos::Impl::FunctorAnalysis<
+        Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, Functor>;
+    using driver = typename Kokkos::Impl::ParallelReduceWrapper<
+        Kokkos::Impl::CombinedFunctorReducer<Functor,
+                                             typename analysis::Reducer>,
+        Policy, exec_space>::wrapped_type;
     return driver::max_tile_size_product(policy, functor);
   }
 };

--- a/core/unit_test/TestFunctorAnalysis.hpp
+++ b/core/unit_test/TestFunctorAnalysis.hpp
@@ -59,7 +59,7 @@ void test_functor_analysis() {
   static_assert(!A01::has_init_member_function, "");
   static_assert(!A01::has_final_member_function, "");
   static_assert(A01::StaticValueSize == 0, "");
-  ASSERT_EQ(R01(&c01).length(), 0);
+  ASSERT_EQ(R01(c01).length(), 0);
 
   //------------------------------
   auto c02  = KOKKOS_LAMBDA(int, double&){};
@@ -78,7 +78,7 @@ void test_functor_analysis() {
   static_assert(!A02::has_init_member_function, "");
   static_assert(!A02::has_final_member_function, "");
   static_assert(A02::StaticValueSize == sizeof(double), "");
-  ASSERT_EQ(R02(&c02).length(), 1);
+  ASSERT_EQ(R02(c02).length(), 1);
 
   //------------------------------
 
@@ -106,7 +106,7 @@ void test_functor_analysis() {
   static_assert(!A03::has_final_member_function, "");
   static_assert(
       A03::StaticValueSize == sizeof(TestFunctorAnalysis_03::value_type), "");
-  ASSERT_EQ(R03(&c03).length(), 1);
+  ASSERT_EQ(R03(c03).length(), 1);
 
   //------------------------------
 }

--- a/core/unit_test/hip/TestHIP_ScanUnit.cpp
+++ b/core/unit_test/hip/TestHIP_ScanUnit.cpp
@@ -33,7 +33,7 @@ __global__ void start_intra_block_scan()
   DummyFunctor f;
   typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN,
-      Kokkos::RangePolicy<Kokkos::HIP>, DummyFunctor>::Reducer reducer(&f);
+      Kokkos::RangePolicy<Kokkos::HIP>, DummyFunctor>::Reducer reducer(f);
   Kokkos::Impl::hip_intra_block_reduce_scan<true>(reducer, values);
 
   __syncthreads();

--- a/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
+++ b/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
@@ -45,7 +45,7 @@ struct NonTrivialReduceFunctor {
   NonTrivialReduceFunctor(NonTrivialReduceFunctor &&)      = default;
   NonTrivialReduceFunctor &operator=(NonTrivialReduceFunctor &&) = default;
   NonTrivialReduceFunctor &operator=(NonTrivialReduceFunctor const &) = default;
-  ~NonTrivialReduceFunctor() {}
+  KOKKOS_FUNCTION ~NonTrivialReduceFunctor() {}
 };
 
 template <class ExecSpace>


### PR DESCRIPTION
Part of #5332. Realizing that converting all backends in one pull request might not be ideal, this pull request introduces a temporary wrapper class ParallelReduceWrapper that allows backends to have either the new or the old interface. This should make discussions easier. So far, this pull request only changes the `Serial` and `Cuda` backend to the new proposed interface.

A general description (largely copied from https://github.com/kokkos/kokkos/pull/5332#issuecomment-1284622238):

The pull request is best understood looking at the changes to Kokkos_Core_fwd.hpp and then Kokkos_Parallel_Reduce.hpp:

The internal classes change from
```
template <class FunctorType, class ExecPolicy, class ReducerType, class ExecutionSpace>
class ParallelReduce;
```
to 
```
template <class CombinedFunctorReducerType, class ExecPolicy, class ExecutionSpace>
class ParallelReduce;
```

meaning that we pass a `CombinedFunctorReducer` instead of a `Functor` and a `Reducer` separately. That class is currently also defined in `Kokkos_Parallel_Reduce.hpp`.
The wrapped functor is the usual functor and the reducer is the reducer wrapped in a `FunctorAnalysis` object (that contains a copy of the reducer). In case, the functor acts as a reducer, the encapsulation gives us the opportunity to avoid having two copies of the functor.

- In `Kokkos_Parallel_Reduce.hpp`, we basically only create the appropriate `CombinedFunctorReducer` object and call the backend implementations.
- The backend implementations only store a copy of the `CombinedFunctorReducer` object (instead of a functor and a reducer separately) that is used whenever access to the functor or reducer is required. Again, the value type comes from the wrapped `FunctorAnalysis` object.
- These changes make it relatively easy to avoid deducing the value type for reductions since we only need to touch the `FunctorAnalysis` class and `Kokkos_Parallel_Reduce.hpp`. This isn't part of the current pull request, though.
- In general, this avoids a lot of code duplication and also removes one of the constructors. It's conceivable for `CombinedFunctorReducer` to also have a call operator that would take care of calling the functor with the correct work tag which would remove more repeated code.
- A caveat with the present implementation is that `FunctorAnalysis` needs to store a copy of the functor which means that there are extra copies in all implementations that don't use the new interface, yet.