### PR TITLE
SIMD: add float simd support

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -169,7 +169,7 @@ using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
 #elif defined(KOKKOS_ARCH_AVX2)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>>;
 using data_type_set =
-    data_types<std::int32_t, std::int64_t, std::uint64_t, double>;
+    data_types<std::int32_t, std::int64_t, std::uint64_t, double, float>;
 #elif defined(__ARM_NEON)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
 using data_type_set =
@@ -177,7 +177,7 @@ using data_type_set =
 #else
 using host_abi_set  = abi_set<simd_abi::scalar>;
 using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
-                                 std::uint64_t, double>;
+                                 std::uint64_t, double, float>;
 #endif
 
 using device_abi_set = abi_set<simd_abi::scalar>;

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -173,7 +173,7 @@ using data_type_set =
 #elif defined(__ARM_NEON)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>>;
 using data_type_set =
-    data_types<std::int32_t, std::int64_t, std::uint64_t, double>;
+    data_types<std::int32_t, std::int64_t, std::uint64_t, double, float>;
 #else
 using host_abi_set  = abi_set<simd_abi::scalar>;
 using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -165,7 +165,7 @@ class data_types {};
 #if defined(KOKKOS_ARCH_AVX512XEON)
 using host_abi_set  = abi_set<simd_abi::scalar, simd_abi::avx512_fixed_size<8>>;
 using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
-                                 std::uint64_t, double>;
+                                 std::uint64_t, double, float>;
 #elif defined(KOKKOS_ARCH_AVX2)
 using host_abi_set = abi_set<simd_abi::scalar, simd_abi::avx2_fixed_size<4>>;
 using data_type_set =

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -756,70 +756,51 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm_cmpeq_ps(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(_mm_sub_ps(_mm_set1_ps(0.0), m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm_cmpgt_ps(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm_mul_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm_cmplt_ps(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm_div_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm_cmple_ps(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm_add_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm_cmpge_ps(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm_sub_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm_cmpneq_ps(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm_cmpeq_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm_cmpgt_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm_cmplt_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm_cmple_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm_cmpge_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm_cmpneq_ps(lhs.m_value, rhs.m_value));
   }
 };
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx2_fixed_size<4>>
-    operator*(simd<float, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<float, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
-      _mm_mul_ps(static_cast<__m128>(lhs), static_cast<__m128>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx2_fixed_size<4>>
-    operator/(simd<float, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<float, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
-      _mm_div_ps(static_cast<__m128>(lhs), static_cast<__m128>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx2_fixed_size<4>>
-    operator-(simd<float, simd_abi::avx2_fixed_size<4>> const& a) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
-      _mm_sub_ps(_mm_set1_ps(0.0), static_cast<__m128>(a)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx2_fixed_size<4>>
-    operator+(simd<float, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<float, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
-      _mm_add_ps(static_cast<__m128>(lhs), static_cast<__m128>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx2_fixed_size<4>>
-    operator-(simd<float, simd_abi::avx2_fixed_size<4>> const& lhs,
-              simd<float, simd_abi::avx2_fixed_size<4>> const& rhs) {
-  return simd<float, simd_abi::avx2_fixed_size<4>>(
-      _mm_sub_ps(static_cast<__m128>(lhs), static_cast<__m128>(rhs)));
-}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<float, simd_abi::avx2_fixed_size<4>> copysign(

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1472,8 +1472,8 @@ class where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
   void gather_from(
       float const* mem,
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
-    m_value = value_type(_mm_mask_i32gather_ps((__m128)m_value, mem,
-                                               static_cast<__m128i>(index),
+    m_value = value_type(_mm_mask_i32gather_ps(static_cast<__m128>(m_value),
+                                               mem, static_cast<__m128i>(index),
                                                static_cast<__m128>(m_mask), 4));
   }
   template <class U,

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1407,6 +1407,15 @@ class const_where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
     _mm_maskstore_ps(mem, _mm_castps_si128(static_cast<__m128>(m_mask)),
                      static_cast<__m128>(m_value));
   }
+  //FIXME?
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      float* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+    for (std::size_t lane = 0; lane < 4; ++lane) {
+      if (m_mask[lane]) mem[index[lane]] = m_value[lane];
+    }
+  }
 
   friend constexpr auto const& Impl::mask<float, abi_type>(
       const_where_expression<mask_type, value_type> const& x);
@@ -1430,6 +1439,15 @@ class where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
   void copy_from(float const* mem, element_aligned_tag) {
     m_value = value_type(
         _mm_maskload_ps(mem, _mm_castps_si128(static_cast<__m128>(m_mask))));
+  }
+  //FIXME?
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      float const* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+    m_value = value_type(_mm_mask_i32gather_ps(
+        _mm_set1_ps(0.0), mem, static_cast<__m128i>(index),
+        static_cast<__m128>(m_mask), 4));
   }
   template <class U,
             std::enable_if_t<std::is_convertible_v<

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -846,6 +846,31 @@ simd<float, simd_abi::avx2_fixed_size<4>> sqrt(
       _mm_sqrt_ps(static_cast<__m128>(a)));
 }
 
+#ifdef __INTEL_COMPILER
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx2_fixed_size<4>> cbrt(
+    simd<float, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<float, simd_abi::avx2_fixed_size<4>>(
+      _mm_cbrt_ps(static_cast<__m128>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx2_fixed_size<4>> exp(
+    simd<float, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<float, simd_abi::avx2_fixed_size<4>>(
+      _mm_exp_ps(static_cast<__m128>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx2_fixed_size<4>> log(
+    simd<float, simd_abi::avx2_fixed_size<4>> const& a) {
+  return simd<float, simd_abi::avx2_fixed_size<4>>(
+      _mm_log_ps(static_cast<__m128>(a)));
+}
+
+#endif
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<float, simd_abi::avx2_fixed_size<4>> fma(
     simd<float, simd_abi::avx2_fixed_size<4>> const& a,
@@ -1447,7 +1472,7 @@ class where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
   void gather_from(
       float const* mem,
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
-    m_value = value_type(_mm_mask_i32gather_ps(m_value, mem,
+    m_value = value_type(_mm_mask_i32gather_ps((__m128)m_value, mem,
                                                static_cast<__m128i>(index),
                                                static_cast<__m128>(m_mask), 4));
   }

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -160,9 +160,7 @@ class simd_mask<float, simd_abi::avx2_fixed_size<4>> {
   };
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask()                 = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(simd_mask&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask() = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit simd_mask(value_type value)
       : m_value(_mm_castsi128_ps(_mm_set1_epi32(-std::int32_t(value)))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
@@ -171,11 +169,6 @@ class simd_mask<float, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd_mask(
       __m128 const& value_in)
       : m_value(value_in) {}
-  template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd_mask(
-      simd_mask<U, abi_type> const& other) {
-    for (std::size_t i = 0; i < size(); ++i) (*this)[i] = other[i];
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128()
       const {
     return m_value;
@@ -777,16 +770,12 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
     return simd(_mm_sub_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm_cmpeq_ps(lhs.m_value, rhs.m_value));
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm_cmplt_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator>(simd const& lhs, simd const& rhs) noexcept {
     return mask_type(_mm_cmpgt_ps(lhs.m_value, rhs.m_value));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator<(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(_mm_cmplt_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator<=(simd const& lhs, simd const& rhs) noexcept {
@@ -795,6 +784,10 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator>=(simd const& lhs, simd const& rhs) noexcept {
     return mask_type(_mm_cmpge_ps(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm_cmpeq_ps(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator!=(simd const& lhs, simd const& rhs) noexcept {
@@ -877,11 +870,11 @@ simd<float, simd_abi::avx2_fixed_size<4>> min(
       _mm_min_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx2_fixed_size<4>>
-    condition(simd_mask<float, simd_abi::avx2_fixed_size<4>> const& a,
-              simd<float, simd_abi::avx2_fixed_size<4>> const& b,
-              simd<float, simd_abi::avx2_fixed_size<4>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx2_fixed_size<4>> condition(
+    simd_mask<float, simd_abi::avx2_fixed_size<4>> const& a,
+    simd<float, simd_abi::avx2_fixed_size<4>> const& b,
+    simd<float, simd_abi::avx2_fixed_size<4>> const& c) {
   return simd<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
       static_cast<__m128>(c), static_cast<__m128>(b), static_cast<__m128>(a)));
 }

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1407,7 +1407,6 @@ class const_where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
     _mm_maskstore_ps(mem, _mm_castps_si128(static_cast<__m128>(m_mask)),
                      static_cast<__m128>(m_value));
   }
-  //FIXME?
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       float* mem,
@@ -1417,11 +1416,15 @@ class const_where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
     }
   }
 
-  friend constexpr auto const& Impl::mask<float, abi_type>(
-      const_where_expression<mask_type, value_type> const& x);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
 
-  friend constexpr auto const& Impl::value<float, abi_type>(
-      const_where_expression<mask_type, value_type> const& x);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
 };
 
 template <>
@@ -1440,14 +1443,13 @@ class where_expression<simd_mask<float, simd_abi::avx2_fixed_size<4>>,
     m_value = value_type(
         _mm_maskload_ps(mem, _mm_castps_si128(static_cast<__m128>(m_mask))));
   }
-  //FIXME?
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
-    m_value = value_type(_mm_mask_i32gather_ps(
-        _mm_set1_ps(0.0), mem, static_cast<__m128i>(index),
-        static_cast<__m128>(m_mask), 4));
+    m_value = value_type(_mm_mask_i32gather_ps(m_value, mem,
+                                               static_cast<__m128i>(index),
+                                               static_cast<__m128>(m_mask), 4));
   }
   template <class U,
             std::enable_if_t<std::is_convertible_v<

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -981,6 +981,189 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
 }
 
 template <>
+class simd<float, simd_abi::avx512_fixed_size<8>> {
+  __m256 m_value;
+
+ public:
+  using value_type = float;
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  using reference  = value_type&;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 8;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(_mm256_set1_ps(value_type(value))) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      __m256 const& value_in)
+      : m_value(value_in) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen)
+      : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
+                               gen(std::integral_constant<std::size_t, 1>()),
+                               gen(std::integral_constant<std::size_t, 2>()),
+                               gen(std::integral_constant<std::size_t, 3>()),
+                               gen(std::integral_constant<std::size_t, 4>()),
+                               gen(std::integral_constant<std::size_t, 5>()),
+                               gen(std::integral_constant<std::size_t, 6>()),
+                               gen(std::integral_constant<std::size_t, 7>()))) {
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reinterpret_cast<value_type*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reinterpret_cast<value_type const*>(&m_value)[i];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_storeu_ps(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_loadu_ps(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
+      const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<(simd const& other) const {
+    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_LT_OS));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>(simd const& other) const {
+    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_GT_OS));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<=(simd const& other) const {
+    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_LE_OS));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>=(simd const& other) const {
+    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_GE_OS));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& other) const {
+    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_EQ_OS));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& other) const {
+    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_NEQ_OS));
+  }
+};
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::avx512_fixed_size<8>>
+    operator*(simd<float, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<float, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_mul_ps(static_cast<__m256>(lhs), static_cast<__m256>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::avx512_fixed_size<8>>
+    operator/(simd<float, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<float, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_div_ps(static_cast<__m256>(lhs), static_cast<__m256>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::avx512_fixed_size<8>>
+    operator+(simd<float, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<float, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_add_ps(static_cast<__m256>(lhs), static_cast<__m256>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::avx512_fixed_size<8>>
+    operator-(simd<float, simd_abi::avx512_fixed_size<8>> const& lhs,
+              simd<float, simd_abi::avx512_fixed_size<8>> const& rhs) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_sub_ps(static_cast<__m256>(lhs), static_cast<__m256>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::avx512_fixed_size<8>>
+    operator-(simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_sub_ps(_mm256_set1_ps(0.0), static_cast<__m256>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>> copysign(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<float, simd_abi::avx512_fixed_size<8>> const& b) {
+  __m256 const sign_mask = _mm256_set1_ps(-0.0);
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_xor_ps(_mm256_andnot_ps(sign_mask, static_cast<__m256>(a)),
+                    _mm256_and_ps(sign_mask, static_cast<__m256>(b))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>> abs(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
+  __m256 const sign_mask = _mm256_set1_ps(-0.0);
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_andnot_ps(sign_mask, static_cast<__m256>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>> sqrt(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_sqrt_ps(static_cast<__m256>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>> fma(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<float, simd_abi::avx512_fixed_size<8>> const& b,
+    simd<float, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(_mm256_fmadd_ps(
+      static_cast<__m256>(a), static_cast<__m256>(b), static_cast<__m256>(c)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>> max(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<float, simd_abi::avx512_fixed_size<8>> const& b) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_max_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>> min(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<float, simd_abi::avx512_fixed_size<8>> const& b) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_min_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>> condition(
+    simd_mask<float, simd_abi::avx512_fixed_size<8>> const& a,
+    simd<float, simd_abi::avx512_fixed_size<8>> const& b,
+    simd<float, simd_abi::avx512_fixed_size<8>> const& c) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_mask_blend_ps(static_cast<__mmask8>(a), static_cast<__m256>(c),
+                           static_cast<__m256>(b)));
+}
+
+template <>
 class const_where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
                              simd<double, simd_abi::avx512_fixed_size<8>>> {
  public:
@@ -1056,6 +1239,66 @@ class where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
     m_value = simd<double, simd_abi::avx512_fixed_size<8>>(_mm512_mask_blend_pd(
         static_cast<__mmask8>(m_mask), static_cast<__m512d>(m_value),
         static_cast<__m512d>(x_as_value_type)));
+  }
+};
+
+template <>
+class const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+                             simd<float, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  using abi_type   = simd_abi::avx512_fixed_size<8>;
+  using value_type = simd<float, abi_type>;
+  using mask_type  = simd_mask<float, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(float* mem, element_aligned_tag) const {
+    _mm256_mask_storeu_ps(mem, static_cast<__mmask8>(m_mask),
+                          static_cast<__m256>(m_value));
+  }
+
+  friend constexpr auto const& Impl::mask<float, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<float, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+};
+
+template <>
+class where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+                       simd<float, simd_abi::avx512_fixed_size<8>>>
+    : public const_where_expression<
+          simd_mask<float, simd_abi::avx512_fixed_size<8>>,
+          simd<float, simd_abi::avx512_fixed_size<8>>> {
+ public:
+  where_expression(
+      simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      simd<float, simd_abi::avx512_fixed_size<8>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(float const* mem, element_aligned_tag) {
+    m_value = value_type(_mm256_mask_loadu_ps(
+        _mm256_set1_ps(0.0), static_cast<__mmask8>(m_mask), mem));
+  }
+  template <
+      class U,
+      std::enable_if_t<
+          std::is_convertible_v<U, simd<float, simd_abi::avx512_fixed_size<8>>>,
+          bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<float, simd_abi::avx512_fixed_size<8>>>(
+            std::forward<U>(x));
+    m_value = simd<float, simd_abi::avx512_fixed_size<8>>(_mm256_mask_blend_ps(
+        static_cast<__mmask8>(m_mask), static_cast<__m256>(m_value),
+        static_cast<__m256>(x_as_value_type)));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -1263,12 +1263,24 @@ class const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
     _mm256_mask_storeu_ps(mem, static_cast<__mmask8>(m_mask),
                           static_cast<__m256>(m_value));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      float* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
+    _mm256_mask_i32scatter_ps(mem, static_cast<__mmask8>(m_mask),
+                              static_cast<__m256i>(index),
+                              static_cast<__m256>(m_value), 4);
+  }
 
-  friend constexpr auto const& Impl::mask<float, abi_type>(
-      const_where_expression<mask_type, value_type> const& x);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
 
-  friend constexpr auto const& Impl::value<float, abi_type>(
-      const_where_expression<mask_type, value_type> const& x);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
 };
 
 template <>
@@ -1286,6 +1298,14 @@ class where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
   void copy_from(float const* mem, element_aligned_tag) {
     m_value = value_type(_mm256_mask_loadu_ps(
         _mm256_set1_ps(0.0), static_cast<__mmask8>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      float const* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+    m_value = value_type(
+        _mm256_mask_i32gather_ps(m_value, static_cast<__mmask8>(m_mask),
+                                 static_cast<__m256>(index), mem, 4));
   }
   template <
       class U,

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -1038,70 +1038,58 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
       const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_LT_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
+  operator-() const noexcept {
+    return simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_GT_OS));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_LE_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_GE_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_EQ_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return mask_type(_mm256_cmp_ps_mask(m_value, other.m_value, _CMP_NEQ_OS));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(
+        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
   }
 };
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx512_fixed_size<8>>
-    operator*(simd<float, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<float, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
-      _mm256_mul_ps(static_cast<__m256>(lhs), static_cast<__m256>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx512_fixed_size<8>>
-    operator/(simd<float, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<float, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
-      _mm256_div_ps(static_cast<__m256>(lhs), static_cast<__m256>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx512_fixed_size<8>>
-    operator+(simd<float, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<float, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
-      _mm256_add_ps(static_cast<__m256>(lhs), static_cast<__m256>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<float, simd_abi::avx512_fixed_size<8>> const& lhs,
-              simd<float, simd_abi::avx512_fixed_size<8>> const& rhs) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
-      _mm256_sub_ps(static_cast<__m256>(lhs), static_cast<__m256>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::avx512_fixed_size<8>>
-    operator-(simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
-  return simd<float, simd_abi::avx512_fixed_size<8>>(
-      _mm256_sub_ps(_mm256_set1_ps(0.0), static_cast<__m256>(a)));
-}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<float, simd_abi::avx512_fixed_size<8>> copysign(

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -1328,9 +1328,11 @@ class where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
   void gather_from(
       float const* mem,
       simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
-    m_value = value_type(_mm256_mask_i32gather_ps(
-        (__m256)m_value, mem, static_cast<__m256i>(index),
-        static_cast<__m256>(m_mask), 4));
+    __m256 on   = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
+    __m256 mask = _mm256_maskz_mov_ps(static_cast<__mmask8>(m_mask), on);
+    m_value     = value_type(
+        _mm256_mask_i32gather_ps(static_cast<__m256>(m_value), mem,
+                                 static_cast<__m256i>(index), mask, 4));
   }
   template <
       class U,

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -1026,13 +1026,13 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
   operator[](std::size_t i) const {
     return reinterpret_cast<value_type const*>(&m_value)[i];
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm256_storeu_ps(ptr, m_value);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm256_loadu_ps(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_storeu_ps(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
       const {

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -1038,8 +1038,8 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
       const {
     return m_value;
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
-  operator-() const noexcept {
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
     return simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
   }
 
@@ -1061,33 +1061,27 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator<(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(
-        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
+    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator>(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(
-        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
+    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator<=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(
-        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
+    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator>=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(
-        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
+    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator==(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(
-        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
+    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator!=(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(
-        _mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
+    return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -1128,6 +1128,31 @@ simd<float, simd_abi::avx512_fixed_size<8>> sqrt(
       _mm256_sqrt_ps(static_cast<__m256>(a)));
 }
 
+#ifdef __INTEL_COMPILER
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>> cbrt(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_cbrt_ps(static_cast<__m256>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>> exp(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_exp_ps(static_cast<__m256>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::avx512_fixed_size<8>> log(
+    simd<float, simd_abi::avx512_fixed_size<8>> const& a) {
+  return simd<float, simd_abi::avx512_fixed_size<8>>(
+      _mm256_log_ps(static_cast<__m256>(a)));
+}
+
+#endif
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<float, simd_abi::avx512_fixed_size<8>> fma(
     simd<float, simd_abi::avx512_fixed_size<8>> const& a,
@@ -1303,9 +1328,9 @@ class where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
   void gather_from(
       float const* mem,
       simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
-    m_value = value_type(
-        _mm256_mask_i32gather_ps(m_value, static_cast<__mmask8>(m_mask),
-                                 static_cast<__m256>(index), mem, 4));
+    m_value = value_type(_mm256_mask_i32gather_ps(
+        (__m256)m_value, mem, static_cast<__m256i>(index),
+        static_cast<__m256>(m_mask), 4));
   }
   template <
       class U,

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -1263,12 +1263,23 @@ class const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
     if (m_mask[0]) mem[0] = m_value[0];
     if (m_mask[1]) mem[1] = m_value[1];
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      float* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
+    if (m_mask[0]) mem[index[0]] = m_value[0];
+    if (m_mask[1]) mem[index[1]] = m_value[1];
+  }
 
-  friend constexpr auto const& Impl::mask<float, abi_type>(
-      const_where_expression<mask_type, value_type> const& x);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
+  impl_get_value() const {
+    return m_value;
+  }
 
-  friend constexpr auto const& Impl::value<float, abi_type>(
-      const_where_expression<mask_type, value_type> const& x);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type const&
+  impl_get_mask() const {
+    return m_mask;
+  }
 };
 
 template <>
@@ -1286,6 +1297,13 @@ class where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
   void copy_from(float const* mem, element_aligned_tag) {
     if (m_mask[0]) m_value[0] = mem[0];
     if (m_mask[1]) m_value[1] = mem[1];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      float const* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+    if (m_mask[0]) m_value[0] = mem[index[0]];
+    if (m_mask[1]) m_value[1] = mem[index[1]];
   }
   template <class U,
             std::enable_if_t<std::is_convertible_v<

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -486,6 +486,193 @@ simd<double, simd_abi::neon_fixed_size<2>> min(
 }
 
 template <>
+class simd<float, simd_abi::neon_fixed_size<2>> {
+  float32x2_t m_value;
+
+ public:
+  using value_type = float;
+  using abi_type   = simd_abi::neon_fixed_size<2>;
+  using mask_type  = simd_mask<value_type, abi_type>;
+  class reference {
+    float32x2_t& m_value;
+    int m_lane;
+
+   public:
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference(float32x2_t& value_arg,
+                                                    int lane_arg)
+        : m_value(value_arg), m_lane(lane_arg) {}
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference
+    operator=(float value) const {
+      switch (m_lane) {
+        case 0: m_value = vset_lane_f32(value, m_value, 0); break;
+        case 1: m_value = vset_lane_f32(value, m_value, 1); break;
+      }
+      return *this;
+    }
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION operator float() const {
+      switch (m_lane) {
+        case 0: return vget_lane_f32(m_value, 0);
+        case 1: return vget_lane_f32(m_value, 1);
+      }
+      return 0;
+    }
+  };
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd()            = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(simd&&)      = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd const&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd& operator=(simd&&) = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
+    return 2;
+  }
+  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
+                                      bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd(U&& value)
+      : m_value(vmov_n_f32(value_type(value))) {}
+  template <class G,
+            std::enable_if_t<
+                std::is_invocable_r_v<value_type, G,
+                                      std::integral_constant<std::size_t, 0>>,
+                bool> = false>
+  KOKKOS_FORCEINLINE_FUNCTION simd(G&& gen) {
+    m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 0>()),
+                            m_value, 0);
+    m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 1>()),
+                            m_value, 1);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit simd(
+      float32x2_t const& value_in)
+      : m_value(value_in) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION reference operator[](std::size_t i) {
+    return reference(m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
+  operator[](std::size_t i) const {
+    return reference(const_cast<simd*>(this)->m_value, int(i));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = vld1_f32(ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    vst1_f32(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit
+  operator float32x2_t() const {
+    return m_value;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator==(simd const& other) const {
+    return mask_type(vceq_f32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>(simd const& other) const {
+    return mask_type(vcgt_f32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<(simd const& other) const {
+    return mask_type(vclt_f32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator<=(simd const& other) const {
+    return mask_type(vcle_f32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator>=(simd const& other) const {
+    return mask_type(vcge_f32(m_value, other.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  operator!=(simd const& other) const {
+    return !((*this) == other);
+  }
+};
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::neon_fixed_size<2>>
+    operator-(simd<float, simd_abi::neon_fixed_size<2>> const& a) {
+  return simd<float, simd_abi::neon_fixed_size<2>>(
+      vneg_f32(static_cast<float32x2_t>(a)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::neon_fixed_size<2>>
+    operator-(simd<float, simd_abi::neon_fixed_size<2>> const& lhs,
+              simd<float, simd_abi::neon_fixed_size<2>> const& rhs) {
+  return simd<float, simd_abi::neon_fixed_size<2>>(
+      vsub_f32(static_cast<float32x2_t>(lhs), static_cast<float32x2_t>(rhs)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::neon_fixed_size<2>>
+    operator+(simd<float, simd_abi::neon_fixed_size<2>> const& lhs,
+              simd<float, simd_abi::neon_fixed_size<2>> const& rhs) {
+  return simd<float, simd_abi::neon_fixed_size<2>>(
+      vadd_f32(static_cast<float32x2_t>(lhs), static_cast<float32x2_t>(rhs)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::neon_fixed_size<2>> abs(
+    simd<float, simd_abi::neon_fixed_size<2>> const& a) {
+  return simd<float, simd_abi::neon_fixed_size<2>>(
+      vabs_f32(static_cast<float32x2_t>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::neon_fixed_size<2>> copysign(
+    simd<float, simd_abi::neon_fixed_size<2>> const& a,
+    simd<float, simd_abi::neon_fixed_size<2>> const& b) {
+  uint32x2_t const sign_mask = vreinterpret_u32_f32(vmov_n_f32(-0.0));
+  return simd<float, simd_abi::neon_fixed_size<2>>(vreinterpret_f32_u32(
+      vorr_u32(vreinterpret_u32_f32(static_cast<float32x2_t>(abs(a))),
+               vand_u32(sign_mask,
+                        vreinterpret_u32_f32(static_cast<float32x2_t>(b))))));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::neon_fixed_size<2>> sqrt(
+    simd<float, simd_abi::neon_fixed_size<2>> const& a) {
+  return simd<float, simd_abi::neon_fixed_size<2>>(
+      vsqrt_f32(static_cast<float32x2_t>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::neon_fixed_size<2>> fma(
+    simd<float, simd_abi::neon_fixed_size<2>> const& a,
+    simd<float, simd_abi::neon_fixed_size<2>> const& b,
+    simd<float, simd_abi::neon_fixed_size<2>> const& c) {
+  return simd<float, simd_abi::neon_fixed_size<2>>(
+      vfma_f32(static_cast<float32x2_t>(c), static_cast<float32x2_t>(b),
+               static_cast<float32x2_t>(a)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::neon_fixed_size<2>> max(
+    simd<float, simd_abi::neon_fixed_size<2>> const& a,
+    simd<float, simd_abi::neon_fixed_size<2>> const& b) {
+  return simd<float, simd_abi::neon_fixed_size<2>>(
+      vmax_f32(static_cast<float32x2_t>(a), static_cast<float32x2_t>(b)));
+}
+
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::neon_fixed_size<2>> min(
+    simd<float, simd_abi::neon_fixed_size<2>> const& a,
+    simd<float, simd_abi::neon_fixed_size<2>> const& b) {
+  return simd<float, simd_abi::neon_fixed_size<2>>(
+      vmin_f32(static_cast<float32x2_t>(a), static_cast<float32x2_t>(b)));
+}
+
+[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    simd<float, simd_abi::neon_fixed_size<2>>
+    condition(simd_mask<float, simd_abi::neon_fixed_size<2>> const& a,
+              simd<float, simd_abi::neon_fixed_size<2>> const& b,
+              simd<float, simd_abi::neon_fixed_size<2>> const& c) {
+  return simd<float, simd_abi::neon_fixed_size<2>>(
+      vbsl_f32(static_cast<uint32x2_t>(a), static_cast<float32x2_t>(b),
+               static_cast<float32x2_t>(c)));
+}
+
+template <>
 class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
   int32x2_t m_value;
 
@@ -1052,6 +1239,66 @@ class where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
         vbslq_f64(static_cast<uint64x2_t>(m_mask),
                   static_cast<float64x2_t>(x_as_value_type),
                   static_cast<float64x2_t>(m_value)));
+  }
+};
+
+template <>
+class const_where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
+                             simd<float, simd_abi::neon_fixed_size<2>>> {
+ public:
+  using abi_type   = simd_abi::neon_fixed_size<2>;
+  using value_type = simd<float, abi_type>;
+  using mask_type  = simd_mask<float, abi_type>;
+
+ protected:
+  value_type& m_value;
+  mask_type const& m_mask;
+
+ public:
+  const_where_expression(mask_type const& mask_arg, value_type const& value_arg)
+      : m_value(const_cast<value_type&>(value_arg)), m_mask(mask_arg) {}
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(float* mem, element_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+  }
+
+  friend constexpr auto const& Impl::mask<float, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+
+  friend constexpr auto const& Impl::value<float, abi_type>(
+      const_where_expression<mask_type, value_type> const& x);
+};
+
+template <>
+class where_expression<simd_mask<float, simd_abi::neon_fixed_size<2>>,
+                       simd<float, simd_abi::neon_fixed_size<2>>>
+    : public const_where_expression<
+          simd_mask<float, simd_abi::neon_fixed_size<2>>,
+          simd<float, simd_abi::neon_fixed_size<2>>> {
+ public:
+  where_expression(
+      simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask_arg,
+      simd<float, simd_abi::neon_fixed_size<2>>& value_arg)
+      : const_where_expression(mask_arg, value_arg) {}
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(float const* mem, element_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+  }
+  template <class U,
+            std::enable_if_t<std::is_convertible_v<
+                                 U, simd<float, simd_abi::neon_fixed_size<2>>>,
+                             bool> = false>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
+    auto const x_as_value_type =
+        static_cast<simd<float, simd_abi::neon_fixed_size<2>>>(
+            std::forward<U>(x));
+    m_value = static_cast<simd<float, simd_abi::neon_fixed_size<2>>>(
+        vbsl_f32(static_cast<uint32x2_t>(m_mask),
+                 static_cast<float32x2_t>(x_as_value_type),
+                 static_cast<float32x2_t>(m_value)));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -562,54 +562,44 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
   operator float32x2_t() const {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator==(simd const& other) const {
-    return mask_type(vceq_f32(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
+      noexcept {
+    return simd(vneg_f32(m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>(simd const& other) const {
-    return mask_type(vcgt_f32(m_value, other.m_value));
+
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vsub_f32(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<(simd const& other) const {
-    return mask_type(vclt_f32(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vadd_f32(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator<=(simd const& other) const {
-    return mask_type(vcle_f32(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vceq_f32(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator>=(simd const& other) const {
-    return mask_type(vcge_f32(m_value, other.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcgt_f32(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  operator!=(simd const& other) const {
-    return !((*this) == other);
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vclt_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcle_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcge_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return !(lhs == rhs);
   }
 };
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::neon_fixed_size<2>>
-    operator-(simd<float, simd_abi::neon_fixed_size<2>> const& a) {
-  return simd<float, simd_abi::neon_fixed_size<2>>(
-      vneg_f32(static_cast<float32x2_t>(a)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::neon_fixed_size<2>>
-    operator-(simd<float, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<float, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<float, simd_abi::neon_fixed_size<2>>(
-      vsub_f32(static_cast<float32x2_t>(lhs), static_cast<float32x2_t>(rhs)));
-}
-
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::neon_fixed_size<2>>
-    operator+(simd<float, simd_abi::neon_fixed_size<2>> const& lhs,
-              simd<float, simd_abi::neon_fixed_size<2>> const& rhs) {
-  return simd<float, simd_abi::neon_fixed_size<2>>(
-      vadd_f32(static_cast<float32x2_t>(lhs), static_cast<float32x2_t>(rhs)));
-}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 simd<float, simd_abi::neon_fixed_size<2>> abs(

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -567,25 +567,29 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
     return simd(vneg_f32(m_value));
   }
 
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
       simd const& lhs, simd const& rhs) noexcept {
-    return simd(vsub_f32(lhs.m_value, rhs.m_value));
+    return simd(vmul_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator/(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vdiv_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
       simd const& lhs, simd const& rhs) noexcept {
     return simd(vadd_f32(lhs.m_value, rhs.m_value));
   }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator==(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(vceq_f32(lhs.m_value, rhs.m_value));
-  }
-  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-  operator>(simd const& lhs, simd const& rhs) noexcept {
-    return mask_type(vcgt_f32(lhs.m_value, rhs.m_value));
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(vsub_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator<(simd const& lhs, simd const& rhs) noexcept {
     return mask_type(vclt_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vcgt_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator<=(simd const& lhs, simd const& rhs) noexcept {
@@ -594,6 +598,10 @@ class simd<float, simd_abi::neon_fixed_size<2>> {
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator>=(simd const& lhs, simd const& rhs) noexcept {
     return mask_type(vcge_f32(lhs.m_value, rhs.m_value));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(vceq_f32(lhs.m_value, rhs.m_value));
   }
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
   operator!=(simd const& lhs, simd const& rhs) noexcept {
@@ -652,11 +660,11 @@ simd<float, simd_abi::neon_fixed_size<2>> min(
       vmin_f32(static_cast<float32x2_t>(a), static_cast<float32x2_t>(b)));
 }
 
-[[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    simd<float, simd_abi::neon_fixed_size<2>>
-    condition(simd_mask<float, simd_abi::neon_fixed_size<2>> const& a,
-              simd<float, simd_abi::neon_fixed_size<2>> const& b,
-              simd<float, simd_abi::neon_fixed_size<2>> const& c) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+simd<float, simd_abi::neon_fixed_size<2>> condition(
+    simd_mask<float, simd_abi::neon_fixed_size<2>> const& a,
+    simd<float, simd_abi::neon_fixed_size<2>> const& b,
+    simd<float, simd_abi::neon_fixed_size<2>> const& c) {
   return simd<float, simd_abi::neon_fixed_size<2>>(
       vbsl_f32(static_cast<uint32x2_t>(a), static_cast<float32x2_t>(b),
                static_cast<float32x2_t>(c)));


### PR DESCRIPTION
Resolves #6054.

This PR adds `float` support for `AVX2`, `AVX512` and `NEON`.

Includes functions and operators for `float`:
- simd simd::operator-() const
- simd operator+(const simd& lhs, const simd& rhs)
- simd operator-(const simd& lhs, const simd& rhs)
- simd operator*(const simd& lhs, const simd& rhs)
- simd operator/(const simd& lhs, const simd& rhs)
- simd Kokkos::copysign(const simd& mag, const simd& sgn)
- simd Kokkos::abs(const simd& lhs)
- simd Kokkos::sqrt(const simd& lhs)
- simd Kokkos::fma(const simd& x, const simd& y, const simd& z)
- simd Kokkos::min(const simd& lhs, const simd& rhs)
- simd Kokkos::max(const simd& lhs, const simd& rhs)