### PR TITLE
Drop unused `ParallelX::WorkRange` member types

### DIFF
--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -908,10 +908,9 @@ template <class FunctorType, class... Traits>
 class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
                   Kokkos::Experimental::HPX> {
  private:
-  using Policy    = Kokkos::RangePolicy<Traits...>;
-  using WorkTag   = typename Policy::work_tag;
-  using WorkRange = typename Policy::WorkRange;
-  using Member    = typename Policy::member_type;
+  using Policy  = Kokkos::RangePolicy<Traits...>;
+  using WorkTag = typename Policy::work_tag;
+  using Member  = typename Policy::member_type;
 
   const FunctorType m_functor;
   const Policy m_policy;
@@ -948,7 +947,6 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   using MDRangePolicy = Kokkos::MDRangePolicy<Traits...>;
   using Policy        = typename MDRangePolicy::impl_range_policy;
   using WorkTag       = typename MDRangePolicy::work_tag;
-  using WorkRange     = typename Policy::WorkRange;
   using Member        = typename Policy::member_type;
   using iterate_type =
       typename Kokkos::Impl::HostIterateTile<MDRangePolicy, FunctorType,
@@ -1000,9 +998,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   using FunctorType = typename CombinedFunctorReducerType::functor_type;
   using ReducerType = typename CombinedFunctorReducerType::reducer_type;
 
-  using WorkTag   = typename Policy::work_tag;
-  using WorkRange = typename Policy::WorkRange;
-  using Member    = typename Policy::member_type;
+  using WorkTag = typename Policy::work_tag;
+  using Member  = typename Policy::member_type;
 
   using value_type     = typename ReducerType::value_type;
   using pointer_type   = typename ReducerType::pointer_type;
@@ -1101,10 +1098,9 @@ class ParallelReduce<CombinedFunctorReducerType,
   using FunctorType   = typename CombinedFunctorReducerType::functor_type;
   using ReducerType   = typename CombinedFunctorReducerType::reducer_type;
 
-  using Policy    = typename MDRangePolicy::impl_range_policy;
-  using WorkTag   = typename MDRangePolicy::work_tag;
-  using WorkRange = typename Policy::WorkRange;
-  using Member    = typename Policy::member_type;
+  using Policy  = typename MDRangePolicy::impl_range_policy;
+  using WorkTag = typename MDRangePolicy::work_tag;
+  using Member  = typename Policy::member_type;
 
   using pointer_type   = typename ReducerType::pointer_type;
   using value_type     = typename ReducerType::value_type;

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -52,10 +52,9 @@ inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
 template <class FunctorType, class... Traits>
 class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::OpenMP> {
  private:
-  using Policy    = Kokkos::RangePolicy<Traits...>;
-  using WorkTag   = typename Policy::work_tag;
-  using WorkRange = typename Policy::WorkRange;
-  using Member    = typename Policy::member_type;
+  using Policy  = Kokkos::RangePolicy<Traits...>;
+  using WorkTag = typename Policy::work_tag;
+  using Member  = typename Policy::member_type;
 
   OpenMPInternal* m_instance;
   const FunctorType m_functor;
@@ -178,8 +177,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   using Policy        = typename MDRangePolicy::impl_range_policy;
   using WorkTag       = typename MDRangePolicy::work_tag;
 
-  using WorkRange = typename Policy::WorkRange;
-  using Member    = typename Policy::member_type;
+  using Member = typename Policy::member_type;
 
   using index_type   = typename Policy::index_type;
   using iterate_type = typename Kokkos::Impl::HostIterateTile<
@@ -300,9 +298,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   using FunctorType = typename CombinedFunctorReducerType::functor_type;
   using ReducerType = typename CombinedFunctorReducerType::reducer_type;
 
-  using WorkTag   = typename Policy::work_tag;
-  using WorkRange = typename Policy::WorkRange;
-  using Member    = typename Policy::member_type;
+  using WorkTag = typename Policy::work_tag;
+  using Member  = typename Policy::member_type;
 
   using pointer_type   = typename ReducerType::pointer_type;
   using reference_type = typename ReducerType::reference_type;
@@ -463,9 +460,8 @@ class ParallelReduce<CombinedFunctorReducerType,
   using FunctorType   = typename CombinedFunctorReducerType::functor_type;
   using ReducerType   = typename CombinedFunctorReducerType::reducer_type;
 
-  using WorkTag   = typename MDRangePolicy::work_tag;
-  using WorkRange = typename Policy::WorkRange;
-  using Member    = typename Policy::member_type;
+  using WorkTag = typename MDRangePolicy::work_tag;
+  using Member  = typename Policy::member_type;
 
   using pointer_type   = typename ReducerType::pointer_type;
   using value_type     = typename ReducerType::value_type;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelFor_Range.hpp
@@ -28,10 +28,9 @@ template <class FunctorType, class... Traits>
 class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
                   Kokkos::Experimental::OpenMPTarget> {
  private:
-  using Policy    = Kokkos::RangePolicy<Traits...>;
-  using WorkTag   = typename Policy::work_tag;
-  using WorkRange = typename Policy::WorkRange;
-  using Member    = typename Policy::member_type;
+  using Policy  = Kokkos::RangePolicy<Traits...>;
+  using WorkTag = typename Policy::work_tag;
+  using Member  = typename Policy::member_type;
 
   const FunctorType m_functor;
   const Policy m_policy;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Range.hpp
@@ -31,8 +31,7 @@ class ParallelReduce<FunctorType, Kokkos::RangePolicy<Traits...>, ReducerType,
  private:
   using Policy = Kokkos::RangePolicy<Traits...>;
 
-  using WorkTag   = typename Policy::work_tag;
-  using WorkRange = typename Policy::WorkRange;
+  using WorkTag = typename Policy::work_tag;
 
   using ReducerTypeFwd =
       std::conditional_t<std::is_same<InvalidType, ReducerType>::value,

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
@@ -30,10 +30,9 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
  protected:
   using Policy = Kokkos::RangePolicy<Traits...>;
 
-  using WorkTag   = typename Policy::work_tag;
-  using WorkRange = typename Policy::WorkRange;
-  using Member    = typename Policy::member_type;
-  using idx_type  = typename Policy::index_type;
+  using WorkTag  = typename Policy::work_tag;
+  using Member   = typename Policy::member_type;
+  using idx_type = typename Policy::index_type;
 
   using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
                                          Policy, FunctorType>;

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -97,7 +97,6 @@ class ParallelScanSYCLBase {
  protected:
   using Member       = typename Policy::member_type;
   using WorkTag      = typename Policy::work_tag;
-  using WorkRange    = typename Policy::WorkRange;
   using LaunchBounds = typename Policy::launch_bounds;
 
  public:


### PR DESCRIPTION
Pointless (because not used and likely just copy pasted all over the place) `WorkRange` member types

I am thinking about refactoring `RangePolicy::WorkRange` and was doing an inventory of usage throughout the code base.