### PR TITLE
Improve compatibility of Kokkos::vector

### DIFF
--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -224,7 +224,13 @@ class vector : public DualView<Scalar*, LayoutLeft, Arg1Type> {
 
   iterator begin() const { return DV::h_view.data(); }
 
+  const_iterator begin() const { return DV::h_view.data(); }
+
   iterator end() const {
+    return _size > 0 ? DV::h_view.data() + _size : DV::h_view.data();
+  }
+
+  const_iterator end() const {
     return _size > 0 ? DV::h_view.data() + _size : DV::h_view.data();
   }
 

--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -224,13 +224,13 @@ class vector : public DualView<Scalar*, LayoutLeft, Arg1Type> {
 
   iterator begin() const { return DV::h_view.data(); }
 
-  const_iterator begin() const { return DV::h_view.data(); }
+  const_iterator cbegin() const { return DV::h_view.data(); }
 
   iterator end() const {
     return _size > 0 ? DV::h_view.data() + _size : DV::h_view.data();
   }
 
-  const_iterator end() const {
+  const_iterator cend() const {
     return _size > 0 ? DV::h_view.data() + _size : DV::h_view.data();
   }
 


### PR DESCRIPTION
This PR improves the compatibility of `Kokkos::vector` with `std::vector` by adding `cbegin()` and `cend()` methods. 