### PR TITLE
Converted a shared_ptr to a host view in UnorderedMap

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -287,7 +287,6 @@ class UnorderedMap {
   enum { modified_idx = 0, erasable_idx = 1, failed_insert_idx = 2 };
   enum { num_scalars = 3 };
   using scalars_view     = View<int[num_scalars], LayoutLeft, device_type>;
-  using scalar_host_view = View<size_type, HostSpace>;
 
  public:
   //! \name Public member functions
@@ -863,7 +862,7 @@ class UnorderedMap {
   bool m_bounded_insert;
   hasher_type m_hasher;
   equal_to_type m_equal_to;
-  scalar_host_view m_size;
+  View<size_type, HostSpace> m_size;
   bitset_type m_available_indexes;
   size_type_view m_hash_lists;
   size_type_view m_next_index;

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -348,7 +348,7 @@ class UnorderedMap {
       Kokkos::deep_copy(m_keys, tmp);
     }
     Kokkos::deep_copy(m_scalars, 0);
-    m_size(0) = 0;
+    m_size() = 0;
   }
 
   KOKKOS_INLINE_FUNCTION constexpr bool is_allocated() const {
@@ -405,7 +405,7 @@ class UnorderedMap {
       m_size() = m_available_indexes.count();
       reset_flag(modified_idx);
     }
-    return m_size(0);
+    return m_size();
   }
 
   /// \brief The current number of failed insert() calls.
@@ -770,7 +770,7 @@ class UnorderedMap {
       tmp.m_bounded_insert    = src.m_bounded_insert;
       tmp.m_hasher            = src.m_hasher;
       tmp.m_equal_to          = src.m_equal_to;
-      tmp.m_size()           = src.m_size();
+      tmp.m_size()            = src.m_size();
       tmp.m_available_indexes = bitset_type(src.capacity());
       tmp.m_hash_lists        = size_type_view(
           view_alloc(WithoutInitializing, "UnorderedMap hash list"),

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -287,7 +287,7 @@ class UnorderedMap {
   enum { modified_idx = 0, erasable_idx = 1, failed_insert_idx = 2 };
   enum { num_scalars = 3 };
   using scalars_view     = View<int[num_scalars], LayoutLeft, device_type>;
-  using scalar_host_view = View<size_type[1], HostSpace>;
+  using scalar_host_view = View<size_type, HostSpace>;
 
  public:
   //! \name Public member functions
@@ -402,7 +402,7 @@ class UnorderedMap {
   size_type size() const {
     if (capacity() == 0u) return 0u;
     if (modified()) {
-      m_size(0) = m_available_indexes.count();
+      m_size() = m_available_indexes.count();
       reset_flag(modified_idx);
     }
     return m_size(0);
@@ -770,7 +770,7 @@ class UnorderedMap {
       tmp.m_bounded_insert    = src.m_bounded_insert;
       tmp.m_hasher            = src.m_hasher;
       tmp.m_equal_to          = src.m_equal_to;
-      tmp.m_size(0)           = src.m_size(0);
+      tmp.m_size()           = src.m_size();
       tmp.m_available_indexes = bitset_type(src.capacity());
       tmp.m_hash_lists        = size_type_view(
           view_alloc(WithoutInitializing, "UnorderedMap hash list"),

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -286,7 +286,7 @@ class UnorderedMap {
 
   enum { modified_idx = 0, erasable_idx = 1, failed_insert_idx = 2 };
   enum { num_scalars = 3 };
-  using scalars_view     = View<int[num_scalars], LayoutLeft, device_type>;
+  using scalars_view = View<int[num_scalars], LayoutLeft, device_type>;
 
  public:
   //! \name Public member functions

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -286,7 +286,8 @@ class UnorderedMap {
 
   enum { modified_idx = 0, erasable_idx = 1, failed_insert_idx = 2 };
   enum { num_scalars = 3 };
-  using scalars_view = View<int[num_scalars], LayoutLeft, device_type>;
+  using scalars_view     = View<int[num_scalars], LayoutLeft, device_type>;
+  using scalar_host_view = View<size_type[1], HostSpace>;
 
  public:
   //! \name Public member functions
@@ -307,7 +308,7 @@ class UnorderedMap {
       : m_bounded_insert(true),
         m_hasher(hasher),
         m_equal_to(equal_to),
-        m_size(std::make_shared<size_type>()),
+        m_size("UnorderedMap size"),
         m_available_indexes(calculate_capacity(capacity_hint)),
         m_hash_lists(view_alloc(WithoutInitializing, "UnorderedMap hash list"),
                      Impl::find_hash_size(capacity())),
@@ -347,7 +348,7 @@ class UnorderedMap {
       Kokkos::deep_copy(m_keys, tmp);
     }
     Kokkos::deep_copy(m_scalars, 0);
-    *m_size = 0;
+    m_size(0) = 0;
   }
 
   KOKKOS_INLINE_FUNCTION constexpr bool is_allocated() const {
@@ -401,10 +402,10 @@ class UnorderedMap {
   size_type size() const {
     if (capacity() == 0u) return 0u;
     if (modified()) {
-      *m_size = m_available_indexes.count();
+      m_size(0) = m_available_indexes.count();
       reset_flag(modified_idx);
     }
-    return *m_size;
+    return m_size(0);
   }
 
   /// \brief The current number of failed insert() calls.
@@ -769,7 +770,7 @@ class UnorderedMap {
       tmp.m_bounded_insert    = src.m_bounded_insert;
       tmp.m_hasher            = src.m_hasher;
       tmp.m_equal_to          = src.m_equal_to;
-      *tmp.m_size             = *src.m_size;
+      tmp.m_size(0)           = src.m_size(0);
       tmp.m_available_indexes = bitset_type(src.capacity());
       tmp.m_hash_lists        = size_type_view(
           view_alloc(WithoutInitializing, "UnorderedMap hash list"),
@@ -862,7 +863,7 @@ class UnorderedMap {
   bool m_bounded_insert;
   hasher_type m_hasher;
   equal_to_type m_equal_to;
-  std::shared_ptr<size_type> m_size;
+  scalar_host_view m_size;
   bitset_type m_available_indexes;
   size_type_view m_hash_lists;
   size_type_view m_next_index;

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -482,16 +482,7 @@ TEST(TEST_CATEGORY, UnorderedMap_consistent_size) {
 
 namespace Impl {
 
-using map_type = Kokkos::UnorderedMap<int, void, Kokkos::DefaultExecutionSpace>;
-
-void test_unordered_map_device_capture() {
-  map_type map;
-
-  Kokkos::parallel_for(
-      1, KOKKOS_LAMBDA(int const &i) { map.insert(i); });
-
-  ASSERT_EQ(1u, map.size());
-}
+using map_type = Kokkos::UnorderedMap<int, void, TEST_EXECSPACE>;
 
 KOKKOS_FUNCTION
 void test_insert_to_map_copy(map_type const &input_map, const int i) {
@@ -508,16 +499,28 @@ struct TestMapCopy {
 
 }  // namespace Impl
 
-TEST(TEST_CATEGORY, UnorderedMap_lambda_capturable) {
-  Impl::test_unordered_map_device_capture();
-}
-
 TEST(TEST_CATEGORY, UnorderedMap_shallow_copyable_on_device) {
   Impl::TestMapCopy test_map_copy;
 
   Kokkos::parallel_for(1, test_map_copy);
   ASSERT_EQ(1u, test_map_copy.m_map.size());
 }
+
+#if !defined(KOKKOS_ENABLE_CUDA) || \
+    (defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ENABLE_CUDA_LAMBDA))
+void test_unordered_map_device_capture() {
+  Impl::map_type map;
+
+  Kokkos::parallel_for(
+      1, KOKKOS_LAMBDA(int const &i) { map.insert(i); });
+
+  ASSERT_EQ(1u, map.size());
+}
+
+TEST(TEST_CATEGORY, UnorderedMap_lambda_capturable) {
+  test_unordered_map_device_capture();
+}
+#endif
 
 }  // namespace Test
 

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -482,7 +482,7 @@ TEST(TEST_CATEGORY, UnorderedMap_consistent_size) {
 
 namespace Impl {
 
-using map_type = Kokkos::UnorderedMap<int, void, TEST_EXECSPACE>;
+using map_type = Kokkos::UnorderedMap<int, void, Kokkos::DefaultExecutionSpace>;
 
 KOKKOS_FUNCTION
 void test_insert_to_map_copy(map_type const &input_map, const int i) {

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -497,7 +497,7 @@ struct TestMapCopy {
 TEST(TEST_CATEGORY, UnorderedMap_shallow_copyable_on_device) {
   TestMapCopy test_map_copy;
 
-  Kokkos::parallel_for(Kokkos::RangePolicy<>(TEST_EXECSPACE(), 0, 1),
+  Kokkos::parallel_for(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1),
                        test_map_copy);
   ASSERT_EQ(1u, test_map_copy.m_map.size());
 }
@@ -508,7 +508,7 @@ void test_unordered_map_device_capture() {
   TestMapCopy::map_type map;
 
   Kokkos::parallel_for(
-      Kokkos::RangePolicy<>(TEST_EXECSPACE(), 0, 1),
+      Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1),
       KOKKOS_LAMBDA(int const &i) { map.insert(i); });
 
   ASSERT_EQ(1u, map.size());

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -508,7 +508,8 @@ void test_unordered_map_device_capture() {
   TestMapCopy::map_type map;
 
   Kokkos::parallel_for(
-      1, KOKKOS_LAMBDA(int const &i) { map.insert(i); });
+      Kokkos::RangePolicy<>(TEST_EXECSPACE(), 0, 1),
+      KOKKOS_LAMBDA(int const &i) { map.insert(i); });
 
   ASSERT_EQ(1u, map.size());
 }


### PR DESCRIPTION
In attempt to resolve #6066.

A shared_ptr for `m_size` was introduced in `UnorderedMap` in #5983 to resolve a memory corruption, but this made `UnorderedMap` no longer copyable on device.

Changed to use a host view in place of `shared_ptr`.