### PR TITLE
updates to nvcc_wrapper to match the 4.0RC default arch and look for c source files

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -148,7 +148,7 @@ do
     remove_duplicate_link_files=1
     ;;
   #handle source files to be compiled as cuda files
-  *.cpp|*.cxx|*.cc|*.C|*.c++|*.cu)
+  *.cpp|*.cxx|*.cc|*.C|*.c++|*.cu|*.c)
     cpp_files="$cpp_files $1"
     ;;
    # Ensure we only have one optimization flag because NVCC doesn't allow multiple


### PR DESCRIPTION
Add *.c source files to be compiled as cuda files by `nvcc_wrapper`
