### PR TITLE
Use CombinedReducer in HostIterateTile

### DIFF
--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -1105,19 +1105,17 @@ class ParallelReduce<CombinedFunctorReducerType,
   using pointer_type   = typename ReducerType::pointer_type;
   using value_type     = typename ReducerType::value_type;
   using reference_type = typename ReducerType::reference_type;
-  using iterate_type =
-      typename Kokkos::Impl::HostIterateTile<MDRangePolicy, FunctorType,
-                                             WorkTag, reference_type>;
+  using iterate_type   = typename Kokkos::Impl::HostIterateTile<
+      MDRangePolicy, CombinedFunctorReducerType, WorkTag, reference_type>;
 
   const iterate_type m_iter;
   const Policy m_policy;
-  const CombinedFunctorReducerType m_functor_reducer;
   const pointer_type m_result_ptr;
   const bool m_force_synchronous;
 
  public:
   void setup() const {
-    const ReducerType &reducer   = m_functor_reducer.get_reducer();
+    const ReducerType &reducer   = m_iter.m_func.get_reducer();
     const std::size_t value_size = reducer.value_size();
     const int num_worker_threads = m_policy.space().concurrency();
 
@@ -1143,7 +1141,7 @@ class ParallelReduce<CombinedFunctorReducerType,
 
   void finalize() const {
     hpx_thread_buffer &buffer    = m_iter.m_rp.space().impl_get_buffer();
-    ReducerType reducer          = m_functor_reducer.get_reducer();
+    ReducerType reducer          = m_iter.m_func.get_reducer();
     const int num_worker_threads = m_policy.space().concurrency();
     for (int i = 1; i < num_worker_threads; ++i) {
       reducer.join(reinterpret_cast<pointer_type>(buffer.get(0)),
@@ -1175,9 +1173,8 @@ class ParallelReduce<CombinedFunctorReducerType,
   template <class ViewType>
   inline ParallelReduce(const CombinedFunctorReducerType &arg_functor_reducer,
                         MDRangePolicy arg_policy, const ViewType &arg_view)
-      : m_iter(arg_policy, arg_functor_reducer.get_functor()),
+      : m_iter(arg_policy, arg_functor_reducer),
         m_policy(Policy(0, arg_policy.m_num_tiles).set_chunk_size(1)),
-        m_functor_reducer(arg_functor_reducer),
         m_result_ptr(arg_view.data()),
         m_force_synchronous(!arg_view.impl_track().has_record()) {}
 

--- a/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
@@ -73,11 +73,9 @@ class ParallelReduce<CombinedFunctorReducerType,
   using value_type     = typename ReducerType::value_type;
   using reference_type = typename ReducerType::reference_type;
 
-  using iterate_type =
-      typename Kokkos::Impl::HostIterateTile<MDRangePolicy, FunctorType,
-                                             WorkTag, reference_type>;
+  using iterate_type = typename Kokkos::Impl::HostIterateTile<
+      MDRangePolicy, CombinedFunctorReducerType, WorkTag, reference_type>;
   const iterate_type m_iter;
-  const ReducerType m_reducer;
   const pointer_type m_result_ptr;
 
   inline void exec(reference_type update) const {
@@ -98,7 +96,8 @@ class ParallelReduce<CombinedFunctorReducerType,
     return 1024;
   }
   inline void execute() const {
-    const size_t pool_reduce_size  = m_reducer.value_size();
+    const ReducerType& reducer     = m_iter.m_func.get_reducer();
+    const size_t pool_reduce_size  = reducer.value_size();
     const size_t team_reduce_size  = 0;  // Never shrinks
     const size_t team_shared_size  = 0;  // Never shrinks
     const size_t thread_local_size = 0;  // Never shrinks
@@ -118,19 +117,18 @@ class ParallelReduce<CombinedFunctorReducerType,
             : pointer_type(
                   internal_instance->m_thread_team_data.pool_reduce_local());
 
-    reference_type update = m_reducer.init(ptr);
+    reference_type update = reducer.init(ptr);
 
     this->exec(update);
 
-    m_reducer.final(ptr);
+    reducer.final(ptr);
   }
 
   template <class ViewType>
   ParallelReduce(const CombinedFunctorReducerType& arg_functor_reducer,
                  const MDRangePolicy& arg_policy,
                  const ViewType& arg_result_view)
-      : m_iter(arg_policy, arg_functor_reducer.get_functor()),
-        m_reducer(arg_functor_reducer.get_reducer()),
+      : m_iter(arg_policy, arg_functor_reducer),
         m_result_ptr(arg_result_view.data()) {
     static_assert(Kokkos::is_view<ViewType>::value,
                   "Kokkos::Serial reduce result must be a View");

--- a/core/src/impl/KokkosExp_Host_IterateTile.hpp
+++ b/core/src/impl/KokkosExp_Host_IterateTile.hpp
@@ -2093,8 +2093,8 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
     const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
     Tile_Loop_Type<RP::rank, (RP::inner_direction == Iterate::Left), index_type,
-                   Tag>::apply(val, m_func, full_tile, m_offset, m_rp.m_tile,
-                               m_tiledims);
+                   Tag>::apply(val, m_func.get_functor(), full_tile, m_offset,
+                               m_rp.m_tile, m_tiledims);
   }
 
 #else


### PR DESCRIPTION
Part of #5908. Addressing https://github.com/kokkos/kokkos/pull/5874#discussion_r1113620098. In particular, this avoids storing the functor twice since recent changes in HostIterateTile made it store the functor to avoid ICEs for ClassIc Intel Compilers.