### PR TITLE
Fix Kokkos_SIMD with AVX2 on 64-bit architectures

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -680,10 +680,12 @@ template <>
 class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;
 
+  static_assert(sizeof(long long) == 8);
+
  public:
   using value_type = std::int64_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = simd_mask<value_type, abi_type>;
+  using mask_type  = simd_mask<std::int64_t, abi_type>;
   using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
@@ -727,11 +729,13 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
-    m_value = _mm256_maskload_epi64(ptr, static_cast<__m256i>(mask_type(true)));
+    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
+                                    static_cast<__m256i>(mask_type(true)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
-    _mm256_maskstore_epi64(ptr, static_cast<__m256i>(mask_type(true)), m_value);
+    _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
+                           static_cast<__m256i>(mask_type(true)), m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -685,7 +685,7 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
  public:
   using value_type = std::int64_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = simd_mask<std::int64_t, abi_type>;
+  using mask_type  = simd_mask<value_type, abi_type>;
   using reference  = value_type&;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;


### PR DESCRIPTION
Fixes #6070. ~~For better test coverage (and convenience for the user?), this pull request also enables the `avx2` overloads if `__AVX2__` is defined (which should be the case when the user sets `Kokkos_ARCH_AVX2` but also for `Kokkos_ARCH_NATIVE=ON`).~~