### PR TITLE
Fix nightlies -- workaround compiler bug in GCC 9.1 and 9.2

### DIFF
--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -789,7 +789,7 @@ struct TestBitCastFunction {
     ASSERT_EQ(errors, 0) << "Failed check no error for bit_cast()";
   }
   template <typename To, typename From>
-#if defined(KOKKOS_COMPILER_GNU) && (910 <= KOKKOS_COMPILER_GNU) && \
+#if defined(KOKKOS_COMPILER_GNU) && (900 <= KOKKOS_COMPILER_GNU) && \
     (KOKKOS_COMPILER_GNU < 930)
   // workaround compiler bug in GCC 9.1 and GCC 9.2
   KOKKOS_FUNCTION bool check(const From& from) const

--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -789,7 +789,14 @@ struct TestBitCastFunction {
     ASSERT_EQ(errors, 0) << "Failed check no error for bit_cast()";
   }
   template <typename To, typename From>
-  static KOKKOS_FUNCTION bool check(const From& from) {
+#if defined(KOKKOS_COMPILER_GCC) && (910 <= KOKKOS_COMPILER_GCC) && \
+    (KOKKOS_COMPILER_GCC < 930)
+  // workaround compiler bug in GCC 9.1 and GCC 9.2
+  KOKKOS_FUNCTION bool check(const From& from) const
+#else
+  static KOKKOS_FUNCTION bool check(const From& from)
+#endif
+  {
     using Kokkos::Experimental::bit_cast_builtin;
     return bit_cast_builtin<From>(bit_cast_builtin<To>(from)) == from;
   }

--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -791,7 +791,7 @@ struct TestBitCastFunction {
   template <typename To, typename From>
 #if defined(KOKKOS_COMPILER_GNU) && (900 <= KOKKOS_COMPILER_GNU) && \
     (KOKKOS_COMPILER_GNU < 930)
-  // workaround compiler bug in GCC 9.1 and GCC 9.2
+  // workaround compiler bug seen in GCC 9.0.1 and GCC 9.2.0
   KOKKOS_FUNCTION bool check(const From& from) const
 #else
   static KOKKOS_FUNCTION bool check(const From& from)

--- a/core/unit_test/TestBitManipulationBuiltins.hpp
+++ b/core/unit_test/TestBitManipulationBuiltins.hpp
@@ -789,8 +789,8 @@ struct TestBitCastFunction {
     ASSERT_EQ(errors, 0) << "Failed check no error for bit_cast()";
   }
   template <typename To, typename From>
-#if defined(KOKKOS_COMPILER_GCC) && (910 <= KOKKOS_COMPILER_GCC) && \
-    (KOKKOS_COMPILER_GCC < 930)
+#if defined(KOKKOS_COMPILER_GNU) && (910 <= KOKKOS_COMPILER_GNU) && \
+    (KOKKOS_COMPILER_GNU < 930)
   // workaround compiler bug in GCC 9.1 and GCC 9.2
   KOKKOS_FUNCTION bool check(const From& from) const
 #else


### PR DESCRIPTION
Resolve #6107 

I was able to reproduce with the `gcc:9.2.0` docker image and did
```
wget https://github.com/Kitware/CMake/releases/download/v3.16.8/cmake-3.16.8-Linux-x86_64.sh
mkdir -p /opt/cmake
sh cmake-3.16.8-Linux-x86_64.sh --skip-license --prefix=/opt/cmake
git clone https://github.com/kokkos/kokkos.git --branch develop --depth 1
cd kokkos/
/opt/cmake/bin/cmake -B build -DKokkos_ENABLE_OPENMP=ON -DKokkos_ENABLE_TESTS=ON
/opt/cmake/bin/cmake --build build --target Kokkos_CoreUnitTest_OpenMP --parallel 6
```
I checked that `gcc:9.3.0` did not need the workaround.
