### PR TITLE
Disable failed bit manipulation tests when compiled by NVHPC 

### DIFF
--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -119,9 +119,14 @@ void test_bit_manip_countl_zero() {
 
 TEST(TEST_CATEGORY, bit_manip_countl_zero) {
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-  test_bit_manip_countl_zero<unsigned char>();
-  test_bit_manip_countl_zero<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+    test_bit_manip_countl_zero<unsigned char>();
+    test_bit_manip_countl_zero<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  }
 #endif
   test_bit_manip_countl_zero<unsigned int>();
   test_bit_manip_countl_zero<unsigned long>();
@@ -174,9 +179,14 @@ void test_bit_manip_countl_one() {
 
 TEST(TEST_CATEGORY, bit_manip_countl_one) {
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-  test_bit_manip_countl_one<unsigned char>();
-  test_bit_manip_countl_one<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+    test_bit_manip_countl_one<unsigned char>();
+    test_bit_manip_countl_one<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  }
 #endif
   test_bit_manip_countl_one<unsigned int>();
   test_bit_manip_countl_one<unsigned long>();
@@ -216,9 +226,14 @@ TEST(TEST_CATEGORY, bit_manip_countr_zero) {
   if (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
 #endif
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-    test_bit_manip_countr_zero<unsigned char>();
-  test_bit_manip_countr_zero<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+    if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                  Kokkos::Experimental::OpenACC>) {
+#endif
+      test_bit_manip_countr_zero<unsigned char>();
+      test_bit_manip_countr_zero<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+    }
 #endif
   test_bit_manip_countr_zero<unsigned int>();
   test_bit_manip_countr_zero<unsigned long>();
@@ -257,9 +272,14 @@ TEST(TEST_CATEGORY, bit_manip_countr_one) {
   if (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
 #endif
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-    test_bit_manip_countr_one<unsigned char>();
-  test_bit_manip_countr_one<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+    if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                  Kokkos::Experimental::OpenACC>) {
+#endif
+      test_bit_manip_countr_one<unsigned char>();
+      test_bit_manip_countr_one<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+    }
 #endif
   test_bit_manip_countr_one<unsigned int>();
   test_bit_manip_countr_one<unsigned long>();
@@ -292,9 +312,14 @@ void test_bit_manip_popcount() {
 
 TEST(TEST_CATEGORY, bit_manip_popcount) {
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-  test_bit_manip_popcount<unsigned char>();
-  test_bit_manip_popcount<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+    test_bit_manip_popcount<unsigned char>();
+    test_bit_manip_popcount<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  }
 #endif
   test_bit_manip_popcount<unsigned int>();
   test_bit_manip_popcount<unsigned long>();
@@ -336,9 +361,14 @@ void test_bit_manip_has_single_bit() {
 
 TEST(TEST_CATEGORY, bit_manip_has_single_bit) {
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-  test_bit_manip_has_single_bit<unsigned char>();
-  test_bit_manip_has_single_bit<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+    test_bit_manip_has_single_bit<unsigned char>();
+    test_bit_manip_has_single_bit<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  }
 #endif
   test_bit_manip_has_single_bit<unsigned int>();
   test_bit_manip_has_single_bit<unsigned long>();
@@ -374,9 +404,14 @@ void test_bit_manip_bit_floor() {
 
 TEST(TEST_CATEGORY, bit_manip_bit_floor) {
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-  test_bit_manip_bit_floor<unsigned char>();
-  test_bit_manip_bit_floor<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+    test_bit_manip_bit_floor<unsigned char>();
+    test_bit_manip_bit_floor<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  }
 #endif
   test_bit_manip_bit_floor<unsigned int>();
   test_bit_manip_bit_floor<unsigned long>();
@@ -417,9 +452,14 @@ void test_bit_manip_bit_ceil() {
 
 TEST(TEST_CATEGORY, bit_manip_bit_ceil) {
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-  test_bit_manip_bit_ceil<unsigned char>();
-  test_bit_manip_bit_ceil<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+    test_bit_manip_bit_ceil<unsigned char>();
+    test_bit_manip_bit_ceil<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  }
 #endif
   test_bit_manip_bit_ceil<unsigned int>();
   test_bit_manip_bit_ceil<unsigned long>();
@@ -451,9 +491,14 @@ void test_bit_manip_bit_width() {
 
 TEST(TEST_CATEGORY, bit_manip_bit_width) {
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-  test_bit_manip_bit_width<unsigned char>();
-  test_bit_manip_bit_width<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+    test_bit_manip_bit_width<unsigned char>();
+    test_bit_manip_bit_width<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  }
 #endif
   test_bit_manip_bit_width<unsigned int>();
   test_bit_manip_bit_width<unsigned long>();
@@ -569,9 +614,14 @@ void test_bit_manip_rotl() {
 
 TEST(TEST_CATEGORY, bit_manip_rotl) {
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-  test_bit_manip_rotl<unsigned char>();
-  test_bit_manip_rotl<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+    test_bit_manip_rotl<unsigned char>();
+    test_bit_manip_rotl<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  }
 #endif
   test_bit_manip_rotl<unsigned int>();
   test_bit_manip_rotl<unsigned long>();
@@ -626,9 +676,14 @@ void test_bit_manip_rotr() {
 
 TEST(TEST_CATEGORY, bit_manip_rotr) {
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-  test_bit_manip_rotr<unsigned char>();
-  test_bit_manip_rotr<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+    test_bit_manip_rotr<unsigned char>();
+    test_bit_manip_rotr<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  }
 #endif
   test_bit_manip_rotr<unsigned int>();
   test_bit_manip_rotr<unsigned long>();
@@ -692,11 +747,16 @@ void test_bit_manip_byteswap() {
 
 TEST(TEST_CATEGORY, bit_manip_byeswap) {
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
-#if !defined(KOKKOS_COMPILER_NVHPC)
-  test_bit_manip_byteswap<char>();
-  test_bit_manip_byteswap<unsigned char>();
-  test_bit_manip_byteswap<short>();
-  test_bit_manip_byteswap<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+    test_bit_manip_byteswap<char>();
+    test_bit_manip_byteswap<unsigned char>();
+    test_bit_manip_byteswap<short>();
+    test_bit_manip_byteswap<unsigned short>();
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
+  }
 #endif
   test_bit_manip_byteswap<int>();
   test_bit_manip_byteswap<unsigned int>();

--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -221,19 +221,19 @@ void test_bit_manip_countr_zero() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_countr_zero) {
-#if defined(KOKKOS_ENABLE_SYCL) && \
-    !defined(KOKKOS_ARCH_INTEL_GPU)  // FIXME_SYCL returns wrong result
-  if (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
-#endif
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
 #if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
-    if constexpr (!std::is_same_v<TEST_EXECSPACE,
-                                  Kokkos::Experimental::OpenACC>) {
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+#if defined(KOKKOS_ENABLE_SYCL) && \
+    !defined(KOKKOS_ARCH_INTEL_GPU)  // FIXME_SYCL returns wrong result
+    if (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
 #endif
       test_bit_manip_countr_zero<unsigned char>();
-      test_bit_manip_countr_zero<unsigned short>();
+    test_bit_manip_countr_zero<unsigned short>();
 #if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
-    }
+  }
 #endif
   test_bit_manip_countr_zero<unsigned int>();
   test_bit_manip_countr_zero<unsigned long>();
@@ -267,19 +267,19 @@ void test_bit_manip_countr_one() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_countr_one) {
-#if defined(KOKKOS_ENABLE_SYCL) && \
-    !defined(KOKKOS_ARCH_INTEL_GPU)  // FIXME_SYCL returns wrong result
-  if (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
-#endif
 // FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
 #if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
-    if constexpr (!std::is_same_v<TEST_EXECSPACE,
-                                  Kokkos::Experimental::OpenACC>) {
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::Experimental::OpenACC>) {
+#endif
+#if defined(KOKKOS_ENABLE_SYCL) && \
+    !defined(KOKKOS_ARCH_INTEL_GPU)  // FIXME_SYCL returns wrong result
+    if (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
 #endif
       test_bit_manip_countr_one<unsigned char>();
-      test_bit_manip_countr_one<unsigned short>();
+    test_bit_manip_countr_one<unsigned short>();
 #if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
-    }
+  }
 #endif
   test_bit_manip_countr_one<unsigned int>();
   test_bit_manip_countr_one<unsigned long>();

--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -118,8 +118,11 @@ void test_bit_manip_countl_zero() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_countl_zero) {
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
   test_bit_manip_countl_zero<unsigned char>();
   test_bit_manip_countl_zero<unsigned short>();
+#endif
   test_bit_manip_countl_zero<unsigned int>();
   test_bit_manip_countl_zero<unsigned long>();
   test_bit_manip_countl_zero<unsigned long long>();
@@ -170,8 +173,11 @@ void test_bit_manip_countl_one() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_countl_one) {
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
   test_bit_manip_countl_one<unsigned char>();
   test_bit_manip_countl_one<unsigned short>();
+#endif
   test_bit_manip_countl_one<unsigned int>();
   test_bit_manip_countl_one<unsigned long>();
   test_bit_manip_countl_one<unsigned long long>();
@@ -209,8 +215,11 @@ TEST(TEST_CATEGORY, bit_manip_countr_zero) {
     !defined(KOKKOS_ARCH_INTEL_GPU)  // FIXME_SYCL returns wrong result
   if (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
 #endif
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
     test_bit_manip_countr_zero<unsigned char>();
   test_bit_manip_countr_zero<unsigned short>();
+#endif
   test_bit_manip_countr_zero<unsigned int>();
   test_bit_manip_countr_zero<unsigned long>();
   test_bit_manip_countr_zero<unsigned long long>();
@@ -247,8 +256,11 @@ TEST(TEST_CATEGORY, bit_manip_countr_one) {
     !defined(KOKKOS_ARCH_INTEL_GPU)  // FIXME_SYCL returns wrong result
   if (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::SYCL>)
 #endif
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
     test_bit_manip_countr_one<unsigned char>();
   test_bit_manip_countr_one<unsigned short>();
+#endif
   test_bit_manip_countr_one<unsigned int>();
   test_bit_manip_countr_one<unsigned long>();
   test_bit_manip_countr_one<unsigned long long>();
@@ -279,8 +291,11 @@ void test_bit_manip_popcount() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_popcount) {
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
   test_bit_manip_popcount<unsigned char>();
   test_bit_manip_popcount<unsigned short>();
+#endif
   test_bit_manip_popcount<unsigned int>();
   test_bit_manip_popcount<unsigned long>();
   test_bit_manip_popcount<unsigned long long>();
@@ -320,8 +335,11 @@ void test_bit_manip_has_single_bit() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_has_single_bit) {
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
   test_bit_manip_has_single_bit<unsigned char>();
   test_bit_manip_has_single_bit<unsigned short>();
+#endif
   test_bit_manip_has_single_bit<unsigned int>();
   test_bit_manip_has_single_bit<unsigned long>();
   test_bit_manip_has_single_bit<unsigned long long>();
@@ -355,8 +373,11 @@ void test_bit_manip_bit_floor() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_bit_floor) {
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
   test_bit_manip_bit_floor<unsigned char>();
   test_bit_manip_bit_floor<unsigned short>();
+#endif
   test_bit_manip_bit_floor<unsigned int>();
   test_bit_manip_bit_floor<unsigned long>();
   test_bit_manip_bit_floor<unsigned long long>();
@@ -395,8 +416,11 @@ void test_bit_manip_bit_ceil() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_bit_ceil) {
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
   test_bit_manip_bit_ceil<unsigned char>();
   test_bit_manip_bit_ceil<unsigned short>();
+#endif
   test_bit_manip_bit_ceil<unsigned int>();
   test_bit_manip_bit_ceil<unsigned long>();
   test_bit_manip_bit_ceil<unsigned long long>();
@@ -426,8 +450,11 @@ void test_bit_manip_bit_width() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_bit_width) {
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
   test_bit_manip_bit_width<unsigned char>();
   test_bit_manip_bit_width<unsigned short>();
+#endif
   test_bit_manip_bit_width<unsigned int>();
   test_bit_manip_bit_width<unsigned long>();
   test_bit_manip_bit_width<unsigned long long>();
@@ -541,8 +568,11 @@ void test_bit_manip_rotl() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_rotl) {
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
   test_bit_manip_rotl<unsigned char>();
   test_bit_manip_rotl<unsigned short>();
+#endif
   test_bit_manip_rotl<unsigned int>();
   test_bit_manip_rotl<unsigned long>();
   test_bit_manip_rotl<unsigned long long>();
@@ -595,8 +625,11 @@ void test_bit_manip_rotr() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_rotr) {
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
   test_bit_manip_rotr<unsigned char>();
   test_bit_manip_rotr<unsigned short>();
+#endif
   test_bit_manip_rotr<unsigned int>();
   test_bit_manip_rotr<unsigned long>();
   test_bit_manip_rotr<unsigned long long>();
@@ -658,10 +691,13 @@ void test_bit_manip_byteswap() {
 }
 
 TEST(TEST_CATEGORY, bit_manip_byeswap) {
+// FIXME_NVHPC: NVC++-W-0155-Compiler failed to translate accelerator region
+#if !defined(KOKKOS_COMPILER_NVHPC)
   test_bit_manip_byteswap<char>();
   test_bit_manip_byteswap<unsigned char>();
   test_bit_manip_byteswap<short>();
   test_bit_manip_byteswap<unsigned short>();
+#endif
   test_bit_manip_byteswap<int>();
   test_bit_manip_byteswap<unsigned int>();
   test_bit_manip_byteswap<long>();


### PR DESCRIPTION
NVHPC compiler failed to correctly translate accelerator region for tests in
core/unit_test/TestBitManipulationBuiltins.hpp if the tested variable type is char
or short; disable those failed tests.