### PR TITLE
SYCL: Make is_device_copyable future-proof

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -323,10 +323,25 @@ struct sycl::is_device_copyable<
     Kokkos::Experimental::Impl::SYCLFunctionWrapper<Functor, Storage, false>>
     : std::true_type {};
 
+// FIXME_SYCL Remove when this specialization when specializations for
+// sycl::device_copyable also apply to const-qualified types.
+template <typename T>
+struct SimpleNonDeviceCopyable {
+  SimpleNonDeviceCopyable(const SimpleNonDeviceCopyable<T>&) {}
+  SimpleNonDeviceCopyable& operator=(const SimpleNonDeviceCopyable<T>&) {
+    return *this;
+  }
+};
+
+template <typename T>
+struct sycl::is_device_copyable<SimpleNonDeviceCopyable<T>> : std::true_type {};
+
 template <typename Functor, typename Storage>
 struct sycl::is_device_copyable<
     const Kokkos::Experimental::Impl::SYCLFunctionWrapper<Functor, Storage,
-                                                          false>>
+                                                          false>,
+    std::enable_if_t<
+        !sycl::is_device_copyable_v<const SimpleNonDeviceCopyable<Functor>>>>
     : std::true_type {};
 #endif
 #endif

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -325,23 +325,27 @@ struct sycl::is_device_copyable<
 
 // FIXME_SYCL Remove when this specialization when specializations for
 // sycl::device_copyable also apply to const-qualified types.
-template <typename T>
-struct SimpleNonDeviceCopyable {
-  SimpleNonDeviceCopyable(const SimpleNonDeviceCopyable<T>&) {}
-  SimpleNonDeviceCopyable& operator=(const SimpleNonDeviceCopyable<T>&) {
-    return *this;
-  }
+template <typename>
+struct NonTriviallyCopyableAndDeviceCopyable {
+  NonTriviallyCopyableAndDeviceCopyable(
+      const NonTriviallyCopyableAndDeviceCopyable&) {}
 };
 
 template <typename T>
-struct sycl::is_device_copyable<SimpleNonDeviceCopyable<T>> : std::true_type {};
+struct is_device_copyable<NonTriviallyCopyableAndDeviceCopyable<T>>
+    : std::true_type {};
+
+static_assert(
+    !std::is_trivially_copyable_v<
+        NonTriviallyCopyableAndDeviceCopyable<void>> &&
+    is_device_copyable_v<NonTriviallyCopyableAndDeviceCopyable<void>>);
 
 template <typename Functor, typename Storage>
 struct sycl::is_device_copyable<
     const Kokkos::Experimental::Impl::SYCLFunctionWrapper<Functor, Storage,
                                                           false>,
-    std::enable_if_t<
-        !sycl::is_device_copyable_v<const SimpleNonDeviceCopyable<Functor>>>>
+    std::enable_if_t<!sycl::is_device_copyable_v<
+        const NonTriviallyCopyableAndDeviceCopyable<Functor>>>>
     : std::true_type {};
 #endif
 #endif


### PR DESCRIPTION
There is a clarification in the SYCL standard (https://github.com/KhronosGroup/SYCL-Docs/pull/357/files) saying 
> [...]
If the implementation provides device support for one of the classes listed
above, arrays of that class and cv-qualified versions of that class are also
device copyable.
[...]
When the application explicitly declares a class type to be device copyable,
arrays of that type and cv-qualified versions of that type are also device
copyable, and the implementation sets the [code]#is_device_copyable_v# trait to
[code]#true# for these array and cv-qualified types.

Previously, Intel's compiler implementation required us to provide a separate template specialization for a const-qualified version of the specialization for a given type. With the clarification, this will now become an error since the implementation provides this specialization itself.
This pull request is an attempt to support both implementations by checking if for a given type that we defined to be `device_copyable` its `const` version is also `device_copyable`. Only if that is not the case, we provide the specialization (SFINAE-guarded) for the `const-qualified` version of the original type.
Note that https://github.com/intel/llvm/blob/10e07a38ae57e2312a44cc7aa1a6999b2813fb14/sycl/include/sycl/types.hpp#L2224-L2225 defines `sycl::device_copyable` as
```C++
template <typename T, typename = void>
struct is_device_copyable : std::false_type {};
```
while the SYCL standard defines it as
```C++
template <typename T>
struct is_device_copyable : std::false_type {};
```
, i.e, without the second template argument that allows SFINAE. To the best of my knowledge, there are no plans to change the type-trait in the Intel compiler, though, (and our `SYCL` backend implementation anyway relies on Intel compiler extensions).