### PR TITLE
Avoid undefined behavior in TestTaskScheduler.hpp

### DIFF
--- a/core/unit_test/TestTaskScheduler.hpp
+++ b/core/unit_test/TestTaskScheduler.hpp
@@ -711,7 +711,7 @@ struct TestMultipleDependence {
     using value_type = int;
     KOKKOS_INLINE_FUNCTION
     void operator()(typename Scheduler::member_type&, int& result) {
-      double value = 0;
+      double value = 1;
       // keep this one busy for a while
       for (int i = 0; i < 10000; ++i) {
         value += i * i / 7.138 / value;


### PR DESCRIPTION
Using `-fsanitize=undefined`, I am seeing
```
/tmp/kokkos/core/unit_test/TestTaskScheduler.hpp:720:20: runtime error: nan is outside the range of representable values of type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/kokkos/core/unit_test/TestTaskScheduler.hpp:720:20 in 
```