### PR TITLE
Fix namespace for is_device_copyable

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -339,13 +339,13 @@ struct NonTriviallyCopyableAndDeviceCopyable {
 };
 
 template <typename T>
-struct is_device_copyable<NonTriviallyCopyableAndDeviceCopyable<T>>
+struct sycl::is_device_copyable<NonTriviallyCopyableAndDeviceCopyable<T>>
     : std::true_type {};
 
 static_assert(
     !std::is_trivially_copyable_v<
         NonTriviallyCopyableAndDeviceCopyable<void>> &&
-    is_device_copyable_v<NonTriviallyCopyableAndDeviceCopyable<void>>);
+    sycl::is_device_copyable_v<NonTriviallyCopyableAndDeviceCopyable<void>>);
 
 template <typename Functor, typename Storage>
 struct sycl::is_device_copyable<


### PR DESCRIPTION
We forgot to prefix `is_device_copyable` with `sycl` in https://github.com/kokkos/kokkos/pull/6009/commits/3d48d63e73667ad416c8cd75614f476438132291. The CI didn't catch it because the branch using `is_device_copyable` is not used for `SYCL+Cuda`.