### PR TITLE
Update `HPX::print_configuration` to print more information

### DIFF
--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -30,6 +30,7 @@
 #include <hpx/local/runtime.hpp>
 #include <hpx/local/thread.hpp>
 #include <hpx/local/mutex.hpp>
+#include <hpx/version.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -88,10 +89,18 @@ hpx::condition_variable_any HPX::m_active_parallel_region_count_cond;
 HPX::instance_data HPX::m_default_instance_data;
 
 void HPX::print_configuration(std::ostream &os, const bool) const {
-  os << "HPX backend\n";
-  os << "HPX Execution Space:\n";
+  os << "Host Parallel Execution Space\n";
   os << "  KOKKOS_ENABLE_HPX: yes\n";
+  os << "HPX Options:\n";
+#if defined(KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH)
+  os << "  KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH: yes\n";
+#else
+  os << "  KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH: no\n";
+#endif
   os << "\nHPX Runtime Configuration:\n";
+  os << "Worker threads: " << hpx::get_num_worker_threads() << '\n';
+  os << hpx::complete_version() << '\n';
+  os << hpx::configuration_string() << '\n';
 }
 
 void HPX::impl_decrement_active_parallel_region_count() {


### PR DESCRIPTION
Attempt to start fixing #5419 for the HPX backend.

Updates the title to be `Host Parallel Execution Space` since this seems to match OpenMP (and Serial prints `Host Serial Execution Space`). I'm tentatively printing `KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH` as well, but do we want to leave out `IMPL` stuff? I don't expect users to turn it off now that it's on by default, but in my opinion it doesn't hurt to have that there.

I also added the number of worker threads in the HPX runtime and I'm printing a short version string from HPX. The output looks like this:
```
Host Parallel Execution Space
  KOKKOS_ENABLE_HPX: yes
HPX Options
  KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH: yes

HPX Runtime Configuration:
V1.8.1 (AGAS: V3.0), Git: unknown
```

There's also a longer version that we could print here which looks like this:
```
Host Parallel Execution Space
  KOKKOS_ENABLE_HPX: yes
HPX Options
  KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH: yes

HPX Runtime Configuration:
{config}:
Core library:
  HPX_AGAS_LOCAL_CACHE_SIZE=4096
  HPX_HAVE_MALLOC=tcmalloc
  HPX_PARCEL_MAX_CONNECTIONS=512
  HPX_PARCEL_MAX_CONNECTIONS_PER_LOCALITY=4
  HPX_PREFIX (configured)=
  HPX_PREFIX=

  HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY=OFF
  HPX_ITERATOR_SUPPORT_WITH_BOOST_ITERATOR_TRAVERSAL_TAG_COMPATIBILITY=OFF
  HPX_WITH_AGAS_DUMP_REFCNT_ENTRIES=OFF
  HPX_WITH_APEX=OFF
  HPX_WITH_ASYNC_MPI=OFF
  HPX_WITH_ATTACH_DEBUGGER_ON_TEST_FAILURE=OFF
  HPX_WITH_AUTOMATIC_SERIALIZATION_REGISTRATION=ON
  HPX_WITH_COROUTINE_COUNTERS=OFF
  HPX_WITH_DISTRIBUTED_RUNTIME=ON
  HPX_WITH_DYNAMIC_HPX_MAIN=ON
  HPX_WITH_IO_COUNTERS=ON
  HPX_WITH_IO_POOL=ON
  HPX_WITH_ITTNOTIFY=OFF
  HPX_WITH_LOGGING=ON
  HPX_WITH_NETWORKING=OFF
  HPX_WITH_PAPI=OFF
  HPX_WITH_PARALLEL_TESTS_BIND_NONE=OFF
  HPX_WITH_SANITIZERS=OFF
  HPX_WITH_SCHEDULER_LOCAL_STORAGE=OFF
  HPX_WITH_SPINLOCK_DEADLOCK_DETECTION=OFF
  HPX_WITH_STACKTRACES=ON
  HPX_WITH_STACKTRACES_DEMANGLE_SYMBOLS=ON
  HPX_WITH_STACKTRACES_STATIC_SYMBOLS=OFF
  HPX_WITH_TESTS_DEBUG_LOG=OFF
  HPX_WITH_THREAD_BACKTRACE_ON_SUSPENSION=OFF
  HPX_WITH_THREAD_CREATION_AND_CLEANUP_RATES=OFF
  HPX_WITH_THREAD_CUMULATIVE_COUNTS=ON
  HPX_WITH_THREAD_DEBUG_INFO=OFF
  HPX_WITH_THREAD_DESCRIPTION_FULL=OFF
  HPX_WITH_THREAD_GUARD_PAGE=ON
  HPX_WITH_THREAD_IDLE_RATES=OFF
  HPX_WITH_THREAD_LOCAL_STORAGE=OFF
  HPX_WITH_THREAD_MANAGER_IDLE_BACKOFF=ON
  HPX_WITH_THREAD_QUEUE_WAITTIME=OFF
  HPX_WITH_THREAD_STACK_MMAP=ON
  HPX_WITH_THREAD_STEALING_COUNTS=OFF
  HPX_WITH_THREAD_TARGET_ADDRESS=OFF
  HPX_WITH_TIMER_POOL=ON
  HPX_WITH_TUPLE_RVALUE_SWAP=ON
  HPX_WITH_VALGRIND=OFF
  HPX_WITH_VERIFY_LOCKS=OFF
  HPX_WITH_VERIFY_LOCKS_BACKTRACE=OFF

Module coroutines:
  HPX_COROUTINES_WITH_SWAP_CONTEXT_EMULATION=OFF

Module datastructures:
  HPX_DATASTRUCTURES_WITH_ADAPT_STD_TUPLE=OFF

Module serialization:
  HPX_SERIALIZATION_WITH_ALLOW_CONST_TUPLE_MEMBERS=OFF
  HPX_SERIALIZATION_WITH_ALLOW_RAW_POINTER_SERIALIZATION=OFF
  HPX_SERIALIZATION_WITH_ALL_TYPES_ARE_BITWISE_SERIALIZABLE=OFF
  HPX_SERIALIZATION_WITH_BOOST_TYPES=OFF
  HPX_SERIALIZATION_WITH_SUPPORTS_ENDIANESS=OFF

Module topology:
  HPX_TOPOLOGY_WITH_ADDITIONAL_HWLOC_TESTING=OFF

{version}: V1.8.1 (AGAS: V3.0), Git: unknown
{boost}: V1.80.0
{build-type}: release
{date}: Feb 16 2023 14:39:50
{platform}: linux
{compiler}: GNU C++ version 12.2.0
{stdlib}: GNU libstdc++ version 20220819

Worker threads: 4
```
The latter is for sure more useful, but it's also printed by HPX e.g. if it terminates with an uncaught exception. 

How detailed do we want to be here? Or rather, what is the expected use case for `--kokkos-print-configuration`? Is there space for a less detailed and a more detailed version of `--kokkos-print-configuration`?

@hkaiser do you have ideas or opinions on what the HPX backend should or could print here?