### PR TITLE
Silence HPX deprecation warning from HPX

### DIFF
--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -210,7 +210,11 @@ void HPX::impl_finalize() {
   if (m_hpx_initialized) {
     hpx::runtime *rt = hpx::get_runtime_ptr();
     if (rt != nullptr) {
+#if HPX_VERSION_FULL >= 0x010900
+      hpx::post([]() { hpx::local::finalize(); });
+#else
       hpx::apply([]() { hpx::local::finalize(); });
+#endif
       hpx::local::stop();
     } else {
       Kokkos::abort(


### PR DESCRIPTION
From HPX version 1.9.0 onwards `hpx::apply` has been renamed to `hpx::post`. `hpx::apply` is still there but it emits a deprecation warning and will be removed in future releases. This uses `hpx::post` when HPX is version 1.9.0 or newer.