### PR TITLE
Remove ParallelReduceWrapper

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_MDRange.hpp
@@ -365,9 +365,8 @@ class ParallelReduce<CombinedFunctorReducerType,
 
   template <typename Policy, typename Functor>
   static int max_tile_size_product(const Policy&, const Functor&) {
-    using closure_type =
-        ParallelReduce<FunctorType, Kokkos::MDRangePolicy<Traits...>,
-                       ReducerType, HIP>;
+    using closure_type  = ParallelReduce<CombinedFunctorReducerType,
+                                        Kokkos::MDRangePolicy<Traits...>, HIP>;
     unsigned block_size = hip_get_max_blocksize<closure_type, LaunchBounds>();
     if (block_size == 0) {
       Kokkos::Impl::throw_runtime_exception(

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -326,20 +326,13 @@ class ParallelFor;
 ///
 /// This is an implementation detail of parallel_reduce.  Users should
 /// skip this and go directly to the nonmember function parallel_reduce.
-template <class FunctorType, class ExecPolicy, class ReducerType = InvalidType,
-          class ExecutionSpace = typename Impl::FunctorPolicyExecutionSpace<
-              FunctorType, ExecPolicy>::execution_space>
+template <typename CombinedFunctorReducerType, typename PolicyType,
+          typename ExecutionSpaceType>
 class ParallelReduce;
 
-// FIXME Remove once all backends implement the new interface
 template <typename FunctorType, typename FunctorAnalysisReducerType,
           typename Enable = void>
 class CombinedFunctorReducer;
-
-// FIXME Remove once all backends implement the new interface
-template <typename CombinedFunctorReducerType, typename PolicyType,
-          typename ExecutionSpaceType, typename Enable = void>
-class ParallelReduceWrapper;
 
 /// \class ParallelScan
 /// \brief Implementation detail of parallel_scan.

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -1070,10 +1070,9 @@ template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelForTag, Args...>
     : type_identity<ParallelFor<Args...>> {};
 
-// FIXME Drop "Wrapper" when all backends implement the new reduce interface
 template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelReduceTag, Args...>
-    : type_identity<ParallelReduceWrapper<Args...>> {};
+    : type_identity<ParallelReduce<Args...>> {};
 
 template <class... Args>
 struct PatternImplSpecializationFromTag<Kokkos::ParallelScanTag, Args...>

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -42,10 +42,10 @@ struct DeduceFunctorPatternInterface<
   using type = FunctorPatternInterface::FOR;
 };
 
-template <class FunctorType, class ExecPolicy, class ReducerType,
+template <class CombinedFunctorReducerType, class ExecPolicy,
           class ExecutionSpace>
 struct DeduceFunctorPatternInterface<
-    ParallelReduce<FunctorType, ExecPolicy, ReducerType, ExecutionSpace>> {
+    ParallelReduce<CombinedFunctorReducerType, ExecPolicy, ExecutionSpace>> {
   using type = FunctorPatternInterface::REDUCE;
 };
 

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -102,10 +102,10 @@ struct SimpleTeamSizeCalculator {
     using exec_space = typename Policy::execution_space;
     using analysis   = Kokkos::Impl::FunctorAnalysis<
         Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, Functor, void>;
-    using driver = typename Kokkos::Impl::ParallelReduceWrapper<
+    using driver = typename Kokkos::Impl::ParallelReduce<
         Kokkos::Impl::CombinedFunctorReducer<Functor,
                                              typename analysis::Reducer>,
-        Policy, exec_space>::wrapped_type;
+        Policy, exec_space>;
     return driver::max_tile_size_product(policy, functor);
   }
 };
@@ -154,10 +154,10 @@ struct ComplexReducerSizeCalculator {
     using Analysis   = Kokkos::Impl::FunctorAnalysis<
         Kokkos::Impl::FunctorPatternInterface::REDUCE, Policy, ReducerType,
         void>;
-    using driver = typename Kokkos::Impl::ParallelReduceWrapper<
+    using driver = typename Kokkos::Impl::ParallelReduce<
         Kokkos::Impl::CombinedFunctorReducer<Functor,
                                              typename Analysis::Reducer>,
-        Policy, exec_space>::wrapped_type;
+        Policy, exec_space>;
     return driver::max_tile_size_product(policy, functor);
   }
 };


### PR DESCRIPTION
Part of #5908. We don't need `ParallelReduceWrapper` anymore.