### PR TITLE
Use insertion sort for sort within a bin in BinSort

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -458,9 +458,9 @@ class BinSort {
     if (bin_size <= 1) return;
     int lower_bound = bin_offsets(i);
     int upper_bound = lower_bound + bin_size;
-    for (int i = lower_bound + 1; i < upper_bound; ++i) {
-      int old_idx = sort_order(i);
-      int j       = i - 1;
+    for (int k = lower_bound + 1; k < upper_bound; ++k) {
+      int old_idx = sort_order(k);
+      int j       = k - 1;
       while (j >= lower_bound) {
         int new_idx = sort_order(j);
         if (!bin_op(keys_rnd, old_idx, new_idx)) break;

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -456,24 +456,18 @@ class BinSort {
   void operator()(const bin_sort_bins_tag& /*tag*/, const int i) const {
     auto bin_size = bin_count_const(i);
     if (bin_size <= 1) return;
-    int upper_bound = bin_offsets(i) + bin_size;
-    bool sorted     = false;
-    while (!sorted) {
-      sorted      = true;
-      int old_idx = sort_order(bin_offsets(i));
-      int new_idx = 0;
-      for (int k = bin_offsets(i) + 1; k < upper_bound; k++) {
-        new_idx = sort_order(k);
-
-        if (!bin_op(keys_rnd, old_idx, new_idx)) {
-          sort_order(k - 1) = new_idx;
-          sort_order(k)     = old_idx;
-          sorted            = false;
-        } else {
-          old_idx = new_idx;
-        }
+    int lower_bound = bin_offsets(i);
+    int upper_bound = lower_bound + bin_size;
+    for (int i = lower_bound + 1; i < upper_bound; ++i) {
+      int old_idx = sort_order(i);
+      int j       = i - 1;
+      while (j >= lower_bound) {
+        int new_idx = sort_order(j);
+        if (!bin_op(keys_rnd, old_idx, new_idx)) break;
+        sort_order(j + 1) = new_idx;
+        --j;
       }
-      upper_bound--;
+      sort_order(j + 1) = old_idx;
     }
   }
 };


### PR DESCRIPTION
This patch is simple in that it replaces a bubble sort with an insertion sort. It should speed things up for all backends. It does not solve all the problems with performance but is a step forward. The sort still struggles in the presence of large repeated indices.

I did a quick check in Serial and CUDA, and I see significant improvement. This is not exhaustive by any stretch. I am not sure what performance study is sufficient to verify it.

Related to #5864.