### PR TITLE
Don't restrict index type in builtin reducers

### DIFF
--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -416,7 +416,6 @@ struct MinLoc {
   using index_type  = std::remove_cv_t<Index>;
   static_assert(!std::is_pointer_v<scalar_type> &&
                 !std::is_array_v<scalar_type>);
-  static_assert(std::is_integral_v<index_type>);
 
  public:
   // Required
@@ -472,7 +471,6 @@ struct MaxLoc {
   using index_type  = std::remove_cv_t<Index>;
   static_assert(!std::is_pointer_v<scalar_type> &&
                 !std::is_array_v<scalar_type>);
-  static_assert(std::is_integral_v<index_type>);
 
  public:
   // Required
@@ -597,7 +595,6 @@ struct MinMaxLoc {
   using index_type  = std::remove_cv_t<Index>;
   static_assert(!std::is_pointer_v<scalar_type> &&
                 !std::is_array_v<scalar_type>);
-  static_assert(std::is_integral_v<index_type>);
 
  public:
   // Required

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1212,6 +1212,9 @@ struct TestReducers {
 #if defined(KOKKOS_ENABLE_OPENMPTARGET)
 #if defined(KOKKOS_COMPILER_CLANG) && (KOKKOS_COMPILER_CLANG >= 1300)
     test_minmaxloc(10007);
+#else
+    if (!std::is_same_v<ExecSpace, Kokkos::Experimental::OpenMPTarget>)
+      test_minmaxloc(10007);
 #endif
 #else
     test_minmaxloc(10007);
@@ -1230,10 +1233,11 @@ struct TestReducers {
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minloc(10003);
-#if !defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC misaligned memory
+#if defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC misaligned memory
+    if (!std::is_same_v<ExecSpace, Kokkos::Cuda>)
     // FIXME_OPENMPTARGET requires custom reductions.
 #if !defined(KOKKOS_ENABLE_OPENMPTARGET)
-    test_minloc_2d(100);
+      test_minloc_2d(100);
 #endif
 #endif
 #endif
@@ -1242,9 +1246,10 @@ struct TestReducers {
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_maxloc(10007);
 #if !defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC misaligned memory
+    if (!std::is_same_v<ExecSpace, Kokkos::Cuda>)
 // FIXME_OPENMPTARGET requires custom reductions.
 #if !defined(KOKKOS_ENABLE_OPENMPTARGET)
-    test_maxloc_2d(100);
+      test_maxloc_2d(100);
 #endif
 #endif
 #endif
@@ -1255,6 +1260,9 @@ struct TestReducers {
 #if defined(KOKKOS_ENABLE_OPENMPTARGET)
 #if defined(KOKKOS_COMPILER_CLANG) && (KOKKOS_COMPILER_CLANG >= 1300)
     test_minmaxloc(10007);
+#else
+      if (!std::is_same_v<ExecSpace, Kokkos::Experimental::OpenMPTarget>)
+        test_minmaxloc(10007);
 #endif
 #else
     test_minmaxloc(10007);

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1221,13 +1221,19 @@ struct TestReducers {
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minloc(10003);
+// FIXME_NVHPC misaligned memory
+#if !defined(KOKKOS_COMPILER_NVHPC)
     test_minloc_2d(100);
+#endif
 #endif
     test_max(10007);
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_maxloc(10007);
+// FIXME_NVHPC misaligned memory
+#if !defined(KOKKOS_COMPILER_NVHPC)
     test_maxloc_2d(100);
+#endif
 #endif
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_CLANG) && \
     (KOKKOS_COMPILER_CLANG < 1300)

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1234,7 +1234,9 @@ struct TestReducers {
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minloc(10003);
 #if defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC misaligned memory
+#if defined(KOKKOS_ENABLE_CUDA)
     if (!std::is_same_v<ExecSpace, Kokkos::Cuda>)
+#endif
     // FIXME_OPENMPTARGET requires custom reductions.
 #if !defined(KOKKOS_ENABLE_OPENMPTARGET)
       test_minloc_2d(100);
@@ -1246,7 +1248,9 @@ struct TestReducers {
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_maxloc(10007);
 #if !defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC misaligned memory
+#if defined(KOKKOS_ENABLE_CUDA)
     if (!std::is_same_v<ExecSpace, Kokkos::Cuda>)
+#endif
 // FIXME_OPENMPTARGET requires custom reductions.
 #if !defined(KOKKOS_ENABLE_OPENMPTARGET)
       test_maxloc_2d(100);
@@ -1261,8 +1265,8 @@ struct TestReducers {
 #if defined(KOKKOS_COMPILER_CLANG) && (KOKKOS_COMPILER_CLANG >= 1300)
     test_minmaxloc(10007);
 #else
-      if (!std::is_same_v<ExecSpace, Kokkos::Experimental::OpenMPTarget>)
-        test_minmaxloc(10007);
+    if (!std::is_same_v<ExecSpace, Kokkos::Experimental::OpenMPTarget>)
+      test_minmaxloc(10007);
 #endif
 #else
     test_minmaxloc(10007);

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1188,30 +1188,29 @@ struct TestReducers {
     test_sum(10001);
     test_prod(35);
     test_min(10003);
-#if !defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC - OpenACC (V3.3) does not
-                                     // support custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENACC)
+    // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minloc(10003);
-#if !defined(KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET requires custom
-                                          // reductions.
+// FIXME_OPENMPTARGET requires custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET)
     test_minloc_2d(100);
 #endif
 #endif
     test_max(10007);
-#if !defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC - OpenACC (V3.3) does not
-                                     // support custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENACC)
+    // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_maxloc(10007);
-#if !defined(KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET requires custom
-                                          // reductions.
+// FIXME_OPENMPTARGET requires custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET)
     test_maxloc_2d(100);
 #endif
 #endif
-#if !defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC - OpenACC (V3.3) does not
-                                     // support custom reductions.
+// FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENACC)
+// FIXME_OPENMPTARGET - The minmaxloc test fails llvm < 13 version,
+// test_minmaxloc_2d requires custom reductions
 #if defined(KOKKOS_ENABLE_OPENMPTARGET)
-#if defined(KOKKOS_COMPILER_CLANG) && \
-    (KOKKOS_COMPILER_CLANG >=         \
-     1300)  // FIXME_OPENMPTARGET - The minmaxloc test fails llvm < 13 version,
-            // test_minmaxloc_2d requires custom reductions
+#if defined(KOKKOS_COMPILER_CLANG) && (KOKKOS_COMPILER_CLANG >= 1300)
     test_minmaxloc(10007);
 #endif
 #else
@@ -1228,12 +1227,12 @@ struct TestReducers {
     test_sum(10001);
     test_prod(sizeof(Scalar) > 4 ? 35 : 19);  // avoid int overflow (see above)
     test_min(10003);
-#if !defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC - OpenACC (V3.3) does not
-                                     // support custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENACC)
+    // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minloc(10003);
-#if !defined(KOKKOS_COMPILER_NVHPC)       // FIXME_NVHPC misaligned memory
-#if !defined(KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET requires custom
-                                          // reductions.
+#if !defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC misaligned memory
+    // FIXME_OPENMPTARGET requires custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET)
     test_minloc_2d(100);
 #endif
 #endif
@@ -1242,20 +1241,19 @@ struct TestReducers {
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_maxloc(10007);
-#if !defined(KOKKOS_COMPILER_NVHPC)       // FIXME_NVHPC misaligned memory
-#if !defined(KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET requires custom
-                                          // reductions.
+#if !defined(KOKKOS_COMPILER_NVHPC)  // FIXME_NVHPC misaligned memory
+// FIXME_OPENMPTARGET requires custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET)
     test_maxloc_2d(100);
 #endif
 #endif
 #endif
-#if !defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC - OpenACC (V3.3) does not
-                                     // support custom reductions.
-#if defined( \
-    KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET - The minmaxloc test
-                                 // fails llvm <= 13 version, the minmaxloc_2d
-                                 // test requires custom reductions.
-#if defined(KOKKOS_COMPILER_CLANG) && (KOKKOS_COMPILER_CLANG > 1300)
+// FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENACC)
+// FIXME_OPENMPTARGET - The minmaxloc test fails llvm < 13 version,
+// the minmaxloc_2d test requires custom reductions.
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)
+#if defined(KOKKOS_COMPILER_CLANG) && (KOKKOS_COMPILER_CLANG >= 1300)
     test_minmaxloc(10007);
 #endif
 #else

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -23,6 +23,17 @@
 //--------------------------------------------------------------------------
 
 namespace Test {
+struct MyPair : Kokkos::pair<int, int> {};
+}  // namespace Test
+
+template <>
+struct Kokkos::reduction_identity<Test::MyPair> {
+  KOKKOS_FUNCTION static Test::MyPair min() {
+    return Test::MyPair{{INT_MAX, INT_MAX}};
+  }
+};
+
+namespace Test {
 
 struct ReducerTag {};
 
@@ -74,6 +85,20 @@ struct TestReducers {
     }
   };
 
+  struct MinLocFunctor2D {
+    Kokkos::View<const Scalar**, ExecSpace> values;
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(
+        const int& i, const int& j,
+        typename Kokkos::MinLoc<Scalar, MyPair>::value_type& value) const {
+      if (values(i, j) < value.val) {
+        value.val = values(i, j);
+        value.loc = {{i, j}};
+      }
+    }
+  };
+
   struct MaxLocFunctor {
     Kokkos::View<const Scalar*, ExecSpace> values;
 
@@ -84,6 +109,20 @@ struct TestReducers {
       if (values(i) > value.val) {
         value.val = values(i);
         value.loc = i;
+      }
+    }
+  };
+
+  struct MaxLocFunctor2D {
+    Kokkos::View<const Scalar**, ExecSpace> values;
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(
+        const int& i, const int& j,
+        typename Kokkos::MaxLoc<Scalar, MyPair>::value_type& value) const {
+      if (values(i, j) > value.val) {
+        value.val = values(i, j);
+        value.loc = {{i, j}};
       }
     }
   };
@@ -103,6 +142,25 @@ struct TestReducers {
       if (values(i) < value.min_val) {
         value.min_val = values(i);
         value.min_loc = i;
+      }
+    }
+  };
+
+  struct MinMaxLocFunctor2D {
+    Kokkos::View<const Scalar**, ExecSpace> values;
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(
+        const int& i, const int& j,
+        typename Kokkos::MinMaxLoc<Scalar, MyPair>::value_type& value) const {
+      if (values(i, j) > value.max_val) {
+        value.max_val = values(i, j);
+        value.max_loc = {{i, j}};
+      }
+
+      if (values(i, j) < value.min_val) {
+        value.min_val = values(i, j);
+        value.min_loc = {{i, j}};
       }
     }
   };
@@ -598,6 +656,44 @@ struct TestReducers {
     }
   }
 
+  static void test_minloc_2d(int N) {
+    using reducer_type = Kokkos::MinLoc<Scalar, MyPair>;
+    using value_type   = typename reducer_type::value_type;
+
+    Kokkos::View<Scalar**, ExecSpace> values("Values", N, N);
+    auto h_values        = Kokkos::create_mirror_view(values);
+    Scalar reference_min = std::numeric_limits<Scalar>::max();
+    MyPair reference_loc = {{-1, -1}};
+
+    for (int i = 0; i < N; i++)
+      for (int j = 0; j < N; j++) {
+        h_values(i, j) = (Scalar)(rand() % 100000 + 2);
+
+        if (h_values(i, j) < reference_min) {
+          reference_min = h_values(i, j);
+          reference_loc = {{i, j}};
+        } else if (h_values(i, j) == reference_min) {
+          // Make min unique.
+          h_values(i, j) += Scalar(1);
+        }
+      }
+    Kokkos::deep_copy(values, h_values);
+
+    MinLocFunctor2D f;
+    f.values = values;
+
+    {
+      value_type min_scalar;
+      reducer_type reducer_scalar(min_scalar);
+
+      Kokkos::parallel_reduce(
+          Kokkos::MDRangePolicy<Kokkos::Rank<2>, ExecSpace>({0, 0}, {N, N}), f,
+          reducer_scalar);
+      ASSERT_EQ(min_scalar.val, reference_min);
+      ASSERT_EQ(min_scalar.loc, reference_loc);
+    }
+  }
+
   static void test_maxloc(int N) {
     using value_type = typename Kokkos::MaxLoc<Scalar, int>::value_type;
 
@@ -658,6 +754,44 @@ struct TestReducers {
       value_type max_view_view = reducer_view.reference();
       ASSERT_EQ(max_view_view.val, reference_max);
       ASSERT_EQ(max_view_view.loc, reference_loc);
+    }
+  }
+
+  static void test_maxloc_2d(int N) {
+    using reducer_type = Kokkos::MaxLoc<Scalar, MyPair>;
+    using value_type   = typename reducer_type::value_type;
+
+    Kokkos::View<Scalar**, ExecSpace> values("Values", N, N);
+    auto h_values        = Kokkos::create_mirror_view(values);
+    Scalar reference_max = std::numeric_limits<Scalar>::min();
+    MyPair reference_loc = {{-1, -1}};
+
+    for (int i = 0; i < N; ++i)
+      for (int j = 0; j < N; ++j) {
+        h_values(i, j) = (Scalar)(rand() % 100000 + 2);
+
+        if (h_values(i, j) > reference_max) {
+          reference_max = h_values(i, j);
+          reference_loc = {{i, j}};
+        } else if (h_values(i, j) == reference_max) {
+          // Make max unique.
+          h_values(i, j) -= Scalar(1);
+        }
+      }
+    Kokkos::deep_copy(values, h_values);
+
+    MaxLocFunctor2D f;
+    f.values = values;
+
+    {
+      value_type max_scalar;
+      reducer_type reducer_scalar(max_scalar);
+
+      Kokkos::parallel_reduce(
+          Kokkos::MDRangePolicy<Kokkos::Rank<2>, ExecSpace>({0, 0}, {N, N}), f,
+          reducer_scalar);
+      ASSERT_EQ(max_scalar.val, reference_max);
+      ASSERT_EQ(max_scalar.loc, reference_loc);
     }
   }
 
@@ -774,6 +908,78 @@ struct TestReducers {
       ASSERT_EQ(minmax_view_view.min_loc, reference_minloc);
       ASSERT_EQ(minmax_view_view.max_val, reference_max);
       ASSERT_EQ(minmax_view_view.max_loc, reference_maxloc);
+    }
+  }
+
+  static void test_minmaxloc_2d(int N) {
+    using reducer_type = Kokkos::MinMaxLoc<Scalar, MyPair>;
+    using value_type   = typename reducer_type::value_type;
+
+    Kokkos::View<Scalar**, ExecSpace> values("Values", N, N);
+    auto h_values           = Kokkos::create_mirror_view(values);
+    Scalar reference_max    = std::numeric_limits<Scalar>::min();
+    Scalar reference_min    = std::numeric_limits<Scalar>::max();
+    MyPair reference_minloc = {{-1, -1}};
+    MyPair reference_maxloc = {{-1, -1}};
+
+    for (int i = 0; i < N; i++)
+      for (int j = 0; j < N; j++) {
+        h_values(i, j) = (Scalar)(rand() % 100000 + 2);
+      }
+
+    for (int i = 0; i < N; i++)
+      for (int j = 0; j < N; j++) {
+        if (h_values(i, j) > reference_max) {
+          reference_max    = h_values(i, j);
+          reference_maxloc = {{i, j}};
+        } else if (h_values(i, j) == reference_max) {
+          // Make max unique.
+          h_values(i, j) -= Scalar(1);
+        }
+      }
+
+    for (int i = 0; i < N; i++)
+      for (int j = 0; j < N; j++) {
+        if (h_values(i, j) < reference_min) {
+          reference_min    = h_values(i, j);
+          reference_minloc = {{i, j}};
+        } else if (h_values(i, j) == reference_min) {
+          // Make min unique.
+          h_values(i, j) += Scalar(1);
+        }
+      }
+
+    Kokkos::deep_copy(values, h_values);
+
+    MinMaxLocFunctor2D f;
+    f.values = values;
+    {
+      value_type minmax_scalar;
+      reducer_type reducer_scalar(minmax_scalar);
+
+      Kokkos::parallel_reduce(
+          Kokkos::MDRangePolicy<Kokkos::Rank<2>, ExecSpace>({0, 0}, {N, N}), f,
+          reducer_scalar);
+
+      ASSERT_EQ(minmax_scalar.min_val, reference_min);
+      for (int i = 0; i < N; i++)
+        for (int j = 0; j < N; j++) {
+          if ((minmax_scalar.min_loc == MyPair{{i, j}}) &&
+              (h_values(i, j) == reference_min)) {
+            reference_minloc = {{i, j}};
+          }
+        }
+      ASSERT_EQ(minmax_scalar.min_loc, reference_minloc);
+
+      ASSERT_EQ(minmax_scalar.max_val, reference_max);
+      for (int i = 0; i < N; i++)
+        for (int j = 0; j < N; j++) {
+          if ((minmax_scalar.max_loc == MyPair{{i, j}}) &&
+              (h_values(i, j) == reference_max)) {
+            reference_maxloc = {{i, j}};
+          }
+        }
+      ASSERT_EQ(minmax_scalar.max_loc, reference_maxloc);
     }
   }
 
@@ -985,11 +1191,13 @@ struct TestReducers {
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minloc(10003);
+    test_minloc_2d(100);
 #endif
     test_max(10007);
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_maxloc(10007);
+    test_maxloc_2d(100);
 #endif
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_CLANG) && \
     (KOKKOS_COMPILER_CLANG < 1300)
@@ -998,6 +1206,7 @@ struct TestReducers {
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minmaxloc(10007);
+    test_minmaxloc_2d(100);
 #endif
 #endif
   }
@@ -1012,11 +1221,13 @@ struct TestReducers {
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minloc(10003);
+    test_minloc_2d(100);
 #endif
     test_max(10007);
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_maxloc(10007);
+    test_maxloc_2d(100);
 #endif
 #if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_CLANG) && \
     (KOKKOS_COMPILER_CLANG < 1300)
@@ -1025,6 +1236,7 @@ struct TestReducers {
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minmaxloc(10007);
+    test_minmaxloc_2d(100);
 #endif
 #endif
     test_BAnd(35);

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1188,23 +1188,33 @@ struct TestReducers {
     test_sum(10001);
     test_prod(35);
     test_min(10003);
-#if !defined(KOKKOS_ENABLE_OPENACC)
-    // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC - OpenACC (V3.3) does not
+                                     // support custom reductions.
     test_minloc(10003);
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET requires custom
+                                          // reductions.
     test_minloc_2d(100);
 #endif
+#endif
     test_max(10007);
-#if !defined(KOKKOS_ENABLE_OPENACC)
-    // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC - OpenACC (V3.3) does not
+                                     // support custom reductions.
     test_maxloc(10007);
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET requires custom
+                                          // reductions.
     test_maxloc_2d(100);
 #endif
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_CLANG) && \
-    (KOKKOS_COMPILER_CLANG < 1300)
-    // FIXME_OPENMPTARGET - The minmaxloc test fails llvm <= 13 version.
+#endif
+#if !defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC - OpenACC (V3.3) does not
+                                     // support custom reductions.
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)
+#if defined(KOKKOS_COMPILER_CLANG) && \
+    (KOKKOS_COMPILER_CLANG >=         \
+     1300)  // FIXME_OPENMPTARGET - The minmaxloc test fails llvm < 13 version,
+            // test_minmaxloc_2d requires custom reductions
+    test_minmaxloc(10007);
+#endif
 #else
-#if !defined(KOKKOS_ENABLE_OPENACC)
-    // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minmaxloc(10007);
     test_minmaxloc_2d(100);
 #endif
@@ -1218,29 +1228,37 @@ struct TestReducers {
     test_sum(10001);
     test_prod(sizeof(Scalar) > 4 ? 35 : 19);  // avoid int overflow (see above)
     test_min(10003);
-#if !defined(KOKKOS_ENABLE_OPENACC)
-    // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
+#if !defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC - OpenACC (V3.3) does not
+                                     // support custom reductions.
     test_minloc(10003);
-// FIXME_NVHPC misaligned memory
-#if !defined(KOKKOS_COMPILER_NVHPC)
+#if !defined(KOKKOS_COMPILER_NVHPC)       // FIXME_NVHPC misaligned memory
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET requires custom
+                                          // reductions.
     test_minloc_2d(100);
+#endif
 #endif
 #endif
     test_max(10007);
 #if !defined(KOKKOS_ENABLE_OPENACC)
     // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_maxloc(10007);
-// FIXME_NVHPC misaligned memory
-#if !defined(KOKKOS_COMPILER_NVHPC)
+#if !defined(KOKKOS_COMPILER_NVHPC)       // FIXME_NVHPC misaligned memory
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET requires custom
+                                          // reductions.
     test_maxloc_2d(100);
 #endif
 #endif
-#if defined(KOKKOS_ENABLE_OPENMPTARGET) && defined(KOKKOS_COMPILER_CLANG) && \
-    (KOKKOS_COMPILER_CLANG < 1300)
-    // FIXME_OPENMPTARGET - The minmaxloc test fails llvm <= 13 version.
+#endif
+#if !defined(KOKKOS_ENABLE_OPENACC)  // FIXME_OPENACC - OpenACC (V3.3) does not
+                                     // support custom reductions.
+#if defined( \
+    KOKKOS_ENABLE_OPENMPTARGET)  // FIXME_OPENMPTARGET - The minmaxloc test
+                                 // fails llvm <= 13 version, the minmaxloc_2d
+                                 // test requires custom reductions.
+#if defined(KOKKOS_COMPILER_CLANG) && (KOKKOS_COMPILER_CLANG > 1300)
+    test_minmaxloc(10007);
+#endif
 #else
-#if !defined(KOKKOS_ENABLE_OPENACC)
-    // FIXME_OPENACC - OpenACC (V3.3) does not support custom reductions.
     test_minmaxloc(10007);
     test_minmaxloc_2d(100);
 #endif


### PR DESCRIPTION
Fixes #6134. Removes index type restrictions for `MinLoc`, `MaxLoc`, and `MinMaxLoc` and adds tests that are reduced versions of existing tests.