### PR TITLE
`sort`: move code from basic overloads API to impl

### DIFF
--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -83,17 +83,15 @@ std::enable_if_t<
      HostSpace, typename Kokkos::View<DataType, Properties...>::memory_space
     >::accessible)
   >
+// clang-format on
 sort(const ExecutionSpace& exec,
-     const Kokkos::View<DataType, Properties...>& view)
-{
-  // clang-format on
-
-  // despite below we are using BinSort which could work on rank-2 views,
+     const Kokkos::View<DataType, Properties...>& view) {
+  // Although we are using BinSort below, which could work on rank-2 views,
   // for now view must be rank-1 because the Impl::min_max_functor
   // used below only works for rank-1 views
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   if (view.extent(0) == 0) {
     return;
@@ -172,12 +170,11 @@ std::enable_if_t<
      HostSpace, typename Kokkos::View<DataType, Properties...>::memory_space
     >::accessible)
   >
-sort(const ExecutionSpace&, const Kokkos::View<DataType, Properties...>& view)
-{
-  // clang-format on
+// clang-format on
+sort(const ExecutionSpace&, const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   if (view.extent(0) == 0) {
     return;
@@ -193,7 +190,7 @@ void sort(const Cuda& space,
           const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   if (view.extent(0) == 0) {
     return;
@@ -209,7 +206,7 @@ template <class DataType, class... Properties>
 void sort(const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   Kokkos::fence("Kokkos::sort: before");
 
@@ -234,7 +231,7 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
   // view must be rank-1 because the Impl::min_max_functor
   // used below only works for rank-1 views for now
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   if (view.extent(0) == 0) {
     return;
@@ -263,7 +260,7 @@ template <class ViewType>
 void sort(ViewType view, size_t const begin, size_t const end) {
   // same constraints as the overload above which this gets dispatched to
   static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently supports rank-1 Views.");
+                "Kokkos::sort: currently only supports rank-1 Views.");
 
   Kokkos::fence("Kokkos::sort: before");
 

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -263,7 +263,7 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
 
 template <class ViewType>
 void sort(ViewType view, size_t const begin, size_t const end) {
-  // same constraints as the overload above to which this gets dispatched to
+  // same constraints as the overload above which this gets dispatched to
   static_assert(
       (ViewType::rank == 1) &&
           (is_view_v<ViewType> || is_dynamic_view_v<ViewType>),

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -89,8 +89,9 @@ sort(const ExecutionSpace& exec,
 {
   // clang-format on
 
-  // view must be rank-1 because the Impl::min_max_functor
-  // used below only works for rank-1 views for now
+  // despite below we are using BinSort which could work on rank-2 views,
+  // for now view must be rank-1 because the Impl::min_max_functor
+  // used below only works for rank-1 views
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
                 "Kokkos::sort: currently supports rank-1 Views.");

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -21,7 +21,6 @@
 #include "Kokkos_BinOpsPublicAPI.hpp"
 #include "Kokkos_BinSortPublicAPI.hpp"
 #include <std_algorithms/Kokkos_BeginEnd.hpp>
-#include <Kokkos_DynamicView.hpp>  // needed for is_dynamic_view
 #include <Kokkos_Core.hpp>
 #include <algorithm>
 
@@ -233,10 +232,8 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
     size_t const end) {
   // view must be rank-1 because the Impl::min_max_functor
   // used below only works for rank-1 views for now
-  static_assert(
-      (ViewType::rank == 1) &&
-          (is_view_v<ViewType> || is_dynamic_view_v<ViewType>),
-      "Kokkos::sort: currently supports rank-1 regular or dynamic Views.");
+  static_assert(ViewType::rank == 1,
+                "Kokkos::sort: currently supports rank-1 Views.");
 
   if (view.extent(0) == 0) {
     return;
@@ -264,10 +261,8 @@ std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
 template <class ViewType>
 void sort(ViewType view, size_t const begin, size_t const end) {
   // same constraints as the overload above which this gets dispatched to
-  static_assert(
-      (ViewType::rank == 1) &&
-          (is_view_v<ViewType> || is_dynamic_view_v<ViewType>),
-      "Kokkos::sort: currently supports rank-1 regular or dynamic Views.");
+  static_assert(ViewType::rank == 1,
+                "Kokkos::sort: currently supports rank-1 Views.");
 
   Kokkos::fence("Kokkos::sort: before");
 

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -21,7 +21,7 @@
 #include "Kokkos_BinOpsPublicAPI.hpp"
 #include "Kokkos_BinSortPublicAPI.hpp"
 #include <std_algorithms/Kokkos_BeginEnd.hpp>
-#include <Kokkos_DynamicView.hpp>
+#include <Kokkos_DynamicView.hpp>  // needed for is_dynamic_view
 #include <Kokkos_Core.hpp>
 #include <algorithm>
 

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -18,56 +18,9 @@
 #define KOKKOS_SORT_PUBLIC_API_HPP_
 
 #include "./impl/Kokkos_SortImpl.hpp"
-#include "Kokkos_BinOpsPublicAPI.hpp"
-#include "Kokkos_BinSortPublicAPI.hpp"
 #include <std_algorithms/Kokkos_BeginEnd.hpp>
 #include <Kokkos_Core.hpp>
 #include <algorithm>
-
-#if defined(KOKKOS_ENABLE_CUDA)
-
-// Workaround for `Instruction 'shfl' without '.sync' is not supported on
-// .target sm_70 and higher from PTX ISA version 6.4`.
-// Also see https://github.com/NVIDIA/cub/pull/170.
-#if !defined(CUB_USE_COOPERATIVE_GROUPS)
-#define CUB_USE_COOPERATIVE_GROUPS
-#endif
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
-
-#if defined(KOKKOS_COMPILER_CLANG)
-// Some versions of Clang fail to compile Thrust, failing with errors like
-// this:
-//    <snip>/thrust/system/cuda/detail/core/agent_launcher.h:557:11:
-//    error: use of undeclared identifier 'va_printf'
-// The exact combination of versions for Clang and Thrust (or CUDA) for this
-// failure was not investigated, however even very recent version combination
-// (Clang 10.0.0 and Cuda 10.0) demonstrated failure.
-//
-// Defining _CubLog here locally allows us to avoid that code path, however
-// disabling some debugging diagnostics
-#pragma push_macro("_CubLog")
-#ifdef _CubLog
-#undef _CubLog
-#endif
-#define _CubLog
-#include <thrust/device_ptr.h>
-#include <thrust/sort.h>
-#pragma pop_macro("_CubLog")
-#else
-#include <thrust/device_ptr.h>
-#include <thrust/sort.h>
-#endif
-
-#pragma GCC diagnostic pop
-
-#endif
-
-#if defined(KOKKOS_ENABLE_ONEDPL)
-#include <oneapi/dpl/execution>
-#include <oneapi/dpl/algorithm>
-#endif
 
 namespace Kokkos {
 
@@ -75,132 +28,31 @@ namespace Kokkos {
 // basic overloads
 // ---------------------------------------------------------------
 
-// clang-format off
 template <class ExecutionSpace, class DataType, class... Properties>
-std::enable_if_t<
-  (Kokkos::is_execution_space<ExecutionSpace>::value) &&
-  (!SpaceAccessibility<
-     HostSpace, typename Kokkos::View<DataType, Properties...>::memory_space
-    >::accessible)
-  >
-// clang-format on
-sort(const ExecutionSpace& exec,
-     const Kokkos::View<DataType, Properties...>& view) {
-  // Although we are using BinSort below, which could work on rank-2 views,
-  // for now view must be rank-1 because the Impl::min_max_functor
-  // used below only works for rank-1 views
-  using ViewType = Kokkos::View<DataType, Properties...>;
-  static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently only supports rank-1 Views.");
-
-  if (view.extent(0) == 0) {
-    return;
-  }
-
-  Kokkos::MinMaxScalar<typename ViewType::non_const_value_type> result;
-  Kokkos::MinMax<typename ViewType::non_const_value_type> reducer(result);
-  parallel_reduce("Kokkos::Sort::FindExtent",
-                  Kokkos::RangePolicy<typename ViewType::execution_space>(
-                      exec, 0, view.extent(0)),
-                  Impl::min_max_functor<ViewType>(view), reducer);
-  if (result.min_val == result.max_val) return;
-  // For integral types the number of bins may be larger than the range
-  // in which case we can exactly have one unique value per bin
-  // and then don't need to sort bins.
-  bool sort_in_bins = true;
-  // TODO: figure out better max_bins then this ...
-  int64_t max_bins = view.extent(0) / 2;
-  if (std::is_integral<typename ViewType::non_const_value_type>::value) {
-    // Cast to double to avoid possible overflow when using integer
-    auto const max_val = static_cast<double>(result.max_val);
-    auto const min_val = static_cast<double>(result.min_val);
-    // using 10M as the cutoff for special behavior (roughly 40MB for the count
-    // array)
-    if ((max_val - min_val) < 10000000) {
-      max_bins     = max_val - min_val + 1;
-      sort_in_bins = false;
-    }
-  }
-  if (std::is_floating_point<typename ViewType::non_const_value_type>::value) {
-    KOKKOS_ASSERT(std::isfinite(static_cast<double>(result.max_val) -
-                                static_cast<double>(result.min_val)));
-  }
-
-  using CompType = BinOp1D<ViewType>;
-  BinSort<ViewType, CompType> bin_sort(
-      view, CompType(max_bins, result.min_val, result.max_val), sort_in_bins);
-  bin_sort.create_permute_vector(exec);
-  bin_sort.sort(exec, view);
-}
-
-#if defined(KOKKOS_ENABLE_ONEDPL)
-template <class DataType, class... Properties>
-void sort(const Experimental::SYCL& space,
+void sort([[maybe_unused]] const ExecutionSpace& exec,
           const Kokkos::View<DataType, Properties...>& view) {
+  // constraints
   using ViewType = Kokkos::View<DataType, Properties...>;
-  static_assert(SpaceAccessibility<Experimental::SYCL,
-                                   typename ViewType::memory_space>::accessible,
-                "SYCL execution space is not able to access the memory space "
-                "of the View argument!");
-
-  // Can't use Experimental::begin/end here since the oneDPL then assumes that
-  // the data is on the host.
-  static_assert(
-      ViewType::rank == 1 &&
-          (std::is_same<typename ViewType::array_layout, LayoutRight>::value ||
-           std::is_same<typename ViewType::array_layout, LayoutLeft>::value),
-      "SYCL sort only supports contiguous rank-1 Views.");
-
-  if (view.extent(0) == 0) {
-    return;
-  }
-
-  auto queue  = space.sycl_queue();
-  auto policy = oneapi::dpl::execution::make_device_policy(queue);
-  const int n = view.extent(0);
-  oneapi::dpl::sort(policy, view.data(), view.data() + n);
-}
-#endif
-
-// clang-format off
-template <class ExecutionSpace, class DataType, class... Properties>
-std::enable_if_t<
-  (Kokkos::is_execution_space<ExecutionSpace>::value) &&
-  (SpaceAccessibility<
-     HostSpace, typename Kokkos::View<DataType, Properties...>::memory_space
-    >::accessible)
-  >
-// clang-format on
-sort(const ExecutionSpace&, const Kokkos::View<DataType, Properties...>& view) {
-  using ViewType = Kokkos::View<DataType, Properties...>;
+  using MemSpace = typename ViewType::memory_space;
   static_assert(ViewType::rank == 1,
                 "Kokkos::sort: currently only supports rank-1 Views.");
+  static_assert(SpaceAccessibility<ExecutionSpace, MemSpace>::accessible,
+                "Kokkos::sort: execution space instance is not able to access "
+                "the memory space of the "
+                "View argument!");
 
-  if (view.extent(0) == 0) {
+  if (view.extent(0) <= 1) {
     return;
   }
-  auto first = Experimental::begin(view);
-  auto last  = Experimental::end(view);
-  std::sort(first, last);
-}
 
-#if defined(KOKKOS_ENABLE_CUDA)
-template <class DataType, class... Properties>
-void sort(const Cuda& space,
-          const Kokkos::View<DataType, Properties...>& view) {
-  using ViewType = Kokkos::View<DataType, Properties...>;
-  static_assert(ViewType::rank == 1,
-                "Kokkos::sort: currently only supports rank-1 Views.");
-
-  if (view.extent(0) == 0) {
-    return;
+  if constexpr (SpaceAccessibility<HostSpace, MemSpace>::accessible) {
+    auto first = ::Kokkos::Experimental::begin(view);
+    auto last  = ::Kokkos::Experimental::end(view);
+    std::sort(first, last);
+  } else {
+    Impl::sort_device_view_without_comparator(exec, view);
   }
-  const auto exec = thrust::cuda::par.on(space.cuda_stream());
-  auto first      = Experimental::begin(view);
-  auto last       = Experimental::end(view);
-  thrust::sort(exec, first, last);
 }
-#endif
 
 template <class DataType, class... Properties>
 void sort(const Kokkos::View<DataType, Properties...>& view) {

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -199,7 +199,7 @@ void sort(const Cuda& space,
           const Kokkos::View<DataType, Properties...>& view)
 {
   // clang-format on
-
+  using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
                 "Kokkos::sort: currently supports rank-1 Views.");
 

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -136,14 +136,10 @@ sort(const ExecutionSpace& exec,
   bin_sort.sort(exec, view);
 }
 
-// clang-format off
 #if defined(KOKKOS_ENABLE_ONEDPL)
 template <class DataType, class... Properties>
 void sort(const Experimental::SYCL& space,
-          const Kokkos::View<DataType, Properties...>& view)
-{
-  // clang-format on
-
+          const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(SpaceAccessibility<Experimental::SYCL,
                                    typename ViewType::memory_space>::accessible,
@@ -192,13 +188,10 @@ sort(const ExecutionSpace&, const Kokkos::View<DataType, Properties...>& view)
   std::sort(first, last);
 }
 
-// clang-format off
 #if defined(KOKKOS_ENABLE_CUDA)
 template <class DataType, class... Properties>
 void sort(const Cuda& space,
-          const Kokkos::View<DataType, Properties...>& view)
-{
-  // clang-format on
+          const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
                 "Kokkos::sort: currently supports rank-1 Views.");
@@ -234,16 +227,10 @@ void sort(ViewType const& view) {
 // specified via integers begin, end
 // ---------------------------------------------------------------
 
-// clang-format off
 template <class ExecutionSpace, class ViewType>
-std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value>
-sort(const ExecutionSpace& exec,
-     ViewType view,
-     size_t const begin,
-     size_t const end)
-{
-  // clang-format on
-
+std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value> sort(
+    const ExecutionSpace& exec, ViewType view, size_t const begin,
+    size_t const end) {
   // view must be rank-1 because the Impl::min_max_functor
   // used below only works for rank-1 views for now
   static_assert(
@@ -274,13 +261,13 @@ sort(const ExecutionSpace& exec,
   bin_sort.sort(exec, view, begin, end);
 }
 
-// clang-format off
 template <class ViewType>
-void sort(ViewType view,
-	  size_t const begin,
-	  size_t const end)
-{
-  // clang-format on
+void sort(ViewType view, size_t const begin, size_t const end) {
+  // same constraints as the overload above to which this gets dispatched to
+  static_assert(
+      (ViewType::rank == 1) &&
+          (is_view_v<ViewType> || is_dynamic_view_v<ViewType>),
+      "Kokkos::sort: currently supports rank-1 regular or dynamic Views.");
 
   Kokkos::fence("Kokkos::sort: before");
 

--- a/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortPublicAPI.hpp
@@ -205,8 +205,9 @@ void sort(const Cuda& space,
 }
 #endif
 
-template <class ViewType>
-void sort(ViewType const& view) {
+template <class DataType, class... Properties>
+void sort(const Kokkos::View<DataType, Properties...>& view) {
+  using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(ViewType::rank == 1,
                 "Kokkos::sort: currently supports rank-1 Views.");
 

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -155,7 +155,7 @@ void sort_cudathrust(const Cuda& space,
 
 #if defined(KOKKOS_ENABLE_ONEDPL)
 template <class DataType, class... Properties>
-void sort_odedpl(const Experimental::SYCL& space,
+void sort_onedpl(const Experimental::SYCL& space,
                  const Kokkos::View<DataType, Properties...>& view) {
   using ViewType = Kokkos::View<DataType, Properties...>;
   static_assert(SpaceAccessibility<Experimental::SYCL,

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -17,7 +17,56 @@
 #ifndef KOKKOS_SORT_FREE_FUNCS_IMPL_HPP_
 #define KOKKOS_SORT_FREE_FUNCS_IMPL_HPP_
 
+#include "../Kokkos_BinOpsPublicAPI.hpp"
+#include "../Kokkos_BinSortPublicAPI.hpp"
+#include <std_algorithms/Kokkos_BeginEnd.hpp>
+#include <std_algorithms/Kokkos_Copy.hpp>
 #include <Kokkos_Core.hpp>
+
+#if defined(KOKKOS_ENABLE_CUDA)
+
+// Workaround for `Instruction 'shfl' without '.sync' is not supported on
+// .target sm_70 and higher from PTX ISA version 6.4`.
+// Also see https://github.com/NVIDIA/cub/pull/170.
+#if !defined(CUB_USE_COOPERATIVE_GROUPS)
+#define CUB_USE_COOPERATIVE_GROUPS
+#endif
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+
+#if defined(KOKKOS_COMPILER_CLANG)
+// Some versions of Clang fail to compile Thrust, failing with errors like
+// this:
+//    <snip>/thrust/system/cuda/detail/core/agent_launcher.h:557:11:
+//    error: use of undeclared identifier 'va_printf'
+// The exact combination of versions for Clang and Thrust (or CUDA) for this
+// failure was not investigated, however even very recent version combination
+// (Clang 10.0.0 and Cuda 10.0) demonstrated failure.
+//
+// Defining _CubLog here locally allows us to avoid that code path, however
+// disabling some debugging diagnostics
+#pragma push_macro("_CubLog")
+#ifdef _CubLog
+#undef _CubLog
+#endif
+#define _CubLog
+#include <thrust/device_ptr.h>
+#include <thrust/sort.h>
+#pragma pop_macro("_CubLog")
+#else
+#include <thrust/device_ptr.h>
+#include <thrust/sort.h>
+#endif
+
+#pragma GCC diagnostic pop
+
+#endif
+
+#if defined(KOKKOS_ENABLE_ONEDPL)
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/algorithm>
+#endif
 
 namespace Kokkos {
 namespace Impl {
@@ -36,6 +85,135 @@ struct min_max_functor {
     if (view(i) > minmax.max_val) minmax.max_val = view(i);
   }
 };
+
+template <class ExecutionSpace, class DataType, class... Properties>
+void sort_via_binsort(const ExecutionSpace& exec,
+                      const Kokkos::View<DataType, Properties...>& view) {
+  // Although we are using BinSort below, which could work on rank-2 views,
+  // for now view must be rank-1 because the min_max_functor
+  // used below only works for rank-1 views
+  using ViewType = Kokkos::View<DataType, Properties...>;
+  static_assert(ViewType::rank == 1,
+                "Kokkos::sort: currently only supports rank-1 Views.");
+
+  if (view.extent(0) == 0) {
+    return;
+  }
+
+  Kokkos::MinMaxScalar<typename ViewType::non_const_value_type> result;
+  Kokkos::MinMax<typename ViewType::non_const_value_type> reducer(result);
+  parallel_reduce("Kokkos::Sort::FindExtent",
+                  Kokkos::RangePolicy<typename ViewType::execution_space>(
+                      exec, 0, view.extent(0)),
+                  min_max_functor<ViewType>(view), reducer);
+  if (result.min_val == result.max_val) return;
+  // For integral types the number of bins may be larger than the range
+  // in which case we can exactly have one unique value per bin
+  // and then don't need to sort bins.
+  bool sort_in_bins = true;
+  // TODO: figure out better max_bins then this ...
+  int64_t max_bins = view.extent(0) / 2;
+  if (std::is_integral<typename ViewType::non_const_value_type>::value) {
+    // Cast to double to avoid possible overflow when using integer
+    auto const max_val = static_cast<double>(result.max_val);
+    auto const min_val = static_cast<double>(result.min_val);
+    // using 10M as the cutoff for special behavior (roughly 40MB for the count
+    // array)
+    if ((max_val - min_val) < 10000000) {
+      max_bins     = max_val - min_val + 1;
+      sort_in_bins = false;
+    }
+  }
+  if (std::is_floating_point<typename ViewType::non_const_value_type>::value) {
+    KOKKOS_ASSERT(std::isfinite(static_cast<double>(result.max_val) -
+                                static_cast<double>(result.min_val)));
+  }
+
+  using CompType = BinOp1D<ViewType>;
+  BinSort<ViewType, CompType> bin_sort(
+      view, CompType(max_bins, result.min_val, result.max_val), sort_in_bins);
+  bin_sort.create_permute_vector(exec);
+  bin_sort.sort(exec, view);
+}
+
+#if defined(KOKKOS_ENABLE_CUDA)
+template <class DataType, class... Properties>
+void sort_cudathrust(const Cuda& space,
+                     const Kokkos::View<DataType, Properties...>& view) {
+  using ViewType = Kokkos::View<DataType, Properties...>;
+  static_assert(ViewType::rank == 1,
+                "Kokkos::sort: currently only supports rank-1 Views.");
+
+  if (view.extent(0) == 0) {
+    return;
+  }
+  const auto exec = thrust::cuda::par.on(space.cuda_stream());
+  auto first      = Experimental::begin(view);
+  auto last       = Experimental::end(view);
+  thrust::sort(exec, first, last);
+}
+#endif
+
+#if defined(KOKKOS_ENABLE_ONEDPL)
+template <class DataType, class... Properties>
+void sort_odedpl(const Experimental::SYCL& space,
+                 const Kokkos::View<DataType, Properties...>& view) {
+  using ViewType = Kokkos::View<DataType, Properties...>;
+  static_assert(SpaceAccessibility<Experimental::SYCL,
+                                   typename ViewType::memory_space>::accessible,
+                "SYCL execution space is not able to access the memory space "
+                "of the View argument!");
+
+  // Can't use Experimental::begin/end here since the oneDPL then assumes that
+  // the data is on the host.
+  static_assert(
+      ViewType::rank == 1 &&
+          (std::is_same<typename ViewType::array_layout, LayoutRight>::value ||
+           std::is_same<typename ViewType::array_layout, LayoutLeft>::value),
+      "SYCL sort only supports contiguous rank-1 Views.");
+
+  if (view.extent(0) == 0) {
+    return;
+  }
+
+  auto queue  = space.sycl_queue();
+  auto policy = oneapi::dpl::execution::make_device_policy(queue);
+  const int n = view.extent(0);
+  oneapi::dpl::sort(policy, view.data(), view.data() + n);
+}
+#endif
+
+// --------------------------------------------------
+//
+// specialize cases for sorting without comparator
+//
+// --------------------------------------------------
+
+#if defined(KOKKOS_ENABLE_CUDA)
+template <class DataType, class... Properties>
+void sort_device_view_without_comparator(
+    const Cuda& exec, const Kokkos::View<DataType, Properties...>& view) {
+  sort_cudathrust(exec, view);
+}
+#endif
+
+#if defined(KOKKOS_ENABLE_ONEDPL)
+template <class DataType, class... Properties>
+void sort_device_view_without_comparator(
+    const Experimental::SYCL& exec,
+    const Kokkos::View<DataType, Properties...>& view) {
+  sort_onedpl(exec, view);
+}
+#endif
+
+// fallback case
+template <class ExecutionSpace, class DataType, class... Properties>
+std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value>
+sort_device_view_without_comparator(
+    const ExecutionSpace& exec,
+    const Kokkos::View<DataType, Properties...>& view) {
+  sort_via_binsort(exec, view);
+}
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -147,8 +147,8 @@ void sort_cudathrust(const Cuda& space,
     return;
   }
   const auto exec = thrust::cuda::par.on(space.cuda_stream());
-  auto first      = Experimental::begin(view);
-  auto last       = Experimental::end(view);
+  auto first      = ::Kokkos::Experimental::begin(view);
+  auto last       = ::Kokkos::Experimental::end(view);
   thrust::sort(exec, first, last);
 }
 #endif

--- a/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortImpl.hpp
@@ -20,7 +20,6 @@
 #include "../Kokkos_BinOpsPublicAPI.hpp"
 #include "../Kokkos_BinSortPublicAPI.hpp"
 #include <std_algorithms/Kokkos_BeginEnd.hpp>
-#include <std_algorithms/Kokkos_Copy.hpp>
 #include <Kokkos_Core.hpp>
 
 #if defined(KOKKOS_ENABLE_CUDA)


### PR DESCRIPTION
THIS NEEDS to be rebased after #6234 is merged

Another step towards the refactoring and a stepping stone for adding the custom comparator in a separate PR. 
This PR moves code from the public API to the impl such that these lower-level functions can be reused if needed, and to have a single public API entry point where it is easier to reason from.

# Before 

```cpp
template <class ExecutionSpace, class DataType, class... Properties>
std::enable_if_t<(Kokkos::is_execution_space<ExecutionSpace>::value) &&
                 (!SpaceAccessibility<
                     HostSpace, typename Kokkos::View<DataType, Properties...>::
                                    memory_space>::accessible)>
sort(const ExecutionSpace& exec, const Kokkos::View<DataType, Properties...>& view){
  // call binsort
}

#if defined(KOKKOS_ENABLE_ONEDPL)
template <class DataType, class... Properties>
void sort(const Experimental::SYCL& space, const Kokkos::View<DataType, Properties...>& view)
{
  // sort via onedpl
}
#endif

template <class ExecutionSpace, class DataType, class... Properties>
std::enable_if_t<(Kokkos::is_execution_space<ExecutionSpace>::value) &&
                 (SpaceAccessibility<
                     HostSpace, typename Kokkos::View<DataType, Properties...>::
                                    memory_space>::accessible)>
sort(const ExecutionSpace&, const Kokkos::View<DataType, Properties...>& view)
{
  // call std sort
}

#if defined(KOKKOS_ENABLE_CUDA)
template <class DataType, class... Properties>
void sort(const Cuda& space, const Kokkos::View<DataType, Properties...>& view)
{
  // call thrust 
}
#endif

template <class ViewType>
void sort(ViewType const& view) {
  // call overload with view's exespace
}
```

<br>

# With this PR

```cpp
template <class ExecutionSpace, class DataType, class... Properties>
void sort([[maybe_unused]] const ExecutionSpace& exec,
          const Kokkos::View<DataType, Properties...>& view) 
{
  // constraints ...
  // ...
  if constexpr (SpaceAccessibility<HostSpace, MemSpace>::accessible) {
    auto first = ::Kokkos::Experimental::begin(view);
    auto last  = ::Kokkos::Experimental::end(view);
    std::sort(first, last);
  } else {
    Impl::sort_device_view_without_comparator(exec, view);
  }
}

template <class DataType, class... Properties>
void sort(const Kokkos::View<DataType, Properties...>& view) {
  // call overload with view's exespace
}
```
whre `Impl::sort_device_view_without_comparator(exec, view);` takes care of dispatching things to maintain same behavior as before but this is inside the impl namespace:

```cpp
namespace Impl{

#if defined(KOKKOS_ENABLE_CUDA)
template <class DataType, class... Properties>
void sort_device_view_without_comparator(const Cuda& exec, 
                                         const Kokkos::View<DataType, Properties...>& view) {
  sort_cudathrust(exec, view);
}
#endif

#if defined(KOKKOS_ENABLE_ONEDPL)
template <class DataType, class... Properties>
void sort_device_view_without_comparator(const Experimental::SYCL& exec,
                                         const Kokkos::View<DataType, Properties...>& view) { 
  sort_onedpl(exec, view);
}
#endif

// fallback case
template <class ExecutionSpace, class DataType, class... Properties>
std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value>
sort_device_view_without_comparator(const ExecutionSpace& exec,
                                     const Kokkos::View<DataType, Properties...>& view) {
  sort_via_binsort(exec, view);
}

} //end namespace Impl
```

