### PR TITLE
KOKKOS_COMPILER_PGI -> KOKKOS_COMPILER_NVHPC

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -283,7 +283,7 @@
 
 //----------------------------------------------------------------------------
 
-#if defined(KOKKOS_COMPILER_PGI)
+#if defined(KOKKOS_COMPILER_NVHPC)
 #define KOKKOS_ENABLE_PRAGMA_UNROLL 1
 #define KOKKOS_ENABLE_PRAGMA_IVDEP 1
 //#define KOKKOS_ENABLE_PRAGMA_LOOPCOUNT 1
@@ -587,8 +587,8 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 
 #define KOKKOS_ATTRIBUTE_NODISCARD [[nodiscard]]
 
-#if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG) ||  \
-     defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_PGI)) && \
+#if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG) ||    \
+     defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_NVHPC)) && \
     !defined(_WIN32) && !defined(__ANDROID__)
 #if __has_include(<execinfo.h>)
 #define KOKKOS_IMPL_ENABLE_STACKTRACE

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -505,9 +505,9 @@ void pre_initialize_internal(const Kokkos::InitializationSettings& settings) {
                                  std::to_string(KOKKOS_COMPILER_NVCC));
   declare_configuration_metadata("tools_only", "compiler_family", "nvcc");
 #endif
-#ifdef KOKKOS_COMPILER_PGI
-  declare_configuration_metadata("compiler_version", "KOKKOS_COMPILER_PGI",
-                                 std::to_string(KOKKOS_COMPILER_PGI));
+#ifdef KOKKOS_COMPILER_NVHPC
+  declare_configuration_metadata("compiler_version", "KOKKOS_COMPILER_NVHPC",
+                                 std::to_string(KOKKOS_COMPILER_NVHPC));
   declare_configuration_metadata("tools_only", "compiler_family", "pgi");
 #endif
 #ifdef KOKKOS_COMPILER_MSVC
@@ -1256,7 +1256,7 @@ bool Kokkos::tune_internals() noexcept { return g_tune_internals; }
 
 namespace Kokkos {
 
-#ifdef KOKKOS_COMPILER_PGI
+#ifdef KOKKOS_COMPILER_NVHPC
 namespace Impl {
 // Bizzarely, an extra jump instruction forces the PGI compiler to not have a
 // bug related to (probably?) empty base optimization and/or aggregate

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -1253,15 +1253,3 @@ void Kokkos::print_configuration(std::ostream& os, bool verbose) {
 bool Kokkos::show_warnings() noexcept { return g_show_warnings; }
 
 bool Kokkos::tune_internals() noexcept { return g_tune_internals; }
-
-namespace Kokkos {
-
-#ifdef KOKKOS_COMPILER_NVHPC
-namespace Impl {
-// Bizzarely, an extra jump instruction forces the PGI compiler to not have a
-// bug related to (probably?) empty base optimization and/or aggregate
-// construction.
-void _kokkos_pgi_compiler_bug_workaround() {}
-}  // end namespace Impl
-#endif
-}  // namespace Kokkos

--- a/core/src/impl/Kokkos_TaskNode.hpp
+++ b/core/src/impl/Kokkos_TaskNode.hpp
@@ -42,7 +42,7 @@
 namespace Kokkos {
 namespace Impl {
 
-#ifdef KOKKOS_COMPILER_PGI
+#ifdef KOKKOS_COMPILER_NVHPC
 // Bizzarely, an extra jump instruction forces the PGI compiler to not have a
 // bug related to (probably?) empty base optimization and/or aggregate
 // construction.  This must be defined out-of-line to generate a jump
@@ -101,7 +101,7 @@ class ReferenceCountedBase {
 
  public:
   KOKKOS_INLINE_FUNCTION
-#ifndef KOKKOS_COMPILER_PGI
+#ifndef KOKKOS_COMPILER_NVHPC
   constexpr
 #endif
       explicit ReferenceCountedBase(
@@ -109,7 +109,7 @@ class ReferenceCountedBase {
       : m_ref_count(initial_reference_count) {
     // This can't be here because it breaks constexpr
     // KOKKOS_EXPECTS(initial_reference_count > 0);
-#ifdef KOKKOS_COMPILER_PGI
+#ifdef KOKKOS_COMPILER_NVHPC
     Impl::_kokkos_pgi_compiler_bug_workaround();
 #endif
   }

--- a/core/src/impl/Kokkos_TaskNode.hpp
+++ b/core/src/impl/Kokkos_TaskNode.hpp
@@ -42,14 +42,6 @@
 namespace Kokkos {
 namespace Impl {
 
-#ifdef KOKKOS_COMPILER_NVHPC
-// Bizzarely, an extra jump instruction forces the PGI compiler to not have a
-// bug related to (probably?) empty base optimization and/or aggregate
-// construction.  This must be defined out-of-line to generate a jump
-// jump instruction
-void _kokkos_pgi_compiler_bug_workaround();
-#endif
-
 enum TaskType : int16_t {
   TaskTeam    = 0,
   TaskSingle  = 1,
@@ -101,17 +93,11 @@ class ReferenceCountedBase {
 
  public:
   KOKKOS_INLINE_FUNCTION
-#ifndef KOKKOS_COMPILER_NVHPC
-  constexpr
-#endif
-      explicit ReferenceCountedBase(
-          reference_count_size_type initial_reference_count)
+  constexpr explicit ReferenceCountedBase(
+      reference_count_size_type initial_reference_count)
       : m_ref_count(initial_reference_count) {
     // This can't be here because it breaks constexpr
     // KOKKOS_EXPECTS(initial_reference_count > 0);
-#ifdef KOKKOS_COMPILER_NVHPC
-    Impl::_kokkos_pgi_compiler_bug_workaround();
-#endif
   }
 
   /** Decrement the reference count,


### PR DESCRIPTION
While working on #5906, I realized that we never define KOKKOS_COMPILER_PGI but still use the macro in some places where it seems appropriate to use KOKKOS_COMPILER_NVHPC instead. Also, it seems that we don't need `_kokkos_pgi_compiler_bug_workaround` for NVHPC.