### PR TITLE
Deprecate `View::Rank` "uppercase R" in favor of `View::rank` "lowercase r"

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -1514,7 +1514,7 @@ void fill_random(const ExecutionSpace& exec, ViewType a, RandomPool g,
         "Kokkos::fill_random",
         Kokkos::RangePolicy<ExecutionSpace>(exec, 0, (LDA + 127) / 128),
         Impl::fill_random_functor_begin_end<ViewType, RandomPool, 128,
-                                            ViewType::Rank, IndexType>(
+                                            ViewType::rank, IndexType>(
             a, g, begin, end));
 }
 

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -75,7 +75,7 @@ namespace Kokkos {
 
 namespace Impl {
 
-template <class DstViewType, class SrcViewType, int Rank = DstViewType::Rank>
+template <class DstViewType, class SrcViewType, int Rank = DstViewType::rank>
 struct CopyOp;
 
 template <class DstViewType, class SrcViewType>

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -346,7 +346,7 @@ class ViewMapping<
     dst.m_map.m_impl_handle = Kokkos::Impl::ViewDataHandle<DstTraits>::assign(
         src.m_map.m_impl_handle, src.m_track.m_tracker);
     dst.m_track.assign(src.m_track.m_tracker, DstTraits::is_managed);
-    dst.m_rank = src.Rank;
+    dst.m_rank = src.rank;
   }
 };
 
@@ -1025,7 +1025,7 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
   // Copy/Assign View to DynRankView
   template <class RT, class... RP>
   KOKKOS_INLINE_FUNCTION DynRankView(const View<RT, RP...>& rhs)
-      : m_track(), m_map(), m_rank(rhs.Rank) {
+      : m_track(), m_map(), m_rank(rhs.rank) {
     using SrcTraits = typename View<RT, RP...>::traits;
     using Mapping =
         Kokkos::Impl::ViewMapping<traits, SrcTraits,
@@ -1573,7 +1573,7 @@ struct DynRankViewFill {
 };
 
 template <class OutputView>
-struct DynRankViewFill<OutputView, std::enable_if_t<OutputView::Rank == 0>> {
+struct DynRankViewFill<OutputView, std::enable_if_t<OutputView::rank == 0>> {
   DynRankViewFill(const OutputView& dst,
                   const typename OutputView::const_value_type& src) {
     Kokkos::Impl::DeepCopy<typename OutputView::memory_space,

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -827,7 +827,7 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
                   "Incompatible OffsetView copy construction");
     Mapping::assign(m_map, aview.impl_map(), m_track);
 
-    for (int i = 0; i < aview.Rank; ++i) {
+    for (int i = 0; i < aview.rank; ++i) {
       m_begins[i] = 0;
     }
   }
@@ -1301,7 +1301,7 @@ KOKKOS_INLINE_FUNCTION
       Kokkos::Impl::ViewMapping<void /* deduce subview type from source view
                                         traits */
                                 ,
-                                ViewTraits<D, P...>, T>::type::Rank;
+                                ViewTraits<D, P...>, T>::type::rank;
 
   auto theSubview = Kokkos::subview(theView, shiftedArg);
 
@@ -1340,7 +1340,7 @@ KOKKOS_INLINE_FUNCTION
       Kokkos::Impl::ViewMapping<void /* deduce subview type from source view
                                         traits */
                                 ,
-                                ViewTraits<D, P...>, T0, T1>::type::Rank;
+                                ViewTraits<D, P...>, T0, T1>::type::rank;
 
   Kokkos::Array<int64_t, rank> subviewBegins;
   size_t counter = 0;
@@ -1381,7 +1381,7 @@ KOKKOS_INLINE_FUNCTION
       Kokkos::Impl::ViewMapping<void /* deduce subview type from source view
                                         traits */
                                 ,
-                                ViewTraits<D, P...>, T0, T1, T2>::type::Rank;
+                                ViewTraits<D, P...>, T0, T1, T2>::type::rank;
 
   Kokkos::Array<int64_t, rank> subviewBegins;
 
@@ -1426,7 +1426,7 @@ KOKKOS_INLINE_FUNCTION
   constexpr size_t rank = Kokkos::Impl::ViewMapping<
       void /* deduce subview type from source view traits */
       ,
-      ViewTraits<D, P...>, T0, T1, T2, T3>::type::Rank;
+      ViewTraits<D, P...>, T0, T1, T2, T3>::type::rank;
   Kokkos::Array<int64_t, rank> subviewBegins;
 
   size_t counter = 0;
@@ -1473,7 +1473,7 @@ KOKKOS_INLINE_FUNCTION
   constexpr size_t rank = Kokkos::Impl::ViewMapping<
       void /* deduce subview type from source view traits */
       ,
-      ViewTraits<D, P...>, T0, T1, T2, T3, T4>::type::Rank;
+      ViewTraits<D, P...>, T0, T1, T2, T3, T4>::type::rank;
   Kokkos::Array<int64_t, rank> subviewBegins;
 
   size_t counter = 0;
@@ -1525,7 +1525,7 @@ KOKKOS_INLINE_FUNCTION
   constexpr size_t rank = Kokkos::Impl::ViewMapping<
       void /* deduce subview type from source view traits */
       ,
-      ViewTraits<D, P...>, T0, T1, T2, T3, T4, T5>::type::Rank;
+      ViewTraits<D, P...>, T0, T1, T2, T3, T4, T5>::type::rank;
 
   Kokkos::Array<int64_t, rank> subviewBegins;
 
@@ -1580,7 +1580,7 @@ KOKKOS_INLINE_FUNCTION
   constexpr size_t rank = Kokkos::Impl::ViewMapping<
       void /* deduce subview type from source view traits */
       ,
-      ViewTraits<D, P...>, T0, T1, T2, T3, T4, T5, T6>::type::Rank;
+      ViewTraits<D, P...>, T0, T1, T2, T3, T4, T5, T6>::type::rank;
 
   Kokkos::Array<int64_t, rank> subviewBegins;
 
@@ -1639,7 +1639,7 @@ KOKKOS_INLINE_FUNCTION
   constexpr size_t rank = Kokkos::Impl::ViewMapping<
       void /* deduce subview type from source view traits */
       ,
-      ViewTraits<D, P...>, T0, T1, T2, T3, T4, T5, T6, T7>::type::Rank;
+      ViewTraits<D, P...>, T0, T1, T2, T3, T4, T5, T6, T7>::type::rank;
 
   Kokkos::Array<int64_t, rank> subviewBegins;
 

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -1019,7 +1019,7 @@ class ScatterView<DataType, Kokkos::LayoutRight, DeviceType, Op,
                                              internal_view_type>::value_type
   subview() const {
     return Kokkos::Impl::Experimental::Slice<
-        Kokkos::LayoutRight, internal_view_type::Rank,
+        Kokkos::LayoutRight, internal_view_type::rank,
         internal_view_type>::get(internal_view, 0);
   }
 

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -1200,19 +1200,19 @@ class TestDynViewAPI {
 
     View7 vtest1("vtest1", 2, 2, 2, 2, 2, 2, 2);
     dView0 dfromv1(vtest1);
-    ASSERT_EQ(dfromv1.rank(), vtest1.Rank);
+    ASSERT_EQ(dfromv1.rank(), vtest1.rank);
     ASSERT_EQ(dfromv1.extent(0), vtest1.extent(0));
     ASSERT_EQ(dfromv1.extent(1), vtest1.extent(1));
     ASSERT_EQ(dfromv1.use_count(), vtest1.use_count());
 
     dView0 dfromv2(vcast);
-    ASSERT_EQ(dfromv2.rank(), vcast.Rank);
+    ASSERT_EQ(dfromv2.rank(), vcast.rank);
     ASSERT_EQ(dfromv2.extent(0), vcast.extent(0));
     ASSERT_EQ(dfromv2.extent(1), vcast.extent(1));
     ASSERT_EQ(dfromv2.use_count(), vcast.use_count());
 
     dView0 dfromv3 = vcast1;
-    ASSERT_EQ(dfromv3.rank(), vcast1.Rank);
+    ASSERT_EQ(dfromv3.rank(), vcast1.rank);
     ASSERT_EQ(dfromv3.extent(0), vcast1.extent(0));
     ASSERT_EQ(dfromv3.extent(1), vcast1.extent(1));
     ASSERT_EQ(dfromv3.use_count(), vcast1.use_count());

--- a/core/perf_test/PerfTestBlasKernels.hpp
+++ b/core/perf_test/PerfTestBlasKernels.hpp
@@ -25,8 +25,8 @@ template <class Type>
 struct Dot {
   using execution_space = typename Type::execution_space;
 
-  static_assert(static_cast<unsigned>(Type::Rank) == static_cast<unsigned>(1),
-                "Dot static_assert Fail: Rank != 1");
+  static_assert(static_cast<unsigned>(Type::rank) == static_cast<unsigned>(1),
+                "Dot static_assert Fail: rank != 1");
 
   using value_type = double;
 
@@ -56,8 +56,8 @@ template <class Type>
 struct DotSingle {
   using execution_space = typename Type::execution_space;
 
-  static_assert(static_cast<unsigned>(Type::Rank) == static_cast<unsigned>(1),
-                "DotSingle static_assert Fail: Rank != 1");
+  static_assert(static_cast<unsigned>(Type::rank) == static_cast<unsigned>(1),
+                "DotSingle static_assert Fail: rank != 1");
 
   using value_type = double;
 
@@ -88,13 +88,13 @@ template <class ScalarType, class VectorType>
 struct Scale {
   using execution_space = typename VectorType::execution_space;
 
-  static_assert(static_cast<unsigned>(ScalarType::Rank) ==
+  static_assert(static_cast<unsigned>(ScalarType::rank) ==
                     static_cast<unsigned>(0),
-                "Scale static_assert Fail: ScalarType::Rank != 0");
+                "Scale static_assert Fail: ScalarType::rank != 0");
 
-  static_assert(static_cast<unsigned>(VectorType::Rank) ==
+  static_assert(static_cast<unsigned>(VectorType::rank) ==
                     static_cast<unsigned>(1),
-                "Scale static_assert Fail: VectorType::Rank != 1");
+                "Scale static_assert Fail: VectorType::rank != 1");
 
 #if 1
   typename ScalarType::const_type alpha;
@@ -115,17 +115,17 @@ template <class ScalarType, class ConstVectorType, class VectorType>
 struct AXPBY {
   using execution_space = typename VectorType::execution_space;
 
-  static_assert(static_cast<unsigned>(ScalarType::Rank) ==
+  static_assert(static_cast<unsigned>(ScalarType::rank) ==
                     static_cast<unsigned>(0),
-                "AXPBY static_assert Fail: ScalarType::Rank != 0");
+                "AXPBY static_assert Fail: ScalarType::rank != 0");
 
-  static_assert(static_cast<unsigned>(ConstVectorType::Rank) ==
+  static_assert(static_cast<unsigned>(ConstVectorType::rank) ==
                     static_cast<unsigned>(1),
-                "AXPBY static_assert Fail: ConstVectorType::Rank != 1");
+                "AXPBY static_assert Fail: ConstVectorType::rank != 1");
 
-  static_assert(static_cast<unsigned>(VectorType::Rank) ==
+  static_assert(static_cast<unsigned>(VectorType::rank) ==
                     static_cast<unsigned>(1),
-                "AXPBY static_assert Fail: VectorType::Rank != 1");
+                "AXPBY static_assert Fail: VectorType::rank != 1");
 
 #if 1
   typename ScalarType::const_type alpha, beta;

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -534,7 +534,7 @@ void view_copy(const ExecutionSpace& space, const DstType& dst,
         "Kokkos::Impl::view_copy called with invalid execution space");
   } else {
     // Figure out iteration order in case we need it
-    int64_t strides[DstType::Rank + 1];
+    int64_t strides[DstType::rank + 1];
     dst.stride(strides);
     Kokkos::Iterate iterate;
     if (Kokkos::is_layouttiled<typename DstType::array_layout>::value) {
@@ -548,7 +548,7 @@ void view_copy(const ExecutionSpace& space, const DstType& dst,
       iterate = Kokkos::Iterate::Left;
     } else if (std::is_same<typename DstType::array_layout,
                             Kokkos::LayoutStride>::value) {
-      if (strides[0] > strides[DstType::Rank - 1])
+      if (strides[0] > strides[DstType::rank - 1])
         iterate = Kokkos::Iterate::Right;
       else
         iterate = Kokkos::Iterate::Left;
@@ -566,26 +566,26 @@ void view_copy(const ExecutionSpace& space, const DstType& dst,
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutRight, ExecutionSpace, DstType::Rank, int64_t>(
+            Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int64_t>(
             dst, src, space);
       else
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutLeft, ExecutionSpace, DstType::Rank, int64_t>(
+            Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int64_t>(
             dst, src, space);
     } else {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutRight, ExecutionSpace, DstType::Rank, int>(dst, src,
+            Kokkos::LayoutRight, ExecutionSpace, DstType::rank, int>(dst, src,
                                                                      space);
       else
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutLeft, ExecutionSpace, DstType::Rank, int>(dst, src,
+            Kokkos::LayoutLeft, ExecutionSpace, DstType::rank, int>(dst, src,
                                                                     space);
     }
   }
@@ -620,7 +620,7 @@ void view_copy(const DstType& dst, const SrcType& src) {
   }
 
   // Figure out iteration order in case we need it
-  int64_t strides[DstType::Rank + 1];
+  int64_t strides[DstType::rank + 1];
   dst.stride(strides);
   Kokkos::Iterate iterate;
   if (Kokkos::is_layouttiled<typename DstType::array_layout>::value) {
@@ -634,7 +634,7 @@ void view_copy(const DstType& dst, const SrcType& src) {
     iterate = Kokkos::Iterate::Left;
   } else if (std::is_same<typename DstType::array_layout,
                           Kokkos::LayoutStride>::value) {
-    if (strides[0] > strides[DstType::Rank - 1])
+    if (strides[0] > strides[DstType::rank - 1])
       iterate = Kokkos::Iterate::Right;
     else
       iterate = Kokkos::Iterate::Left;
@@ -653,26 +653,26 @@ void view_copy(const DstType& dst, const SrcType& src) {
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutRight, dst_execution_space, DstType::Rank, int64_t>(
+            Kokkos::LayoutRight, dst_execution_space, DstType::rank, int64_t>(
             dst, src);
       else
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutLeft, dst_execution_space, DstType::Rank, int64_t>(
+            Kokkos::LayoutLeft, dst_execution_space, DstType::rank, int64_t>(
             dst, src);
     } else {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutRight, src_execution_space, DstType::Rank, int64_t>(
+            Kokkos::LayoutRight, src_execution_space, DstType::rank, int64_t>(
             dst, src);
       else
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutLeft, src_execution_space, DstType::Rank, int64_t>(
+            Kokkos::LayoutLeft, src_execution_space, DstType::rank, int64_t>(
             dst, src);
     }
   } else {
@@ -681,26 +681,26 @@ void view_copy(const DstType& dst, const SrcType& src) {
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutRight, dst_execution_space, DstType::Rank, int>(dst,
+            Kokkos::LayoutRight, dst_execution_space, DstType::rank, int>(dst,
                                                                           src);
       else
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutLeft, dst_execution_space, DstType::Rank, int>(dst,
+            Kokkos::LayoutLeft, dst_execution_space, DstType::rank, int>(dst,
                                                                          src);
     } else {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutRight, src_execution_space, DstType::Rank, int>(dst,
+            Kokkos::LayoutRight, src_execution_space, DstType::rank, int>(dst,
                                                                           src);
       else
         Kokkos::Impl::ViewCopy<
             typename DstType::uniform_runtime_nomemspace_type,
             typename SrcType::uniform_runtime_const_nomemspace_type,
-            Kokkos::LayoutLeft, src_execution_space, DstType::Rank, int>(dst,
+            Kokkos::LayoutLeft, src_execution_space, DstType::rank, int>(dst,
                                                                          src);
     }
   }
@@ -832,7 +832,7 @@ struct CommonSubview<DstType, SrcType, 8, Arg0, Arg1, Arg2, Arg3, Arg4, Arg5,
 
 template <class DstType, class SrcType,
           class ExecSpace = typename DstType::execution_space,
-          int Rank        = DstType::Rank>
+          int Rank        = DstType::rank>
 struct ViewRemap;
 
 template <class DstType, class SrcType, class ExecSpace>
@@ -1310,7 +1310,7 @@ inline void contiguous_fill(
   using ViewTypeFlat = Kokkos::View<
       typename ViewType::value_type*, Kokkos::LayoutRight,
       Kokkos::Device<typename ViewType::execution_space,
-                     std::conditional_t<ViewType::Rank == 0,
+                     std::conditional_t<ViewType::rank == 0,
                                         typename ViewType::memory_space,
                                         Kokkos::AnonymousSpace>>,
       Kokkos::MemoryTraits<0>>;
@@ -1318,11 +1318,11 @@ inline void contiguous_fill(
   ViewTypeFlat dst_flat(dst.data(), dst.size());
   if (dst.span() < static_cast<size_t>(std::numeric_limits<int>::max())) {
     Kokkos::Impl::ViewFill<ViewTypeFlat, Kokkos::LayoutRight, ExecutionSpace,
-                           ViewTypeFlat::Rank, int>(dst_flat, value,
+                           ViewTypeFlat::rank, int>(dst_flat, value,
                                                     exec_space);
   } else
     Kokkos::Impl::ViewFill<ViewTypeFlat, Kokkos::LayoutRight, ExecutionSpace,
-                           ViewTypeFlat::Rank, int64_t>(dst_flat, value,
+                           ViewTypeFlat::rank, int64_t>(dst_flat, value,
                                                         exec_space);
 }
 
@@ -1447,7 +1447,7 @@ inline void deep_copy(
   }
 
   // Figure out iteration order to do the ViewFill
-  int64_t strides[ViewType::Rank + 1];
+  int64_t strides[ViewType::rank + 1];
   dst.stride(strides);
   Kokkos::Iterate iterate;
   if (std::is_same<typename ViewType::array_layout,
@@ -1458,7 +1458,7 @@ inline void deep_copy(
     iterate = Kokkos::Iterate::Left;
   } else if (std::is_same<typename ViewType::array_layout,
                           Kokkos::LayoutStride>::value) {
-    if (strides[0] > strides[ViewType::Rank > 0 ? ViewType::Rank - 1 : 0])
+    if (strides[0] > strides[ViewType::rank > 0 ? ViewType::rank - 1 : 0])
       iterate = Kokkos::Iterate::Right;
     else
       iterate = Kokkos::Iterate::Left;
@@ -1473,26 +1473,26 @@ inline void deep_copy(
   // Lets call the right ViewFill functor based on integer space needed and
   // iteration type
   using ViewTypeUniform =
-      std::conditional_t<ViewType::Rank == 0,
+      std::conditional_t<ViewType::rank == 0,
                          typename ViewType::uniform_runtime_type,
                          typename ViewType::uniform_runtime_nomemspace_type>;
   if (dst.span() > static_cast<size_t>(std::numeric_limits<int>::max())) {
     if (iterate == Kokkos::Iterate::Right)
       Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutRight,
-                             exec_space_type, ViewType::Rank, int64_t>(
+                             exec_space_type, ViewType::rank, int64_t>(
           dst, value, exec_space_type());
     else
       Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutLeft,
-                             exec_space_type, ViewType::Rank, int64_t>(
+                             exec_space_type, ViewType::rank, int64_t>(
           dst, value, exec_space_type());
   } else {
     if (iterate == Kokkos::Iterate::Right)
       Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutRight,
-                             exec_space_type, ViewType::Rank, int>(
+                             exec_space_type, ViewType::rank, int>(
           dst, value, exec_space_type());
     else
       Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutLeft,
-                             exec_space_type, ViewType::Rank, int>(
+                             exec_space_type, ViewType::rank, int>(
           dst, value, exec_space_type());
   }
   Kokkos::fence("Kokkos::deep_copy: scalar copy, post copy fence");
@@ -1636,19 +1636,19 @@ inline void deep_copy(
           "match: ");
       message += dst.label();
       message += "(";
-      for (int r = 0; r < dst_type::Rank - 1; r++) {
+      for (int r = 0; r < dst_type::rank - 1; r++) {
         message += std::to_string(dst.extent(r));
         message += ",";
       }
-      message += std::to_string(dst.extent(dst_type::Rank - 1));
+      message += std::to_string(dst.extent(dst_type::rank - 1));
       message += ") ";
       message += src.label();
       message += "(";
-      for (int r = 0; r < src_type::Rank - 1; r++) {
+      for (int r = 0; r < src_type::rank - 1; r++) {
         message += std::to_string(src.extent(r));
         message += ",";
       }
-      message += std::to_string(src.extent(src_type::Rank - 1));
+      message += std::to_string(src.extent(src_type::rank - 1));
       message += ") ";
 
       Kokkos::Impl::throw_runtime_exception(message);
@@ -1719,19 +1719,19 @@ inline void deep_copy(
         "Deprecation Error: Kokkos::deep_copy extents of views don't match: ");
     message += dst.label();
     message += "(";
-    for (int r = 0; r < dst_type::Rank - 1; r++) {
+    for (int r = 0; r < dst_type::rank - 1; r++) {
       message += std::to_string(dst.extent(r));
       message += ",";
     }
-    message += std::to_string(dst.extent(dst_type::Rank - 1));
+    message += std::to_string(dst.extent(dst_type::rank - 1));
     message += ") ";
     message += src.label();
     message += "(";
-    for (int r = 0; r < src_type::Rank - 1; r++) {
+    for (int r = 0; r < src_type::rank - 1; r++) {
       message += std::to_string(src.extent(r));
       message += ",";
     }
-    message += std::to_string(src.extent(src_type::Rank - 1));
+    message += std::to_string(src.extent(src_type::rank - 1));
     message += ") ";
 
     Kokkos::Impl::throw_runtime_exception(message);
@@ -2559,7 +2559,7 @@ inline void deep_copy(
   } else {
     using ViewType = View<DT, DP...>;
     // Figure out iteration order to do the ViewFill
-    int64_t strides[ViewType::Rank + 1];
+    int64_t strides[ViewType::rank + 1];
     dst.stride(strides);
     Kokkos::Iterate iterate;
     if (std::is_same<typename ViewType::array_layout,
@@ -2570,7 +2570,7 @@ inline void deep_copy(
       iterate = Kokkos::Iterate::Left;
     } else if (std::is_same<typename ViewType::array_layout,
                             Kokkos::LayoutStride>::value) {
-      if (strides[0] > strides[ViewType::Rank > 0 ? ViewType::Rank - 1 : 0])
+      if (strides[0] > strides[ViewType::rank > 0 ? ViewType::rank - 1 : 0])
         iterate = Kokkos::Iterate::Right;
       else
         iterate = Kokkos::Iterate::Left;
@@ -2585,23 +2585,23 @@ inline void deep_copy(
     // Lets call the right ViewFill functor based on integer space needed and
     // iteration type
     using ViewTypeUniform =
-        std::conditional_t<ViewType::Rank == 0,
+        std::conditional_t<ViewType::rank == 0,
                            typename ViewType::uniform_runtime_type,
                            typename ViewType::uniform_runtime_nomemspace_type>;
     if (dst.span() > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutRight, ExecSpace,
-                               ViewType::Rank, int64_t>(dst, value, space);
+                               ViewType::rank, int64_t>(dst, value, space);
       else
         Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutLeft, ExecSpace,
-                               ViewType::Rank, int64_t>(dst, value, space);
+                               ViewType::rank, int64_t>(dst, value, space);
     } else {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutRight, ExecSpace,
-                               ViewType::Rank, int32_t>(dst, value, space);
+                               ViewType::rank, int32_t>(dst, value, space);
       else
         Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutLeft, ExecSpace,
-                               ViewType::Rank, int32_t>(dst, value, space);
+                               ViewType::rank, int32_t>(dst, value, space);
     }
   }
   if (Kokkos::Tools::Experimental::get_callbacks().end_deep_copy != nullptr) {
@@ -2643,7 +2643,7 @@ inline void deep_copy(
       Impl::contiguous_fill_or_memset(fill_exec_space(), dst, value);
     } else {
       using ViewTypeUniform = std::conditional_t<
-          View<DT, DP...>::Rank == 0,
+          View<DT, DP...>::rank == 0,
           typename View<DT, DP...>::uniform_runtime_type,
           typename View<DT, DP...>::uniform_runtime_nomemspace_type>;
       Kokkos::Impl::ViewFill<ViewTypeUniform, typename dst_traits::array_layout,
@@ -2800,19 +2800,19 @@ inline void deep_copy(
           "match: ");
       message += dst.label();
       message += "(";
-      for (int r = 0; r < dst_type::Rank - 1; r++) {
+      for (int r = 0; r < dst_type::rank - 1; r++) {
         message += std::to_string(dst.extent(r));
         message += ",";
       }
-      message += std::to_string(dst.extent(dst_type::Rank - 1));
+      message += std::to_string(dst.extent(dst_type::rank - 1));
       message += ") ";
       message += src.label();
       message += "(";
-      for (int r = 0; r < src_type::Rank - 1; r++) {
+      for (int r = 0; r < src_type::rank - 1; r++) {
         message += std::to_string(src.extent(r));
         message += ",";
       }
-      message += std::to_string(src.extent(src_type::Rank - 1));
+      message += std::to_string(src.extent(src_type::rank - 1));
       message += ") ";
 
       Kokkos::Impl::throw_runtime_exception(message);
@@ -2869,19 +2869,19 @@ inline void deep_copy(
         "Deprecation Error: Kokkos::deep_copy extents of views don't match: ");
     message += dst.label();
     message += "(";
-    for (int r = 0; r < dst_type::Rank - 1; r++) {
+    for (int r = 0; r < dst_type::rank - 1; r++) {
       message += std::to_string(dst.extent(r));
       message += ",";
     }
-    message += std::to_string(dst.extent(dst_type::Rank - 1));
+    message += std::to_string(dst.extent(dst_type::rank - 1));
     message += ") ";
     message += src.label();
     message += "(";
-    for (int r = 0; r < src_type::Rank - 1; r++) {
+    for (int r = 0; r < src_type::rank - 1; r++) {
       message += std::to_string(src.extent(r));
       message += ",";
     }
-    message += std::to_string(src.extent(src_type::Rank - 1));
+    message += std::to_string(src.extent(src_type::rank - 1));
     message += ") ";
 
     Kokkos::Impl::throw_runtime_exception(message);

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -298,7 +298,7 @@ struct ZeroMemset;
 
 template <class ViewType, class Layout = typename ViewType::array_layout,
           class ExecSpace = typename ViewType::execution_space,
-          int Rank = ViewType::Rank, typename iType = int64_t>
+          int Rank = ViewType::rank, typename iType = int64_t>
 struct ViewFill;
 
 template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -650,7 +650,7 @@ class View : public ViewTraits<DataType, Properties...> {
    */
   // KOKKOS_INLINE_FUNCTION
   // static
-  // constexpr unsigned rank() { return map_type::Rank; }
+  // constexpr unsigned rank() { return map_type::rank; }
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
@@ -811,14 +811,14 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename... Is>
   static KOKKOS_FUNCTION void check_access_member_function_valid_args(Is...) {
-    static_assert(Rank <= sizeof...(Is), "");
+    static_assert(rank <= sizeof...(Is), "");
     static_assert(sizeof...(Is) <= 8, "");
     static_assert(Kokkos::Impl::are_integral<Is...>::value, "");
   }
 
   template <typename... Is>
   static KOKKOS_FUNCTION void check_operator_parens_valid_args(Is...) {
-    static_assert(Rank == sizeof...(Is), "");
+    static_assert(rank == sizeof...(Is), "");
     static_assert(Kokkos::Impl::are_integral<Is...>::value, "");
   }
 
@@ -829,7 +829,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0>::value &&  //
-                        (1 == Rank) && is_default_map && !is_layout_stride),
+                        (1 == rank) && is_default_map && !is_layout_stride),
                        reference_type>
       operator()(I0 i0) const {
     check_operator_parens_valid_args(i0);
@@ -840,7 +840,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0>::value &&  //
-                        (1 == Rank) && is_default_map && is_layout_stride),
+                        (1 == rank) && is_default_map && is_layout_stride),
                        reference_type>
       operator()(I0 i0) const {
     check_operator_parens_valid_args(i0);
@@ -853,7 +853,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      ((1 == Rank) && Kokkos::Impl::are_integral<I0>::value && !is_default_map),
+      ((1 == rank) && Kokkos::Impl::are_integral<I0>::value && !is_default_map),
       reference_type>
   operator[](I0 i0) const {
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, i0)
@@ -862,7 +862,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0>
   KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<((1 == Rank) && Kokkos::Impl::are_integral<I0>::value &&
+      std::enable_if_t<((1 == rank) && Kokkos::Impl::are_integral<I0>::value &&
                         is_default_map && !is_layout_stride),
                        reference_type>
       operator[](I0 i0) const {
@@ -872,7 +872,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0>
   KOKKOS_FORCEINLINE_FUNCTION
-      std::enable_if_t<((1 == Rank) && Kokkos::Impl::are_integral<I0>::value &&
+      std::enable_if_t<((1 == rank) && Kokkos::Impl::are_integral<I0>::value &&
                         is_default_map && is_layout_stride),
                        reference_type>
       operator[](I0 i0) const {
@@ -886,7 +886,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1>::value &&  //
-                        (2 == Rank) && is_default_map && is_layout_left &&
+                        (2 == rank) && is_default_map && is_layout_left &&
                         (traits::rank_dynamic == 0)),
                        reference_type>
       operator()(I0 i0, I1 i1) const {
@@ -898,7 +898,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1>::value &&  //
-                        (2 == Rank) && is_default_map && is_layout_left &&
+                        (2 == rank) && is_default_map && is_layout_left &&
                         (traits::rank_dynamic != 0)),
                        reference_type>
       operator()(I0 i0, I1 i1) const {
@@ -910,7 +910,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1>::value &&  //
-                        (2 == Rank) && is_default_map && is_layout_right &&
+                        (2 == rank) && is_default_map && is_layout_right &&
                         (traits::rank_dynamic == 0)),
                        reference_type>
       operator()(I0 i0, I1 i1) const {
@@ -922,7 +922,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1>::value &&  //
-                        (2 == Rank) && is_default_map && is_layout_right &&
+                        (2 == rank) && is_default_map && is_layout_right &&
                         (traits::rank_dynamic != 0)),
                        reference_type>
       operator()(I0 i0, I1 i1) const {
@@ -934,7 +934,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1>::value &&  //
-                        (2 == Rank) && is_default_map && is_layout_stride),
+                        (2 == rank) && is_default_map && is_layout_stride),
                        reference_type>
       operator()(I0 i0, I1 i1) const {
     check_operator_parens_valid_args(i0, i1);
@@ -949,7 +949,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<Is...>::value &&  //
-       (2 != Rank) && (1 != Rank) && (0 != Rank) && is_default_map),
+       (2 != rank) && (1 != rank) && (0 != rank) && is_default_map),
       reference_type>
   operator()(Is... indices) const {
     check_operator_parens_valid_args(indices...);
@@ -960,7 +960,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<Is...>::value &&  //
-                        ((0 == Rank) || !is_default_map)),
+                        ((0 == rank) || !is_default_map)),
                        reference_type>
       operator()(Is... indices) const {
     check_operator_parens_valid_args(indices...);
@@ -973,7 +973,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<Is...>::value && (0 == Rank)), reference_type>
+      (Kokkos::Impl::always_true<Is...>::value && (0 == rank)), reference_type>
   access(Is... extra) const {
     check_access_member_function_valid_args(extra...);
     KOKKOS_IMPL_VIEW_OPERATOR_VERIFY(m_track, m_map, extra...)
@@ -986,7 +986,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, Is...>::value &&
-                        (1 == Rank) && !is_default_map),
+                        (1 == rank) && !is_default_map),
                        reference_type>
       access(I0 i0, Is... extra) const {
     check_access_member_function_valid_args(i0, extra...);
@@ -997,7 +997,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, Is...>::value &&
-                        (1 == Rank) && is_default_map && !is_layout_stride),
+                        (1 == rank) && is_default_map && !is_layout_stride),
                        reference_type>
       access(I0 i0, Is... extra) const {
     check_access_member_function_valid_args(i0, extra...);
@@ -1008,7 +1008,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, Is...>::value &&
-                        (1 == Rank) && is_default_map && is_layout_stride),
+                        (1 == rank) && is_default_map && is_layout_stride),
                        reference_type>
       access(I0 i0, Is... extra) const {
     check_access_member_function_valid_args(i0, extra...);
@@ -1022,7 +1022,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, Is...>::value &&
-                        (2 == Rank) && !is_default_map),
+                        (2 == rank) && !is_default_map),
                        reference_type>
       access(I0 i0, I1 i1, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, extra...);
@@ -1032,7 +1032,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == Rank) &&
+      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == rank) &&
        is_default_map && is_layout_left && (traits::rank_dynamic == 0)),
       reference_type>
   access(I0 i0, I1 i1, Is... extra) const {
@@ -1043,7 +1043,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == Rank) &&
+      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == rank) &&
        is_default_map && is_layout_left && (traits::rank_dynamic != 0)),
       reference_type>
   access(I0 i0, I1 i1, Is... extra) const {
@@ -1054,7 +1054,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == Rank) &&
+      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == rank) &&
        is_default_map && is_layout_right && (traits::rank_dynamic == 0)),
       reference_type>
   access(I0 i0, I1 i1, Is... extra) const {
@@ -1065,7 +1065,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == Rank) &&
+      (Kokkos::Impl::always_true<I0, I1, Is...>::value && (2 == rank) &&
        is_default_map && is_layout_right && (traits::rank_dynamic != 0)),
       reference_type>
   access(I0 i0, I1 i1, Is... extra) const {
@@ -1077,7 +1077,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, Is...>::value &&
-                        (2 == Rank) && is_default_map && is_layout_stride),
+                        (2 == rank) && is_default_map && is_layout_stride),
                        reference_type>
       access(I0 i0, I1 i1, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, extra...);
@@ -1092,7 +1092,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1, typename I2, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, I2, Is...>::value &&
-                        (3 == Rank) && is_default_map),
+                        (3 == rank) && is_default_map),
                        reference_type>
       access(I0 i0, I1 i1, I2 i2, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, extra...);
@@ -1103,7 +1103,7 @@ class View : public ViewTraits<DataType, Properties...> {
   template <typename I0, typename I1, typename I2, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, I2, Is...>::value &&
-                        (3 == Rank) && !is_default_map),
+                        (3 == rank) && !is_default_map),
                        reference_type>
       access(I0 i0, I1 i1, I2 i2, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, extra...);
@@ -1116,7 +1116,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename I2, typename I3, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, I2, I3, Is...>::value && (4 == Rank) &&
+      (Kokkos::Impl::always_true<I0, I1, I2, I3, Is...>::value && (4 == rank) &&
        is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, Is... extra) const {
@@ -1127,7 +1127,7 @@ class View : public ViewTraits<DataType, Properties...> {
 
   template <typename I0, typename I1, typename I2, typename I3, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
-      (Kokkos::Impl::always_true<I0, I1, I2, I3, Is...>::value && (4 == Rank) &&
+      (Kokkos::Impl::always_true<I0, I1, I2, I3, Is...>::value && (4 == rank) &&
        !is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, Is... extra) const {
@@ -1143,7 +1143,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, Is...>::value &&
-       (5 == Rank) && is_default_map),
+       (5 == rank) && is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, extra...);
@@ -1156,7 +1156,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, Is...>::value &&
-       (5 == Rank) && !is_default_map),
+       (5 == rank) && !is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, extra...);
@@ -1172,7 +1172,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename I5, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, Is...>::value &&
-       (6 == Rank) && is_default_map),
+       (6 == rank) && is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, i5, extra...);
@@ -1185,7 +1185,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename I5, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, Is...>::value &&
-       (6 == Rank) && !is_default_map),
+       (6 == rank) && !is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, i5, extra...);
@@ -1201,7 +1201,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename I5, typename I6, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, I6, Is...>::value &&
-       (7 == Rank) && is_default_map),
+       (7 == rank) && is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, I6 i6, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, i5, i6,
@@ -1215,7 +1215,7 @@ class View : public ViewTraits<DataType, Properties...> {
             typename I5, typename I6, typename... Is>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<
       (Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, I6, Is...>::value &&
-       (7 == Rank) && !is_default_map),
+       (7 == rank) && !is_default_map),
       reference_type>
   access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, I6 i6, Is... extra) const {
     check_access_member_function_valid_args(i0, i1, i2, i3, i4, i5, i6,
@@ -1233,7 +1233,7 @@ class View : public ViewTraits<DataType, Properties...> {
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, I6,
                                                   I7, Is...>::value &&
-                        (8 == Rank) && is_default_map),
+                        (8 == rank) && is_default_map),
                        reference_type>
       access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, I6 i6, I7 i7,
              Is... extra) const {
@@ -1250,7 +1250,7 @@ class View : public ViewTraits<DataType, Properties...> {
   KOKKOS_FORCEINLINE_FUNCTION
       std::enable_if_t<(Kokkos::Impl::always_true<I0, I1, I2, I3, I4, I5, I6,
                                                   I7, Is...>::value &&
-                        (8 == Rank) && !is_default_map),
+                        (8 == rank) && !is_default_map),
                        reference_type>
       access(I0 i0, I1 i1, I2 i2, I3 i3, I4 i4, I5 i5, I6 i6, I7 i7,
              Is... extra) const {
@@ -1693,7 +1693,7 @@ class View : public ViewTraits<DataType, Properties...> {
  */
 template <typename D, class... P>
 KOKKOS_INLINE_FUNCTION constexpr unsigned rank(const View<D, P...>& V) {
-  return V.Rank;
+  return V.rank;
 }  // Temporary until added to view
 
 namespace Impl {
@@ -1710,7 +1710,7 @@ struct RankDataType<ValueType, 0> {
 
 template <unsigned N, typename... Args>
 KOKKOS_FUNCTION std::enable_if_t<
-    N == View<Args...>::Rank &&
+    N == View<Args...>::rank &&
         std::is_same<typename ViewTraits<Args...>::specialize, void>::value,
     View<Args...>>
 as_view_of_rank_n(View<Args...> v) {
@@ -1721,7 +1721,7 @@ as_view_of_rank_n(View<Args...> v) {
 // never be called
 template <unsigned N, typename T, typename... Args>
 KOKKOS_FUNCTION std::enable_if_t<
-    N != View<T, Args...>::Rank &&
+    N != View<T, Args...>::rank &&
         std::is_same<typename ViewTraits<T, Args...>::specialize, void>::value,
     View<typename RankDataType<typename View<T, Args...>::value_type, N>::type,
          Args...>>
@@ -1753,7 +1753,7 @@ KOKKOS_INLINE_FUNCTION
                                        ,
                                        ViewTraits<D, P...>, Args...>::type
     subview(const View<D, P...>& src, Args... args) {
-  static_assert(View<D, P...>::Rank == sizeof...(Args),
+  static_assert(View<D, P...>::rank == sizeof...(Args),
                 "subview requires one argument for each source View rank");
 
   return typename Kokkos::Impl::ViewMapping<
@@ -1768,7 +1768,7 @@ KOKKOS_INLINE_FUNCTION typename Kokkos::Impl::ViewMapping<
     ,
     ViewTraits<D, P...>, Args...>::template apply<MemoryTraits>::type
 subview(const View<D, P...>& src, Args... args) {
-  static_assert(View<D, P...>::Rank == sizeof...(Args),
+  static_assert(View<D, P...>::rank == sizeof...(Args),
                 "subview requires one argument for each source View rank");
 
   return typename Kokkos::Impl::ViewMapping<

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -644,7 +644,10 @@ class View : public ViewTraits<DataType, Properties...> {
   //----------------------------------------
   // Domain rank and extents
 
-  enum { Rank = map_type::Rank };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  enum {Rank KOKKOS_DEPRECATED_WITH_COMMENT("Use rank instead.") =
+            map_type::Rank};
+#endif
 
   /** \brief rank() to be implemented
    */

--- a/core/unit_test/TestAggregate.hpp
+++ b/core/unit_test/TestAggregate.hpp
@@ -56,8 +56,8 @@ void TestViewAggregate() {
                 "");
   static_assert(std::is_same<typename a32_type::pointer_type, double *>::value,
                 "");
-  static_assert(a32_type::Rank == 2, "");
-  static_assert(a32_flat_type::Rank == 3, "");
+  static_assert(a32_type::rank == 2, "");
+  static_assert(a32_flat_type::rank == 3, "");
 
   a32_type x("test", 4, 5);
   a32_flat_type y(x);

--- a/core/unit_test/TestViewMapping_a.hpp
+++ b/core/unit_test/TestViewMapping_a.hpp
@@ -713,7 +713,7 @@ void test_view_mapping() {
                               typename Space::memory_space>::value));
     ASSERT_TRUE((std::is_same<typename T::reference_type, int&>::value));
 
-    ASSERT_EQ(T::Rank, 1);
+    ASSERT_EQ(T::rank, 1);
 
     ASSERT_TRUE((std::is_same<typename C::data_type, const int*>::value));
     ASSERT_TRUE((std::is_same<typename C::const_data_type, const int*>::value));
@@ -734,7 +734,7 @@ void test_view_mapping() {
                               typename Space::memory_space>::value));
     ASSERT_TRUE((std::is_same<typename C::reference_type, const int&>::value));
 
-    ASSERT_EQ(C::Rank, 1);
+    ASSERT_EQ(C::rank, 1);
 
     ASSERT_EQ(vr1.extent(0), size_t(N));
 
@@ -781,7 +781,7 @@ void test_view_mapping() {
     ASSERT_TRUE((std::is_same<typename T::memory_space,
                               typename Space::memory_space>::value));
     ASSERT_TRUE((std::is_same<typename T::reference_type, int&>::value));
-    ASSERT_EQ(T::Rank, 1);
+    ASSERT_EQ(T::rank, 1);
 
     ASSERT_EQ(vr1.extent(0), size_t(N));
 

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -865,7 +865,7 @@ struct FillView_3D {
   using exec_t = typename Space::execution_space;
   using view_t = Kokkos::View<int***, Layout, Space>;
   using rank_t = Kokkos::Rank<
-      view_t::Rank,
+      view_t::rank,
       std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left
                                                       : Kokkos::Iterate::Right,
       std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left
@@ -893,7 +893,7 @@ struct FillView_4D {
   using exec_t = typename Space::execution_space;
   using view_t = Kokkos::View<int****, Layout, Space>;
   using rank_t = Kokkos::Rank<
-      view_t::Rank,
+      view_t::rank,
       std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left
                                                       : Kokkos::Iterate::Right,
       std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left
@@ -922,7 +922,7 @@ struct FillView_5D {
   using exec_t = typename Space::execution_space;
   using view_t = Kokkos::View<int*****, Layout, Space>;
   using rank_t = Kokkos::Rank<
-      view_t::Rank,
+      view_t::rank,
       std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left
                                                       : Kokkos::Iterate::Right,
       std::is_same<Layout, Kokkos::LayoutLeft>::value ? Kokkos::Iterate::Left


### PR DESCRIPTION
Moving the easier part of #5870 into its own PR to facilitate review.
Rational for the change: duplicate facility that was never mentioned in the documentation.