### PR TITLE
Enable OpenMP in CUDA-11.0-NVCC-RDC to test DEPRECATED_CODE_3=ON

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -384,7 +384,7 @@ pipeline {
                                 -DCMAKE_CXX_STANDARD=17 \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
-                                -DKokkos_ENABLE_OPENMP=OFF \
+                                -DKokkos_ENABLE_OPENMP=ON \
                                 -DKokkos_ENABLE_CUDA=ON \
                                 -DKokkos_ENABLE_CUDA_LAMBDA=OFF \
                                 -DKokkos_ENABLE_CUDA_UVM=ON \

--- a/.jenkins
+++ b/.jenkins
@@ -384,7 +384,7 @@ pipeline {
                                 -DCMAKE_CXX_STANDARD=17 \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
-                                -DKokkos_ENABLE_OPENMP=ON \
+                                -DKokkos_ENABLE_OPENMP=OFF \
                                 -DKokkos_ENABLE_CUDA=ON \
                                 -DKokkos_ENABLE_CUDA_LAMBDA=OFF \
                                 -DKokkos_ENABLE_CUDA_UVM=ON \
@@ -414,7 +414,11 @@ pipeline {
                                 -DCMAKE_CXX_FLAGS=-Werror \
                                 -DCMAKE_CXX_STANDARD=17 \
                               .. && \
-                              make -j8 && ctest --verbose'''
+                              make -j8 && ctest --verbose && \
+                              cd ../.. && \
+                              cmake -B build_cmake_installed_different_compiler/build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_CXX_STANDARD=17 build_cmake_installed_different_compiler && \
+                              cmake --build build_cmake_installed_different_compiler/build --target all && \
+                              cmake --build build_cmake_installed_different_compiler/build --target test'''
                     }
                     post {
                         always {
@@ -485,6 +489,7 @@ pipeline {
                                 -DCMAKE_CXX_FLAGS=-Werror \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
+                                -DKokkos_ENABLE_DEPRECATED_CODE_3=ON \
                                 -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
                                 -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
                                 -DKokkos_ENABLE_TESTS=ON \

--- a/.jenkins
+++ b/.jenkins
@@ -414,11 +414,7 @@ pipeline {
                                 -DCMAKE_CXX_FLAGS=-Werror \
                                 -DCMAKE_CXX_STANDARD=17 \
                               .. && \
-                              make -j8 && ctest --verbose && \
-                              cd ../.. && \
-                              cmake -B build_cmake_installed_different_compiler/build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_CXX_STANDARD=17 build_cmake_installed_different_compiler && \
-                              cmake --build build_cmake_installed_different_compiler/build --target all && \
-                              cmake --build build_cmake_installed_different_compiler/build --target test'''
+                              make -j8 && ctest --verbose'''
                     }
                     post {
                         always {

--- a/core/unit_test/TestDefaultDeviceTypeInit.hpp
+++ b/core/unit_test/TestDefaultDeviceTypeInit.hpp
@@ -262,7 +262,7 @@ void check_correct_initialization(const Kokkos::InitArguments& argstruct) {
 #endif
   }
 
-  ASSERT_EQ(Kokkos::HostSpace::execution_space::impl_thread_pool_size(),
+  ASSERT_EQ(Kokkos::HostSpace::execution_space().impl_thread_pool_size(),
             expected_nthreads);
 
 #ifdef KOKKOS_ENABLE_CUDA


### PR DESCRIPTION
Follow-up to #5963. A lot of functionality guarded by `KOKKOS_ENABLE_DEPRECATED_CODE_3` is related to OpenMP, in particular `partition_master`, but also other changes from static to non-static member functions. We don't have a CI configuration with OpenMP and  `KOKKOS_ENABLE_DEPRECATED_CODE_3=ON`, though.
~~`CUDA-11.0-NVCC-RDC` currently uses `KOKKOS_ENABLE_DEPRECATED_CODE_3=ON` but explicitly disables `OpenMP` (although it configures OpenMP in environment variables). Let's see if this works now or if we have to pick a different build.~~
This pull request enables `DEPRECATED_CODE_3` for the `gcc-8.4.0` jenkins build.