### PR TITLE
Revert to `DualView<class,class=void,class=void,class=void>` when deprecated code 4 is enabled

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -87,8 +87,14 @@ inline const Kokkos::Cuda& get_cuda_space(const NonCudaExecSpace&) {
 
 }  // namespace Impl
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+template <class DataType, class Arg1Type = void, class Arg2Type = void,
+          class Arg3Type = void>
+class DualView;
+#else
 template <class DataType, class... Properties>
 class DualView;
+#endif
 
 template <class>
 struct is_dual_view : public std::false_type {};
@@ -102,21 +108,35 @@ struct is_dual_view<const DualView<DT, DP...>> : public std::true_type {};
 template <class T>
 inline constexpr bool is_dual_view_v = is_dual_view<T>::value;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+template <class DataType, class Arg1Type, class Arg2Type, class Arg3Type>
+class DualView : public ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type> {
+  template <class, class, class, class>
+#else
 template <class DataType, class... Properties>
 class DualView : public ViewTraits<DataType, Properties...> {
   template <class, class...>
+#endif
   friend class DualView;
 
  public:
   //! \name Typedefs for device types and various Kokkos::View specializations.
   //@{
-  using traits = ViewTraits<DataType, Properties...>;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using traits = ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type>;
+#else
+  using traits      = ViewTraits<DataType, Properties...>;
+#endif
 
   //! The Kokkos Host Device type;
   using host_mirror_space = typename traits::host_mirror_space;
 
   //! The type of a Kokkos::View on the device.
-  using t_dev = View<typename traits::data_type, Properties...>;
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using t_dev = View<typename traits::data_type, Arg1Type, Arg2Type, Arg3Type>;
+#else
+  using t_dev       = View<typename traits::data_type, Properties...>;
+#endif
 
   /// \typedef t_host
   /// \brief The type of a Kokkos::View host mirror of \c t_dev.
@@ -124,7 +144,12 @@ class DualView : public ViewTraits<DataType, Properties...> {
 
   //! The type of a const View on the device.
   //! The type of a Kokkos::View on the device.
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  using t_dev_const =
+      View<typename traits::const_data_type, Arg1Type, Arg2Type, Arg3Type>;
+#else
   using t_dev_const = View<typename traits::const_data_type, Properties...>;
+#endif
 
   /// \typedef t_host_const
   /// \brief The type of a const View host mirror of \c t_dev_const.

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -49,6 +49,7 @@ endforeach()
 
 SET(COMPILE_ONLY_SOURCES
   TestCreateMirror.cpp
+  TestDualViewParameterPack.cpp
 )
 KOKKOS_ADD_EXECUTABLE(
   ContainersTestCompileOnly

--- a/containers/unit_tests/TestDualViewParameterPack.cpp
+++ b/containers/unit_tests/TestDualViewParameterPack.cpp
@@ -1,0 +1,43 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_DualView.hpp>
+
+namespace {
+
+template <class DataType, class Arg1Type = void, class Arg2Type = void,
+          class Arg3Type = void>
+void not_supported_anymore(
+    Kokkos::DualView<DataType, Arg1Type, Arg2Type, Arg2Type> x) {
+  static_assert(Kokkos::is_dual_view_v<decltype(x)>);
+}
+
+template <class DataType, class... Properties>
+void prefer_instead(Kokkos::DualView<DataType, Properties...> x) {
+  static_assert(Kokkos::is_dual_view_v<decltype(x)>);
+}
+
+using KDV = Kokkos::DualView<int*>;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+static_assert(
+    std::is_void_v<decltype(not_supported_anymore(std::declval<KDV>()))>);
+#endif
+
+static_assert(std::is_void_v<decltype(prefer_instead(std::declval<KDV>()))>);
+
+}  // namespace


### PR DESCRIPTION
Fixes #6141 and #6154 

The `DualView<class, class=void, class=void, class=void>` -> `DualView<class, class...>` change in #6120 broke Trilinos.  Even though we were able to update Trilinos (https://github.com/trilinos/Trilinos/pull/11906) so it works both we older versions of Kokkos and the develop branch, we decided we should only use a parameter pack with DualView when deprecated code 4 is not enabled.

cc @romintomasetti 