### PR TITLE
Fix bit_cast for SYCL again

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -107,7 +107,7 @@ pipeline {
                                 -DCMAKE_BUILD_TYPE=Release \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=/opt/intel/oneapi/compiler/2023.0.0/linux/bin-llvm/clang++ \
-                                -DCMAKE_CXX_FLAGS="-fsycl-device-code-split=per_kernel -Werror -Wno-gnu-zero-variadic-macro-arguments -Wno-unknown-cuda-version -Wno-sycl-target" \
+                                -DCMAKE_CXX_FLAGS="-fsycl-device-code-split=per_kernel -Wno-deprecated-declarations -Werror -Wno-gnu-zero-variadic-macro-arguments -Wno-unknown-cuda-version -Wno-sycl-target" \
                                 -DKOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED=0 \
                                 -DKokkos_ARCH_NATIVE=ON \
                                 -DKokkos_ARCH_VOLTA70=ON \

--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -103,7 +103,7 @@ namespace Kokkos {
 // FIXME_SYCL intel/llvm has unqualified calls to bit_cast which are ambiguous
 // if we declare our own bit_cast function
 #ifdef KOKKOS_ENABLE_SYCL
-using sycl::bit_cast;
+using sycl::detail::bit_cast;
 #else
 template <class To, class From>
 KOKKOS_FUNCTION std::enable_if_t<sizeof(To) == sizeof(From) &&


### PR DESCRIPTION
After getting access to relevant compiler versions again, it turns out that https://github.com/kokkos/kokkos/pull/6121 wasn't quite enough to workaround the ambiguity caused by unqualified calls to `bitcast` in the SYCL compiler since the other candidate considered is `sycl::detail::bit_cast` (https://github.com/intel/llvm/blob/931203f26b8e10d273d89fcd7f90f11885a1baf5/sycl/include/sycl/bit_cast.hpp#L48-L57) that is forwarding to `sycl::bit_cast`. Hence, we get an ambiguity between `sycl::bit_cast` and `sycl::detail::bit_cast` with the current code.
Until https://github.com/intel/llvm/pull/9398 shows up in the compiler releases we are using, we have to import `sycl::detail::bit_cast` instead or drop defining `Kokkos::bit_cast` altogether. Neither of these options is particularly appealing but I lean towards the former.