### PR TITLE
Bring back git info to benchmarks' output

### DIFF
--- a/core/perf_test/Benchmark_Context.cpp
+++ b/core/perf_test/Benchmark_Context.cpp
@@ -57,9 +57,25 @@ void add_kokkos_configuration(bool verbose) {
   }
 }
 
+void add_git_info() {
+  if (!Kokkos::Impl::GIT_BRANCH.empty()) {
+    benchmark::AddCustomContext("GIT_BRANCH", Kokkos::Impl::GIT_BRANCH);
+    benchmark::AddCustomContext("GIT_COMMIT_HASH",
+                                Kokkos::Impl::GIT_COMMIT_HASH);
+    benchmark::AddCustomContext("GIT_CLEAN_STATUS",
+                                Kokkos::Impl::GIT_CLEAN_STATUS);
+    benchmark::AddCustomContext("GIT_COMMIT_DESCRIPTION",
+                                Kokkos::Impl::GIT_COMMIT_DESCRIPTION);
+    benchmark::AddCustomContext("GIT_COMMIT_DATE",
+                                Kokkos::Impl::GIT_COMMIT_DATE);
+  }
+}
+
 void add_benchmark_context(bool verbose) {
   // Add Kokkos configuration to benchmark context data
   add_kokkos_configuration(verbose);
+  // Add git information to benchmark context data
+  add_git_info();
 }
 
 }  // namespace KokkosBenchmark


### PR DESCRIPTION
Part of git info integration was accidentally removed in #5620. Bring it back to make it available in benchmarks' output:
```
2023-03-08T21:34:03+01:00
Running ./build/algorithms/unit_tests/KokkosAlgorithms_Benchmark_Kokkos_ForEach
Run on (8 X 4700 MHz CPU s)
(...)
Default Device: N6Kokkos6OpenMPE
GIT_BRANCH: benchmark-algorithms
GIT_CLEAN_STATUS: CLEAN
GIT_COMMIT_DATE: 2023-03-08T21:33:55+01:00
GIT_COMMIT_DESCRIPTION: Merge branch 'benchmark-add-git-info' into benchmark-algorithms
GIT_COMMIT_HASH: 52b2ce31b
GPU architecture: none
KOKKOS_COMPILER_CLANG: 1507
(...)
```