### PR TITLE
Intel compiler macro cleanup

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_Reverse.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Reverse.hpp
@@ -39,16 +39,7 @@ struct StdReverseFunctor {
 
   KOKKOS_FUNCTION
   void operator()(index_type i) const {
-    // the swap below is doing the same thing, but
-    // for Intel 18.0.5 does not work.
-    // But putting the impl directly here, it works.
-#ifdef KOKKOS_COMPILER_INTEL
-    typename InputIterator::value_type tmp = std::move(m_first[i]);
-    m_first[i]                             = std::move(m_last[-i - 1]);
-    m_last[-i - 1]                         = std::move(tmp);
-#else
     ::Kokkos::Experimental::swap(m_first[i], m_last[-i - 1]);
-#endif
   }
 
   StdReverseFunctor(InputIterator first, InputIterator last)

--- a/algorithms/src/std_algorithms/impl/Kokkos_SwapRanges.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_SwapRanges.hpp
@@ -35,16 +35,7 @@ struct StdSwapRangesFunctor {
 
   KOKKOS_FUNCTION
   void operator()(IndexType i) const {
-    // the swap below is doing the same thing, but
-    // for Intel 18.0.5 does not work.
-    // But putting the impl directly here, it works.
-#ifdef KOKKOS_COMPILER_INTEL
-    typename IteratorType1::value_type tmp = std::move(m_first1[i]);
-    m_first1[i]                            = std::move(m_first2[i]);
-    m_first2[i]                            = std::move(tmp);
-#else
     ::Kokkos::Experimental::swap(m_first1[i], m_first2[i]);
-#endif
   }
 
   KOKKOS_FUNCTION

--- a/containers/unit_tests/TestVector.hpp
+++ b/containers/unit_tests/TestVector.hpp
@@ -49,61 +49,27 @@ struct test_vector_insert {
 
     it = a.begin();
     it += 17;
-// Looks like some std::vector implementations do not have the restriction
-// right on the overload taking three iterators, and thus the following call
-// will hit that overload and then fail to compile.
-#if defined(KOKKOS_COMPILER_INTEL)
-// And at least GCC 4.8.4 doesn't implement vector insert correct for C++11
-// Return type is void ...
-#if (__GNUC__ < 5)
-    a.insert(it, typename Vector::size_type(n + 5), scalar_type(5));
-    it_return = a.begin() + 17;
-#else
-    it_return = a.insert(it, typename Vector::size_type(n + 5), scalar_type(5));
-#endif
-#else
-#if (__GNUC__ < 5)
-    a.insert(it, n + 5, scalar_type(5));
-    it_return = a.begin() + 17;
-#else
     it_return = a.insert(it, n + 5, scalar_type(5));
-#endif
-#endif
 
     ASSERT_EQ(a.size(), n + 1 + n + 5);
     ASSERT_EQ(std::distance(it_return, a.begin() + 17), 0u);
 
     Vector b;
 
-// Looks like some std::vector implementations do not have the restriction
-// right on the overload taking three iterators, and thus the following call
-// will hit that overload and then fail to compile.
-#if defined(KOKKOS_COMPILER_INTEL)
-    b.insert(b.begin(), typename Vector::size_type(7), 9);
-#else
     b.insert(b.begin(), 7, 9);
-#endif
     ASSERT_EQ(b.size(), 7u);
     ASSERT_EQ(b[0], scalar_type(9));
 
     it = a.begin();
     it += 27 + n;
-#if (__GNUC__ < 5)
-    a.insert(it, b.begin(), b.end());
-    it_return = a.begin() + (27 + n);
-#else
     it_return = a.insert(it, b.begin(), b.end());
-#endif
+
     ASSERT_EQ(a.size(), n + 1 + n + 5 + 7);
     ASSERT_EQ(std::distance(it_return, a.begin() + 27 + n), 0u);
 
     // Testing insert at end via all three function interfaces
     a.insert(a.end(), 11);
-#if defined(KOKKOS_COMPILER_INTEL)
-    a.insert(a.end(), typename Vector::size_type(2), 12);
-#else
     a.insert(a.end(), 2, 12);
-#endif
     a.insert(a.end(), b.begin(), b.end());
   }
 

--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -2708,18 +2708,11 @@ struct TestMDRange_6D {
                            const int N3, const int N4, const int N5) {
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<128, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2738,18 +2731,11 @@ struct TestMDRange_6D {
 #endif
 
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2782,18 +2768,11 @@ struct TestMDRange_6D {
 
     // Test with reducers - scalar
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
-#endif
 #ifdef KOKKOS_ENABLE_SYCL
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 2, 2, 2}});
@@ -2816,18 +2795,11 @@ struct TestMDRange_6D {
 
     // Test with reducers - scalar + label
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
-#endif
 
 #ifdef KOKKOS_ENABLE_SYCL
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
@@ -2851,19 +2823,12 @@ struct TestMDRange_6D {
 
     // Test with reducers - scalar view
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
                                          Kokkos::IndexType<int>,
                                          Kokkos::LaunchBounds<512, 1>>;
-#endif
 #ifdef KOKKOS_ENABLE_SYCL
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 2, 2, 2}});
@@ -2891,18 +2856,11 @@ struct TestMDRange_6D {
     // Test Min reducer with lambda
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<128, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
-#endif
       range_type range({{1, 1, 1, 1, 1, 1}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 2, 2, 1}});
 
@@ -2935,19 +2893,12 @@ struct TestMDRange_6D {
 
     // Tagged operator test
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type = typename Kokkos::MDRangePolicy<
-          ExecSpace, Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
-          Kokkos::IndexType<int>, InitTag>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
           Kokkos::IndexType<int>, InitTag>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2999,18 +2950,11 @@ struct TestMDRange_6D {
                         const int N4, const int N5) {
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<128, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3059,16 +3003,10 @@ struct TestMDRange_6D {
 #endif
 
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>>;
-#endif
       using point_type = typename range_type::point_type;
 
       range_type range(point_type{{0, 0, 0, 0, 0, 0}},
@@ -3101,18 +3039,11 @@ struct TestMDRange_6D {
     }
 
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int>, InitTag>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>, InitTag>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3163,18 +3094,11 @@ struct TestMDRange_6D {
     }
 
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3215,19 +3139,12 @@ struct TestMDRange_6D {
     }
 
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type = typename Kokkos::MDRangePolicy<
-          ExecSpace, Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
-          Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
           Kokkos::IndexType<int>>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3268,19 +3185,12 @@ struct TestMDRange_6D {
     }
 
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type = typename Kokkos::MDRangePolicy<
-          ExecSpace, Kokkos::Rank<6, Iterate::Left, Iterate::Left>,
-          Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Left, Iterate::Left>,
           Kokkos::IndexType<int>>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3321,19 +3231,12 @@ struct TestMDRange_6D {
     }
 
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type = typename Kokkos::MDRangePolicy<
-          ExecSpace, Kokkos::Rank<6, Iterate::Left, Iterate::Right>,
-          Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Left, Iterate::Right>,
           Kokkos::IndexType<int>>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3374,19 +3277,12 @@ struct TestMDRange_6D {
     }
 
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type = typename Kokkos::MDRangePolicy<
-          ExecSpace, Kokkos::Rank<6, Iterate::Right, Iterate::Left>,
-          Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Right, Iterate::Left>,
           Kokkos::IndexType<int>>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3427,19 +3323,12 @@ struct TestMDRange_6D {
     }
 
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type = typename Kokkos::MDRangePolicy<
-          ExecSpace, Kokkos::Rank<6, Iterate::Right, Iterate::Right>,
-          Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Right, Iterate::Right>,
           Kokkos::IndexType<int>>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3790,18 +3679,11 @@ struct TestMDRange_6D_NegIdx {
   static void test_6D_negidx(const int N0, const int N1, const int N2,
                              const int N3, const int N4, const int N5) {
     {
-#if defined(KOKKOS_COMPILER_INTEL)
-      // Launchbounds causes hang with intel compilers
-      using range_type =
-          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
-                                         Kokkos::IndexType<int>>;
-#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<256, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
-#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 


### PR DESCRIPTION
Remove various workarounds for old versions of the Intel Classic Compiler (before the current-minimum 19.0.5) that are no longer necessary