### PR TITLE
Fix -Wmissing-field-initializers warning

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -177,7 +177,8 @@ Kokkos::Tools::Impl::InitializationStatus parse_environment_variables(
     args = env_tools_args;
   }
   return {
-      Kokkos::Tools::Impl::InitializationStatus::InitializationResult::success};
+      Kokkos::Tools::Impl::InitializationStatus::InitializationResult::success,
+      ""};
 }
 InitializationStatus initialize_tools_subsystem(
     const Kokkos::Tools::InitArguments& args) {
@@ -192,13 +193,13 @@ InitializationStatus initialize_tools_subsystem(
     if (!Kokkos::Tools::printHelp(final_args)) {
       std::cerr << "Tool has not provided a help message" << std::endl;
     }
-    return {InitializationStatus::InitializationResult::help_request};
+    return {InitializationStatus::InitializationResult::help_request, ""};
   }
   Kokkos::Tools::parseArgs(final_args);
 #else
   (void)args;
 #endif
-  return {InitializationStatus::InitializationResult::success};
+  return {InitializationStatus::InitializationResult::success, ""};
 }
 
 }  // namespace Impl


### PR DESCRIPTION
Part of #6016. The uninitialized member is "error_message", see https://github.com/kokkos/kokkos/blob/5e574380cbca98ec45d92f62fe861d38aab0d825/core/src/impl/Kokkos_Profiling.hpp#L49-L58