### PR TITLE
Make in-order queues the default via macro

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -92,6 +92,13 @@ void SYCL::print_configuration(std::ostream& os, bool verbose) const {
 #else
   os << "macro  KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED : undefined\n";
 #endif
+
+#ifdef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
+  os << "macro  KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES : defined\n";
+#else
+  os << "macro  KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES : undefined\n";
+#endif
+
   if (verbose)
     SYCL::impl_sycl_info(os, m_space_instance->m_queue->get_device());
 }

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -41,7 +41,9 @@ void DeepCopyAsyncSYCL(const Kokkos::Experimental::SYCL& instance, void* dst,
                        const void* src, size_t n) {
   sycl::queue& q = *instance.impl_internal_space_instance()->m_queue;
   auto event     = q.memcpy(dst, src, n);
+#ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
   q.ext_oneapi_submit_barrier(std::vector<sycl::event>{event});
+#endif
 }
 
 void DeepCopyAsyncSYCL(void* dst, const void* src, size_t n) {

--- a/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ZeroMemset.hpp
@@ -30,8 +30,10 @@ struct ZeroMemset<Kokkos::Experimental::SYCL, View<T, P...>> {
              typename View<T, P...>::const_value_type&) {
     auto event = exec_space.impl_internal_space_instance()->m_queue->memset(
         dst.data(), 0, dst.size() * sizeof(typename View<T, P...>::value_type));
+#ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
     exec_space.impl_internal_space_instance()
         ->m_queue->ext_oneapi_submit_barrier(std::vector<sycl::event>{event});
+#endif
   }
 
   ZeroMemset(const View<T, P...>& dst,

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -17,6 +17,11 @@
 #ifndef KOKKOS_SETUP_SYCL_HPP_
 #define KOKKOS_SETUP_SYCL_HPP_
 
+// FIXME_SYCL Using in-order queues currently gives better performance on Intel
+// GPUs and we run into correctness issues with out-of-order queues on NVIDIA
+// GPUs.
+#define KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
+
 // FIXME_SYCL the fallback assert is temporarily disabled by default in the
 // compiler so we need to force it
 #ifndef SYCL_ENABLE_FALLBACK_ASSERT


### PR DESCRIPTION
This pull request makes in-order queues the default but retains the option for us to change this later easily.
If we are using in-order queues, we don't need any of the `depends_on` or `submit_barrier` calls and for benchmarks up to moderate sizes, I see `zeCommandListAppendBarrier` dominating without this patch.
Related to #6035.

This pull request is in some way reverting back to in-order queues after we lifted the requirement in https://github.com/kokkos/kokkos/pull/5065 (but also guarding a bunch of other synchronization points necessary for out-of-order queues). Thus, this is for performance, not correctness (which was the issue before).