### PR TITLE
#6027: replace remaining instances of ALL_t with Kokkos::ALL_t

### DIFF
--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -565,7 +565,8 @@ struct SubviewExtents {
   // std::pair range
   template <size_t... DimArgs, class... Args>
   void error(char* buf, int buf_len, unsigned domain_rank, unsigned range_rank,
-             const ViewDimension<DimArgs...>& dim, Kokkos::ALL_t, Args... args) const {
+             const ViewDimension<DimArgs...>& dim, Kokkos::ALL_t,
+             Args... args) const {
     const int n = std::min(buf_len, snprintf(buf, buf_len, " Kokkos::ALL %c",
                                              int(sizeof...(Args) ? ',' : ')')));
 
@@ -3773,8 +3774,8 @@ struct SubViewDataTypeImpl<
 /* for ALL slice, subview has the same dimension */
 template <class ValueType, ptrdiff_t Ext, ptrdiff_t... Exts, class... Args>
 struct SubViewDataTypeImpl<void, ValueType,
-                           Kokkos::Experimental::Extents<Ext, Exts...>, Kokkos::ALL_t,
-                           Args...>
+                           Kokkos::Experimental::Extents<Ext, Exts...>,
+                           Kokkos::ALL_t, Args...>
     : SubViewDataTypeImpl<void, typename ApplyExtent<ValueType, Ext>::type,
                           Kokkos::Experimental::Extents<Exts...>, Args...> {};
 

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -565,7 +565,7 @@ struct SubviewExtents {
   // std::pair range
   template <size_t... DimArgs, class... Args>
   void error(char* buf, int buf_len, unsigned domain_rank, unsigned range_rank,
-             const ViewDimension<DimArgs...>& dim, ALL_t, Args... args) const {
+             const ViewDimension<DimArgs...>& dim, Kokkos::ALL_t, Args... args) const {
     const int n = std::min(buf_len, snprintf(buf, buf_len, " Kokkos::ALL %c",
                                              int(sizeof...(Args) ? ',' : ')')));
 
@@ -3773,7 +3773,7 @@ struct SubViewDataTypeImpl<
 /* for ALL slice, subview has the same dimension */
 template <class ValueType, ptrdiff_t Ext, ptrdiff_t... Exts, class... Args>
 struct SubViewDataTypeImpl<void, ValueType,
-                           Kokkos::Experimental::Extents<Ext, Exts...>, ALL_t,
+                           Kokkos::Experimental::Extents<Ext, Exts...>, Kokkos::ALL_t,
                            Args...>
     : SubViewDataTypeImpl<void, typename ApplyExtent<ValueType, Ext>::type,
                           Kokkos::Experimental::Extents<Exts...>, Args...> {};


### PR DESCRIPTION
Fixes #6027

See https://github.com/kokkos/kokkos/pull/5807 and https://github.com/kokkos/kokkos/pull/5818

Also, I did a grep:

```sh
git grep -n -v "Kokkos::ALL_t" | grep "ALL_t"
```

The only instances found are the actual struct `ALL_t` so I'm fairly sure this is the last of them.

```
core/src/impl/Kokkos_ViewMapping.hpp:290:struct ALL_t {
core/src/impl/Kokkos_ViewMapping.hpp:292:  constexpr const ALL_t& operator()() const { return *this; }
core/src/impl/Kokkos_ViewMapping.hpp:295:  constexpr bool operator==(const ALL_t&) const { return true; }
core/src/impl/Kokkos_ViewMapping.hpp:300:// TODO This alias declaration forces us to fully qualify ALL_t inside the
core/src/impl/Kokkos_ViewMapping.hpp:302:// fully-qualified name when we remove Kokkos::Impl::ALL_t.
core/src/impl/Kokkos_ViewMapping.hpp:468:  // ALL_t
```

Maybe this should also be for the patch release?