### PR TITLE
Fix whitespace in bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 ---
 **Describe the bug**
 
-Please provide a concise, clear description of the bug, as well as any available error logs.  Feel free to contact the Kokkos Slack `# build` channel for further discussion of your issue. 
+Please provide a concise, clear description of the bug, as well as any available error logs.  Feel free to contact the Kokkos Slack `# build` channel for further discussion of your issue.
 
 **Please include the following for a minimal reproducer**
 


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/5034 broke our indentation CI by introducing trailing whitespace. This pull request fixes that.