### PR TITLE
#5635: CUDA: Add Overloads for parallel_scan with return value for ThreadVectorRange

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -782,7 +782,7 @@ parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
         // exclusive scan -- the final accumulation
         // of i's val will be included in the second
         // closure call later.
-        if (i < loop_boundaries.end && threadIdx.x > 0) {
+        if (i - 1 < loop_boundaries.end && threadIdx.x > 0) {
           closure(i - 1, val, false);
         }
 

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -815,6 +815,7 @@ parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
       }
 
       ))
+  reducer.reference() = accum;
 }
 
 //----------------------------------------------------------------------------

--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -814,8 +814,9 @@ parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
         Impl::in_place_shfl(accum, val, mask, blockDim.x, active_mask);
       }
 
+      reducer.reference() = accum;
+
       ))
-  reducer.reference() = accum;
 }
 
 //----------------------------------------------------------------------------

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -607,11 +607,9 @@ struct functor_vec_scan {
 
 // Temporary: This condition will progressively be reduced when parallel_scan
 // with return value will be implemented for more backends.
-#if defined(KOKKOS_ENABLE_SERIAL) || defined(KOKKOS_ENABLE_OPENMP)
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) &&             \
-    !defined(KOKKOS_ENABLE_OPENACC) && !defined(KOKKOS_ENABLE_SYCL) &&         \
-    !defined(KOKKOS_ENABLE_THREADS) && !defined(KOKKOS_ENABLE_OPENMPTARGET) && \
-    !defined(KOKKOS_ENABLE_HPX)
+#if !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_OPENACC) &&  \
+    !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_THREADS) && \
+    !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ENABLE_HPX)
 template <typename Scalar, class ExecutionSpace>
 struct functor_vec_scan_ret_val {
   using policy_type     = Kokkos::TeamPolicy<ExecutionSpace>;
@@ -666,7 +664,6 @@ struct functor_vec_scan_ret_val {
     }
   }
 };
-#endif
 #endif
 
 template <typename Scalar, class ExecutionSpace>
@@ -741,19 +738,15 @@ bool test_scalar(int nteams, int team_size, int test) {
         "B", Kokkos::TeamPolicy<ExecutionSpace>(nteams, team_size, 8),
         functor_vec_single<Scalar, ExecutionSpace>(d_flag, 4, 13));
   } else if (test == 12) {
-// Temporary: This condition will progressively be reduced when
-// parallel_scan
+// Temporary: This condition will progressively be reduced when parallel_scan
 // with return value will be implemented for more backends.
-#if defined(KOKKOS_ENABLE_SERIAL) || defined(KOKKOS_ENABLE_OPENMP)
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) &&             \
-    !defined(KOKKOS_ENABLE_OPENACC) && !defined(KOKKOS_ENABLE_SYCL) &&         \
-    !defined(KOKKOS_ENABLE_THREADS) && !defined(KOKKOS_ENABLE_OPENMPTARGET) && \
-    !defined(KOKKOS_ENABLE_HPX)
+#if !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_OPENACC) &&  \
+    !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_THREADS) && \
+    !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ENABLE_HPX)
     Kokkos::parallel_for(
         Kokkos::TeamPolicy<ExecutionSpace>(nteams, team_size, 8),
         functor_vec_scan_ret_val<Scalar, ExecutionSpace>(d_flag, nteams,
                                                          team_size));
-#endif
 #endif
   }
 

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -614,31 +614,26 @@ template <typename Scalar, class ExecutionSpace>
 struct functor_vec_scan_ret_val {
   using policy_type     = Kokkos::TeamPolicy<ExecutionSpace>;
   using execution_space = ExecutionSpace;
-  using view_type       = Kokkos::View<Scalar **, execution_space>;
 
   Kokkos::View<int, ExecutionSpace> flag;
-  view_type return_values;
   int team_size;
 
-  functor_vec_scan_ret_val(Kokkos::View<int, ExecutionSpace> flag_, int nteams,
-                           int tsize)
-      : flag(flag_), team_size(tsize) {
-    return_values = view_type("return_values", nteams, tsize);
-  }
+  functor_vec_scan_ret_val(Kokkos::View<int, ExecutionSpace> flag_, int tsize)
+      : flag(flag_), team_size(tsize) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(typename policy_type::member_type team) const {
     Scalar return_val;
+    int upper_bound = 13;
 
     Kokkos::parallel_scan(
-        Kokkos::ThreadVectorRange(team, 13),
+        Kokkos::ThreadVectorRange(team, upper_bound),
         [&](int i, Scalar &val, bool final) {
           val += i;
 
           if (final) {
             Scalar test = 0;
             for (int k = 0; k <= i; k++) test += k;
-            return_values(team.league_rank(), team.team_rank()) = test;
 
             if (test != val) {
               Kokkos::printf("FAILED vector_par_scan %i %i %lf %lf\n",
@@ -652,13 +647,14 @@ struct functor_vec_scan_ret_val {
         },
         return_val);
 
-    if (flag() == 0 &&
-        return_values(team.league_rank(), team.team_rank()) != return_val) {
-      Kokkos::printf("FAILED vector_scan_ret_val %i %i %lf %lf\n",
-                     team.league_rank(), team.team_rank(),
-                     static_cast<double>(
-                         return_values(team.league_rank(), team.team_rank())),
-                     static_cast<double>(return_val));
+    Scalar sum_ref = ((upper_bound - 1) * (upper_bound)) / 2;
+
+    if (flag() == 0 && return_val != sum_ref) {
+      Kokkos::printf(
+          "FAILED vector_scan_ret_val: league_rank %i, team_rank %i, sum_ref "
+          "%lf, return_val %lf\n",
+          team.league_rank(), team.team_rank(), static_cast<double>(sum_ref),
+          static_cast<double>(return_val));
 
       flag() = 1;
     }
@@ -745,8 +741,7 @@ bool test_scalar(int nteams, int team_size, int test) {
     !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ENABLE_HPX)
     Kokkos::parallel_for(
         Kokkos::TeamPolicy<ExecutionSpace>(nteams, team_size, 8),
-        functor_vec_scan_ret_val<Scalar, ExecutionSpace>(d_flag, nteams,
-                                                         team_size));
+        functor_vec_scan_ret_val<Scalar, ExecutionSpace>(d_flag, team_size));
 #endif
   }
 


### PR DESCRIPTION
Related to #5635 #6453
~Depends on https://github.com/kokkos/kokkos/pull/6292~ (merged)

---

Edit: this now also contains a fix for Cuda parallel_scan ThreadVectorRange range (4a819b6b799b07e818727d49650571a02d87d5d1).