### PR TITLE
UnorderedMap: Fix mutable m_size corruption bug

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -296,6 +296,18 @@ class UnorderedMap {
     Kokkos::deep_copy(m_next_index, invalid_index);
   }
 
+  /// When creating a host mirror of UnorderedMap within
+  /// a deeper scope than the original map, the mutable
+  /// m_size member within the original map gets reset
+  /// to 0 when the host mirror object falls out of scope.
+  /// Calling set_flag upon destruction ensures that m_size
+  /// will be recomputed in the parent scope. I think this
+  /// is only a problem when the original map resides on
+  /// the host since some of the host mirror members likely
+  /// point to the same memory locations as the original map
+  /// members.
+  ~UnorderedMap() { set_flag(modified_idx); }
+
   void reset_failed_insert_flag() { reset_flag(failed_insert_idx); }
 
   histogram_type get_histogram() { return histogram_type(*this); }

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -54,7 +54,12 @@ struct TestInsert {
       }
     } while (rehash_on_fail && failed_count > 0u);
 
+    // Trigger the m_size mutable bug.
+    typename map_type::HostMirror map_h;
     execution_space().fence();
+    Kokkos::deep_copy(map_h, map);
+    execution_space().fence();
+    ASSERT_EQ(map_h.size(), map.size());
   }
 
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
Using the changes in this PR without the new ~UnorderMap destructor in Kokkos_UnorderedMap.hpp:
```
./containers/unit_tests/KokkosContainers_UnitTest_Cuda --gtest_filter=*UnorderedMap_insert
<snip>
kokkos/containers/unit_tests/TestUnorderedMap.hpp:189: Failure
Expected equality of these values:
  expected_inserts
    Which is: 900
  map_size
    Which is: 0
[  FAILED  ] cuda.UnorderedMap_insert (1507 ms)
[----------] 1 test from cuda (1507 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1508 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] cuda.UnorderedMap_insert
```

With all the changes in this PR:
```
./containers/unit_tests/KokkosContainers_UnitTest_Cuda --gtest_filter=*UnorderedMap_insert
Note: Google Test filter = *UnorderedMap_insert
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from cuda
[ RUN      ] cuda.UnorderedMap_insert
[       OK ] cuda.UnorderedMap_insert (1495 ms)
[----------] 1 test from cuda (1495 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1495 ms total)
[  PASSED  ] 1 test.
```
