### PR TITLE
Don't use Kokkos_ARCH_NATIVE=ON in GitHub CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow-hpx.yml
+++ b/.github/workflows/continuous-integration-workflow-hpx.yml
@@ -69,7 +69,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_CXX_FLAGS="-Werror" \
             -DHPX_ROOT=$PWD/../../hpx/install \
-            -DKokkos_ARCH_NATIVE=ON \
             -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
             -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
             -DKokkos_ENABLE_EXAMPLES=ON \

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -90,7 +90,6 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr \
             ${{ matrix.clang-tidy }} \
             -Ddesul_ROOT=/usr/desul-install/ \
-            -DKokkos_ARCH_NATIVE=ON \
             -DKokkos_ENABLE_DESUL_ATOMICS_EXTERNAL=ON \
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_${{ matrix.backend }}=ON \

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -31,7 +31,6 @@ jobs:
             -DKokkos_ENABLE_${{ matrix.backend }}=On
             -DCMAKE_CXX_FLAGS="-Werror"
             -DCMAKE_CXX_STANDARD=17
-            -DKokkos_ARCH_NATIVE=ON
             -DKokkos_ENABLE_COMPILER_WARNINGS=ON
             -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF
             -DKokkos_ENABLE_TESTS=On

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Configure Kokkos
         run: |
           cmake -B builddir \
-            -DKokkos_ARCH_NATIVE=ON \
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_${{ matrix.backend }}=ON \
             -DKokkos_ENABLE_BENCHMARKS=ON \


### PR DESCRIPTION
We are seeing GitHub CI failing with illegal instructions regularly. While it's not quite clear why using `-march=native` causes problems here (different stages might be run on different platforms?) it seems that there is not that much benefit from enabling the architecture in the GItHub CI. All other CI runs use the flag anyway.