### PR TITLE
Reduce the size of ScatterView in the CI when using OpenMP

### DIFF
--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -773,9 +773,18 @@ TEST(TEST_CATEGORY, scatterview) {
   int big_n = 100 * 1000;
 #else
 
-#ifdef KOKKOS_ENABLE_SERIAL
+#if defined(KOKKOS_ENABLE_SERIAL) || defined(KOKKOS_ENABLE_OPENMP)
+#if defined(KOKKOS_ENABLE_SERIAL)
   bool is_serial = std::is_same<TEST_EXECSPACE, Kokkos::Serial>::value;
-  int big_n      = is_serial ? 100 * 1000 : 10000 * 1000;
+#else
+  bool is_serial = false;
+#endif
+#if defined(KOKKOS_ENABLE_OPENMP)
+  bool is_openmp = std::is_same<TEST_EXECSPACE, Kokkos::OpenMP>::value;
+#else
+  bool is_openmp = false;
+#endif
+  int big_n      = is_serial || is_openmp ? 100 * 1000 : 10000 * 1000;
 #else
   int big_n = 10000 * 1000;
 #endif


### PR DESCRIPTION
This fixes the CI issues we are having with gcc 8.4.  Oak Ridge started to enforce limits on the memory used by our CI instances.  This PR reduces the memory  footprint of the ScatterView test.