### PR TITLE
Cuda: Remove unused attach_texture_object

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -423,49 +423,6 @@ SharedAllocationRecord<void, void>
     SharedAllocationRecord<Kokkos::CudaHostPinnedSpace, void>::s_root_record;
 #endif
 
-::cudaTextureObject_t
-SharedAllocationRecord<Kokkos::CudaSpace, void>::attach_texture_object(
-    const unsigned sizeof_alias, void *const alloc_ptr,
-    size_t const alloc_size) {
-  enum { TEXTURE_BOUND_1D = 1u << 27 };
-
-  if ((alloc_ptr == nullptr) ||
-      (sizeof_alias * TEXTURE_BOUND_1D <= alloc_size)) {
-    std::ostringstream msg;
-    msg << "Kokkos::CudaSpace ERROR: Cannot attach texture object to"
-        << " alloc_ptr(" << alloc_ptr << ")"
-        << " alloc_size(" << alloc_size << ")"
-        << " max_size(" << (sizeof_alias * TEXTURE_BOUND_1D) << ")";
-    std::cerr << msg.str() << std::endl;
-    std::cerr.flush();
-    Kokkos::Impl::throw_runtime_exception(msg.str());
-  }
-
-  ::cudaTextureObject_t tex_obj;
-
-  struct cudaResourceDesc resDesc;
-  struct cudaTextureDesc texDesc;
-
-  memset(&resDesc, 0, sizeof(resDesc));
-  memset(&texDesc, 0, sizeof(texDesc));
-
-  resDesc.resType = cudaResourceTypeLinear;
-  resDesc.res.linear.desc =
-      (sizeof_alias == 4
-           ? cudaCreateChannelDesc<int>()
-           : (sizeof_alias == 8
-                  ? cudaCreateChannelDesc< ::int2>()
-                  :
-                  /* sizeof_alias == 16 */ cudaCreateChannelDesc< ::int4>()));
-  resDesc.res.linear.sizeInBytes = alloc_size;
-  resDesc.res.linear.devPtr      = alloc_ptr;
-
-  KOKKOS_IMPL_CUDA_SAFE_CALL(
-      cudaCreateTextureObject(&tex_obj, &resDesc, &texDesc, nullptr));
-
-  return tex_obj;
-}
-
 //==============================================================================
 // <editor-fold desc="SharedAllocationRecord destructors"> {{{1
 
@@ -524,7 +481,6 @@ SharedAllocationRecord<Kokkos::CudaSpace, void>::SharedAllocationRecord(
                                                arg_alloc_size),
           sizeof(SharedAllocationHeader) + arg_alloc_size, arg_dealloc,
           arg_label),
-      m_tex_obj(0),
       m_space(arg_space) {
 
   SharedAllocationHeader header;
@@ -555,7 +511,6 @@ SharedAllocationRecord<Kokkos::CudaSpace, void>::SharedAllocationRecord(
                                                arg_label, arg_alloc_size),
           sizeof(SharedAllocationHeader) + arg_alloc_size, arg_dealloc,
           arg_label),
-      m_tex_obj(0),
       m_space(arg_space) {
 
   SharedAllocationHeader header;
@@ -582,7 +537,6 @@ SharedAllocationRecord<Kokkos::CudaUVMSpace, void>::SharedAllocationRecord(
                                                arg_alloc_size),
           sizeof(SharedAllocationHeader) + arg_alloc_size, arg_dealloc,
           arg_label),
-      m_tex_obj(0),
       m_space(arg_space) {
   this->base_t::_fill_host_accessible_header_info(*base_t::m_alloc_ptr,
                                                   arg_label);


### PR DESCRIPTION
`attach_texture_object` isn't used anymore since https://github.com/kokkos/kokkos/pull/5623. Also, see https://github.com/kokkos/kokkos/pull/5989/files#r1191202517.
Technically, some of the functions are `public` but I don't think it's necessary to deprecate them first.