### PR TITLE
Remove Aligned memory trait when creating subviews and deprecate subview overload

### DIFF
--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -49,7 +49,7 @@ struct MemoryTraits {
   //! Tag this class as a kokkos memory traits:
   using memory_traits = MemoryTraits<T>;
 
-  static constexpr unsigned value = T;
+  static constexpr unsigned impl_value = T;
 
   static constexpr bool is_unmanaged =
       (unsigned(0) != (T & unsigned(Kokkos::Unmanaged)));

--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -48,17 +48,19 @@ template <unsigned T>
 struct MemoryTraits {
   //! Tag this class as a kokkos memory traits:
   using memory_traits = MemoryTraits<T>;
-  enum : bool {
-    is_unmanaged = (unsigned(0) != (T & unsigned(Kokkos::Unmanaged)))
-  };
-  enum : bool {
-    is_random_access = (unsigned(0) != (T & unsigned(Kokkos::RandomAccess)))
-  };
-  enum : bool { is_atomic = (unsigned(0) != (T & unsigned(Kokkos::Atomic))) };
-  enum : bool {
-    is_restrict = (unsigned(0) != (T & unsigned(Kokkos::Restrict)))
-  };
-  enum : bool { is_aligned = (unsigned(0) != (T & unsigned(Kokkos::Aligned))) };
+
+  static constexpr unsigned value = T;
+
+  static constexpr bool is_unmanaged =
+      (unsigned(0) != (T & unsigned(Kokkos::Unmanaged)));
+  static constexpr bool is_random_access =
+      (unsigned(0) != (T & unsigned(Kokkos::RandomAccess)));
+  static constexpr bool is_atomic =
+      (unsigned(0) != (T & unsigned(Kokkos::Atomic)));
+  static constexpr bool is_restrict =
+      (unsigned(0) != (T & unsigned(Kokkos::Restrict)));
+  static constexpr bool is_aligned =
+      (unsigned(0) != (T & unsigned(Kokkos::Aligned)));
 };
 
 }  // namespace Kokkos

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1788,8 +1788,10 @@ KOKKOS_INLINE_FUNCTION auto subview(const View<D, P...>& src, Args... args) {
       Args...>::type(src, args...);
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class MemoryTraits, class D, class... P, class... Args>
-KOKKOS_INLINE_FUNCTION auto subview(const View<D, P...>& src, Args... args) {
+KOKKOS_DEPRECATED KOKKOS_INLINE_FUNCTION auto subview(const View<D, P...>& src,
+                                                      Args... args) {
   static_assert(View<D, P...>::rank == sizeof...(Args),
                 "subview requires one argument for each source View rank");
   static_assert(Kokkos::is_memory_traits<MemoryTraits>::value);
@@ -1800,6 +1802,7 @@ KOKKOS_INLINE_FUNCTION auto subview(const View<D, P...>& src, Args... args) {
       typename Impl::RemoveAlignedMemoryTrait<D, P..., MemoryTraits>::type,
       Args...>::type(src, args...);
 }
+#endif
 
 template <class V, class... Args>
 using Subview = decltype(subview(std::declval<V>(), std::declval<Args>()...));

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1766,7 +1766,7 @@ struct RemoveAlignedMemoryTrait {
       typename Kokkos::Impl::type_list_remove_first<memory_traits,
                                                     type_list_in>::type;
   using new_memory_traits =
-      Kokkos::MemoryTraits<memory_traits::value & ~Kokkos::Aligned>;
+      Kokkos::MemoryTraits<memory_traits::impl_value & ~Kokkos::Aligned>;
   using new_type_list = typename Kokkos::Impl::concat_type_list<
       type_list_in_wo_memory_traits,
       Kokkos::Impl::type_list<new_memory_traits>>::type;

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2712,14 +2712,8 @@ struct ViewDataHandle<
     Traits,
     std::enable_if_t<(std::is_void<typename Traits::specialize>::value &&
                       (!Traits::memory_traits::is_aligned) &&
-                      Traits::memory_traits::is_restrict
-#ifdef KOKKOS_ENABLE_CUDA
-                      && (!(std::is_same<typename Traits::memory_space,
-                                         Kokkos::CudaSpace>::value ||
-                            std::is_same<typename Traits::memory_space,
-                                         Kokkos::CudaUVMSpace>::value))
-#endif
-                      && (!Traits::memory_traits::is_atomic))>> {
+                      Traits::memory_traits::is_restrict &&
+                      (!Traits::memory_traits::is_atomic))>> {
   using value_type  = typename Traits::value_type;
   using handle_type = typename Traits::value_type* KOKKOS_RESTRICT;
   using return_type = typename Traits::value_type& KOKKOS_RESTRICT;
@@ -2742,14 +2736,8 @@ struct ViewDataHandle<
     Traits,
     std::enable_if_t<(std::is_void<typename Traits::specialize>::value &&
                       Traits::memory_traits::is_aligned &&
-                      (!Traits::memory_traits::is_restrict)
-#ifdef KOKKOS_ENABLE_CUDA
-                      && (!(std::is_same<typename Traits::memory_space,
-                                         Kokkos::CudaSpace>::value ||
-                            std::is_same<typename Traits::memory_space,
-                                         Kokkos::CudaUVMSpace>::value))
-#endif
-                      && (!Traits::memory_traits::is_atomic))>> {
+                      (!Traits::memory_traits::is_restrict) &&
+                      (!Traits::memory_traits::is_atomic))>> {
   using value_type = typename Traits::value_type;
   // typedef work-around for intel compilers error #3186: expected typedef
   // declaration
@@ -2787,14 +2775,8 @@ struct ViewDataHandle<
     Traits,
     std::enable_if_t<(std::is_void<typename Traits::specialize>::value &&
                       Traits::memory_traits::is_aligned &&
-                      Traits::memory_traits::is_restrict
-#ifdef KOKKOS_ENABLE_CUDA
-                      && (!(std::is_same<typename Traits::memory_space,
-                                         Kokkos::CudaSpace>::value ||
-                            std::is_same<typename Traits::memory_space,
-                                         Kokkos::CudaUVMSpace>::value))
-#endif
-                      && (!Traits::memory_traits::is_atomic))>> {
+                      Traits::memory_traits::is_restrict &&
+                      (!Traits::memory_traits::is_atomic))>> {
   using value_type = typename Traits::value_type;
   // typedef work-around for intel compilers error #3186: expected typedef
   // declaration

--- a/core/unit_test/TestViewMapping_subview.hpp
+++ b/core/unit_test/TestViewMapping_subview.hpp
@@ -100,8 +100,7 @@ struct TestViewMappingSubview {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int, long& error_count) const {
-    auto Ad = Kokkos::subview<Kokkos::MemoryUnmanaged>(
-        Aa, Kokkos::pair<int, int>(1, AN - 1));
+    auto Ad = Kokkos::subview(Aa, Kokkos::pair<int, int>(1, AN - 1));
 
     for (int i = 1; i < AN - 1; ++i)
       if (&Aa[i] != &Ab[i - 1]) ++error_count;

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2124,13 +2124,15 @@ struct TestSubviewMemoryTraitsConstruction {
 
     // check that the subview memory traits are the same as the original view
     // (with the Aligned trait stripped).
-    static_assert(decltype(v)::memory_traits::impl_value ==
+    using view_memory_traits    = typename decltype(v)::memory_traits;
+    using subview_memory_traits = typename decltype(sv)::memory_traits;
+    static_assert(view_memory_traits::impl_value ==
                   memory_traits_type::impl_value);
     if constexpr (memory_traits_type::is_aligned)
-      static_assert(decltype(sv)::memory_traits::impl_value + Kokkos::Aligned ==
+      static_assert(subview_memory_traits::impl_value + Kokkos::Aligned ==
                     memory_traits_type::impl_value);
     else
-      static_assert(decltype(sv)::memory_traits::impl_value ==
+      static_assert(subview_memory_traits::impl_value ==
                     memory_traits_type::impl_value);
 
     ASSERT_EQ(2u, sv.size());

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2123,11 +2123,11 @@ struct TestSubviewMemoryTraitsConstruction {
     // check that the subview memory traits are the same as the original view
     // (with the Aligned trait stripped).
     if constexpr (memory_traits_type::is_aligned)
-      static_assert(decltype(sv)::memory_traits::value + Kokkos::Aligned ==
-                    memory_traits_type::value);
+      static_assert(decltype(sv)::memory_traits::impl_value + Kokkos::Aligned ==
+                    memory_traits_type::impl_value);
     else
-      static_assert(decltype(sv)::memory_traits::value ==
-                    memory_traits_type::value);
+      static_assert(decltype(sv)::memory_traits::impl_value ==
+                    memory_traits_type::impl_value);
 
     ASSERT_EQ(2u, sv.size());
     EXPECT_EQ(3., sv[0]);

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2115,6 +2115,9 @@ struct TestSubviewMemoryTraitsConstruction {
         Kokkos::View<double*, Kokkos::HostSpace, memory_traits_type>;
     using size_type = typename view_type::size_type;
 
+    // Create a managed View first and then apply the desired memory traits to
+    // an unmanaged version of it since a managed View can't use the Unmanaged
+    // trait.
     Kokkos::View<double*, Kokkos::HostSpace> v_original("v", 7);
     view_type v(v_original.data(), v_original.size());
     for (size_type i = 0; i != v.size(); ++i) v[i] = static_cast<double>(i);

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2120,6 +2120,13 @@ struct TestSubviewMemoryTraitsConstruction {
     std::pair<int, int> range(3, 5);
     auto sv = Kokkos::subview<memory_traits_type>(v, range);
 
+    if constexpr (memory_traits_type::is_aligned)
+      static_assert(decltype(sv)::memory_traits::value + Kokkos::Aligned ==
+                    memory_traits_type::value);
+    else
+      static_assert(decltype(sv)::memory_traits::value ==
+                    memory_traits_type::value);
+
     ASSERT_EQ(2u, sv.size());
     EXPECT_EQ(3., sv[0]);
     EXPECT_EQ(4., sv[1]);
@@ -2132,6 +2139,7 @@ inline void test_subview_memory_traits_construction() {
   // RandomAccess (2)
   // Atomic (4)
   // Restricted (8)
+  // Aligned (16)
   TestSubviewMemoryTraitsConstruction<0>()();
   TestSubviewMemoryTraitsConstruction<1>()();
   TestSubviewMemoryTraitsConstruction<2>()();
@@ -2148,6 +2156,22 @@ inline void test_subview_memory_traits_construction() {
   TestSubviewMemoryTraitsConstruction<13>()();
   TestSubviewMemoryTraitsConstruction<14>()();
   TestSubviewMemoryTraitsConstruction<15>()();
+  TestSubviewMemoryTraitsConstruction<16>()();
+  TestSubviewMemoryTraitsConstruction<17>()();
+  TestSubviewMemoryTraitsConstruction<18>()();
+  TestSubviewMemoryTraitsConstruction<19>()();
+  TestSubviewMemoryTraitsConstruction<20>()();
+  TestSubviewMemoryTraitsConstruction<21>()();
+  TestSubviewMemoryTraitsConstruction<22>()();
+  TestSubviewMemoryTraitsConstruction<23>()();
+  TestSubviewMemoryTraitsConstruction<24>()();
+  TestSubviewMemoryTraitsConstruction<25>()();
+  TestSubviewMemoryTraitsConstruction<26>()();
+  TestSubviewMemoryTraitsConstruction<27>()();
+  TestSubviewMemoryTraitsConstruction<28>()();
+  TestSubviewMemoryTraitsConstruction<29>()();
+  TestSubviewMemoryTraitsConstruction<30>()();
+  TestSubviewMemoryTraitsConstruction<31>()();
 }
 
 //----------------------------------------------------------------------------

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2120,6 +2120,8 @@ struct TestSubviewMemoryTraitsConstruction {
     std::pair<int, int> range(3, 5);
     auto sv = Kokkos::subview<memory_traits_type>(v, range);
 
+    // check that the subview memory traits are the same as the original view
+    // (with the Aligned trait stripped).
     if constexpr (memory_traits_type::is_aligned)
       static_assert(decltype(sv)::memory_traits::value + Kokkos::Aligned ==
                     memory_traits_type::value);


### PR DESCRIPTION
Fixes #5862. It's not safe to assume that subviews of views with the Aligned memory trait are also aligned. Hence, just remove that attribute when creating subviews.

The implementation required to have access to the template argument of `MemoryTraits` which is why I added a static `impl_value` variable. 

This pull request also deprecates the subview overload that takes memory traits template parameters.