### PR TITLE
graph(hip): enable test

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -729,6 +729,12 @@ if(Kokkos_ENABLE_HIP)
       UnitTestMain.cpp
       hip/TestHIP_InterOp_Streams.cpp
   )
+  KOKKOS_ADD_EXECUTABLE_AND_TEST(
+    UnitTest_HIPGraph
+    SOURCES
+      UnitTestMainInit.cpp
+      hip/TestHIP_Graph.cpp
+  )
 endif()
 
 if(Kokkos_ENABLE_SYCL)

--- a/core/unit_test/hip/TestHIP_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_Graph.cpp
@@ -14,15 +14,5 @@
 //
 //@HEADER
 
-#ifndef KOKKOS_TEST_HIP_HPP
-#define KOKKOS_TEST_HIP_HPP
-
-#include <gtest/gtest.h>
-
-#define TEST_CATEGORY hip
-#define TEST_CATEGORY_NUMBER 6
-#define TEST_CATEGORY_DEATH hip_DeathTest
-#define TEST_EXECSPACE Kokkos::HIP
-#define TEST_CATEGORY_FIXTURE(name) hip_##name
-
-#endif
+#include <TestHIP_Category.hpp>
+#include <TestGraph.hpp>


### PR DESCRIPTION
This PR simply adds a missing test for `Kokkos::Experimental::Graph` on `HIP`.

I think that `Kokkos::Experimental::Graph<Kokkos::Cuda>` will be mapped to `Cuda`'s graph API.

However, I don't think that it will be mapped to `HIP`'s graph API (I searched for `hipGraph_t` for instance, and there was no match in `Kokkos`).

I guess it's falling back on the default `GraphImpl` from `core/src/impl/Kokkos_Default_Graph_Impl.hpp`.