### PR TITLE
Add -Wdeprecated-copy warning and fix OMPT scan bug related to assignment operators

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_PartitionCopy.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_PartitionCopy.hpp
@@ -31,25 +31,6 @@ template <class ValueType>
 struct StdPartitionCopyScalar {
   ValueType true_count_;
   ValueType false_count_;
-
-  // Here we implement the copy assignment operators explicitly for consistency
-  // with how the Scalar structs are implemented inside
-  // Kokkos_Parallel_Reduce.hpp.
-  KOKKOS_FUNCTION
-  void operator=(const StdPartitionCopyScalar& other) {
-    true_count_  = other.true_count_;
-    false_count_ = other.false_count_;
-  }
-
-  // this is needed for
-  // OpenMPTarget/Kokkos_OpenMPTarget_Parallel.hpp:699:21: error: no viable
-  // overloaded '=' m_returnvalue = 0;
-  //
-  KOKKOS_FUNCTION
-  void operator=(const ValueType value) {
-    true_count_  = value;
-    false_count_ = value;
-  }
 };
 
 template <class IndexType, class FirstFrom, class FirstDestTrue,

--- a/algorithms/src/std_algorithms/impl/Kokkos_ValueWrapperForNoNeutralElement.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ValueWrapperForNoNeutralElement.hpp
@@ -29,12 +29,6 @@ template <class Scalar>
 struct ValueWrapperForNoNeutralElement {
   Scalar val;
   bool is_initial = true;
-
-  KOKKOS_FUNCTION
-  void operator=(const ValueWrapperForNoNeutralElement& rhs) {
-    val        = rhs.val;
-    is_initial = rhs.is_initial;
-  }
 };
 
 }  // namespace Impl

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -121,7 +121,7 @@ KOKKOS_ARCH_OPTION(INTEL_PVC       GPU  "Intel GPU Ponte Vecchio"               
 IF(KOKKOS_ENABLE_COMPILER_WARNINGS)
   SET(COMMON_WARNINGS
     "-Wall" "-Wunused-parameter" "-Wshadow" "-pedantic"
-    "-Wsign-compare" "-Wtype-limits" "-Wuninitialized")
+    "-Wsign-compare" "-Wtype-limits" "-Wuninitialized" "-Wdeprecated-copy")
 
   # NOTE KOKKOS_ prefixed variable (all uppercase) is not set yet because TPLs are processed after ARCH
   IF(Kokkos_ENABLE_LIBQUADMATH)

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -121,7 +121,7 @@ KOKKOS_ARCH_OPTION(INTEL_PVC       GPU  "Intel GPU Ponte Vecchio"               
 IF(KOKKOS_ENABLE_COMPILER_WARNINGS)
   SET(COMMON_WARNINGS
     "-Wall" "-Wunused-parameter" "-Wshadow" "-pedantic"
-    "-Wsign-compare" "-Wtype-limits" "-Wuninitialized" "-Wdeprecated-copy")
+    "-Wsign-compare" "-Wtype-limits" "-Wuninitialized")
 
   # NOTE KOKKOS_ prefixed variable (all uppercase) is not set yet because TPLs are processed after ARCH
   IF(Kokkos_ENABLE_LIBQUADMATH)

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -721,10 +721,11 @@ class ScatterView<DataType, Layout, DeviceType, Op, ScatterNonDuplicated,
       : internal_view(other_view.internal_view) {}
 
   template <typename OtherDataType, typename OtherDeviceType>
-  KOKKOS_FUNCTION void operator=(
+  KOKKOS_FUNCTION ScatterView& operator=(
       const ScatterView<OtherDataType, Layout, OtherDeviceType, Op,
                         ScatterNonDuplicated, Contribution>& other_view) {
     internal_view = other_view.internal_view;
+    return *this;
   }
 
   template <typename OverrideContribution = Contribution>
@@ -942,11 +943,12 @@ class ScatterView<DataType, Kokkos::LayoutRight, DeviceType, Op,
         internal_view(other_view.internal_view) {}
 
   template <typename OtherDataType, typename OtherDeviceType>
-  KOKKOS_FUNCTION void operator=(
+  KOKKOS_FUNCTION ScatterView& operator=(
       const ScatterView<OtherDataType, Kokkos::LayoutRight, OtherDeviceType, Op,
                         ScatterDuplicated, Contribution>& other_view) {
     unique_token  = other_view.unique_token;
     internal_view = other_view.internal_view;
+    return *this;
   }
 
   template <typename RT, typename... RP>
@@ -1278,11 +1280,12 @@ class ScatterView<DataType, Kokkos::LayoutLeft, DeviceType, Op,
         internal_view(other_view.internal_view) {}
 
   template <typename OtherDataType, typename OtherDeviceType>
-  KOKKOS_FUNCTION void operator=(
+  KOKKOS_FUNCTION ScatterView& operator=(
       const ScatterView<OtherDataType, Kokkos::LayoutLeft, OtherDeviceType, Op,
                         ScatterDuplicated, Contribution>& other_view) {
     unique_token  = other_view.unique_token;
     internal_view = other_view.internal_view;
+    return *this;
   }
 
   template <typename OverrideContribution = Contribution>

--- a/core/src/Kokkos_Half.hpp
+++ b/core/src/Kokkos_Half.hpp
@@ -226,9 +226,19 @@ class alignas(FloatType) floating_point_wrapper {
 #if defined(_WIN32) && defined(KOKKOS_ENABLE_CUDA)
   KOKKOS_FUNCTION
   floating_point_wrapper(const floating_point_wrapper& rhs) : val(rhs.val) {}
+
+  KOKKOS_FUNCTION
+  floating_point_wrapper& operator=(const floating_point_wrapper& rhs) {
+    val = rhs.val;
+    return *this;
+  }
 #else
   KOKKOS_DEFAULTED_FUNCTION
   floating_point_wrapper(const floating_point_wrapper&) noexcept = default;
+
+  KOKKOS_DEFAULTED_FUNCTION
+  floating_point_wrapper& operator=(const floating_point_wrapper&) noexcept =
+      default;
 #endif
 
   KOKKOS_INLINE_FUNCTION

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -407,12 +407,6 @@ template <class Scalar, class Index>
 struct ValLocScalar {
   Scalar val;
   Index loc;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const ValLocScalar& rhs) {
-    val = rhs.val;
-    loc = rhs.loc;
-  }
 };
 
 template <class Scalar, class Index, class Space>
@@ -530,12 +524,6 @@ MaxLoc(View<ValLocScalar<Scalar, Index>, Properties...> const&)
 template <class Scalar>
 struct MinMaxScalar {
   Scalar min_val, max_val;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const MinMaxScalar& rhs) {
-    min_val = rhs.min_val;
-    max_val = rhs.max_val;
-  }
 };
 
 template <class Scalar, class Space>
@@ -600,14 +588,6 @@ template <class Scalar, class Index>
 struct MinMaxLocScalar {
   Scalar min_val, max_val;
   Index min_loc, max_loc;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const MinMaxLocScalar& rhs) {
-    min_val = rhs.min_val;
-    min_loc = rhs.min_loc;
-    max_val = rhs.max_val;
-    max_loc = rhs.max_loc;
-  }
 };
 
 template <class Scalar, class Index, class Space>
@@ -1106,9 +1086,6 @@ MinMaxFirstLastLocCustomComparator(
 template <class Index>
 struct FirstLocScalar {
   Index min_loc_true;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const FirstLocScalar& rhs) { min_loc_true = rhs.min_loc_true; }
 };
 
 template <class Index, class Space>
@@ -1170,9 +1147,6 @@ FirstLoc(View<FirstLocScalar<Index>, Properties...> const&)
 template <class Index>
 struct LastLocScalar {
   Index max_loc_true;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const LastLocScalar& rhs) { max_loc_true = rhs.max_loc_true; }
 };
 
 template <class Index, class Space>
@@ -1231,12 +1205,6 @@ LastLoc(View<LastLocScalar<Index>, Properties...> const&)
 template <class Index>
 struct StdIsPartScalar {
   Index max_loc_true, min_loc_false;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const StdIsPartScalar& rhs) {
-    min_loc_false = rhs.min_loc_false;
-    max_loc_true  = rhs.max_loc_true;
-  }
 };
 
 //
@@ -1304,11 +1272,6 @@ StdIsPartitioned(View<StdIsPartScalar<Index>, Properties...> const&)
 template <class Index>
 struct StdPartPointScalar {
   Index min_loc_false;
-
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const StdPartPointScalar& rhs) {
-    min_loc_false = rhs.min_loc_false;
-  }
 };
 
 //

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_ParallelScan_Range.hpp
@@ -241,7 +241,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
             base_t::m_result_ptr, chunk_values.data() + (n_chunks - 1), size);
       }
     } else if (!base_t::m_result_ptr_device_accessible) {
-      *base_t::m_result_ptr = 0;
+      base_t::m_functor_reducer.get_reducer().init(base_t::m_result_ptr);
     }
   }
 

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -248,6 +248,9 @@ struct long_wrapper {
   long_wrapper(long val) : value(val) {}
 
   KOKKOS_FUNCTION
+  long_wrapper(const long_wrapper& val) : value(val.value) {}
+
+  KOKKOS_FUNCTION
   friend void operator+=(long_wrapper& lhs, const long_wrapper& rhs) {
     lhs.value += rhs.value;
   }

--- a/core/unit_test/TestTeamTeamSize.hpp
+++ b/core/unit_test/TestTeamTeamSize.hpp
@@ -31,10 +31,6 @@ class MyArray {
   void operator+=(const MyArray& src) {
     for (int i = 0; i < N; i++) values[i] += src.values[i];
   }
-  KOKKOS_INLINE_FUNCTION
-  void operator=(const MyArray& src) {
-    for (int i = 0; i < N; i++) values[i] = src.values[i];
-  }
 };
 
 template <class T, int N, class PolicyType, int S>

--- a/core/unit_test/incremental/Test14_MDRangeReduce.hpp
+++ b/core/unit_test/incremental/Test14_MDRangeReduce.hpp
@@ -39,6 +39,13 @@ struct MyComplex {
   MyComplex(const MyComplex& src) : _re(src._re), _im(src._im) {}
 
   KOKKOS_INLINE_FUNCTION
+  MyComplex& operator=(const MyComplex& src) {
+    _re = src._re;
+    _im = src._im;
+    return *this;
+  }
+
+  KOKKOS_INLINE_FUNCTION
   void operator+=(const MyComplex& src) {
     _re += src._re;
     _im += src._im;


### PR DESCRIPTION
Part of #6016 (adding `-Wextra` to the warning flags we use in the CI). 
We can't easily add `-Wdeprecated-copy` to the warning flags since it depends very much on the compiler and the compiler version if it's supported or not.