### PR TITLE
Add more digits to version components in `KOKKOS_NVHPC_COMPILER`

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -163,8 +163,8 @@
 #endif
 
 #if defined(__NVCOMPILER)
-#define KOKKOS_COMPILER_NVHPC                              \
-  __NVCOMPILER_MAJOR__ * 100 + __NVCOMPILER_MINOR__ * 10 + \
+#define KOKKOS_COMPILER_NVHPC                                 \
+  __NVCOMPILER_MAJOR__ * 10000 + __NVCOMPILER_MINOR__ * 100 + \
       __NVCOMPILER_PATCHLEVEL__
 #endif
 


### PR DESCRIPTION
Currently the `KOKKOS_NVHPC_COMPILER` macro assumes that all version components are at most one digit (i.e. <= 9). This is at least not the case for nvhpc, which is versioned as `<two-digit-year>.<month>`. For example, nvhpc 22.11 ends up with `KOKKOS_NVHPC_COMPILER` as `2310` which I don't think is intended (see https://godbolt.org/z/xYxox97Mx).

This PR adds one more digit to the minor and patch components, though I'm unsure what values `__NVCOMPILER_PATCHLEVEL__` is allowed to take in the wild. I've only ever seen it be 0, but I could also not find any documentation to confirm that. It could also be left out (as for `KOKKOS_COMPILER_NVCC`).

As far as I can tell, no checks in Kokkos rely on the value of `KOKKOS_NVHPC_COMPILER` so this change shouldn't affect anything.

Other compiler version macros may also benefit from the same change though I've never seen e.g. GCC or clang use minor releases of 10 or higher, so I don't know if it's necessary.