### PR TITLE
Check for overflow during backend initialization (Cuda, HIP, SYCL)

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -42,7 +42,6 @@
 /* Standard 'C++' libraries */
 #include <vector>
 #include <iostream>
-#include <limits>
 #include <sstream>
 #include <string>
 
@@ -443,15 +442,12 @@ using ScratchGrain = Cuda::size_type[Impl::CudaTraits::WarpSize];
 static constexpr auto sizeScratchGrain = sizeof(ScratchGrain);
 
 constexpr std::size_t scratch_count(const std::size_t size) {
-  if (size + sizeScratchGrain - 1 > sizeScratchGrain)  // check overflow
-    return (size + sizeScratchGrain - 1) / sizeScratchGrain;
-  else
-    return std::numeric_limits<std::size_t>::max() / sizeScratchGrain;
+  return (size + sizeScratchGrain - 1) / sizeScratchGrain;
 }
 
 Cuda::size_type *CudaInternal::scratch_flags(const std::size_t size) const {
   if (verify_is_initialized("scratch_flags") &&
-      m_scratchFlagsCount * sizeScratchGrain < size) {
+      m_scratchFlagsCount < scratch_count(size)) {
     m_scratchFlagsCount = scratch_count(size);
 
     using Record =
@@ -476,7 +472,7 @@ Cuda::size_type *CudaInternal::scratch_flags(const std::size_t size) const {
 
 Cuda::size_type *CudaInternal::scratch_space(const std::size_t size) const {
   if (verify_is_initialized("scratch_space") &&
-      m_scratchSpaceCount * sizeScratchGrain < size) {
+      m_scratchSpaceCount < scratch_count(size)) {
     m_scratchSpaceCount = scratch_count(size);
 
     using Record =
@@ -498,7 +494,7 @@ Cuda::size_type *CudaInternal::scratch_space(const std::size_t size) const {
 
 Cuda::size_type *CudaInternal::scratch_unified(const std::size_t size) const {
   if (verify_is_initialized("scratch_unified") && m_scratchUnifiedSupported &&
-      m_scratchUnifiedCount * sizeScratchGrain < size) {
+      m_scratchUnifiedCount < scratch_count(size)) {
     m_scratchUnifiedCount = scratch_count(size);
 
     using Record =

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -110,8 +110,8 @@ int cuda_kernel_arch() {
   return arch;
 }
 
-using ScratchGrain = Cuda::size_type[Impl::CudaTraits::WarpSize];
-static constexpr auto sizeScratchGrain = sizeof(ScratchGrain);
+using ScratchGrain              = Cuda::size_type[Impl::CudaTraits::WarpSize];
+constexpr auto sizeScratchGrain = sizeof(ScratchGrain);
 
 std::size_t scratch_count(const std::size_t size) {
   return (size + sizeScratchGrain - 1) / sizeScratchGrain;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -456,10 +456,8 @@ Cuda::size_type *CudaInternal::scratch_flags(const std::size_t size) const {
 
     if (m_scratchFlags) Record::decrement(Record::get_record(m_scratchFlags));
 
-    std::size_t alloc_size;
-    if (multiply_overflow(m_scratchFlagsCount, sizeScratchGrain, alloc_size)) {
-      Kokkos::abort("Arithmetic overflow detected.");
-    }
+    std::size_t alloc_size =
+        multiply_overflow_abort(m_scratchFlagsCount, sizeScratchGrain);
     Record *const r = Record::allocate(
         Kokkos::CudaSpace(), "Kokkos::InternalScratchFlags", alloc_size);
 
@@ -483,10 +481,8 @@ Cuda::size_type *CudaInternal::scratch_space(const std::size_t size) const {
 
     if (m_scratchSpace) Record::decrement(Record::get_record(m_scratchSpace));
 
-    std::size_t alloc_size;
-    if (multiply_overflow(m_scratchSpaceCount, sizeScratchGrain, alloc_size)) {
-      Kokkos::abort("Arithmetic overflow detected.");
-    }
+    std::size_t alloc_size =
+        multiply_overflow_abort(m_scratchSpaceCount, sizeScratchGrain);
     Record *const r = Record::allocate(
         Kokkos::CudaSpace(), "Kokkos::InternalScratchSpace", alloc_size);
 
@@ -509,11 +505,8 @@ Cuda::size_type *CudaInternal::scratch_unified(const std::size_t size) const {
     if (m_scratchUnified)
       Record::decrement(Record::get_record(m_scratchUnified));
 
-    std::size_t alloc_size;
-    if (multiply_overflow(m_scratchUnifiedCount, sizeScratchGrain,
-                          alloc_size)) {
-      Kokkos::abort("Arithmetic overflow detected.");
-    }
+    std::size_t alloc_size =
+        multiply_overflow_abort(m_scratchUnifiedCount, sizeScratchGrain);
     Record *const r =
         Record::allocate(Kokkos::CudaHostPinnedSpace(),
                          "Kokkos::InternalScratchUnified", alloc_size);

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -190,12 +190,16 @@ void HIPInternal::initialize(hipStream_t stream, bool manage_stream) {
 //----------------------------------------------------------------------------
 
 using ScratchGrain = Kokkos::HIP::size_type[Impl::HIPTraits::WarpSize];
-enum { sizeScratchGrain = sizeof(ScratchGrain) };
+static constexpr auto sizeScratchGrain = sizeof(ScratchGrain);
+
+constexpr std::size_t scratch_count(const std::size_t size) {
+  return (size + sizeScratchGrain - 1) / sizeScratchGrain;
+}
 
 Kokkos::HIP::size_type *HIPInternal::scratch_space(const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&
-      m_scratchSpaceCount * sizeScratchGrain < size) {
-    m_scratchSpaceCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
+      m_scratchSpaceCount < scratch_count(size)) {
+    m_scratchSpaceCount = scratch_count(size);
 
     using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPSpace, void>;
 
@@ -215,8 +219,8 @@ Kokkos::HIP::size_type *HIPInternal::scratch_space(const std::size_t size) {
 
 Kokkos::HIP::size_type *HIPInternal::scratch_flags(const std::size_t size) {
   if (verify_is_initialized("scratch_flags") &&
-      m_scratchFlagsCount * sizeScratchGrain < size) {
-    m_scratchFlagsCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
+      m_scratchFlagsCount < scratch_count(size)) {
+    m_scratchFlagsCount = scratch_count(size);
 
     using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPSpace, void>;
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -59,8 +59,18 @@ Kokkos::View<uint32_t *, HIPSpace> hip_global_unique_token_locks(
 }  // namespace Kokkos
 
 namespace Kokkos {
-
 namespace Impl {
+
+namespace {
+
+using ScratchGrain = Kokkos::HIP::size_type[Impl::HIPTraits::WarpSize];
+constexpr auto sizeScratchGrain = sizeof(ScratchGrain);
+
+std::size_t scratch_count(const std::size_t size) {
+  return (size + sizeScratchGrain - 1) / sizeScratchGrain;
+}
+
+}  // namespace
 
 //----------------------------------------------------------------------------
 
@@ -188,13 +198,6 @@ void HIPInternal::initialize(hipStream_t stream, bool manage_stream) {
 }
 
 //----------------------------------------------------------------------------
-
-using ScratchGrain = Kokkos::HIP::size_type[Impl::HIPTraits::WarpSize];
-static constexpr auto sizeScratchGrain = sizeof(ScratchGrain);
-
-std::size_t scratch_count(const std::size_t size) {
-  return (size + sizeScratchGrain - 1) / sizeScratchGrain;
-}
 
 Kokkos::HIP::size_type *HIPInternal::scratch_space(const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -204,14 +204,15 @@ Kokkos::HIP::size_type *HIPInternal::scratch_space(const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&
       m_scratchSpaceCount < scratch_count(size)) {
     m_scratchSpaceCount = scratch_count(size);
-    std::size_t alloc_size;
-    if (multiply_overflow(m_scratchFlagsCount, sizeScratchGrain, alloc_size))
-      Kokkos::abort("Arithmetic overflow detected.");
 
     using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPSpace, void>;
 
     if (m_scratchSpace) Record::decrement(Record::get_record(m_scratchSpace));
 
+    std::size_t alloc_size;
+    if (multiply_overflow(m_scratchSpaceCount, sizeScratchGrain, alloc_size)) {
+      Kokkos::abort("Arithmetic overflow detected.");
+    }
     Record *const r = Record::allocate(
         Kokkos::HIPSpace(), "Kokkos::InternalScratchSpace", alloc_size);
 
@@ -227,14 +228,15 @@ Kokkos::HIP::size_type *HIPInternal::scratch_flags(const std::size_t size) {
   if (verify_is_initialized("scratch_flags") &&
       m_scratchFlagsCount < scratch_count(size)) {
     m_scratchFlagsCount = scratch_count(size);
-    std::size_t alloc_size;
-    if (multiply_overflow(m_scratchFlagsCount, sizeScratchGrain, alloc_size))
-      Kokkos::abort("Arithmetic overflow detected.");
 
     using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPSpace, void>;
 
     if (m_scratchFlags) Record::decrement(Record::get_record(m_scratchFlags));
 
+    std::size_t alloc_size;
+    if (multiply_overflow(m_scratchFlagsCount, sizeScratchGrain, alloc_size)) {
+      Kokkos::abort("Arithmetic overflow detected.");
+    }
     Record *const r = Record::allocate(
         Kokkos::HIPSpace(), "Kokkos::InternalScratchFlags", alloc_size);
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -26,6 +26,7 @@
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
+#include <impl/Kokkos_CheckedIntegerOps.hpp>
 #include <impl/Kokkos_Error.hpp>
 
 /*--------------------------------------------------------------------------*/
@@ -202,8 +203,10 @@ void HIPInternal::initialize(hipStream_t stream, bool manage_stream) {
 Kokkos::HIP::size_type *HIPInternal::scratch_space(const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&
       m_scratchSpaceCount < scratch_count(size)) {
-    m_scratchSpaceCount   = scratch_count(size);
-    const auto alloc_size = check_mul_of(m_scratchSpaceCount, sizeScratchGrain);
+    m_scratchSpaceCount = scratch_count(size);
+    std::size_t alloc_size;
+    if (multiply_overflow(m_scratchFlagsCount, sizeScratchGrain, alloc_size))
+      Kokkos::abort("Arithmetic overflow detected.");
 
     using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPSpace, void>;
 
@@ -223,8 +226,10 @@ Kokkos::HIP::size_type *HIPInternal::scratch_space(const std::size_t size) {
 Kokkos::HIP::size_type *HIPInternal::scratch_flags(const std::size_t size) {
   if (verify_is_initialized("scratch_flags") &&
       m_scratchFlagsCount < scratch_count(size)) {
-    m_scratchFlagsCount   = scratch_count(size);
-    const auto alloc_size = check_mul_of(m_scratchFlagsCount, sizeScratchGrain);
+    m_scratchFlagsCount = scratch_count(size);
+    std::size_t alloc_size;
+    if (multiply_overflow(m_scratchFlagsCount, sizeScratchGrain, alloc_size))
+      Kokkos::abort("Arithmetic overflow detected.");
 
     using Record = Kokkos::Impl::SharedAllocationRecord<Kokkos::HIPSpace, void>;
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -209,10 +209,8 @@ Kokkos::HIP::size_type *HIPInternal::scratch_space(const std::size_t size) {
 
     if (m_scratchSpace) Record::decrement(Record::get_record(m_scratchSpace));
 
-    std::size_t alloc_size;
-    if (multiply_overflow(m_scratchSpaceCount, sizeScratchGrain, alloc_size)) {
-      Kokkos::abort("Arithmetic overflow detected.");
-    }
+    std::size_t alloc_size =
+        multiply_overflow_abort(m_scratchSpaceCount, sizeScratchGrain);
     Record *const r = Record::allocate(
         Kokkos::HIPSpace(), "Kokkos::InternalScratchSpace", alloc_size);
 
@@ -233,10 +231,8 @@ Kokkos::HIP::size_type *HIPInternal::scratch_flags(const std::size_t size) {
 
     if (m_scratchFlags) Record::decrement(Record::get_record(m_scratchFlags));
 
-    std::size_t alloc_size;
-    if (multiply_overflow(m_scratchFlagsCount, sizeScratchGrain, alloc_size)) {
-      Kokkos::abort("Arithmetic overflow detected.");
-    }
+    std::size_t alloc_size =
+        multiply_overflow_abort(m_scratchFlagsCount, sizeScratchGrain);
     Record *const r = Record::allocate(
         Kokkos::HIPSpace(), "Kokkos::InternalScratchFlags", alloc_size);
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -255,11 +255,8 @@ sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
     if (nullptr != m_scratchSpace)
       Record::decrement(Record::get_record(m_scratchSpace));
 
-    std::size_t alloc_size;
-    if (Kokkos::Impl::multiply_overflow(m_scratchSpaceCount, sizeScratchGrain,
-                                        alloc_size)) {
-      Kokkos::abort("Arithmetic overflow detected.");
-    }
+    std::size_t alloc_size = Kokkos::Impl::multiply_overflow_abort(
+        m_scratchSpaceCount, sizeScratchGrain);
     Record* const r = Record::allocate(
         Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
         "Kokkos::Experimental::SYCL::InternalScratchSpace", alloc_size);
@@ -283,11 +280,8 @@ sycl::device_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
     if (nullptr != m_scratchFlags)
       Record::decrement(Record::get_record(m_scratchFlags));
 
-    std::size_t alloc_size;
-    if (Kokkos::Impl::multiply_overflow(m_scratchFlagsCount, sizeScratchGrain,
-                                        alloc_size)) {
-      Kokkos::abort("Arithmetic overflow detected.");
-    }
+    std::size_t alloc_size = Kokkos::Impl::multiply_overflow_abort(
+        m_scratchFlagsCount, sizeScratchGrain);
     Record* const r = Record::allocate(
         Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
         "Kokkos::Experimental::SYCL::InternalScratchFlags", alloc_size);

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -230,12 +230,16 @@ void SYCLInternal::finalize() {
   m_queue.reset();
 }
 
+static constexpr auto sizeScratchGrain =
+    sizeof(Kokkos::Experimental::SYCL::size_type);
+constexpr std::size_t scratch_count(const std::size_t size) {
+  return (size + sizeScratchGrain - 1) / sizeScratchGrain;
+}
+
 sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
-  const size_type sizeScratchGrain =
-      sizeof(Kokkos::Experimental::SYCL::size_type);
   if (verify_is_initialized("scratch_space") &&
-      m_scratchSpaceCount * sizeScratchGrain < size) {
-    m_scratchSpaceCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
+      m_scratchSpaceCount < scratch_count(size)) {
+    m_scratchSpaceCount = scratch_count(size);
 
     using Record = Kokkos::Impl::SharedAllocationRecord<
         Kokkos::Experimental::SYCLDeviceUSMSpace, void>;
@@ -257,11 +261,9 @@ sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
 }
 
 sycl::device_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
-  const size_type sizeScratchGrain =
-      sizeof(Kokkos::Experimental::SYCL::size_type);
   if (verify_is_initialized("scratch_flags") &&
-      m_scratchFlagsCount * sizeScratchGrain < size) {
-    m_scratchFlagsCount = (size + sizeScratchGrain - 1) / sizeScratchGrain;
+      m_scratchFlagsCount < scratch_count(size)) {
+    m_scratchFlagsCount = scratch_count(size);
 
     using Record = Kokkos::Impl::SharedAllocationRecord<
         Kokkos::Experimental::SYCLDeviceUSMSpace, void>;

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -247,11 +247,6 @@ sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&
       m_scratchSpaceCount < scratch_count(size)) {
     m_scratchSpaceCount = scratch_count(size);
-    std::size_t alloc_size;
-    if (Kokkos::Impl::multiply_overflow(m_scratchFlagsCount, sizeScratchGrain,
-                                        alloc_size)) {
-      Kokkos::abort("Arithmetic overflow detected.");
-    }
 
     using Record = Kokkos::Impl::SharedAllocationRecord<
         Kokkos::Experimental::SYCLDeviceUSMSpace, void>;
@@ -259,6 +254,11 @@ sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
     if (nullptr != m_scratchSpace)
       Record::decrement(Record::get_record(m_scratchSpace));
 
+    std::size_t alloc_size;
+    if (Kokkos::Impl::multiply_overflow(m_scratchSpaceCount, sizeScratchGrain,
+                                        alloc_size)) {
+      Kokkos::abort("Arithmetic overflow detected.");
+    }
     Record* const r = Record::allocate(
         Kokkos::Experimental::SYCLDeviceUSMSpace(*m_queue),
         "Kokkos::Experimental::SYCL::InternalScratchSpace", alloc_size);

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -20,6 +20,8 @@
 
 #include <Kokkos_Core.hpp>  //kokkos_malloc
 
+#include <impl/Kokkos_CheckedIntegerOps.hpp>
+
 namespace Kokkos {
 namespace Experimental {
 namespace Impl {
@@ -244,8 +246,10 @@ void SYCLInternal::finalize() {
 sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&
       m_scratchSpaceCount < scratch_count(size)) {
-    m_scratchSpaceCount   = scratch_count(size);
-    const auto alloc_size = check_mul_of(m_scratchSpaceCount, sizeScratchGrain);
+    m_scratchSpaceCount = scratch_count(size);
+    std::size_t alloc_size;
+    if (multiply_overflow(m_scratchFlagsCount, sizeScratchGrain, alloc_size))
+      Kokkos::abort("Arithmetic overflow detected.");
 
     using Record = Kokkos::Impl::SharedAllocationRecord<
         Kokkos::Experimental::SYCLDeviceUSMSpace, void>;
@@ -268,8 +272,10 @@ sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
 sycl::device_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
   if (verify_is_initialized("scratch_flags") &&
       m_scratchFlagsCount < scratch_count(size)) {
-    m_scratchFlagsCount   = scratch_count(size);
-    const auto alloc_size = check_mul_of(m_scratchFlagsCount, sizeScratchGrain);
+    m_scratchFlagsCount = scratch_count(size);
+    std::size_t alloc_size;
+    if (multiply_overflow(m_scratchFlagsCount, sizeScratchGrain, alloc_size))
+      Kokkos::abort("Arithmetic overflow detected.");
 
     using Record = Kokkos::Impl::SharedAllocationRecord<
         Kokkos::Experimental::SYCLDeviceUSMSpace, void>;

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -28,8 +28,9 @@ namespace Impl {
 
 namespace {
 
+// FIXME_SYCL Should be a multiple of the maximum subgroup size.
 static constexpr auto sizeScratchGrain =
-    sizeof(Kokkos::Experimental::SYCL::size_type);
+    sizeof(Kokkos::Experimental::SYCL::size_type[32]);
 
 std::size_t scratch_count(const std::size_t size) {
   return (size + sizeScratchGrain - 1) / sizeScratchGrain;

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -24,6 +24,17 @@ namespace Kokkos {
 namespace Experimental {
 namespace Impl {
 
+namespace {
+
+static constexpr auto sizeScratchGrain =
+    sizeof(Kokkos::Experimental::SYCL::size_type);
+
+std::size_t scratch_count(const std::size_t size) {
+  return (size + sizeScratchGrain - 1) / sizeScratchGrain;
+}
+
+}  // namespace
+
 std::vector<std::optional<sycl::queue>*> SYCLInternal::all_queues;
 std::mutex SYCLInternal::mutex;
 
@@ -228,13 +239,6 @@ void SYCLInternal::finalize() {
     all_queues.erase(std::find(all_queues.begin(), all_queues.end(), &m_queue));
   }
   m_queue.reset();
-}
-
-static constexpr auto sizeScratchGrain =
-    sizeof(Kokkos::Experimental::SYCL::size_type);
-
-std::size_t scratch_count(const std::size_t size) {
-  return (size + sizeScratchGrain - 1) / sizeScratchGrain;
 }
 
 sycl::device_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {

--- a/core/src/impl/Kokkos_CheckedIntegerOps.hpp
+++ b/core/src/impl/Kokkos_CheckedIntegerOps.hpp
@@ -28,7 +28,7 @@ std::enable_if_t<std::is_integral_v<T>, bool> constexpr multiply_overflow(
   static_assert(std::is_unsigned_v<T>,
                 "Operation not implemented for signed integers.");
   auto product = a * b;
-  if ((a == 0) or (b == 0) or (a == product / b)) {
+  if ((a == 0) || (b == 0) || (a == product / b)) {
     res = product;
     return false;
   } else {

--- a/core/src/impl/Kokkos_CheckedIntegerOps.hpp
+++ b/core/src/impl/Kokkos_CheckedIntegerOps.hpp
@@ -1,0 +1,42 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_CHECKED_INTEGER_OPS_HPP
+#define KOKKOS_CHECKED_INTEGER_OPS_HPP
+
+#include <type_traits>
+
+namespace Kokkos {
+namespace Impl {
+
+template <typename T>
+std::enable_if_t<std::is_integral_v<T>, bool> constexpr multiply_overflow(
+    T a, T b, T& res) {
+  static_assert(std::is_unsigned_v<T>,
+                "Operation not implemented for signed integers.");
+  auto product = a * b;
+  if ((a == 0) or (b == 0) or (a == product / b)) {
+    res = product;
+    return false;
+  } else {
+    return true;
+  }
+}
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif  // KOKKOS_CHECKED_INTEGER_OPS_HPP

--- a/core/src/impl/Kokkos_CheckedIntegerOps.hpp
+++ b/core/src/impl/Kokkos_CheckedIntegerOps.hpp
@@ -19,6 +19,8 @@
 
 #include <type_traits>
 
+#include <impl/Kokkos_Error.hpp>
+
 namespace Kokkos {
 namespace Impl {
 
@@ -34,6 +36,15 @@ std::enable_if_t<std::is_integral_v<T>, bool> constexpr multiply_overflow(
   } else {
     return true;
   }
+}
+
+template <typename T>
+T multiply_overflow_abort(T a, T b) {
+  T result;
+  if (multiply_overflow(a, b, result))
+    Kokkos::abort("Arithmetic overflow detected.");
+
+  return result;
 }
 
 }  // namespace Impl

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -18,7 +18,6 @@
 #define KOKKOS_CORE_IMPL_UTILITIES_HPP
 
 #include <Kokkos_Macros.hpp>
-#include <impl/Kokkos_Error.hpp>
 #include <cstdint>
 #include <type_traits>
 #include <initializer_list>  // in-order comma operator fold emulation
@@ -202,18 +201,6 @@ using filter_type_list_t =
 template <typename T>
 constexpr bool dependent_false_v = !sizeof(T*);
 //==============================================================================
-
-template <typename T>
-std::enable_if_t<std::is_integral_v<T> and std::is_unsigned_v<T>, T>
-check_mul_of(T a, T b) {
-  auto product = a * b;
-  if ((a == 0) or (b == 0) or (a == product / b)) {
-    return product;
-  } else {
-    Kokkos::abort("Arithmetic overflow detected.");
-  }
-  return 0;
-}
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -202,6 +202,17 @@ template <typename T>
 constexpr bool dependent_false_v = !sizeof(T*);
 //==============================================================================
 
+template <typename T>
+T check_mul_of(T a, T b) {
+  auto product = a * b;
+  if ((a == 0) or (b == 0) or (a == product / b)) {
+    return product;
+  } else {
+    Kokkos::abort("Arithmetic overflow detected.");
+  }
+  return 0;
+}
+
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -18,6 +18,7 @@
 #define KOKKOS_CORE_IMPL_UTILITIES_HPP
 
 #include <Kokkos_Macros.hpp>
+#include <impl/Kokkos_Error.hpp>
 #include <cstdint>
 #include <type_traits>
 #include <initializer_list>  // in-order comma operator fold emulation
@@ -203,7 +204,8 @@ constexpr bool dependent_false_v = !sizeof(T*);
 //==============================================================================
 
 template <typename T>
-T check_mul_of(T a, T b) {
+std::enable_if_t<std::is_integral_v<T> and std::is_unsigned_v<T>, T>
+check_mul_of(T a, T b) {
   auto product = a * b;
   if ((a == 0) or (b == 0) or (a == product / b)) {
     return product;

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -128,6 +128,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
         AtomicViews
         BitManipulationBuiltins
         BlockSizeDeduction
+        CheckedIntegerOps
         CommonPolicyConstructors
         CommonPolicyInterface
         Complex

--- a/core/unit_test/TestCheckedIntegerOps.hpp
+++ b/core/unit_test/TestCheckedIntegerOps.hpp
@@ -35,4 +35,16 @@ TEST(TEST_CATEGORY, checked_integer_operations_multiply_overflow) {
   }
 }
 
+TEST(TEST_CATEGORY, checked_integer_operations_multiply_overflow_abort) {
+  {
+    auto result = Kokkos::Impl::multiply_overflow_abort(1u, 2u);
+    EXPECT_EQ(result, 2u);
+  }
+  {
+    ASSERT_DEATH(Kokkos::Impl::multiply_overflow_abort(
+                     std::numeric_limits<unsigned>::max(), 2u),
+                 "Arithmetic overflow detected.");
+  }
+}
+
 }  // namespace

--- a/core/unit_test/TestCheckedIntegerOps.hpp
+++ b/core/unit_test/TestCheckedIntegerOps.hpp
@@ -18,9 +18,9 @@
 #include <impl/Kokkos_CheckedIntegerOps.hpp>
 #include <limits>
 
-namespace Test {
+namespace {
 
-TEST(TEST_CATEGORY, test_multiply) {
+TEST(TEST_CATEGORY, checked_integer_operations_multiply_overflow) {
   {
     auto result      = 1u;
     auto is_overflow = Kokkos::Impl::multiply_overflow(1u, 2u, result);
@@ -31,9 +31,8 @@ TEST(TEST_CATEGORY, test_multiply) {
     auto result      = 1u;
     auto is_overflow = Kokkos::Impl::multiply_overflow(
         std::numeric_limits<unsigned>::max(), 2u, result);
-    EXPECT_EQ(result, 1u);
     EXPECT_TRUE(is_overflow);
   }
 }
 
-}  // namespace Test
+}  // namespace

--- a/core/unit_test/TestCheckedIntegerOps.hpp
+++ b/core/unit_test/TestCheckedIntegerOps.hpp
@@ -1,0 +1,39 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+#include <impl/Kokkos_CheckedIntegerOps.hpp>
+#include <limits>
+
+namespace Test {
+
+TEST(TEST_CATEGORY, test_multiply) {
+  {
+    auto result      = 1u;
+    auto is_overflow = Kokkos::Impl::multiply_overflow(1u, 2u, result);
+    EXPECT_EQ(result, 2u);
+    EXPECT_FALSE(is_overflow);
+  }
+  {
+    auto result      = 1u;
+    auto is_overflow = Kokkos::Impl::multiply_overflow(
+        std::numeric_limits<unsigned>::max(), 2u, result);
+    EXPECT_EQ(result, 1u);
+    EXPECT_TRUE(is_overflow);
+  }
+}
+
+}  // namespace Test


### PR DESCRIPTION
fixes #3805 

---
- refactor the code to avoid potential overflow when possible
- check for overflow when initializing scratch flags / scratch space
  - note: the code will `Kokkos::abort` when an overflow is detected (which should be fine in this case since we cannot allocate that much memory anyways)
