### PR TITLE
Check AVX, AVX2, AVX512XEON compiler macros on KokkosCore_config.h

### DIFF
--- a/cmake/KokkosCore_config.h.in
+++ b/cmake/KokkosCore_config.h.in
@@ -70,17 +70,8 @@
 #cmakedefine KOKKOS_ARCH_ARMV8_THUNDERX2
 #cmakedefine KOKKOS_ARCH_A64FX
 #cmakedefine KOKKOS_ARCH_AVX
-#if defined(KOKKOS_ARCH_AVX) && !defined(__AVX__)
-#error "__AVX__ must be defined for KOKKOS_ARCH_AVX"
-#endif
 #cmakedefine KOKKOS_ARCH_AVX2
-#if defined(KOKKOS_ARCH_AVX2) && !defined(__AVX2__)
-#error "__AVX2__ must be defined for KOKKOS_ARCH_AVX2"
-#endif
 #cmakedefine KOKKOS_ARCH_AVX512XEON
-#if defined(KOKKOS_ARCH_AVX512XEON) && !defined(__AVX512F__)
-#error "__AVX512F__ must be defined for KOKKOS_ARCH_AVX512XEON"
-#endif
 #cmakedefine KOKKOS_ARCH_KNC
 #cmakedefine KOKKOS_ARCH_AVX512MIC
 #cmakedefine KOKKOS_ARCH_POWER7

--- a/cmake/KokkosCore_config.h.in
+++ b/cmake/KokkosCore_config.h.in
@@ -70,8 +70,17 @@
 #cmakedefine KOKKOS_ARCH_ARMV8_THUNDERX2
 #cmakedefine KOKKOS_ARCH_A64FX
 #cmakedefine KOKKOS_ARCH_AVX
+#if defined(KOKKOS_ARCH_AVX) && !defined(__AVX__)
+#error "__AVX__ must be defined for KOKKOS_ARCH_AVX"
+#endif
 #cmakedefine KOKKOS_ARCH_AVX2
+#if defined(KOKKOS_ARCH_AVX2) && !defined(__AVX2__)
+#error "__AVX2__ must be defined for KOKKOS_ARCH_AVX2"
+#endif
 #cmakedefine KOKKOS_ARCH_AVX512XEON
+#if defined(KOKKOS_ARCH_AVX512XEON) && !defined(__AVX512F__)
+#error "__AVX512F__ must be defined for KOKKOS_ARCH_AVX512XEON"
+#endif
 #cmakedefine KOKKOS_ARCH_KNC
 #cmakedefine KOKKOS_ARCH_AVX512MIC
 #cmakedefine KOKKOS_ARCH_POWER7

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -26,12 +26,14 @@
 #if defined(KOKKOS_ARCH_AVX) && !defined(__AVX__)
 #error "__AVX__ must be defined for KOKKOS_ARCH_AVX"
 #endif
+
 #if defined(KOKKOS_ARCH_AVX2)
 #if !defined(__AVX2__)
 #error "__AVX2__ must be defined for KOKKOS_ARCH_AVX2"
 #endif
 #include <Kokkos_SIMD_AVX2.hpp>
 #endif
+
 #if defined(KOKKOS_ARCH_AVX512XEON)
 #if !defined(__AVX512F__)
 #error "__AVX512F__ must be defined for KOKKOS_ARCH_AVX512XEON"

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -21,11 +21,21 @@
 
 #include <Kokkos_SIMD_Scalar.hpp>
 
-#ifdef KOKKOS_ARCH_AVX2
+#include <Kokkos_Macros.hpp>
+
+#if defined(KOKKOS_ARCH_AVX) && !defined(__AVX__)
+#error "__AVX__ must be defined for KOKKOS_ARCH_AVX"
+#endif
+#if defined(KOKKOS_ARCH_AVX2)
+#if !defined(__AVX2__)
+#error "__AVX2__ must be defined for KOKKOS_ARCH_AVX2"
+#endif
 #include <Kokkos_SIMD_AVX2.hpp>
 #endif
-
-#ifdef KOKKOS_ARCH_AVX512XEON
+#if defined(KOKKOS_ARCH_AVX512XEON)
+#if !defined(__AVX512F__)
+#error "__AVX512F__ must be defined for KOKKOS_ARCH_AVX512XEON"
+#endif
 #include <Kokkos_SIMD_AVX512.hpp>
 #endif
 


### PR DESCRIPTION
We discussed that we also want to have the reverse check as the one in #6188, i.e., check that we actually see the expected compiler macro when setting an architecture (for `AVX`, `AVX2`, `AVX512XEON` in this pull request).