### PR TITLE
[HIP] Optimize parallel_reduce

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -322,7 +322,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
       //    2. Have each thread reduce > 1 value to minimize overheads
       //    3. Limit the total # of blocks, to avoid unbounded scratch space
       constexpr int block_max           = 4096;
-      constexpr int preferred_block_min = 256;
+      constexpr int preferred_block_min = 1024;
 
       if (nblocks < preferred_block_min) {
         // keep blocks as is, already have low parallelism

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -180,7 +180,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
     const integral_nonzero_constant<word_size_type,
                                     ReducerType::static_value_size() /
                                         sizeof(word_size_type)>
-        word_count(reducer.value_size() / sizeof(size_type));
+        word_count(reducer.value_size() / sizeof(word_size_type));
 
     {
       reference_type value = reducer.init(reinterpret_cast<pointer_type>(

--- a/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_Parallel_Range.hpp
@@ -134,8 +134,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   size_type* m_scratch_space = nullptr;
   size_type* m_scratch_flags = nullptr;
 
-  static bool constexpr UseShflReduction =
-      static_cast<bool>(ReducerType::static_value_size());
+  static bool constexpr UseShflReduction = false;
 
  private:
   struct ShflReductionTag {};

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -387,11 +387,11 @@ __device__ bool hip_single_inter_block_reduce_scan_impl(
   // Contributing blocks note that their contribution has been completed via an
   // atomic-increment flag If this block is not the last block to contribute to
   // this group then the block is done.
-  int n_done = 0;
+  int n_done               = 0;
   const bool is_last_block = !__syncthreads_or(
-     threadIdx.y
-         ? 0
-         : (1 + atomicInc(global_flags, block_count - 1) < block_count));
+      threadIdx.y
+          ? 0
+          : (1 + atomicInc(global_flags, block_count - 1) < block_count));
   if (is_last_block) {
     size_type const b = (static_cast<long long int>(block_count) *
                          static_cast<long long int>(threadIdx.y)) >>

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -387,7 +387,6 @@ __device__ bool hip_single_inter_block_reduce_scan_impl(
   // Contributing blocks note that their contribution has been completed via an
   // atomic-increment flag If this block is not the last block to contribute to
   // this group then the block is done.
-  int n_done               = 0;
   const bool is_last_block = !__syncthreads_or(
       threadIdx.y
           ? 0


### PR DESCRIPTION
Based on #6160, I spent a bit of time to understand the original regression introduced by #6029.

Essentially, the issue was most exacerbated when each thread was doing a reduction over a single element of the array (i.e., each thread loads two values, multiplies them, sums, and passes to the rest of the reduction).
This was mostly due to the cost of `hip_single_inter_block_reduce_scan`, namely due to runtime int divisions of (e.g.,) `blockDim.x` in `hip_inter_warp_shuffle_reduction` and friends.
After spending some time playing with various reduction algorithms, I discovered that the SHMEM reduction was faster in pretty much all cases, so I flipped the default from `UseShflReduction=true` to `false`.
In addition, I did a bit of cleanup to use `__syncthreads_or` (implemented since ROCm 4.5), which bumps perf a little more, and finally, I tweaked @Rombur's heuristic to have three ranges:

- "small" -> not a lot of parallelism, don't touch it.
- "intermediate" -> this is where we saw the largest regressions, there's not enough parallelism to hide some of the cost in reductions.  Here, we target trying to have four reduction items per-thread (~ what 4.0.01 did)
- "large" -> lots of parallelism (RHODO is here), so we leave it alone

I've plotted the performance (runtime, in seconds) for DOT products over various commits:

![image](https://github.com/kokkos/kokkos/assets/6463881/fac9ba90-760e-4fe7-bbbf-896e1a7e7f47)

- 4.0.01 -> the latest stable release
- dev -> the last commit before #6160 (43a797b59b17f9939178ab1f5e2df8c72099a33e)
- rombur (light) -> d78a24f72a4aeb439b19843b0c8b158f96c3a370, with the lightweighthint applied
- new reduce -> shmem reduction
- new reduce + new heur -> shmem reduction + the new heuristic

Generally we see the large perf regressions:

![image](https://github.com/kokkos/kokkos/assets/6463881/51752f43-f4e2-4ed3-96e5-41c056395418)

are solved, and the "new reduce + new heur" line is fasted _except_ one point where it's a bit slower:

![image](https://github.com/kokkos/kokkos/assets/6463881/8a81af3b-193b-4ef4-b22a-22245c2b77a0)

this (as you might guess from the above) happens right at the "4096 blocks" crossover point.  Perhaps we could tweak it a bit more, but generally this is a large improvement.

Finally, I compared LAMMPS perf over a # of benchmarks, and this maintains perf (to within the typical noise of 1%) as compared to @Rombur's patch:

```
+---------+-----------------------+--------------------+
|         | lammps-dev-baseline   | lammps-newreduce   |
|---------+-----------------------+--------------------|
| eam     | 0.00%                 | 0.75%              |
| lj      | 0.00%                 | -0.16%             |
| reaxff  | 0.00%                 | -0.80%             |
| rhodo   | 0.00%                 | -0.20%             |
| snap    | 0.00%                 | 0.07%              |
| tersoff | 0.00%                 | 0.04%              |
+---------+-----------------------+--------------------+
```


