### PR TITLE
simd: Fixed an incorrectly returning size for uint64_t in avx2

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -804,7 +804,7 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
-    return 8;
+    return 4;
   }
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -505,7 +505,8 @@ TEST(simd, test_size) {
 #else
   constexpr auto width = 1;
   using Abi            = Kokkos::Experimental::simd_abi::scalar;
-  auto uint32_abi_size = Kokkos::Experimental::simd<std::uint32_t, Abi>::size();
+  static_assert(width ==
+                Kokkos::Experimental::simd<std::uint32_t, Abi>::size());
 #endif
 
   static_assert(width == Kokkos::Experimental::simd<double, Abi>::size());

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -486,3 +486,62 @@ TEST(simd, device) {
   Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::IndexType<int>>(0, 1),
                        simd_device_functor());
 }
+
+TEST(simd, test_size) {
+#if defined(KOKKOS_ARCH_AVX512XEON)
+  constexpr int width = 8;
+  using Abi = Kokkos::Experimental::simd_abi::avx512_fixed_size<width>;
+  auto double_abi_size = Kokkos::Experimental::simd<double, Abi>::size();
+  auto int64_abi_size  = Kokkos::Experimental::simd<int64_t, Abi>::size();
+  auto uint32_abi_size = Kokkos::Experimental::simd<uint32_t, Abi>::size();
+  auto int32_abi_size  = Kokkos::Experimental::simd<int32_t, Abi>::size();
+  auto uint64_abi_size = Kokkos::Experimental::simd<uint64_t, Abi>::size();
+
+  EXPECT_EQ(width, double_abi_size);
+  EXPECT_EQ(width, uint64_abi_size);
+  EXPECT_EQ(width, int64_abi_size);
+  EXPECT_EQ(width, uint32_abi_size);
+  EXPECT_EQ(width, int32_abi_size);
+
+#elif defined(KOKKOS_ARCH_AVX2)
+  constexpr int width  = 4;
+  using Abi            = Kokkos::Experimental::simd_abi::avx2_fixed_size<width>;
+  auto double_abi_size = Kokkos::Experimental::simd<double, Abi>::size();
+  auto uint64_abi_size = Kokkos::Experimental::simd<uint64_t, Abi>::size();
+  auto int64_abi_size  = Kokkos::Experimental::simd<int64_t, Abi>::size();
+  auto int32_abi_size  = Kokkos::Experimental::simd<int32_t, Abi>::size();
+
+  EXPECT_EQ(width, double_abi_size);
+  EXPECT_EQ(width, uint64_abi_size);
+  EXPECT_EQ(width, int64_abi_size);
+  EXPECT_EQ(width, int32_abi_size);
+
+#elif defined(__ARM_NEON)
+  constexpr int width  = 2;
+  using Abi            = Kokkos::Experimental::simd_abi::neon_fixed_size<width>;
+  auto double_abi_size = Kokkos::Experimental::simd<double, Abi>::size();
+  auto uint64_abi_size = Kokkos::Experimental::simd<uint64_t, Abi>::size();
+  auto int64_abi_size  = Kokkos::Experimental::simd<int64_t, Abi>::size();
+  auto int32_abi_size  = Kokkos::Experimental::simd<int32_t, Abi>::size();
+
+  EXPECT_EQ(width, double_abi_size);
+  EXPECT_EQ(width, uint64_abi_size);
+  EXPECT_EQ(width, int64_abi_size);
+  EXPECT_EQ(width, int32_abi_size);
+
+#else
+  constexpr int width  = 1;
+  using Abi            = Kokkos::Experimental::simd_abi::scalar;
+  auto double_abi_size = Kokkos::Experimental::simd<double, Abi>::size();
+  auto uint64_abi_size = Kokkos::Experimental::simd<uint64_t, Abi>::size();
+  auto int64_abi_size  = Kokkos::Experimental::simd<int64_t, Abi>::size();
+  auto uint32_abi_size = Kokkos::Experimental::simd<uint32_t, Abi>::size();
+  auto int32_abi_size  = Kokkos::Experimental::simd<int32_t, Abi>::size();
+
+  EXPECT_EQ(width, double_abi_size);
+  EXPECT_EQ(width, uint64_abi_size);
+  EXPECT_EQ(width, int64_abi_size);
+  EXPECT_EQ(width, uint32_abi_size);
+  EXPECT_EQ(width, int32_abi_size);
+#endif
+}

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -489,59 +489,28 @@ TEST(simd, device) {
 
 TEST(simd, test_size) {
 #if defined(KOKKOS_ARCH_AVX512XEON)
-  constexpr int width = 8;
+  constexpr auto width = 8;
   using Abi = Kokkos::Experimental::simd_abi::avx512_fixed_size<width>;
-  auto double_abi_size = Kokkos::Experimental::simd<double, Abi>::size();
-  auto int64_abi_size  = Kokkos::Experimental::simd<int64_t, Abi>::size();
-  auto uint32_abi_size = Kokkos::Experimental::simd<uint32_t, Abi>::size();
-  auto int32_abi_size  = Kokkos::Experimental::simd<int32_t, Abi>::size();
-  auto uint64_abi_size = Kokkos::Experimental::simd<uint64_t, Abi>::size();
-
-  EXPECT_EQ(width, double_abi_size);
-  EXPECT_EQ(width, uint64_abi_size);
-  EXPECT_EQ(width, int64_abi_size);
-  EXPECT_EQ(width, uint32_abi_size);
-  EXPECT_EQ(width, int32_abi_size);
+  static_assert(width ==
+                Kokkos::Experimental::simd<std::uint32_t, Abi>::size());
 
 #elif defined(KOKKOS_ARCH_AVX2)
-  constexpr int width  = 4;
+  constexpr auto width = 4;
   using Abi            = Kokkos::Experimental::simd_abi::avx2_fixed_size<width>;
-  auto double_abi_size = Kokkos::Experimental::simd<double, Abi>::size();
-  auto uint64_abi_size = Kokkos::Experimental::simd<uint64_t, Abi>::size();
-  auto int64_abi_size  = Kokkos::Experimental::simd<int64_t, Abi>::size();
-  auto int32_abi_size  = Kokkos::Experimental::simd<int32_t, Abi>::size();
-
-  EXPECT_EQ(width, double_abi_size);
-  EXPECT_EQ(width, uint64_abi_size);
-  EXPECT_EQ(width, int64_abi_size);
-  EXPECT_EQ(width, int32_abi_size);
 
 #elif defined(__ARM_NEON)
-  constexpr int width  = 2;
+  constexpr auto width = 2;
   using Abi            = Kokkos::Experimental::simd_abi::neon_fixed_size<width>;
-  auto double_abi_size = Kokkos::Experimental::simd<double, Abi>::size();
-  auto uint64_abi_size = Kokkos::Experimental::simd<uint64_t, Abi>::size();
-  auto int64_abi_size  = Kokkos::Experimental::simd<int64_t, Abi>::size();
-  auto int32_abi_size  = Kokkos::Experimental::simd<int32_t, Abi>::size();
-
-  EXPECT_EQ(width, double_abi_size);
-  EXPECT_EQ(width, uint64_abi_size);
-  EXPECT_EQ(width, int64_abi_size);
-  EXPECT_EQ(width, int32_abi_size);
 
 #else
-  constexpr int width  = 1;
+  constexpr auto width = 1;
   using Abi            = Kokkos::Experimental::simd_abi::scalar;
-  auto double_abi_size = Kokkos::Experimental::simd<double, Abi>::size();
-  auto uint64_abi_size = Kokkos::Experimental::simd<uint64_t, Abi>::size();
-  auto int64_abi_size  = Kokkos::Experimental::simd<int64_t, Abi>::size();
-  auto uint32_abi_size = Kokkos::Experimental::simd<uint32_t, Abi>::size();
-  auto int32_abi_size  = Kokkos::Experimental::simd<int32_t, Abi>::size();
-
-  EXPECT_EQ(width, double_abi_size);
-  EXPECT_EQ(width, uint64_abi_size);
-  EXPECT_EQ(width, int64_abi_size);
-  EXPECT_EQ(width, uint32_abi_size);
-  EXPECT_EQ(width, int32_abi_size);
+  auto uint32_abi_size = Kokkos::Experimental::simd<std::uint32_t, Abi>::size();
 #endif
+
+  static_assert(width == Kokkos::Experimental::simd<double, Abi>::size());
+  static_assert(width == Kokkos::Experimental::simd<std::int64_t, Abi>::size());
+  static_assert(width ==
+                Kokkos::Experimental::simd<std::uint64_t, Abi>::size());
+  static_assert(width == Kokkos::Experimental::simd<std::int32_t, Abi>::size());
 }


### PR DESCRIPTION
Following up from https://github.com/kokkos/kokkos/pull/5913#discussion_r1137432586.

This fixes an incorrectly returning width size for simd ABI with uint64_t in AVX2 backend.

The added unit test in this PR is temporary that is to quickly test `size()` for each ABI. Because current unit-tests in kokkos simd are set up to only test for `double` for all ABIs, existing tests do not expose this bug. This unit test will be refactored and be integrated with rest of unit tests as part of #5913.