### PR TITLE
simd: support vector_aligned_tag

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -836,8 +836,8 @@ class simd<float, simd_abi::avx2_fixed_size<4>> {
       value_type* ptr, element_aligned_tag) const {
     _mm_storeu_ps(ptr, m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, vector_aligned_tag) const {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
     _mm_store_ps(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128()

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -193,9 +193,17 @@ class simd<double, simd_abi::avx512_fixed_size<8>> {
                                                        element_aligned_tag) {
     m_value = _mm512_loadu_pd(ptr);
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm512_load_pd(ptr);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
     _mm512_storeu_pd(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm512_store_pd(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512d()
       const {
@@ -471,25 +479,21 @@ class simd<float, simd_abi::avx512_fixed_size<8>> {
   operator[](std::size_t i) const {
     return reinterpret_cast<value_type const*>(&m_value)[i];
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
-                                                     vector_aligned_tag) const {
-    _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
-                            m_value);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm256_loadu_ps(ptr);
   }
-
-  // FIXME vector aligned
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        vector_aligned_tag) {
-    m_value = _mm256_mask_load_epi32(
-        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
+    m_value = _mm256_load_ps(ptr);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
     _mm256_storeu_ps(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm256_store_ps(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
       const {
@@ -747,16 +751,6 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   operator[](std::size_t i) const {
     return reinterpret_cast<value_type const*>(&m_value)[i];
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
-                             m_value);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
-                                                     vector_aligned_tag) const {
-    _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
-                            m_value);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm256_mask_loadu_epi32(
@@ -766,6 +760,16 @@ class simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
                                                        vector_aligned_tag) {
     m_value = _mm256_mask_load_epi32(
         _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
+                             m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
+                            m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
@@ -956,96 +960,96 @@ class simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   operator[](std::size_t i) const {
     return reinterpret_cast<value_type const*>(&m_value)[i];
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
-                             m_value);
-  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        element_aligned_tag) {
     m_value = _mm256_mask_loadu_epi32(
         _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm256_mask_load_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(mask_type(true)), ptr);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
+                             m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
+                            m_value);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
       const {
     return m_value;
   }
-
-  // FIXME vector aligned
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator*(
       simd const& lhs, simd const& rhs) noexcept {
     return simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
                                    static_cast<__m256i>(rhs)));
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                         vector_aligned_tag) {
-      m_value = _mm512_load_si512(ptr);
-    }
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-        value_type * ptr, vector_aligned_tag) const {
-      _mm512_store_si512(ptr, m_value);
-    }
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(
+        _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
 
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator+(
-        simd const& lhs, simd const& rhs) noexcept {
-      return simd(_mm256_add_epi32(static_cast<__m256i>(lhs),
-                                   static_cast<__m256i>(rhs)));
-    }
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator-(
-        simd const& lhs, simd const& rhs) noexcept {
-      return simd(_mm256_sub_epi32(static_cast<__m256i>(lhs),
-                                   static_cast<__m256i>(rhs)));
-    }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator<=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator>=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(rhs),
+                                             static_cast<__m256i>(lhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator==(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpeq_epu32_mask(static_cast<__m256i>(lhs),
+                                             static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
+  operator!=(simd const& lhs, simd const& rhs) noexcept {
+    return mask_type(_mm256_cmpneq_epu32_mask(static_cast<__m256i>(lhs),
+                                              static_cast<__m256i>(rhs)));
+  }
 
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-    operator<(simd const& lhs, simd const& rhs) noexcept {
-      return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(lhs),
-                                               static_cast<__m256i>(rhs)));
-    }
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-    operator>(simd const& lhs, simd const& rhs) noexcept {
-      return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(rhs),
-                                               static_cast<__m256i>(lhs)));
-    }
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-    operator<=(simd const& lhs, simd const& rhs) noexcept {
-      return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(lhs),
-                                               static_cast<__m256i>(rhs)));
-    }
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-    operator>=(simd const& lhs, simd const& rhs) noexcept {
-      return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(rhs),
-                                               static_cast<__m256i>(lhs)));
-    }
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-    operator==(simd const& lhs, simd const& rhs) noexcept {
-      return mask_type(_mm256_cmpeq_epu32_mask(static_cast<__m256i>(lhs),
-                                               static_cast<__m256i>(rhs)));
-    }
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type
-    operator!=(simd const& lhs, simd const& rhs) noexcept {
-      return mask_type(_mm256_cmpneq_epu32_mask(static_cast<__m256i>(lhs),
-                                                static_cast<__m256i>(rhs)));
-    }
-
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-        simd const& lhs, int rhs) noexcept {
-      return simd(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
-    }
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
-        simd const& lhs, simd const& rhs) noexcept {
-      return simd(_mm256_srlv_epi32(static_cast<__m256i>(lhs),
-                                    static_cast<__m256i>(rhs)));
-    }
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-        simd const& lhs, int rhs) noexcept {
-      return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
-    }
-    [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
-        simd const& lhs, simd const& rhs) noexcept {
-      return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
-                                    static_cast<__m256i>(rhs)));
-    }
-  };
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator>>(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_srlv_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, int rhs) noexcept {
+    return simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend simd operator<<(
+      simd const& lhs, simd const& rhs) noexcept {
+    return simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                  static_cast<__m256i>(rhs)));
+  }
+};
 
 }  // namespace Experimental
 
@@ -1169,15 +1173,14 @@ class simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
       value_type* ptr, element_aligned_tag) const {
     _mm512_storeu_si512(ptr, m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
-      const {
-    return m_value;
-  }
-
-  // FIXME vector aligned
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
                                                      vector_aligned_tag) const {
     _mm512_store_si512(ptr, m_value);
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
+      const {
+    return m_value;
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION simd operator-() const
@@ -1374,17 +1377,15 @@ class simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        vector_aligned_tag) {
-    m_value = _mm512_load_pd(ptr);
+    m_value = _mm512_load_si512(ptr);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
     _mm512_storeu_si512(ptr, m_value);
   }
-
-  // FIXME vector aligned
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
                                                      vector_aligned_tag) const {
-    _mm512_store_pd(ptr, m_value);
+    _mm512_store_si512(ptr, m_value);
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
@@ -1646,6 +1647,11 @@ class const_where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
                           static_cast<__m256>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(float* mem, vector_aligned_tag) const {
+    _mm256_mask_store_ps(mem, static_cast<__mmask8>(m_mask),
+                         static_cast<__m256>(m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       float* mem,
       simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
@@ -1679,6 +1685,10 @@ class where_expression<simd_mask<float, simd_abi::avx512_fixed_size<8>>,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
     m_value = value_type(_mm256_mask_loadu_ps(
+        _mm256_set1_ps(0.0), static_cast<__mmask8>(m_mask), mem));
+  }
+  void copy_from(float const* mem, vector_aligned_tag) {
+    m_value = value_type(_mm256_mask_load_ps(
         _mm256_set1_ps(0.0), static_cast<__mmask8>(m_mask), mem));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -1729,18 +1739,18 @@ class const_where_expression<
                              static_cast<__m256i>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, vector_aligned_tag) const {
+    _mm256_mask_store_epi32(mem, static_cast<__mmask8>(m_mask),
+                            static_cast<__m256i>(m_value));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::int32_t* mem,
       simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
     _mm256_mask_i32scatter_epi32(mem, static_cast<__mmask8>(m_mask),
                                  static_cast<__m256i>(index),
                                  static_cast<__m256i>(m_value), 4);
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_to(std::int32_t* mem, vector_aligned_tag) const {
-    _mm256_mask_store_epi32(mem, static_cast<__mmask8>(m_mask),
-                            static_cast<__m256i>(m_value));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
@@ -1770,6 +1780,11 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
     m_value = value_type(_mm256_mask_loadu_epi32(
         _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
   }
+  void copy_from(std::int32_t const* mem, vector_aligned_tag) {
+    m_value = value_type(_mm256_mask_load_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
@@ -1777,12 +1792,6 @@ class where_expression<simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
     m_value = value_type(_mm256_mmask_i32gather_epi32(
         static_cast<__m256i>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 4));
-  }
-
-  // FIXME vector aligned
-  void copy_from(std::int32_t const* mem, vector_aligned_tag) {
-    m_value = value_type(_mm256_mask_load_epi32(
-        _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
   }
 
   template <class U,
@@ -1824,18 +1833,18 @@ class const_where_expression<
                              static_cast<__m256i>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint32_t* mem, vector_aligned_tag) const {
+    _mm256_mask_store_epi32(mem, static_cast<__mmask8>(m_mask),
+                            static_cast<__m256i>(m_value));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::uint32_t* mem,
       simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
     _mm256_mask_i32scatter_epi32(mem, static_cast<__mmask8>(m_mask),
                                  static_cast<__m256i>(index),
                                  static_cast<__m256i>(m_value), 4);
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_to(std::uint32_t* mem, vector_aligned_tag) const {
-    _mm256_mask_store_epi32(mem, static_cast<__mmask8>(m_mask),
-                            static_cast<__m256i>(m_value));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
@@ -1866,18 +1875,18 @@ class where_expression<simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
         _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::uint32_t const* mem, vector_aligned_tag) {
+    m_value = value_type(_mm256_mask_load_epi32(
+        _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint32_t const* mem,
       simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm256_mmask_i32gather_epi32(
         static_cast<__m256i>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 4));
-  }
-
-  // FIXME vector aligned
-  void copy_from(std::uint32_t const* mem, vector_aligned_tag) {
-    m_value = value_type(_mm256_mask_load_epi32(
-        _mm256_set1_epi32(0), static_cast<__mmask8>(m_mask), mem));
   }
 
   template <class U,
@@ -1919,18 +1928,18 @@ class const_where_expression<
                              static_cast<__m512i>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int64_t* mem, vector_aligned_tag) const {
+    _mm512_mask_store_epi64(mem, static_cast<__mmask8>(m_mask),
+                            static_cast<__m512i>(m_value));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::int64_t* mem,
       simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
     _mm512_mask_i32scatter_epi64(mem, static_cast<__mmask8>(m_mask),
                                  static_cast<__m256i>(index),
                                  static_cast<__m512i>(m_value), 8);
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_to(std::int64_t* mem, vector_aligned_tag) const {
-    _mm512_mask_store_epi64(mem, static_cast<__mmask8>(m_mask),
-                            static_cast<__m512i>(m_value));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
@@ -1961,18 +1970,18 @@ class where_expression<simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
         _mm512_set1_epi64(0.0), static_cast<__mmask8>(m_mask), mem));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int64_t const* mem, vector_aligned_tag) {
+    m_value = value_type(_mm512_mask_load_epi64(
+        _mm512_set1_epi64(0.0), static_cast<__mmask8>(m_mask), mem));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
       simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_epi64(
         static_cast<__m512i>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 8));
-  }
-
-  // FIXME vector aligned
-  void copy_from(std::int64_t const* mem, vector_aligned_tag) {
-    m_value = value_type(_mm512_mask_load_epi64(
-        _mm512_set1_epi64(0.0), static_cast<__mmask8>(m_mask), mem));
   }
 
   template <class U,
@@ -2014,18 +2023,18 @@ class const_where_expression<
                              static_cast<__m512i>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint64_t* mem, vector_aligned_tag) const {
+    _mm512_mask_store_epi64(mem, static_cast<__mmask8>(m_mask),
+                            static_cast<__m512i>(m_value));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::uint64_t* mem,
       simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) const {
     _mm512_mask_i32scatter_epi64(mem, static_cast<__mmask8>(m_mask),
                                  static_cast<__m256i>(index),
                                  static_cast<__m512i>(m_value), 8);
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_to(std::uint64_t* mem, vector_aligned_tag) const {
-    _mm512_mask_store_epi64(mem, static_cast<__mmask8>(m_mask),
-                            static_cast<__m512i>(m_value));
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
@@ -2056,18 +2065,17 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
         _mm512_set1_epi64(0.0), static_cast<__mmask8>(m_mask), mem));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::uint64_t const* mem, vector_aligned_tag) {
+    m_value = value_type(_mm512_mask_load_epi64(
+        _mm512_set1_epi64(0.0), static_cast<__mmask8>(m_mask), mem));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
       simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_epi64(
         static_cast<__m512i>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 8));
-  }
-
-  // FIXME vector aligned
-  void copy_from(std::uint64_t const* mem, vector_aligned_tag) {
-    m_value = value_type(_mm512_mask_load_epi64(
-        _mm512_set1_epi64(0.0), static_cast<__mmask8>(m_mask), mem));
   }
 
   template <class U,
@@ -2122,6 +2130,6 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
 }
 
 }  // namespace Experimental
-}  // namespace Experimental
+}  // namespace Kokkos
 
 #endif

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -31,10 +31,17 @@ class simd;
 template <class T, class Abi>
 class simd_mask;
 
-struct element_aligned_tag {};
-struct vector_aligned_tag {};
-inline constexpr element_aligned_tag element_aligned{};
-inline constexpr vector_aligned_tag vector_aligned{};
+class element_aligned {};
+class vector_aligned {};
+
+template <typename... Flags>
+struct loadstore_flags {};
+
+inline constexpr loadstore_flags<element_aligned> loadstore_default{};
+inline constexpr loadstore_flags<vector_aligned> loadstore_aligned{};
+
+using element_aligned_tag = loadstore_flags<element_aligned>;
+using vector_aligned_tag  = loadstore_flags<vector_aligned>;
 
 // class template declarations for const_where_expression and where_expression
 

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -31,17 +31,16 @@ class simd;
 template <class T, class Abi>
 class simd_mask;
 
-class element_aligned {};
-class vector_aligned {};
+class simd_alignment_vector_aligned {};
 
 template <typename... Flags>
-struct loadstore_flags {};
+struct simd_flags {};
 
-inline constexpr loadstore_flags<element_aligned> loadstore_default{};
-inline constexpr loadstore_flags<vector_aligned> loadstore_aligned{};
+inline constexpr simd_flags<> simd_flag_default{};
+inline constexpr simd_flags<simd_alignment_vector_aligned> simd_flag_aligned{};
 
-using element_aligned_tag = loadstore_flags<element_aligned>;
-using vector_aligned_tag  = loadstore_flags<vector_aligned>;
+using element_aligned_tag = simd_flags<>;
+using vector_aligned_tag  = simd_flags<simd_alignment_vector_aligned>;
 
 // class template declarations for const_where_expression and where_expression
 

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -32,6 +32,9 @@ template <class T, class Abi>
 class simd_mask;
 
 struct element_aligned_tag {};
+struct vector_aligned_tag {};
+inline constexpr element_aligned_tag element_aligned{};
+inline constexpr vector_aligned_tag vector_aligned{};
 
 // class template declarations for const_where_expression and where_expression
 

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -363,8 +363,16 @@ class simd<double, simd_abi::neon_fixed_size<2>> {
                                                        element_aligned_tag) {
     m_value = vld1q_f64(ptr);
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = vld1q_f64(ptr);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
+    vst1q_f64(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
     vst1q_f64(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit
@@ -844,8 +852,16 @@ class simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
                                                        element_aligned_tag) {
     m_value = vld1_s32(ptr);
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = vld1_s32(ptr);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
+    vst1_s32(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
     vst1_s32(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator int32x2_t()
@@ -1048,8 +1064,16 @@ class simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
                                                        element_aligned_tag) {
     m_value = vld1q_s64(ptr);
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = vld1q_s64(ptr);
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
       value_type* ptr, element_aligned_tag) const {
+    vst1q_s64(ptr, m_value);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
     vst1q_s64(ptr, m_value);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator int64x2_t()
@@ -1253,6 +1277,13 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
                                                        element_aligned_tag) {
     m_value = vld1q_u64(ptr);
   }
+
+  // FIXME vector aligned
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = vld1q_u64(ptr);
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint64x2_t()
       const {
     return m_value;
@@ -1396,6 +1427,11 @@ class const_where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
     if (m_mask[1]) mem[1] = m_value[1];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(double* mem, vector_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       double* mem,
       simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
@@ -1427,6 +1463,11 @@ class where_expression<simd_mask<double, simd_abi::neon_fixed_size<2>>,
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(double const* mem, vector_aligned_tag) {
     if (m_mask[0]) m_value[0] = mem[0];
     if (m_mask[1]) m_value[1] = mem[1];
   }
@@ -1560,6 +1601,12 @@ class const_where_expression<
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, vector_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
     return m_value;
@@ -1594,6 +1641,13 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
   }
+
+  // FIXME vector aligned
+  void copy_from(std::int32_t const* mem, vector_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+  }
+
   template <
       class U,
       std::enable_if_t<
@@ -1640,6 +1694,12 @@ class const_where_expression<
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int64_t* mem, vector_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
     return m_value;
@@ -1674,6 +1734,13 @@ class where_expression<simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
   }
+
+  // FIXME vector aligned
+  void copy_from(std::int64_t const* mem, vector_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+  }
+
   template <
       class U,
       std::enable_if_t<std::is_convertible_v<
@@ -1720,6 +1787,12 @@ class const_where_expression<
     if (m_mask[1]) mem[index[1]] = m_value[1];
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint64_t* mem, vector_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+  }
+
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
   impl_get_value() const {
     return m_value;
@@ -1754,6 +1827,13 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
   }
+
+  // FIXME vector aligned
+  void copy_from(std::uint64_t const* mem, vector_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+  }
+
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -1277,8 +1277,6 @@ class simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
                                                        element_aligned_tag) {
     m_value = vld1q_u64(ptr);
   }
-
-  // FIXME vector aligned
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
                                                        vector_aligned_tag) {
     m_value = vld1q_u64(ptr);
@@ -1594,17 +1592,17 @@ class const_where_expression<
     if (m_mask[1]) mem[1] = m_value[1];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int32_t* mem, vector_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::int32_t* mem,
       simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_to(std::int32_t* mem, vector_aligned_tag) const {
-    if (m_mask[0]) mem[0] = m_value[0];
-    if (m_mask[1]) mem[1] = m_value[1];
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
@@ -1635,17 +1633,17 @@ class where_expression<simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
     if (m_mask[1]) m_value[1] = mem[1];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int32_t const* mem, vector_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
       simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
-  }
-
-  // FIXME vector aligned
-  void copy_from(std::int32_t const* mem, vector_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
   }
 
   template <
@@ -1687,17 +1685,17 @@ class const_where_expression<
     if (m_mask[1]) mem[1] = m_value[1];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::int64_t* mem, vector_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::int64_t* mem,
       simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_to(std::int64_t* mem, vector_aligned_tag) const {
-    if (m_mask[0]) mem[0] = m_value[0];
-    if (m_mask[1]) mem[1] = m_value[1];
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
@@ -1728,17 +1726,17 @@ class where_expression<simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
     if (m_mask[1]) m_value[1] = mem[1];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::int64_t const* mem, vector_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
       simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
-  }
-
-  // FIXME vector aligned
-  void copy_from(std::int64_t const* mem, vector_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
   }
 
   template <
@@ -1780,17 +1778,17 @@ class const_where_expression<
     if (m_mask[1]) mem[1] = m_value[1];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_to(std::uint64_t* mem, vector_aligned_tag) const {
+    if (m_mask[0]) mem[0] = m_value[0];
+    if (m_mask[1]) mem[1] = m_value[1];
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::uint64_t* mem,
       simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void copy_to(std::uint64_t* mem, vector_aligned_tag) const {
-    if (m_mask[0]) mem[0] = m_value[0];
-    if (m_mask[1]) mem[1] = m_value[1];
   }
 
   [[nodiscard]] KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type const&
@@ -1821,17 +1819,17 @@ class where_expression<simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
     if (m_mask[1]) m_value[1] = mem[1];
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  void copy_from(std::uint64_t const* mem, vector_aligned_tag) {
+    if (m_mask[0]) m_value[0] = mem[0];
+    if (m_mask[1]) m_value[1] = mem[1];
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
       simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     if (m_mask[0]) m_value[0] = mem[index[0]];
     if (m_mask[1]) m_value[1] = mem[index[1]];
-  }
-
-  // FIXME vector aligned
-  void copy_from(std::uint64_t const* mem, vector_aligned_tag) {
-    if (m_mask[0]) m_value[0] = mem[0];
-    if (m_mask[1]) m_value[1] = mem[1];
   }
 
   template <class U,

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -127,8 +127,6 @@ class simd<T, simd_abi::scalar> {
                                              element_aligned_tag) {
     m_value = *ptr;
   }
-
-  // FIXME vector aligned
   KOKKOS_FORCEINLINE_FUNCTION void copy_from(T const* ptr, vector_aligned_tag) {
     m_value = *ptr;
   }

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -127,9 +127,18 @@ class simd<T, simd_abi::scalar> {
                                              element_aligned_tag) {
     m_value = *ptr;
   }
+
+  // FIXME vector aligned
+  KOKKOS_FORCEINLINE_FUNCTION void copy_from(T const* ptr, vector_aligned_tag) {
+    m_value = *ptr;
+  }
   KOKKOS_FORCEINLINE_FUNCTION void copy_to(T* ptr, element_aligned_tag) const {
     *ptr = m_value;
   }
+  KOKKOS_FORCEINLINE_FUNCTION void copy_to(T* ptr, vector_aligned_tag) const {
+    *ptr = m_value;
+  }
+
   KOKKOS_FORCEINLINE_FUNCTION reference operator[](std::size_t) {
     return m_value;
   }
@@ -308,6 +317,10 @@ class const_where_expression<simd_mask<T, simd_abi::scalar>,
   void copy_to(T* mem, element_aligned_tag) const {
     if (static_cast<bool>(m_mask)) *mem = static_cast<T>(m_value);
   }
+  KOKKOS_FORCEINLINE_FUNCTION
+  void copy_to(T* mem, vector_aligned_tag) const {
+    if (static_cast<bool>(m_mask)) *mem = static_cast<T>(m_value);
+  }
   template <class Integral>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<std::is_integral_v<Integral>>
   scatter_to(T* mem, simd<Integral, simd_abi::scalar> const& index) const {
@@ -342,6 +355,10 @@ class where_expression<simd_mask<T, simd_abi::scalar>,
       : base_type(mask_arg, value_arg) {}
   KOKKOS_FORCEINLINE_FUNCTION
   void copy_from(T const* mem, element_aligned_tag) {
+    if (static_cast<bool>(this->m_mask)) this->m_value = *mem;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  void copy_from(T const* mem, vector_aligned_tag) {
     if (static_cast<bool>(this->m_mask)) this->m_value = *mem;
   }
   template <class Integral>

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -135,8 +135,7 @@ class load_masked {
     for (std::size_t i = 0; i < n; ++i) {
       mask[i] = true;
     }
-    where(mask, result)
-        .copy_from(mem, Kokkos::Experimental::simd_flag_default);
+    where(mask, result).copy_from(mem, Kokkos::Experimental::simd_flag_default);
     where(!mask, result) = 0;
     return true;
   }
@@ -149,8 +148,7 @@ class load_masked {
     for (std::size_t i = 0; i < n; ++i) {
       mask[i] = true;
     }
-    where(mask, result)
-        .copy_from(mem, Kokkos::Experimental::simd_flag_default);
+    where(mask, result).copy_from(mem, Kokkos::Experimental::simd_flag_default);
     where(!mask, result) = T(0);
     return true;
   }

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -93,7 +93,7 @@ class load_element_aligned {
   bool host_load(T const* mem, std::size_t n,
                  Kokkos::Experimental::simd<T, Abi>& result) const {
     if (n < result.size()) return false;
-    result.copy_from(mem, Kokkos::Experimental::element_aligned_tag());
+    result.copy_from(mem, Kokkos::Experimental::simd_flag_default);
     return true;
   }
   template <class T, class Abi>
@@ -101,7 +101,7 @@ class load_element_aligned {
       T const* mem, std::size_t n,
       Kokkos::Experimental::simd<T, Abi>& result) const {
     if (n < result.size()) return false;
-    result.copy_from(mem, Kokkos::Experimental::element_aligned_tag());
+    result.copy_from(mem, Kokkos::Experimental::simd_flag_default);
     return true;
   }
 };
@@ -112,7 +112,7 @@ class load_vector_aligned {
   bool host_load(T const* mem, std::size_t n,
                  Kokkos::Experimental::simd<T, Abi>& result) const {
     if (n < result.size()) return false;
-    result.copy_from(mem, Kokkos::Experimental::vector_aligned_tag());
+    result.copy_from(mem, Kokkos::Experimental::simd_flag_aligned);
     return true;
   }
   template <class T, class Abi>
@@ -120,7 +120,7 @@ class load_vector_aligned {
       T const* mem, std::size_t n,
       Kokkos::Experimental::simd<T, Abi>& result) const {
     if (n < result.size()) return false;
-    result.copy_from(mem, Kokkos::Experimental::vector_aligned_tag());
+    result.copy_from(mem, Kokkos::Experimental::simd_flag_aligned);
     return true;
   }
 };
@@ -136,7 +136,7 @@ class load_masked {
       mask[i] = true;
     }
     where(mask, result)
-        .copy_from(mem, Kokkos::Experimental::element_aligned_tag());
+        .copy_from(mem, Kokkos::Experimental::simd_flag_default);
     where(!mask, result) = 0;
     return true;
   }
@@ -150,7 +150,7 @@ class load_masked {
       mask[i] = true;
     }
     where(mask, result)
-        .copy_from(mem, Kokkos::Experimental::element_aligned_tag());
+        .copy_from(mem, Kokkos::Experimental::simd_flag_default);
     where(!mask, result) = T(0);
     return true;
   }

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -106,6 +106,26 @@ class load_element_aligned {
   }
 };
 
+// FIXME vector aligned
+class load_vector_aligned {
+ public:
+  template <class T, class Abi>
+  bool host_load(T const* mem, std::size_t n,
+                 Kokkos::Experimental::simd<T, Abi>& result) const {
+    if (n < result.size()) return false;
+    result.copy_from(mem, Kokkos::Experimental::vector_aligned_tag());
+    return true;
+  }
+  template <class T, class Abi>
+  KOKKOS_INLINE_FUNCTION bool device_load(
+      T const* mem, std::size_t n,
+      Kokkos::Experimental::simd<T, Abi>& result) const {
+    if (n < result.size()) return false;
+    result.copy_from(mem, Kokkos::Experimental::vector_aligned_tag());
+    return true;
+  }
+};
+
 class load_masked {
  public:
   template <class T, class Abi>

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -106,7 +106,6 @@ class load_element_aligned {
   }
 };
 
-// FIXME vector aligned
 class load_vector_aligned {
  public:
   template <class T, class Abi>

--- a/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
+++ b/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
@@ -37,10 +37,10 @@ inline void host_check_gen_ctor() {
   }
 
   simd_type rhs;
-  rhs.copy_from(init, Kokkos::Experimental::element_aligned_tag());
+  rhs.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
   simd_type blend;
-  blend.copy_from(expected, Kokkos::Experimental::element_aligned_tag());
+  blend.copy_from(expected, Kokkos::Experimental::simd_flag_default);
 
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
   if constexpr (std::is_same_v<Abi, Kokkos::Experimental::simd_abi::scalar>) {
@@ -98,7 +98,7 @@ KOKKOS_INLINE_FUNCTION void device_check_gen_ctor() {
 
   simd_type basic(KOKKOS_LAMBDA(std::size_t i) { return init[i]; });
   simd_type rhs;
-  rhs.copy_from(init, Kokkos::Experimental::element_aligned_tag());
+  rhs.copy_from(init, Kokkos::Experimental::simd_flag_default);
   device_check_equality(basic, rhs, lanes);
 
   simd_type lhs(KOKKOS_LAMBDA(std::size_t i) { return init[i] * 9; });
@@ -106,7 +106,7 @@ KOKKOS_INLINE_FUNCTION void device_check_gen_ctor() {
       KOKKOS_LAMBDA(std::size_t i) { return (mask[i]) ? lhs[i] : rhs[i]; });
 
   simd_type blend;
-  blend.copy_from(expected, Kokkos::Experimental::element_aligned_tag());
+  blend.copy_from(expected, Kokkos::Experimental::simd_flag_default);
   device_check_equality(result, blend, lanes);
 }
 

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -83,6 +83,10 @@ inline void host_check_math_op_all_loaders(Op op, std::size_t n,
   host_check_math_op_one_loader<Abi, load_element_aligned>(op, n, args...);
   host_check_math_op_one_loader<Abi, load_masked>(op, n, args...);
   host_check_math_op_one_loader<Abi, load_as_scalars>(op, n, args...);
+
+  // FIXME vector aligned
+    host_check_binary_op_one_loader<Abi, load_vector_aligned>(
+      binary_op, n, first_args, second_args);
 }
 
 template <typename Abi, typename DataType, size_t n>
@@ -122,21 +126,31 @@ template <typename Abi, typename DataType>
 inline void host_check_math_ops() {
   constexpr size_t n = 11;
 
+  // FIXME vector aligned
+    constexpr size_t alignment =
+      Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
+
   host_check_abi_size<Abi, DataType>();
 
   if constexpr (!std::is_integral_v<DataType>) {
+alignas(alignment)
     DataType const first_args[n]  = {0.1,  0.4,  0.5, 0.7, 1.0, 1.5,
                                     -2.0, 10.0, 0.0, 1.2, -2.8};
+alignas(alignment)
     DataType const second_args[n] = {1.0,  0.2, 1.1,  1.8,  -0.1, -3.0,
                                      -2.4, 1.0, 13.0, -3.2, -2.1};
     host_check_all_math_ops<Abi>(first_args, second_args);
   } else {
     if constexpr (std::is_signed_v<DataType>) {
+alignas(alignment)
       DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
+alignas(alignment)
       DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
       host_check_all_math_ops<Abi>(first_args, second_args);
     } else {
+alignas(alignment)
       DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
+alignas(alignment)
       DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
       host_check_all_math_ops<Abi>(first_args, second_args);
     }
@@ -214,6 +228,10 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_all_loaders(Op op,
   device_check_math_op_one_loader<Abi, load_element_aligned>(op, n, args...);
   device_check_math_op_one_loader<Abi, load_masked>(op, n, args...);
   device_check_math_op_one_loader<Abi, load_as_scalars>(op, n, args...);
+
+  // FIXME vector aligned
+    device_check_binary_op_one_loader<Abi, load_vector_aligned>(
+      binary_op, n, first_args, second_args);
 }
 
 template <typename Abi, typename DataType, size_t n>

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -83,10 +83,7 @@ inline void host_check_math_op_all_loaders(Op op, std::size_t n,
   host_check_math_op_one_loader<Abi, load_element_aligned>(op, n, args...);
   host_check_math_op_one_loader<Abi, load_masked>(op, n, args...);
   host_check_math_op_one_loader<Abi, load_as_scalars>(op, n, args...);
-
-  // FIXME vector aligned
-    host_check_binary_op_one_loader<Abi, load_vector_aligned>(
-      binary_op, n, first_args, second_args);
+  host_check_math_op_one_loader<Abi, load_vector_aligned>(op, n, args...);
 }
 
 template <typename Abi, typename DataType, size_t n>
@@ -125,33 +122,29 @@ inline void host_check_abi_size() {
 template <typename Abi, typename DataType>
 inline void host_check_math_ops() {
   constexpr size_t n = 11;
-
-  // FIXME vector aligned
-    constexpr size_t alignment =
+  constexpr size_t alignment =
       Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
 
   host_check_abi_size<Abi, DataType>();
 
   if constexpr (!std::is_integral_v<DataType>) {
-alignas(alignment)
-    DataType const first_args[n]  = {0.1,  0.4,  0.5, 0.7, 1.0, 1.5,
-                                    -2.0, 10.0, 0.0, 1.2, -2.8};
-alignas(alignment)
-    DataType const second_args[n] = {1.0,  0.2, 1.1,  1.8,  -0.1, -3.0,
-                                     -2.4, 1.0, 13.0, -3.2, -2.1};
+    alignas(alignment) DataType const first_args[n] = {
+        0.1, 0.4, 0.5, 0.7, 1.0, 1.5, -2.0, 10.0, 0.0, 1.2, -2.8};
+    alignas(alignment) DataType const second_args[n] = {
+        1.0, 0.2, 1.1, 1.8, -0.1, -3.0, -2.4, 1.0, 13.0, -3.2, -2.1};
     host_check_all_math_ops<Abi>(first_args, second_args);
   } else {
     if constexpr (std::is_signed_v<DataType>) {
-alignas(alignment)
-      DataType const first_args[n]  = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
-alignas(alignment)
-      DataType const second_args[n] = {1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2};
+      alignas(alignment)
+          DataType const first_args[n] = {1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2};
+      alignas(alignment) DataType const second_args[n] = {1,  2, 1,  1,  1, -3,
+                                                          -2, 1, 13, -3, -2};
       host_check_all_math_ops<Abi>(first_args, second_args);
     } else {
-alignas(alignment)
-      DataType const first_args[n]  = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
-alignas(alignment)
-      DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
+      alignas(alignment)
+          DataType const first_args[n] = {1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2};
+      alignas(alignment)
+          DataType const second_args[n] = {1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2};
       host_check_all_math_ops<Abi>(first_args, second_args);
     }
   }
@@ -228,10 +221,7 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_all_loaders(Op op,
   device_check_math_op_one_loader<Abi, load_element_aligned>(op, n, args...);
   device_check_math_op_one_loader<Abi, load_masked>(op, n, args...);
   device_check_math_op_one_loader<Abi, load_as_scalars>(op, n, args...);
-
-  // FIXME vector aligned
-    device_check_binary_op_one_loader<Abi, load_vector_aligned>(
-      binary_op, n, first_args, second_args);
+  device_check_math_op_one_loader<Abi, load_vector_aligned>(op, n, args...);
 }
 
 template <typename Abi, typename DataType, size_t n>

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -85,6 +85,8 @@ inline void host_check_shift_op_all_loaders(ShiftOp shift_op,
                                                    shift_by, n);
   host_check_shift_on_one_loader<Abi, load_as_scalars>(shift_op, test_vals,
                                                        shift_by, n);
+  host_check_shift_on_one_loader<Abi, load_vector_aligned>(shift_op, test_vals,
+                                                           shift_by, n);
 
   Kokkos::Experimental::simd<DataType, Abi> shift_by_lanes;
   shift_by_lanes.copy_from(shift_by,
@@ -96,6 +98,8 @@ inline void host_check_shift_op_all_loaders(ShiftOp shift_op,
                                                             shift_by_lanes);
   host_check_shift_by_lanes_on_one_loader<Abi, load_as_scalars>(
       shift_op, test_vals, shift_by_lanes);
+  host_check_shift_by_lanes_on_one_loader<Abi, load_vector_aligned>(
+      shift_op, test_vals, shift_by_lanes);
 }
 
 template <typename Abi, typename DataType>
@@ -104,12 +108,14 @@ inline void host_check_shift_ops() {
     using simd_type                 = Kokkos::Experimental::simd<DataType, Abi>;
     constexpr std::size_t width     = simd_type::size();
     constexpr std::size_t num_cases = 8;
+    constexpr size_t alignment =
+        Kokkos::Experimental::simd<DataType, Abi>::size() * sizeof(DataType);
 
     DataType max = std::numeric_limits<DataType>::max();
 
-    DataType shift_by[num_cases] = {
+    alignas(alignment) DataType shift_by[num_cases] = {
         0, 1, 3, width / 2, width / 2 + 1, width - 1, width, width + 1};
-    DataType test_vals[width];
+    alignas(alignment) DataType test_vals[width];
     for (std::size_t i = 0; i < width; ++i) {
       DataType inc = max / width;
       test_vals[i] = i * inc + 1;
@@ -201,6 +207,8 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_op_all_loaders(
                                                      shift_by, n);
   device_check_shift_on_one_loader<Abi, load_as_scalars>(shift_op, test_vals,
                                                          shift_by, n);
+  device_check_shift_on_one_loader<Abi, load_vector_aligned>(
+      shift_op, test_vals, shift_by, n);
 
   Kokkos::Experimental::simd<DataType, Abi> shift_by_lanes;
   shift_by_lanes.copy_from(shift_by,
@@ -211,6 +219,8 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_op_all_loaders(
   device_check_shift_by_lanes_on_one_loader<Abi, load_masked>(
       shift_op, test_vals, shift_by_lanes);
   device_check_shift_by_lanes_on_one_loader<Abi, load_as_scalars>(
+      shift_op, test_vals, shift_by_lanes);
+  device_check_shift_by_lanes_on_one_loader<Abi, load_vector_aligned>(
       shift_op, test_vals, shift_by_lanes);
 }
 

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -89,8 +89,7 @@ inline void host_check_shift_op_all_loaders(ShiftOp shift_op,
                                                            shift_by, n);
 
   Kokkos::Experimental::simd<DataType, Abi> shift_by_lanes;
-  shift_by_lanes.copy_from(shift_by,
-                           Kokkos::Experimental::element_aligned_tag());
+  shift_by_lanes.copy_from(shift_by, Kokkos::Experimental::simd_flag_default);
 
   host_check_shift_by_lanes_on_one_loader<Abi, load_element_aligned>(
       shift_op, test_vals, shift_by_lanes);
@@ -211,8 +210,7 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_op_all_loaders(
       shift_op, test_vals, shift_by, n);
 
   Kokkos::Experimental::simd<DataType, Abi> shift_by_lanes;
-  shift_by_lanes.copy_from(shift_by,
-                           Kokkos::Experimental::element_aligned_tag());
+  shift_by_lanes.copy_from(shift_by, Kokkos::Experimental::simd_flag_default);
 
   device_check_shift_by_lanes_on_one_loader<Abi, load_element_aligned>(
       shift_op, test_vals, shift_by_lanes);

--- a/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
+++ b/simd/unit_tests/include/TestSIMD_WhereExpressions.hpp
@@ -29,7 +29,7 @@ inline void host_check_where_expr_scatter_to() {
   std::size_t nlanes = simd_type::size();
   DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37};
   simd_type src;
-  src.copy_from(init, Kokkos::Experimental::element_aligned_tag());
+  src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
   for (std::size_t idx = 0; idx < nlanes; ++idx) {
     mask_type mask(true);
@@ -46,7 +46,7 @@ inline void host_check_where_expr_scatter_to() {
     where(mask, src).scatter_to(dst, index);
 
     simd_type dst_simd;
-    dst_simd.copy_from(dst, Kokkos::Experimental::element_aligned_tag());
+    dst_simd.copy_from(dst, Kokkos::Experimental::simd_flag_default);
 
     host_check_equality(expected_result, dst_simd, nlanes);
   }
@@ -107,7 +107,7 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
   std::size_t nlanes = simd_type::size();
   DataType init[]    = {11, 13, 17, 19, 23, 29, 31, 37};
   simd_type src;
-  src.copy_from(init, Kokkos::Experimental::element_aligned_tag());
+  src.copy_from(init, Kokkos::Experimental::simd_flag_default);
 
   for (std::size_t idx = 0; idx < nlanes; ++idx) {
     mask_type mask(true);
@@ -124,7 +124,7 @@ KOKKOS_INLINE_FUNCTION void device_check_where_expr_scatter_to() {
     where(mask, src).scatter_to(dst, index);
 
     simd_type dst_simd;
-    dst_simd.copy_from(dst, Kokkos::Experimental::element_aligned_tag());
+    dst_simd.copy_from(dst, Kokkos::Experimental::simd_flag_default);
 
     device_check_equality(expected_result, dst_simd, nlanes);
   }


### PR DESCRIPTION
This SIMD load/store tag is defined in the ISO C++ TS and specifies that the load or store operation is being done with a pointer aligned to vector width.

The Intel backends (AVX2, AVX512) do have different intrinsics in this case, and this enhancement allows users of Kokkos SIMD to make use of those intrinsics.

In particular, the copy_from and copy_to methods for simd<double> differ in the AVX2 backend,
while all of the intrinsics added in the AVX512 backend are different (see "loadu" versus "load")