### PR TITLE
SIMD: make binary op tests to test against all data types

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -153,7 +153,8 @@ using data_type_set =
     data_types<std::int32_t, std::int64_t, std::uint64_t, double>;
 #else
 using host_abi_set  = abi_set<simd_abi::scalar>;
-using data_type_set = data_types<double>;
+using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
+                                 std::uint64_t, double>;
 #endif
 
 using device_abi_set = abi_set<simd_abi::scalar>;

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -47,7 +47,7 @@ using host_native  = avx2_fixed_size<4>;
 #elif defined(__ARM_NEON)
 using host_native  = neon_fixed_size<2>;
 #else
-using host_native  = scalar;
+using host_native   = scalar;
 #endif
 
 template <class T>
@@ -136,14 +136,22 @@ namespace Impl {
 template <class... Abis>
 class abi_set {};
 
+template <typename... Ts>
+class data_types {};
+
 #if defined(KOKKOS_ARCH_AVX512XEON)
-using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx512_fixed_size<8>>;
+using host_abi_set  = abi_set<simd_abi::scalar, simd_abi::avx512_fixed_size<8>>;
+using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
+                                 std::uint64_t, double>;
 #elif defined(KOKKOS_ARCH_AVX2)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>>;
+using data_type_set = data_types<double>;
 #elif defined(__ARM_NEON)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
+using data_type_set = data_types<double>;
 #else
-using host_abi_set = abi_set<simd_abi::scalar>;
+using host_abi_set  = abi_set<simd_abi::scalar>;
+using data_type_set = data_types<double>;
 #endif
 
 using device_abi_set = abi_set<simd_abi::scalar>;

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -45,7 +45,7 @@ using host_native = avx512_fixed_size<8>;
 #elif defined(KOKKOS_ARCH_AVX2)
 using host_native  = avx2_fixed_size<4>;
 #elif defined(__ARM_NEON)
-using host_native   = neon_fixed_size<2>;
+using host_native  = neon_fixed_size<2>;
 #else
 using host_native   = scalar;
 #endif

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -149,7 +149,7 @@ using data_type_set =
     data_types<std::int32_t, std::int64_t, std::uint64_t, double>;
 #elif defined(__ARM_NEON)
 using host_abi_set  = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
-using data_type_set = data_types<double>;
+using data_type_set = data_types<std::int32_t, std::int64_t, std::uint64_t, double>;
 #else
 using host_abi_set  = abi_set<simd_abi::scalar>;
 using data_type_set = data_types<double>;

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -148,8 +148,9 @@ using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>>;
 using data_type_set =
     data_types<std::int32_t, std::int64_t, std::uint64_t, double>;
 #elif defined(__ARM_NEON)
-using host_abi_set  = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
-using data_type_set = data_types<std::int32_t, std::int64_t, std::uint64_t, double>;
+using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
+using data_type_set =
+    data_types<std::int32_t, std::int64_t, std::uint64_t, double>;
 #else
 using host_abi_set  = abi_set<simd_abi::scalar>;
 using data_type_set = data_types<double>;

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -45,7 +45,7 @@ using host_native = avx512_fixed_size<8>;
 #elif defined(KOKKOS_ARCH_AVX2)
 using host_native  = avx2_fixed_size<4>;
 #elif defined(__ARM_NEON)
-using host_native  = neon_fixed_size<2>;
+using host_native   = neon_fixed_size<2>;
 #else
 using host_native   = scalar;
 #endif
@@ -145,9 +145,10 @@ using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
                                  std::uint64_t, double>;
 #elif defined(KOKKOS_ARCH_AVX2)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>>;
-using data_type_set = data_types<double>;
+using data_type_set =
+    data_types<std::int32_t, std::int64_t, std::uint64_t, double>;
 #elif defined(__ARM_NEON)
-using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
+using host_abi_set  = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
 using data_type_set = data_types<double>;
 #else
 using host_abi_set  = abi_set<simd_abi::scalar>;

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -824,6 +824,19 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm256_set1_epi64x(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::uint64_t a, std::uint64_t b,
+                                             std::uint64_t c, std::uint64_t d)
+      : m_value(_mm256_setr_epi64x(a, b, c, d)) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
+      : simd(gen(std::integral_constant<std::size_t, 0>()),
+             gen(std::integral_constant<std::size_t, 1>()),
+             gen(std::integral_constant<std::size_t, 2>()),
+             gen(std::integral_constant<std::size_t, 3>())) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m256i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(
@@ -887,6 +900,22 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& other)
     : m_value(static_cast<__m256i>(other)) {}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    operator+(simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+              simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
+  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    operator-(simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+              simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
+  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -845,7 +845,8 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
-    m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
+    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
+                                    static_cast<__m256i>(mask_type(true)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator>>(unsigned int rhs) const {
@@ -1082,7 +1083,8 @@ class const_where_expression<
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       std::int64_t* mem, element_aligned_tag) const {
-    _mm256_maskstore_epi64(mem, static_cast<__m256i>(m_mask),
+    _mm256_maskstore_epi64(reinterpret_cast<long long*>(mem),
+                           static_cast<__m256i>(m_mask),
                            static_cast<__m256i>(m_value));
   }
 
@@ -1106,8 +1108,8 @@ class where_expression<simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(std::int64_t const* mem,
                                                        element_aligned_tag) {
-    m_value =
-        value_type(_mm256_maskload_epi64(mem, static_cast<__m256i>(m_mask)));
+    m_value = value_type(_mm256_maskload_epi64(
+        reinterpret_cast<long long const*>(mem), static_cast<__m256i>(m_mask)));
   }
   template <
       class u,
@@ -1145,7 +1147,8 @@ class const_where_expression<
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       std::uint64_t* mem, element_aligned_tag) const {
-    _mm256_maskstore_epi64(mem, static_cast<__m256i>(m_mask),
+    _mm256_maskstore_epi64(reinterpret_cast<long long*>(mem),
+                           static_cast<__m256i>(m_mask),
                            static_cast<__m256i>(m_value));
   }
 
@@ -1169,8 +1172,8 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(std::uint64_t const* mem,
                                                        element_aligned_tag) {
-    m_value =
-        value_type(_mm256_maskload_epi64(mem, static_cast<__m256i>(m_mask)));
+    m_value = value_type(_mm256_maskload_epi64(
+        reinterpret_cast<long long const*>(mem), static_cast<__m256i>(m_mask)));
   }
   template <class u,
             std::enable_if_t<

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -390,9 +390,6 @@ class simd<double, simd_abi::avx2_fixed_size<4>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm256_set1_pd(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(double a, double b, double c,
-                                             double d)
-      : m_value(_mm256_setr_pd(a, b, c, d)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256d const& value_in)
       : m_value(value_in) {}
@@ -587,19 +584,17 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm_set1_epi32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::int32_t a, std::int32_t b,
-                                             std::int32_t c, std::int32_t d)
-      : m_value(_mm_setr_epi32(a, b, c, d)) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
-      : simd(gen(std::integral_constant<std::size_t, 0>()),
-             gen(std::integral_constant<std::size_t, 1>()),
-             gen(std::integral_constant<std::size_t, 2>()),
-             gen(std::integral_constant<std::size_t, 3>())) {}
+      : m_value(_mm_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
+                               gen(std::integral_constant<std::size_t, 1>()),
+                               gen(std::integral_constant<std::size_t, 2>()),
+                               gen(std::integral_constant<std::size_t, 3>()))) {
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m128i const& value_in)
       : m_value(value_in) {}
@@ -700,19 +695,17 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm256_set1_epi64x(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::int64_t a, std::int64_t b,
-                                             std::int64_t c, std::int64_t d)
-      : m_value(_mm256_setr_epi64x(a, b, c, d)) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
-      : simd(gen(std::integral_constant<std::size_t, 0>()),
-             gen(std::integral_constant<std::size_t, 1>()),
-             gen(std::integral_constant<std::size_t, 2>()),
-             gen(std::integral_constant<std::size_t, 3>())) {}
+      : m_value(_mm256_setr_epi64x(
+            gen(std::integral_constant<std::size_t, 0>()),
+            gen(std::integral_constant<std::size_t, 1>()),
+            gen(std::integral_constant<std::size_t, 2>()),
+            gen(std::integral_constant<std::size_t, 3>()))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256i const& value_in)
       : m_value(value_in) {}
@@ -824,19 +817,17 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm256_set1_epi64x(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(std::uint64_t a, std::uint64_t b,
-                                             std::uint64_t c, std::uint64_t d)
-      : m_value(_mm256_setr_epi64x(a, b, c, d)) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
-      : simd(gen(std::integral_constant<std::size_t, 0>()),
-             gen(std::integral_constant<std::size_t, 1>()),
-             gen(std::integral_constant<std::size_t, 2>()),
-             gen(std::integral_constant<std::size_t, 3>())) {}
+      : m_value(_mm256_setr_epi64x(
+            gen(std::integral_constant<std::size_t, 0>()),
+            gen(std::integral_constant<std::size_t, 1>()),
+            gen(std::integral_constant<std::size_t, 2>()),
+            gen(std::integral_constant<std::size_t, 3>()))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m256i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -942,14 +942,7 @@ class const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(double* mem, element_aligned_tag) const {
     _mm256_maskstore_pd(mem, _mm256_castpd_si256(static_cast<__m256d>(m_mask)),
@@ -963,6 +956,12 @@ class const_where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
     }
   }
+
+  friend constexpr auto const& Impl::mask<double, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<double, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>
@@ -1019,19 +1018,18 @@ class const_where_expression<
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(std::int32_t* mem, element_aligned_tag) const {
     _mm_maskstore_epi32(mem, static_cast<__m128i>(m_mask),
                         static_cast<__m128i>(m_value));
   }
+
+  friend constexpr auto const& Impl::mask<std::int32_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<std::int32_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>
@@ -1081,19 +1079,18 @@ class const_where_expression<
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       std::int64_t* mem, element_aligned_tag) const {
     _mm256_maskstore_epi64(mem, static_cast<__m256i>(m_mask),
                            static_cast<__m256i>(m_value));
   }
+
+  friend constexpr auto const& Impl::mask<std::int64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<std::int64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>
@@ -1145,19 +1142,18 @@ class const_where_expression<
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       std::uint64_t* mem, element_aligned_tag) const {
     _mm256_maskstore_epi64(mem, static_cast<__m256i>(m_mask),
                            static_cast<__m256i>(m_value));
   }
+
+  friend constexpr auto const& Impl::mask<std::uint64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<std::uint64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -1064,18 +1064,19 @@ class where_expression<simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
     m_value = value_type(_mm512_mask_loadu_epi64(
         _mm512_set1_epi64(0.0), static_cast<__mmask8>(m_mask), mem));
   }
-  template <class U, std::enable_if_t<
-                         std::is_convertible_v<
-                             U, simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>,
-                         bool> = false>
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
         static_cast<simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value =
-        simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(_mm512_mask_blend_epi64(
-            static_cast<__mmask8>(m_mask), static_cast<__m512i>(m_value),
-            static_cast<__m512i>(x_as_value_type)));
+    m_value = simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+        _mm512_mask_blend_epi64(static_cast<__mmask8>(m_mask),
+                                static_cast<__m512i>(m_value),
+                                static_cast<__m512i>(x_as_value_type)));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -638,10 +638,6 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
       : m_value(_mm512_set1_pd(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(double a, double b, double c,
-                                             double d, double e, double f,
-                                             double g, double h)
-      : m_value(_mm512_setr_pd(a, b, c, d, e, f, g, h)) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m512d const& value_in)
       : m_value(value_in) {}

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -277,6 +277,11 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   operator[](std::size_t i) const {
     return reinterpret_cast<value_type const*>(&m_value)[i];
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_mask_loadu_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
     return m_value;
@@ -375,6 +380,10 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm512_loadu_epi64(ptr);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
@@ -503,6 +512,10 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm512_loadu_epi64(ptr);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator>>(unsigned int rhs) const {
@@ -930,6 +943,83 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
     m_value = value_type(_mm256_mask_loadu_epi32(
         _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
   }
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>(
+            std::forward<U>(x));
+    m_value = simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+        _mm256_mask_blend_epi32(static_cast<__mmask8>(m_mask),
+                                static_cast<__m256i>(m_value),
+                                static_cast<__m256i>(x_as_value_type)));
+  }
+};
+
+template <>
+class const_where_expression<
+    simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using value_type = simd<std::uint32_t, abi_type>;
+  using mask_type  = simd_mask<std::uint32_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
+  mask() const {
+    return m_mask;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
+  value() const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint32_t* mem, element_aligned_tag) const {
+    _mm256_mask_storeu_epi32(mem, static_cast<__mmask8>(m_mask),
+                             static_cast<__m256i>(m_value));
+  }
+};
+
+template <>
+class where_expression<simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+                       simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+    : public const_where_expression<
+          simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+          simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  where_expression(
+      simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::uint32_t const* mem, element_aligned_tag) {
+    m_value = value_type(_mm256_mask_loadu_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
+  }
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>,
+                bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>(
+            std::forward<U>(x));
+    m_value = simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+        _mm256_mask_blend_epi32(static_cast<__mmask8>(m_mask),
+                                static_cast<__m256i>(m_value),
+                                static_cast<__m256i>(x_as_value_type)));
+  }
 };
 
 template <>
@@ -955,6 +1045,94 @@ class const_where_expression<
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
   value() const {
     return m_value;
+  }
+};
+
+template <>
+class where_expression<simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+                       simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+    : public const_where_expression<
+          simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+          simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  where_expression(
+      simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      simd<std::int64_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int64_t const* mem, element_aligned_tag) {
+    m_value = value_type(_mm512_mask_loadu_epi64(
+        _mm512_set1_epi64(0.0), static_cast<__mmask8>(m_mask), mem));
+  }
+  template <class U, std::enable_if_t<
+                         std::is_convertible_v<
+                             U, simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>,
+                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>(
+            std::forward<U>(x));
+    m_value =
+        simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(_mm512_mask_blend_epi64(
+            static_cast<__mmask8>(m_mask), static_cast<__m512i>(m_value),
+            static_cast<__m512i>(x_as_value_type)));
+  }
+};
+
+template <>
+class const_where_expression<
+    simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using value_type = simd<std::uint64_t, abi_type>;
+  using mask_type  = simd_mask<std::uint64_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
+  mask() const {
+    return m_mask;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
+  value() const {
+    return m_value;
+  }
+};
+
+template <>
+class where_expression<simd_mask<uint64_t, simd_abi::avx512_fixed_size<8>>,
+                       simd<uint64_t, simd_abi::avx512_fixed_size<8>>>
+    : public const_where_expression<
+          simd_mask<uint64_t, simd_abi::avx512_fixed_size<8>>,
+          simd<uint64_t, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  where_expression(
+      simd_mask<uint64_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      simd<uint64_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(uint64_t const* mem, element_aligned_tag) {
+    m_value = value_type(_mm512_mask_loadu_epi64(
+        _mm512_set1_epi64(0.0), static_cast<__mmask8>(m_mask), mem));
+  }
+  template <class U, std::enable_if_t<
+                         std::is_convertible_v<
+                             U, simd<uint64_t, simd_abi::avx512_fixed_size<8>>>,
+                         bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<uint64_t, simd_abi::avx512_fixed_size<8>>>(
+            std::forward<U>(x));
+    m_value =
+        simd<uint64_t, simd_abi::avx512_fixed_size<8>>(_mm512_mask_blend_epi64(
+            static_cast<__mmask8>(m_mask), static_cast<__m512i>(m_value),
+            static_cast<__m512i>(x_as_value_type)));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -831,14 +831,7 @@ class const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(double* mem, element_aligned_tag) const {
     _mm512_mask_storeu_pd(mem, static_cast<__mmask8>(m_mask),
@@ -852,6 +845,12 @@ class const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                               static_cast<__m256i>(index),
                               static_cast<__m512d>(m_value), 8);
   }
+
+  friend constexpr auto const& Impl::mask<double, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<double, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>
@@ -908,19 +907,18 @@ class const_where_expression<
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(std::int32_t* mem, element_aligned_tag) const {
     _mm256_mask_storeu_epi32(mem, static_cast<__mmask8>(m_mask),
                              static_cast<__m256i>(m_value));
   }
+
+  friend constexpr auto const& Impl::mask<std::int32_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<std::int32_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>
@@ -971,19 +969,18 @@ class const_where_expression<
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(std::uint32_t* mem, element_aligned_tag) const {
     _mm256_mask_storeu_epi32(mem, static_cast<__mmask8>(m_mask),
                              static_cast<__m256i>(m_value));
   }
+
+  friend constexpr auto const& Impl::mask<std::uint32_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<std::uint32_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>
@@ -1034,14 +1031,12 @@ class const_where_expression<
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
+  friend constexpr auto const& Impl::mask<std::int64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<std::int64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>
@@ -1092,14 +1087,12 @@ class const_where_expression<
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
+  friend constexpr auto const& Impl::mask<std::uint64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<std::uint64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>
@@ -1138,16 +1131,16 @@ class where_expression<simd_mask<uint64_t, simd_abi::avx512_fixed_size<8>>,
         simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
         simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   return _mm512_mask_reduce_max_epi32(
-      static_cast<__mmask8>(x.mask()),
-      _mm512_castsi256_si512(static_cast<__m256i>(x.value())));
+      static_cast<__mmask8>(Impl::mask(x)),
+      _mm512_castsi256_si512(static_cast<__m256i>(Impl::value(x))));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double hmin(
     const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                            simd<double, simd_abi::avx512_fixed_size<8>>> const&
         x) {
-  return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(x.mask()),
-                                   static_cast<__m512d>(x.value()));
+  return _mm512_mask_reduce_min_pd(static_cast<__mmask8>(Impl::mask(x)),
+                                   static_cast<__m512d>(Impl::value(x)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
@@ -1155,8 +1148,8 @@ class where_expression<simd_mask<uint64_t, simd_abi::avx512_fixed_size<8>>,
         simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
         simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x,
     std::int64_t, std::plus<>) {
-  return _mm512_mask_reduce_add_epi64(static_cast<__mmask8>(x.mask()),
-                                      static_cast<__m512i>(x.value()));
+  return _mm512_mask_reduce_add_epi64(static_cast<__mmask8>(Impl::mask(x)),
+                                      static_cast<__m512i>(Impl::value(x)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
@@ -1164,8 +1157,8 @@ class where_expression<simd_mask<uint64_t, simd_abi::avx512_fixed_size<8>>,
                            simd<double, simd_abi::avx512_fixed_size<8>>> const&
         x,
     double, std::plus<>) {
-  return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(x.mask()),
-                                   static_cast<__m512d>(x.value()));
+  return _mm512_mask_reduce_add_pd(static_cast<__mmask8>(Impl::mask(x)),
+                                   static_cast<__m512d>(Impl::value(x)));
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -277,6 +277,11 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   operator[](std::size_t i) const {
     return reinterpret_cast<value_type const*>(&m_value)[i];
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
+                             m_value);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm256_mask_loadu_epi32(
@@ -387,8 +392,7 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
-    _mm512_mask_storeu_epi64(ptr, static_cast<__mmask8>(mask_type(true)),
-                             m_value);
+    _mm512_storeu_epi64(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(int rhs) const {
     return _mm512_srai_epi64(m_value, rhs);
@@ -519,8 +523,7 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
-    _mm512_mask_storeu_epi64(ptr, static_cast<__mmask8>(mask_type(true)),
-                             m_value);
+    _mm512_storeu_epi64(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator>>(unsigned int rhs) const {

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -991,10 +991,11 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
     if (m_mask[0]) m_value[0] = mem[0];
     if (m_mask[1]) m_value[1] = mem[1];
   }
-  template <class U,
-            std::enable_if_t<std::is_convertible_v<
-                                 U, simd<int32_t, simd_abi::neon_fixed_size<2>>>,
-                             bool> = false>
+  template <
+      class U,
+      std::enable_if_t<
+          std::is_convertible_v<U, simd<int32_t, simd_abi::neon_fixed_size<2>>>,
+          bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
         static_cast<simd<int32_t, simd_abi::neon_fixed_size<2>>>(
@@ -1007,8 +1008,9 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
 };
 
 template <>
-class const_where_expression<simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
-                             simd<std::int64_t, simd_abi::neon_fixed_size<2>>> {
+class const_where_expression<
+    simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
   using value_type = simd<std::int64_t, abi_type>;
@@ -1052,10 +1054,11 @@ class where_expression<simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
     if (m_mask[0]) m_value[0] = mem[0];
     if (m_mask[1]) m_value[1] = mem[1];
   }
-  template <class U,
-            std::enable_if_t<std::is_convertible_v<
-                                 U, simd<std::int64_t, simd_abi::neon_fixed_size<2>>>,
-                             bool> = false>
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<
+                           U, simd<std::int64_t, simd_abi::neon_fixed_size<2>>>,
+                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
         static_cast<simd<std::int64_t, simd_abi::neon_fixed_size<2>>>(
@@ -1068,8 +1071,9 @@ class where_expression<simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
 };
 
 template <>
-class const_where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
-                             simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
+class const_where_expression<
+    simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
   using value_type = simd<std::uint64_t, abi_type>;
@@ -1114,9 +1118,10 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
     if (m_mask[1]) m_value[1] = mem[1];
   }
   template <class U,
-            std::enable_if_t<std::is_convertible_v<
-                                 U, simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>,
-                             bool> = false>
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
         static_cast<simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>(

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -798,6 +798,10 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   operator[](std::size_t i) const {
     return reference(const_cast<simd*>(this)->m_value, int(i));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = vld1q_u64(ptr);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator&(simd const& other) const {
     return simd(vandq_u64(m_value, other.m_value));
@@ -986,6 +990,141 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
     if (m_mask[0]) m_value[0] = mem[0];
     if (m_mask[1]) m_value[1] = mem[1];
+  }
+  template <class U,
+            std::enable_if_t<std::is_convertible_v<
+                                 U, simd<int32_t, simd_abi::neon_fixed_size<2>>>,
+                             bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<int32_t, simd_abi::neon_fixed_size<2>>>(
+            std::forward<U>(x));
+    m_value = static_cast<simd<int32_t, simd_abi::neon_fixed_size<2>>>(
+        vbsl_s32(static_cast<uint32x2_t>(m_mask),
+                 static_cast<int32x2_t>(x_as_value_type),
+                 static_cast<int32x2_t>(m_value)));
+  }
+};
+
+template <>
+class const_where_expression<simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
+                             simd<std::int64_t, simd_abi::neon_fixed_size<2>>> {
+ public:
+  using abi_type   = simd_abi::neon_fixed_size<2>;
+  using value_type = simd<std::int64_t, abi_type>;
+  using mask_type  = simd_mask<std::int64_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
+  mask() const {
+    return m_mask;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
+  value() const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int64_t* mem, element_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+  }
+};
+
+template <>
+class where_expression<simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
+                       simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+    : public const_where_expression<
+          simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
+          simd<std::int64_t, simd_abi::neon_fixed_size<2>>> {
+ public:
+  where_expression(
+      simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask_arg,
+      simd<std::int64_t, simd_abi::neon_fixed_size<2>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int64_t const* mem, element_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+  }
+  template <class U,
+            std::enable_if_t<std::is_convertible_v<
+                                 U, simd<std::int64_t, simd_abi::neon_fixed_size<2>>>,
+                             bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<std::int64_t, simd_abi::neon_fixed_size<2>>>(
+            std::forward<U>(x));
+    m_value = static_cast<simd<std::int64_t, simd_abi::neon_fixed_size<2>>>(
+        vbslq_s64(static_cast<uint64x2_t>(m_mask),
+                  static_cast<int64x2_t>(x_as_value_type),
+                  static_cast<int64x2_t>(m_value)));
+  }
+};
+
+template <>
+class const_where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
+                             simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
+ public:
+  using abi_type   = simd_abi::neon_fixed_size<2>;
+  using value_type = simd<std::uint64_t, abi_type>;
+  using mask_type  = simd_mask<std::uint64_t, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
+  mask() const {
+    return m_mask;
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
+  value() const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint64_t* mem, element_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+  }
+};
+
+template <>
+class where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
+                       simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+    : public const_where_expression<
+          simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
+          simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
+ public:
+  where_expression(
+      simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask_arg,
+      simd<std::uint64_t, simd_abi::neon_fixed_size<2>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::uint64_t const* mem, element_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+  }
+  template <class U,
+            std::enable_if_t<std::is_convertible_v<
+                                 U, simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>,
+                             bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>(
+            std::forward<U>(x));
+    m_value = static_cast<simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>(
+        vbslq_u64(static_cast<uint64x2_t>(m_mask),
+                  static_cast<uint64x2_t>(x_as_value_type),
+                  static_cast<uint64x2_t>(m_value)));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -884,14 +884,7 @@ class const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(double* mem, element_aligned_tag) const {
     if (m_mask[0]) mem[0] = m_value[0];
@@ -904,6 +897,12 @@ class const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
+
+  friend constexpr auto const& Impl::mask<double, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<double, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>
@@ -960,19 +959,18 @@ class const_where_expression<
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(std::int32_t* mem, element_aligned_tag) const {
     if (m_mask[0]) mem[0] = m_value[0];
     if (m_mask[1]) mem[1] = m_value[1];
   }
+
+  friend constexpr auto const& Impl::mask<std::int32_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<std::int32_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>
@@ -1023,19 +1021,18 @@ class const_where_expression<
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(std::int64_t* mem, element_aligned_tag) const {
     if (m_mask[0]) mem[0] = m_value[0];
     if (m_mask[1]) mem[1] = m_value[1];
   }
+
+  friend constexpr auto const& Impl::mask<std::int64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<std::int64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>
@@ -1086,19 +1083,18 @@ class const_where_expression<
  public:
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr mask_type const&
-  mask() const {
-    return m_mask;
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr value_type const&
-  value() const {
-    return m_value;
-  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_to(std::uint64_t* mem, element_aligned_tag) const {
     if (m_mask[0]) mem[0] = m_value[0];
     if (m_mask[1]) mem[1] = m_value[1];
   }
+
+  friend constexpr auto const& Impl::mask<std::uint64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<std::uint64_t, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -256,10 +256,12 @@ class const_where_expression<simd_mask<T, simd_abi::scalar>,
       mem[static_cast<Integral>(index)] = static_cast<T>(m_value);
   }
 
-  friend constexpr auto const& Impl::mask<T, abi_type>(
+  template <typename U, typename Abi>
+  friend constexpr auto const& Impl::mask(
       const_where_expression<mask_type, value_type> const& x);
 
-  friend constexpr auto const& Impl::value<T, abi_type>(
+  template <typename U, typename Abi>
+  friend constexpr auto const& Impl::value(
       const_where_expression<mask_type, value_type> const& x);
 };
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -244,10 +244,7 @@ class const_where_expression<simd_mask<T, simd_abi::scalar>,
   KOKKOS_FORCEINLINE_FUNCTION
   const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
       : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
-  KOKKOS_FORCEINLINE_FUNCTION
-  mask_type const& mask() const { return m_mask; }
-  KOKKOS_FORCEINLINE_FUNCTION
-  value_type const& value() const { return m_value; }
+
   KOKKOS_FORCEINLINE_FUNCTION
   void copy_to(T* mem, element_aligned_tag) const {
     if (static_cast<bool>(m_mask)) *mem = static_cast<T>(m_value);
@@ -258,6 +255,12 @@ class const_where_expression<simd_mask<T, simd_abi::scalar>,
     if (static_cast<bool>(m_mask))
       mem[static_cast<Integral>(index)] = static_cast<T>(m_value);
   }
+
+  friend constexpr auto const& Impl::mask<T, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<T, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
 };
 
 template <class T>
@@ -299,24 +302,24 @@ template <class T>
 reduce(const_where_expression<simd_mask<T, simd_abi::scalar>,
                               simd<T, simd_abi::scalar>> const& x,
        T identity_element, std::plus<>) {
-  return static_cast<bool>(x.mask()) ? static_cast<T>(x.value())
-                                     : identity_element;
+  return static_cast<bool>(Impl::mask(x)) ? static_cast<T>(Impl::value(x))
+                                          : identity_element;
 }
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
 hmax(const_where_expression<simd_mask<T, simd_abi::scalar>,
                             simd<T, simd_abi::scalar>> const& x) {
-  return static_cast<bool>(x.mask()) ? static_cast<T>(x.value())
-                                     : Kokkos::reduction_identity<T>::max();
+  return static_cast<bool>(Impl::mask(x)) ? static_cast<T>(Impl::value(x))
+                                          : Kokkos::reduction_identity<T>::max();
 }
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
 hmin(const_where_expression<simd_mask<T, simd_abi::scalar>,
                             simd<T, simd_abi::scalar>> const& x) {
-  return static_cast<bool>(x.mask()) ? static_cast<T>(x.value())
-                                     : Kokkos::reduction_identity<T>::min();
+  return static_cast<bool>(Impl::mask(x)) ? static_cast<T>(Impl::value(x))
+                                          : Kokkos::reduction_identity<T>::min();
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -256,12 +256,10 @@ class const_where_expression<simd_mask<T, simd_abi::scalar>,
       mem[static_cast<Integral>(index)] = static_cast<T>(m_value);
   }
 
-  template <typename U, typename Abi>
-  friend constexpr auto const& Impl::mask(
+  friend KOKKOS_FUNCTION constexpr auto const& Impl::mask<T, abi_type>(
       const_where_expression<mask_type, value_type> const& x);
 
-  template <typename U, typename Abi>
-  friend constexpr auto const& Impl::value(
+  friend KOKKOS_FUNCTION constexpr auto const& Impl::value<T, abi_type>(
       const_where_expression<mask_type, value_type> const& x);
 };
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -310,16 +310,18 @@ template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
 hmax(const_where_expression<simd_mask<T, simd_abi::scalar>,
                             simd<T, simd_abi::scalar>> const& x) {
-  return static_cast<bool>(Impl::mask(x)) ? static_cast<T>(Impl::value(x))
-                                          : Kokkos::reduction_identity<T>::max();
+  return static_cast<bool>(Impl::mask(x))
+             ? static_cast<T>(Impl::value(x))
+             : Kokkos::reduction_identity<T>::max();
 }
 
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION T
 hmin(const_where_expression<simd_mask<T, simd_abi::scalar>,
                             simd<T, simd_abi::scalar>> const& x) {
-  return static_cast<bool>(Impl::mask(x)) ? static_cast<T>(Impl::value(x))
-                                          : Kokkos::reduction_identity<T>::min();
+  return static_cast<bool>(Impl::mask(x))
+             ? static_cast<T>(Impl::value(x))
+             : Kokkos::reduction_identity<T>::min();
 }
 
 }  // namespace Experimental

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -278,21 +278,23 @@ class divides {
 };
 
 template <class Abi, size_t n, typename DataType>
-inline void host_check_all_math_ops(DataType const& first_args, DataType const& second_args) {
+inline void host_check_all_math_ops(DataType const& first_args,
+                                    DataType const& second_args) {
   host_check_binary_op_all_loaders<Abi>(plus(), n, first_args, second_args);
   host_check_binary_op_all_loaders<Abi>(minus(), n, first_args, second_args);
   host_check_binary_op_all_loaders<Abi>(multiplies(), n, first_args,
                                         second_args);
 
-  if constexpr(std::is_same_v<DataType, double>)
-    host_check_binary_op_all_loaders<Abi>(divides(), n, first_args, second_args);
+  if constexpr (std::is_same_v<DataType, double>)
+    host_check_binary_op_all_loaders<Abi>(divides(), n, first_args,
+                                          second_args);
 }
 
 template <class Abi, typename DataType>
 inline void host_check_math_ops() {
   constexpr size_t n = 11;
 
-  if constexpr(std::is_signed_v<DataType>) {
+  if constexpr (std::is_signed_v<DataType>) {
     DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
     DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
     host_check_all_math_ops<Abi, n>(first_args, second_args);

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -285,6 +285,7 @@ inline void host_check_all_math_ops(const DataType (&first_args)[n],
   host_check_binary_op_all_loaders<Abi>(multiplies(), n, first_args,
                                         second_args);
 
+  // TODO: Place fallback division implementations for all simd integer types
   if constexpr (std::is_same_v<DataType, double>)
     host_check_binary_op_all_loaders<Abi>(divides(), n, first_args,
                                           second_args);

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -278,8 +278,8 @@ class divides {
 };
 
 template <class Abi, size_t n, typename DataType>
-inline void host_check_all_math_ops(DataType const& first_args,
-                                    DataType const& second_args) {
+inline void host_check_all_math_ops(const DataType (&first_args)[n],
+                                    const DataType (&second_args)[n]) {
   host_check_binary_op_all_loaders<Abi>(plus(), n, first_args, second_args);
   host_check_binary_op_all_loaders<Abi>(minus(), n, first_args, second_args);
   host_check_binary_op_all_loaders<Abi>(multiplies(), n, first_args,
@@ -306,11 +306,11 @@ inline void host_check_math_ops() {
   if constexpr (std::is_signed_v<DataType>) {
     DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
     DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
-    host_check_all_math_ops<Abi, n>(first_args, second_args);
+    host_check_all_math_ops<Abi>(first_args, second_args);
   } else {
     DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
     DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
-    host_check_all_math_ops<Abi, n>(first_args, second_args);
+    host_check_all_math_ops<Abi>(first_args, second_args);
   }
 }
 
@@ -380,7 +380,7 @@ inline void host_check_condition() {
 
 template <class Abi, size_t n, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
-    DataType const& first_args, DataType const& second_args) {
+    const DataType (&first_args)[n], const DataType (&second_args)[n]) {
   device_check_binary_op_all_loaders<Abi>(plus(), n, first_args, second_args);
   device_check_binary_op_all_loaders<Abi>(minus(), n, first_args, second_args);
   device_check_binary_op_all_loaders<Abi>(multiplies(), n, first_args,
@@ -407,11 +407,11 @@ KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
   if constexpr (std::is_signed_v<DataType>) {
     DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
     DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
-    device_check_all_math_ops<Abi, n>(first_args, second_args);
+    device_check_all_math_ops<Abi>(first_args, second_args);
   } else {
     DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
     DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
-    device_check_all_math_ops<Abi, n>(first_args, second_args);
+    device_check_all_math_ops<Abi>(first_args, second_args);
   }
 }
 

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -465,15 +465,11 @@ inline void host_check_math_ops_all_types(
   (host_check_math_ops<Abi, DataTypes>(), ...);
 }
 
-template <typename Abi>
-inline void host_check_math_ops_all_types() {
-  host_check_math_ops_all_types<Abi>(
-      Kokkos::Experimental::Impl::data_type_set());
-}
-
 template <class Abi>
 inline void host_check_abi() {
-  host_check_math_ops_all_types<Abi>();
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+
+  host_check_math_ops_all_types<Abi>(DataTypes());
   host_check_mask_ops<Abi>();
   host_check_conversions<Abi>();
   host_check_shifts<Abi>();

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -277,7 +277,7 @@ class divides {
   }
 };
 
-template <class Abi, size_t n, typename DataType>
+template <typename Abi, typename DataType, size_t n>
 inline void host_check_all_math_ops(const DataType (&first_args)[n],
                                     const DataType (&second_args)[n]) {
   host_check_binary_op_all_loaders<Abi>(plus(), n, first_args, second_args);
@@ -379,7 +379,7 @@ inline void host_check_condition() {
   EXPECT_TRUE(all_of(a == decltype(a)(16)));
 }
 
-template <class Abi, size_t n, typename DataType>
+template <typename Abi, typename DataType, size_t n>
 KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
     const DataType (&first_args)[n], const DataType (&second_args)[n]) {
   device_check_binary_op_all_loaders<Abi>(plus(), n, first_args, second_args);

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -459,17 +459,10 @@ KOKKOS_INLINE_FUNCTION void device_check_condition() {
   checker.truth(all_of(a == decltype(a)(16)));
 }
 
-template <typename Abi>
+template <typename Abi, typename... DataTypes>
 inline void host_check_math_ops_all_types(
-    Kokkos::Experimental::Impl::data_types<>) {}
-
-template <typename Abi, typename DataType, typename... RestTypes>
-inline void host_check_math_ops_all_types(
-    Kokkos::Experimental::Impl::data_types<DataType, RestTypes...> =
-        Kokkos::Experimental::Impl::data_type_set()) {
-  host_check_math_ops<Abi, DataType>();
-  host_check_math_ops_all_types<Abi>(
-      Kokkos::Experimental::Impl::data_types<RestTypes...>());
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (host_check_math_ops<Abi, DataTypes>(), ...);
 }
 
 template <typename Abi>


### PR DESCRIPTION
A prerequisite work for tasks in #5674.

SIMD unit tests are currently only testing for `double` type for all abi sets.
This PR modifies unit tests for binary ops and adds missing functions to simd classes to make them testable against all supported data types.

This PR adds:
- AVX2:
  - `copy_from` function for `int64_t`
  - Add and subtract operators for `uint64_t`
  - `const_where_expression` and `where_experssion` for `int64_t` and `uint64_t`
- AVX512:
  - `copy_to` and `copy_from` functions for `uint32_t` and `uint64_t`
  - Subtract operator for `int32_t`
  - `const_where_expression` and `where_experssion` for `uint32_t`, `int64_t` and `uint64_t`
- NEON:
  - `copy_from` function for `uint64_t`
  - `const_where_expression` and `where_experssion` for `int64_t` and `uint64_t`
