### PR TITLE
make constraints on `Kokkos::sort` more visible/clear

### DIFF
--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -83,17 +83,15 @@ std::enable_if_t<
      HostSpace, typename Kokkos::View<DataType, Properties...>::memory_space
     >::accessible)
   >
+// clang-format on
 sort(const ExecutionSpace& exec,
-     const Kokkos::View<DataType, Properties...>& view)
-{
-  // clang-format on
-
-  // despite below we are using BinSort which could work on rank-2 views,
+     const Kokkos::View<DataType, Properties...>& view) {
+  // Although we are using BinSort below, which could work on rank-2 views,
   // for now view must be rank-1 because the Impl::min_max_functor
   // used below only works for rank-1 views
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   if (view.extent(0) == 0) {
     return;
@@ -172,12 +170,11 @@ std::enable_if_t<
      HostSpace, typename Kokkos::View<DataType, Properties...>::memory_space
     >::accessible)
   >
-sort(const ExecutionSpace&, const Kokkos::View<DataType, Properties...>& view)
-{
-  // clang-format on
+// clang-format on
+sort(const ExecutionSpace&, const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   if (view.extent(0) == 0) {
     return;
@@ -193,7 +190,7 @@ void sort(const Cuda& space,
           const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   if (view.extent(0) == 0) {
     return;
@@ -209,7 +206,7 @@ template <class DataType, class... Properties>
 void sort(const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   Kokkos::fence("Kokkos::sort: before");
 
@@ -234,7 +231,7 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
   // view must be rank-1 because the Impl::min_max_functor
   // used below only works for rank-1 views for now
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   if (view.extent(0) == 0) {
     return;
@@ -263,7 +260,7 @@ template <class ViewType>
 void sort(ViewType view, size_t const begin, size_t const end) {
   // same constraints as the overload above which this gets dispatched to
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   Kokkos::fence("Kokkos::sort: before");
 

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -263,7 +263,7 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
 
 template <class ViewType>
 void sort(ViewType view, size_t const begin, size_t const end) {
-  // same constraints as the overload above to which this gets dispatched to
+  // same constraints as the overload above which this gets dispatched to
   static_assert(
       (ViewType::rank == 1) &&
           (is_view_v<ViewType> || is_dynamic_view_v<ViewType>),

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -89,8 +89,9 @@ sort(const ExecutionSpace& exec,
 {
   // clang-format on
 
-  // view must be rank-1 because the Impl::min_max_functor
-  // used below only works for rank-1 views for now
+  // despite below we are using BinSort which could work on rank-2 views,
+  // for now view must be rank-1 because the Impl::min_max_functor
+  // used below only works for rank-1 views
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
                 "Kokkos::sort: currently supports rank-1 Views.");

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -21,7 +21,6 @@
 #include "Kokkos_BinOpsPublicAPI.hpp"
 #include "Kokkos_BinSortPublicAPI.hpp"
 #include <std_algorithms/Kokkos_BeginEnd.hpp>
-#include <Kokkos_DynamicView.hpp>  // needed for is_dynamic_view
 #include <Kokkos_Core.hpp>
 #include <algorithm>
 
@@ -233,10 +232,8 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
     size_t const end) {
   // view must be rank-1 because the Impl::min_max_functor
   // used below only works for rank-1 views for now
-  static_assert(
-      (ViewType::rank == 1) &&
-          (is_view_v<ViewType> || is_dynamic_view_v<ViewType>),
-      "Kokkos::sort: currently supports rank-1 regular or dynamic Views.");
+  static_assert(ViewType::rank == 1,
+                "Kokkos::sort: currently supports rank-1 Views.");
 
   if (view.extent(0) == 0) {
     return;
@@ -264,10 +261,8 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
 template <class ViewType>
 void sort(ViewType view, size_t const begin, size_t const end) {
   // same constraints as the overload above which this gets dispatched to
-  static_assert(
-      (ViewType::rank == 1) &&
-          (is_view_v<ViewType> || is_dynamic_view_v<ViewType>),
-      "Kokkos::sort: currently supports rank-1 regular or dynamic Views.");
+  static_assert(ViewType::rank == 1,
+                "Kokkos::sort: currently supports rank-1 Views.");
 
   Kokkos::fence("Kokkos::sort: before");
 

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -21,7 +21,7 @@
 #include "Kokkos_BinOpsPublicAPI.hpp"
 #include "Kokkos_BinSortPublicAPI.hpp"
 #include <std_algorithms/Kokkos_BeginEnd.hpp>
-#include <Kokkos_DynamicView.hpp>
+#include <Kokkos_DynamicView.hpp>  // needed for is_dynamic_view
 #include <Kokkos_Core.hpp>
 #include <algorithm>
 

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -199,7 +199,7 @@ void sort(const Cuda& space,
           const Kokkos::View<DataType, Properties...>& view)
 {
   // clang-format on
-
+  using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
                 "Kokkos::sort: currently supports rank-1 Views.");
 

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -136,14 +136,10 @@ sort(const ExecutionSpace& exec,
   bin_sort.sort(exec, view);
 }
 
-// clang-format off
 #if defined(KOKKOS_ENABLE_ONEDPL)
 template <class DataType, class... Properties>
 void sort(const Experimental::SYCL& space,
-          const Kokkos::View<DataType, Properties...>& view)
-{
-  // clang-format on
-
+          const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(SpaceAccessibility<Experimental::SYCL,
                                    typename ViewType::memory_space>::accessible,
@@ -192,13 +188,10 @@ sort(const ExecutionSpace&, const Kokkos::View<DataType, Properties...>& view)
   std::sort(first, last);
 }
 
-// clang-format off
 #if defined(KOKKOS_ENABLE_CUDA)
 template <class DataType, class... Properties>
 void sort(const Cuda& space,
-          const Kokkos::View<DataType, Properties...>& view)
-{
-  // clang-format on
+          const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
                 "Kokkos::sort: currently supports rank-1 Views.");
@@ -234,16 +227,10 @@ void sort(ViewType const& view) {
 // specified via integers begin, end
 // ---------------------------------------------------------------
 
-// clang-format off
 template <class ExecutionSpace, class ViewType>
-std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value>
-sort(const ExecutionSpace& exec,
-     ViewType view,
-     size_t const begin,
-     size_t const end)
-{
-  // clang-format on
-
+std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
+    const ExecutionSpace& exec, ViewType view, size_t const begin,
+    size_t const end) {
   // view must be rank-1 because the Impl::min_max_functor
   // used below only works for rank-1 views for now
   static_assert(
@@ -274,13 +261,13 @@ sort(const ExecutionSpace& exec,
   bin_sort.sort(exec, view, begin, end);
 }
 
-// clang-format off
 template <class ViewType>
-void sort(ViewType view,
-	  size_t const begin,
-	  size_t const end)
-{
-  // clang-format on
+void sort(ViewType view, size_t const begin, size_t const end) {
+  // same constraints as the overload above to which this gets dispatched to
+  static_assert(
+      (ViewType::rank == 1) &&
+          (is_view_v<ViewType> || is_dynamic_view_v<ViewType>),
+      "Kokkos::sort: currently supports rank-1 regular or dynamic Views.");
 
   Kokkos::fence("Kokkos::sort: before");
 

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -205,8 +205,9 @@ void sort(const Cuda& space,
 }
 #endif
 
-template <class ViewType>
-void sort(ViewType const& view) {
+template <class DataType, class... Properties>
+void sort(const Kokkos::View<DataType, Properties...>& view) {
+  using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
                 "Kokkos::sort: currently supports rank-1 Views.");
 


### PR DESCRIPTION
Some of the constraints on the sort functions were a bit hidden: for example some overloads accept a dynamic view, while some others don't. This PR clarifies directly at the API level what the constraints are on the current sort API, thus making it clearly visible right away (aka one does not have to dig a few layers to figure out what is allowed)

Minor: clang format is turned off so that the the public API is more readable (IMMO)