### PR TITLE
Fix `OpenMPTarget::concurrency()`

### DIFF
--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
@@ -65,11 +65,7 @@ void OpenMPTargetInternal::fence(const std::string& name,
         [&]() {});
   }
 }
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-int OpenMPTargetInternal::concurrency() {
-#else
 int OpenMPTargetInternal::concurrency() const {
-#endif
   return 128000;  // FIXME_OPENMPTARGET
 }
 const char* OpenMPTargetInternal::name() { return "OpenMPTarget"; }
@@ -131,9 +127,15 @@ uint32_t OpenMPTarget::impl_instance_id() const noexcept {
   return m_space_instance->impl_get_instance_id();
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 int OpenMPTarget::concurrency() {
   return Impl::OpenMPTargetInternal::impl_singleton()->concurrency();
 }
+#else
+int OpenMPTarget::concurrency() const {
+  return m_space_instance->concurrency();
+}
+#endif
 
 void OpenMPTarget::fence(const std::string& name) {
   Impl::OpenMPTargetInternal::impl_singleton()->fence(name);

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.hpp
@@ -37,7 +37,7 @@ class OpenMPTargetInternal {
              openmp_fence_is_static is_static = openmp_fence_is_static::no);
 
   /** \brief  Return the maximum amount of concurrency.  */
-  int concurrency();
+  int concurrency() const;
 
   //! Print configuration information to the given output stream.
   void print_configuration(std::ostream& os, bool verbose) const;


### PR DESCRIPTION
Fixup for #5662
Need to be cherry-picked into 4.0.01