### PR TITLE
Fix reducer result check for Serial+HPX ParallelReduce

### DIFF
--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -1089,7 +1089,12 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
       : m_functor_reducer(arg_functor_reducer),
         m_policy(arg_policy),
         m_result_ptr(arg_view.data()),
-        m_force_synchronous(!arg_view.impl_track().has_record()) {}
+        m_force_synchronous(!arg_view.impl_track().has_record()) {
+    static_assert(
+        Kokkos::Impl::MemorySpaceAccess<typename ViewType::memory_space,
+                                        Kokkos::HostSpace>::accessible,
+        "HPX reduce result must be a View accessible from HostSpace");
+  }
 };
 
 template <class CombinedFunctorReducerType, class... Traits>
@@ -1183,7 +1188,12 @@ class ParallelReduce<CombinedFunctorReducerType,
         m_policy(Policy(0, arg_policy.m_num_tiles).set_chunk_size(1)),
         m_functor_reducer(arg_functor_reducer),
         m_result_ptr(arg_view.data()),
-        m_force_synchronous(!arg_view.impl_track().has_record()) {}
+        m_force_synchronous(!arg_view.impl_track().has_record()) {
+    static_assert(
+        Kokkos::Impl::MemorySpaceAccess<typename ViewType::memory_space,
+                                        Kokkos::HostSpace>::accessible,
+        "HPX reduce result must be a View accessible from HostSpace");
+  }
 
   template <typename Policy, typename Functor>
   static int max_tile_size_product(const Policy &, const Functor &) {
@@ -1586,7 +1596,12 @@ class ParallelReduce<CombinedFunctorReducerType,
         m_shared(arg_policy.scratch_size(0) + arg_policy.scratch_size(1) +
                  FunctorTeamShmemSize<FunctorType>::value(
                      m_functor_reducer.get_functor(), arg_policy.team_size())),
-        m_force_synchronous(!arg_result.impl_track().has_record()) {}
+        m_force_synchronous(!arg_result.impl_track().has_record()) {
+    static_assert(
+        Kokkos::Impl::MemorySpaceAccess<typename ViewType::memory_space,
+                                        Kokkos::HostSpace>::accessible,
+        "HPX reduce result must be a View accessible from HostSpace");
+  }
 };
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
@@ -138,7 +138,8 @@ class ParallelReduce<CombinedFunctorReducerType,
     static_assert(
         Kokkos::Impl::MemorySpaceAccess<typename ViewType::memory_space,
                                         Kokkos::HostSpace>::accessible,
-        "Kokkos::Serial reduce result must be a View in HostSpace");
+        "Kokkos::Serial reduce result must be a View accessible from "
+        "HostSpace");
   }
 };
 

--- a/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
@@ -135,7 +135,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
     static_assert(
         Kokkos::Impl::MemorySpaceAccess<typename ViewType::memory_space,
                                         Kokkos::HostSpace>::accessible,
-        "Kokkos::Serial reduce result must be a View in HostSpace");
+        "Kokkos::Serial reduce result must be a View accessible from "
+        "HostSpace");
   }
 };
 

--- a/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
@@ -355,7 +355,7 @@ class ParallelReduce<CombinedFunctorReducerType,
     static_assert(
         Kokkos::Impl::MemorySpaceAccess<typename ViewType::memory_space,
                                         Kokkos::HostSpace>::accessible,
-        "Reduction result on Kokkos::Serial must be a Kokkos::View in "
+        "Kokkos::Serial reduce result must be a View accessible from "
         "HostSpace");
   }
 };


### PR DESCRIPTION
Part of #5908. We have the same check for `Threads` and `OpenMP` already.