### PR TITLE
Fix ambiguity for bit_cast

### DIFF
--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -100,6 +100,11 @@ inline constexpr bool is_standard_unsigned_integer_type_v =
 namespace Kokkos {
 
 //<editor-fold desc="[bit.cast], bit_cast">
+// FIXME_SYCL intel/llvm has unqualified calls to bit_cast which are ambiguous
+// if we declare our own bit_cast function
+#ifdef KOKKOS_ENABLE_SYCL
+using sycl::bit_cast;
+#else
 template <class To, class From>
 KOKKOS_FUNCTION std::enable_if_t<sizeof(To) == sizeof(From) &&
                                      std::is_trivially_copyable_v<To> &&
@@ -110,6 +115,7 @@ bit_cast(From const& from) noexcept {
   memcpy(&to, &from, sizeof(To));
   return to;
 }
+#endif
 //</editor-fold>
 
 //<editor-fold desc="[bit.byteswap], byteswap">

--- a/core/unit_test/TestBitManipulation.cpp
+++ b/core/unit_test/TestBitManipulation.cpp
@@ -500,6 +500,8 @@ constexpr X test_bit_cast(...) {
   return {};
 }
 
+// FIXME_SYCL The SYCL implementation is unconstrained
+#ifndef KOKKOS_ENABLE_SYCL
 namespace TypesNotTheSameSize {
 struct To {
   char a;
@@ -532,6 +534,7 @@ struct From {
 };
 static_assert(test_bit_cast<To, From>().did_not_match());
 }  // namespace FromNotTriviallyCopyable
+#endif
 
 namespace ReturnTypeIllFormed {
 struct From {


### PR DESCRIPTION
It turns out that we are seeing ambiguities with SYCL builds since there is also `sycl::bit_cast`. In the `intel/llvm` code base (https://github.com/intel/llvm/blob/sycl/sycl/include/sycl/detail/spirv.hpp) there are unconstrained calls to `bit_cast` with templated types (that are coming from the `Kokkos` namespace in the failing case). For these unconstrained calls, ADL kicks in and the compiler both finds `Kokkos::bit_cast` and `sycl::bit_cast`.
As a workaround, this pull request imports `sycl::bit_cast` into the `Kokkos` namespace directly. It turns out that `sycl::bit_cast` is unconstrained and participates in overload resolution for all types (but there are `static_assert`s in the body of the function). Thus, we also have to disable some tests that check for matching types.

It also turns out that we have some unconstrained calls to `bit_cast` in `Kokkos` that are susceptible to the same ambiguity through ADL problem (also see https://godbolt.org/z/vc5oEeMWa). This is addressed in the second commit.