### PR TITLE
Store a team handle reference in ThreadVectorRangeBoundariesStructs

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -369,17 +369,19 @@ struct TeamVectorRangeBoundariesStruct<iType, CudaTeamMember> {
 template <typename iType>
 struct ThreadVectorRangeBoundariesStruct<iType, CudaTeamMember> {
   using index_type = iType;
+  const CudaTeamMember& member;
   const index_type start;
   const index_type end;
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const CudaTeamMember, index_type count)
-      : start(static_cast<index_type>(0)), end(count) {}
+  ThreadVectorRangeBoundariesStruct(const CudaTeamMember& thread_,
+                                    index_type count)
+      : member(thread_), start(static_cast<index_type>(0)), end(count) {}
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const CudaTeamMember, index_type arg_begin,
-                                    index_type arg_end)
-      : start(arg_begin), end(arg_end) {}
+  ThreadVectorRangeBoundariesStruct(const CudaTeamMember& thread_,
+                                    index_type arg_begin, index_type arg_end)
+      : member(thread_), start(arg_begin), end(arg_end) {}
 };
 
 }  // namespace Impl

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -360,17 +360,19 @@ struct TeamVectorRangeBoundariesStruct<iType, HIPTeamMember> {
 template <typename iType>
 struct ThreadVectorRangeBoundariesStruct<iType, HIPTeamMember> {
   using index_type = iType;
+  const HIPTeamMember& member;
   const index_type start;
   const index_type end;
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const HIPTeamMember, index_type count)
-      : start(static_cast<index_type>(0)), end(count) {}
+  ThreadVectorRangeBoundariesStruct(const HIPTeamMember& thread_,
+                                    index_type count)
+      : member(thread_), start(static_cast<index_type>(0)), end(count) {}
 
   KOKKOS_INLINE_FUNCTION
-  ThreadVectorRangeBoundariesStruct(const HIPTeamMember, index_type arg_begin,
-                                    index_type arg_end)
-      : start(arg_begin), end(arg_end) {}
+  ThreadVectorRangeBoundariesStruct(const HIPTeamMember& thread_,
+                                    index_type arg_begin, index_type arg_end)
+      : member(thread_), start(arg_begin), end(arg_end) {}
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -732,17 +732,20 @@ struct ThreadVectorRangeBoundariesStruct {
   const index_type start;
   const index_type end;
   enum { increment = 1 };
+  const TeamMemberType& thread;
 
   KOKKOS_INLINE_FUNCTION
-  constexpr ThreadVectorRangeBoundariesStruct(const TeamMemberType,
+  constexpr ThreadVectorRangeBoundariesStruct(const TeamMemberType& arg_thread,
                                               const index_type& count) noexcept
-      : start(static_cast<index_type>(0)), end(count) {}
+      : start(static_cast<index_type>(0)), end(count), thread(arg_thread) {}
 
   KOKKOS_INLINE_FUNCTION
   constexpr ThreadVectorRangeBoundariesStruct(
-      const TeamMemberType, const index_type& arg_begin,
+      const TeamMemberType& arg_thread, const index_type& arg_begin,
       const index_type& arg_end) noexcept
-      : start(static_cast<index_type>(arg_begin)), end(arg_end) {}
+      : start(static_cast<index_type>(arg_begin)),
+        end(arg_end),
+        thread(arg_thread) {}
 };
 
 template <class TeamMemberType>


### PR DESCRIPTION
Storing a reference to `TeamMemberType` handle in `ThreadVectorRangeBoundariesStruct` in serial, cuda and hip for consistencies with other backends' `ThreadVectorRangeBoundariesStruct` implementation.

This allows retrieval of the team member handle from `ThreadVectorRangeBoundariesStruct`.