### PR TITLE
Allow templated functors in parallel_for, parallel_reduce and parallel_scan

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -321,8 +321,8 @@ class ParallelReduce<CombinedFunctorReducerType,
   inline unsigned local_block_size(const FunctorType& f) {
     unsigned n = CudaTraits::WarpSize * 8;
     int shmem_size =
-        cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag>(
-            f, n);
+        cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag,
+                                                  value_type>(f, n);
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              Policy, Kokkos::Cuda>;
@@ -339,8 +339,9 @@ class ParallelReduce<CombinedFunctorReducerType,
                  m_policy.space().impl_internal_space_instance(), attr, f, 1,
                  shmem_size, 0)))) {
       n >>= 1;
-      shmem_size = cuda_single_inter_block_reduce_scan_shmem<false, FunctorType,
-                                                             WorkTag>(f, n);
+      shmem_size =
+          cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag,
+                                                    value_type>(f, n);
     }
     return n;
   }
@@ -382,7 +383,7 @@ class ParallelReduce<CombinedFunctorReducerType,
           UseShflReduction
               ? 0
               : cuda_single_inter_block_reduce_scan_shmem<false, FunctorType,
-                                                          WorkTag>(
+                                                          WorkTag, value_type>(
                     m_functor_reducer.get_functor(), block.y);
 
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(
@@ -428,8 +429,8 @@ class ParallelReduce<CombinedFunctorReducerType,
         m_scratch_space(nullptr),
         m_scratch_flags(nullptr),
         m_unified_space(nullptr) {
-    check_reduced_view_shmem_size<WorkTag>(m_policy,
-                                           m_functor_reducer.get_functor());
+    check_reduced_view_shmem_size<WorkTag, value_type>(
+        m_policy, m_functor_reducer.get_functor());
   }
 };
 }  // namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -321,8 +321,8 @@ class ParallelReduce<CombinedFunctorReducerType,
   inline unsigned local_block_size(const FunctorType& f) {
     unsigned n = CudaTraits::WarpSize * 8;
     int shmem_size =
-        cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag,
-                                                  value_type>(f, n);
+        cuda_single_inter_block_reduce_scan_shmem<false, WorkTag, value_type>(
+            f, n);
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              Policy, Kokkos::Cuda>;
@@ -340,8 +340,8 @@ class ParallelReduce<CombinedFunctorReducerType,
                  shmem_size, 0)))) {
       n >>= 1;
       shmem_size =
-          cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag,
-                                                    value_type>(f, n);
+          cuda_single_inter_block_reduce_scan_shmem<false, WorkTag, value_type>(
+              f, n);
     }
     return n;
   }
@@ -382,8 +382,8 @@ class ParallelReduce<CombinedFunctorReducerType,
       const int shmem =
           UseShflReduction
               ? 0
-              : cuda_single_inter_block_reduce_scan_shmem<false, FunctorType,
-                                                          WorkTag, value_type>(
+              : cuda_single_inter_block_reduce_scan_shmem<false, WorkTag,
+                                                          value_type>(
                     m_functor_reducer.get_functor(), block.y);
 
       CudaParallelLaunch<ParallelReduce, LaunchBounds>(

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -255,8 +255,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   inline unsigned local_block_size(const FunctorType& f) {
     unsigned n = CudaTraits::WarpSize * 8;
     int shmem_size =
-        cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag,
-                                                  value_type>(f, n);
+        cuda_single_inter_block_reduce_scan_shmem<false, WorkTag, value_type>(
+            f, n);
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              Policy, Kokkos::Cuda>;
@@ -274,8 +274,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
                  shmem_size, 0)))) {
       n >>= 1;
       shmem_size =
-          cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag,
-                                                    value_type>(f, n);
+          cuda_single_inter_block_reduce_scan_shmem<false, WorkTag, value_type>(
+              f, n);
     }
     return n;
   }
@@ -315,8 +315,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
       const int shmem =
           UseShflReduction
               ? 0
-              : cuda_single_inter_block_reduce_scan_shmem<false, FunctorType,
-                                                          WorkTag, value_type>(
+              : cuda_single_inter_block_reduce_scan_shmem<false, WorkTag,
+                                                          value_type>(
                     m_functor_reducer.get_functor(), block.y);
 
       if ((nwork == 0)
@@ -610,11 +610,12 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
     // testing
 
     unsigned n = CudaTraits::WarpSize * 4;
-    while (n && unsigned(m_policy.space()
-                             .impl_internal_space_instance()
-                             ->m_maxShmemPerBlock) <
-                    cuda_single_inter_block_reduce_scan_shmem<
-                        true, FunctorType, WorkTag, value_type>(f, n)) {
+    while (n &&
+           unsigned(m_policy.space()
+                        .impl_internal_space_instance()
+                        ->m_maxShmemPerBlock) <
+               cuda_single_inter_block_reduce_scan_shmem<true, WorkTag,
+                                                         value_type>(f, n)) {
       n >>= 1;
     }
     return n;
@@ -933,11 +934,12 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
     // testing
 
     unsigned n = CudaTraits::WarpSize * 4;
-    while (n && unsigned(m_policy.space()
-                             .impl_internal_space_instance()
-                             ->m_maxShmemPerBlock) <
-                    cuda_single_inter_block_reduce_scan_shmem<
-                        true, FunctorType, WorkTag, value_type>(f, n)) {
+    while (n &&
+           unsigned(m_policy.space()
+                        .impl_internal_space_instance()
+                        ->m_maxShmemPerBlock) <
+               cuda_single_inter_block_reduce_scan_shmem<true, WorkTag,
+                                                         value_type>(f, n)) {
       n >>= 1;
     }
     return n;

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -893,8 +893,8 @@ class ParallelReduce<CombinedFunctorReducerType,
     m_team_begin =
         UseShflReduction
             ? 0
-            : cuda_single_inter_block_reduce_scan_shmem<false, FunctorType,
-                                                        WorkTag, value_type>(
+            : cuda_single_inter_block_reduce_scan_shmem<false, WorkTag,
+                                                        value_type>(
                   arg_functor_reducer.get_functor(), m_team_size);
     m_shmem_begin = sizeof(double) * (m_team_size + 2);
     m_shmem_size  = m_policy.scratch_size(0, m_team_size) +

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -114,7 +114,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
                            const ParallelReduceTag&) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                              TeamPolicyInternal, FunctorType>;
+                              TeamPolicyInternal, FunctorType, void>;
     using closure_type = Impl::ParallelReduce<
         CombinedFunctorReducer<FunctorType,
                                typename functor_analysis_type::Reducer>,
@@ -153,7 +153,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
                                    const ParallelReduceTag&) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                              TeamPolicyInternal, FunctorType>;
+                              TeamPolicyInternal, FunctorType, void>;
     using closure_type = Impl::ParallelReduce<
         CombinedFunctorReducer<FunctorType,
                                typename functor_analysis_type::Reducer>,
@@ -365,7 +365,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
         typename Impl::DeduceFunctorPatternInterface<ClosureType>::type;
     using Analysis =
         Impl::FunctorAnalysis<Interface, typename ClosureType::Policy,
-                              FunctorType>;
+                              FunctorType, void>;
 
     cudaFuncAttributes attr =
         CudaParallelLaunch<closure_type, typename traits::launch_bounds>::
@@ -894,7 +894,7 @@ class ParallelReduce<CombinedFunctorReducerType,
         UseShflReduction
             ? 0
             : cuda_single_inter_block_reduce_scan_shmem<false, FunctorType,
-                                                        WorkTag>(
+                                                        WorkTag, value_type>(
                   arg_functor_reducer.get_functor(), m_team_size);
     m_shmem_begin = sizeof(double) * (m_team_size + 2);
     m_shmem_size  = m_policy.scratch_size(0, m_team_size) +

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -672,7 +672,7 @@ __device__ bool cuda_single_inter_block_reduce_scan(
 }
 
 // Size in bytes required for inter block reduce or scan
-template <bool DoScan, class FunctorType, class ArgTag, class ValueType>
+template <bool DoScan, class ArgTag, class ValueType, class FunctorType>
 inline std::enable_if_t<DoScan, unsigned>
 cuda_single_inter_block_reduce_scan_shmem(const FunctorType& functor,
                                           const unsigned BlockSize) {
@@ -683,7 +683,7 @@ cuda_single_inter_block_reduce_scan_shmem(const FunctorType& functor,
   return (BlockSize + 2) * Analysis::value_size(functor);
 }
 
-template <bool DoScan, class FunctorType, class ArgTag, class ValueType>
+template <bool DoScan, class ArgTag, class ValueType, class FunctorType>
 inline std::enable_if_t<!DoScan, unsigned>
 cuda_single_inter_block_reduce_scan_shmem(const FunctorType& functor,
                                           const unsigned BlockSize) {
@@ -700,9 +700,8 @@ inline void check_reduced_view_shmem_size(const Policy& policy,
                                           const FunctorType& functor) {
   size_t minBlockSize = CudaTraits::WarpSize * 1;
   unsigned reqShmemSize =
-      cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag,
-                                                ValueType>(functor,
-                                                           minBlockSize);
+      cuda_single_inter_block_reduce_scan_shmem<false, WorkTag, ValueType>(
+          functor, minBlockSize);
   size_t maxShmemPerBlock =
       policy.space().impl_internal_space_instance()->m_maxShmemPerBlock;
 

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -672,35 +672,37 @@ __device__ bool cuda_single_inter_block_reduce_scan(
 }
 
 // Size in bytes required for inter block reduce or scan
-template <bool DoScan, class FunctorType, class ArgTag>
+template <bool DoScan, class FunctorType, class ArgTag, class ValueType>
 inline std::enable_if_t<DoScan, unsigned>
 cuda_single_inter_block_reduce_scan_shmem(const FunctorType& functor,
                                           const unsigned BlockSize) {
   using Analysis =
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
-                            RangePolicy<Cuda, ArgTag>, FunctorType>;
+                            RangePolicy<Cuda, ArgTag>, FunctorType, ValueType>;
 
   return (BlockSize + 2) * Analysis::value_size(functor);
 }
 
-template <bool DoScan, class FunctorType, class ArgTag>
+template <bool DoScan, class FunctorType, class ArgTag, class ValueType>
 inline std::enable_if_t<!DoScan, unsigned>
 cuda_single_inter_block_reduce_scan_shmem(const FunctorType& functor,
                                           const unsigned BlockSize) {
   using Analysis =
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                            RangePolicy<Cuda, ArgTag>, FunctorType>;
+                            RangePolicy<Cuda, ArgTag>, FunctorType, ValueType>;
 
   return (BlockSize + 2) * Analysis::value_size(functor);
 }
 
-template <typename WorkTag, typename Policy, typename FunctorType>
+template <typename WorkTag, typename ValueType, typename Policy,
+          typename FunctorType>
 inline void check_reduced_view_shmem_size(const Policy& policy,
                                           const FunctorType& functor) {
   size_t minBlockSize = CudaTraits::WarpSize * 1;
   unsigned reqShmemSize =
-      cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag>(
-          functor, minBlockSize);
+      cuda_single_inter_block_reduce_scan_shmem<false, FunctorType, WorkTag,
+                                                ValueType>(functor,
+                                                           minBlockSize);
   size_t maxShmemPerBlock =
       policy.space().impl_internal_space_instance()->m_maxShmemPerBlock;
 

--- a/core/src/Cuda/Kokkos_Cuda_Task.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Task.hpp
@@ -1042,7 +1042,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   // Extract value_type from closure
 
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
+      void>::value_type;
 
   if (1 < loop_boundaries.thread.team_size()) {
     // make sure all threads perform all loop iterations
@@ -1107,7 +1108,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
   // Extract value_type from closure
 
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
+      void>::value_type;
 
   if (1 < loop_boundaries.thread.team_size()) {
     // make sure all threads perform all loop iterations

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -196,8 +196,9 @@ class CudaTeamMember {
     (void)reducer;
     (void)value;
     KOKKOS_IF_ON_DEVICE(
-        (typename Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                                        TeamPolicy<Cuda>, ReducerType>::Reducer
+        (typename Impl::FunctorAnalysis<
+             Impl::FunctorPatternInterface::REDUCE, TeamPolicy<Cuda>,
+             ReducerType, typename ReducerType::value_type>::Reducer
              wrapped_reducer(reducer);
          cuda_intra_block_reduction(value, wrapped_reducer, blockDim.y);
          reducer.reference() = value;))
@@ -228,7 +229,8 @@ class CudaTeamMember {
         Impl::CudaJoinFunctor<Type> cuda_join_functor;
         typename Impl::FunctorAnalysis<
             Impl::FunctorPatternInterface::SCAN, TeamPolicy<Cuda>,
-            Impl::CudaJoinFunctor<Type>>::Reducer reducer(cuda_join_functor);
+            Impl::CudaJoinFunctor<Type>, Type>::Reducer
+            reducer(cuda_join_functor);
         Impl::cuda_intra_block_reduce_scan<true>(reducer, base_data + 1);
 
         if (global_accum) {
@@ -688,8 +690,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     const FunctorType& lambda) {
   // Extract value_type from lambda
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void,
-      FunctorType>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, FunctorType,
+      void>::value_type;
 
   const auto start     = loop_bounds.start;
   const auto end       = loop_bounds.end;
@@ -825,7 +827,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
         loop_boundaries,
     const Closure& closure) {
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
+      void>::value_type;
   value_type dummy;
   parallel_scan(loop_boundaries, closure, Kokkos::Sum<value_type>(dummy));
 }

--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -281,8 +281,8 @@ class ParallelReduce<CombinedFunctorReducerType,
   inline unsigned local_block_size(const FunctorType& f) {
     const auto& instance = m_policy.space().impl_internal_space_instance();
     auto shmem_functor   = [&f](unsigned n) {
-      return hip_single_inter_block_reduce_scan_shmem<false, FunctorType,
-                                                      WorkTag>(f, n);
+      return hip_single_inter_block_reduce_scan_shmem<false, WorkTag,
+                                                      value_type>(f, n);
     };
 
     unsigned block_size =
@@ -331,8 +331,8 @@ class ParallelReduce<CombinedFunctorReducerType,
 
       const int shmem =
           ::Kokkos::Impl::hip_single_inter_block_reduce_scan_shmem<
-              false, FunctorType, WorkTag>(m_functor_reducer.get_functor(),
-                                           block.y);
+              false, WorkTag, value_type>(m_functor_reducer.get_functor(),
+                                          block.y);
 
       hip_parallel_launch<ParallelReduce, LaunchBounds>(
           *this, grid, block, shmem,

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -477,22 +477,24 @@ __device__ bool hip_single_inter_block_reduce_scan(
 }
 
 // Size in bytes required for inter block reduce or scan
-template <bool DoScan, class FunctorType, class ArgTag>
+template <bool DoScan, class ArgTag, class ValueType, class FunctorType>
 inline std::enable_if_t<DoScan, unsigned>
 hip_single_inter_block_reduce_scan_shmem(const FunctorType& functor,
                                          const unsigned BlockSize) {
-  using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
-                                         RangePolicy<HIP, ArgTag>, FunctorType>;
+  using Analysis =
+      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
+                            RangePolicy<HIP, ArgTag>, FunctorType, ValueType>;
 
   return (BlockSize + 2) * Analysis::value_size(functor);
 }
 
-template <bool DoScan, class FunctorType, class ArgTag>
+template <bool DoScan, class ArgTag, class ValueType, class FunctorType>
 inline std::enable_if_t<!DoScan, unsigned>
 hip_single_inter_block_reduce_scan_shmem(const FunctorType& functor,
                                          const unsigned BlockSize) {
-  using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                                         RangePolicy<HIP, ArgTag>, FunctorType>;
+  using Analysis =
+      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                            RangePolicy<HIP, ArgTag>, FunctorType, ValueType>;
 
   return (BlockSize + 2) * Analysis::value_size(functor);
 }

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -181,8 +181,8 @@ class HIPTeamMember {
               typename ReducerType::value_type& value) const noexcept {
 #ifdef __HIP_DEVICE_COMPILE__
     typename Kokkos::Impl::FunctorAnalysis<
-        FunctorPatternInterface::REDUCE, TeamPolicy<HIP>, ReducerType>::Reducer
-        wrapped_reducer(reducer);
+        FunctorPatternInterface::REDUCE, TeamPolicy<HIP>, ReducerType,
+        typename ReducerType::value_type>::Reducer wrapped_reducer(reducer);
     hip_intra_block_shuffle_reduction(value, wrapped_reducer, blockDim.y);
     reducer.reference() = value;
 #else
@@ -219,7 +219,7 @@ class HIPTeamMember {
     Impl::HIPJoinFunctor<Type> hip_join_functor;
     typename Kokkos::Impl::FunctorAnalysis<
         FunctorPatternInterface::REDUCE, TeamPolicy<HIP>,
-        Impl::HIPJoinFunctor<Type>>::Reducer reducer(hip_join_functor);
+        Impl::HIPJoinFunctor<Type>, Type>::Reducer reducer(hip_join_functor);
     Impl::hip_intra_block_reduce_scan<true>(reducer, base_data + 1);
 
     if (global_accum) {
@@ -544,8 +544,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     const FunctorType& lambda) {
   // Extract value_type from lambda
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void,
-      FunctorType>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, FunctorType,
+      void>::value_type;
 
   const auto start     = loop_bounds.start;
   const auto end       = loop_bounds.end;
@@ -824,7 +824,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
         loop_boundaries,
     const Closure& closure) {
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
+      void>::value_type;
   value_type dummy;
   parallel_scan(loop_boundaries, closure, Kokkos::Sum<value_type>(dummy));
 }

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -1213,7 +1213,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   using WorkRange = typename Policy::WorkRange;
   using Member    = typename Policy::member_type;
   using Analysis =
-      FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType>;
+      FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType, void>;
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
   using value_type     = typename Analysis::value_type;
@@ -1310,12 +1310,12 @@ template <class FunctorType, class ReturnType, class... Traits>
 class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
                             ReturnType, Kokkos::Experimental::HPX> {
  private:
-  using Policy    = Kokkos::RangePolicy<Traits...>;
-  using WorkTag   = typename Policy::work_tag;
-  using WorkRange = typename Policy::WorkRange;
-  using Member    = typename Policy::member_type;
-  using Analysis =
-      FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType>;
+  using Policy         = Kokkos::RangePolicy<Traits...>;
+  using WorkTag        = typename Policy::work_tag;
+  using WorkRange      = typename Policy::WorkRange;
+  using Member         = typename Policy::member_type;
+  using Analysis       = FunctorAnalysis<FunctorPatternInterface::SCAN, Policy,
+                                   FunctorType, ReturnType>;
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
   using value_type     = typename Analysis::value_type;
@@ -1777,8 +1777,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
         &loop_boundaries,
     const FunctorType &lambda) {
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void,
-      FunctorType>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, FunctorType,
+      void>::value_type;
 
   value_type scan_val = value_type();
 
@@ -1815,8 +1815,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     const FunctorType &lambda) {
   using value_type =
       typename Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
-                                     TeamPolicy<Experimental::HPX>,
-                                     FunctorType>::value_type;
+                                     TeamPolicy<Experimental::HPX>, FunctorType,
+                                     void>::value_type;
 
   value_type scan_val = value_type();
 

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -383,7 +383,8 @@ class GraphNodeRef {
         passed_reducer_type>;
     using analysis = Kokkos::Impl::FunctorAnalysis<
         Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy,
-        typename reducer_selector::type>;
+        typename reducer_selector::type,
+        typename return_value_adapter::value_type>;
     typename analysis::Reducer final_reducer(
         reducer_selector::select(functor, return_value));
     Kokkos::Impl::CombinedFunctorReducer<functor_type,

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -399,7 +399,8 @@ inline void parallel_scan(const std::string& str, const ExecutionPolicy& policy,
 
   if constexpr (Kokkos::is_view<ReturnType>::value) {
     Kokkos::Impl::shared_allocation_tracking_disable();
-    Impl::ParallelScanWithTotal<FunctorType, ExecutionPolicy, ReturnType>
+    Impl::ParallelScanWithTotal<FunctorType, ExecutionPolicy,
+                                typename ReturnType::value_type>
         closure(functor, inner_policy, return_value);
     Kokkos::Impl::shared_allocation_tracking_enable();
     closure.execute();

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -1613,9 +1613,9 @@ struct ParallelReduceAdaptor {
     using ReducerSelector =
         Kokkos::Impl::if_c<std::is_same<InvalidType, PassedReducerType>::value,
                            FunctorType, PassedReducerType>;
-    using Analysis =
-        FunctorAnalysis<FunctorPatternInterface::REDUCE, PolicyType,
-                        typename ReducerSelector::type>;
+    using Analysis = FunctorAnalysis<FunctorPatternInterface::REDUCE,
+                                     PolicyType, typename ReducerSelector::type,
+                                     typename return_value_adapter::value_type>;
     Kokkos::Impl::shared_allocation_tracking_disable();
     CombinedFunctorReducer functor_reducer(
         functor, typename Analysis::Reducer(
@@ -1635,8 +1635,9 @@ struct ParallelReduceAdaptor {
   }
 
   static constexpr bool is_array_reduction =
-      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
-                            FunctorType>::StaticValueSize == 0;
+      Impl::FunctorAnalysis<
+          Impl::FunctorPatternInterface::REDUCE, PolicyType, FunctorType,
+          typename return_value_adapter::value_type>::StaticValueSize == 0;
 
   template <typename Dummy = ReturnType>
   static inline std::enable_if_t<!(is_array_reduction &&
@@ -1936,7 +1937,7 @@ inline void parallel_reduce(
         nullptr) {
   using FunctorAnalysis =
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
-                            FunctorType>;
+                            FunctorType, void>;
   using value_type = std::conditional_t<(FunctorAnalysis::StaticValueSize != 0),
                                         typename FunctorAnalysis::value_type,
                                         typename FunctorAnalysis::pointer_type>;
@@ -1961,7 +1962,7 @@ inline void parallel_reduce(
         nullptr) {
   using FunctorAnalysis =
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
-                            FunctorType>;
+                            FunctorType, void>;
   using value_type = std::conditional_t<(FunctorAnalysis::StaticValueSize != 0),
                                         typename FunctorAnalysis::value_type,
                                         typename FunctorAnalysis::pointer_type>;
@@ -1986,7 +1987,7 @@ inline void parallel_reduce(const size_t& policy, const FunctorType& functor) {
                                               FunctorType>::policy_type;
   using FunctorAnalysis =
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, policy_type,
-                            FunctorType>;
+                            FunctorType, void>;
   using value_type = std::conditional_t<(FunctorAnalysis::StaticValueSize != 0),
                                         typename FunctorAnalysis::value_type,
                                         typename FunctorAnalysis::pointer_type>;
@@ -2013,7 +2014,7 @@ inline void parallel_reduce(const std::string& label, const size_t& policy,
                                               FunctorType>::policy_type;
   using FunctorAnalysis =
       Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, policy_type,
-                            FunctorType>;
+                            FunctorType, void>;
   using value_type = std::conditional_t<(FunctorAnalysis::StaticValueSize != 0),
                                         typename FunctorAnalysis::value_type,
                                         typename FunctorAnalysis::pointer_type>;

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel.hpp
@@ -622,7 +622,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   using Policy = Kokkos::RangePolicy<Traits...>;
 
   using Analysis =
-      FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType>;
+      FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType, void>;
 
   using WorkTag   = typename Policy::work_tag;
   using WorkRange = typename Policy::WorkRange;
@@ -749,8 +749,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
  private:
   using Policy = Kokkos::RangePolicy<Traits...>;
 
-  using Analysis =
-      FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType>;
+  using Analysis = FunctorAnalysis<FunctorPatternInterface::SCAN, Policy,
+                                   FunctorType, ReturnType>;
 
   using WorkTag   = typename Policy::work_tag;
   using WorkRange = typename Policy::WorkRange;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Range.hpp
@@ -38,9 +38,9 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   using pointer_type   = typename ReducerType::pointer_type;
   using reference_type = typename ReducerType::reference_type;
 
-  static constexpr bool FunctorHasJoin =
-      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, Policy,
-                            FunctorType>::Reducer::has_join_member_function();
+  static constexpr bool FunctorHasJoin = Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE, Policy, FunctorType,
+      typename ReducerType::value_type>::Reducer::has_join_member_function();
   static constexpr bool UseReducer =
       !std::is_same_v<FunctorType, typename ReducerType::functor_type>;
   static constexpr bool IsArray = std::is_pointer_v<reference_type>;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelReduce_Team.hpp
@@ -453,9 +453,9 @@ class ParallelReduce<CombinedFunctorReducerType,
   bool m_result_ptr_on_device;
   const int m_result_ptr_num_elems;
 
-  static constexpr bool FunctorHasJoin =
-      Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, Policy,
-                            FunctorType>::Reducer::has_join_member_function();
+  static constexpr bool FunctorHasJoin = Impl::FunctorAnalysis<
+      Impl::FunctorPatternInterface::REDUCE, Policy, FunctorType,
+      typename ReducerType::value_type>::Reducer::has_join_member_function();
   static constexpr bool UseReducer =
       !std::is_same_v<FunctorType, typename ReducerType::functor_type>;
   static constexpr bool IsArray = std::is_pointer_v<reference_type>;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
@@ -35,7 +35,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   using idx_type = typename Policy::index_type;
 
   using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
-                                         Policy, FunctorType>;
+                                         Policy, FunctorType, void>;
 
   using value_type     = typename Analysis::value_type;
   using pointer_type   = typename Analysis::pointer_type;

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Team.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Team.hpp
@@ -39,7 +39,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     const FunctorType& lambda) {
   using Analysis   = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
                                          TeamPolicy<Experimental::OpenMPTarget>,
-                                         FunctorType>;
+                                         FunctorType, void>;
   using value_type = typename Analysis::value_type;
 
   const auto start = loop_bounds.start;
@@ -107,7 +107,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     const FunctorType& lambda) {
   using Analysis   = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
                                          TeamPolicy<Experimental::OpenMPTarget>,
-                                         FunctorType>;
+                                         FunctorType, void>;
   using value_type = typename Analysis::value_type;
 
   value_type scan_val = value_type();

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Parallel_Common.hpp
@@ -51,7 +51,8 @@ struct ParallelReduceSpecialize {
                              PointerType /*result_ptr*/) {
     constexpr int FunctorHasJoin =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
-                              FunctorType>::Reducer::has_join_member_function();
+                              FunctorType,
+                              ValueType>::Reducer::has_join_member_function();
     constexpr int UseReducerType = is_reducer_v<ReducerType>;
 
     std::stringstream error_message;
@@ -72,7 +73,7 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
       std::conditional_t<std::is_same<InvalidType, ReducerType>::value,
                          FunctorType, ReducerType>;
   using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                                         PolicyType, ReducerTypeFwd>;
+                                         PolicyType, ReducerTypeFwd, ValueType>;
   using ReferenceType = typename Analysis::reference_type;
 
   using ParReduceCopy = ParallelReduceCopy<PointerType>;
@@ -198,7 +199,7 @@ struct ParallelReduceSpecialize<FunctorType, Kokkos::RangePolicy<PolicyArgs...>,
 
     using FunctorAnalysis =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
-                              FunctorType>;
+                              FunctorType, ValueType>;
 
     // Initialize the result pointer.
 
@@ -330,7 +331,7 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
       std::conditional_t<std::is_same<InvalidType, ReducerType>::value,
                          FunctorType, ReducerType>;
   using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                                         PolicyType, ReducerTypeFwd>;
+                                         PolicyType, ReducerTypeFwd, ValueType>;
 
   using ReferenceType = typename Analysis::reference_type;
 
@@ -540,7 +541,7 @@ struct ParallelReduceSpecialize<FunctorType, TeamPolicyInternal<PolicyArgs...>,
                                 PointerType ptr, const bool ptr_on_device) {
     using FunctorAnalysis =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE, PolicyType,
-                              FunctorType>;
+                              FunctorType, ValueType>;
 
     const int league_size   = p.league_size();
     const int team_size     = p.team_size();

--- a/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Parallel_Scan.hpp
@@ -89,7 +89,7 @@ void workgroup_scan(sycl::nd_item<dim> item, const FunctorType& final_reducer,
     final_reducer.join(&local_value, &local_mem[sg_group_id - 1]);
 }
 
-template <class FunctorType, class... Traits>
+template <class FunctorType, class ValueType, class... Traits>
 class ParallelScanSYCLBase {
  public:
   using Policy = Kokkos::RangePolicy<Traits...>;
@@ -100,8 +100,8 @@ class ParallelScanSYCLBase {
   using LaunchBounds = typename Policy::launch_bounds;
 
  public:
-  using Analysis =
-      FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType>;
+  using Analysis       = FunctorAnalysis<FunctorPatternInterface::SCAN, Policy,
+                                   FunctorType, ValueType>;
   using pointer_type   = typename Analysis::pointer_type;
   using value_type     = typename Analysis::value_type;
   using reference_type = typename Analysis::reference_type;
@@ -319,9 +319,9 @@ class ParallelScanSYCLBase {
 template <class FunctorType, class... Traits>
 class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
                    Kokkos::Experimental::SYCL>
-    : private ParallelScanSYCLBase<FunctorType, Traits...> {
+    : private ParallelScanSYCLBase<FunctorType, void, Traits...> {
  public:
-  using Base = ParallelScanSYCLBase<FunctorType, Traits...>;
+  using Base = ParallelScanSYCLBase<FunctorType, void, Traits...>;
 
   inline void execute() {
     Base::impl_execute([]() {});
@@ -337,9 +337,9 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
 template <class FunctorType, class ReturnType, class... Traits>
 class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
                             ReturnType, Kokkos::Experimental::SYCL>
-    : public ParallelScanSYCLBase<FunctorType, Traits...> {
+    : public ParallelScanSYCLBase<FunctorType, ReturnType, Traits...> {
  public:
-  using Base = ParallelScanSYCLBase<FunctorType, Traits...>;
+  using Base = ParallelScanSYCLBase<FunctorType, ReturnType, Traits...>;
 
   const Kokkos::Experimental::SYCL& m_exec;
 

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -579,8 +579,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     const FunctorType& lambda) {
   // Extract value_type from lambda
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void,
-      FunctorType>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, FunctorType,
+      void>::value_type;
 
   const auto start     = loop_bounds.start;
   const auto end       = loop_bounds.end;
@@ -775,7 +775,8 @@ parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
                   iType, Impl::SYCLTeamMember>& loop_boundaries,
               const Closure& closure, const ReducerType& reducer) {
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
+      void>::value_type;
 
   value_type accum;
   reducer.init(accum);
@@ -844,7 +845,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
         loop_boundaries,
     const Closure& closure) {
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
+      void>::value_type;
   value_type dummy;
   parallel_scan(loop_boundaries, closure, Kokkos::Sum<value_type>{dummy});
 }

--- a/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Range.hpp
@@ -150,7 +150,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   using WorkTag = typename Policy::work_tag;
 
   using Analysis =
-      FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType>;
+      FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType, void>;
 
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
@@ -214,8 +214,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   using Policy  = Kokkos::RangePolicy<Traits...>;
   using WorkTag = typename Policy::work_tag;
 
-  using Analysis =
-      FunctorAnalysis<FunctorPatternInterface::SCAN, Policy, FunctorType>;
+  using Analysis = FunctorAnalysis<FunctorPatternInterface::SCAN, Policy,
+                                   FunctorType, ReturnType>;
 
   using value_type     = typename Analysis::value_type;
   using pointer_type   = typename Analysis::pointer_type;

--- a/core/src/Threads/Kokkos_ThreadsTeam.hpp
+++ b/core/src/Threads/Kokkos_ThreadsTeam.hpp
@@ -982,8 +982,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
         iType, Impl::ThreadsExecTeamMember>& loop_bounds,
     const FunctorType& lambda) {
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void,
-      FunctorType>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, FunctorType,
+      void>::value_type;
 
   auto scan_val = value_type{};
 
@@ -1027,8 +1027,8 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     const FunctorType& lambda) {
   using value_type =
       typename Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
-                                     TeamPolicy<Threads>,
-                                     FunctorType>::value_type;
+                                     TeamPolicy<Threads>, FunctorType,
+                                     void>::value_type;
 
   value_type scan_val = value_type();
 

--- a/core/src/Threads/Kokkos_Threads_Parallel_Range.hpp
+++ b/core/src/Threads/Kokkos_Threads_Parallel_Range.hpp
@@ -268,7 +268,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
   using WorkTag   = typename Policy::work_tag;
   using Member    = typename Policy::member_type;
   using Analysis  = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
-                                         Policy, FunctorType>;
+                                         Policy, FunctorType, void>;
   using pointer_type   = typename Analysis::pointer_type;
   using reference_type = typename Analysis::reference_type;
 
@@ -345,7 +345,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   using Member    = typename Policy::member_type;
 
   using Analysis = Impl::FunctorAnalysis<Impl::FunctorPatternInterface::SCAN,
-                                         Policy, FunctorType>;
+                                         Policy, FunctorType, ReturnType>;
 
   using value_type     = typename Analysis::value_type;
   using pointer_type   = typename Analysis::pointer_type;

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -71,7 +71,8 @@ struct DeduceFunctorPatternInterface<ParallelScanWithTotal<
  *  For the REDUCE pattern generate a Reducer and finalization function
  *  derived from what is available within the functor.
  */
-template <typename PatternInterface, class Policy, class Functor>
+template <typename PatternInterface, class Policy, class Functor,
+          typename OverrideValueType>
 struct FunctorAnalysis {
  private:
   using FOR    = FunctorPatternInterface::FOR;
@@ -126,7 +127,7 @@ struct FunctorAnalysis {
 
   template <typename F, typename = std::false_type>
   struct has_value_type {
-    using type = void;
+    using type = OverrideValueType;
   };
 
   template <typename F>

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -64,9 +64,9 @@ struct DeduceFunctorPatternInterface<ParallelScanWithTotal<
 
 /** \brief  Query Functor and execution policy argument tag for value type.
  *
- *  If 'value_type' is not explicitly declared in the functor
- *  then attempt to deduce the type from FunctorType::operator()
- *  interface used by the pattern and policy.
+ *  If 'value_type' is not explicitly declared in the functor and
+ * OverrideValueType is void, then attempt to deduce the type from
+ * FunctorType::operator() interface used by the pattern and policy.
  *
  *  For the REDUCE pattern generate a Reducer and finalization function
  *  derived from what is available within the functor.
@@ -125,6 +125,7 @@ struct FunctorAnalysis {
   //----------------------------------------
   // Check for Functor::value_type, which is either a simple type T or T[]
 
+  // If the functor doesn't have a value_type alias, use OverrideValueType.
   template <typename F, typename = std::false_type>
   struct has_value_type {
     using type = OverrideValueType;
@@ -142,9 +143,9 @@ struct FunctorAnalysis {
   };
 
   //----------------------------------------
-  // If Functor::value_type does not exist then evaluate operator(),
-  // depending upon the pattern and whether the policy has a work tag,
-  // to determine the reduction or scan value_type.
+  // If Functor::value_type does not exist and OverrideValueType is void, then
+  // evaluate operator(), depending upon the pattern and whether the policy has
+  // a work tag, to determine the reduction or scan value_type.
 
   template <typename F, typename P = PatternInterface,
             typename V = typename has_value_type<F>::type,

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -873,7 +873,8 @@ KOKKOS_INLINE_FUNCTION
   // Extract ValueType from the closure
 
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure>::value_type;
+      Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
+      void>::value_type;
 
   value_type accum = 0;
 
@@ -899,7 +900,7 @@ KOKKOS_INLINE_FUNCTION
                       loop_boundaries,
                   ClosureType const& closure) {
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
-      Impl::FunctorPatternInterface::SCAN, void, ClosureType>::value_type;
+      Impl::FunctorPatternInterface::SCAN, void, ClosureType, void>::value_type;
 
   value_type scan_val = value_type();
 

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -101,7 +101,7 @@ struct SimpleTeamSizeCalculator {
                                         const Kokkos::ParallelReduceTag&) {
     using exec_space = typename Policy::execution_space;
     using analysis   = Kokkos::Impl::FunctorAnalysis<
-        Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, Functor>;
+        Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, Functor, void>;
     using driver = typename Kokkos::Impl::ParallelReduceWrapper<
         Kokkos::Impl::CombinedFunctorReducer<Functor,
                                              typename analysis::Reducer>,
@@ -126,7 +126,8 @@ struct ComplexReducerSizeCalculator {
     ReducerType reducer_example = ReducerType(value);
 
     using Analysis = Kokkos::Impl::FunctorAnalysis<
-        Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, ReducerType>;
+        Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, ReducerType,
+        value_type>;
     typename Analysis::Reducer final_reducer(reducer_example);
 
     return policy.team_size_max(functor, final_reducer, tag);
@@ -139,7 +140,8 @@ struct ComplexReducerSizeCalculator {
     ReducerType reducer_example = ReducerType(value);
 
     using Analysis = Kokkos::Impl::FunctorAnalysis<
-        Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, ReducerType>;
+        Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, ReducerType,
+        value_type>;
     typename Analysis::Reducer final_reducer(reducer_example);
 
     return policy.team_size_recommended(functor, final_reducer, tag);
@@ -150,7 +152,8 @@ struct ComplexReducerSizeCalculator {
                                         const Kokkos::ParallelReduceTag&) {
     using exec_space = typename Policy::execution_space;
     using Analysis   = Kokkos::Impl::FunctorAnalysis<
-        Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, ReducerType>;
+        Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, ReducerType,
+        void>;
     using driver = typename Kokkos::Impl::ParallelReduceWrapper<
         Kokkos::Impl::CombinedFunctorReducer<Functor,
                                              typename Analysis::Reducer>,

--- a/core/unit_test/TestFunctorAnalysis.hpp
+++ b/core/unit_test/TestFunctorAnalysis.hpp
@@ -45,7 +45,7 @@ void test_functor_analysis() {
   using A01 =
       Kokkos::Impl::FunctorAnalysis<Kokkos::Impl::FunctorPatternInterface::FOR,
                                     Kokkos::RangePolicy<ExecSpace>,
-                                    decltype(c01)>;
+                                    decltype(c01), void>;
 
   using R01 = typename A01::Reducer;
 
@@ -65,7 +65,7 @@ void test_functor_analysis() {
   auto c02  = KOKKOS_LAMBDA(int, double&){};
   using A02 = Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::REDUCE,
-      Kokkos::RangePolicy<ExecSpace>, decltype(c02)>;
+      Kokkos::RangePolicy<ExecSpace>, decltype(c02), void>;
   using R02 = typename A02::Reducer;
 
   static_assert(std::is_same<typename A02::value_type, double>::value, "");
@@ -85,7 +85,7 @@ void test_functor_analysis() {
   TestFunctorAnalysis_03 c03;
   using A03 = Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::REDUCE,
-      Kokkos::RangePolicy<ExecSpace>, TestFunctorAnalysis_03>;
+      Kokkos::RangePolicy<ExecSpace>, TestFunctorAnalysis_03, void>;
   using R03 = typename A03::Reducer;
 
   static_assert(std::is_same<typename A03::value_type,

--- a/core/unit_test/hip/TestHIP_ScanUnit.cpp
+++ b/core/unit_test/hip/TestHIP_ScanUnit.cpp
@@ -33,7 +33,8 @@ __global__ void start_intra_block_scan()
   DummyFunctor f;
   typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN,
-      Kokkos::RangePolicy<Kokkos::HIP>, DummyFunctor>::Reducer reducer(f);
+      Kokkos::RangePolicy<Kokkos::HIP>, DummyFunctor,
+      DummyFunctor::value_type>::Reducer reducer(f);
   Kokkos::Impl::hip_intra_block_reduce_scan<true>(reducer, values);
 
   __syncthreads();

--- a/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
+++ b/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
@@ -28,8 +28,9 @@ using value_type       = double;
 constexpr double value = 0.5;
 
 struct ReduceFunctor {
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const int i, double &UpdateSum) const {
+  template <typename SizeType, typename ValueType>
+  KOKKOS_INLINE_FUNCTION void operator()(const SizeType i,
+                                         ValueType &UpdateSum) const {
     UpdateSum += (i + 1) * value;
   }
 };

--- a/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
+++ b/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
@@ -28,6 +28,8 @@ using value_type       = double;
 constexpr double value = 0.5;
 
 struct ReduceFunctor {
+  // The functor is templated on purpose to check that the value_type deduction
+  // in parallel_reduce even works in this case.
   template <typename SizeType, typename ValueType>
   KOKKOS_INLINE_FUNCTION void operator()(const SizeType i,
                                          ValueType &UpdateSum) const {

--- a/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
+++ b/core/unit_test/incremental/Test05_ParallelReduce_RangePolicy.hpp
@@ -30,8 +30,8 @@ constexpr double value = 0.5;
 struct ReduceFunctor {
   // The functor is templated on purpose to check that the value_type deduction
   // in parallel_reduce even works in this case.
-  template <typename SizeType, typename ValueType>
-  KOKKOS_INLINE_FUNCTION void operator()(const SizeType i,
+  template <typename IndexType, typename ValueType>
+  KOKKOS_INLINE_FUNCTION void operator()(const IndexType i,
                                          ValueType &UpdateSum) const {
     UpdateSum += (i + 1) * value;
   }

--- a/core/unit_test/incremental/Test16_ParallelScan.hpp
+++ b/core/unit_test/incremental/Test16_ParallelScan.hpp
@@ -77,18 +77,16 @@ struct GenericExclusiveScanFunctor {
 template <class ExecSpace>
 struct TestScan {
   // 1D  View of double
-  using View_1D  = typename Kokkos::View<value_type *, ExecSpace>;
-  View_1D d_data = View_1D("data", N);
-
-  template <typename IndexType>
-  KOKKOS_FUNCTION void operator()(IndexType i) const {
-    d_data(i) = i * 0.5;
-  }
+  using View_1D = typename Kokkos::View<value_type *, ExecSpace>;
 
   template <typename FunctorType>
   void parallel_scan() {
+    View_1D d_data("data", N);
+
     // Initialize data.
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, N), *this);
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<ExecSpace>(0, N),
+        KOKKOS_LAMBDA(const int i) { d_data(i) = i * 0.5; });
 
     // Exclusive parallel_scan call
     Kokkos::parallel_scan(Kokkos::RangePolicy<ExecSpace>(0, N),

--- a/core/unit_test/incremental/Test16_ParallelScan.hpp
+++ b/core/unit_test/incremental/Test16_ParallelScan.hpp
@@ -62,7 +62,7 @@ struct NonTrivialScanFunctor {
 };
 
 template <typename ExecSpace>
-struct GenericScanFunctor {
+struct GenericExclusiveScanFunctor {
   Kokkos::View<value_type *, ExecSpace> d_data;
 
   template <typename SizeType, typename ValueType>
@@ -151,7 +151,7 @@ TEST(TEST_CATEGORY, IncrTest_16_parallelscan) {
   TestScanWithTotal<TEST_EXECSPACE> test_total;
   test_total.parallel_scan<TrivialScanFunctor<TEST_EXECSPACE>>();
   test_total.parallel_scan<NonTrivialScanFunctor<TEST_EXECSPACE>>();
-  test_total.parallel_scan<GenericScanFunctor<TEST_EXECSPACE>>();
+  test_total.parallel_scan<GenericExclusiveScanFunctor<TEST_EXECSPACE>>();
 }
 
 }  // namespace Test

--- a/core/unit_test/incremental/Test16_ParallelScan.hpp
+++ b/core/unit_test/incremental/Test16_ParallelScan.hpp
@@ -65,8 +65,8 @@ template <typename ExecSpace>
 struct GenericExclusiveScanFunctor {
   Kokkos::View<value_type *, ExecSpace> d_data;
 
-  template <typename SizeType, typename ValueType>
-  KOKKOS_FUNCTION void operator()(const SizeType i, ValueType &update_value,
+  template <typename IndexType, typename ValueType>
+  KOKKOS_FUNCTION void operator()(const IndexType i, ValueType &update_value,
                                   const bool final) const {
     const ValueType val_i = d_data(i);
     if (final) d_data(i) = update_value;
@@ -80,8 +80,8 @@ struct TestScan {
   using View_1D  = typename Kokkos::View<value_type *, ExecSpace>;
   View_1D d_data = View_1D("data", N);
 
-  template <typename SizeType>
-  KOKKOS_FUNCTION void operator()(SizeType i) const {
+  template <typename IndexType>
+  KOKKOS_FUNCTION void operator()(IndexType i) const {
     d_data(i) = i * 0.5;
   }
 
@@ -114,8 +114,8 @@ struct TestScanWithTotal {
   using View_1D  = typename Kokkos::View<value_type *, ExecSpace>;
   View_1D d_data = View_1D("data", N);
 
-  template <typename SizeType>
-  KOKKOS_FUNCTION void operator()(SizeType i) const {
+  template <typename IndexType>
+  KOKKOS_FUNCTION void operator()(IndexType i) const {
     d_data(i) = i * 0.5;
   }
 


### PR DESCRIPTION
Part of #5908. Fixes https://github.com/kokkos/kokkos/issues/5156, improves https://github.com/kokkos/kokkos/issues/2034. This is basically #5420:

Extending `FunctorAnalysis` to be able to be used with templated call operators appears to be very difficult. On the other hand, the overloads of `parallel_reduce` and `parallel_scan` taking a return value already contain a hint for the `value_type` to use so that we can avoid using the deduction in `FunctorAnalysis` in those cases.

This pull request does exactly that. If the functor has a `value_type` alias, we use that, otherwise, we use the `value_type` deduced from the return type and if that is void, too, we do the deduction in FunctorAnalysis based on the functor's call operator.

edit: Copied description from #5420.