### PR TITLE
fix uninitialized variables when using dynamic libraries with `RTLD_DEEPBIND`

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -23,7 +23,7 @@ jobs:
         cxx_extra_flags: ['']
         cmake_build_type: ['Release', 'Debug']
         backend: ['OPENMP']
-        clang-tidy: ['']
+        cmake_extra_args: ['']
         include:
           - distro: 'fedora:intel'
             cxx: 'icpc'
@@ -49,11 +49,16 @@ jobs:
             cxx: 'clang++'
             cmake_build_type: 'RelWithDebInfo'
             backend: 'THREADS'
-            clang-tidy: '-DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"'
+            cmake_extra_args: '-DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*"'
           - distro: 'ubuntu:latest'
             cxx: 'g++'
             cmake_build_type: 'RelWithDebInfo'
             backend: 'THREADS'
+          - distro: 'ubuntu:latest'
+            cxx: 'clang++'
+            cmake_build_type: 'Debug'
+            backend: 'OPENMP'
+            cmake_extra_args: '-DBUILD_SHARED_LIBS=ON'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/kokkos/ci-containers/${{ matrix.distro }}
@@ -87,13 +92,13 @@ jobs:
         if: ${{ matrix.distro == 'ubuntu:latest' }}
         run: sudo apt-get update && sudo apt-get install -y libgtest-dev
       - name: maybe_install_clang_tidy
-        if: ${{ matrix.clang-tidy != '' }}
+        if: ${{ contains(matrix.cmake_extra_args, 'clang-tidy') }}
         run: sudo apt-get update && sudo apt-get install -y clang-tidy
       - name: Configure Kokkos
         run: |
           cmake -B builddir \
             -DCMAKE_INSTALL_PREFIX=/usr \
-            ${{ matrix.clang-tidy }} \
+            ${{ matrix.cmake_extra_args }} \
             -Ddesul_ROOT=/usr/desul-install/ \
             -DKokkos_ENABLE_DESUL_ATOMICS_EXTERNAL=ON \
             -DKokkos_ENABLE_HWLOC=ON \

--- a/.jenkins
+++ b/.jenkins
@@ -151,6 +151,7 @@ pipeline {
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
+                                -DBUILD_SHARED_LIBS=ON \
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER=hipcc \
                                 -DCMAKE_CXX_FLAGS="-Werror -Wno-unused-command-line-argument -DNDEBUG" \
@@ -301,6 +302,7 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''rm -rf build && mkdir -p build && cd build && \
                               cmake \
+                                -DBUILD_SHARED_LIBS=ON \
                                 -DCMAKE_BUILD_TYPE=Release \
                                 -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -1073,6 +1073,17 @@ KOKKOS_ADD_ADVANCED_TEST( CoreUnitTest_PushFinalizeHook_terminate
       tools/TestAllCalls.cpp
     )
 
+    if(BUILD_SHARED_LIBS)
+      add_library(RtldDeepbind_TestKernel SHARED TestKernel.cpp)
+      target_link_libraries(RtldDeepbind_TestKernel PUBLIC Kokkos::kokkos)
+
+      KOKKOS_ADD_EXECUTABLE_AND_TEST(
+        RtldDeepbind
+        SOURCES TestRtldDeepbind.cpp
+      )
+      add_dependencies(Kokkos_RtldDeepbind RtldDeepbind_TestKernel)
+    endif()
+
     KOKKOS_ADD_TEST_EXECUTABLE(
       ToolsInitialization
       UnitTestMain.cpp

--- a/core/unit_test/TestKernel.cpp
+++ b/core/unit_test/TestKernel.cpp
@@ -1,0 +1,33 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+extern "C" double time_step(size_t N, double dx, const Kokkos::View<double*>& u,
+                            const Kokkos::View<double*>& c) {
+  double dt_global = INFINITY;
+
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy<>(0, N),
+      KOKKOS_LAMBDA(const Kokkos::RangePolicy<>::index_type i, double& dt) {
+        double max_cx =
+            Kokkos::max(Kokkos::abs(u[i] + c[i]), Kokkos::abs(u[i] - c[i]));
+        dt = Kokkos::min(dt, dx / max_cx);
+      },
+      Kokkos::Min<double>(dt_global));
+
+  return dt_global;
+}

--- a/core/unit_test/TestRtldDeepbind.cpp
+++ b/core/unit_test/TestRtldDeepbind.cpp
@@ -1,0 +1,50 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+#include <dlfcn.h>
+#include <iostream>
+
+double time_step(size_t N, double dx, const Kokkos::View<double*>& u,
+                 const Kokkos::View<double*>& c);
+using time_step_fptr_t = decltype(time_step)*;
+
+int main(int argc, char** argv) {
+  Kokkos::initialize(argc, argv);
+  Kokkos::print_configuration(std::cout);
+
+  void* kernel_lib = dlopen("./libRtldDeepbind_TestKernel.so",
+                            RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+  if (kernel_lib == nullptr) {
+    std::cout << "Could not dlopen libRtldDeepbind_TestKernel.so.\n";
+    return 1;
+  }
+
+  auto time_step_fptr =
+      reinterpret_cast<time_step_fptr_t>(dlsym(kernel_lib, "time_step"));
+  if (time_step_fptr == nullptr) return 2;
+
+  {
+    size_t N  = 10;
+    double dx = 0.1;
+
+    Kokkos::View<double*> u("u", N), c("c", N);
+
+    time_step_fptr(N, dx, u, c);
+  }
+
+  Kokkos::finalize();
+}


### PR DESCRIPTION
fixes #6178 
fixes #6366 

This reverts #5442 and https://github.com/kokkos/kokkos/pull/5444 in order to fix issues with uninitialized static variables when using using dynamic libraries with `RTLD_DEEPBIND`.

The changes here affect Cuda and HIP backend.
In its current shape this might reintroduce the issue that #5442 was fixing - "the default stream was created before calling `cudaSetDevice`".

----
Added unit test (`Kokkos_RtldDeepbind`) reproduces the issue when building with `BUILD_SHARED_LIBS` enabled. Note that for Cuda it only reproduces when compiling with `clang`.

Details for Cuda are described in the original issue. HIP-ROCm error message:
```
15: terminate called after throwing an instance of 'std::runtime_error'
15:   what():  Kokkos::Impl::ParallelReduce< HIP > could not find a valid execution configuration.
15/42 Test #15: Kokkos_RtldDeepbind .........................Child aborted***Exception:   1.25 sec
```
[rocm-rtld-deepbind.log](https://github.com/kokkos/kokkos/files/11897795/rocm-rtld-deepbind.log)
