### PR TITLE
Deprecate `Kokkos::vector`

### DIFF
--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -21,6 +21,17 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_VECTOR
 #endif
 
+#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
+    defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
+namespace {
+[[deprecated("Deprecated <Kokkos_Vector.hpp> header is included")]] int
+emit_warning_kokkos_vector_deprecated() {
+  return 0;
+}
+static auto do_not_include = emit_warning_kokkos_vector_deprecated();
+}  // namespace
+#endif
+
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_DualView.hpp>
 

--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -21,6 +21,8 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_VECTOR
 #endif
 
+#include <Kokkos_Macros.hpp>
+
 #if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
     defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
 namespace {

--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -23,8 +23,8 @@
 
 #include <Kokkos_Macros.hpp>
 
-#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
-    defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
+#if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
 namespace {
 [[deprecated("Deprecated <Kokkos_Vector.hpp> header is included")]] int
 emit_warning_kokkos_vector_deprecated() {
@@ -32,6 +32,9 @@ emit_warning_kokkos_vector_deprecated() {
 }
 static auto do_not_include = emit_warning_kokkos_vector_deprecated();
 }  // namespace
+#endif
+#else
+#error "Deprecated <Kokkos_Vector.hpp> header is included"
 #endif
 
 #include <Kokkos_Core_fwd.hpp>

--- a/containers/src/Kokkos_Vector.hpp
+++ b/containers/src/Kokkos_Vector.hpp
@@ -31,8 +31,10 @@
  */
 namespace Kokkos {
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class Scalar, class Arg1Type = void>
-class vector : public DualView<Scalar*, LayoutLeft, Arg1Type> {
+class KOKKOS_DEPRECATED vector
+    : public DualView<Scalar*, LayoutLeft, Arg1Type> {
  public:
   using value_type      = Scalar;
   using pointer         = Scalar*;
@@ -312,6 +314,7 @@ class vector : public DualView<Scalar*, LayoutLeft, Arg1Type> {
     void operator()(const int& i) const { _data(i) = _val; }
   };
 };
+#endif
 
 }  // namespace Kokkos
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_VECTOR

--- a/containers/unit_tests/CMakeLists.txt
+++ b/containers/unit_tests/CMakeLists.txt
@@ -28,6 +28,9 @@ foreach(Tag Threads;Serial;OpenMP;HPX;Cuda;HIP;SYCL)
         Vector
         ViewCtorPropEmbeddedDim
         )
+      if(NOT Kokkos_ENABLE_DEPRECATED_CODE_4 AND Name STREQUAL "Vector")
+        continue() # skip Kokkos::vector test if deprecated code 4 is not enabled
+      endif()
       # Write to a temporary intermediate file and call configure_file to avoid
       # updating timestamps triggering unnecessary rebuilds on subsequent cmake runs.
       set(file ${dir}/Test${Tag}_${Name}.cpp)

--- a/containers/unit_tests/Makefile
+++ b/containers/unit_tests/Makefile
@@ -31,7 +31,7 @@ KOKKOS_CXXFLAGS += -I$(GTEST_PATH) -I${KOKKOS_PATH}/containers/unit_tests -I${KO
 TEST_TARGETS =
 TARGETS =
 
-TESTS = Bitset DualView DynamicView DynViewAPI_generic DynViewAPI_rank12345 DynViewAPI_rank67 ErrorReporter OffsetView ScatterView StaticCrsGraph UnorderedMap Vector ViewCtorPropEmbeddedDim
+TESTS = Bitset DualView DynamicView DynViewAPI_generic DynViewAPI_rank12345 DynViewAPI_rank67 ErrorReporter OffsetView ScatterView StaticCrsGraph UnorderedMap ViewCtorPropEmbeddedDim
 tmp := $(foreach device, $(KOKKOS_DEVICELIST), \
   tmp2 := $(foreach test, $(TESTS), \
     $(if $(filter Test$(device)_$(test).cpp, $(shell ls Test$(device)_$(test).cpp 2>/dev/null)),,\
@@ -54,7 +54,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_CUDA), 1)
 	OBJ_CUDA += TestCuda_ScatterView.o
 	OBJ_CUDA += TestCuda_StaticCrsGraph.o
 	OBJ_CUDA += TestCuda_UnorderedMap.o
-	OBJ_CUDA += TestCuda_Vector.o
 	OBJ_CUDA += TestCuda_ViewCtorPropEmbeddedDim.o
 	TARGETS += KokkosContainers_UnitTest_Cuda
 	TEST_TARGETS += test-cuda
@@ -73,7 +72,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_THREADS), 1)
 	OBJ_THREADS += TestThreads_ScatterView.o
 	OBJ_THREADS += TestThreads_StaticCrsGraph.o
 	OBJ_THREADS += TestThreads_UnorderedMap.o
-	OBJ_THREADS += TestThreads_Vector.o
 	OBJ_THREADS += TestThreads_ViewCtorPropEmbeddedDim.o
 	TARGETS += KokkosContainers_UnitTest_Threads
 	TEST_TARGETS += test-threads
@@ -92,7 +90,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_OPENMP), 1)
 	OBJ_OPENMP += TestOpenMP_ScatterView.o
 	OBJ_OPENMP += TestOpenMP_StaticCrsGraph.o
 	OBJ_OPENMP += TestOpenMP_UnorderedMap.o
-	OBJ_OPENMP += TestOpenMP_Vector.o
 	OBJ_OPENMP += TestOpenMP_ViewCtorPropEmbeddedDim.o
 	TARGETS += KokkosContainers_UnitTest_OpenMP
 	TEST_TARGETS += test-openmp
@@ -111,7 +108,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_HPX), 1)
 	OBJ_HPX += TestHPX_ScatterView.o
 	OBJ_HPX += TestHPX_StaticCrsGraph.o
 	OBJ_HPX += TestHPX_UnorderedMap.o
-	OBJ_HPX += TestHPX_Vector.o
 	OBJ_HPX += TestHPX_ViewCtorPropEmbeddedDim.o
 	TARGETS += KokkosContainers_UnitTest_HPX
 	TEST_TARGETS += test-hpx
@@ -130,7 +126,6 @@ ifeq ($(KOKKOS_INTERNAL_USE_SERIAL), 1)
 	OBJ_SERIAL += TestSerial_ScatterView.o
 	OBJ_SERIAL += TestSerial_StaticCrsGraph.o
 	OBJ_SERIAL += TestSerial_UnorderedMap.o
-	OBJ_SERIAL += TestSerial_Vector.o
 	OBJ_SERIAL += TestSerial_ViewCtorPropEmbeddedDim.o
 	TARGETS += KokkosContainers_UnitTest_Serial
 	TEST_TARGETS += test-serial

--- a/core/unit_test/headers_self_contained/CMakeLists.txt
+++ b/core/unit_test/headers_self_contained/CMakeLists.txt
@@ -10,6 +10,10 @@ file(GLOB KOKKOS_CONTAINERS_HEADERS RELATIVE ${BASE_DIR}/containers/src
 file(GLOB KOKKOS_ALGORITHMS_HEADERS RELATIVE  ${BASE_DIR}/algorithms/src
      ${BASE_DIR}/algorithms/src/*.hpp)
 
+if(NOT Kokkos_ENABLE_DEPRECATED_CODE_4)
+  list(REMOVE_ITEM KOKKOS_CONTAINERS_HEADERS "Kokkos_Vector.hpp")
+endif()
+
 foreach (_header ${KOKKOS_CORE_HEADERS} ${KOKKOS_CONTAINERS_HEADERS} ${KOKKOS_ALGORITHMS_HEADERS})
   string(REGEX REPLACE "[\./]" "_" header_test_name ${_header})
   set(header_test_name Kokkos_HeaderSelfContained_${header_test_name})


### PR DESCRIPTION
Rational: `Kokkos::vector` might have been relevant in the past to ease the transition to Kokkos but this is really not something we want people to use any more.
It is at times the source of confusion (quite different to `Kokkos::array`, `Kokkos::pair`, or `Kokkos::complex`).

I suggest we mark it as deprecated and prepare for removal in Kokkos 5.0