### PR TITLE
Increase minimum required HPX version to 1.8.0

### DIFF
--- a/cmake/Modules/FindTPLHPX.cmake
+++ b/cmake/Modules/FindTPLHPX.cmake
@@ -1,5 +1,5 @@
 
-FIND_PACKAGE(HPX REQUIRED 1.7.0)
+FIND_PACKAGE(HPX REQUIRED 1.8.0)
 #as of right now, HPX doesn't export correctly
 #so let's convert it to an interface target
 KOKKOS_CREATE_IMPORTED_TPL(HPX INTERFACE


### PR DESCRIPTION
This should really already have been part of #5628.