### PR TITLE
Update clang-format CI build

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -17,7 +17,7 @@ pipeline {
                 dockerfile {
                     filename 'Dockerfile.clang'
                     dir 'scripts/docker'
-                    label 'nvidia-docker || docker'
+                    label 'nvidia-docker || rocm-docker || docker'
                     args '-v /tmp/ccache.kokkos:/tmp/ccache'
                 }
             }

--- a/scripts/docker/Dockerfile.clang
+++ b/scripts/docker/Dockerfile.clang
@@ -34,7 +34,7 @@ ENV PATH=${CMAKE_DIR}/bin:$PATH
 
 ENV LLVM_DIR=/opt/llvm
 RUN LLVM_VERSION=8.0.0 && \
-    LLVM_URL=http://releases.llvm.org/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-18.04.tar.xz && \
+    LLVM_URL=https://releases.llvm.org/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-18.04.tar.xz && \
     LLVM_ARCHIVE=llvm-${LLVM_VERSION}.tar.xz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${LLVM_URL} --output-document=${LLVM_ARCHIVE} && \

--- a/scripts/docker/Dockerfile.clang
+++ b/scripts/docker/Dockerfile.clang
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:9.2-devel
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y \
         bc \
@@ -34,7 +34,7 @@ ENV PATH=${CMAKE_DIR}/bin:$PATH
 
 ENV LLVM_DIR=/opt/llvm
 RUN LLVM_VERSION=8.0.0 && \
-    LLVM_URL=http://releases.llvm.org/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \
+    LLVM_URL=http://releases.llvm.org/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-18.04.tar.xz && \
     LLVM_ARCHIVE=llvm-${LLVM_VERSION}.tar.xz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${LLVM_URL} --output-document=${LLVM_ARCHIVE} && \

--- a/scripts/docker/Dockerfile.clang
+++ b/scripts/docker/Dockerfile.clang
@@ -3,6 +3,7 @@ FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y \
         bc \
         git \
+        build-essential \
         wget \
         ccache \
         && \


### PR DESCRIPTION
The `nvidia/cuda:9.2-devel` image is wildly outdated and we don't actually use CUDA.  Clang+LLVM binaries are available for Ubuntu 14.04 and 16.04.  I picked the more recent one.  In my opinion we need to consider seriously bumping the clang-format version to something much more recent very soon.

As a drive-by-change, the clang-format CI build was already allowed to run on CPU-only nodes or on nodes that had NVIDIA GPUs (marked by labels "docker" and "nvidia-docker" respectively) and I enabled also running on nodes with AMD GPUs ("rocm-docker" label)