### PR TITLE
Tell when Kokkos atomics are disabled in print_configuration

### DIFF
--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -149,6 +149,10 @@ void Serial::print_configuration(std::ostream& os, bool /*verbose*/) const {
   os << "Host Serial Execution Space:\n";
   os << "  KOKKOS_ENABLE_SERIAL: yes\n";
 
+#ifdef KOKKOS_INTERNAL_NOT_PARALLEL
+  os << "Kokkos atomics disabled\n";
+#endif
+
   os << "\nSerial Runtime Configuration:\n";
 }
 


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/5940/files#diff-a65afa415b3ce21110d0c6f16b1565b9d832b2b4a804f9a037f7cd47bad36524L152-L158
was pointless because it would always say `no` but we do disable atomics when the `Serial` backend is the only one enabled
https://github.com/kokkos/kokkos/blob/d9fc6cb78688886907938a28a56eb85ca6ef2124/core/src/Kokkos_Atomics_Desul_Wrapper.hpp#L52-L56

This PR makes sure this is reflected in `Kokkos::print_configuration`.
Let me know if you have suggestions to improve the message.