### PR TITLE
fix ternary op in subset of std algorithms not working with nvhpc

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_AdjacentFind.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_AdjacentFind.hpp
@@ -42,13 +42,7 @@ struct StdAdjacentFindFunctor {
     const auto& next_value = m_first[i + 1];
     const bool are_equal   = m_p(my_value, next_value);
 
-    /* FRIZZI: 05/2023
-       Originally the code below was using a ternary operator but nvc++ for 22.9
-       did not work with that, which was the reason for
-       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
-       works.
-    */
-
+    // FIXME_NVHPC using a ternary operator causes problems
     red_value_type value = {::Kokkos::reduction_identity<IndexType>::min()};
     if (are_equal) {
       value.min_loc_true = i;

--- a/algorithms/src/std_algorithms/impl/Kokkos_AdjacentFind.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_AdjacentFind.hpp
@@ -43,14 +43,10 @@ struct StdAdjacentFindFunctor {
     const bool are_equal   = m_p(my_value, next_value);
 
     /* FRIZZI: 05/2023
-       Originally this was:
-        auto rv =  are_equal
-          ? red_value_type{i}
-          : red_value_type{::Kokkos::reduction_identity<IndexType>::min()};
-        m_reducer.join(red_value, rv);
-       For nvc++ 22.9 that caused tests to fail, which was the reason
-       for disabling algorithms in fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff
-       This is now fixed by using the code below.
+       Originally the code below was using a ternary operator but nvc++ for 22.9
+       did not work with that, which was the reason for
+       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
+       works.
     */
 
     red_value_type value = {::Kokkos::reduction_identity<IndexType>::min()};

--- a/algorithms/src/std_algorithms/impl/Kokkos_AdjacentFind.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_AdjacentFind.hpp
@@ -46,14 +46,14 @@ struct StdAdjacentFindFunctor {
        Originally this was:
         auto rv =  are_equal
           ? red_value_type{i}
-          : red_value_type{::Kokkos::reduction_identity<index_type>::min()};
+          : red_value_type{::Kokkos::reduction_identity<IndexType>::min()};
         m_reducer.join(red_value, rv);
        For nvc++ 22.9 that caused tests to fail, which was the reason
        for disabling algorithms in fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff
        This is now fixed by using the code below.
     */
 
-    red_value_type value = {::Kokkos::reduction_identity<index_type>::min()};
+    red_value_type value = {::Kokkos::reduction_identity<IndexType>::min()};
     if (are_equal) {
       value.min_loc_true = i;
     }

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindEnd.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindEnd.hpp
@@ -59,12 +59,7 @@ struct StdFindEndFunctor {
       }
     }
 
-    /* FRIZZI: 05/2023
-       Originally the code below was using a ternary operator but nvc++ for 22.9
-       did not work with that, which was the reason for
-       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
-       works.
-    */
+    // FIXME_NVHPC using a ternary operator causes problems
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::max()};
     if (found) {
       rv.max_loc_true = i;

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindEnd.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindEnd.hpp
@@ -59,6 +59,12 @@ struct StdFindEndFunctor {
       }
     }
 
+    /* FRIZZI: 05/2023
+       Originally the code below was using a ternary operator but nvc++ for 22.9
+       did not work with that, which was the reason for
+       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
+       works.
+    */
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::max()};
     if (found) {
       rv.max_loc_true = i;

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindEnd.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindEnd.hpp
@@ -59,9 +59,10 @@ struct StdFindEndFunctor {
       }
     }
 
-    const auto rv =
-        found ? red_value_type{i}
-              : red_value_type{::Kokkos::reduction_identity<IndexType>::max()};
+    red_value_type rv = {::Kokkos::reduction_identity<IndexType>::max()};
+    if (found) {
+      rv.max_loc_true = i;
+    }
 
     m_reducer.join(red_value, rv);
   }

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindFirstOf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindFirstOf.hpp
@@ -52,6 +52,12 @@ struct StdFindFirstOfFunctor {
       }
     }
 
+    /* FRIZZI: 05/2023
+       Originally the code below was using a ternary operator but nvc++ for 22.9
+       did not work with that, which was the reason for
+       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
+       works.
+    */
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
     if (found) {
       rv.min_loc_true = i;

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindFirstOf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindFirstOf.hpp
@@ -52,10 +52,10 @@ struct StdFindFirstOfFunctor {
       }
     }
 
-    const auto rv =
-        found ? red_value_type{i}
-              : red_value_type{::Kokkos::reduction_identity<IndexType>::min()};
-
+    red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
+    if (found) {
+      rv.min_loc_true = i;
+    }
     m_reducer.join(red_value, rv);
   }
 

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindFirstOf.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindFirstOf.hpp
@@ -52,12 +52,7 @@ struct StdFindFirstOfFunctor {
       }
     }
 
-    /* FRIZZI: 05/2023
-       Originally the code below was using a ternary operator but nvc++ for 22.9
-       did not work with that, which was the reason for
-       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
-       works.
-    */
+    // FIXME_NVHPC using a ternary operator causes problems
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
     if (found) {
       rv.min_loc_true = i;

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindIfOrNot.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindIfOrNot.hpp
@@ -43,11 +43,10 @@ struct StdFindIfOrNotFunctor {
     // if doing find_if, look for when predicate is true
     // if doing find_if_not, look for when predicate is false
     const bool found_condition = is_find_if ? m_p(my_value) : !m_p(my_value);
-
-    auto rv =
-        found_condition
-            ? red_value_type{i}
-            : red_value_type{::Kokkos::reduction_identity<IndexType>::min()};
+    red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
+    if (found_condition) {
+      rv = {i};
+    }
 
     m_reducer.join(red_value, rv);
   }

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindIfOrNot.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindIfOrNot.hpp
@@ -44,12 +44,7 @@ struct StdFindIfOrNotFunctor {
     // if doing find_if_not, look for when predicate is false
     const bool found_condition = is_find_if ? m_p(my_value) : !m_p(my_value);
 
-    /* FRIZZI: 05/2023
-       Originally the code below was using a ternary operator but nvc++ for 22.9
-       did not work with that, which was the reason for
-       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
-       works.
-    */
+    // FIXME_NVHPC using a ternary operator causes problems
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
     if (found_condition) {
       rv.min_loc_true = i;

--- a/algorithms/src/std_algorithms/impl/Kokkos_FindIfOrNot.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_FindIfOrNot.hpp
@@ -43,9 +43,16 @@ struct StdFindIfOrNotFunctor {
     // if doing find_if, look for when predicate is true
     // if doing find_if_not, look for when predicate is false
     const bool found_condition = is_find_if ? m_p(my_value) : !m_p(my_value);
+
+    /* FRIZZI: 05/2023
+       Originally the code below was using a ternary operator but nvc++ for 22.9
+       did not work with that, which was the reason for
+       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
+       works.
+    */
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
     if (found_condition) {
-      rv = {i};
+      rv.min_loc_true = i;
     }
 
     m_reducer.join(red_value, rv);

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
@@ -44,12 +44,7 @@ struct StdIsPartitionedFunctor {
     constexpr index_type m_red_id_max =
         ::Kokkos::reduction_identity<index_type>::max();
 
-    /* FRIZZI: 05/2023
-       Originally the code below was using a ternary operator but nvc++ for 22.9
-       did not work with that, which was the reason for
-       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
-       works.
-    */
+    // FIXME_NVHPC using a ternary operator causes problems
     red_value_type rv = {m_red_id_max, i};
     if (predicate_value) {
       rv = {i, m_red_id_min};

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
@@ -43,6 +43,13 @@ struct StdIsPartitionedFunctor {
         ::Kokkos::reduction_identity<index_type>::min();
     constexpr index_type m_red_id_max =
         ::Kokkos::reduction_identity<index_type>::max();
+
+    /* FRIZZI: 05/2023
+       Originally the code below was using a ternary operator but nvc++ for 22.9
+       did not work with that, which was the reason for
+       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
+       works.
+    */
     red_value_type rv = {m_red_id_max, i};
     if (predicate_value) {
       rv = {i, m_red_id_min};

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsPartitioned.hpp
@@ -43,8 +43,10 @@ struct StdIsPartitionedFunctor {
         ::Kokkos::reduction_identity<index_type>::min();
     constexpr index_type m_red_id_max =
         ::Kokkos::reduction_identity<index_type>::max();
-    auto rv = predicate_value ? red_value_type{i, m_red_id_min}
-                              : red_value_type{m_red_id_max, i};
+    red_value_type rv = {m_red_id_max, i};
+    if (predicate_value) {
+      rv = {i, m_red_id_min};
+    }
 
     m_reducer.join(redValue, rv);
   }

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsSortedUntil.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsSortedUntil.hpp
@@ -71,8 +71,8 @@ IteratorType is_sorted_until_impl(const std::string& label,
 
   /*
     Do a par_reduce computing the *min* index that breaks the sorting.
-    If one such index is found, then the range is sorted until that element,
-    if no such index is found, then it means the range is sorted until the end.
+    If such an index is found, then the range is sorted until that element.
+    If no such index is found, then the range is sorted until the end.
   */
   using index_type = typename IteratorType::difference_type;
   index_type red_result;
@@ -87,11 +87,11 @@ IteratorType is_sorted_until_impl(const std::string& label,
       StdIsSortedUntilFunctor(first, comp, reducer), reducer);
 
   /* If the reduction result is equal to the initial value,
-     and it means the range is sorted until the end */
+     it means the range is sorted until the end */
   if (red_result == red_result_init) {
     return last;
   } else {
-    /* If  such index is found, then the range is sorted until there and
+    /* If such an index is found, then the range is sorted until there and
        we need to return an iterator past the element found so do +1 */
     return first + (red_result + 1);
   }

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsSortedUntil.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsSortedUntil.hpp
@@ -28,30 +28,33 @@ namespace Kokkos {
 namespace Experimental {
 namespace Impl {
 
-template <class IteratorType, class ComparatorType, class ReducerType>
+template <class IteratorType, class IndicatorViewType, class ComparatorType>
 struct StdIsSortedUntilFunctor {
-  using index_type     = typename IteratorType::difference_type;
-  using red_value_type = typename ReducerType::value_type;
-
+  using index_type = typename IteratorType::difference_type;
   IteratorType m_first;
+  IndicatorViewType m_indicator;
   ComparatorType m_comparator;
-  ReducerType m_reducer;
 
   KOKKOS_FUNCTION
-  void operator()(const index_type i, red_value_type& red_value) const {
+  void operator()(const index_type i, int& update, const bool final) const {
     const auto& val_i   = m_first[i];
     const auto& val_ip1 = m_first[i + 1];
+
     if (m_comparator(val_ip1, val_i)) {
-      m_reducer.join(red_value, i);
+      ++update;
+    }
+
+    if (final) {
+      m_indicator(i) = update;
     }
   }
 
   KOKKOS_FUNCTION
-  StdIsSortedUntilFunctor(IteratorType first, ComparatorType comparator,
-                          ReducerType reducer)
-      : m_first(std::move(first)),
-        m_comparator(std::move(comparator)),
-        m_reducer(std::move(reducer)) {}
+  StdIsSortedUntilFunctor(IteratorType _first1, IndicatorViewType indicator,
+                          ComparatorType comparator)
+      : m_first(std::move(_first1)),
+        m_indicator(std::move(indicator)),
+        m_comparator(std::move(comparator)) {}
 };
 
 template <class ExecutionSpace, class IteratorType, class ComparatorType>
@@ -70,31 +73,40 @@ IteratorType is_sorted_until_impl(const std::string& label,
   }
 
   /*
-    Do a par_reduce computing the *min* index that breaks the sorting.
-    If such an index is found, then the range is sorted until that element.
-    If no such index is found, then the range is sorted until the end.
-  */
-  using index_type = typename IteratorType::difference_type;
-  index_type red_result;
-  index_type red_result_init;
-  ::Kokkos::Min<index_type> reducer(red_result);
-  reducer.init(red_result_init);
-  ::Kokkos::parallel_reduce(
-      label,
-      // use num_elements-1 because each index handles i and i+1
-      RangePolicy<ExecutionSpace>(ex, 0, num_elements - 1),
-      // use CTAD
-      StdIsSortedUntilFunctor(first, comp, reducer), reducer);
+    use scan and a helper "indicator" view
+    such that we scan the data and fill the indicator with
+    partial sum that is always 0 unless we find a pair that
+    breaks the sorting, so in that case the indicator will
+    have a 1 starting at the location where the sorting breaks.
+    So finding that 1 means finding the location we want.
+   */
 
-  /* If the reduction result is equal to the initial value,
-     it means the range is sorted until the end */
-  if (red_result == red_result_init) {
-    return last;
-  } else {
-    /* If such an index is found, then the range is sorted until there and
-       we need to return an iterator past the element found so do +1 */
-    return first + (red_result + 1);
-  }
+  // aliases
+  using indicator_value_type = std::size_t;
+  using indicator_view_type =
+      ::Kokkos::View<indicator_value_type*, ExecutionSpace>;
+  using functor_type =
+      StdIsSortedUntilFunctor<IteratorType, indicator_view_type,
+                              ComparatorType>;
+
+  // do scan
+  // use num_elements-1 because each index handles i and i+1
+  const auto num_elements_minus_one = num_elements - 1;
+  indicator_view_type indicator("is_sorted_until_indicator_helper",
+                                num_elements_minus_one);
+  ::Kokkos::parallel_scan(
+      label, RangePolicy<ExecutionSpace>(ex, 0, num_elements_minus_one),
+      functor_type(first, indicator, std::move(comp)));
+
+  // try to find the first sentinel value, which indicates
+  // where the sorting condition breaks
+  namespace KE                                  = ::Kokkos::Experimental;
+  constexpr indicator_value_type sentinel_value = 1;
+  auto r =
+      KE::find(ex, KE::cbegin(indicator), KE::cend(indicator), sentinel_value);
+  const auto shift = r - ::Kokkos::Experimental::cbegin(indicator);
+
+  return first + (shift + 1);
 }
 
 template <class ExecutionSpace, class IteratorType>

--- a/algorithms/src/std_algorithms/impl/Kokkos_IsSortedUntil.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_IsSortedUntil.hpp
@@ -28,33 +28,30 @@ namespace Kokkos {
 namespace Experimental {
 namespace Impl {
 
-template <class IteratorType, class IndicatorViewType, class ComparatorType>
+template <class IteratorType, class ComparatorType, class ReducerType>
 struct StdIsSortedUntilFunctor {
-  using index_type = typename IteratorType::difference_type;
+  using index_type     = typename IteratorType::difference_type;
+  using red_value_type = typename ReducerType::value_type;
+
   IteratorType m_first;
-  IndicatorViewType m_indicator;
   ComparatorType m_comparator;
+  ReducerType m_reducer;
 
   KOKKOS_FUNCTION
-  void operator()(const index_type i, int& update, const bool final) const {
+  void operator()(const index_type i, red_value_type& red_value) const {
     const auto& val_i   = m_first[i];
     const auto& val_ip1 = m_first[i + 1];
-
     if (m_comparator(val_ip1, val_i)) {
-      ++update;
-    }
-
-    if (final) {
-      m_indicator(i) = update;
+      m_reducer.join(red_value, i);
     }
   }
 
   KOKKOS_FUNCTION
-  StdIsSortedUntilFunctor(IteratorType _first1, IndicatorViewType indicator,
-                          ComparatorType comparator)
-      : m_first(std::move(_first1)),
-        m_indicator(std::move(indicator)),
-        m_comparator(std::move(comparator)) {}
+  StdIsSortedUntilFunctor(IteratorType first, ComparatorType comparator,
+                          ReducerType reducer)
+      : m_first(std::move(first)),
+        m_comparator(std::move(comparator)),
+        m_reducer(std::move(reducer)) {}
 };
 
 template <class ExecutionSpace, class IteratorType, class ComparatorType>
@@ -73,40 +70,31 @@ IteratorType is_sorted_until_impl(const std::string& label,
   }
 
   /*
-    use scan and a helper "indicator" view
-    such that we scan the data and fill the indicator with
-    partial sum that is always 0 unless we find a pair that
-    breaks the sorting, so in that case the indicator will
-    have a 1 starting at the location where the sorting breaks.
-    So finding that 1 means finding the location we want.
-   */
+    Do a par_reduce computing the *min* index that breaks the sorting.
+    If one such index is found, then the range is sorted until that element,
+    if no such index is found, then it means the range is sorted until the end.
+  */
+  using index_type = typename IteratorType::difference_type;
+  index_type red_result;
+  index_type red_result_init;
+  ::Kokkos::Min<index_type> reducer(red_result);
+  reducer.init(red_result_init);
+  ::Kokkos::parallel_reduce(
+      label,
+      // use num_elements-1 because each index handles i and i+1
+      RangePolicy<ExecutionSpace>(ex, 0, num_elements - 1),
+      // use CTAD
+      StdIsSortedUntilFunctor(first, comp, reducer), reducer);
 
-  // aliases
-  using indicator_value_type = std::size_t;
-  using indicator_view_type =
-      ::Kokkos::View<indicator_value_type*, ExecutionSpace>;
-  using functor_type =
-      StdIsSortedUntilFunctor<IteratorType, indicator_view_type,
-                              ComparatorType>;
-
-  // do scan
-  // use num_elements-1 because each index handles i and i+1
-  const auto num_elements_minus_one = num_elements - 1;
-  indicator_view_type indicator("is_sorted_until_indicator_helper",
-                                num_elements_minus_one);
-  ::Kokkos::parallel_scan(
-      label, RangePolicy<ExecutionSpace>(ex, 0, num_elements_minus_one),
-      functor_type(first, indicator, std::move(comp)));
-
-  // try to find the first sentinel value, which indicates
-  // where the sorting condition breaks
-  namespace KE                                  = ::Kokkos::Experimental;
-  constexpr indicator_value_type sentinel_value = 1;
-  auto r =
-      KE::find(ex, KE::cbegin(indicator), KE::cend(indicator), sentinel_value);
-  const auto shift = r - ::Kokkos::Experimental::cbegin(indicator);
-
-  return first + (shift + 1);
+  /* If the reduction result is equal to the initial value,
+     and it means the range is sorted until the end */
+  if (red_result == red_result_init) {
+    return last;
+  } else {
+    /* If  such index is found, then the range is sorted until there and
+       we need to return an iterator past the element found so do +1 */
+    return first + (red_result + 1);
+  }
 }
 
 template <class ExecutionSpace, class IteratorType>

--- a/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
@@ -65,10 +65,10 @@ struct StdLexicographicalCompareFunctor {
 
     bool different = m_comparator(my_value1, my_value2) ||
                      m_comparator(my_value2, my_value1);
-    auto rv =
-        different
-            ? red_value_type{i}
-            : red_value_type{::Kokkos::reduction_identity<IndexType>::min()};
+    red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
+    if (different) {
+      rv.min_loc_true = i;
+    }
 
     m_reducer.join(red_value, rv);
   }

--- a/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
@@ -66,12 +66,7 @@ struct StdLexicographicalCompareFunctor {
     const bool different = m_comparator(my_value1, my_value2) ||
                            m_comparator(my_value2, my_value1);
 
-    /* FRIZZI: 05/2023
-       Originally the code below was using a ternary operator but nvc++ for 22.9
-       did not work with that, which was the reason for
-       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
-       works.
-    */
+    // FIXME_NVHPC using a ternary operator causes problems
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
     if (different) {
       rv.min_loc_true = i;

--- a/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_LexicographicalCompare.hpp
@@ -63,8 +63,15 @@ struct StdLexicographicalCompareFunctor {
     const auto& my_value1 = m_first1[i];
     const auto& my_value2 = m_first2[i];
 
-    bool different = m_comparator(my_value1, my_value2) ||
-                     m_comparator(my_value2, my_value1);
+    const bool different = m_comparator(my_value1, my_value2) ||
+                           m_comparator(my_value2, my_value1);
+
+    /* FRIZZI: 05/2023
+       Originally the code below was using a ternary operator but nvc++ for 22.9
+       did not work with that, which was the reason for
+       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
+       works.
+    */
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
     if (different) {
       rv.min_loc_true = i;

--- a/algorithms/src/std_algorithms/impl/Kokkos_Mismatch.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Mismatch.hpp
@@ -73,6 +73,7 @@ template <class ExecutionSpace, class IteratorType1, class IteratorType2,
   Impl::expect_valid_range(first2, last2);
 
   // aliases
+  using index_type           = typename IteratorType1::difference_type;
   using return_type          = ::Kokkos::pair<IteratorType1, IteratorType2>;
   using reducer_type         = FirstLoc<index_type>;
   using reduction_value_type = typename reducer_type::value_type;

--- a/algorithms/src/std_algorithms/impl/Kokkos_Mismatch.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Mismatch.hpp
@@ -43,6 +43,12 @@ struct StdMismatchRedFunctor {
     const auto& my_value1 = m_first1[i];
     const auto& my_value2 = m_first2[i];
 
+    /* FRIZZI: 05/2023
+       Originally the code below was using a ternary operator but nvc++ for 22.9
+       did not work with that, which was the reason for
+       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
+       works.
+    */
     red_value_type rv = {i};
     if (m_predicate(my_value1, my_value2)) {
       rv = {::Kokkos::reduction_identity<index_type>::min()};

--- a/algorithms/src/std_algorithms/impl/Kokkos_PartitionPoint.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_PartitionPoint.hpp
@@ -39,10 +39,11 @@ struct StdPartitionPointFunctor {
   KOKKOS_FUNCTION
   void operator()(const index_type i, red_value_type& redValue) const {
     const auto predicate_value = m_p(m_first[i]);
-    auto rv =
-        predicate_value
-            ? red_value_type{::Kokkos::reduction_identity<index_type>::min()}
-            : red_value_type{i};
+    red_value_type rv          = {i};
+    if (predicate_value) {
+      rv = {::Kokkos::reduction_identity<index_type>::min()};
+    }
+
     m_reducer.join(redValue, rv);
   }
 

--- a/algorithms/src/std_algorithms/impl/Kokkos_PartitionPoint.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_PartitionPoint.hpp
@@ -40,12 +40,7 @@ struct StdPartitionPointFunctor {
   void operator()(const index_type i, red_value_type& redValue) const {
     const auto predicate_value = m_p(m_first[i]);
 
-    /* FRIZZI: 05/2023
-       Originally the code below was using a ternary operator but nvc++ for 22.9
-       did not work with that, which was the reason for
-       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
-       works.
-    */
+    // FIXME_NVHPC using a ternary operator causes problems
     red_value_type rv = {i};
     if (predicate_value) {
       rv = {::Kokkos::reduction_identity<index_type>::min()};

--- a/algorithms/src/std_algorithms/impl/Kokkos_PartitionPoint.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_PartitionPoint.hpp
@@ -39,7 +39,14 @@ struct StdPartitionPointFunctor {
   KOKKOS_FUNCTION
   void operator()(const index_type i, red_value_type& redValue) const {
     const auto predicate_value = m_p(m_first[i]);
-    red_value_type rv          = {i};
+
+    /* FRIZZI: 05/2023
+       Originally the code below was using a ternary operator but nvc++ for 22.9
+       did not work with that, which was the reason for
+       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
+       works.
+    */
+    red_value_type rv = {i};
     if (predicate_value) {
       rv = {::Kokkos::reduction_identity<index_type>::min()};
     }

--- a/algorithms/src/std_algorithms/impl/Kokkos_Search.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Search.hpp
@@ -60,9 +60,10 @@ struct StdSearchFunctor {
       }
     }
 
-    const auto rv =
-        found ? red_value_type{i}
-              : red_value_type{::Kokkos::reduction_identity<IndexType>::min()};
+    red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
+    if (found) {
+      rv = {i};
+    }
 
     m_reducer.join(red_value, rv);
   }

--- a/algorithms/src/std_algorithms/impl/Kokkos_Search.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Search.hpp
@@ -60,6 +60,12 @@ struct StdSearchFunctor {
       }
     }
 
+    /* FRIZZI: 05/2023
+       Originally the code below was using a ternary operator but nvc++ for 22.9
+       did not work with that, which was the reason for
+       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
+       works.
+    */
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
     if (found) {
       rv = {i};

--- a/algorithms/src/std_algorithms/impl/Kokkos_Search.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Search.hpp
@@ -60,12 +60,7 @@ struct StdSearchFunctor {
       }
     }
 
-    /* FRIZZI: 05/2023
-       Originally the code below was using a ternary operator but nvc++ for 22.9
-       did not work with that, which was the reason for
-       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
-       works.
-    */
+    // FIXME_NVHPC using a ternary operator causes problems
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
     if (found) {
       rv = {i};

--- a/algorithms/src/std_algorithms/impl/Kokkos_SearchN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_SearchN.hpp
@@ -59,6 +59,12 @@ struct StdSearchNFunctor {
       }
     }
 
+    /* FRIZZI: 05/2023
+       Originally the code below was using a ternary operator but nvc++ for 22.9
+       did not work with that, which was the reason for
+       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
+       works.
+    */
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
     if (found) {
       rv.min_loc_true = i;

--- a/algorithms/src/std_algorithms/impl/Kokkos_SearchN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_SearchN.hpp
@@ -59,9 +59,10 @@ struct StdSearchNFunctor {
       }
     }
 
-    const auto rv =
-        found ? red_value_type{i}
-              : red_value_type{::Kokkos::reduction_identity<IndexType>::min()};
+    red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
+    if (found) {
+      rv.min_loc_true = i;
+    }
 
     m_reducer.join(red_value, rv);
   }

--- a/algorithms/src/std_algorithms/impl/Kokkos_SearchN.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_SearchN.hpp
@@ -59,12 +59,7 @@ struct StdSearchNFunctor {
       }
     }
 
-    /* FRIZZI: 05/2023
-       Originally the code below was using a ternary operator but nvc++ for 22.9
-       did not work with that, which was the reason for
-       fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff Using the "simpler" code below
-       works.
-    */
+    // FIXME_NVHPC using a ternary operator causes problems
     red_value_type rv = {::Kokkos::reduction_identity<IndexType>::min()};
     if (found) {
       rv.min_loc_true = i;

--- a/algorithms/unit_tests/TestStdAlgorithmsAdjacentFind.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsAdjacentFind.cpp
@@ -287,12 +287,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_nonmod_seq_ops, adjacent_find) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedThreeTag, int>();

--- a/algorithms/unit_tests/TestStdAlgorithmsAllAnyNoneOf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsAllAnyNoneOf.cpp
@@ -147,12 +147,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_all_any_none_of_test, test) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoTag, int>();
   run_all_scenarios<StridedThreeTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsFind.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsFind.cpp
@@ -151,12 +151,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_find_test, test) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoTag, int>();
   run_all_scenarios<StridedThreeTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsFindEnd.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsFindEnd.cpp
@@ -348,12 +348,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_non_mod_seq_ops, find_end) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsFindFirstOf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsFindFirstOf.cpp
@@ -264,12 +264,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_non_mod_seq_ops, find_first_of) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsIsSortedUntil.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsIsSortedUntil.cpp
@@ -185,12 +185,6 @@ void run_is_sorted_until_all_scenarios() {
 }
 
 TEST(std_algorithms_sorting_ops_test, is_sorted_until) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   run_is_sorted_until_all_scenarios<DynamicTag, double>();
   run_is_sorted_until_all_scenarios<StridedTwoTag, double>();
   run_is_sorted_until_all_scenarios<StridedThreeTag, double>();

--- a/algorithms/unit_tests/TestStdAlgorithmsLexicographicalCompare.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsLexicographicalCompare.cpp
@@ -140,12 +140,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_lexicographical_compare_test, test) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
 // FIXME: should this disable only custom comparator tests?
 #if !defined KOKKOS_ENABLE_OPENMPTARGET
   run_all_scenarios<DynamicTag, double>();

--- a/algorithms/unit_tests/TestStdAlgorithmsMismatch.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsMismatch.cpp
@@ -189,12 +189,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_mismatch_test, test) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedThreeTag, int>();
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsPartitioningOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsPartitioningOps.cpp
@@ -148,12 +148,6 @@ struct std_algorithms_partitioning_test : public std_algorithms_test {
 };
 
 TEST_F(std_algorithms_partitioning_test, is_partitioned_trivial) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   IsNegativeFunctor<value_type> p;
   const auto result1 = KE::is_partitioned(exespace(), KE::cbegin(m_static_view),
                                           KE::cbegin(m_static_view), p);
@@ -169,12 +163,6 @@ TEST_F(std_algorithms_partitioning_test, is_partitioned_trivial) {
 }
 
 TEST_F(std_algorithms_partitioning_test, is_partitioned_accepting_iterators) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   const IsNegativeFunctor<value_type> p;
 
   for (int id = 0; id < FixtureViews::Count; ++id) {
@@ -196,12 +184,6 @@ TEST_F(std_algorithms_partitioning_test, is_partitioned_accepting_iterators) {
 }
 
 TEST_F(std_algorithms_partitioning_test, is_partitioned_accepting_view) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   const IsNegativeFunctor<value_type> p;
 
   for (int id = 0; id < FixtureViews::Count; ++id) {
@@ -220,12 +202,6 @@ TEST_F(std_algorithms_partitioning_test, is_partitioned_accepting_view) {
 }
 
 TEST_F(std_algorithms_partitioning_test, partition_point) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   const IsNegativeFunctor<value_type> p;
 
   for (int id = 0; id < FixtureViews::Count; ++id) {

--- a/algorithms/unit_tests/TestStdAlgorithmsSearch.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsSearch.cpp
@@ -325,12 +325,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_non_mod_seq_ops, search) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsSearch_n.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsSearch_n.cpp
@@ -297,12 +297,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_non_mod_seq_ops, search_n) {
-#if defined(KOKKOS_ENABLE_CUDA) && \
-    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
-  if constexpr (std::is_same_v<exespace, Kokkos::Cuda>) {
-    GTEST_SKIP() << "FIXME wrong result";
-  }
-#endif
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
 }


### PR DESCRIPTION
fb8179f4bae685e8fc29c9fdd890b41e4c8b92ff forced skipping a subset of the std algorithms tests because failing for the NVHPC CI build. 
Looks like the problem was the use of a ternary operator which hvc++ (version 22.9) did not like for some reasons, so using a simpler `if` fixes it and all tests pass. 

NOTE: this is related to but should be merged before #5150 

Co-authored-by: Cezary Skrzyński

