### PR TITLE
sorting an empty view should exit early and not fail

### DIFF
--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -329,6 +329,10 @@ class BinSort {
   template <class ExecutionSpace, class ValuesViewType>
   void sort(const ExecutionSpace& exec, ValuesViewType const& values,
             int values_range_begin, int values_range_end) const {
+    if (values.extent(0) == 0) {
+      return;
+    }
+
     static_assert(
         Kokkos::SpaceAccessibility<ExecutionSpace,
                                    typename Space::memory_space>::accessible,

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -606,6 +606,10 @@ std::enable_if_t<(Kokkos::is_execution_space<ExecutionSpace>::value) &&
                                     memory_space>::accessible)>
 sort(const ExecutionSpace& exec,
      const Kokkos::View<DataType, Properties...>& view) {
+  if (view.extent(0) == 0) {
+    return;
+  }
+
   using ViewType = Kokkos::View<DataType, Properties...>;
   using CompType = BinOp1D<ViewType>;
 
@@ -648,8 +652,11 @@ sort(const ExecutionSpace& exec,
 template <class DataType, class... Properties>
 void sort(const Experimental::SYCL& space,
           const Kokkos::View<DataType, Properties...>& view) {
-  using ViewType = Kokkos::View<DataType, Properties...>;
+  if (view.extent(0) == 0) {
+    return;
+  }
 
+  using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(SpaceAccessibility<Experimental::SYCL,
                                    typename ViewType::memory_space>::accessible,
                 "SYCL execution space is not able to access the memory space "
@@ -676,6 +683,9 @@ std::enable_if_t<(Kokkos::is_execution_space<ExecutionSpace>::value) &&
                      HostSpace, typename Kokkos::View<DataType, Properties...>::
                                     memory_space>::accessible)>
 sort(const ExecutionSpace&, const Kokkos::View<DataType, Properties...>& view) {
+  if (view.extent(0) == 0) {
+    return;
+  }
   auto first = Experimental::begin(view);
   auto last  = Experimental::end(view);
   std::sort(first, last);
@@ -685,6 +695,9 @@ sort(const ExecutionSpace&, const Kokkos::View<DataType, Properties...>& view) {
 template <class DataType, class... Properties>
 void sort(const Cuda& space,
           const Kokkos::View<DataType, Properties...>& view) {
+  if (view.extent(0) == 0) {
+    return;
+  }
   const auto exec = thrust::cuda::par.on(space.cuda_stream());
   auto first      = Experimental::begin(view);
   auto last       = Experimental::end(view);
@@ -694,6 +707,9 @@ void sort(const Cuda& space,
 
 template <class ViewType>
 void sort(ViewType const& view) {
+  if (view.extent(0) == 0) {
+    return;
+  }
   Kokkos::fence("Kokkos::sort: before");
   typename ViewType::execution_space exec;
   sort(exec, view);
@@ -704,6 +720,10 @@ template <class ExecutionSpace, class ViewType>
 std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
     const ExecutionSpace& exec, ViewType view, size_t const begin,
     size_t const end) {
+  if (view.extent(0) == 0) {
+    return;
+  }
+
   using range_policy = Kokkos::RangePolicy<typename ViewType::execution_space>;
   using CompType     = BinOp1D<ViewType>;
 
@@ -725,6 +745,10 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
 
 template <class ViewType>
 void sort(ViewType view, size_t const begin, size_t const end) {
+  if (view.extent(0) == 0) {
+    return;
+  }
+
   Kokkos::fence("Kokkos::sort: before");
   typename ViewType::execution_space exec;
   sort(exec, view, begin, end);

--- a/algorithms/src/Kokkos_Sort.hpp
+++ b/algorithms/src/Kokkos_Sort.hpp
@@ -711,10 +711,12 @@ void sort(const Cuda& space,
 
 template <class ViewType>
 void sort(ViewType const& view) {
+  Kokkos::fence("Kokkos::sort: before");
+
   if (view.extent(0) == 0) {
     return;
   }
-  Kokkos::fence("Kokkos::sort: before");
+
   typename ViewType::execution_space exec;
   sort(exec, view);
   exec.fence("Kokkos::sort: fence after sorting");
@@ -749,11 +751,12 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
 
 template <class ViewType>
 void sort(ViewType view, size_t const begin, size_t const end) {
+  Kokkos::fence("Kokkos::sort: before");
+
   if (view.extent(0) == 0) {
     return;
   }
 
-  Kokkos::fence("Kokkos::sort: before");
   typename ViewType::execution_space exec;
   sort(exec, view, begin, end);
   exec.fence("Kokkos::Sort: fence after sorting");

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -425,6 +425,21 @@ void test_sort(unsigned int N) {
   test_sort_integer_overflow<ExecutionSpace, unsigned long long>();
   test_sort_integer_overflow<ExecutionSpace, int>();
 }
+
+template <class ExecutionSpace>
+void test_sort_empty_view() {
+  // does not matter if we use int or something else
+  Kokkos::View<int*, ExecutionSpace> v;
+
+  Kokkos::sort(v);
+  // nothing should have changed
+  ASSERT_TRUE(v.extent(0) == 0);
+
+  Kokkos::sort(ExecutionSpace(), v);
+  // nothing should have changed
+  ASSERT_TRUE(v.extent(0) == 0);
+}
+
 }  // namespace Impl
 }  // namespace Test
 #endif /* KOKKOS_ALGORITHMS_UNITTESTS_TESTSORT_HPP */

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -444,7 +444,6 @@ template <class ExecutionSpace>
 void test_binsort_empty_view() {
   using KeyViewType = Kokkos::View<int*, ExecutionSpace>;
   using BinOp_t     = Kokkos::BinOp1D<KeyViewType>;
-  BinOp_t binner;
   Kokkos::BinSort<KeyViewType, BinOp_t> Sorter;
 
   // does not matter if we use int or something else

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -429,15 +429,11 @@ void test_sort(unsigned int N) {
 template <class ExecutionSpace>
 void test_sort_empty_view() {
   // does not matter if we use int or something else
-  Kokkos::View<int*, ExecutionSpace> v;
+  Kokkos::View<int*, ExecutionSpace> v("v", 0);
 
-  Kokkos::sort(v);
-  // nothing should have changed
-  ASSERT_TRUE(v.extent(0) == 0);
-
-  Kokkos::sort(ExecutionSpace(), v);
-  // nothing should have changed
-  ASSERT_TRUE(v.extent(0) == 0);
+  // TODO check the synchronous behavior of the calls below
+  ASSERT_NO_THROW(Kokkos::sort(ExecutionSpace(), v));
+  ASSERT_NO_THROW(Kokkos::sort(v));
 }
 
 template <class ExecutionSpace>

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -453,20 +453,13 @@ void test_binsort_empty_view() {
   Kokkos::BinSort<KeyViewType, BinOp_t> Sorter(ExecutionSpace{}, kv, binOp);
 
   // does not matter if we use int or something else
-  Kokkos::View<int*, ExecutionSpace> v;
+  Kokkos::View<int*, ExecutionSpace> v("v", 0);
 
   // test all exposed public sort methods
-  Sorter.sort(ExecutionSpace(), v, 3, 8);
-  ASSERT_TRUE(v.extent(0) == 0);
-
-  Sorter.sort(v, 3, 8);
-  ASSERT_TRUE(v.extent(0) == 0);
-
-  Sorter.sort(ExecutionSpace(), v);
-  ASSERT_TRUE(v.extent(0) == 0);
-
-  Sorter.sort(v);
-  ASSERT_TRUE(v.extent(0) == 0);
+  ASSERT_NO_THROW(Sorter.sort(ExecutionSpace(), v, 0, 0));
+  ASSERT_NO_THROW(Sorter.sort(v, 0, 0));
+  ASSERT_NO_THROW(Sorter.sort(ExecutionSpace(), v));
+  ASSERT_NO_THROW(Sorter.sort(v));
 }
 
 }  // namespace Impl

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -467,8 +467,6 @@ void test_binsort_empty_keys() {
   BinOp_t binOp(5, 0, 10);
   Kokkos::BinSort<KeyViewType, BinOp_t> Sorter(ExecutionSpace{}, kv, binOp);
 
-  // does not matter if we use int or something else
-  Kokkos::View<int*, ExecutionSpace> v("v", 0);
   ASSERT_NO_THROW(Sorter.create_permute_vector(ExecutionSpace{}));
 }
 

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -440,6 +440,30 @@ void test_sort_empty_view() {
   ASSERT_TRUE(v.extent(0) == 0);
 }
 
+template <class ExecutionSpace>
+void test_binsort_empty_view() {
+  using KeyViewType = Kokkos::View<int*, ExecutionSpace>;
+  using BinOp_t     = Kokkos::BinOp1D<KeyViewType>;
+  BinOp_t binner;
+  Kokkos::BinSort<KeyViewType, BinOp_t> Sorter;
+
+  // does not matter if we use int or something else
+  Kokkos::View<int*, ExecutionSpace> v;
+
+  // test all exposed public sort methods
+  Sorter.sort(ExecutionSpace(), v, 3, 8);
+  ASSERT_TRUE(v.extent(0) == 0);
+
+  Sorter.sort(v, 3, 8);
+  ASSERT_TRUE(v.extent(0) == 0);
+
+  Sorter.sort(ExecutionSpace(), v);
+  ASSERT_TRUE(v.extent(0) == 0);
+
+  Sorter.sort(v);
+  ASSERT_TRUE(v.extent(0) == 0);
+}
+
 }  // namespace Impl
 }  // namespace Test
 #endif /* KOKKOS_ALGORITHMS_UNITTESTS_TESTSORT_HPP */

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -442,6 +442,9 @@ void test_sort_empty_view() {
 
 template <class ExecutionSpace>
 void test_binsort_empty_view() {
+  // the bounds and extents used below are totally arbitrary
+  // and, in theory, should have no impact
+
   using KeyViewType = Kokkos::View<int*, ExecutionSpace>;
   KeyViewType kv("kv", 20);
 

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -443,8 +443,11 @@ void test_sort_empty_view() {
 template <class ExecutionSpace>
 void test_binsort_empty_view() {
   using KeyViewType = Kokkos::View<int*, ExecutionSpace>;
-  using BinOp_t     = Kokkos::BinOp1D<KeyViewType>;
-  Kokkos::BinSort<KeyViewType, BinOp_t> Sorter;
+  KeyViewType kv("kv", 20);
+
+  using BinOp_t = Kokkos::BinOp1D<KeyViewType>;
+  BinOp_t binOp(5, 0, 10);
+  Kokkos::BinSort<KeyViewType, BinOp_t> Sorter(ExecutionSpace{}, kv, binOp);
 
   // does not matter if we use int or something else
   Kokkos::View<int*, ExecutionSpace> v;

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -458,6 +458,20 @@ void test_binsort_empty_view() {
   ASSERT_NO_THROW(Sorter.sort(v));
 }
 
+template <class ExecutionSpace>
+void test_binsort_empty_keys() {
+  using KeyViewType = Kokkos::View<int*, ExecutionSpace>;
+  KeyViewType kv("kv", 0);
+
+  using BinOp_t = Kokkos::BinOp1D<KeyViewType>;
+  BinOp_t binOp(5, 0, 10);
+  Kokkos::BinSort<KeyViewType, BinOp_t> Sorter(ExecutionSpace{}, kv, binOp);
+
+  // does not matter if we use int or something else
+  Kokkos::View<int*, ExecutionSpace> v("v", 0);
+  ASSERT_NO_THROW(Sorter.create_permute_vector(ExecutionSpace{}));
+}
+
 }  // namespace Impl
 }  // namespace Test
 #endif /* KOKKOS_ALGORITHMS_UNITTESTS_TESTSORT_HPP */

--- a/algorithms/unit_tests/TestSortCommon.hpp
+++ b/algorithms/unit_tests/TestSortCommon.hpp
@@ -23,8 +23,13 @@ namespace Test {
 TEST(TEST_CATEGORY, SortUnsigned) {
   Impl::test_sort<TEST_EXECSPACE, unsigned>(171);
 }
+
 TEST(TEST_CATEGORY, SortEmptyView) {
   Impl::test_sort_empty_view<TEST_EXECSPACE>();
+}
+
+TEST(TEST_CATEGORY, BinSortEmptyView) {
+  Impl::test_binsort_empty_view<TEST_EXECSPACE>();
 }
 }  // namespace Test
 #endif

--- a/algorithms/unit_tests/TestSortCommon.hpp
+++ b/algorithms/unit_tests/TestSortCommon.hpp
@@ -23,5 +23,8 @@ namespace Test {
 TEST(TEST_CATEGORY, SortUnsigned) {
   Impl::test_sort<TEST_EXECSPACE, unsigned>(171);
 }
+TEST(TEST_CATEGORY, SortEmptyView) {
+  Impl::test_sort_empty_view<TEST_EXECSPACE>();
+}
 }  // namespace Test
 #endif

--- a/algorithms/unit_tests/TestSortCommon.hpp
+++ b/algorithms/unit_tests/TestSortCommon.hpp
@@ -31,5 +31,9 @@ TEST(TEST_CATEGORY, SortEmptyView) {
 TEST(TEST_CATEGORY, BinSortEmptyView) {
   Impl::test_binsort_empty_view<TEST_EXECSPACE>();
 }
+
+TEST(TEST_CATEGORY, BinSortEmptyKeys) {
+  Impl::test_binsort_empty_keys<TEST_EXECSPACE>();
+}
 }  // namespace Test
 #endif


### PR DESCRIPTION
## `sort`
The current impl of `sort` does not handle nor test the special case of an empty view. 
Passing an empty view to sort should not fail. 
Currently, the code fails because if we look here: 

https://github.com/kokkos/kokkos/blob/3f602b6f283f82ecee2648f5606214a633d5e737/algorithms/src/Kokkos_Sort.hpp#L607-L640

when `view` is empty, the reduction does not happen and so `result` contains the reduction_identity values. 
Since those values are *not* equal, the following if is *not* satisfied:
```cpp
if (result.min_val == result.max_val) return;
```

and the code fails because it hits this:
```cpp
if (std::is_floating_point<typename ViewType::non_const_value_type>::value) {
    KOKKOS_ASSERT(std::isfinite(static_cast<double>(result.max_val) -
                                static_cast<double>(result.min_val)));
  }
```

## `BinSort`

For BinSort there is a similar problem here:

https://github.com/kokkos/kokkos/blob/3f602b6f283f82ecee2648f5606214a633d5e737/algorithms/src/Kokkos_Sort.hpp#L327-L331

## Comments

Note that an empty view is not a precondition violation. 
Also, the std lib behaves similarly: if we try to call std::sort on an empty vector the code does not crash. 

When merging, need to be careful with #6081 
