### PR TITLE
Reorganize ZeroMemset

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -241,28 +241,6 @@ struct DeviceTypeTraits<Cuda> {
 };
 }  // namespace Experimental
 }  // namespace Tools
-
-namespace Impl {
-
-template <class DT, class... DP>
-struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
-  ZeroMemset(const Kokkos::Cuda& exec_space_instance,
-             const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemsetAsync(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type),
-        exec_space_instance.cuda_stream()));
-  }
-
-  ZeroMemset(const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
-    KOKKOS_IMPL_CUDA_SAFE_CALL(
-        cudaMemset(dst.data(), 0,
-                   dst.size() * sizeof(typename View<DT, DP...>::value_type)));
-  }
-};
-}  // namespace Impl
 }  // namespace Kokkos
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
@@ -17,8 +17,7 @@
 #define KOKKOS_CUDA_ZEROMEMSET_HPP
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_CUDA
-
+#include <Cuda/Kokkos_Cuda.hpp>
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>
 
 namespace Kokkos {
@@ -46,5 +45,4 @@ struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
 }  // namespace Impl
 }  // namespace Kokkos
 
-#endif  // defined(KOKKOS_ENABLE_CUDA)
 #endif  // !defined(KOKKOS_CUDA_ZEROMEMSET_HPP)

--- a/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
@@ -1,0 +1,50 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOS_CUDA_ZEROMEMSET_HPP
+#define KOKKOS_CUDA_ZEROMEMSET_HPP
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_CUDA
+
+#include <impl/Kokkos_ZeroMemset_fwd.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+template <class DT, class... DP>
+struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
+  ZeroMemset(const Kokkos::Cuda& exec_space_instance,
+             const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemsetAsync(
+        dst.data(), 0,
+        dst.size() * sizeof(typename View<DT, DP...>::value_type),
+        exec_space_instance.cuda_stream()));
+  }
+
+  ZeroMemset(const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        cudaMemset(dst.data(), 0,
+                   dst.size() * sizeof(typename View<DT, DP...>::value_type)));
+  }
+};
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif  // defined(KOKKOS_ENABLE_CUDA)
+#endif  // !defined(KOKKOS_CUDA_ZEROMEMSET_HPP)

--- a/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
@@ -23,22 +23,20 @@
 namespace Kokkos {
 namespace Impl {
 
-template <class DT, class... DP>
-struct ZeroMemset<Kokkos::Cuda, DT, DP...> {
-  ZeroMemset(const Kokkos::Cuda& exec_space_instance,
-             const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
+template <class T, class... P>
+struct ZeroMemset<Kokkos::Cuda, View<T, P...>> {
+  ZeroMemset(const Kokkos::Cuda& exec_space_instance, const View<T, P...>& dst,
+             typename View<T, P...>::const_value_type&) {
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemsetAsync(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type),
+        dst.data(), 0, dst.size() * sizeof(typename View<T, P...>::value_type),
         exec_space_instance.cuda_stream()));
   }
 
-  ZeroMemset(const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
+  ZeroMemset(const View<T, P...>& dst,
+             typename View<T, P...>::const_value_type&) {
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         cudaMemset(dst.data(), 0,
-                   dst.size() * sizeof(typename View<DT, DP...>::value_type)));
+                   dst.size() * sizeof(typename View<T, P...>::value_type)));
   }
 };
 

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -137,26 +137,6 @@ struct DeviceTypeTraits<HIP> {
 };
 }  // namespace Experimental
 }  // namespace Tools
-
-namespace Impl {
-template <class DT, class... DP>
-struct ZeroMemset<HIP, DT, DP...> {
-  ZeroMemset(const HIP& exec_space, const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipMemsetAsync(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type),
-        exec_space.hip_stream()));
-  }
-
-  ZeroMemset(const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
-    KOKKOS_IMPL_HIP_SAFE_CALL(
-        hipMemset(dst.data(), 0,
-                  dst.size() * sizeof(typename View<DT, DP...>::value_type)));
-  }
-};
-}  // namespace Impl
 }  // namespace Kokkos
 
 #endif

--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
@@ -23,21 +23,20 @@
 namespace Kokkos {
 namespace Impl {
 
-template <class DT, class... DP>
-struct ZeroMemset<HIP, DT, DP...> {
-  ZeroMemset(const HIP& exec_space, const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
+template <class T, class... P>
+struct ZeroMemset<HIP, View<T, P...>> {
+  ZeroMemset(const HIP& exec_space, const View<T, P...>& dst,
+             typename View<T, P...>::const_value_type&) {
     KOKKOS_IMPL_HIP_SAFE_CALL(hipMemsetAsync(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type),
+        dst.data(), 0, dst.size() * sizeof(typename View<T, P...>::value_type),
         exec_space.hip_stream()));
   }
 
-  ZeroMemset(const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
+  ZeroMemset(const View<T, P...>& dst,
+             typename View<T, P...>::const_value_type&) {
     KOKKOS_IMPL_HIP_SAFE_CALL(
         hipMemset(dst.data(), 0,
-                  dst.size() * sizeof(typename View<DT, DP...>::value_type)));
+                  dst.size() * sizeof(typename View<T, P...>::value_type)));
   }
 };
 

--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
@@ -1,0 +1,49 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOS_HIP_ZEROMEMSET_HPP
+#define KOKKOS_HIP_ZEROMEMSET_HPP
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_HIP
+
+#include <impl/Kokkos_ZeroMemset_fwd.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+template <class DT, class... DP>
+struct ZeroMemset<HIP, DT, DP...> {
+  ZeroMemset(const HIP& exec_space, const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipMemsetAsync(
+        dst.data(), 0,
+        dst.size() * sizeof(typename View<DT, DP...>::value_type),
+        exec_space.hip_stream()));
+  }
+
+  ZeroMemset(const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
+    KOKKOS_IMPL_HIP_SAFE_CALL(
+        hipMemset(dst.data(), 0,
+                  dst.size() * sizeof(typename View<DT, DP...>::value_type)));
+  }
+};
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif  // defined(KOKKOS_ENABLE_HIP)
+#endif  // !defined(KOKKOS_HIP_ZEROMEMSET_HPP)

--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
@@ -17,8 +17,7 @@
 #define KOKKOS_HIP_ZEROMEMSET_HPP
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_HIP
-
+#include <HIP/Kokkos_HIP.hpp>
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>
 
 namespace Kokkos {

--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
@@ -44,5 +44,4 @@ struct ZeroMemset<HIP, DT, DP...> {
 }  // namespace Impl
 }  // namespace Kokkos
 
-#endif  // defined(KOKKOS_ENABLE_HIP)
 #endif  // !defined(KOKKOS_HIP_ZEROMEMSET_HPP)

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -25,6 +25,7 @@ static_assert(false,
 #include <Kokkos_Parallel.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>
 #include <Kokkos_Layout.hpp>
+#include <impl/Kokkos_HostSpace_ZeroMemset.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -25,6 +25,7 @@ static_assert(false,
 #include <Kokkos_Parallel.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>
 #include <Kokkos_Layout.hpp>
+#include <impl/Kokkos_ZeroMemset.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -1325,19 +1326,6 @@ inline void contiguous_fill(
                            ViewTypeFlat::rank, int64_t>(dst_flat, value,
                                                         exec_space);
 }
-
-template <typename ExecutionSpace, class DT, class... DP>
-struct ZeroMemset {
-  ZeroMemset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
-             typename ViewTraits<DT, DP...>::const_value_type& value) {
-    contiguous_fill(exec_space, dst, value);
-  }
-
-  ZeroMemset(const View<DT, DP...>& dst,
-             typename ViewTraits<DT, DP...>::const_value_type& value) {
-    contiguous_fill(ExecutionSpace(), dst, value);
-  }
-};
 
 template <typename ExecutionSpace, class DT, class... DP>
 inline std::enable_if_t<

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1327,15 +1327,14 @@ inline void contiguous_fill(
 }
 
 // Default implementation for execution spaces that don't provide a definition
-template <typename ExecutionSpace, class DT, class... DP>
+template <typename ExecutionSpace, class ViewType>
 struct ZeroMemset {
-  ZeroMemset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
-             typename ViewTraits<DT, DP...>::const_value_type& value) {
+  ZeroMemset(const ExecutionSpace& exec_space, const ViewType& dst,
+             typename ViewType::const_value_type& value) {
     contiguous_fill(exec_space, dst, value);
   }
 
-  ZeroMemset(const View<DT, DP...>& dst,
-             typename ViewTraits<DT, DP...>::const_value_type& value) {
+  ZeroMemset(const ViewType& dst, typename ViewType::const_value_type& value) {
     contiguous_fill(ExecutionSpace(), dst, value);
   }
 };
@@ -1352,7 +1351,7 @@ contiguous_fill_or_memset(
 // leading to the significant performance issues
 #ifndef KOKKOS_ARCH_A64FX
   if (Impl::is_zero_byte(value))
-    ZeroMemset<ExecutionSpace, DT, DP...>(exec_space, dst, value);
+    ZeroMemset<ExecutionSpace, View<DT, DP...>>(exec_space, dst, value);
   else
 #endif
     contiguous_fill(exec_space, dst, value);
@@ -1384,7 +1383,7 @@ contiguous_fill_or_memset(
 // leading to the significant performance issues
 #ifndef KOKKOS_ARCH_A64FX
   if (Impl::is_zero_byte(value))
-    ZeroMemset<exec_space_type, DT, DP...>(dst, value);
+    ZeroMemset<exec_space_type, View<DT, DP...>>(dst, value);
   else
 #endif
     contiguous_fill(exec_space_type(), dst, value);

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -25,7 +25,6 @@ static_assert(false,
 #include <Kokkos_Parallel.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>
 #include <Kokkos_Layout.hpp>
-#include <impl/Kokkos_ZeroMemset.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -1326,6 +1325,20 @@ inline void contiguous_fill(
                            ViewTypeFlat::rank, int64_t>(dst_flat, value,
                                                         exec_space);
 }
+
+// Default implementation for execution spaces that don't provide a definition
+template <typename ExecutionSpace, class DT, class... DP>
+struct ZeroMemset {
+  ZeroMemset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
+             typename ViewTraits<DT, DP...>::const_value_type& value) {
+    contiguous_fill(exec_space, dst, value);
+  }
+
+  ZeroMemset(const View<DT, DP...>& dst,
+             typename ViewTraits<DT, DP...>::const_value_type& value) {
+    contiguous_fill(ExecutionSpace(), dst, value);
+  }
+};
 
 template <typename ExecutionSpace, class DT, class... DP>
 inline std::enable_if_t<

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -297,9 +297,6 @@ template <class DstSpace, class SrcSpace,
           class Enable         = void>
 struct DeepCopy;
 
-template <typename ExecutionSpace, class DT, class... DP>
-struct ZeroMemset;
-
 template <class ViewType, class Layout = typename ViewType::array_layout,
           class ExecSpace = typename ViewType::execution_space,
           int Rank = ViewType::rank, typename iType = int64_t>

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -38,6 +38,7 @@ static_assert(false,
 
 #include "impl/Kokkos_HostSpace_deepcopy.hpp"
 #include <impl/Kokkos_MemorySpace.hpp>
+#include <impl/Kokkos_ZeroMemset_fwd.hpp>
 
 /*--------------------------------------------------------------------------*/
 

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -38,7 +38,6 @@ static_assert(false,
 
 #include "impl/Kokkos_HostSpace_deepcopy.hpp"
 #include <impl/Kokkos_MemorySpace.hpp>
-#include <impl/Kokkos_ZeroMemset_fwd.hpp>
 
 /*--------------------------------------------------------------------------*/
 
@@ -241,27 +240,6 @@ class SharedAllocationRecord<Kokkos::HostSpace, void>
 namespace Kokkos {
 
 namespace Impl {
-
-template <class DT, class... DP>
-struct ZeroMemset<typename HostSpace::execution_space, DT, DP...> {
-  ZeroMemset(const typename HostSpace::execution_space& exec,
-             const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
-    // Host spaces, except for HPX, are synchronous and we need to fence for HPX
-    // since we can't properly enqueue a std::memset otherwise.
-    // We can't use exec.fence() directly since we don't have a full definition
-    // of HostSpace here.
-    hostspace_fence(exec);
-    using ValueType = typename View<DT, DP...>::value_type;
-    std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
-  }
-
-  ZeroMemset(const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
-    using ValueType = typename View<DT, DP...>::value_type;
-    std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
-  }
-};
 
 template <>
 struct DeepCopy<HostSpace, HostSpace, DefaultHostExecutionSpace> {

--- a/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
@@ -18,7 +18,6 @@
 #define KOKKOS_SYCLDEEPCOPY_HPP
 
 #include <Kokkos_Core_fwd.hpp>
-#include <impl/Kokkos_ZeroMemset_fwd.hpp>
 #include <SYCL/Kokkos_SYCL.hpp>
 
 #include <vector>
@@ -27,26 +26,6 @@
 
 namespace Kokkos {
 namespace Impl {
-
-template <class DT, class... DP>
-struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
-  ZeroMemset(const Kokkos::Experimental::SYCL& exec_space,
-             const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
-    auto event = exec_space.impl_internal_space_instance()->m_queue->memset(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type));
-    exec_space.impl_internal_space_instance()
-        ->m_queue->ext_oneapi_submit_barrier(std::vector<sycl::event>{event});
-  }
-
-  ZeroMemset(const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
-    Experimental::Impl::SYCLInternal::singleton().m_queue->memset(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type));
-  }
-};
 
 void DeepCopySYCL(void* dst, const void* src, size_t n);
 void DeepCopyAsyncSYCL(const Kokkos::Experimental::SYCL& instance, void* dst,

--- a/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_DeepCopy.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_SYCLDEEPCOPY_HPP
 
 #include <Kokkos_Core_fwd.hpp>
+#include <impl/Kokkos_ZeroMemset_fwd.hpp>
 #include <SYCL/Kokkos_SYCL.hpp>
 
 #include <vector>

--- a/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
@@ -23,23 +23,21 @@
 namespace Kokkos {
 namespace Impl {
 
-template <class DT, class... DP>
-struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
+template <class T, class... P>
+struct ZeroMemset<Kokkos::Experimental::SYCL, View<T, P...>> {
   ZeroMemset(const Kokkos::Experimental::SYCL& exec_space,
-             const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
+             const View<T, P...>& dst,
+             typename View<T, P...>::const_value_type&) {
     auto event = exec_space.impl_internal_space_instance()->m_queue->memset(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type));
+        dst.data(), 0, dst.size() * sizeof(typename View<T, P...>::value_type));
     exec_space.impl_internal_space_instance()
         ->m_queue->ext_oneapi_submit_barrier(std::vector<sycl::event>{event});
   }
 
-  ZeroMemset(const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
+  ZeroMemset(const View<T, P...>& dst,
+             typename View<T, P...>::const_value_type&) {
     Experimental::Impl::SYCLInternal::singleton().m_queue->memset(
-        dst.data(), 0,
-        dst.size() * sizeof(typename View<DT, DP...>::value_type));
+        dst.data(), 0, dst.size() * sizeof(typename View<T, P...>::value_type));
   }
 };
 

--- a/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
@@ -1,0 +1,49 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_SYCL_ZEROMEMSET_HPP
+#define KOKKOS_SYCL_ZEROMEMSET_HPP
+
+#include <impl/Kokkos_ZeroMemset_fwd.hpp>
+#include <SYCL/Kokkos_SYCL.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+template <class DT, class... DP>
+struct ZeroMemset<Kokkos::Experimental::SYCL, DT, DP...> {
+  ZeroMemset(const Kokkos::Experimental::SYCL& exec_space,
+             const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
+    auto event = exec_space.impl_internal_space_instance()->m_queue->memset(
+        dst.data(), 0,
+        dst.size() * sizeof(typename View<DT, DP...>::value_type));
+    exec_space.impl_internal_space_instance()
+        ->m_queue->ext_oneapi_submit_barrier(std::vector<sycl::event>{event});
+  }
+
+  ZeroMemset(const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
+    Experimental::Impl::SYCLInternal::singleton().m_queue->memset(
+        dst.data(), 0,
+        dst.size() * sizeof(typename View<DT, DP...>::value_type));
+  }
+};
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif  // !defined(KOKKOS_SYCL_ZEROMEMSET_HPP)

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -43,6 +43,7 @@ static_assert(false,
 #include <impl/Kokkos_Tools.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_InitializationSettings.hpp>
+#include <impl/Kokkos_ZeroMemset_fwd.hpp>
 
 namespace Kokkos {
 

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -43,7 +43,6 @@ static_assert(false,
 #include <impl/Kokkos_Tools.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_InitializationSettings.hpp>
-#include <impl/Kokkos_ZeroMemset_fwd.hpp>
 
 namespace Kokkos {
 
@@ -207,23 +206,6 @@ struct DeviceTypeTraits<Serial> {
 
 namespace Kokkos {
 namespace Impl {
-
-// We only need to provide a specialization for Serial if there is a host
-// parallel execution space since the specialization for
-// DefaultHostExecutionSpace is defined elsewhere.
-struct DummyExecutionSpace;
-template <class DT, class... DP>
-struct ZeroMemset<
-    std::conditional_t<!std::is_same<Serial, DefaultHostExecutionSpace>::value,
-                       Serial, DummyExecutionSpace>,
-    DT, DP...> : public ZeroMemset<DefaultHostExecutionSpace, DT, DP...> {
-  using Base = ZeroMemset<DefaultHostExecutionSpace, DT, DP...>;
-  using Base::Base;
-
-  ZeroMemset(const Serial&, const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type& value)
-      : Base(dst, value) {}
-};
 
 template <>
 struct MemorySpaceAccess<Kokkos::Serial::memory_space,

--- a/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
+++ b/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
@@ -30,16 +30,17 @@ namespace Impl {
 // parallel execution space since the specialization for
 // DefaultHostExecutionSpace is defined elsewhere.
 struct DummyExecutionSpace;
-template <class DT, class... DP>
+template <class T, class... P>
 struct ZeroMemset<
     std::conditional_t<!std::is_same<Serial, DefaultHostExecutionSpace>::value,
                        Serial, DummyExecutionSpace>,
-    DT, DP...> : public ZeroMemset<DefaultHostExecutionSpace, DT, DP...> {
-  using Base = ZeroMemset<DefaultHostExecutionSpace, DT, DP...>;
+    View<T, P...>>
+    : public ZeroMemset<DefaultHostExecutionSpace, View<T, P...>> {
+  using Base = ZeroMemset<DefaultHostExecutionSpace, View<T, P...>>;
   using Base::Base;
 
-  ZeroMemset(const Serial&, const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type& value)
+  ZeroMemset(const Serial&, const View<T, P...>& dst,
+             typename View<T, P...>::const_value_type& value)
       : Base(dst, value) {}
 };
 

--- a/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
+++ b/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
@@ -19,11 +19,16 @@
 
 #include <Kokkos_Macros.hpp>
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>
+#include <Serial/Kokkos_Serial.hpp>
+
+#include <type_traits>
 
 namespace Kokkos {
 namespace Impl {
 
-// We only need to provide a specialization for Serial if there is a host parallel execution space since the specialization for DefaultHostExecutionSpace is defined elsewhere.
+// We only need to provide a specialization for Serial if there is a host
+// parallel execution space since the specialization for
+// DefaultHostExecutionSpace is defined elsewhere.
 struct DummyExecutionSpace;
 template <class DT, class... DP>
 struct ZeroMemset<

--- a/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
+++ b/core/src/Serial/Kokkos_Serial_ZeroMemset.hpp
@@ -1,0 +1,44 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_SERIAL_ZEROMEMSET_HPP
+#define KOKKOS_SERIAL_ZEROMEMSET_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <impl/Kokkos_ZeroMemset_fwd.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+// We only need to provide a specialization for Serial if there is a host parallel execution space since the specialization for DefaultHostExecutionSpace is defined elsewhere.
+struct DummyExecutionSpace;
+template <class DT, class... DP>
+struct ZeroMemset<
+    std::conditional_t<!std::is_same<Serial, DefaultHostExecutionSpace>::value,
+                       Serial, DummyExecutionSpace>,
+    DT, DP...> : public ZeroMemset<DefaultHostExecutionSpace, DT, DP...> {
+  using Base = ZeroMemset<DefaultHostExecutionSpace, DT, DP...>;
+  using Base::Base;
+
+  ZeroMemset(const Serial&, const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type& value)
+      : Base(dst, value) {}
+};
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif  // !defined(KOKKOS_SERIAL_ZEROMEMSET_HPP)

--- a/core/src/decl/Kokkos_Declare_CUDA.hpp
+++ b/core/src/decl/Kokkos_Declare_CUDA.hpp
@@ -31,6 +31,7 @@
 #include <Cuda/Kokkos_Cuda_Task.hpp>
 #include <Cuda/Kokkos_Cuda_MDRangePolicy.hpp>
 #include <Cuda/Kokkos_Cuda_UniqueToken.hpp>
+#include <Cuda/Kokkos_Cuda_ZeroMemset.hpp>
 #endif
 
 #endif

--- a/core/src/decl/Kokkos_Declare_HIP.hpp
+++ b/core/src/decl/Kokkos_Declare_HIP.hpp
@@ -30,6 +30,7 @@
 #include <HIP/Kokkos_HIP_Parallel_Team.hpp>
 #include <HIP/Kokkos_HIP_SharedAllocationRecord.hpp>
 #include <HIP/Kokkos_HIP_UniqueToken.hpp>
+#include <HIP/Kokkos_HIP_ZeroMemset.hpp>
 
 namespace Kokkos {
 namespace Experimental {

--- a/core/src/decl/Kokkos_Declare_SERIAL.hpp
+++ b/core/src/decl/Kokkos_Declare_SERIAL.hpp
@@ -20,6 +20,7 @@
 #if defined(KOKKOS_ENABLE_SERIAL)
 #include <Serial/Kokkos_Serial.hpp>
 #include <Serial/Kokkos_Serial_MDRangePolicy.hpp>
+#include <Serial/Kokkos_Serial_ZeroMemset.hpp>
 #endif
 
 #endif

--- a/core/src/decl/Kokkos_Declare_SYCL.hpp
+++ b/core/src/decl/Kokkos_Declare_SYCL.hpp
@@ -28,6 +28,7 @@
 #include <SYCL/Kokkos_SYCL_Parallel_Scan.hpp>
 #include <SYCL/Kokkos_SYCL_Parallel_Team.hpp>
 #include <SYCL/Kokkos_SYCL_UniqueToken.hpp>
+#include <SYCL/Kokkos_SYCL_ZeroMemset.hpp>
 #endif
 
 #endif

--- a/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
+++ b/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
@@ -26,23 +26,23 @@
 namespace Kokkos {
 namespace Impl {
 
-template <class DT, class... DP>
-struct ZeroMemset<typename HostSpace::execution_space, DT, DP...> {
+template <class T, class... P>
+struct ZeroMemset<typename HostSpace::execution_space, View<T, P...>> {
   ZeroMemset(const typename HostSpace::execution_space& exec,
-             const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
+             const View<T, P...>& dst,
+             typename View<T, P...>::const_value_type&) {
     // Host spaces, except for HPX, are synchronous and we need to fence for HPX
     // since we can't properly enqueue a std::memset otherwise.
     // We can't use exec.fence() directly since we don't have a full definition
     // of HostSpace here.
     hostspace_fence(exec);
-    using ValueType = typename View<DT, DP...>::value_type;
+    using ValueType = typename View<T, P...>::value_type;
     std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
   }
 
-  ZeroMemset(const View<DT, DP...>& dst,
-             typename View<DT, DP...>::const_value_type&) {
-    using ValueType = typename View<DT, DP...>::value_type;
+  ZeroMemset(const View<T, P...>& dst,
+             typename View<T, P...>::const_value_type&) {
+    using ValueType = typename View<T, P...>::value_type;
     std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
   }
 };

--- a/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
+++ b/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
@@ -27,8 +27,8 @@ namespace Kokkos {
 namespace Impl {
 
 template <class T, class... P>
-struct ZeroMemset<typename HostSpace::execution_space, View<T, P...>> {
-  ZeroMemset(const typename HostSpace::execution_space& exec,
+struct ZeroMemset<HostSpace::execution_space, View<T, P...>> {
+  ZeroMemset(const HostSpace::execution_space& exec,
              const View<T, P...>& dst,
              typename View<T, P...>::const_value_type&) {
     // Host spaces, except for HPX, are synchronous and we need to fence for HPX

--- a/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
+++ b/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
@@ -14,31 +14,18 @@
 //
 //@HEADER
 
-#ifndef KOKKOS_ZEROMEMSET_HPP
-#define KOKKOS_ZEROMEMSET_HPP
+#ifndef KOKKOS_HOSTSPACE_ZEROMEMSET_HPP
+#define KOKKOS_HOSTSPACE_ZEROMEMSET_HPP
 
 #include <Kokkos_Macros.hpp>
+#include <Kokkos_HostSpace.hpp>
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>
-#include <Kokkos_View.hpp>
+
+#include <iostream>
 
 namespace Kokkos {
 namespace Impl {
 
-// Default implementation for execution spaces that don't provide a definition
-template <typename ExecutionSpace, class DT, class... DP>
-struct ZeroMemset {
-  ZeroMemset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
-             typename ViewTraits<DT, DP...>::const_value_type& value) {
-    contiguous_fill(exec_space, dst, value);
-  }
-
-  ZeroMemset(const View<DT, DP...>& dst,
-             typename ViewTraits<DT, DP...>::const_value_type& value) {
-    contiguous_fill(ExecutionSpace(), dst, value);
-  }
-};
-
-// Default HostSpace implementation
 template <class DT, class... DP>
 struct ZeroMemset<typename HostSpace::execution_space, DT, DP...> {
   ZeroMemset(const typename HostSpace::execution_space& exec,
@@ -63,4 +50,4 @@ struct ZeroMemset<typename HostSpace::execution_space, DT, DP...> {
 }  // end namespace Impl
 }  // end namespace Kokkos
 
-#endif  // KOKKOS_ZEROMEMSET_HPP
+#endif  // KOKKOS_HOSTSPACE_ZEROMEMSET_HPP

--- a/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
+++ b/core/src/impl/Kokkos_HostSpace_ZeroMemset.hpp
@@ -28,8 +28,7 @@ namespace Impl {
 
 template <class T, class... P>
 struct ZeroMemset<HostSpace::execution_space, View<T, P...>> {
-  ZeroMemset(const HostSpace::execution_space& exec,
-             const View<T, P...>& dst,
+  ZeroMemset(const HostSpace::execution_space& exec, const View<T, P...>& dst,
              typename View<T, P...>::const_value_type&) {
     // Host spaces, except for HPX, are synchronous and we need to fence for HPX
     // since we can't properly enqueue a std::memset otherwise.

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -2919,8 +2919,9 @@ struct ViewValueFunctor<DeviceType, ValueType, false /* is_scalar */> {
             "Kokkos::View::initialization [" + name + "] via memset",
             Kokkos::Profiling::Experimental::device_id(space), &kpID);
       }
-      (void)ZeroMemset<ExecSpace, ValueType*, typename DeviceType::memory_space,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
+      (void)ZeroMemset<
+          ExecSpace, Kokkos::View<ValueType*, typename DeviceType::memory_space,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>>(
           space,
           Kokkos::View<ValueType*, typename DeviceType::memory_space,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n),
@@ -3056,8 +3057,9 @@ struct ViewValueFunctor<DeviceType, ValueType, true /* is_scalar */> {
             Kokkos::Profiling::Experimental::device_id(space), &kpID);
       }
 
-      (void)ZeroMemset<ExecSpace, ValueType*, typename DeviceType::memory_space,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
+      (void)ZeroMemset<
+          ExecSpace, Kokkos::View<ValueType*, typename DeviceType::memory_space,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>>(
           space,
           Kokkos::View<ValueType*, typename DeviceType::memory_space,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ptr, n),

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -32,7 +32,7 @@
 #include <impl/Kokkos_Atomic_View.hpp>
 #include <impl/Kokkos_Tools.hpp>
 #include <impl/Kokkos_StringManipulation.hpp>
-#include <impl/Kokkos_HostSpace_ZeroMemset.hpp>
+#include <impl/Kokkos_ZeroMemset_fwd.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -32,7 +32,7 @@
 #include <impl/Kokkos_Atomic_View.hpp>
 #include <impl/Kokkos_Tools.hpp>
 #include <impl/Kokkos_StringManipulation.hpp>
-#include <impl/Kokkos_ZeroMemset.hpp>
+#include <impl/Kokkos_HostSpace_ZeroMemset.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -32,7 +32,7 @@
 #include <impl/Kokkos_Atomic_View.hpp>
 #include <impl/Kokkos_Tools.hpp>
 #include <impl/Kokkos_StringManipulation.hpp>
-#include <impl/Kokkos_ZeroMemset_fwd.hpp>
+#include <impl/Kokkos_ZeroMemset.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_ViewMapping.hpp
+++ b/core/src/impl/Kokkos_ViewMapping.hpp
@@ -32,6 +32,7 @@
 #include <impl/Kokkos_Atomic_View.hpp>
 #include <impl/Kokkos_Tools.hpp>
 #include <impl/Kokkos_StringManipulation.hpp>
+#include <impl/Kokkos_ZeroMemset_fwd.hpp>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/core/src/impl/Kokkos_ZeroMemset.hpp
+++ b/core/src/impl/Kokkos_ZeroMemset.hpp
@@ -19,8 +19,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <impl/Kokkos_ZeroMemset_fwd.hpp>
-
-#include <iostream>
+#include <Kokkos_View.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/impl/Kokkos_ZeroMemset.hpp
+++ b/core/src/impl/Kokkos_ZeroMemset.hpp
@@ -1,0 +1,67 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_ZEROMEMSET_HPP
+#define KOKKOS_ZEROMEMSET_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <impl/Kokkos_ZeroMemset_fwd.hpp>
+
+#include <iostream>
+
+namespace Kokkos {
+namespace Impl {
+
+// Default implementation for execution spaces that don't provide a definition
+template <typename ExecutionSpace, class DT, class... DP>
+struct ZeroMemset {
+  ZeroMemset(const ExecutionSpace& exec_space, const View<DT, DP...>& dst,
+             typename ViewTraits<DT, DP...>::const_value_type& value) {
+    contiguous_fill(exec_space, dst, value);
+  }
+
+  ZeroMemset(const View<DT, DP...>& dst,
+             typename ViewTraits<DT, DP...>::const_value_type& value) {
+    contiguous_fill(ExecutionSpace(), dst, value);
+  }
+};
+
+// Default HostSpace implementation
+template <class DT, class... DP>
+struct ZeroMemset<typename HostSpace::execution_space, DT, DP...> {
+  ZeroMemset(const typename HostSpace::execution_space& exec,
+             const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
+    // Host spaces, except for HPX, are synchronous and we need to fence for HPX
+    // since we can't properly enqueue a std::memset otherwise.
+    // We can't use exec.fence() directly since we don't have a full definition
+    // of HostSpace here.
+    hostspace_fence(exec);
+    using ValueType = typename View<DT, DP...>::value_type;
+    std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
+  }
+
+  ZeroMemset(const View<DT, DP...>& dst,
+             typename View<DT, DP...>::const_value_type&) {
+    using ValueType = typename View<DT, DP...>::value_type;
+    std::memset(dst.data(), 0, sizeof(ValueType) * dst.size());
+  }
+};
+
+}  // end namespace Impl
+}  // end namespace Kokkos
+
+#endif  // KOKKOS_ZEROMEMSET_HPP

--- a/core/src/impl/Kokkos_ZeroMemset_fwd.hpp
+++ b/core/src/impl/Kokkos_ZeroMemset_fwd.hpp
@@ -20,7 +20,7 @@
 namespace Kokkos {
 namespace Impl {
 
-template <typename ExecutionSpace, class DT, class... DP>
+template <typename ExecutionSpace, class ViewType>
 struct ZeroMemset;
 
 }  // namespace Impl

--- a/core/src/impl/Kokkos_ZeroMemset_fwd.hpp
+++ b/core/src/impl/Kokkos_ZeroMemset_fwd.hpp
@@ -1,0 +1,29 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_ZEROMEMSET_FWD_HPP
+#define KOKKOS_ZEROMEMSET_FWD_HPP
+
+namespace Kokkos {
+namespace Impl {
+
+template <typename ExecutionSpace, class DT, class... DP>
+struct ZeroMemset;
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif  // #ifndef KOKKOS_ZEROMEMSET_FWD_HPP


### PR DESCRIPTION
Changes:
- Move forward declaration of `ZeroMemset` to new `impl/Kokkos_ZeroMemset_fwd.hpp` file
- Move impl to exec specific files:
  -  `ZeroMemset<Cuda,...>` to new `Cuda/Kokkos_Cuda_ZeroMemset.hpp` file
  - HIP, Serial, SYCL likewise
  - `ZeroMemset<HostSpace,...>` to new `impl/Kokkos_HostSpace_ZeroMemset.hpp`