### PR TITLE
Fix up SYCL execution space instance creation for Intel GPUs

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -81,8 +81,7 @@ void SYCLInternal::initialize(const sycl::device& d) {
   initialize(
       sycl::queue{d, exception_handler, sycl::property::queue::in_order()});
 #else
-  initialize(
-      sycl::queue{d, exception_handler);
+  initialize(sycl::queue{d, exception_handler});
 #endif
 }
 


### PR DESCRIPTION
Fixes #6074 for Intel GPUs. I missed a "{" for the case that is not tested in the CI. 