### PR TITLE
SIMD: add shift ops for all int types

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -146,7 +146,7 @@ using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
 #elif defined(KOKKOS_ARCH_AVX2)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>>;
 using data_type_set =
-    data_types<std::int32_t, std::int64_t, std::uint64_t, double>;
+    data_types</*std::int32_t,*/ std::int64_t/*, std::uint64_t, double*/>;
 #elif defined(__ARM_NEON)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
 using data_type_set =

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -146,7 +146,7 @@ using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
 #elif defined(KOKKOS_ARCH_AVX2)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>>;
 using data_type_set =
-    data_types</*std::int32_t,*/ std::int64_t/*, std::uint64_t, double*/>;
+    data_types<std::int32_t, std::int64_t, std::uint64_t, double>;
 #elif defined(__ARM_NEON)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
 using data_type_set =

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -661,7 +661,7 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator>>(
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
     int rhs) noexcept {
@@ -669,7 +669,7 @@ simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator>>(
       _mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator>>(
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
@@ -677,7 +677,7 @@ simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator>>(
       _mm_srav_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator<<(
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
     int rhs) noexcept {
@@ -685,7 +685,7 @@ simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator<<(
       _mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator<<(
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
@@ -693,7 +693,7 @@ simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator<<(
       _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx2_fixed_size<4>> abs(
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a) {
   __m128i const rhs = static_cast<__m128i>(a);
@@ -824,7 +824,7 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
 }
 
 // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 // simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
 //     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
 //     int rhs) noexcept {
@@ -832,7 +832,7 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
 //       _mm256_srai_epi64(static_cast<__m256i>(lhs), rhs));
 // }
 
-// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 // simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
 //     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
 //     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
@@ -841,7 +841,7 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
 //       _mm256_cvtepi32_epi64(static_cast<__m128i>(static_cast<__m128i>(rhs))));
 // }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator<<(
     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
     int rhs) noexcept {
@@ -849,7 +849,7 @@ simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator<<(
       _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator<<(
     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
@@ -860,14 +860,14 @@ simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator<<(
 
 // Manually computing absolute values, because _mm256_abs_epi64
 // is not in AVX2; it's available in AVX512.
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx2_fixed_size<4>> abs(
     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
       [&](std::size_t i) { return (a[i] < 0) ? -a[i] : a[i]; });
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
     simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
@@ -974,7 +974,7 @@ simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
       _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
     int rhs) noexcept {
@@ -982,7 +982,7 @@ simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
       _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
@@ -990,7 +990,7 @@ simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
       _mm256_srlv_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
     int rhs) noexcept {
@@ -998,7 +998,7 @@ simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
       _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
@@ -1006,13 +1006,13 @@ simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
       _mm256_sllv_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> abs(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(
     simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -662,6 +662,38 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator>>(
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+    int rhs) noexcept {
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+      _mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator>>(
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+    simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+      _mm_srav_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator<<(
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+    int rhs) noexcept {
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+      _mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator<<(
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+    simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+      _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx2_fixed_size<4>> abs(
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a) {
   __m128i const rhs = static_cast<__m128i>(a);
@@ -791,6 +823,41 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
+// Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+// simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
+//     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+//     int rhs) noexcept {
+//   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+//       _mm256_srai_epi64(static_cast<__m256i>(lhs), rhs));
+// }
+
+// KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+// simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
+//     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+//     simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+//   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+//       _mm256_srav_epi64(static_cast<__m256i>(lhs),
+//       _mm256_cvtepi32_epi64(static_cast<__m128i>(static_cast<__m128i>(rhs))));
+// }
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator<<(
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+    int rhs) noexcept {
+  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator<<(
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+    simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_sllv_epi64(static_cast<__m256i>(lhs),
+                        _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs))));
+}
+
 // Manually computing absolute values, because _mm256_abs_epi64
 // is not in AVX2; it's available in AVX512.
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -865,15 +932,6 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
                                     static_cast<__m256i>(mask_type(true)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator>>(unsigned int rhs) const {
-    return _mm256_srli_epi64(m_value, rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) const {
-    return _mm256_srlv_epi64(m_value,
-                             _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator<<(unsigned int rhs) const {
     return _mm256_slli_epi64(m_value, rhs);
   }
@@ -923,6 +981,40 @@ simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
               simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) {
   return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
       _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+    int rhs) noexcept {
+  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+    simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_srlv_epi64(static_cast<__m256i>(lhs),
+                        _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+    int rhs) noexcept {
+  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+    simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+      _mm256_sllv_epi64(static_cast<__m256i>(lhs),
+                        _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -643,6 +643,40 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   operator!=(simd const& other) const {
     return !((*this) == other);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::avx2_fixed_size<4>>
+  operator>>(simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+             int rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+        _mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::avx2_fixed_size<4>>
+  operator>>(
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+        _mm_srav_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::avx2_fixed_size<4>>
+  operator<<(simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+             int rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+        _mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::avx2_fixed_size<4>>
+  operator<<(
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+        _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -662,40 +696,8 @@ class simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator>>(
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    int rhs) noexcept {
-  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
-      _mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator>>(
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
-      _mm_srav_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator<<(
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    int rhs) noexcept {
-  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
-      _mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator<<(
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-  return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
-      _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx2_fixed_size<4>> abs(
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a) {
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    abs(simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a) {
   __m128i const rhs = static_cast<__m128i>(a);
   return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(_mm_abs_epi32(rhs));
 }
@@ -799,6 +801,42 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   operator!=(simd const& other) const {
     return !((*this) == other);
   }
+
+  // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
+  // KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend
+  // simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
+  //     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+  //     int rhs) noexcept {
+  //   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+  //       _mm256_srai_epi64(static_cast<__m256i>(lhs), rhs));
+  // }
+
+  // KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend
+  // simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
+  //     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+  //     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+  //   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+  //       _mm256_srav_epi64(static_cast<__m256i>(lhs),
+  //       _mm256_cvtepi32_epi64(static_cast<__m128i>(static_cast<__m128i>(rhs))));
+  // }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int64_t, simd_abi::avx2_fixed_size<4>>
+  operator<<(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+             int rhs) noexcept {
+    return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+        _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int64_t, simd_abi::avx2_fixed_size<4>>
+  operator<<(
+      simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+        _mm256_sllv_epi64(static_cast<__m256i>(lhs),
+                          _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs))));
+  }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -823,55 +861,20 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
-// Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-// simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
-//     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-//     int rhs) noexcept {
-//   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-//       _mm256_srai_epi64(static_cast<__m256i>(lhs), rhs));
-// }
-
-// [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-// simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
-//     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-//     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-//   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-//       _mm256_srav_epi64(static_cast<__m256i>(lhs),
-//       _mm256_cvtepi32_epi64(static_cast<__m128i>(static_cast<__m128i>(rhs))));
-// }
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator<<(
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    int rhs) noexcept {
-  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator<<(
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-  return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_sllv_epi64(static_cast<__m256i>(lhs),
-                        _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs))));
-}
-
 // Manually computing absolute values, because _mm256_abs_epi64
 // is not in AVX2; it's available in AVX512.
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx2_fixed_size<4>> abs(
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    abs(simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a) {
   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
       [&](std::size_t i) { return (a[i] < 0) ? -a[i] : a[i]; });
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
-    simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
-    simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
+    simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    condition(simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
+              simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
+              simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(_mm256_castpd_si256(
       _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
                        _mm256_castsi256_pd(static_cast<__m256i>(b)),
@@ -951,6 +954,40 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   operator!=(simd const& other) const {
     return !((*this) == other);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::avx2_fixed_size<4>>
+  operator>>(simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+             int rhs) noexcept {
+    return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+        _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::avx2_fixed_size<4>>
+  operator>>(
+      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(_mm256_srlv_epi64(
+        static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::avx2_fixed_size<4>>
+  operator<<(simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+             int rhs) noexcept {
+    return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+        _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::avx2_fixed_size<4>>
+  operator<<(
+      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
+      simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(_mm256_sllv_epi64(
+        static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
 };
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -975,48 +1012,16 @@ simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::simd(
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    int rhs) noexcept {
-  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_srlv_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    int rhs) noexcept {
-  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
-  return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_sllv_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> abs(
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a) {
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    abs(simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a) {
   return a;
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(
-    simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,
-    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& c) {
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    condition(simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
+              simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,
+              simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& c) {
   return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(_mm256_castpd_si256(
       _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
                        _mm256_castsi256_pd(static_cast<__m256i>(b)),

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -835,7 +835,7 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
 // KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 // simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
 //     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-//     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+//     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
 //   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
 //       _mm256_srav_epi64(static_cast<__m256i>(lhs),
 //       _mm256_cvtepi32_epi64(static_cast<__m128i>(static_cast<__m128i>(rhs))));
@@ -928,6 +928,7 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
+    // if(ptr)
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask_type(true)));
   }
@@ -985,10 +986,9 @@ simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
   return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_srlv_epi64(static_cast<__m256i>(lhs),
-                        _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs))));
+      _mm256_srlv_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -1002,10 +1002,9 @@ simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
   return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_sllv_epi64(static_cast<__m256i>(lhs),
-                        _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs))));
+      _mm256_sllv_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -928,7 +928,6 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
-    // if(ptr)
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask_type(true)));
   }

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -672,7 +672,7 @@ simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator>>(
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
   return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
       _mm_srav_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
 }
@@ -688,7 +688,7 @@ simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx2_fixed_size<4>> operator<<(
     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
   return simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
       _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
 }
@@ -835,7 +835,7 @@ class simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
 // KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 // simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator>>(
 //     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-//     simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+//     simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
 //   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
 //       _mm256_srav_epi64(static_cast<__m256i>(lhs),
 //       _mm256_cvtepi32_epi64(static_cast<__m128i>(static_cast<__m128i>(rhs))));
@@ -852,7 +852,7 @@ simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx2_fixed_size<4>> operator<<(
     simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
   return simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
       _mm256_sllv_epi64(static_cast<__m256i>(lhs),
                         _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs))));
@@ -932,15 +932,6 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
                                     static_cast<__m256i>(mask_type(true)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator<<(unsigned int rhs) const {
-    return _mm256_slli_epi64(m_value, rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator<<(
-      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) const {
-    return _mm256_sllv_epi64(m_value,
-                             _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator&(simd const& other) const {
     return _mm256_and_si256(m_value, other.m_value);
   }
@@ -994,7 +985,7 @@ simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator>>(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
   return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
       _mm256_srlv_epi64(static_cast<__m256i>(lhs),
                         _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs))));
@@ -1011,7 +1002,7 @@ simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> operator<<(
     simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& lhs,
-    simd<int, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& rhs) noexcept {
   return simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
       _mm256_sllv_epi64(static_cast<__m256i>(lhs),
                         _mm256_cvtepi32_epi64(static_cast<__m128i>(rhs))));

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -250,7 +250,7 @@ simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
   return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_srav_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
@@ -264,7 +264,7 @@ simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
   return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_sllv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
@@ -394,7 +394,7 @@ simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
   return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_srlv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
@@ -408,7 +408,7 @@ simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
   return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_sllv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
@@ -543,7 +543,7 @@ simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_srav_epi64(static_cast<__m512i>(lhs),
                         _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
@@ -557,7 +557,7 @@ simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_sllv_epi64(static_cast<__m512i>(lhs),
                         _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
@@ -695,7 +695,7 @@ simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return _mm512_srlv_epi64(
       static_cast<__m512i>(lhs),
       static_cast<__m512i>(_mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
@@ -709,7 +709,7 @@ simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_sllv_epi64(static_cast<__m512i>(lhs),
                         _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -394,7 +394,7 @@ simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
   return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_srlv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
@@ -408,7 +408,7 @@ simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
   return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_sllv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
@@ -543,10 +543,9 @@ simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_srav_epi64(static_cast<__m512i>(lhs),
-                        _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
+      _mm512_srav_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
 }
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
@@ -557,10 +556,9 @@ simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sllv_epi64(static_cast<__m512i>(lhs),
-                        _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
+      _mm512_sllv_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -695,10 +693,9 @@ simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return _mm512_srlv_epi64(
-      static_cast<__m512i>(lhs),
-      static_cast<__m512i>(_mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return _mm512_srlv_epi64(static_cast<__m512i>(lhs),
+                           static_cast<__m512i>(rhs));
 }
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
@@ -709,10 +706,9 @@ simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sllv_epi64(static_cast<__m512i>(lhs),
-                        _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
+      _mm512_sllv_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -555,9 +555,9 @@ simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
       _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
 }
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
-    operator<<(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-               simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
+simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_sllv_epi64(static_cast<__m512i>(lhs),
                         _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
@@ -707,9 +707,9 @@ simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
       _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
 }
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
-    operator<<(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-               simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
+simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_sllv_epi64(static_cast<__m512i>(lhs),
                         _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -200,6 +200,37 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   operator!=(simd const& other) const {
     return mask_type(_mm256_cmpneq_epi32_mask(m_value, other.m_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::avx512_fixed_size<8>>
+  operator>>(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             int rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+        _mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::avx512_fixed_size<8>>
+  operator>>(
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(_mm256_srav_epi32(
+        static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::avx512_fixed_size<8>>
+  operator<<(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             int rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+        _mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::avx512_fixed_size<8>>
+  operator<<(
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+    return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(_mm256_sllv_epi32(
+        static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -233,47 +264,18 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx512_fixed_size<8>> abs(
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a) {
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    abs(simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a) {
   __m256i const rhs = static_cast<__m256i>(a);
   return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_abs_epi32(rhs));
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator>>(
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    int rhs) noexcept {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator>>(
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_srav_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator<<(
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    int rhs) noexcept {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator<<(
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
-  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_sllv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
-    simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    condition(simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
+              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
+              simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
   return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
                               static_cast<__m256i>(b)));
@@ -352,6 +354,39 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   operator!=(simd const& other) const {
     return mask_type(_mm256_cmpneq_epu32_mask(m_value, other.m_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint32_t, simd_abi::avx512_fixed_size<8>>
+  operator>>(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             int rhs) noexcept {
+    return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+        _mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint32_t, simd_abi::avx512_fixed_size<8>>
+  operator>>(
+      simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+      simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+    return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+        _mm256_srlv_epi32(static_cast<__m256i>(lhs),
+                          static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint32_t, simd_abi::avx512_fixed_size<8>>
+  operator<<(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             int rhs) noexcept {
+    return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+        _mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint32_t, simd_abi::avx512_fixed_size<8>>
+  operator<<(
+      simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+      simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+    return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+        _mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                          static_cast<__m256i>(rhs)));
+  }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -379,45 +414,16 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> abs(
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a) {
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    abs(simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator>>(
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    int rhs) noexcept {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator>>(
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_srlv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator<<(
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    int rhs) noexcept {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator<<(
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
-  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
-      _mm256_sllv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> condition(
-    simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    condition(simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
+              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
+              simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
   return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
                               static_cast<__m256i>(b)));
@@ -494,6 +500,35 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   operator!=(simd const& other) const {
     return mask_type(_mm512_cmpneq_epi64_mask(m_value, other.m_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int64_t, simd_abi::avx512_fixed_size<8>>
+  operator>>(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             int rhs) {
+    return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+        _mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int64_t, simd_abi::avx512_fixed_size<8>>
+  operator>>(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+    return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(_mm512_srav_epi64(
+        static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int64_t, simd_abi::avx512_fixed_size<8>>
+  operator<<(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             int rhs) {
+    return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+        _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int64_t, simd_abi::avx512_fixed_size<8>>
+  operator<<(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+    return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(_mm512_sllv_epi64(
+        static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -535,37 +570,10 @@ simd<std::int64_t, simd_abi::avx512_fixed_size<8>> abs(
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator>>(
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator>>(
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_srav_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sllv_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
-    simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    condition(simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
+              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
+              simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
   return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));
@@ -652,6 +660,36 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   operator!=(simd const& other) const {
     return mask_type(_mm512_cmpneq_epu64_mask(m_value, other.m_value));
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::avx512_fixed_size<8>>
+  operator>>(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             int rhs) {
+    return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+        _mm512_srli_epi64(static_cast<__m512i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::avx512_fixed_size<8>>
+  operator>>(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+    return _mm512_srlv_epi64(static_cast<__m512i>(lhs),
+                             static_cast<__m512i>(rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::avx512_fixed_size<8>>
+  operator<<(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             int rhs) {
+    return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+        _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::avx512_fixed_size<8>>
+  operator<<(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+             simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
+    return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+        _mm512_sllv_epi64(static_cast<__m512i>(lhs),
+                          static_cast<__m512i>(rhs)));
+  }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -685,37 +723,10 @@ simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> abs(
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator>>(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_srli_epi64(static_cast<__m512i>(lhs), rhs));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator>>(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return _mm512_srlv_epi64(static_cast<__m512i>(lhs),
-                           static_cast<__m512i>(rhs));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
-      _mm512_sllv_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> condition(
-    simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
-    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    condition(simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
+              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
+              simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
   return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -232,7 +232,7 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(0) - a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx512_fixed_size<8>> abs(
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a) {
   __m256i const rhs = static_cast<__m256i>(a);
@@ -240,28 +240,28 @@ simd<std::int32_t, simd_abi::avx512_fixed_size<8>> abs(
       _mm256_abs_epi32(rhs));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     int rhs) noexcept {
   return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
   return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_srav_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     int rhs) noexcept {
   return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
@@ -269,7 +269,7 @@ simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator<<(
       _mm256_sllv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
     simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
@@ -378,34 +378,34 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
       _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> abs(
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     int rhs) noexcept {
   return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
   return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_srlv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     int rhs) noexcept {
   return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
@@ -413,7 +413,7 @@ simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator<<(
       _mm256_sllv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> condition(
     simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
@@ -534,26 +534,26 @@ simd<std::int64_t, simd_abi::avx512_fixed_size<8>> abs(
       _mm512_abs_epi64(rhs));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
   return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_srav_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
   return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
@@ -561,7 +561,7 @@ simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
       _mm512_sllv_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
     simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
@@ -684,26 +684,26 @@ simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> abs(
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
   return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_srli_epi64(static_cast<__m512i>(lhs), rhs));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator>>(
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
   return _mm512_srlv_epi64(static_cast<__m512i>(lhs),
                            static_cast<__m512i>(rhs));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
   return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& rhs) {
@@ -711,7 +711,7 @@ simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
       _mm512_sllv_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> condition(
     simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -241,6 +241,35 @@ simd<std::int32_t, simd_abi::avx512_fixed_size<8>> abs(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator>>(
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    int rhs) noexcept {
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator>>(
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_srav_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator<<(
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    int rhs) noexcept {
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::avx512_fixed_size<8>> operator<<(
+    simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+  return simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_sllv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
     simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
     simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
@@ -356,6 +385,35 @@ simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> abs(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator>>(
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    int rhs) noexcept {
+  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator>>(
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_srlv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator<<(
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    int rhs) noexcept {
+  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> operator<<(
+    simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) noexcept {
+  return simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+      _mm256_sllv_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> condition(
     simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
     simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
@@ -407,22 +465,6 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
     _mm512_storeu_si512(ptr, m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(int rhs) const {
-    return _mm512_srai_epi64(m_value, rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator>>(simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) const {
-    return _mm512_srav_epi64(m_value,
-                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator<<(int rhs) const {
-    return _mm512_slli_epi64(m_value, rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator<<(simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) const {
-    return _mm512_sllv_epi64(m_value,
-                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
       const {
@@ -493,6 +535,35 @@ simd<std::int64_t, simd_abi::avx512_fixed_size<8>> abs(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator>>(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
+  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator>>(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_srav_epi64(static_cast<__m512i>(lhs),
+                        _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::avx512_fixed_size<8>> operator<<(
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
+  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    operator<<(simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+               simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_sllv_epi64(static_cast<__m512i>(lhs),
+                        _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
     simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
     simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
@@ -546,24 +617,6 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
     _mm512_storeu_si512(ptr, m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator>>(unsigned int rhs) const {
-    return _mm512_srli_epi64(m_value, rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) const {
-    return _mm512_srlv_epi64(m_value,
-                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator<<(unsigned int rhs) const {
-    return _mm512_slli_epi64(m_value, rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator<<(
-      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& rhs) const {
-    return _mm512_sllv_epi64(m_value,
-                             _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator&(simd const& other) const {
@@ -631,6 +684,35 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> abs(
     simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator>>(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
+  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_srli_epi64(static_cast<__m512i>(lhs), rhs));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator>>(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+    simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return _mm512_srlv_epi64(
+      static_cast<__m512i>(lhs),
+      static_cast<__m512i>(_mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> operator<<(
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs, int rhs) {
+  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    operator<<(simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& lhs,
+               simd<int, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+      _mm512_sllv_epi64(static_cast<__m512i>(lhs),
+                        _mm512_cvtepi32_epi64(static_cast<__m256i>(rhs))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -148,14 +148,14 @@ template <typename T, typename Abi>
 
 template <typename T, typename Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator>>(
-    simd<T, Abi> const& lhs, simd<std::int32_t, Abi> const& rhs) {
+    simd<T, Abi> const& lhs, simd<T, Abi> const& rhs) {
   static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] >> rhs[i]; });
 }
 
 template <typename T, typename Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator<<(
-    simd<T, Abi> const& lhs, simd<std::int32_t, Abi> const& rhs) {
+    simd<T, Abi> const& lhs, simd<T, Abi> const& rhs) {
   static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] << rhs[i]; });
 }

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -132,27 +132,31 @@ template <class T, class Abi>
 // At the time of this edit, only the fallback for shift vectors of
 // 64-bit signed integers for the AVX2 backend is used
 
-template <class T, class Abi>
+template <typename T, typename Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator>>(
     simd<T, Abi> const& lhs, unsigned int rhs) {
+  static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] >> rhs; });
 }
 
-template <class T, class U, class Abi>
+template <typename T, typename Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator<<(
     simd<T, Abi> const& lhs, unsigned int rhs) {
+  static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] << rhs; });
 }
 
-template <class T, class U, class Abi>
+template <typename T, typename Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator>>(
-    simd<T, Abi> const& lhs, simd<U, Abi> const& rhs) {
+    simd<T, Abi> const& lhs, simd<std::int32_t, Abi> const& rhs) {
+  static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] >> rhs[i]; });
 }
 
-template <class T, class U, class Abi>
+template <typename T, typename Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator<<(
-    simd<T, Abi> const& lhs, simd<U, Abi> const& rhs) {
+    simd<T, Abi> const& lhs, simd<std::int32_t, Abi> const& rhs) {
+  static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] << rhs[i]; });
 }
 

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -132,31 +132,31 @@ template <class T, class Abi>
 // At the time of this edit, only the fallback for shift vectors of
 // 64-bit signed integers for the AVX2 backend is used
 
-template <typename T, typename Abi>
+template <typename T, typename Abi,
+          typename = std::enable_if_t<std::is_integral_v<T>>>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator>>(
     simd<T, Abi> const& lhs, int rhs) {
-  static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] >> rhs; });
 }
 
-template <typename T, typename Abi>
+template <typename T, typename Abi,
+          typename = std::enable_if_t<std::is_integral_v<T>>>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator<<(
     simd<T, Abi> const& lhs, int rhs) {
-  static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] << rhs; });
 }
 
-template <typename T, typename Abi>
+template <typename T, typename Abi,
+          typename = std::enable_if_t<std::is_integral_v<T>>>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator>>(
     simd<T, Abi> const& lhs, simd<T, Abi> const& rhs) {
-  static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] >> rhs[i]; });
 }
 
-template <typename T, typename Abi>
+template <typename T, typename Abi,
+          typename = std::enable_if_t<std::is_integral_v<T>>>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator<<(
     simd<T, Abi> const& lhs, simd<T, Abi> const& rhs) {
-  static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] << rhs[i]; });
 }
 

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -134,14 +134,14 @@ template <class T, class Abi>
 
 template <typename T, typename Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator>>(
-    simd<T, Abi> const& lhs, unsigned int rhs) {
+    simd<T, Abi> const& lhs, int rhs) {
   static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] >> rhs; });
 }
 
 template <typename T, typename Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator<<(
-    simd<T, Abi> const& lhs, unsigned int rhs) {
+    simd<T, Abi> const& lhs, int rhs) {
   static_assert(std::is_integral_v<T>);
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] << rhs; });
 }

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -129,10 +129,10 @@ template <class T, class Abi>
 }
 
 // fallback simd shift using generator constructor
-// At the time of this writing, these fallbacks are only used
-// to shift vectors of 64-bit unsigned integers for the NEON backend
+// At the time of this edit, only the fallback for shift vectors of
+// 64-bit signed integers for the AVX2 backend is used
 
-template <class T, class U, class Abi>
+template <class T, class Abi>
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd<T, Abi> operator>>(
     simd<T, Abi> const& lhs, unsigned int rhs) {
   return simd<T, Abi>([&](std::size_t i) { return lhs[i] >> rhs; });

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -556,6 +556,37 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
   operator!=(simd const& other) const {
     return !((*this) == other);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::neon_fixed_size<2>>
+  operator>>(simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
+             const int rhs) noexcept {
+    return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(vshl_s32(
+        static_cast<int32x2_t>(lhs), vneg_s32(vmov_n_s32(std::int32_t(rhs)))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::neon_fixed_size<2>>
+  operator>>(
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(vshl_s32(
+        static_cast<int32x2_t>(lhs), vneg_s32(static_cast<int32x2_t>(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::neon_fixed_size<2>>
+  operator<<(simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
+             const int rhs) noexcept {
+    return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
+        vshl_s32(static_cast<int32x2_t>(lhs), vmov_n_s32(std::int32_t(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int32_t, simd_abi::neon_fixed_size<2>>
+  operator<<(
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
+        vshl_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
+  }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -582,37 +613,8 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator>>(
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    const int rhs) noexcept {
-  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(vshl_s32(
-      static_cast<int32x2_t>(lhs), vneg_s32(vmov_n_s32(std::int32_t(rhs)))));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator>>(
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(vshl_s32(
-      static_cast<int32x2_t>(lhs), vneg_s32(static_cast<int32x2_t>(rhs))));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator<<(
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    const int rhs) noexcept {
-  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
-      vshl_s32(static_cast<int32x2_t>(lhs), vmov_n_s32(std::int32_t(rhs))));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator<<(
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
-      vshl_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int32_t, simd_abi::neon_fixed_size<2>> abs(
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& a) {
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>>
+    abs(simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& a) {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
       vabs_s32(static_cast<int32x2_t>(a)));
 }
@@ -730,6 +732,38 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   operator!=(simd const& other) const {
     return !((*this) == other);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int64_t, simd_abi::neon_fixed_size<2>>
+  operator>>(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+             const int rhs) noexcept {
+    return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+        vshlq_s64(static_cast<int64x2_t>(lhs),
+                  vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int64_t, simd_abi::neon_fixed_size<2>>
+  operator>>(
+      simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+      simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(vshlq_s64(
+        static_cast<int64x2_t>(lhs), vnegq_s64(static_cast<int64x2_t>(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int64_t, simd_abi::neon_fixed_size<2>>
+  operator<<(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+             const int rhs) noexcept {
+    return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+        vshlq_s64(static_cast<int64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::int64_t, simd_abi::neon_fixed_size<2>>
+  operator<<(
+      simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+      simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+        vshlq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
+  }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -756,37 +790,8 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
 }
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator>>(
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    const int rhs) noexcept {
-  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(vshlq_s64(
-      static_cast<int64x2_t>(lhs), vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator>>(
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(vshlq_s64(
-      static_cast<int64x2_t>(lhs), vnegq_s64(static_cast<int64x2_t>(rhs))));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    const int rhs) noexcept {
-  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
-      vshlq_s64(static_cast<int64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
-}
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
-      vshlq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::int64_t, simd_abi::neon_fixed_size<2>> abs(
-    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& a) {
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>>
+    abs(simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& a) {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
       vabsq_s64(static_cast<int64x2_t>(a)));
 }
@@ -894,6 +899,38 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   operator!=(simd const& other) const {
     return !((*this) == other);
   }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::neon_fixed_size<2>>
+  operator>>(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+             const int rhs) noexcept {
+    return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
+        vshlq_u64(static_cast<uint64x2_t>(lhs),
+                  vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::neon_fixed_size<2>>
+  operator>>(
+      simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+      simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
+        static_cast<uint64x2_t>(lhs), vnegq_s64(static_cast<uint64x2_t>(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::neon_fixed_size<2>>
+  operator<<(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+             const int rhs) noexcept {
+    return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
+        static_cast<uint64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd<
+      std::uint64_t, simd_abi::neon_fixed_size<2>>
+  operator<<(
+      simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+      simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
+        vshlq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+  }
 };
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -924,40 +961,8 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
     : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
 
 [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    const int rhs) noexcept {
-  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
-      static_cast<uint64x2_t>(lhs), vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
-      static_cast<uint64x2_t>(lhs), vnegq_s64(static_cast<uint64x2_t>(rhs))));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    const int rhs) noexcept {
-  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
-      vshlq_u64(static_cast<uint64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
-      vshlq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-simd<std::uint64_t, simd_abi::neon_fixed_size<2>> abs(
-    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
+    abs(simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -582,6 +582,35 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator>>(
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    const int rhs) noexcept {
+  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(vshl_s32(
+      static_cast<int32x2_t>(lhs), vneg_s32(vmov_n_s32(std::int32_t(rhs)))));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator>>(
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(vshl_s32(
+      static_cast<int32x2_t>(lhs), vneg_s32(static_cast<int32x2_t>(rhs))));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator<<(
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    const int rhs) noexcept {
+  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
+      vshl_s32(static_cast<int32x2_t>(lhs), vmov_n_s32(std::int32_t(rhs))));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator<<(
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+  return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
+      vshl_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::neon_fixed_size<2>> abs(
     simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& a) {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
@@ -727,6 +756,36 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator>>(
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    const int rhs) noexcept {
+  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(vshlq_s64(
+      static_cast<int64x2_t>(lhs), vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator>>(
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+      vshlq_s64(static_cast<int64x2_t>(lhs),
+                vnegq_s64(vmovl_s32(static_cast<int32x2_t>(rhs)))));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    const int rhs) noexcept {
+  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+      vshlq_s64(static_cast<int64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
+}
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(vshlq_s64(
+      static_cast<int64x2_t>(lhs), vmovl_s32(static_cast<int32x2_t>(rhs))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> abs(
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& a) {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
@@ -828,14 +887,6 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator<<(unsigned int rhs) const {
-    return simd(vshlq_u64(m_value, vmovq_n_s64(std::int64_t(rhs))));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator>>(unsigned int rhs) const {
-    return simd(vshlq_u64(m_value, vmovq_n_s64(-std::int64_t(rhs))));
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
   operator==(simd const& other) const {
     return mask_type(vceqq_u64(m_value, other.m_value));
@@ -872,6 +923,39 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
     : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    const int rhs) noexcept {
+  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
+      static_cast<uint64x2_t>(lhs), vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
+      vshlq_u64(static_cast<uint64x2_t>(lhs),
+                vnegq_s64(vmovl_s32(static_cast<int32x2_t>(rhs)))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    const int rhs) noexcept {
+  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
+      vshlq_u64(static_cast<uint64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
+    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
+      static_cast<uint64x2_t>(lhs), vmovl_s32(static_cast<int32x2_t>(rhs))));
+}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> abs(

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -765,10 +765,9 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator>>(
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
-      vshlq_s64(static_cast<int64x2_t>(lhs),
-                vnegq_s64(vmovl_s32(static_cast<int32x2_t>(rhs)))));
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(vshlq_s64(
+      static_cast<int64x2_t>(lhs), vnegq_s64(static_cast<int64x2_t>(rhs))));
 }
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
@@ -780,9 +779,9 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(vshlq_s64(
-      static_cast<int64x2_t>(lhs), vmovl_s32(static_cast<int32x2_t>(rhs))));
+    simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+  return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+      vshlq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -935,10 +934,9 @@ simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
-      vshlq_u64(static_cast<uint64x2_t>(lhs),
-                vnegq_s64(vmovl_s32(static_cast<int32x2_t>(rhs)))));
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
+      static_cast<uint64x2_t>(lhs), vnegq_s64(static_cast<uint64x2_t>(rhs))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -952,9 +950,9 @@ simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
-  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
-      static_cast<uint64x2_t>(lhs), vmovl_s32(static_cast<int32x2_t>(rhs))));
+    simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+  return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
+      vshlq_u64(static_cast<uint64x2_t>(lhs), static_cast<int32x2_t>(rhs)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -581,28 +581,28 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       vadd_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator>>(
     simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
     const int rhs) noexcept {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(vshl_s32(
       static_cast<int32x2_t>(lhs), vneg_s32(vmov_n_s32(std::int32_t(rhs)))));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator>>(
     simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
     simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(vshl_s32(
       static_cast<int32x2_t>(lhs), vneg_s32(static_cast<int32x2_t>(rhs))));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
     const int rhs) noexcept {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
       vshl_s32(static_cast<int32x2_t>(lhs), vmov_n_s32(std::int32_t(rhs))));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
     simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
@@ -610,7 +610,7 @@ simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator<<(
       vshl_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::neon_fixed_size<2>> abs(
     simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& a) {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
@@ -755,28 +755,28 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
       vaddq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator>>(
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
     const int rhs) noexcept {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(vshlq_s64(
       static_cast<int64x2_t>(lhs), vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator>>(
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(vshlq_s64(
       static_cast<int64x2_t>(lhs), vnegq_s64(static_cast<int64x2_t>(rhs))));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
     const int rhs) noexcept {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
       vshlq_s64(static_cast<int64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
 }
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
@@ -784,7 +784,7 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
       vshlq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> abs(
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& a) {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
@@ -923,7 +923,7 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>>::simd(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& other)
     : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
     const int rhs) noexcept {
@@ -931,7 +931,7 @@ simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
       static_cast<uint64x2_t>(lhs), vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
@@ -939,7 +939,7 @@ simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
       static_cast<uint64x2_t>(lhs), vnegq_s64(static_cast<uint64x2_t>(rhs))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
     const int rhs) noexcept {
@@ -947,7 +947,7 @@ simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
       vshlq_u64(static_cast<uint64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
@@ -955,7 +955,7 @@ simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
       vshlq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> abs(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
   return a;

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -591,7 +591,7 @@ simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator>>(
     simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(vshl_s32(
       static_cast<int32x2_t>(lhs), vneg_s32(static_cast<int32x2_t>(rhs))));
 }
@@ -605,7 +605,7 @@ simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int32_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
   return simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
       vshl_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
 }
@@ -765,7 +765,7 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator>>(
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
       vshlq_s64(static_cast<int64x2_t>(lhs),
                 vnegq_s64(vmovl_s32(static_cast<int32x2_t>(rhs)))));
@@ -780,7 +780,7 @@ simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::int64_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
   return simd<std::int64_t, simd_abi::neon_fixed_size<2>>(vshlq_s64(
       static_cast<int64x2_t>(lhs), vmovl_s32(static_cast<int32x2_t>(rhs))));
 }
@@ -935,7 +935,7 @@ simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator>>(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
   return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
       vshlq_u64(static_cast<uint64x2_t>(lhs),
                 vnegq_s64(vmovl_s32(static_cast<int32x2_t>(rhs)))));
@@ -952,7 +952,7 @@ simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
-    simd<int, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
+    simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
   return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(vshlq_u64(
       static_cast<uint64x2_t>(lhs), vmovl_s32(static_cast<int32x2_t>(rhs))));
 }

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -952,7 +952,7 @@ simd<std::uint64_t, simd_abi::neon_fixed_size<2>> operator<<(
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& lhs,
     simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& rhs) noexcept {
   return simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
-      vshlq_u64(static_cast<uint64x2_t>(lhs), static_cast<int32x2_t>(rhs)));
+      vshlq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -109,18 +109,6 @@ class simd<T, simd_abi::scalar> {
   KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
       : m_value(gen(std::integral_constant<std::size_t, 0>())) {}
   KOKKOS_FORCEINLINE_FUNCTION simd operator-() const { return simd(-m_value); }
-  KOKKOS_FORCEINLINE_FUNCTION simd operator>>(int rhs) const {
-    return simd(m_value >> rhs);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION simd operator>>(simd const& rhs) const {
-    return simd(m_value >> static_cast<int>(rhs[0]));
-  }
-  KOKKOS_FORCEINLINE_FUNCTION simd operator<<(int rhs) const {
-    return simd(m_value << rhs);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION simd operator<<(simd const& rhs) const {
-    return simd(m_value << static_cast<int>(rhs[0]));
-  }
   KOKKOS_FORCEINLINE_FUNCTION simd operator&(simd const& other) const {
     return m_value & other.m_value;
   }
@@ -160,6 +148,23 @@ class simd<T, simd_abi::scalar> {
   }
   KOKKOS_FORCEINLINE_FUNCTION value_type operator[](std::size_t) const {
     return m_value;
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(lhs.m_value >> rhs);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(lhs.m_value >> static_cast<int>(rhs[0]));
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(lhs.m_value << rhs);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(lhs.m_value << static_cast<int>(rhs[0]));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -113,14 +113,14 @@ class simd<T, simd_abi::scalar> {
     return simd(m_value >> rhs);
   }
   KOKKOS_FORCEINLINE_FUNCTION simd
-  operator>>(simd<value_type, abi_type> const& rhs) const {
+  operator>>(simd const& rhs) const {
     return simd(m_value >> static_cast<int>(rhs[0]));
   }
   KOKKOS_FORCEINLINE_FUNCTION simd operator<<(int rhs) const {
     return simd(m_value << rhs);
   }
   KOKKOS_FORCEINLINE_FUNCTION simd
-  operator<<(simd<value_type, abi_type> const& rhs) const {
+  operator<<(simd const& rhs) const {
     return simd(m_value << static_cast<int>(rhs[0]));
   }
   KOKKOS_FORCEINLINE_FUNCTION simd operator&(simd const& other) const {

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -113,15 +113,15 @@ class simd<T, simd_abi::scalar> {
     return simd(m_value >> rhs);
   }
   KOKKOS_FORCEINLINE_FUNCTION simd
-  operator>>(simd<int, abi_type> const& rhs) const {
-    return simd(m_value >> static_cast<int>(rhs));
+  operator>>(simd<value_type, abi_type> const& rhs) const {
+    return simd(m_value >> static_cast<int>(rhs[0]));
   }
   KOKKOS_FORCEINLINE_FUNCTION simd operator<<(int rhs) const {
     return simd(m_value << rhs);
   }
   KOKKOS_FORCEINLINE_FUNCTION simd
-  operator<<(simd<int, abi_type> const& rhs) const {
-    return simd(m_value << static_cast<int>(rhs));
+  operator<<(simd<value_type, abi_type> const& rhs) const {
+    return simd(m_value << static_cast<int>(rhs[0]));
   }
   KOKKOS_FORCEINLINE_FUNCTION simd operator&(simd const& other) const {
     return m_value & other.m_value;

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -112,15 +112,13 @@ class simd<T, simd_abi::scalar> {
   KOKKOS_FORCEINLINE_FUNCTION simd operator>>(int rhs) const {
     return simd(m_value >> rhs);
   }
-  KOKKOS_FORCEINLINE_FUNCTION simd
-  operator>>(simd const& rhs) const {
+  KOKKOS_FORCEINLINE_FUNCTION simd operator>>(simd const& rhs) const {
     return simd(m_value >> static_cast<int>(rhs[0]));
   }
   KOKKOS_FORCEINLINE_FUNCTION simd operator<<(int rhs) const {
     return simd(m_value << rhs);
   }
-  KOKKOS_FORCEINLINE_FUNCTION simd
-  operator<<(simd const& rhs) const {
+  KOKKOS_FORCEINLINE_FUNCTION simd operator<<(simd const& rhs) const {
     return simd(m_value << static_cast<int>(rhs[0]));
   }
   KOKKOS_FORCEINLINE_FUNCTION simd operator&(simd const& other) const {

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -546,6 +546,13 @@ inline void host_check_shift_op_all_loaders(ShiftOp shift_op,
       shift_op, test_vals, shift_by_lanes);
 }
 
+template <typename DataType>
+inline void host_check_shift_op_corner_case() {
+  DataType value = -1;
+  auto shifted = value >> 1;
+  EXPECT_EQ(shifted, value);
+}
+
 template <typename Abi, typename DataType>
 inline void host_check_shift_op() {
   if constexpr (std::is_integral_v<DataType>) {
@@ -573,6 +580,9 @@ inline void host_check_shift_op() {
     }
     host_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
                                          num_cases);
+
+    if constexpr (std::is_signed_v<DataType>)
+      host_check_shift_op_corner_case<DataType>();
   }
 }
 
@@ -757,6 +767,13 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_op_all_loaders(
       shift_op, test_vals, shift_by_lanes);
 }
 
+template <typename DataType>
+KOKKOS_INLINE_FUNCTION void device_check_shift_op_corner_case() {
+  DataType value = -1;
+  auto shifted = value >> 1;
+  kokkos_checker().equality(shifted, value);
+}
+
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_shift_op() {
   if constexpr (std::is_integral_v<DataType>) {
@@ -784,6 +801,9 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_op() {
     }
     device_check_shift_op_all_loaders<Abi>(shift_left(), test_vals, shift_by,
                                            num_cases);
+
+    if constexpr (std::is_signed_v<DataType>)
+      device_check_shift_op_corner_case<DataType>();
   }
 }
 

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -549,7 +549,7 @@ inline void host_check_shift_op_all_loaders(ShiftOp shift_op,
 template <typename DataType>
 inline void host_check_shift_op_corner_case() {
   DataType value = -1;
-  auto shifted = value >> 1;
+  auto shifted   = value >> 1;
   EXPECT_EQ(shifted, value);
 }
 
@@ -770,7 +770,7 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_op_all_loaders(
 template <typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_shift_op_corner_case() {
   DataType value = -1;
-  auto shifted = value >> 1;
+  auto shifted   = value >> 1;
   kokkos_checker().equality(shifted, value);
 }
 

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -483,7 +483,7 @@ inline void host_check_shift_on_one_loader(ShiftOp shift_op,
     simd_type expected_result;
 
     for (std::size_t lane = 0; lane < width; ++lane) {
-      auto value = simd_vals[lane];
+      DataType value = simd_vals[lane];
       if (value)
         expected_result[lane] =
             shift_op.on_host(value, static_cast<int>(shift_by[i]));
@@ -510,7 +510,7 @@ inline void host_check_shift_by_lanes_on_one_loader(
   simd_type expected_result;
 
   for (std::size_t lane = 0; lane < width; ++lane) {
-    auto value = simd_vals[lane];
+    DataType value = simd_vals[lane];
     if (value) {
       expected_result[lane] =
           shift_op.on_host(value, static_cast<int>(shift_by[lane]));


### PR DESCRIPTION
Related to #5674 

This PR adds following shift operators for integer simd types in each backend:
- simd operator>>(const simd& lhs, const simd& rhs)
- simd operator>>(const simd& lhs, const int rhs)
- simd operator<<(const simd& lhs, const simd& rhs)
- simd operator<<(const simd& lhs, const int rhs)

AVX2:
- Added shifts for `int32_t`, `int64_t`[^1] and `uint64_t`

AVX512:
- Added shifts for `int32_t`[^2], `uint32_t`, `int64_t`[^2] and `uint64_t`

NEON:
- Added shifts for `int32_t`, `int64_t` and `uint64_t`

[^1]: 64-bit integer shift right arithmetic intrinsics (`_mm256_srai_epi64` and `_mm256_srav_epi64`) aren't available in AVX2. Because of this, 64-bit integer shift right in AVX2 is currently set to use the fallback method that uses generator constructor.
[^2]: Shift operators are modified to non-member functions to be consistent with [TS extensions for parallelism v2](https://en.cppreference.com/w/cpp/experimental/simd/simd)