### PR TITLE
Support --compiler-options in nvcc_wrapper

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -407,7 +407,7 @@ do
   -Woverloaded-virtual)
     ;;
   #strip -Xcompiler because we add it
-  -Xcompiler)
+  -Xcompiler|--compiler-options)
     if [[ $2 != "-o" ]]; then
       if [ $first_xcompiler_arg -eq 1 ]; then
         xcompiler_args="$2"


### PR DESCRIPTION
According to 'nvcc --help', it is just an alias to -Xcompiler.

nvcc --help
...
--compiler-options <options>,...                (-Xcompiler)                    
        Specify options directly to the compiler/preprocessor.