### PR TITLE
view(uvm): don't fence during view's allocation (#6005)

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -239,7 +239,8 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
       : modified_flags(t_modified_flags("DualView::modified_flags")),
         d_view(arg_prop, n0, n1, n2, n3, n4, n5, n6, n7) {
     // without UVM, host View mirrors
-    if (Kokkos::Impl::has_type<Impl::WithoutInitializing_t, P...>::value)
+    if constexpr (Kokkos::Impl::has_type<Impl::WithoutInitializing_t,
+                                         P...>::value)
       h_view = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, d_view);
     else
       h_view = Kokkos::create_mirror_view(d_view);
@@ -576,8 +577,8 @@ class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
         impl_report_host_sync();
       }
     }
-    if (std::is_same<typename t_host::memory_space,
-                     typename t_dev::memory_space>::value) {
+    if constexpr (std::is_same<typename t_host::memory_space,
+                               typename t_dev::memory_space>::value) {
       typename t_dev::execution_space().fence(
           "Kokkos::DualView<>::sync: fence after syncing DualView");
       typename t_host::execution_space().fence(

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1089,36 +1089,11 @@ class DynRankView : public ViewTraits<DataType, Properties...> {
           "execution space");
     }
 
-//------------------------------------------------------------
-#if defined(KOKKOS_ENABLE_CUDA)
-    // If allocating in CudaUVMSpace must fence before and after
-    // the allocation to protect against possible concurrent access
-    // on the CPU and the GPU.
-    // Fence using the trait's executon space (which will be Kokkos::Cuda)
-    // to avoid incomplete type errors from usng Kokkos::Cuda directly.
-    if (std::is_same<Kokkos::CudaUVMSpace,
-                     typename traits::device_type::memory_space>::value) {
-      typename traits::device_type::memory_space::execution_space().fence(
-          "Kokkos::DynRankView<>::DynRankView: fence before UVM allocation");
-    }
-#endif
-    //------------------------------------------------------------
-
     Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
         prop_copy,
         Impl::DynRankDimTraits<typename traits::specialize>::
             template createLayout<traits, P...>(arg_prop, arg_layout),
         Impl::ViewCtorProp<P...>::has_execution_space);
-
-//------------------------------------------------------------
-#if defined(KOKKOS_ENABLE_CUDA)
-    if (std::is_same<Kokkos::CudaUVMSpace,
-                     typename traits::device_type::memory_space>::value) {
-      typename traits::device_type::memory_space::execution_space().fence(
-          "Kokkos::DynRankView<>::DynRankView: fence after UVM allocation");
-    }
-#endif
-    //------------------------------------------------------------
 
     // Setup and initialization complete, start tracking
     m_track.assign_allocated_record_to_uninitialized(record);

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1191,34 +1191,9 @@ class OffsetView : public ViewTraits<DataType, Properties...> {
           "execution space");
     }
 
-    //------------------------------------------------------------
-#if defined(KOKKOS_ENABLE_CUDA)
-    // If allocating in CudaUVMSpace must fence before and after
-    // the allocation to protect against possible concurrent access
-    // on the CPU and the GPU.
-    // Fence using the trait's executon space (which will be Kokkos::Cuda)
-    // to avoid incomplete type errors from usng Kokkos::Cuda directly.
-    if (std::is_same<Kokkos::CudaUVMSpace,
-                     typename traits::device_type::memory_space>::value) {
-      typename traits::device_type::memory_space::execution_space().fence(
-          "Kokkos::OffsetView::OffsetView(): fence before UVM allocation");
-    }
-#endif
-    //------------------------------------------------------------
-
     Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
         prop_copy, arg_layout,
         Kokkos::Impl::ViewCtorProp<P...>::has_execution_space);
-
-    //------------------------------------------------------------
-#if defined(KOKKOS_ENABLE_CUDA)
-    if (std::is_same<Kokkos::CudaUVMSpace,
-                     typename traits::device_type::memory_space>::value) {
-      typename traits::device_type::memory_space::execution_space().fence(
-          "Kokkos::OffsetView::OffsetView(): fence after UVM allocation");
-    }
-#endif
-    //------------------------------------------------------------
 
     // Setup and initialization complete, start tracking
     m_track.assign_allocated_record_to_uninitialized(record);

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -24,6 +24,19 @@
 
 #include <../../core/unit_test/tools/include/ToolTestingUtilities.hpp>
 
+/// Some tests are skipped for @c CudaUVM memory space.
+/// @todo To be revised according to the future of @c KOKKOS_ENABLE_CUDA_UVM.
+///@{
+#ifdef KOKKOS_ENABLE_CUDA
+#define GTEST_SKIP_IF_CUDAUVM_MEMORY_SPACE                            \
+  if constexpr (std::is_same_v<typename TEST_EXECSPACE::memory_space, \
+                               Kokkos::CudaUVMSpace>)                 \
+    GTEST_SKIP() << "skipping since CudaUVMSpace requires additional fences";
+#else
+#define GTEST_SKIP_IF_CUDAUVM_MEMORY_SPACE
+#endif
+///@}
+
 TEST(TEST_CATEGORY, resize_realloc_no_init_dualview) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());
@@ -125,11 +138,7 @@ TEST(TEST_CATEGORY, resize_exec_space_dualview) {
 }
 
 TEST(TEST_CATEGORY, realloc_exec_space_dualview) {
-#ifdef KOKKOS_ENABLE_CUDA
-  if (std::is_same<typename TEST_EXECSPACE::memory_space,
-                   Kokkos::CudaUVMSpace>::value)
-    GTEST_SKIP() << "skipping since CudaUVMSpace requires additional fences";
-#endif
+  GTEST_SKIP_IF_CUDAUVM_MEMORY_SPACE
 
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableFences());
@@ -221,11 +230,8 @@ TEST(TEST_CATEGORY, resize_exec_space_dynrankview) {
 }
 
 TEST(TEST_CATEGORY, realloc_exec_space_dynrankview) {
-#ifdef KOKKOS_ENABLE_CUDA
-  if (std::is_same<typename TEST_EXECSPACE::memory_space,
-                   Kokkos::CudaUVMSpace>::value)
-    GTEST_SKIP() << "skipping since CudaUVMSpace requires additional fences";
-#endif
+  GTEST_SKIP_IF_CUDAUVM_MEMORY_SPACE
+
 // FIXME_THREADS The Threads backend fences every parallel_for
 #ifdef KOKKOS_ENABLE_THREADS
   if (std::is_same<TEST_EXECSPACE, Kokkos::Threads>::value)
@@ -363,11 +369,8 @@ TEST(TEST_CATEGORY, resize_exec_space_scatterview) {
 }
 
 TEST(TEST_CATEGORY, realloc_exec_space_scatterview) {
-#ifdef KOKKOS_ENABLE_CUDA
-  if (std::is_same<typename TEST_EXECSPACE::memory_space,
-                   Kokkos::CudaUVMSpace>::value)
-    GTEST_SKIP() << "skipping since CudaUVMSpace requires additional fences";
-#endif
+  GTEST_SKIP_IF_CUDAUVM_MEMORY_SPACE
+
 // FIXME_THREADS The Threads backend fences every parallel_for
 #ifdef KOKKOS_ENABLE_THREADS
   if (std::is_same<typename TEST_EXECSPACE, Kokkos::Threads>::value)
@@ -477,11 +480,8 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynrankview_viewctor) {
 }
 
 TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynrankview) {
-#ifdef KOKKOS_ENABLE_CUDA
-  if (std::is_same<typename TEST_EXECSPACE::memory_space,
-                   Kokkos::CudaUVMSpace>::value)
-    return;
-#endif
+  GTEST_SKIP_IF_CUDAUVM_MEMORY_SPACE
+
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
                      Config::EnableFences());
@@ -584,11 +584,8 @@ TEST(TEST_CATEGORY, create_mirror_no_init_offsetview_view_ctor) {
 }
 
 TEST(TEST_CATEGORY, create_mirror_view_and_copy_offsetview) {
-#ifdef KOKKOS_ENABLE_CUDA
-  if (std::is_same<typename TEST_EXECSPACE::memory_space,
-                   Kokkos::CudaUVMSpace>::value)
-    return;
-#endif
+  GTEST_SKIP_IF_CUDAUVM_MEMORY_SPACE
+
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
                      Config::EnableFences());
@@ -659,11 +656,8 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
 }
 
 TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynamicview) {
-#ifdef KOKKOS_ENABLE_CUDA
-  if (std::is_same<typename TEST_EXECSPACE::memory_space,
-                   Kokkos::CudaUVMSpace>::value)
-    return;
-#endif
+  GTEST_SKIP_IF_CUDAUVM_MEMORY_SPACE
+
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels(),
                      Config::EnableFences());

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -172,10 +172,11 @@ void *impl_allocate_common(const Cuda &exec_space, const char *arg_label,
     if (exec_space_provided) {
       cudaStream_t stream = exec_space.cuda_stream();
       error_code          = cudaMallocAsync(&ptr, arg_alloc_size, stream);
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(stream));
+      exec_space.fence("Kokkos::Cuda: backend fence after async malloc");
     } else {
       error_code = cudaMallocAsync(&ptr, arg_alloc_size, 0);
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceSynchronize());
+      Impl::cuda_device_synchronize(
+          "Kokkos::Cuda: backend fence after async malloc");
     }
   } else {
     error_code = cudaMalloc(&ptr, arg_alloc_size);
@@ -324,9 +325,11 @@ void CudaSpace::impl_deallocate(
 #error CUDART_VERSION undefined!
 #elif (defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC) && CUDART_VERSION >= 11020)
     if (arg_alloc_size >= memory_threshold_g) {
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceSynchronize());
+      Impl::cuda_device_synchronize(
+          "Kokkos::Cuda: backend fence before async free");
       KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeAsync(arg_alloc_ptr, 0));
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceSynchronize());
+      Impl::cuda_device_synchronize(
+          "Kokkos::Cuda: backend fence after async free");
     } else {
       KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(arg_alloc_ptr));
     }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1418,33 +1418,8 @@ class View : public ViewTraits<DataType, Properties...> {
         std::is_same<typename traits::specialize, void>::value, i0, i1, i2, i3,
         i4, i5, i6, i7, alloc_name);
 
-//------------------------------------------------------------
-#if defined(KOKKOS_ENABLE_CUDA)
-    // If allocating in CudaUVMSpace must fence before and after
-    // the allocation to protect against possible concurrent access
-    // on the CPU and the GPU.
-    // Fence using the trait's execution space (which will be Kokkos::Cuda)
-    // to avoid incomplete type errors from using Kokkos::Cuda directly.
-    if (std::is_same<Kokkos::CudaUVMSpace,
-                     typename traits::device_type::memory_space>::value) {
-      typename traits::device_type::memory_space::execution_space().fence(
-          "Kokkos::View<...>::View: fence before allocating UVM");
-    }
-#endif
-    //------------------------------------------------------------
-
     Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
         prop_copy, arg_layout, Impl::ViewCtorProp<P...>::has_execution_space);
-
-//------------------------------------------------------------
-#if defined(KOKKOS_ENABLE_CUDA)
-    if (std::is_same<Kokkos::CudaUVMSpace,
-                     typename traits::device_type::memory_space>::value) {
-      typename traits::device_type::memory_space::execution_space().fence(
-          "Kokkos::View<...>::View: fence after allocating UVM");
-    }
-#endif
-    //------------------------------------------------------------
 
     // Setup and initialization complete, start tracking
     m_track.m_tracker.assign_allocated_record_to_uninitialized(record);


### PR DESCRIPTION
This PR is a fix for
* #6005

Basically, when `CudaUVM` is enabled, there is a fence *before* and *after* the view's allocation (whether the `space` instance was given via `arg_prop` or not).

However, the fence was not performed on the *space* instance the user provided (if any).

According to the ["poll" below](https://github.com/kokkos/kokkos/pull/6008#issuecomment-1492054336), it was decided to
> enforce `Kokkos` semantics: Don't ever fence for the view initialization when an execution space instance is given

Therefore, any additional fence that was added for `CudaUVM` in view's allocation has been removed. Note that fencing still occurs in the backend implementations.