### PR TITLE
Relax scratch space limits for HIP reductions

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -296,10 +296,11 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
 
       // REQUIRED ( 1 , N , 1 )
       dim3 block(1, block_size, 1);
-      // use a slightly less constrained, but still well bounded limit for scratch
+      // use a slightly less constrained, but still well bounded limit for
+      // scratch
       uint32_t nblocks = static_cast<uint32_t>((nwork + block.y - 1) / block.y);
-      nblocks = std::min(nblocks, 4096u);
-      m_scratch_space = ::Kokkos::Impl::hip_internal_scratch_space(
+      nblocks          = std::min(nblocks, 4096u);
+      m_scratch_space  = ::Kokkos::Impl::hip_internal_scratch_space(
           m_policy.space(), reducer.value_size() * nblocks);
       m_scratch_flags = ::Kokkos::Impl::hip_internal_scratch_flags(
           m_policy.space(), sizeof(size_type));

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -294,18 +294,17 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
                         "valid execution configuration."));
       }
 
-      m_scratch_space = ::Kokkos::Impl::hip_internal_scratch_space(
-          m_policy.space(), reducer.value_size() *
-                                block_size /* block_size == max block_count */);
-      m_scratch_flags = ::Kokkos::Impl::hip_internal_scratch_flags(
-          m_policy.space(), sizeof(size_type));
-
       // REQUIRED ( 1 , N , 1 )
       dim3 block(1, block_size, 1);
+      // use a slightly less constrained, but still well bounded limit for scratch
+      uint32_t nblocks = static_cast<uint32_t>((nwork + block.y - 1) / block.y);
+      nblocks = std::min(nblocks, 4096u);
+      m_scratch_space = ::Kokkos::Impl::hip_internal_scratch_space(
+          m_policy.space(), reducer.value_size() * nblocks);
+      m_scratch_flags = ::Kokkos::Impl::hip_internal_scratch_flags(
+          m_policy.space(), sizeof(size_type));
       // Required grid.x <= block.y
-      dim3 grid(std::min(block.y, static_cast<uint32_t>((nwork + block.y - 1) /
-                                                        block.y)),
-                1, 1);
+      dim3 grid(nblocks, 1, 1);
 
       if (nwork == 0) {
         block = dim3(1, 1, 1);


### PR DESCRIPTION
This change is motivated by profiling of some LJ reduction kernels in LAMMPS.  Essentially we noticed that in some cases, we ended up severely occupancy limited by the "gridDim <= blockDim" restriction.  Omniperf showed very low L1/L2 utilization, but the limiter was simply that we were not launching enough blocks.

This is a simple change to relax the scratch space limit slightly (from blockDim to 4096) to increase occupancy, but still keep the scratch limits well bounded.  I was not particularly scientific about choosing the new limit, and I'm definitely open to better heuristics, but this increased [RHODO](https://github.com/lammps/lammps/blob/develop/bench/in.rhodo.scaled) (4^3) perf in LAMMPS by ~28% (the key kernel is a ParReduce)