### PR TITLE
Allow passing a temporary std::vector to partition_space

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -240,6 +240,8 @@ std::vector<Cuda> partition_space(const Cuda&, std::vector<T> const& weights) {
       std::is_arithmetic<T>::value,
       "Kokkos Error: partitioning arguments must be integers or floats");
 
+  // We only care about the number of instances to create and ignore weights
+  // otherwise.
   std::vector<Cuda> instances(weights.size());
   Impl::create_Cuda_instances(instances);
   return instances;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -235,7 +235,7 @@ std::vector<Cuda> partition_space(const Cuda&, Args...) {
 }
 
 template <class T>
-std::vector<Cuda> partition_space(const Cuda&, std::vector<T>& weights) {
+std::vector<Cuda> partition_space(const Cuda&, std::vector<T> const& weights) {
   static_assert(
       std::is_arithmetic<T>::value,
       "Kokkos Error: partitioning arguments must be integers or floats");

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -184,6 +184,8 @@ std::vector<HIP> partition_space(const HIP &, std::vector<T> const &weights) {
       std::is_arithmetic<T>::value,
       "Kokkos Error: partitioning arguments must be integers or floats");
 
+  // We only care about the number of instances to create and ignore weights
+  // otherwise.
   std::vector<HIP> instances(weights.size());
   Impl::create_HIP_instances(instances);
   return instances;

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -179,7 +179,7 @@ std::vector<HIP> partition_space(const HIP &, Args...) {
 }
 
 template <class T>
-std::vector<HIP> partition_space(const HIP &, std::vector<T> &weights) {
+std::vector<HIP> partition_space(const HIP &, std::vector<T> const &weights) {
   static_assert(
       std::is_arithmetic<T>::value,
       "Kokkos Error: partitioning arguments must be integers or floats");

--- a/core/src/Kokkos_Core.hpp
+++ b/core/src/Kokkos_Core.hpp
@@ -274,7 +274,7 @@ std::vector<ExecSpace> partition_space(ExecSpace const& space, Args...) {
 
 template <class ExecSpace, class T>
 std::vector<ExecSpace> partition_space(ExecSpace const& space,
-                                       std::vector<T>& weights) {
+                                       std::vector<T> const& weights) {
   static_assert(is_execution_space<ExecSpace>::value,
                 "Kokkos Error: partition_space expects an Execution Space as "
                 "first argument");

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -186,7 +186,7 @@ std::vector<OpenMP> partition_space(OpenMP const& main_instance, Args... args) {
 
 template <typename T>
 std::vector<OpenMP> partition_space(OpenMP const& main_instance,
-                                    std::vector<T>& weights) {
+                                    std::vector<T> const& weights) {
   return Impl::create_OpenMP_instances(main_instance, weights);
 }
 }  // namespace Experimental

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -169,7 +169,7 @@ std::vector<SYCL> partition_space(const SYCL& sycl_space, Args...) {
 
 template <class T>
 std::vector<SYCL> partition_space(const SYCL& sycl_space,
-                                  std::vector<T>& weights) {
+                                  std::vector<T> const& weights) {
   static_assert(
       std::is_arithmetic<T>::value,
       "Kokkos Error: partitioning arguments must be integers or floats");

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -178,6 +178,9 @@ std::vector<SYCL> partition_space(const SYCL& sycl_space,
   sycl::device device =
       sycl_space.impl_internal_space_instance()->m_queue->get_device();
   std::vector<SYCL> instances;
+
+  // We only care about the number of instances to create and ignore weights
+  // otherwise.
   instances.reserve(weights.size());
   for (unsigned int i = 0; i < weights.size(); ++i)
     instances.emplace_back(sycl::queue(context, device));

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -131,9 +131,8 @@ TEST(TEST_CATEGORY, partitioning_by_args) {
 }
 
 TEST(TEST_CATEGORY, partitioning_by_vector) {
-  std::vector<int> weights{1, 1};
-  auto instances =
-      Kokkos::Experimental::partition_space(TEST_EXECSPACE(), weights);
+  auto instances = Kokkos::Experimental::partition_space(
+      TEST_EXECSPACE(), std::vector<int> /*weights*/ {1, 1});
   ASSERT_EQ(int(instances.size()), 2);
   test_partitioning(instances);
 }

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -131,6 +131,7 @@ TEST(TEST_CATEGORY, partitioning_by_args) {
 }
 
 TEST(TEST_CATEGORY, partitioning_by_vector) {
+  // Make sure we can use a temporary as argument for weights
   auto instances = Kokkos::Experimental::partition_space(
       TEST_EXECSPACE(), std::vector<int> /*weights*/ {1, 1});
   ASSERT_EQ(int(instances.size()), 2);


### PR DESCRIPTION
Related to https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1685215235868969. There doesn't seem to be a good reason not to allow passing a temporary `std::vector` to `partition_space`.
Also, this overload is not mentioned at https://kokkos.github.io/kokkos-core-wiki/API/core/spaces/partition_space.html?highlight=partition_space#_CPPv4I0DpE15partition_spaceNSt6vectorI9ExecSpaceEERK9ExecSpaceDp4Args.