### PR TITLE
Fix join for ValueWrapperForNoNeutralElement

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_ExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ExclusiveScan.hpp
@@ -96,6 +96,8 @@ struct ExclusiveScanDefaultFunctor {
 
   KOKKOS_FUNCTION
   void join(value_type& update, const value_type& input) const {
+    if (input.is_initial) return;
+
     if (update.is_initial) {
       update.val        = input.val;
       update.is_initial = false;

--- a/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
@@ -90,6 +90,8 @@ struct InclusiveScanDefaultFunctor {
 
   KOKKOS_FUNCTION
   void join(value_type& update, const value_type& input) const {
+    if (input.is_initial) return;
+
     if (update.is_initial) {
       update.val = input.val;
     } else {

--- a/algorithms/src/std_algorithms/impl/Kokkos_TransformExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_TransformExclusiveScan.hpp
@@ -76,6 +76,8 @@ struct TransformExclusiveScanFunctor {
 
   KOKKOS_FUNCTION
   void join(value_type& update, const value_type& input) const {
+    if (input.is_initial) return;
+
     if (update.is_initial) {
       update.val = input.val;
     } else {

--- a/algorithms/src/std_algorithms/impl/Kokkos_TransformInclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_TransformInclusiveScan.hpp
@@ -67,6 +67,8 @@ struct TransformInclusiveScanNoInitValueFunctor {
 
   KOKKOS_FUNCTION
   void join(value_type& update, const value_type& input) const {
+    if (input.is_initial) return;
+
     if (update.is_initial) {
       update.val = input.val;
     } else {
@@ -118,6 +120,8 @@ struct TransformInclusiveScanWithInitValueFunctor {
 
   KOKKOS_FUNCTION
   void join(value_type& update, const value_type& input) const {
+    if (input.is_initial) return;
+
     if (update.is_initial) {
       update.val = input.val;
     } else {

--- a/algorithms/unit_tests/TestStdAlgorithmsInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsInclusiveScan.cpp
@@ -353,6 +353,45 @@ TEST(std_algorithms_numeric_ops_test, inclusive_scan) {
   run_inclusive_scan_all_scenarios<StridedThreeTag, CustomValueType>();
 }
 
+TEST(std_algorithms_numeric_ops_test, inclusive_scan_functor) {
+  using view_type = Kokkos::View<int*, exespace>;
+  view_type dummy_view("dummy_view", 0);
+  using functor_type = Kokkos::Experimental::Impl::InclusiveScanDefaultFunctor<
+      exespace, int, int, view_type, view_type>;
+  functor_type functor(dummy_view, dummy_view);
+  using value_type = functor_type::value_type;
+
+  value_type value1;
+  functor.init(value1);
+  EXPECT_EQ(value1.val, 0);
+  EXPECT_EQ(value1.is_initial, true);
+
+  value_type value2;
+  value2.val        = 1;
+  value2.is_initial = false;
+  functor.join(value1, value2);
+  EXPECT_EQ(value1.val, 1);
+  EXPECT_EQ(value1.is_initial, false);
+
+  functor.init(value1);
+  functor.join(value2, value1);
+  EXPECT_EQ(value2.val, 1);
+  EXPECT_EQ(value2.is_initial, false);
+
+  functor.init(value2);
+  functor.join(value2, value1);
+  EXPECT_EQ(value2.val, 0);
+  EXPECT_EQ(value2.is_initial, true);
+
+  value1.val        = 1;
+  value1.is_initial = false;
+  value2.val        = 2;
+  value2.is_initial = false;
+  functor.join(value2, value1);
+  EXPECT_EQ(value2.val, 3);
+  EXPECT_EQ(value2.is_initial, false);
+}
+
 }  // namespace IncScan
 }  // namespace stdalgos
 }  // namespace Test

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformInclusiveScan.cpp
@@ -306,6 +306,73 @@ TEST(std_algorithms_numeric_ops_test, transform_inclusive_scan) {
 }
 #endif
 
+template <class ValueType>
+struct MultiplyFunctor {
+  KOKKOS_INLINE_FUNCTION
+  ValueType operator()(const ValueType& a, const ValueType& b) const {
+    return (a * b);
+  }
+};
+
+TEST(std_algorithms_numeric_ops_test, transform_inclusive_scan_functor) {
+  using value_type = KE::Impl::ValueWrapperForNoNeutralElement<int>;
+
+  auto test_lambda = [&](auto& functor) {
+    value_type value1;
+    functor.init(value1);
+    EXPECT_EQ(value1.val, 0);
+    EXPECT_EQ(value1.is_initial, true);
+
+    value_type value2;
+    value2.val        = 1;
+    value2.is_initial = false;
+    functor.join(value1, value2);
+    EXPECT_EQ(value1.val, 1);
+    EXPECT_EQ(value1.is_initial, false);
+
+    functor.init(value1);
+    functor.join(value2, value1);
+    EXPECT_EQ(value2.val, 1);
+    EXPECT_EQ(value2.is_initial, false);
+
+    functor.init(value2);
+    functor.join(value2, value1);
+    EXPECT_EQ(value2.val, 0);
+    EXPECT_EQ(value2.is_initial, true);
+
+    value1.val        = 3;
+    value1.is_initial = false;
+    value2.val        = 2;
+    value2.is_initial = false;
+    functor.join(value2, value1);
+    EXPECT_EQ(value2.val, 6);
+    EXPECT_EQ(value2.is_initial, false);
+  };
+
+  int dummy       = 0;
+  using view_type = Kokkos::View<int*, exespace>;
+  view_type dummy_view("dummy_view", 0);
+  using unary_op_type =
+      KE::Impl::StdNumericScanIdentityReferenceUnaryFunctor<int>;
+  {
+    using functor_type = KE::Impl::TransformInclusiveScanNoInitValueFunctor<
+        exespace, int, int, view_type, view_type, MultiplyFunctor<int>,
+        unary_op_type>;
+    functor_type functor(dummy_view, dummy_view, {}, {});
+
+    test_lambda(functor);
+  }
+
+  {
+    using functor_type = KE::Impl::TransformInclusiveScanWithInitValueFunctor<
+        exespace, int, int, view_type, view_type, MultiplyFunctor<int>,
+        unary_op_type>;
+    functor_type functor(dummy_view, dummy_view, {}, {}, dummy);
+
+    test_lambda(functor);
+  }
+}
+
 }  // namespace TransformIncScan
 }  // namespace stdalgos
 }  // namespace Test


### PR DESCRIPTION
While working in #6064, I noticed that the `join` implementations don't treat ` ValueWrapperForNoNeutralElement` as neutral element.
With a simplified `parallel_scan` implementation I noticed that
```
reducer.init(value2);
reducer.join(value1, value2);
```
would give wrong results (`value1` shouldn't change but does) as opposed to
```
reducer.init(value2);
reducer.join(value2, value1);
```
where we get `value2==value1` as expected (assuming `value1` doesn't have initial value).