### PR TITLE
Revert removal of icpc hanging workaround

### DIFF
--- a/core/unit_test/TestMDRange.hpp
+++ b/core/unit_test/TestMDRange.hpp
@@ -2708,11 +2708,18 @@ struct TestMDRange_6D {
                            const int N3, const int N4, const int N5) {
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<128, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2731,11 +2738,18 @@ struct TestMDRange_6D {
 #endif
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2768,11 +2782,18 @@ struct TestMDRange_6D {
 
     // Test with reducers - scalar
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
 #ifdef KOKKOS_ENABLE_SYCL
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 2, 2, 2}});
@@ -2795,11 +2816,18 @@ struct TestMDRange_6D {
 
     // Test with reducers - scalar + label
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
 
 #ifdef KOKKOS_ENABLE_SYCL
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
@@ -2823,12 +2851,19 @@ struct TestMDRange_6D {
 
     // Test with reducers - scalar view
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type =
           typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
                                          Kokkos::IndexType<int>,
                                          Kokkos::LaunchBounds<512, 1>>;
+#endif
 #ifdef KOKKOS_ENABLE_SYCL
       range_type range({{0, 0, 0, 0, 0, 0}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 2, 2, 2}});
@@ -2856,11 +2891,18 @@ struct TestMDRange_6D {
     // Test Min reducer with lambda
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<128, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       range_type range({{1, 1, 1, 1, 1, 1}}, {{N0, N1, N2, N3, N4, N5}},
                        {{3, 3, 3, 2, 2, 1}});
 
@@ -2893,12 +2935,19 @@ struct TestMDRange_6D {
 
     // Tagged operator test
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
+          Kokkos::IndexType<int>, InitTag>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
           Kokkos::IndexType<int>, InitTag>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -2950,11 +2999,18 @@ struct TestMDRange_6D {
                         const int N4, const int N5) {
 #if defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<128, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3003,10 +3059,16 @@ struct TestMDRange_6D {
 #endif
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>>;
+#endif
       using point_type = typename range_type::point_type;
 
       range_type range(point_type{{0, 0, 0, 0, 0, 0}},
@@ -3039,11 +3101,18 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>, InitTag>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>, InitTag>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3094,11 +3163,18 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3139,12 +3215,19 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
+          Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Default, Iterate::Default>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3185,12 +3268,19 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Left, Iterate::Left>,
+          Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Left, Iterate::Left>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3231,12 +3321,19 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Left, Iterate::Right>,
+          Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Left, Iterate::Right>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3277,12 +3374,19 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Right, Iterate::Left>,
+          Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Right, Iterate::Left>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3323,12 +3427,19 @@ struct TestMDRange_6D {
     }
 
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type = typename Kokkos::MDRangePolicy<
+          ExecSpace, Kokkos::Rank<6, Iterate::Right, Iterate::Right>,
+          Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<512, 1>,
           Kokkos::Rank<6, Iterate::Right, Iterate::Right>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 
@@ -3679,11 +3790,18 @@ struct TestMDRange_6D_NegIdx {
   static void test_6D_negidx(const int N0, const int N1, const int N2,
                              const int N3, const int N4, const int N5) {
     {
+#if defined(KOKKOS_COMPILER_INTEL)
+      // Launchbounds causes hang with intel compilers
+      using range_type =
+          typename Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<6>,
+                                         Kokkos::IndexType<int>>;
+#else
       // Launchbounds to ensure the tile fits into a CUDA block under register
       // constraints
       using range_type = typename Kokkos::MDRangePolicy<
           ExecSpace, Kokkos::LaunchBounds<256, 1>, Kokkos::Rank<6>,
           Kokkos::IndexType<int>>;
+#endif
       using tile_type  = typename range_type::tile_type;
       using point_type = typename range_type::point_type;
 


### PR DESCRIPTION
The workaround was specifically for a hang in icpc 19.0.5 compiling with -O3. It resurfaced in nightly testing.

Fixes #5933

This reverts commit 33e5ef694ef4cd11eae1f4dd931d5d56cd84c3e3.