### PR TITLE
SIMD: add remaining gather_from and scatter_to

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1108,9 +1108,9 @@ class where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
   void gather_from(
       double const* mem,
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
-    m_value = value_type(_mm256_mask_i32gather_pd(
-        _mm256_set1_pd(0.0), mem, static_cast<__m128i>(index),
-        static_cast<__m256d>(m_mask), 8));
+    m_value = value_type(
+        _mm256_mask_i32gather_pd(m_value, mem, static_cast<__m128i>(index),
+                                 static_cast<__m256d>(m_mask), 8));
   }
   template <class U,
             std::enable_if_t<std::is_convertible_v<
@@ -1148,6 +1148,14 @@ class const_where_expression<
     _mm_maskstore_epi32(mem, static_cast<__m128i>(m_mask),
                         static_cast<__m128i>(m_value));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::int32_t* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+    for (std::size_t lane = 0; lane < 4; ++lane) {
+      if (m_mask[lane]) mem[index[lane]] = m_value[lane];
+    }
+  }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
@@ -1174,6 +1182,14 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
     m_value = value_type(_mm_maskload_epi32(mem, static_cast<__m128i>(m_mask)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::int32_t const* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+    m_value = value_type(
+        _mm_mask_i32gather_epi32(m_value, mem, static_cast<__m128i>(index),
+                                 static_cast<__m128i>(m_mask), 4));
   }
   template <
       class U,
@@ -1214,6 +1230,14 @@ class const_where_expression<
                            static_cast<__m256i>(m_mask),
                            static_cast<__m256i>(m_value));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::int64_t* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+    for (std::size_t lane = 0; lane < 4; ++lane) {
+      if (m_mask[lane]) mem[index[lane]] = m_value[lane];
+    }
+  }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
@@ -1241,6 +1265,14 @@ class where_expression<simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
                                                        element_aligned_tag) {
     m_value = value_type(_mm256_maskload_epi64(
         reinterpret_cast<long long const*>(mem), static_cast<__m256i>(m_mask)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::int64_t const* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+    m_value = value_type(
+        _mm256_mask_i32gather_epi64(m_value, mem, static_cast<__m128i>(index),
+                                    static_cast<__m256i>(m_mask), 8));
   }
   template <
       class u,
@@ -1282,6 +1314,14 @@ class const_where_expression<
                            static_cast<__m256i>(m_mask),
                            static_cast<__m256i>(m_value));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::uint64_t* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) const {
+    for (std::size_t lane = 0; lane < 4; ++lane) {
+      if (m_mask[lane]) mem[index[lane]] = m_value[lane];
+    }
+  }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
@@ -1309,6 +1349,14 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
                                                        element_aligned_tag) {
     m_value = value_type(_mm256_maskload_epi64(
         reinterpret_cast<long long const*>(mem), static_cast<__m256i>(m_mask)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::uint64_t const* mem,
+      simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+    m_value = value_type(
+        _mm256_mask_i32gather_epi64(m_value, mem, static_cast<__m128i>(index),
+                                    static_cast<__m256i>(m_mask), 8));
   }
   template <class u,
             std::enable_if_t<

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1108,9 +1108,9 @@ class where_expression<simd_mask<double, simd_abi::avx2_fixed_size<4>>,
   void gather_from(
       double const* mem,
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
-    m_value = value_type(
-        _mm256_mask_i32gather_pd(m_value, mem, static_cast<__m128i>(index),
-                                 static_cast<__m256d>(m_mask), 8));
+    m_value = value_type(_mm256_mask_i32gather_pd(
+        static_cast<__m256d>(m_value), mem, static_cast<__m128i>(index),
+        static_cast<__m256d>(m_mask), 8));
   }
   template <class U,
             std::enable_if_t<std::is_convertible_v<
@@ -1187,9 +1187,9 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
   void gather_from(
       std::int32_t const* mem,
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
-    m_value = value_type(
-        _mm_mask_i32gather_epi32(m_value, mem, static_cast<__m128i>(index),
-                                 static_cast<__m128i>(m_mask), 4));
+    m_value = value_type(_mm_mask_i32gather_epi32(
+        static_cast<__m128i>(m_value), mem, static_cast<__m128i>(index),
+        static_cast<__m128i>(m_mask), 4));
   }
   template <
       class U,
@@ -1270,9 +1270,9 @@ class where_expression<simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
   void gather_from(
       std::int64_t const* mem,
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
-    m_value = value_type(
-        _mm256_mask_i32gather_epi64(m_value, mem, static_cast<__m128i>(index),
-                                    static_cast<__m256i>(m_mask), 8));
+    m_value = value_type(_mm256_mask_i32gather_epi64(
+        static_cast<__m256i>(m_value), reinterpret_cast<long long const*>(mem),
+        static_cast<__m128i>(index), static_cast<__m256i>(m_mask), 8));
   }
   template <
       class u,
@@ -1354,9 +1354,9 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
   void gather_from(
       std::uint64_t const* mem,
       simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
-    m_value = value_type(
-        _mm256_mask_i32gather_epi64(m_value, mem, static_cast<__m128i>(index),
-                                    static_cast<__m256i>(m_mask), 8));
+    m_value = value_type(_mm256_mask_i32gather_epi64(
+        static_cast<__m256i>(m_value), reinterpret_cast<long long const*>(mem),
+        static_cast<__m128i>(index), static_cast<__m256i>(m_mask), 8));
   }
   template <class u,
             std::enable_if_t<

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -1042,7 +1042,7 @@ class where_expression<simd_mask<double, simd_abi::avx512_fixed_size<8>>,
       double const* mem,
       simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_pd(
-        _mm512_set1_pd(0.0), static_cast<__mmask8>(m_mask),
+        static_cast<__m512d>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 8));
   }
   template <class U, std::enable_if_t<
@@ -1081,6 +1081,14 @@ class const_where_expression<
     _mm256_mask_storeu_epi32(mem, static_cast<__mmask8>(m_mask),
                              static_cast<__m256i>(m_value));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::int32_t* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
+    _mm256_mask_i32scatter_epi32(mem, static_cast<__mmask8>(m_mask),
+                                 static_cast<__m256i>(index),
+                                 static_cast<__m256i>(m_value), 4);
+  }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
@@ -1108,6 +1116,14 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
     m_value = value_type(_mm256_mask_loadu_epi32(
         _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::int32_t const* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+    m_value = value_type(_mm256_mmask_i32gather_epi32(
+        static_cast<__m256i>(m_value), static_cast<__mmask8>(m_mask),
+        static_cast<__m256i>(index), mem, 4));
   }
   template <class U,
             std::enable_if_t<
@@ -1147,6 +1163,14 @@ class const_where_expression<
     _mm256_mask_storeu_epi32(mem, static_cast<__mmask8>(m_mask),
                              static_cast<__m256i>(m_value));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::uint32_t* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
+    _mm256_mask_i32scatter_epi32(mem, static_cast<__mmask8>(m_mask),
+                                 static_cast<__m256i>(index),
+                                 static_cast<__m256i>(m_value), 4);
+  }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
@@ -1174,6 +1198,14 @@ class where_expression<simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
   void copy_from(std::uint32_t const* mem, element_aligned_tag) {
     m_value = value_type(_mm256_mask_loadu_epi32(
         _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::uint32_t const* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+    m_value = value_type(_mm256_mmask_i32gather_epi32(
+        static_cast<__m256i>(m_value), static_cast<__mmask8>(m_mask),
+        static_cast<__m256i>(index), mem, 4));
   }
   template <class U,
             std::enable_if_t<
@@ -1213,6 +1245,14 @@ class const_where_expression<
     _mm512_mask_storeu_epi64(mem, static_cast<__mmask8>(m_mask),
                              static_cast<__m512i>(m_value));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::int64_t* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
+    _mm512_mask_i32scatter_epi64(mem, static_cast<__mmask8>(m_mask),
+                                 static_cast<__m256i>(index),
+                                 static_cast<__m512i>(m_value), 8);
+  }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
@@ -1240,6 +1280,14 @@ class where_expression<simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
   void copy_from(std::int64_t const* mem, element_aligned_tag) {
     m_value = value_type(_mm512_mask_loadu_epi64(
         _mm512_set1_epi64(0.0), static_cast<__mmask8>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::int64_t const* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+    m_value = value_type(_mm512_mask_i32gather_epi64(
+        static_cast<__m512i>(m_value), static_cast<__mmask8>(m_mask),
+        static_cast<__m256i>(index), mem, 8));
   }
   template <class U,
             std::enable_if_t<
@@ -1279,6 +1327,14 @@ class const_where_expression<
     _mm512_mask_storeu_epi64(mem, static_cast<__mmask8>(m_mask),
                              static_cast<__m512i>(m_value));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::uint64_t* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
+    _mm512_mask_i32scatter_epi64(mem, static_cast<__mmask8>(m_mask),
+                                 static_cast<__m256i>(index),
+                                 static_cast<__m512i>(m_value), 8);
+  }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
@@ -1306,6 +1362,14 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
   void copy_from(std::uint64_t const* mem, element_aligned_tag) {
     m_value = value_type(_mm512_mask_loadu_epi64(
         _mm512_set1_epi64(0.0), static_cast<__mmask8>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::uint64_t const* mem,
+      simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+    m_value = value_type(_mm512_mask_i32gather_epi64(
+        static_cast<__m512i>(m_value), static_cast<__mmask8>(m_mask),
+        static_cast<__m256i>(index), mem, 8));
   }
   template <class U,
             std::enable_if_t<

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -1077,6 +1077,13 @@ class const_where_expression<
     if (m_mask[0]) mem[0] = m_value[0];
     if (m_mask[1]) mem[1] = m_value[1];
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::int32_t* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
+    if (m_mask[0]) mem[index[0]] = m_value[0];
+    if (m_mask[1]) mem[index[1]] = m_value[1];
+  }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
@@ -1104,6 +1111,13 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
     if (m_mask[0]) m_value[0] = mem[0];
     if (m_mask[1]) m_value[1] = mem[1];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::int32_t const* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+    if (m_mask[0]) m_value[0] = mem[index[0]];
+    if (m_mask[1]) m_value[1] = mem[index[1]];
   }
   template <
       class U,
@@ -1143,6 +1157,13 @@ class const_where_expression<
     if (m_mask[0]) mem[0] = m_value[0];
     if (m_mask[1]) mem[1] = m_value[1];
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::int64_t* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
+    if (m_mask[0]) mem[index[0]] = m_value[0];
+    if (m_mask[1]) mem[index[1]] = m_value[1];
+  }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
@@ -1170,6 +1191,13 @@ class where_expression<simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
   void copy_from(std::int64_t const* mem, element_aligned_tag) {
     if (m_mask[0]) m_value[0] = mem[0];
     if (m_mask[1]) m_value[1] = mem[1];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::int64_t const* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+    if (m_mask[0]) m_value[0] = mem[index[0]];
+    if (m_mask[1]) m_value[1] = mem[index[1]];
   }
   template <
       class U,
@@ -1209,6 +1237,13 @@ class const_where_expression<
     if (m_mask[0]) mem[0] = m_value[0];
     if (m_mask[1]) mem[1] = m_value[1];
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void scatter_to(
+      std::uint64_t* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
+    if (m_mask[0]) mem[index[0]] = m_value[0];
+    if (m_mask[1]) mem[index[1]] = m_value[1];
+  }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
@@ -1236,6 +1271,13 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
   void copy_from(std::uint64_t const* mem, element_aligned_tag) {
     if (m_mask[0]) m_value[0] = mem[0];
     if (m_mask[1]) m_value[1] = mem[1];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void gather_from(
+      std::uint64_t const* mem,
+      simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+    if (m_mask[0]) m_value[0] = mem[index[0]];
+    if (m_mask[1]) m_value[1] = mem[index[1]];
   }
   template <class U,
             std::enable_if_t<

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -20,3 +20,4 @@
 #include <TestSIMD_ShiftOps.hpp>
 #include <TestSIMD_Condition.hpp>
 #include <TestSIMD_GeneratorCtors.hpp>
+#include <TestSIMD_WhereExpressions.hpp>

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -1,0 +1,195 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_TEST_SIMD_WHERE_EXPRESSIONS_HPP
+#define KOKKOS_TEST_SIMD_WHERE_EXPRESSIONS_HPP
+
+#include <Kokkos_SIMD.hpp>
+#include <SIMDTesting_Utilities.hpp>
+
+template <typename Abi, typename DataType>
+inline void host_check_where_expr_scatter_to() {
+  using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
+  using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
+  using mask_type  = typename simd_type::mask_type;
+
+  std::size_t nlanes = simd_type::size();
+  DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37};
+  simd_type src;
+  src.copy_from(init, Kokkos::Experimental::element_aligned_tag());
+
+  for (std::size_t idx = 0; idx < nlanes; ++idx) {
+    mask_type mask(true);
+    mask[idx] = false;
+
+    DataType dst[8] = {0};
+    index_type index;
+    simd_type expected_result;
+    for (std::size_t i = 0; i < nlanes; ++i) {
+      dst[i]             = (2 + (i * 2));
+      index[i]           = i;
+      expected_result[i] = (mask[i]) ? src[index[i]] : (2 + (i * 2));
+    }
+    where(mask, src).scatter_to(dst, index);
+
+    simd_type dst_simd;
+    dst_simd.copy_from(dst, Kokkos::Experimental::element_aligned_tag());
+
+    host_check_equality(expected_result, dst_simd, nlanes);
+  }
+}
+
+template <typename Abi, typename DataType>
+inline void host_check_where_expr_gather_from() {
+  using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
+  using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
+  using mask_type  = typename simd_type::mask_type;
+
+  std::size_t nlanes = simd_type::size();
+  DataType src[]     = {11, 13, 17, 19, 23, 29, 31, 37};
+
+  for (std::size_t idx = 0; idx < nlanes; ++idx) {
+    mask_type mask(true);
+    mask[idx] = false;
+
+    simd_type dst;
+    index_type index;
+    simd_type expected_result;
+    for (std::size_t i = 0; i < nlanes; ++i) {
+      dst[i]             = (2 + (i * 2));
+      index[i]           = i;
+      expected_result[i] = (mask[i]) ? src[index[i]] : (2 + (i * 2));
+    }
+    where(mask, dst).gather_from(src, index);
+
+    host_check_equality(expected_result, dst, nlanes);
+  }
+}
+
+template <class Abi, typename DataType>
+inline void host_check_where_expr() {
+  host_check_where_expr_scatter_to<Abi, DataType>();
+  host_check_where_expr_gather_from<Abi, DataType>();
+}
+
+template <typename Abi, typename... DataTypes>
+inline void host_check_where_expr_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (host_check_where_expr<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+inline void host_check_where_expr_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (host_check_where_expr_all_types<Abis>(DataTypes()), ...);
+}
+
+template <typename Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
+  using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
+  using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
+  using mask_type  = typename simd_type::mask_type;
+
+  std::size_t nlanes = simd_type::size();
+  DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37};
+  simd_type src;
+  src.copy_from(init, Kokkos::Experimental::element_aligned_tag());
+
+  for (std::size_t idx = 0; idx < nlanes; ++idx) {
+    mask_type mask(true);
+    mask[idx] = false;
+
+    DataType dst[8] = {0};
+    index_type index;
+    simd_type expected_result;
+    for (std::size_t i = 0; i < nlanes; ++i) {
+      dst[i]             = (2 + (i * 2));
+      index[i]           = i;
+      expected_result[i] = (mask[i]) ? src[index[i]] : (2 + (i * 2));
+    }
+    where(mask, src).scatter_to(dst, index);
+
+    simd_type dst_simd;
+    dst_simd.copy_from(dst, Kokkos::Experimental::element_aligned_tag());
+
+    device_check_equality(expected_result, dst_simd, nlanes);
+  }
+}
+
+template <typename Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void device_check_where_expr_gather_from() {
+  using simd_type  = Kokkos::Experimental::simd<DataType, Abi>;
+  using index_type = Kokkos::Experimental::simd<std::int32_t, Abi>;
+  using mask_type  = typename simd_type::mask_type;
+
+  std::size_t nlanes = simd_type::size();
+  DataType src[]     = {11, 13, 17, 19, 23, 29, 31, 37};
+
+  for (std::size_t idx = 0; idx < nlanes; ++idx) {
+    mask_type mask(true);
+    mask[idx] = false;
+
+    simd_type dst;
+    index_type index;
+    simd_type expected_result;
+    for (std::size_t i = 0; i < nlanes; ++i) {
+      dst[i]             = (2 + (i * 2));
+      index[i]           = i;
+      expected_result[i] = (mask[i]) ? src[index[i]] : (2 + (i * 2));
+    }
+    where(mask, dst).gather_from(src, index);
+
+    device_check_equality(expected_result, dst, nlanes);
+  }
+}
+
+template <class Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void device_check_where_expr() {
+  device_check_where_expr_scatter_to<Abi, DataType>();
+  device_check_where_expr_gather_from<Abi, DataType>();
+}
+
+template <typename Abi, typename... DataTypes>
+KOKKOS_INLINE_FUNCTION void device_check_where_expr_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (device_check_where_expr<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+KOKKOS_INLINE_FUNCTION void device_check_where_expr_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (device_check_where_expr_all_types<Abis>(DataTypes()), ...);
+}
+
+class simd_device_where_expr_functor {
+ public:
+  KOKKOS_INLINE_FUNCTION void operator()(int) const {
+    device_check_where_expr_all_abis(
+        Kokkos::Experimental::Impl::device_abi_set());
+  }
+};
+
+TEST(simd, host_where_expressions) {
+  host_check_where_expr_all_abis(Kokkos::Experimental::Impl::host_abi_set());
+}
+
+TEST(simd, device_where_expressions) {
+  Kokkos::parallel_for(1, simd_device_where_expr_functor());
+}
+
+#endif

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -41,7 +41,7 @@ inline void host_check_where_expr_scatter_to() {
     for (std::size_t i = 0; i < nlanes; ++i) {
       dst[i]             = (2 + (i * 2));
       index[i]           = i;
-      expected_result[i] = (mask[i]) ? src[index[i]] : (2 + (i * 2));
+      expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
     }
     where(mask, src).scatter_to(dst, index);
 
@@ -71,7 +71,7 @@ inline void host_check_where_expr_gather_from() {
     for (std::size_t i = 0; i < nlanes; ++i) {
       dst[i]             = (2 + (i * 2));
       index[i]           = i;
-      expected_result[i] = (mask[i]) ? src[index[i]] : (2 + (i * 2));
+      expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
     }
     where(mask, dst).gather_from(src, index);
 
@@ -119,7 +119,7 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
     for (std::size_t i = 0; i < nlanes; ++i) {
       dst[i]             = (2 + (i * 2));
       index[i]           = i;
-      expected_result[i] = (mask[i]) ? src[index[i]] : (2 + (i * 2));
+      expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
     }
     where(mask, src).scatter_to(dst, index);
 
@@ -149,7 +149,7 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_gather_from() {
     for (std::size_t i = 0; i < nlanes; ++i) {
       dst[i]             = (2 + (i * 2));
       index[i]           = i;
-      expected_result[i] = (mask[i]) ? src[index[i]] : (2 + (i * 2));
+      expected_result[i] = (mask[i]) ? src[index[i]] : dst[i];
     }
     where(mask, dst).gather_from(src, index);
 


### PR DESCRIPTION
This PR adds missing `gather_from` and `scatter_to` functions:

- `void where_expression::gather_from(const double* mem, simd<std::int32_t, Abi> const& index)`
- `void const_where_expression::scatter_to(double* mem, simd<std::int32_t, Abi> const& index) const`

described in Kokkos documentation on SIMD [`when_expression`](https://kokkos.github.io/kokkos-core-wiki/API/simd/where_expression.html#).

Added for:

AVX2: `int32_t`, `int64_t` and `uint64_t`

AVX512: `int32_t`, `uint32_t`, `int64_t` and `uint64_t`

NEON: `int32_t`, `int64_t` and `uint64_t`