### PR TITLE
Desul atomics: Fix warning with NVC++

### DIFF
--- a/tpls/desul/include/desul/atomics/Common.hpp
+++ b/tpls/desul/include/desul/atomics/Common.hpp
@@ -83,11 +83,11 @@ struct numeric_limits_max;
 
 template <>
 struct numeric_limits_max<uint32_t> {
-  static constexpr uint32_t value = -1;
+  static constexpr auto value = static_cast<uint32_t>(-1);
 };
 template <>
 struct numeric_limits_max<uint64_t> {
-  static constexpr uint64_t value = -1;
+  static constexpr auto value = static_cast<uint64_t>(-1);
 };
 
 constexpr bool atomic_always_lock_free(std::size_t size) {


### PR DESCRIPTION
Fixup for #5965
https://godbolt.org/z/1c58TKfP7
I was wrong and warning are being emitted, not only with NVC++ but also with NVCC.
```
"<desul>/include/desul/atomics/Common.hpp", line 86: warning: integer conversion resulted in a change of sign [integer_sign_change]
    static constexpr uint32_t value = -1;
                                      ^
```
See desul/desul#104