### PR TITLE
Fix partition_master test

### DIFF
--- a/core/unit_test/openmp/TestOpenMP_PartitionMaster.cpp
+++ b/core/unit_test/openmp/TestOpenMP_PartitionMaster.cpp
@@ -29,7 +29,7 @@ TEST(openmp, partition_master) {
   int errors = 0;
 
   auto master = [&errors, &mtx](int /*partition_id*/, int /*num_partitions*/) {
-    const int pool_size = Kokkos::OpenMP::impl_thread_pool_size();
+    const int pool_size = Kokkos::OpenMP().impl_thread_pool_size();
 
     {
       std::unique_lock<Mutex> lock(mtx);
@@ -46,7 +46,7 @@ TEST(openmp, partition_master) {
       Kokkos::parallel_reduce(
           Kokkos::RangePolicy<Kokkos::OpenMP>(0, 1000),
           [pool_size](const int, int& errs) {
-            if (Kokkos::OpenMP::impl_thread_pool_size() != pool_size) {
+            if (Kokkos::OpenMP().impl_thread_pool_size() != pool_size) {
               ++errs;
             }
           },


### PR DESCRIPTION
`impl_thread_pool_size` is not `static` anymore. The test is only triggered with `KOKKOS_ENABLE_DEPRECATED_CODE_3=ON`.

edit: This test got broken in https://github.com/kokkos/kokkos/pull/5836 which is not included in any release. Hence, there is no need to cherry-pick this unless #5836 is cherry-picked and even then only to be able to run the tests with `KOKKOS_ENABLE_DEPRECATED_CODE_3=ON`.