### PR TITLE
Drop `KOKKOS_ENABLE_*_ATOMICS` and `KOKKOS_ENABLE_CUDA_ASM*` macros

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -867,14 +867,6 @@ void Cuda::print_configuration(std::ostream &os, bool /*verbose*/) const {
   os << "Device Execution Space:\n";
   os << "  KOKKOS_ENABLE_CUDA: yes\n";
 
-  os << "Cuda Atomics:\n";
-  os << "  KOKKOS_ENABLE_CUDA_ATOMICS: ";
-#ifdef KOKKOS_ENABLE_CUDA_ATOMICS
-  os << "yes\n";
-#else
-  os << "no\n";
-#endif
-
   os << "Cuda Options:\n";
   os << "  KOKKOS_ENABLE_CUDA_LAMBDA: ";
 #ifdef KOKKOS_ENABLE_CUDA_LAMBDA

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -71,13 +71,6 @@
  *  KOKKOS_COMPILER_NVHPC
  *  KOKKOS_COMPILER_MSVC
  *
- *  Macros for which compiler extension to use for atomics on intrinsic types
- *
- *  KOKKOS_ENABLE_CUDA_ATOMICS
- *  KOKKOS_ENABLE_GNU_ATOMICS
- *  KOKKOS_ENABLE_INTEL_ATOMICS
- *  KOKKOS_ENABLE_OPENMP_ATOMICS
- *
  *  A suite of 'KOKKOS_ENABLE_PRAGMA_...' are defined for internal use.
  *
  *  Macros for marking functions to run in an execution space:

--- a/core/src/OpenMP/Kokkos_OpenMP.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.cpp
@@ -57,14 +57,6 @@ void OpenMP::print_configuration(std::ostream &os, bool /*verbose*/) const {
   os << "Host Parallel Execution Space:\n";
   os << "  KOKKOS_ENABLE_OPENMP: yes\n";
 
-  os << "OpenMP Atomics:\n";
-  os << "  KOKKOS_ENABLE_OPENMP_ATOMICS: ";
-#ifdef KOKKOS_ENABLE_OPENMP_ATOMICS
-  os << "yes\n";
-#else
-  os << "no\n";
-#endif
-
   os << "\nOpenMP Runtime Configuration:\n";
 
   m_space_instance->print_configuration(os);

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -149,14 +149,6 @@ void Serial::print_configuration(std::ostream& os, bool /*verbose*/) const {
   os << "Host Serial Execution Space:\n";
   os << "  KOKKOS_ENABLE_SERIAL: yes\n";
 
-  os << "Serial Atomics:\n";
-  os << "  KOKKOS_ENABLE_SERIAL_ATOMICS: ";
-#ifdef KOKKOS_ENABLE_SERIAL_ATOMICS
-  os << "yes\n";
-#else
-  os << "no\n";
-#endif
-
   os << "\nSerial Runtime Configuration:\n";
 }
 

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -516,26 +516,6 @@ void pre_initialize_internal(const Kokkos::InitializationSettings& settings) {
   declare_configuration_metadata("tools_only", "compiler_family", "msvc");
 #endif
 
-#ifdef KOKKOS_ENABLE_GNU_ATOMICS
-  declare_configuration_metadata("atomics", "KOKKOS_ENABLE_GNU_ATOMICS", "yes");
-#else
-  declare_configuration_metadata("atomics", "KOKKOS_ENABLE_GNU_ATOMICS", "no");
-#endif
-#ifdef KOKKOS_ENABLE_INTEL_ATOMICS
-  declare_configuration_metadata("atomics", "KOKKOS_ENABLE_INTEL_ATOMICS",
-                                 "yes");
-#else
-  declare_configuration_metadata("atomics", "KOKKOS_ENABLE_INTEL_ATOMICS",
-                                 "no");
-#endif
-#ifdef KOKKOS_ENABLE_WINDOWS_ATOMICS
-  declare_configuration_metadata("atomics", "KOKKOS_ENABLE_WINDOWS_ATOMICS",
-                                 "yes");
-#else
-  declare_configuration_metadata("atomics", "KOKKOS_ENABLE_WINDOWS_ATOMICS",
-                                 "no");
-#endif
-
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
   declare_configuration_metadata("vectorization", "KOKKOS_ENABLE_PRAGMA_IVDEP",
                                  "yes");

--- a/core/src/setup/Kokkos_Setup_Cuda.hpp
+++ b/core/src/setup/Kokkos_Setup_Cuda.hpp
@@ -62,19 +62,6 @@
 #undef KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA
 #endif  // !defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700)
-// PTX atomics with memory order semantics are only available on volta and later
-#if !defined(KOKKOS_DISABLE_CUDA_ASM)
-#if !defined(KOKKOS_ENABLE_CUDA_ASM)
-#define KOKKOS_ENABLE_CUDA_ASM
-#if !defined(KOKKOS_DISABLE_CUDA_ASM_ATOMICS) && \
-    defined(KOKKOS_ENABLE_GNU_ATOMICS)
-#define KOKKOS_ENABLE_CUDA_ASM_ATOMICS
-#endif
-#endif
-#endif
-#endif
-
 #define KOKKOS_IMPL_FORCEINLINE_FUNCTION __device__ __host__ __forceinline__
 #define KOKKOS_IMPL_FORCEINLINE __forceinline__
 #define KOKKOS_IMPL_INLINE_FUNCTION __device__ __host__ inline


### PR DESCRIPTION
Related to step 3 in #5789

`KOKKOS_ENABLE_CUDA_ASM*` macros were exclusively used in our legacy atomics that we removed in #5804. They are never mentioned in the documentation.

`KOKKOS_ENABLE_*_ATOMICS` macros were not defined any more and we had reports like #5920 because `print_configuration` would give the impressions all atomics are disabled.  All these print statements are being removed too.