### PR TITLE
Don't create a shared state for size() in UnorderedMap's deep_copy

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -769,7 +769,7 @@ class UnorderedMap {
       tmp.m_bounded_insert    = src.m_bounded_insert;
       tmp.m_hasher            = src.m_hasher;
       tmp.m_equal_to          = src.m_equal_to;
-      tmp.m_size              = src.m_size;
+      *tmp.m_size             = *src.m_size;
       tmp.m_available_indexes = bitset_type(src.capacity());
       tmp.m_hash_lists        = size_type_view(
           view_alloc(WithoutInitializing, "UnorderedMap hash list"),

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -85,6 +85,11 @@ struct TestInsert {
         }
       }
     }
+
+    const unsigned int old_size = map_h.size();
+    map_h.clear();
+    ASSERT_EQ(map.size(), old_size);
+    ASSERT_EQ(map_h.size(), 0u);
   }
 
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/5983 copied the whole `m_size` `std::shared_ptr` instead of just its value. There should be no shared state created when calling `deep_copy`.