### PR TITLE
Desul atomics: Fix NVCC warning "integer conversion resulted in a change of sign"

### DIFF
--- a/tpls/desul/include/desul/atomics/Fetch_Op_CUDA.hpp
+++ b/tpls/desul/include/desul/atomics/Fetch_Op_CUDA.hpp
@@ -63,7 +63,7 @@ inline __device__ unsigned long long device_atomic_fetch_inc(unsigned long long*
 
 inline __device__                int device_atomic_fetch_dec(               int* ptr,                         MemoryOrderRelaxed, MemoryScopeDevice) { return atomicSub(ptr,  1  ); }
 inline __device__       unsigned int device_atomic_fetch_dec(      unsigned int* ptr,                         MemoryOrderRelaxed, MemoryScopeDevice) { return atomicSub(ptr,  1u ); }
-inline __device__ unsigned long long device_atomic_fetch_dec(unsigned long long* ptr,                         MemoryOrderRelaxed, MemoryScopeDevice) { return atomicAdd(ptr, -1  ); }
+inline __device__ unsigned long long device_atomic_fetch_dec(unsigned long long* ptr,                         MemoryOrderRelaxed, MemoryScopeDevice) { return atomicAdd(ptr, -1ull);}
 
 inline __device__       unsigned int device_atomic_fetch_inc_mod(  unsigned int* ptr,       unsigned int val, MemoryOrderRelaxed, MemoryScopeDevice) { return atomicInc(ptr,  val); }
 inline __device__       unsigned int device_atomic_fetch_dec_mod(  unsigned int* ptr,       unsigned int val, MemoryOrderRelaxed, MemoryScopeDevice) { return atomicDec(ptr,  val); }


### PR DESCRIPTION
Fix #5992 
Corresponds to desul/desul#102