### PR TITLE
Default hip/cuda memset async in zero memset

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ZeroMemset.hpp
@@ -38,7 +38,7 @@ struct ZeroMemset<Kokkos::Cuda, View<T, P...>> {
              typename View<T, P...>::const_value_type&) {
     // FIXME_CUDA_MULTIPLE_DEVICES
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (Kokkos::Impl::CudaInternal::singleton().cuda_memset_wrapper(
+        (Kokkos::Impl::CudaInternal::singleton().cuda_memset_async_wrapper(
             dst.data(), 0,
             dst.size() * sizeof(typename View<T, P...>::value_type))));
   }

--- a/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
+++ b/core/src/HIP/Kokkos_HIP_ZeroMemset.hpp
@@ -34,9 +34,9 @@ struct ZeroMemset<HIP, View<T, P...>> {
 
   ZeroMemset(const View<T, P...>& dst,
              typename View<T, P...>::const_value_type&) {
-    KOKKOS_IMPL_HIP_SAFE_CALL(
-        hipMemset(dst.data(), 0,
-                  dst.size() * sizeof(typename View<T, P...>::value_type)));
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipMemsetAsync(
+        dst.data(), 0, dst.size() * sizeof(typename View<T, P...>::value_type),
+        Kokkos::HIP().hip_stream()));
   }
 };
 


### PR DESCRIPTION
For ZeroMemset, if no execution space is given, use stream from default cuda/hip instance in a `{cuda|hip}MemsetAsync` call instead of `{cuda|hip}Memset`.

Update to https://github.com/kokkos/kokkos/pull/6087, from comment https://github.com/kokkos/kokkos/pull/6087#discussion_r1186314333.