### PR TITLE
SYCL: Use in-order queue for SYCL+Cuda

### DIFF
--- a/algorithms/unit_tests/TestStdAlgorithmsCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCopyIf.cpp
@@ -270,9 +270,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_mod_seq_ops, copy_if) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsRemove.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRemove.cpp
@@ -195,9 +195,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_mod_seq_ops, remove) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsRemoveCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRemoveCopy.cpp
@@ -224,9 +224,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_mod_seq_ops, remove_copy) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
   run_all_scenarios<DynamicTag, double>();

--- a/algorithms/unit_tests/TestStdAlgorithmsRemoveCopyIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRemoveCopyIf.cpp
@@ -208,9 +208,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_mod_seq_ops, remove_copy_if) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsRemoveIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRemoveIf.cpp
@@ -192,9 +192,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_mod_seq_ops, remove_if) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsReplaceIf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsReplaceIf.cpp
@@ -216,9 +216,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_replace_ops_test, replace_if) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedThreeTag, double>();
   run_all_scenarios<DynamicTag, int>();

--- a/algorithms/unit_tests/TestStdAlgorithmsRotate.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsRotate.cpp
@@ -234,9 +234,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_mod_seq_ops, rotate) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
   run_all_scenarios<DynamicTag, double>();

--- a/algorithms/unit_tests/TestStdAlgorithmsShiftLeft.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsShiftLeft.cpp
@@ -202,9 +202,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_mod_seq_ops, shift_left) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
   run_all_scenarios<DynamicTag, double>();

--- a/algorithms/unit_tests/TestStdAlgorithmsShiftRight.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsShiftRight.cpp
@@ -206,9 +206,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_mod_seq_ops, shift_right) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
   run_all_scenarios<DynamicTag, double>();

--- a/algorithms/unit_tests/TestStdAlgorithmsUnique.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsUnique.cpp
@@ -273,9 +273,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_mod_seq_ops, unique) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsUniqueCopy.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsUniqueCopy.cpp
@@ -322,9 +322,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_mod_seq_ops, unique_copy) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
 }

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -758,9 +758,6 @@ void test_scatter_view(int64_t n) {
 }
 
 TEST(TEST_CATEGORY, scatterview) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   test_scatter_view<TEST_EXECSPACE, Kokkos::Experimental::ScatterSum, double>(
       10);
 
@@ -801,10 +798,6 @@ TEST(TEST_CATEGORY, scatterview) {
 }
 
 TEST(TEST_CATEGORY, scatterview_devicetype) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
-
   using device_type =
       Kokkos::Device<TEST_EXECSPACE, typename TEST_EXECSPACE::memory_space>;
 

--- a/core/perf_test/PerfTestGramSchmidt.cpp
+++ b/core/perf_test/PerfTestGramSchmidt.cpp
@@ -175,6 +175,16 @@ static void GramSchmidt(benchmark::State& state) {
   }
 }
 
+// FIXME_SYCL SYCL+Cuda reports "an illegal memory access was encountered"
+#if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
+BENCHMARK(GramSchmidt<double>)
+    ->ArgName("Count")
+    ->ArgsProduct({
+        benchmark::CreateRange(1 << 10, 1 << 18, 2),
+    })
+    ->UseManualTime()
+    ->Iterations(5);
+#else
 BENCHMARK(GramSchmidt<double>)
     ->ArgName("Count")
     ->ArgsProduct({
@@ -182,5 +192,6 @@ BENCHMARK(GramSchmidt<double>)
     })
     ->UseManualTime()
     ->Iterations(5);
+#endif
 
 }  // namespace Test

--- a/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
+++ b/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
@@ -154,8 +154,6 @@ struct FunctorTeamReduce {
   }
 };
 
-// skip for SYCL+Cuda
-#if !(defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU))
 static void OverlapRangePolicy(benchmark::State& state) {
   int N = state.range(0);
   int M = state.range(1);
@@ -697,6 +695,5 @@ static void OverlapTeamPolicy(benchmark::State& state) {
 BENCHMARK(OverlapTeamPolicy)
     ->ArgNames({"N", "M", "R"})
     ->Args({20, 1'000'000, 10});
-#endif  // skip for SYCL+Cuda
 
 }  // namespace Test

--- a/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
+++ b/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
@@ -154,6 +154,8 @@ struct FunctorTeamReduce {
   }
 };
 
+// skip for SYCL+Cuda
+#if !(defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU))
 static void OverlapRangePolicy(benchmark::State& state) {
   int N = state.range(0);
   int M = state.range(1);
@@ -695,5 +697,6 @@ static void OverlapTeamPolicy(benchmark::State& state) {
 BENCHMARK(OverlapTeamPolicy)
     ->ArgNames({"N", "M", "R"})
     ->Args({20, 1'000'000, 10});
+#endif  // skip for SYCL+Cuda
 
 }  // namespace Test

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -75,7 +75,15 @@ void SYCLInternal::initialize(const sycl::device& d) {
       Kokkos::Impl::throw_runtime_exception(
           "There was an asynchronous SYCL error!\n");
   };
-  initialize(sycl::queue{d, exception_handler});
+  // FIXME SYCL+Cuda Apparently, submit_barrier doesn't quite work as expected
+  // for oneAPI 2023.0.0 on NVIDIA GPUs.
+#if defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
+  initialize(
+      sycl::queue{d, exception_handler, sycl::property::queue::in_order()});
+#else
+  initialize(
+      sycl::queue{d, exception_handler);
+#endif
 }
 
 // FIXME_SYCL

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -40,13 +40,7 @@ void DeepCopySYCL(void* dst, const void* src, size_t n) {
 void DeepCopyAsyncSYCL(const Kokkos::Experimental::SYCL& instance, void* dst,
                        const void* src, size_t n) {
   sycl::queue& q = *instance.impl_internal_space_instance()->m_queue;
-  // FIXME_SYCL memcpy doesn't respect submit_barrier which means that we need
-  // to actually fence the execution space to make sure the memcpy is properly
-  // enqueued when using out-of-order queues.
-#ifndef KOKKOS_ARCH_INTEL_GPU
-  q.wait_and_throw();
-#endif
-  auto event = q.memcpy(dst, src, n);
+  auto event     = q.memcpy(dst, src, n);
   q.ext_oneapi_submit_barrier(std::vector<sycl::event>{event});
 }
 

--- a/core/unit_test/TestCrs.hpp
+++ b/core/unit_test/TestCrs.hpp
@@ -174,9 +174,6 @@ void test_constructor(std::int32_t nrows) {
 }  // anonymous namespace
 
 TEST(TEST_CATEGORY, crs_count_fill) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   test_count_fill<TEST_EXECSPACE>(0);
   test_count_fill<TEST_EXECSPACE>(1);
   test_count_fill<TEST_EXECSPACE>(2);
@@ -188,9 +185,6 @@ TEST(TEST_CATEGORY, crs_count_fill) {
 }
 
 TEST(TEST_CATEGORY, crs_copy_constructor) {
-#if defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ARCH_INTEL_GPU)
-  GTEST_SKIP() << "skipping for SYCL+Cuda";
-#endif
   test_constructor<TEST_EXECSPACE>(0);
   test_constructor<TEST_EXECSPACE>(1);
   test_constructor<TEST_EXECSPACE>(2);


### PR DESCRIPTION
Apparently, the cause for all the test failures when requiring `oneAPI 2023.0.0` (https://github.com/kokkos/kokkos/pull/5707) was that `submit_barrier` is not quite working as intended for `SYCL+Cuda`.
Reverts #6056.