### PR TITLE
Remove extra double quote in CUDA and HIP allocation error messages

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Error.hpp
+++ b/core/src/HIP/Kokkos_HIP_Error.hpp
@@ -70,7 +70,7 @@ class HIPRawMemoryAllocationFailure : public RawMemoryAllocationFailure {
 
   void append_additional_error_information(std::ostream& o) const override {
     if (m_error_code != hipSuccess) {
-      o << "  The HIP allocation returned the error code \"\""
+      o << "  The HIP allocation returned the error code \""
         << hipGetErrorName(m_error_code) << "\".";
     }
   }

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -151,7 +151,7 @@ namespace Experimental {
 void CudaRawMemoryAllocationFailure::append_additional_error_information(
     std::ostream &o) const {
   if (m_error_code != cudaSuccess) {
-    o << "  The Cuda allocation returned the error code \"\""
+    o << "  The Cuda allocation returned the error code \""
       << cudaGetErrorName(m_error_code) << "\".";
   }
 }


### PR DESCRIPTION
Noticed it earlier today when investigating the out of memory error when using the same device from 128 MPI processes and  turns out the HIP backend has the same issue.