### PR TITLE
.github/workflows: Remove push trigger

### DIFF
--- a/.github/workflows/continuous-integration-workflow-32bit.yml
+++ b/.github/workflows/continuous-integration-workflow-32bit.yml
@@ -1,6 +1,9 @@
 name: github-Linux-32bit
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
     paths-ignore:
     - '**/*.md'

--- a/.github/workflows/continuous-integration-workflow-32bit.yml
+++ b/.github/workflows/continuous-integration-workflow-32bit.yml
@@ -1,5 +1,10 @@
 name: github-Linux-32bit
-on: [push, pull_request]
+
+on:
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/continuous-integration-workflow-hpx.yml
+++ b/.github/workflows/continuous-integration-workflow-hpx.yml
@@ -1,6 +1,9 @@
 name: github-Linux-hpx
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
     paths-ignore:
     - '**/*.md'

--- a/.github/workflows/continuous-integration-workflow-hpx.yml
+++ b/.github/workflows/continuous-integration-workflow-hpx.yml
@@ -1,6 +1,10 @@
 name: github-Linux-hpx
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,6 +1,9 @@
 name: github-Linux
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
     paths-ignore:
     - '**/*.md'

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,5 +1,10 @@
 name: github-Linux
-on: [push, pull_request]
+
+on:
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,6 +1,9 @@
 name: github-OSX
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
     paths-ignore:
     - '**/*.md'

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,6 +1,10 @@
 name: github-OSX
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+    types: [ opened, reopened, synchronize ]
 
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - develop
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   CI:


### PR DESCRIPTION
Removed push trigger in favor or pull_request with types opened, reopened, and synchronize. This avoids having the CI run when developers push branches to their forks of Kokkos. This was reported by @stanmoore1 on slack.