### PR TITLE
Add `bit_cast` function template to `<Kokkos_BitManipulation.hpp>`

### DIFF
--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -20,6 +20,7 @@
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_NumericTraits.hpp>
 #include <climits>  // CHAR_BIT
+#include <cstring>  //memcpy
 #include <type_traits>
 
 namespace Kokkos::Impl {
@@ -97,6 +98,19 @@ inline constexpr bool is_standard_unsigned_integer_type_v =
 }  // namespace Kokkos::Impl
 
 namespace Kokkos {
+
+//<editor-fold desc="[bit.cast], bit_cast">
+template <class To, class From>
+KOKKOS_FUNCTION std::enable_if_t<sizeof(To) == sizeof(From) &&
+                                     std::is_trivially_copyable_v<To> &&
+                                     std::is_trivially_copyable_v<From>,
+                                 To>
+bit_cast(From const& from) noexcept {
+  To to;
+  memcpy(&to, &from, sizeof(To));
+  return to;
+}
+//</editor-fold>
 
 //<editor-fold desc="[bit.byteswap], byteswap">
 template <class T>

--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -392,6 +392,15 @@ KOKKOS_IMPL_HOST_FUNCTION
 
 namespace Kokkos::Experimental {
 
+template <class To, class From>
+KOKKOS_FUNCTION std::enable_if_t<sizeof(To) == sizeof(From) &&
+                                     std::is_trivially_copyable_v<To> &&
+                                     std::is_trivially_copyable_v<From>,
+                                 To>
+bit_cast_builtin(From const& from) noexcept {
+  return bit_cast<To>(from);  // no benefit to call the _builtin variant
+}
+
 template <class T>
 KOKKOS_FUNCTION std::enable_if_t<std::is_integral_v<T>, T> byteswap_builtin(
     T x) noexcept {

--- a/core/unit_test/TestBitManipulation.cpp
+++ b/core/unit_test/TestBitManipulation.cpp
@@ -484,3 +484,61 @@ static_assert(test_byteswap2());
 //</editor-fold>
 
 #undef TEST_BIT_MANIPULATION
+
+//<editor-fold desc="[bit.bit_cast]">
+template <class To, class From>
+constexpr auto test_bit_cast() -> typename std::is_same<
+    decltype(Kokkos::bit_cast<To>(std::declval<From const &>())),
+    To>::value_type {
+  static_assert(
+      std::is_same_v<
+          decltype(Kokkos::bit_cast<To>(std::declval<From const &>())), To>);
+  return true;
+}
+template <class To, class From>
+constexpr X test_bit_cast(...) {
+  return {};
+}
+
+namespace TypesNotTheSameSize {
+struct To {
+  char a;
+};
+struct From {
+  char b;
+  char c;
+};
+static_assert(test_bit_cast<To, From>().did_not_match());
+}  // namespace TypesNotTheSameSize
+
+namespace ToNotTriviallyCopyable {
+struct To {
+  char a;
+  To(To const &);
+};
+struct From {
+  char b;
+};
+static_assert(test_bit_cast<To, From>().did_not_match());
+}  // namespace ToNotTriviallyCopyable
+
+namespace FromNotTriviallyCopyable {
+struct To {
+  char a;
+};
+struct From {
+  char b;
+  From(From const &);
+};
+static_assert(test_bit_cast<To, From>().did_not_match());
+}  // namespace FromNotTriviallyCopyable
+
+namespace ReturnTypeIllFormed {
+struct From {
+  char a;
+  char b;
+};
+static_assert(test_bit_cast<int(), From>().did_not_match());
+static_assert(test_bit_cast<char[2], From>().did_not_match());
+}  // namespace ReturnTypeIllFormed
+   //</editor-fold>

--- a/core/unit_test/TestBitManipulation.cpp
+++ b/core/unit_test/TestBitManipulation.cpp
@@ -30,7 +30,7 @@ struct X {
   static_assert(test_##FUNC((bool)0).did_not_match());  \
   static_assert(test_##FUNC((int)0).did_not_match());   \
   static_assert(test_##FUNC((float)0).did_not_match()); \
-  static_assert(test_##FUNC((void*)0).did_not_match())
+  static_assert(test_##FUNC((void *)0).did_not_match())
 
 //<editor-fold desc="[bit.rotate]">
 template <class UInt>
@@ -442,7 +442,7 @@ constexpr auto test_byteswap(T x) -> decltype(Kokkos::byteswap(x)) {
 
 constexpr X test_byteswap(...) { return {}; }
 
-static_assert(test_byteswap((void*)0).did_not_match());  // NOLINT
+static_assert(test_byteswap((void *)0).did_not_match());  // NOLINT
 static_assert(test_byteswap((float)0).did_not_match());
 constexpr char c2[2] = {};
 static_assert(test_byteswap(c2).did_not_match());

--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -821,6 +821,12 @@ struct TestBitCastFunction {
       }
     }
 
+#if defined(KOKKOS_ENABLE_CUDA) && \
+    defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC
+    if constexpr (std::is_same_v<Space, Kokkos::Cuda>) {
+      return;
+    }
+#endif
     struct S {
       int i;
 

--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -766,7 +766,7 @@ TEST(TEST_CATEGORY, bit_manip_byeswap) {
   test_bit_manip_byteswap<unsigned long long>();
 }
 
-// CUDA doesn't provide memcpy
+// CUDA doesn't provide memcmp
 KOKKOS_FUNCTION int my_memcmp(void const* lhs, void const* rhs, size_t count) {
   auto u1 = static_cast<unsigned char const*>(lhs);
   auto u2 = static_cast<unsigned char const*>(rhs);
@@ -852,9 +852,5 @@ struct TestBitCastFunction {
 };
 
 TEST(TEST_CATEGORY, bit_manip_bit_cast) {
-  using Kokkos::bit_cast;
-  ASSERT_EQ(bit_cast<int>(123), 123);
-  ASSERT_EQ(bit_cast<int>(123u), 123);
-  ASSERT_EQ(bit_cast<int>(~0u), ~0);
   TestBitCastFunction<TEST_EXECSPACE>();
 }

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -21,6 +21,7 @@
 #include <type_traits>
 
 #include <Kokkos_SIMD_Common.hpp>
+#include <Kokkos_BitManipulation.hpp>  // bit_cast
 
 #include <immintrin.h>
 

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -21,6 +21,7 @@
 #include <type_traits>
 
 #include <Kokkos_SIMD_Common.hpp>
+#include <Kokkos_BitManipulation.hpp>  // bit_cast
 
 #include <immintrin.h>
 

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -26,14 +26,6 @@ namespace Kokkos {
 
 namespace Experimental {
 
-template <class To, class From>
-[[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr To bit_cast(
-    From const& src) {
-  To dst;
-  std::memcpy(&dst, &src, sizeof(To));
-  return dst;
-}
-
 template <class T, class Abi>
 class simd;
 


### PR DESCRIPTION
This was the last function template missing that is present in the header `<bit>` from the standard library.
One thing worth noting is that `Kokkos::bit_cast` is not usable in constant expressions.  It is not implementable as a library and needs compiler magic to work so we just can't declare it `constexpr`.

I went ahead and replaced the `Kokkos::Experimental::bit_cast` in the SIMD sub package.  We had agreed we'd do so when it is provided by Core.