### PR TITLE
SYCL: Support for bhalf_t

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -128,4 +128,112 @@ struct reduction_identity<Kokkos::Experimental::half_t> {
 
 }  // namespace Kokkos
 #endif  // KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
+
+#ifdef KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
+
+namespace Kokkos {
+namespace Experimental {
+
+/************************** bhalf conversions *********************************/
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(float val) { return bhalf_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(double val) { return bhalf_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(short val) { return bhalf_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(unsigned short val) { return bhalf_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(int val) { return bhalf_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(unsigned int val) { return bhalf_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(long long val) { return bhalf_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(unsigned long long val) {
+  return bhalf_t::impl_type(val);
+}
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(long val) { return bhalf_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(unsigned long val) { return bhalf_t::impl_type(val); }
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, float>::value, T>
+cast_from_bhalf(bhalf_t val) {
+  return bhalf_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, double>::value, T>
+cast_from_bhalf(bhalf_t val) {
+  return bhalf_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, short>::value, T>
+cast_from_bhalf(bhalf_t val) {
+  return bhalf_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<std::is_same<T, unsigned short>::value, T>
+    cast_from_bhalf(bhalf_t val) {
+  return bhalf_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, int>::value, T>
+cast_from_bhalf(bhalf_t val) {
+  return bhalf_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, unsigned int>::value, T>
+cast_from_bhalf(bhalf_t val) {
+  return bhalf_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long long>::value, T>
+cast_from_bhalf(bhalf_t val) {
+  return bhalf_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<std::is_same<T, unsigned long long>::value, T>
+    cast_from_bhalf(bhalf_t val) {
+  return bhalf_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long>::value, T>
+cast_from_bhalf(bhalf_t val) {
+  return bhalf_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<std::is_same<T, unsigned long>::value, T>
+    cast_from_bhalf(bhalf_t val) {
+  return bhalf_t::impl_type(val);
+}
+}  // namespace Experimental
+
+// sycl::bfloat16 doesn't have constexpr constructors so we return float
+template <>
+struct reduction_identity<Kokkos::Experimental::bhalf_t> {
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static float sum() noexcept {
+    return 0.f;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static float prod() noexcept {
+    return 1.0f;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static float max() noexcept {
+    return -0x7f7f;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static float min() noexcept {
+    return 0x7f7f;
+  }
+};
+
+}  // namespace Kokkos
+#endif  // KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
+
 #endif

--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -53,55 +53,55 @@ half_t cast_to_half(unsigned long val) { return half_t::impl_type(val); }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, float>::value, T>
 cast_from_half(half_t val) {
-  return half_t::impl_type(val);
+  return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, double>::value, T>
 cast_from_half(half_t val) {
-  return half_t::impl_type(val);
+  return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, short>::value, T>
 cast_from_half(half_t val) {
-  return half_t::impl_type(val);
+  return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned short>::value, T>
     cast_from_half(half_t val) {
-  return half_t::impl_type(val);
+  return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, int>::value, T>
 cast_from_half(half_t val) {
-  return half_t::impl_type(val);
+  return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, unsigned int>::value, T>
 cast_from_half(half_t val) {
-  return half_t::impl_type(val);
+  return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long long>::value, T>
 cast_from_half(half_t val) {
-  return half_t::impl_type(val);
+  return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned long long>::value, T>
     cast_from_half(half_t val) {
-  return half_t::impl_type(val);
+  return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long>::value, T>
 cast_from_half(half_t val) {
-  return half_t::impl_type(val);
+  return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned long>::value, T>
     cast_from_half(half_t val) {
-  return half_t::impl_type(val);
+  return static_cast<T>(half_t::impl_type(val));
 }
 }  // namespace Experimental
 
@@ -164,55 +164,55 @@ bhalf_t cast_to_bhalf(unsigned long val) { return bhalf_t::impl_type(val); }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, float>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return bhalf_t::impl_type(val);
+  return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, double>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return bhalf_t::impl_type(val);
+  return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, short>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return bhalf_t::impl_type(val);
+  return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned short>::value, T>
     cast_from_bhalf(bhalf_t val) {
-  return bhalf_t::impl_type(val);
+  return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, int>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return bhalf_t::impl_type(val);
+  return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, unsigned int>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return bhalf_t::impl_type(val);
+  return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long long>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return bhalf_t::impl_type(val);
+  return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned long long>::value, T>
     cast_from_bhalf(bhalf_t val) {
-  return bhalf_t::impl_type(val);
+  return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long>::value, T>
 cast_from_bhalf(bhalf_t val) {
-  return bhalf_t::impl_type(val);
+  return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same<T, unsigned long>::value, T>
     cast_from_bhalf(bhalf_t val) {
-  return bhalf_t::impl_type(val);
+  return static_cast<T>(bhalf_t::impl_type(val));
 }
 }  // namespace Experimental
 

--- a/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
@@ -26,8 +26,8 @@
 #include <CL/sycl.hpp>
 #endif
 
-#ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
 // Make sure no one else tries to define half_t
+#ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
 #define KOKKOS_IMPL_HALF_TYPE_DEFINED
 #define KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
 

--- a/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
@@ -18,7 +18,6 @@
 #define KOKKOS_SYCL_HALF_IMPL_TYPE_HPP_
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_SYCL
 
 // FIXME_SYCL
 #if __has_include(<sycl/sycl.hpp>)
@@ -32,13 +31,33 @@
 #define KOKKOS_IMPL_HALF_TYPE_DEFINED
 #define KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
 
-namespace Kokkos {
-namespace Impl {
+namespace Kokkos::Impl {
 struct half_impl_t {
   using type = sycl::half;
 };
-}  // namespace Impl
-}  // namespace Kokkos
+}  // namespace Kokkos::Impl
 #endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
-#endif  // KOKKOS_ENABLE_SYCL
-#endif
+
+// Make sure no one else tries to define bhalf_t
+#ifndef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+// FIXME_SYCL Evaluate when to drop the check
+#if __has_include(<sycl/ext/oneapi/bfloat16.hpp>)
+#define KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#define KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
+namespace Kokkos::Impl {
+struct bhalf_impl_t {
+  using type = sycl::ext::oneapi::bfloat16;
+};
+}  // namespace Kokkos::Impl
+#elif defined(SYCL_EXT_ONEAPI_BFLOAT16)
+// Only the experimental feature doesn't have a fallback implementation
+#define KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#define KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
+namespace Kokkos::Impl {
+struct bhalf_impl_t {
+  using type = sycl::ext::oneapi::experimental::bfloat16;
+};
+}  // namespace Kokkos::Impl
+#endif  // test for bfloat16 support
+#endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#endif  // KOKKOS_SYCL_HALF_IMPL_TYPE_HPP_

--- a/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
@@ -49,8 +49,10 @@ struct bhalf_impl_t {
   using type = sycl::ext::oneapi::bfloat16;
 };
 }  // namespace Kokkos::Impl
-#elif defined(SYCL_EXT_ONEAPI_BFLOAT16)
-// Only the experimental feature doesn't have a fallback implementation
+#elif defined(SYCL_EXT_ONEAPI_BFLOAT16) && defined(KOKKOS_ARCH_INTEL_GPU)
+// FIXME_SYCL bfloat16 is only supported for compute capability 8.0 or higher
+// on Nvidia GPUs but SYCL_EXT_ONEAPI_BFLOAT16 is defined even for lower compute
+// capability.
 #define KOKKOS_IMPL_BHALF_TYPE_DEFINED
 #define KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
 namespace Kokkos::Impl {


### PR DESCRIPTION
- `sycl::ext::oneapi::bfloat16` has a fallback implementation if there is no hardware support, see https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_bfloat16.asciidoc 
- `sycl::ext::oneapi::experimental::bfloat16` doesn't have a fallback implementation and we have to check the feature macro `SYCL_EXT_ONEAPI_BFLOAT16` as well, see https://github.com/intel/llvm/pull/6524/files#diff-797454c0033752eea278cd39646559c04e516cbf1fb1ab9cd3f51216262a7de3. Interestingly, it's defined when compiling for `Nvidia` GPUs regardless of compute capability but it's only supported for compute capability 8.0 and higher.
-  Similar to the `Cuda` implementation, there is no `constexpr` constructor for the underlying type and we fall back to return `float` in the `reduction_identity` specializations.