### PR TITLE
OpenMP: Ensure kernels submitted by multiple threads to the same instance don't run concurrently

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.cpp
@@ -72,9 +72,28 @@ int OpenMP::concurrency(OpenMP const &instance) {
 int OpenMP::concurrency() const { return impl_thread_pool_size(); }
 #endif
 
+void OpenMP::impl_static_fence(std::string const &name) {
+  Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::OpenMP>(
+      name,
+      Kokkos::Tools::Experimental::SpecialSynchronizationCases::
+          GlobalDeviceSynchronization,
+      []() {
+        std::lock_guard<std::mutex> lock_all_instances(
+            Impl::OpenMPInternal::all_instances_mutex);
+        for (auto *instance_ptr : Impl::OpenMPInternal::all_instances) {
+          std::lock_guard<std::mutex> lock_instance(
+              instance_ptr->m_instance_mutex);
+        }
+      });
+}
+
 void OpenMP::fence(const std::string &name) const {
   Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::OpenMP>(
-      name, Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{1}, []() {});
+      name, Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{1},
+      [this]() {
+        auto *internal_instance = this->impl_internal_space_instance();
+        std::lock_guard<std::mutex> lock(internal_instance->m_instance_mutex);
+      });
 }
 
 bool OpenMP::impl_is_initialized() noexcept {

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -146,14 +146,6 @@ inline int OpenMP::impl_thread_pool_rank() noexcept {
   KOKKOS_IF_ON_DEVICE((return -1;))
 }
 
-inline void OpenMP::impl_static_fence(std::string const& name) {
-  Kokkos::Tools::Experimental::Impl::profile_fence_event<Kokkos::OpenMP>(
-      name,
-      Kokkos::Tools::Experimental::SpecialSynchronizationCases::
-          GlobalDeviceSynchronization,
-      []() {});
-}
-
 inline bool OpenMP::is_asynchronous(OpenMP const& /*instance*/) noexcept {
   return false;
 }

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -304,7 +304,8 @@ void OpenMPInternal::finalize() {
     if (it == all_instances.end())
       Kokkos::abort(
           "Execution space instance to be removed couldn't be found!");
-    all_instances.erase(it);
+    *it = all_instances.back();
+    all_instances.pop_back();
   }
 }
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -89,12 +89,6 @@ class OpenMPInternal {
 
   int thread_pool_size() const { return m_pool_size; }
 
-  // Acquire lock used to protect access to m_pool
-  void acquire_lock();
-
-  // Release lock used to protect access to m_pool
-  void release_lock();
-
   void resize_thread_data(size_t pool_reduce_bytes, size_t team_reduce_bytes,
                           size_t team_shared_bytes, size_t thread_local_bytes);
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -72,7 +72,6 @@ class OpenMPInternal {
 
   int m_pool_size;
   int m_level;
-  int m_pool_mutex = 0;
 
   HostThreadTeamData* m_pool[OpenMPTraits::MAX_THREAD_COUNT];
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel_For.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel_For.hpp
@@ -338,20 +338,16 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
     const size_t team_shared_size  = m_shmem_size;
     const size_t thread_local_size = 0;  // Never shrinks
 
-    m_instance->acquire_lock();
+    // Serialize kernels on the same execution space instance
+    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
     m_instance->resize_thread_data(pool_reduce_size, team_reduce_size,
                                    team_shared_size, thread_local_size);
-
-    // Serialize kernels on the same execution space instance
-    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
     if (execute_in_serial(m_policy.space())) {
       ParallelFor::template exec_team<WorkTag>(
           m_functor, *(m_instance->get_thread_data()), 0,
           m_policy.league_size(), m_policy.league_size());
-
-      m_instance->release_lock();
 
       return;
     }
@@ -391,8 +387,6 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
       data.disband_team();
     }
-
-    m_instance->release_lock();
   }
 
   inline ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel_Reduce.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel_Reduce.hpp
@@ -83,7 +83,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
 
     const size_t pool_reduce_bytes = reducer.value_size();
 
-    m_instance->acquire_lock();
+    // Serialize kernels on the same execution space instance
+    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
     m_instance->resize_thread_data(pool_reduce_bytes, 0  // team_reduce_bytes
                                    ,
@@ -91,9 +92,6 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
                                    ,
                                    0  // thread_local_bytes
     );
-
-    // Serialize kernels on the same execution space instance
-    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
     if (execute_in_serial(m_policy.space())) {
       const pointer_type ptr =
@@ -109,8 +107,6 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
           update);
 
       reducer.final(ptr);
-
-      m_instance->release_lock();
 
       return;
     }
@@ -163,8 +159,6 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
         m_result_ptr[j] = ptr[j];
       }
     }
-
-    m_instance->release_lock();
   }
 
   //----------------------------------------
@@ -224,7 +218,8 @@ class ParallelReduce<CombinedFunctorReducerType,
     const ReducerType& reducer     = m_iter.m_func.get_reducer();
     const size_t pool_reduce_bytes = reducer.value_size();
 
-    m_instance->acquire_lock();
+    // Serialize kernels on the same execution space instance
+    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
     m_instance->resize_thread_data(pool_reduce_bytes, 0  // team_reduce_bytes
                                    ,
@@ -232,9 +227,6 @@ class ParallelReduce<CombinedFunctorReducerType,
                                    ,
                                    0  // thread_local_bytes
     );
-
-    // Serialize kernels on the same execution space instance
-    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
 #ifndef KOKKOS_COMPILER_INTEL
     if (execute_in_serial(m_iter.m_rp.space())) {
@@ -249,8 +241,6 @@ class ParallelReduce<CombinedFunctorReducerType,
       ParallelReduce::exec_range(0, m_iter.m_rp.m_num_tiles, update);
 
       reducer.final(ptr);
-
-      m_instance->release_lock();
 
       return;
     }
@@ -308,8 +298,6 @@ class ParallelReduce<CombinedFunctorReducerType,
         m_result_ptr[j] = ptr[j];
       }
     }
-
-    m_instance->release_lock();
   }
 
   //----------------------------------------
@@ -424,13 +412,11 @@ class ParallelReduce<CombinedFunctorReducerType,
     const size_t team_shared_size  = m_shmem_size + m_policy.scratch_size(1);
     const size_t thread_local_size = 0;  // Never shrinks
 
-    m_instance->acquire_lock();
+    // Serialize kernels on the same execution space instance
+    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
     m_instance->resize_thread_data(pool_reduce_size, team_reduce_size,
                                    team_shared_size, thread_local_size);
-
-    // Serialize kernels on the same execution space instance
-    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
     if (execute_in_serial(m_policy.space())) {
       HostThreadTeamData& data = *(m_instance->get_thread_data());
@@ -444,8 +430,6 @@ class ParallelReduce<CombinedFunctorReducerType,
           league_rank_end, m_policy.league_size());
 
       reducer.final(ptr);
-
-      m_instance->release_lock();
 
       return;
     }
@@ -522,8 +506,6 @@ class ParallelReduce<CombinedFunctorReducerType,
         m_result_ptr[j] = ptr[j];
       }
     }
-
-    m_instance->release_lock();
   }
 
   //----------------------------------------

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel_Scan.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel_Scan.hpp
@@ -70,7 +70,8 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
     const int value_count          = Analysis::value_count(m_functor);
     const size_t pool_reduce_bytes = 2 * Analysis::value_size(m_functor);
 
-    m_instance->acquire_lock();
+    // Serialize kernels on the same execution space instance
+    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
     m_instance->resize_thread_data(pool_reduce_bytes, 0  // team_reduce_bytes
                                    ,
@@ -78,9 +79,6 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
                                    ,
                                    0  // thread_local_bytes
     );
-
-    // Serialize kernels on the same execution space instance
-    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
     if (execute_in_serial(m_policy.space())) {
       typename Analysis::Reducer final_reducer(m_functor);
@@ -90,8 +88,6 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
 
       ParallelScan::template exec_range<WorkTag>(m_functor, m_policy.begin(),
                                                  m_policy.end(), update, true);
-
-      m_instance->release_lock();
 
       return;
     }
@@ -141,7 +137,6 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
       ParallelScan::template exec_range<WorkTag>(
           m_functor, range.begin(), range.end(), update_base, true);
     }
-    m_instance->release_lock();
   }
 
   //----------------------------------------
@@ -201,7 +196,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
     const int value_count          = Analysis::value_count(m_functor);
     const size_t pool_reduce_bytes = 2 * Analysis::value_size(m_functor);
 
-    m_instance->acquire_lock();
+    // Serialize kernels on the same execution space instance
+    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
     m_instance->resize_thread_data(pool_reduce_bytes, 0  // team_reduce_bytes
                                    ,
@@ -209,9 +205,6 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
                                    ,
                                    0  // thread_local_bytes
     );
-
-    // Serialize kernels on the same execution space instance
-    std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
     if (execute_in_serial(m_policy.space())) {
       typename Analysis::Reducer final_reducer(m_functor);
@@ -223,8 +216,6 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
                                          m_policy.end(), update, true);
 
       *m_result_ptr = update;
-
-      m_instance->release_lock();
 
       return;
     }
@@ -277,8 +268,6 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
         *m_result_ptr = update_base;
       }
     }
-
-    m_instance->release_lock();
   }
 
   //----------------------------------------

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -73,7 +73,8 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::OpenMP, QueueType>> {
         execution_space().impl_internal_space_instance();
     const int pool_size = get_max_team_count(scheduler.get_execution_space());
 
-    instance->acquire_lock();
+    // Serialize kernels on the same execution space instance
+    std::lock_guard<std::mutex> lock(instance->m_instance_mutex);
 
     // TODO @tasking @new_feature DSH allow team sizes other than 1
     const int team_size = 1;                      // Threads per core
@@ -83,9 +84,6 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::OpenMP, QueueType>> {
                                  0                /* thread local buffer */
     );
     assert(pool_size % team_size == 0);
-
-    // Serialize kernels on the same execution space instance
-    std::lock_guard<std::mutex> lock(instance->m_instance_mutex);
 
     auto& queue = scheduler.queue();
 
@@ -155,8 +153,6 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::OpenMP, QueueType>> {
       }
       self.disband_team();
     }  // end pragma omp parallel
-
-    instance->release_lock();
   }
 
   static uint32_t get_max_team_count(execution_space const& espace) {
@@ -241,7 +237,8 @@ class TaskQueueSpecializationConstrained<
         execution_space().impl_internal_space_instance();
     const int pool_size = instance->thread_pool_size();
 
-    instance->acquire_lock();
+    // Serialize kernels on the same execution space instance
+    std::lock_guard<std::mutex> lock(instance->m_instance_mutex);
 
     const int team_size = 1;       // Threads per core
     instance->resize_thread_data(0 /* global reduce buffer */
@@ -253,9 +250,6 @@ class TaskQueueSpecializationConstrained<
                                  0 /* thread local buffer */
     );
     assert(pool_size % team_size == 0);
-
-    // Serialize kernels on the same execution space instance
-    std::lock_guard<std::mutex> lock(instance->m_instance_mutex);
 
     auto& queue = scheduler.queue();
     queue.initialize_team_queues(pool_size / team_size);
@@ -350,8 +344,6 @@ class TaskQueueSpecializationConstrained<
       }
       self.disband_team();
     }  // end pragma omp parallel
-
-    instance->release_lock();
   }
 
   template <typename TaskType>

--- a/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Task.hpp
@@ -84,6 +84,9 @@ class TaskQueueSpecialization<SimpleTaskScheduler<Kokkos::OpenMP, QueueType>> {
     );
     assert(pool_size % team_size == 0);
 
+    // Serialize kernels on the same execution space instance
+    std::lock_guard<std::mutex> lock(instance->m_instance_mutex);
+
     auto& queue = scheduler.queue();
 
     // queue.initialize_team_queues(pool_size / team_size);
@@ -250,6 +253,10 @@ class TaskQueueSpecializationConstrained<
                                  0 /* thread local buffer */
     );
     assert(pool_size % team_size == 0);
+
+    // Serialize kernels on the same execution space instance
+    std::lock_guard<std::mutex> lock(instance->m_instance_mutex);
+
     auto& queue = scheduler.queue();
     queue.initialize_team_queues(pool_size / team_size);
 

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -109,9 +109,7 @@ void HostSpace::deallocate(void *const arg_alloc_ptr,
 
 void HostSpace::deallocate(const char *arg_label, void *const arg_alloc_ptr,
                            const size_t arg_alloc_size,
-                           const size_t
-
-                               arg_logical_size) const {
+                           const size_t arg_logical_size) const {
   if (arg_alloc_ptr) Kokkos::fence("HostSpace::impl_deallocate before free");
   impl_deallocate(arg_label, arg_alloc_ptr, arg_alloc_size, arg_logical_size);
 }

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -680,9 +680,6 @@ if(Kokkos_ENABLE_THREADS)
 endif()
 
 if (Kokkos_ENABLE_OPENMP)
-  list(REMOVE_ITEM OpenMP_SOURCES
-    ${CMAKE_CURRENT_BINARY_DIR}/openmp/TestOpenMP_ExecSpaceThreadSafety.cpp)
-
   set(OpenMP_EXTRA_SOURCES
     openmp/TestOpenMP_Task.cpp
   )


### PR DESCRIPTION
Related to thread-safety questions in #6051 and #4385.
This pull request ensures that kernels submitted to the same execution space instance from multiple threads don't run concurrently. Also, calling `fence` ensures that any kernel running when `fence` completes before returning. This should be enough to ensure that `is_running` in #6051 can use
```
fence();
return false;
```
as fallback implementation.

There are still some cases where the test added failed but I think it's better to address that in follow-up pull requests to limit the size of this pull request (and unblock #6051).

Note that the behavior we aim for is that of the GPU backends:
Kernels submitted to the same execution space instance don't run concurrently and are executed in submission order (which needs external thread-synchronization to be well-defined if multiple threads submit to the same instance).