### PR TITLE
Update OpenACC FunctorAdapter

### DIFF
--- a/core/src/OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp
@@ -19,9 +19,12 @@
 
 #include <type_traits>
 
+#define KOKKOS_OPENACC_CONTAIN_SEQLOOP 0
+#define KOKKOS_OPENACC_CONTAIN_WORKERLOOP 1
+
 namespace Kokkos::Experimental::Impl {
 
-template <class Functor, class Policy>
+template <class Functor, class Policy, int N, typename = void>
 class FunctorAdapter {
   Functor m_functor;
   using WorkTag = typename Policy::work_tag;
@@ -29,6 +32,28 @@ class FunctorAdapter {
  public:
   FunctorAdapter(Functor const &functor) : m_functor(functor) {}
 
+#pragma acc routine seq
+  template <class... Args>
+  KOKKOS_FUNCTION void operator()(Args &&... args) const {
+    if constexpr (std::is_void_v<WorkTag>) {
+      m_functor(static_cast<Args &&>(args)...);
+    } else {
+      m_functor(WorkTag(), static_cast<Args &&>(args)...);
+    }
+  }
+};
+
+template <class Functor, class Policy, int N>
+class FunctorAdapter<
+    Functor, Policy, N,
+    typename std::enable_if<N == KOKKOS_OPENACC_CONTAIN_WORKERLOOP>::type> {
+  Functor m_functor;
+  using WorkTag = typename Policy::work_tag;
+
+ public:
+  FunctorAdapter(Functor const &functor) : m_functor(functor) {}
+
+#pragma acc routine worker
   template <class... Args>
   KOKKOS_FUNCTION void operator()(Args &&... args) const {
     if constexpr (std::is_void_v<WorkTag>) {

--- a/core/src/OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp
@@ -17,52 +17,40 @@
 #ifndef KOKKOS_OPENACC_FUNCTOR_ADAPTER_HPP
 #define KOKKOS_OPENACC_FUNCTOR_ADAPTER_HPP
 
+#include <OpenACC/Kokkos_OpenACC_Macros.hpp>
 #include <type_traits>
-
-#define KOKKOS_OPENACC_CONTAIN_SEQLOOP 0
-#define KOKKOS_OPENACC_CONTAIN_WORKERLOOP 1
 
 namespace Kokkos::Experimental::Impl {
 
-template <class Functor, class Policy, int N, typename = void>
-class FunctorAdapter {
-  Functor m_functor;
-  using WorkTag = typename Policy::work_tag;
+enum class RoutineClause { worker, seq };
 
- public:
-  FunctorAdapter(Functor const &functor) : m_functor(functor) {}
+template <class Functor, class Policy, RoutineClause>
+class FunctorAdapter;
 
-#pragma acc routine seq
-  template <class... Args>
-  KOKKOS_FUNCTION void operator()(Args &&... args) const {
-    if constexpr (std::is_void_v<WorkTag>) {
-      m_functor(static_cast<Args &&>(args)...);
-    } else {
-      m_functor(WorkTag(), static_cast<Args &&>(args)...);
-    }
+#define KOKKOS_IMPL_ACC_FUNCTOR_ADAPTER(CLAUSE)                    \
+  template <class Functor, class Policy>                           \
+  class FunctorAdapter<Functor, Policy, RoutineClause::CLAUSE> {   \
+    Functor m_functor;                                             \
+    using WorkTag = typename Policy::work_tag;                     \
+                                                                   \
+   public:                                                         \
+    FunctorAdapter(Functor const &functor) : m_functor(functor) {} \
+                                                                   \
+    KOKKOS_IMPL_ACC_PRAGMA_HELPER(routine CLAUSE)                  \
+    template <class... Args>                                       \
+    KOKKOS_FUNCTION void operator()(Args &&... args) const {       \
+      if constexpr (std::is_void_v<WorkTag>) {                     \
+        m_functor(static_cast<Args &&>(args)...);                  \
+      } else {                                                     \
+        m_functor(WorkTag(), static_cast<Args &&>(args)...);       \
+      }                                                            \
+    }                                                              \
   }
-};
 
-template <class Functor, class Policy, int N>
-class FunctorAdapter<
-    Functor, Policy, N,
-    typename std::enable_if<N == KOKKOS_OPENACC_CONTAIN_WORKERLOOP>::type> {
-  Functor m_functor;
-  using WorkTag = typename Policy::work_tag;
+KOKKOS_IMPL_ACC_FUNCTOR_ADAPTER(worker);
+KOKKOS_IMPL_ACC_FUNCTOR_ADAPTER(seq);
 
- public:
-  FunctorAdapter(Functor const &functor) : m_functor(functor) {}
-
-#pragma acc routine worker
-  template <class... Args>
-  KOKKOS_FUNCTION void operator()(Args &&... args) const {
-    if constexpr (std::is_void_v<WorkTag>) {
-      m_functor(static_cast<Args &&>(args)...);
-    } else {
-      m_functor(WorkTag(), static_cast<Args &&>(args)...);
-    }
-  }
-};
+#undef KOKKOS_IMPL_ACC_FUNCTOR_ADAPTER
 
 }  // namespace Kokkos::Experimental::Impl
 

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_MDRange.hpp
@@ -640,7 +640,9 @@ template <class Functor, class... Traits>
 class Kokkos::Impl::ParallelFor<Functor, Kokkos::MDRangePolicy<Traits...>,
                                 Kokkos::Experimental::OpenACC> {
   using Policy = MDRangePolicy<Traits...>;
-  Kokkos::Experimental::Impl::FunctorAdapter<Functor, Policy> m_functor;
+  Kokkos::Experimental::Impl::FunctorAdapter<Functor, Policy,
+                                             KOKKOS_OPENACC_CONTAIN_SEQLOOP>
+      m_functor;
   Policy m_policy;
 
  public:

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_MDRange.hpp
@@ -640,8 +640,8 @@ template <class Functor, class... Traits>
 class Kokkos::Impl::ParallelFor<Functor, Kokkos::MDRangePolicy<Traits...>,
                                 Kokkos::Experimental::OpenACC> {
   using Policy = MDRangePolicy<Traits...>;
-  Kokkos::Experimental::Impl::FunctorAdapter<Functor, Policy,
-                                             KOKKOS_OPENACC_CONTAIN_SEQLOOP>
+  Kokkos::Experimental::Impl::FunctorAdapter<
+      Functor, Policy, Kokkos::Experimental::Impl::RoutineClause::seq>
       m_functor;
   Policy m_policy;
 

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Range.hpp
@@ -78,7 +78,9 @@ template <class Functor, class... Traits>
 class Kokkos::Impl::ParallelFor<Functor, Kokkos::RangePolicy<Traits...>,
                                 Kokkos::Experimental::OpenACC> {
   using Policy = Kokkos::RangePolicy<Traits...>;
-  Kokkos::Experimental::Impl::FunctorAdapter<Functor, Policy> m_functor;
+  Kokkos::Experimental::Impl::FunctorAdapter<Functor, Policy,
+                                             KOKKOS_OPENACC_CONTAIN_SEQLOOP>
+      m_functor;
   Policy m_policy;
   using ScheduleType = Kokkos::Experimental::Impl::OpenACCScheduleType<Policy>;
 

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Range.hpp
@@ -78,8 +78,8 @@ template <class Functor, class... Traits>
 class Kokkos::Impl::ParallelFor<Functor, Kokkos::RangePolicy<Traits...>,
                                 Kokkos::Experimental::OpenACC> {
   using Policy = Kokkos::RangePolicy<Traits...>;
-  Kokkos::Experimental::Impl::FunctorAdapter<Functor, Policy,
-                                             KOKKOS_OPENACC_CONTAIN_SEQLOOP>
+  Kokkos::Experimental::Impl::FunctorAdapter<
+      Functor, Policy, Kokkos::Experimental::Impl::RoutineClause::seq>
       m_functor;
   Policy m_policy;
   using ScheduleType = Kokkos::Experimental::Impl::OpenACCScheduleType<Policy>;

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
@@ -31,8 +31,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
  private:
   using Policy = Kokkos::Impl::TeamPolicyInternal<Kokkos::Experimental::OpenACC,
                                                   Properties...>;
-  Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy,
-                                             KOKKOS_OPENACC_CONTAIN_SEQLOOP>
+  Kokkos::Experimental::Impl::FunctorAdapter<
+      FunctorType, Policy, Kokkos::Experimental::Impl::RoutineClause::seq>
       m_functor;
   using Member = typename Policy::member_type;
 
@@ -132,8 +132,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
  private:
   using Policy = Kokkos::Impl::TeamPolicyInternal<Kokkos::Experimental::OpenACC,
                                                   Properties...>;
-  Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy,
-                                             KOKKOS_OPENACC_CONTAIN_WORKERLOOP>
+  Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy, worker>
       m_functor;
   using Member = typename Policy::member_type;
 

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelFor_Team.hpp
@@ -31,7 +31,9 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
  private:
   using Policy = Kokkos::Impl::TeamPolicyInternal<Kokkos::Experimental::OpenACC,
                                                   Properties...>;
-  Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy> m_functor;
+  Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy,
+                                             KOKKOS_OPENACC_CONTAIN_SEQLOOP>
+      m_functor;
   using Member = typename Policy::member_type;
 
   const Policy m_policy;
@@ -130,7 +132,9 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
  private:
   using Policy = Kokkos::Impl::TeamPolicyInternal<Kokkos::Experimental::OpenACC,
                                                   Properties...>;
-  Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy> m_functor;
+  Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy,
+                                             KOKKOS_OPENACC_CONTAIN_WORKERLOOP>
+      m_functor;
   using Member = typename Policy::member_type;
 
   const Policy m_policy;

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
@@ -76,7 +76,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     reducer.init(&val);
 
     Kokkos::Experimental::Impl::OpenACCParallelReduceMDRangeHelper(
-        Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy>(
+        Kokkos::Experimental::Impl::FunctorAdapter<
+            FunctorType, Policy, KOKKOS_OPENACC_CONTAIN_SEQLOOP>(
             m_functor_reducer.get_functor()),
         std::conditional_t<
             std::is_same_v<FunctorType, typename ReducerType::functor_type>,

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_MDRange.hpp
@@ -77,7 +77,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 
     Kokkos::Experimental::Impl::OpenACCParallelReduceMDRangeHelper(
         Kokkos::Experimental::Impl::FunctorAdapter<
-            FunctorType, Policy, KOKKOS_OPENACC_CONTAIN_SEQLOOP>(
+            FunctorType, Policy,
+            Kokkos::Experimental::Impl::RoutineClause::seq>(
             m_functor_reducer.get_functor()),
         std::conditional_t<
             std::is_same_v<FunctorType, typename ReducerType::functor_type>,

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
@@ -74,7 +74,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     reducer.init(&val);
 
     Kokkos::Experimental::Impl::OpenACCParallelReduceHelper(
-        Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy>(
+        Kokkos::Experimental::Impl::FunctorAdapter<
+            FunctorType, Policy, KOKKOS_OPENACC_CONTAIN_SEQLOOP>(
             m_functor_reducer.get_functor()),
         std::conditional_t<
             std::is_same_v<FunctorType, typename ReducerType::functor_type>,

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Range.hpp
@@ -75,7 +75,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 
     Kokkos::Experimental::Impl::OpenACCParallelReduceHelper(
         Kokkos::Experimental::Impl::FunctorAdapter<
-            FunctorType, Policy, KOKKOS_OPENACC_CONTAIN_SEQLOOP>(
+            FunctorType, Policy,
+            Kokkos::Experimental::Impl::RoutineClause::seq>(
             m_functor_reducer.get_functor()),
         std::conditional_t<
             std::is_same_v<FunctorType, typename ReducerType::functor_type>,

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -22,9 +22,11 @@
 #include <OpenACC/Kokkos_OpenACC_Macros.hpp>
 
 #ifdef KOKKOS_ENABLE_OPENACC_COLLAPSE_HIERARCHICAL_CONSTRUCTS
-#define KOKKOS_OPENACC_CONTAIN_LOOP KOKKOS_OPENACC_CONTAIN_SEQLOOP
+#define KOKKOS_OPENACC_LOOP_CLAUSE \
+  Kokkos::Experimental::Impl::RoutineClause::seq
 #else
-#define KOKKOS_OPENACC_CONTAIN_LOOP KOKKOS_OPENACC_CONTAIN_WORKERLOOP
+#define KOKKOS_OPENACC_LOOP_CLAUSE \
+  Kokkos::Experimental::Impl::RoutineClause::worker
 #endif
 
 //----------------------------------------------------------------------------
@@ -74,7 +76,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 
     Kokkos::Experimental::Impl::OpenACCParallelReduceTeamHelper(
         Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy,
-                                                   KOKKOS_OPENACC_CONTAIN_LOOP>(
+                                                   KOKKOS_OPENACC_LOOP_CLAUSE>(
             m_functor_reducer.get_functor()),
         std::conditional_t<
             std::is_same_v<FunctorType, typename ReducerType::functor_type>,

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -22,10 +22,10 @@
 #include <OpenACC/Kokkos_OpenACC_Macros.hpp>
 
 #ifdef KOKKOS_ENABLE_OPENACC_COLLAPSE_HIERARCHICAL_CONSTRUCTS
-#define KOKKOS_OPENACC_LOOP_CLAUSE \
+#define KOKKOS_IMPL_OPENACC_LOOP_CLAUSE \
   Kokkos::Experimental::Impl::RoutineClause::seq
 #else
-#define KOKKOS_OPENACC_LOOP_CLAUSE \
+#define KOKKOS_IMPL_OPENACC_LOOP_CLAUSE \
   Kokkos::Experimental::Impl::RoutineClause::worker
 #endif
 
@@ -75,8 +75,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     reducer.init(&tmp);
 
     Kokkos::Experimental::Impl::OpenACCParallelReduceTeamHelper(
-        Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy,
-                                                   KOKKOS_OPENACC_LOOP_CLAUSE>(
+        Kokkos::Experimental::Impl::FunctorAdapter<
+            FunctorType, Policy, KOKKOS_IMPL_OPENACC_LOOP_CLAUSE>(
             m_functor_reducer.get_functor()),
         std::conditional_t<
             std::is_same_v<FunctorType, typename ReducerType::functor_type>,

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelReduce_Team.hpp
@@ -21,6 +21,12 @@
 #include <OpenACC/Kokkos_OpenACC_FunctorAdapter.hpp>
 #include <OpenACC/Kokkos_OpenACC_Macros.hpp>
 
+#ifdef KOKKOS_ENABLE_OPENACC_COLLAPSE_HIERARCHICAL_CONSTRUCTS
+#define KOKKOS_OPENACC_CONTAIN_LOOP KOKKOS_OPENACC_CONTAIN_SEQLOOP
+#else
+#define KOKKOS_OPENACC_CONTAIN_LOOP KOKKOS_OPENACC_CONTAIN_WORKERLOOP
+#endif
+
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 // Hierarchical Parallelism -> Team level implementation
@@ -67,7 +73,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
     reducer.init(&tmp);
 
     Kokkos::Experimental::Impl::OpenACCParallelReduceTeamHelper(
-        Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy>(
+        Kokkos::Experimental::Impl::FunctorAdapter<FunctorType, Policy,
+                                                   KOKKOS_OPENACC_CONTAIN_LOOP>(
             m_functor_reducer.get_functor()),
         std::conditional_t<
             std::is_same_v<FunctorType, typename ReducerType::functor_type>,

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelScan_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelScan_Range.hpp
@@ -63,8 +63,9 @@ class Kokkos::Impl::ParallelScan<Functor, Kokkos::RangePolicy<Traits...>,
     } else {
       chunk_size = default_scan_chunk_size;
     }
-    const Kokkos::Experimental::Impl::FunctorAdapter<Functor, Policy> functor(
-        m_functor);
+    const Kokkos::Experimental::Impl::FunctorAdapter<
+        Functor, Policy, KOKKOS_OPENACC_CONTAIN_SEQLOOP>
+        functor(m_functor);
     const IndexType N        = end - begin;
     const IndexType n_chunks = (N + chunk_size - 1) / chunk_size;
     Kokkos::View<ValueType*, Kokkos::Experimental::OpenACCSpace> chunk_values(

--- a/core/src/OpenACC/Kokkos_OpenACC_ParallelScan_Range.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_ParallelScan_Range.hpp
@@ -64,7 +64,7 @@ class Kokkos::Impl::ParallelScan<Functor, Kokkos::RangePolicy<Traits...>,
       chunk_size = default_scan_chunk_size;
     }
     const Kokkos::Experimental::Impl::FunctorAdapter<
-        Functor, Policy, KOKKOS_OPENACC_CONTAIN_SEQLOOP>
+        Functor, Policy, Kokkos::Experimental::Impl::RoutineClause::seq>
         functor(m_functor);
     const IndexType N        = end - begin;
     const IndexType n_chunks = (N + chunk_size - 1) / chunk_size;

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -546,7 +546,6 @@ IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_f.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewMapping_b.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewResize.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_BitManipulationBuiltins.cpp
     )
 endif()
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -546,6 +546,7 @@ IF(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_f.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewMapping_b.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewResize.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_BitManipulationBuiltins.cpp
     )
 endif()
 


### PR DESCRIPTION
Update OpenACC FunctorAdapter to be able to handle functors containing parallel loops.

In OpenACC, any device function called in a compute region should be annotated with an `acc routine` directive unless it does not have any OpenACC parallel loop, in which case an OpenACC compiler implicitly adds an `acc routine seq` directive. 
The current Kokkos OpenACC backend has two implementations for Kokkos parallel constructs with Team Policy: a version where the hierarchical parallel constructs with the Team Policy are logically flattened using a manual collapsing, and the other version keeps the hierarchical parallel constructs, each of which contains different OpenACC parallel loops.
This PR is to support the second implementation (non-collapsed version), where some Kokkos parallel construct can call a nested lambda containing an OpenACC parallel loop.
If the Kokkos OpenACC backend is compiled by NVHPC OpenACC compiler, the collapsed version is used and thus we didn't have to add `acc routine` directives. However, Clacc/LLVM OpenACC compiler uses the non-collapsed version; this PR is for the Clacc OpenACC compiler. (The non-collapsed version fully exploits hierarchical parallelism available in OpenACC, while the collapsed version does not.) 