### PR TITLE
Weed out verbose output from `dynamic_view` container unit test

### DIFF
--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -274,20 +274,10 @@ struct TestDynamicView {
       // swapped in the deep_copy implementation.
       // Once that's fixed, both deep_copy's will fail at runtime because the
       // destination execution space cannot access the source memory space.
-      try {
-        Kokkos::deep_copy(host_view, device_dynamic_view);
-      } catch (std::runtime_error const& error) {
-        std::string msg = error.what();
-        std::cerr << "Copy from on-device DynamicView to on-host View failed:\n"
-                  << msg << std::endl;
-      }
-      try {
-        Kokkos::deep_copy(device_dynamic_view, host_view);
-      } catch (std::runtime_error const& error) {
-        std::string msg = error.what();
-        std::cerr << "Copy from on-host View to on-device DynamicView failed:\n"
-                  << msg << std::endl;
-      }
+      ASSERT_THROW(Kokkos::deep_copy(host_view, device_dynamic_view),
+                   std::runtime_error);
+      ASSERT_THROW(Kokkos::deep_copy(device_dynamic_view, host_view),
+                   std::runtime_error);
     }
   }
 };

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -274,10 +274,14 @@ struct TestDynamicView {
       // swapped in the deep_copy implementation.
       // Once that's fixed, both deep_copy's will fail at runtime because the
       // destination execution space cannot access the source memory space.
-      ASSERT_THROW(Kokkos::deep_copy(host_view, device_dynamic_view),
-                   std::runtime_error);
-      ASSERT_THROW(Kokkos::deep_copy(device_dynamic_view, host_view),
-                   std::runtime_error);
+      // Check if the memory spaces are different before testing the deep_copy.
+      if (!Kokkos::SpaceAccessibility<Kokkos::HostSpace,
+                                      memory_space>::accessible) {
+        ASSERT_THROW(Kokkos::deep_copy(host_view, device_dynamic_view),
+                     std::runtime_error);
+        ASSERT_THROW(Kokkos::deep_copy(device_dynamic_view, host_view),
+                     std::runtime_error);
+      }
     }
   }
 };


### PR DESCRIPTION
The PR is an attempt to fix issue #6039 