### PR TITLE
Drop legacy host lock arrays

### DIFF
--- a/core/src/Kokkos_HBWSpace.hpp
+++ b/core/src/Kokkos_HBWSpace.hpp
@@ -31,41 +31,6 @@ namespace Kokkos {
 
 namespace Experimental {
 
-namespace Impl {
-
-/// \brief Initialize lock array for arbitrary size atomics.
-///
-/// Arbitrary atomics are implemented using a hash table of locks
-/// where the hash value is derived from the address of the
-/// object for which an atomic operation is performed.
-/// This function initializes the locks to zero (unset).
-void init_lock_array_hbw_space();
-
-/// \brief Acquire a lock for the address
-///
-/// This function tries to acquire the lock for the hash value derived
-/// from the provided ptr. If the lock is successfully acquired the
-/// function returns true. Otherwise it returns false.
-bool lock_address_hbw_space(void* ptr);
-
-/// \brief Release lock for the address
-///
-/// This function releases the lock for the hash value derived
-/// from the provided ptr. This function should only be called
-/// after previously successfully acquiring a lock with
-/// lock_address.
-void unlock_address_hbw_space(void* ptr);
-
-}  // namespace Impl
-
-}  // namespace Experimental
-
-}  // namespace Kokkos
-
-namespace Kokkos {
-
-namespace Experimental {
-
 /// \class HBWSpace
 /// \brief Memory management for host memory.
 ///

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -42,37 +42,6 @@ static_assert(false,
 /*--------------------------------------------------------------------------*/
 
 namespace Kokkos {
-
-namespace Impl {
-
-/// \brief Initialize lock array for arbitrary size atomics.
-///
-/// Arbitrary atomics are implemented using a hash table of locks
-/// where the hash value is derived from the address of the
-/// object for which an atomic operation is performed.
-/// This function initializes the locks to zero (unset).
-void init_lock_array_host_space();
-
-/// \brief Acquire a lock for the address
-///
-/// This function tries to acquire the lock for the hash value derived
-/// from the provided ptr. If the lock is successfully acquired the
-/// function returns true. Otherwise it returns false.
-bool lock_address_host_space(void* ptr);
-
-/// \brief Release lock for the address
-///
-/// This function releases the lock for the hash value derived
-/// from the provided ptr. This function should only be called
-/// after previously successfully acquiring a lock with
-/// lock_address.
-void unlock_address_host_space(void* ptr);
-
-}  // namespace Impl
-
-}  // namespace Kokkos
-
-namespace Kokkos {
 /// \class HostSpace
 /// \brief Memory management for host memory.
 ///

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -324,8 +324,6 @@ void OpenMPInternal::initialize(int thread_count) {
     std::cerr << "                                    Requested: "
               << thread_count << " threads per process." << std::endl;
   }
-  // Init the array used for arbitrarily sized atomics
-  init_lock_array_host_space();
 
   m_initialized = true;
 }

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.cpp
@@ -165,39 +165,6 @@ SharedAllocationRecord<Kokkos::Experimental::OpenMPTargetSpace, void>::
 }  // namespace Impl
 }  // namespace Kokkos
 
-/*--------------------------------------------------------------------------*/
-/*--------------------------------------------------------------------------*/
-/*
-namespace Kokkos {
-namespace {
-  const unsigned HOST_SPACE_ATOMIC_MASK = 0xFFFF;
-  const unsigned HOST_SPACE_ATOMIC_XOR_MASK = 0x5A39;
-  static int HOST_SPACE_ATOMIC_LOCKS[HOST_SPACE_ATOMIC_MASK+1];
-}
-
-namespace Impl {
-void init_lock_array_host_space() {
-  static int is_initialized = 0;
-  if(! is_initialized)
-    for(int i = 0; i < static_cast<int> (HOST_SPACE_ATOMIC_MASK+1); i++)
-      HOST_SPACE_ATOMIC_LOCKS[i] = 0;
-}
-
-bool lock_address_host_space(void* ptr) {
-  return 0 == atomic_compare_exchange( &HOST_SPACE_ATOMIC_LOCKS[
-      (( size_t(ptr) >> 2 ) & HOST_SPACE_ATOMIC_MASK) ^
-HOST_SPACE_ATOMIC_XOR_MASK] , 0 , 1);
-}
-
-void unlock_address_host_space(void* ptr) {
-   atomic_exchange( &HOST_SPACE_ATOMIC_LOCKS[
-      (( size_t(ptr) >> 2 ) & HOST_SPACE_ATOMIC_MASK) ^
-HOST_SPACE_ATOMIC_XOR_MASK] , 0);
-}
-
-}
-}*/
-
 //==============================================================================
 // <editor-fold desc="Explicit instantiations of CRTP Base classes"> {{{1
 

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTargetSpace.hpp
@@ -35,37 +35,6 @@ static_assert(false,
 #include <Kokkos_HostSpace.hpp>
 #include <omp.h>
 
-/*--------------------------------------------------------------------------*/
-
-namespace Kokkos {
-namespace Impl {
-
-/// \brief Initialize lock array for arbitrary size atomics.
-///
-/// Arbitrary atomics are implemented using a hash table of locks
-/// where the hash value is derived from the address of the
-/// object for which an atomic operation is performed.
-/// This function initializes the locks to zero (unset).
-// void init_lock_array_host_space();
-
-/// \brief Acquire a lock for the address
-///
-/// This function tries to acquire the lock for the hash value derived
-/// from the provided ptr. If the lock is successfully acquired the
-/// function returns true. Otherwise it returns false.
-// bool lock_address_host_space(void* ptr);
-
-/// \brief Release lock for the address
-///
-/// This function releases the lock for the hash value derived
-/// from the provided ptr. This function should only be called
-/// after previously successfully acquiring a lock with
-/// lock_address.
-// void unlock_address_host_space(void* ptr);
-
-}  // namespace Impl
-}  // namespace Kokkos
-
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -42,9 +42,6 @@ void SerialInternal::initialize() {
 
   Impl::SharedAllocationRecord<void, void>::tracking_enable();
 
-  // Init the array of locks used for arbitrarily sized atomics
-  Impl::init_lock_array_host_space();
-
   m_is_initialized = true;
 }
 

--- a/core/src/Threads/Kokkos_ThreadsExec.cpp
+++ b/core/src/Threads/Kokkos_ThreadsExec.cpp
@@ -768,9 +768,6 @@ void ThreadsExec::initialize(int thread_count_arg) {
               << thread_count << " threads per process." << std::endl;
   }
 
-  // Init the array for used for arbitrarily sized atomics
-  Impl::init_lock_array_host_space();
-
   Impl::SharedAllocationRecord<void, void>::tracking_enable();
 }
 

--- a/core/src/impl/Kokkos_HBWSpace.cpp
+++ b/core/src/impl/Kokkos_HBWSpace.cpp
@@ -310,41 +310,4 @@ void SharedAllocationRecord<Kokkos::Experimental::HBWSpace, void>::
 }  // namespace Impl
 }  // namespace Kokkos
 
-/*--------------------------------------------------------------------------*/
-/*--------------------------------------------------------------------------*/
-
-namespace Kokkos {
-namespace Experimental {
-namespace {
-const unsigned HBW_SPACE_ATOMIC_MASK     = 0xFFFF;
-const unsigned HBW_SPACE_ATOMIC_XOR_MASK = 0x5A39;
-static int HBW_SPACE_ATOMIC_LOCKS[HBW_SPACE_ATOMIC_MASK + 1];
-}  // namespace
-
-namespace Impl {
-void init_lock_array_hbw_space() {
-  static int is_initialized = 0;
-  if (!is_initialized)
-    for (int i = 0; i < static_cast<int>(HBW_SPACE_ATOMIC_MASK + 1); i++)
-      HBW_SPACE_ATOMIC_LOCKS[i] = 0;
-}
-
-bool lock_address_hbw_space(void *ptr) {
-  return 0 == atomic_compare_exchange(
-                  &HBW_SPACE_ATOMIC_LOCKS[((size_t(ptr) >> 2) &
-                                           HBW_SPACE_ATOMIC_MASK) ^
-                                          HBW_SPACE_ATOMIC_XOR_MASK],
-                  0, 1);
-}
-
-void unlock_address_hbw_space(void *ptr) {
-  atomic_exchange(
-      &HBW_SPACE_ATOMIC_LOCKS[((size_t(ptr) >> 2) & HBW_SPACE_ATOMIC_MASK) ^
-                              HBW_SPACE_ATOMIC_XOR_MASK],
-      0);
-}
-
-}  // namespace Impl
-}  // namespace Experimental
-}  // namespace Kokkos
 #endif

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -284,42 +284,6 @@ SharedAllocationRecord<Kokkos::HostSpace, void>::SharedAllocationRecord(
 }  // namespace Impl
 }  // namespace Kokkos
 
-/*--------------------------------------------------------------------------*/
-/*--------------------------------------------------------------------------*/
-
-namespace Kokkos {
-namespace {
-const unsigned HOST_SPACE_ATOMIC_MASK     = 0xFFFF;
-const unsigned HOST_SPACE_ATOMIC_XOR_MASK = 0x5A39;
-static int HOST_SPACE_ATOMIC_LOCKS[HOST_SPACE_ATOMIC_MASK + 1];
-}  // namespace
-
-namespace Impl {
-void init_lock_array_host_space() {
-  static int is_initialized = 0;
-  if (!is_initialized)
-    for (int i = 0; i < static_cast<int>(HOST_SPACE_ATOMIC_MASK + 1); i++)
-      HOST_SPACE_ATOMIC_LOCKS[i] = 0;
-}
-
-bool lock_address_host_space(void *ptr) {
-  return 0 == atomic_compare_exchange(
-                  &HOST_SPACE_ATOMIC_LOCKS[((size_t(ptr) >> 2) &
-                                            HOST_SPACE_ATOMIC_MASK) ^
-                                           HOST_SPACE_ATOMIC_XOR_MASK],
-                  0, 1);
-}
-
-void unlock_address_host_space(void *ptr) {
-  atomic_exchange(
-      &HOST_SPACE_ATOMIC_LOCKS[((size_t(ptr) >> 2) & HOST_SPACE_ATOMIC_MASK) ^
-                               HOST_SPACE_ATOMIC_XOR_MASK],
-      0);
-}
-
-}  // namespace Impl
-}  // namespace Kokkos
-
 //==============================================================================
 // <editor-fold desc="Explicit instantiations of CRTP Base classes"> {{{1
 


### PR DESCRIPTION
Addressing step 3 in #5789
#5817 dropped the device-side lock arrays.  This PR takes care of the host ones.