### PR TITLE
Potential data race in Cuda parallel reduce

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -315,7 +315,7 @@ struct CudaReductionsFunctor<FunctorType, false, false> {
     __syncwarp(mask);
 
     for (int delta = skip_vector ? blockDim.x : 1; delta < width; delta *= 2) {
-      if (lane_id + delta < 32) {
+      if ((lane_id + delta < 32) && (lane_id % (delta * 2) == 0)) {
         functor.join(value, value + delta);
       }
       __syncwarp(mask);


### PR DESCRIPTION
See comment https://github.com/kokkos/kokkos/issues/6217#issuecomment-1603420863. Suggested in https://github.com/kokkos/kokkos/pull/4855#discussion_r822238516 as being a potential issue, I think this is an actual issue. At the very least we avoid doing computation that is unnecessary, and it clears a warning when running `compute-sanitizer --tool=racecheck` (see https://github.com/kokkos/kokkos/issues/6217).