### PR TITLE
CMake: update package compatibility mode when building within Trilinos

### DIFF
--- a/cmake/kokkos_install.cmake
+++ b/cmake/kokkos_install.cmake
@@ -38,7 +38,7 @@ ELSE()
 
   WRITE_BASIC_PACKAGE_VERSION_FILE("${CMAKE_CURRENT_BINARY_DIR}/KokkosConfigVersion.cmake"
       VERSION "${Kokkos_VERSION}"
-      COMPATIBILITY SameMajorVersion)
+      COMPATIBILITY AnyNewerVersion)
 
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/KokkosConfigVersion.cmake
       DESTINATION "${${PROJECT_NAME}_INSTALL_LIB_DIR}/cmake/${PACKAGE_NAME}")


### PR DESCRIPTION
Missed in #5759.

This is needed when building applications against Kokkos installed as part of the Trilinos. For example, it does not allow building ALEGRA using both recent versions of both ArborX and Trilinos.