### PR TITLE
Qualify possibly ambiguous calls to bit_cast

### DIFF
--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -398,7 +398,8 @@ KOKKOS_FUNCTION std::enable_if_t<sizeof(To) == sizeof(From) &&
                                      std::is_trivially_copyable_v<From>,
                                  To>
 bit_cast_builtin(From const& from) noexcept {
-  return bit_cast<To>(from);  // no benefit to call the _builtin variant
+  // qualify the call to avoid ADL
+  return Kokkos::bit_cast<To>(from);  // no benefit to call the _builtin variant
 }
 
 template <class T>

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -814,8 +814,8 @@ class simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm256_set1_epi64x(bit_cast<std::int64_t>(value_type(value)))) {
-  }
+      : m_value(_mm256_set1_epi64x(
+            Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m256i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -262,7 +262,8 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm256_set1_epi32(bit_cast<std::int32_t>(value_type(value)))) {}
+      : m_value(_mm256_set1_epi32(
+            Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
       __m256i const& value_in)
       : m_value(value_in) {}
@@ -486,7 +487,8 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
-      : m_value(_mm512_set1_epi64(bit_cast<std::int64_t>(value_type(value)))) {}
+      : m_value(_mm512_set1_epi64(
+            Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr simd(__m512i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd(


### PR DESCRIPTION
Split from #6121.
It turns out that we have some unconstrained calls to bit_cast in Kokkos that are susceptible to ambiguity through ADL problem (also see [godbolt.org/z/vc5oEeMWa](https://godbolt.org/z/vc5oEeMWa)).