### PR TITLE
Ensure that `Kokkos::complex` only gets instantiated for cv-unqualified floating-point types

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -44,6 +44,11 @@ class
     alignas(2 * sizeof(RealType))
 #endif
         complex {
+  static_assert(std::is_floating_point_v<RealType> &&
+                    std::is_same_v<RealType, std::remove_cv_t<RealType>>,
+                "Kokkos::complex can only be instantiated for a cv-unqualified "
+                "floating point type");
+
  private:
   RealType re_{};
   RealType im_{};


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/6069#discussion_r1243571228 uncovered a bug where we accidentally instantiated `Kokkos::complex` for integral types.

This PR is open as a base for discussion and proposes to static assert that `complex` is being instantiated for a cv-unqualified floating-point type.  The current implementation would not allow for using half types.