### PR TITLE
[HIP] Improve heuristic deciding the number of blocks used in parallel_reduce

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -306,9 +306,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
               Kokkos::Experimental::WorkItemProperty::HintLightWeight;
       static constexpr typename Policy::work_item_property property =
           typename Policy::work_item_property();
-      if ((property & light_weight) == light_weight)
-      // Kokkos::Experimental::WorkItemProperty::HintHeavyWeight_t) {
-      {
+      if ((property & light_weight) == light_weight) {
         if (nblocks < block_size) {
           // Keep nblocks as is
         } else if (nblocks < 16 * block_size) {

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -299,8 +299,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
       // use a slightly less constrained, but still well bounded limit for
       // scratch
       int nblocks = (nwork + block.y - 1) / block.y;
-      // Heuristic deciding the value of nblocks. The values for the light weight case
-      // have been chosen using a vector product benchmark on MI250.
+      // Heuristic deciding the value of nblocks. The values for the light
+      // weight case have been chosen using a vector product benchmark on MI250.
       constexpr auto light_weight =
           Kokkos::Experimental::WorkItemProperty::HintLightWeight;
       constexpr typename Policy::work_item_property property;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -299,8 +299,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
       // use a slightly less constrained, but still well bounded limit for
       // scratch
       int nblocks = (nwork + block.y - 1) / block.y;
-      // Heuristic deciding the value of nblocks. The values have been chosen
-      // using a vector product benchmark on MI250.
+      // Heuristic deciding the value of nblocks. The values for the light weight case
+      // have been chosen using a vector product benchmark on MI250.
       constexpr auto light_weight =
           Kokkos::Experimental::WorkItemProperty::HintLightWeight;
       constexpr typename Policy::work_item_property property;

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -301,11 +301,9 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
       int nblocks = (nwork + block.y - 1) / block.y;
       // Heuristic deciding the value of nblocks. The values have been chosen
       // using a vector product benchmark on MI250.
-      static constexpr Kokkos::Experimental::WorkItemProperty::HintLightWeight_t
-          light_weight =
-              Kokkos::Experimental::WorkItemProperty::HintLightWeight;
-      static constexpr typename Policy::work_item_property property =
-          typename Policy::work_item_property();
+      constexpr auto light_weight =
+          Kokkos::Experimental::WorkItemProperty::HintLightWeight;
+      constexpr auto property = typename Policy::work_item_property();
       if ((property & light_weight) == light_weight) {
         if (nblocks < block_size) {
           // Keep nblocks as is

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -303,7 +303,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
       // using a vector product benchmark on MI250.
       constexpr auto light_weight =
           Kokkos::Experimental::WorkItemProperty::HintLightWeight;
-      constexpr auto property = typename Policy::work_item_property();
+      constexpr typename Policy::work_item_property property;
       if ((property & light_weight) == light_weight) {
         if (nblocks < block_size) {
           // Keep nblocks as is


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/6029 introduced a regression when using `parallel_reduce` to perform a vector dot product (which is done by PETSc). I have a new heuristic based on a vector dot product benchmark.

@arghdos  @stanmoore1 is this change OK for LAMMPS?