### PR TITLE
SIMD: Add abs() for all int types

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -791,11 +791,13 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
+// Manually computing absolute values, because _mm256_abs_epi64
+// is not in AVX2; it's available in AVX512.
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx2_fixed_size<4>> abs(
     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-      [&](std::size_t i) { return (a[i] < 0) ? a[i] * -1 : a[i]; });
+      [&](std::size_t i) { return (a[i] < 0) ? -a[i] : a[i]; });
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -791,9 +791,9 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    abs(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx2_fixed_size<4>> abs(
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
       [&](std::size_t i) { return (a[i] < 0) ? a[i] * -1 : a[i]; });
 }

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -791,14 +791,12 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
-// FIXME: _mm256_abs_epi64() is not supported in AVX2
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-//     simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-//     abs(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
-//   __m256i const rhs = static_cast<__m256i>(a);
-//   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-//       _mm256_abs_epi64(rhs));
-// }
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    abs(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+      [&](std::size_t i) { return a[i] * ((a[i] > 0) - (a[i] < 0)); });
+}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -661,6 +661,13 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
 }
 
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx2_fixed_size<4>> abs(
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a) {
+  __m128i const rhs = static_cast<__m128i>(a);
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(_mm_abs_epi32(rhs));
+}
+
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
     condition(simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
@@ -783,6 +790,15 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
       _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
+
+// FIXME: _mm256_abs_epi64() is not supported in AVX2
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+//     simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+//     abs(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
+//   __m256i const rhs = static_cast<__m256i>(a);
+//   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+//       _mm256_abs_epi64(rhs));
+// }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
@@ -907,6 +923,12 @@ simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
               simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
   return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
       _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> abs(
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a) {
+  return a;
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -795,7 +795,7 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
     abs(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-      [&](std::size_t i) { return a[i] * ((a[i] > 0) - (a[i] < 0)); });
+      [&](std::size_t i) { return (a[i] < 0) ? a[i] * -1 : a[i]; });
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -233,6 +233,14 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx512_fixed_size<8>> abs(
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a) {
+  __m256i const rhs = static_cast<__m256i>(a);
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_abs_epi32(rhs));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
     simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
@@ -339,6 +347,12 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
               simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> abs(
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a) {
+  return a;
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -468,6 +482,14 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
     operator-(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a) {
   return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(0) - a;
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx512_fixed_size<8>> abs(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a) {
+  __m512i const rhs = static_cast<__m512i>(a);
+  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_abs_epi64(rhs));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -603,6 +625,12 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
               simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> abs(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a) {
+  return a;
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -751,9 +779,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<double, simd_abi::avx512_fixed_size<8>> abs(
     simd<double, simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const rhs = static_cast<__m512d>(a);
-  return simd<double, simd_abi::avx512_fixed_size<8>>(reinterpret_cast<__m512d>(
-      _mm512_and_epi64(_mm512_set1_epi64(0x7FFFFFFFFFFFFFFF),
-                       reinterpret_cast<__m512i>(rhs))));
+  return simd<double, simd_abi::avx512_fixed_size<8>>(_mm512_abs_pd(rhs));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -118,17 +118,6 @@ template <class T>
   return const_where_expression(mask, value);
 }
 
-// fallback simd abs using generator constructor
-// At the time of this writing, this fallback is only used
-// to compute abs() for vectors of 64-bit signed integers for the AVX2 backend
-
-template <class T, class Abi>
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> abs(
-    simd<T, Abi> const& lhs) {
-  return simd<T, Abi>(
-      [&](std::size_t i) { return std::abs(static_cast<T>(lhs[i])); });
-}
-
 // fallback simd multiplication using generator constructor
 // At the time of this writing, this fallback is only used
 // to multiply vectors of 64-bit signed integers for the AVX2 backend

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -118,6 +118,17 @@ template <class T>
   return const_where_expression(mask, value);
 }
 
+// fallback simd abs using generator constructor
+// At the time of this writing, this fallback is only used
+// to compute abs() for vectors of 64-bit signed integers for the AVX2 backend
+
+template <class T, class Abi>
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> abs(
+    simd<T, Abi> const& lhs) {
+  return simd<T, Abi>(
+      [&](std::size_t i) { return std::abs(static_cast<T>(lhs[i])); });
+}
+
 // fallback simd multiplication using generator constructor
 // At the time of this writing, this fallback is only used
 // to multiply vectors of 64-bit signed integers for the AVX2 backend

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -876,7 +876,7 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> abs(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
-  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(a);
+  return a;
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -581,6 +581,13 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       vadd_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
 }
 
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::neon_fixed_size<2>> abs(
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& a) {
+  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
+      vabs_s32(static_cast<int32x2_t>(a)));
+}
+
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::int32_t, simd_abi::neon_fixed_size<2>>
     condition(simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& a,
@@ -717,6 +724,13 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
               simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
       vaddq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::neon_fixed_size<2>> abs(
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& a) {
+  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+      vabsq_s64(static_cast<int64x2_t>(a)));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -858,6 +872,12 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
     : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::neon_fixed_size<2>> abs(
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
+  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(a);
+}
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -196,7 +196,7 @@ template <class T>
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> abs(
     simd<T, simd_abi::scalar> const& a) {
-  return simd<T, simd_abi::scalar>(Kokkos::abs<T>(a[0]));
+  return simd<T, simd_abi::scalar>(Kokkos::abs(a[0]));
 }
 
 template <class T>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -196,7 +196,10 @@ template <class T>
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> abs(
     simd<T, simd_abi::scalar> const& a) {
-  return simd<T, simd_abi::scalar>(std::abs(static_cast<T>(a)));
+  if constexpr (std::is_signed_v<T>)
+    return simd<T, simd_abi::scalar>(std::abs(static_cast<T>(a)));
+  else
+    return simd<T, simd_abi::scalar>(static_cast<T>(a));
 }
 
 template <class T>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -196,7 +196,7 @@ template <class T>
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> abs(
     simd<T, simd_abi::scalar> const& a) {
-  return simd<T, simd_abi::scalar>(((a < 0) ? a * -1 : a));
+  return simd<T, simd_abi::scalar>(((a < 0) ? -a : a));
 }
 
 template <class T>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -196,7 +196,7 @@ template <class T>
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> abs(
     simd<T, simd_abi::scalar> const& a) {
-  return simd<T, simd_abi::scalar>(((a < 0) ? -a : a));
+  return simd<T, simd_abi::scalar>(Kokkos::abs<T>(a[0]));
 }
 
 template <class T>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -196,10 +196,7 @@ template <class T>
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> abs(
     simd<T, simd_abi::scalar> const& a) {
-  if constexpr (std::is_signed_v<T>)
-    return simd<T, simd_abi::scalar>(std::abs(static_cast<T>(a)));
-  else
-    return simd<T, simd_abi::scalar>(static_cast<T>(a));
+  return simd<T, simd_abi::scalar>(Kokkos::abs<T>(static_cast<T>(a)));
 }
 
 template <class T>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -196,7 +196,7 @@ template <class T>
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> abs(
     simd<T, simd_abi::scalar> const& a) {
-  return simd<T, simd_abi::scalar>(Kokkos::abs<T>(static_cast<T>(a)));
+  return simd<T, simd_abi::scalar>(((a < 0) ? a * -1 : a));
 }
 
 template <class T>

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -196,7 +196,10 @@ template <class T>
 template <class T>
 [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION simd<T, simd_abi::scalar> abs(
     simd<T, simd_abi::scalar> const& a) {
-  return simd<T, simd_abi::scalar>(Kokkos::abs(a[0]));
+  if constexpr (std::is_signed_v<T>) {
+    return (a < 0 ? -a : a);
+  }
+  return a;
 }
 
 template <class T>


### PR DESCRIPTION
Related to #5674 

This PR adds abs() function for all integer simd in each backend:
- simd Kokkos::abs(const simd& lhs)

AVX2:
- Added abs() for `int32_t`, `int64_t` and `int64_t`

AVX512:
- Added shifts for `int32_t`, `uint32_t`, `int64_t` and `uint64_t`

NEON:
- Added shifts for `int32_t`, `int64_t` and `uint64_t`