### PR TITLE
SIMD: Replace unavailable loadu/storeu instructions

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -388,11 +388,11 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
-    m_value = _mm512_loadu_epi64(ptr);
+    m_value = _mm512_loadu_si512(ptr);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
-    _mm512_storeu_epi64(ptr, m_value);
+    _mm512_storeu_si512(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator>>(int rhs) const {
     return _mm512_srai_epi64(m_value, rhs);
@@ -519,11 +519,11 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
-    m_value = _mm512_loadu_epi64(ptr);
+    m_value = _mm512_loadu_si512(ptr);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
-    _mm512_storeu_epi64(ptr, m_value);
+    _mm512_storeu_si512(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd
   operator>>(unsigned int rhs) const {


### PR DESCRIPTION
Resolves #6182.

`_mm512_loadu_epi64` and `_mm512_storeu_epi64` became available in `gcc/avx512fintrin.h` starting GCC 10. Compiling with previous versions of gcc causes undeclared errors on these.

This PR replaces `_mm512_loadu_epi64` with `_mm512_loadu_si512` and `_mm512_storeu_epi64` with `_mm512_storeu_si512`. 
Functionally, both replaced and replacing calls operate on 512 bits of memory that are not expected to be aligned in any boundary.