### PR TITLE
SYCL: Improve and simplify parallel_scan implementation

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -280,11 +280,9 @@ sycl::device_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
 
     m_scratchFlags = reinterpret_cast<size_type*>(r->data());
   }
-  m_queue->memset(m_scratchFlags, 0, m_scratchFlagsCount * sizeScratchGrain);
-  fence(*m_queue,
-        "Kokkos::Experimental::SYCLInternal::scratch_flags fence after "
-        "initializing m_scratchFlags",
-        m_instance_id);
+  auto memset_event = m_queue->memset(m_scratchFlags, 0,
+                                      m_scratchFlagsCount * sizeScratchGrain);
+  m_queue->ext_oneapi_submit_barrier(std::vector{memset_event});
 
   return m_scratchFlags;
 }


### PR DESCRIPTION
This pull request changes the previous recursive `parallel_scan` in the `SYCL` backend to a two-pass one as we use for `Cuda` and `HIP` and `SYCL` reductions. This simplifies the code (also making it more uniform) and reduces the memory footprint (since we only need to store intermediate results for all items and group scans but not recursive group scans).
On the way, I made sure that all local operations operate on indices of type `int` avoiding 64-bit index operations. 

A second improvement is switching to an auto-detection of the work group size as we do for reductions by querying a dummy kernel for the maximum group size.

Finally, this fixes a couple of unit tests that were failing with `SYCL+Cuda` since https://github.com/kokkos/kokkos/pull/5707.