### PR TITLE
Add UnorderedMapInsertOps for coo2crs

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -569,7 +569,9 @@ class UnorderedMap {
         }
 
         result.set_existing(curr, free_existing);
-        if (!is_set) arg_insert_op.op(m_values, curr, v);
+        if constexpr (!is_set) {
+          arg_insert_op.op(m_values, curr, v);
+        }
         not_done = false;
       }
       //------------------------------------------------------------

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -482,6 +482,11 @@ class UnorderedMap {
   KOKKOS_INLINE_FUNCTION insert_result
   insert(key_type const &k, impl_value_type const &v = impl_value_type(),
          InsertOpType arg_insert_op = InsertOpType()) const {
+    if constexpr (is_set) {
+      static_assert(std::is_same_v<InsertOpType, default_op_type>,
+                    "Insert Operations are not supported on sets.");
+    }
+
     insert_result result;
 
     if (!is_insertable_map || capacity() == 0u ||

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -481,12 +481,10 @@ class UnorderedMap {
   template <typename InsertOpType = default_op_type>
   KOKKOS_INLINE_FUNCTION insert_result
   insert(key_type const &k, impl_value_type const &v = impl_value_type(),
-         InsertOpType arg_insert_op = InsertOpType()) const {
+         [[maybe_unused]] InsertOpType arg_insert_op = InsertOpType()) const {
     if constexpr (is_set) {
       static_assert(std::is_same_v<InsertOpType, default_op_type>,
                     "Insert Operations are not supported on sets.");
-      // Silence error #869: parameter "arg_insert_op" was never referenced
-      (void)arg_insert_op;
     }
 
     insert_result result;

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -485,6 +485,8 @@ class UnorderedMap {
     if constexpr (is_set) {
       static_assert(std::is_same_v<InsertOpType, default_op_type>,
                     "Insert Operations are not supported on sets.");
+      // Silence error #869: parameter "arg_insert_op" was never referenced
+      (void)arg_insert_op;
     }
 
     insert_result result;

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -204,7 +204,6 @@ struct UnorderedMapInsertOpTypes {
 /// \tparam EqualTo Definition of the equality function for instances of
 ///   <tt>Key</tt>.  The default will do a bitwise equality comparison.
 ///
-///
 template <typename Key, typename Value,
           typename Device  = Kokkos::DefaultExecutionSpace,
           typename Hasher  = pod_hash<std::remove_const_t<Key>>,

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -313,7 +313,6 @@ class UnorderedMap {
         m_hasher(hasher),
         m_equal_to(equal_to),
         m_size(std::make_shared<size_type>()),
-        m_insert_op(insert_op),
         m_available_indexes(calculate_capacity(capacity_hint)),
         m_hash_lists(view_alloc(WithoutInitializing, "UnorderedMap hash list"),
                      Impl::find_hash_size(capacity())),
@@ -769,7 +768,6 @@ class UnorderedMap {
       tmp.m_hasher            = src.m_hasher;
       tmp.m_equal_to          = src.m_equal_to;
       tmp.m_size              = src.m_size;
-      tmp.m_insert_op         = src.m_insert_op;
       tmp.m_available_indexes = bitset_type(src.capacity());
       tmp.m_hash_lists        = size_type_view(
           view_alloc(WithoutInitializing, "UnorderedMap hash list"),
@@ -863,7 +861,6 @@ class UnorderedMap {
   hasher_type m_hasher;
   equal_to_type m_equal_to;
   std::shared_ptr<size_type> m_size;
-  insert_op_type m_insert_op;
   bitset_type m_available_indexes;
   size_type_view m_hash_lists;
   size_type_view m_next_index;

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -779,6 +779,7 @@ class UnorderedMap {
       tmp.m_hasher            = src.m_hasher;
       tmp.m_equal_to          = src.m_equal_to;
       tmp.m_size              = src.m_size;
+      tmp.m_insert_op         = src.m_insert_op;
       tmp.m_available_indexes = bitset_type(src.capacity());
       tmp.m_hash_lists        = size_type_view(
           view_alloc(WithoutInitializing, "UnorderedMap hash list"),

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -217,12 +217,6 @@ class UnorderedMap {
  public:
   //! \name Public types and constants
   //@{
-  using default_op_type = typename UnorderedMapInsertOpTypes<
-      Kokkos::View<std::remove_const_t<
-                       std::conditional_t<std::is_void_v<Value>, int, Value>> *,
-                   Device>,
-      uint32_t>::NoOp;
-
   // key_types
   using declared_key_type = Key;
   using key_type          = std::remove_const_t<declared_key_type>;
@@ -298,6 +292,8 @@ class UnorderedMap {
  public:
   //! \name Public member functions
   //@{
+  using default_op_type =
+      typename UnorderedMapInsertOpTypes<value_type_view, uint32_t>::NoOp;
 
   /// \brief Constructor
   ///

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -277,22 +277,17 @@ void test_insert(uint32_t num_nodes, uint32_t num_inserts,
 template <typename Device>
 void test_all_insert_ops(uint32_t num_nodes, uint32_t num_inserts,
                          uint32_t num_duplicates, bool near) {
-  using key_type              = uint32_t;
-  using value_type            = uint32_t;
-  using value_view_type       = Kokkos::View<value_type *, Device>;
-  using const_value_view_type = Kokkos::View<value_type *, Device>;
-  using size_type             = uint32_t;
-  using hasher_type           = typename Kokkos::pod_hash<key_type>;
-  using equal_to_type         = typename Kokkos::pod_equal_to<key_type>;
+  using key_type        = uint32_t;
+  using value_type      = uint32_t;
+  using value_view_type = Kokkos::View<value_type *, Device>;
+  using size_type       = uint32_t;
+  using hasher_type     = typename Kokkos::pod_hash<key_type>;
+  using equal_to_type   = typename Kokkos::pod_equal_to<key_type>;
 
   using map_op_type =
       Kokkos::UnorderedMapInsertOpTypes<value_view_type, size_type>;
-  using const_map_op_type =
-      Kokkos::UnorderedMapInsertOpTypes<const_value_view_type, size_type>;
-  using noop_type             = typename map_op_type::NoOp;
-  using atomic_add_type       = typename map_op_type::AtomicAdd;
-  using const_noop_type       = typename const_map_op_type::NoOp;
-  using const_atomic_add_type = typename const_map_op_type::AtomicAdd;
+  using noop_type       = typename map_op_type::NoOp;
+  using atomic_add_type = typename map_op_type::AtomicAdd;
 
   using map_type = Kokkos::UnorderedMap<key_type, value_type, Device,
                                         hasher_type, equal_to_type>;

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -65,17 +65,20 @@ struct TestInsert {
     } while (rehash_on_fail && failed_count > 0u);
 
     // Trigger the m_size mutable bug.
+    typename expected_values_type::HostMirror expected_values_h =
+        create_mirror_view(expected_values);
     typename map_type::HostMirror map_h;
     execution_space().fence();
+    Kokkos::deep_copy(expected_values_h, expected_values);
     Kokkos::deep_copy(map_h, map);
     execution_space().fence();
     ASSERT_EQ(map_h.size(), map.size());
 
     if (!rehash_on_fail) {
-      for (unsigned i = 0; i < map.size(); i++) {
-        auto map_idx = expected_values(i).map_idx;
+      for (unsigned i = 0; i < map_h.size(); i++) {
+        auto map_idx = expected_values_h(i).map_idx;
         if (map_idx != static_cast<unsigned>(~0)) {
-          ASSERT_EQ(expected_values(map_idx).v, map.value_at(map_idx));
+          ASSERT_EQ(expected_values_h(map_idx).v, map_h.value_at(map_idx));
         }
       }
     }

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -94,10 +94,8 @@ struct TestInsert {
       auto idx = map.find(key);
       auto ptr = expected_values.data();
       if (map.is_op_add()) {
-        // Kokkos::abort("adding");
         Kokkos::atomic_add(&((ptr + idx)[0].v), i);
       } else if (ret.success() && map.is_op_noop()) {
-        // Kokkos::abort("noop");
         Kokkos::atomic_store(&((ptr + idx)[0].v), i);
       }
     }


### PR DESCRIPTION
To implement the sparse conversion kernel, coo2crs, I would like to have duplicate key insertions accumulate values in a `Kokkos::UnorderedMap`. This PR adds `UnorderedMapInsertOps::AtomicAdd` and `UnorderedMapInsertOps::NoOp` (the current insertion behavior for duplicate keys).

Related to https://github.com/kokkos/kokkos-kernels/issues/1164.

Going forward, I would also like to extend `Kokkos::UnorderedMap` to support shared memory and add `UnorderedMapInsertOps::Overwrite`.